### PR TITLE
feat(dev): make local development work with no container runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,9 @@ If no feature file exists for your task, create one before writing code.
 
 Nothing in the day-to-day loop needs Docker or colima. If you run ClickHouse,
 Postgres and Redis natively (brew, or a LaunchAgent), point `.env` at them and
-set these three, and a full `pnpm dev:haven` stack comes up with no container
-runtime installed at all:
+set these three, and `pnpm dev:haven` brings up the whole application stack,
+everything except the observability container, with no container runtime
+installed at all:
 
 ```bash
 LANGWATCH_HAVEN_CH=0          # use .env CLICKHOUSE_URL instead of a managed container
@@ -34,7 +35,7 @@ LANGY_UNSAFE_HOST_ACCESS=1    # run the langyagent worker on the host, not in co
 
 haven resolves its own knobs from `langwatch/.env` (then `.env.portless`) as
 well as the shell, so these travel with the worktree; an exported variable still
-wins for a single run. Postgres and Redis stay haven-managed either way — it
+wins for a single run. Postgres and Redis stay haven-managed either way: it
 starts them through brew, not a container.
 
 Tests follow the same rule. `pnpm test:unit` never needed a container, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,37 @@ If no feature file exists for your task, create one before writing code.
 
 `make quickstart` is the single entry point. It asks what you're working on and starts only the services you need, overriding only the URLs whose services are local. Your `langwatch/.env` is the source of truth for everything else.
 
+### Running with no container runtime
+
+Nothing in the day-to-day loop needs Docker or colima. If you run ClickHouse,
+Postgres and Redis natively (brew, or a LaunchAgent), point `.env` at them and
+set these three, and a full `pnpm dev:haven` stack comes up with no container
+runtime installed at all:
+
+```bash
+LANGWATCH_HAVEN_CH=0          # use .env CLICKHOUSE_URL instead of a managed container
+LANGWATCH_HAVEN_OBS=0         # skip the LGTM telemetry stack
+LANGY_UNSAFE_HOST_ACCESS=1    # run the langyagent worker on the host, not in colima
+```
+
+haven resolves its own knobs from `langwatch/.env` (then `.env.portless`) as
+well as the shell, so these travel with the worktree; an exported variable still
+wins for a single run. Postgres and Redis stay haven-managed either way — it
+starts them through brew, not a container.
+
+Tests follow the same rule. `pnpm test:unit` never needed a container, and
+`pnpm test:integration` runs against native services when
+`LANGWATCH_TEST_CLICKHOUSE_URL`, `LANGWATCH_TEST_REDIS_URL` and
+`LANGWATCH_TEST_DATABASE_URL` are set, using dedicated test databases so dev
+data is untouched (`specs/ci/no-docker-integration-tests.feature`). Suites that
+need several mutually isolated ClickHouse endpoints ask
+`startTestClickHouseEndpoints` for them rather than starting their own
+containers. `CI=1` disables the native mode and forces testcontainers, so locally
+use `pnpm test:integration <path> --watch=false` and never `CI=1`.
+
+What still wants a container: `make observability` (the Grafana LGTM stack) and
+the sandboxed/container langy tiers. Both are opt-in.
+
 ### Local dev by hostname — thuishaven / portless (recommended)
 
 Stop juggling ports. Opt in with `pnpm dev:haven` and traffic routes through

--- a/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -2,40 +2,33 @@
  * @vitest-environment node
  *
  * Integration tests for per-organization ClickHouse client routing.
- * Spins up two ClickHouse containers to verify that data is routed
+ * Uses two isolated ClickHouse endpoints to verify that data is routed
  * to the correct instance based on env var configuration.
  *
  * Env var format: CLICKHOUSE_URL__<label>__<orgId>=<connectionUrl>
  */
-import {
-  ClickHouseContainer,
-  type StartedClickHouseContainer,
-} from "@testcontainers/clickhouse";
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { prisma } from "~/server/db";
+import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
 
 const TEST_TABLE = "routing_test";
-const TEST_DATABASE = "test_routing";
 
-let sharedContainer: StartedClickHouseContainer;
-let privateContainer: StartedClickHouseContainer;
 let sharedClient: ClickHouseClient;
 let privateClient: ClickHouseClient;
-let sharedUrl: string;
-let privateUrl: string;
 
 // The org IDs we'll use — set the env var BEFORE importing clickhouseClient
 const PRIVATE_ORG_ID = `test-private-org-${nanoid(6)}`;
 const SHARED_ORG_ID = `test-shared-org-${nanoid(6)}`;
 
+// Table names stay unqualified throughout: each endpoint's client carries its
+// own database in the connection URL, and that is precisely the separation
+// under test — a query can only ever reach the database its client was built
+// for.
 async function setupTestSchema(client: ClickHouseClient): Promise<void> {
   await client.command({
-    query: `CREATE DATABASE IF NOT EXISTS ${TEST_DATABASE}`,
-  });
-  await client.command({
-    query: `CREATE TABLE IF NOT EXISTS ${TEST_DATABASE}.${TEST_TABLE} (
+    query: `CREATE TABLE IF NOT EXISTS ${TEST_TABLE} (
       id String,
       project_id String,
       data String
@@ -49,7 +42,7 @@ async function insertTestRow(
   { id, projectId, data }: { id: string; projectId: string; data: string },
 ): Promise<void> {
   await client.insert({
-    table: `${TEST_DATABASE}.${TEST_TABLE}`,
+    table: TEST_TABLE,
     values: [{ id, project_id: projectId, data }],
     format: "JSONEachRow",
   });
@@ -60,7 +53,7 @@ async function queryTestRow(
   id: string,
 ): Promise<{ id: string; project_id: string; data: string }[]> {
   const result = await client.query({
-    query: `SELECT * FROM ${TEST_DATABASE}.${TEST_TABLE} WHERE id = {id:String}`,
+    query: `SELECT * FROM ${TEST_TABLE} WHERE id = {id:String}`,
     query_params: { id },
     format: "JSONEachRow",
   });
@@ -125,24 +118,13 @@ vi.mock("../client", () => ({
 
 describe("ClickHouse routing via env vars", () => {
   beforeAll(async () => {
-    const [shared, private_] = await Promise.all([
-      new ClickHouseContainer("clickhouse/clickhouse-server:25.10.2.65")
-        .withLabels({ "langwatch.test.routing": "shared" })
-        .withReuse()
-        .withStartupTimeout(120_000)
-        .start(),
-      new ClickHouseContainer("clickhouse/clickhouse-server:25.10.2.65")
-        .withLabels({ "langwatch.test.routing": "private" })
-        .withReuse()
-        .withStartupTimeout(120_000)
-        .start(),
-    ]);
+    const [shared, private_] = await startTestClickHouseEndpoints({
+      suite: "ch-routing",
+      names: ["shared", "private"],
+    });
 
-    sharedContainer = shared;
-    privateContainer = private_;
-
-    sharedUrl = sharedContainer.getConnectionUrl();
-    privateUrl = privateContainer.getConnectionUrl();
+    const sharedUrl = shared!.url;
+    const privateUrl = private_!.url;
 
     // Set the private CH env var BEFORE importing clickhouseClient
     process.env[`CLICKHOUSE_URL__testcustomer__${PRIVATE_ORG_ID}`] = privateUrl;
@@ -164,18 +146,24 @@ describe("ClickHouse routing via env vars", () => {
   }, 300_000);
 
   afterAll(async () => {
-    const { clearCustomClientCache, clearProjectOrgCache } = await import("../clickhouseClient");
+    const { clearCustomClientCache, clearProjectOrgCache } = await import(
+      "../clickhouseClient"
+    );
     await clearCustomClientCache();
     clearProjectOrgCache();
 
     if (createdProjectIds.length > 0) {
-      await prisma.project.deleteMany({ where: { id: { in: createdProjectIds } } });
+      await prisma.project.deleteMany({
+        where: { id: { in: createdProjectIds } },
+      });
     }
     if (createdTeamIds.length > 0) {
       await prisma.team.deleteMany({ where: { id: { in: createdTeamIds } } });
     }
     if (createdOrgIds.length > 0) {
-      await prisma.organization.deleteMany({ where: { id: { in: createdOrgIds } } });
+      await prisma.organization.deleteMany({
+        where: { id: { in: createdOrgIds } },
+      });
     }
 
     await Promise.all([sharedClient?.close(), privateClient?.close()]);
@@ -190,12 +178,15 @@ describe("ClickHouse routing via env vars", () => {
     /** @scenario Project in a standard org routes to the shared instance */
     /** @scenario Data written for a standard org does not appear in private */
     it("returns the shared (default) client", async () => {
-      const { getClickHouseClientForProject } = await import("../clickhouseClient");
+      const { getClickHouseClientForProject } = await import(
+        "../clickhouseClient"
+      );
 
-      const { projectId, organizationId, teamId } = await createTestOrgWithProject({
-        namespace: "no-custom",
-        organizationId: SHARED_ORG_ID,
-      });
+      const { projectId, organizationId, teamId } =
+        await createTestOrgWithProject({
+          namespace: "no-custom",
+          organizationId: SHARED_ORG_ID,
+        });
       createdProjectIds.push(projectId);
       createdTeamIds.push(teamId);
       createdOrgIds.push(organizationId);
@@ -204,7 +195,11 @@ describe("ClickHouse routing via env vars", () => {
       expect(client).toBe(sharedClient);
 
       const rowId = `shared-${nanoid(8)}`;
-      await insertTestRow(client!, { id: rowId, projectId, data: "shared-data" });
+      await insertTestRow(client!, {
+        id: rowId,
+        projectId,
+        data: "shared-data",
+      });
 
       const rows = await queryTestRow(sharedClient, rowId);
       expect(rows).toHaveLength(1);
@@ -222,12 +217,15 @@ describe("ClickHouse routing via env vars", () => {
     /** @scenario Project in a private-CH org routes to the private instance */
     /** @scenario Data written for a private-CH org does not appear in shared */
     it("returns a client connected to the private instance", async () => {
-      const { getClickHouseClientForProject } = await import("../clickhouseClient");
+      const { getClickHouseClientForProject } = await import(
+        "../clickhouseClient"
+      );
 
-      const { projectId, organizationId, teamId } = await createTestOrgWithProject({
-        namespace: "with-private",
-        organizationId: PRIVATE_ORG_ID,
-      });
+      const { projectId, organizationId, teamId } =
+        await createTestOrgWithProject({
+          namespace: "with-private",
+          organizationId: PRIVATE_ORG_ID,
+        });
       createdProjectIds.push(projectId);
       createdTeamIds.push(teamId);
       createdOrgIds.push(organizationId);
@@ -236,7 +234,11 @@ describe("ClickHouse routing via env vars", () => {
       expect(client).not.toBe(sharedClient);
 
       const rowId = `private-${nanoid(8)}`;
-      await insertTestRow(client!, { id: rowId, projectId, data: "private-data" });
+      await insertTestRow(client!, {
+        id: rowId,
+        projectId,
+        data: "private-data",
+      });
 
       const privateRows = await queryTestRow(privateClient, rowId);
       expect(privateRows).toHaveLength(1);
@@ -264,7 +266,9 @@ describe("ClickHouse routing via env vars", () => {
 
   describe("when getClickHouseClientForOrganization is called", () => {
     it("routes to the private instance without any DB query", async () => {
-      const { getClickHouseClientForOrganization } = await import("../clickhouseClient");
+      const { getClickHouseClientForOrganization } = await import(
+        "../clickhouseClient"
+      );
 
       const client = await getClickHouseClientForOrganization(PRIVATE_ORG_ID);
       expect(client).not.toBeNull();

--- a/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -3,7 +3,10 @@
  *
  * Integration tests for per-organization ClickHouse client routing.
  * Uses two isolated ClickHouse endpoints to verify that data is routed
- * to the correct instance based on env var configuration.
+ * to the correct endpoint based on env var configuration. An endpoint is a
+ * database on the local server natively, and a container in CI; either way a
+ * client built for one cannot read the other's rows, which is the property
+ * these tests turn on.
  *
  * Env var format: CLICKHOUSE_URL__<label>__<orgId>=<connectionUrl>
  */
@@ -24,7 +27,7 @@ const SHARED_ORG_ID = `test-shared-org-${nanoid(6)}`;
 
 // Table names stay unqualified throughout: each endpoint's client carries its
 // own database in the connection URL, and that is precisely the separation
-// under test — a query can only ever reach the database its client was built
+// under test: a query can only ever reach the database its client was built
 // for.
 async function setupTestSchema(client: ClickHouseClient): Promise<void> {
   await client.command({

--- a/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -51,13 +51,16 @@ async function insertTestRow(
   });
 }
 
+// project_id leads the predicate even though the row id is already unique per
+// run: the tenant column is what every read of a real table is scoped by, and a
+// fixture is the first thing someone copies when writing the next one.
 async function queryTestRow(
   client: ClickHouseClient,
-  id: string,
+  { id, projectId }: { id: string; projectId: string },
 ): Promise<{ id: string; project_id: string; data: string }[]> {
   const result = await client.query({
-    query: `SELECT * FROM ${TEST_TABLE} WHERE id = {id:String}`,
-    query_params: { id },
+    query: `SELECT * FROM ${TEST_TABLE} WHERE project_id = {projectId:String} AND id = {id:String}`,
+    query_params: { projectId, id },
     format: "JSONEachRow",
   });
   return result.json();
@@ -204,11 +207,14 @@ describe("ClickHouse routing via env vars", () => {
         data: "shared-data",
       });
 
-      const rows = await queryTestRow(sharedClient, rowId);
+      const rows = await queryTestRow(sharedClient, { id: rowId, projectId });
       expect(rows).toHaveLength(1);
       expect(rows[0]!.data).toBe("shared-data");
 
-      const privateRows = await queryTestRow(privateClient, rowId);
+      const privateRows = await queryTestRow(privateClient, {
+        id: rowId,
+        projectId,
+      });
       expect(privateRows).toHaveLength(0);
     });
   });
@@ -243,11 +249,17 @@ describe("ClickHouse routing via env vars", () => {
         data: "private-data",
       });
 
-      const privateRows = await queryTestRow(privateClient, rowId);
+      const privateRows = await queryTestRow(privateClient, {
+        id: rowId,
+        projectId,
+      });
       expect(privateRows).toHaveLength(1);
       expect(privateRows[0]!.data).toBe("private-data");
 
-      const sharedRows = await queryTestRow(sharedClient, rowId);
+      const sharedRows = await queryTestRow(sharedClient, {
+        id: rowId,
+        projectId,
+      });
       expect(sharedRows).toHaveLength(0);
     });
   });

--- a/langwatch/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
@@ -4,7 +4,9 @@
  * Integration tests for private ClickHouse data isolation through the
  * event-sourcing pipeline. Uses 2 isolated ClickHouse endpoints and proves
  * that EventRepositoryClickHouse and SpanStorageClickHouseRepository
- * route data to the correct instance based on env var configuration.
+ * route data to the correct endpoint based on env var configuration. An
+ * endpoint is a database on the local server natively, and a container in CI;
+ * either way a client built for one cannot read the other's rows.
  */
 
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
@@ -35,7 +37,7 @@ vi.mock("../client", () => ({
 
 // Both DDLs below stay unqualified: each endpoint's client carries its own
 // database in the connection URL, and that separation is what these tests
-// assert — a repository can only reach the database its resolved client
+// assert: a repository can only reach the database its resolved client
 // was built for.
 const EVENT_LOG_DDL = `
 CREATE TABLE IF NOT EXISTS event_log

--- a/langwatch/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
@@ -2,25 +2,20 @@
  * @vitest-environment node
  *
  * Integration tests for private ClickHouse data isolation through the
- * event-sourcing pipeline. Spins up 2 ClickHouse containers and proves
+ * event-sourcing pipeline. Uses 2 isolated ClickHouse endpoints and proves
  * that EventRepositoryClickHouse and SpanStorageClickHouseRepository
  * route data to the correct instance based on env var configuration.
  */
 
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
-import {
-  ClickHouseContainer,
-  type StartedClickHouseContainer,
-} from "@testcontainers/clickhouse";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SpanInsertData } from "~/server/app-layer/traces/types";
 import { prisma } from "~/server/db";
 import type { EventRecord } from "~/server/event-sourcing/stores/repositories/eventRepository.types";
+import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
 import type { ClickHouseClientResolver } from "../clickhouseClient";
 
-let sharedContainer: StartedClickHouseContainer;
-let privateContainer: StartedClickHouseContainer;
 let sharedClient: ClickHouseClient;
 let privateClient: ClickHouseClient;
 
@@ -38,46 +33,10 @@ vi.mock("../client", () => ({
   _getSharedClickHouseClient: () => sharedClient,
 }));
 
-/**
- * XML config for ClickHouse storage policy required by the table schemas.
- */
-const STORAGE_POLICY_CONFIG = `
-<clickhouse>
-    <storage_configuration>
-        <disks>
-            <hot>
-                <path>/var/lib/clickhouse/hot/</path>
-            </hot>
-            <cold>
-                <path>/var/lib/clickhouse/cold/</path>
-            </cold>
-        </disks>
-        <policies>
-            <local_primary>
-                <volumes>
-                    <hot>
-                        <disk>hot</disk>
-                    </hot>
-                    <cold>
-                        <disk>cold</disk>
-                    </cold>
-                </volumes>
-            </local_primary>
-        </policies>
-    </storage_configuration>
-</clickhouse>
-`.trim();
-
-function createStoragePolicyConfigFile(): string {
-  const fs = require("node:fs");
-  const os = require("node:os");
-  const path = require("node:path");
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ch-iso-test-"));
-  const configPath = path.join(tempDir, "storage_policy.xml");
-  fs.writeFileSync(configPath, STORAGE_POLICY_CONFIG);
-  return configPath;
-}
-
+// Both DDLs below stay unqualified: each endpoint's client carries its own
+// database in the connection URL, and that separation is what these tests
+// assert — a repository can only reach the database its resolved client
+// was built for.
 const EVENT_LOG_DDL = `
 CREATE TABLE IF NOT EXISTS event_log
 (
@@ -288,38 +247,13 @@ describe("Private ClickHouse data isolation through event-sourcing repositories"
   let sharedProjectId: string;
 
   beforeAll(async () => {
-    const storagePolicyConfigPath = createStoragePolicyConfigFile();
+    const [shared, private_] = await startTestClickHouseEndpoints({
+      suite: "ch-isolation",
+      names: ["shared", "private"],
+    });
 
-    const [shared, private_] = await Promise.all([
-      new ClickHouseContainer("clickhouse/clickhouse-server:25.10.2.65")
-        .withLabels({ "langwatch.test.isolation": "shared" })
-        .withCopyFilesToContainer([
-          {
-            source: storagePolicyConfigPath,
-            target: "/etc/clickhouse-server/config.d/storage.xml",
-          },
-        ])
-        .withReuse()
-        .withStartupTimeout(120_000)
-        .start(),
-      new ClickHouseContainer("clickhouse/clickhouse-server:25.10.2.65")
-        .withLabels({ "langwatch.test.isolation": "private" })
-        .withCopyFilesToContainer([
-          {
-            source: storagePolicyConfigPath,
-            target: "/etc/clickhouse-server/config.d/storage.xml",
-          },
-        ])
-        .withReuse()
-        .withStartupTimeout(120_000)
-        .start(),
-    ]);
-
-    sharedContainer = shared;
-    privateContainer = private_;
-
-    const sharedUrl = sharedContainer.getConnectionUrl();
-    const privateUrl = privateContainer.getConnectionUrl();
+    const sharedUrl = shared!.url;
+    const privateUrl = private_!.url;
 
     // Set the private CH env var so the clickhouseClient module resolves it
     process.env[`CLICKHOUSE_URL__testcustomer__${PRIVATE_ORG_ID}`] = privateUrl;

--- a/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
@@ -12,6 +12,7 @@ import {
   type StartedRedisContainer,
 } from "@testcontainers/redis";
 import { migrateUp } from "~/server/clickhouse/goose";
+import { nativeClickHouseBaseUrl } from "~/test-utils/clickhouseTestEndpoints";
 import { shardSawFailure } from "~/test-utils/shardFailureReporter";
 
 const TEST_DATABASE = "test_langwatch";
@@ -134,8 +135,7 @@ type LocalServiceUrls = {
  * touch dev data. Never active in CI.
  */
 function localServiceUrls(): LocalServiceUrls | null {
-  if (process.env.CI) return null;
-  const clickHouseBaseUrl = process.env.LANGWATCH_TEST_CLICKHOUSE_URL;
+  const clickHouseBaseUrl = nativeClickHouseBaseUrl();
   const redisUrl = process.env.LANGWATCH_TEST_REDIS_URL;
   if (!clickHouseBaseUrl || !redisUrl) return null;
   return {

--- a/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
@@ -12,7 +12,10 @@ import {
   type StartedRedisContainer,
 } from "@testcontainers/redis";
 import { migrateUp } from "~/server/clickhouse/goose";
-import { nativeClickHouseBaseUrl } from "~/test-utils/clickhouseTestEndpoints";
+import {
+  nativeClickHouseBaseUrl,
+  TEST_CLICKHOUSE_IMAGE,
+} from "~/test-utils/clickhouseTestEndpoints";
 import { shardSawFailure } from "~/test-utils/shardFailureReporter";
 
 const TEST_DATABASE = "test_langwatch";
@@ -294,9 +297,7 @@ export async function setup(): Promise<void> {
   // Start ClickHouse container (reusable to speed up subsequent test runs)
   const storagePolicyConfigPath = createStoragePolicyConfigFile();
 
-  clickHouseContainer = await new ClickHouseContainer(
-    "clickhouse/clickhouse-server:25.10.2.65",
-  )
+  clickHouseContainer = await new ClickHouseContainer(TEST_CLICKHOUSE_IMAGE)
     .withLabels(CONTAINER_LABELS)
     .withReuse()
     .withCopyFilesToContainer([

--- a/langwatch/src/server/ops/explain-core.ts
+++ b/langwatch/src/server/ops/explain-core.ts
@@ -30,8 +30,8 @@ const TABLE_FUNCTION_RE =
 const SYSTEM_SCHEMA_RE = /\bsystem\s*\./i;
 
 /// Per-query ClickHouse-side guardrails. Must stay aligned with the
-/// langwatch_ops profile in
-/// infrastructure/clickhouse-serverless/config/users.xml.template.
+/// langwatch_ops profile, which is provisioned per deployment rather than
+/// from this repo: a readonly=1 profile with no SOURCES grant.
 /// ClickHouseSettings is picky: `readonly` / `max_result_bytes` /
 /// `max_memory_usage` are typed `UInt64 = string`, `max_execution_time`
 /// is `Seconds = number`.

--- a/langwatch/src/server/routes/__tests__/ops-explain.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/ops-explain.integration.test.ts
@@ -11,24 +11,27 @@
  * api-router.ts would show up as a 404 here instead of a green CI and a
  * 404 in production.
  *
- * ClickHouse comes from @testcontainers/clickhouse (same image and
- * .withReuse() pattern as src/server/clickhouse/__tests__/
- * clickhouseClient.integration.test.ts).
+ * ClickHouse comes from startTestClickHouseEndpoints: the native local server
+ * when one is configured, a container otherwise. Either way the suite gets its
+ * own database, so the EXPLAIN targets here can never be confused with — or
+ * create a stub table inside — a developer's real `langwatch` database on a
+ * shared native server.
  */
-import {
-  ClickHouseContainer,
-  type StartedClickHouseContainer,
-} from "@testcontainers/clickhouse";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
-import { _resetOpsClickHouseClientForTesting } from "~/server/ops/explain-core";
 import { createApiRouter } from "~/server/api-router";
+import { _resetOpsClickHouseClientForTesting } from "~/server/ops/explain-core";
+import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
 
 const API_KEY = "integration-test-key";
-let container: StartedClickHouseContainer;
+/** This suite's database, resolved in beforeAll and templated into every query. */
+let DB: string;
 let router: ReturnType<typeof createApiRouter>;
 
-async function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+async function post(
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
   return router.request(path, {
     method: "POST",
     headers: {
@@ -42,17 +45,15 @@ async function post(path: string, body: unknown, headers: Record<string, string>
 
 describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
   beforeAll(async () => {
-    container = await new ClickHouseContainer("clickhouse/clickhouse-server:25.10.2.65")
-      .withLabels({ "langwatch.test.ops-explain": "http" })
-      .withReuse()
-      .withStartupTimeout(120_000)
-      .start();
-    const url = container.getConnectionUrl();
+    const [ops] = await startTestClickHouseEndpoints({
+      suite: "ops-explain",
+      names: ["http"],
+    });
+    DB = ops!.database;
     const { createClient } = await import("@clickhouse/client");
-    const c = createClient({ url });
-    await c.command({ query: "CREATE DATABASE IF NOT EXISTS langwatch" });
+    const c = createClient({ url: ops!.url });
     await c.command({
-      query: `CREATE TABLE IF NOT EXISTS langwatch.stored_spans (
+      query: `CREATE TABLE IF NOT EXISTS ${DB}.stored_spans (
         TenantId String,
         SpanId String,
         OccurredAt DateTime,
@@ -62,7 +63,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
     await c.close();
 
     process.env.LANGWATCH_OPS_API_KEY = API_KEY;
-    process.env.CLICKHOUSE_OPS_URL = url;
+    process.env.CLICKHOUSE_OPS_URL = ops!.url;
     process.env.NODE_ENV = "test";
     _resetOpsClickHouseClientForTesting();
 
@@ -79,7 +80,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("is mounted at /api/ops/clickhouse/explain and serves EXPLAIN PLAN rows", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT count() FROM langwatch.stored_spans WHERE TenantId = 'p_test'",
+      query: `SELECT count() FROM ${DB}.stored_spans WHERE TenantId = 'p_test'`,
       type: "PLAN",
     });
     expect(res.status).toBe(200);
@@ -91,18 +92,18 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("accepts a cross-tenant query — operator endpoint by design", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT count() FROM langwatch.stored_spans",
+      query: `SELECT count() FROM ${DB}.stored_spans`,
     });
     expect(res.status).toBe(200);
   });
 
   it("honours the EXPLAIN type (PIPELINE returns different rows than PLAN)", async () => {
     const plan = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT TenantId, count() FROM langwatch.stored_spans GROUP BY TenantId",
+      query: `SELECT TenantId, count() FROM ${DB}.stored_spans GROUP BY TenantId`,
       type: "PLAN",
     });
     const pipe = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT TenantId, count() FROM langwatch.stored_spans GROUP BY TenantId",
+      query: `SELECT TenantId, count() FROM ${DB}.stored_spans GROUP BY TenantId`,
       type: "PIPELINE",
     });
     expect(plan.status).toBe(200);
@@ -114,7 +115,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("rejects a multi-statement query at the input filter (never reaches CH)", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT 1 FROM langwatch.stored_spans WHERE TenantId='x'; DROP TABLE langwatch.stored_spans",
+      query: `SELECT 1 FROM ${DB}.stored_spans WHERE TenantId='x'; DROP TABLE ${DB}.stored_spans`,
     });
     expect(res.status).toBe(400);
     expect((await res.json()).message).toMatch(/single statement/i);
@@ -122,7 +123,8 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("rejects a table function (SSRF surface)", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT * FROM url('http://evil.example/x', CSV, 'a String') WHERE TenantId = 'p_x'",
+      query:
+        "SELECT * FROM url('http://evil.example/x', CSV, 'a String') WHERE TenantId = 'p_x'",
     });
     expect(res.status).toBe(400);
     expect((await res.json()).message).toMatch(/table function/i);
@@ -130,14 +132,16 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("rejects the string-vs-comment ordering bypass end-to-end", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: `SELECT * FROM langwatch.stored_spans WHERE '/*' = 'literal' OR SpanId IN (SELECT SpanId FROM url('http://127.0.0.1:9/', CSV)) /* trailing */`,
+      query: `SELECT * FROM ${DB}.stored_spans WHERE '/*' = 'literal' OR SpanId IN (SELECT SpanId FROM url('http://127.0.0.1:9/', CSV)) /* trailing */`,
     });
     expect(res.status).toBe(400);
     expect((await res.json()).message).toMatch(/table function/i);
   });
 
   it("rejects the system.* schema", async () => {
-    const res = await post("/api/ops/clickhouse/explain", { query: "SELECT * FROM system.parts" });
+    const res = await post("/api/ops/clickhouse/explain", {
+      query: "SELECT * FROM system.parts",
+    });
     expect(res.status).toBe(400);
     expect((await res.json()).message).toMatch(/system/i);
   });
@@ -146,7 +150,9 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
     const res = await router.request("/api/ops/clickhouse/explain", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ query: "SELECT 1 FROM langwatch.stored_spans WHERE TenantId='x'" }),
+      body: JSON.stringify({
+        query: `SELECT 1 FROM ${DB}.stored_spans WHERE TenantId='x'`,
+      }),
     });
     expect(res.status).toBe(401);
   });
@@ -154,7 +160,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
   it("returns 401 with a wrong API key", async () => {
     const res = await post(
       "/api/ops/clickhouse/explain",
-      { query: "SELECT 1 FROM langwatch.stored_spans WHERE TenantId='x'" },
+      { query: `SELECT 1 FROM ${DB}.stored_spans WHERE TenantId='x'` },
       { authorization: "Bearer totally-wrong" },
     );
     expect(res.status).toBe(401);
@@ -172,7 +178,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
 
   it("returns 502 on a syntactically valid SELECT against a missing table", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
-      query: "SELECT 1 FROM langwatch.does_not_exist_table WHERE TenantId='x'",
+      query: `SELECT 1 FROM ${DB}.does_not_exist_table WHERE TenantId='x'`,
     });
     expect(res.status).toBe(502);
     expect((await res.json()).message).toMatch(/ClickHouse error/i);
@@ -181,7 +187,7 @@ describe("POST /api/ops/clickhouse/explain (HTTP integration)", () => {
   it("realistic arrayJoin shape the optimizer agent actually runs", async () => {
     const res = await post("/api/ops/clickhouse/explain", {
       query: `SELECT arrayJoin(mapKeys(SpanAttributes)) AS key, count() AS n
-              FROM langwatch.stored_spans
+              FROM ${DB}.stored_spans
               WHERE OccurredAt > now() - INTERVAL 1 DAY
               GROUP BY key ORDER BY n DESC LIMIT 50`,
       type: "PLAN",

--- a/langwatch/src/server/routes/__tests__/ops-explain.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/ops-explain.integration.test.ts
@@ -13,8 +13,8 @@
  *
  * ClickHouse comes from startTestClickHouseEndpoints: the native local server
  * when one is configured, a container otherwise. Either way the suite gets its
- * own database, so the EXPLAIN targets here can never be confused with — or
- * create a stub table inside — a developer's real `langwatch` database on a
+ * own database, so the EXPLAIN targets here can never be confused with, or
+ * create a stub table inside, a developer's real `langwatch` database on a
  * shared native server.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/langwatch/src/server/routes/ops.ts
+++ b/langwatch/src/server/routes/ops.ts
@@ -109,8 +109,8 @@ secured
       if (process.env.NODE_ENV === "production") {
         logger.error(
           "CLICKHOUSE_OPS_URL is not set in production — refusing to fall back to the default-user client. " +
-            "Provision the langwatch_ops user (see infrastructure/clickhouse-serverless/config/users.xml.template) " +
-            "and set CLICKHOUSE_OPS_URL.",
+            "Provision a langwatch_ops ClickHouse user with a readonly=1 profile " +
+            "and no SOURCES grant, then set CLICKHOUSE_OPS_URL to it.",
         );
         return c.json(
           {
@@ -123,8 +123,8 @@ secured
       if (consumeMissingOpsUrlWarning()) {
         logger.warn(
           "CLICKHOUSE_OPS_URL is not set — /ops/clickhouse/explain is falling back to the default-user client. " +
-            "Provision the langwatch_ops user (see infrastructure/clickhouse-serverless/config/users.xml.template) " +
-            "and set CLICKHOUSE_OPS_URL to remove this fallback.",
+            "Provision a langwatch_ops ClickHouse user with a readonly=1 profile " +
+            "and no SOURCES grant, then set CLICKHOUSE_OPS_URL to it to remove this fallback.",
         );
       }
       usingFallback = true;

--- a/langwatch/src/test-utils/clickhouseTestEndpoints.ts
+++ b/langwatch/src/test-utils/clickhouseTestEndpoints.ts
@@ -4,7 +4,7 @@
  *
  * Those suites need two or more endpoints whose data cannot leak into one
  * another, so they can prove that a row written for a private-ClickHouse org
- * lands in that org's instance and nowhere else. Two backends provide that:
+ * lands on that org's endpoint and nowhere else. Two backends provide that:
  *
  *   - Native: one database per endpoint on the always-on local ClickHouse
  *     (LANGWATCH_TEST_CLICKHOUSE_URL), so a laptop runs the suite with no
@@ -25,8 +25,12 @@ import {
   type StartedClickHouseContainer,
 } from "@testcontainers/clickhouse";
 
-/** Kept in step with the image globalSetup.ts starts. */
-const CONTAINER_IMAGE = "clickhouse/clickhouse-server:25.10.2.65";
+/**
+ * The ClickHouse image every container-backed test starts, here and in
+ * globalSetup.ts. One symbol rather than one string per call site, so a version
+ * bump cannot leave half the suite on the old image.
+ */
+export const TEST_CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:25.10.2.65";
 
 export interface TestClickHouseEndpoint {
   /** Connection URL, with this endpoint's own database in the path. */
@@ -67,11 +71,7 @@ export async function startTestClickHouseEndpoints({
     : await startContainerEndpoints({ suite, names });
 }
 
-/**
- * One database per endpoint on the shared native server. `CREATE DATABASE` runs
- * against the server root: the database in the endpoint URL does not exist yet,
- * and connecting to a missing database fails before the statement is sent.
- */
+/** One database per endpoint on the shared native server. */
 async function startNativeEndpoints({
   suite,
   names,
@@ -81,20 +81,16 @@ async function startNativeEndpoints({
   names: string[];
   baseUrl: string;
 }): Promise<TestClickHouseEndpoint[]> {
-  const root = createClient({ url: rootUrl(baseUrl) });
-  try {
-    const endpoints: TestClickHouseEndpoint[] = [];
-    for (const name of names) {
-      const database = databaseName({ suite, name });
-      await root.command({
-        query: `CREATE DATABASE IF NOT EXISTS ${database}`,
-      });
-      endpoints.push({ database, url: endpointUrl(baseUrl, database) });
-    }
-    return endpoints;
-  } finally {
-    await root.close();
+  const endpoints: TestClickHouseEndpoint[] = [];
+  for (const name of names) {
+    endpoints.push(
+      await ensureEndpoint({
+        baseUrl,
+        database: databaseName({ suite, name }),
+      }),
+    );
   }
+  return endpoints;
 }
 
 /**
@@ -114,7 +110,7 @@ async function startContainerEndpoints({
     names.map(
       async (name): Promise<[string, StartedClickHouseContainer]> => [
         name,
-        await new ClickHouseContainer(CONTAINER_IMAGE)
+        await new ClickHouseContainer(TEST_CLICKHOUSE_IMAGE)
           .withLabels({
             "langwatch.test": "true",
             [`langwatch.test.${suite}`]: name,
@@ -128,19 +124,37 @@ async function startContainerEndpoints({
 
   const endpoints: TestClickHouseEndpoint[] = [];
   for (const [name, container] of started) {
-    const database = databaseName({ suite, name });
-    const baseUrl = container.getConnectionUrl();
-    const root = createClient({ url: rootUrl(baseUrl) });
-    try {
-      await root.command({
-        query: `CREATE DATABASE IF NOT EXISTS ${database}`,
-      });
-    } finally {
-      await root.close();
-    }
-    endpoints.push({ database, url: endpointUrl(baseUrl, database) });
+    endpoints.push(
+      await ensureEndpoint({
+        baseUrl: container.getConnectionUrl(),
+        database: databaseName({ suite, name }),
+      }),
+    );
   }
   return endpoints;
+}
+
+/**
+ * Creates the endpoint's database and returns the URL that selects it.
+ *
+ * `CREATE DATABASE` goes to the server root rather than the endpoint URL: the
+ * database does not exist yet, and connecting to a missing one fails before the
+ * statement is ever sent.
+ */
+async function ensureEndpoint({
+  baseUrl,
+  database,
+}: {
+  baseUrl: string;
+  database: string;
+}): Promise<TestClickHouseEndpoint> {
+  const root = createClient({ url: rootUrl(baseUrl) });
+  try {
+    await root.command({ query: `CREATE DATABASE IF NOT EXISTS ${database}` });
+  } finally {
+    await root.close();
+  }
+  return { database, url: endpointUrl(baseUrl, database) };
 }
 
 /**

--- a/langwatch/src/test-utils/clickhouseTestEndpoints.ts
+++ b/langwatch/src/test-utils/clickhouseTestEndpoints.ts
@@ -1,0 +1,171 @@
+/**
+ * Isolated ClickHouse endpoints for suites that assert per-organization
+ * ClickHouse routing.
+ *
+ * Those suites need two or more endpoints whose data cannot leak into one
+ * another, so they can prove that a row written for a private-ClickHouse org
+ * lands in that org's instance and nowhere else. Two backends provide that:
+ *
+ *   - Native: one database per endpoint on the always-on local ClickHouse
+ *     (LANGWATCH_TEST_CLICKHOUSE_URL), so a laptop runs the suite with no
+ *     docker at all. Isolation is by database, the same shape haven gives each
+ *     worktree, and it exercises exactly what the suites assert: a distinct URL
+ *     resolves to a distinct client that cannot see the other's rows.
+ *   - Containers: one ClickHouse container per endpoint. Used in CI, and
+ *     locally whenever the native server is not configured.
+ *
+ * Databases and tables are created if absent and never dropped. The suites key
+ * their rows on ids that are unique per run, so leftovers are invisible to
+ * them, and leaving the schema in place keeps concurrent runs from pulling it
+ * out from under each other.
+ */
+import { createClient } from "@clickhouse/client";
+import {
+  ClickHouseContainer,
+  type StartedClickHouseContainer,
+} from "@testcontainers/clickhouse";
+
+/** Kept in step with the image globalSetup.ts starts. */
+const CONTAINER_IMAGE = "clickhouse/clickhouse-server:25.10.2.65";
+
+export interface TestClickHouseEndpoint {
+  /** Connection URL, with this endpoint's own database in the path. */
+  url: string;
+  /** The database this endpoint owns, for statements that qualify a table. */
+  database: string;
+}
+
+/**
+ * The always-on local ClickHouse that the docker-free test mode runs against,
+ * or null when the caller should fall back to containers.
+ *
+ * The single place that decides whether the native mode is on: globalSetup.ts
+ * reads it too, so the two can never disagree about which backend a run uses.
+ * Never active in CI, where the service containers are the point.
+ */
+export function nativeClickHouseBaseUrl(): string | null {
+  if (process.env.CI) return null;
+  return process.env.LANGWATCH_TEST_CLICKHOUSE_URL ?? null;
+}
+
+/**
+ * Provisions one isolated endpoint per entry in `names`.
+ *
+ * `suite` and the names together form each database name, so two suites asking
+ * for a "shared" endpoint get different databases and cannot collide.
+ */
+export async function startTestClickHouseEndpoints({
+  suite,
+  names,
+}: {
+  suite: string;
+  names: string[];
+}): Promise<TestClickHouseEndpoint[]> {
+  const baseUrl = nativeClickHouseBaseUrl();
+  return baseUrl
+    ? await startNativeEndpoints({ suite, names, baseUrl })
+    : await startContainerEndpoints({ suite, names });
+}
+
+/**
+ * One database per endpoint on the shared native server. `CREATE DATABASE` runs
+ * against the server root: the database in the endpoint URL does not exist yet,
+ * and connecting to a missing database fails before the statement is sent.
+ */
+async function startNativeEndpoints({
+  suite,
+  names,
+  baseUrl,
+}: {
+  suite: string;
+  names: string[];
+  baseUrl: string;
+}): Promise<TestClickHouseEndpoint[]> {
+  const root = createClient({ url: rootUrl(baseUrl) });
+  try {
+    const endpoints: TestClickHouseEndpoint[] = [];
+    for (const name of names) {
+      const database = databaseName({ suite, name });
+      await root.command({
+        query: `CREATE DATABASE IF NOT EXISTS ${database}`,
+      });
+      endpoints.push({ database, url: endpointUrl(baseUrl, database) });
+    }
+    return endpoints;
+  } finally {
+    await root.close();
+  }
+}
+
+/**
+ * One reusable container per endpoint, each labelled so `docker ps` and the
+ * cleanup command in globalSetup.ts can find them. Reuse is keyed on the
+ * container's own configuration, so the distinct labels are what keep the
+ * endpoints on separate servers rather than collapsing into one.
+ */
+async function startContainerEndpoints({
+  suite,
+  names,
+}: {
+  suite: string;
+  names: string[];
+}): Promise<TestClickHouseEndpoint[]> {
+  const started = await Promise.all(
+    names.map(
+      async (name): Promise<[string, StartedClickHouseContainer]> => [
+        name,
+        await new ClickHouseContainer(CONTAINER_IMAGE)
+          .withLabels({
+            "langwatch.test": "true",
+            [`langwatch.test.${suite}`]: name,
+          })
+          .withReuse()
+          .withStartupTimeout(120_000)
+          .start(),
+      ],
+    ),
+  );
+
+  const endpoints: TestClickHouseEndpoint[] = [];
+  for (const [name, container] of started) {
+    const database = databaseName({ suite, name });
+    const baseUrl = container.getConnectionUrl();
+    const root = createClient({ url: rootUrl(baseUrl) });
+    try {
+      await root.command({
+        query: `CREATE DATABASE IF NOT EXISTS ${database}`,
+      });
+    } finally {
+      await root.close();
+    }
+    endpoints.push({ database, url: endpointUrl(baseUrl, database) });
+  }
+  return endpoints;
+}
+
+/**
+ * ClickHouse identifiers take letters, digits and underscores, while suite and
+ * endpoint names read better with dashes. The `test_` prefix marks the database
+ * as disposable next to a developer's real `langwatch` one on the same server.
+ */
+function databaseName({
+  suite,
+  name,
+}: {
+  suite: string;
+  name: string;
+}): string {
+  return `test_${[suite, name].join("_").replace(/[^a-zA-Z0-9_]/g, "_")}`;
+}
+
+function rootUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = "/";
+  return url.toString();
+}
+
+function endpointUrl(baseUrl: string, database: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = `/${database}`;
+  return url.toString();
+}

--- a/specs/ci/no-docker-integration-tests.feature
+++ b/specs/ci/no-docker-integration-tests.feature
@@ -34,3 +34,29 @@ Feature: Integration tests against native local services
   Scenario: CI is unaffected
     Given the suite runs in CI
     Then CI service containers are used regardless of LANGWATCH_TEST_* variables
+
+  # Suites that assert per-organization ClickHouse routing need two or more
+  # endpoints that cannot see each other's rows. They ask for those endpoints
+  # instead of starting their own containers, so the native mode covers them too.
+
+  @unimplemented
+  Scenario: Routing suites get isolated endpoints without docker
+    Given a suite needs two mutually isolated ClickHouse endpoints
+    And the native local ClickHouse is configured
+    When the suite starts
+    Then each endpoint is a separate database on the native server
+    And a row written through one endpoint is invisible to the other
+    And no docker container is started
+
+  @unimplemented
+  Scenario: A suite never writes into the developer's own database
+    Given the native server also holds the developer's dev ClickHouse database
+    When a suite provisions its endpoints
+    Then every database it creates is named for that suite
+    And the dev database is neither read nor written
+
+  @unimplemented
+  Scenario: The same suites still run on containers in CI
+    Given the suite runs in CI
+    When it asks for two isolated endpoints
+    Then each endpoint is a separate ClickHouse container

--- a/specs/ci/no-docker-integration-tests.feature
+++ b/specs/ci/no-docker-integration-tests.feature
@@ -42,21 +42,20 @@ Feature: Integration tests against native local services
   @unimplemented
   Scenario: Routing suites get isolated endpoints without docker
     Given a suite needs two mutually isolated ClickHouse endpoints
-    And the native local ClickHouse is configured
-    When the suite starts
-    Then each endpoint is a separate database on the native server
-    And a row written through one endpoint is invisible to the other
+    And the native local services are configured
+    When the suite runs
+    Then a row written through one endpoint is invisible to the other
     And no docker container is started
 
   @unimplemented
-  Scenario: A suite never writes into the developer's own database
-    Given the native server also holds the developer's dev ClickHouse database
-    When a suite provisions its endpoints
-    Then every database it creates is named for that suite
-    And the dev database is neither read nor written
+  Scenario: A suite never touches the developer's own data
+    Given the native server also holds the developer's dev ClickHouse data
+    When a suite runs against its own endpoints
+    Then the dev data is neither read nor written
 
   @unimplemented
-  Scenario: The same suites still run on containers in CI
+  Scenario: The same suites still run in CI
     Given the suite runs in CI
-    When it asks for two isolated endpoints
-    Then each endpoint is a separate ClickHouse container
+    When the suite asks for isolated endpoints
+    Then the endpoints stay isolated from one another
+    And the suite passes with no native service configured

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -169,6 +169,12 @@ COMMANDS
     help          This text.
 
 ENVIRONMENT
+    Everything below except LANGWATCH_SLUG, HAVEN_AGENT and the colour switches
+    also resolves from langwatch/.env (then .env.portless), so a lasting
+    preference — "this machine runs native ClickHouse, never provision one" —
+    lives next to the URL it belongs with and travels into every new worktree.
+    An exported variable still wins, for overriding a single run.
+
     LANGWATCH_SLUG=<slug>        Pin this worktree's slug (else the sanitised
                                  worktree directory name, cached).
     LANGWATCH_LOCAL_TLD=test     Use a different TLD (default: localhost).
@@ -228,6 +234,13 @@ ENVIRONMENT
     LANGWATCH_HAVEN_OBS=0        Skip starting the observability stack on "up".
                                  On by default: it shares ClickHouse's colima VM,
                                  which is already paying for itself.
+    LANGY_UNSAFE_CONTAINER=1     Run the langyagent worker in colima with the
+                                 per-worker UID sandbox off. Default (neither
+                                 flag) keeps the sandbox on, mirroring production.
+    LANGY_UNSAFE_HOST_ACCESS=1   Run the langyagent worker as a bare host process
+                                 — no colima, no VM boundary, full host access.
+                                 The fast-iteration tier, and the one that lets a
+                                 stack come up with no container runtime at all.
     HAVEN_COLIMA_PROFILE=name    colima profile ClickHouse + observability run on
                                  (default: default). A profile haven creates is
                                  capped; one that already exists is never resized.

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -169,11 +169,17 @@ COMMANDS
     help          This text.
 
 ENVIRONMENT
-    Everything below except LANGWATCH_SLUG, HAVEN_AGENT and the colour switches
-    also resolves from langwatch/.env (then .env.portless), so a lasting
-    preference — "this machine runs native ClickHouse, never provision one" —
-    lives next to the URL it belongs with and travels into every new worktree.
-    An exported variable still wins, for overriding a single run.
+    Most of the knobs below also resolve from langwatch/.env (then
+    .env.portless), so a lasting preference like "this machine runs native
+    ClickHouse, never provision one" lives next to the URL it belongs with and
+    travels into every new worktree. An exported variable still wins, for
+    overriding a single run.
+
+    These describe ONE run rather than one machine, so they are read from the
+    process environment only: LANGWATCH_SLUG, HAVEN_BASELINE, LANGWATCH_SEED,
+    HAVEN_SEED_TRACES, HAVEN_STUB, HAVEN_AGENT, NO_COLOR, FORCE_COLOR. Every
+    worktree shares one .env, so pinning a slug or a baseline marker there would
+    apply it to all of them, and a seed flag would re-seed on every up.
 
     LANGWATCH_SLUG=<slug>        Pin this worktree's slug (else the sanitised
                                  worktree directory name, cached).
@@ -238,7 +244,8 @@ ENVIRONMENT
                                  per-worker UID sandbox off. Default (neither
                                  flag) keeps the sandbox on, mirroring production.
     LANGY_UNSAFE_HOST_ACCESS=1   Run the langyagent worker as a bare host process
-                                 — no colima, no VM boundary, full host access.
+                                 with no colima and no VM boundary, so it has
+                                 full host access.
                                  The fast-iteration tier, and the one that lets a
                                  stack come up with no container runtime at all.
     HAVEN_COLIMA_PROFILE=name    colima profile ClickHouse + observability run on

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -100,7 +101,7 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 	worktree := gitTopLevel(cwd)
 	lwDir := filepath.Join(worktree, "langwatch")
 
-	naming := domain.DefaultNaming(os.Getenv("LANGWATCH_LOCAL_TLD"))
+	naming := domain.DefaultNaming(devEnv("LANGWATCH_LOCAL_TLD"))
 	proxy := portlessproxy.New(naming, lwDir)
 	store := fileregistry.New(havenHome())
 	sup := procsupervisor.New(isAgent)
@@ -137,7 +138,7 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 	// needs what wants a human. LW_OBS_CONSOLE_LEVEL overrides it; "off"/"none"/""
 	// opts out and leaves the console to .env.
 	obsConsoleLevel := "warn"
-	if v, ok := os.LookupEnv("LW_OBS_CONSOLE_LEVEL"); ok {
+	if v, ok := dotenvLookup("LW_OBS_CONSOLE_LEVEL"); ok {
 		obsConsoleLevel = v
 	}
 	if obsConsoleLevel == "off" || obsConsoleLevel == "none" {
@@ -152,13 +153,13 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		HeartbeatEvery:           30 * time.Second,
 		DaemonArgv:               selfArgv(worktree, "daemon"),
 		IsAgent:                  isAgent,
-		ShouldManageClickHouse:   os.Getenv("LANGWATCH_HAVEN_CH") != "0",
-		ShouldStopClickHouseIdle: os.Getenv("LANGWATCH_HAVEN_CH_STOP_IDLE") == "1",
-		ShouldManagePostgres:     os.Getenv("LANGWATCH_HAVEN_PG") != "0",
-		ShouldManageRedis:        os.Getenv("LANGWATCH_HAVEN_REDIS") != "0",
+		ShouldManageClickHouse:   devEnv("LANGWATCH_HAVEN_CH") != "0",
+		ShouldStopClickHouseIdle: devEnv("LANGWATCH_HAVEN_CH_STOP_IDLE") == "1",
+		ShouldManagePostgres:     devEnv("LANGWATCH_HAVEN_PG") != "0",
+		ShouldManageRedis:        devEnv("LANGWATCH_HAVEN_REDIS") != "0",
 		// Observability shares CH's colima VM, so it defaults ON now — the VM is
 		// already paying for itself. LANGWATCH_HAVEN_OBS=0 opts out.
-		ShouldStartObservability:  os.Getenv("LANGWATCH_HAVEN_OBS") != "0",
+		ShouldStartObservability:  devEnv("LANGWATCH_HAVEN_OBS") != "0",
 		LocalAPIKey:               envOr("LANGWATCH_LOCAL_API_KEY", domain.DefaultLocalAPIKey),
 		RepoRoot:                  worktree,
 		ObservabilityConsoleLevel: obsConsoleLevel,
@@ -344,18 +345,18 @@ func (d deps) dispatch(ctx context.Context, sub string, rest []string) error {
 
 func optionsFromEnv(repoRoot string) app.PlanOptions {
 	return app.PlanOptions{
-		ShouldGoWatch:      os.Getenv("LANGWATCH_GO_WATCH") == "1",
-		ShouldStartWorkers: os.Getenv("START_WORKERS") != "false" && os.Getenv("START_WORKERS") != "0",
+		ShouldGoWatch:      devEnv("LANGWATCH_GO_WATCH") == "1",
+		ShouldStartWorkers: devEnv("START_WORKERS") != "false" && devEnv("START_WORKERS") != "0",
 		// Under haven the worker stack defaults to IN-PROCESS (hosted in the app
 		// process), saving the RAM of a second Node process — the sensible default on
 		// a laptop juggling several worktrees. Workers keep their own logger name
 		// ("langwatch:workers"), so their lines stay identifiable even without a
 		// separate lane. Opt back into a standalone `workers` lane with
 		// WORKERS_IN_PROCESS=0.
-		ShouldRunWorkersInProcess: os.Getenv("WORKERS_IN_PROCESS") != "0" && os.Getenv("WORKERS_IN_PROCESS") != "false",
-		ShouldSkipNLP:             os.Getenv("LANGWATCH_SKIP_NLP") == "1",
-		ShouldSkipGateway:         os.Getenv("LANGWATCH_SKIP_AIGATEWAY") == "1",
-		ShouldSkipLangyAgent:      os.Getenv("LANGWATCH_SKIP_LANGYAGENT") == "1",
+		ShouldRunWorkersInProcess: devEnv("WORKERS_IN_PROCESS") != "0" && devEnv("WORKERS_IN_PROCESS") != "false",
+		ShouldSkipNLP:             devEnv("LANGWATCH_SKIP_NLP") == "1",
+		ShouldSkipGateway:         devEnv("LANGWATCH_SKIP_AIGATEWAY") == "1",
+		ShouldSkipLangyAgent:      devEnv("LANGWATCH_SKIP_LANGYAGENT") == "1",
 		ShouldSeed:                os.Getenv("LANGWATCH_SEED") == "1",
 		// The langyagent worker's local isolation posture. Default (neither flag) is
 		// the sandboxed, production-like tier: the worker runs in colima with the
@@ -387,7 +388,7 @@ func resolveAgent() bool {
 }
 
 func havenHome() string {
-	if v := os.Getenv("LANGWATCH_PORTLESS_HOME"); v != "" {
+	if v := devEnv("LANGWATCH_PORTLESS_HOME"); v != "" {
 		return v
 	}
 	home, _ := os.UserHomeDir()
@@ -596,7 +597,7 @@ func runLogs(ctx context.Context, d deps, shouldFollow bool) error {
 // set, else the sibling `worktrees/` dir next to the main checkout (matching the
 // existing layout, e.g. .../langwatch/worktrees).
 func prWorktreeBase(dir string) string {
-	if v := os.Getenv("HAVEN_WORKTREE_DIR"); v != "" {
+	if v := devEnv("HAVEN_WORKTREE_DIR"); v != "" {
 		return v
 	}
 	return filepath.Join(filepath.Dir(gitMainWorktree(dir)), "worktrees")
@@ -705,22 +706,75 @@ func hasFlag(args []string, flag string) bool {
 	return false
 }
 
+// devEnv reads one of haven's own knobs: the process environment first, then
+// the merged dotenv layers (langwatch/.env, then langwatch/.env.portless).
+//
+// The same precedence Prisma and tsx give the app's settings, and for the same
+// reason — a preference like "never manage ClickHouse, this machine runs a
+// native one" belongs next to the CLICKHOUSE_URL it goes with, travels into
+// every new worktree with the .env the checkout hook copies, and is still
+// overridable by exporting the variable for a single run.
+//
+// Deliberately not used for per-invocation switches (HAVEN_AGENT, NO_COLOR,
+// FORCE_COLOR, LANGWATCH_SLUG): those describe one run, not a machine, and
+// pinning them in a file that every worktree inherits is a trap.
+func devEnv(key string) string {
+	v, _ := resolveKnob(key, os.LookupEnv, dotenvKnobs)
+	return v
+}
+
+// dotenvLookup is devEnv's two-value form, for knobs that distinguish "set to
+// empty" from "not set at all".
+func dotenvLookup(key string) (string, bool) {
+	return resolveKnob(key, os.LookupEnv, dotenvKnobs)
+}
+
+// resolveKnob is the precedence itself, kept pure so it can be tested without a
+// checkout on disk. dotenv is a thunk so the file is never read when the
+// process environment already answers.
+func resolveKnob(
+	key string,
+	lookup func(string) (string, bool),
+	dotenv func() map[string]string,
+) (string, bool) {
+	if v, ok := lookup(key); ok {
+		return v, true
+	}
+	v, ok := dotenv()[key]
+	return v, ok
+}
+
+// dotenvKnobs loads the dotenv layers once per process, from the langwatch/
+// directory of the checkout haven was invoked in.
+func dotenvKnobs() map[string]string {
+	dotenvOnce.Do(func() {
+		cwd, _ := os.Getwd()
+		dotenvVars = domain.LoadDotenv(filepath.Join(gitTopLevel(cwd), "langwatch"))
+	})
+	return dotenvVars
+}
+
+var (
+	dotenvOnce sync.Once
+	dotenvVars map[string]string
+)
+
 // envTruthy reports whether an env var is set to a common "on" value. Accepts the
 // two spellings haven's flags already use across the codebase ("1" / "true").
 func envTruthy(key string) bool {
-	v := os.Getenv(key)
+	v := devEnv(key)
 	return v == "1" || v == "true"
 }
 
 func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
+	if v := devEnv(key); v != "" {
 		return v
 	}
 	return def
 }
 
 func envInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
+	if v := devEnv(key); v != "" {
 		var n int
 		if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
 			return n
@@ -730,7 +784,7 @@ func envInt(key string, def int) int {
 }
 
 func envDuration(key string, def time.Duration) time.Duration {
-	if v := os.Getenv(key); v != "" {
+	if v := devEnv(key); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			return d
 		}

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -710,14 +710,17 @@ func hasFlag(args []string, flag string) bool {
 // the merged dotenv layers (langwatch/.env, then langwatch/.env.portless).
 //
 // The same precedence Prisma and tsx give the app's settings, and for the same
-// reason — a preference like "never manage ClickHouse, this machine runs a
+// reason: a preference like "never manage ClickHouse, this machine runs a
 // native one" belongs next to the CLICKHOUSE_URL it goes with, travels into
 // every new worktree with the .env the checkout hook copies, and is still
 // overridable by exporting the variable for a single run.
 //
-// Deliberately not used for per-invocation switches (HAVEN_AGENT, NO_COLOR,
-// FORCE_COLOR, LANGWATCH_SLUG): those describe one run, not a machine, and
-// pinning them in a file that every worktree inherits is a trap.
+// Deliberately not used for the switches that describe one run rather than one
+// machine: LANGWATCH_SLUG, HAVEN_BASELINE, LANGWATCH_SEED, HAVEN_SEED_TRACES,
+// HAVEN_STUB, HAVEN_AGENT, NO_COLOR, FORCE_COLOR. Every worktree inherits the
+// same .env, so a slug or a baseline marker pinned there would claim all of
+// them at once, and a seed flag would re-seed on every up. Keep this list and
+// the ENVIRONMENT section of help.go in step.
 func devEnv(key string) string {
 	v, _ := resolveKnob(key, os.LookupEnv, dotenvKnobs)
 	return v

--- a/tools/thuishaven/cmd/root_test.go
+++ b/tools/thuishaven/cmd/root_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -240,8 +242,8 @@ func TestClickHouseLimitsEnvWiring(t *testing.T) {
 }
 
 // haven's own knobs (LANGWATCH_HAVEN_CH, LANGY_UNSAFE_HOST_ACCESS, …) resolve
-// from langwatch/.env as well as the shell, so a machine-level preference —
-// "this laptop runs native ClickHouse, never provision one" — is pinned next to
+// from langwatch/.env as well as the shell, so a machine-level preference like
+// "this laptop runs native ClickHouse, never provision one" is pinned next to
 // the CLICKHOUSE_URL it belongs with and travels into every new worktree.
 func TestResolveKnob(t *testing.T) {
 	dotenv := func() map[string]string {
@@ -267,7 +269,7 @@ func TestResolveKnob(t *testing.T) {
 			t.Run("the process environment wins over the dotenv layers", func(t *testing.T) {
 				got, _ := resolveKnob("LANGWATCH_HAVEN_CH", exported, dotenv)
 				if got != "1" {
-					t.Errorf("got %q, want %q — an export must override .env for a one-off run", got, "1")
+					t.Errorf("got %q, want %q; an export must override .env for a one-off run", got, "1")
 				}
 			})
 		})
@@ -311,4 +313,37 @@ func TestResolveKnob(t *testing.T) {
 			})
 		})
 	})
+}
+
+// The ENVIRONMENT help text promises that haven's knobs resolve from
+// langwatch/.env, and names the ones that do not. That promise is only as good
+// as its exclusion list: a knob added on plain os.Getenv without being listed
+// reads, to anyone following the docs, as configurable from .env when it
+// silently is not. Derive the real list from the source so the two cannot part.
+func TestProcessOnlyKnobsAreDocumented(t *testing.T) {
+	source, err := os.ReadFile("root.go")
+	if err != nil {
+		t.Fatalf("read root.go: %v", err)
+	}
+	help, err := os.ReadFile("help.go")
+	if err != nil {
+		t.Fatalf("read help.go: %v", err)
+	}
+
+	found := regexp.MustCompile(`os\.(?:Getenv|LookupEnv)\("([A-Z_]+)"\)`).
+		FindAllStringSubmatch(string(source), -1)
+	if len(found) == 0 {
+		t.Fatal("no os.Getenv knobs found: the pattern stopped matching, not a clean bill of health")
+	}
+
+	for _, match := range found {
+		key := match[1]
+		if !strings.Contains(string(help), key) {
+			t.Errorf(
+				"%s is read straight from the process environment but never named in help.go: "+
+					"either route it through devEnv or add it to the ENVIRONMENT exclusion list",
+				key,
+			)
+		}
+	}
 }

--- a/tools/thuishaven/cmd/root_test.go
+++ b/tools/thuishaven/cmd/root_test.go
@@ -238,3 +238,77 @@ func TestClickHouseLimitsEnvWiring(t *testing.T) {
 		})
 	})
 }
+
+// haven's own knobs (LANGWATCH_HAVEN_CH, LANGY_UNSAFE_HOST_ACCESS, …) resolve
+// from langwatch/.env as well as the shell, so a machine-level preference —
+// "this laptop runs native ClickHouse, never provision one" — is pinned next to
+// the CLICKHOUSE_URL it belongs with and travels into every new worktree.
+func TestResolveKnob(t *testing.T) {
+	dotenv := func() map[string]string {
+		return map[string]string{"LANGWATCH_HAVEN_CH": "0"}
+	}
+	unset := func(string) (string, bool) { return "", false }
+
+	t.Run("given a knob set only in the dotenv layers", func(t *testing.T) {
+		t.Run("when resolving it", func(t *testing.T) {
+			t.Run("falls back to the dotenv value", func(t *testing.T) {
+				got, ok := resolveKnob("LANGWATCH_HAVEN_CH", unset, dotenv)
+				if !ok || got != "0" {
+					t.Errorf(`got (%q, %v), want ("0", true)`, got, ok)
+				}
+			})
+		})
+	})
+
+	t.Run("given the same knob exported in the process environment", func(t *testing.T) {
+		exported := func(string) (string, bool) { return "1", true }
+
+		t.Run("when resolving it", func(t *testing.T) {
+			t.Run("the process environment wins over the dotenv layers", func(t *testing.T) {
+				got, _ := resolveKnob("LANGWATCH_HAVEN_CH", exported, dotenv)
+				if got != "1" {
+					t.Errorf("got %q, want %q — an export must override .env for a one-off run", got, "1")
+				}
+			})
+		})
+	})
+
+	t.Run("given a knob exported as the empty string", func(t *testing.T) {
+		emptyExport := func(string) (string, bool) { return "", true }
+
+		t.Run("when resolving it", func(t *testing.T) {
+			t.Run("reports it as set, so an explicit opt-out is not re-read from .env", func(t *testing.T) {
+				got, ok := resolveKnob("LANGWATCH_HAVEN_CH", emptyExport, dotenv)
+				if got != "" || !ok {
+					t.Errorf(`got (%q, %v), want ("", true)`, got, ok)
+				}
+			})
+		})
+	})
+
+	t.Run("given a knob absent from both sources", func(t *testing.T) {
+		t.Run("when resolving it", func(t *testing.T) {
+			t.Run("reports it unset so the caller's default applies", func(t *testing.T) {
+				if _, ok := resolveKnob("LANGWATCH_HAVEN_NOPE", unset, dotenv); ok {
+					t.Error("an absent knob must not report as set")
+				}
+			})
+		})
+	})
+
+	t.Run("given a knob answered by the process environment", func(t *testing.T) {
+		t.Run("when resolving it", func(t *testing.T) {
+			t.Run("never reads the dotenv layers", func(t *testing.T) {
+				read := false
+				counting := func() map[string]string {
+					read = true
+					return nil
+				}
+				resolveKnob("LANGWATCH_HAVEN_CH", func(string) (string, bool) { return "1", true }, counting)
+				if read {
+					t.Error("dotenv was loaded even though the environment answered")
+				}
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Why

Local dev on a machine that already runs ClickHouse, Postgres and Redis natively still pulled in Docker or colima in three places. Docker Desktop and colima are heavy on CPU and RAM, and none of these three actually needed a container.

## What still reached for a container

**Three integration suites** called `new ClickHouseContainer()` directly, bypassing the native-services path that `globalSetup` already had. Any run touching them needed a container runtime regardless of `LANGWATCH_TEST_*`.

They now ask `startTestClickHouseEndpoints({ suite, names })` for the isolated endpoints they need. Natively that is one database per endpoint on the local server; in CI it is one container each. This works because what the suites actually assert is that a distinct connection URL resolves to a distinct client that cannot see the other's rows, and a database boundary tests exactly that. Every DDL and query in them was already unqualified, so the URL's database is the boundary.

**`ops-explain` hardcoded the `langwatch` database** in its query strings. Against a shared native server, its `CREATE TABLE IF NOT EXISTS langwatch.stored_spans` would have created a 4-column stub inside a developer's real dev database and shadowed the real schema. Its qualifiers now point at the suite's own database.

**haven read its own knobs from the process environment only.** Setting `LANGWATCH_HAVEN_CH=0` in `langwatch/.env` did nothing, because `pnpm dev:haven` execs a Go binary and nothing loaded the dotenv layers for it. haven now falls back to `.env` then `.env.portless`, the same precedence Prisma and tsx give the app, so a machine-level preference travels with the worktree while an exported variable still wins for a single run. Per-invocation switches (`LANGWATCH_SLUG`, `HAVEN_AGENT`, colours) are deliberately excluded, since pinning those in a file every worktree inherits is a trap.

`globalSetup` and the new helper now share one predicate for "is the native mode on", so they cannot disagree about which backend a run uses.

## Using it

With native services and these three in `langwatch/.env`, no container runtime is needed at all:

```bash
LANGWATCH_HAVEN_CH=0          # use .env CLICKHOUSE_URL instead of a managed container
LANGWATCH_HAVEN_OBS=0         # skip the LGTM telemetry stack
LANGY_UNSAFE_HOST_ACCESS=1    # run the langyagent worker on the host, not in colima
```

Postgres and Redis stay haven-managed either way: it starts them through brew, never a container. What remains container-only is `make observability` and the sandboxed/container langy tiers, both opt-in and neither needed to land work.

## Docker is still fully supported

This adds a native option, it does not take the container path away. Containers remain the default and are what CI uses.

The native mode is opt-in via `LANGWATCH_TEST_*` and is **explicitly disabled whenever `CI` is set**, so a CI run can never take the native path even if those variables leak into its environment. Locally, removing the variables puts you back on testcontainers.

Both paths were run on the same commit:

| Path | Selected when | Result |
| --- | --- | --- |
| Containers | `CI=1`, i.e. what CI does | 21/21 (ops-explain 12/12, routing + isolation 9/9) |
| Native | `LANGWATCH_TEST_*` set, not CI | 21/21 |

Under containers the two-endpoint suites each spawned two genuinely separate ClickHouse containers (distinct published ports), confirming that keying reuse on distinct labels still yields separate servers, which is what the isolation assertions depend on.

## Verification

Docker Desktop and colima both stopped (`docker ps` → "Cannot connect", `colima status` → "not running"):

- `pnpm dev:haven` brought up the full stack, `/api/health` → 204, UI → 200, seed completed. ClickHouse migrations ran against the native server, degrading to the `default` storage policy as `goose.ts` already handles.
- The three suites pass **21/21** with `DOCKER_HOST=unix:///nonexistent/docker.sock`, proving docker is never contacted rather than merely unused.
- `go test ./tools/thuishaven/...` green; `TestResolveKnob` pins the new precedence including that the dotenv layers are not read when the environment answers.
- `tsgo --noEmit` clean on the tests project.

## Notes

One unrelated drive-by, surfaced while answering a review point. Two runtime messages and a source comment told operators to see `infrastructure/clickhouse-serverless/config/users.xml.template` when `CLICKHOUSE_OPS_URL` is unset. That path resolves nowhere in the repo, and the production branch is fail-closed, so the one message an operator reads while the endpoint is refusing to serve pointed at a file that is not there. They now describe what to provision: a `langwatch_ops` user with a `readonly=1` profile and no SOURCES grant. Six lines, no behaviour change.


`biome.json` declares schema 2.4.14 while the pinned binary is 2.5.1, so `pnpm exec biome` errors on config and checks nothing, which is why the lint job goes green in ~22s. `biome migrate` fixes it cleanly, but turning that gate back on lands on a 3584-error pre-existing baseline, so it is left for its own change rather than ridden in here.