### PR TITLE
fix(coding-agent): monotonic version stamp — two session upserts can no longer tie on UpdatedAt

### DIFF
--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -258,7 +258,11 @@ describe("coding_agent_sessions round-trip (migrations 00051-00054)", () => {
     await sessions.upsert(
       sessionRow({
         sessionId: drifted,
-        startedAtMs: baseMs - 30 * 24 * 60 * 60 * 1000,
+        // Far outside the read window, but WELL inside the 30-day retention:
+        // a drift equal to retentionDays parks this row exactly on the table's
+        // `StartedAt + toIntervalDay(_retention_days)` TTL boundary, where any
+        // background merge DELETEs it mid-test and the reads fall back to v1.
+        startedAtMs: baseMs - 15 * 24 * 60 * 60 * 1000,
         costUsd: 2,
       }),
       30,

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment node
+ *
+ * The RMT version stamp. The IN-tuple dedup read depends on the repo-wide
+ * invariant that no two versions of one row tie on UpdatedAt
+ * (dev/docs/best_practices/clickhouse-queries.md): a tie makes both versions
+ * match max(UpdatedAt), and the drifted-window read then returns the stale
+ * in-window version instead of empty — the flake observed on the
+ * "returns empty, not a stale version" integration scenario when two upserts
+ * landed in the same millisecond.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { CodingAgentSessionRow } from "~/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection";
+import { CodingAgentSessionClickHouseRepository } from "../coding-agent-session.clickhouse.repository";
+
+/**
+ * The stamp logic reads only identity, bookkeeping timestamps and the
+ * threaded prior version; the remaining ~80 columns are irrelevant to it, so
+ * the fixture stays a partial cast rather than a full row factory.
+ */
+function rowWith(over: Partial<CodingAgentSessionRow>): CodingAgentSessionRow {
+  return {
+    tenantId: "tenant-1",
+    sessionId: "sess-1",
+    startedAtMs: 1_000,
+    createdAt: 1_000,
+    updatedAt: 0,
+    traceIds: [],
+    metricSeries: [],
+    stepStartedAt: [],
+    subAgentIds: [],
+    steps: [],
+    toolCounts: {},
+    toolDurationMs: {},
+    filesTouched: [],
+    skills: [],
+    subAgentTypes: [],
+    slashCommands: [],
+    models: [],
+    mcpServers: [],
+    mcpTools: [],
+    errorTypes: {},
+    refusalCategories: [],
+    languagesEdited: [],
+    ...over,
+  } as unknown as CodingAgentSessionRow;
+}
+
+function makeRepository() {
+  const captured: Array<{ UpdatedAt: Date }> = [];
+  const client = {
+    insert: async (args: { values: Array<{ UpdatedAt: Date }> }) => {
+      captured.push(...args.values);
+    },
+  } as unknown as ClickHouseClient;
+  const repository = new CodingAgentSessionClickHouseRepository(
+    async () => client,
+  );
+  return { repository, captured };
+}
+
+describe("CodingAgentSessionClickHouseRepository version stamp", () => {
+  describe("given two upserts landing in the same millisecond", () => {
+    it("stamps strictly increasing versions so the latest always wins", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
+      try {
+        const { repository, captured } = makeRepository();
+
+        await repository.upsert(rowWith({ updatedAt: 0 }));
+        await repository.upsert(rowWith({ updatedAt: 0 }));
+
+        expect(captured).toHaveLength(2);
+        expect(captured[1]!.UpdatedAt.getTime()).toBeGreaterThan(
+          captured[0]!.UpdatedAt.getTime(),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("given a row threading its superseded version's timestamp", () => {
+    it("stamps past the prior version even when this writer's clock lags it", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
+      try {
+        const { repository, captured } = makeRepository();
+        const priorMs = Date.now() + 60_000;
+
+        await repository.upsert(rowWith({ updatedAt: priorMs }));
+
+        expect(captured[0]!.UpdatedAt.getTime()).toBeGreaterThan(priorMs);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("given a batch of versions for one session", () => {
+    it("stamps each entry past the one before it", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
+      try {
+        const { repository, captured } = makeRepository();
+
+        await repository.upsertBatch([
+          { row: rowWith({ updatedAt: 0 }) },
+          { row: rowWith({ updatedAt: 0 }) },
+          { row: rowWith({ updatedAt: 0 }) },
+        ]);
+
+        const stamps = captured.map((r) => r.UpdatedAt.getTime());
+        expect(stamps).toHaveLength(3);
+        expect(stamps[1]).toBeGreaterThan(stamps[0]!);
+        expect(stamps[2]).toBeGreaterThan(stamps[1]!);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
@@ -4,10 +4,10 @@
  * The RMT version stamp. The IN-tuple dedup read depends on the repo-wide
  * invariant that no two versions of one row tie on UpdatedAt
  * (dev/docs/best_practices/clickhouse-queries.md): a tie makes both versions
- * match max(UpdatedAt), and the drifted-window read then returns the stale
- * in-window version instead of empty — the flake observed on the
- * "returns empty, not a stale version" integration scenario when two upserts
- * landed in the same millisecond.
+ * match max(UpdatedAt), so a windowed read can return a stale in-window
+ * version instead of empty. The full write→read contract, including the
+ * drifted-window scenario, lives in the sibling integration suite against
+ * real ClickHouse; this suite pins the stamp seam itself.
  */
 import { describe, expect, it, vi } from "vitest";
 import type { ClickHouseClient } from "@clickhouse/client";
@@ -60,64 +60,69 @@ function makeRepository() {
   return { repository, captured };
 }
 
+/** Freezes the clock for one case so every stamp starts from the same now. */
+async function withFrozenClock(run: () => Promise<void>): Promise<void> {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
+  try {
+    await run();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe("CodingAgentSessionClickHouseRepository version stamp", () => {
-  describe("given two upserts landing in the same millisecond", () => {
-    it("stamps strictly increasing versions so the latest always wins", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
-      try {
-        const { repository, captured } = makeRepository();
+  describe("given two versions of one session inside the same millisecond", () => {
+    describe("when both are written through the repository", () => {
+      it("stamps strictly increasing versions so the latest always wins", async () => {
+        await withFrozenClock(async () => {
+          const { repository, captured } = makeRepository();
 
-        await repository.upsert(rowWith({ updatedAt: 0 }));
-        await repository.upsert(rowWith({ updatedAt: 0 }));
+          await repository.upsert(rowWith({ updatedAt: 0 }));
+          await repository.upsert(rowWith({ updatedAt: 0 }));
 
-        expect(captured).toHaveLength(2);
-        expect(captured[1]!.UpdatedAt.getTime()).toBeGreaterThan(
-          captured[0]!.UpdatedAt.getTime(),
-        );
-      } finally {
-        vi.useRealTimers();
-      }
+          expect(captured).toHaveLength(2);
+          expect(captured[1]!.UpdatedAt.getTime()).toBeGreaterThan(
+            captured[0]!.UpdatedAt.getTime(),
+          );
+        });
+      });
     });
   });
 
   describe("given a row threading its superseded version's timestamp", () => {
-    it("stamps past the prior version even when this writer's clock lags it", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
-      try {
-        const { repository, captured } = makeRepository();
-        const priorMs = Date.now() + 60_000;
+    describe("when it is written while this writer's clock lags that prior", () => {
+      it("stamps past the prior version", async () => {
+        await withFrozenClock(async () => {
+          const { repository, captured } = makeRepository();
+          const priorMs = Date.now() + 60_000;
 
-        await repository.upsert(rowWith({ updatedAt: priorMs }));
+          await repository.upsert(rowWith({ updatedAt: priorMs }));
 
-        expect(captured[0]!.UpdatedAt.getTime()).toBeGreaterThan(priorMs);
-      } finally {
-        vi.useRealTimers();
-      }
+          expect(captured[0]!.UpdatedAt.getTime()).toBeGreaterThan(priorMs);
+        });
+      });
     });
   });
 
   describe("given a batch of versions for one session", () => {
-    it("stamps each entry past the one before it", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
-      try {
-        const { repository, captured } = makeRepository();
+    describe("when the batch is written in one insert", () => {
+      it("stamps each entry past the one before it", async () => {
+        await withFrozenClock(async () => {
+          const { repository, captured } = makeRepository();
 
-        await repository.upsertBatch([
-          { row: rowWith({ updatedAt: 0 }) },
-          { row: rowWith({ updatedAt: 0 }) },
-          { row: rowWith({ updatedAt: 0 }) },
-        ]);
+          await repository.upsertBatch([
+            { row: rowWith({ updatedAt: 0 }) },
+            { row: rowWith({ updatedAt: 0 }) },
+            { row: rowWith({ updatedAt: 0 }) },
+          ]);
 
-        const stamps = captured.map((r) => r.UpdatedAt.getTime());
-        expect(stamps).toHaveLength(3);
-        expect(stamps[1]).toBeGreaterThan(stamps[0]!);
-        expect(stamps[2]).toBeGreaterThan(stamps[1]!);
-      } finally {
-        vi.useRealTimers();
-      }
+          const stamps = captured.map((r) => r.UpdatedAt.getTime());
+          expect(stamps).toHaveLength(3);
+          expect(stamps[1]).toBeGreaterThan(stamps[0]!);
+          expect(stamps[2]).toBeGreaterThan(stamps[1]!);
+        });
+      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -134,11 +134,17 @@ interface ClickHouseWriteRecord {
 /** UInt64 columns ride as strings — see the interface docblock. */
 const big = (n: number): string => String(Math.max(0, Math.round(n)));
 
-function toRecord(
-  row: CodingAgentSessionRow,
-  retentionDays?: number,
-  appliedEventIds: readonly string[] = [],
-): ClickHouseWriteRecord {
+function toRecord({
+  row,
+  retentionDays,
+  appliedEventIds = [],
+  versionStampMs,
+}: {
+  row: CodingAgentSessionRow;
+  retentionDays?: number;
+  appliedEventIds?: readonly string[];
+  versionStampMs: number;
+}): ClickHouseWriteRecord {
   const now = new Date();
   return {
     TenantId: row.tenantId,
@@ -147,9 +153,10 @@ function toRecord(
     Version: row.version,
     StartedAt: new Date(row.startedAtMs),
     // Preserve first-seen creation across re-folds; UpdatedAt is the RMT
-    // version and must be the write time so the latest version wins.
+    // version and must be strictly greater than the version it supersedes —
+    // see nextVersionStamp for why write time alone is not enough.
     CreatedAt: row.createdAt > 0 ? new Date(row.createdAt) : now,
-    UpdatedAt: now,
+    UpdatedAt: new Date(versionStampMs),
 
     Agent: row.agent,
     AgentVersion: row.agentVersion,
@@ -257,6 +264,30 @@ export class CodingAgentSessionClickHouseRepository
 {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
+  /**
+   * Monotonic floor for the RMT version stamp this writer issues. The
+   * IN-tuple read pattern requires that no two versions of one session tie on
+   * UpdatedAt (dev/docs/best_practices/clickhouse-queries.md: "nextUpdatedAt =
+   * max(now, prevUpdatedAt + 1) … no ties possible"): a tie makes BOTH rows
+   * match max(UpdatedAt), and a windowed read can then resurrect the stale
+   * in-window version while the true latest sits outside the window. The
+   * stamp combines the superseded version's timestamp threaded through the
+   * row (the read-back path) with this writer's own last stamp (covers
+   * writers that did not read back); per-aggregate group serialization covers
+   * the cross-process window.
+   */
+  private lastVersionStampMs = 0;
+
+  private nextVersionStamp(priorUpdatedAtMs: number): number {
+    const stamp = Math.max(
+      Date.now(),
+      priorUpdatedAtMs + 1,
+      this.lastVersionStampMs + 1,
+    );
+    this.lastVersionStampMs = stamp;
+    return stamp;
+  }
+
   async upsert(
     row: CodingAgentSessionRow,
     retentionDays?: number,
@@ -270,7 +301,14 @@ export class CodingAgentSessionClickHouseRepository
     try {
       await client.insert({
         table: TABLE_NAME,
-        values: [toRecord(row, retentionDays, appliedEventIds)],
+        values: [
+          toRecord({
+            row,
+            retentionDays,
+            appliedEventIds,
+            versionStampMs: this.nextVersionStamp(row.updatedAt),
+          }),
+        ],
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
       });
@@ -481,7 +519,12 @@ export class CodingAgentSessionClickHouseRepository
       await client.insert({
         table: TABLE_NAME,
         values: entries.map(({ row, retentionDays, appliedEventIds }) =>
-          toRecord(row, retentionDays, appliedEventIds),
+          toRecord({
+            row,
+            retentionDays,
+            appliedEventIds,
+            versionStampMs: this.nextVersionStamp(row.updatedAt),
+          }),
         ),
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },


### PR DESCRIPTION
## What

The session repository stamped plain write time as the ReplacingMergeTree version, violating the repo's own dedup invariant (`clickhouse-queries.md`: "nextUpdatedAt = max(now, prevUpdatedAt + 1) … no ties possible"). Two commits for one session inside the same millisecond tied on `UpdatedAt`; both then match the IN-tuple `max(UpdatedAt)` seek, and a windowed read can return a stale in-window version instead of empty. In prod the same tie lets a fold read-back resurrect stale state.

The stamp is now `max(now, superseded version + 1, this writer's last stamp + 1)`: the threaded prior covers the read-back path (the row already carries its superseded version's timestamp), the per-writer monotonic floor covers writers that did not read back (including tests writing raw rows), and per-aggregate group serialization covers the cross-process window. `toRecord` moved to named parameters to carry the stamp.

## The CI flake — both contributors found

The intermittent "returns empty, not a stale version, when the latest StartedAt drifted outside the window" failure had **two** contributors, both fixed here:

1. **TTL boundary race (the one CI was actually tripping on).** The fixture backdated the latest version's `StartedAt` by exactly `retentionDays` (30d), parking that row precisely on the table's `TTL toDateTime(StartedAt) + toIntervalDay(_retention_days) DELETE` boundary — any background merge between insert and read deleted the true latest, and the reads fell back to the stale version. Proven locally: `OPTIMIZE TABLE … FINAL` deterministically deletes a 30d-drift row and keeps a 15d one; which assertion failed depended on when the merge landed. The fixture now drifts 15 days — still past the read window, far from the TTL.
2. **The UpdatedAt tie (this PR's headline).** Not what CI tripped on in this test (sequential awaited upserts sit ~100ms apart), but a real invariant violation reachable in prod through same-millisecond writes across writer cycles — fixed as above.

## Tests

- Unit suite (3/3): same-millisecond double upsert stamps strictly increasing versions; a future-threaded prior is stamped past; batch entries each stamp past the previous. (The full write→read contract, including the drifted-window scenario, is the sibling round-trip integration suite against real ClickHouse — 8/8.)
- tslsp diagnostics clean.

## Deployment Impact

- **Env vars / Helm / migrations:** none.
- **Default helm install:** unaffected. **BYOC dataplane:** no impact.
- **Behavioural:** session row versions become strictly monotonic per session; a version can stamp up to a few ms ahead of wall clock after a burst (bounded by write count, irrelevant to TTL which keys off StartedAt). Rollback-safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated session upserts in ClickHouse to use a monotonic “version stamp” for `UpdatedAt`, ensuring the latest write wins even within the same millisecond.
  * Improved stamping for superseded/older records and batch writes to avoid timestamp ties that could cause stale reads.
* **Tests**
  * Added unit coverage validating monotonic `UpdatedAt` “version stamp” behavior for upserts and batch upserts.
  * Tweaked an integration test scenario to align drift/TTL boundary expectations more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->