### PR TITLE
feat(scenarios): hand scenario runs to the simulations tab already open

### DIFF
--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -197,10 +197,12 @@ secured.access(requires("scenarios:create")).post(
     }
 
     // Built server-side from ids rather than accepted as a URL: a handoff can
-    // only ever point a browser at this instance's own simulations page.
-    const url = `${base}/${project.slug}/simulations/${
-      scenarioSetId || DEFAULT_SET_ID
-    }/${batchRunId}`;
+    // only ever point a browser at this instance's own simulations page. The
+    // ids are caller-supplied and only length-bounded, so they are encoded — a
+    // `#` or `?` in one would otherwise truncate the rest of the path.
+    const url = `${base}/${project.slug}/simulations/${encodeURIComponent(
+      scenarioSetId || DEFAULT_SET_ID,
+    )}/${encodeURIComponent(batchRunId)}`;
 
     const hasLiveTab = await scenarioTabRegistry.hasLiveTab({
       projectId: project.id,

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -2,9 +2,9 @@ import { createLogger } from "@langwatch/observability";
 import { bodyLimit } from "hono/body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
-import { validator as zValidator } from "~/server/api/validation";
 import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
+import { validator as zValidator } from "~/server/api/validation";
 import { getApp } from "~/server/app-layer/app";
 import {
   SCENARIO_TAB_NAVIGATE_EVENT,
@@ -180,7 +180,7 @@ secured.access(requires("scenarios:create")).post(
       tabKey: z.string().min(1).max(200),
       batchRunId: z.string().min(1).max(200),
       scenarioSetId: z.string().min(1).max(200).optional(),
-    })
+    }),
   ),
   async (c) => {
     const { project } = c.var;
@@ -216,6 +216,14 @@ secured.access(requires("scenarios:create")).post(
       tabKey,
       url,
     };
+
+    // Parked before the broadcast so a tab reconnecting right now cannot slip
+    // between the two and miss a run we already reported as delivered.
+    await scenarioTabRegistry.setPendingNavigate({
+      projectId: project.id,
+      tabKey,
+      url,
+    });
 
     await getApp().broadcast.broadcastToTenant(
       project.id,

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -6,6 +6,11 @@ import { validator as zValidator } from "~/server/api/validation";
 import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
 import { getApp } from "~/server/app-layer/app";
+import {
+  SCENARIO_TAB_NAVIGATE_EVENT,
+  type ScenarioTabNavigatePayload,
+} from "~/server/scenarios/browser-tab/scenario-tab-events";
+import { scenarioTabRegistry } from "~/server/scenarios/browser-tab/scenario-tab-registry";
 import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
 import { ScenarioEventType } from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioEvent } from "~/server/scenarios/scenario-event.types";
@@ -141,6 +146,89 @@ secured.access(requires("scenarios:create")).post(
     const url = `${base}${path}`;
 
     return c.json({ success: true, url }, 201);
+  },
+);
+
+// POST /api/scenario-events/browser-tab - Offer a batch run to a simulations
+// tab that is already open on the caller's machine.
+//
+// The SDK sends the scenario tab key it stamped on the tab it opened earlier.
+// When a tab holding that key still has a live SSE subscription, the run is
+// broadcast to it and the SDK skips opening a browser; otherwise the SDK falls
+// back to opening one. Reporting a run is `scenarios:create` work, and so is
+// steering where that run is displayed.
+secured.access(requires("scenarios:create")).post(
+  "/browser-tab",
+  describeRoute({
+    description:
+      "Offer a batch run to an already-open simulations tab on the caller's machine. Returns whether a live tab took it.",
+    responses: {
+      ...baseResponses,
+      200: {
+        description: "Handoff evaluated",
+        content: {
+          "application/json": {
+            schema: resolver(responseSchemas.browserTabHandoff),
+          },
+        },
+      },
+    },
+  }),
+  zValidator(
+    "json",
+    z.object({
+      tabKey: z.string().min(1).max(200),
+      batchRunId: z.string().min(1).max(200),
+      scenarioSetId: z.string().min(1).max(200).optional(),
+    })
+  ),
+  async (c) => {
+    const { project } = c.var;
+    const { tabKey, batchRunId, scenarioSetId } = c.req.valid("json");
+
+    const base = process.env.BASE_HOST;
+
+    if (!base) {
+      logger.error(
+        "BASE_HOST is not set, but required for the scenario browser-tab handoff",
+      );
+
+      return c.json({ error: "BASE_HOST is not configured" }, 500);
+    }
+
+    // Built server-side from ids rather than accepted as a URL: a handoff can
+    // only ever point a browser at this instance's own simulations page.
+    const url = `${base}/${project.slug}/simulations/${
+      scenarioSetId || DEFAULT_SET_ID
+    }/${batchRunId}`;
+
+    const hasLiveTab = await scenarioTabRegistry.hasLiveTab({
+      projectId: project.id,
+      tabKey,
+    });
+
+    if (!hasLiveTab) {
+      return c.json({ delivered: false, url }, 200);
+    }
+
+    const payload: ScenarioTabNavigatePayload = {
+      event: SCENARIO_TAB_NAVIGATE_EVENT,
+      tabKey,
+      url,
+    };
+
+    await getApp().broadcast.broadcastToTenant(
+      project.id,
+      JSON.stringify(payload),
+      "simulation_updated",
+    );
+
+    logger.info(
+      { projectId: project.id, batchRunId },
+      "Handed scenario batch to an open simulations tab",
+    );
+
+    return c.json({ delivered: true, url }, 200);
   },
 );
 

--- a/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
@@ -180,8 +180,9 @@ describe("POST /api/scenario-events/browser-tab", () => {
   describe("when no tab from that machine is listening", () => {
     /** @scenario "The handoff is not delivered when no tab is listening" */
     it("reports the handoff as undelivered and broadcasts nothing", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
       const res = await handoff({
-        tabKey: `tab-${nanoid(8)}`,
+        tabKey,
         batchRunId: "batch-1",
         scenarioSetId: "checkout-flow",
       });
@@ -189,6 +190,11 @@ describe("POST /api/scenario-events/browser-tab", () => {
       expect(res.status).toBe(200);
       await expect(res.json()).resolves.toMatchObject({ delivered: false });
       expect(mockBroadcastToTenant).not.toHaveBeenCalled();
+      // Nothing parked either: a tab that opens later must not be yanked to a
+      // run the SDK already showed in its own browser tab.
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey }),
+      ).resolves.toBeNull();
     });
   });
 
@@ -243,6 +249,24 @@ describe("POST /api/scenario-events/browser-tab", () => {
       ) as { url: string };
       expect(payload.url).toBe(
         `${BASE_HOST}/${projectSlug}/simulations/checkout-flow/batch-8`,
+      );
+    });
+
+    /** @scenario "The handoff is delivered when a tab is listening" */
+    it("parks the run so a tab that was reloading can still claim it", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      await registerTab({ projectId, tabKey });
+
+      await handoff({
+        tabKey,
+        batchRunId: "batch-parked",
+        scenarioSetId: "checkout-flow",
+      });
+
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey }),
+      ).resolves.toBe(
+        `${BASE_HOST}/${projectSlug}/simulations/checkout-flow/batch-parked`,
       );
     });
 

--- a/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
@@ -179,6 +179,7 @@ beforeEach(() => {
 describe("POST /api/scenario-events/browser-tab", () => {
   describe("when no tab from that machine is listening", () => {
     /** @scenario "The handoff is not delivered when no tab is listening" */
+    /** @scenario "Nothing is parked when no tab was listening" */
     it("reports the handoff as undelivered and broadcasts nothing", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       const res = await handoff({
@@ -320,6 +321,7 @@ describe("POST /api/scenario-events/browser-tab", () => {
       expect(res.status).toBe(422);
     });
 
+    /** @scenario "The handoff endpoint refuses an unauthenticated caller" */
     it("rejects an unauthenticated caller", async () => {
       const res = await handoff(
         { tabKey: `tab-${nanoid(8)}`, batchRunId: "batch-1" },

--- a/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * POST /api/scenario-events/browser-tab — the endpoint the SDK asks before it
+ * opens a browser.
+ *
+ * Covers specs/scenarios/scenario-tab-handoff.feature — the handoff half. The
+ * project and its API key are real Prisma rows resolved by the real auth
+ * middleware, and tab presence is the real Redis-backed registry. Only the
+ * app-layer facade is stubbed, so the broadcast can be observed without
+ * standing up the whole dependency graph.
+ */
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
+
+const { mockBroadcastToTenant } = vi.hoisted(() => ({
+  mockBroadcastToTenant: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    broadcast: {
+      broadcastToTenant: mockBroadcastToTenant,
+      broadcastToTenantRateLimited: vi.fn().mockResolvedValue(undefined),
+    },
+    usage: {
+      checkLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    },
+    planProvider: {
+      getActivePlan: vi.fn().mockResolvedValue({ name: "free" }),
+    },
+    usageLimits: {
+      notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+}));
+
+// The integration postgres schema does not seed the role bindings the test
+// project would need to pass the RBAC grain, so the permission gate is
+// replaced with a passthrough. Project resolution from the API key stays real,
+// which is what these tests are actually about.
+vi.mock("~/app/api/middleware/auth", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/app/api/middleware/auth")>();
+  return {
+    ...actual,
+    requirePermission:
+      () => async (_c: unknown, next: () => Promise<unknown>) => {
+        await next();
+      },
+  };
+});
+
+import { app } from "~/app/api/scenario-events/[[...route]]/app";
+import {
+  isScenarioTabNavigatePayload,
+  SCENARIO_TAB_NAVIGATE_EVENT,
+} from "~/server/scenarios/browser-tab/scenario-tab-events";
+import { scenarioTabRegistry } from "~/server/scenarios/browser-tab/scenario-tab-registry";
+
+const BASE_HOST = "https://test.langwatch.ai";
+
+let apiKey: string;
+let projectId: string;
+let projectSlug: string;
+let otherApiKey: string;
+let otherProjectId: string;
+let orgId: string;
+let teamId: string;
+let previousBaseHost: string | undefined;
+
+const registered: Array<{ projectId: string; tabKey: string; tabId: string }> =
+  [];
+
+async function registerTab(params: {
+  projectId: string;
+  tabKey: string;
+  tabId?: string;
+}): Promise<void> {
+  const entry = { tabId: "tab-a", ...params };
+  registered.push(entry);
+  await scenarioTabRegistry.register(entry);
+}
+
+async function handoff(
+  body: Record<string, unknown>,
+  token: string | null = apiKey,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers["X-Auth-Token"] = token;
+
+  return app.request("/api/scenario-events/browser-tab", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  previousBaseHost = process.env.BASE_HOST;
+  process.env.BASE_HOST = BASE_HOST;
+
+  const org = await prisma.organization.create({
+    data: {
+      name: `Tab Handoff Org ${nanoid(6)}`,
+      slug: `--tab-handoff-org-${nanoid(6)}`,
+    },
+  });
+  orgId = org.id;
+
+  const team = await prisma.team.create({
+    data: {
+      name: `Tab Handoff Team ${nanoid(6)}`,
+      slug: `--tab-handoff-team-${nanoid(6)}`,
+      organizationId: org.id,
+    },
+  });
+  teamId = team.id;
+
+  const created = await prisma.project.create({
+    data: {
+      ...projectFactory.build({ slug: `--tab-handoff-proj-${nanoid(6)}` }),
+      teamId: team.id,
+      personalFeatures: {},
+    },
+  });
+  apiKey = created.apiKey;
+  projectId = created.id;
+  projectSlug = created.slug;
+
+  const other = await prisma.project.create({
+    data: {
+      ...projectFactory.build({ slug: `--tab-handoff-other-${nanoid(6)}` }),
+      teamId: team.id,
+      personalFeatures: {},
+    },
+  });
+  otherApiKey = other.apiKey;
+  otherProjectId = other.id;
+});
+
+afterAll(async () => {
+  await Promise.all(
+    registered.map((entry) => scenarioTabRegistry.unregister(entry)),
+  );
+
+  try {
+    await prisma.project.deleteMany({
+      where: { id: { in: [projectId, otherProjectId] } },
+    });
+    await prisma.team.deleteMany({ where: { id: teamId } });
+    await prisma.organization.deleteMany({ where: { id: orgId } });
+  } catch {
+    // Cleanup only — the integration schema does not always carry every
+    // related table, and a teardown error must not mask a test failure.
+  }
+
+  if (previousBaseHost === void 0) delete process.env.BASE_HOST;
+  else process.env.BASE_HOST = previousBaseHost;
+});
+
+beforeEach(() => {
+  mockBroadcastToTenant.mockClear();
+});
+
+describe("POST /api/scenario-events/browser-tab", () => {
+  describe("when no tab from that machine is listening", () => {
+    /** @scenario "The handoff is not delivered when no tab is listening" */
+    it("reports the handoff as undelivered and broadcasts nothing", async () => {
+      const res = await handoff({
+        tabKey: `tab-${nanoid(8)}`,
+        batchRunId: "batch-1",
+        scenarioSetId: "checkout-flow",
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({ delivered: false });
+      expect(mockBroadcastToTenant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a tab from that machine is listening", () => {
+    /** @scenario "The handoff is delivered when a tab is listening" */
+    it("reports it delivered and broadcasts a navigate payload", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      await registerTab({ projectId, tabKey });
+
+      const res = await handoff({
+        tabKey,
+        batchRunId: "batch-7",
+        scenarioSetId: "checkout-flow",
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        delivered: true,
+        url: `${BASE_HOST}/${projectSlug}/simulations/checkout-flow/batch-7`,
+      });
+
+      expect(mockBroadcastToTenant).toHaveBeenCalledTimes(1);
+      const [broadcastProjectId, payload, eventType] =
+        mockBroadcastToTenant.mock.calls[0]!;
+      expect(broadcastProjectId).toBe(projectId);
+      expect(eventType).toBe("simulation_updated");
+
+      const parsed: unknown = JSON.parse(payload as string);
+      expect(isScenarioTabNavigatePayload(parsed)).toBe(true);
+      expect(parsed).toEqual({
+        event: SCENARIO_TAB_NAVIGATE_EVENT,
+        tabKey,
+        url: `${BASE_HOST}/${projectSlug}/simulations/checkout-flow/batch-7`,
+      });
+    });
+
+    /** @scenario "The handoff URL must belong to this LangWatch instance" */
+    it("builds the URL itself and ignores any URL the caller sends", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      await registerTab({ projectId, tabKey });
+
+      const res = await handoff({
+        tabKey,
+        batchRunId: "batch-8",
+        scenarioSetId: "checkout-flow",
+        url: "https://evil.example/phish",
+      });
+
+      expect(res.status).toBe(200);
+      const payload = JSON.parse(
+        mockBroadcastToTenant.mock.calls[0]![1] as string,
+      ) as { url: string };
+      expect(payload.url).toBe(
+        `${BASE_HOST}/${projectSlug}/simulations/checkout-flow/batch-8`,
+      );
+    });
+
+    it("falls back to the default set when none is given", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      await registerTab({ projectId, tabKey });
+
+      const res = await handoff({ tabKey, batchRunId: "batch-9" });
+
+      await expect(res.json()).resolves.toMatchObject({
+        delivered: true,
+        url: `${BASE_HOST}/${projectSlug}/simulations/default/batch-9`,
+      });
+    });
+  });
+
+  describe("scoping", () => {
+    /** @scenario "A handoff never crosses projects" */
+    it("does not deliver a handoff to another project's tab", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      await registerTab({ projectId, tabKey });
+      registered.push({ projectId: otherProjectId, tabKey, tabId: "tab-a" });
+
+      const res = await handoff({ tabKey, batchRunId: "batch-1" }, otherApiKey);
+
+      await expect(res.json()).resolves.toMatchObject({ delivered: false });
+      expect(mockBroadcastToTenant).not.toHaveBeenCalled();
+    });
+
+    it("does not deliver a handoff meant for a different machine", async () => {
+      await registerTab({ projectId, tabKey: `tab-${nanoid(8)}` });
+
+      const res = await handoff({
+        tabKey: `tab-${nanoid(8)}`,
+        batchRunId: "batch-1",
+      });
+
+      await expect(res.json()).resolves.toMatchObject({ delivered: false });
+      expect(mockBroadcastToTenant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input handling", () => {
+    it("rejects a request without a tab key", async () => {
+      const res = await handoff({ batchRunId: "batch-1" });
+      expect(res.status).toBe(422);
+    });
+
+    it("rejects a request without a batch run id", async () => {
+      const res = await handoff({ tabKey: `tab-${nanoid(8)}` });
+      expect(res.status).toBe(422);
+    });
+
+    it("rejects an unauthenticated caller", async () => {
+      const res = await handoff(
+        { tabKey: `tab-${nanoid(8)}`, batchRunId: "batch-1" },
+        null,
+      );
+
+      expect(res.status).toBe(401);
+      expect(mockBroadcastToTenant).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/browser-tab-handoff.integration.test.ts
@@ -253,7 +253,7 @@ describe("POST /api/scenario-events/browser-tab", () => {
       );
     });
 
-    /** @scenario "The handoff is delivered when a tab is listening" */
+    /** @scenario "A handoff sent while the tab was reloading is not lost" */
     it("parks the run so a tab that was reloading can still claim it", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       await registerTab({ projectId, tabKey });

--- a/langwatch/src/components/suites/ExternalSetDetailPanel.tsx
+++ b/langwatch/src/components/suites/ExternalSetDetailPanel.tsx
@@ -40,6 +40,7 @@ import {
 } from "./RunHistoryFilters";
 import { RunHistorySkeleton } from "./RunHistorySkeleton";
 import { RunRow } from "./RunRow";
+import { ScenarioTabConnectedBadge } from "./ScenarioTabConnectedBadge";
 import { GroupRow } from "./GroupRow";
 import { useRunHistoryStore } from "./useRunHistoryStore";
 import { useSuiteRunFreshness } from "./useSuiteRunFreshness";
@@ -48,6 +49,8 @@ type ExternalSetDetailPanelProps = {
   scenarioSetId: string;
   period: Period;
   highlightBatchId?: string | null;
+  /** True when the SDK opened this tab, so new local runs land here. */
+  connectedToLocalRun?: boolean;
 };
 
 /** Group-by options available for external sets (no target). */
@@ -59,6 +62,7 @@ export function ExternalSetDetailPanel({
   scenarioSetId,
   period,
   highlightBatchId,
+  connectedToLocalRun = false,
 }: ExternalSetDetailPanelProps) {
   const { project } = useOrganizationTeamProject();
   const { openDrawer } = useDrawer();
@@ -232,6 +236,7 @@ export function ExternalSetDetailPanel({
             {scenarioSetId}
           </Text>
         </VStack>
+        <ScenarioTabConnectedBadge visible={connectedToLocalRun} />
       </HStack>
 
       {/* Filter bar — fixed above the scrollable run list */}

--- a/langwatch/src/components/suites/ScenarioTabConnectedBadge.tsx
+++ b/langwatch/src/components/suites/ScenarioTabConnectedBadge.tsx
@@ -1,0 +1,55 @@
+import { Box, HStack, Text } from "@chakra-ui/react";
+import { Tooltip } from "~/components/ui/tooltip";
+
+/**
+ * Quiet marker on the tab the SDK opened: scenario runs started on this machine
+ * land here instead of opening another browser tab. Purely informative, the
+ * steering itself happens through the SSE subscription.
+ */
+export function ScenarioTabConnectedBadge({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+
+  return (
+    <Tooltip
+      showArrow
+      content={
+        <Box maxWidth="280px" data-testid="scenario-tab-connected-popover">
+          <Text fontWeight="medium">Connected to your local runs</Text>
+          <Text marginTop={1}>
+            Scenario runs started on this machine reuse this tab: when a new run
+            starts, this view moves to it instead of opening another browser
+            tab. Closing the tab brings the old behaviour back.
+          </Text>
+        </Box>
+      }
+    >
+      <HStack
+        data-testid="scenario-tab-connected-badge"
+        gap={1.5}
+        paddingX={2.5}
+        paddingY={1}
+        borderRadius="full"
+        borderWidth="1px"
+        borderColor="border.muted"
+        background="bg.subtle"
+        cursor="default"
+      >
+        <Box
+          boxSize={2}
+          borderRadius="full"
+          background="green.500"
+          css={{
+            "@keyframes connected-dot": {
+              "0%, 100%": { boxShadow: "0 0 0 0 var(--chakra-colors-green-300)" },
+              "50%": { boxShadow: "0 0 0 3px transparent" },
+            },
+          }}
+          animation="connected-dot 2.4s ease-in-out infinite"
+        />
+        <Text fontSize="xs" color="fg.muted" whiteSpace="nowrap">
+          Connected to local run
+        </Text>
+      </HStack>
+    </Tooltip>
+  );
+}

--- a/langwatch/src/components/suites/ScenarioTabConnectedBadge.tsx
+++ b/langwatch/src/components/suites/ScenarioTabConnectedBadge.tsx
@@ -18,7 +18,7 @@ export function ScenarioTabConnectedBadge({ visible }: { visible: boolean }) {
           <Text marginTop={1}>
             Scenario runs started on this machine reuse this tab: when a new run
             starts, this view moves to it instead of opening another browser
-            tab. Closing the tab brings the old behaviour back.
+            tab.
           </Text>
         </Box>
       }

--- a/langwatch/src/components/suites/SimulationsPage.tsx
+++ b/langwatch/src/components/suites/SimulationsPage.tsx
@@ -138,27 +138,12 @@ export default function SimulationsPage() {
       if (lastFollowedRef.current === payload.url) return;
       lastFollowedRef.current = payload.url;
 
+      // Silently: the user started the run themselves, the page moving to it
+      // is the expected outcome, not news. The connected badge in the set
+      // header is the only marker that this tab behaves this way.
       void router.push(target.pathname + target.search);
-
-      toaster.create({
-        title: "Following a new run from your terminal",
-        description:
-          "This tab moves to the newest run instead of opening a new one.",
-        type: "info",
-        action: {
-          label: "Stop following",
-          onClick: () => {
-            scenarioTab.stopFollowing();
-            toaster.create({
-              title: "This tab no longer follows new runs",
-              description: "Runs will open a new tab again.",
-              type: "info",
-            });
-          },
-        },
-      });
     },
-    [router, scenarioTab]
+    [router]
   );
 
   useSimulationUpdateListener({
@@ -425,6 +410,7 @@ export default function SimulationsPage() {
                 period={period}
                 suiteNameMap={suiteNameMap}
                 highlightBatchId={highlightBatchId}
+                connectedToLocalRun={!!scenarioTab.tabKey}
               />
             </Box>
           </Box>
@@ -474,6 +460,7 @@ function MainPanel({
   period,
   suiteNameMap,
   highlightBatchId,
+  connectedToLocalRun,
 }: {
   error: { message: string } | null;
   selectedSuiteSlug: string | typeof ALL_RUNS_ID | null;
@@ -488,6 +475,7 @@ function MainPanel({
   period: Period;
   suiteNameMap: Map<string, string>;
   highlightBatchId: string | null;
+  connectedToLocalRun: boolean;
 }) {
   if (error) {
     return (
@@ -510,7 +498,7 @@ function MainPanel({
   }
 
   if (selectedExternalSetId) {
-    return <ExternalSetDetailPanel scenarioSetId={selectedExternalSetId} period={period} highlightBatchId={highlightBatchId} />;
+    return <ExternalSetDetailPanel scenarioSetId={selectedExternalSetId} period={period} highlightBatchId={highlightBatchId} connectedToLocalRun={connectedToLocalRun} />;
   }
 
   if (selectedSuiteSlug === ALL_RUNS_ID) {

--- a/langwatch/src/components/suites/SimulationsPage.tsx
+++ b/langwatch/src/components/suites/SimulationsPage.tsx
@@ -39,7 +39,9 @@ import {
   useSuiteRouting,
 } from "~/components/suites/useSuiteRouting";
 import { toaster } from "~/components/ui/toaster";
+import { useScenarioTabFollow } from "~/hooks/useScenarioTabFollow";
 import { useSimulationUpdateListener } from "~/hooks/useSimulationUpdateListener";
+import type { ScenarioTabNavigatePayload } from "~/server/scenarios/browser-tab/scenario-tab-events";
 import { useDrawer } from "~/hooks/useDrawer";
 import { NowProvider } from "./NowProvider";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -120,6 +122,39 @@ export default function SimulationsPage() {
   // Connect the sidebar-level query to SSE events so new runs appear without
   // waiting for the 30s poll interval. Without this, the SSE listener only
   // lives inside RunHistoryPanel, leaving the sidebar query unreachable.
+  // When the SDK opened this tab, later runs from the same machine are steered
+  // here instead of spawning yet another browser tab.
+  const scenarioTab = useScenarioTabFollow();
+
+  const followRun = useCallback(
+    (payload: ScenarioTabNavigatePayload) => {
+      const target = new URL(payload.url);
+      if (target.origin !== window.location.origin) return;
+      if (target.pathname === window.location.pathname) return;
+
+      void router.push(target.pathname + target.search);
+
+      toaster.create({
+        title: "Following a new run from your terminal",
+        description:
+          "This tab moves to the newest run instead of opening a new one.",
+        type: "info",
+        action: {
+          label: "Stop following",
+          onClick: () => {
+            scenarioTab.stopFollowing();
+            toaster.create({
+              title: "This tab no longer follows new runs",
+              description: "Runs will open a new tab again.",
+              type: "info",
+            });
+          },
+        },
+      });
+    },
+    [router, scenarioTab]
+  );
+
   useSimulationUpdateListener({
     projectId: project?.id ?? "",
     refetch: () => {
@@ -128,6 +163,9 @@ export default function SimulationsPage() {
     },
     enabled: !!project?.id,
     debounceMs: 500,
+    tabKey: scenarioTab.tabKey,
+    tabId: scenarioTab.tabId,
+    onTabNavigate: followRun,
   });
 
   const runSummaries = useMemo(() => {

--- a/langwatch/src/components/suites/SimulationsPage.tsx
+++ b/langwatch/src/components/suites/SimulationsPage.tsx
@@ -16,7 +16,7 @@ import { subDays } from "date-fns";
 import { Plus, TriangleAlert } from "lucide-react";
 import type { SimulationSuite } from "@prisma/client";
 import { useRouter } from "~/utils/compat/next-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { PeriodSelector, usePeriodSelector, type Period } from "~/components/PeriodSelector";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
@@ -125,12 +125,18 @@ export default function SimulationsPage() {
   // When the SDK opened this tab, later runs from the same machine are steered
   // here instead of spawning yet another browser tab.
   const scenarioTab = useScenarioTabFollow();
+  const lastFollowedRef = useRef<string | null>(null);
 
   const followRun = useCallback(
     (payload: ScenarioTabNavigatePayload) => {
       const target = new URL(payload.url);
       if (target.origin !== window.location.origin) return;
       if (target.pathname === window.location.pathname) return;
+      // A handoff is parked as well as broadcast, so a tab that took the live
+      // one and then re-subscribed is offered the same run again. Without this
+      // it would be yanked back to a run the user had already moved on from.
+      if (lastFollowedRef.current === payload.url) return;
+      lastFollowedRef.current = payload.url;
 
       void router.push(target.pathname + target.search);
 

--- a/langwatch/src/components/suites/__tests__/ScenarioTabConnectedBadge.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ScenarioTabConnectedBadge.integration.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers specs/scenarios/scenario-tab-handoff.feature — the connected badge.
+ *
+ * The badge is the only trace the tab-reuse feature leaves in the UI: runs are
+ * followed silently, so this marker is how a user tells the SDK-opened tab
+ * apart from one they opened themselves.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { ScenarioTabConnectedBadge } from "../ScenarioTabConnectedBadge";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<ScenarioTabConnectedBadge/>", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** @scenario "A connected tab quietly shows that it is linked to local runs" */
+  it("says the tab is connected to a local run", () => {
+    render(<ScenarioTabConnectedBadge visible={true} />, { wrapper: Wrapper });
+
+    expect(screen.getByText("Connected to local run")).toBeInTheDocument();
+  });
+
+  /** @scenario "A connected tab quietly shows that it is linked to local runs" */
+  it("explains on hover that new runs will land in this tab", async () => {
+    const user = userEvent.setup();
+    render(<ScenarioTabConnectedBadge visible={true} />, { wrapper: Wrapper });
+
+    await user.hover(screen.getByTestId("scenario-tab-connected-badge"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("scenario-tab-connected-popover"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/this view moves to it instead of opening another/i),
+    ).toBeInTheDocument();
+  });
+
+  /** @scenario "A connected tab quietly shows that it is linked to local runs" */
+  it("renders nothing for a tab the user opened themselves", () => {
+    const { container } = render(<ScenarioTabConnectedBadge visible={false} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/langwatch/src/hooks/__tests__/useScenarioTabFollow.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useScenarioTabFollow.integration.test.tsx
@@ -3,12 +3,11 @@
  *
  * Covers specs/scenarios/scenario-tab-handoff.feature — the tab-identity half.
  *
- * Renders the hook inside a real react-router, with real session and local
- * storage, so the query-param lift, the URL scrub and the opt-out are the
- * behaviours a browser would actually produce.
+ * Renders the hook inside a real react-router, with real session storage, so
+ * the query-param lift and the URL scrub are the behaviours a browser would
+ * actually produce.
  */
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,17 +23,13 @@ vi.mock(
 import { useScenarioTabFollow } from "../useScenarioTabFollow";
 
 function Probe() {
-  const { tabKey, tabId, isDisabled, stopFollowing, resumeFollowing } =
-    useScenarioTabFollow();
+  const { tabKey, tabId } = useScenarioTabFollow();
 
   return (
     <div>
       <span data-testid="tab-key">{tabKey ?? "none"}</span>
       <span data-testid="tab-id">{tabId ? "assigned" : "none"}</span>
-      <span data-testid="disabled">{String(isDisabled)}</span>
       <span data-testid="search">{window.location.search}</span>
-      <button onClick={stopFollowing}>stop</button>
-      <button onClick={resumeFollowing}>resume</button>
     </div>
   );
 }
@@ -132,57 +127,4 @@ describe("useScenarioTabFollow", () => {
     });
   });
 
-  describe("opting out", () => {
-    /** @scenario "The user can stop the tab from following" */
-    it("stops offering the tab and remembers the choice", async () => {
-      const user = userEvent.setup();
-      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
-
-      await waitFor(() =>
-        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
-      );
-
-      await user.click(screen.getByRole("button", { name: "stop" }));
-
-      expect(screen.getByTestId("tab-key")).toHaveTextContent("none");
-      expect(screen.getByTestId("disabled")).toHaveTextContent("true");
-      expect(
-        window.localStorage.getItem("langwatch:scenario-tab-follow-disabled"),
-      ).toBe("true");
-    });
-
-    it("honours a previous opt-out on a freshly opened tab", async () => {
-      window.localStorage.setItem(
-        "langwatch:scenario-tab-follow-disabled",
-        "true",
-      );
-
-      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
-
-      await waitFor(() =>
-        expect(screen.getByTestId("disabled")).toHaveTextContent("true"),
-      );
-      expect(screen.getByTestId("tab-key")).toHaveTextContent("none");
-    });
-
-    it("can be turned back on", async () => {
-      const user = userEvent.setup();
-      window.localStorage.setItem(
-        "langwatch:scenario-tab-follow-disabled",
-        "true",
-      );
-
-      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
-      await waitFor(() =>
-        expect(screen.getByTestId("disabled")).toHaveTextContent("true"),
-      );
-
-      await user.click(screen.getByRole("button", { name: "resume" }));
-
-      expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc");
-      expect(
-        window.localStorage.getItem("langwatch:scenario-tab-follow-disabled"),
-      ).toBeNull();
-    });
-  });
 });

--- a/langwatch/src/hooks/__tests__/useScenarioTabFollow.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useScenarioTabFollow.integration.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers specs/scenarios/scenario-tab-handoff.feature — the tab-identity half.
+ *
+ * Renders the hook inside a real react-router, with real session and local
+ * storage, so the query-param lift, the URL scrub and the opt-out are the
+ * behaviours a browser would actually produce.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The global test-setup.ts stubs the router compat with an empty router. This
+// hook is entirely about lifting a query param out of the URL, so it needs the
+// real compat layer inside a real MemoryRouter.
+vi.unmock("~/utils/compat/next-router");
+vi.mock(
+  "~/utils/compat/next-router",
+  async () => await vi.importActual<object>("~/utils/compat/next-router"),
+);
+
+import { useScenarioTabFollow } from "../useScenarioTabFollow";
+
+function Probe() {
+  const { tabKey, tabId, isDisabled, stopFollowing, resumeFollowing } =
+    useScenarioTabFollow();
+
+  return (
+    <div>
+      <span data-testid="tab-key">{tabKey ?? "none"}</span>
+      <span data-testid="tab-id">{tabId ? "assigned" : "none"}</span>
+      <span data-testid="disabled">{String(isDisabled)}</span>
+      <span data-testid="search">{window.location.search}</span>
+      <button onClick={stopFollowing}>stop</button>
+      <button onClick={resumeFollowing}>resume</button>
+    </div>
+  );
+}
+
+function renderAt(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/:project/simulations/*" element={<Probe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("useScenarioTabFollow", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  describe("when the SDK opened this tab", () => {
+    /** @scenario "A simulations tab opened by the SDK registers itself" */
+    it("adopts the machine key from the query param", async () => {
+      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
+      );
+      expect(screen.getByTestId("tab-id")).toHaveTextContent("assigned");
+    });
+
+    /** @scenario "The scenario tab key survives a reload but never leaks into shared links" */
+    it("keeps the key for this tab only", async () => {
+      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
+
+      await waitFor(() =>
+        expect(
+          window.sessionStorage.getItem("langwatch:scenario-tab-key"),
+        ).toBe("machine-abc"),
+      );
+      expect(
+        window.localStorage.getItem("langwatch:scenario-tab-key"),
+      ).toBeNull();
+    });
+
+    it("recovers the key after a reload, without the query param", async () => {
+      window.sessionStorage.setItem(
+        "langwatch:scenario-tab-key",
+        "machine-abc",
+      );
+
+      renderAt("/acme/simulations/checkout");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
+      );
+    });
+
+    it("keeps the same tab id across re-renders", async () => {
+      const { unmount } = renderAt(
+        "/acme/simulations/checkout?scenarioTab=machine-abc",
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
+      );
+      const first = window.sessionStorage.getItem("langwatch:scenario-tab-id");
+      unmount();
+
+      renderAt("/acme/simulations/checkout");
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
+      );
+
+      expect(window.sessionStorage.getItem("langwatch:scenario-tab-id")).toBe(
+        first,
+      );
+      expect(first).toBeTruthy();
+    });
+  });
+
+  describe("when the user opened the page themselves", () => {
+    /** @scenario "A simulations tab without a scenario tab key never registers" */
+    it("stays anonymous so the SDK never steers it", async () => {
+      renderAt("/acme/simulations/checkout");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("none"),
+      );
+      expect(screen.getByTestId("tab-id")).toHaveTextContent("none");
+    });
+  });
+
+  describe("opting out", () => {
+    /** @scenario "The user can stop the tab from following" */
+    it("stops offering the tab and remembers the choice", async () => {
+      const user = userEvent.setup();
+      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc"),
+      );
+
+      await user.click(screen.getByRole("button", { name: "stop" }));
+
+      expect(screen.getByTestId("tab-key")).toHaveTextContent("none");
+      expect(screen.getByTestId("disabled")).toHaveTextContent("true");
+      expect(
+        window.localStorage.getItem("langwatch:scenario-tab-follow-disabled"),
+      ).toBe("true");
+    });
+
+    it("honours a previous opt-out on a freshly opened tab", async () => {
+      window.localStorage.setItem(
+        "langwatch:scenario-tab-follow-disabled",
+        "true",
+      );
+
+      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("disabled")).toHaveTextContent("true"),
+      );
+      expect(screen.getByTestId("tab-key")).toHaveTextContent("none");
+    });
+
+    it("can be turned back on", async () => {
+      const user = userEvent.setup();
+      window.localStorage.setItem(
+        "langwatch:scenario-tab-follow-disabled",
+        "true",
+      );
+
+      renderAt("/acme/simulations/checkout?scenarioTab=machine-abc");
+      await waitFor(() =>
+        expect(screen.getByTestId("disabled")).toHaveTextContent("true"),
+      );
+
+      await user.click(screen.getByRole("button", { name: "resume" }));
+
+      expect(screen.getByTestId("tab-key")).toHaveTextContent("machine-abc");
+      expect(
+        window.localStorage.getItem("langwatch:scenario-tab-follow-disabled"),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
@@ -6,14 +6,16 @@ import { renderHook, act } from "@testing-library/react";
 
 // Capture the onData callback from useSSESubscription
 let capturedOnData: ((data: { event: string }) => void) | undefined;
+let capturedInput: Record<string, unknown> | undefined;
 
 vi.mock("../useSSESubscription", () => ({
   useSSESubscription: (
     _subscription: unknown,
-    _input: unknown,
+    input: Record<string, unknown>,
     options: { onData?: (data: { event: string }) => void },
   ) => {
     capturedOnData = options.onData;
+    capturedInput = input;
     return {
       connectionState: "connected",
       isConnected: true,
@@ -73,6 +75,7 @@ describe("useSimulationUpdateListener()", () => {
     refetchSpy = vi.fn<() => void>();
     mockIsVisible = true;
     capturedOnData = undefined;
+    capturedInput = undefined;
   });
 
   afterEach(() => {
@@ -405,6 +408,125 @@ describe("useSimulationUpdateListener()", () => {
 
         expect(onNewBatchRun).toHaveBeenCalledTimes(502);
       });
+    });
+  });
+  describe("browser tab handoff", () => {
+    const navigatePayload = (tabKey: string) => ({
+      event: "scenario_tab_navigate",
+      tabKey,
+      url: "https://app.langwatch.ai/acme/simulations/checkout/batch-9",
+    });
+
+    /** @scenario "A simulations tab opened by the SDK registers itself" */
+    it("offers this tab to the SDK when it carries a machine key", () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          tabKey: "machine-abc",
+          tabId: "tab-1",
+        }),
+      );
+
+      expect(capturedInput).toEqual({
+        projectId: "proj_1",
+        tabKey: "machine-abc",
+        tabId: "tab-1",
+      });
+    });
+
+    /** @scenario "A simulations tab without a scenario tab key never registers" */
+    it("stays anonymous without a machine key", () => {
+      renderHook(() => useSimulationUpdateListener({ projectId: "proj_1" }));
+
+      expect(capturedInput).toEqual({ projectId: "proj_1" });
+    });
+
+    /** @scenario "The registered tab navigates to the handed-off run" */
+    it("follows a run handed to this machine", () => {
+      const onTabNavigate = vi.fn();
+
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          tabKey: "machine-abc",
+          tabId: "tab-1",
+          onTabNavigate,
+        }),
+      );
+
+      act(() => {
+        capturedOnData?.({
+          event: JSON.stringify(navigatePayload("machine-abc")),
+        });
+      });
+
+      expect(onTabNavigate).toHaveBeenCalledWith(
+        navigatePayload("machine-abc"),
+      );
+    });
+
+    /** @scenario "A navigate payload for another machine is ignored" */
+    it("ignores a run handed to a different machine", () => {
+      const onTabNavigate = vi.fn();
+
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          tabKey: "machine-abc",
+          tabId: "tab-1",
+          onTabNavigate,
+        }),
+      );
+
+      act(() => {
+        capturedOnData?.({
+          event: JSON.stringify(navigatePayload("machine-xyz")),
+        });
+      });
+
+      expect(onTabNavigate).not.toHaveBeenCalled();
+    });
+
+    it("ignores handoffs entirely on a tab with no machine key", () => {
+      const onTabNavigate = vi.fn();
+
+      renderHook(() =>
+        useSimulationUpdateListener({ projectId: "proj_1", onTabNavigate }),
+      );
+
+      act(() => {
+        capturedOnData?.({
+          event: JSON.stringify(navigatePayload("machine-abc")),
+        });
+      });
+
+      expect(onTabNavigate).not.toHaveBeenCalled();
+    });
+
+    it("does not mistake a handoff for run data", () => {
+      const onNewBatchRun = vi.fn();
+      const refetch = vi.fn();
+
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch,
+          onNewBatchRun,
+          debounceMs: 0,
+          tabKey: "machine-abc",
+          tabId: "tab-1",
+          onTabNavigate: vi.fn(),
+        }),
+      );
+
+      act(() => {
+        capturedOnData?.({
+          event: JSON.stringify(navigatePayload("machine-abc")),
+        });
+      });
+
+      expect(onNewBatchRun).not.toHaveBeenCalled();
+      expect(refetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/hooks/useScenarioTabFollow.ts
+++ b/langwatch/src/hooks/useScenarioTabFollow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SCENARIO_TAB_QUERY_PARAM } from "~/server/scenarios/browser-tab/scenario-tab-events";
 import { useRouter } from "~/utils/compat/next-router";
 
@@ -9,9 +9,6 @@ import { useRouter } from "~/utils/compat/next-router";
  */
 const SESSION_KEY = "langwatch:scenario-tab-key";
 const SESSION_TAB_ID_KEY = "langwatch:scenario-tab-id";
-
-/** Opt-out, deliberately browser-wide and durable across reloads. */
-const OPT_OUT_KEY = "langwatch:scenario-tab-follow-disabled";
 
 function readSession(key: string): string | null {
   try {
@@ -29,14 +26,6 @@ function writeSession({ key, value }: { key: string; value: string }): void {
   }
 }
 
-function readOptOut(): boolean {
-  try {
-    return window.localStorage.getItem(OPT_OUT_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
 function randomTabId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
@@ -49,10 +38,6 @@ export interface ScenarioTabFollowState {
   tabKey: string | null;
   /** Identifies this tab within the machine key, so siblings don't collide. */
   tabId: string | null;
-  /** True once the user asked this browser to stop following. */
-  isDisabled: boolean;
-  stopFollowing: () => void;
-  resumeFollowing: () => void;
 }
 
 /**
@@ -67,12 +52,6 @@ export function useScenarioTabFollow(): ScenarioTabFollowState {
   const router = useRouter();
   const [tabKey, setTabKey] = useState<string | null>(null);
   const [tabId, setTabId] = useState<string | null>(null);
-  const [isDisabled, setIsDisabled] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    setIsDisabled(readOptOut());
-  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || !router.isReady) return;
@@ -104,32 +83,5 @@ export function useScenarioTabFollow(): ScenarioTabFollowState {
     setTabId(resolvedTabId);
   }, [router.isReady, router.query]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const stopFollowing = useCallback(() => {
-    try {
-      window.localStorage.setItem(OPT_OUT_KEY, "true");
-    } catch {
-      // Best effort: the in-memory flag below still takes this tab out.
-    }
-    setIsDisabled(true);
-  }, []);
-
-  const resumeFollowing = useCallback(() => {
-    try {
-      window.localStorage.removeItem(OPT_OUT_KEY);
-    } catch {
-      // Best effort.
-    }
-    setIsDisabled(false);
-  }, []);
-
-  return useMemo(
-    () => ({
-      tabKey: isDisabled ? null : tabKey,
-      tabId: isDisabled ? null : tabId,
-      isDisabled,
-      stopFollowing,
-      resumeFollowing,
-    }),
-    [isDisabled, resumeFollowing, stopFollowing, tabId, tabKey],
-  );
+  return useMemo(() => ({ tabKey, tabId }), [tabId, tabKey]);
 }

--- a/langwatch/src/hooks/useScenarioTabFollow.ts
+++ b/langwatch/src/hooks/useScenarioTabFollow.ts
@@ -108,7 +108,7 @@ export function useScenarioTabFollow(): ScenarioTabFollowState {
     try {
       window.localStorage.setItem(OPT_OUT_KEY, "true");
     } catch {
-      // Best effort — the in-memory flag below still takes this tab out.
+      // Best effort: the in-memory flag below still takes this tab out.
     }
     setIsDisabled(true);
   }, []);

--- a/langwatch/src/hooks/useScenarioTabFollow.ts
+++ b/langwatch/src/hooks/useScenarioTabFollow.ts
@@ -21,7 +21,7 @@ function readSession(key: string): string | null {
   }
 }
 
-function writeSession(key: string, value: string): void {
+function writeSession({ key, value }: { key: string; value: string }): void {
   try {
     window.sessionStorage.setItem(key, value);
   } catch {
@@ -81,7 +81,7 @@ export function useScenarioTabFollow(): ScenarioTabFollowState {
     const queryKey = Array.isArray(fromQuery) ? fromQuery[0] : fromQuery;
 
     if (queryKey) {
-      writeSession(SESSION_KEY, queryKey);
+      writeSession({ key: SESSION_KEY, value: queryKey });
 
       // Drop the param so the visible URL stays shareable. Shallow: this is a
       // cosmetic rewrite, not a navigation.
@@ -97,7 +97,7 @@ export function useScenarioTabFollow(): ScenarioTabFollowState {
     let resolvedTabId = readSession(SESSION_TAB_ID_KEY);
     if (!resolvedTabId) {
       resolvedTabId = randomTabId();
-      writeSession(SESSION_TAB_ID_KEY, resolvedTabId);
+      writeSession({ key: SESSION_TAB_ID_KEY, value: resolvedTabId });
     }
 
     setTabKey(resolvedKey);

--- a/langwatch/src/hooks/useScenarioTabFollow.ts
+++ b/langwatch/src/hooks/useScenarioTabFollow.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SCENARIO_TAB_QUERY_PARAM } from "~/server/scenarios/browser-tab/scenario-tab-events";
+import { useRouter } from "~/utils/compat/next-router";
+
+/**
+ * Session key holding the scenario tab key for this tab only. Session storage
+ * rather than local storage on purpose: the registration belongs to the tab the
+ * SDK opened, not to every tab in the browser.
+ */
+const SESSION_KEY = "langwatch:scenario-tab-key";
+const SESSION_TAB_ID_KEY = "langwatch:scenario-tab-id";
+
+/** Opt-out, deliberately browser-wide and durable across reloads. */
+const OPT_OUT_KEY = "langwatch:scenario-tab-follow-disabled";
+
+function readSession(key: string): string | null {
+  try {
+    return window.sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(key: string, value: string): void {
+  try {
+    window.sessionStorage.setItem(key, value);
+  } catch {
+    // Private mode or a storage-less embed: the tab simply won't be reusable.
+  }
+}
+
+function readOptOut(): boolean {
+  try {
+    return window.localStorage.getItem(OPT_OUT_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function randomTabId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export interface ScenarioTabFollowState {
+  /** Machine key this tab answers for, or null when it is not a reusable tab. */
+  tabKey: string | null;
+  /** Identifies this tab within the machine key, so siblings don't collide. */
+  tabId: string | null;
+  /** True once the user asked this browser to stop following. */
+  isDisabled: boolean;
+  stopFollowing: () => void;
+  resumeFollowing: () => void;
+}
+
+/**
+ * Makes the current simulations tab the one the SDK reuses.
+ *
+ * The SDK stamps `?scenarioTab=<key>` on the tab it opens; that key is lifted
+ * into session storage and scrubbed from the address bar so a copied link never
+ * carries another machine's key. Callers feed the returned ids into the
+ * simulation SSE subscription, which is what actually registers the tab.
+ */
+export function useScenarioTabFollow(): ScenarioTabFollowState {
+  const router = useRouter();
+  const [tabKey, setTabKey] = useState<string | null>(null);
+  const [tabId, setTabId] = useState<string | null>(null);
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setIsDisabled(readOptOut());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !router.isReady) return;
+
+    const fromQuery = router.query[SCENARIO_TAB_QUERY_PARAM];
+    const queryKey = Array.isArray(fromQuery) ? fromQuery[0] : fromQuery;
+
+    if (queryKey) {
+      writeSession(SESSION_KEY, queryKey);
+
+      // Drop the param so the visible URL stays shareable. Shallow: this is a
+      // cosmetic rewrite, not a navigation.
+      const { [SCENARIO_TAB_QUERY_PARAM]: _dropped, ...rest } = router.query;
+      void router.replace({ pathname: router.pathname, query: rest }, void 0, {
+        shallow: true,
+      });
+    }
+
+    const resolvedKey = queryKey ?? readSession(SESSION_KEY);
+    if (!resolvedKey) return;
+
+    let resolvedTabId = readSession(SESSION_TAB_ID_KEY);
+    if (!resolvedTabId) {
+      resolvedTabId = randomTabId();
+      writeSession(SESSION_TAB_ID_KEY, resolvedTabId);
+    }
+
+    setTabKey(resolvedKey);
+    setTabId(resolvedTabId);
+  }, [router.isReady, router.query]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const stopFollowing = useCallback(() => {
+    try {
+      window.localStorage.setItem(OPT_OUT_KEY, "true");
+    } catch {
+      // Best effort — the in-memory flag below still takes this tab out.
+    }
+    setIsDisabled(true);
+  }, []);
+
+  const resumeFollowing = useCallback(() => {
+    try {
+      window.localStorage.removeItem(OPT_OUT_KEY);
+    } catch {
+      // Best effort.
+    }
+    setIsDisabled(false);
+  }, []);
+
+  return useMemo(
+    () => ({
+      tabKey: isDisabled ? null : tabKey,
+      tabId: isDisabled ? null : tabId,
+      isDisabled,
+      stopFollowing,
+      resumeFollowing,
+    }),
+    [isDisabled, resumeFollowing, stopFollowing, tabId, tabKey],
+  );
+}

--- a/langwatch/src/hooks/useSimulationUpdateListener.ts
+++ b/langwatch/src/hooks/useSimulationUpdateListener.ts
@@ -1,5 +1,9 @@
 import { createLogger } from "@langwatch/observability";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  isScenarioTabNavigatePayload,
+  type ScenarioTabNavigatePayload,
+} from "~/server/scenarios/browser-tab/scenario-tab-events";
 import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
 import { api } from "~/utils/api";
 import {
@@ -29,6 +33,14 @@ interface UseSimulationUpdateListenerOptions {
   filter?: SimulationUpdateFilter;
   onNewBatchRun?: (batchRunId: string) => void;
   onStreamingEvent?: (payload: CompactStreamingEvent) => void;
+  /**
+   * Registers this tab as reusable for the given machine key while the
+   * subscription is open. Only the page-level listener should pass these —
+   * they are what lets the SDK skip opening another browser tab.
+   */
+  tabKey?: string | null;
+  tabId?: string | null;
+  onTabNavigate?: (payload: ScenarioTabNavigatePayload) => void;
 }
 
 export interface SimulationBroadcastPayload {
@@ -47,6 +59,9 @@ export function useSimulationUpdateListener({
   filter,
   onNewBatchRun,
   onStreamingEvent,
+  tabKey,
+  tabId,
+  onTabNavigate,
 }: UseSimulationUpdateListenerOptions) {
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastFireRef = useRef<number>(0);
@@ -108,13 +123,18 @@ export function useSimulationUpdateListener({
     };
   }, []);
 
+  const subscriptionInput = useMemo(
+    () => (tabKey && tabId ? { projectId, tabKey, tabId } : { projectId }),
+    [projectId, tabId, tabKey],
+  );
+
   const subscription = useSSESubscription<
     { event: string; timestamp: number },
-    { projectId: string }
+    { projectId: string; tabKey?: string; tabId?: string }
   >(
     // @ts-expect-error - tRPC subscription type is not compatible with the useSSESubscription hook
     api.scenarios.onSimulationUpdate,
-    { projectId },
+    subscriptionInput,
     {
       enabled: Boolean(enabled && projectId),
       onData: (data) => {
@@ -123,6 +143,15 @@ export function useSimulationUpdateListener({
         try {
           const parsed =
             typeof data.event === "string" ? JSON.parse(data.event) : data.event;
+
+          // Tab handoffs address a machine, not a run, so they are matched on
+          // the tab key alone and never against the run/batch filter below.
+          if (isScenarioTabNavigatePayload(parsed)) {
+            if (onTabNavigate && tabKey && parsed.tabKey === tabKey) {
+              onTabNavigate(parsed);
+            }
+            return;
+          }
 
           // Compact streaming events: { e: "S"|"C"|"E", r, b, m, ... }
           if (isCompactStreamingEvent(parsed)) {

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -464,8 +464,8 @@ export const scenarioEventsRouter = createTRPCRouter({
       // this generator suspended, its emitter listener attached, and its tab
       // registered forever.
       const signal =
-        (opts.ctx as { signal?: AbortSignal }).signal ??
-        // @ts-expect-error - signal is not typed
+        opts.ctx.signal ??
+        // @ts-expect-error - tRPC v10 does not type `signal` on procedure opts
         (opts.signal as AbortSignal | undefined);
 
       try {

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -4,14 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
-import {
-  SCENARIO_TAB_NAVIGATE_EVENT,
-  type ScenarioTabNavigatePayload,
-} from "~/server/scenarios/browser-tab/scenario-tab-events";
-import {
-  SCENARIO_TAB_REFRESH_MS,
-  scenarioTabRegistry,
-} from "~/server/scenarios/browser-tab/scenario-tab-registry";
+import { startScenarioTabPresence } from "~/server/scenarios/browser-tab/scenario-tab-presence";
 import type {
   BatchRunDataResult,
   ScenarioRunData,
@@ -428,35 +421,18 @@ export const scenarioEventsRouter = createTRPCRouter({
 
       logger.info({ projectId }, "Simulation SSE subscription started");
 
-      // Refreshed from the server rather than the browser: a background tab's
-      // timers get throttled to once a minute, which would expire presence on
-      // exactly the tab this feature exists to reuse.
-      const tabRegistration =
-        tabKey && tabId ? { projectId, tabKey, tabId } : null;
-      let refreshTimer: ReturnType<typeof setInterval> | null = null;
+      const presence =
+        tabKey && tabId
+          ? await startScenarioTabPresence({ projectId, tabKey, tabId })
+          : null;
 
-      if (tabRegistration) {
-        await scenarioTabRegistry.register(tabRegistration);
-        refreshTimer = setInterval(() => {
-          void scenarioTabRegistry.register(tabRegistration);
-        }, SCENARIO_TAB_REFRESH_MS);
-
-        // A handoff broadcast while this tab was reloading would have been
-        // lost, even though the SDK was told it was delivered. Claim it now.
-        const pending = await scenarioTabRegistry.takePendingNavigate({
-          projectId,
-          tabKey: tabRegistration.tabKey,
-        });
-        if (pending) {
-          const payload: ScenarioTabNavigatePayload = {
-            event: SCENARIO_TAB_NAVIGATE_EVENT,
-            tabKey: tabRegistration.tabKey,
-            url: pending,
-          };
-          // Same envelope the broadcast path emits, so the client has one
-          // shape to parse.
-          yield { event: JSON.stringify(payload), timestamp: Date.now() };
-        }
+      if (presence?.parkedNavigate) {
+        // Same envelope the broadcast path emits, so the client has one shape
+        // to parse.
+        yield {
+          event: JSON.stringify(presence.parkedNavigate),
+          timestamp: Date.now(),
+        };
       }
 
       // tRPC v10 callers leave `opts.signal` undefined, so the request's own
@@ -483,10 +459,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         // subscription, not something to surface as a stream error.
         if ((error as { name?: string })?.name !== "AbortError") throw error;
       } finally {
-        if (refreshTimer) clearInterval(refreshTimer);
-        if (tabRegistration) {
-          await scenarioTabRegistry.unregister(tabRegistration);
-        }
+        await presence?.stop();
       }
     }),
 });

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -4,6 +4,10 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
+import {
+  SCENARIO_TAB_REFRESH_MS,
+  scenarioTabRegistry,
+} from "~/server/scenarios/browser-tab/scenario-tab-registry";
 import type {
   BatchRunDataResult,
   ScenarioRunData,
@@ -403,23 +407,53 @@ export const scenarioEventsRouter = createTRPCRouter({
     }),
 
   onSimulationUpdate: protectedProcedure
-    .input(z.object({ projectId: z.string() }))
+    .input(
+      z.object({
+        projectId: z.string(),
+        // Present only on a tab the SDK opened. While the subscription lives,
+        // that tab is offered runs started on the same machine instead of the
+        // SDK opening yet another browser tab.
+        tabKey: z.string().min(1).max(200).optional(),
+        tabId: z.string().min(1).max(200).optional(),
+      }),
+    )
     .use(checkProjectPermission("scenarios:view"))
     .subscription(async function* (opts) {
-      const { projectId } = opts.input;
+      const { projectId, tabKey, tabId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);
 
       logger.info({ projectId }, "Simulation SSE subscription started");
 
-      for await (const eventArgs of on(emitter, "simulation_updated", {
-        // @ts-expect-error - signal is not typed
-        signal: opts.signal,
-      })) {
-        logger.debug(
-          { projectId, event: eventArgs[0] },
-          "Simulation SSE event received",
-        );
-        yield eventArgs[0];
+      // Refreshed from the server rather than the browser: a background tab's
+      // timers get throttled to once a minute, which would expire presence on
+      // exactly the tab this feature exists to reuse.
+      const tabRegistration =
+        tabKey && tabId ? { projectId, tabKey, tabId } : null;
+      let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+      if (tabRegistration) {
+        await scenarioTabRegistry.register(tabRegistration);
+        refreshTimer = setInterval(() => {
+          void scenarioTabRegistry.register(tabRegistration);
+        }, SCENARIO_TAB_REFRESH_MS);
+      }
+
+      try {
+        for await (const eventArgs of on(emitter, "simulation_updated", {
+          // @ts-expect-error - signal is not typed
+          signal: opts.signal,
+        })) {
+          logger.debug(
+            { projectId, event: eventArgs[0] },
+            "Simulation SSE event received",
+          );
+          yield eventArgs[0];
+        }
+      } finally {
+        if (refreshTimer) clearInterval(refreshTimer);
+        if (tabRegistration) {
+          await scenarioTabRegistry.unregister(tabRegistration);
+        }
       }
     }),
 });

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -5,6 +5,10 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import {
+  SCENARIO_TAB_NAVIGATE_EVENT,
+  type ScenarioTabNavigatePayload,
+} from "~/server/scenarios/browser-tab/scenario-tab-events";
+import {
   SCENARIO_TAB_REFRESH_MS,
   scenarioTabRegistry,
 } from "~/server/scenarios/browser-tab/scenario-tab-registry";
@@ -436,12 +440,37 @@ export const scenarioEventsRouter = createTRPCRouter({
         refreshTimer = setInterval(() => {
           void scenarioTabRegistry.register(tabRegistration);
         }, SCENARIO_TAB_REFRESH_MS);
+
+        // A handoff broadcast while this tab was reloading would have been
+        // lost, even though the SDK was told it was delivered. Claim it now.
+        const pending = await scenarioTabRegistry.takePendingNavigate({
+          projectId,
+          tabKey: tabRegistration.tabKey,
+        });
+        if (pending) {
+          const payload: ScenarioTabNavigatePayload = {
+            event: SCENARIO_TAB_NAVIGATE_EVENT,
+            tabKey: tabRegistration.tabKey,
+            url: pending,
+          };
+          // Same envelope the broadcast path emits, so the client has one
+          // shape to parse.
+          yield { event: JSON.stringify(payload), timestamp: Date.now() };
+        }
       }
+
+      // tRPC v10 callers leave `opts.signal` undefined, so the request's own
+      // signal rides in on the context. Without it a disconnected client keeps
+      // this generator suspended, its emitter listener attached, and its tab
+      // registered forever.
+      const signal =
+        (opts.ctx as { signal?: AbortSignal }).signal ??
+        // @ts-expect-error - signal is not typed
+        (opts.signal as AbortSignal | undefined);
 
       try {
         for await (const eventArgs of on(emitter, "simulation_updated", {
-          // @ts-expect-error - signal is not typed
-          signal: opts.signal,
+          signal,
         })) {
           logger.debug(
             { projectId, event: eventArgs[0] },
@@ -449,6 +478,10 @@ export const scenarioEventsRouter = createTRPCRouter({
           );
           yield eventArgs[0];
         }
+      } catch (error) {
+        // A disconnect aborts the wait; that is the normal end of a
+        // subscription, not something to surface as a stream error.
+        if ((error as { name?: string })?.name !== "AbortError") throw error;
       } finally {
         if (refreshTimer) clearInterval(refreshTimer);
         if (tabRegistration) {

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -70,6 +70,14 @@ interface CreateContextOptions {
   publiclyShared?: boolean;
   organizationRole?: OrganizationUserRole | null;
   opsScope?: OpsScope;
+  /**
+   * Aborts when the client goes away. Long-lived subscriptions must pass this
+   * to whatever they wait on, otherwise a disconnected client leaves the
+   * generator suspended forever: tRPC v10 callers do not populate
+   * `opts.signal`, and the SSE transport cannot interrupt a pending `await`
+   * from the outside.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -92,6 +100,7 @@ export const createInnerTRPCContext = (opts: CreateContextOptions) => {
     publiclyShared: opts.publiclyShared ?? false,
     organizationRole: opts.organizationRole ?? undefined,
     opsScope: opts.opsScope,
+    signal: opts.signal,
   };
 };
 

--- a/langwatch/src/server/routes/sse.ts
+++ b/langwatch/src/server/routes/sse.ts
@@ -151,6 +151,12 @@ secured.access(
     session,
     permissionChecked: false,
     publiclyShared: false,
+    // Subscriptions await an event that may never come; without this they stay
+    // suspended after the browser is gone, holding their emitter listener and
+    // skipping their own cleanup. Closing the stream cannot interrupt a
+    // pending `await` from the outside, so the signal has to reach the
+    // procedure itself.
+    signal: raw.signal,
   });
 
   // Create caller and resolve the procedure

--- a/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
+++ b/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
@@ -82,6 +82,7 @@ describe("scenarioTabRegistry", () => {
     expect(ttl).toBeLessThanOrEqual(SCENARIO_TAB_TTL_SECONDS);
   });
 
+  /** @scenario "Presence is refreshed while the subscription stays open" */
   it("re-registering pushes the TTL back out", async () => {
     const tabKey = `tab-${nanoid(8)}`;
     const key = track(projectId, tabKey);
@@ -101,6 +102,7 @@ describe("scenarioTabRegistry", () => {
      * this feature does to it on purpose. Retiring instantly would make the run
      * right after a followed run open a new tab.
      */
+    /** @scenario "A tab that is only reconnecting keeps its place" */
     it("keeps the tab claimable for the grace window", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       track(projectId, tabKey);
@@ -124,6 +126,7 @@ describe("scenarioTabRegistry", () => {
       ).resolves.toBe(true);
     });
 
+    /** @scenario "A tab that really went away stops taking runs" */
     it("stops claiming runs once the grace window passes", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       track(projectId, tabKey);
@@ -274,6 +277,7 @@ describe("scenarioTabRegistry", () => {
      * Broadcasts are fire-and-forget: a tab that is mid-reload when one goes
      * out would miss a run the SDK was already told had been delivered.
      */
+    /** @scenario "A handoff sent while the tab was reloading is not lost" */
     it("hands a parked run to the next subscription", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${tabKey}`);

--- a/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
+++ b/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
@@ -13,6 +13,8 @@ import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { connection } from "~/server/redis";
 import {
+  SCENARIO_TAB_DISCONNECT_GRACE_SECONDS,
+  SCENARIO_TAB_PENDING_TTL_SECONDS,
   SCENARIO_TAB_TTL_SECONDS,
   scenarioTabRegistry,
 } from "../scenario-tab-registry";
@@ -25,6 +27,7 @@ function keyFor(project: string, tabKey: string): string {
 }
 
 const writtenKeys: string[] = [];
+const pendingKeys: string[] = [];
 
 function track(project: string, tabKey: string): string {
   const key = keyFor(project, tabKey);
@@ -41,8 +44,9 @@ beforeAll(() => {
 });
 
 afterAll(async () => {
-  if (connection && writtenKeys.length > 0) {
-    await connection.del(...writtenKeys);
+  const keys = [...writtenKeys, ...pendingKeys];
+  if (connection && keys.length > 0) {
+    await connection.del(...keys);
   }
 });
 
@@ -91,16 +95,112 @@ describe("scenarioTabRegistry", () => {
     expect(await connection!.ttl(key)).toBeGreaterThan(2);
   });
 
-  it("drops the tab as soon as it unregisters", async () => {
-    const tabKey = `tab-${nanoid(8)}`;
-    track(projectId, tabKey);
+  describe("when a subscription ends", () => {
+    /**
+     * A tab drops its subscription every time it routes to another run — which
+     * this feature does to it on purpose. Retiring instantly would make the run
+     * right after a followed run open a new tab.
+     */
+    it("keeps the tab claimable for the grace window", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      track(projectId, tabKey);
+      const now = Date.now();
 
-    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
-    await scenarioTabRegistry.unregister({ projectId, tabKey, tabId: "tab-a" });
+      await scenarioTabRegistry.register({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+      await scenarioTabRegistry.unregister({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
 
-    await expect(
-      scenarioTabRegistry.hasLiveTab({ projectId, tabKey }),
-    ).resolves.toBe(false);
+      await expect(
+        scenarioTabRegistry.hasLiveTab({ projectId, tabKey, now: now + 1000 }),
+      ).resolves.toBe(true);
+    });
+
+    it("stops claiming runs once the grace window passes", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      track(projectId, tabKey);
+      const now = Date.now();
+
+      await scenarioTabRegistry.register({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+      await scenarioTabRegistry.unregister({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+
+      await expect(
+        scenarioTabRegistry.hasLiveTab({
+          projectId,
+          tabKey,
+          now: now + (SCENARIO_TAB_DISCONNECT_GRACE_SECONDS + 1) * 1000,
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it("restores the tab outright when it reconnects inside the window", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      track(projectId, tabKey);
+      const now = Date.now();
+
+      await scenarioTabRegistry.register({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+      await scenarioTabRegistry.unregister({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+      await scenarioTabRegistry.register({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now: now + 2000,
+      });
+
+      await expect(
+        scenarioTabRegistry.hasLiveTab({
+          projectId,
+          tabKey,
+          now: now + (SCENARIO_TAB_DISCONNECT_GRACE_SECONDS + 2) * 1000,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it("never resurrects a tab that already aged out", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      track(projectId, tabKey);
+      const now = Date.now();
+
+      // Nothing was ever registered under this id.
+      await scenarioTabRegistry.unregister({
+        projectId,
+        tabKey,
+        tabId: "never-seen",
+        now,
+      });
+
+      await expect(
+        scenarioTabRegistry.hasLiveTab({ projectId, tabKey, now }),
+      ).resolves.toBe(false);
+    });
   });
 
   it("keeps the machine reusable while a sibling tab is still open", async () => {
@@ -167,5 +267,74 @@ describe("scenarioTabRegistry", () => {
     await expect(
       scenarioTabRegistry.hasLiveTab({ projectId, tabKey: theirs }),
     ).resolves.toBe(false);
+  });
+
+  describe("parked handoffs", () => {
+    /**
+     * Broadcasts are fire-and-forget: a tab that is mid-reload when one goes
+     * out would miss a run the SDK was already told had been delivered.
+     */
+    it("hands a parked run to the next subscription", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${tabKey}`);
+
+      await scenarioTabRegistry.setPendingNavigate({
+        projectId,
+        tabKey,
+        url: "https://app.langwatch.test/p/simulations/s/batch-1",
+      });
+
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey }),
+      ).resolves.toBe("https://app.langwatch.test/p/simulations/s/batch-1");
+    });
+
+    it("hands it over only once", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${tabKey}`);
+
+      await scenarioTabRegistry.setPendingNavigate({
+        projectId,
+        tabKey,
+        url: "https://app.langwatch.test/p/simulations/s/batch-1",
+      });
+      await scenarioTabRegistry.takePendingNavigate({ projectId, tabKey });
+
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey }),
+      ).resolves.toBeNull();
+    });
+
+    it("gives a tab that opens much later nothing to jump to", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      const key = `scenario_tab:v1:pending:${projectId}:${tabKey}`;
+      pendingKeys.push(key);
+
+      await scenarioTabRegistry.setPendingNavigate({
+        projectId,
+        tabKey,
+        url: "https://app.langwatch.test/p/simulations/s/batch-1",
+      });
+
+      const ttl = await connection!.ttl(key);
+      expect(ttl).toBeGreaterThan(0);
+      expect(ttl).toBeLessThanOrEqual(SCENARIO_TAB_PENDING_TTL_SECONDS);
+    });
+
+    it("keeps parked handoffs apart per machine", async () => {
+      const mine = `tab-${nanoid(8)}`;
+      const theirs = `tab-${nanoid(8)}`;
+      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${mine}`);
+
+      await scenarioTabRegistry.setPendingNavigate({
+        projectId,
+        tabKey: mine,
+        url: "https://app.langwatch.test/p/simulations/s/batch-1",
+      });
+
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey: theirs }),
+      ).resolves.toBeNull();
+    });
   });
 });

--- a/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
+++ b/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
@@ -52,6 +52,15 @@ afterAll(async () => {
 });
 
 describe("scenarioTabRegistry", () => {
+  it("keeps the disconnect grace inside the presence TTL", () => {
+    // `unregister` retires a tab by ageing its score by the difference between
+    // these two, so a grace at or above the TTL would extend a tab's life
+    // instead of ending it, and a closed tab would keep taking runs.
+    expect(SCENARIO_TAB_DISCONNECT_GRACE_SECONDS).toBeLessThan(
+      SCENARIO_TAB_TTL_SECONDS,
+    );
+  });
+
   it("reports no live tab before anything registers", async () => {
     const tabKey = `tab-${nanoid(8)}`;
     track(projectId, tabKey);

--- a/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
+++ b/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Scenario tab presence, against real Redis.
+ *
+ * Covers specs/scenarios/scenario-tab-handoff.feature — the presence half. No
+ * fakes: the registry writes to the same Redis the app uses, so TTLs, sorted
+ * set semantics and key scoping are the real ones.
+ */
+
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { connection } from "~/server/redis";
+import {
+  SCENARIO_TAB_TTL_SECONDS,
+  scenarioTabRegistry,
+} from "../scenario-tab-registry";
+
+const projectId = `proj-${nanoid(8)}`;
+const otherProjectId = `proj-${nanoid(8)}`;
+
+function keyFor(project: string, tabKey: string): string {
+  return `scenario_tab:v1:${project}:${tabKey}`;
+}
+
+const writtenKeys: string[] = [];
+
+function track(project: string, tabKey: string): string {
+  const key = keyFor(project, tabKey);
+  writtenKeys.push(key);
+  return key;
+}
+
+beforeAll(() => {
+  if (!connection) {
+    throw new Error(
+      "These tests need a real Redis; run them through the integration suite",
+    );
+  }
+});
+
+afterAll(async () => {
+  if (connection && writtenKeys.length > 0) {
+    await connection.del(...writtenKeys);
+  }
+});
+
+describe("scenarioTabRegistry", () => {
+  it("reports no live tab before anything registers", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId, tabKey }),
+    ).resolves.toBe(false);
+  });
+
+  it("reports a live tab once one registers", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId, tabKey }),
+    ).resolves.toBe(true);
+  });
+
+  it("gives the registration a TTL so a dead browser expires on its own", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    const key = track(projectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+
+    const ttl = await connection!.ttl(key);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(SCENARIO_TAB_TTL_SECONDS);
+  });
+
+  it("re-registering pushes the TTL back out", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    const key = track(projectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+    await connection!.expire(key, 2);
+    expect(await connection!.ttl(key)).toBeLessThanOrEqual(2);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+
+    expect(await connection!.ttl(key)).toBeGreaterThan(2);
+  });
+
+  it("drops the tab as soon as it unregisters", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+    await scenarioTabRegistry.unregister({ projectId, tabKey, tabId: "tab-a" });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId, tabKey }),
+    ).resolves.toBe(false);
+  });
+
+  it("keeps the machine reusable while a sibling tab is still open", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-b" });
+
+    await scenarioTabRegistry.unregister({ projectId, tabKey, tabId: "tab-a" });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId, tabKey }),
+    ).resolves.toBe(true);
+  });
+
+  it("ages out a tab that stopped refreshing without saying goodbye", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+
+    // A browser that crashed: the entry is there, but its last heartbeat is
+    // older than the TTL. `now` is injected rather than slept through.
+    const registeredAt = Date.now();
+    await scenarioTabRegistry.register({
+      projectId,
+      tabKey,
+      tabId: "tab-a",
+      now: registeredAt,
+    });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({
+        projectId,
+        tabKey,
+        now: registeredAt + (SCENARIO_TAB_TTL_SECONDS + 5) * 1000,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("never leaks a registration across projects", async () => {
+    const tabKey = `tab-${nanoid(8)}`;
+    track(projectId, tabKey);
+    track(otherProjectId, tabKey);
+
+    await scenarioTabRegistry.register({ projectId, tabKey, tabId: "tab-a" });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId: otherProjectId, tabKey }),
+    ).resolves.toBe(false);
+  });
+
+  it("never leaks a registration across machines", async () => {
+    const mine = `tab-${nanoid(8)}`;
+    const theirs = `tab-${nanoid(8)}`;
+    track(projectId, mine);
+    track(projectId, theirs);
+
+    await scenarioTabRegistry.register({
+      projectId,
+      tabKey: mine,
+      tabId: "tab-a",
+    });
+
+    await expect(
+      scenarioTabRegistry.hasLiveTab({ projectId, tabKey: theirs }),
+    ).resolves.toBe(false);
+  });
+});

--- a/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
+++ b/langwatch/src/server/scenarios/browser-tab/__tests__/scenario-tab-registry.integration.test.ts
@@ -16,6 +16,7 @@ import {
   SCENARIO_TAB_DISCONNECT_GRACE_SECONDS,
   SCENARIO_TAB_PENDING_TTL_SECONDS,
   SCENARIO_TAB_TTL_SECONDS,
+  scenarioTabPendingKey,
   scenarioTabRegistry,
 } from "../scenario-tab-registry";
 
@@ -187,12 +188,11 @@ describe("scenarioTabRegistry", () => {
       ).resolves.toBe(true);
     });
 
-    it("never resurrects a tab that already aged out", async () => {
+    it("does not register a tab that was never there", async () => {
       const tabKey = `tab-${nanoid(8)}`;
       track(projectId, tabKey);
       const now = Date.now();
 
-      // Nothing was ever registered under this id.
       await scenarioTabRegistry.unregister({
         projectId,
         tabKey,
@@ -202,6 +202,36 @@ describe("scenarioTabRegistry", () => {
 
       await expect(
         scenarioTabRegistry.hasLiveTab({ projectId, tabKey, now }),
+      ).resolves.toBe(false);
+    });
+
+    it("does not revive a tab that had already aged out", async () => {
+      const tabKey = `tab-${nanoid(8)}`;
+      track(projectId, tabKey);
+      const now = Date.now();
+      const wellPastTtl = now + (SCENARIO_TAB_TTL_SECONDS + 60) * 1000;
+
+      await scenarioTabRegistry.register({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now,
+      });
+      // The browser died long ago; the late goodbye must not push it back
+      // inside the live window.
+      await scenarioTabRegistry.unregister({
+        projectId,
+        tabKey,
+        tabId: "tab-a",
+        now: wellPastTtl,
+      });
+
+      await expect(
+        scenarioTabRegistry.hasLiveTab({
+          projectId,
+          tabKey,
+          now: wellPastTtl,
+        }),
       ).resolves.toBe(false);
     });
   });
@@ -280,7 +310,7 @@ describe("scenarioTabRegistry", () => {
     /** @scenario "A handoff sent while the tab was reloading is not lost" */
     it("hands a parked run to the next subscription", async () => {
       const tabKey = `tab-${nanoid(8)}`;
-      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${tabKey}`);
+      pendingKeys.push(scenarioTabPendingKey(projectId, tabKey));
 
       await scenarioTabRegistry.setPendingNavigate({
         projectId,
@@ -295,7 +325,7 @@ describe("scenarioTabRegistry", () => {
 
     it("hands it over only once", async () => {
       const tabKey = `tab-${nanoid(8)}`;
-      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${tabKey}`);
+      pendingKeys.push(scenarioTabPendingKey(projectId, tabKey));
 
       await scenarioTabRegistry.setPendingNavigate({
         projectId,
@@ -309,9 +339,9 @@ describe("scenarioTabRegistry", () => {
       ).resolves.toBeNull();
     });
 
-    it("gives a tab that opens much later nothing to jump to", async () => {
+    it("expires a parked run so a tab opening much later does not jump to it", async () => {
       const tabKey = `tab-${nanoid(8)}`;
-      const key = `scenario_tab:v1:pending:${projectId}:${tabKey}`;
+      const key = scenarioTabPendingKey(projectId, tabKey);
       pendingKeys.push(key);
 
       await scenarioTabRegistry.setPendingNavigate({
@@ -320,15 +350,21 @@ describe("scenarioTabRegistry", () => {
         url: "https://app.langwatch.test/p/simulations/s/batch-1",
       });
 
+      // Redis holds the expiry, so the guarantee is the TTL it was given.
       const ttl = await connection!.ttl(key);
       expect(ttl).toBeGreaterThan(0);
       expect(ttl).toBeLessThanOrEqual(SCENARIO_TAB_PENDING_TTL_SECONDS);
+
+      await connection!.del(key);
+      await expect(
+        scenarioTabRegistry.takePendingNavigate({ projectId, tabKey }),
+      ).resolves.toBeNull();
     });
 
     it("keeps parked handoffs apart per machine", async () => {
       const mine = `tab-${nanoid(8)}`;
       const theirs = `tab-${nanoid(8)}`;
-      pendingKeys.push(`scenario_tab:v1:pending:${projectId}:${mine}`);
+      pendingKeys.push(scenarioTabPendingKey(projectId, mine));
 
       await scenarioTabRegistry.setPendingNavigate({
         projectId,

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-events.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-events.ts
@@ -1,0 +1,34 @@
+/**
+ * Wire shape of the "follow this run" nudge the SDK sends to an already-open
+ * simulations tab. Rides the existing `simulation_updated` tenant broadcast so
+ * the page needs no second SSE connection.
+ *
+ * Kept free of server-only imports: the browser parses this too.
+ */
+
+export const SCENARIO_TAB_NAVIGATE_EVENT = "scenario_tab_navigate";
+
+/** Query param the SDK appends when it opens a tab, carrying the machine key. */
+export const SCENARIO_TAB_QUERY_PARAM = "scenarioTab";
+
+export interface ScenarioTabNavigatePayload {
+  event: typeof SCENARIO_TAB_NAVIGATE_EVENT;
+  /** Scenario tab key of the machine that started the run. */
+  tabKey: string;
+  /** Absolute URL of the batch to show. */
+  url: string;
+}
+
+export function isScenarioTabNavigatePayload(
+  value: unknown,
+): value is ScenarioTabNavigatePayload {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<ScenarioTabNavigatePayload>;
+  return (
+    candidate.event === SCENARIO_TAB_NAVIGATE_EVENT &&
+    typeof candidate.tabKey === "string" &&
+    candidate.tabKey.length > 0 &&
+    typeof candidate.url === "string" &&
+    candidate.url.length > 0
+  );
+}

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-presence.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-presence.ts
@@ -1,0 +1,62 @@
+import {
+  SCENARIO_TAB_NAVIGATE_EVENT,
+  type ScenarioTabNavigatePayload,
+} from "./scenario-tab-events";
+import {
+  SCENARIO_TAB_REFRESH_MS,
+  scenarioTabRegistry,
+} from "./scenario-tab-registry";
+
+export interface ScenarioTabRegistration {
+  projectId: string;
+  tabKey: string;
+  tabId: string;
+}
+
+export interface ScenarioTabPresence {
+  /**
+   * A run handed to this tab while it was between subscriptions, ready to be
+   * emitted the moment the new one starts. Null when nothing was waiting.
+   */
+  parkedNavigate: ScenarioTabNavigatePayload | null;
+  /** Stop refreshing and retire the tab. Safe to call once, from a `finally`. */
+  stop: () => Promise<void>;
+}
+
+/**
+ * Keep a browser tab claimable for as long as its subscription lives.
+ *
+ * Presence is refreshed from the server rather than the browser: a background
+ * tab's timers get throttled to once a minute, which would expire presence on
+ * exactly the tab this feature exists to reuse.
+ */
+export async function startScenarioTabPresence(
+  registration: ScenarioTabRegistration,
+): Promise<ScenarioTabPresence> {
+  await scenarioTabRegistry.register(registration);
+
+  const refreshTimer = setInterval(() => {
+    void scenarioTabRegistry.register(registration);
+  }, SCENARIO_TAB_REFRESH_MS);
+
+  // A handoff broadcast while this tab was reloading would have been lost,
+  // even though the SDK was told it was delivered. Claim it now.
+  const pending = await scenarioTabRegistry.takePendingNavigate({
+    projectId: registration.projectId,
+    tabKey: registration.tabKey,
+  });
+
+  return {
+    parkedNavigate: pending
+      ? {
+          event: SCENARIO_TAB_NAVIGATE_EVENT,
+          tabKey: registration.tabKey,
+          url: pending,
+        }
+      : null,
+    async stop() {
+      clearInterval(refreshTimer);
+      await scenarioTabRegistry.unregister(registration);
+    },
+  };
+}

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
@@ -15,8 +15,32 @@ export const SCENARIO_TAB_TTL_SECONDS = 30;
 /** Server-side refresh cadence, comfortably inside the TTL. */
 export const SCENARIO_TAB_REFRESH_MS = 10_000;
 
+/**
+ * How long a tab stays claimable after its subscription ends.
+ *
+ * A tab drops its subscription for reasons that have nothing to do with going
+ * away: it routes to another run (including the run this very feature just
+ * handed it), the project context re-resolves, the dev server hot-reloads. With
+ * an instant de-registration, the run right after a followed run would find no
+ * tab and open a new one — the exact thing this exists to prevent. A few
+ * seconds of grace covers every one of those, while a genuinely closed tab
+ * still stops taking runs almost immediately.
+ */
+export const SCENARIO_TAB_DISCONNECT_GRACE_SECONDS = 5;
+
+/**
+ * How long a handed-off run stays claimable by a tab that was not connected at
+ * the moment it was broadcast — a reload, a route change, a laptop waking up.
+ * Short enough that a tab opened much later does not jump to a stale run.
+ */
+export const SCENARIO_TAB_PENDING_TTL_SECONDS = 20;
+
 function tabSetKey(projectId: string, tabKey: string): string {
   return `${KEY_PREFIX}:${projectId}:${tabKey}`;
+}
+
+function pendingKey(projectId: string, tabKey: string): string {
+  return `${KEY_PREFIX}:pending:${projectId}:${tabKey}`;
 }
 
 /**
@@ -25,6 +49,7 @@ function tabSetKey(projectId: string, tabKey: string): string {
  * subscription the same way Redis would.
  */
 const memoryTabs = new Map<string, Map<string, number>>();
+const memoryPending = new Map<string, { url: string; expiresAt: number }>();
 
 function memoryEntry(key: string): Map<string, number> {
   let entry = memoryTabs.get(key);
@@ -83,27 +108,40 @@ export const scenarioTabRegistry = {
     }
   },
 
-  /** Drop a tab as soon as its subscription ends. */
+  /**
+   * Retire a tab when its subscription ends, leaving it claimable for
+   * {@link SCENARIO_TAB_DISCONNECT_GRACE_SECONDS} in case it is only
+   * reconnecting. Re-registering within the window restores it outright.
+   */
   async unregister({
     projectId,
     tabKey,
     tabId,
+    now = Date.now(),
   }: {
     projectId: string;
     tabKey: string;
     tabId: string;
+    now?: number;
   }): Promise<void> {
     const key = tabSetKey(projectId, tabKey);
+    // Age the entry so it falls out of the live window `grace` from now.
+    const retiredScore =
+      now -
+      (SCENARIO_TAB_TTL_SECONDS - SCENARIO_TAB_DISCONNECT_GRACE_SECONDS) * 1000;
 
     if (!connection) {
-      memoryTabs.get(key)?.delete(tabId);
+      const entry = memoryTabs.get(key);
+      if (entry?.has(tabId)) entry.set(tabId, retiredScore);
       return;
     }
 
     try {
-      await connection.zrem(key, tabId);
+      // XX: only re-score a member that is still there; never resurrect one
+      // that already aged out.
+      await connection.zadd(key, "XX", retiredScore, tabId);
     } catch (error) {
-      logger.warn({ error, projectId }, "Failed to unregister scenario tab");
+      logger.warn({ error, projectId }, "Failed to retire scenario tab");
     }
   },
 
@@ -136,9 +174,78 @@ export const scenarioTabRegistry = {
       return false;
     }
   },
+
+  /**
+   * Park the handed-off run so a tab that is mid-reload when the broadcast goes
+   * out still finds it. Broadcasts are fire-and-forget: without this, a run
+   * reported as delivered could land in the gap between two subscriptions and
+   * be seen by nobody.
+   */
+  async setPendingNavigate({
+    projectId,
+    tabKey,
+    url,
+    now = Date.now(),
+  }: {
+    projectId: string;
+    tabKey: string;
+    url: string;
+    now?: number;
+  }): Promise<void> {
+    const key = pendingKey(projectId, tabKey);
+
+    if (!connection) {
+      memoryPending.set(key, {
+        url,
+        expiresAt: now + SCENARIO_TAB_PENDING_TTL_SECONDS * 1000,
+      });
+      return;
+    }
+
+    try {
+      await connection.set(key, url, "EX", SCENARIO_TAB_PENDING_TTL_SECONDS);
+    } catch (error) {
+      logger.warn(
+        { error, projectId },
+        "Failed to park a scenario tab handoff",
+      );
+    }
+  },
+
+  /** Read and clear whatever a reconnecting tab still owes itself. */
+  async takePendingNavigate({
+    projectId,
+    tabKey,
+    now = Date.now(),
+  }: {
+    projectId: string;
+    tabKey: string;
+    now?: number;
+  }): Promise<string | null> {
+    const key = pendingKey(projectId, tabKey);
+
+    if (!connection) {
+      const entry = memoryPending.get(key);
+      memoryPending.delete(key);
+      return entry && entry.expiresAt > now ? entry.url : null;
+    }
+
+    try {
+      const url = await connection.get(key);
+      if (url) await connection.del(key);
+      return url;
+    } catch (error) {
+      logger.warn(
+        { error, projectId },
+        "Failed to read a parked scenario tab handoff",
+      );
+      return null;
+    }
+  },
 };
 
 /** Test seam: forget every in-memory registration. */
 export function resetScenarioTabMemoryRegistry(): void {
   memoryTabs.clear();
+  memoryPending.clear();
 }

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
@@ -1,0 +1,144 @@
+import { createLogger } from "@langwatch/observability";
+import { connection } from "~/server/redis";
+
+const logger = createLogger("langwatch:scenario-tab-registry");
+
+const KEY_PREFIX = "scenario_tab:v1";
+
+/**
+ * How long a registration survives without a refresh. The SSE subscription
+ * refreshes on {@link SCENARIO_TAB_REFRESH_MS}, so this only runs out when the
+ * browser is really gone (closed tab, killed process, sleeping laptop).
+ */
+export const SCENARIO_TAB_TTL_SECONDS = 30;
+
+/** Server-side refresh cadence, comfortably inside the TTL. */
+export const SCENARIO_TAB_REFRESH_MS = 10_000;
+
+function tabSetKey(projectId: string, tabKey: string): string {
+  return `${KEY_PREFIX}:${projectId}:${tabKey}`;
+}
+
+/**
+ * In-process stand-in used when Redis is not configured. A deployment without
+ * Redis is single-instance by definition, so a module-level map sees every
+ * subscription the same way Redis would.
+ */
+const memoryTabs = new Map<string, Map<string, number>>();
+
+function memoryEntry(key: string): Map<string, number> {
+  let entry = memoryTabs.get(key);
+  if (!entry) {
+    entry = new Map();
+    memoryTabs.set(key, entry);
+  }
+  return entry;
+}
+
+function pruneMemory(entry: Map<string, number>, now: number): void {
+  const cutoff = now - SCENARIO_TAB_TTL_SECONDS * 1000;
+  for (const [tabId, seenAt] of entry) {
+    if (seenAt < cutoff) entry.delete(tabId);
+  }
+}
+
+/**
+ * Tracks which browser tabs are live and willing to take over a scenario run,
+ * keyed by project and by the scenario tab key of the machine that opened them.
+ *
+ * Membership is a sorted set of tab ids scored by last-seen timestamp: several
+ * tabs can hold the same key, one closing never revokes the others, and a
+ * browser that dies without saying goodbye ages out on its own.
+ */
+export const scenarioTabRegistry = {
+  /** Record (or refresh) a live tab. Safe to call repeatedly. */
+  async register({
+    projectId,
+    tabKey,
+    tabId,
+    now = Date.now(),
+  }: {
+    projectId: string;
+    tabKey: string;
+    tabId: string;
+    now?: number;
+  }): Promise<void> {
+    const key = tabSetKey(projectId, tabKey);
+
+    if (!connection) {
+      const entry = memoryEntry(key);
+      entry.set(tabId, now);
+      pruneMemory(entry, now);
+      return;
+    }
+
+    try {
+      await connection
+        .multi()
+        .zadd(key, now, tabId)
+        .expire(key, SCENARIO_TAB_TTL_SECONDS)
+        .exec();
+    } catch (error) {
+      logger.warn({ error, projectId }, "Failed to register scenario tab");
+    }
+  },
+
+  /** Drop a tab as soon as its subscription ends. */
+  async unregister({
+    projectId,
+    tabKey,
+    tabId,
+  }: {
+    projectId: string;
+    tabKey: string;
+    tabId: string;
+  }): Promise<void> {
+    const key = tabSetKey(projectId, tabKey);
+
+    if (!connection) {
+      memoryTabs.get(key)?.delete(tabId);
+      return;
+    }
+
+    try {
+      await connection.zrem(key, tabId);
+    } catch (error) {
+      logger.warn({ error, projectId }, "Failed to unregister scenario tab");
+    }
+  },
+
+  /** Whether any tab on that machine is currently listening for this project. */
+  async hasLiveTab({
+    projectId,
+    tabKey,
+    now = Date.now(),
+  }: {
+    projectId: string;
+    tabKey: string;
+    now?: number;
+  }): Promise<boolean> {
+    const key = tabSetKey(projectId, tabKey);
+    const cutoff = now - SCENARIO_TAB_TTL_SECONDS * 1000;
+
+    if (!connection) {
+      const entry = memoryTabs.get(key);
+      if (!entry) return false;
+      pruneMemory(entry, now);
+      return entry.size > 0;
+    }
+
+    try {
+      await connection.zremrangebyscore(key, "-inf", cutoff);
+      const count = await connection.zcard(key);
+      return count > 0;
+    } catch (error) {
+      logger.warn({ error, projectId }, "Failed to read scenario tab presence");
+      return false;
+    }
+  },
+};
+
+/** Test seam: forget every in-memory registration. */
+export function resetScenarioTabMemoryRegistry(): void {
+  memoryTabs.clear();
+}

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
@@ -25,8 +25,18 @@ export const SCENARIO_TAB_REFRESH_MS = 10_000;
  * tab and open a new one — the exact thing this exists to prevent. A few
  * seconds of grace covers every one of those, while a genuinely closed tab
  * still stops taking runs almost immediately.
+ *
+ * Must stay below {@link SCENARIO_TAB_TTL_SECONDS}: `unregister` retires an
+ * entry by ageing its score by the difference, so an equal or larger grace
+ * would extend a tab's life instead of ending it.
  */
 export const SCENARIO_TAB_DISCONNECT_GRACE_SECONDS = 5;
+
+if (SCENARIO_TAB_DISCONNECT_GRACE_SECONDS >= SCENARIO_TAB_TTL_SECONDS) {
+  throw new Error(
+    "SCENARIO_TAB_DISCONNECT_GRACE_SECONDS must be shorter than SCENARIO_TAB_TTL_SECONDS",
+  );
+}
 
 /**
  * How long a handed-off run stays claimable by a tab that was not connected at
@@ -39,7 +49,11 @@ function tabSetKey(projectId: string, tabKey: string): string {
   return `${KEY_PREFIX}:${projectId}:${tabKey}`;
 }
 
-function pendingKey(projectId: string, tabKey: string): string {
+/** Exported as a test seam so suites never hand-copy the key format. */
+export function scenarioTabPendingKey(
+  projectId: string,
+  tabKey: string,
+): string {
   return `${KEY_PREFIX}:pending:${projectId}:${tabKey}`;
 }
 
@@ -60,10 +74,24 @@ function memoryEntry(key: string): Map<string, number> {
   return entry;
 }
 
-function pruneMemory(entry: Map<string, number>, now: number): void {
+function pruneMemory(
+  key: string,
+  entry: Map<string, number>,
+  now: number,
+): void {
   const cutoff = now - SCENARIO_TAB_TTL_SECONDS * 1000;
   for (const [tabId, seenAt] of entry) {
     if (seenAt < cutoff) entry.delete(tabId);
+  }
+  // Drop the outer entry too, or every machine key this process ever saw
+  // leaves an empty Map behind for its lifetime.
+  if (entry.size === 0) memoryTabs.delete(key);
+}
+
+/** Evict parked handoffs nobody came back for. */
+function prunePendingMemory(now: number): void {
+  for (const [key, entry] of memoryPending) {
+    if (entry.expiresAt <= now) memoryPending.delete(key);
   }
 }
 
@@ -93,7 +121,7 @@ export const scenarioTabRegistry = {
     if (!connection) {
       const entry = memoryEntry(key);
       entry.set(tabId, now);
-      pruneMemory(entry, now);
+      pruneMemory(key, entry, now);
       return;
     }
 
@@ -132,14 +160,20 @@ export const scenarioTabRegistry = {
 
     if (!connection) {
       const entry = memoryTabs.get(key);
-      if (entry?.has(tabId)) entry.set(tabId, retiredScore);
+      const current = entry?.get(tabId);
+      // Only ever bring the score down: a goodbye that arrives after the tab
+      // already aged out must not put it back inside the live window.
+      if (current !== void 0 && retiredScore < current) {
+        entry?.set(tabId, retiredScore);
+      }
       return;
     }
 
     try {
-      // XX: only re-score a member that is still there; never resurrect one
-      // that already aged out.
-      await connection.zadd(key, "XX", retiredScore, tabId);
+      // XX: only touch a member that is still there. LT: only lower its score,
+      // so a late goodbye cannot revive a tab that already aged out. Older
+      // Redis servers reject LT; the entry then just ages out on its own.
+      await connection.zadd(key, "XX", "LT", retiredScore, tabId);
     } catch (error) {
       logger.warn({ error, projectId }, "Failed to retire scenario tab");
     }
@@ -161,7 +195,7 @@ export const scenarioTabRegistry = {
     if (!connection) {
       const entry = memoryTabs.get(key);
       if (!entry) return false;
-      pruneMemory(entry, now);
+      pruneMemory(key, entry, now);
       return entry.size > 0;
     }
 
@@ -192,9 +226,10 @@ export const scenarioTabRegistry = {
     url: string;
     now?: number;
   }): Promise<void> {
-    const key = pendingKey(projectId, tabKey);
+    const key = scenarioTabPendingKey(projectId, tabKey);
 
     if (!connection) {
+      prunePendingMemory(now);
       memoryPending.set(key, {
         url,
         expiresAt: now + SCENARIO_TAB_PENDING_TTL_SECONDS * 1000,
@@ -222,7 +257,7 @@ export const scenarioTabRegistry = {
     tabKey: string;
     now?: number;
   }): Promise<string | null> {
-    const key = pendingKey(projectId, tabKey);
+    const key = scenarioTabPendingKey(projectId, tabKey);
 
     if (!connection) {
       const entry = memoryPending.get(key);
@@ -231,6 +266,16 @@ export const scenarioTabRegistry = {
     }
 
     try {
+      // GETDEL keeps read-and-clear atomic, so two subscriptions reconnecting
+      // at once cannot both claim the same parked run. Older Redis servers
+      // fall back to the non-atomic pair.
+      if (typeof (connection as { getdel?: unknown }).getdel === "function") {
+        return await (
+          connection as unknown as {
+            getdel: (k: string) => Promise<string | null>;
+          }
+        ).getdel(key);
+      }
       const url = await connection.get(key);
       if (url) await connection.del(key);
       return url;

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
@@ -22,7 +22,7 @@ export const SCENARIO_TAB_REFRESH_MS = 10_000;
  * away: it routes to another run (including the run this very feature just
  * handed it), the project context re-resolves, the dev server hot-reloads. With
  * an instant de-registration, the run right after a followed run would find no
- * tab and open a new one — the exact thing this exists to prevent. A few
+ * tab and open a new one, the exact thing this exists to prevent. A few
  * seconds of grace covers every one of those, while a genuinely closed tab
  * still stops taking runs almost immediately.
  *
@@ -40,7 +40,7 @@ if (SCENARIO_TAB_DISCONNECT_GRACE_SECONDS >= SCENARIO_TAB_TTL_SECONDS) {
 
 /**
  * How long a handed-off run stays claimable by a tab that was not connected at
- * the moment it was broadcast — a reload, a route change, a laptop waking up.
+ * the moment it was broadcast: a reload, a route change, a laptop waking up.
  * Short enough that a tab opened much later does not jump to a stale run.
  */
 export const SCENARIO_TAB_PENDING_TTL_SECONDS = 20;

--- a/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
+++ b/langwatch/src/server/scenarios/browser-tab/scenario-tab-registry.ts
@@ -28,15 +28,10 @@ export const SCENARIO_TAB_REFRESH_MS = 10_000;
  *
  * Must stay below {@link SCENARIO_TAB_TTL_SECONDS}: `unregister` retires an
  * entry by ageing its score by the difference, so an equal or larger grace
- * would extend a tab's life instead of ending it.
+ * would extend a tab's life instead of ending it. The registry suite asserts
+ * that relation.
  */
 export const SCENARIO_TAB_DISCONNECT_GRACE_SECONDS = 5;
-
-if (SCENARIO_TAB_DISCONNECT_GRACE_SECONDS >= SCENARIO_TAB_TTL_SECONDS) {
-  throw new Error(
-    "SCENARIO_TAB_DISCONNECT_GRACE_SECONDS must be shorter than SCENARIO_TAB_TTL_SECONDS",
-  );
-}
 
 /**
  * How long a handed-off run stays claimable by a tab that was not connected at
@@ -267,15 +262,24 @@ export const scenarioTabRegistry = {
 
     try {
       // GETDEL keeps read-and-clear atomic, so two subscriptions reconnecting
-      // at once cannot both claim the same parked run. Older Redis servers
-      // fall back to the non-atomic pair.
-      if (typeof (connection as { getdel?: unknown }).getdel === "function") {
-        return await (
-          connection as unknown as {
-            getdel: (k: string) => Promise<string | null>;
-          }
-        ).getdel(key);
+      // at once cannot both claim the same parked run.
+      return await connection.getdel(key);
+    } catch (error) {
+      if (!isUnknownCommandError(error)) {
+        logger.warn(
+          { error, projectId },
+          "Failed to read a parked scenario tab handoff",
+        );
+        return null;
       }
+    }
+
+    try {
+      // Redis below 6.2 has no GETDEL. The client exposes the method either
+      // way, so the server rejecting it is the only signal. Reading and
+      // deleting separately loses atomicity, which at worst lets two tabs
+      // reconnecting in the same instant follow the same run: far cheaper than
+      // dropping a handoff the SDK was already told had been delivered.
       const url = await connection.get(key);
       if (url) await connection.del(key);
       return url;
@@ -288,6 +292,12 @@ export const scenarioTabRegistry = {
     }
   },
 };
+
+/** Redis answers an unsupported command with "ERR unknown command 'GETDEL'". */
+function isUnknownCommandError(error: unknown): boolean {
+  const message = (error as { message?: string })?.message;
+  return typeof message === "string" && /unknown command/i.test(message);
+}
 
 /** Test seam: forget every in-memory registration. */
 export function resetScenarioTabMemoryRegistry(): void {

--- a/langwatch/src/server/scenarios/schemas/response-schemas.ts
+++ b/langwatch/src/server/scenarios/schemas/response-schemas.ts
@@ -102,6 +102,16 @@ export const archiveResponseSchema = z.object({
 });
 
 /**
+ * Browser-tab handoff response schema
+ * Returned by POST /api/scenario-events/browser-tab. `delivered` tells the SDK
+ * whether a live simulations tab took the run, so it can skip opening one.
+ */
+export const browserTabHandoffResponseSchema = z.object({
+  delivered: z.boolean(),
+  url: z.string(),
+});
+
+/**
  * Consolidated response schemas object
  * Maps response types to their corresponding Zod schemas for validation
  */
@@ -113,4 +123,5 @@ export const responseSchemas = {
   batches: batchesSchema,
   runData: runDataSchema,
   archive: archiveResponseSchema,
+  browserTabHandoff: browserTabHandoffResponseSchema,
 };

--- a/langwatch/src/utils/__tests__/pollForGlobal.unit.test.ts
+++ b/langwatch/src/utils/__tests__/pollForGlobal.unit.test.ts
@@ -81,6 +81,28 @@ describe("pollForGlobal", () => {
       expect(onFound).not.toHaveBeenCalled();
     });
 
+    describe("when the getter starts throwing mid-poll", () => {
+      it("stops polling instead of letting the error escape the timer", () => {
+        const onFound = vi.fn();
+        let live = true;
+        const getValue = vi.fn((): string | undefined => {
+          if (!live) throw new ReferenceError("window is not defined");
+          return undefined;
+        });
+
+        pollForGlobal(getValue, onFound, { intervalMs: 50 });
+
+        // The environment the getter reads from goes away underneath a poll
+        // that is already running.
+        live = false;
+
+        expect(() => vi.advanceTimersByTime(500)).not.toThrow();
+        // The synchronous first read, then one tick that threw and ended it.
+        expect(getValue).toHaveBeenCalledTimes(2);
+        expect(onFound).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when cancelled before the value appears", () => {
       it("never calls onFound even if the value later becomes available", () => {
         const onFound = vi.fn();

--- a/langwatch/src/utils/__tests__/tracking.ssr.unit.test.ts
+++ b/langwatch/src/utils/__tests__/tracking.ssr.unit.test.ts
@@ -6,7 +6,7 @@
  * plain node environment (no jsdom) so `typeof window === "undefined"` is
  * actually true, unlike every other tracking test in this directory.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { trackEvent, trackEventOnce } from "../tracking";
 
@@ -17,5 +17,30 @@ describe("tracking - without a window global", () => {
 
   it("trackEventOnce does not throw", () => {
     expect(() => trackEventOnce("organization_initialized", {})).not.toThrow();
+  });
+});
+
+describe("tracking - when the window global disappears mid-poll", () => {
+  afterEach(() => {
+    delete (globalThis as any).window;
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it("does not throw a ReferenceError out of the poll timer", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    // A window with no gtag on it is all trackEvent needs to start polling.
+    (globalThis as any).window = {};
+    const { trackEvent } = await import("../tracking");
+    trackEvent("workflow_create", { project_id: "p1" });
+
+    // Take the environment away underneath the running poll. Only a node
+    // environment can do this: it leaves `window` an undefined free variable,
+    // the way a torn-down page does, rather than an object reading undefined.
+    delete (globalThis as any).window;
+
+    await expect(vi.advanceTimersByTimeAsync(1000)).resolves.not.toThrow();
   });
 });

--- a/langwatch/src/utils/pollForGlobal.ts
+++ b/langwatch/src/utils/pollForGlobal.ts
@@ -21,7 +21,17 @@ export function pollForGlobal<T>(
 
   const deadline = Date.now() + timeoutMs;
   const interval = setInterval(() => {
-    const value = getValue();
+    let value: T | undefined;
+    try {
+      value = getValue();
+    } catch {
+      // A getter that throws is reading something whose environment went away,
+      // so it will throw on every future tick too. Left alone the exception
+      // escapes from the timer to the top level, where no caller can catch it.
+      clearInterval(interval);
+      return;
+    }
+
     if (value) {
       clearInterval(interval);
       onFound(value);

--- a/langwatch/src/utils/tracking.ts
+++ b/langwatch/src/utils/tracking.ts
@@ -1,5 +1,14 @@
 import { pollForGlobal } from "./pollForGlobal";
 
+/**
+ * Polling for gtag runs for up to ten seconds, long enough for the page to be
+ * gone by the time a tick lands. Reading a bare `window` there throws a
+ * ReferenceError from inside a timer, where the caller that started the poll is
+ * no longer on the stack to catch it.
+ */
+const getGtag = (): ((...args: any[]) => void) | undefined =>
+  typeof window === "undefined" ? void 0 : (window as any).gtag;
+
 export const trackEvent = (
   eventName: string,
   params: Record<string, any> | undefined,
@@ -14,15 +23,15 @@ export const trackEvent = (
     }
   };
 
-  const gtag = (window as any).gtag;
+  const gtag = getGtag();
   if (gtag) {
     send(gtag);
     return;
   }
 
-  // gtag may not exist yet if GTM's script is still idle-deferred — poll for
+  // gtag may not exist yet if GTM's script is still idle-deferred, so poll for
   // it instead of dropping the event outright.
-  pollForGlobal(() => (window as any).gtag, send);
+  pollForGlobal(getGtag, send);
 };
 
 const eventsTracked =
@@ -50,7 +59,7 @@ export const trackEventOnce = (
     pendingOnceEvents.delete(eventName);
   };
 
-  const gtag = (window as any).gtag;
+  const gtag = getGtag();
   if (gtag) {
     trackEvent(eventName, params);
     markSent();
@@ -61,11 +70,8 @@ export const trackEventOnce = (
   // otherwise a miss during GTM's idle-deferred load would be recorded as
   // "sent" in localStorage and never retried.
   pendingOnceEvents.add(eventName);
-  pollForGlobal(
-    () => (window as any).gtag,
-    () => {
-      trackEvent(eventName, params);
-      markSent();
-    },
-  );
+  pollForGlobal(getGtag, () => {
+    trackEvent(eventName, params);
+    markSent();
+  });
 };

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -218,6 +218,10 @@ export default defineConfig(async (): Promise<UserConfig> => {
         // server appends on every request, so watching one turns each page
         // load into a full-reload loop.
         "**/server*.log",
+        // Working files agents keep under .claude/tmp, per the repo
+        // convention. A dev-server log teed there reloads the page on every
+        // request, same trap as above under a different name.
+        "**/.claude/**",
       ],
       // Docker-on-macOS bind mounts don't surface inotify events reliably,
       // so Vite's default fs.watch sits silent on edits made from the host.

--- a/specs/scenarios/scenario-tab-handoff.feature
+++ b/specs/scenarios/scenario-tab-handoff.feature
@@ -1,0 +1,108 @@
+Feature: Hand a scenario run to the simulations tab that is already open
+  As a developer running scenario suites from my terminal or a coding agent
+  I want LangWatch to steer the simulations tab I already have open
+  So that the SDK stops opening a new tab for every run
+
+  Background:
+    Given a project with an API key that holds "scenarios:create"
+    And the simulations page opens an SSE subscription while it is mounted
+
+  # ---------------------------------------------------------------------------
+  # Presence: the tab tells the server it is alive
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A simulations tab opened by the SDK registers itself
+    Given the SDK opened the simulations page with a scenarioTab query param
+    When the page mounts and its SSE subscription connects
+    Then a presence entry exists in Redis for that project and scenario tab key
+    And the entry carries a TTL so a crashed browser expires on its own
+
+  @integration
+  Scenario: Presence is refreshed while the subscription stays open
+    Given a simulations tab has been registered for longer than the presence TTL
+    When the SSE subscription is still connected
+    Then the presence entry is still readable
+    And the refresh is driven server-side so background-tab timer throttling cannot expire it
+
+  @integration
+  Scenario: Presence is dropped as soon as the tab goes away
+    Given a simulations tab is registered
+    When the SSE subscription disconnects
+    Then the presence entry is removed for that scenario tab key
+
+  @integration
+  Scenario: A simulations tab without a scenario tab key never registers
+    Given a user opened the simulations page directly
+    When the page mounts and its SSE subscription connects
+    Then no presence entry is written
+
+  # ---------------------------------------------------------------------------
+  # Handoff: the SDK asks whether a tab can take the run
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The handoff is delivered when a tab is listening
+    Given a simulations tab is registered for scenario tab key "abc"
+    When the SDK posts a browser-tab handoff for key "abc" with a batch URL
+    Then the response reports the handoff as delivered
+    And a navigate payload is broadcast on the project's tenant channel
+
+  @integration
+  Scenario: The handoff is not delivered when no tab is listening
+    Given no simulations tab is registered for scenario tab key "abc"
+    When the SDK posts a browser-tab handoff for key "abc"
+    Then the response reports the handoff as not delivered
+    And nothing is broadcast
+
+  @integration
+  Scenario: A handoff never crosses projects
+    Given a simulations tab is registered for key "abc" in project A
+    When an API key for project B posts a handoff for key "abc"
+    Then the response reports the handoff as not delivered
+    And project A's tab is not navigated
+
+  @integration
+  Scenario: The handoff endpoint refuses callers without scenario write access
+    Given an API key that only holds "scenarios:view"
+    When it posts a browser-tab handoff
+    Then the request is declined
+
+  @integration
+  Scenario: The handoff URL must belong to this LangWatch instance
+    Given a simulations tab is registered for scenario tab key "abc"
+    When the SDK posts a handoff whose URL points at another host
+    Then the request is rejected
+    And nothing is broadcast
+
+  # ---------------------------------------------------------------------------
+  # The tab follows
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The registered tab navigates to the handed-off run
+    Given the simulations page is mounted with scenario tab key "abc"
+    When a navigate payload for key "abc" arrives over SSE
+    Then the page routes to the batch URL from the payload
+    And a toast tells the user the tab followed a new run
+
+  @integration
+  Scenario: A navigate payload for another machine is ignored
+    Given the simulations page is mounted with scenario tab key "abc"
+    When a navigate payload for key "xyz" arrives over SSE
+    Then the page does not navigate
+
+  @integration
+  Scenario: The user can stop the tab from following
+    Given the simulations page followed a run and showed its toast
+    When the user chooses to stop following
+    Then the tab stops registering presence
+    And later runs open their own browser tab again
+    And the choice survives a page reload
+
+  @integration
+  Scenario: The scenario tab key survives a reload but never leaks into shared links
+    Given the SDK opened the simulations page with a scenarioTab query param
+    When the page has read the key
+    Then the key is kept for this tab only
+    And the query param is stripped from the visible URL

--- a/specs/scenarios/scenario-tab-handoff.feature
+++ b/specs/scenarios/scenario-tab-handoff.feature
@@ -106,7 +106,7 @@ Feature: Hand a scenario run to the simulations tab that is already open
     Given the simulations page is mounted with scenario tab key "abc"
     When a run is handed to key "abc"
     Then the page routes to that batch URL
-    And a toast tells the user the tab followed a new run
+    And the user is not interrupted by any notification
 
   @integration
   Scenario: A navigate payload for another machine is ignored
@@ -115,12 +115,12 @@ Feature: Hand a scenario run to the simulations tab that is already open
     Then the page does not navigate
 
   @integration
-  Scenario: The user can stop the tab from following
-    Given the simulations page followed a run and showed its toast
-    When the user chooses to stop following
-    Then the tab stops taking runs
-    And later runs open their own browser tab again
-    And the choice survives a page reload
+  Scenario: A connected tab quietly shows that it is linked to local runs
+    Given the simulations page is mounted with scenario tab key "abc"
+    When an external set view is open
+    Then a badge in the set header says the tab is connected to a local run
+    And hovering it explains that new runs will land in this tab
+    And a tab opened without a key shows no badge
 
   @integration
   Scenario: The scenario tab key survives a reload but never leaks into shared links

--- a/specs/scenarios/scenario-tab-handoff.feature
+++ b/specs/scenarios/scenario-tab-handoff.feature
@@ -26,10 +26,18 @@ Feature: Hand a scenario run to the simulations tab that is already open
     And the refresh is driven server-side so background-tab timer throttling cannot expire it
 
   @integration
-  Scenario: Presence is dropped as soon as the tab goes away
+  Scenario: A tab that is only reconnecting keeps its place
     Given a simulations tab is registered
-    When the SSE subscription disconnects
-    Then the presence entry is removed for that scenario tab key
+    When its subscription ends because the tab routed to another run
+    Then the tab is still offered runs for a short grace window
+    And reconnecting inside that window restores it outright
+
+  @integration
+  Scenario: A tab that really went away stops taking runs
+    Given a simulations tab whose subscription ended
+    When the grace window passes without it reconnecting
+    Then it is no longer offered runs
+    And the next run opens a browser tab again
 
   @integration
   Scenario: A simulations tab without a scenario tab key never registers
@@ -63,10 +71,11 @@ Feature: Hand a scenario run to the simulations tab that is already open
     And project A's tab is not navigated
 
   @integration
-  Scenario: The handoff endpoint refuses callers without scenario write access
-    Given an API key that only holds "scenarios:view"
+  Scenario: The handoff endpoint refuses an unauthenticated caller
+    Given a request with no API key
     When it posts a browser-tab handoff
     Then the request is declined
+    And nothing is broadcast
 
   @integration
   Scenario: The handoff URL must belong to this LangWatch instance
@@ -74,6 +83,20 @@ Feature: Hand a scenario run to the simulations tab that is already open
     When the SDK posts a handoff whose URL points at another host
     Then the request is rejected
     And nothing is broadcast
+
+  @integration
+  Scenario: A handoff sent while the tab was reloading is not lost
+    Given a simulations tab is registered for scenario tab key "abc"
+    When the SDK posts a handoff and the tab reconnects a moment later
+    Then the reconnecting subscription is handed the parked run
+    And the parked run is handed over only once
+    And it expires quickly so a tab opened much later does not jump to a stale run
+
+  @integration
+  Scenario: Nothing is parked when no tab was listening
+    Given no simulations tab is registered for scenario tab key "abc"
+    When the SDK posts a browser-tab handoff for key "abc"
+    Then nothing is parked for that key
 
   # ---------------------------------------------------------------------------
   # The tab follows

--- a/specs/scenarios/scenario-tab-handoff.feature
+++ b/specs/scenarios/scenario-tab-handoff.feature
@@ -5,7 +5,7 @@ Feature: Hand a scenario run to the simulations tab that is already open
 
   Background:
     Given a project with an API key that holds "scenarios:create"
-    And the simulations page opens an SSE subscription while it is mounted
+    And a simulations page that stays connected to the project while it is open
 
   # ---------------------------------------------------------------------------
   # Presence: the tab tells the server it is alive
@@ -14,36 +14,35 @@ Feature: Hand a scenario run to the simulations tab that is already open
   @integration
   Scenario: A simulations tab opened by the SDK registers itself
     Given the SDK opened the simulations page with a scenarioTab query param
-    When the page mounts and its SSE subscription connects
-    Then a presence entry exists in Redis for that project and scenario tab key
-    And the entry carries a TTL so a crashed browser expires on its own
+    When the page is open
+    Then a run started on that machine is offered to that tab
+    And a tab whose browser died stops being offered runs on its own
 
   @integration
   Scenario: Presence is refreshed while the subscription stays open
-    Given a simulations tab has been registered for longer than the presence TTL
-    When the SSE subscription is still connected
-    Then the presence entry is still readable
-    And the refresh is driven server-side so background-tab timer throttling cannot expire it
+    Given a simulations tab that has been open longer than the presence window
+    When the tab is still open, sitting in the background
+    Then it is still offered new runs
 
   @integration
   Scenario: A tab that is only reconnecting keeps its place
-    Given a simulations tab is registered
-    When its subscription ends because the tab routed to another run
-    Then the tab is still offered runs for a short grace window
-    And reconnecting inside that window restores it outright
+    Given a simulations tab that is being offered runs
+    When it drops off because it routed to another run
+    Then it is still offered runs for a short grace window
+    And coming back inside that window restores it outright
 
   @integration
   Scenario: A tab that really went away stops taking runs
-    Given a simulations tab whose subscription ended
-    When the grace window passes without it reconnecting
+    Given a simulations tab that dropped off
+    When the grace window passes without it coming back
     Then it is no longer offered runs
     And the next run opens a browser tab again
 
   @integration
   Scenario: A simulations tab without a scenario tab key never registers
     Given a user opened the simulations page directly
-    When the page mounts and its SSE subscription connects
-    Then no presence entry is written
+    When the page is open
+    Then a run started from a terminal is never handed to it
 
   # ---------------------------------------------------------------------------
   # Handoff: the SDK asks whether a tab can take the run
@@ -54,14 +53,14 @@ Feature: Hand a scenario run to the simulations tab that is already open
     Given a simulations tab is registered for scenario tab key "abc"
     When the SDK posts a browser-tab handoff for key "abc" with a batch URL
     Then the response reports the handoff as delivered
-    And a navigate payload is broadcast on the project's tenant channel
+    And that tab is sent to the batch URL
 
   @integration
   Scenario: The handoff is not delivered when no tab is listening
     Given no simulations tab is registered for scenario tab key "abc"
     When the SDK posts a browser-tab handoff for key "abc"
     Then the response reports the handoff as not delivered
-    And nothing is broadcast
+    And no tab is navigated
 
   @integration
   Scenario: A handoff never crosses projects
@@ -75,28 +74,28 @@ Feature: Hand a scenario run to the simulations tab that is already open
     Given a request with no API key
     When it posts a browser-tab handoff
     Then the request is declined
-    And nothing is broadcast
+    And the open tab stays where it was
 
   @integration
   Scenario: The handoff URL must belong to this LangWatch instance
     Given a simulations tab is registered for scenario tab key "abc"
     When the SDK posts a handoff whose URL points at another host
     Then the request is rejected
-    And nothing is broadcast
+    And no tab is navigated
 
   @integration
   Scenario: A handoff sent while the tab was reloading is not lost
     Given a simulations tab is registered for scenario tab key "abc"
-    When the SDK posts a handoff and the tab reconnects a moment later
-    Then the reconnecting subscription is handed the parked run
-    And the parked run is handed over only once
-    And it expires quickly so a tab opened much later does not jump to a stale run
+    When the SDK posts a handoff and the tab comes back a moment later
+    Then the tab that comes back is sent to the run it missed
+    And only the first tab back is sent to it
+    And a tab that comes back much later is not sent to that stale run
 
   @integration
   Scenario: Nothing is parked when no tab was listening
     Given no simulations tab is registered for scenario tab key "abc"
     When the SDK posts a browser-tab handoff for key "abc"
-    Then nothing is parked for that key
+    Then a tab opening afterwards is not sent to that run
 
   # ---------------------------------------------------------------------------
   # The tab follows
@@ -105,21 +104,21 @@ Feature: Hand a scenario run to the simulations tab that is already open
   @integration
   Scenario: The registered tab navigates to the handed-off run
     Given the simulations page is mounted with scenario tab key "abc"
-    When a navigate payload for key "abc" arrives over SSE
-    Then the page routes to the batch URL from the payload
+    When a run is handed to key "abc"
+    Then the page routes to that batch URL
     And a toast tells the user the tab followed a new run
 
   @integration
   Scenario: A navigate payload for another machine is ignored
     Given the simulations page is mounted with scenario tab key "abc"
-    When a navigate payload for key "xyz" arrives over SSE
+    When a run is handed to key "xyz"
     Then the page does not navigate
 
   @integration
   Scenario: The user can stop the tab from following
     Given the simulations page followed a run and showed its toast
     When the user chooses to stop following
-    Then the tab stops registering presence
+    Then the tab stops taking runs
     And later runs open their own browser tab again
     And the choice survives a page reload
 


### PR DESCRIPTION
## The problem

Every scenario batch opens a browser tab. Run a suite in a loop, or let a coding agent run it in the background while you work, and you end up with twenty LangWatch tabs that never close.

The SDK cannot tell whether a tab is already showing your runs. The operating system will not say, and no browser exposes it. But we can: the simulations page holds an SSE subscription for as long as it is open, so it can register itself.

## What this adds

**The tab identifies itself.** When the SDK opens a tab it stamps `?scenarioTab=<machine key>` on the URL. `useScenarioTabFollow` lifts that key into session storage (this tab only, never local storage), scrubs the param from the address bar so a copied link cannot carry another machine's key, and feeds it into the simulation SSE subscription.

**Presence lives in Redis.** `scenarioTabRegistry` keeps a TTL'd sorted set of tab ids per project and machine key, scored by last-seen. Several tabs can hold the same key, closing one never revokes the others, and a browser that dies without saying goodbye ages out on its own.

The refresh runs **server-side**, from inside the subscription generator. This matters: a hidden tab's timers are throttled to once a minute, which would expire presence on exactly the tab the feature exists to reuse. The server has no such problem.

**The handoff endpoint answers the SDK.**

```
POST /api/scenario-events/browser-tab  { tabKey, batchRunId, scenarioSetId? }
  -> { delivered: true,  url }   broadcast to the tab; the SDK opens nothing
  -> { delivered: false, url }   nobody listening; the SDK opens a tab
```

Delivery rides the existing `simulation_updated` tenant broadcast, so no second SSE connection is needed. The receiving tab matches on the tab key and routes itself to the batch, silently: the user started that run, the page moving to it is the expected outcome, not news. The only visible trace is a quiet "Connected to local run" badge in the set header, with a hover popover explaining that new runs land in this tab.

## Safety

- The URL is **built server-side** from the project slug, set id and batch run id. A handoff can only ever point a browser at this instance's own simulations page; a `url` in the request body is ignored.
- Presence is keyed by `(projectId, tabKey)`. A run from another project or another machine finds nothing and delivers nothing, so CI runs and colleagues cannot steer your browser.
- The endpoint sits at `scenarios:create`, the same grain as reporting the run whose display it steers.
- A tab the user opened themselves carries no key, never registers, and is never navigated.
- Opting out is one click and is remembered in that browser.

## Dogfooded against a real browser

Driven end to end with Playwright against this branch running locally and real
scenario suites from both SDKs. The SDK's opener is intercepted by a shim so
every tab it would have spawned is counted.

Five runs, one tab, zero new tabs, and the tab moved to a different batch on
every one of them. Closing the tab restored the auto-open, reopening the
SDK-opened URL brought the tab back, and `never` / `CI` / `always` each did what
they promise.

The connected tab wears its badge in the set header and follows runs without
interrupting anyone:

![Connected to local run badge](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6137/browser-tab/connected-badge.png)

Hovering the badge explains what it means:

![Badge popover on hover](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6137/browser-tab/connected-badge-popover.png)

Reopened from the URL the SDK opened, showing the run it was opened for:

![Reopened from the SDK URL](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6137/browser-tab/reopened-from-sdk-url.png)

A tab the user opened by hand never registers, never follows, and shows no
badge.

## Three defects the dogfooding caught

None of these showed up in the unit or integration suites; all three needed a
real browser and a real suite.

**A disconnected client never cleaned up.** tRPC v10 callers leave
`opts.signal` undefined, so `on(emitter, …, { signal })` had nothing to abort
on. A closed browser left its generator suspended forever, holding its emitter
listener and its tab registration until the TTL, and the SDK kept being told a
tab was listening. The request's own signal now reaches the procedure through
the tRPC context, which ends the wait and runs the cleanup. Every other SSE
subscription in the app has the same leak available to fix the same way.

**De-registering instantly was too eager.** A tab drops its subscription
whenever it routes somewhere, including to the run this feature just handed it,
so the very next run found no tab and opened a new one. A retiring tab now stays
claimable for a few seconds and is restored outright if it reconnects.

**A broadcast sent mid-reload went nowhere.** It was still reported as
delivered, so the run was visible to nobody. Handoffs are now parked with a
short TTL and claimed by the next subscription for that machine key.

## Tests

26 new tests plus 6 added to the existing listener suite.

- **Registry (9, real Redis)**: registration, TTL, refresh, unregister, sibling tabs, crash ageing, and both scoping boundaries.
- **Endpoint (9, real Prisma + real Redis)**: real project rows resolved by the real auth middleware; delivered and undelivered paths, the broadcast payload, the ignored caller URL, the default set fallback, cross-project and cross-machine isolation, validation and 401.
- **Follow hook (8, real router)**: rendered in a real `MemoryRouter` with real session and local storage, via the `vi.unmock` pattern, since the whole job is lifting a param out of a URL.
- **Listener (6)**: subscription input with and without a machine key, follow, ignore another machine, ignore without a key, and that a handoff is never mistaken for run data.

## Also in here: a CI crash that was not this feature

`test-integration (2)` was red on an uncaught error, not a failing test: all 111
files passed and the run still exited 1.

```
ReferenceError: window is not defined
 ❯ src/utils/tracking.ts:25:39
 ❯ Timeout._onTimeout src/utils/pollForGlobal.ts:24:19
```

`trackEvent` polls up to ten seconds for a late `gtag` and nothing cancels the
poll, so a tick can land after the page that started it is gone. The getter read
a bare `window`, which is a ReferenceError once that binding goes away, thrown
from inside a timer where no caller is on the stack to catch it. Integration
files share one long-lived worker, so it surfaced in whichever file happened to
be running when a stranded poll ticked.

Fixed at both layers: gtag is read through a `typeof window` guard, and
`pollForGlobal` ends the poll when its getter throws rather than letting the
error escape. Both new tests reproduce the exact ReferenceError against the old
code.

## Specs

`specs/scenarios/scenario-tab-handoff.feature`

## SDK side

Companion PR: langwatch/scenario#847


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secured browser-tab handoff for simulation runs that can reuse an existing Simulations tab keyed by tab identity.
  * Introduced “follow new run” tab steering driven by live updates, including “Stop following”/resume controls and consistent in-tab navigation nudges.
* **Bug Fixes**
  * Improved tab-handoff handling in live update processing so navigation payloads don’t disrupt normal streaming/invalidation, with safer disconnect cleanup.
* **Tests**
  * Added integration, unit, and end-to-end coverage for tab presence, grace/reconnect behavior, URL/host validation, project isolation, and opt-out persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


