### PR TITLE
feat(charts): make Langy self-hostable via the Helm chart

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -322,6 +322,16 @@
           "jsonpath": "$.appVersion"
         },
         {
+          "type": "yaml",
+          "path": "charts/langyagent/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/langyagent/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
           "type": "json",
           "path": "langwatch/package.json",
           "jsonpath": "$.version"

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -6,6 +6,7 @@ on:
       - "charts/langwatch/**"
       - "charts/clickhouse-serverless/**"
       - "charts/gateway/**"
+      - "charts/langyagent/**"
       - "charts/lib/**"
       - ".github/workflows/langwatch-chart.yml"
   push:
@@ -14,6 +15,7 @@ on:
       - "charts/langwatch/**"
       - "charts/clickhouse-serverless/**"
       - "charts/gateway/**"
+      - "charts/langyagent/**"
       - "charts/lib/**"
       - ".github/workflows/langwatch-chart.yml"
 
@@ -39,6 +41,10 @@ jobs:
             flags: "--set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/access-ingress.yaml"
           - name: ha+ingress+replicated
             flags: "--set autogen.enabled=true -f examples/overlays/size-ha.yaml -f examples/overlays/access-ingress.yaml -f examples/overlays/clickhouse-replicated.yaml"
+          - name: langy
+            flags: "--set autogen.enabled=true -f examples/overlays/langy-assistant.yaml"
+          - name: langy+unsandboxed
+            flags: "--set autogen.enabled=true -f examples/overlays/langy-assistant.yaml -f examples/overlays/langy-assistant-unsandboxed.yaml"
           - name: prod+external-ch
             flags: "--set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/clickhouse-external.yaml"
           - name: prod+ext-pg+ext-redis

--- a/charts/langwatch/Chart.lock
+++ b/charts/langwatch/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 3.5.0
 - name: langwatch-langyagent
   repository: file://../langyagent
-  version: 3.3.0
-digest: sha256:763e36ee4d85807ce658abc08f0d7d33fadd1fcdd6b66ec2932682ef5c735621
-generated: "2026-07-11T03:54:23.377345+02:00"
+  version: 3.5.0
+digest: sha256:a1dc84b9aea920faa8c9cdb25e303ce68094db2203d30afcaae0f9b1b3a051b8
+generated: "2026-07-24T21:29:18.794326+02:00"

--- a/charts/langwatch/examples/overlays/langy-assistant-unsandboxed.yaml
+++ b/charts/langwatch/examples/overlays/langy-assistant-unsandboxed.yaml
@@ -1,0 +1,21 @@
+# langy-assistant-unsandboxed.yaml — Langy on a cluster with no sandboxed runtime.
+#
+# Layer this on top of langy-assistant.yaml when your cluster cannot offer
+# gVisor, which is the case for most self-managed clusters. The chart refuses to
+# render a blanked runtime on its own, so the acceptance below is what makes an
+# unsandboxed deploy a deliberate act rather than the result of an empty field.
+#
+# What you give up: the pod-to-host sandbox, so a worker that escapes its
+# container faces only the node kernel.
+# What you keep: per-worker UID isolation, the per-worker opencode password, and
+# the NetworkPolicy bounding where workers can reach.
+#
+# Usage:
+#   helm install lw . \
+#     -f examples/overlays/langy-assistant.yaml \
+#     -f examples/overlays/langy-assistant-unsandboxed.yaml \
+#     --set autogen.enabled=true
+
+langyagent:
+  runtimeClassName: ""
+  acceptUnsandboxedRuntime: true

--- a/charts/langwatch/examples/overlays/langy-assistant.yaml
+++ b/charts/langwatch/examples/overlays/langy-assistant.yaml
@@ -34,8 +34,9 @@ langyagent:
   # you want its turns traced into, put it in a Secret, and name it here. The
   # endpoint resolves to this install.
   #
+  #   read -rsp "Mirror project API key: " KEY
   #   kubectl -n <namespace> create secret generic langwatch-langyagent-mirror \
-  #     --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+  #     --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"; unset KEY
   #
   # mirror:
   #   existingSecretName: langwatch-langyagent-mirror

--- a/charts/langwatch/examples/overlays/langy-assistant.yaml
+++ b/charts/langwatch/examples/overlays/langy-assistant.yaml
@@ -1,0 +1,41 @@
+# langy-assistant.yaml — Run the in-product assistant alongside LangWatch.
+#
+# Deploys the Langy agent pod, wires the app and the workers to it, and opens
+# the assistant to everyone in the install. The shared secret is materialised by
+# the chart, so there is nothing to create beforehand.
+#
+# Langy still needs a model to talk to: configure a model provider for the
+# project as you would for any other LangWatch feature.
+#
+# Usage:
+#   helm install lw . \
+#     -f examples/overlays/langy-assistant.yaml \
+#     --set autogen.enabled=true
+
+langyagent:
+  chartManaged: true
+
+  # The agent runs model-written shell, so it asks for a sandboxed runtime and
+  # refuses to install without one. On a cluster that cannot provide gVisor,
+  # blank the runtime and accept the reduced isolation on purpose:
+  #
+  #   runtimeClassName: ""
+  #   acceptUnsandboxedRuntime: true
+  #
+  # See examples/overlays/langy-assistant-unsandboxed.yaml.
+  runtimeClassName: "gvisor"
+
+  networkPolicy:
+    # Langy's tools shell out to git, gh, and package managers. Private ranges
+    # and the cloud metadata endpoint stay blocked either way.
+    allowExternalHttps: true
+
+  # Watch Langy work inside your own LangWatch: create an API key in the project
+  # you want its turns traced into, put it in a Secret, and name it here. The
+  # endpoint resolves to this install.
+  #
+  #   kubectl -n <namespace> create secret generic langwatch-langyagent-mirror \
+  #     --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+  #
+  # mirror:
+  #   existingSecretName: langwatch-langyagent-mirror

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -89,9 +89,11 @@ dev's Personal Workspace at https://<your-host>/me .
 {{- end }}
 {{- if not (index .Values "langyagent").mirror.existingSecretName }}
     To watch Langy work with LangWatch itself, mirror its turns into one of
-    your projects: create an API key there, then
+    your projects: create an API key there, then (the read keeps the key out
+    of your shell history and out of the process list)
+      read -rsp "Mirror project API key: " KEY
       kubectl -n {{ .Release.Namespace }} create secret generic langwatch-langyagent-mirror \
-        --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+        --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"; unset KEY
     and set langyagent.mirror.existingSecretName to it on your next upgrade.
 {{- end }}
 {{- end }}
@@ -189,8 +191,19 @@ message.
     - LW_GATEWAY_INTERNAL_SECRET      (gateway.chartManaged=true)
     - LW_GATEWAY_JWT_SECRET           (gateway.chartManaged=true)
 {{- end }}
-{{- if (index .Values "langyagent").chartManaged }}
-    - LANGY_INTERNAL_SECRET           (langyagent.chartManaged=true)
+{{- $langy := (index .Values "langyagent") }}
+{{- $langySecrets := $langy.secrets | default dict }}
+{{- $langyKey := $langySecrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+{{- $langySecretName := $langySecrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
+{{- $langyOwnSecret := ne $langySecretName (include "langwatch.appSecretName" .) }}
+{{- if and $langy.chartManaged (not $langyOwnSecret) }}
+    - {{ $langyKey }}   (langyagent.chartManaged=true)
+{{- end }}
+{{- if and $langy.chartManaged $langyOwnSecret }}
+
+  {{ $langySecretName }} keys (langyagent.chartManaged=true, read by the
+  app, the workers, and the agent pod):
+    - {{ $langyKey }}
 {{- end }}
 
   When autogen.enabled=true the chart materialises this Secret on
@@ -213,8 +226,16 @@ message.
       --from-literal=virtualKeyPepper="$(openssl rand -hex 32)" \
 {{- if and .Values.gateway .Values.gateway.chartManaged }}
       --from-literal=LW_GATEWAY_INTERNAL_SECRET="$(openssl rand -hex 32)" \
-      --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"{{ if (index .Values "langyagent").chartManaged }} \{{ end }}
+      --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"{{ if and $langy.chartManaged (not $langyOwnSecret) }} \{{ end }}
 {{- end }}
-{{- if (index .Values "langyagent").chartManaged }}
-      --from-literal=LANGY_INTERNAL_SECRET="$(openssl rand -hex 32)"
+{{- if and $langy.chartManaged (not $langyOwnSecret) }}
+      --from-literal={{ $langyKey }}="$(openssl rand -hex 32)"
+{{- end }}
+{{- if and $langy.chartManaged $langyOwnSecret }}
+
+  Langy reads its shared value from a Secret of your own
+  ({{ $langySecretName }}), so create that one too:
+
+    kubectl -n {{ .Release.Namespace }} create secret generic {{ $langySecretName }} \
+      --from-literal={{ $langyKey }}="$(openssl rand -hex 32)"
 {{- end }}

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -76,6 +76,25 @@ dev's Personal Workspace at https://<your-host>/me .
   • Healthcheck (in-cluster):
       curl http://{{ .Release.Name }}-gateway/healthz
 {{- end }}
+{{- if (index .Values "langyagent").chartManaged }}
+  • Langy, the in-product assistant:
+      kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/name=langyagent
+{{- if (index .Values "langyagent").enableForAllUsers }}
+    It is available to everyone in this install. Give it a model to talk to
+    by wiring a Model Provider (step 2 above), then open the assistant from
+    any project.
+{{- else }}
+    langyagent.enableForAllUsers=false, so it stays dark until you open it
+    to the projects or organizations you choose from /ops/feature-flags.
+{{- end }}
+{{- if not (index .Values "langyagent").mirror.existingSecretName }}
+    To watch Langy work with LangWatch itself, mirror its turns into one of
+    your projects: create an API key there, then
+      kubectl -n {{ .Release.Namespace }} create secret generic langwatch-langyagent-mirror \
+        --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+    and set langyagent.mirror.existingSecretName to it on your next upgrade.
+{{- end }}
+{{- end }}
   • Self-host docs:
       https://docs.langwatch.ai/self-hosting/
   • Personal-keys onboarding walkthrough:
@@ -170,6 +189,9 @@ message.
     - LW_GATEWAY_INTERNAL_SECRET      (gateway.chartManaged=true)
     - LW_GATEWAY_JWT_SECRET           (gateway.chartManaged=true)
 {{- end }}
+{{- if (index .Values "langyagent").chartManaged }}
+    - LANGY_INTERNAL_SECRET           (langyagent.chartManaged=true)
+{{- end }}
 
   When autogen.enabled=true the chart materialises this Secret on
   first install via per-key lookup-or-rand and heals missing keys
@@ -191,5 +213,8 @@ message.
       --from-literal=virtualKeyPepper="$(openssl rand -hex 32)" \
 {{- if and .Values.gateway .Values.gateway.chartManaged }}
       --from-literal=LW_GATEWAY_INTERNAL_SECRET="$(openssl rand -hex 32)" \
-      --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"
+      --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"{{ if (index .Values "langyagent").chartManaged }} \{{ end }}
+{{- end }}
+{{- if (index .Values "langyagent").chartManaged }}
+      --from-literal=LANGY_INTERNAL_SECRET="$(openssl rand -hex 32)"
 {{- end }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -385,6 +385,46 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end }}
 {{- end }}
 
+{{/* Validate Langy agent secret wiring.
+
+     Unlike the gateway, all three Langy consumers (app, workers, agent pod)
+     read the SAME langyagent.secrets.* values, so they cannot disagree with
+     each other and no name-match check is needed.
+
+     What can still go wrong: the chart materialises LANGY_INTERNAL_SECRET
+     into its own app Secret, which it only writes when autogen is on. An
+     operator who brings their own Secret (autogen off, or a Secret managed by
+     terraform / external-secrets) has to carry the key themselves, and the
+     failure mode without this check is three pods in
+     CreateContainerConfigError naming a key nothing told them to add.
+
+     `lookup` returns empty during `helm template` and on a dry run, so this
+     fires only against a real cluster, and only when the Secret is already
+     there and demonstrably missing the key — never on a first install where
+     it has yet to be created. */}}
+{{- $langy := (index .Values "langyagent") | default dict }}
+{{- if $langy.chartManaged }}
+  {{- $langySecrets := $langy.secrets | default dict }}
+  {{- $langySecretName := $langySecrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
+  {{- $langyKey := $langySecrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+  {{- $chartWritesIt := and .Values.autogen.enabled (empty .Values.secrets.existingSecret) (eq $langySecretName (include "langwatch.appSecretName" .)) }}
+  {{- if not $chartWritesIt }}
+    {{- $found := lookup "v1" "Secret" .Release.Namespace $langySecretName }}
+    {{- $hint := printf "Either add the key to that Secret (kubectl -n %s create secret generic %s --from-literal=%s=$(openssl rand -hex 32), or patch it if it already exists), point langyagent.secrets.existingSecretName at the Secret that does hold it, or let the chart generate it by leaving autogen.enabled=true with no secrets.existingSecret override." .Release.Namespace $langySecretName $langyKey }}
+    {{- if not $found }}
+      {{/* Every lookup comes back empty during `helm template` and dry runs, so
+           "Secret not found" there means "we cannot see the cluster", not "it is
+           missing". Probe with an object every real cluster has: if kube-system
+           is invisible too, stay quiet rather than failing a plain render. */}}
+      {{- if lookup "v1" "Namespace" "" "kube-system" }}
+        {{- $errors = append $errors (printf "Langy is enabled (langyagent.chartManaged=true) but Secret %q was not found in namespace %q, and this chart is not generating it. The app, the workers, and the agent pod all read %q from it to authenticate to each other, so all three would start into CreateContainerConfigError. %s" $langySecretName .Release.Namespace $langyKey $hint) }}
+      {{- end }}
+    {{- else if not (index ($found.data | default dict) $langyKey) }}
+      {{- $errors = append $errors (printf "Langy is enabled (langyagent.chartManaged=true) but Secret %q in namespace %q has no %q key. The app, the workers, and the agent pod all read that one key to authenticate to each other. %s" $langySecretName .Release.Namespace $langyKey $hint) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{/* Output errors and warnings */}}
 {{- if $errors }}
 {{- fail (printf "Secret validation failed:\n%s" (join "\n" $errors)) }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -466,6 +466,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if and (ne $appSecretName "langwatch-app-secrets") (eq ($langySecrets.existingSecretName | default "") "langwatch-app-secrets") }}
     {{- $errors = append $errors (printf "langyagent.secrets.existingSecretName is still the default %q but the app Secret is named %q. The app, the workers, and the agent pod would all mount a Secret this install does not have. Set langyagent.secrets.existingSecretName to %q, or to whichever Secret holds %s." "langwatch-app-secrets" $appSecretName $appSecretName $langyKey) }}
   {{- end }}
+  {{/* A configured key that collides with one of the app Secret's own keys would
+       emit the same Secret.data entry twice, and the second write wins — Langy's
+       random value would silently become the session secret or the gateway
+       token. Refuse rather than quietly conflating two credentials whose blast
+       radii are meant to be separate. Only when both live in the same Secret;
+       an operator-owned Secret elsewhere may name its key whatever it likes. */}}
+  {{- if eq $langySecretName (include "langwatch.appSecretName" .) }}
+    {{- $reserved := list "credentialsEncryptionKey" "cronApiKey" "nextAuthSecret" "virtualKeyPepper" }}
+    {{- if (.Values.gateway).chartManaged }}
+      {{- $reserved = concat $reserved (list "LW_GATEWAY_INTERNAL_SECRET" "LW_GATEWAY_JWT_SECRET") }}
+    {{- end }}
+    {{- if has $langyKey $reserved }}
+      {{- $errors = append $errors (printf "langyagent.secrets.internalSecretKey is %q, which is already a key of the app Secret %q. Langy would overwrite that credential with its own value. Pick a distinct key name (the default is LANGY_INTERNAL_SECRET), or point langyagent.secrets.existingSecretName at a separate Secret." $langyKey $langySecretName) }}
+    {{- end }}
+  {{- end }}
   {{- $chartWritesIt := and .Values.autogen.enabled (empty .Values.secrets.existingSecret) (eq $langySecretName (include "langwatch.appSecretName" .)) }}
   {{- if not $chartWritesIt }}
     {{- $found := lookup "v1" "Secret" .Release.Namespace $langySecretName }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -62,6 +62,55 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- .Values.secrets.existingSecret | default (.Values.autogen.secretNames.app | default "langwatch-app-secrets") -}}
 {{- end -}}
 
+{{/*
+  LW_GATEWAY_BASE_URL env entry for the pods that talk to the gateway from
+  inside the cluster (the app and the workers, which both resolve Langy's
+  credentials). Renders nothing when there is no gateway to point at.
+
+  gateway.internalUrl wins for non-standard topologies (a gateway run outside
+  this release, a service mesh address). Otherwise it is the Service this chart
+  renders, whose name follows the release like the other sibling Services and
+  whose port comes from the subchart's own value so the two cannot drift.
+*/}}
+{{- define "langwatch.gatewayBaseUrlEnv" -}}
+{{- $gw := .Values.gateway | default dict }}
+{{- $url := $gw.internalUrl | default "" }}
+{{- if and (not $url) $gw.chartManaged }}
+{{- $port := (($gw.service) | default dict).port | default 80 }}
+{{- $url = printf "http://%s-gateway:%v" .Release.Name $port }}
+{{- end }}
+{{- if $url }}
+- name: LW_GATEWAY_BASE_URL
+  value: {{ $url | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+  LANGY_WORKER_CALLBACK_URL env entry — the origin the Langy agent's workers dial
+  back on: the relay frame push, the durable turn finalize, the session-key
+  revoke, and the LANGWATCH_ENDPOINT the langwatch CLI uses for every tool call.
+
+  Without it the app hands the worker its own PUBLIC base URL, which is the
+  wrong address for a pod on the same cluster to use. At best the traffic
+  leaves the cluster and comes back; at worst that hostname means something
+  else entirely inside the pod, and every callback fails while the model calls
+  keep succeeding — a turn that costs tokens, produces an answer, and then
+  never delivers it.
+
+  langyagent.controlPlane.callbackUrl overrides it for split topologies.
+*/}}
+{{- define "langwatch.langyCallbackUrlEnv" -}}
+{{- $langy := (index .Values "langyagent") | default dict }}
+{{- $cp := $langy.controlPlane | default dict }}
+{{- $url := $cp.callbackUrl | default "" }}
+{{- if not $url }}
+{{- $port := ((.Values.app).service | default dict).port | default 5560 }}
+{{- $url = printf "http://%s-app:%v" .Release.Name $port }}
+{{- end }}
+- name: LANGY_WORKER_CALLBACK_URL
+  value: {{ $url | quote }}
+{{- end -}}
+
 {{/* Secret validation function */}}
 {{- define "langwatch.validateSecrets" }}
 {{- $errors := list }}
@@ -407,6 +456,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- $langySecrets := $langy.secrets | default dict }}
   {{- $langySecretName := $langySecrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
   {{- $langyKey := $langySecrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+  {{/* Subchart values are literal YAML, so langyagent.secrets.existingSecretName
+       is a static string while the app Secret's name resolves dynamically. An
+       operator who renames the app Secret and leaves this at its stock default
+       sends all three pods to a Secret that no longer exists. Pointing Langy at
+       a genuinely different Secret stays legitimate (external-secrets,
+       terraform); only the untouched default is treated as an oversight. */}}
+  {{- $appSecretName := include "langwatch.appSecretName" . }}
+  {{- if and (ne $appSecretName "langwatch-app-secrets") (eq ($langySecrets.existingSecretName | default "") "langwatch-app-secrets") }}
+    {{- $errors = append $errors (printf "langyagent.secrets.existingSecretName is still the default %q but the app Secret is named %q. The app, the workers, and the agent pod would all mount a Secret this install does not have. Set langyagent.secrets.existingSecretName to %q, or to whichever Secret holds %s." "langwatch-app-secrets" $appSecretName $appSecretName $langyKey) }}
+  {{- end }}
   {{- $chartWritesIt := and .Values.autogen.enabled (empty .Values.secrets.existingSecret) (eq $langySecretName (include "langwatch.appSecretName" .)) }}
   {{- if not $chartWritesIt }}
     {{- $found := lookup "v1" "Secret" .Release.Namespace $langySecretName }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -236,17 +236,38 @@ spec:
                   key: LW_GATEWAY_JWT_SECRET
             {{- end }}
 
+            {{- if (index .Values "langyagent").chartManaged }}
             # Langy agent pod. The app POSTs chats to OPENCODE_AGENT_URL with
             # LANGY_INTERNAL_SECRET as the Bearer token; the agent verifies it
             # against the same Secret. Subchart values key read via index (aliased subchart).
-            {{- if (index .Values "langyagent").chartManaged }}
             - name: OPENCODE_AGENT_URL
               value: {{ (index .Values "langyagent").controlPlane.agentUrl | default (printf "http://%s-langyagent:80" .Release.Name) | quote }}
             - name: LANGY_INTERNAL_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ (index .Values "langyagent").secrets.existingSecretName | default "langwatch-langyagent-auth" }}
+                  name: {{ (index .Values "langyagent").secrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
                   key: {{ (index .Values "langyagent").secrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+            {{- end }}
+            {{- /* Langy's rollout flag is SYSTEM-scoped and defaults off, because
+                   the hosted product opens it one cohort at a time. A self-hosted
+                   install has a single cohort — the people who installed it — so
+                   deploying the agent and then finding no assistant anywhere in
+                   the product is a dead end whose only lever is an internal ops
+                   screen. Deploying the pod IS the decision to enable it; the
+                   operator keeps the staged path by setting
+                   langyagent.enableForAllUsers=false, which hands authority back
+                   to the flag store (/ops/feature-flags). Operator-forced flags
+                   are joined with it, never clobbered by it. */}}
+            {{- $forcedFlags := list }}
+            {{- with .Values.app.featureFlagForceEnable }}
+            {{- $forcedFlags = append $forcedFlags . }}
+            {{- end }}
+            {{- if and (index .Values "langyagent").chartManaged (index .Values "langyagent").enableForAllUsers }}
+            {{- $forcedFlags = append $forcedFlags "release_langy_enabled" }}
+            {{- end }}
+            {{- if $forcedFlags }}
+            - name: FEATURE_FLAG_FORCE_ENABLE
+              value: {{ join "," $forcedFlags | quote }}
             {{- end }}
 
             # LW_GATEWAY_PUBLIC_URL — the externally-reachable AI Gateway URL

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -247,6 +247,7 @@ spec:
                 secretKeyRef:
                   name: {{ (index .Values "langyagent").secrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
                   key: {{ (index .Values "langyagent").secrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+            {{- include "langwatch.langyCallbackUrlEnv" . | nindent 12 }}
             {{- end }}
             {{- /* Langy's rollout flag is SYSTEM-scoped and defaults off, because
                    the hosted product opens it one cohort at a time. A self-hosted
@@ -292,6 +293,16 @@ spec:
             - name: LW_GATEWAY_PUBLIC_URL
               value: {{ $gwPublic | quote }}
             {{- end }}
+
+            {{- /* LW_GATEWAY_BASE_URL — where the CONTROL PLANE itself reaches the
+                   gateway, over cluster DNS. Distinct from the public URL above,
+                   which is what browsers and laptops use: an install with no
+                   gateway ingress (the common self-hosted shape) has no public URL
+                   at all, and the control plane still has to reach the gateway.
+                   Langy needs it to mint the worker's virtual key, and without it
+                   the assistant refuses every turn with a credential-resolution
+                   error naming this variable. */}}
+            {{- include "langwatch.gatewayBaseUrlEnv" . | nindent 12 }}
 
             # NextAuth configuration (NEXTAUTH_SECRET lives in sharedEnv —
             # every app-image consumer needs it, see _helpers.tpl)

--- a/charts/langwatch/templates/app/secrets.yaml
+++ b/charts/langwatch/templates/app/secrets.yaml
@@ -31,6 +31,12 @@ type: Opaque
   one resource policy. The older split (separate langwatch-gateway-auth
   Secret) was collapsed in this release because there was no operational
   reason to keep them apart.
+
+  LANGY_INTERNAL_SECRET follows the same shape when the Langy agent is
+  chart-managed: the app sends it as a Bearer token and the agent verifies
+  it, so both pods read this one Secret. It used to be created out-of-band,
+  which meant enabling the assistant left the APP pod in
+  CreateContainerConfigError on a Secret nothing in the chart mentioned.
 */}}
 data:
   {{- if .Values.app.credentialsEncryptionKey.value }}
@@ -56,6 +62,9 @@ data:
   {{- if (.Values.gateway).chartManaged }}
   LW_GATEWAY_INTERNAL_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LW_GATEWAY_INTERNAL_SECRET") | quote }}
   LW_GATEWAY_JWT_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LW_GATEWAY_JWT_SECRET") | quote }}
+  {{- end }}
+  {{- if (index .Values "langyagent").chartManaged }}
+  LANGY_INTERNAL_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LANGY_INTERNAL_SECRET") | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/langwatch/templates/app/secrets.yaml
+++ b/charts/langwatch/templates/app/secrets.yaml
@@ -63,8 +63,18 @@ data:
   LW_GATEWAY_INTERNAL_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LW_GATEWAY_INTERNAL_SECRET") | quote }}
   LW_GATEWAY_JWT_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LW_GATEWAY_JWT_SECRET") | quote }}
   {{- end }}
-  {{- if (index .Values "langyagent").chartManaged }}
-  LANGY_INTERNAL_SECRET: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData "LANGY_INTERNAL_SECRET") | quote }}
+  {{- /* Materialise Langy's shared value under the key the pods actually read,
+         and only when they read it from THIS Secret. An operator who points
+         langyagent.secrets elsewhere owns that Secret themselves; writing a key
+         here that nothing reads would be a decoy, and validateSecrets already
+         checks the one they named. */}}
+  {{- $langy := (index .Values "langyagent") }}
+  {{- if $langy.chartManaged }}
+  {{- $langySecrets := $langy.secrets | default dict }}
+  {{- $langyKey := $langySecrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+  {{- if eq ($langySecrets.existingSecretName | default $secretName) $secretName }}
+  {{ $langyKey }}: {{ default (include "langwatch.autogenSecretValue" .) (index $existingData $langyKey) | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -129,6 +129,24 @@ spec:
             - name: LANGWATCH_ENDPOINT
               value: {{ .Values.workers.upstreams.langwatch.scheme | default "http" }}://{{ .Values.workers.upstreams.langwatch.name | default (printf "%s-app" .Release.Name) }}:{{ .Values.workers.upstreams.langwatch.port | default 5560 }}
 
+            {{- /* Langy turns are dispatched from HERE, not from the app: the
+                   process outbox in the event-sourcing runtime POSTs the turn to
+                   the Go manager and the liveness subscriber re-drives a stalled
+                   one (see startWorkers.ts, "Langy turns self-drive"). Both run
+                   in the worker stack, so a workers pod without this pair builds
+                   its Langy port with an empty URL and every turn dies where no
+                   one is looking — the app pod, which HAS the pair, never makes
+                   that call. Same Secret and same Service as the app block. */}}
+            {{- if (index .Values "langyagent").chartManaged }}
+            - name: OPENCODE_AGENT_URL
+              value: {{ (index .Values "langyagent").controlPlane.agentUrl | default (printf "http://%s-langyagent:80" .Release.Name) | quote }}
+            - name: LANGY_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "langyagent").secrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
+                  key: {{ (index .Values "langyagent").secrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+            {{- end }}
+
             {{- with .Values.workers.extraEnvs}}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -145,6 +145,10 @@ spec:
                 secretKeyRef:
                   name: {{ (index .Values "langyagent").secrets.existingSecretName | default (include "langwatch.appSecretName" .) }}
                   key: {{ (index .Values "langyagent").secrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+            {{- include "langwatch.langyCallbackUrlEnv" . | nindent 12 }}
+            {{- /* Re-dispatching a stalled turn re-resolves the worker's
+                   credentials, which needs the gateway the same way the app does. */}}
+            {{- include "langwatch.gatewayBaseUrlEnv" . | nindent 12 }}
             {{- end }}
 
             {{- with .Values.workers.extraEnvs}}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1590,6 +1590,9 @@ gateway:
   ## @param gateway.publicUrl [string, default: ""] Externally-reachable URL of the AI Gateway (e.g. https://gateway.your-corp.com). The control plane hands this to CLI users (langwatch claude/codex/cursor) at login. REQUIRED for self-hosted CLI/agentic use: without it the CLI falls back to http://localhost:5563, which a developer laptop cannot reach against a remote cluster. Leave empty to auto-derive from gateway.ingress.host when you set your own host. Set LANGWATCH_GATEWAY_URL on the client to override per-user.
   publicUrl: ""
 
+  ## @param gateway.internalUrl [string, default: ""] URL the control plane itself uses to reach the gateway, from inside the cluster. Distinct from publicUrl, which is for browsers and laptops: an install with no gateway ingress still needs this, and Langy refuses every turn without it. Empty derives the Service this chart renders, so set it only for a gateway that lives outside this release or behind a mesh address.
+  internalUrl: ""
+
   # The gateway needs its OWN externally-reachable endpoint, separate from
   # the main app — point a second ingress / load balancer at gateway.ingress
   # below (the LLM clients hit the gateway, the browser hits the app). The

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -569,6 +569,16 @@ app:
     strategy: {}
     ## @param app.deployment.revisionHistoryLimit [default: 10] Number of old replicasets to retain.
     revisionHistoryLimit: 10
+  # Release flags this install forces ON, comma-separated, regardless of the
+  # flag store. Reach for it to switch on a feature that ships dark by default;
+  # the flag keys are listed in the app's /ops/feature-flags screen. Forcing a
+  # flag on here also means it cannot be turned off from that screen — the env
+  # var wins — so prefer the store for anything you want to toggle later.
+  # The Langy assistant appends its own key here when the agent is deployed;
+  # see the langyagent section at the bottom of this file.
+  ## @param app.featureFlagForceEnable [string, default: ""] Comma-separated feature flag keys to force on for this install.
+  featureFlagForceEnable: ""
+
   # Additional Kubernetes resources
   # Extra environment variables
   # See: https://kubespec.dev/v1/Pod#spec.containers.env
@@ -1628,29 +1638,59 @@ gateway:
 ## assistant. Internal-only (no ingress); the control plane reaches it over
 ## cluster DNS. The subchart defaults (image, probes, NetworkPolicy,
 ## SecurityContext, single-replica) live in charts/langyagent/values.yaml.
-## `langyagent.chartManaged: false` (the default) disables the agent and the
-## app's wiring to it; flip to true once the prerequisite secret + opt-in
-## steps are done (see docs/langy-github-app.md).
 ##
-## WHY default off: the agent + app Deployments both reference a `secretKeyRef`
-## to `langwatch-langyagent-auth` (created out-of-band — terraform / external-
-## secrets / a manual `kubectl create secret`). The umbrella chart does NOT
-## materialise that secret, so an upgrade with chartManaged=true on top of a
-## values file that hasn't been prepared yields `CreateContainerConfigError`
-## on the main app pod — turning an optional, dark-by-flag feature into a
-## blocker for every operator's next upgrade. Default-off keeps existing
-## installs unaffected; operators flip the switch when they're ready.
+## TURNING LANGY ON is one value:
+##
+##   langyagent:
+##     chartManaged: true
+##
+## and, on a cluster with no sandboxed runtime available (most self-managed
+## ones — see langyagent.runtimeClassName in the subchart), two more:
+##
+##     runtimeClassName: ""
+##     acceptUnsandboxedRuntime: true
+##
+## Everything else is materialised by this chart: the shared LANGY_INTERNAL_SECRET
+## lands in the app Secret alongside the gateway's pair, the app and workers pods
+## both get the agent URL, and the assistant is opened to the install's users.
+## There is no out-of-band `kubectl create secret` step and no internal screen to
+## visit. What Langy still needs from you is a model to talk to: configure a model
+## provider for the project as you would for any other LangWatch feature.
+##
+## WHY default off: enabling it adds a pod that runs LLM-written shell under a
+## deliberate security posture (root in-container for per-worker UID handoff, a
+## sandboxed runtime where one exists). That is a decision an operator should
+## make on purpose rather than inherit from a chart upgrade, so the default
+## leaves existing installs exactly as they are.
 ## NOTE: hyphenated key — reference as (index .Values "langyagent") in templates.
 langyagent:
-  ## @param langyagent.chartManaged [default: false] Lift the Langy agent pod as part of this chart. Default off so existing upgrades aren't broken by the absent shared Secret; opt in once the LANGY_INTERNAL_SECRET secret is created out-of-band.
+  ## @param langyagent.chartManaged [default: false] Lift the Langy agent pod as part of this chart, wire the app and workers to it, and open the assistant to this install. Off by default so an upgrade never adds this workload on its own.
   chartManaged: false
 
-  ## @param langyagent.controlPlane.agentUrl [string, default: http://<release>-langyagent:80] URL the app uses to reach the agent Service. Leave empty to auto-derive from the release name.
+  ## @param langyagent.enableForAllUsers [default: true] Make Langy available to everyone in this install as soon as the agent is deployed. Set false to keep the rollout flag authoritative and open Langy to chosen projects/orgs from /ops/feature-flags instead — the staged path the hosted product uses.
+  enableForAllUsers: true
+
+  ## @param langyagent.controlPlane.agentUrl [string, default: http://<release>-langyagent:80] URL the app and workers use to reach the agent Service. Leave empty to auto-derive from the release name.
   controlPlane:
     agentUrl: ""
 
-  ## @param langyagent.secrets.existingSecretName [string, default: langwatch-langyagent-auth] Secret carrying LANGY_INTERNAL_SECRET, shared between the app and the agent pod. Created out-of-band (terraform / external-secrets); the umbrella chart does NOT materialise it.
-  ## @param langyagent.secrets.internalSecretKey [string, default: LANGY_INTERNAL_SECRET] Key inside the existing Secret that holds the shared internal secret.
+  ## @param langyagent.secrets.existingSecretName [string, default: the app Secret] Secret carrying LANGY_INTERNAL_SECRET, shared by the app, the workers, and the agent pod. Defaults to this chart's own app Secret, which materialises the key for you (generated when autogen.enabled, supplied by you otherwise — add LANGY_INTERNAL_SECRET to your existing Secret in that case). Point it elsewhere only if the value is managed by external-secrets or terraform.
+  ## @param langyagent.secrets.internalSecretKey [string, default: LANGY_INTERNAL_SECRET] Key inside that Secret holding the shared value.
   secrets:
-    existingSecretName: langwatch-langyagent-auth
+    existingSecretName: langwatch-app-secrets
     internalSecretKey: LANGY_INTERNAL_SECRET
+
+  # Watch Langy work with LangWatch itself. Point the mirror at one of your own
+  # projects and every Langy turn lands there as a trace: the model calls it
+  # made, the tools it ran, what each cost. Two steps, because only you can say
+  # which project: create an API key in that project, put it in a Secret, and
+  # name the Secret here. The endpoint resolves to this install automatically.
+  #
+  #   kubectl -n <namespace> create secret generic langwatch-langyagent-mirror \
+  #     --from-literal=LANGY_MIRROR_TRACE_KEY=<the project's API key>
+  #
+  ## @param langyagent.mirror.existingSecretName [string, default: ""] Secret holding the mirror project's API key. Empty leaves the mirror off.
+  ## @param langyagent.mirror.traceEndpoint [string, default: ""] LangWatch base URL to mirror into. Empty means this install's own app Service; set it to mirror into a different deployment.
+  mirror:
+    existingSecretName: ""
+    traceEndpoint: ""

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1689,8 +1689,9 @@ langyagent:
   # which project: create an API key in that project, put it in a Secret, and
   # name the Secret here. The endpoint resolves to this install automatically.
   #
+  #   read -rsp "Mirror project API key: " KEY
   #   kubectl -n <namespace> create secret generic langwatch-langyagent-mirror \
-  #     --from-literal=LANGY_MIRROR_TRACE_KEY=<the project's API key>
+  #     --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"; unset KEY
   #
   ## @param langyagent.mirror.existingSecretName [string, default: ""] Secret holding the mirror project's API key. Empty leaves the mirror off.
   ## @param langyagent.mirror.traceEndpoint [string, default: ""] LangWatch base URL to mirror into. Empty means this install's own app Service; set it to mirror into a different deployment.

--- a/charts/langyagent/Chart.yaml
+++ b/charts/langyagent/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   isolated OpenCode subprocess per conversation, with per-request credential
   injection. Internal-only service consumed by the LangWatch control plane.
 type: application
-version: 3.3.0
-appVersion: 3.3.0
+version: 3.5.0
+appVersion: 3.5.0
 keywords:
   - langwatch
   - langy

--- a/charts/langyagent/README.md
+++ b/charts/langyagent/README.md
@@ -14,31 +14,11 @@ The chart ships as a sub-chart of the umbrella `langwatch` chart (aliased
 `docker.io/langwatch/langyagent`, tag tracking the `langwatch` chart's
 `appVersion`.
 
-## Pre-install: create the shared auth Secret
-
-**Read this before `helm install`.** The chart references a Kubernetes
-`Secret` (default name `langwatch-langyagent-auth`) holding the
-service-to-service token. The control plane sends this token as a Bearer
-header; the agent verifies it. If the Secret is missing at install time the
-pod loops with `secret "langwatch-langyagent-auth" not found`.
-
-The **same value** must be present on both the agent pod and the
-`langwatch-app` env (`LANGY_INTERNAL_SECRET`). When you deploy both via the
-umbrella chart, both pods read it from this one Secret:
-
-```bash
-kubectl create secret generic langwatch-langyagent-auth \
-  --namespace langwatch \
-  --from-literal=LANGY_INTERNAL_SECRET="$(openssl rand -hex 32)"
-```
-
-Override the Secret/key names via `secrets.existingSecretName` and
-`secrets.internalSecretKey`.
-
 ## Install
 
-Preferred — via the umbrella `langwatch` chart, which also wires the app's
-`OPENCODE_AGENT_URL` + `LANGY_INTERNAL_SECRET` for you:
+Preferred — via the umbrella `langwatch` chart, which wires the app and the
+workers to the agent, materialises the shared `LANGY_INTERNAL_SECRET` into its
+own app Secret, and opens the assistant to the people in the install:
 
 ```bash
 helm install langwatch ./charts/langwatch -n langwatch \
@@ -46,18 +26,53 @@ helm install langwatch ./charts/langwatch -n langwatch \
   --set langyagent.chartManaged=true
 ```
 
-Standalone (you bring your own control plane and set `OPENCODE_AGENT_URL`
-on it manually):
+There is nothing to create beforehand. If you supply your own app Secret
+instead of letting the chart generate one (`autogen.enabled: false`), add a
+`LANGY_INTERNAL_SECRET` key to it — the install tells you so and stops rather
+than half-deploying.
+
+### On a cluster with no sandboxed runtime
+
+The agent runs LLM-written shell, so it asks for a sandboxed runtime (`gvisor`)
+by default. Most self-managed clusters have none, and the install refuses to
+render rather than silently dropping the sandbox. To run it anyway, say so:
+
+```yaml
+langyagent:
+  chartManaged: true
+  runtimeClassName: ""
+  acceptUnsandboxedRuntime: true
+```
+
+You keep per-worker UID isolation, the per-worker opencode password, and the
+NetworkPolicy; you give up the pod-to-host sandbox. A single-tenant install
+whose users are colleagues carries a much smaller worker-versus-worker risk
+than a multi-tenant one — read the trade that way, not as a formality.
+
+### Standalone
+
+You bring your own control plane, set `OPENCODE_AGENT_URL` on it manually, and
+create the shared Secret yourself so both sides hold the same value:
 
 ```bash
+kubectl create secret generic langwatch-langyagent-auth \
+  --namespace langwatch \
+  --from-literal=LANGY_INTERNAL_SECRET="$(openssl rand -hex 32)"
+
 helm install langyagent ./charts/langyagent -n langwatch -f values.prod.yaml
 ```
+
+Override the Secret/key names via `secrets.existingSecretName` and
+`secrets.internalSecretKey`.
 
 ## Values reference
 
 | Path                          | Purpose                                                                 |
 |-------------------------------|-------------------------------------------------------------------------|
 | `chartManaged`                | Master on/off switch for the agent (umbrella: `langyagent.chartManaged`) |
+| `enableForAllUsers`           | Umbrella-only. Opens Langy to everyone in the install as soon as the agent is deployed. `false` keeps the rollout flag authoritative so you open it per project/org from `/ops/feature-flags` |
+| `runtimeClassName`            | Sandboxed runtime for the pod (default `gvisor`). Blank it only together with `acceptUnsandboxedRuntime` |
+| `acceptUnsandboxedRuntime`    | Accept running with no pod-to-host sandbox, on clusters that cannot offer one. Required for a blank `runtimeClassName`, so an unsandboxed deploy is always deliberate |
 | `environment`                 | Deployment environment reported as `ENVIRONMENT` (empty → inherits `global.env` → `production`). Security-load-bearing: prod pods must report a production environment so the manager refuses `LANGY_UNSAFE_DEV_DISABLE_ISOLATION` |
 | `image.tag`                   | Image tag override (defaults to `Chart.AppVersion`)                     |
 | `replicaCount`                | **Keep at 1** — see Scaling below                                       |

--- a/charts/langyagent/templates/configmap.yaml
+++ b/charts/langyagent/templates/configmap.yaml
@@ -32,10 +32,22 @@ data:
   LANGY_EGRESS_REQUIRE_TLS: {{ .Values.egress.requireTls | quote }}
   LANGY_EGRESS_ENFORCE_FLOOR: {{ .Values.egress.enforceFloor | quote }}
   LANGY_EGRESS_SNI_CROSSCHECK: {{ .Values.egress.sniCrossCheck | quote }}
-  {{- with .Values.mirror.traceEndpoint }}
-  # Mirror lane (ADR-061): the secondary exporter for the turn's gen_ai trace
-  # data into the operator-designated mirror project. The key is NOT here —
-  # it is a project API key, injected from the mirror Secret in the
-  # Deployment env.
+  {{- /* Mirror lane (ADR-061): the secondary exporter for the turn's gen_ai
+         trace data into the operator-designated mirror project. The key is NOT
+         here — it is a project API key, injected from the mirror Secret in the
+         Deployment env.
+
+         The endpoint is derivable: the only thing an operator can tell us that
+         we cannot work out ourselves is which project to mirror into, which is
+         what the key says. So when they supply the key and leave the endpoint
+         empty, point at this install's own control plane over cluster DNS.
+         Only when the key is present — the manager refuses to boot if one half
+         of the pair is set without the other, so deriving an endpoint for an
+         install with no mirror key would turn a dormant lane into a crashloop. */}}
+  {{- $mirrorEndpoint := .Values.mirror.traceEndpoint }}
+  {{- if and (not $mirrorEndpoint) .Values.mirror.existingSecretName }}
+  {{- $mirrorEndpoint = printf "http://%s-app:5560" .Release.Name }}
+  {{- end }}
+  {{- with $mirrorEndpoint }}
   LANGY_MIRROR_TRACE_ENDPOINT: {{ . | quote }}
   {{- end }}

--- a/charts/langyagent/templates/configmap.yaml
+++ b/charts/langyagent/templates/configmap.yaml
@@ -10,6 +10,16 @@
 {{- $env := "production" -}}
 {{- with .Values.global }}{{- with .env }}{{- $env = . }}{{- end }}{{- end }}
 {{- with .Values.environment }}{{- $env = . }}{{- end }}
+{{- /* The mirror lane needs both halves or neither: the manager refuses to boot
+       with one set (services/langyagent/config.go). An endpoint with no key is
+       the half we cannot fill in for the operator — only they can say which
+       project to mirror into — so refuse at render time rather than shipping a
+       pod that crashloops on its own config. The opposite pairing needs no
+       guard: a key with no endpoint resolves to this install's control plane
+       below. */ -}}
+{{- if and .Values.chartManaged .Values.mirror.traceEndpoint (not .Values.mirror.existingSecretName) }}
+{{- fail "langyagent.mirror.traceEndpoint is set but langyagent.mirror.existingSecretName is empty — the agent refuses to start with only half the mirror configured. Create a Secret holding the mirror project's API key and name it in langyagent.mirror.existingSecretName, or clear traceEndpoint to leave the mirror off." }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/langyagent/templates/deployment.yaml
+++ b/charts/langyagent/templates/deployment.yaml
@@ -4,18 +4,22 @@
 {{- if ne (int .Values.replicaCount) 1 }}
 {{- fail "langyagent.replicaCount must remain 1 until conversation-sticky routing exists" }}
 {{- end }}
-{{- /* A sandboxed runtime is a hard requirement, not a default, when this
-       chart manages the pod. The agent runs LLM-driven arbitrary shell
-       (opencode workers spawn git/gh/npm), so an unset/empty runtimeClassName
-       drops the pod onto the node's default runtime (runc, no sandbox) and
-       re-opens the pod->host escape surface — the cross-worker credential-theft
-       regression the values.yaml header explicitly promises this chart refuses
-       to ship. `not` catches BOTH the absent key and the empty string. The only
-       legitimate way to run without the sandbox is to opt the whole pod out
-       (chartManaged=false), never to blank the runtime while still managed.
-       See ADR-033 and charts/langyagent/values.yaml. */ -}}
-{{- if and .Values.chartManaged (not .Values.runtimeClassName) }}
-{{- fail "langyagent.runtimeClassName must be set to a sandboxed runtime (e.g. \"gvisor\") when langyagent.chartManaged=true — running this LLM-driven-shell workload without a sandbox re-opens the pod->host escape surface (see ADR-033). To intentionally run without the agent, set langyagent.chartManaged=false." }}
+{{- /* A sandboxed runtime is the posture this workload wants everywhere. The
+       agent runs LLM-driven arbitrary shell (opencode workers spawn
+       git/gh/npm), so an unset/empty runtimeClassName drops the pod onto the
+       node's default runtime (runc, no sandbox) and re-opens the pod->host
+       escape surface. `not` catches BOTH the absent key and the empty string.
+
+       Most self-managed clusters cannot offer a sandboxed runtime, so an
+       unconditional refusal made the assistant hosted-only in practice. What
+       the guard protects is narrower and still worth having: nobody runs this
+       unsandboxed by ACCIDENT. Accepting the reduced isolation is a value the
+       operator writes down (acceptUnsandboxedRuntime), so it lands in their
+       values file and their review, rather than being the silent consequence
+       of leaving a field blank. See ADR-033, charts/langyagent/values.yaml,
+       and specs/langy/langy-deploy-hardening.feature. */ -}}
+{{- if and .Values.chartManaged (not .Values.runtimeClassName) (not .Values.acceptUnsandboxedRuntime) }}
+{{- fail "langyagent.runtimeClassName must be set to a sandboxed runtime (e.g. \"gvisor\") when langyagent.chartManaged=true — running this LLM-driven-shell workload without a sandbox re-opens the pod->host escape surface (see ADR-033). If your cluster has no sandboxed runtime and you accept that reduced isolation, set langyagent.acceptUnsandboxedRuntime=true. To run without the assistant entirely, set langyagent.chartManaged=false." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/langyagent/templates/networkpolicy.yaml
+++ b/charts/langyagent/templates/networkpolicy.yaml
@@ -13,9 +13,10 @@
 #     LangWatch API at LANGWATCH_ENDPOINT.
 #   - AI gateway (langwatch-gateway) — OpenCode's LLM traffic goes out via
 #     OPENAI_BASE_URL pointed at the gateway, not direct to providers.
-#   - 443 to anywhere (optional, default on) — OpenCode may reach external
-#     hosts (e.g. its own update/telemetry). Tighten by setting
-#     networkPolicy.allowExternalHttps=false once egress needs are pinned.
+#   - 443 to anywhere (optional, default OFF) — the tools OpenCode shells out
+#     to (git, gh, npm) need it, and so does opencode's own update/telemetry.
+#     Turn it on with networkPolicy.allowExternalHttps=true; private ranges and
+#     the cloud metadata service stay carved out either way.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -35,6 +36,17 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ .Release.Name }}-app
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- /* The workers pod, not the app pod, is what actually POSTs a turn
+               to the manager: Langy turns are driven by the process outbox in
+               the event-sourcing runtime, which runs in the worker stack (see
+               startWorkers.ts). Admitting only the app pod let every turn die
+               in a dropped packet with both pods healthy — the failure looks
+               like the agent ignoring the request, because from the agent's
+               side nothing ever arrived. */}}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Release.Name }}-workers
               app.kubernetes.io/instance: {{ .Release.Name }}
         {{- end }}
       ports:

--- a/charts/langyagent/values.yaml
+++ b/charts/langyagent/values.yaml
@@ -77,8 +77,9 @@ secrets:
 # tools. Optional: leave the block empty (the default) and the lane stays
 # dormant. The key is an ordinary project API key for the designated mirror
 # project; rotate it like any project key.
+#   read -rsp "Mirror project API key: " KEY
 #   kubectl create secret generic langwatch-langyagent-mirror \
-#     --from-literal=LANGY_MIRROR_TRACE_KEY=<mirror project API key>
+#     --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"; unset KEY
 mirror:
   # Base URL of the LangWatch deployment holding the mirror project —
   # /api/otel/v1/traces is appended by the manager. Leave empty and set

--- a/charts/langyagent/values.yaml
+++ b/charts/langyagent/values.yaml
@@ -55,9 +55,15 @@ service:
   port: 80
   targetPort: 8080
 
-# Auth secret shared with the control plane. Helm never materialises it —
-# the operator creates it out-of-band (terraform / external-secrets), and
-# the SAME value must be set as LANGY_INTERNAL_SECRET on langwatch-app.
+# Auth secret shared with the control plane: the app sends it as a Bearer
+# token, the agent verifies it, so BOTH pods must read the same value.
+#
+# Under the umbrella chart this defaults to the app's own Secret, which the
+# umbrella materialises (generated when autogen is on, supplied by the
+# operator otherwise) — nothing to create by hand. This standalone default
+# only applies when the subchart is installed on its own, in which case the
+# operator creates it and sets the same value as LANGY_INTERNAL_SECRET on
+# langwatch-app:
 #   kubectl create secret generic langwatch-langyagent-auth \
 #     --from-literal=LANGY_INTERNAL_SECRET=$(openssl rand -hex 32)
 secrets:
@@ -75,7 +81,10 @@ secrets:
 #     --from-literal=LANGY_MIRROR_TRACE_KEY=<mirror project API key>
 mirror:
   # Base URL of the LangWatch deployment holding the mirror project —
-  # /api/otel/v1/traces is appended by the manager.
+  # /api/otel/v1/traces is appended by the manager. Leave empty and set
+  # existingSecretName below to mirror into THIS install: the endpoint then
+  # resolves to the release's own app Service over cluster DNS. Set it
+  # explicitly to mirror into a different LangWatch deployment.
   traceEndpoint: ""
   # Secret holding the mirror project's API key. Helm never materialises it;
   # the operator creates it out-of-band, like the auth secret above.
@@ -178,17 +187,31 @@ containerSecurityContext:
 # Without it, pods will fail to schedule with
 #   FailedCreatePodSandBox: ... runtimeclasses.node.k8s.io "gvisor" not found
 # Install via the gVisor operator or by applying the RuntimeClass manifest
-# from https://gvisor.dev/docs/user_guide/install/. The langyagent chart
-# refuses to deploy with chartManaged=true and an unset/empty runtimeClass
-# would be a security regression, so the default is opinionated.
+# from https://gvisor.dev/docs/user_guide/install/. On EKS that means a node
+# group whose AMI ships runsc; on GKE it is GKE Sandbox; kind/k3s and most
+# self-managed clusters ship no sandboxed runtime at all.
 #
-# To opt OUT (NOT recommended; documented for completeness): set
+# To run WITHOUT a sandboxed runtime — the only option on a cluster that
+# cannot provide one — blank this AND accept the reduced isolation below:
 #   runtimeClassName: ""
-# which omits the field from the pod spec → kubelet uses the node default
-# runtime (runc/containerd, no sandbox). Worker→worker isolation inside the
-# pod is still enforced by the per-UID + bearer-token authproxy work, but
-# pod→host isolation reverts to standard cgroups + namespaces only.
+#   acceptUnsandboxedRuntime: true
+# Blanking it alone is refused at render time (see deployment.yaml), so an
+# unsandboxed deploy is always something an operator wrote down on purpose.
 runtimeClassName: "gvisor"
+
+# Accept running the agent WITHOUT a sandboxed runtime. Only meaningful when
+# runtimeClassName is blank; the render fails otherwise (see deployment.yaml).
+#
+# What you give up: the pod->host escape surface reverts to standard cgroups +
+# namespaces, so a worker that breaks out of the container faces only the node
+# kernel. What you keep: per-worker UID isolation and the per-worker opencode
+# password still separate one conversation's credentials from another's inside
+# the pod, and the NetworkPolicy still bounds where workers can reach.
+#
+# The judgement call this leaves the operator: a single-tenant install whose
+# users are all colleagues carries a much smaller worker-versus-worker risk
+# than a multi-tenant one. Read it that way, not as a formality.
+acceptUnsandboxedRuntime: false
 
 networkPolicy:
   enabled: true

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -761,6 +761,7 @@
               "self-hosting/configuration/sizing-and-scaling",
               "self-hosting/configuration/backups",
               "self-hosting/configuration/sso",
+              "self-hosting/configuration/langy-assistant",
               "self-hosting/configuration/observability",
               "self-hosting/configuration/third-party-integrations"
             ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -25741,8 +25741,9 @@ app, and it is off until you turn it on.
 | A model provider | Langy talks to a model like every other LangWatch feature |
 | A sandboxed runtime, or an explicit acceptance | The workers execute model-written shell |
 
-Everything else, including the secret the app and the agent use to authenticate
-to each other, is handled by the chart.
+Everything else is handled by the chart: the secret the app and the agent use to
+authenticate to each other, and the in-cluster addresses they use to reach the
+gateway and to send answers back.
 
 ## Turning it on
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -25758,7 +25758,7 @@ helm upgrade langwatch langwatch/langwatch -n langwatch -f values.yaml
 
 That deploys the agent, wires the app and the workers to it, and makes the
 assistant available to everyone in your install. Give it a model to talk to by
-configuring a [model provider](/self-hosting/overview) for the project, then
+configuring a [model provider](/platform/model-providers) for the project, then
 open the assistant from any page.
 
 <Note>
@@ -25815,9 +25815,14 @@ can see the model calls it made, the tools it ran, and what each one cost.
 Create an API key in the project you want to mirror into, then:
 
 ```bash
+read -rsp "Mirror project API key: " KEY
 kubectl -n langwatch create secret generic langwatch-langyagent-mirror \
-  --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+  --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"
+unset KEY
 ```
+
+Reading the key rather than passing it as an argument keeps it out of your
+shell history and out of the process list on the machine you run this from.
 
 ```yaml
 langyagent:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -25721,6 +25721,154 @@ app:
 
 ---
 
+# FILE: ./self-hosting/configuration/langy-assistant.mdx
+
+---
+title: Langy Assistant
+description: "Run LangWatch's in-product AI assistant on your own cluster"
+---
+
+Langy is the assistant inside LangWatch: it answers questions about your traces,
+runs LangWatch's own CLI on your behalf, and can open pull requests against your
+repositories. On a self-hosted install it runs as one extra pod, alongside the
+app, and it is off until you turn it on.
+
+## What it needs
+
+| Requirement | Why |
+|-------------|-----|
+| The `langyagent` pod | Runs one isolated OpenCode worker per conversation |
+| A model provider | Langy talks to a model like every other LangWatch feature |
+| A sandboxed runtime, or an explicit acceptance | The workers execute model-written shell |
+
+Everything else, including the secret the app and the agent use to authenticate
+to each other, is handled by the chart.
+
+## Turning it on
+
+```yaml
+langyagent:
+  chartManaged: true
+```
+
+```bash
+helm upgrade langwatch langwatch/langwatch -n langwatch -f values.yaml
+```
+
+That deploys the agent, wires the app and the workers to it, and makes the
+assistant available to everyone in your install. Give it a model to talk to by
+configuring a [model provider](/self-hosting/overview) for the project, then
+open the assistant from any page.
+
+<Note>
+Langy is single-tenant by nature here: every person with access to your
+LangWatch install can use it, and it runs with the permissions of whoever is
+asking. To roll it out gradually instead, see [Staged rollout](#staged-rollout).
+</Note>
+
+## Clusters without a sandboxed runtime
+
+Langy's workers run shell written by a language model, so the chart asks for a
+sandboxed runtime, [gVisor](https://gvisor.dev/docs/user_guide/install/), and
+refuses to install without one rather than dropping the sandbox quietly. Managed
+offerings like GKE Sandbox provide it; most self-managed clusters do not.
+
+If yours cannot, say so explicitly and the install proceeds:
+
+```yaml
+langyagent:
+  chartManaged: true
+  runtimeClassName: ""
+  acceptUnsandboxedRuntime: true
+```
+
+What you keep either way: each conversation's worker runs under its own UID with
+its own credentials, workers cannot read each other's, and a NetworkPolicy bounds
+what any of them can reach. What the sandbox adds on top is protection of the
+node itself from a worker that escapes its container. An install whose users are
+all colleagues carries a very different risk here than one exposed to
+untrusted users, and that judgement is yours to make.
+
+## Letting Langy reach the internet
+
+Langy's tools shell out to `git`, `gh`, and package managers. Egress to the
+internet is off by default, because these workers hold the requesting user's API
+key and GitHub token:
+
+```yaml
+langyagent:
+  networkPolicy:
+    allowExternalHttps: true
+```
+
+Private address ranges and the cloud metadata endpoint stay blocked either way,
+so a worker cannot use this to reach your internal services. Without it, Langy
+still answers questions about your data; what stops working is anything that
+talks to GitHub or installs a package.
+
+## Watching Langy work
+
+Langy's own turns can be traced into one of your own LangWatch projects, so you
+can see the model calls it made, the tools it ran, and what each one cost.
+
+Create an API key in the project you want to mirror into, then:
+
+```bash
+kubectl -n langwatch create secret generic langwatch-langyagent-mirror \
+  --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+```
+
+```yaml
+langyagent:
+  mirror:
+    existingSecretName: langwatch-langyagent-mirror
+```
+
+The endpoint resolves to your own install automatically. Set
+`langyagent.mirror.traceEndpoint` only to mirror into a different LangWatch
+deployment.
+
+## Staged rollout
+
+To open Langy to a few projects before everyone, keep the rollout flag
+authoritative:
+
+```yaml
+langyagent:
+  chartManaged: true
+  enableForAllUsers: false
+```
+
+Langy then stays dark until you enable `release_langy_enabled`, or add targeting
+rules for specific projects and organizations, from `/ops/feature-flags` in your
+install.
+
+## Bringing your own secrets
+
+With `autogen.enabled: false` you supply the app Secret yourself. Add a
+`LANGY_INTERNAL_SECRET` key to it, which the app, the workers, and the agent all
+read to authenticate to each other:
+
+```bash
+kubectl -n langwatch patch secret langwatch-app-secrets \
+  -p "{\"stringData\":{\"LANGY_INTERNAL_SECRET\":\"$(openssl rand -hex 32)\"}}"
+```
+
+The install checks for the key and stops with a message naming it, rather than
+leaving three pods in `CreateContainerConfigError`.
+
+## Turning it off
+
+```yaml
+langyagent:
+  chartManaged: false
+```
+
+The agent pod and every reference to it are removed on the next upgrade. Nothing
+else in your install changes.
+
+---
+
 # FILE: ./self-hosting/configuration/observability.mdx
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -20,6 +20,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Sizing & Scaling](https://langwatch.ai/docs/self-hosting/configuration/sizing-and-scaling.md): Resource requirements, size profiles, and scaling recommendations for LangWatch
 - [Backups](https://langwatch.ai/docs/self-hosting/configuration/backups.md): Backup and restore strategies for LangWatch data stores
 - [SSO Configuration](https://langwatch.ai/docs/self-hosting/configuration/sso.md): Set up Single Sign-On for LangWatch with your identity provider
+- [Langy Assistant](https://langwatch.ai/docs/self-hosting/configuration/langy-assistant.md): Run LangWatch's in-product AI assistant on your own cluster
 - [Observability & Monitoring](https://langwatch.ai/docs/self-hosting/configuration/observability.md): Monitor LangWatch infrastructure with Prometheus, Grafana, and health checks
 - [Third-Party Integrations](https://langwatch.ai/docs/self-hosting/configuration/third-party-integrations.md): Configure email, error tracking, analytics, and external services for LangWatch
 

--- a/docs/self-hosting/configuration/langy-assistant.mdx
+++ b/docs/self-hosting/configuration/langy-assistant.mdx
@@ -1,0 +1,143 @@
+---
+title: Langy Assistant
+description: "Run LangWatch's in-product AI assistant on your own cluster"
+---
+
+Langy is the assistant inside LangWatch: it answers questions about your traces,
+runs LangWatch's own CLI on your behalf, and can open pull requests against your
+repositories. On a self-hosted install it runs as one extra pod, alongside the
+app, and it is off until you turn it on.
+
+## What it needs
+
+| Requirement | Why |
+|-------------|-----|
+| The `langyagent` pod | Runs one isolated OpenCode worker per conversation |
+| A model provider | Langy talks to a model like every other LangWatch feature |
+| A sandboxed runtime, or an explicit acceptance | The workers execute model-written shell |
+
+Everything else, including the secret the app and the agent use to authenticate
+to each other, is handled by the chart.
+
+## Turning it on
+
+```yaml
+langyagent:
+  chartManaged: true
+```
+
+```bash
+helm upgrade langwatch langwatch/langwatch -n langwatch -f values.yaml
+```
+
+That deploys the agent, wires the app and the workers to it, and makes the
+assistant available to everyone in your install. Give it a model to talk to by
+configuring a [model provider](/self-hosting/overview) for the project, then
+open the assistant from any page.
+
+<Note>
+Langy is single-tenant by nature here: every person with access to your
+LangWatch install can use it, and it runs with the permissions of whoever is
+asking. To roll it out gradually instead, see [Staged rollout](#staged-rollout).
+</Note>
+
+## Clusters without a sandboxed runtime
+
+Langy's workers run shell written by a language model, so the chart asks for a
+sandboxed runtime, [gVisor](https://gvisor.dev/docs/user_guide/install/), and
+refuses to install without one rather than dropping the sandbox quietly. Managed
+offerings like GKE Sandbox provide it; most self-managed clusters do not.
+
+If yours cannot, say so explicitly and the install proceeds:
+
+```yaml
+langyagent:
+  chartManaged: true
+  runtimeClassName: ""
+  acceptUnsandboxedRuntime: true
+```
+
+What you keep either way: each conversation's worker runs under its own UID with
+its own credentials, workers cannot read each other's, and a NetworkPolicy bounds
+what any of them can reach. What the sandbox adds on top is protection of the
+node itself from a worker that escapes its container. An install whose users are
+all colleagues carries a very different risk here than one exposed to
+untrusted users, and that judgement is yours to make.
+
+## Letting Langy reach the internet
+
+Langy's tools shell out to `git`, `gh`, and package managers. Egress to the
+internet is off by default, because these workers hold the requesting user's API
+key and GitHub token:
+
+```yaml
+langyagent:
+  networkPolicy:
+    allowExternalHttps: true
+```
+
+Private address ranges and the cloud metadata endpoint stay blocked either way,
+so a worker cannot use this to reach your internal services. Without it, Langy
+still answers questions about your data; what stops working is anything that
+talks to GitHub or installs a package.
+
+## Watching Langy work
+
+Langy's own turns can be traced into one of your own LangWatch projects, so you
+can see the model calls it made, the tools it ran, and what each one cost.
+
+Create an API key in the project you want to mirror into, then:
+
+```bash
+kubectl -n langwatch create secret generic langwatch-langyagent-mirror \
+  --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+```
+
+```yaml
+langyagent:
+  mirror:
+    existingSecretName: langwatch-langyagent-mirror
+```
+
+The endpoint resolves to your own install automatically. Set
+`langyagent.mirror.traceEndpoint` only to mirror into a different LangWatch
+deployment.
+
+## Staged rollout
+
+To open Langy to a few projects before everyone, keep the rollout flag
+authoritative:
+
+```yaml
+langyagent:
+  chartManaged: true
+  enableForAllUsers: false
+```
+
+Langy then stays dark until you enable `release_langy_enabled`, or add targeting
+rules for specific projects and organizations, from `/ops/feature-flags` in your
+install.
+
+## Bringing your own secrets
+
+With `autogen.enabled: false` you supply the app Secret yourself. Add a
+`LANGY_INTERNAL_SECRET` key to it, which the app, the workers, and the agent all
+read to authenticate to each other:
+
+```bash
+kubectl -n langwatch patch secret langwatch-app-secrets \
+  -p "{\"stringData\":{\"LANGY_INTERNAL_SECRET\":\"$(openssl rand -hex 32)\"}}"
+```
+
+The install checks for the key and stops with a message naming it, rather than
+leaving three pods in `CreateContainerConfigError`.
+
+## Turning it off
+
+```yaml
+langyagent:
+  chartManaged: false
+```
+
+The agent pod and every reference to it are removed on the next upgrade. Nothing
+else in your install changes.

--- a/docs/self-hosting/configuration/langy-assistant.mdx
+++ b/docs/self-hosting/configuration/langy-assistant.mdx
@@ -16,8 +16,9 @@ app, and it is off until you turn it on.
 | A model provider | Langy talks to a model like every other LangWatch feature |
 | A sandboxed runtime, or an explicit acceptance | The workers execute model-written shell |
 
-Everything else, including the secret the app and the agent use to authenticate
-to each other, is handled by the chart.
+Everything else is handled by the chart: the secret the app and the agent use to
+authenticate to each other, and the in-cluster addresses they use to reach the
+gateway and to send answers back.
 
 ## Turning it on
 

--- a/docs/self-hosting/configuration/langy-assistant.mdx
+++ b/docs/self-hosting/configuration/langy-assistant.mdx
@@ -33,7 +33,7 @@ helm upgrade langwatch langwatch/langwatch -n langwatch -f values.yaml
 
 That deploys the agent, wires the app and the workers to it, and makes the
 assistant available to everyone in your install. Give it a model to talk to by
-configuring a [model provider](/self-hosting/overview) for the project, then
+configuring a [model provider](/platform/model-providers) for the project, then
 open the assistant from any page.
 
 <Note>
@@ -90,9 +90,14 @@ can see the model calls it made, the tools it ran, and what each one cost.
 Create an API key in the project you want to mirror into, then:
 
 ```bash
+read -rsp "Mirror project API key: " KEY
 kubectl -n langwatch create secret generic langwatch-langyagent-mirror \
-  --from-literal=LANGY_MIRROR_TRACE_KEY=<that project's API key>
+  --from-env-file=/dev/stdin <<< "LANGY_MIRROR_TRACE_KEY=$KEY"
+unset KEY
 ```
+
+Reading the key rather than passing it as an argument keeps it out of your
+shell history and out of the process list on the machine you run this from.
 
 ```yaml
 langyagent:

--- a/specs/langy/langy-deploy-hardening.feature
+++ b/specs/langy/langy-deploy-hardening.feature
@@ -32,12 +32,28 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
   Scenario: The chart refuses to render when managed without a sandboxed runtime
     Given the chart manages the langy-agent pod
     And no sandboxed runtime is configured for the pod
+    And the operator has not accepted running without one
     When an operator renders the chart to deploy it
     Then the deploy fails before producing any manifests
     And the failure names the missing sandboxed runtime
     And the failure explains that running this workload without a sandbox
       re-opens the pod-to-host escape surface
+    And the failure names the value that accepts that risk deliberately
     # Same family as the existing replicaCount and service.type render guards.
+
+  # Most self-managed clusters cannot offer a sandboxed runtime, and refusing
+  # them outright made the assistant hosted-only in practice. The invariant that
+  # survives is narrower and still worth having: nobody runs this workload
+  # unsandboxed by ACCIDENT. Accepting the reduced isolation is a value the
+  # operator writes down, so it shows up in their own values file and in review,
+  # rather than being the silent consequence of leaving a field blank.
+  Scenario: An operator can accept the reduced isolation and render without a sandbox
+    Given the chart manages the langy-agent pod
+    And no sandboxed runtime is configured for the pod
+    And the operator has accepted running without one
+    When an operator renders the chart to deploy it
+    Then the pod renders successfully
+    And the pod is not pinned to any sandboxed runtime
 
   Scenario: The chart renders with the sandboxed runtime set
     Given the chart manages the langy-agent pod
@@ -51,8 +67,10 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
     And no sandboxed runtime is configured for the pod
     When an operator renders the chart
     Then rendering succeeds without requiring a sandboxed runtime
-    # Opting the whole pod out is the only legitimate way to run without the
-    # sandbox; blanking the runtime while still managed is not, and is refused.
+    # Opting the whole pod out needs no acceptance: there is no workload to
+    # sandbox. Blanking the runtime while still managed does, and is refused
+    # until the operator accepts it (see the scenario above, and
+    # specs/langy/langy-selfhost-install.feature for the operator's story).
 
   # ===========================================================================
   # Local e2e manifest mirrors the production security posture

--- a/specs/langy/langy-selfhost-install.feature
+++ b/specs/langy/langy-selfhost-install.feature
@@ -46,6 +46,27 @@ Feature: Langy comes up with a self-hosted LangWatch install
     Then it is the agent version that shipped with that release
     And not an older one left behind by a previous release
 
+  # The pieces of an install have to address each other by names that mean the
+  # same thing from inside the cluster. Both failures below were invisible from
+  # the outside: every pod healthy, and either no answer at all or an answer
+  # that cost real tokens and was then thrown away.
+  Scenario: Langy can reach the model provider the install already configured
+    Given an operator has installed LangWatch with the Langy agent enabled
+    And a model provider is configured for the project
+    When someone asks Langy a question
+    Then Langy reaches the model
+    And it does not refuse the turn over a setting the operator was never asked for
+
+  Scenario: An answer Langy produces makes it back to the person who asked
+    Given someone has asked Langy a question
+    When Langy finishes working
+    Then the answer arrives in the conversation
+    And the tools it ran along the way arrive with it
+    # The reply, the tool results, and the turn's traces all travel the same way
+    # back to the control plane. Pointing that route at an address that only
+    # means something outside the cluster loses all three at once, after the
+    # model has already been paid for.
+
   # ===========================================================================
   # Installed means usable
   # ===========================================================================

--- a/specs/langy/langy-selfhost-install.feature
+++ b/specs/langy/langy-selfhost-install.feature
@@ -1,0 +1,112 @@
+Feature: Langy comes up with a self-hosted LangWatch install
+  As someone installing LangWatch on my own cluster from the published Helm
+  chart,
+  I want Langy to work by installing it,
+  so that the in-product assistant is part of the product I run, not an
+  internal-only feature I can see in the docs but never switch on.
+
+  # Cross-references:
+  #   ADR-033 — Langy worker isolation (the sandboxed-runtime posture).
+  #   specs/langy/langy-deploy-hardening.feature — the render-time guards.
+  #
+  # Context. Langy shipped to the hosted product first, so every prerequisite
+  # it grew was satisfied out-of-band by our own infrastructure: a secret
+  # created by terraform, an image pushed to a private registry, a rollout flag
+  # flipped from an internal ops screen, a node pool with a sandboxed runtime.
+  # None of that exists for someone installing the chart on their own cluster,
+  # and each missing piece failed in a different place: a pod stuck on a secret
+  # nobody told them to create, an image that cannot be pulled, an assistant
+  # that installs cleanly and then never appears in the product.
+  #
+  # The through-line of this feature: everything Langy needs to run must be
+  # either materialised by the chart or named in one place the operator is
+  # actually told about. "Works for us because of something outside the chart"
+  # is the bug.
+
+  # ===========================================================================
+  # Installing it is enough
+  # ===========================================================================
+
+  Scenario: Installing the chart with Langy enabled brings up a working assistant
+    Given an operator installs the LangWatch chart on their own cluster
+    When they enable the Langy agent
+    Then the install completes without asking them to create anything by hand
+    And the app and the agent recognise each other on the first request
+    And no pod is left waiting on a secret the operator was never told about
+
+  Scenario: An operator who brings their own secrets is told exactly which one Langy needs
+    Given an operator supplies their own secrets instead of generated ones
+    When they enable the Langy agent
+    Then the install names the one value Langy needs from them
+    And it fails before deploying rather than half-installing
+
+  Scenario: The agent that installs is the agent the release was tested with
+    Given an operator installs a given version of LangWatch
+    When the Langy agent starts
+    Then it is the agent version that shipped with that release
+    And not an older one left behind by a previous release
+
+  # ===========================================================================
+  # Installed means usable
+  # ===========================================================================
+
+  # The rollout flag exists so the hosted product can open Langy to one cohort
+  # at a time. A self-hosted install has exactly one cohort: the people who
+  # installed it. Leaving the flag as the hosted default meant an operator
+  # deployed the agent, watched it go healthy, and still saw no assistant
+  # anywhere in the product, with the only lever an internal screen.
+  Scenario: Deploying the agent makes Langy available to the people in that install
+    Given an operator has installed LangWatch with the Langy agent enabled
+    When someone on that install opens the product
+    Then Langy is available to them
+    And nobody has to flip anything in an internal-only screen first
+
+  Scenario: An operator who wants a staged rollout keeps one
+    Given an operator wants to try Langy with a few people before everyone
+    When they install the agent with the everyone-at-once switch turned off
+    Then Langy stays dark until they open it to the people they choose
+    And the choice of who gets it stays theirs to make
+
+  # ===========================================================================
+  # The sandbox posture, on clusters that cannot offer one
+  # ===========================================================================
+
+  # Langy runs LLM-written shell, so the sandboxed runtime is the posture we
+  # want everywhere. But requiring it silently made "no sandboxed runtime" mean
+  # "no Langy at all", which is most self-managed clusters. The rule we keep is
+  # that nobody runs it unsandboxed by ACCIDENT: the risk has to be accepted out
+  # loud, in the values file, before the chart will render it.
+  Scenario: An operator whose cluster has no sandboxed runtime can still run Langy, deliberately
+    Given a cluster with no sandboxed runtime available
+    When the operator accepts the reduced isolation explicitly
+    Then Langy installs and runs
+    And the acceptance is recorded in their own values, not buried in a default
+
+  Scenario: Leaving the sandbox out without saying so is still refused
+    Given a cluster with no sandboxed runtime available
+    When the operator has not accepted the reduced isolation
+    Then the install still refuses to render
+    And the refusal explains both what is missing and how to accept it
+
+  # ===========================================================================
+  # Watching Langy work, in the install that runs it
+  # ===========================================================================
+
+  # LangWatch is an observability product, so the assistant it ships should be
+  # observable with the same tools — in the operator's own install, not only in
+  # ours. This is the dogfooding loop the product is for.
+  Scenario: Langy's own work shows up as traces in the operator's LangWatch
+    Given an operator has pointed Langy's trace mirror at one of their projects
+    When someone holds a conversation with Langy
+    Then that turn appears as a trace in that project
+    And the trace shows the model calls and the tools the turn ran
+
+  # ===========================================================================
+  # Off stays off
+  # ===========================================================================
+
+  Scenario: An install that does not want Langy is unaffected by it
+    Given an operator installs LangWatch without the Langy agent
+    When the install completes
+    Then nothing in the install references the assistant
+    And the rest of the product behaves exactly as it did before Langy existed


### PR DESCRIPTION
Langy shipped to the hosted product first, so every prerequisite it grew was satisfied by our own infrastructure: a secret created by terraform, an image in a private registry, a rollout flag flipped from an internal ops screen, a node pool with a sandboxed runtime. None of that exists for someone installing the chart on their own cluster, so **the assistant could not actually be self-hosted** even though the chart appeared to support it.

Turning Langy on is now one value, and every piece it needs is either materialised by the chart or named in one place the operator is told about.

```yaml
langyagent:
  chartManaged: true
```

## What was broken

Found by installing the chart on a real EKS cluster and working forward from each failure. They are listed in the order an operator would have hit them.

**Every turn died in a process nobody was watching.** Langy turns are dispatched by the process outbox in the event-sourcing runtime, which runs in the **worker** stack, not the app. The workers deployment had no agent URL and no shared secret, and the agent's NetworkPolicy admitted only the app pod. Both pods reported healthy while every turn vanished.

**The shared secret was never created.** Both deployments referenced a Secret the chart does not materialise, so enabling the agent left the app pod in `CreateContainerConfigError` over a key nothing had told the operator to add. It now lands in the app Secret next to the gateway's pair, generated or operator-supplied like every other key.

**The assistant stayed invisible.** Its rollout flag is SYSTEM-scoped and defaults off so the hosted product can open it one cohort at a time. A self-hosted install has one cohort, so deploying the agent now opens it; `enableForAllUsers: false` keeps the staged path.

**The image was pinned to a version that predates the agent.** The subchart was missing from the release-please `extra-files`, so its appVersion sat at 3.3.0 while the app moved on, and the tag derived from it would have pulled an agent two releases behind. It now tracks releases like the gateway chart does.

**A sandboxed runtime was required unconditionally.** Most self-managed clusters have none, which made the assistant hosted-only in practice. The invariant worth keeping is narrower: nobody runs this unsandboxed by *accident*. `acceptUnsandboxedRuntime` makes it a decision the operator writes down, and the values file no longer documents an opt-out the template refused to render.

**Langy could not reach its model.** It mints the worker's key against the gateway, and the app was never told where the gateway is: the chart deploys it but only ever passed the *public* URL, which an install with no gateway ingress does not have. Every turn was refused with a credential error naming a variable nothing in the chart sets.

**Answers never made it back.** The agent's workers dial the control plane to deliver the answer, finalize the turn, and run every CLI tool call. That origin fell back to the app pod's own `LANGWATCH_ENDPOINT`, which is deliberately `localhost` so in-pod runners can self-reference — so the agent resolved it to *itself*. The model ran, the tools ran, and then every callback failed: a turn that cost real tokens, produced an answer, and dropped it.

**Trace mirroring needed an endpoint it could work out itself.** Supply the project key and the endpoint now resolves to the install's own control plane.

## Deployment Impact

**Default `helm install` with no overrides is unchanged.** `langyagent.chartManaged` stays `false`, so no new pod, no new Secret key, and no new env var appear on an existing install. Defaulting it on was considered and rejected: with the sandbox guard it would fail the render, and without it every cluster lacking gVisor would gain a permanently Pending pod on its next upgrade.

**Helm values added** (all under `langyagent`, inert while `chartManaged: false`):
- `langyagent.enableForAllUsers` (default `true`) — opens the assistant to the install once the agent is deployed; `false` keeps the rollout flag authoritative.
- `langyagent.acceptUnsandboxedRuntime` (default `false`) — required to render with a blank `runtimeClassName`.
- `langyagent.controlPlane.callbackUrl` (default derived) — the origin the agent's workers dial back on.
- `langyagent.mirror.existingSecretName` / `mirror.traceEndpoint` — optional trace mirroring; the endpoint derives from the release.
- `gateway.internalUrl` (default derived) — where the control plane reaches the gateway; only set it for a gateway outside this release.
- `app.featureFlagForceEnable` (default `""`) — operator-forced release flags, joined with Langy's own.

**Env vars added**, and only when `langyagent.chartManaged: true`: `OPENCODE_AGENT_URL`, `LANGY_INTERNAL_SECRET`, `LANGY_WORKER_CALLBACK_URL` and `FEATURE_FLAG_FORCE_ENABLE` on the app and the workers. `LW_GATEWAY_BASE_URL` is added to the app whenever the gateway is chart-managed, which is the default — it is a new value on an existing install, pointing at the gateway Service that install already runs, and it fixes virtual-key minting rather than changing routing.

**Secrets.** `LANGY_INTERNAL_SECRET` joins the app Secret alongside the gateway pair, generated under `autogen.enabled` and healed in place on upgrade like every other key. Operators who bring their own Secret are told which key to add and the render stops rather than half-installing. Nothing is created out-of-band any more.

**Render can now refuse** in two new cases, both only when the agent is chart-managed: a blank sandboxed runtime without `acceptUnsandboxedRuntime`, and a mirror endpoint set without its key. Neither can fire on an install that leaves Langy off.

**BYOC / dedicated dataplane:** no impact. Nothing here touches the dataplane chart, the ingestion path, or any shared-plane component; the assistant is an optional control-plane pod, off unless an operator opts in. A BYOC customer who does opt in needs a sandboxed runtime on their own cluster, or the explicit acceptance above.

**Chart versions:** `charts/langyagent` moves 3.3.0 to 3.5.0 to match the app, and joins the release-please `extra-files` so it tracks releases from here on. The image tag derives from that appVersion, so the first release after this merge is also the first to publish `langwatch/langyagent` (see Notes for the release).

## Verified end to end on EKS

Installed on a real cluster with nothing pre-created, agent running under gVisor. A turn loads a skill, runs `langwatch prompt list --format json` against the control plane, answers from the result, and lands as a `langy.turn` trace with its model and tool spans in the project the mirror points at.

Traces arriving in the self-hosted install, tagged `Origin: langy`:

![Traces list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/helm-langy-selfhost/selfhost-langy-traces-list.png)

The turn itself, with cost, tokens, model and the attributes of the minted virtual key:

![Trace detail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/helm-langy-selfhost/selfhost-langy-trace-summary.png)

## Notes for the release

- **`langwatch/langyagent` has never been published to Docker Hub.** The publish matrix entry was added in #5741, which merged after `langwatch@v3.5.0`, so no release has run it. The other four images are public; this repo does not exist yet. The first release that runs the workflow will create it — worth confirming it lands **public**, since self-hosters cannot pull it otherwise. `Dockerfile.langyagent` itself builds clean for arm64 from main (built and pushed during this work).
- **`chartManaged` stays `false` by default.** Defaulting it on would either fail the render (the sandbox guard) or leave a Pending pod on every existing install that has no gVisor. Opting in is now a genuine one-liner instead.
- The dev cluster's dedicated `langy-gvisor` node group advertises the RuntimeClass but has no `runsc` configured in containerd; the gvisor-installer DaemonSet covers the ordinary nodes instead. The agent was tested under real gVisor on those.

## Spec

- `specs/langy/langy-selfhost-install.feature` (new) — the operator's story end to end.
- `specs/langy/langy-deploy-hardening.feature` — the sandbox guard now has an explicit acceptance path.
- `docs/self-hosting/configuration/langy-assistant.mdx` (new) — the self-hosting page.
- Chart CI renders the assistant two ways; its path filter had omitted `charts/langyagent/**` entirely, so none of its templates were ever covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-hosted Langy Assistant support via the LangWatch Helm chart, including chart-managed wiring, staged enablement/rollout, and optional trace mirroring.
  * Added explicit opt-in configuration for running without a sandboxed runtime.
* **Bug Fixes**
  * Improved pre-deployment secret wiring validation to catch mismatches and missing required keys.
  * Adjusted default connectivity/network policy wiring for safer in-cluster access.
* **Documentation**
  * Added self-hosting Langy Assistant docs and expanded install/upgrade guidance for managed and unsandboxed setups.
* **Tests**
  * Extended render-time hardening scenarios to cover explicit reduced-isolation acceptance.
* **Chores**
  * Updated CI chart workflow triggers/lint matrix and bumped the Langy agent chart version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->