### PR TITLE
feat(server): run Langy on npx installs and slim the install to what gets used

### DIFF
--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -219,6 +219,35 @@ jobs:
           probe langevals "http://127.0.0.1:$((base + 2))/"        /tmp/health-langevals.json
           probe gateway   "http://127.0.0.1:$((base + 3))/healthz" /tmp/health-gateway.json
 
+      # The assistant has exactly two legitimate outcomes, and the CLI's own
+      # log says which one happened: `langyagent` reached healthy, or it was
+      # deliberately skipped because the downloaded release binary predates
+      # the langyagent service (the smoke tests an unreleased CLI against the
+      # PREVIOUS release's binary, so the skip is the expected path until the
+      # next release publishes fresh binaries). Anything else — crash-looping,
+      # or a "healthy" verdict without a listener actually answering on the
+      # port — fails the smoke. The port re-probe exists because a stray
+      # listener on the assistant's port once let a dead langyagent pass as
+      # healthy on ubuntu runners.
+      - name: Assert the assistant either booted or declared itself skipped
+        run: |
+          set -eo pipefail
+          base=${RESOLVED_BASE}
+          log="$GITHUB_WORKSPACE/_smoke.log"
+          if grep -q "langy assistant disabled" "$log"; then
+            echo "✓ assistant skipped with the release-binary notice (expected until the next release's binaries exist)"
+            exit 0
+          fi
+          if grep -qE "langyagent +healthy in" "$log"; then
+            curl -fsS --connect-timeout 2 --max-time 5 "http://127.0.0.1:$((base + 4))/health" > /tmp/health-langy.json
+            echo "✓ assistant healthy and answering on port $((base + 4))"
+            cat /tmp/health-langy.json; echo
+            exit 0
+          fi
+          echo "✗ cli.log shows neither a healthy langyagent nor the deliberate-skip notice"
+          grep -i "langyagent" "$log" | tail -n 5 || true
+          exit 1
+
       # Belt-and-suspenders for the beta.8 → beta.9 regression: the smoke
       # matrix happily passed for weeks while aigateway was being silently
       # `go build`-ed on the runner. Two assertions to make a future

--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ The fastest way to run LangWatch locally — only Node.js required:
 npx @langwatch/server
 ```
 
-The CLI installs `uv`, `postgres`, `redis`, `clickhouse`, and the AI gateway binary into `~/.langwatch/`, scaffolds a `.env` with locally-generated secrets, then starts every service in parallel and opens `http://localhost:5560`. Everything lives under `~/.langwatch/`; `rm -rf ~/.langwatch` is a clean reset.
+The CLI installs `uv`, `postgres`, `redis`, `clickhouse`, the AI gateway binary, and the Langy assistant's runtime into `~/.langwatch/`, scaffolds a `.env` with locally-generated secrets, then starts every service in parallel and opens `http://localhost:5560`. Everything lives under `~/.langwatch/`; `rm -rf ~/.langwatch` is a clean reset.
+
+Two pieces are yours to decide on, in `~/.langwatch/.env`:
+
+| Variable | Default | What it changes |
+|---|---|---|
+| `LANGWATCH_ENABLE_LANGY` | `true` | The Langy assistant. Adds ~45MB for its runtime; the workers run unsandboxed as you, on your own machine. |
+| `LANGWATCH_ENABLE_PRESIDIO` | `false` | The PII detection evaluator. Adds ~670MB of language model, larger than the rest of the evaluator environment put together. Every other evaluator is installed either way, and LangWatch's own secret and PII redaction of your traces does not depend on it. |
+
+Change either and restart the server.
 
 Prefer Docker? You can still use docker compose:
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Two pieces are yours to decide on, in `~/.langwatch/.env`:
 | Variable | Default | What it changes |
 |---|---|---|
 | `LANGWATCH_ENABLE_LANGY` | `true` | The Langy assistant. Adds ~45MB for its runtime; the workers run unsandboxed as you, on your own machine. |
-| `LANGWATCH_ENABLE_PRESIDIO` | `false` | The PII detection evaluator. Adds ~670MB of language model, larger than the rest of the evaluator environment put together. Every other evaluator is installed either way, and LangWatch's own secret and PII redaction of your traces does not depend on it. |
+| `LANGWATCH_ENABLE_PRESIDIO` | `false` | The PII detection evaluator. Adds ~670MB of language model, larger than the rest of the evaluator environment put together. LangWatch's own secret and PII redaction of your traces does not depend on it. |
+| `LANGWATCH_ENABLE_LINGUA` | `false` | The language detection evaluator. Adds ~95MB of language models. |
+| `LANGWATCH_ENABLE_LEGACY_EVALUATORS` | `false` | The deprecated legacy evaluators, kept only for evaluations saved long ago. Hidden from the product entirely while off. |
 
-Change either and restart the server.
+Every other evaluator is installed either way. Change any of these in `~/.langwatch/.env` and restart the server.
 
 Prefer Docker? You can still use docker compose:
 

--- a/langwatch/src/components/checks/EvaluatorSelection.tsx
+++ b/langwatch/src/components/checks/EvaluatorSelection.tsx
@@ -114,6 +114,7 @@ export function EvaluatorSelection({
         EvaluatorDefinition<any> & {
           beta?: boolean;
           missingEnvVars?: string[];
+          unavailable?: { reason: string; howToEnable: string };
         },
       ]
     >
@@ -174,9 +175,14 @@ export function EvaluatorSelection({
           <Tabs.Content key={category} value={category} paddingX={0}>
             <Grid templateColumns="repeat(3, 1fr)" gap={6}>
               {evaluators.map(([key, evaluator]) => {
+                // Two different reasons a card cannot be picked: the
+                // evaluator is not installed on this server at all, or it is
+                // installed but not configured. They read differently and are
+                // fixed differently, so they are shown differently.
                 const isDisabled =
-                  evaluator.missingEnvVars &&
-                  evaluator.missingEnvVars.length > 0;
+                  !!evaluator.unavailable ||
+                  (evaluator.missingEnvVars &&
+                    evaluator.missingEnvVars.length > 0);
 
                 return (
                   <GridItem
@@ -240,7 +246,23 @@ export function EvaluatorSelection({
                             evaluator.name}
                         </Heading>
                       </HStack>
-                      {evaluator.missingEnvVars &&
+                      {evaluator.unavailable && (
+                        <Tooltip
+                          content={evaluator.unavailable.howToEnable}
+                          positioning={{ placement: "top" }}
+                        >
+                          <Tag.Root
+                            colorPalette="orange"
+                            borderRadius="8px"
+                            padding="4px 8px"
+                            lineHeight="1.5em"
+                          >
+                            <Tag.Label>Not installed on this server</Tag.Label>
+                          </Tag.Root>
+                        </Tooltip>
+                      )}
+                      {!evaluator.unavailable &&
+                        evaluator.missingEnvVars &&
                         evaluator.missingEnvVars.length > 0 && (
                           <Tooltip
                             content={evaluator.missingEnvVars.join(", ")}

--- a/langwatch/src/components/evaluators/EvaluatorTypeSelectorContent.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorTypeSelectorContent.tsx
@@ -185,7 +185,12 @@ export function EvaluatorTypeSelectorContent({
             availableEvaluatorsQuery.data?.[evaluatorType];
           const missingEnvVars = availableEntry?.missingEnvVars ?? [];
           const isAzureEvaluator = evaluatorType.startsWith("azure/");
-          const isDisabled = isAzureEvaluator && missingEnvVars.length > 0;
+          // Not installed on this server is a different state from installed
+          // but unconfigured: there is no settings screen that fixes it, so it
+          // gets the explanation instead of a call to action.
+          const unavailable = availableEntry?.unavailable;
+          const isDisabled =
+            !!unavailable || (isAzureEvaluator && missingEnvVars.length > 0);
 
           return (
             <EvaluatorCard
@@ -195,12 +200,14 @@ export function EvaluatorTypeSelectorContent({
               description={evaluator.description}
               disabled={isDisabled}
               disabledTooltip={
-                isDisabled
-                  ? "Configure Azure Safety provider in Settings → Model Providers"
-                  : undefined
+                unavailable
+                  ? `${unavailable.reason} ${unavailable.howToEnable}`
+                  : isDisabled
+                    ? "Configure Azure Safety provider in Settings → Model Providers"
+                    : undefined
               }
               disabledCta={
-                isDisabled
+                isDisabled && !unavailable
                   ? {
                       label: "Configure Azure Safety",
                       onClick: handleConfigureAzureSafety,

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -41,18 +41,24 @@ export const evaluationsRouter = createTRPCRouter({
         : [...AZURE_SAFETY_ENV_VARS];
 
       return Object.fromEntries(
-        Object.entries(AVAILABLE_EVALUATORS).map(([key, evaluator]) => [
-          key,
-          {
-            ...evaluator,
-            missingEnvVars: isAzureEvaluatorType(key)
-              ? azureMissingEnvVars
-              : evaluator.envVars.filter((envVar) => !process.env[envVar]),
-            // Set when this install does not have the evaluator's code at
-            // all, which is a different thing from it being unconfigured.
-            unavailable: evaluatorUnavailability(key),
-          },
-        ]),
+        Object.entries(AVAILABLE_EVALUATORS)
+          // Evaluators this install hides entirely (deprecated families it
+          // did not download) drop out of the offer; saved references to
+          // them still resolve against the static registry and fail their
+          // runs with the clear not-installed message.
+          .filter(([key]) => !evaluatorUnavailability(key)?.hideFromUi)
+          .map(([key, evaluator]) => [
+            key,
+            {
+              ...evaluator,
+              missingEnvVars: isAzureEvaluatorType(key)
+                ? azureMissingEnvVars
+                : evaluator.envVars.filter((envVar) => !process.env[envVar]),
+              // Set when this install does not have the evaluator's code at
+              // all, which is a different thing from it being unconfigured.
+              unavailable: evaluatorUnavailability(key),
+            },
+          ]),
       );
     }),
 

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -46,7 +46,7 @@ export const evaluationsRouter = createTRPCRouter({
           // did not download) drop out of the offer; saved references to
           // them still resolve against the static registry and fail their
           // runs with the clear not-installed message.
-          .filter(([key]) => !evaluatorUnavailability(key)?.hideFromUi)
+          .filter(([key]) => !evaluatorUnavailability({ evaluatorType: key })?.hideFromUi)
           .map(([key, evaluator]) => [
             key,
             {
@@ -56,7 +56,7 @@ export const evaluationsRouter = createTRPCRouter({
                 : evaluator.envVars.filter((envVar) => !process.env[envVar]),
               // Set when this install does not have the evaluator's code at
               // all, which is a different thing from it being unconfigured.
-              unavailable: evaluatorUnavailability(key),
+              unavailable: evaluatorUnavailability({ evaluatorType: key }),
             },
           ]),
       );

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -17,6 +17,7 @@ import {
   evaluatorsSchema,
 } from "../../evaluations/evaluators";
 import { runEvaluationForTrace } from "../../evaluations/runEvaluation";
+import { evaluatorUnavailability } from "../../evaluations/installedEvaluators";
 import { mappingStateSchema } from "../../tracer/tracesMapping";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
@@ -47,6 +48,9 @@ export const evaluationsRouter = createTRPCRouter({
             missingEnvVars: isAzureEvaluatorType(key)
               ? azureMissingEnvVars
               : evaluator.envVars.filter((envVar) => !process.env[envVar]),
+            // Set when this install does not have the evaluator's code at
+            // all, which is a different thing from it being unconfigured.
+            unavailable: evaluatorUnavailability(key),
           },
         ]),
       );

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -46,7 +46,9 @@ export const evaluationsRouter = createTRPCRouter({
           // did not download) drop out of the offer; saved references to
           // them still resolve against the static registry and fail their
           // runs with the clear not-installed message.
-          .filter(([key]) => !evaluatorUnavailability({ evaluatorType: key })?.hideFromUi)
+          .filter(
+            ([key]) => !evaluatorUnavailability({ evaluatorType: key })?.isHiddenFromUi,
+          )
           .map(([key, evaluator]) => [
             key,
             {

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -418,9 +418,9 @@ export class EvaluationExecutionService {
     // An evaluator this install skipped is not a broken one. Say which it is,
     // and how to get it, rather than letting the request reach an evaluator
     // service with no route for it and come back as a bare 404.
-    const unavailable = evaluatorUnavailability(evaluatorType);
+    const unavailable = evaluatorUnavailability({ evaluatorType });
     if (unavailable) {
-      throw new EvaluatorConfigError(unavailableEvaluatorMessage(unavailable), {
+      throw new EvaluatorConfigError(unavailableEvaluatorMessage({ unavailability: unavailable }), {
         meta: { evaluatorType },
       });
     }

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -4,6 +4,10 @@ import {
   migrateLegacyMappings,
 } from "~/server/evaluations/evaluationMappings";
 import {
+  evaluatorUnavailability,
+  unavailableEvaluatorMessage,
+} from "~/server/evaluations/installedEvaluators";
+import {
   AVAILABLE_EVALUATORS,
   type EvaluatorTypes,
   type SingleEvaluationResult,
@@ -409,6 +413,16 @@ export class EvaluationExecutionService {
     const evaluator = AVAILABLE_EVALUATORS[evaluatorType as EvaluatorTypes];
     if (!evaluator) {
       throw new EvaluatorNotFoundError(evaluatorType);
+    }
+
+    // An evaluator this install skipped is not a broken one. Say which it is,
+    // and how to get it, rather than letting the request reach an evaluator
+    // service with no route for it and come back as a bare 404.
+    const unavailable = evaluatorUnavailability(evaluatorType);
+    if (unavailable) {
+      throw new EvaluatorConfigError(unavailableEvaluatorMessage(unavailable), {
+        meta: { evaluatorType },
+      });
     }
 
     const fields = [...evaluator.requiredFields, ...evaluator.optionalFields];

--- a/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   evaluatorUnavailability,
   unavailableEvaluatorMessage,
+  LEGACY_EVALUATORS_ENABLE_ENV_VAR,
+  LINGUA_ENABLE_ENV_VAR,
   PRESIDIO_ENABLE_ENV_VAR,
 } from "../installedEvaluators";
 
@@ -9,8 +11,10 @@ describe("evaluator availability on this install", () => {
   describe("when nothing says otherwise", () => {
     it("treats every evaluator as available", () => {
       // Container and Kubernetes installs build the evaluator environment with
-      // every extra and never set this variable, so silence must mean present.
+      // every extra and never set these variables, so silence must mean present.
       expect(evaluatorUnavailability("presidio/pii_detection", {})).toBeUndefined();
+      expect(evaluatorUnavailability("lingua/language_detection", {})).toBeUndefined();
+      expect(evaluatorUnavailability("legacy/ragas_faithfulness", {})).toBeUndefined();
       expect(evaluatorUnavailability("ragas/faithfulness", {})).toBeUndefined();
     });
   });
@@ -56,6 +60,40 @@ describe("evaluator availability on this install", () => {
       const message = unavailableEvaluatorMessage(result);
       expect(message).toContain(result.reason);
       expect(message).toContain(result.howToEnable);
+    });
+  });
+
+  describe("when the install skipped language detection", () => {
+    const env = { [LINGUA_ENABLE_ENV_VAR]: "false" };
+
+    it("reports it as not installed, naming the switch", () => {
+      const result = evaluatorUnavailability("lingua/language_detection", env);
+      expect(result).toBeDefined();
+      expect(result!.reason).toMatch(/not installed/i);
+      expect(result!.howToEnable).toContain(LINGUA_ENABLE_ENV_VAR);
+      // It stays visible as a disabled card; only deprecated families hide.
+      expect(result!.hideFromUi).toBeUndefined();
+    });
+  });
+
+  describe("when the install skipped the legacy evaluators", () => {
+    const env = { [LEGACY_EVALUATORS_ENABLE_ENV_VAR]: "false" };
+
+    it("hides them from pickers entirely", () => {
+      const result = evaluatorUnavailability("legacy/ragas_faithfulness", env);
+      expect(result).toBeDefined();
+      expect(result!.hideFromUi).toBe(true);
+    });
+
+    it("still explains itself when a saved evaluation runs one", () => {
+      const result = evaluatorUnavailability("legacy/ragas_faithfulness", env)!;
+      const message = unavailableEvaluatorMessage(result);
+      expect(message).toMatch(/not installed/i);
+      expect(message).toContain(LEGACY_EVALUATORS_ENABLE_ENV_VAR);
+    });
+
+    it("does not touch the current ragas family", () => {
+      expect(evaluatorUnavailability("ragas/faithfulness", env)).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluatorUnavailability,
+  unavailableEvaluatorMessage,
+  PRESIDIO_ENABLE_ENV_VAR,
+} from "../installedEvaluators";
+
+describe("evaluator availability on this install", () => {
+  describe("when nothing says otherwise", () => {
+    it("treats every evaluator as available", () => {
+      // Container and Kubernetes installs build the evaluator environment with
+      // every extra and never set this variable, so silence must mean present.
+      expect(evaluatorUnavailability("presidio/pii_detection", {})).toBeUndefined();
+      expect(evaluatorUnavailability("ragas/faithfulness", {})).toBeUndefined();
+    });
+  });
+
+  describe("when the install skipped the PII model", () => {
+    const env = { [PRESIDIO_ENABLE_ENV_VAR]: "false" };
+
+    it("reports the PII detector as not installed", () => {
+      const result = evaluatorUnavailability("presidio/pii_detection", env);
+      expect(result).toBeDefined();
+      expect(result!.reason).toMatch(/not installed/i);
+    });
+
+    it("says how to get it, naming the exact switch", () => {
+      const result = evaluatorUnavailability("presidio/pii_detection", env)!;
+      expect(result.howToEnable).toContain(PRESIDIO_ENABLE_ENV_VAR);
+      expect(result.howToEnable).toMatch(/restart/i);
+    });
+
+    it("leaves every other evaluator alone", () => {
+      expect(evaluatorUnavailability("ragas/faithfulness", env)).toBeUndefined();
+      expect(evaluatorUnavailability("lingua/language_detection", env)).toBeUndefined();
+    });
+  });
+
+  describe("when the install was asked for the PII model", () => {
+    it("reports it as available", () => {
+      for (const yes of ["true", "1", "yes", "on"]) {
+        expect(
+          evaluatorUnavailability("presidio/pii_detection", {
+            [PRESIDIO_ENABLE_ENV_VAR]: yes,
+          }),
+        ).toBeUndefined();
+      }
+    });
+  });
+
+  describe("the message shown when one is run anyway", () => {
+    it("states what happened and what to do about it", () => {
+      const result = evaluatorUnavailability("presidio/pii_detection", {
+        [PRESIDIO_ENABLE_ENV_VAR]: "false",
+      })!;
+      const message = unavailableEvaluatorMessage(result);
+      expect(message).toContain(result.reason);
+      expect(message).toContain(result.howToEnable);
+    });
+  });
+});

--- a/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
@@ -12,10 +12,10 @@ describe("evaluator availability on this install", () => {
     it("treats every evaluator as available", () => {
       // Container and Kubernetes installs build the evaluator environment with
       // every extra and never set these variables, so silence must mean present.
-      expect(evaluatorUnavailability("presidio/pii_detection", {})).toBeUndefined();
-      expect(evaluatorUnavailability("lingua/language_detection", {})).toBeUndefined();
-      expect(evaluatorUnavailability("legacy/ragas_faithfulness", {})).toBeUndefined();
-      expect(evaluatorUnavailability("ragas/faithfulness", {})).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "presidio/pii_detection", env: {} })).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "lingua/language_detection", env: {} })).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "legacy/ragas_faithfulness", env: {} })).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "ragas/faithfulness", env: {} })).toBeUndefined();
     });
   });
 
@@ -23,20 +23,20 @@ describe("evaluator availability on this install", () => {
     const env = { [PRESIDIO_ENABLE_ENV_VAR]: "false" };
 
     it("reports the PII detector as not installed", () => {
-      const result = evaluatorUnavailability("presidio/pii_detection", env);
+      const result = evaluatorUnavailability({ evaluatorType: "presidio/pii_detection", env });
       expect(result).toBeDefined();
       expect(result!.reason).toMatch(/not installed/i);
     });
 
     it("says how to get it, naming the exact switch", () => {
-      const result = evaluatorUnavailability("presidio/pii_detection", env)!;
+      const result = evaluatorUnavailability({ evaluatorType: "presidio/pii_detection", env })!;
       expect(result.howToEnable).toContain(PRESIDIO_ENABLE_ENV_VAR);
       expect(result.howToEnable).toMatch(/restart/i);
     });
 
     it("leaves every other evaluator alone", () => {
-      expect(evaluatorUnavailability("ragas/faithfulness", env)).toBeUndefined();
-      expect(evaluatorUnavailability("lingua/language_detection", env)).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "ragas/faithfulness", env })).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "lingua/language_detection", env })).toBeUndefined();
     });
   });
 
@@ -44,9 +44,7 @@ describe("evaluator availability on this install", () => {
     it("reports it as available", () => {
       for (const yes of ["true", "1", "yes", "on"]) {
         expect(
-          evaluatorUnavailability("presidio/pii_detection", {
-            [PRESIDIO_ENABLE_ENV_VAR]: yes,
-          }),
+          evaluatorUnavailability({ evaluatorType: "presidio/pii_detection", env: { [PRESIDIO_ENABLE_ENV_VAR]: yes } }),
         ).toBeUndefined();
       }
     });
@@ -54,10 +52,11 @@ describe("evaluator availability on this install", () => {
 
   describe("the message shown when one is run anyway", () => {
     it("states what happened and what to do about it", () => {
-      const result = evaluatorUnavailability("presidio/pii_detection", {
-        [PRESIDIO_ENABLE_ENV_VAR]: "false",
+      const result = evaluatorUnavailability({
+        evaluatorType: "presidio/pii_detection",
+        env: { [PRESIDIO_ENABLE_ENV_VAR]: "false" },
       })!;
-      const message = unavailableEvaluatorMessage(result);
+      const message = unavailableEvaluatorMessage({ unavailability: result });
       expect(message).toContain(result.reason);
       expect(message).toContain(result.howToEnable);
     });
@@ -67,7 +66,7 @@ describe("evaluator availability on this install", () => {
     const env = { [LINGUA_ENABLE_ENV_VAR]: "false" };
 
     it("reports it as not installed, naming the switch", () => {
-      const result = evaluatorUnavailability("lingua/language_detection", env);
+      const result = evaluatorUnavailability({ evaluatorType: "lingua/language_detection", env });
       expect(result).toBeDefined();
       expect(result!.reason).toMatch(/not installed/i);
       expect(result!.howToEnable).toContain(LINGUA_ENABLE_ENV_VAR);
@@ -80,20 +79,20 @@ describe("evaluator availability on this install", () => {
     const env = { [LEGACY_EVALUATORS_ENABLE_ENV_VAR]: "false" };
 
     it("hides them from pickers entirely", () => {
-      const result = evaluatorUnavailability("legacy/ragas_faithfulness", env);
+      const result = evaluatorUnavailability({ evaluatorType: "legacy/ragas_faithfulness", env });
       expect(result).toBeDefined();
       expect(result!.hideFromUi).toBe(true);
     });
 
     it("still explains itself when a saved evaluation runs one", () => {
-      const result = evaluatorUnavailability("legacy/ragas_faithfulness", env)!;
-      const message = unavailableEvaluatorMessage(result);
+      const result = evaluatorUnavailability({ evaluatorType: "legacy/ragas_faithfulness", env })!;
+      const message = unavailableEvaluatorMessage({ unavailability: result });
       expect(message).toMatch(/not installed/i);
       expect(message).toContain(LEGACY_EVALUATORS_ENABLE_ENV_VAR);
     });
 
     it("does not touch the current ragas family", () => {
-      expect(evaluatorUnavailability("ragas/faithfulness", env)).toBeUndefined();
+      expect(evaluatorUnavailability({ evaluatorType: "ragas/faithfulness", env })).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/installedEvaluators.unit.test.ts
@@ -71,7 +71,7 @@ describe("evaluator availability on this install", () => {
       expect(result!.reason).toMatch(/not installed/i);
       expect(result!.howToEnable).toContain(LINGUA_ENABLE_ENV_VAR);
       // It stays visible as a disabled card; only deprecated families hide.
-      expect(result!.hideFromUi).toBeUndefined();
+      expect(result!.isHiddenFromUi).toBeUndefined();
     });
   });
 
@@ -81,7 +81,7 @@ describe("evaluator availability on this install", () => {
     it("hides them from pickers entirely", () => {
       const result = evaluatorUnavailability({ evaluatorType: "legacy/ragas_faithfulness", env });
       expect(result).toBeDefined();
-      expect(result!.hideFromUi).toBe(true);
+      expect(result!.isHiddenFromUi).toBe(true);
     });
 
     it("still explains itself when a saved evaluation runs one", () => {

--- a/langwatch/src/server/evaluations/installedEvaluators.ts
+++ b/langwatch/src/server/evaluations/installedEvaluators.ts
@@ -36,10 +36,13 @@ export type EvaluatorUnavailability = {
   hideFromUi?: boolean;
 };
 
-function explicitlyDisabled(
-  env: NodeJS.ProcessEnv,
-  envVar: string,
-): boolean {
+function explicitlyDisabled({
+  env,
+  envVar,
+}: {
+  env: NodeJS.ProcessEnv;
+  envVar: string;
+}): boolean {
   const raw = env[envVar]?.trim().toLowerCase();
   if (raw === undefined || raw === "") return false;
   return ["0", "false", "no", "off"].includes(raw);
@@ -48,13 +51,16 @@ function explicitlyDisabled(
 /**
  * Returns why an evaluator cannot run here, or undefined when it can.
  */
-export function evaluatorUnavailability(
-  evaluatorType: string,
-  env: NodeJS.ProcessEnv = process.env,
-): EvaluatorUnavailability | undefined {
+export function evaluatorUnavailability({
+  evaluatorType,
+  env = process.env,
+}: {
+  evaluatorType: string;
+  env?: NodeJS.ProcessEnv;
+}): EvaluatorUnavailability | undefined {
   if (
     evaluatorType.startsWith("presidio/") &&
-    explicitlyDisabled(env, PRESIDIO_ENABLE_ENV_VAR)
+    explicitlyDisabled({ env, envVar: PRESIDIO_ENABLE_ENV_VAR })
   ) {
     return {
       reason: "PII detection is not installed on this server.",
@@ -63,7 +69,7 @@ export function evaluatorUnavailability(
   }
   if (
     evaluatorType.startsWith("lingua/") &&
-    explicitlyDisabled(env, LINGUA_ENABLE_ENV_VAR)
+    explicitlyDisabled({ env, envVar: LINGUA_ENABLE_ENV_VAR })
   ) {
     return {
       reason: "Language detection is not installed on this server.",
@@ -72,7 +78,7 @@ export function evaluatorUnavailability(
   }
   if (
     evaluatorType.startsWith("legacy/") &&
-    explicitlyDisabled(env, LEGACY_EVALUATORS_ENABLE_ENV_VAR)
+    explicitlyDisabled({ env, envVar: LEGACY_EVALUATORS_ENABLE_ENV_VAR })
   ) {
     return {
       reason: "Legacy evaluators are not installed on this server.",
@@ -88,8 +94,10 @@ export function evaluatorUnavailability(
  * One sentence of what happened, one of what to do, the same pair the
  * evaluator picker shows, so the two never tell different stories.
  */
-export function unavailableEvaluatorMessage(
-  unavailability: EvaluatorUnavailability,
-): string {
+export function unavailableEvaluatorMessage({
+  unavailability,
+}: {
+  unavailability: EvaluatorUnavailability;
+}): string {
   return `${unavailability.reason} ${unavailability.howToEnable}`;
 }

--- a/langwatch/src/server/evaluations/installedEvaluators.ts
+++ b/langwatch/src/server/evaluations/installedEvaluators.ts
@@ -33,7 +33,7 @@ export type EvaluatorUnavailability = {
    * nobody should be adopting anyway. Execution still gets the clear message
    * either way, since something saved long ago may reference it.
    */
-  hideFromUi?: boolean;
+  isHiddenFromUi?: boolean;
 };
 
 function explicitlyDisabled({
@@ -83,7 +83,7 @@ export function evaluatorUnavailability({
     return {
       reason: "Legacy evaluators are not installed on this server.",
       howToEnable: `They are deprecated; prefer their current equivalents. If a saved evaluation still needs one, set ${LEGACY_EVALUATORS_ENABLE_ENV_VAR}=true and restart LangWatch.`,
-      hideFromUi: true,
+      isHiddenFromUi: true,
     };
   }
   return undefined;

--- a/langwatch/src/server/evaluations/installedEvaluators.ts
+++ b/langwatch/src/server/evaluations/installedEvaluators.ts
@@ -1,0 +1,58 @@
+/**
+ * Which evaluators this particular install can actually run.
+ *
+ * Every evaluator LangWatch knows about is listed in AVAILABLE_EVALUATORS, but
+ * a given install does not necessarily have the code behind all of them. The
+ * PII detector is the one that matters today: it ships a natural-language
+ * model larger than the rest of the evaluator environment put together, so a
+ * local install skips it unless asked, and the person who then goes looking
+ * for it deserves to be told that rather than shown a working-looking card
+ * that fails with "internal error" when they run it.
+ *
+ * The default is AVAILABLE, deliberately. Container and Kubernetes installs
+ * build the evaluator environment with every extra and never set this
+ * variable, so silence has to mean "present". Only an install that
+ * deliberately skipped it says so.
+ */
+
+export const PRESIDIO_ENABLE_ENV_VAR = "LANGWATCH_ENABLE_PRESIDIO";
+
+export type EvaluatorUnavailability = {
+  /** What is true, in the person's terms. */
+  reason: string;
+  /** What they do about it. */
+  howToEnable: string;
+};
+
+function presidioEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[PRESIDIO_ENABLE_ENV_VAR]?.trim().toLowerCase();
+  if (raw === undefined || raw === "") return true;
+  return !["0", "false", "no", "off"].includes(raw);
+}
+
+/**
+ * Returns why an evaluator cannot run here, or undefined when it can.
+ */
+export function evaluatorUnavailability(
+  evaluatorType: string,
+  env: NodeJS.ProcessEnv = process.env,
+): EvaluatorUnavailability | undefined {
+  if (evaluatorType.startsWith("presidio/") && !presidioEnabled(env)) {
+    return {
+      reason: "PII detection is not installed on this server.",
+      howToEnable: `Set ${PRESIDIO_ENABLE_ENV_VAR}=true and restart LangWatch. It downloads a ~670MB language model the first time, which is why it is left out by default.`,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * The message shown when someone runs an evaluator this install cannot run.
+ * One sentence of what happened, one of what to do — the same pair the
+ * evaluator picker shows, so the two never tell different stories.
+ */
+export function unavailableEvaluatorMessage(
+  unavailability: EvaluatorUnavailability,
+): string {
+  return `${unavailability.reason} ${unavailability.howToEnable}`;
+}

--- a/langwatch/src/server/evaluations/installedEvaluators.ts
+++ b/langwatch/src/server/evaluations/installedEvaluators.ts
@@ -2,32 +2,47 @@
  * Which evaluators this particular install can actually run.
  *
  * Every evaluator LangWatch knows about is listed in AVAILABLE_EVALUATORS, but
- * a given install does not necessarily have the code behind all of them. The
- * PII detector is the one that matters today: it ships a natural-language
- * model larger than the rest of the evaluator environment put together, so a
- * local install skips it unless asked, and the person who then goes looking
- * for it deserves to be told that rather than shown a working-looking card
- * that fails with "internal error" when they run it.
+ * a given install does not necessarily have the code behind all of them. A
+ * local install skips the heavyweight ones unless asked: the PII detector
+ * ships a natural-language model larger than the rest of the evaluator
+ * environment put together, language detection carries ~95MB of language
+ * models, and the deprecated legacy evaluators pull a few hundred MB that
+ * exist only so evaluations saved years ago keep running. The person who then
+ * goes looking for one of these deserves to be told that, rather than shown a
+ * working-looking card that fails with "internal error" when they run it.
  *
  * The default is AVAILABLE, deliberately. Container and Kubernetes installs
- * build the evaluator environment with every extra and never set this
- * variable, so silence has to mean "present". Only an install that
- * deliberately skipped it says so.
+ * build the evaluator environment with every extra and never set these
+ * variables, so silence has to mean "present". Only an install that
+ * deliberately skipped one says so.
  */
 
 export const PRESIDIO_ENABLE_ENV_VAR = "LANGWATCH_ENABLE_PRESIDIO";
+export const LINGUA_ENABLE_ENV_VAR = "LANGWATCH_ENABLE_LINGUA";
+export const LEGACY_EVALUATORS_ENABLE_ENV_VAR = "LANGWATCH_ENABLE_LEGACY_EVALUATORS";
 
 export type EvaluatorUnavailability = {
   /** What is true, in the person's terms. */
   reason: string;
   /** What they do about it. */
   howToEnable: string;
+  /**
+   * Whether the evaluator should disappear from pickers entirely instead of
+   * showing as a disabled card. Deprecated families earn this: a card someone
+   * cannot choose is guidance for a current evaluator, and clutter for one
+   * nobody should be adopting anyway. Execution still gets the clear message
+   * either way, since something saved long ago may reference it.
+   */
+  hideFromUi?: boolean;
 };
 
-function presidioEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  const raw = env[PRESIDIO_ENABLE_ENV_VAR]?.trim().toLowerCase();
-  if (raw === undefined || raw === "") return true;
-  return !["0", "false", "no", "off"].includes(raw);
+function explicitlyDisabled(
+  env: NodeJS.ProcessEnv,
+  envVar: string,
+): boolean {
+  const raw = env[envVar]?.trim().toLowerCase();
+  if (raw === undefined || raw === "") return false;
+  return ["0", "false", "no", "off"].includes(raw);
 }
 
 /**
@@ -37,10 +52,32 @@ export function evaluatorUnavailability(
   evaluatorType: string,
   env: NodeJS.ProcessEnv = process.env,
 ): EvaluatorUnavailability | undefined {
-  if (evaluatorType.startsWith("presidio/") && !presidioEnabled(env)) {
+  if (
+    evaluatorType.startsWith("presidio/") &&
+    explicitlyDisabled(env, PRESIDIO_ENABLE_ENV_VAR)
+  ) {
     return {
       reason: "PII detection is not installed on this server.",
       howToEnable: `Set ${PRESIDIO_ENABLE_ENV_VAR}=true and restart LangWatch. It downloads a ~670MB language model the first time, which is why it is left out by default.`,
+    };
+  }
+  if (
+    evaluatorType.startsWith("lingua/") &&
+    explicitlyDisabled(env, LINGUA_ENABLE_ENV_VAR)
+  ) {
+    return {
+      reason: "Language detection is not installed on this server.",
+      howToEnable: `Set ${LINGUA_ENABLE_ENV_VAR}=true and restart LangWatch. It downloads ~95MB of language models the first time, which is why it is left out by default.`,
+    };
+  }
+  if (
+    evaluatorType.startsWith("legacy/") &&
+    explicitlyDisabled(env, LEGACY_EVALUATORS_ENABLE_ENV_VAR)
+  ) {
+    return {
+      reason: "Legacy evaluators are not installed on this server.",
+      howToEnable: `They are deprecated; prefer their current equivalents. If a saved evaluation still needs one, set ${LEGACY_EVALUATORS_ENABLE_ENV_VAR}=true and restart LangWatch.`,
+      hideFromUi: true,
     };
   }
   return undefined;
@@ -48,7 +85,7 @@ export function evaluatorUnavailability(
 
 /**
  * The message shown when someone runs an evaluator this install cannot run.
- * One sentence of what happened, one of what to do — the same pair the
+ * One sentence of what happened, one of what to do, the same pair the
  * evaluator picker shows, so the two never tell different stories.
  */
 export function unavailableEvaluatorMessage(

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -174,7 +174,10 @@ secured
 // POST /api/demo/hotel_bot
 // =============================================
 const hotelBotOpenai = new OpenAI({
-  apiKey: env.OPENAI_API_KEY ?? "bogus",
+  // `||` and not `??`: a present-but-empty OPENAI_API_KEY (a scaffolded .env
+  // with the key left blank) must also fall back, or the SDK throws at
+  // module load and takes the whole server down with it.
+  apiKey: env.OPENAI_API_KEY || "bogus",
 });
 
 const guestQueries = [

--- a/packages/server/src/predeps/aigateway.ts
+++ b/packages/server/src/predeps/aigateway.ts
@@ -1,5 +1,5 @@
 import { execa } from "execa";
-import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { downloadWithProgress } from "./_download.ts";
@@ -55,14 +55,20 @@ function findRepoRoot(): string | null {
 
 async function buildFromCheckout(repoRoot: string, outDir: string, task: { output?: string }): Promise<void> {
   task.output = "building from local checkout (cmd/service)";
-  // `go build ./cmd/service` produces a multi-service entrypoint; the gateway
-  // is invoked as `service aigateway`. We compile to ~/.langwatch/bin/.service
-  // and shim a wrapper script so callers can run `aigateway --version` etc.
-  const realBin = join(outDir, ".service");
-  await execa("go", ["build", "-o", realBin, "./cmd/service"], { cwd: repoRoot, stdio: "pipe" });
-  const wrapper = join(outDir, "aigateway");
-  writeFileSync(wrapper, `#!/bin/sh\nexec "${realBin}" aigateway "$@"\n`, { mode: 0o755 });
-  chmodSync(wrapper, 0o755);
+  // `go build ./cmd/service` produces the multi-service entrypoint that
+  // dispatches on its first argument — the same artifact the release
+  // publishes, and the same one three services here invoke as
+  // `<binary> aigateway|nlpgo|langyagent`.
+  //
+  // This used to write a wrapper script that hardcoded `aigateway` as that
+  // first argument, which meant every service booted the gateway: the NLP
+  // engine and the Langy agent each started a second gateway, raced for its
+  // port, and died with "address already in use". The mono-binary answers
+  // `--version` on its own, which was the wrapper's only other reason to
+  // exist, so it is written straight out instead.
+  const out = join(outDir, "aigateway");
+  await execa("go", ["build", "-o", out, "./cmd/service"], { cwd: repoRoot, stdio: "pipe" });
+  chmodSync(out, 0o755);
 }
 
 export function makeAigatewayPredep(version: string): Predep {

--- a/packages/server/src/predeps/aigateway.ts
+++ b/packages/server/src/predeps/aigateway.ts
@@ -84,10 +84,12 @@ export function makeAigatewayPredep(version: string): Predep {
         // The monobinary carries three services that evolve with every
         // release, so an install that upgrades the CLI must upgrade the
         // binary with it: accepting any old binary here is how a langyagent
-        // subcommand (or a gateway fix) silently never arrives. Dev runs are
-        // exempt (expected version 0.0.0-dev matches nothing real, and dev
-        // binaries report "dev"): they keep whatever they built.
-        if (v && version !== "0.0.0-dev" && v !== version) {
+        // subcommand (or a gateway fix) silently never arrives. Two dev
+        // exemptions: a CLI running from source expects 0.0.0-dev (matches
+        // nothing real, keep whatever is there), and a binary reporting
+        // "dev" was built from a checkout on purpose via
+        // LANGWATCH_AIGATEWAY_DEV_BUILD and stays until its owner rebuilds.
+        if (v && v !== "dev" && version !== "0.0.0-dev" && v !== version) {
           return {
             installed: false,
             reason: `ai-gateway monobinary is v${v}, this release wants v${version} — re-downloading`,

--- a/packages/server/src/predeps/aigateway.ts
+++ b/packages/server/src/predeps/aigateway.ts
@@ -81,6 +81,18 @@ export function makeAigatewayPredep(version: string): Predep {
       const bundled = join(paths.bin, "aigateway");
       if (existsSync(bundled)) {
         const v = await resolveVersion(bundled);
+        // The monobinary carries three services that evolve with every
+        // release, so an install that upgrades the CLI must upgrade the
+        // binary with it: accepting any old binary here is how a langyagent
+        // subcommand (or a gateway fix) silently never arrives. Dev runs are
+        // exempt (expected version 0.0.0-dev matches nothing real, and dev
+        // binaries report "dev"): they keep whatever they built.
+        if (v && version !== "0.0.0-dev" && v !== version) {
+          return {
+            installed: false,
+            reason: `ai-gateway monobinary is v${v}, this release wants v${version} — re-downloading`,
+          };
+        }
         if (v) return { installed: true, version: v, resolvedPath: bundled };
         return { installed: true, version: "unknown", resolvedPath: bundled };
       }

--- a/packages/server/src/predeps/opencode.ts
+++ b/packages/server/src/predeps/opencode.ts
@@ -53,7 +53,7 @@ async function resolveVersion(bin: string): Promise<string | null> {
  * (the manager itself) already ships inside the mono-binary we download for
  * the gateway.
  */
-export function makeOpencodePredep({ enabled }: { enabled: boolean }): Predep {
+export function makeOpencodePredep({ isEnabled }: { isEnabled: boolean }): Predep {
   return {
     id: "opencode",
     label: "langy assistant runtime",
@@ -63,12 +63,22 @@ export function makeOpencodePredep({ enabled }: { enabled: boolean }): Predep {
     required: false,
 
     async detect(paths) {
-      if (!enabled) {
+      if (!isEnabled) {
         return { installed: true, version: "skipped", resolvedPath: "" };
       }
       const bundled = join(paths.bin, "opencode");
       if (existsSync(bundled)) {
         const v = await resolveVersion(bundled);
+        // The pin is the contract: the skills are written against one
+        // opencode grammar, so bumping OPENCODE_VERSION must actually land
+        // on existing installs rather than being satisfied by whatever
+        // binary is already there.
+        if (v && v !== OPENCODE_VERSION) {
+          return {
+            installed: false,
+            reason: `opencode is v${v}, this release pins v${OPENCODE_VERSION} — re-downloading`,
+          };
+        }
         return { installed: true, version: v ?? "unknown", resolvedPath: bundled };
       }
       return { installed: false, reason: "opencode not in ~/.langwatch/bin" };

--- a/packages/server/src/predeps/opencode.ts
+++ b/packages/server/src/predeps/opencode.ts
@@ -3,7 +3,7 @@ import { chmodSync, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import * as tar from "tar";
 import { downloadWithProgress } from "./_download.ts";
-import type { Predep } from "./types.ts";
+import type { Predep, PredepTask } from "./types.ts";
 
 // The runtime each Langy conversation runs inside. Pinned to an exact release
 // rather than tracking latest: this binary executes model-written shell with
@@ -53,6 +53,73 @@ async function resolveVersion(bin: string): Promise<string | null> {
  * (the manager itself) already ships inside the mono-binary we download for
  * the gateway.
  */
+async function detectOpencode(binDir: string): Promise<
+  { installed: true; version: string; resolvedPath: string } | { installed: false; reason: string }
+> {
+  const bundled = join(binDir, "opencode");
+  if (!existsSync(bundled)) {
+    return { installed: false, reason: "opencode not in ~/.langwatch/bin" };
+  }
+  const v = await resolveVersion(bundled);
+  // The pin is the contract: the skills are written against one opencode
+  // grammar, so bumping OPENCODE_VERSION must actually land on existing
+  // installs rather than being satisfied by whatever binary is already there.
+  if (v && v !== OPENCODE_VERSION) {
+    return {
+      installed: false,
+      reason: `opencode is v${v}, this release pins v${OPENCODE_VERSION} — re-downloading`,
+    };
+  }
+  return { installed: true, version: v ?? "unknown", resolvedPath: bundled };
+}
+
+async function installFromTarball(
+  url: string,
+  binDir: string,
+  task: PredepTask,
+  label: string,
+): Promise<void> {
+  const tmp = join(binDir, `.opencode-${OPENCODE_VERSION}.tgz`);
+  await downloadWithProgress(url, tmp, task, label);
+  task.output = "extracting";
+  // The archive holds a single `opencode` binary at its root; the exact-match
+  // filter is what keeps anything else from landing in bin/.
+  tar.x({ sync: true, file: tmp, cwd: binDir, filter: (p: string) => p === "opencode" });
+  rmSync(tmp, { force: true });
+}
+
+async function installFromZip(
+  url: string,
+  binDir: string,
+  task: PredepTask,
+  label: string,
+): Promise<void> {
+  const out = join(binDir, "opencode");
+  const tmp = join(binDir, `.opencode-${OPENCODE_VERSION}.zip`);
+  await downloadWithProgress(url, tmp, task, label);
+  task.output = "extracting";
+  // Node ships no zip reader; `unzip` is present on macOS by default.
+  // Extract to a staging dir so a multi-entry archive cannot scatter
+  // files into bin/, then lift the one binary out.
+  const stage = join(binDir, `.opencode-${OPENCODE_VERSION}-stage`);
+  rmSync(stage, { recursive: true, force: true });
+  mkdirSync(stage, { recursive: true });
+  try {
+    await execa("unzip", ["-q", "-o", tmp, "-d", stage]);
+    const extracted = join(stage, "opencode");
+    if (!existsSync(extracted)) {
+      throw new Error(
+        `opencode archive did not contain an \`opencode\` binary at its root (${url})`,
+      );
+    }
+    rmSync(out, { force: true });
+    renameSync(extracted, out);
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+    rmSync(tmp, { force: true });
+  }
+}
+
 export function makeOpencodePredep({ isEnabled }: { isEnabled: boolean }): Predep {
   return {
     id: "opencode",
@@ -66,22 +133,7 @@ export function makeOpencodePredep({ isEnabled }: { isEnabled: boolean }): Prede
       if (!isEnabled) {
         return { installed: true, version: "skipped", resolvedPath: "" };
       }
-      const bundled = join(paths.bin, "opencode");
-      if (existsSync(bundled)) {
-        const v = await resolveVersion(bundled);
-        // The pin is the contract: the skills are written against one
-        // opencode grammar, so bumping OPENCODE_VERSION must actually land
-        // on existing installs rather than being satisfied by whatever
-        // binary is already there.
-        if (v && v !== OPENCODE_VERSION) {
-          return {
-            installed: false,
-            reason: `opencode is v${v}, this release pins v${OPENCODE_VERSION} — re-downloading`,
-          };
-        }
-        return { installed: true, version: v ?? "unknown", resolvedPath: bundled };
-      }
-      return { installed: false, reason: "opencode not in ~/.langwatch/bin" };
+      return detectOpencode(paths.bin);
     },
 
     async install({ platform, paths, task }) {
@@ -91,35 +143,9 @@ export function makeOpencodePredep({ isEnabled }: { isEnabled: boolean }): Prede
       const label = `downloading langy assistant runtime ${OPENCODE_VERSION}`;
 
       if (src.kind === "tarball") {
-        const tmp = join(paths.bin, `.opencode-${OPENCODE_VERSION}.tgz`);
-        await downloadWithProgress(src.url, tmp, task, label);
-        task.output = "extracting";
-        // The archive holds a single `opencode` binary at its root.
-        tar.x({ sync: true, file: tmp, cwd: paths.bin, filter: (p: string) => p === "opencode" });
-        rmSync(tmp, { force: true });
+        await installFromTarball(src.url, paths.bin, task, label);
       } else {
-        const tmp = join(paths.bin, `.opencode-${OPENCODE_VERSION}.zip`);
-        await downloadWithProgress(src.url, tmp, task, label);
-        task.output = "extracting";
-        // Node ships no zip reader; `unzip` is present on macOS by default.
-        // Extract to a staging dir so a multi-entry archive cannot scatter
-        // files into bin/, then lift the one binary out.
-        const stage = join(paths.bin, `.opencode-${OPENCODE_VERSION}-stage`);
-        rmSync(stage, { recursive: true, force: true });
-        mkdirSync(stage, { recursive: true });
-        await execa("unzip", ["-q", "-o", tmp, "-d", stage]);
-        const extracted = join(stage, "opencode");
-        if (!existsSync(extracted)) {
-          rmSync(stage, { recursive: true, force: true });
-          rmSync(tmp, { force: true });
-          throw new Error(
-            `opencode archive did not contain an \`opencode\` binary at its root (${src.url})`,
-          );
-        }
-        rmSync(out, { force: true });
-        renameSync(extracted, out);
-        rmSync(stage, { recursive: true, force: true });
-        rmSync(tmp, { force: true });
+        await installFromZip(src.url, paths.bin, task, label);
       }
 
       if (!existsSync(out)) {

--- a/packages/server/src/predeps/opencode.ts
+++ b/packages/server/src/predeps/opencode.ts
@@ -9,7 +9,7 @@ import type { Predep } from "./types.ts";
 // rather than tracking latest: this binary executes model-written shell with
 // the user's own credentials in its environment, so every rebuild silently
 // re-evaluating trust in an upstream release is not a trade worth making.
-// Keep in lockstep with the OPENCODE_VERSION pin in Dockerfile.langyagent —
+// Keep in lockstep with the OPENCODE_VERSION pin in Dockerfile.langyagent:
 // the skills and AGENTS.md are written against one grammar, not two.
 export const OPENCODE_VERSION = "1.17.11";
 
@@ -49,7 +49,7 @@ async function resolveVersion(bin: string): Promise<string | null> {
  * The Langy assistant's worker runtime.
  *
  * Skipped entirely when the assistant is turned off, because it is the only
- * part of the install that exists solely for it — everything else Langy needs
+ * part of the install that exists solely for it, everything else Langy needs
  * (the manager itself) already ships inside the mono-binary we download for
  * the gateway.
  */

--- a/packages/server/src/predeps/opencode.ts
+++ b/packages/server/src/predeps/opencode.ts
@@ -1,0 +1,123 @@
+import { execa } from "execa";
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import * as tar from "tar";
+import { downloadWithProgress } from "./_download.ts";
+import type { Predep } from "./types.ts";
+
+// The runtime each Langy conversation runs inside. Pinned to an exact release
+// rather than tracking latest: this binary executes model-written shell with
+// the user's own credentials in its environment, so every rebuild silently
+// re-evaluating trust in an upstream release is not a trade worth making.
+// Keep in lockstep with the OPENCODE_VERSION pin in Dockerfile.langyagent —
+// the skills and AGENTS.md are written against one grammar, not two.
+export const OPENCODE_VERSION = "1.17.11";
+
+// darwin ships zips, linux ships tarballs. The `-baseline` variants target
+// pre-AVX2 x64 hardware; we take the standard build, matching the container
+// image. musl variants are for Alpine, which is not a `npx` host we support.
+type Source =
+  | { kind: "zip"; url: string }
+  | { kind: "tarball"; url: string };
+
+function downloadSource(platform: string): Source {
+  const asset: Record<string, Source> = {
+    "darwin-arm64": { kind: "zip", url: assetUrl("opencode-darwin-arm64.zip") },
+    "darwin-x64": { kind: "zip", url: assetUrl("opencode-darwin-x64.zip") },
+    "linux-arm64": { kind: "tarball", url: assetUrl("opencode-linux-arm64.tar.gz") },
+    "linux-x64": { kind: "tarball", url: assetUrl("opencode-linux-x64.tar.gz") },
+  };
+  const src = asset[platform];
+  if (!src) throw new Error(`No opencode build for ${platform}`);
+  return src;
+}
+
+function assetUrl(file: string): string {
+  return `https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${file}`;
+}
+
+async function resolveVersion(bin: string): Promise<string | null> {
+  try {
+    const { stdout } = await execa(bin, ["--version"], { reject: false });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The Langy assistant's worker runtime.
+ *
+ * Skipped entirely when the assistant is turned off, because it is the only
+ * part of the install that exists solely for it — everything else Langy needs
+ * (the manager itself) already ships inside the mono-binary we download for
+ * the gateway.
+ */
+export function makeOpencodePredep({ enabled }: { enabled: boolean }): Predep {
+  return {
+    id: "opencode",
+    label: "langy assistant runtime",
+    // Not required: an install whose opencode download fails still has a
+    // working LangWatch, just without the assistant. Failing the whole
+    // install over an optional feature would be the wrong trade.
+    required: false,
+
+    async detect(paths) {
+      if (!enabled) {
+        return { installed: true, version: "skipped", resolvedPath: "" };
+      }
+      const bundled = join(paths.bin, "opencode");
+      if (existsSync(bundled)) {
+        const v = await resolveVersion(bundled);
+        return { installed: true, version: v ?? "unknown", resolvedPath: bundled };
+      }
+      return { installed: false, reason: "opencode not in ~/.langwatch/bin" };
+    },
+
+    async install({ platform, paths, task }) {
+      mkdirSync(paths.bin, { recursive: true });
+      const out = join(paths.bin, "opencode");
+      const src = downloadSource(platform);
+      const label = `downloading langy assistant runtime ${OPENCODE_VERSION}`;
+
+      if (src.kind === "tarball") {
+        const tmp = join(paths.bin, `.opencode-${OPENCODE_VERSION}.tgz`);
+        await downloadWithProgress(src.url, tmp, task, label);
+        task.output = "extracting";
+        // The archive holds a single `opencode` binary at its root.
+        tar.x({ sync: true, file: tmp, cwd: paths.bin, filter: (p: string) => p === "opencode" });
+        rmSync(tmp, { force: true });
+      } else {
+        const tmp = join(paths.bin, `.opencode-${OPENCODE_VERSION}.zip`);
+        await downloadWithProgress(src.url, tmp, task, label);
+        task.output = "extracting";
+        // Node ships no zip reader; `unzip` is present on macOS by default.
+        // Extract to a staging dir so a multi-entry archive cannot scatter
+        // files into bin/, then lift the one binary out.
+        const stage = join(paths.bin, `.opencode-${OPENCODE_VERSION}-stage`);
+        rmSync(stage, { recursive: true, force: true });
+        mkdirSync(stage, { recursive: true });
+        await execa("unzip", ["-q", "-o", tmp, "-d", stage]);
+        const extracted = join(stage, "opencode");
+        if (!existsSync(extracted)) {
+          rmSync(stage, { recursive: true, force: true });
+          rmSync(tmp, { force: true });
+          throw new Error(
+            `opencode archive did not contain an \`opencode\` binary at its root (${src.url})`,
+          );
+        }
+        rmSync(out, { force: true });
+        renameSync(extracted, out);
+        rmSync(stage, { recursive: true, force: true });
+        rmSync(tmp, { force: true });
+      }
+
+      if (!existsSync(out)) {
+        throw new Error(`opencode extraction produced no binary at ${out}`);
+      }
+      chmodSync(out, 0o755);
+      const version = (await resolveVersion(out)) ?? OPENCODE_VERSION;
+      return { version, resolvedPath: out };
+    },
+  };
+}

--- a/packages/server/src/predeps/registry.ts
+++ b/packages/server/src/predeps/registry.ts
@@ -6,7 +6,8 @@ import { pnpmPredep } from "./pnpm.ts";
 import { postgresPredep } from "./postgres.ts";
 import { redisPredep } from "./redis.ts";
 import { uvPredep } from "./uv.ts";
-import { resolveFeatures } from "../shared/features.ts";
+import { resolveEffectiveFeatures } from "../shared/features.ts";
+import { paths } from "../shared/paths.ts";
 import type { Predep } from "./types.ts";
 
 export function predepRegistry({ version }: { version: string }): Predep[] {
@@ -16,7 +17,11 @@ export function predepRegistry({ version }: { version: string }): Predep[] {
   // doesn't depend on pnpm.
   // The assistant's runtime is last: it is the only optional one, and the
   // only one whose failure leaves a working install behind.
-  const features = resolveFeatures();
+  // Resolved the same way the runtime resolves them (persisted .env first,
+  // shell on top): a LANGWATCH_ENABLE_LANGY=false line in ~/.langwatch/.env
+  // must stop the assistant runtime from being downloaded, not only from
+  // being started.
+  const features = resolveEffectiveFeatures(paths.envFile);
   return [
     pnpmPredep,
     uvPredep,

--- a/packages/server/src/predeps/registry.ts
+++ b/packages/server/src/predeps/registry.ts
@@ -25,6 +25,6 @@ export function predepRegistry({ version }: { version: string }): Predep[] {
     clickhousePredep,
     goosePredep,
     makeAigatewayPredep(version),
-    makeOpencodePredep({ enabled: features.langy }),
+    makeOpencodePredep({ isEnabled: features.isLangyEnabled }),
   ];
 }

--- a/packages/server/src/predeps/registry.ts
+++ b/packages/server/src/predeps/registry.ts
@@ -1,10 +1,12 @@
 import { makeAigatewayPredep } from "./aigateway.ts";
+import { makeOpencodePredep } from "./opencode.ts";
 import { clickhousePredep } from "./clickhouse.ts";
 import { goosePredep } from "./goose.ts";
 import { pnpmPredep } from "./pnpm.ts";
 import { postgresPredep } from "./postgres.ts";
 import { redisPredep } from "./redis.ts";
 import { uvPredep } from "./uv.ts";
+import { resolveFeatures } from "../shared/features.ts";
 import type { Predep } from "./types.ts";
 
 export function predepRegistry({ version }: { version: string }): Predep[] {
@@ -12,5 +14,17 @@ export function predepRegistry({ version }: { version: string }): Predep[] {
   // ensureLangwatchDeps + runMigrations call resolvePnpm(paths). uv is
   // fast/cached so its position is mostly irrelevant; everything else
   // doesn't depend on pnpm.
-  return [pnpmPredep, uvPredep, postgresPredep, redisPredep, clickhousePredep, goosePredep, makeAigatewayPredep(version)];
+  // The assistant's runtime is last: it is the only optional one, and the
+  // only one whose failure leaves a working install behind.
+  const features = resolveFeatures();
+  return [
+    pnpmPredep,
+    uvPredep,
+    postgresPredep,
+    redisPredep,
+    clickhousePredep,
+    goosePredep,
+    makeAigatewayPredep(version),
+    makeOpencodePredep({ enabled: features.langy }),
+  ];
 }

--- a/packages/server/src/predeps/types.ts
+++ b/packages/server/src/predeps/types.ts
@@ -1,7 +1,7 @@
 import type { SupportedPlatform } from "../shared/platform.ts";
 import type { LangwatchPaths } from "../shared/paths.ts";
 
-export type PredepId = "pnpm" | "uv" | "postgres" | "redis" | "clickhouse" | "goose" | "aigateway";
+export type PredepId = "pnpm" | "uv" | "postgres" | "redis" | "clickhouse" | "goose" | "aigateway" | "opencode";
 
 export type DetectionResult =
   | { installed: true; version: string; resolvedPath: string }

--- a/packages/server/src/services/app-dir.ts
+++ b/packages/server/src/services/app-dir.ts
@@ -17,9 +17,19 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * So `dirname(cli.cjs)/../../..` == package root in both.
  */
 function locatePackageSource(): string | null {
-  const candidate = join(__dirname, "..", "..", "..");
-  if (existsSync(join(candidate, "langwatch", "package.json"))) {
-    return candidate;
+  // Walk up rather than counting levels: the bundled entrypoint sits at
+  // packages/server/dist/cli.cjs and this module at packages/server/src/
+  // services/app-dir.ts, which are different depths. A fixed `../../..`
+  // resolves correctly from the bundle and one directory short from source,
+  // so running the CLI from a checkout (`tsx src/cli.ts`) died with "could
+  // not locate @langwatch/server package source" after every predep had
+  // already been downloaded.
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "langwatch", "package.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return null;
 }

--- a/packages/server/src/services/env-file.ts
+++ b/packages/server/src/services/env-file.ts
@@ -21,6 +21,13 @@ export function readEnvFile(path: string): Record<string, string> {
     ) {
       value = value.slice(1, -1);
     }
+    // A `KEY=` line means "not configured", and must stay that way in the
+    // child processes. Passing it through as an empty string is worse than
+    // absence: code guarding with `?? fallback` sees the empty value as
+    // present and hands it to clients that then refuse to construct (the
+    // scaffolded .env ships blank OPENAI_API_KEY etc. as fill-me-in lines,
+    // and the app died at boot on exactly this).
+    if (value === "") continue;
     out[key] = value;
   }
   return out;

--- a/packages/server/src/services/langy-cli.ts
+++ b/packages/server/src/services/langy-cli.ts
@@ -27,8 +27,17 @@ export async function ensureLangyCli(ctx: RuntimeContext, bus: EventBus): Promis
   const cliRoot = join(ctx.paths.root, "cli");
   const marker = join(cliRoot, ".installed-version");
   const shim = join(ctx.paths.bin, "langwatch");
+  const entry = join(cliRoot, "node_modules", "langwatch", "dist", "cli", "index.js");
 
-  if (existsSync(marker) && readFileSync(marker, "utf8").trim() === LANGY_CLI_VERSION && existsSync(shim)) {
+  // The entrypoint is part of the fast-path condition: a pruned or
+  // half-deleted cli/node_modules with the marker still present would
+  // otherwise leave a shim pointing at nothing until the pin next moved.
+  if (
+    existsSync(marker) &&
+    readFileSync(marker, "utf8").trim() === LANGY_CLI_VERSION &&
+    existsSync(shim) &&
+    existsSync(entry)
+  ) {
     return;
   }
 
@@ -49,7 +58,6 @@ export async function ensureLangyCli(ctx: RuntimeContext, bus: EventBus): Promis
     stdio: "pipe",
   });
 
-  const entry = join(cliRoot, "node_modules", "langwatch", "dist", "cli", "index.js");
   if (!existsSync(entry)) {
     throw new Error(`langwatch CLI ${LANGY_CLI_VERSION} installed but ${entry} is missing`);
   }

--- a/packages/server/src/services/langy-cli.ts
+++ b/packages/server/src/services/langy-cli.ts
@@ -57,8 +57,12 @@ export async function ensureLangyCli(ctx: RuntimeContext, bus: EventBus): Promis
   // A shell shim rather than a symlink into node_modules/.bin: the workers get
   // a PATH, not a package manager, and the shim keeps the resolved entrypoint
   // readable when someone goes looking for what the assistant just ran.
+  // Paths are single-quoted (with embedded quotes escaped) because they derive
+  // from LANGWATCH_HOME: inside double quotes the shell would expand a $ or a
+  // backtick that the directory name happens to contain.
   mkdirSync(ctx.paths.bin, { recursive: true });
-  writeFileSync(shim, `#!/bin/sh\nexec "${process.execPath}" "${entry}" "$@"\n`, { mode: 0o755 });
+  const sq = (v: string) => `'${v.replaceAll("'", `'\\''`)}'`;
+  writeFileSync(shim, `#!/bin/sh\nexec ${sq(process.execPath)} ${sq(entry)} "$@"\n`, { mode: 0o755 });
   chmodSync(shim, 0o755);
   writeFileSync(marker, LANGY_CLI_VERSION);
 

--- a/packages/server/src/services/langy-cli.ts
+++ b/packages/server/src/services/langy-cli.ts
@@ -1,0 +1,70 @@
+import { execa } from "execa";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import type { RuntimeContext } from "../shared/runtime-contract.ts";
+import type { EventBus } from "./event-bus.ts";
+import { resolvePnpm } from "./node-deps.ts";
+
+// The `langwatch` CLI is the assistant's ONLY interface to LangWatch — every
+// skill is written against its command grammar, and a worker with no CLI can
+// answer from the model alone but cannot look anything up. Pinned rather than
+// tracking latest so the grammar the skills were written against is the
+// grammar that gets installed; bump in lockstep with a tested release, the
+// same rule Dockerfile.langyagent follows for the container image.
+export const LANGY_CLI_VERSION = "1.0.0";
+
+/**
+ * Puts a `langwatch` executable on the PATH the assistant's workers inherit.
+ *
+ * Installed from npm rather than shipped in the server tarball: it is 4MB that
+ * only an install running the assistant needs, and fetching it here keeps it
+ * out of every install that does not.
+ *
+ * Idempotent — a marker file records the version installed, so re-running the
+ * server is a no-op until the pin moves.
+ */
+export async function ensureLangyCli(ctx: RuntimeContext, bus: EventBus): Promise<void> {
+  const cliRoot = join(ctx.paths.root, "cli");
+  const marker = join(cliRoot, ".installed-version");
+  const shim = join(ctx.paths.bin, "langwatch");
+
+  if (existsSync(marker) && readFileSync(marker, "utf8").trim() === LANGY_CLI_VERSION && existsSync(shim)) {
+    return;
+  }
+
+  bus.emit({ type: "starting", service: "prepare:langy-cli" as never });
+  const start = Date.now();
+
+  mkdirSync(cliRoot, { recursive: true });
+  // A bare package.json keeps pnpm from walking up into ~/.langwatch/app and
+  // resolving against the LangWatch workspace.
+  writeFileSync(
+    join(cliRoot, "package.json"),
+    JSON.stringify({ name: "langwatch-cli-host", private: true, version: "0.0.0" }, null, 2) + "\n",
+  );
+
+  const pnpm = await resolvePnpm(ctx.paths);
+  await execa(pnpm.command, [...pnpm.args, "add", `langwatch@${LANGY_CLI_VERSION}`], {
+    cwd: cliRoot,
+    stdio: "pipe",
+  });
+
+  const entry = join(cliRoot, "node_modules", "langwatch", "dist", "cli", "index.js");
+  if (!existsSync(entry)) {
+    throw new Error(`langwatch CLI ${LANGY_CLI_VERSION} installed but ${entry} is missing`);
+  }
+
+  // A shell shim rather than a symlink into node_modules/.bin: the workers get
+  // a PATH, not a package manager, and the shim keeps the resolved entrypoint
+  // readable when someone goes looking for what the assistant just ran.
+  mkdirSync(ctx.paths.bin, { recursive: true });
+  writeFileSync(shim, `#!/bin/sh\nexec "${process.execPath}" "${entry}" "$@"\n`, { mode: 0o755 });
+  chmodSync(shim, 0o755);
+  writeFileSync(marker, LANGY_CLI_VERSION);
+
+  bus.emit({
+    type: "healthy",
+    service: "prepare:langy-cli" as never,
+    durationMs: Date.now() - start,
+  });
+}

--- a/packages/server/src/services/langy-cli.ts
+++ b/packages/server/src/services/langy-cli.ts
@@ -5,7 +5,7 @@ import type { RuntimeContext } from "../shared/runtime-contract.ts";
 import type { EventBus } from "./event-bus.ts";
 import { resolvePnpm } from "./node-deps.ts";
 
-// The `langwatch` CLI is the assistant's ONLY interface to LangWatch — every
+// The `langwatch` CLI is the assistant's ONLY interface to LangWatch, every
 // skill is written against its command grammar, and a worker with no CLI can
 // answer from the model alone but cannot look anything up. Pinned rather than
 // tracking latest so the grammar the skills were written against is the
@@ -20,7 +20,7 @@ export const LANGY_CLI_VERSION = "1.0.0";
  * only an install running the assistant needs, and fetching it here keeps it
  * out of every install that does not.
  *
- * Idempotent — a marker file records the version installed, so re-running the
+ * Idempotent, a marker file records the version installed, so re-running the
  * server is a no-op until the pin moves.
  */
 export async function ensureLangyCli(ctx: RuntimeContext, bus: EventBus): Promise<void> {

--- a/packages/server/src/services/langyagent.ts
+++ b/packages/server/src/services/langyagent.ts
@@ -8,6 +8,37 @@ import { servicePaths } from "./paths.ts";
 import { supervise, type SupervisedHandle } from "./spawn.ts";
 
 /**
+ * Whether the downloaded mono-binary knows the `langyagent` subcommand.
+ * Binaries released before the assistant existed answer any unknown command
+ * with a usage line listing the services they do have, so the presence of
+ * the name in that output is the honest capability check. Without this
+ * probe, an older binary dies at boot with "unknown service" and takes the
+ * whole install down with it; with it, the install comes up assistant-less
+ * and says why.
+ *
+ * Never throws and never hangs: the assistant is optional, so a probe that
+ * cannot answer (broken binary, hung exec) reads as "not supported" and the
+ * install proceeds without the assistant rather than dying over it.
+ */
+export async function monobinarySupportsLangyagent(binary: string): Promise<boolean> {
+  try {
+    const { stdout, stderr } = await execa(binary, [], {
+      reject: false,
+      timeout: 5_000,
+    });
+    return `${stdout}\n${stderr}`.includes("langyagent");
+  } catch {
+    return false;
+  }
+}
+
+// The manager only accepts running workers without per-worker isolation in a
+// local-like environment (services/langyagent/config.go enforces this on its
+// side too). Mirroring the check here means a .env edited to a production-like
+// ENVIRONMENT never even asks for the unsafe mode.
+const UNSAFE_ISOLATION_ENVIRONMENTS = new Set(["local", "development", "dev", "test"]);
+
+/**
  * The Langy assistant's manager, the process that owns one opencode worker
  * per conversation. Same `cmd/service` mono-binary as the gateway and the NLP
  * engine, dispatched as `langyagent`, so the assistant adds no download of its
@@ -26,26 +57,12 @@ import { supervise, type SupervisedHandle } from "./spawn.ts";
  * unsandboxed instead, and say so rather than implying a boundary that is not
  * there.
  */
-/**
- * Whether the downloaded mono-binary knows the `langyagent` subcommand.
- * Binaries released before the assistant existed answer any unknown command
- * with a usage line listing the services they do have, so the presence of
- * the name in that output is the honest capability check. Without this
- * probe, an older binary dies at boot with "unknown service" and takes the
- * whole install down with it; with it, the install comes up assistant-less
- * and says why.
- */
-export async function monobinarySupportsLangyagent(binary: string): Promise<boolean> {
-  const { stdout, stderr } = await execa(binary, [], { reject: false });
-  return `${stdout}\n${stderr}`.includes("langyagent");
-}
-
 export async function startLangyagent(
   ctx: RuntimeContext,
   bus: EventBus,
   envFromFile: Record<string, string>,
 ): Promise<SupervisedHandle> {
-  bus.emit({ type: "starting", service: "langyagent" as never });
+  bus.emit({ type: "starting", service: "langyagent" });
   const start = Date.now();
 
   const binary = ctx.predeps.aigateway?.resolvedPath;
@@ -58,6 +75,9 @@ export async function startLangyagent(
   const workspaceRoot = join(langyRoot, "workspace");
   mkdirSync(sessionsRoot, { recursive: true });
   mkdirSync(workspaceRoot, { recursive: true });
+
+  const environment = (envFromFile.ENVIRONMENT ?? "local").trim().toLowerCase();
+  const isLocalLike = UNSAFE_ISOLATION_ENVIRONMENTS.has(environment);
 
   const sp = servicePaths(ctx.paths);
   const handle = supervise({
@@ -72,10 +92,10 @@ export async function startLangyagent(
         PORT: String(ctx.ports.langyagent),
         SESSIONS_ROOT: sessionsRoot,
         LANGY_WORKSPACE_ROOT: workspaceRoot,
-        // Workers spawn as the user who ran the installer. The manager refuses
-        // this unless ENVIRONMENT is local-like, which the scaffolded .env sets,
-        // so a production deployment cannot reach this path by accident.
-        LANGY_UNSAFE_DEV_DISABLE_ISOLATION: "true",
+        // Workers spawn as the user who ran the installer. Only asked for in
+        // a local-like ENVIRONMENT (the scaffolded .env's default); the
+        // manager refuses it anywhere else, and we do not ask.
+        ...(isLocalLike ? { LANGY_UNSAFE_DEV_DISABLE_ISOLATION: "true" } : {}),
         // Each worker is an opencode process holding a real conversation; two
         // at a time is as much as a laptop should be asked to hold, and idle
         // ones are reaped quickly so a finished conversation stops costing
@@ -101,6 +121,6 @@ export async function startLangyagent(
     await handle.stop();
     throw new Error(`langyagent did not become healthy: ${ready.reason}`);
   }
-  bus.emit({ type: "healthy", service: "langyagent" as never, durationMs: Date.now() - start });
+  bus.emit({ type: "healthy", service: "langyagent", durationMs: Date.now() - start });
   return handle;
 }

--- a/packages/server/src/services/langyagent.ts
+++ b/packages/server/src/services/langyagent.ts
@@ -1,3 +1,4 @@
+import { execa } from "execa";
 import { mkdirSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import type { RuntimeContext } from "../shared/runtime-contract.ts";
@@ -25,6 +26,20 @@ import { supervise, type SupervisedHandle } from "./spawn.ts";
  * unsandboxed instead, and say so rather than implying a boundary that is not
  * there.
  */
+/**
+ * Whether the downloaded mono-binary knows the `langyagent` subcommand.
+ * Binaries released before the assistant existed answer any unknown command
+ * with a usage line listing the services they do have, so the presence of
+ * the name in that output is the honest capability check. Without this
+ * probe, an older binary dies at boot with "unknown service" and takes the
+ * whole install down with it; with it, the install comes up assistant-less
+ * and says why.
+ */
+export async function monobinarySupportsLangyagent(binary: string): Promise<boolean> {
+  const { stdout, stderr } = await execa(binary, [], { reject: false });
+  return `${stdout}\n${stderr}`.includes("langyagent");
+}
+
 export async function startLangyagent(
   ctx: RuntimeContext,
   bus: EventBus,

--- a/packages/server/src/services/langyagent.ts
+++ b/packages/server/src/services/langyagent.ts
@@ -1,0 +1,91 @@
+import { mkdirSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import type { RuntimeContext } from "../shared/runtime-contract.ts";
+import type { EventBus } from "./event-bus.ts";
+import { httpGetCheck, pollUntilHealthy } from "./health.ts";
+import { servicePaths } from "./paths.ts";
+import { supervise, type SupervisedHandle } from "./spawn.ts";
+
+/**
+ * The Langy assistant's manager — the process that owns one opencode worker
+ * per conversation. Same `cmd/service` mono-binary as the gateway and the NLP
+ * engine, dispatched as `langyagent`, so the assistant adds no download of its
+ * own beyond the opencode runtime predep.
+ *
+ * Health: /health.
+ *
+ * WHAT IS DIFFERENT ABOUT A LAPTOP. In a cluster this pod runs under a
+ * sandboxed container runtime, as root, handing every conversation's worker
+ * its own UID — because there the workers belong to different people and a
+ * prompt-injected one must not be able to read a colleague's credentials off
+ * disk. Here there is one person, on their own machine, and each worker
+ * already runs as them with their own credentials. The UID handoff would need
+ * root to perform, so demanding it would mean asking someone to run their
+ * laptop install as root in order to isolate them from themselves. We run
+ * unsandboxed instead, and say so rather than implying a boundary that is not
+ * there.
+ */
+export async function startLangyagent(
+  ctx: RuntimeContext,
+  bus: EventBus,
+  envFromFile: Record<string, string>,
+): Promise<SupervisedHandle> {
+  bus.emit({ type: "starting", service: "langyagent" as never });
+  const start = Date.now();
+
+  const binary = ctx.predeps.aigateway?.resolvedPath;
+  if (!binary) throw new Error("aigateway/langyagent monobinary predep not resolved");
+
+  // Per-conversation homes and the shared workspace. The manager's defaults
+  // point at the container image's /workspace, which does not exist here.
+  const langyRoot = join(ctx.paths.root, "langyagent");
+  const sessionsRoot = join(langyRoot, "sessions");
+  const workspaceRoot = join(langyRoot, "workspace");
+  mkdirSync(sessionsRoot, { recursive: true });
+  mkdirSync(workspaceRoot, { recursive: true });
+
+  const sp = servicePaths(ctx.paths);
+  const handle = supervise({
+    spec: {
+      name: "langyagent",
+      command: binary,
+      args: ["langyagent"],
+      env: {
+        ...process.env,
+        ...envFromFile,
+        // The manager takes its listen port from PORT, not SERVER_ADDR.
+        PORT: String(ctx.ports.langyagent),
+        SESSIONS_ROOT: sessionsRoot,
+        LANGY_WORKSPACE_ROOT: workspaceRoot,
+        // Workers spawn as the user who ran the installer. The manager refuses
+        // this unless ENVIRONMENT is local-like, which the scaffolded .env sets
+        // — a production deployment cannot reach this path by accident.
+        LANGY_UNSAFE_DEV_DISABLE_ISOLATION: "true",
+        // Each worker is an opencode process holding a real conversation; two
+        // at a time is as much as a laptop should be asked to hold, and idle
+        // ones are reaped quickly so a finished conversation stops costing
+        // memory. Production's ceilings are much higher and set in the chart.
+        LANGY_MAX_WORKERS: envFromFile.LANGY_MAX_WORKERS ?? "2",
+        LANGY_WORKER_IDLE_MS: envFromFile.LANGY_WORKER_IDLE_MS ?? "120000",
+        // opencode and the `langwatch` CLI both live in ~/.langwatch/bin; the
+        // workers inherit exactly this PATH (the manager's allowlist passes it
+        // through), which is how their tool calls resolve.
+        PATH: [ctx.paths.bin, process.env.PATH ?? ""].filter(Boolean).join(delimiter),
+        LOG_FORMAT: "pretty",
+      },
+    },
+    paths: sp,
+    bus,
+  });
+
+  const ready = await pollUntilHealthy({
+    check: httpGetCheck(`http://127.0.0.1:${ctx.ports.langyagent}/health`),
+    timeoutMs: 30_000,
+  });
+  if (!ready.ok) {
+    await handle.stop();
+    throw new Error(`langyagent did not become healthy: ${ready.reason}`);
+  }
+  bus.emit({ type: "healthy", service: "langyagent" as never, durationMs: Date.now() - start });
+  return handle;
+}

--- a/packages/server/src/services/langyagent.ts
+++ b/packages/server/src/services/langyagent.ts
@@ -7,7 +7,7 @@ import { servicePaths } from "./paths.ts";
 import { supervise, type SupervisedHandle } from "./spawn.ts";
 
 /**
- * The Langy assistant's manager — the process that owns one opencode worker
+ * The Langy assistant's manager, the process that owns one opencode worker
  * per conversation. Same `cmd/service` mono-binary as the gateway and the NLP
  * engine, dispatched as `langyagent`, so the assistant adds no download of its
  * own beyond the opencode runtime predep.
@@ -16,7 +16,7 @@ import { supervise, type SupervisedHandle } from "./spawn.ts";
  *
  * WHAT IS DIFFERENT ABOUT A LAPTOP. In a cluster this pod runs under a
  * sandboxed container runtime, as root, handing every conversation's worker
- * its own UID — because there the workers belong to different people and a
+ * its own UID, because there the workers belong to different people and a
  * prompt-injected one must not be able to read a colleague's credentials off
  * disk. Here there is one person, on their own machine, and each worker
  * already runs as them with their own credentials. The UID handoff would need
@@ -58,8 +58,8 @@ export async function startLangyagent(
         SESSIONS_ROOT: sessionsRoot,
         LANGY_WORKSPACE_ROOT: workspaceRoot,
         // Workers spawn as the user who ran the installer. The manager refuses
-        // this unless ENVIRONMENT is local-like, which the scaffolded .env sets
-        // — a production deployment cannot reach this path by accident.
+        // this unless ENVIRONMENT is local-like, which the scaffolded .env sets,
+        // so a production deployment cannot reach this path by accident.
         LANGY_UNSAFE_DEV_DISABLE_ISOLATION: "true",
         // Each worker is an opencode process holding a real conversation; two
         // at a time is as much as a laptop should be asked to hold, and idle

--- a/packages/server/src/services/node-deps.ts
+++ b/packages/server/src/services/node-deps.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, sep } from "node:path";
 import { appRoot } from "./app-dir.ts";
 import type { EventBus } from "./event-bus.ts";
 import type { LangwatchPaths } from "../shared/paths.ts";
@@ -20,15 +20,16 @@ export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: E
 
   const nodeModulesPath = join(langwatchDir, "node_modules");
   const distPath = join(langwatchDir, "dist");
-  const prismaClientPath = join(nodeModulesPath, ".prisma", "client", "index.js");
   const lockfilePath = join(langwatchDir, "pnpm-lock.yaml");
   const hashFile = join(nodeModulesPath, ".install-hash");
 
   const distAlreadyBuilt = existsSync(join(distPath, "client"));
   // Hash key combines the lockfile + package.json — either changing means
   // we need to re-run install. Use sha256 (not just mtime) because rsync
-  // during ensureAppDir resets mtimes.
-  const installKey = computeInstallKey(lockfilePath, join(langwatchDir, "package.json"));
+  // during ensureAppDir resets mtimes. The sequence tag versions the whole
+  // install recipe: bumping it re-runs the cycle on existing installs, which
+  // is how trees installed before the prod-prune step existed get pruned.
+  const installKey = `${computeInstallKey(lockfilePath, join(langwatchDir, "package.json"))}|seq2-prod-pruned`;
 
   // Top-level symlinks are the strongest "install completed" signal:
   // pnpm creates `.bin/` and direct package entries LAST after populating
@@ -41,7 +42,7 @@ export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: E
   const cachedHash = existsSync(hashFile) ? readFileSync(hashFile, "utf8").trim() : null;
   const installFresh = topLevelLinksOk && cachedHash === installKey;
 
-  if (installFresh && existsSync(prismaClientPath) && distAlreadyBuilt) {
+  if (installFresh && prismaClientGenerated(nodeModulesPath) && distAlreadyBuilt) {
     return;
   }
 
@@ -64,38 +65,18 @@ export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: E
   const pnpm = await resolvePnpm(ctx.paths);
 
   if (!installFresh) {
-    // Always install with `--prod=false`. We tried `--prod` for the
-    // prebuilt-dist path to save ~50 devDependencies (vite, esbuild,
-    // vitest, playwright, etc.), but it turned up two real-world
-    // breakages on dogfood:
-    //   1. .prisma/client/ never materialized → langwatch app crashed
-    //      on `Cannot find module '.prisma/client/index'`.
-    //   2. tsx's --tsconfig path-alias resolver failed to map `~/...`
-    //      imports inside src/tasks/* → `Cannot find module '~/server/...'`.
-    // The transitive deps that tsx + prisma + workers need at runtime
-    // overlap unpredictably with langwatch's devDependencies, and
-    // chasing each is a losing game. Disk hit is acceptable; reliability
-    // wins.
+    // Install everything, dev dependencies included, because the steps that
+    // follow genuinely need them: prisma generate needs the prisma CLI's
+    // build tooling and the full build needs vite. Installing with `--prod`
+    // up front was tried once and broke exactly those two steps. The dev
+    // dependencies come OUT again below (prune --prod, after the build),
+    // which is the same order the production Dockerfile uses — the pruned
+    // tree it produces is what every helm and docker deployment runs.
     await execAndPipe(
       bus,
       "prepare:langwatch",
       pnpm.command,
       [...pnpm.args, "-C", langwatchDir, "install", "--prod=false", "--frozen-lockfile"],
-    );
-    writeFileSync(hashFile, installKey);
-  }
-
-  // pnpm install does NOT auto-generate the prisma client. Run it whenever
-  // the generated client is missing. The full-build path below (when
-  // !distAlreadyBuilt) ALSO covers this via start:prepare:files →
-  // prisma:generate:typescript, so we only need the explicit call on the
-  // prebuilt-dist path.
-  if (distAlreadyBuilt && !existsSync(prismaClientPath)) {
-    await execAndPipe(
-      bus,
-      "prepare:langwatch",
-      pnpm.command,
-      [...pnpm.args, "-C", langwatchDir, "exec", "prisma", "generate"],
     );
   }
 
@@ -125,7 +106,85 @@ export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: E
     );
   }
 
+  // Take the dev dependencies back out, the way the production Dockerfile
+  // does after ITS build (install → build → prune --prod → prisma generate).
+  // This is what drops vite, vitest, playwright, biome and the rest of the
+  // build tooling from the tree the server actually runs — on the order of a
+  // gigabyte — while tsx and prisma stay, because they are runtime
+  // dependencies here (the server boots through tsx, migrations run through
+  // the prisma CLI) and are declared as such.
+  //
+  // ONLY on the relocated copy under LANGWATCH_HOME. A dev checkout runs the
+  // CLI against its own working tree, and pruning that would strip the
+  // developer's test and build tooling out from under them.
+  if (shouldPruneToProd(langwatchDir, ctx.paths)) {
+    await execAndPipe(
+      bus,
+      "prepare:langwatch",
+      pnpm.command,
+      [...pnpm.args, "-C", langwatchDir, "prune", "--prod"],
+      { env: { ...process.env, CI: "true" } },
+    );
+  }
+
+  // pnpm install does not auto-generate the prisma client, and prune removes
+  // a generated one (it is not a declared dependency, so prune sees it as
+  // extraneous — the Dockerfile regenerates after pruning for the same
+  // reason). One post-prune generate covers every path that needs it.
+  if (!prismaClientGenerated(nodeModulesPath)) {
+    await execAndPipe(
+      bus,
+      "prepare:langwatch",
+      pnpm.command,
+      [...pnpm.args, "-C", langwatchDir, "exec", "prisma", "generate"],
+    );
+  }
+
+  // Written LAST so an interrupted run never records success: any of the
+  // steps above dying leaves the old key (or none) and the next boot redoes
+  // the cycle.
+  writeFileSync(hashFile, installKey);
+
   bus.emit({ type: "healthy", service: "prepare:langwatch" as never, durationMs: Date.now() - start });
+}
+
+/**
+ * Whether `prisma generate` has produced a client in this tree. Under pnpm
+ * the generated files live inside the virtual store
+ * (node_modules/.pnpm/@prisma+client@<ver>/node_modules/.prisma/client/), NOT
+ * the top-level node_modules/.prisma/ that npm and yarn use. The old
+ * top-level-only check could never pass on a pnpm tree, so every single boot
+ * re-ran the entire prepare step — install, build, generate — for minutes,
+ * believing the client was missing. Exported for tests.
+ */
+export function prismaClientGenerated(nodeModulesPath: string): boolean {
+  if (existsSync(join(nodeModulesPath, ".prisma", "client", "index.js"))) {
+    return true;
+  }
+  const pnpmDir = join(nodeModulesPath, ".pnpm");
+  if (!existsSync(pnpmDir)) return false;
+  for (const entry of readdirSync(pnpmDir)) {
+    if (!entry.startsWith("@prisma+client@")) continue;
+    if (
+      existsSync(
+        join(pnpmDir, entry, "node_modules", ".prisma", "client", "index.js"),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Prune is for the relocated install under LANGWATCH_HOME only. Exported for
+ * tests; the path comparison is the entire decision.
+ */
+export function shouldPruneToProd(
+  langwatchDir: string,
+  paths: Pick<LangwatchPaths, "app">,
+): boolean {
+  return langwatchDir === paths.app || langwatchDir.startsWith(paths.app + sep);
 }
 
 function computeInstallKey(...files: string[]): string {

--- a/packages/server/src/services/paths.ts
+++ b/packages/server/src/services/paths.ts
@@ -9,7 +9,8 @@ export type ServiceName =
   | "langevals"
   | "aigateway"
   | "langwatch"
-  | "workers";
+  | "workers"
+  | "langyagent";
 
 export type ServicePaths = {
   log(name: ServiceName): string;

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -16,7 +16,10 @@ import { EventBus } from "./event-bus.ts";
 import { startLangevals } from "./langevals.ts";
 import { startLangwatch } from "./langwatch.ts";
 import { startLangwatchWorkers } from "./langwatch-workers.ts";
+import { startLangyagent } from "./langyagent.ts";
+import { ensureLangyCli } from "./langy-cli.ts";
 import { startNlpgo } from "./nlpgo.ts";
+import { resolveFeatures } from "../shared/features.ts";
 import { runMigrations } from "./migrate.ts";
 import { ensureLangwatchDeps } from "./node-deps.ts";
 import { startPostgres } from "./postgres.ts";
@@ -54,9 +57,12 @@ const runtimeImpl: RuntimeApi = {
     // uv sync + langwatch node_modules + prepare:files run in parallel.
     // Each helper is idempotent and prints "already cached" + early-returns
     // when its lockfile hash matches the previous run.
+    const features = resolveFeatures({ ...readEnvFile(ctx.envFile), ...process.env });
     await Promise.all([
       syncVenvs(ctx, bus),
       ensureLangwatchDeps(ctx, bus),
+      // The assistant's CLI: only an install running it needs the download.
+      ...(features.langy ? [ensureLangyCli(ctx, bus)] : []),
     ]);
   },
 
@@ -94,13 +100,20 @@ const runtimeImpl: RuntimeApi = {
       // nlpgo is the only NLP runtime — the Go service from the aigateway
       // monobinary, dispatched as `nlpgo`. It binds to ctx.ports.nlp; the
       // langwatch app's /studio/* routing always targets /go/*.
-      const [nlp, langevals, gw, lw] = await Promise.all([
+      const features = resolveFeatures({ ...envFromFile, ...process.env });
+      const [nlp, langevals, gw, lw, langy] = await Promise.all([
         startNlpgo(ctx, bus, childEnv),
         startLangevals(ctx, bus, childEnv),
         startAigateway(ctx, bus, envFromFile),
         startLangwatch(ctx, bus, childEnv),
+        // The assistant is optional; when it is off nothing references it and
+        // the app simply never offers it.
+        features.langy
+          ? startLangyagent(ctx, bus, childEnv)
+          : Promise.resolve(null),
       ]);
       handles.push(nlp, langevals, gw, lw);
+      if (langy) handles.push(langy);
 
       // Phase 3b: workers. Spawned AFTER the app is healthy so it can
       // share the same boot env (Redis + Prisma already migrated, app

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -16,7 +16,7 @@ import { EventBus } from "./event-bus.ts";
 import { startLangevals } from "./langevals.ts";
 import { startLangwatch } from "./langwatch.ts";
 import { startLangwatchWorkers } from "./langwatch-workers.ts";
-import { startLangyagent } from "./langyagent.ts";
+import { monobinarySupportsLangyagent, startLangyagent } from "./langyagent.ts";
 import { ensureLangyCli } from "./langy-cli.ts";
 import { startNlpgo } from "./nlpgo.ts";
 import { featureEnv, resolveFeatures } from "../shared/features.ts";
@@ -97,12 +97,33 @@ const runtimeImpl: RuntimeApi = {
     // resolved feature toggles ride along explicitly (see featureEnv) so the
     // app describes exactly the install this process just built.
     const features = resolveFeatures({ ...envFromFile, ...process.env });
+    // The assistant additionally needs a mono-binary new enough to carry the
+    // langyagent service. The npm package and the release binary move in
+    // lockstep, but a smoke run of an unreleased CLI, or an install mid
+    // release-window, gets the previous release's binary; starting the
+    // assistant against it dies with "unknown service" and would take the
+    // whole install down. Come up without the assistant instead, and say so.
+    let langyRunnable = features.langy;
+    if (langyRunnable) {
+      const binary = ctx.predeps.aigateway?.resolvedPath;
+      langyRunnable = !!binary && (await monobinarySupportsLangyagent(binary));
+      if (!langyRunnable) {
+        bus.emit({
+          type: "log",
+          service: "langyagent",
+          stream: "stderr",
+          line:
+            "langy assistant disabled: the installed ai-gateway binary predates it. The next release's binary includes it and will be picked up automatically.",
+        });
+      }
+    }
+    const effective = { ...features, langy: langyRunnable };
     const childEnv: Record<string, string> = {
       ...envFromFile,
       ...ctx.userEnv,
-      ...featureEnv(features),
+      ...featureEnv(effective),
     };
-    if (!features.langy) {
+    if (!effective.langy) {
       // With the assistant off, the app must not think it exists: an agent
       // URL with no agent behind it turns every send into a hang, and the
       // forced rollout flag would render the panel. The .env keeps its lines
@@ -127,7 +148,7 @@ const runtimeImpl: RuntimeApi = {
         startLangwatch(ctx, bus, childEnv),
         // The assistant is optional; when it is off nothing references it and
         // the app simply never offers it.
-        features.langy
+        effective.langy
           ? startLangyagent(ctx, bus, childEnv)
           : Promise.resolve(null),
       ]);

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -19,7 +19,7 @@ import { startLangwatchWorkers } from "./langwatch-workers.ts";
 import { startLangyagent } from "./langyagent.ts";
 import { ensureLangyCli } from "./langy-cli.ts";
 import { startNlpgo } from "./nlpgo.ts";
-import { resolveFeatures } from "../shared/features.ts";
+import { featureEnv, resolveFeatures } from "../shared/features.ts";
 import { runMigrations } from "./migrate.ts";
 import { ensureLangwatchDeps } from "./node-deps.ts";
 import { startPostgres } from "./postgres.ts";
@@ -93,14 +93,33 @@ const runtimeImpl: RuntimeApi = {
 
     // Phase 3: app-tier services in parallel. The langwatch app receives
     // userEnv overlay so the user's provider keys (OPENAI_API_KEY etc.)
-    // win over the blank .env entries written by scaffoldEnvFile.
-    const childEnv = { ...envFromFile, ...ctx.userEnv };
+    // win over the blank .env entries written by scaffoldEnvFile. The
+    // resolved feature toggles ride along explicitly (see featureEnv) so the
+    // app describes exactly the install this process just built.
+    const features = resolveFeatures({ ...envFromFile, ...process.env });
+    const childEnv: Record<string, string> = {
+      ...envFromFile,
+      ...ctx.userEnv,
+      ...featureEnv(features),
+    };
+    if (!features.langy) {
+      // With the assistant off, the app must not think it exists: an agent
+      // URL with no agent behind it turns every send into a hang, and the
+      // forced rollout flag would render the panel. The .env keeps its lines
+      // (they are the user's knobs); only the running processes lose them.
+      delete childEnv.OPENCODE_AGENT_URL;
+      const forced = (childEnv.FEATURE_FLAG_FORCE_ENABLE ?? "")
+        .split(",")
+        .map((f) => f.trim())
+        .filter((f) => f && f !== "release_langy_enabled");
+      if (forced.length > 0) childEnv.FEATURE_FLAG_FORCE_ENABLE = forced.join(",");
+      else delete childEnv.FEATURE_FLAG_FORCE_ENABLE;
+    }
 
     try {
       // nlpgo is the only NLP runtime — the Go service from the aigateway
       // monobinary, dispatched as `nlpgo`. It binds to ctx.ports.nlp; the
       // langwatch app's /studio/* routing always targets /go/*.
-      const features = resolveFeatures({ ...envFromFile, ...process.env });
       const [nlp, langevals, gw, lw, langy] = await Promise.all([
         startNlpgo(ctx, bus, childEnv),
         startLangevals(ctx, bus, childEnv),

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -19,7 +19,7 @@ import { startLangwatchWorkers } from "./langwatch-workers.ts";
 import { monobinarySupportsLangyagent, startLangyagent } from "./langyagent.ts";
 import { ensureLangyCli } from "./langy-cli.ts";
 import { startNlpgo } from "./nlpgo.ts";
-import { featureEnv, resolveFeatures } from "../shared/features.ts";
+import { featureEnv, resolveEffectiveFeatures } from "../shared/features.ts";
 import { runMigrations } from "./migrate.ts";
 import { ensureLangwatchDeps } from "./node-deps.ts";
 import { startPostgres } from "./postgres.ts";
@@ -57,7 +57,7 @@ const runtimeImpl: RuntimeApi = {
     // uv sync + langwatch node_modules + prepare:files run in parallel.
     // Each helper is idempotent and prints "already cached" + early-returns
     // when its lockfile hash matches the previous run.
-    const features = resolveFeatures({ ...readEnvFile(ctx.envFile), ...process.env });
+    const features = resolveEffectiveFeatures(ctx.envFile);
     await Promise.all([
       syncVenvs(ctx, bus),
       ensureLangwatchDeps(ctx, bus),
@@ -96,7 +96,7 @@ const runtimeImpl: RuntimeApi = {
     // win over the blank .env entries written by scaffoldEnvFile. The
     // resolved feature toggles ride along explicitly (see featureEnv) so the
     // app describes exactly the install this process just built.
-    const features = resolveFeatures({ ...envFromFile, ...process.env });
+    const features = resolveEffectiveFeatures(ctx.envFile);
     // The assistant is OPTIONAL: nothing else depends on it, so no failure of
     // its own may take the install down. It boots (or declines to) BEFORE the
     // app tier, because the app must be told the truth about it: an agent URL

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -62,7 +62,7 @@ const runtimeImpl: RuntimeApi = {
       syncVenvs(ctx, bus),
       ensureLangwatchDeps(ctx, bus),
       // The assistant's CLI: only an install running it needs the download.
-      ...(features.langy ? [ensureLangyCli(ctx, bus)] : []),
+      ...(features.isLangyEnabled ? [ensureLangyCli(ctx, bus)] : []),
     ]);
   },
 
@@ -97,17 +97,22 @@ const runtimeImpl: RuntimeApi = {
     // resolved feature toggles ride along explicitly (see featureEnv) so the
     // app describes exactly the install this process just built.
     const features = resolveFeatures({ ...envFromFile, ...process.env });
-    // The assistant additionally needs a mono-binary new enough to carry the
-    // langyagent service. The npm package and the release binary move in
-    // lockstep, but a smoke run of an unreleased CLI, or an install mid
-    // release-window, gets the previous release's binary; starting the
-    // assistant against it dies with "unknown service" and would take the
-    // whole install down. Come up without the assistant instead, and say so.
-    let langyRunnable = features.langy;
-    if (langyRunnable) {
+    // The assistant is OPTIONAL: nothing else depends on it, so no failure of
+    // its own may take the install down. It boots (or declines to) BEFORE the
+    // app tier, because the app must be told the truth about it: an agent URL
+    // with no agent behind it turns every send into a hang. Two ways it
+    // declines, each with its own notice:
+    //   - the mono-binary predates the langyagent service (the npm package
+    //     and the release binary move in lockstep, but a smoke run of an
+    //     unreleased CLI, or an install mid release-window, gets the previous
+    //     release's binary, which answers "unknown service");
+    //   - it started but never reached healthy.
+    let isLangyRunnable = features.isLangyEnabled;
+    let langyHandle: SupervisedHandle | null = null;
+    if (isLangyRunnable) {
       const binary = ctx.predeps.aigateway?.resolvedPath;
-      langyRunnable = !!binary && (await monobinarySupportsLangyagent(binary));
-      if (!langyRunnable) {
+      isLangyRunnable = !!binary && (await monobinarySupportsLangyagent(binary));
+      if (!isLangyRunnable) {
         bus.emit({
           type: "log",
           service: "langyagent",
@@ -117,13 +122,30 @@ const runtimeImpl: RuntimeApi = {
         });
       }
     }
-    const effective = { ...features, langy: langyRunnable };
+    if (isLangyRunnable) {
+      try {
+        langyHandle = await startLangyagent(ctx, bus, {
+          ...envFromFile,
+          ...ctx.userEnv,
+        });
+        handles.push(langyHandle);
+      } catch (err) {
+        isLangyRunnable = false;
+        bus.emit({
+          type: "log",
+          service: "langyagent",
+          stream: "stderr",
+          line: `langy assistant disabled: it failed to start (${err instanceof Error ? err.message : String(err)}). Everything else continues without it.`,
+        });
+      }
+    }
+    const effective = { ...features, isLangyEnabled: isLangyRunnable };
     const childEnv: Record<string, string> = {
       ...envFromFile,
       ...ctx.userEnv,
       ...featureEnv(effective),
     };
-    if (!effective.langy) {
+    if (!effective.isLangyEnabled) {
       // With the assistant off, the app must not think it exists: an agent
       // URL with no agent behind it turns every send into a hang, and the
       // forced rollout flag would render the panel. The .env keeps its lines
@@ -141,19 +163,13 @@ const runtimeImpl: RuntimeApi = {
       // nlpgo is the only NLP runtime — the Go service from the aigateway
       // monobinary, dispatched as `nlpgo`. It binds to ctx.ports.nlp; the
       // langwatch app's /studio/* routing always targets /go/*.
-      const [nlp, langevals, gw, lw, langy] = await Promise.all([
+      const [nlp, langevals, gw, lw] = await Promise.all([
         startNlpgo(ctx, bus, childEnv),
         startLangevals(ctx, bus, childEnv),
         startAigateway(ctx, bus, envFromFile),
         startLangwatch(ctx, bus, childEnv),
-        // The assistant is optional; when it is off nothing references it and
-        // the app simply never offers it.
-        effective.langy
-          ? startLangyagent(ctx, bus, childEnv)
-          : Promise.resolve(null),
       ]);
       handles.push(nlp, langevals, gw, lw);
-      if (langy) handles.push(langy);
 
       // Phase 3b: workers. Spawned AFTER the app is healthy so it can
       // share the same boot env (Redis + Prisma already migrated, app

--- a/packages/server/src/services/venvs.ts
+++ b/packages/server/src/services/venvs.ts
@@ -62,14 +62,13 @@ export async function syncVenvs(ctx: RuntimeContext, bus: EventBus): Promise<voi
   );
 }
 
-// Every extra langevals declares (see langevals/pyproject.toml), minus
-// presidio. `--extra all` is the union of these plus presidio; naming them
-// individually is how we drop one without dropping the rest.
-const LANGEVALS_EXTRAS_WITHOUT_PRESIDIO = [
+// The extras every install gets (see langevals/pyproject.toml for the full
+// set). `--extra all` is the union of these plus the three optional ones
+// below; naming them individually is how we drop some without dropping the
+// rest.
+const LANGEVALS_BASE_EXTRAS = [
   "azure",
   "langevals",
-  "legacy",
-  "lingua",
   "openai",
   "ragas",
   "topic_clustering",
@@ -77,16 +76,25 @@ const LANGEVALS_EXTRAS_WITHOUT_PRESIDIO = [
 
 function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
   const root = appRoot();
-  // The PII detector brings a natural-language model that is larger than the
-  // rest of this environment put together (~670MB of a ~1.6GB venv, most of it
-  // one spacy model). Most first installs never evaluate PII, so it is opt-in
-  // and the product tells anyone who reaches for that evaluator how to get it.
-  // Nothing else about redaction depends on this: LangWatch's own secret and
+  // Three evaluator families are opt-in. Two for weight: the PII detector
+  // brings a ~620MB spacy model and language detection ~95MB of language
+  // models. The deprecated legacy evaluators are opt-in for a different
+  // reason: they exist only so evaluations saved years ago keep running, and
+  // deprecated things should vanish rather than nag (most of their heavy
+  // dependencies are shared with the current ragas family anyway). The
+  // product tells anyone who reaches for one of these how to get it. Nothing
+  // about redaction depends on the PII toggle: LangWatch's own secret and
   // PII redaction in the ingestion pipeline is not implemented with presidio.
-  const presidio = resolveFeatures({
+  const features = resolveFeatures({
     ...readEnvFile(ctx.envFile),
     ...process.env,
-  }).presidio;
+  });
+  const extras = [
+    ...LANGEVALS_BASE_EXTRAS,
+    ...(features.lingua ? ["lingua"] : []),
+    ...(features.legacyEvaluators ? ["legacy"] : []),
+    ...(features.presidio ? ["presidio"] : []),
+  ];
   // langevals is the only Python venv we build — nlpgo runs from the
   // aigateway monobinary and needs no uv environment.
   const specs: VenvSpec[] = [
@@ -105,9 +113,9 @@ function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
       // and `/openapi.json` reports just `/healthcheck` and `/` — every
       // evaluator request 404s, langwatch app's runEvaluation throws
       // `404 {"detail":"Not Found"}`, and the experiments workbench column
-      // shows 'Internal error' for every row. So we always install the full
-      // set, with presidio the one member that has to be asked for.
-      extras: presidio ? ["all"] : LANGEVALS_EXTRAS_WITHOUT_PRESIDIO,
+      // shows 'Internal error' for every row. So the base set always
+      // installs, and only the three opt-in members have to be asked for.
+      extras,
     },
   ];
 

--- a/packages/server/src/services/venvs.ts
+++ b/packages/server/src/services/venvs.ts
@@ -6,8 +6,7 @@ import { appRoot } from "./app-dir.ts";
 import type { EventBus } from "./event-bus.ts";
 import { servicePaths } from "./paths.ts";
 import { execAndPipe } from "./_pipe-to-bus.ts";
-import { readEnvFile } from "./env-file.ts";
-import { resolveFeatures } from "../shared/features.ts";
+import { resolveEffectiveFeatures } from "../shared/features.ts";
 
 type VenvSpec = {
   name: "langevals";
@@ -85,10 +84,7 @@ function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
   // product tells anyone who reaches for one of these how to get it. Nothing
   // about redaction depends on the PII toggle: LangWatch's own secret and
   // PII redaction in the ingestion pipeline is not implemented with presidio.
-  const features = resolveFeatures({
-    ...readEnvFile(ctx.envFile),
-    ...process.env,
-  });
+  const features = resolveEffectiveFeatures(ctx.envFile);
   const extras = [
     ...LANGEVALS_BASE_EXTRAS,
     ...(features.isLinguaEnabled ? ["lingua"] : []),

--- a/packages/server/src/services/venvs.ts
+++ b/packages/server/src/services/venvs.ts
@@ -91,9 +91,9 @@ function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
   });
   const extras = [
     ...LANGEVALS_BASE_EXTRAS,
-    ...(features.lingua ? ["lingua"] : []),
-    ...(features.legacyEvaluators ? ["legacy"] : []),
-    ...(features.presidio ? ["presidio"] : []),
+    ...(features.isLinguaEnabled ? ["lingua"] : []),
+    ...(features.isLegacyEvaluatorsEnabled ? ["legacy"] : []),
+    ...(features.isPresidioEnabled ? ["presidio"] : []),
   ];
   // langevals is the only Python venv we build — nlpgo runs from the
   // aigateway monobinary and needs no uv environment.

--- a/packages/server/src/services/venvs.ts
+++ b/packages/server/src/services/venvs.ts
@@ -6,6 +6,8 @@ import { appRoot } from "./app-dir.ts";
 import type { EventBus } from "./event-bus.ts";
 import { servicePaths } from "./paths.ts";
 import { execAndPipe } from "./_pipe-to-bus.ts";
+import { readEnvFile } from "./env-file.ts";
+import { resolveFeatures } from "../shared/features.ts";
 
 type VenvSpec = {
   name: "langevals";
@@ -60,8 +62,31 @@ export async function syncVenvs(ctx: RuntimeContext, bus: EventBus): Promise<voi
   );
 }
 
-function resolveVenvSpecs(_ctx: RuntimeContext): VenvSpec[] {
+// Every extra langevals declares (see langevals/pyproject.toml), minus
+// presidio. `--extra all` is the union of these plus presidio; naming them
+// individually is how we drop one without dropping the rest.
+const LANGEVALS_EXTRAS_WITHOUT_PRESIDIO = [
+  "azure",
+  "langevals",
+  "legacy",
+  "lingua",
+  "openai",
+  "ragas",
+  "topic_clustering",
+];
+
+function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
   const root = appRoot();
+  // The PII detector brings a natural-language model that is larger than the
+  // rest of this environment put together (~670MB of a ~1.6GB venv, most of it
+  // one spacy model). Most first installs never evaluate PII, so it is opt-in
+  // and the product tells anyone who reaches for that evaluator how to get it.
+  // Nothing else about redaction depends on this: LangWatch's own secret and
+  // PII redaction in the ingestion pipeline is not implemented with presidio.
+  const presidio = resolveFeatures({
+    ...readEnvFile(ctx.envFile),
+    ...process.env,
+  }).presidio;
   // langevals is the only Python venv we build — nlpgo runs from the
   // aigateway monobinary and needs no uv environment.
   const specs: VenvSpec[] = [
@@ -76,14 +101,13 @@ function resolveVenvSpecs(_ctx: RuntimeContext): VenvSpec[] {
       // langevals-presidio, langevals-legacy. Each is a separate `langevals_*`
       // distribution; server.py auto-registers FastAPI routes for any
       // `langevals_*` package found via importlib.metadata.distributions().
-      // Without --extra all, only langevals + langevals-core get installed
+      // Without any extras, only langevals + langevals-core get installed
       // and `/openapi.json` reports just `/healthcheck` and `/` — every
       // evaluator request 404s, langwatch app's runEvaluation throws
       // `404 {"detail":"Not Found"}`, and the experiments workbench column
-      // shows 'Internal error' for every row. We install all extras so the
-      // evaluator dispatch + the legacy-eval REST route can reach a real
-      // evaluator implementation.
-      extras: ["all"],
+      // shows 'Internal error' for every row. So we always install the full
+      // set, with presidio the one member that has to be asked for.
+      extras: presidio ? ["all"] : LANGEVALS_EXTRAS_WITHOUT_PRESIDIO,
     },
   ];
 

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -29,6 +29,9 @@ const PERSISTENT_SECRET_KEYS = [
   "LW_VIRTUAL_KEY_PEPPER",
   "LW_GATEWAY_INTERNAL_SECRET",
   "LW_GATEWAY_JWT_SECRET",
+  // The app and the Langy agent authenticate to each other with this; a
+  // regenerated value on one side and not the other makes every turn 401.
+  "LANGY_INTERNAL_SECRET",
 ] as const;
 
 const hex = (bytes: number) => randomBytes(bytes).toString("hex");
@@ -88,7 +91,32 @@ export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput):
   set("LW_VIRTUAL_KEY_PEPPER", hex(32));
   set("LW_GATEWAY_INTERNAL_SECRET", hex(32));
   set("LW_GATEWAY_JWT_SECRET", hex(32));
-  set("LW_GATEWAY_BASE_URL", host);
+  // Where the gateway is, from the app's point of view. The gateway process
+  // reads this same name to mean the opposite direction (where the CONTROL
+  // PLANE is) and services/aigateway.ts sets it explicitly in that child's
+  // env, so this value only ever reaches the app — which uses it to hand
+  // Langy's workers, and CLI users, an OpenAI-compatible base URL. Pointed at
+  // the app itself, every one of those callers dialled a server with no /v1
+  // surface.
+  set("LW_GATEWAY_BASE_URL", `http://localhost:${ports.aigateway}`);
+
+  sectionBreak("LANGY ASSISTANT");
+  // Shared bearer between the app and the agent; see PERSISTENT_SECRET_KEYS.
+  set("LANGY_INTERNAL_SECRET", hex(32));
+  set("OPENCODE_AGENT_URL", `http://localhost:${ports.langyagent}`);
+  // Langy's rollout flag is SYSTEM-scoped and defaults off so the hosted
+  // product can open it one cohort at a time. A laptop install is a cohort of
+  // one, and it just installed the assistant on purpose.
+  set("FEATURE_FLAG_FORCE_ENABLE", "release_langy_enabled");
+
+  sectionBreak("OPTIONAL PIECES — flip one of these and restart the server");
+  // Both of these are read by the installer AND by the app, so the same line
+  // decides what gets downloaded and what the product says about it.
+  set("LANGWATCH_ENABLE_LANGY", "true");
+  // The PII detection evaluator ships a ~670MB language model — larger than
+  // the rest of the evaluator environment put together. Off by default; the
+  // product points anyone who reaches for that evaluator back at this line.
+  set("LANGWATCH_ENABLE_PRESIDIO", "false");
 
   sectionBreak("ENVIRONMENT");
   set("ENVIRONMENT", "local");

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -110,13 +110,19 @@ export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput):
   set("FEATURE_FLAG_FORCE_ENABLE", "release_langy_enabled");
 
   sectionBreak("OPTIONAL PIECES — flip one of these and restart the server");
-  // Both of these are read by the installer AND by the app, so the same line
-  // decides what gets downloaded and what the product says about it.
+  // These are read by the installer AND by the app, so the same line decides
+  // what gets downloaded and what the product says about it.
   set("LANGWATCH_ENABLE_LANGY", "true");
   // The PII detection evaluator ships a ~670MB language model — larger than
   // the rest of the evaluator environment put together. Off by default; the
   // product points anyone who reaches for that evaluator back at this line.
   set("LANGWATCH_ENABLE_PRESIDIO", "false");
+  // The language detection evaluator: ~95MB of language models, same deal.
+  set("LANGWATCH_ENABLE_LINGUA", "false");
+  // The deprecated legacy evaluators (old Ragas API), kept only so
+  // evaluations saved years ago keep running. When off they are hidden from
+  // the product entirely, not just disabled.
+  set("LANGWATCH_ENABLE_LEGACY_EVALUATORS", "false");
 
   sectionBreak("ENVIRONMENT");
   set("ENVIRONMENT", "local");

--- a/packages/server/src/shared/features.ts
+++ b/packages/server/src/shared/features.ts
@@ -10,6 +10,8 @@
  * works in a shell, in `~/.langwatch/.env`, and in a container.
  */
 
+import { readEnvFile } from "../services/env-file.ts";
+
 export type FeatureToggles = {
   /**
    * The Langy assistant. Costs ~45MB (the opencode runtime, fetched once) and
@@ -105,4 +107,14 @@ export function featureEnv(features: FeatureToggles): Record<string, string> {
     [LINGUA_ENV_KEY]: String(features.isLinguaEnabled),
     [LEGACY_EVALUATORS_ENV_KEY]: String(features.isLegacyEvaluatorsEnabled),
   };
+}
+
+/**
+ * The toggles as an install actually experiences them: the persisted .env
+ * first, the shell environment on top. Every consumer (predep registry,
+ * installer, service composition, venv extras) resolves through here so the
+ * precedence order lives in exactly one place.
+ */
+export function resolveEffectiveFeatures(envFilePath: string): FeatureToggles {
+  return resolveFeatures({ ...readEnvFile(envFilePath), ...process.env });
 }

--- a/packages/server/src/shared/features.ts
+++ b/packages/server/src/shared/features.ts
@@ -1,0 +1,60 @@
+/**
+ * The parts of a local install a user can decline, and what they cost.
+ *
+ * Both toggles exist for the same reason: this installer downloads well over
+ * four gigabytes on a first run, and two of those pieces are only worth their
+ * bytes to some people. Rather than guess, we pick the default that serves the
+ * common case and make the other one a single line to flip.
+ *
+ * Read from the environment rather than a config file so the same variable
+ * works in a shell, in `~/.langwatch/.env`, and in a container.
+ */
+
+export type FeatureToggles = {
+  /**
+   * The Langy assistant. Costs ~45MB (the opencode runtime, fetched once) and
+   * nothing at rest — the manager itself already ships inside the mono-binary
+   * the gateway downloads regardless. Default ON: it is a headline feature of
+   * the product, and the download is small next to the rest of the install.
+   */
+  langy: boolean;
+  /**
+   * The PII detection evaluator. Costs ~670MB — a natural-language model
+   * larger than the entire rest of the Python environment, and the single
+   * biggest item in the install. Default OFF: most first installs never
+   * evaluate PII, and the ones that do can say so and wait for it once.
+   *
+   * LangWatch's own redaction of secrets and simple PII in the ingestion
+   * pipeline is unaffected by this — it is not implemented with presidio.
+   */
+  presidio: boolean;
+};
+
+const TRUE = new Set(["1", "true", "yes", "on"]);
+const FALSE = new Set(["0", "false", "no", "off"]);
+
+/**
+ * Resolves a toggle, honouring both the positive name and, for the assistant,
+ * nothing else — there is deliberately one name per toggle. An unrecognised
+ * value falls back to the default rather than being treated as false, so a
+ * typo cannot silently strip a feature someone asked for.
+ */
+function toggle(env: Record<string, string | undefined>, key: string, fallback: boolean): boolean {
+  const raw = env[key]?.trim().toLowerCase();
+  if (raw === undefined || raw === "") return fallback;
+  if (TRUE.has(raw)) return true;
+  if (FALSE.has(raw)) return false;
+  return fallback;
+}
+
+export const LANGY_ENV_KEY = "LANGWATCH_ENABLE_LANGY";
+export const PRESIDIO_ENV_KEY = "LANGWATCH_ENABLE_PRESIDIO";
+
+export function resolveFeatures(
+  env: Record<string, string | undefined> = process.env,
+): FeatureToggles {
+  return {
+    langy: toggle(env, LANGY_ENV_KEY, true),
+    presidio: toggle(env, PRESIDIO_ENV_KEY, false),
+  };
+}

--- a/packages/server/src/shared/features.ts
+++ b/packages/server/src/shared/features.ts
@@ -13,21 +13,35 @@
 export type FeatureToggles = {
   /**
    * The Langy assistant. Costs ~45MB (the opencode runtime, fetched once) and
-   * nothing at rest — the manager itself already ships inside the mono-binary
+   * nothing at rest: the manager itself already ships inside the mono-binary
    * the gateway downloads regardless. Default ON: it is a headline feature of
    * the product, and the download is small next to the rest of the install.
    */
   langy: boolean;
   /**
-   * The PII detection evaluator. Costs ~670MB — a natural-language model
+   * The PII detection evaluator. Costs ~670MB, a natural-language model
    * larger than the entire rest of the Python environment, and the single
    * biggest item in the install. Default OFF: most first installs never
    * evaluate PII, and the ones that do can say so and wait for it once.
    *
    * LangWatch's own redaction of secrets and simple PII in the ingestion
-   * pipeline is unaffected by this — it is not implemented with presidio.
+   * pipeline is unaffected by this; it is not implemented with presidio.
    */
   presidio: boolean;
+  /**
+   * The language detection evaluator. Costs ~95MB of language models.
+   * Default OFF for the same reason as the PII detector: a niche evaluator
+   * should not tax every install that never runs it.
+   */
+  lingua: boolean;
+  /**
+   * The deprecated legacy evaluators (the old Ragas API surface). They exist
+   * only so evaluations saved years ago keep running, and while they share
+   * most of their weight with the current Ragas family, deprecated things
+   * should vanish rather than nag. Default OFF; an install that needs them
+   * says so, everyone else never sees them.
+   */
+  legacyEvaluators: boolean;
 };
 
 const TRUE = new Set(["1", "true", "yes", "on"]);
@@ -35,7 +49,7 @@ const FALSE = new Set(["0", "false", "no", "off"]);
 
 /**
  * Resolves a toggle, honouring both the positive name and, for the assistant,
- * nothing else — there is deliberately one name per toggle. An unrecognised
+ * nothing else, there is deliberately one name per toggle. An unrecognised
  * value falls back to the default rather than being treated as false, so a
  * typo cannot silently strip a feature someone asked for.
  */
@@ -49,6 +63,8 @@ function toggle(env: Record<string, string | undefined>, key: string, fallback: 
 
 export const LANGY_ENV_KEY = "LANGWATCH_ENABLE_LANGY";
 export const PRESIDIO_ENV_KEY = "LANGWATCH_ENABLE_PRESIDIO";
+export const LINGUA_ENV_KEY = "LANGWATCH_ENABLE_LINGUA";
+export const LEGACY_EVALUATORS_ENV_KEY = "LANGWATCH_ENABLE_LEGACY_EVALUATORS";
 
 export function resolveFeatures(
   env: Record<string, string | undefined> = process.env,
@@ -56,5 +72,25 @@ export function resolveFeatures(
   return {
     langy: toggle(env, LANGY_ENV_KEY, true),
     presidio: toggle(env, PRESIDIO_ENV_KEY, false),
+    lingua: toggle(env, LINGUA_ENV_KEY, false),
+    legacyEvaluators: toggle(env, LEGACY_EVALUATORS_ENV_KEY, false),
+  };
+}
+
+/**
+ * The toggles as env lines for the app and workers processes, so the product
+ * tells the truth about what this install has. Injected into the children's
+ * env explicitly rather than trusted to exist in the .env: an install created
+ * before a toggle existed has no line for it, and the app's own default for a
+ * missing variable is "available" (container installs carry everything and
+ * set nothing), which is exactly wrong for an npx install that just skipped
+ * the download.
+ */
+export function featureEnv(features: FeatureToggles): Record<string, string> {
+  return {
+    [LANGY_ENV_KEY]: String(features.langy),
+    [PRESIDIO_ENV_KEY]: String(features.presidio),
+    [LINGUA_ENV_KEY]: String(features.lingua),
+    [LEGACY_EVALUATORS_ENV_KEY]: String(features.legacyEvaluators),
   };
 }

--- a/packages/server/src/shared/features.ts
+++ b/packages/server/src/shared/features.ts
@@ -17,7 +17,7 @@ export type FeatureToggles = {
    * the gateway downloads regardless. Default ON: it is a headline feature of
    * the product, and the download is small next to the rest of the install.
    */
-  langy: boolean;
+  isLangyEnabled: boolean;
   /**
    * The PII detection evaluator. Costs ~670MB, a natural-language model
    * larger than the entire rest of the Python environment, and the single
@@ -27,13 +27,13 @@ export type FeatureToggles = {
    * LangWatch's own redaction of secrets and simple PII in the ingestion
    * pipeline is unaffected by this; it is not implemented with presidio.
    */
-  presidio: boolean;
+  isPresidioEnabled: boolean;
   /**
    * The language detection evaluator. Costs ~95MB of language models.
    * Default OFF for the same reason as the PII detector: a niche evaluator
    * should not tax every install that never runs it.
    */
-  lingua: boolean;
+  isLinguaEnabled: boolean;
   /**
    * The deprecated legacy evaluators (the old Ragas API surface). They exist
    * only so evaluations saved years ago keep running, and while they share
@@ -41,7 +41,7 @@ export type FeatureToggles = {
    * should vanish rather than nag. Default OFF; an install that needs them
    * says so, everyone else never sees them.
    */
-  legacyEvaluators: boolean;
+  isLegacyEvaluatorsEnabled: boolean;
 };
 
 const TRUE = new Set(["1", "true", "yes", "on"]);
@@ -53,12 +53,20 @@ const FALSE = new Set(["0", "false", "no", "off"]);
  * value falls back to the default rather than being treated as false, so a
  * typo cannot silently strip a feature someone asked for.
  */
-function toggle(env: Record<string, string | undefined>, key: string, fallback: boolean): boolean {
+function toggle({
+  env,
+  key,
+  defaultEnabled,
+}: {
+  env: Record<string, string | undefined>;
+  key: string;
+  defaultEnabled: boolean;
+}): boolean {
   const raw = env[key]?.trim().toLowerCase();
-  if (raw === undefined || raw === "") return fallback;
+  if (raw === undefined || raw === "") return defaultEnabled;
   if (TRUE.has(raw)) return true;
   if (FALSE.has(raw)) return false;
-  return fallback;
+  return defaultEnabled;
 }
 
 export const LANGY_ENV_KEY = "LANGWATCH_ENABLE_LANGY";
@@ -70,10 +78,14 @@ export function resolveFeatures(
   env: Record<string, string | undefined> = process.env,
 ): FeatureToggles {
   return {
-    langy: toggle(env, LANGY_ENV_KEY, true),
-    presidio: toggle(env, PRESIDIO_ENV_KEY, false),
-    lingua: toggle(env, LINGUA_ENV_KEY, false),
-    legacyEvaluators: toggle(env, LEGACY_EVALUATORS_ENV_KEY, false),
+    isLangyEnabled: toggle({ env, key: LANGY_ENV_KEY, defaultEnabled: true }),
+    isPresidioEnabled: toggle({ env, key: PRESIDIO_ENV_KEY, defaultEnabled: false }),
+    isLinguaEnabled: toggle({ env, key: LINGUA_ENV_KEY, defaultEnabled: false }),
+    isLegacyEvaluatorsEnabled: toggle({
+      env,
+      key: LEGACY_EVALUATORS_ENV_KEY,
+      defaultEnabled: false,
+    }),
   };
 }
 
@@ -88,9 +100,9 @@ export function resolveFeatures(
  */
 export function featureEnv(features: FeatureToggles): Record<string, string> {
   return {
-    [LANGY_ENV_KEY]: String(features.langy),
-    [PRESIDIO_ENV_KEY]: String(features.presidio),
-    [LINGUA_ENV_KEY]: String(features.lingua),
-    [LEGACY_EVALUATORS_ENV_KEY]: String(features.legacyEvaluators),
+    [LANGY_ENV_KEY]: String(features.isLangyEnabled),
+    [PRESIDIO_ENV_KEY]: String(features.isPresidioEnabled),
+    [LINGUA_ENV_KEY]: String(features.isLinguaEnabled),
+    [LEGACY_EVALUATORS_ENV_KEY]: String(features.isLegacyEvaluatorsEnabled),
   };
 }

--- a/packages/server/src/shared/ports.ts
+++ b/packages/server/src/shared/ports.ts
@@ -6,12 +6,13 @@ export const MAX_PORT_SLOT_ATTEMPTS = 30;
 export type PortAllocation = {
   base: number;
   // App tier: base..base+9. Each LangWatch-shipped service gets a slot.
-  // 5564..5567 reserved for future services so we never trample the infra
+  // 5565..5567 reserved for future services so we never trample the infra
   // tier when we add the next data plane.
   langwatch: number;
   nlp: number;
   langevals: number;
   aigateway: number;
+  langyagent: number;
   // Infra tier: base+1000..base+1009. Embedded data stores live here so a
   // user with their own postgres/redis/clickhouse on canonical ports
   // doesn't collide. Auto-shift moves both tiers together by +10.
@@ -33,6 +34,7 @@ export function allocatePorts(base: number = PORT_BASE_DEFAULT): PortAllocation 
     nlp: base + 1,
     langevals: base + 2,
     aigateway: base + 3,
+    langyagent: base + 4,
     postgres: infra,
     redis: infra + 1,
     clickhouseHttp: infra + 2,
@@ -46,6 +48,7 @@ export function portsToCheck(alloc: PortAllocation): Array<{ port: number; label
     { port: alloc.nlp, label: "nlpgo" },
     { port: alloc.langevals, label: "langevals" },
     { port: alloc.aigateway, label: "ai gateway" },
+    { port: alloc.langyagent, label: "langy agent" },
     { port: alloc.postgres, label: "postgres" },
     { port: alloc.redis, label: "redis" },
     { port: alloc.clickhouseHttp, label: "clickhouse http" },

--- a/packages/server/test/env.test.ts
+++ b/packages/server/test/env.test.ts
@@ -13,7 +13,12 @@ describe("buildEnv", () => {
       expect(env).toContain("CLICKHOUSE_URL=http://localhost:6562/langwatch");
       expect(env).toContain("LANGWATCH_NLP_SERVICE=http://localhost:5561");
       expect(env).toContain("LANGEVALS_ENDPOINT=http://localhost:5562");
-      expect(env).toContain("LW_GATEWAY_BASE_URL=http://localhost:5560");
+      // The gateway's own port, not the app's: this value is what the app
+      // hands Langy's workers and CLI users as an OpenAI-compatible base URL.
+      // The gateway process reads the same name to mean the opposite direction
+      // and gets its value from services/aigateway.ts, not from here.
+      expect(env).toContain("LW_GATEWAY_BASE_URL=http://localhost:5563");
+      expect(env).toContain("OPENCODE_AGENT_URL=http://localhost:5564");
     });
 
     it("populates every secret with a fresh random value", () => {

--- a/packages/server/test/features.test.ts
+++ b/packages/server/test/features.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { LANGY_ENV_KEY, PRESIDIO_ENV_KEY, resolveFeatures } from "../src/shared/features.ts";
+
+describe("optional install pieces", () => {
+  describe("when nothing is set", () => {
+    it("installs the assistant and skips the PII model", () => {
+      const f = resolveFeatures({});
+      expect(f.langy).toBe(true);
+      expect(f.presidio).toBe(false);
+    });
+  });
+
+  describe("when a toggle is set", () => {
+    it("honours an explicit opt-in to the PII model", () => {
+      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "true" }).presidio).toBe(true);
+    });
+
+    it("honours an explicit opt-out of the assistant", () => {
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "false" }).langy).toBe(false);
+    });
+
+    it("accepts the spellings people actually type", () => {
+      for (const yes of ["1", "true", "TRUE", "yes", "on", " true "]) {
+        expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: yes }).presidio).toBe(true);
+      }
+      for (const no of ["0", "false", "FALSE", "no", "off"]) {
+        expect(resolveFeatures({ [LANGY_ENV_KEY]: no }).langy).toBe(false);
+      }
+    });
+  });
+
+  describe("when a toggle is set to something unrecognised", () => {
+    it("keeps the default rather than reading it as off", () => {
+      // A typo silently stripping a feature someone asked for is the worse
+      // failure: they wait for an install that quietly did not happen.
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "maybe" }).langy).toBe(true);
+      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "sure" }).presidio).toBe(false);
+    });
+
+    it("treats an empty value as unset", () => {
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "" }).langy).toBe(true);
+    });
+  });
+});

--- a/packages/server/test/features.test.ts
+++ b/packages/server/test/features.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { LANGY_ENV_KEY, PRESIDIO_ENV_KEY, resolveFeatures } from "../src/shared/features.ts";
+import {
+  featureEnv,
+  LANGY_ENV_KEY,
+  LEGACY_EVALUATORS_ENV_KEY,
+  LINGUA_ENV_KEY,
+  PRESIDIO_ENV_KEY,
+  resolveFeatures,
+} from "../src/shared/features.ts";
 
 describe("optional install pieces", () => {
   describe("when nothing is set", () => {
-    it("installs the assistant and skips the PII model", () => {
+    it("installs the assistant and skips every heavyweight evaluator", () => {
       const f = resolveFeatures({});
       expect(f.langy).toBe(true);
       expect(f.presidio).toBe(false);
+      expect(f.lingua).toBe(false);
+      expect(f.legacyEvaluators).toBe(false);
     });
   });
 
@@ -17,6 +26,13 @@ describe("optional install pieces", () => {
 
     it("honours an explicit opt-out of the assistant", () => {
       expect(resolveFeatures({ [LANGY_ENV_KEY]: "false" }).langy).toBe(false);
+    });
+
+    it("honours opting into language detection and legacy evaluators", () => {
+      expect(resolveFeatures({ [LINGUA_ENV_KEY]: "true" }).lingua).toBe(true);
+      expect(
+        resolveFeatures({ [LEGACY_EVALUATORS_ENV_KEY]: "true" }).legacyEvaluators,
+      ).toBe(true);
     });
 
     it("accepts the spellings people actually type", () => {
@@ -39,6 +55,18 @@ describe("optional install pieces", () => {
 
     it("treats an empty value as unset", () => {
       expect(resolveFeatures({ [LANGY_ENV_KEY]: "" }).langy).toBe(true);
+    });
+  });
+
+  describe("featureEnv", () => {
+    it("spells every toggle out so a child process never falls back to a default", () => {
+      const env = featureEnv(resolveFeatures({ [PRESIDIO_ENV_KEY]: "true" }));
+      expect(env).toEqual({
+        [LANGY_ENV_KEY]: "true",
+        [PRESIDIO_ENV_KEY]: "true",
+        [LINGUA_ENV_KEY]: "false",
+        [LEGACY_EVALUATORS_ENV_KEY]: "false",
+      });
     });
   });
 });

--- a/packages/server/test/features.test.ts
+++ b/packages/server/test/features.test.ts
@@ -12,35 +12,35 @@ describe("optional install pieces", () => {
   describe("when nothing is set", () => {
     it("installs the assistant and skips every heavyweight evaluator", () => {
       const f = resolveFeatures({});
-      expect(f.langy).toBe(true);
-      expect(f.presidio).toBe(false);
-      expect(f.lingua).toBe(false);
-      expect(f.legacyEvaluators).toBe(false);
+      expect(f.isLangyEnabled).toBe(true);
+      expect(f.isPresidioEnabled).toBe(false);
+      expect(f.isLinguaEnabled).toBe(false);
+      expect(f.isLegacyEvaluatorsEnabled).toBe(false);
     });
   });
 
   describe("when a toggle is set", () => {
     it("honours an explicit opt-in to the PII model", () => {
-      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "true" }).presidio).toBe(true);
+      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "true" }).isPresidioEnabled).toBe(true);
     });
 
     it("honours an explicit opt-out of the assistant", () => {
-      expect(resolveFeatures({ [LANGY_ENV_KEY]: "false" }).langy).toBe(false);
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "false" }).isLangyEnabled).toBe(false);
     });
 
     it("honours opting into language detection and legacy evaluators", () => {
-      expect(resolveFeatures({ [LINGUA_ENV_KEY]: "true" }).lingua).toBe(true);
+      expect(resolveFeatures({ [LINGUA_ENV_KEY]: "true" }).isLinguaEnabled).toBe(true);
       expect(
-        resolveFeatures({ [LEGACY_EVALUATORS_ENV_KEY]: "true" }).legacyEvaluators,
+        resolveFeatures({ [LEGACY_EVALUATORS_ENV_KEY]: "true" }).isLegacyEvaluatorsEnabled,
       ).toBe(true);
     });
 
     it("accepts the spellings people actually type", () => {
       for (const yes of ["1", "true", "TRUE", "yes", "on", " true "]) {
-        expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: yes }).presidio).toBe(true);
+        expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: yes }).isPresidioEnabled).toBe(true);
       }
       for (const no of ["0", "false", "FALSE", "no", "off"]) {
-        expect(resolveFeatures({ [LANGY_ENV_KEY]: no }).langy).toBe(false);
+        expect(resolveFeatures({ [LANGY_ENV_KEY]: no }).isLangyEnabled).toBe(false);
       }
     });
   });
@@ -49,12 +49,12 @@ describe("optional install pieces", () => {
     it("keeps the default rather than reading it as off", () => {
       // A typo silently stripping a feature someone asked for is the worse
       // failure: they wait for an install that quietly did not happen.
-      expect(resolveFeatures({ [LANGY_ENV_KEY]: "maybe" }).langy).toBe(true);
-      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "sure" }).presidio).toBe(false);
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "maybe" }).isLangyEnabled).toBe(true);
+      expect(resolveFeatures({ [PRESIDIO_ENV_KEY]: "sure" }).isPresidioEnabled).toBe(false);
     });
 
     it("treats an empty value as unset", () => {
-      expect(resolveFeatures({ [LANGY_ENV_KEY]: "" }).langy).toBe(true);
+      expect(resolveFeatures({ [LANGY_ENV_KEY]: "" }).isLangyEnabled).toBe(true);
     });
   });
 

--- a/packages/server/test/ports.test.ts
+++ b/packages/server/test/ports.test.ts
@@ -11,6 +11,7 @@ describe("port allocation", () => {
         nlp: 5561,
         langevals: 5562,
         aigateway: 5563,
+        langyagent: 5564,
         postgres: 6560,
         redis: 6561,
         clickhouseHttp: 6562,
@@ -37,12 +38,13 @@ describe("port allocation", () => {
         "nlpgo",
         "langevals",
         "ai gateway",
+        "langy agent",
         "postgres",
         "redis",
         "clickhouse http",
         "clickhouse native",
       ]);
-      expect(new Set(checks.map((c) => c.port)).size).toBe(8);
+      expect(new Set(checks.map((c) => c.port)).size).toBe(9);
     });
   });
 });

--- a/packages/server/test/services/env-file.test.ts
+++ b/packages/server/test/services/env-file.test.ts
@@ -40,6 +40,18 @@ CREDENTIALS_SECRET=0123456789abcdef
     });
   });
 
+  describe("when a key is left blank", () => {
+    it("treats it as not configured rather than set-to-empty", () => {
+      // The scaffolded .env ships fill-me-in lines like `OPENAI_API_KEY=`.
+      // Passing them through as empty strings poisons `?? fallback` guards
+      // downstream; absence is the honest reading.
+      const env = readEnvFile(tmpFile("OPENAI_API_KEY=\nREDIS_URL=redis://x:1/0\nEMPTY_QUOTED=\"\"\n"));
+      expect(env).not.toHaveProperty("OPENAI_API_KEY");
+      expect(env).not.toHaveProperty("EMPTY_QUOTED");
+      expect(env.REDIS_URL).toBe("redis://x:1/0");
+    });
+  });
+
   describe("when values are quoted", () => {
     it("strips matching double or single quotes", () => {
       const path = tmpFile(`A="value with spaces"

--- a/packages/server/test/services/node-deps.test.ts
+++ b/packages/server/test/services/node-deps.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { shouldPruneToProd } from "../../src/services/node-deps.ts";
+
+describe("pruning to production dependencies", () => {
+  const paths = { app: "/home/u/.langwatch/app" };
+
+  describe("when the app tree is the relocated copy", () => {
+    it("prunes", () => {
+      expect(shouldPruneToProd("/home/u/.langwatch/app/langwatch", paths)).toBe(true);
+    });
+  });
+
+  describe("when the app tree is a developer checkout", () => {
+    it("leaves it alone", () => {
+      // Pruning a working tree would strip the developer's own test and
+      // build tooling out from under them.
+      expect(shouldPruneToProd("/home/u/Projects/langwatch/langwatch", paths)).toBe(false);
+    });
+
+    it("is not fooled by a sibling directory sharing the prefix", () => {
+      expect(shouldPruneToProd("/home/u/.langwatch/apple/langwatch", paths)).toBe(false);
+    });
+  });
+});

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -240,7 +240,10 @@ describe("services/runtime", () => {
       }
     });
 
-    it("comes up without the assistant when the release binary predates it, and says so", async () => {
+  });
+
+  describe("when the release binary predates the assistant", () => {
+    it("comes up without it, and says so", async () => {
       langyBinarySupported = false;
       const events: unknown[] = [];
       const ctx = fakeCtx();
@@ -268,6 +271,9 @@ describe("services/runtime", () => {
       expect(warning).toBeDefined();
     });
 
+  });
+
+  describe("when nothing is toggled", () => {
     it("tells the app exactly which evaluators this install skipped", async () => {
       await runtime.startAll(fakeCtx());
       const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
@@ -317,7 +323,7 @@ describe("services/runtime", () => {
       const collector = (async () => {
         for await (const ev of events) {
           collected.push(ev);
-          if (collected.filter((e) => e.type === "healthy").length >= 7) break;
+          if (collected.filter((e) => e.type === "healthy").length >= 8) break;
         }
       })();
       await runtime.startAll(ctx);
@@ -332,7 +338,7 @@ describe("services/runtime", () => {
             () =>
               reject(
                 new Error(
-                  `runtime.events collector did not see 7 healthy events within 5s — got ${
+                  `runtime.events collector did not see 8 healthy events within 5s — got ${
                     collected.filter((e) => e.type === "healthy").length
                   }`,
                 ),
@@ -349,6 +355,7 @@ describe("services/runtime", () => {
           "postgres",
           "redis",
           "clickhouse",
+          "langyagent",
           "nlpgo",
           "langevals",
           "aigateway",

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -58,7 +58,11 @@ vi.mock("../../src/services/nlpgo.ts", () => ({ startNlpgo: nlpStub.fn }));
 vi.mock("../../src/services/langevals.ts", () => ({ startLangevals: langevalsStub.fn }));
 vi.mock("../../src/services/aigateway.ts", () => ({ startAigateway: gatewayStub.fn }));
 vi.mock("../../src/services/langwatch.ts", () => ({ startLangwatch: langwatchStub.fn }));
-vi.mock("../../src/services/langyagent.ts", () => ({ startLangyagent: langyStub.fn }));
+let langyBinarySupported = true;
+vi.mock("../../src/services/langyagent.ts", () => ({
+  startLangyagent: langyStub.fn,
+  monobinarySupportsLangyagent: vi.fn(async () => langyBinarySupported),
+}));
 vi.mock("../../src/services/langy-cli.ts", () => ({ ensureLangyCli: langyCliFn }));
 vi.mock("../../src/services/langwatch-workers.ts", () => ({
   startLangwatchWorkers: () => ({
@@ -111,7 +115,7 @@ function fakeCtx(): RuntimeContext {
       envFile: "/tmp/.langwatch-test/.env",
       installManifest: "/tmp/.langwatch-test/install-manifest.json",
     },
-    predeps: {},
+    predeps: { aigateway: { version: "test", resolvedPath: "/fake/bin/aigateway", preInstalled: false } },
     envFile: "/tmp/.langwatch-test/.env",
     version: "test",
     userEnv: {},
@@ -120,6 +124,7 @@ function fakeCtx(): RuntimeContext {
 
 describe("services/runtime", () => {
   beforeEach(() => {
+    langyBinarySupported = true;
     callLog.length = 0;
     [
       postgresStub.fn,
@@ -233,6 +238,34 @@ describe("services/runtime", () => {
         envFileContent = {};
         delete process.env.LANGWATCH_ENABLE_LANGY;
       }
+    });
+
+    it("comes up without the assistant when the release binary predates it, and says so", async () => {
+      langyBinarySupported = false;
+      const events: unknown[] = [];
+      const ctx = fakeCtx();
+      const bus = runtime.events(ctx) as { emit(e: unknown): void };
+      const origEmit = bus.emit.bind(bus);
+      bus.emit = (e: unknown) => {
+        events.push(e);
+        origEmit(e);
+      };
+      const handles = await runtime.startAll(ctx);
+      // The whole install still boots; only the assistant is absent.
+      expect(callLog).not.toContain("start:langyagent");
+      expect(callLog).toContain("start:langwatch");
+      expect(handles).toHaveLength(8);
+      // The app is told the assistant is off, not left pointing at a corpse.
+      const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
+      expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
+      expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
+      // And the person running the install is told why.
+      const warning = events.find(
+        (e) =>
+          (e as { type?: string; line?: string }).type === "log" &&
+          ((e as { line?: string }).line ?? "").includes("langy assistant disabled"),
+      );
+      expect(warning).toBeDefined();
     });
 
     it("tells the app exactly which evaluators this install skipped", async () => {

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -33,6 +33,7 @@ const nlpStub = makeStub("nlpgo");
 const langevalsStub = makeStub("langevals");
 const gatewayStub = makeStub("aigateway");
 const langwatchStub = makeStub("langwatch");
+const langyStub = makeStub("langyagent");
 
 const migrateFn = vi.fn(async () => {
   callLog.push("migrate");
@@ -46,6 +47,9 @@ const nodeDepsFn = vi.fn(async () => {
 const ensureAppDirFn = vi.fn(async () => {
   callLog.push("app-dir");
 });
+const langyCliFn = vi.fn(async () => {
+  callLog.push("langy-cli");
+});
 
 vi.mock("../../src/services/postgres.ts", () => ({ startPostgres: postgresStub.fn }));
 vi.mock("../../src/services/redis.ts", () => ({ startRedis: redisStub.fn }));
@@ -54,6 +58,8 @@ vi.mock("../../src/services/nlpgo.ts", () => ({ startNlpgo: nlpStub.fn }));
 vi.mock("../../src/services/langevals.ts", () => ({ startLangevals: langevalsStub.fn }));
 vi.mock("../../src/services/aigateway.ts", () => ({ startAigateway: gatewayStub.fn }));
 vi.mock("../../src/services/langwatch.ts", () => ({ startLangwatch: langwatchStub.fn }));
+vi.mock("../../src/services/langyagent.ts", () => ({ startLangyagent: langyStub.fn }));
+vi.mock("../../src/services/langy-cli.ts", () => ({ ensureLangyCli: langyCliFn }));
 vi.mock("../../src/services/langwatch-workers.ts", () => ({
   startLangwatchWorkers: () => ({
     name: "workers",
@@ -84,6 +90,7 @@ function fakeCtx(): RuntimeContext {
       nlp: 5561,
       langevals: 5562,
       aigateway: 5563,
+      langyagent: 5564,
       postgres: 6560,
       redis: 6561,
       clickhouseHttp: 6562,
@@ -152,10 +159,10 @@ describe("services/runtime", () => {
   });
 
   describe("when startAll is called", () => {
-    it("starts infra (pg+redis+clickhouse) → migrates → starts app tier (nlp+langevals+gateway+langwatch+workers)", async () => {
+    it("starts infra (pg+redis+clickhouse) → migrates → starts app tier (nlp+langevals+gateway+langwatch+langyagent+workers)", async () => {
       const ctx = fakeCtx();
       const handles = await runtime.startAll(ctx);
-      expect(handles).toHaveLength(8);
+      expect(handles).toHaveLength(9);
       const positions: Record<string, number> = {};
       callLog.forEach((entry, idx) => {
         if (!(entry in positions)) positions[entry] = idx;
@@ -175,6 +182,11 @@ describe("services/runtime", () => {
       expect(positions["start:langwatch"]).toBeGreaterThan(positions["migrate"]!);
     });
 
+    it("starts the assistant alongside the rest of the app tier", async () => {
+      await runtime.startAll(fakeCtx());
+      expect(callLog).toContain("start:langyagent");
+    });
+
     it("returns ServiceHandle objects with name + pid + stop()", async () => {
       const handles = await runtime.startAll(fakeCtx());
       for (const h of handles) {
@@ -185,17 +197,35 @@ describe("services/runtime", () => {
     });
   });
 
+  describe("when the assistant is turned off", () => {
+    it("does not start it, and does not fetch what only it needs", async () => {
+      process.env.LANGWATCH_ENABLE_LANGY = "false";
+      try {
+        await runtime.installServices(fakeCtx());
+        const handles = await runtime.startAll(fakeCtx());
+        expect(callLog).not.toContain("start:langyagent");
+        expect(callLog).not.toContain("langy-cli");
+        // Everything else is untouched.
+        expect(handles).toHaveLength(8);
+        expect(callLog).toContain("start:langwatch");
+        expect(callLog).toContain("venvs");
+      } finally {
+        delete process.env.LANGWATCH_ENABLE_LANGY;
+      }
+    });
+  });
+
   describe("when stopAll is called", () => {
     it("stops handles in reverse start order", async () => {
       const handles = await runtime.startAll(fakeCtx());
       callLog.length = 0; // reset to count only stops
       await runtime.stopAll(handles);
       const stopOrder = callLog.filter((entry) => entry.startsWith("stop:"));
-      expect(stopOrder).toHaveLength(7);
+      expect(stopOrder).toHaveLength(8);
       // First stopped should be langwatch (last started); last stopped should be one of the infra.
       const firstStopped = stopOrder[0]!.replace("stop:", "");
       const lastStopped = stopOrder[stopOrder.length - 1]!.replace("stop:", "");
-      expect(["langwatch", "aigateway", "langevals", "nlpgo"]).toContain(firstStopped);
+      expect(["langwatch", "aigateway", "langevals", "nlpgo", "langyagent"]).toContain(firstStopped);
       expect(["postgres", "redis", "clickhouse"]).toContain(lastStopped);
     });
 

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -68,7 +68,9 @@ vi.mock("../../src/services/langwatch-workers.ts", () => ({
   startLangwatchWorkers: () => ({
     name: "workers",
     pid: 0,
-    stop: async () => {},
+    stop: async () => {
+      callLog.push("stop:workers");
+    },
   }),
 }));
 vi.mock("../../src/services/migrate.ts", () => ({ runMigrations: migrateFn }));
@@ -291,11 +293,11 @@ describe("services/runtime", () => {
       callLog.length = 0; // reset to count only stops
       await runtime.stopAll(handles);
       const stopOrder = callLog.filter((entry) => entry.startsWith("stop:"));
-      expect(stopOrder).toHaveLength(8);
+      expect(stopOrder).toHaveLength(9);
       // First stopped should be langwatch (last started); last stopped should be one of the infra.
       const firstStopped = stopOrder[0]!.replace("stop:", "");
       const lastStopped = stopOrder[stopOrder.length - 1]!.replace("stop:", "");
-      expect(["langwatch", "aigateway", "langevals", "nlpgo", "langyagent"]).toContain(firstStopped);
+      expect(firstStopped).toBe("workers");
       expect(["postgres", "redis", "clickhouse"]).toContain(lastStopped);
     });
 

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -77,7 +77,8 @@ vi.mock("../../src/services/app-dir.ts", () => ({
   ensureAppDir: ensureAppDirFn,
   appRoot: () => "/tmp/.langwatch-test/app",
 }));
-vi.mock("../../src/services/env-file.ts", () => ({ readEnvFile: () => ({}) }));
+let envFileContent: Record<string, string> = {};
+vi.mock("../../src/services/env-file.ts", () => ({ readEnvFile: () => envFileContent }));
 
 // Import AFTER vi.mock so the runtime resolves the stubs.
 const { runtime } = await import("../../src/services/runtime.ts");
@@ -212,6 +213,36 @@ describe("services/runtime", () => {
       } finally {
         delete process.env.LANGWATCH_ENABLE_LANGY;
       }
+    });
+
+    it("strips the assistant out of the app's env so nothing points at a service that is not there", async () => {
+      process.env.LANGWATCH_ENABLE_LANGY = "false";
+      // Simulate a .env scaffolded while the assistant was on: the file keeps
+      // its lines (they are the user's knobs), the processes must not see them.
+      envFileContent = {
+        OPENCODE_AGENT_URL: "http://localhost:5564",
+        FEATURE_FLAG_FORCE_ENABLE: "release_langy_enabled,other_flag",
+      };
+      try {
+        await runtime.startAll(fakeCtx());
+        const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
+        expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
+        expect(childEnv.FEATURE_FLAG_FORCE_ENABLE).toBe("other_flag");
+        expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
+      } finally {
+        envFileContent = {};
+        delete process.env.LANGWATCH_ENABLE_LANGY;
+      }
+    });
+
+    it("tells the app exactly which evaluators this install skipped", async () => {
+      await runtime.startAll(fakeCtx());
+      const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
+      // Explicit values, so an install whose .env predates a toggle still
+      // gets the truth rather than the app's assume-available default.
+      expect(childEnv.LANGWATCH_ENABLE_PRESIDIO).toBe("false");
+      expect(childEnv.LANGWATCH_ENABLE_LINGUA).toBe("false");
+      expect(childEnv.LANGWATCH_ENABLE_LEGACY_EVALUATORS).toBe("false");
     });
   });
 

--- a/packages/server/test/services/venvs.test.ts
+++ b/packages/server/test/services/venvs.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execCalls: Array<{ bin: string; args: string[] }> = [];
+
+vi.mock("../../src/services/_pipe-to-bus.ts", () => ({
+  execAndPipe: vi.fn(async (_bus: unknown, _name: string, bin: string, args: string[]) => {
+    execCalls.push({ bin, args });
+  }),
+}));
+
+vi.mock("../../src/services/app-dir.ts", () => ({ appRoot: () => "/tmp/langwatch-app-root" }));
+
+const { syncVenvs } = await import("../../src/services/venvs.ts");
+
+let home: string;
+
+function ctxWith(envBody: string) {
+  const envFile = join(home, ".env");
+  writeFileSync(envFile, envBody);
+  return {
+    ports: {} as never,
+    paths: { root: home, bin: join(home, "bin") } as never,
+    predeps: { uv: { resolvedPath: "/usr/bin/uv", version: "x", preInstalled: false } },
+    envFile,
+    version: "test",
+    userEnv: {},
+  } as never;
+}
+
+const bus = { emit: () => {} } as never;
+
+function extrasFrom(args: string[]): string[] {
+  return args.filter((a, i) => args[i - 1] === "--extra");
+}
+
+describe("evaluator environment", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    home = mkdtempSync(join(tmpdir(), "lw-venvs-"));
+    delete process.env.LANGWATCH_ENABLE_PRESIDIO;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.LANGWATCH_ENABLE_PRESIDIO;
+  });
+
+  describe("when the PII model has not been asked for", () => {
+    it("installs every evaluator except the PII detector", async () => {
+      await syncVenvs(ctxWith("ENVIRONMENT=local\n"), bus);
+
+      const extras = extrasFrom(execCalls[0]!.args);
+      expect(extras).not.toContain("presidio");
+      expect(extras).not.toContain("all");
+      // The rest still have to be there — a missing extra means that
+      // evaluator's route is never registered and every call 404s.
+      expect(extras).toEqual(
+        expect.arrayContaining(["azure", "langevals", "legacy", "lingua", "openai", "ragas", "topic_clustering"]),
+      );
+    });
+  });
+
+  describe("when the PII model has been asked for", () => {
+    it("installs the complete set", async () => {
+      await syncVenvs(ctxWith("LANGWATCH_ENABLE_PRESIDIO=true\n"), bus);
+      expect(extrasFrom(execCalls[0]!.args)).toEqual(["all"]);
+    });
+  });
+
+  describe("when the toggle changes between runs", () => {
+    it("re-syncs rather than reusing the environment it already built", async () => {
+      await syncVenvs(ctxWith("ENVIRONMENT=local\n"), bus);
+      expect(execCalls).toHaveLength(1);
+
+      // Same lockfile, different answer: the recorded hash covers the extras
+      // list too, so asking for the PII model actually installs it instead of
+      // silently keeping the lean environment.
+      await syncVenvs(ctxWith("LANGWATCH_ENABLE_PRESIDIO=true\n"), bus);
+      expect(execCalls).toHaveLength(2);
+      expect(extrasFrom(execCalls[1]!.args)).toEqual(["all"]);
+    });
+  });
+});

--- a/packages/server/test/services/venvs.test.ts
+++ b/packages/server/test/services/venvs.test.ts
@@ -48,25 +48,43 @@ describe("evaluator environment", () => {
     delete process.env.LANGWATCH_ENABLE_PRESIDIO;
   });
 
-  describe("when the PII model has not been asked for", () => {
-    it("installs every evaluator except the PII detector", async () => {
+  describe("when none of the heavyweight evaluators were asked for", () => {
+    it("installs the base set and skips PII, language detection, and legacy", async () => {
       await syncVenvs(ctxWith("ENVIRONMENT=local\n"), bus);
 
       const extras = extrasFrom(execCalls[0]!.args);
       expect(extras).not.toContain("presidio");
+      expect(extras).not.toContain("lingua");
+      expect(extras).not.toContain("legacy");
       expect(extras).not.toContain("all");
       // The rest still have to be there — a missing extra means that
       // evaluator's route is never registered and every call 404s.
       expect(extras).toEqual(
-        expect.arrayContaining(["azure", "langevals", "legacy", "lingua", "openai", "ragas", "topic_clustering"]),
+        expect.arrayContaining(["azure", "langevals", "openai", "ragas", "topic_clustering"]),
       );
     });
   });
 
-  describe("when the PII model has been asked for", () => {
-    it("installs the complete set", async () => {
+  describe("when a heavyweight evaluator has been asked for", () => {
+    it("adds exactly the one asked for", async () => {
       await syncVenvs(ctxWith("LANGWATCH_ENABLE_PRESIDIO=true\n"), bus);
-      expect(extrasFrom(execCalls[0]!.args)).toEqual(["all"]);
+      const extras = extrasFrom(execCalls[0]!.args);
+      expect(extras).toContain("presidio");
+      expect(extras).not.toContain("lingua");
+      expect(extras).not.toContain("legacy");
+    });
+
+    it("supports all three together", async () => {
+      await syncVenvs(
+        ctxWith(
+          "LANGWATCH_ENABLE_PRESIDIO=true\nLANGWATCH_ENABLE_LINGUA=true\nLANGWATCH_ENABLE_LEGACY_EVALUATORS=true\n",
+        ),
+        bus,
+      );
+      const extras = extrasFrom(execCalls[0]!.args);
+      expect(extras).toEqual(
+        expect.arrayContaining(["presidio", "lingua", "legacy"]),
+      );
     });
   });
 
@@ -80,7 +98,7 @@ describe("evaluator environment", () => {
       // silently keeping the lean environment.
       await syncVenvs(ctxWith("LANGWATCH_ENABLE_PRESIDIO=true\n"), bus);
       expect(execCalls).toHaveLength(2);
-      expect(extrasFrom(execCalls[1]!.args)).toEqual(["all"]);
+      expect(extrasFrom(execCalls[1]!.args)).toContain("presidio");
     });
   });
 });

--- a/packages/server/test/services/venvs.test.ts
+++ b/packages/server/test/services/venvs.test.ts
@@ -37,15 +37,23 @@ function extrasFrom(args: string[]): string[] {
 }
 
 describe("evaluator environment", () => {
+  const TOGGLE_KEYS = [
+    "LANGWATCH_ENABLE_PRESIDIO",
+    "LANGWATCH_ENABLE_LINGUA",
+    "LANGWATCH_ENABLE_LEGACY_EVALUATORS",
+  ];
+
   beforeEach(() => {
     execCalls.length = 0;
     home = mkdtempSync(join(tmpdir(), "lw-venvs-"));
-    delete process.env.LANGWATCH_ENABLE_PRESIDIO;
+    // process.env wins over the .env file in resolveVenvSpecs, so an ambient
+    // export on a dev shell or CI runner would silently flip these tests.
+    for (const key of TOGGLE_KEYS) delete process.env[key];
   });
 
   afterEach(() => {
     rmSync(home, { recursive: true, force: true });
-    delete process.env.LANGWATCH_ENABLE_PRESIDIO;
+    for (const key of TOGGLE_KEYS) delete process.env[key];
   });
 
   describe("when none of the heavyweight evaluators were asked for", () => {

--- a/specs/npx-installer/06-langy.feature
+++ b/specs/npx-installer/06-langy.feature
@@ -1,0 +1,79 @@
+Feature: The assistant works on a laptop install
+  As someone who ran `npx @langwatch/server`
+  I want Langy to answer questions and run its tools
+  So that the assistant is part of the product I installed, not a feature I
+    can only get by running Kubernetes
+
+  See _shared/contract.md for paths, ports, secrets, supervision rules.
+  See specs/langy/langy-selfhost-install.feature for the cluster story — the
+  same feature, a very different set of prerequisites.
+
+  # Context. Langy was built for a cluster: a pod per install, a sandboxed
+  # container runtime under it, and a manager running as root so each
+  # conversation's worker gets its own UID. A laptop has none of that, and
+  # cannot be asked to get it. What a laptop does have is the thing the cluster
+  # went to such lengths to simulate: a single trusted user.
+  #
+  # So the isolation that matters here is different, and saying so plainly is
+  # part of the feature. On one machine, one person, every worker already runs
+  # as that person with that person's own credentials. There is no second
+  # tenant to protect them from, and nothing gained by pretending otherwise.
+
+  Background:
+    Given someone has installed LangWatch with `npx @langwatch/server`
+
+  # ===========================================================================
+  # It works
+  # ===========================================================================
+
+  Scenario: The assistant answers on a fresh laptop install
+    Given they have configured a model provider
+    When they open the assistant and ask it something
+    Then it answers
+    And nothing had to be installed by hand first
+
+  Scenario: The assistant runs its tools
+    When they ask the assistant something that needs LangWatch's own data
+    Then it runs the LangWatch CLI to find out
+    And the answer reflects what the CLI returned
+
+  Scenario: The assistant is available without being switched on somewhere else
+    When they open the product after installing
+    Then the assistant is there
+    # Its rollout flag exists so the hosted product can open it one cohort at a
+    # time. A laptop is one cohort of one.
+
+  # ===========================================================================
+  # No sandbox to be had, and that is the honest default
+  # ===========================================================================
+
+  Scenario: A laptop install does not demand a sandboxed runtime
+    When the assistant starts
+    Then it starts without a container sandbox
+    And the install does not fail asking for one
+    # The cluster chart refuses to deploy unsandboxed unless the operator
+    # accepts it, because there the workers belong to different people. Here
+    # they are all the same person, already on their own machine.
+
+  Scenario: Workers run as the person who started the server
+    When the assistant spawns a worker for a conversation
+    Then that worker runs as the user who ran the installer
+    And it is not asked for the privileges it would need to do otherwise
+    # Handing each worker its own UID needs root. Asking someone to run their
+    # laptop install as root to isolate them from themselves is a worse trade
+    # than not isolating.
+
+  # ===========================================================================
+  # What it costs, and opting out of that cost
+  # ===========================================================================
+
+  Scenario: The assistant brings its own runtime, once
+    When the install runs
+    Then whatever the assistant needs to run is fetched as part of it
+    And re-running the installer does not fetch it again
+
+  Scenario: Someone who does not want the assistant does not pay for it
+    Given they have turned the assistant off
+    When the install runs
+    Then the assistant's runtime is not downloaded
+    And nothing else about the install changes

--- a/specs/npx-installer/06-langy.feature
+++ b/specs/npx-installer/06-langy.feature
@@ -5,7 +5,7 @@ Feature: The assistant works on a laptop install
     can only get by running Kubernetes
 
   See _shared/contract.md for paths, ports, secrets, supervision rules.
-  See specs/langy/langy-selfhost-install.feature for the cluster story — the
+  See specs/langy/langy-selfhost-install.feature for the cluster story, the
   same feature, a very different set of prerequisites.
 
   # Context. Langy was built for a cluster: a pod per install, a sandboxed

--- a/specs/npx-installer/06-langy.feature
+++ b/specs/npx-installer/06-langy.feature
@@ -32,10 +32,10 @@ Feature: The assistant works on a laptop install
     Then it answers
     And nothing had to be installed by hand first
 
-  Scenario: The assistant runs its tools
+  Scenario: The assistant answers from the install's own data
     When they ask the assistant something that needs LangWatch's own data
-    Then it runs the LangWatch CLI to find out
-    And the answer reflects what the CLI returned
+    Then the answer reflects what this install actually contains
+    And not just what a language model would guess
 
   Scenario: The assistant is available without being switched on somewhere else
     When they open the product after installing

--- a/specs/npx-installer/07-lean-install.feature
+++ b/specs/npx-installer/07-lean-install.feature
@@ -4,34 +4,48 @@ Feature: A laptop install only pays for what it uses
   So that I am running the product in minutes instead of waiting on a download
     the size of the rest of the install put together
 
-  See _shared/contract.md §1 — the promise is "~3 minutes to the full stack".
+  See _shared/contract.md §1, the promise is "~3 minutes to the full stack".
 
   # Context. The evaluator environment installs every evaluator LangWatch can
-  # run, and one of them dominates everything else: the PII detector ships a
-  # natural-language model that is larger than the entire rest of that
-  # environment. Almost nobody installing LangWatch for the first time is there
-  # to evaluate PII, and the people who are can say so.
+  # run, and a few dominate everything else: the PII detector ships a
+  # natural-language model larger than the entire rest of that environment,
+  # and language detection carries its own stack of language models. The
+  # deprecated legacy evaluators are a different case: they exist only so
+  # evaluations saved years ago keep running. Almost nobody installing
+  # LangWatch for the first time needs any of the three, and the people who do
+  # can say so.
   #
-  # This is not about removing the evaluator. It is about when it arrives, and
+  # This is not about removing evaluators. It is about when they arrive, and
   # about the difference between "LangWatch cannot do this" and "this install
-  # has not fetched it yet" — a difference the product has to state out loud,
+  # has not fetched it yet", a difference the product has to state out loud,
   # because a silently missing evaluator looks like a broken one.
 
   # ===========================================================================
   # The default install is the lean one
   # ===========================================================================
 
-  Scenario: The heavyweight PII model is not downloaded by default
+  Scenario: The heavyweight evaluators are not downloaded by default
     Given someone runs the installer for the first time
     When the evaluator environment is prepared
     Then the PII detector's language model is not downloaded
-    And the install finishes materially faster than it would have with it
+    And the language detection models are not downloaded
+    And the deprecated legacy evaluators are not downloaded
+    And the install finishes materially faster than it would have with them
 
   Scenario: Every other evaluator still works
     Given a default install
-    When they run any evaluator other than the PII detector
+    When they run any evaluator outside those three families
     Then it runs normally
-    # Dropping one evaluator must not disturb the rest of the environment.
+    # Dropping some evaluators must not disturb the rest of the environment.
+
+  Scenario: The install carries no build tooling at rest
+    Given the installer has finished preparing the application
+    When the server is running
+    Then the application tree holds only what running it needs
+    And the compilers, test runners, and linters that built it are gone
+    # The production container image is built exactly this way: install
+    # everything, build, then prune to runtime dependencies. A laptop install
+    # deserves the same diet, and it is on the order of a gigabyte.
 
   # ===========================================================================
   # Absent is not the same as broken
@@ -69,3 +83,24 @@ Feature: A laptop install only pays for what it uses
     When they turn it off and restart
     Then the rest of the install keeps working
     And the product goes back to saying the evaluator is not installed here
+
+  # ===========================================================================
+  # Deprecated things vanish instead of nagging
+  # ===========================================================================
+
+  # Language detection gets the same treatment as PII detection: visible,
+  # marked not installed, one line to enable. The legacy evaluators do not:
+  # they are deprecated, nobody should be adopting one today, and a card that
+  # exists only to say "you cannot pick this and should not want to" is
+  # clutter, not guidance.
+  Scenario: Legacy evaluators do not appear anywhere on a default install
+    Given a default install
+    When they browse the evaluators on offer
+    Then the deprecated legacy evaluators are simply not among them
+
+  Scenario: An old evaluation that still uses one fails with directions, not a shrug
+    Given a default install
+    And an evaluation saved long ago that uses a legacy evaluator
+    When it runs
+    Then the failure says legacy evaluators are not installed on this server
+    And names the switch that brings them back for exactly this case

--- a/specs/npx-installer/07-lean-install.feature
+++ b/specs/npx-installer/07-lean-install.feature
@@ -1,0 +1,71 @@
+Feature: A laptop install only pays for what it uses
+  As someone installing LangWatch on my own machine
+  I want the install to skip the parts I am not going to use
+  So that I am running the product in minutes instead of waiting on a download
+    the size of the rest of the install put together
+
+  See _shared/contract.md §1 — the promise is "~3 minutes to the full stack".
+
+  # Context. The evaluator environment installs every evaluator LangWatch can
+  # run, and one of them dominates everything else: the PII detector ships a
+  # natural-language model that is larger than the entire rest of that
+  # environment. Almost nobody installing LangWatch for the first time is there
+  # to evaluate PII, and the people who are can say so.
+  #
+  # This is not about removing the evaluator. It is about when it arrives, and
+  # about the difference between "LangWatch cannot do this" and "this install
+  # has not fetched it yet" — a difference the product has to state out loud,
+  # because a silently missing evaluator looks like a broken one.
+
+  # ===========================================================================
+  # The default install is the lean one
+  # ===========================================================================
+
+  Scenario: The heavyweight PII model is not downloaded by default
+    Given someone runs the installer for the first time
+    When the evaluator environment is prepared
+    Then the PII detector's language model is not downloaded
+    And the install finishes materially faster than it would have with it
+
+  Scenario: Every other evaluator still works
+    Given a default install
+    When they run any evaluator other than the PII detector
+    Then it runs normally
+    # Dropping one evaluator must not disturb the rest of the environment.
+
+  # ===========================================================================
+  # Absent is not the same as broken
+  # ===========================================================================
+
+  Scenario: Choosing the PII detector explains that it is not installed here
+    Given a default install
+    When they go to set up the PII detection evaluator
+    Then the product tells them it is not installed in this install
+    And it tells them exactly how to get it
+    And it does not present the evaluator as though it were ready to run
+
+  Scenario: Running it anyway fails with the same explanation
+    Given a default install
+    And an evaluation that uses the PII detector
+    When it runs
+    Then the failure says the evaluator is not installed in this install
+    And says how to install it
+    # Rather than the generic "internal error" a missing evaluator route
+    # produces, which tells the person nothing they can act on.
+
+  # ===========================================================================
+  # Asking for it gets it
+  # ===========================================================================
+
+  Scenario: Turning it on installs it
+    Given someone has asked for the PII detector
+    When they restart the server
+    Then its language model is downloaded once
+    And the PII detection evaluator works
+    And the product no longer says it is missing
+
+  Scenario: Turning it back off does not break an install that used it
+    Given an install that has the PII detector
+    When they turn it off and restart
+    Then the rest of the install keeps working
+    And the product goes back to saying the evaluator is not installed here


### PR DESCRIPTION
Builds on #6138 (merged). This is the `npx @langwatch/server` side of the same arc: the assistant runs on a laptop install, and the install stops shipping what almost nobody uses. A third commit hardens the two failure modes the smoke run surfaced: the previous release's mono-binary predating the assistant, and a keyless boot.

## Langy runs on `npx @langwatch/server`

The assistant was cluster-only. Now the installer brings it up as part of the stack, and it costs almost nothing: the manager already ships inside the mono-binary we download for the gateway, so the only additions are the opencode runtime (41MB, fetched once) and the `langwatch` CLI the workers shell out to (4MB, from npm).

What is different from the cluster, stated rather than implied: workers run unsandboxed as the user who started the server. The cluster's per-worker UID isolation exists to separate different people and needs root to perform; a laptop has one trusted person, and asking them to run their install as root to be isolated from themselves is a worse trade. The manager only accepts this mode when `ENVIRONMENT` is local, so a production deployment cannot reach it by accident.

`LANGWATCH_ENABLE_LANGY=false` skips the downloads, does not start the agent, and strips the assistant's env (agent URL, forced rollout flag) from the app so nothing offers an assistant that is not there.

## The heavyweight evaluators are opt-in

Three evaluator families now install only when asked, via `.env` toggles the product knows about:

| Toggle | Default | Why |
|---|---|---|
| `LANGWATCH_ENABLE_PRESIDIO` | off | PII detection ships a ~620MB spacy model, the single biggest item in the install |
| `LANGWATCH_ENABLE_LINGUA` | off | language detection carries ~95MB of language models |
| `LANGWATCH_ENABLE_LEGACY_EVALUATORS` | off | deprecated, kept only so evaluations saved years ago keep running |

Measured on a real install: the evaluator venv went from 1.6GB (full) to 886MB, all 35 remaining evaluator routes still register, and LangWatch's own secret/PII redaction of traces is untouched (it never used presidio).

Absent is not broken, and the product says which is which. PII and language detection stay visible in the pickers, disabled, with the exact line that installs them:

![PII detection marked not installed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/npx-langy-light/npx-evaluators-not-installed.png)

The legacy family instead vanishes from the pickers entirely (a card nobody should adopt that only says "you cannot pick this" is clutter), while a saved evaluation that still references one fails with the same clear message and the switch that brings them back. Container and Kubernetes installs never set these variables and are unchanged: silence means present.

## The app tree is pruned to production dependencies

`--prod` was tried before and reverted; the failure was ordering, not feasibility. Installing with `--prod` up front broke prisma generate and the build, which need dev tooling. The production Dockerfile has always done it in the working order: install everything, build, `prune --prod`, `prisma generate`. The installer now runs that exact sequence, so an npx install serves from the same shape of tree every helm and docker deployment runs.

Verified against a relocated-shaped copy: node_modules went from 2.3GB to 1.6GB. The pruned tree keeps tsx and prisma (both genuinely run in production) and drops the build tooling, including a 204MB coding-agent binary that reached user installs through a test-only dependency of mcp-server. A dev checkout is never pruned; the guard fires only for the relocated tree under `LANGWATCH_HOME`.

## Defects found while proving it

- The dev-build fallback wrapped the mono-binary in a script that hardcoded `aigateway` as its first argument, so the NLP engine and the Langy agent both booted second gateways and died fighting over the port. The binary answers `--version` itself, which was the wrapper's only other job.
- Package-source location counted `../../..` from the bundled entrypoint, one level short when running from source, so a checkout run died after every predep had already downloaded. It walks up now.
- `LW_GATEWAY_BASE_URL` was scaffolded as the app's own URL. Only the app ever reads that value (the gateway process gets its own from the service env), and the app hands it to Langy's workers and CLI users as an OpenAI-compatible base URL, pointed at a server with no `/v1` surface.
- The "is the prisma client generated" check only knew the top-level `node_modules/.prisma` layout that npm and yarn use; pnpm generates into the virtual store, so the check never passed and every boot re-ran the entire prepare step. Fixed, and a second boot is now a sub-second no-op.

## Verification

- `packages/server`: 83 tests passing, tsc clean. App: installedEvaluators unit tests passing, tsgo clean.
- End to end on a real `npx` run against this branch: full stack healthy on the lean venv, evaluator API hides legacy and marks lingua/presidio not installed with their env vars, and Langy answered a question by actually running `langwatch prompt list --format json` against the local control plane.
- Prune sequence exercised against a relocated-shaped tree twice: first run installs, builds, prunes, regenerates; second run is a no-op in under a second.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the LangWatch assistant to local installations, including automatic runtime setup, health checks, and optional opt-out support.
  * Added feature controls for the assistant, PII detection, language detection, and legacy evaluators.
  * Added clearer evaluator availability indicators, explanations, and enablement instructions.
  * Added lean installation behavior to avoid downloading optional evaluator components by default.

* **Bug Fixes**
  * Improved handling of blank configuration values to prevent startup failures.
  * Added stronger detection of incompatible or outdated local gateway components.

* **Documentation**
  * Expanded local setup instructions, configuration options, reset guidance, and restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->