### PR TITLE
feat(event-sourcing): span jobs travel as claim-checks — versioned span_referenced event resolved through the span store

### DIFF
--- a/dev/docs/adr/069-payload-cost-doctrine.md
+++ b/dev/docs/adr/069-payload-cost-doctrine.md
@@ -152,7 +152,9 @@ visible.
    coding-agent span stops riding whole: with the event carrying a cost-honest
    claim-check, the subscriber reads the slice from the reference instead of the
    full payload — the slice-on-the-wire win phase 1 deferred, landed on the
-   right substrate instead of on the routing-dispatch seam.
+   right substrate instead of on the routing-dispatch seam. (The claim-check
+   half of this clause shipped early for `codingAgentSpanFactsDispatch`; the
+   cost-honesty half did not — see the 2026-07 amendment below.)
 3. **Phase 3 — invariant 3.** The per-process memory grant pool.
    **Precondition: phase 2** — a grant is taken against a declared cost, so
    costs must be honest before a pool can budget them.
@@ -191,7 +193,8 @@ visible.
   for refolds: not "tuned smaller", but "no configuration surface on which to
   recur". Matched spans still travel as full payloads until phase 2 replaces
   them with claim-checks; that residual is bounded by real coding-agent volume,
-  not by all-project span volume.
+  not by all-project span volume. (Superseded for this one subscriber — see the
+  2026-07 amendment below.)
 - **The platform gains a cost vocabulary.** "How many bytes is this job, and
   who granted them?" becomes an answerable question, which is what phases 2–4
   are built on — and what alerting can finally be written against, instead of
@@ -218,6 +221,47 @@ visible.
   phase 3, memory is still discovered rather than granted. The sequencing
   section exists so this gap is a tracked plan, not an ambient hope — the
   ADR-066 scope-table deferral is the cautionary precedent.
+
+## Amendment: the claim-check half of phase 2, shipped early for one subscriber (2026-07, #6117)
+
+`codingAgentSpanFactsDispatch` no longer stages the matched span whole. The
+enqueue seam grew a second total hook (`stage`) beside `filter`, and a matched
+`span_received` is swapped for a small versioned `span_referenced` event
+carrying the span's identity — tenant, trace, span id, and the span's own
+`startTimeUnixMs` — while the payload stays in the span store. The handler
+resolves it back through `spanStorage` and lifts the facts from that canonical
+row. This is the "matched coding-agent span stops riding whole" clause of phase
+2 above, landed ahead of its phase.
+
+Read the sequencing accordingly: **the claim-check half is shipped for this one
+subscriber; the cost-honesty half is not.** `span_referenced` declares no byte
+size, so invariant 1 is still unmet and the phase-2 work it gates — byte-bounded
+in-flight and retry stages (invariant 2), and the grant pool behind it (phase 3)
+— is untouched. The remaining `@planned` scenarios in the spec are the honest
+statement of what is left. A future phase-2 implementer should read this as "the
+reference mechanism exists and has one adopter", not as "phase 2 is underway".
+
+Two consequences worth naming rather than discovering:
+
+- **Span-facts delivery is now store-dependent.** The subscriber was previously
+  self-contained: everything it needed was in the job. It now depends on the
+  spanStorage projection having landed the row and on the ClickHouse read
+  succeeding. A miss is thrown deliberately (retry, never a silent drop) and the
+  2s stage delay debounces the ordinary race against the sibling write — but a
+  genuine store outage now delays these facts, where before it could not touch
+  them.
+- **The recovery path is the shared one, on purpose.** Store misses retry on the
+  platform-wide `JOB_RETRY_CONFIG` (25 attempts, ≈2h27m cumulative), which is
+  sized for exactly this failure — riding out a ClickHouse rolling restart or
+  ZooKeeper session recovery without parking the group. An outage outliving that
+  budget exhausts the job and blocks the per-trace group; the staged references
+  are preserved in Redis, so recovery is an operator unblock (delayed delivery
+  and toil, never loss). A store-miss-specific backoff or per-error-class
+  attempt budget was considered and **not** taken: the budget is one shared
+  platform policy, and carving out a per-subscriber knob is a change to the
+  queue contract with its own blast radius, not a line in this PR. If this class
+  of blocked group is observed in practice, that knob is the follow-up — with
+  the retry metrics to size it, per ADR-068's measure-before-you-limit rule.
 
 ## References
 

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1016,38 +1016,14 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         { tenantId, traceId, occurredAtMs },
         (span) => span === null,
         async (window) => {
-          const partition = partitionFragment(window);
-          const client = await this.resolveClient(tenantId);
-          // Single-span fetch. WHERE pins (TenantId, TraceId, SpanId) - the
-          // primary key prefix - so we hit a tiny granule range. ORDER BY
-          // UpdatedAt DESC LIMIT 1 deliberately picks up CH 25.10's
-          // LazilyRead optimiser: heavy columns (SpanAttributes, Events.*,
-          // Links.*) are deferred past the LIMIT, so unmerged versions
-          // don't materialise them. Investigation numbers + the per-query
-          // lock that keeps the optimiser engaged live in
-          // SINGLE_SPAN_FETCH_SETTINGS above. The doc's "Anti-Pattern 1"
-          // rule predates LazilyRead and isn't load-bearing on this shape.
-          const result = await client.query({
-            query: `
-              SELECT ${FULL_SPAN_SELECT}
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId = {traceId:String}
-                AND SpanId = {spanId:String}
-                ${partition.sqlAnd}
-              ORDER BY UpdatedAt DESC
-              LIMIT 1
-            `,
-            query_params: { tenantId, traceId, spanId, ...partition.params },
-            clickhouse_settings: SINGLE_SPAN_FETCH_SETTINGS,
-            format: "JSONEachRow",
+          const row = await this.fetchNormalizedSpanRow({
+            tenantId,
+            traceId,
+            spanId,
+            window,
           });
-
-          const rows = (await result.json()) as FullSpanRow[];
-          if (rows.length === 0) return null;
-          const [span] = mapNormalizedSpansToSpans(
-            rows.map(mapChRowToNormalized),
-          );
+          if (row === null) return null;
+          const [span] = mapNormalizedSpansToSpans([row]);
           return span ?? null;
         },
       );
@@ -1063,6 +1039,100 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       );
       throw error;
     }
+  }
+
+  /**
+   * Claim-check resolution read (ADR-069): the canonical single-span read for
+   * internal derivation consumers holding a `span_referenced` staging. A miss
+   * is an EXPECTED transient state here — the reference is often dequeued
+   * before the sibling spanStorage write lands — so `fallback: "none"` keeps a
+   * miss one cheap windowed probe (the caller throws into the queue's backoff)
+   * instead of an unbounded scan per retry. The occurredAt hint comes from the
+   * reference envelope, so the window is authoritative, not guessed.
+   */
+  async getNormalizedSpanById({
+    tenantId,
+    traceId,
+    spanId,
+    occurredAtMs,
+  }: {
+    tenantId: string;
+    traceId: string;
+    spanId: string;
+  } & OccurredAtHint): Promise<NormalizedSpan | null> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "SpanStorageClickHouseRepository.getNormalizedSpanById",
+    );
+
+    try {
+      return await queryWindowed<NormalizedSpan | null>({
+        table: TABLE_NAME,
+        hintMs: occurredAtMs ?? null,
+        windowMs: DEFAULT_PARTITION_WINDOW_MS,
+        fallback: "none",
+        isEmpty: (row) => row === null,
+        run: (window) =>
+          this.fetchNormalizedSpanRow({ tenantId, traceId, spanId, window }),
+      });
+    } catch (error) {
+      logger.error(
+        {
+          tenantId,
+          traceId,
+          spanId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to get normalized span by id from ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Single-span fetch shared by {@link getSpanByIds} and
+   * {@link getNormalizedSpanById}. WHERE pins (TenantId, TraceId, SpanId) - the
+   * primary key prefix - so we hit a tiny granule range. ORDER BY
+   * UpdatedAt DESC LIMIT 1 deliberately picks up CH 25.10's
+   * LazilyRead optimiser: heavy columns (SpanAttributes, Events.*,
+   * Links.*) are deferred past the LIMIT, so unmerged versions
+   * don't materialise them. Investigation numbers + the per-query
+   * lock that keeps the optimiser engaged live in
+   * SINGLE_SPAN_FETCH_SETTINGS above. The doc's "Anti-Pattern 1"
+   * rule predates LazilyRead and isn't load-bearing on this shape.
+   */
+  private async fetchNormalizedSpanRow({
+    tenantId,
+    traceId,
+    spanId,
+    window,
+  }: {
+    tenantId: string;
+    traceId: string;
+    spanId: string;
+    window: WindowFragment | null;
+  }): Promise<NormalizedSpan | null> {
+    const partition = partitionFragment(window);
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT ${FULL_SPAN_SELECT}
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+          AND SpanId = {spanId:String}
+          ${partition.sqlAnd}
+        ORDER BY UpdatedAt DESC
+        LIMIT 1
+      `,
+      query_params: { tenantId, traceId, spanId, ...partition.params },
+      clickhouse_settings: SINGLE_SPAN_FETCH_SETTINGS,
+      format: "JSONEachRow",
+    });
+
+    const rows = (await result.json()) as FullSpanRow[];
+    if (rows.length === 0) return null;
+    return mapChRowToNormalized(rows[0]!);
   }
 
   async findSpanResourcesByTraceId({

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1047,8 +1047,15 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
    * is an EXPECTED transient state here — the reference is often dequeued
    * before the sibling spanStorage write lands — so `fallback: "none"` keeps a
    * miss one cheap windowed probe (the caller throws into the queue's backoff)
-   * instead of an unbounded scan per retry. The occurredAt hint comes from the
-   * reference envelope, so the window is authoritative, not guessed.
+   * instead of an unbounded scan per retry.
+   *
+   * The hint must be the SPAN'S OWN start, not the ingest time of the event
+   * that referenced it: this table's partition column is `StartTime`, so a
+   * window centred on ingest time excludes any span whose duration plus export
+   * lag exceeded it — and spans export on end. Such a span would sit outside
+   * every retry's window forever. Callers pass the reference's parsed
+   * `startTimeUnixMs`, falling back to the envelope's occurredAt only when the
+   * wire span carried no parseable start.
    */
   async getNormalizedSpanById({
     tenantId,

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -213,6 +213,18 @@ export interface SpanStorageRepository {
     } & OccurredAtHint,
   ): Promise<Span | null>;
   /**
+   * Claim-check resolution read (ADR-069): one canonical span by identity,
+   * windowed by the reference's occurredAt hint with no unbounded fallback —
+   * a miss stays cheap because the caller retries via the queue.
+   */
+  getNormalizedSpanById(
+    params: {
+      tenantId: string;
+      traceId: string;
+      spanId: string;
+    } & OccurredAtHint,
+  ): Promise<NormalizedSpan | null>;
+  /**
    * Trace-level events ({spanId, timestamp, name, attributes}) for the
    * trace-detail read, derived from the spans' OTel events. Events-only
    * (ARRAY JOIN over the `Events.*` columns, no heavy span attribute scan),
@@ -334,6 +346,16 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
     } & OccurredAtHint,
   ): Promise<NormalizedSpan[]> {
     return [];
+  }
+
+  async getNormalizedSpanById(
+    _params: {
+      tenantId: string;
+      traceId: string;
+      spanId: string;
+    } & OccurredAtHint,
+  ): Promise<NormalizedSpan | null> {
+    return null;
   }
 
   async getSpanByIds(

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -131,15 +131,6 @@ export class SpanStorageService {
   }
 
   /**
-   * Returns a single span by its ID, resolving any ADR-022 offloaded eventref
-   * pointers when `blobResolutionDeps` were supplied at construction.
-   *
-   * Resolution fetches normalized spans for the whole trace and isolates the
-   * requested span after resolution — this reuses the same
-   * `resolveOffloadedTraces` path as `getSpansByTraceId` so that sibling
-   * eventref pointers on the same trace are also resolved consistently.
-   */
-  /**
    * Claim-check resolution read (ADR-069): one canonical span by identity for
    * internal derivation consumers (the coding-agent facts lift). Deliberately
    * ungated and unresolved: the consumers lift scalar span attributes only —
@@ -151,6 +142,15 @@ export class SpanStorageService {
     return this.repository.getNormalizedSpanById(params);
   }
 
+  /**
+   * Returns a single span by its ID, resolving any ADR-022 offloaded eventref
+   * pointers when `blobResolutionDeps` were supplied at construction.
+   *
+   * Resolution fetches normalized spans for the whole trace and isolates the
+   * requested span after resolution — this reuses the same
+   * `resolveOffloadedTraces` path as `getSpansByTraceId` so that sibling
+   * eventref pointers on the same trace are also resolved consistently.
+   */
   async getSpanById(params: BySpanId & VisibilityGate): Promise<Span | null> {
     const gateOne = (span: Span | null): Span | null =>
       span

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -139,6 +139,18 @@ export class SpanStorageService {
    * `resolveOffloadedTraces` path as `getSpansByTraceId` so that sibling
    * eventref pointers on the same trace are also resolved consistently.
    */
+  /**
+   * Claim-check resolution read (ADR-069): one canonical span by identity for
+   * internal derivation consumers (the coding-agent facts lift). Deliberately
+   * ungated and unresolved: the consumers lift scalar span attributes only —
+   * never offloaded bodies — and run server-side, so neither the visibility
+   * gate nor blob resolution applies. A `null` means "not readable yet";
+   * callers on a queue retry into it rather than treating it as absence.
+   */
+  async getNormalizedSpanById(params: BySpanId): Promise<NormalizedSpan | null> {
+    return this.repository.getNormalizedSpanById(params);
+  }
+
   async getSpanById(params: BySpanId & VisibilityGate): Promise<Span | null> {
     const gateOne = (span: Span | null): Span | null =>
       span

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -468,6 +468,8 @@ export class PipelineRegistry {
       codingAgentSubscribers: [
         createCodingAgentSpanFactsDispatchSubscriber({
           contributeSpanFacts: codingAgentCommands.contributeSpanFacts,
+          getNormalizedSpanById: (params) =>
+            this.deps.traces.spans.getNormalizedSpanById(params),
         }),
       ],
     });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
@@ -124,6 +124,12 @@ export function resolveConversationKey(
   for (const key of candidates) {
     const value = attrs[key];
     if (typeof value === "string" && value.length > 0) return value;
+    // The span-store read-back deserializes purely numeric attribute strings
+    // as numbers, so an agent whose session key is all digits must resolve
+    // to the same key on both the inline and the claim-check path.
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
   }
   return null;
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -9,6 +9,10 @@
  */
 import { describe, expect, it } from "vitest";
 import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
+import {
+  deserializeAttributes,
+  serializeAttributes,
+} from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
 import { SpanNormalizationPipelineService } from "~/server/app-layer/traces/span-normalization.service";
 import { createTenantId } from "~/server/event-sourcing";
 import { SPAN_RECEIVED_EVENT_TYPE } from "../../../trace-processing/schemas/constants";
@@ -28,6 +32,7 @@ function rawSpanEvent({
   name,
   spanId,
   attributes = {},
+  resourceAttributes = {},
   startMs = 1_000,
   endMs = 2_000,
   statusCode = 0,
@@ -35,6 +40,7 @@ function rawSpanEvent({
   name: string;
   spanId: string;
   attributes?: Record<string, string | number>;
+  resourceAttributes?: Record<string, string>;
   startMs?: number;
   endMs?: number;
   /** OTLP status: 0 UNSET, 1 OK, 2 ERROR. */
@@ -67,7 +73,12 @@ function rawSpanEvent({
         events: [],
         links: [],
       },
-      resource: { attributes: [] },
+      resource: {
+        attributes: Object.entries(resourceAttributes).map(([key, value]) => ({
+          key,
+          value: { stringValue: value },
+        })),
+      },
       instrumentationScope: { name: "com.anthropic.claude_code.tracing" },
     },
   } as unknown as TraceProcessingEvent;
@@ -87,6 +98,26 @@ function normalizedFrom(event: SpanReceivedEvent): NormalizedSpan {
   );
 }
 
+/**
+ * What the claim-check path actually reads: the normalized span AFTER its
+ * attributes round-tripped ClickHouse's Map(String, String) columns — the
+ * deliberately lossy deserialize turns "true"/"1.0"/"90210" style strings
+ * into booleans and numbers, which is exactly the divergence the
+ * identical-command contract has to absorb.
+ */
+function storeReadBackFrom(event: SpanReceivedEvent): NormalizedSpan {
+  const span = normalizedFrom(event);
+  return {
+    ...span,
+    spanAttributes: deserializeAttributes(
+      serializeAttributes(span.spanAttributes),
+    ),
+    resourceAttributes: deserializeAttributes(
+      serializeAttributes(span.resourceAttributes),
+    ),
+  };
+}
+
 function makeSubscriber(
   spanStore: (params: {
     tenantId: string;
@@ -96,13 +127,21 @@ function makeSubscriber(
   }) => Promise<NormalizedSpan | null> = async () => null,
 ) {
   const dispatched: ContributeSpanFactsCommandData[] = [];
-  const reads: Array<{ traceId: string; spanId: string }> = [];
+  const reads: Array<{
+    traceId: string;
+    spanId: string;
+    occurredAtMs?: number;
+  }> = [];
   const subscriber = createCodingAgentSpanFactsDispatchSubscriber({
     contributeSpanFacts: async (data) => {
       dispatched.push(data);
     },
     getNormalizedSpanById: async (params) => {
-      reads.push({ traceId: params.traceId, spanId: params.spanId });
+      reads.push({
+        traceId: params.traceId,
+        spanId: params.spanId,
+        occurredAtMs: params.occurredAtMs,
+      });
       return spanStore(params);
     },
   });
@@ -269,9 +308,7 @@ describe("codingAgentSpanFactsDispatch", () => {
         }
 
         expect(
-          dedup.makeId(
-            makeSpanReferencedEvent(event) as TraceProcessingEvent,
-          ),
+          dedup.makeId(makeSpanReferencedEvent(event) as TraceProcessingEvent),
         ).toBe(dedup.makeId(event));
       });
     });
@@ -294,7 +331,7 @@ describe("codingAgentSpanFactsDispatch", () => {
         const fullPath = makeSubscriber();
         await fullPath.subscriber.handle(event, context);
 
-        const refPath = makeSubscriber(async () => normalizedFrom(event));
+        const refPath = makeSubscriber(async () => storeReadBackFrom(event));
         await refPath.subscriber.handle(
           makeSpanReferencedEvent(event) as TraceProcessingEvent,
           context,
@@ -303,10 +340,105 @@ describe("codingAgentSpanFactsDispatch", () => {
         expect(refPath.dispatched).toHaveLength(1);
         expect(refPath.dispatched[0]).toEqual(fullPath.dispatched[0]);
         expect(refPath.reads).toEqual([
-          { traceId: TRACE_ID, spanId: "llm-ref" },
+          { traceId: TRACE_ID, spanId: "llm-ref", occurredAtMs: 1_000 },
         ]);
         // The full-event path never touches the store.
         expect(fullPath.reads).toHaveLength(0);
+      });
+    });
+
+    describe("when the store read-back deserialized numeric-looking scalars", () => {
+      /** @scenario a matched event's heavy payload travels as a claim-check, not inline */
+      it("keys the session and keeps the version fact identically to the full-event path", async () => {
+        // A purely numeric session key and a numeric-looking service.version:
+        // the Map(String, String) round-trip hands them back as NUMBERS, and
+        // the lift must land on the same command either way — not fall back
+        // to trace-keyed sessions or silently drop the fact.
+        const event = rawSpanEvent({
+          name: "claude_code.llm_request",
+          spanId: "llm-numeric",
+          attributes: { "gen_ai.conversation.id": "175335720123" },
+          resourceAttributes: { "service.version": "1.0" },
+        }) as SpanReceivedEvent;
+
+        const fullPath = makeSubscriber();
+        await fullPath.subscriber.handle(event, context);
+
+        const refPath = makeSubscriber(async () => storeReadBackFrom(event));
+        await refPath.subscriber.handle(
+          makeSpanReferencedEvent(event) as TraceProcessingEvent,
+          context,
+        );
+
+        // The session key — the field that decides which aggregate the facts
+        // land on — is identical across paths.
+        expect(fullPath.dispatched[0]?.sessionId).toBe("175335720123");
+        expect(fullPath.dispatched[0]?.sessionKeySource).toBe("provider");
+        expect(refPath.dispatched[0]?.sessionId).toBe("175335720123");
+        expect(refPath.dispatched[0]?.sessionKeySource).toBe("provider");
+        // The version fact survives, canonicalized: the Map(String, String)
+        // round-trip collapses "1.0" to the number 1, so the claim-check path
+        // reports "1" — kept (not dropped), with the numeric formatting lost.
+        expect(fullPath.dispatched[0]?.facts["service.version"]).toBe("1.0");
+        expect(refPath.dispatched[0]?.facts["service.version"]).toBe("1");
+      });
+    });
+
+    describe("when the referenced span outlived the ingest-time window", () => {
+      /** @scenario a reference that cannot be resolved yet retries, never drops */
+      it("centers the store read on the span's own start, not on ingest time", async () => {
+        const threeDays = 3 * 24 * 60 * 60 * 1000;
+        const startMs = 1_000_000;
+        const base = rawSpanEvent({
+          name: "claude_code.blocked_on_user",
+          spanId: "long-span",
+          startMs,
+          endMs: startMs + threeDays,
+        }) as SpanReceivedEvent;
+        // Ingest happened when the span ENDED — three days after it started,
+        // which is outside a fixed window centered on ingest time.
+        const event = { ...base, occurredAt: startMs + threeDays };
+
+        const { subscriber, reads } = makeSubscriber(async () =>
+          normalizedFrom(event),
+        );
+        await subscriber.handle(
+          makeSpanReferencedEvent(event) as TraceProcessingEvent,
+          context,
+        );
+
+        expect(reads).toEqual([
+          { traceId: TRACE_ID, spanId: "long-span", occurredAtMs: startMs },
+        ]);
+      });
+
+      it("falls back to ingest time when the wire span carried no parseable start", async () => {
+        const valid = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "no-start",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+        const base = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "no-start",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+        const span = base.data.span as { startTimeUnixNano?: unknown };
+        span.startTimeUnixNano = "not-a-timestamp";
+        const event = { ...base, occurredAt: 5_000 };
+
+        // Only the read HINT is under test; the stub's span content just has
+        // to be a well-formed store row (a garbage start can't normalize, so
+        // the store never holds one).
+        const { subscriber, reads } = makeSubscriber(async () =>
+          normalizedFrom(valid),
+        );
+        await subscriber.handle(
+          makeSpanReferencedEvent(event) as TraceProcessingEvent,
+          context,
+        );
+
+        expect(reads[0]?.occurredAtMs).toBe(5_000);
       });
     });
 

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -8,9 +8,16 @@
  * @see specs/coding-agent/session-aggregate.feature
  */
 import { describe, expect, it } from "vitest";
+import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
+import { SpanNormalizationPipelineService } from "~/server/app-layer/traces/span-normalization.service";
 import { createTenantId } from "~/server/event-sourcing";
 import { SPAN_RECEIVED_EVENT_TYPE } from "../../../trace-processing/schemas/constants";
-import type { TraceProcessingEvent } from "../../../trace-processing/schemas/events";
+import {
+  makeSpanReferencedEvent,
+  type SpanReceivedEvent,
+  type TraceProcessingEvent,
+} from "../../../trace-processing/schemas/events";
+import type { NormalizedSpan } from "../../../trace-processing/schemas/spans";
 import type { ContributeSpanFactsCommandData } from "../../schemas/commands";
 import { createCodingAgentSpanFactsDispatchSubscriber } from "../codingAgentSpanFactsDispatch.subscriber";
 
@@ -66,14 +73,40 @@ function rawSpanEvent({
   } as unknown as TraceProcessingEvent;
 }
 
-function makeSubscriber() {
+/** The same normalization the platform runs — builds expected store rows. */
+const normalization = new SpanNormalizationPipelineService(
+  new CanonicalizeSpanAttributesService(),
+);
+
+function normalizedFrom(event: SpanReceivedEvent): NormalizedSpan {
+  return normalization.normalizeSpanReceived(
+    event.tenantId,
+    event.data.span,
+    event.data.resource,
+    event.data.instrumentationScope,
+  );
+}
+
+function makeSubscriber(
+  spanStore: (params: {
+    tenantId: string;
+    traceId: string;
+    spanId: string;
+    occurredAtMs?: number;
+  }) => Promise<NormalizedSpan | null> = async () => null,
+) {
   const dispatched: ContributeSpanFactsCommandData[] = [];
+  const reads: Array<{ traceId: string; spanId: string }> = [];
   const subscriber = createCodingAgentSpanFactsDispatchSubscriber({
     contributeSpanFacts: async (data) => {
       dispatched.push(data);
     },
+    getNormalizedSpanById: async (params) => {
+      reads.push({ traceId: params.traceId, spanId: params.spanId });
+      return spanStore(params);
+    },
   });
-  return { subscriber, dispatched };
+  return { subscriber, dispatched, reads };
 }
 
 const context = { tenantId: "tenant-1", aggregateId: TRACE_ID };
@@ -217,6 +250,125 @@ describe("codingAgentSpanFactsDispatch", () => {
         expect(dedup.makeId(event)).toBe(
           `coding-agent-span-facts:tenant-1:${TRACE_ID}:tool-dedup`,
         );
+      });
+    });
+
+    describe("when keying a claim-check job", () => {
+      /** @scenario a matched event's heavy payload travels as a claim-check, not inline */
+      it("derives the identical key from the reference shape", () => {
+        const { subscriber } = makeSubscriber();
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-dedup",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+
+        const dedup = subscriber.options?.deduplication;
+        if (dedup === undefined || dedup === "aggregate") {
+          throw new Error("expected a custom deduplication config");
+        }
+
+        expect(
+          dedup.makeId(
+            makeSpanReferencedEvent(event) as TraceProcessingEvent,
+          ),
+        ).toBe(dedup.makeId(event));
+      });
+    });
+  });
+
+  describe("given a claim-check staged job (ADR-069)", () => {
+    describe("when the referenced span is readable in the store", () => {
+      /** @scenario a matched event's heavy payload travels as a claim-check, not inline */
+      it("lifts the identical command the full-event path produces", async () => {
+        const event = rawSpanEvent({
+          name: "claude_code.llm_request",
+          spanId: "llm-ref",
+          attributes: {
+            "gen_ai.conversation.id": "sess-ref",
+            input_tokens: 42,
+            stop_reason: "end_turn",
+          },
+        }) as SpanReceivedEvent;
+
+        const fullPath = makeSubscriber();
+        await fullPath.subscriber.handle(event, context);
+
+        const refPath = makeSubscriber(async () => normalizedFrom(event));
+        await refPath.subscriber.handle(
+          makeSpanReferencedEvent(event) as TraceProcessingEvent,
+          context,
+        );
+
+        expect(refPath.dispatched).toHaveLength(1);
+        expect(refPath.dispatched[0]).toEqual(fullPath.dispatched[0]);
+        expect(refPath.reads).toEqual([
+          { traceId: TRACE_ID, spanId: "llm-ref" },
+        ]);
+        // The full-event path never touches the store.
+        expect(fullPath.reads).toHaveLength(0);
+      });
+    });
+
+    describe("when the referenced span is not readable yet", () => {
+      /** @scenario a reference that cannot be resolved yet retries, never drops */
+      it("throws into the queue's retry instead of dropping silently", async () => {
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-late",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+        const { subscriber, dispatched } = makeSubscriber(async () => null);
+
+        await expect(
+          subscriber.handle(
+            makeSpanReferencedEvent(event) as TraceProcessingEvent,
+            context,
+          ),
+        ).rejects.toThrow(/not readable yet/);
+        expect(dispatched).toHaveLength(0);
+      });
+    });
+
+    describe("when the reference carries a version this build does not know", () => {
+      /** @scenario a reference this build cannot read fails loudly, never half-parses */
+      it("throws into the queue's retry instead of no-opping as another shape", async () => {
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-vnext",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+        const future = {
+          ...makeSpanReferencedEvent(event),
+          version: "2199-01-01",
+        };
+        const { subscriber, dispatched } = makeSubscriber(async () =>
+          normalizedFrom(event),
+        );
+
+        await expect(
+          subscriber.handle(future as TraceProcessingEvent, context),
+        ).rejects.toThrow();
+        expect(dispatched).toHaveLength(0);
+      });
+    });
+
+    describe("when the matched span has no span id to reference", () => {
+      /** @scenario an event that cannot be referenced stages whole */
+      it("stages the full event unchanged and the handler processes it as before", async () => {
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "",
+          attributes: { tool_name: "Bash" },
+        }) as SpanReceivedEvent;
+
+        const staged = makeSpanReferencedEvent(event);
+        expect(staged).toBe(event);
+
+        const { subscriber, dispatched, reads } = makeSubscriber();
+        await subscriber.handle(staged as TraceProcessingEvent, context);
+        expect(dispatched).toHaveLength(1);
+        expect(reads).toHaveLength(0);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -101,7 +101,12 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
           tenantId: ref.tenantId,
           traceId: ref.data.traceId,
           spanId: ref.data.spanId,
-          occurredAtMs: ref.occurredAt,
+          // Center the store's partition window on the span's OWN start (the
+          // stored row's StartTime is this exact value), not on ingest time:
+          // a span that ran longer than the window and exported on end would
+          // otherwise sit permanently outside an occurredAt-centered read and
+          // exhaust its retries into a blocked group.
+          occurredAtMs: ref.data.startTimeUnixMs ?? ref.occurredAt,
         });
         if (span === null) {
           // Not readable YET — the reference raced the sibling span write.
@@ -162,6 +167,14 @@ function liftContribution({
   const serviceVersion = span.resourceAttributes["service.version"];
   if (typeof serviceVersion === "string" && serviceVersion.length > 0) {
     facts["service.version"] = serviceVersion;
+  } else if (
+    // The store read-back deserializes numeric-looking versions ("1.0",
+    // "2024") as numbers — keep the fact instead of silently dropping it on
+    // the claim-check path only.
+    typeof serviceVersion === "number" &&
+    Number.isFinite(serviceVersion)
+  ) {
+    facts["service.version"] = String(serviceVersion);
   }
 
   return {

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -4,6 +4,7 @@ import type { EventSubscriberDefinition } from "../../../subscribers/eventSubscr
 import { SPAN_RECEIVED_EVENT_TYPE } from "../../trace-processing/schemas/constants";
 import {
   isSpanReceivedEvent,
+  makeSpanReferencedEvent,
   parseSpanReferencedEvent,
   type SpanReceivedEvent,
   type TraceProcessingEvent,
@@ -66,7 +67,14 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
     name: "codingAgentSpanFactsDispatch",
     eventTypes: [SPAN_RECEIVED_EVENT_TYPE],
     options: {
-      enqueue: { filter: isCodingAgentSpan },
+      enqueue: {
+        filter: isCodingAgentSpan,
+        // `filter` has already established a coding-agent span_received
+        // event; the stage hook is a total field-pick that swaps the staged
+        // payload for its claim-check (or returns the event unchanged when
+        // the span has no id to reference).
+        stage: (event) => makeSpanReferencedEvent(event as SpanReceivedEvent),
+      },
       // Debounce past the spanStorage sibling write: the reference resolves
       // against the span store, and both jobs are staged by the same fan-out.
       // Two seconds puts the first attempt after that write in the common

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -4,9 +4,11 @@ import type { EventSubscriberDefinition } from "../../../subscribers/eventSubscr
 import { SPAN_RECEIVED_EVENT_TYPE } from "../../trace-processing/schemas/constants";
 import {
   isSpanReceivedEvent,
+  parseSpanReferencedEvent,
   type SpanReceivedEvent,
   type TraceProcessingEvent,
 } from "../../trace-processing/schemas/events";
+import type { NormalizedSpan } from "../../trace-processing/schemas/spans";
 import type { ContributeSpanFactsCommandData } from "../schemas/commands";
 import {
   CODING_AGENT_CONTRIBUTION_KEYS,
@@ -20,22 +22,32 @@ import { CODING_AGENT_SPAN_NAMES } from "../services/coding-agent-session.deriva
  * stored `span_received` events that lifts a coding-agent span's facts and
  * contributes them to its session.
  *
- * The raw span-name gate runs twice, on purpose:
+ * Payload-cost shape (ADR-069):
  *
- *   - as `enqueue.filter` at the fan-out seam (ADR-069 invariant 4), so a span
- *     from any other trace never mints a job. Every span in the project flows
- *     past that predicate; one set lookup keeps an ordinary chat trace's cost
- *     at zero. Origin gating is exactly this predicate — no gate reactor
+ *   - `enqueue.filter` runs the RAW span-name gate at the fan-out seam, so a
+ *     span from any other trace never mints a job. Every span in the project
+ *     flows past that predicate; one set lookup keeps an ordinary chat trace's
+ *     cost at zero. Origin gating is exactly this predicate — no gate reactor
  *     (ADR-056 §3).
- *   - inline in the handler, which still receives jobs staged by a build
- *     deployed before the filter existed during the rollover window.
- *
- * Normalization and fact lifting stay in the handler's own consumer lane, so a
- * span the registry cannot decode fails and retries only this subscriber's
- * job — never the shared routing dispatch.
+ *   - A freshly staged job is a `span_referenced` claim-check: the span's
+ *     identity, not its payload. The handler reads the canonical span back
+ *     from the span store — where spanStorage already normalized it once —
+ *     and lifts the facts from that row. The read races the sibling
+ *     spanStorage write, so a miss throws into the queue's backoff and the
+ *     `delay` below debounces the common case past the race.
+ *   - A full `span_received` job still processes exactly as before references
+ *     existed: jobs staged by a previous release, and matched events the seam
+ *     could not reference, carry the whole event, and the handler normalizes
+ *     inline in its own lane.
  */
 export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
   contributeSpanFacts: (data: ContributeSpanFactsCommandData) => Promise<void>;
+  getNormalizedSpanById: (params: {
+    tenantId: string;
+    traceId: string;
+    spanId: string;
+    occurredAtMs?: number;
+  }) => Promise<NormalizedSpan | null>;
 }): EventSubscriberDefinition<TraceProcessingEvent> {
   const normalization = new SpanNormalizationPipelineService(
     new CanonicalizeSpanAttributesService(),
@@ -55,58 +67,142 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
     eventTypes: [SPAN_RECEIVED_EVENT_TYPE],
     options: {
       enqueue: { filter: isCodingAgentSpan },
+      // Debounce past the spanStorage sibling write: the reference resolves
+      // against the span store, and both jobs are staged by the same fan-out.
+      // Two seconds puts the first attempt after that write in the common
+      // case; the queue's backoff covers the tail.
+      delay: 2_000,
       deduplication: {
         makeId: (event) => {
-          const spanId =
-            isSpanReceivedEvent(event) &&
-            typeof event.data.span.spanId === "string"
-              ? event.data.span.spanId
-              : "";
+          const { tenantId, aggregateId, spanId } = dedupIdentity(event);
           // aggregateId is the trace id — span ids are only unique WITHIN a
           // trace, so the key needs both or two traces' spans can collide
-          // inside the TTL and silently drop facts.
-          return `coding-agent-span-facts:${event.tenantId}:${String(event.aggregateId)}:${spanId}`;
+          // inside the TTL and silently drop facts. Both staged shapes expose
+          // the RAW wire span id, so the key is identical across the
+          // reference upgrade.
+          return `coding-agent-span-facts:${tenantId}:${aggregateId}:${spanId}`;
         },
         ttlMs: 60_000,
       },
     },
     handle: async (event) => {
-      if (!isCodingAgentSpan(event)) return;
+      // Freshly staged job: a claim-check. Resolve it through the span store.
+      const ref = parseSpanReferencedEvent(event);
+      if (ref) {
+        const span = await deps.getNormalizedSpanById({
+          tenantId: ref.tenantId,
+          traceId: ref.data.traceId,
+          spanId: ref.data.spanId,
+          occurredAtMs: ref.occurredAt,
+        });
+        if (span === null) {
+          // Not readable YET — the reference raced the sibling span write.
+          // Throwing is the contract: the queue retries with backoff, and a
+          // span that never lands surfaces as a loud exhausted job, never a
+          // silent drop.
+          throw new Error(
+            `Referenced span is not readable yet (trace ${ref.data.traceId}, span ${ref.data.spanId}); retrying until the span store write lands`,
+          );
+        }
+        await deps.contributeSpanFacts(
+          liftContribution({
+            span,
+            tenantId: ref.tenantId,
+            occurredAt: ref.occurredAt,
+          }),
+        );
+        return;
+      }
 
+      // Full-event job: a pre-reference release staged it, or the seam could
+      // not build a reference. Gate, normalize and lift inline — identical to
+      // the pre-reference handler.
+      if (!isCodingAgentSpan(event)) return;
       const span = normalization.normalizeSpanReceived(
         event.tenantId,
         event.data.span,
         event.data.resource,
         event.data.instrumentationScope,
       );
-
-      const sessionKey = resolveConversationKey(span.spanAttributes);
-      const facts = liftSpanFacts(span.spanAttributes);
-      const serviceVersion = span.resourceAttributes["service.version"];
-      if (typeof serviceVersion === "string" && serviceVersion.length > 0) {
-        facts["service.version"] = serviceVersion;
-      }
-
-      await deps.contributeSpanFacts({
-        tenantId: event.tenantId,
-        sessionId: sessionKey ?? span.traceId,
-        sessionKeySource: sessionKey !== null ? "provider" : "trace_fallback",
-        agent: detectCodingAgent({
-          recordName: span.name,
-          scopeName: span.instrumentationScope.name,
+      await deps.contributeSpanFacts(
+        liftContribution({
+          span,
+          tenantId: event.tenantId,
+          occurredAt: event.occurredAt,
         }),
-        occurredAt: event.occurredAt,
-        traceId: span.traceId,
-        spanId: span.spanId,
-        name: span.name,
-        startTimeUnixMs: span.startTimeUnixMs,
-        endTimeUnixMs: span.endTimeUnixMs,
-        statusCode: span.statusCode ?? 0,
-        facts,
-        scopeName: span.instrumentationScope.name || null,
-      });
+      );
     },
   };
+}
+
+/**
+ * The facts lift off one canonical span — shared verbatim by the claim-check
+ * path (span read back from the store) and the full-event path (span
+ * normalized inline), so both produce the identical command.
+ */
+function liftContribution({
+  span,
+  tenantId,
+  occurredAt,
+}: {
+  span: NormalizedSpan;
+  tenantId: string;
+  occurredAt: number;
+}): ContributeSpanFactsCommandData {
+  const sessionKey = resolveConversationKey(span.spanAttributes);
+  const facts = liftSpanFacts(span.spanAttributes);
+  const serviceVersion = span.resourceAttributes["service.version"];
+  if (typeof serviceVersion === "string" && serviceVersion.length > 0) {
+    facts["service.version"] = serviceVersion;
+  }
+
+  return {
+    tenantId,
+    sessionId: sessionKey ?? span.traceId,
+    sessionKeySource: sessionKey !== null ? "provider" : "trace_fallback",
+    agent: detectCodingAgent({
+      recordName: span.name,
+      scopeName: span.instrumentationScope.name,
+    }),
+    occurredAt,
+    traceId: span.traceId,
+    spanId: span.spanId,
+    name: span.name,
+    startTimeUnixMs: span.startTimeUnixMs,
+    endTimeUnixMs: span.endTimeUnixMs,
+    statusCode: span.statusCode ?? 0,
+    facts,
+    scopeName: span.instrumentationScope.name || null,
+  };
+}
+
+/**
+ * The dedup identity, read from either staged shape with total field picks —
+ * `makeId` runs on the staging path, so it must never throw.
+ */
+function dedupIdentity(payload: TraceProcessingEvent): {
+  tenantId: string;
+  aggregateId: string;
+  spanId: string;
+} {
+  const base = {
+    tenantId: String(payload.tenantId),
+    aggregateId: String(payload.aggregateId),
+  };
+  const data = (payload as { data?: unknown }).data;
+  if (typeof data === "object" && data !== null) {
+    const direct = (data as { spanId?: unknown }).spanId;
+    if (typeof direct === "string") {
+      // span_referenced: the raw wire span id sits on the reference itself.
+      return { ...base, spanId: direct };
+    }
+    const nested = (data as { span?: { spanId?: unknown } }).span?.spanId;
+    if (typeof nested === "string") {
+      // span_received: the raw wire span id inside the OTLP payload.
+      return { ...base, spanId: nested };
+    }
+  }
+  return { ...base, spanId: "" };
 }
 
 /** The scalar coding-agent vocabulary off one span's attributes. */

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
@@ -5,6 +5,28 @@ export const SPAN_RECEIVED_EVENT_VERSIONS = [
   SPAN_RECEIVED_EVENT_VERSION_LATEST,
 ] as const;
 
+/**
+ * The claim-check twin of `span_received` (ADR-069): staged onto a
+ * subscriber's queue in place of the full event, carrying only the span's
+ * identity — the payload stays in its canonical store and the handler reads
+ * it back from there. It is never appended to the event log, which is why it
+ * is deliberately absent from TRACE_PROCESSING_EVENT_TYPES: it exists only
+ * between the routing seam and the subscriber that opted into it.
+ *
+ * The versions array is load-bearing: a consumer parses a reference by
+ * version, and a version it does not know fails loudly into the queue's
+ * retry rather than half-parsing. Bump the date and append here whenever the
+ * reference's shape — or the contract of the store it resolves through —
+ * changes incompatibly.
+ */
+export const SPAN_REFERENCED_EVENT_TYPE =
+  "lw.obs.trace.span_referenced" as const;
+export const SPAN_REFERENCED_EVENT_VERSION_LATEST = "2026-07-24" as const;
+
+export const SPAN_REFERENCED_EVENT_VERSIONS = [
+  SPAN_REFERENCED_EVENT_VERSION_LATEST,
+] as const;
+
 export const TOPIC_ASSIGNED_EVENT_TYPE = "lw.obs.trace.topic_assigned" as const;
 export const TOPIC_ASSIGNED_EVENT_VERSION_LATEST = "2025-02-01" as const;
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
@@ -124,6 +124,20 @@ export const TRACE_PROCESSING_EVENT_TYPES = [
 export type TraceProcessingEventType =
   (typeof TRACE_PROCESSING_EVENT_TYPES)[number];
 
+/**
+ * Staging-only event types (ADR-069): valid Event brands that travel between
+ * the routing seam and a subscriber's queue but are NEVER appended to the
+ * event log — which is why they stay out of TRACE_PROCESSING_EVENT_TYPES. They
+ * are registered as type identifiers (see typeIdentifiers.ts) solely so a
+ * `stage` hook can return them as well-typed Events.
+ */
+export const TRACE_PROCESSING_STAGING_EVENT_TYPES = [
+  SPAN_REFERENCED_EVENT_TYPE,
+] as const;
+
+export type TraceProcessingStagingEventType =
+  (typeof TRACE_PROCESSING_STAGING_EVENT_TYPES)[number];
+
 export const RECORD_SPAN_COMMAND_TYPE = "lw.obs.trace.record_span" as const;
 export const ASSIGN_TOPIC_COMMAND_TYPE = "lw.obs.trace.assign_topic" as const;
 export const RECORD_LOG_CONTRIBUTION_COMMAND_TYPE =

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/events.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/events.ts
@@ -12,6 +12,9 @@ import {
   METRIC_DATA_POINT_CORRELATED_EVENT_TYPE,
   ORIGIN_RESOLVED_EVENT_TYPE,
   SPAN_RECEIVED_EVENT_TYPE,
+  SPAN_REFERENCED_EVENT_TYPE,
+  SPAN_REFERENCED_EVENT_VERSION_LATEST,
+  SPAN_REFERENCED_EVENT_VERSIONS,
   TOPIC_ASSIGNED_EVENT_TYPE,
   TRACE_NAME_CHANGED_EVENT_TYPE,
   TRACE_NAME_MAX_LENGTH,
@@ -61,6 +64,83 @@ export function isSpanReceivedEvent(
   event: TraceProcessingEvent,
 ): event is SpanReceivedEvent {
   return event.type === SPAN_RECEIVED_EVENT_TYPE;
+}
+
+/**
+ * The claim-check twin of `span_received` (ADR-069): the routing seam stages
+ * this in place of the full event for a subscriber that opted in, and the
+ * handler reads the span back from its canonical store. Never appended to the
+ * event log — see the constant's docblock for the versioning contract.
+ */
+export const spanReferencedEventDataSchema = z.object({
+  traceId: z.string(),
+  spanId: z.string(),
+  /** The raw wire span name, mirrored so gates and debugging never need the store. */
+  spanName: z.string(),
+});
+
+export const spanReferencedEventSchema = EventSchema.extend({
+  type: z.literal(SPAN_REFERENCED_EVENT_TYPE),
+  version: z.enum(SPAN_REFERENCED_EVENT_VERSIONS),
+  data: spanReferencedEventDataSchema,
+});
+
+export type SpanReferencedEventData = z.infer<
+  typeof spanReferencedEventDataSchema
+>;
+export type SpanReferencedEvent = z.infer<typeof spanReferencedEventSchema>;
+
+/**
+ * Discriminate-then-validate read of a staged payload.
+ *
+ * Returns `null` when the payload does not even claim to be a span reference
+ * (the caller falls through to its full-event path). But once the payload
+ * claims the type, a shape or version this build cannot read THROWS into the
+ * queue's retry — falling through would let a mixed-deploy job be mistaken
+ * for another kind of payload and silently no-op.
+ */
+export function parseSpanReferencedEvent(
+  value: unknown,
+): SpanReferencedEvent | null {
+  if (typeof value !== "object" || value === null) return null;
+  if (
+    (value as { type?: unknown }).type !== SPAN_REFERENCED_EVENT_TYPE
+  ) {
+    return null;
+  }
+  return spanReferencedEventSchema.parse(value);
+}
+
+/**
+ * Builds the staged reference for a matched `span_received` event, mirroring
+ * the envelope fields the scheduler orders, groups, and dedups by (same id,
+ * aggregate, tenant, occurredAt). Total by construction: a span missing the
+ * identity a reference needs stages the full event unchanged instead — the
+ * pre-reference behavior, never a reference that could not resolve.
+ */
+export function makeSpanReferencedEvent(
+  event: SpanReceivedEvent,
+): SpanReferencedEvent | SpanReceivedEvent {
+  const span = event.data.span as { spanId?: unknown; name?: unknown };
+  if (typeof span.spanId !== "string" || span.spanId.length === 0) {
+    return event;
+  }
+  return {
+    id: event.id,
+    version: SPAN_REFERENCED_EVENT_VERSION_LATEST,
+    aggregateId: event.aggregateId,
+    aggregateType: event.aggregateType,
+    tenantId: event.tenantId,
+    createdAt: event.createdAt,
+    occurredAt: event.occurredAt,
+    type: SPAN_REFERENCED_EVENT_TYPE,
+    data: {
+      traceId: String(event.aggregateId),
+      spanId: span.spanId,
+      spanName: typeof span.name === "string" ? span.name : "",
+    },
+    metadata: event.metadata,
+  };
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/events.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/events.ts
@@ -77,6 +77,17 @@ export const spanReferencedEventDataSchema = z.object({
   spanId: z.string(),
   /** The raw wire span name, mirrored so gates and debugging never need the store. */
   spanName: z.string(),
+  /**
+   * The span's own start, epoch ms, parsed off the wire `startTimeUnixNano`.
+   * The resolution read centers its partition window here: the stored row's
+   * StartTime IS this value, so the read stays a pruned point-read no matter
+   * how long the span ran or how late it exported — `occurredAt` is ingest
+   * time, which trails a long-lived span's start by the span's whole
+   * duration, and a fixed window around it goes permanently blind past that.
+   * Null when the wire span carried no parseable start; the reader then
+   * falls back to `occurredAt`, matching the store's own fallback stamping.
+   */
+  startTimeUnixMs: z.number().nullable(),
 });
 
 export const spanReferencedEventSchema = EventSchema.extend({
@@ -103,9 +114,7 @@ export function parseSpanReferencedEvent(
   value: unknown,
 ): SpanReferencedEvent | null {
   if (typeof value !== "object" || value === null) return null;
-  if (
-    (value as { type?: unknown }).type !== SPAN_REFERENCED_EVENT_TYPE
-  ) {
+  if ((value as { type?: unknown }).type !== SPAN_REFERENCED_EVENT_TYPE) {
     return null;
   }
   return spanReferencedEventSchema.parse(value);
@@ -121,7 +130,11 @@ export function parseSpanReferencedEvent(
 export function makeSpanReferencedEvent(
   event: SpanReceivedEvent,
 ): SpanReferencedEvent | SpanReceivedEvent {
-  const span = event.data.span as { spanId?: unknown; name?: unknown };
+  const span = event.data.span as {
+    spanId?: unknown;
+    name?: unknown;
+    startTimeUnixNano?: unknown;
+  };
   if (typeof span.spanId !== "string" || span.spanId.length === 0) {
     return event;
   }
@@ -138,9 +151,27 @@ export function makeSpanReferencedEvent(
       traceId: String(event.aggregateId),
       spanId: span.spanId,
       spanName: typeof span.name === "string" ? span.name : "",
+      startTimeUnixMs: parseStartTimeUnixMs(span.startTimeUnixNano),
     },
     metadata: event.metadata,
   };
+}
+
+/**
+ * ns→ms off the wire `startTimeUnixNano` (string or number), total: null on
+ * anything unparseable or non-positive. Parsing a 19-digit ns string as a
+ * double loses sub-microsecond precision, which is sub-millisecond after the
+ * divide — well inside what partition windowing tolerates.
+ */
+function parseStartTimeUnixMs(value: unknown): number | null {
+  const nano =
+    typeof value === "string" && /^\d+$/.test(value)
+      ? Number(value)
+      : typeof value === "number"
+        ? value
+        : Number.NaN;
+  if (!Number.isFinite(nano) || nano <= 0) return null;
+  return Math.floor(nano / 1e6);
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -1212,22 +1212,31 @@ export class ProjectionRouter<
             continue;
           }
 
+          // Claim-check staging (ADR-069): the subscriber may swap the staged
+          // payload for a small reference event mirroring the source event's
+          // scheduling identity. Total field-picks only — a throw fails into
+          // the routing retry like the filter's.
+          const staged = enqueue?.stage
+            ? (enqueue.stage(event) as EventType)
+            : event;
+
           const queue = queued
             ? this.queueManager.getSubscriberQueue(name)
             : undefined;
           if (queue) {
-            await queue.send(event);
+            await queue.send(staged);
           } else {
-            await this.handleSubscriber(subscriber, event);
+            await this.handleSubscriber(subscriber, staged);
           }
 
           // Counted only once the handoff succeeded. A failed send throws to
-          // the catch below, so a queue outage never inflates `staged` — the
-          // filtered/staged split stays an honest picture of what the seam did.
+          // the catch below, so a queue outage never inflates `staged` or
+          // `referenced` — the outcome split stays an honest picture of what
+          // the seam did.
           incrementEsSubscriberEnqueueTotal({
             pipelineName: this.pipelineName,
             subscriberName: name,
-            outcome: "staged",
+            outcome: staged === event ? "staged" : "referenced",
           });
         } catch (error) {
           this.logger.error(

--- a/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
+++ b/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
@@ -53,6 +53,7 @@ import {
 import {
   TRACE_PROCESSING_COMMAND_TYPES,
   TRACE_PROCESSING_EVENT_TYPES,
+  TRACE_PROCESSING_STAGING_EVENT_TYPES,
 } from "../pipelines/trace-processing/schemas/constants";
 
 /**
@@ -67,6 +68,9 @@ const TEST_EVENT_TYPES = ["test.integration.event"] as const;
 export const EVENT_TYPE_IDENTIFIERS = [
   ...AUTOMATIONS_EVENT_TYPES,
   ...TRACE_PROCESSING_EVENT_TYPES,
+  // Staging-only brands (ADR-069): valid Event types that a `stage` hook may
+  // return but that are never appended to the event log.
+  ...TRACE_PROCESSING_STAGING_EVENT_TYPES,
   ...METRIC_PROCESSING_EVENT_TYPES,
   ...LOG_PROCESSING_EVENT_TYPES,
   ...CODING_AGENT_PROCESSING_EVENT_TYPES,

--- a/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
+++ b/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
@@ -57,10 +57,12 @@ import {
 } from "../pipelines/trace-processing/schemas/constants";
 
 /**
- * Test event type identifiers for integration tests.
- * These are minimal identifiers without full schemas - used only for validation.
+ * Test-only event type identifiers. Minimal brands without full schemas, used
+ * only to validate the pipeline in tests: `test.integration.event` for
+ * integration coverage, and `test.referenced` for the enqueue-staging seam's
+ * claim-check unit (a synthetic reference a `stage` hook returns).
  */
-const TEST_EVENT_TYPES = ["test.integration.event"] as const;
+const TEST_EVENT_TYPES = ["test.integration.event", "test.referenced"] as const;
 
 /**
  * All event type identifiers defined in schemas.

--- a/langwatch/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
@@ -303,4 +303,99 @@ describe("subscriber enqueue-time contract", () => {
       });
     });
   });
+
+  describe("given a subscriber with a claim-check stage hook", () => {
+    describe("when the hook swaps the payload for a reference", () => {
+      /** @scenario a matched event's heavy payload travels as a claim-check, not inline */
+      it("stages the reference in place of the event and counts it as referenced", async () => {
+        const received: unknown[] = [];
+        const before = await enqueueOutcomeCount("referenced");
+        const event = makeEvent("evt-ref");
+        const router = makeRouter({
+          name: "seamSubscriber",
+          eventTypes: [],
+          handle: async (staged) => {
+            received.push(staged);
+          },
+          options: {
+            enqueue: {
+              stage: (source) => ({
+                ...source,
+                type: "test.referenced",
+                data: { ref: source.id },
+              }),
+            },
+          },
+        });
+
+        await router.dispatch([event], readContext);
+
+        expect(received).toHaveLength(1);
+        const staged = received[0] as {
+          type: string;
+          data: unknown;
+          id: string;
+          aggregateId: unknown;
+          occurredAt: number;
+        };
+        expect(staged.type).toBe("test.referenced");
+        expect(staged.data).toEqual({ ref: event.id });
+        // The scheduling identity travels on the reference.
+        expect(staged.id).toBe(event.id);
+        expect(staged.aggregateId).toBe(event.aggregateId);
+        expect(staged.occurredAt).toBe(event.occurredAt);
+        expect(await enqueueOutcomeCount("referenced")).toBe(before + 1);
+      });
+    });
+
+    describe("when the hook returns the event unchanged", () => {
+      /** @scenario an event that cannot be referenced stages whole */
+      it("stages the full event and counts it as staged, not referenced", async () => {
+        const received: unknown[] = [];
+        const beforeStaged = await enqueueOutcomeCount("staged");
+        const beforeReferenced = await enqueueOutcomeCount("referenced");
+        const event = makeEvent("evt-passthrough");
+        const router = makeRouter({
+          name: "seamSubscriber",
+          eventTypes: [],
+          handle: async (staged) => {
+            received.push(staged);
+          },
+          options: { enqueue: { stage: (source) => source } },
+        });
+
+        await router.dispatch([event], readContext);
+
+        expect(received[0]).toEqual(event);
+        expect(await enqueueOutcomeCount("staged")).toBe(beforeStaged + 1);
+        expect(await enqueueOutcomeCount("referenced")).toBe(beforeReferenced);
+      });
+    });
+
+    describe("when the hook throws", () => {
+      /** @scenario a throwing enqueue filter surfaces into retry, never a silent drop */
+      it("fails loudly into the routing retry rather than dropping silently", async () => {
+        let handlerRan = false;
+        const router = makeRouter({
+          name: "seamSubscriber",
+          eventTypes: [],
+          handle: async () => {
+            handlerRan = true;
+          },
+          options: {
+            enqueue: {
+              stage: () => {
+                throw new Error("stage blew up");
+              },
+            },
+          },
+        });
+
+        await expect(
+          router.dispatch([makeEvent("evt-stage-throw")], readContext),
+        ).rejects.toThrow();
+        expect(handlerRan).toBe(false);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
@@ -373,7 +373,7 @@ describe("subscriber enqueue-time contract", () => {
     });
 
     describe("when the hook throws", () => {
-      /** @scenario a throwing enqueue filter surfaces into retry, never a silent drop */
+      /** @scenario a raising claim-check stage is reported as a failure, not as a quiet full stage */
       it("fails loudly into the routing retry rather than dropping silently", async () => {
         let handlerRan = false;
         const router = makeRouter({

--- a/langwatch/src/server/event-sourcing/subscribers/eventSubscriber.types.ts
+++ b/langwatch/src/server/event-sourcing/subscribers/eventSubscriber.types.ts
@@ -41,6 +41,17 @@ export interface EnqueueDispatchOptions<E extends Event = Event> {
    * typeof check, a field comparison).
    */
   filter?: (event: E) => boolean;
+  /**
+   * Claim-check staging (ADR-069): swap the staged payload for a small
+   * reference event that mirrors the source event's scheduling identity (id,
+   * aggregate, tenant, occurredAt) while the payload stays in its canonical
+   * store. Total field-picks only — no decoding, no normalization; return the
+   * source event unchanged when a reference cannot be built. The handler must
+   * understand every shape this can return, plus the full event (pre-upgrade
+   * jobs). Runs after `filter` accepted the event; a throw fails loudly into
+   * the routing retry.
+   */
+  stage?: (event: E) => Event;
 }
 
 export interface EventSubscriberOptions<E extends Event = Event> {

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -636,20 +636,24 @@ export const observeEsSubscriberDuration = ({
  * doctrine invariant 4 — ADR-069):
  *
  * - `filtered` — the predicate declined; no job was minted.
- * - `staged` — the event was handed off to the subscriber's lane, counted only
- *   after the handoff succeeded: the queue accepted the job, or (in the
- *   no-queue configuration) the handler ran inline. A handoff that throws
- *   counts neither outcome — it is reported as a dispatch failure instead, so
- *   a queue outage cannot inflate `staged`.
+ * - `staged` — a job carrying the full event was handed off to the
+ *   subscriber's lane.
+ * - `referenced` — a job carrying a claim-check reference instead of the
+ *   payload was handed off.
  *
- * The two outcomes therefore do not sum to "events routed"; the shortfall is
+ * `staged` and `referenced` are counted only after the handoff succeeded: the
+ * queue accepted the job, or (in the no-queue configuration) the handler ran
+ * inline. A handoff that throws counts no outcome at all — it is reported as a
+ * dispatch failure instead, so a queue outage cannot inflate either.
+ *
+ * The outcomes therefore do not sum to "events routed"; the shortfall is
  * the failure count, which is the honest reading.
  */
-type SubscriberEnqueueOutcome = "filtered" | "staged";
+type SubscriberEnqueueOutcome = "filtered" | "staged" | "referenced";
 register.removeSingleMetric("es_subscriber_enqueue_total");
 const esSubscriberEnqueueTotal = new Counter({
   name: "es_subscriber_enqueue_total",
-  help: "Event-sourcing subscriber fan-out outcomes decided at enqueue time (ADR-069): filtered before staging, or staged once the handoff to the subscriber's lane succeeded",
+  help: "Event-sourcing subscriber fan-out outcomes decided at enqueue time (ADR-069): filtered before staging, or — once the handoff to the subscriber's lane succeeded — staged as a full event or referenced as a claim-check",
   labelNames: ["pipeline_name", "subscriber_name", "outcome"] as const,
 });
 

--- a/specs/event-sourcing/payload-cost.feature
+++ b/specs/event-sourcing/payload-cost.feature
@@ -2,13 +2,15 @@ Feature: Payload cost governs the scheduling plane
   A subscriber that needs a small slice of a large event must not mint a job for
   every event it does not care about. The event is already in memory when it is
   routed; that is where an irrelevant event is discarded — so the job never
-  exists. The routing seam is shared by the whole fan-out, so only a cheap,
-  total predicate runs there; deriving the slice from a relevant event stays in
-  the subscriber's own lane until the event carries a cost-honest claim-check
-  (phase 2). Work waiting in a queue is cheap as a pointer and fatal as resident
-  memory; when the platform kills a worker for memory it did not choose to hold,
-  a shedding layer is missing. (ADR-069; phase 1 scenarios below are shipping,
-  the planned scenarios record phases 2–4.)
+  exists. The routing seam is shared by the whole fan-out, so only cheap, total
+  work runs there: a predicate that declines an event, or a field-pick that
+  turns a matched event into a small reference. Deriving the slice from the
+  payload stays in the subscriber's own lane, where the payload's canonical
+  store already holds it and a failure retries only that subscriber's job. Work
+  waiting in a queue is cheap as a pointer and fatal as resident memory; when
+  the platform kills a worker for memory it did not choose to hold, a shedding
+  layer is missing. (ADR-069; the scenarios below are shipping, the planned
+  scenarios record phases 2–4.)
 
   See dev/docs/adr/069-payload-cost-doctrine.md.
 
@@ -86,17 +88,35 @@ Feature: Payload cost governs the scheduling plane
     Then the routing attempt reports the failure
     And the event is not counted among those staged as a job
 
-  # --- Phases 2-4: the remaining ADR-069 invariants ---
+  # --- Claim-check staging: a matched event's job carries a reference ---
 
-  @planned
-  # Not yet implemented as of 2026-07-24 — ADR-069 phase 2: with the event
-  # carrying a cost-honest claim-check, the subscriber reads its slice from the
-  # reference instead of the full payload riding the queue.
   Scenario: a matched event's heavy payload travels as a claim-check, not inline
     Given an event the subscriber considers relevant whose payload is large
     When the event is routed to subscribers
     Then the staged job carries a reference to the payload, not the payload
-    And the handler reads only the small slice it needs through that reference
+    And the handler completes its work by reading the payload from its canonical store
+    And the reference preserves the identity the scheduler orders and dedups by
+
+  Scenario: a reference that cannot be resolved yet retries, never drops
+    Given a relevant event staged as a reference
+    And the referenced payload is not yet readable in its store
+    When the handler processes the job
+    Then the attempt fails into the queue's retry
+    And the job completes once the payload becomes readable
+
+  Scenario: a reference this build cannot read fails loudly, never half-parses
+    Given a staged reference carrying a schema version this build does not know
+    When the handler processes the job
+    Then the attempt fails into the queue's retry
+    And the job is never mistaken for another kind of payload
+
+  Scenario: an event that cannot be referenced stages whole
+    Given a relevant event missing the identity a reference needs
+    When the event is routed to subscribers
+    Then the staged job carries the full event
+    And the handler processes it to the same outcome as before references existed
+
+  # --- Phases 2-4: the remaining ADR-069 invariants ---
 
   @planned
   # Not yet implemented as of 2026-07-24 — ADR-069 phase 2: offloaded payloads

--- a/specs/event-sourcing/payload-cost.feature
+++ b/specs/event-sourcing/payload-cost.feature
@@ -90,6 +90,7 @@ Feature: Payload cost governs the scheduling plane
 
   # --- Claim-check staging: a matched event's job carries a reference ---
 
+  @unit
   Scenario: a matched event's heavy payload travels as a claim-check, not inline
     Given an event the subscriber considers relevant whose payload is large
     When the event is routed to subscribers
@@ -97,6 +98,7 @@ Feature: Payload cost governs the scheduling plane
     And the handler completes its work by reading the payload from its canonical store
     And the reference preserves the identity the scheduler orders and dedups by
 
+  @unit
   Scenario: a reference that cannot be resolved yet retries, never drops
     Given a relevant event staged as a reference
     And the referenced payload is not yet readable in its store
@@ -104,17 +106,32 @@ Feature: Payload cost governs the scheduling plane
     Then the attempt fails into the queue's retry
     And the job completes once the payload becomes readable
 
+  @unit
   Scenario: a reference this build cannot read fails loudly, never half-parses
     Given a staged reference carrying a schema version this build does not know
     When the handler processes the job
     Then the attempt fails into the queue's retry
     And the job is never mistaken for another kind of payload
 
+  @unit
   Scenario: an event that cannot be referenced stages whole
     Given a relevant event missing the identity a reference needs
     When the event is routed to subscribers
     Then the staged job carries the full event
     And the handler processes it to the same outcome as before references existed
+
+  # The stage hook shares the filter's seam and therefore the filter's sharp
+  # edge: the routing path has no retry, so a throw here loses this
+  # subscriber's job for this event. It is pinned separately because the
+  # tempting failure mode is the quiet one — falling back to staging the
+  # payload whole, which would hide a broken reference behind the very cost
+  # the claim-check exists to avoid.
+  @unit
+  Scenario: a raising claim-check stage is reported as a failure, not as a quiet full stage
+    Given a relevant event whose subscriber's claim-check stage raises
+    When the event is routed to subscribers
+    Then the routing attempt reports the failure
+    And the subscriber's handler never runs for that event
 
   # --- Phases 2-4: the remaining ADR-069 invariants ---
 


### PR DESCRIPTION
## What

Stacked on #6111 (merge that first — this PR's base is its branch). The coding-agent span-facts subscriber's jobs stop carrying span payloads: a matched `span_received` stages a small **`span_referenced`** claim-check, and the handler reads the canonical span back from the span store — where `spanStorage` already normalized it exactly once. ADR-069 invariant 4 taken to its resolution: the payload never rides the scheduling plane, and the platform normalizes each span once instead of twice.

### The versioned event (the first one whose versions array is load-bearing)

`span_referenced` follows the house `_EVENT_VERSION_LATEST`/`_EVENT_VERSIONS` convention, and its parse is **discriminate-then-validate**: a payload that doesn't claim the type returns `null` (caller falls through to the full-event path); a payload that claims the type but carries an unknown version **throws into the queue retry** — a mixed-deploy job can never be mistaken for another shape and silently no-op. It is never appended to the event log (deliberately absent from `TRACE_PROCESSING_EVENT_TYPES`, and registered in a staging-only brand list): the durable audit already exists at both ends (`span_received` in the trace log, the facts contribution in the session log), and a derived, single-consumer event in a write-hot log is transport wearing an event costume. If span-relevance ever becomes a non-rederivable decision (model/config-based) or grows a second consumer, it graduates to a durable event — recorded as the flip condition.

### Resolution discipline

- `getNormalizedSpanById`: primary-key point read `(TenantId, TraceId, SpanId)` with **`fallback: "none"`** — a miss is an *expected transient* (the reference races the sibling `spanStorage` write), so it stays one cheap windowed probe and throws into the queue's backoff (25 attempts, 500ms→10min). Never an unbounded scan on the delivery path.
- **The window centres on the span's own start, not on ingest time.** The reference carries `startTimeUnixMs` parsed off the wire span, and the read centres there — the stored row's `StartTime` *is* that value. Centring on `occurredAt` (ingest time) instead would put any span whose duration plus export lag exceeded the window permanently outside its own read: spans export on *end*, and `claude_code.blocked_on_user` is exactly that long-duration class. Such a job could never succeed on any retry — it would exhaust its budget and block the group forever. Falls back to `occurredAt` when the wire span carried no parseable start.
- `delay: 2s` on the subscriber debounces the common case past the sibling write.
- The facts lift is shared verbatim by both paths — a reference job and a full-event job produce the **identical command** (pinned by test, with the store stub routed through `serializeAttributes`/`deserializeAttributes` so the assertion sees a real round-trip rather than the inline normalization output).
- **The round-trip is lossy on purpose, so both picks tolerate it.** `deserializeAttributes` returns numeric-looking strings as numbers, so `resolveConversationKey` and the `service.version` pick accept finite numbers in canonical string form. Without that, an agent emitting a purely numeric session key would key by provider on the full-event path and fall back to the trace on the claim-check path — one session's facts split across per-trace aggregates, during every deploy window in which both paths coexist.
- Dedup keys on the raw wire span id in **both** shapes — the identity is unchanged across the upgrade.
- The seam hook (`enqueue.stage`) is contract-bound to total field-picks; a span with no id stages the full event unchanged, and a throw is reported as a routing failure rather than quietly staging the payload whole. `es_subscriber_enqueue_total` grows the `referenced` outcome, counted only after the handoff succeeds (per the base PR's contract).

### Deploy sequencing (why the consumer commit comes first)

The first commit is the consumer (handler understands references), the second the producer (seam stages them). An old worker dequeuing a reference would silently no-op it, so if a zero-loss window matters, land+deploy the consumer before the producer (deploys run several times daily). Merged together, the exposure is the minutes of one rolling deploy, for coding-agent facts only.

## ADR

ADR-069 sequenced claim-checks into phase 2 and defines one as always carrying the payload's true byte size. This PR ships the claim-check half early for one subscriber and `span_referenced` declares no size, so the ADR gains an amendment stating the split — the reference mechanism exists and has one adopter; invariant 1 is still unmet, so byte-bounded stages and the grant pool behind them are untouched. It also names the two consequences: span-facts delivery is now dependent on the spanStorage projection and the ClickHouse read, and a store outage outliving the shared 25-attempt budget blocks the per-trace group until an operator unblocks it (staged references preserved in Redis — delayed delivery and toil, never loss). A store-miss-specific backoff was considered and declined: the budget is one shared platform policy already sized for ClickHouse recovery cycles, and carving out a per-error-class knob is a queue-contract change with its own blast radius.

## Tests

- Subscriber suite **15/15**: identical-command proof across both paths (through a serialize/deserialize round-trip); numeric-scalar session keys and versions; a 3-day-old span resolving on the start-centred window, and garbage start falling back to ingest time; miss → throws into retry; unknown version → throws; no-span-id → stages whole and processes as before; dedup identity equal across shapes; filter cases.
- Seam contract suite **9/9**: stage swaps payload + counts `referenced`; passthrough counts `staged`; throwing stage fails the routing attempt and never runs the handler; filter and queue-outage cases.
- Span-storage suites **69/69** (the `getSpanByIds` → shared `fetchNormalizedSpanRow` refactor is behavior-preserving).
- tslsp diagnostics clean on all touched files.
- Spec: `specs/event-sourcing/payload-cost.feature` claim-check block, **5 scenarios** bound via `@scenario`. The four original claim-check scenarios carried annotations but no `@unit` tag, so the parity check counted 9 of 13 and never enforced them — tagged, now 14/14 bound.

## Deployment Impact

- **Env vars:** none. **Helm values / chart:** none. **Migrations:** none.
- **Default helm install:** unaffected; one metric label value added on an existing counter.
- **BYOC dataplane:** no impact.
- **Behavioural:** coding-agent span jobs shrink from full span payloads to small references resolved via one keyed ClickHouse point read (+2s dispatch delay). Non-agent projects unaffected (already filtered by the base PR). Rollback-safe: pre-upgrade full-event jobs process identically on new code; a rollback mid-window leaves reference jobs that old code no-ops (facts loss bounded to that window's coding-agent spans, dedup TTL 60s).

## Expected prod effect

Worker RSS pressure from the span-facts queue drops to near-zero per job; `es_subscriber_enqueue_total{outcome="referenced"}` becomes the staging signal, and `clickhouse_windowed_read_total{table="stored_spans"}` picks up the resolution reads (windowed, no unbounded fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added claim-check staging for coding-agent span facts to reduce queued payload size while keeping behavior consistent.
  * Introduced claim-check resolution for referenced spans using a persisted normalized-span read, including retries when spans aren’t readable yet.
  * Added fallback processing for cases where a span reference can’t be constructed.
  * Added new “referenced” enqueue outcome and related version validation behavior.

* **Bug Fixes**
  * Standardized single-span retrieval semantics for referenced span resolution.

* **Documentation**
  * Updated payload-cost and claim-check staging scenarios to match the new flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
