### PR TITLE
fix(annotations): stop shipping full User rows to the browser

### DIFF
--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -257,8 +257,19 @@ export const annotationRouter = createTRPCRouter({
           },
           projectId: input.projectId,
         },
+        // Only what the UI renders. `include: { user: true }` returned every
+        // User column — email, emailVerified, lastLoginAt, deactivatedAt — and
+        // there is no output schema on this procedure, so all of it reached
+        // the browser for every annotation on screen. Mirrors the sibling
+        // getByTraceId above, which already selects narrowly.
         include: {
-          user: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
         },
         orderBy: {
           createdAt: "asc",

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -12,9 +12,16 @@ import {
 import { getRAGChunks, getRAGInfo } from "./utils";
 
 // Define a Trace type that includes annotations for use within this file
-// This assumes the Annotation type comes from Prisma
+// This assumes the Annotation type comes from Prisma.
+//
+// `user` asks for only the field this file reads (`author` uses `user.name`).
+// Requiring the whole Prisma `User` forced every caller to fetch every user
+// column — email, lastLoginAt and the rest — just to satisfy the type, which
+// is how those columns ended up being shipped to the browser.
 type TraceWithAnnotations = BaseTrace & {
-  annotations?: (Annotation & { user?: User | null })[];
+  annotations?: (Annotation & {
+    user?: { name?: string | null } | null;
+  })[];
 };
 
 /**

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -1,4 +1,4 @@
-import type { Annotation, AnnotationScore, User } from "@prisma/client";
+import type { Annotation, AnnotationScore } from "@prisma/client";
 import { z } from "zod";
 import { getSpanNameOrModel } from "../../utils/trace";
 import { datasetSpanSchema } from "../datasets/types";
@@ -562,12 +562,10 @@ export const TRACE_EXPANSIONS = {
     label: "annotation",
     expansion: (trace: TraceWithAnnotations) => {
       const annotations = trace.annotations ?? [];
-      return annotations.map(
-        (annotation: Annotation & { user?: User | null }) => ({
-          ...trace,
-          annotations: [annotation],
-        }),
-      );
+      return annotations.map((annotation) => ({
+        ...trace,
+        annotations: [annotation],
+      }));
     },
   },
   "events.event_id": {


### PR DESCRIPTION
## What this is now

`annotation.getByTraceIds` used `include: { user: true }`, returning **every** `User` column — `email`, `emailVerified`, `lastLoginAt`, `deactivatedAt`, `image` — for every annotation on screen. There is no output schema on the procedure, so all of it was serialised to the browser.

The sibling `getByTraceId`, immediately above it in the same file, already selects only `{ id, name, image }`. This brings the batch variant in line.

Checked every consumer before narrowing: the annotation surfaces render `user.name` / `user.image`, and the dataset mapping's author field falls back to `annotation.email`, not `user.email`. Nothing reads the dropped columns.

## Correction — this PR originally claimed something false

It opened as "the `annotations.*` dataset mapping is dead code — nothing populates `trace.annotations`", and added a join to fix it.

**That was wrong.** `TracesMapping.tsx` on `main` already fetches annotations (line 166) and attaches them to each trace (lines 198-207). Mapping `annotations.expected_output` into a dataset **already works today**. My original research grepped for the type name `TraceWithAnnotations` rather than for the attach itself, which uses a plain object spread — so I missed it and drew the wrong conclusion.

The join has been removed. It was redundant with `TracesMapping`'s own, it fired a second uncached fan-out of the same queries (different chunk boundaries → different query keys), and its result was overwritten downstream anyway.

What survives is the one genuine finding: the over-fetch above.

Closes nothing on #6132 — see that issue for the corrected scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation user data handling so the annotations UI returns and displays only essential user details (e.g., name and image) rather than full user records.
  * Aligned the annotation user data shape with what the UI actually uses, keeping the existing filtering and sort order behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->