### PR TITLE
feat(gateway): full voice support — /v1/audio/speech + /v1/audio/transcriptions for OpenAI and ElevenLabs

### DIFF
--- a/.github/workflows/gateway-matrix.yaml
+++ b/.github/workflows/gateway-matrix.yaml
@@ -34,7 +34,7 @@ on:
       providers:
         description: 'Build tags (space-separated). Default = all six.'
         type: string
-        default: 'live_openai live_anthropic live_gemini live_bedrock live_azure live_vertex live_embeddings'
+        default: 'live_openai live_anthropic live_gemini live_bedrock live_azure live_vertex live_embeddings live_audio'
       run_id_label:
         description: 'Optional label appended to trace tags for grep.'
         type: string
@@ -115,6 +115,12 @@ jobs:
       # when VOYAGE_ENABLED is unset so this stays inert until then.
       TEST_VK_VOYAGE: ${{ secrets.MATRIX_TEST_VK_VOYAGE }}
       VOYAGE_API_KEY: ${{ secrets.MATRIX_VOYAGE_API_KEY }}
+      # Audio cells (live_audio): ElevenLabs VK + a voice id for TTS. The
+      # audio_test.go cells t.Skip when unset, so this stays inert until
+      # the secrets are provisioned (seed with
+      # scripts/dogfood/audio/seed-audio-vk.ts).
+      TEST_VK_ELEVENLABS: ${{ secrets.MATRIX_TEST_VK_ELEVENLABS }}
+      ELEVENLABS_VOICE_ID: ${{ secrets.MATRIX_ELEVENLABS_VOICE_ID }}
       LW_PROJECT_API_KEY: ${{ secrets.MATRIX_LW_PROJECT_API_KEY }}
 
     services:
@@ -201,7 +207,7 @@ jobs:
           # still produces useful coverage signal — a missing-cred
           # cell t.Skips with a clear reason instead of silently
           # being absent from the report.
-          MATRIX_TAGS: ${{ github.event.inputs.providers || 'live_openai live_anthropic live_gemini live_bedrock live_azure live_vertex live_embeddings' }}
+          MATRIX_TAGS: ${{ github.event.inputs.providers || 'live_openai live_anthropic live_gemini live_bedrock live_azure live_vertex live_embeddings live_audio' }}
         run: |
           go test -tags="$MATRIX_TAGS" -v -count=1 -timeout 1200s \
             ./tests/matrix/... 2>&1 | tee /tmp/matrix.log

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -4,7 +4,7 @@ description: OpenAI-compatible text to speech and transcription through the Lang
 sidebarTitle: Audio (TTS + STT)
 ---
 
-OpenAI-compatible audio endpoints. Any client that speaks OpenAI's audio API — the official SDKs, LiveKit and Pipecat voice agents, [Scenario](https://scenario.langwatch.ai)'s voice testing harness — works with zero code change by pointing its `OPENAI_BASE_URL` at the gateway and its `OPENAI_API_KEY` at a LangWatch virtual key. Voice traffic gets the same governance as chat: virtual-key auth, model allowlists, budgets, rate limits, and per-call observability.
+OpenAI-compatible audio endpoints. Any client that speaks OpenAI's audio API (the official SDKs, LiveKit and Pipecat voice agents, [Scenario](https://scenario.langwatch.ai)'s voice testing harness) works with zero code change by pointing its `OPENAI_BASE_URL` at the gateway and its `OPENAI_API_KEY` at a LangWatch virtual key. Voice traffic gets the same governance as chat: virtual-key auth, model allowlists, budgets, rate limits, and per-call observability.
 
 Two providers ship today:
 
@@ -34,7 +34,7 @@ Body matches OpenAI's [speech schema](https://platform.openai.com/docs/api-refer
 }
 ```
 
-The response body is the **raw audio bytes** with the matching `Content-Type` (`audio/mpeg`, `audio/wav`, `audio/pcm`, …) — no JSON envelope, exactly like OpenAI, so `client.audio.speech.create(...)` consumes it unchanged. `response_format: "pcm"` returns raw PCM16 for realtime consumers.
+The response body is the **raw audio bytes** with the matching `Content-Type` (`audio/mpeg`, `audio/wav`, `audio/pcm`, …) with no JSON envelope, exactly like OpenAI, so `client.audio.speech.create(...)` consumes it unchanged. `response_format: "pcm"` returns raw PCM16 for realtime consumers.
 
 ```python
 from openai import OpenAI
@@ -83,9 +83,9 @@ Every audio call lands as a gateway trace like chat does. Providers that report 
 
 ## Errors
 
-Same error surface as every other endpoint — see [Errors](/ai-gateway/api/errors). Provider rejections (an invalid ElevenLabs voice id, an unsupported format) pass through with the provider's own status code and body. A model outside the virtual key's allowlist returns the standard `model_not_allowed`; a provider with no key configured returns `no_provider_configured`.
+Same error surface as every other endpoint; see [Errors](/ai-gateway/api/errors). Provider rejections (an invalid ElevenLabs voice id, an unsupported format) pass through with the provider's own status code and body. A model outside the virtual key's allowlist returns the standard `model_not_allowed`; a provider with no key configured returns `no_provider_configured`.
 
 ## Not yet supported
 
-- **Streaming TTS/STT** (`stream=true`) — requests are served complete; streaming is a follow-up.
-- **Realtime voice websockets** (OpenAI Realtime, ElevenLabs ConvAI) — connect directly to the provider for realtime sessions; the gateway serves the request/response audio endpoints.
+- **Streaming TTS/STT** (`stream=true`): requests are served complete; streaming is a follow-up.
+- **Realtime voice websockets** (OpenAI Realtime, ElevenLabs ConvAI): connect directly to the provider for realtime sessions; the gateway serves the request/response audio endpoints.

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -1,0 +1,91 @@
+---
+title: POST /v1/audio/*
+description: OpenAI-compatible text to speech and transcription through the LangWatch AI Gateway, for OpenAI and ElevenLabs voice models.
+sidebarTitle: Audio (TTS + STT)
+---
+
+OpenAI-compatible audio endpoints. Any client that speaks OpenAI's audio API — the official SDKs, LiveKit and Pipecat voice agents, [Scenario](https://scenario.langwatch.ai)'s voice testing harness — works with zero code change by pointing its `OPENAI_BASE_URL` at the gateway and its `OPENAI_API_KEY` at a LangWatch virtual key. Voice traffic gets the same governance as chat: virtual-key auth, model allowlists, budgets, rate limits, and per-call observability.
+
+Two providers ship today:
+
+| Provider | TTS (`/v1/audio/speech`) | STT (`/v1/audio/transcriptions`) |
+|---|---|---|
+| OpenAI | `openai/gpt-4o-mini-tts`, `openai/tts-1`, `openai/tts-1-hd` | `openai/gpt-4o-transcribe`, `openai/gpt-4o-mini-transcribe`, `openai/whisper-1` |
+| ElevenLabs | `elevenlabs/eleven_flash_v2`, `elevenlabs/eleven_turbo_v2_5`, `elevenlabs/eleven_multilingual_v2` | `elevenlabs/scribe_v1` |
+
+Configure the provider key once in **Settings → Model Providers** (OpenAI and ElevenLabs both take a plain API key); every virtual key routed to that provider can then call its voice models.
+
+## Text to speech
+
+```
+POST /v1/audio/speech
+Authorization: Bearer vk-lw-<ULID>
+Content-Type: application/json
+```
+
+Body matches OpenAI's [speech schema](https://platform.openai.com/docs/api-reference/audio/createSpeech). For ElevenLabs models, put the ElevenLabs **voice id** in the same `voice` field.
+
+```json
+{
+  "model": "elevenlabs/eleven_flash_v2",
+  "voice": "cjVigY5qzO86Huf0OWal",
+  "input": "Hello! How can I help you today?",
+  "response_format": "mp3"
+}
+```
+
+The response body is the **raw audio bytes** with the matching `Content-Type` (`audio/mpeg`, `audio/wav`, `audio/pcm`, …) — no JSON envelope, exactly like OpenAI, so `client.audio.speech.create(...)` consumes it unchanged. `response_format: "pcm"` returns raw PCM16 for realtime consumers.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://gateway.langwatch.ai/v1",
+    api_key="vk-lw-...",
+)
+audio = client.audio.speech.create(
+    model="openai/gpt-4o-mini-tts",
+    voice="nova",
+    input="Hello from the gateway.",
+    response_format="pcm",
+)
+pcm_bytes = audio.read()
+```
+
+## Transcription
+
+```
+POST /v1/audio/transcriptions
+Authorization: Bearer vk-lw-<ULID>
+Content-Type: multipart/form-data
+```
+
+Form matches OpenAI's [transcription schema](https://platform.openai.com/docs/api-reference/audio/createTranscription): a `file` part plus `model`, and optionally `language`, `prompt`, `response_format`, `temperature`. Uploads are capped at 25 MB (matching OpenAI's own limit); larger uploads get a `413` before any provider is contacted.
+
+```python
+transcript = client.audio.transcriptions.create(
+    model="elevenlabs/scribe_v1",
+    file=open("call-recording.wav", "rb"),
+)
+print(transcript.text)
+```
+
+The response is the standard JSON transcript with `text`, plus whatever the provider reports (duration, segments, token usage).
+
+## Observability and cost measures
+
+Every audio call lands as a gateway trace like chat does. Providers that report token usage (`gpt-4o-mini-tts`, `gpt-4o-transcribe`) fill the standard `gen_ai.usage.*` token attributes; character- and duration-priced providers are measured by two audio-specific attributes:
+
+| Attribute | Meaning |
+|---|---|
+| `gen_ai.usage.input_chars` | Characters synthesized by a TTS call |
+| `gen_ai.usage.audio_seconds` | Seconds of audio transcribed by an STT call |
+
+## Errors
+
+Same error surface as every other endpoint — see [Errors](/ai-gateway/api/errors). Provider rejections (an invalid ElevenLabs voice id, an unsupported format) pass through with the provider's own status code and body. A model outside the virtual key's allowlist returns the standard `model_not_allowed`; a provider with no key configured returns `no_provider_configured`.
+
+## Not yet supported
+
+- **Streaming TTS/STT** (`stream=true`) — requests are served complete; streaming is a follow-up.
+- **Realtime voice websockets** (OpenAI Realtime, ElevenLabs ConvAI) — connect directly to the provider for realtime sessions; the gateway serves the request/response audio endpoints.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -622,6 +622,7 @@
               "ai-gateway/api/chat-completions",
               "ai-gateway/api/messages",
               "ai-gateway/api/embeddings",
+              "ai-gateway/api/audio",
               "ai-gateway/api/models",
               "ai-gateway/api/errors",
               "ai-gateway/api/management"

--- a/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
+++ b/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
@@ -1,0 +1,182 @@
+/**
+ * Audio dogfood seeder — provisions everything the gateway audio endpoints
+ * need for a live local run, in one shot:
+ *
+ *   1. OpenAI + ElevenLabs ModelProvider rows on the user's org (keys from
+ *      OPENAI_API_KEY / ELEVENLABS_API_KEY in env; each skipped when unset).
+ *   2. An org-default routing policy carrying BOTH providers with NO model
+ *      allowlist (audio model ids like gpt-4o-mini-tts and scribe_v1 must
+ *      not be filtered by a chat-shaped allowlist).
+ *   3. A personal VK for the user, printed once to stdout.
+ *
+ * Pairs with the live audio matrix cells (services/aigateway/tests/matrix/
+ * audio_test.go): export the printed secret as TEST_VK_OPENAI and
+ * TEST_VK_ELEVENLABS, and with Scenario-voice dogfooding (OPENAI_BASE_URL
+ * pointed at the gateway).
+ *
+ * Usage:
+ *   pnpm tsx scripts/dogfood/audio/seed-audio-vk.ts --email you@example.com
+ *
+ * Idempotent: reuses existing provider rows (matched by org + provider) and
+ * updates the default policy in place.
+ */
+import { prisma } from "~/server/db";
+import { encrypt } from "~/utils/encryption";
+import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
+import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtualKey.service";
+
+interface Args {
+  email: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  let email = "";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--email") email = argv[++i] ?? "";
+  }
+  if (!email) throw new Error("--email is required");
+  return { email };
+}
+
+async function ensureProvider(
+  organizationId: string,
+  provider: string,
+  name: string,
+  keys: Record<string, string>,
+): Promise<string> {
+  const existing = await prisma.modelProvider.findFirst({
+    where: { organizationId, provider },
+    select: { id: true },
+  });
+  if (existing) {
+    await prisma.modelProvider.update({
+      where: { id: existing.id },
+      data: { enabled: true, customKeys: encrypt(JSON.stringify(keys)) },
+    });
+    process.stderr.write(`[seed-audio] refreshed ${provider} provider ${existing.id}\n`);
+    return existing.id;
+  }
+  const created = await prisma.modelProvider.create({
+    data: {
+      name,
+      provider,
+      enabled: true,
+      organizationId,
+      customKeys: encrypt(JSON.stringify(keys)),
+      scopes: { create: [{ scopeType: "ORGANIZATION", scopeId: organizationId }] },
+    },
+  });
+  process.stderr.write(`[seed-audio] created ${provider} provider ${created.id}\n`);
+  return created.id;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const user = await prisma.user.findFirst({ where: { email: args.email } });
+  if (!user) throw new Error(`no user with email ${args.email} — sign up first`);
+  // Query through Organization (not OrganizationUser): the tenancy guard
+  // requires an org-scoped where clause on membership models, and the
+  // org-with-member shape is the sanctioned way to resolve "this user's org".
+  const org = await prisma.organization.findFirst({
+    where: { members: { some: { userId: user.id } } },
+  });
+  if (!org) throw new Error(`user ${args.email} belongs to no organization`);
+  process.stderr.write(`[seed-audio] user=${user.id} org=${org.id} (${org.name})\n`);
+
+  const providerIds: string[] = [];
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (openaiKey) {
+    providerIds.push(
+      await ensureProvider(org.id, "openai", "OpenAI", { OPENAI_API_KEY: openaiKey }),
+    );
+  } else {
+    process.stderr.write("[seed-audio] OPENAI_API_KEY unset — skipping openai provider\n");
+  }
+  const elevenKey = process.env.ELEVENLABS_API_KEY;
+  if (elevenKey) {
+    providerIds.push(
+      await ensureProvider(org.id, "elevenlabs", "ElevenLabs", {
+        ELEVENLABS_API_KEY: elevenKey,
+      }),
+    );
+  } else {
+    process.stderr.write("[seed-audio] ELEVENLABS_API_KEY unset — skipping elevenlabs provider\n");
+  }
+  if (providerIds.length === 0) {
+    throw new Error("no provider keys in env — nothing to route");
+  }
+
+  // Org-default policy with all providers and NO model allowlist: the
+  // audio endpoints route by explicit provider/model, and an allowlist
+  // seeded for chat models would reject every audio model id.
+  const existingPolicy = await prisma.routingPolicy.findFirst({
+    where: { organizationId: org.id, isDefault: true },
+    select: { id: true, modelProviderIds: true },
+  });
+  if (existingPolicy) {
+    const merged = Array.from(
+      new Set([...existingPolicy.modelProviderIds, ...providerIds]),
+    );
+    await prisma.routingPolicy.update({
+      where: { id: existingPolicy.id },
+      data: { modelProviderIds: merged, modelAllowlist: [] },
+    });
+    process.stderr.write(
+      `[seed-audio] updated default policy ${existingPolicy.id}: providers=${merged.length} allowlist cleared\n`,
+    );
+  } else {
+    const policy = await prisma.routingPolicy.create({
+      data: {
+        organizationId: org.id,
+        scopes: { create: [{ scopeType: "ORGANIZATION", scopeId: org.id }] },
+        name: "audio-dogfood-default",
+        isDefault: true,
+        strategy: "priority",
+        modelProviderIds: providerIds,
+        modelAllowlist: [],
+      },
+    });
+    process.stderr.write(`[seed-audio] created default policy ${policy.id}\n`);
+  }
+
+  const workspaceSvc = new PersonalWorkspaceService(prisma);
+  const workspace = await workspaceSvc.ensure({
+    userId: user.id,
+    organizationId: org.id,
+    displayName: user.name ?? null,
+    displayEmail: user.email ?? args.email,
+  });
+
+  const vkSvc = PersonalVirtualKeyService.create(prisma, {
+    gatewayBaseUrl: process.env.LW_GATEWAY_BASE_URL ?? "http://localhost:5563",
+  });
+  const issued = await vkSvc.issue({
+    userId: user.id,
+    organizationId: org.id,
+    personalProjectId: workspace.project.id,
+    personalTeamId: workspace.team.id,
+    label: "audio-dogfood",
+  });
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        vk: issued.secret,
+        vkId: issued.id,
+        baseUrl: issued.baseUrl,
+        projectId: workspace.project.id,
+        providers: providerIds.length,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
+++ b/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
@@ -1,5 +1,5 @@
 /**
- * Audio dogfood seeder — provisions everything the gateway audio endpoints
+ * Audio dogfood seeder: provisions everything the gateway audio endpoints
  * need for a live local run, in one shot:
  *
  *   1. OpenAI + ElevenLabs ModelProvider rows on the user's org (keys from
@@ -38,12 +38,17 @@ function parseArgs(argv: string[]): Args {
   return { email };
 }
 
-async function ensureProvider(
-  organizationId: string,
-  provider: string,
-  name: string,
-  keys: Record<string, string>,
-): Promise<string> {
+async function ensureProvider({
+  organizationId,
+  provider,
+  name,
+  keys,
+}: {
+  organizationId: string;
+  provider: string;
+  name: string;
+  keys: Record<string, string>;
+}): Promise<string> {
   const existing = await prisma.modelProvider.findFirst({
     where: { organizationId, provider },
     select: { id: true },
@@ -74,7 +79,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
 
   const user = await prisma.user.findFirst({ where: { email: args.email } });
-  if (!user) throw new Error(`no user with email ${args.email} — sign up first`);
+  if (!user) throw new Error(`no user with email ${args.email}, sign up first`);
   // Query through Organization (not OrganizationUser): the tenancy guard
   // requires an org-scoped where clause on membership models, and the
   // org-with-member shape is the sanctioned way to resolve "this user's org".
@@ -88,23 +93,31 @@ async function main() {
   const openaiKey = process.env.OPENAI_API_KEY;
   if (openaiKey) {
     providerIds.push(
-      await ensureProvider(org.id, "openai", "OpenAI", { OPENAI_API_KEY: openaiKey }),
+      await ensureProvider({
+        organizationId: org.id,
+        provider: "openai",
+        name: "OpenAI",
+        keys: { OPENAI_API_KEY: openaiKey },
+      }),
     );
   } else {
-    process.stderr.write("[seed-audio] OPENAI_API_KEY unset — skipping openai provider\n");
+    process.stderr.write("[seed-audio] OPENAI_API_KEY unset, skipping openai provider\n");
   }
   const elevenKey = process.env.ELEVENLABS_API_KEY;
   if (elevenKey) {
     providerIds.push(
-      await ensureProvider(org.id, "elevenlabs", "ElevenLabs", {
-        ELEVENLABS_API_KEY: elevenKey,
+      await ensureProvider({
+        organizationId: org.id,
+        provider: "elevenlabs",
+        name: "ElevenLabs",
+        keys: { ELEVENLABS_API_KEY: elevenKey },
       }),
     );
   } else {
-    process.stderr.write("[seed-audio] ELEVENLABS_API_KEY unset — skipping elevenlabs provider\n");
+    process.stderr.write("[seed-audio] ELEVENLABS_API_KEY unset, skipping elevenlabs provider\n");
   }
   if (providerIds.length === 0) {
-    throw new Error("no provider keys in env — nothing to route");
+    throw new Error("no provider keys in env, nothing to route");
   }
 
   // Org-default policy with all providers and NO model allowlist: the
@@ -115,9 +128,13 @@ async function main() {
     select: { id: true, modelProviderIds: true },
   });
   if (existingPolicy) {
-    const merged = Array.from(
-      new Set([...existingPolicy.modelProviderIds, ...providerIds]),
-    );
+    // modelProviderIds is a Json column, so Prisma types it as JsonValue.
+    const priorIds = Array.isArray(existingPolicy.modelProviderIds)
+      ? existingPolicy.modelProviderIds.filter(
+          (id): id is string => typeof id === "string",
+        )
+      : [];
+    const merged = Array.from(new Set([...priorIds, ...providerIds]));
     await prisma.routingPolicy.update({
       where: { id: existingPolicy.id },
       data: { modelProviderIds: merged, modelAllowlist: [] },

--- a/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
+++ b/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
@@ -19,6 +19,11 @@
  *
  * Idempotent: reuses existing provider rows (matched by org + provider) and
  * updates the default policy in place.
+ *
+ * Guardrails, because provider keys and the default policy are org-wide
+ * records: refuses to run against a non-local DATABASE_URL unless
+ * --allow-remote-db is passed, and refuses to wipe a curated default-policy
+ * modelAllowlist unless --clear-allowlist is passed.
  */
 import { prisma } from "~/server/db";
 import { encrypt } from "~/utils/encryption";
@@ -27,15 +32,45 @@ import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtu
 
 interface Args {
   email: string;
+  allowRemoteDb: boolean;
+  clearAllowlist: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
   let email = "";
+  let allowRemoteDb = false;
+  let clearAllowlist = false;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--email") email = argv[++i] ?? "";
+    if (argv[i] === "--allow-remote-db") allowRemoteDb = true;
+    if (argv[i] === "--clear-allowlist") clearAllowlist = true;
   }
   if (!email) throw new Error("--email is required");
-  return { email };
+  return { email, allowRemoteDb, clearAllowlist };
+}
+
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * This seeder mutates org-wide records (provider keys, the default routing
+ * policy), so it only runs against a local database by default. Pointing it
+ * at staging or prod by accident would overwrite shared credentials.
+ */
+function assertLocalDatabase(allowRemoteDb: boolean): void {
+  if (allowRemoteDb) return;
+  const raw = process.env.DATABASE_URL ?? "";
+  let host = "";
+  try {
+    host = new URL(raw).hostname;
+  } catch {
+    throw new Error("DATABASE_URL is unset or unparseable, refusing to seed");
+  }
+  if (!LOCAL_DB_HOSTS.has(host)) {
+    throw new Error(
+      `DATABASE_URL points at ${host}, not a local database. ` +
+        "Re-run with --allow-remote-db if you really mean it.",
+    );
+  }
 }
 
 async function ensureProvider({
@@ -49,11 +84,20 @@ async function ensureProvider({
   name: string;
   keys: Record<string, string>;
 }): Promise<string> {
-  const existing = await prisma.modelProvider.findFirst({
+  // Deterministic pick: oldest row first, and be loud when the org carries
+  // more than one row for the provider, since only one gets the fresh key.
+  const existingRows = await prisma.modelProvider.findMany({
     where: { organizationId, provider },
+    orderBy: { createdAt: "asc" },
     select: { id: true },
   });
+  const existing = existingRows[0];
   if (existing) {
+    if (existingRows.length > 1) {
+      process.stderr.write(
+        `[seed-audio] WARNING: ${existingRows.length} ${provider} provider rows on this org, refreshing the oldest (${existing.id}) and leaving the rest untouched\n`,
+      );
+    }
     await prisma.modelProvider.update({
       where: { id: existing.id },
       data: { enabled: true, customKeys: encrypt(JSON.stringify(keys)) },
@@ -77,6 +121,7 @@ async function ensureProvider({
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  assertLocalDatabase(args.allowRemoteDb);
 
   const user = await prisma.user.findFirst({ where: { email: args.email } });
   if (!user) throw new Error(`no user with email ${args.email}, sign up first`);
@@ -125,9 +170,22 @@ async function main() {
   // seeded for chat models would reject every audio model id.
   const existingPolicy = await prisma.routingPolicy.findFirst({
     where: { organizationId: org.id, isDefault: true },
-    select: { id: true, modelProviderIds: true },
+    select: { id: true, modelProviderIds: true, modelAllowlist: true },
   });
   if (existingPolicy) {
+    // A curated allowlist on the existing default policy is someone's
+    // deliberate restriction; wiping it silently would lift model limits
+    // for every caller in the org. Require the explicit flag.
+    const hasCuratedAllowlist =
+      Array.isArray(existingPolicy.modelAllowlist) &&
+      existingPolicy.modelAllowlist.length > 0;
+    if (hasCuratedAllowlist && !args.clearAllowlist) {
+      throw new Error(
+        `default policy ${existingPolicy.id} has a curated modelAllowlist, ` +
+          "which would reject audio model ids. Re-run with --clear-allowlist " +
+          "to clear it, or add the audio models to the allowlist yourself.",
+      );
+    }
     // modelProviderIds is a Json column, so Prisma types it as JsonValue.
     const priorIds = Array.isArray(existingPolicy.modelProviderIds)
       ? existingPolicy.modelProviderIds.filter(

--- a/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
+++ b/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
@@ -88,7 +88,7 @@ async function ensureProvider({
   // more than one row for the provider, since only one gets the fresh key.
   const existingRows = await prisma.modelProvider.findMany({
     where: { organizationId, provider },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     select: { id: true },
   });
   const existing = existingRows[0];

--- a/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
+++ b/langwatch/scripts/dogfood/audio/seed-audio-vk.ts
@@ -22,8 +22,9 @@
  *
  * Guardrails, because provider keys and the default policy are org-wide
  * records: refuses to run against a non-local DATABASE_URL unless
- * --allow-remote-db is passed, and refuses to wipe a curated default-policy
- * modelAllowlist unless --clear-allowlist is passed.
+ * --allow-remote-db is passed, refuses to wipe a curated default-policy
+ * modelAllowlist unless --clear-allowlist is passed, and refuses to pick
+ * among multiple org memberships implicitly (pass --org <id or name>).
  */
 import { prisma } from "~/server/db";
 import { encrypt } from "~/utils/encryption";
@@ -32,21 +33,24 @@ import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtu
 
 interface Args {
   email: string;
+  org: string;
   allowRemoteDb: boolean;
   clearAllowlist: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
   let email = "";
+  let org = "";
   let allowRemoteDb = false;
   let clearAllowlist = false;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--email") email = argv[++i] ?? "";
+    if (argv[i] === "--org") org = argv[++i] ?? "";
     if (argv[i] === "--allow-remote-db") allowRemoteDb = true;
     if (argv[i] === "--clear-allowlist") clearAllowlist = true;
   }
   if (!email) throw new Error("--email is required");
-  return { email, allowRemoteDb, clearAllowlist };
+  return { email, org, allowRemoteDb, clearAllowlist };
 }
 
 const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
@@ -128,10 +132,34 @@ async function main() {
   // Query through Organization (not OrganizationUser): the tenancy guard
   // requires an org-scoped where clause on membership models, and the
   // org-with-member shape is the sanctioned way to resolve "this user's org".
-  const org = await prisma.organization.findFirst({
+  // Never pick among multiple memberships implicitly: seeding the wrong
+  // tenant would plant credentials and a default policy on someone else's
+  // org, so ambiguity requires an explicit --org.
+  const orgs = await prisma.organization.findMany({
     where: { members: { some: { userId: user.id } } },
+    select: { id: true, name: true },
   });
-  if (!org) throw new Error(`user ${args.email} belongs to no organization`);
+  if (orgs.length === 0) {
+    throw new Error(`user ${args.email} belongs to no organization`);
+  }
+  let org: { id: string; name: string };
+  if (args.org) {
+    const picked = orgs.find((o) => o.id === args.org || o.name === args.org);
+    if (!picked) {
+      throw new Error(
+        `--org ${args.org} does not match any of ${args.email}'s organizations: ` +
+          orgs.map((o) => `${o.name} [${o.id}]`).join(", "),
+      );
+    }
+    org = picked;
+  } else if (orgs.length === 1) {
+    org = orgs[0]!;
+  } else {
+    throw new Error(
+      `user ${args.email} belongs to ${orgs.length} organizations, pass --org <id or name>: ` +
+        orgs.map((o) => `${o.name} [${o.id}]`).join(", "),
+    );
+  }
   process.stderr.write(`[seed-audio] user=${user.id} org=${org.id} (${org.name})\n`);
 
   const providerIds: string[] = [];

--- a/langwatch/src/components/icons/ElevenLabs.tsx
+++ b/langwatch/src/components/icons/ElevenLabs.tsx
@@ -1,0 +1,16 @@
+export function ElevenLabs() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      className="fill-foreground"
+      viewBox="0 0 24 24"
+    >
+      {/* ElevenLabs wordmark reduces to the "II" glyph: two vertical bars. */}
+      <path
+        className="fill-foreground"
+        d="M8 3.5h3v17H8v-17zm5 0h3v17h-3v-17z"
+      ></path>
+    </svg>
+  );
+}

--- a/langwatch/src/components/icons/ElevenLabs.tsx
+++ b/langwatch/src/components/icons/ElevenLabs.tsx
@@ -3,12 +3,11 @@ export function ElevenLabs() {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
-      className="fill-foreground"
       viewBox="0 0 24 24"
     >
       {/* ElevenLabs wordmark reduces to the "II" glyph: two vertical bars. */}
       <path
-        className="fill-foreground"
+        fill="currentColor"
         d="M8 3.5h3v17H8v-17zm5 0h3v17h-3v-17z"
       ></path>
     </svg>

--- a/langwatch/src/server/modelProviders/iconsMap.tsx
+++ b/langwatch/src/server/modelProviders/iconsMap.tsx
@@ -10,6 +10,7 @@ import { Custom } from "../../components/icons/Custom";
 import { DeepSeek } from "../../components/icons/DeepSeek";
 import { Gemini } from "../../components/icons/Gemini";
 import { GoogleCloud } from "../../components/icons/GoogleCloud";
+import { ElevenLabs } from "../../components/icons/ElevenLabs";
 import { Groq } from "../../components/icons/Groq";
 import { OpenAI } from "../../components/icons/OpenAI";
 import { Voyage } from "../../components/icons/Voyage";
@@ -24,6 +25,7 @@ export const modelProviderIcons: Record<
   openai_codex: <Codex />,
   azure: <Azure />,
   anthropic: <Anthropic />,
+  elevenlabs: <ElevenLabs />,
   groq: <Groq />,
   vertex_ai: <GoogleCloud />,
   gemini: <Gemini />,

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -337,7 +337,7 @@ export const modelProviders = {
     }),
     enabledSince: new Date("2026-07-25"),
     blurb:
-      "Voice models — text to speech and transcription — served through the AI Gateway's /v1/audio endpoints.",
+      "Voice models for lifelike text to speech and accurate transcription.",
   },
   azure: {
     name: "Azure OpenAI",

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -323,6 +323,22 @@ export const modelProviders = {
     }),
     enabledSince: new Date("2023-01-01"),
   },
+  elevenlabs: {
+    name: "ElevenLabs",
+    // Ships audio only (TTS + STT through the gateway's /v1/audio routes).
+    // Registered like every provider so the key lives in Settings -> Model
+    // Providers; the LLM model catalog carries no elevenlabs chat models, so
+    // it never shows up in chat model selectors.
+    type: "llm",
+    apiKey: "ELEVENLABS_API_KEY",
+    endpointKey: undefined,
+    keysSchema: z.object({
+      ELEVENLABS_API_KEY: z.string().min(1),
+    }),
+    enabledSince: new Date("2026-07-25"),
+    blurb:
+      "Voice models — text to speech and transcription — served through the AI Gateway's /v1/audio endpoints.",
+  },
   azure: {
     name: "Azure OpenAI",
     type: "llm",

--- a/pkg/customertracebridge/emitter.go
+++ b/pkg/customertracebridge/emitter.go
@@ -456,9 +456,11 @@ func clientSessionID(ctx context.Context, params domain.AITraceParams) string {
 		if sid := gjson.GetBytes(params.RequestBody, "prompt_cache_key").String(); sid != "" {
 			return sid
 		}
-	case domain.RequestTypeChat, domain.RequestTypeEmbeddings, domain.RequestTypePassthrough:
-		// No inline session id on these request shapes; the header lifted above
-		// (when present) is the only source.
+	case domain.RequestTypeChat, domain.RequestTypeEmbeddings, domain.RequestTypePassthrough,
+		domain.RequestTypeSpeech, domain.RequestTypeTranscription:
+		// No inline session id on these request shapes (audio bodies carry no
+		// session field at all); the header lifted above (when present) is
+		// the only source.
 	}
 	return ""
 }

--- a/services/aigateway/adapters/gatewaytracer/attrs_genai.go
+++ b/services/aigateway/adapters/gatewaytracer/attrs_genai.go
@@ -26,4 +26,10 @@ const (
 	AttrGenAIResponseFinish   = "gen_ai.response.finish_reasons"
 	AttrGenAIUsageOut         = "gen_ai.usage.output_tokens"
 	AttrGenAIUsageTotal       = "gen_ai.usage.total_tokens"
+	// Audio usage measures (no upstream semconv exists yet for either):
+	// characters synthesized by a TTS call and seconds of audio transcribed
+	// by an STT call — the units character- and duration-priced audio
+	// providers bill by.
+	AttrGenAIUsageInputChars   = "gen_ai.usage.input_chars"
+	AttrGenAIUsageAudioSeconds = "gen_ai.usage.audio_seconds"
 )

--- a/services/aigateway/adapters/gatewaytracer/attrs_genai.go
+++ b/services/aigateway/adapters/gatewaytracer/attrs_genai.go
@@ -28,7 +28,7 @@ const (
 	AttrGenAIUsageTotal       = "gen_ai.usage.total_tokens"
 	// Audio usage measures (no upstream semconv exists yet for either):
 	// characters synthesized by a TTS call and seconds of audio transcribed
-	// by an STT call — the units character- and duration-priced audio
+	// by an STT call, the units character- and duration-priced audio
 	// providers bill by.
 	AttrGenAIUsageInputChars   = "gen_ai.usage.input_chars"
 	AttrGenAIUsageAudioSeconds = "gen_ai.usage.audio_seconds"

--- a/services/aigateway/adapters/gatewaytracer/internal_span.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span.go
@@ -125,5 +125,11 @@ func usageAttributes(usage domain.Usage) []attribute.KeyValue {
 	if usage.CostMicroUSD > 0 {
 		attrs = append(attrs, attribute.Float64(AttrCostUSD, float64(usage.CostMicroUSD)/1_000_000))
 	}
+	if usage.InputChars > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageInputChars, usage.InputChars))
+	}
+	if usage.AudioSeconds > 0 {
+		attrs = append(attrs, attribute.Float64(AttrGenAIUsageAudioSeconds, usage.AudioSeconds))
+	}
 	return attrs
 }

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -1,6 +1,6 @@
 package httpapi
 
-// Binds specs/ai-gateway/audio-endpoints.feature — the @unit scenarios for
+// Binds specs/ai-gateway/audio-endpoints.feature: the @unit scenarios for
 // POST /v1/audio/speech and POST /v1/audio/transcriptions: routing, multipart
 // parsing, the size cap, missing-field errors, allowlist enforcement, and
 // binary response writing. The @integration/@e2e scenarios run live via the
@@ -94,7 +94,7 @@ func TestAudioSpeech_ReturnsBinaryAudioWithContentType(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	// Raw bytes, no JSON envelope — an OpenAI SDK consumes this unchanged.
+	// Raw bytes, no JSON envelope; an OpenAI SDK consumes this unchanged.
 	assert.Equal(t, "RIFF-fake-pcm-bytes", rec.Body.String())
 	assert.Equal(t, "audio/pcm", rec.Header().Get("Content-Type"))
 
@@ -132,7 +132,7 @@ func TestAudioSpeech_ModelAllowlistApplies(t *testing.T) {
 	provider := &mockProvider{
 		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
 			// A t.Fatal here would Goexit the heartbeat goroutine and wedge
-			// the handler — record and assert from the test goroutine instead.
+			// the handler; record and assert from the test goroutine instead.
 			dispatched = true
 			return successResponse(), nil
 		},
@@ -263,7 +263,7 @@ func TestAudioTranscriptions_UnknownFormFieldsAreDropped(t *testing.T) {
 }
 
 // Guard: the speech success path must never be wrapped in a JSON envelope by
-// a future refactor — a body that starts with '{' would break every OpenAI
+// a future refactor: a body that starts with '{' would break every OpenAI
 // SDK's `audio.speech.create`, which hands the bytes straight to the caller.
 func TestAudioSpeech_BodyIsNotJSONWrapped(t *testing.T) {
 	router := audioRouter(nil)

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -1,0 +1,280 @@
+package httpapi
+
+// Binds specs/ai-gateway/audio-endpoints.feature — the @unit scenarios for
+// POST /v1/audio/speech and POST /v1/audio/transcriptions: routing, multipart
+// parsing, the size cap, missing-field errors, allowlist enforcement, and
+// binary response writing. The @integration/@e2e scenarios run live via the
+// tests/matrix audio cells and the Scenario-voice dogfood run.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/services/aigateway/adapters/modelresolver"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func audioRouter(capture *domain.Request) http.Handler {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, req *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			if capture != nil {
+				*capture = *req
+			}
+			switch req.Type {
+			case domain.RequestTypeSpeech:
+				return &domain.Response{
+					Body:       []byte("RIFF-fake-pcm-bytes"),
+					StatusCode: http.StatusOK,
+					Headers:    map[string]string{"Content-Type": "audio/pcm"},
+					Usage:      domain.Usage{InputChars: 23},
+				}, nil
+			case domain.RequestTypeTranscription:
+				return &domain.Response{
+					Body:       []byte(`{"text":"hello from the fake provider"}`),
+					StatusCode: http.StatusOK,
+					Usage:      domain.Usage{AudioSeconds: 1.5},
+				}, nil
+			default:
+				return successResponse(), nil
+			}
+		},
+	}
+	return buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+}
+
+func multipartBody(t *testing.T, fields map[string]string, fileField, filename string, fileBytes []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+	if fileField != "" {
+		fw, err := w.CreateFormFile(fileField, filename)
+		require.NoError(t, err)
+		_, err = fw.Write(fileBytes)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return buf, w.FormDataContentType()
+}
+
+// --- /v1/audio/speech ---
+
+func TestAudioSpeech_ReturnsBinaryAudioWithContentType(t *testing.T) {
+	var captured domain.Request
+	router := audioRouter(&captured)
+
+	body := `{"model":"openai/gpt-4o-mini-tts","voice":"nova","input":"Hello from the gateway.","response_format":"pcm"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Raw bytes, no JSON envelope — an OpenAI SDK consumes this unchanged.
+	assert.Equal(t, "RIFF-fake-pcm-bytes", rec.Body.String())
+	assert.Equal(t, "audio/pcm", rec.Header().Get("Content-Type"))
+
+	assert.Equal(t, domain.RequestTypeSpeech, captured.Type)
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "gpt-4o-mini-tts", captured.Resolved.ModelID)
+	assert.Equal(t, domain.ProviderOpenAI, captured.Resolved.ProviderID)
+}
+
+func TestAudioSpeech_ElevenLabsModelResolvesToElevenLabsProvider(t *testing.T) {
+	var captured domain.Request
+	router := audioRouter(&captured)
+
+	body := `{"model":"elevenlabs/eleven_flash_v2","voice":"cjVigY5qzO86Huf0OWal","input":"Hola."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "eleven_flash_v2", captured.Resolved.ModelID)
+	assert.Equal(t, domain.ProviderElevenLabs, captured.Resolved.ProviderID)
+}
+
+func TestAudioSpeech_ModelAllowlistApplies(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			b := testBundle()
+			b.Config.AllowedModels = []string{"gpt-5-mini"}
+			return b, nil
+		},
+	}
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			// A t.Fatal here would Goexit the heartbeat goroutine and wedge
+			// the handler — record and assert from the test goroutine instead.
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	router := buildRouter(app.WithAuth(auth), app.WithProviders(provider),
+		app.WithModels(modelresolver.New()), app.WithLogger(zap.NewNop()))
+
+	body := `{"model":"openai/gpt-4o-mini-tts","voice":"nova","input":"hi"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// Same status the chat endpoint returns for a disallowed model (the
+	// registered mapping for model_not_allowed).
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "model_not_allowed")
+	assert.False(t, dispatched, "provider must not be contacted for a disallowed model")
+}
+
+func TestAudioSpeech_RequiresAuthLikeChat(t *testing.T) {
+	router := audioRouter(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(`{"model":"gpt-4o-mini-tts"}`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// --- /v1/audio/transcriptions ---
+
+func TestAudioTranscriptions_MultipartHappyPath(t *testing.T) {
+	var captured domain.Request
+	router := audioRouter(&captured)
+
+	buf, contentType := multipartBody(t,
+		map[string]string{"model": "openai/gpt-4o-transcribe", "language": "en"},
+		"file", "turn.wav", []byte("fake-wav-bytes"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", buf)
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var parsed struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	assert.Equal(t, "hello from the fake provider", parsed.Text)
+
+	assert.Equal(t, domain.RequestTypeTranscription, captured.Type)
+	require.NotNil(t, captured.Transcription)
+	assert.Equal(t, []byte("fake-wav-bytes"), captured.Transcription.File)
+	assert.Equal(t, "turn.wav", captured.Transcription.Filename)
+	assert.Equal(t, "en", captured.Transcription.Params["language"])
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "gpt-4o-transcribe", captured.Resolved.ModelID)
+}
+
+func TestAudioTranscriptions_MissingFileIs400BeforeDispatch(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	auth := &mockAuth{resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) { return testBundle(), nil }}
+	router := buildRouter(app.WithAuth(auth), app.WithProviders(provider),
+		app.WithModels(modelresolver.New()), app.WithLogger(zap.NewNop()))
+
+	buf, contentType := multipartBody(t, map[string]string{"model": "openai/gpt-4o-transcribe"}, "", "", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", buf)
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "file")
+	assert.False(t, dispatched, "provider must not be contacted without a file")
+}
+
+func TestAudioTranscriptions_OversizedUploadIs413BeforeDispatch(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	auth := &mockAuth{resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) { return testBundle(), nil }}
+	router := buildRouter(app.WithAuth(auth), app.WithProviders(provider),
+		app.WithModels(modelresolver.New()), app.WithLogger(zap.NewNop()))
+
+	// One byte past the cap. The handler must reject while parsing, without
+	// buffering the whole body into a provider request.
+	big := bytes.Repeat([]byte("a"), maxTranscriptionBodyBytes+1)
+	buf, contentType := multipartBody(t, map[string]string{"model": "openai/gpt-4o-transcribe"}, "file", "big.wav", big)
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", buf)
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.False(t, dispatched, "provider must not be contacted for an oversized upload")
+}
+
+func TestAudioTranscriptions_UnknownFormFieldsAreDropped(t *testing.T) {
+	var captured domain.Request
+	router := audioRouter(&captured)
+
+	buf, contentType := multipartBody(t,
+		map[string]string{"model": "openai/gpt-4o-transcribe", "evil_field": "1; DROP TABLE"},
+		"file", "turn.wav", []byte("bytes"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", buf)
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	_, present := captured.Transcription.Params["evil_field"]
+	assert.False(t, present, "unknown form fields must not be forwarded")
+}
+
+// Guard: the speech success path must never be wrapped in a JSON envelope by
+// a future refactor — a body that starts with '{' would break every OpenAI
+// SDK's `audio.speech.create`, which hands the bytes straight to the caller.
+func TestAudioSpeech_BodyIsNotJSONWrapped(t *testing.T) {
+	router := audioRouter(nil)
+
+	body := `{"model":"openai/gpt-4o-mini-tts","voice":"nova","input":"hi","response_format":"mp3"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	first, _ := io.ReadAll(io.LimitReader(bytes.NewReader(rec.Body.Bytes()), 1))
+	assert.NotEqual(t, byte('{'), first[0])
+}

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -83,6 +83,7 @@ func multipartBody(t *testing.T, fields map[string]string, fileField, filename s
 
 // --- /v1/audio/speech ---
 
+// @scenario "OpenAI-shape TTS request returns binary audio"
 func TestAudioSpeech_ReturnsBinaryAudioWithContentType(t *testing.T) {
 	var captured domain.Request
 	router := audioRouter(&captured)
@@ -120,6 +121,7 @@ func TestAudioSpeech_ElevenLabsModelResolvesToElevenLabsProvider(t *testing.T) {
 	assert.Equal(t, domain.ProviderElevenLabs, captured.Resolved.ProviderID)
 }
 
+// @scenario "The virtual key's model allowlist applies"
 func TestAudioSpeech_ModelAllowlistApplies(t *testing.T) {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
@@ -153,6 +155,7 @@ func TestAudioSpeech_ModelAllowlistApplies(t *testing.T) {
 	assert.False(t, dispatched, "provider must not be contacted for a disallowed model")
 }
 
+// @scenario "Audio requests authenticate exactly like chat"
 func TestAudioSpeech_RequiresAuthLikeChat(t *testing.T) {
 	router := audioRouter(nil)
 
@@ -165,6 +168,7 @@ func TestAudioSpeech_RequiresAuthLikeChat(t *testing.T) {
 
 // --- /v1/audio/transcriptions ---
 
+// @scenario "OpenAI-shape multipart transcription returns the transcript JSON"
 func TestAudioTranscriptions_MultipartHappyPath(t *testing.T) {
 	var captured domain.Request
 	router := audioRouter(&captured)
@@ -194,6 +198,7 @@ func TestAudioTranscriptions_MultipartHappyPath(t *testing.T) {
 	assert.Equal(t, "gpt-4o-transcribe", captured.Resolved.ModelID)
 }
 
+// @scenario "A multipart request with no file part fails informatively"
 func TestAudioTranscriptions_MissingFileIs400BeforeDispatch(t *testing.T) {
 	dispatched := false
 	provider := &mockProvider{
@@ -218,6 +223,7 @@ func TestAudioTranscriptions_MissingFileIs400BeforeDispatch(t *testing.T) {
 	assert.False(t, dispatched, "provider must not be contacted without a file")
 }
 
+// @scenario "Oversized uploads are rejected before provider dispatch"
 func TestAudioTranscriptions_OversizedUploadIs413BeforeDispatch(t *testing.T) {
 	dispatched := false
 	provider := &mockProvider{
@@ -265,6 +271,7 @@ func TestAudioTranscriptions_UnknownFormFieldsAreDropped(t *testing.T) {
 // Guard: the speech success path must never be wrapped in a JSON envelope by
 // a future refactor: a body that starts with '{' would break every OpenAI
 // SDK's `audio.speech.create`, which hands the bytes straight to the caller.
+// @scenario "PCM response format passes through for realtime consumers"
 func TestAudioSpeech_BodyIsNotJSONWrapped(t *testing.T) {
 	router := audioRouter(nil)
 
@@ -277,4 +284,154 @@ func TestAudioSpeech_BodyIsNotJSONWrapped(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	first, _ := io.ReadAll(io.LimitReader(bytes.NewReader(rec.Body.Bytes()), 1))
 	assert.NotEqual(t, byte('{'), first[0])
+}
+
+// --- governance parity ---
+
+// @scenario "A bare model name resolves like chat models do"
+func TestAudioSpeech_BareModelNameResolvesLikeChat(t *testing.T) {
+	// Bare names ride the same resolver as chat: no provider pin (credential
+	// eligibility picks the provider, exactly like /v1/chat/completions)...
+	var captured domain.Request
+	router := audioRouter(&captured)
+
+	body := `{"model":"gpt-4o-mini-tts","voice":"nova","input":"Hi."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "gpt-4o-mini-tts", captured.Resolved.ModelID)
+	assert.Empty(t, captured.Resolved.ProviderID,
+		"a bare name must not pin a provider; credential eligibility decides, as in chat")
+
+	// ...and the virtual key's allowlist gates the bare form the same way.
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			b := testBundle()
+			b.Config.AllowedModels = []string{"gpt-5-mini"}
+			return b, nil
+		},
+	}
+	gated := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(&mockProvider{}),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+	req = httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec = httptest.NewRecorder()
+	gated.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "model_not_allowed")
+}
+
+// @scenario "Budgets and rate limits gate audio calls"
+func TestAudioSpeech_BudgetBlockGatesLikeChat(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	block := &mockBudget{
+		precheckFn: func(_ context.Context, _ *domain.Bundle) (domain.BudgetVerdict, error) {
+			return domain.BudgetBlock, nil
+		},
+	}
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithBudget(block),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	body := `{"model":"openai/gpt-4o-mini-tts","voice":"nova","input":"Hi."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusPaymentRequired, rec.Code)
+	assert.Contains(t, rec.Body.String(), "budget_exceeded")
+	assert.False(t, dispatched, "a blocked call must not reach the provider")
+}
+
+// @scenario "A missing provider key is a clear terminal error"
+func TestAudioSpeech_NoProviderConfiguredIsTerminal(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			b := testBundle()
+			b.Credentials = nil
+			return b, nil
+		},
+	}
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	body := `{"model":"elevenlabs/eleven_flash_v2","voice":"cjVigY5qzO86Huf0OWal","input":"Hi."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no_provider_configured")
+	assert.False(t, dispatched, "with zero credentials nothing must reach the provider")
+}
+
+// @scenario "Upstream provider errors pass through transparently"
+func TestAudioSpeech_UpstreamProviderErrorPassesThrough(t *testing.T) {
+	providerBody := `{"detail":{"status":"voice_not_found","message":"A voice with that voice_id was not found."}}`
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			return &domain.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       []byte(providerBody),
+				Headers:    map[string]string{"Content-Type": "application/json"},
+			}, nil
+		},
+	}
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	body := `{"model":"elevenlabs/eleven_flash_v2","voice":"nope","input":"Hi."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.JSONEq(t, providerBody, rec.Body.String())
 }

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -349,8 +349,8 @@ var transcriptionFormFields = []string{"language", "prompt", "response_format", 
 
 // transcriptionsHandler terminates POST /v1/audio/transcriptions (OpenAI-wire
 // multipart STT). Unlike every other v1 route the body is multipart/form-data,
-// so the handler parses the form here — the only layer with the *http.Request
-// — and hands the app a normalized upload. Never streams.
+// so the handler parses the form here, the only layer with the *http.Request,
+// and hands the app a normalized upload. Never streams.
 func transcriptionsHandler(deps RouterDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		bundle, ok := requireBundle(w, r, deps.Logger)

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -93,6 +93,8 @@ func NewRouter(deps RouterDeps) http.Handler {
 		v1.Post("/messages", messagesHandler(deps))
 		v1.Post("/responses", responsesHandler(deps))
 		v1.Post("/embeddings", embeddingsHandler(deps))
+		v1.Post("/audio/speech", speechHandler(deps))
+		v1.Post("/audio/transcriptions", transcriptionsHandler(deps))
 		v1.Get("/models", modelsHandler(deps))
 	})
 
@@ -295,6 +297,111 @@ func embeddingsHandler(deps RouterDeps) http.HandlerFunc {
 
 		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.EmbeddingResult, error) {
 			return deps.App.HandleEmbeddings(r.Context(), bundle, body, app.PeekModel(peek))
+		})
+		if err != nil {
+			writeError(deps.Logger, hw, r.Context(), err)
+			return
+		}
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
+	}
+}
+
+// speechHandler terminates POST /v1/audio/speech (OpenAI-wire TTS). The
+// request body is small JSON; the response body is binary audio whose
+// Content-Type the dispatcher attached, so writeJSONResponse forwards it
+// without a JSON envelope. Never streams.
+func speechHandler(deps RouterDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bundle, ok := requireBundle(w, r, deps.Logger)
+		if !ok {
+			return
+		}
+
+		peek, body, release, ok := readAndPeekBody(w, r, deps.MaxRequestBodyBytes)
+		if !ok {
+			return
+		}
+		defer release()
+
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			return deps.App.HandleSpeech(r.Context(), bundle, body, app.PeekModel(peek))
+		})
+		if err != nil {
+			writeError(deps.Logger, hw, r.Context(), err)
+			return
+		}
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
+	}
+}
+
+// maxTranscriptionBodyBytes caps a /v1/audio/transcriptions upload. OpenAI's
+// own endpoint accepts at most 25 MB of audio; one extra MB covers multipart
+// framing and the small text fields. Requests over the cap get 413 before any
+// provider is contacted.
+const maxTranscriptionBodyBytes = 26 << 20
+
+// transcriptionFormFields are the OpenAI-wire optional text fields forwarded
+// to the provider. Anything else in the form is dropped rather than sent
+// blind.
+var transcriptionFormFields = []string{"language", "prompt", "response_format", "temperature"}
+
+// transcriptionsHandler terminates POST /v1/audio/transcriptions (OpenAI-wire
+// multipart STT). Unlike every other v1 route the body is multipart/form-data,
+// so the handler parses the form here — the only layer with the *http.Request
+// — and hands the app a normalized upload. Never streams.
+func transcriptionsHandler(deps RouterDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bundle, ok := requireBundle(w, r, deps.Logger)
+		if !ok {
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxTranscriptionBodyBytes)
+		// Memory threshold: files up to 10 MB stay in memory, larger ones
+		// spill to a temp file ParseMultipartForm cleans up on r.Body close.
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeError(deps.Logger, w, r.Context(), herr.New(r.Context(), domain.ErrPayloadTooLarge, herr.M{
+					"message": "audio upload exceeds the 25 MB transcription limit",
+				}))
+				return
+			}
+			writeError(deps.Logger, w, r.Context(), herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+				"message": "malformed multipart/form-data body: " + err.Error(),
+			}))
+			return
+		}
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			writeError(deps.Logger, w, r.Context(), herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+				"message": `missing required multipart field: "file"`,
+			}))
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		data, err := io.ReadAll(file)
+		if err != nil {
+			writeError(deps.Logger, w, r.Context(), herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+				"message": "failed reading uploaded file: " + err.Error(),
+			}))
+			return
+		}
+
+		params := make(map[string]string, len(transcriptionFormFields))
+		for _, f := range transcriptionFormFields {
+			if v := r.FormValue(f); v != "" {
+				params[f] = v
+			}
+		}
+		upload := &domain.TranscriptionUpload{File: data, Filename: header.Filename, Params: params}
+
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			return deps.App.HandleTranscription(r.Context(), bundle, upload, r.FormValue("model"))
 		})
 		if err != nil {
 			writeError(deps.Logger, hw, r.Context(), err)
@@ -915,6 +1022,7 @@ func registerErrorStatuses() {
 	herr.RegisterStatus(domain.ErrProviderError, http.StatusBadGateway)
 	herr.RegisterStatus(domain.ErrProviderTimeout, http.StatusGatewayTimeout)
 	herr.RegisterStatus(domain.ErrBadRequest, http.StatusBadRequest)
+	herr.RegisterStatus(domain.ErrPayloadTooLarge, http.StatusRequestEntityTooLarge)
 	herr.RegisterStatus(domain.ErrChainExhausted, http.StatusBadGateway)
 	herr.RegisterStatus(domain.ErrNotFound, http.StatusNotFound)
 	herr.RegisterStatus(domain.ErrInternal, http.StatusInternalServerError)

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -179,6 +179,14 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 		return r.dispatchEmbeddings(ctx, req, provider, model, cred)
 	}
 
+	if req.Type == domain.RequestTypeSpeech {
+		return r.dispatchSpeech(ctx, req, provider, model, cred)
+	}
+
+	if req.Type == domain.RequestTypeTranscription {
+		return r.dispatchTranscription(ctx, req, provider, model, cred)
+	}
+
 	if req.Type == domain.RequestTypePassthrough {
 		return r.dispatchPassthrough(ctx, req, provider, model, cred)
 	}

--- a/services/aigateway/adapters/providers/bifrost_audio.go
+++ b/services/aigateway/adapters/providers/bifrost_audio.go
@@ -45,6 +45,22 @@ func audioContentType(format string) string {
 	return "audio/mpeg"
 }
 
+// speechResponseFormatFor maps the OpenAI wire response_format onto what the
+// provider should actually be asked for. OpenAI's "pcm" means raw PCM16 @
+// 24kHz, but Bifrost translates pcm to ElevenLabs pcm_44100, which is gated
+// to the ElevenLabs Pro tier AND the wrong sample rate for the OpenAI
+// contract; pcm_24000 is available on every tier and matches OpenAI's
+// semantics. Bifrost passes formats outside its translation table through to
+// output_format verbatim, so the rewrite lands on the ElevenLabs API as-is.
+// The response Content-Type stays keyed on the wire format ("pcm" ->
+// audio/pcm) regardless.
+func speechResponseFormatFor(provider bfschemas.ModelProvider, wireFormat string) string {
+	if provider == bfschemas.Elevenlabs && strings.EqualFold(wireFormat, "pcm") {
+		return "pcm_24000"
+	}
+	return wireFormat
+}
+
 // dispatchSpeech routes /v1/audio/speech traffic through Bifrost's
 // SpeechRequest endpoint (openai + elevenlabs providers). The inbound body is
 // OpenAI-shape; ElevenLabs callers put their voice id in the same `voice`
@@ -67,7 +83,7 @@ func (r *BifrostRouter) dispatchSpeech(
 
 	params := &bfschemas.SpeechParameters{
 		Instructions:   wire.Instructions,
-		ResponseFormat: wire.ResponseFormat,
+		ResponseFormat: speechResponseFormatFor(provider, wire.ResponseFormat),
 		Speed:          wire.Speed,
 	}
 	if wire.Voice != "" {

--- a/services/aigateway/adapters/providers/bifrost_audio.go
+++ b/services/aigateway/adapters/providers/bifrost_audio.go
@@ -1,0 +1,212 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// speechWireRequest is the OpenAI /v1/audio/speech wire shape. Bifrost's
+// SpeechRequest takes a structured input, so the gateway parses the JSON
+// here (unlike /v1/messages, which raw-forwards).
+type speechWireRequest struct {
+	Model          string   `json:"model"`
+	Input          string   `json:"input"`
+	Voice          string   `json:"voice"`
+	Instructions   string   `json:"instructions,omitempty"`
+	ResponseFormat string   `json:"response_format,omitempty"`
+	Speed          *float64 `json:"speed,omitempty"`
+}
+
+// audioContentTypes maps OpenAI response_format values to the MIME type the
+// binary response is served under. Matches what api.openai.com itself emits.
+var audioContentTypes = map[string]string{
+	"mp3":  "audio/mpeg",
+	"opus": "audio/ogg",
+	"aac":  "audio/aac",
+	"flac": "audio/flac",
+	"wav":  "audio/wav",
+	"pcm":  "audio/pcm",
+}
+
+func audioContentType(format string) string {
+	if ct, ok := audioContentTypes[strings.ToLower(format)]; ok {
+		return ct
+	}
+	// Default format is mp3, both on OpenAI and on Bifrost's speech path.
+	return "audio/mpeg"
+}
+
+// dispatchSpeech routes /v1/audio/speech traffic through Bifrost's
+// SpeechRequest endpoint (openai + elevenlabs providers). The inbound body is
+// OpenAI-shape; ElevenLabs callers put their voice id in the same `voice`
+// field. The success body is the raw audio bytes with the Content-Type
+// attached here, so the HTTP writer forwards it without a JSON envelope.
+func (r *BifrostRouter) dispatchSpeech(
+	ctx context.Context,
+	req *domain.Request,
+	provider bfschemas.ModelProvider,
+	model string,
+	cred domain.Credential,
+) (*domain.Response, error) {
+	var wire speechWireRequest
+	if err := sonic.Unmarshal(req.Body, &wire); err != nil {
+		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": "invalid JSON body: " + err.Error()})
+	}
+	if wire.Input == "" {
+		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": "missing required field: input"})
+	}
+
+	params := &bfschemas.SpeechParameters{
+		Instructions:   wire.Instructions,
+		ResponseFormat: wire.ResponseFormat,
+		Speed:          wire.Speed,
+	}
+	if wire.Voice != "" {
+		voice := wire.Voice
+		params.VoiceConfig = &bfschemas.SpeechVoiceInput{Voice: &voice}
+	}
+
+	bfReq := &bfschemas.BifrostSpeechRequest{
+		Provider: provider,
+		Model:    model,
+		Input:    &bfschemas.SpeechInput{Input: wire.Input},
+		Params:   params,
+	}
+	bfCtx := bfschemas.NewBifrostContext(withCredential(ctx, cred), time.Time{})
+
+	resp, berr := r.bf.SpeechRequest(bfCtx, bfReq)
+	if berr != nil {
+		if rawBody, status, ok := rawResponseFromBifrostError(berr); ok {
+			return &domain.Response{
+				Body:       rawBody,
+				StatusCode: status,
+				Headers:    forwardableUpstreamHeaders(bifrostResponseHeaders(bfCtx)),
+			}, nil
+		}
+		return nil, errFromBifrost(ctx, berr, bifrostResponseHeaders(bfCtx))
+	}
+
+	return &domain.Response{
+		Body:       resp.Audio,
+		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"Content-Type": audioContentType(wire.ResponseFormat)},
+		Usage:      extractSpeechUsage(resp),
+	}, nil
+}
+
+// dispatchTranscription routes /v1/audio/transcriptions traffic through
+// Bifrost's TranscriptionRequest endpoint (openai + elevenlabs providers).
+// The router already parsed the multipart form into req.Transcription.
+func (r *BifrostRouter) dispatchTranscription(
+	ctx context.Context,
+	req *domain.Request,
+	provider bfschemas.ModelProvider,
+	model string,
+	cred domain.Credential,
+) (*domain.Response, error) {
+	upload := req.Transcription
+	if upload == nil || len(upload.File) == 0 {
+		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": "missing required field: file"})
+	}
+
+	params := &bfschemas.TranscriptionParameters{}
+	if v := upload.Params["language"]; v != "" {
+		params.Language = &v
+	}
+	if v := upload.Params["prompt"]; v != "" {
+		params.Prompt = &v
+	}
+	if v := upload.Params["response_format"]; v != "" {
+		params.ResponseFormat = &v
+	}
+	if v := upload.Params["temperature"]; v != "" {
+		if temp, err := strconv.ParseFloat(v, 64); err == nil {
+			params.Temperature = &temp
+		}
+	}
+
+	bfReq := &bfschemas.BifrostTranscriptionRequest{
+		Provider: provider,
+		Model:    model,
+		Input: &bfschemas.TranscriptionInput{
+			File:     upload.File,
+			Filename: upload.Filename,
+		},
+		Params: params,
+	}
+	bfCtx := bfschemas.NewBifrostContext(withCredential(ctx, cred), time.Time{})
+
+	resp, berr := r.bf.TranscriptionRequest(bfCtx, bfReq)
+	if berr != nil {
+		if rawBody, status, ok := rawResponseFromBifrostError(berr); ok {
+			return &domain.Response{
+				Body:       rawBody,
+				StatusCode: status,
+				Headers:    forwardableUpstreamHeaders(bifrostResponseHeaders(bfCtx)),
+			}, nil
+		}
+		return nil, errFromBifrost(ctx, berr, bifrostResponseHeaders(bfCtx))
+	}
+
+	body, _ := sonic.Marshal(resp)
+	return &domain.Response{
+		Body:       body,
+		StatusCode: http.StatusOK,
+		Usage:      extractTranscriptionUsage(resp),
+	}, nil
+}
+
+// extractSpeechUsage maps Bifrost speech usage onto the domain measure. TTS
+// providers that report token usage (gpt-4o-mini-tts) fill the token fields;
+// InputChars is Bifrost's backfill from the request text, the measure
+// character-priced providers (ElevenLabs, tts-1) bill by.
+func extractSpeechUsage(resp *bfschemas.BifrostSpeechResponse) domain.Usage {
+	if resp == nil || resp.Usage == nil {
+		return domain.Usage{}
+	}
+	return domain.Usage{
+		PromptTokens:     resp.Usage.InputTokens,
+		CompletionTokens: resp.Usage.OutputTokens,
+		TotalTokens:      resp.Usage.TotalTokens,
+		InputChars:       resp.Usage.InputChars,
+	}
+}
+
+// extractTranscriptionUsage maps Bifrost transcription usage onto the domain
+// measure. gpt-4o-transcribe reports token usage ("tokens" type); whisper-1
+// and ElevenLabs report duration ("duration" type), and the response-level
+// Duration field is the fallback when usage is absent entirely.
+func extractTranscriptionUsage(resp *bfschemas.BifrostTranscriptionResponse) domain.Usage {
+	if resp == nil {
+		return domain.Usage{}
+	}
+	u := domain.Usage{}
+	if resp.Duration != nil {
+		u.AudioSeconds = *resp.Duration
+	}
+	if resp.Usage == nil {
+		return u
+	}
+	if resp.Usage.InputTokens != nil {
+		u.PromptTokens = *resp.Usage.InputTokens
+	}
+	if resp.Usage.OutputTokens != nil {
+		u.CompletionTokens = *resp.Usage.OutputTokens
+	}
+	if resp.Usage.TotalTokens != nil {
+		u.TotalTokens = *resp.Usage.TotalTokens
+	}
+	if resp.Usage.Seconds != nil {
+		u.AudioSeconds = float64(*resp.Usage.Seconds)
+	}
+	return u
+}

--- a/services/aigateway/adapters/providers/bifrost_audio_test.go
+++ b/services/aigateway/adapters/providers/bifrost_audio_test.go
@@ -1,0 +1,34 @@
+package providers
+
+// Binds specs/ai-gateway/audio-endpoints.feature: the PCM response-format
+// contract. OpenAI's "pcm" is raw PCM16 @ 24kHz; ElevenLabs must be asked
+// for pcm_24000 (every tier, right rate), never Bifrost's default pcm_44100
+// (Pro-tier-gated, wrong rate for the OpenAI contract).
+
+import (
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpeechResponseFormatFor(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider bfschemas.ModelProvider
+		wire     string
+		want     string
+	}{
+		{"elevenlabs pcm becomes 24k", bfschemas.Elevenlabs, "pcm", "pcm_24000"},
+		{"elevenlabs pcm case-insensitive", bfschemas.Elevenlabs, "PCM", "pcm_24000"},
+		{"elevenlabs mp3 untouched", bfschemas.Elevenlabs, "mp3", "mp3"},
+		{"elevenlabs empty untouched", bfschemas.Elevenlabs, "", ""},
+		{"openai pcm untouched", bfschemas.OpenAI, "pcm", "pcm"},
+		{"openai mp3 untouched", bfschemas.OpenAI, "mp3", "mp3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, speechResponseFormatFor(tc.provider, tc.wire))
+		})
+	}
+}

--- a/services/aigateway/adapters/providers/bifrost_audio_test.go
+++ b/services/aigateway/adapters/providers/bifrost_audio_test.go
@@ -61,13 +61,13 @@ func TestExtractTranscriptionUsage_DurationMeasure(t *testing.T) {
 
 	dur := 2.51
 	u := extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{Duration: &dur})
-	assert.Equal(t, 2.51, u.AudioSeconds)
+	assert.InDelta(t, 2.51, u.AudioSeconds, 1e-9)
 
 	secs := 3
 	u = extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{
 		Usage: &bfschemas.TranscriptionUsage{Type: "duration", Seconds: &secs},
 	})
-	assert.Equal(t, 3.0, u.AudioSeconds)
+	assert.InDelta(t, 3.0, u.AudioSeconds, 1e-9)
 
 	in, out, tot := 11, 0, 11
 	u = extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{

--- a/services/aigateway/adapters/providers/bifrost_audio_test.go
+++ b/services/aigateway/adapters/providers/bifrost_audio_test.go
@@ -10,8 +10,11 @@ import (
 
 	bfschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
+// @scenario "PCM means 24kHz on every provider, matching OpenAI semantics"
 func TestSpeechResponseFormatFor(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -31,4 +34,50 @@ func TestSpeechResponseFormatFor(t *testing.T) {
 			assert.Equal(t, tc.want, speechResponseFormatFor(tc.provider, tc.wire))
 		})
 	}
+}
+
+// @scenario "A TTS call lands as a trace with character usage"
+func TestExtractSpeechUsage_CharacterMeasure(t *testing.T) {
+	assert.Equal(t, domain.Usage{}, extractSpeechUsage(nil))
+	assert.Equal(t, domain.Usage{}, extractSpeechUsage(&bfschemas.BifrostSpeechResponse{}))
+
+	u := extractSpeechUsage(&bfschemas.BifrostSpeechResponse{
+		Usage: &bfschemas.SpeechUsage{
+			InputTokens:  12,
+			OutputTokens: 34,
+			TotalTokens:  46,
+			InputChars:   57,
+		},
+	})
+	assert.Equal(t, 57, u.InputChars)
+	assert.Equal(t, 12, u.PromptTokens)
+	assert.Equal(t, 34, u.CompletionTokens)
+	assert.Equal(t, 46, u.TotalTokens)
+}
+
+// @scenario "A transcription call lands as a trace with duration usage"
+func TestExtractTranscriptionUsage_DurationMeasure(t *testing.T) {
+	assert.Equal(t, domain.Usage{}, extractTranscriptionUsage(nil))
+
+	dur := 2.51
+	u := extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{Duration: &dur})
+	assert.Equal(t, 2.51, u.AudioSeconds)
+
+	secs := 3
+	u = extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{
+		Usage: &bfschemas.TranscriptionUsage{Type: "duration", Seconds: &secs},
+	})
+	assert.Equal(t, 3.0, u.AudioSeconds)
+
+	in, out, tot := 11, 0, 11
+	u = extractTranscriptionUsage(&bfschemas.BifrostTranscriptionResponse{
+		Usage: &bfschemas.TranscriptionUsage{
+			Type:         "tokens",
+			InputTokens:  &in,
+			OutputTokens: &out,
+			TotalTokens:  &tot,
+		},
+	})
+	assert.Equal(t, 11, u.PromptTokens)
+	assert.Equal(t, 11, u.TotalTokens)
 }

--- a/services/aigateway/app/handlers.go
+++ b/services/aigateway/app/handlers.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"io"
+	"strconv"
 
 	"github.com/tidwall/gjson"
 
@@ -41,6 +42,28 @@ func (a *App) HandleResponsesStream(ctx context.Context, bundle *domain.Bundle, 
 
 func (a *App) HandleEmbeddings(ctx context.Context, bundle *domain.Bundle, body io.Reader, model string) (*EmbeddingResult, error) {
 	return a.pipeline.Sync(ctx, bundle, &domain.Request{Type: domain.RequestTypeEmbeddings, Model: model, BodyReader: body})
+}
+
+// HandleSpeech dispatches POST /v1/audio/speech (OpenAI-wire TTS). Same
+// pipeline as every sync call; the response body is binary audio with the
+// Content-Type attached by the dispatcher.
+func (a *App) HandleSpeech(ctx context.Context, bundle *domain.Bundle, body io.Reader, model string) (*CompletionResult, error) {
+	return a.pipeline.Sync(ctx, bundle, &domain.Request{Type: domain.RequestTypeSpeech, Model: model, BodyReader: body})
+}
+
+// HandleTranscription dispatches POST /v1/audio/transcriptions (OpenAI-wire
+// multipart STT). The router already parsed the form; the upload rides on
+// req.Transcription and Body carries a small synthesized JSON summary so
+// body-reading pipeline stages see well-formed bytes instead of multipart
+// framing.
+func (a *App) HandleTranscription(ctx context.Context, bundle *domain.Bundle, upload *domain.TranscriptionUpload, model string) (*CompletionResult, error) {
+	body := []byte(`{"model":` + strconv.Quote(model) + `}`)
+	return a.pipeline.Sync(ctx, bundle, &domain.Request{
+		Type:          domain.RequestTypeTranscription,
+		Model:         model,
+		Body:          body,
+		Transcription: upload,
+	})
 }
 
 // HandlePassthrough dispatches a provider-native request whose wire shape

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -36,6 +36,11 @@ const (
 	// themselves (vLLM, LiteLLM proxy, ...). Requires a base URL; the
 	// API key is optional (many self-hosted servers run unauthenticated).
 	ProviderCustom ProviderID = "custom"
+	// ElevenLabs is a Bifrost-native provider (enum value "elevenlabs",
+	// plain API key). It ships speech (TTS) and transcription (STT) only;
+	// chat-family calls against an ElevenLabs credential surface the
+	// provider's reject directly, same policy as Anthropic embeddings.
+	ProviderElevenLabs ProviderID = "elevenlabs"
 	// OpenAICodex is the user's own ChatGPT subscription, reached through
 	// OpenAI's codex backend (chatgpt.com/backend-api/codex) with an OAuth
 	// access token instead of an API key. Responses-API + SSE only; the

--- a/services/aigateway/domain/request.go
+++ b/services/aigateway/domain/request.go
@@ -28,6 +28,24 @@ type Request struct {
 	// (provider-native paths like Gemini /v1beta/models/{m}:generateContent).
 	// Zero for all other request types.
 	Passthrough PassthroughRequest
+
+	// Transcription carries the parsed multipart upload for
+	// RequestTypeTranscription. The router parses the form (the only place
+	// with access to the HTTP request) so the rest of the pipeline works on
+	// materialized bytes like every other request type. Nil otherwise.
+	Transcription *TranscriptionUpload
+}
+
+// TranscriptionUpload is the normalized content of a /v1/audio/transcriptions
+// multipart form: the audio file plus the OpenAI-wire optional parameters.
+type TranscriptionUpload struct {
+	File     []byte
+	Filename string
+	// Params holds the optional string form fields exactly as received
+	// (language, prompt, response_format, temperature). The dispatcher maps
+	// them onto the provider request; unknown fields are dropped by the
+	// router rather than forwarded blind.
+	Params map[string]string
 }
 
 // PassthroughRequest captures HTTP-level fields a raw-forward route needs
@@ -55,6 +73,12 @@ const (
 	// of the OpenAI/Anthropic-family schemas Bifrost exposes through its
 	// typed entry points.
 	RequestTypePassthrough RequestType = "passthrough"
+	// RequestTypeSpeech is POST /v1/audio/speech (OpenAI-wire TTS). The
+	// response body is binary audio, not JSON.
+	RequestTypeSpeech RequestType = "speech"
+	// RequestTypeTranscription is POST /v1/audio/transcriptions
+	// (OpenAI-wire multipart STT).
+	RequestTypeTranscription RequestType = "transcription"
 )
 
 // RequestMetadata holds extracted fields for policy evaluation (guardrails, blocked patterns).

--- a/services/aigateway/domain/response.go
+++ b/services/aigateway/domain/response.go
@@ -31,6 +31,14 @@ type Usage struct {
 	CacheCreationTokens int    // tokens written to the prompt cache (priced at the cache-write rate)
 	CostMicroUSD        int64  // cost in microdollars (1/1_000_000 USD)
 	Model               string // resolved model name from the request
+
+	// Audio measures. TTS is priced by input characters and STT by audio
+	// duration on providers that do not report token usage (ElevenLabs,
+	// whisper-1); providers that DO report tokens (gpt-4o-mini-tts,
+	// gpt-4o-transcribe) fill the token fields above as usual. Zero when
+	// not applicable.
+	InputChars   int     // TTS: characters synthesized
+	AudioSeconds float64 // STT: seconds of audio transcribed
 }
 
 // StreamIterator provides pull-based iteration over streaming response chunks.

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -2,7 +2,7 @@
 
 package matrix
 
-// Live audio cells — bind the @integration scenarios of
+// Live audio cells: bind the @integration scenarios of
 // specs/ai-gateway/audio-endpoints.feature against a REAL local stack and
 // REAL provider keys (no mocks): gateway on :5563, control plane on :5560, a
 // VK with the provider's credentials bound.
@@ -119,7 +119,7 @@ func transcribe(t *testing.T, vk, model, filename string, file []byte) string {
 		Text string `json:"text"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		t.Fatalf("transcription response is not the OpenAI JSON shape: %v — %s", err, truncate(body, 300))
+		t.Fatalf("transcription response is not the OpenAI JSON shape: %v; body: %s", err, truncate(body, 300))
 	}
 	if parsed.Text == "" {
 		t.Fatalf("transcription returned empty text: %s", truncate(body, 300))
@@ -128,13 +128,13 @@ func transcribe(t *testing.T, vk, model, filename string, file []byte) string {
 }
 
 // assertHeardTheFox requires the transcript to carry the distinctive words of
-// spokenLine — the proof real audio crossed both directions.
+// spokenLine, the proof real audio crossed both directions.
 func assertHeardTheFox(t *testing.T, transcript string) {
 	t.Helper()
 	lower := strings.ToLower(transcript)
 	for _, word := range []string{"quick", "brown", "fox", "lazy", "dog"} {
 		if !strings.Contains(lower, word) {
-			t.Fatalf("transcript %q does not contain %q — the audio did not survive the round trip", transcript, word)
+			t.Fatalf("transcript %q does not contain %q; the audio did not survive the round trip", transcript, word)
 		}
 	}
 }
@@ -185,7 +185,7 @@ func TestAudio_OpenAI_SpeechToTranscriptionRoundTrip(t *testing.T) {
 func TestAudio_OpenAI_SpeechMP3(t *testing.T) {
 	vk := requireEnv(t, "TEST_VK_OPENAI")
 	audio := speak(t, vk, "openai/gpt-4o-mini-tts", "nova", "mp3")
-	// MP3 sync bytes or ID3 tag — cheap sanity that the format matched.
+	// MP3 sync bytes or ID3 tag, cheap sanity that the format matched.
 	if !bytes.HasPrefix(audio, []byte("ID3")) && (len(audio) < 2 || audio[0] != 0xFF) {
 		t.Fatalf("mp3 response does not look like MP3 (first bytes: % x)", audio[:8])
 	}

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -193,6 +193,7 @@ func TestAudio_OpenAI_SpeechMP3(t *testing.T) {
 
 // --- ElevenLabs cells ---
 
+// @scenario "ElevenLabs TTS through the same OpenAI wire shape"
 func TestAudio_ElevenLabs_SpeechToOpenAITranscription(t *testing.T) {
 	elVK := requireEnv(t, "TEST_VK_ELEVENLABS")
 	voice := os.Getenv("ELEVENLABS_VOICE_ID")
@@ -217,6 +218,7 @@ func TestAudio_ElevenLabs_SpeechToOpenAITranscription(t *testing.T) {
 	assertHeardTheFox(t, transcript)
 }
 
+// @scenario "ElevenLabs transcription through the same multipart shape"
 func TestAudio_ElevenLabs_Transcription(t *testing.T) {
 	elVK := requireEnv(t, "TEST_VK_ELEVENLABS")
 	oaVK := requireEnv(t, "TEST_VK_OPENAI")

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -1,0 +1,225 @@
+//go:build live_audio
+
+package matrix
+
+// Live audio cells — bind the @integration scenarios of
+// specs/ai-gateway/audio-endpoints.feature against a REAL local stack and
+// REAL provider keys (no mocks): gateway on :5563, control plane on :5560, a
+// VK with the provider's credentials bound.
+//
+//	GATEWAY_URL=http://localhost:5563 \
+//	TEST_VK_OPENAI=vk-lw-... \
+//	  go test -tags=live_audio -run TestAudio_OpenAI ./services/aigateway/tests/matrix/... -v
+//
+//	TEST_VK_ELEVENLABS=vk-lw-... \
+//	ELEVENLABS_VOICE_ID=cjVigY5qzO86Huf0OWal \
+//	  go test -tags=live_audio -run TestAudio_ElevenLabs ./services/aigateway/tests/matrix/... -v
+//
+// TTS→STT round-trip is the assertion where it matters: the transcription
+// cells feed the speech cell's own output back in and require the transcript
+// to contain the spoken words, proving both directions carried REAL audio.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const spokenLine = "The quick brown fox jumps over the lazy dog"
+
+func audioHTTPClient() *http.Client {
+	return &http.Client{Timeout: 120 * time.Second}
+}
+
+// speak fires /v1/audio/speech and returns the raw audio bytes.
+func speak(t *testing.T, vk, model, voice, format string) []byte {
+	t.Helper()
+	body := fmt.Sprintf(`{"model":%q,"voice":%q,"input":%q,"response_format":%q}`,
+		model, voice, spokenLine, format)
+	req, err := http.NewRequest(http.MethodPost, gatewayURL()+"/v1/audio/speech", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build speech request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+vk)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := audioHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("speech request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	audio, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read speech response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("speech returned %d: %s", resp.StatusCode, truncate(audio, 500))
+	}
+	if len(audio) < 1024 {
+		t.Fatalf("speech returned implausibly small audio (%d bytes): %s", len(audio), truncate(audio, 200))
+	}
+	if json.Valid(audio) {
+		t.Fatalf("speech response is JSON, expected raw audio bytes: %s", truncate(audio, 300))
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "audio/") {
+		t.Fatalf("speech Content-Type = %q, want audio/*", ct)
+	}
+	return audio
+}
+
+// transcribe fires /v1/audio/transcriptions with the given file bytes and
+// returns the transcript text.
+func transcribe(t *testing.T, vk, model, filename string, file []byte) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+	fw, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write(file); err != nil {
+		t.Fatalf("write form file: %v", err)
+	}
+	if err := w.WriteField("model", model); err != nil {
+		t.Fatalf("write model field: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, gatewayURL()+"/v1/audio/transcriptions", buf)
+	if err != nil {
+		t.Fatalf("build transcription request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+vk)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := audioHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("transcription request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read transcription response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transcription returned %d: %s", resp.StatusCode, truncate(body, 500))
+	}
+	var parsed struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("transcription response is not the OpenAI JSON shape: %v — %s", err, truncate(body, 300))
+	}
+	if parsed.Text == "" {
+		t.Fatalf("transcription returned empty text: %s", truncate(body, 300))
+	}
+	return parsed.Text
+}
+
+// assertHeardTheFox requires the transcript to carry the distinctive words of
+// spokenLine — the proof real audio crossed both directions.
+func assertHeardTheFox(t *testing.T, transcript string) {
+	t.Helper()
+	lower := strings.ToLower(transcript)
+	for _, word := range []string{"quick", "brown", "fox", "lazy", "dog"} {
+		if !strings.Contains(lower, word) {
+			t.Fatalf("transcript %q does not contain %q — the audio did not survive the round trip", transcript, word)
+		}
+	}
+}
+
+// wavFromPCM wraps raw PCM16 mono in a minimal WAV header so a "pcm"
+// speech response can be posted to the transcription endpoint, which
+// (like OpenAI's) wants a container format it can sniff.
+func wavFromPCM(pcm []byte, sampleRate int) []byte {
+	buf := &bytes.Buffer{}
+	dataLen := uint32(len(pcm))
+	_, _ = buf.WriteString("RIFF")
+	_ = binary.Write(buf, binary.LittleEndian, 36+dataLen)
+	_, _ = buf.WriteString("WAVEfmt ")
+	_ = binary.Write(buf, binary.LittleEndian, uint32(16))
+	_ = binary.Write(buf, binary.LittleEndian, uint16(1)) // PCM
+	_ = binary.Write(buf, binary.LittleEndian, uint16(1)) // mono
+	_ = binary.Write(buf, binary.LittleEndian, uint32(sampleRate))
+	_ = binary.Write(buf, binary.LittleEndian, uint32(sampleRate*2)) // byte rate
+	_ = binary.Write(buf, binary.LittleEndian, uint16(2))            // block align
+	_ = binary.Write(buf, binary.LittleEndian, uint16(16))           // bits/sample
+	_, _ = buf.WriteString("data")
+	_ = binary.Write(buf, binary.LittleEndian, dataLen)
+	_, _ = buf.Write(pcm)
+	return buf.Bytes()
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// --- OpenAI cells ---
+
+func TestAudio_OpenAI_SpeechToTranscriptionRoundTrip(t *testing.T) {
+	vk := requireEnv(t, "TEST_VK_OPENAI")
+
+	// TTS: pcm output so the bytes can be re-containered deterministically.
+	pcm := speak(t, vk, "openai/gpt-4o-mini-tts", "nova", "pcm")
+
+	// STT: feed the synthesized speech straight back through the gateway.
+	transcript := transcribe(t, vk, "openai/gpt-4o-transcribe", "roundtrip.wav", wavFromPCM(pcm, 24000))
+	t.Logf("openai transcript: %q", transcript)
+	assertHeardTheFox(t, transcript)
+}
+
+func TestAudio_OpenAI_SpeechMP3(t *testing.T) {
+	vk := requireEnv(t, "TEST_VK_OPENAI")
+	audio := speak(t, vk, "openai/gpt-4o-mini-tts", "nova", "mp3")
+	// MP3 sync bytes or ID3 tag — cheap sanity that the format matched.
+	if !bytes.HasPrefix(audio, []byte("ID3")) && (len(audio) < 2 || audio[0] != 0xFF) {
+		t.Fatalf("mp3 response does not look like MP3 (first bytes: % x)", audio[:8])
+	}
+}
+
+// --- ElevenLabs cells ---
+
+func TestAudio_ElevenLabs_SpeechToOpenAITranscription(t *testing.T) {
+	elVK := requireEnv(t, "TEST_VK_ELEVENLABS")
+	voice := os.Getenv("ELEVENLABS_VOICE_ID")
+	if voice == "" {
+		t.Skip("ELEVENLABS_VOICE_ID not set")
+	}
+	model := os.Getenv("ELEVENLABS_TTS_MODEL")
+	if model == "" {
+		model = "eleven_flash_v2"
+	}
+
+	audio := speak(t, elVK, "elevenlabs/"+model, voice, "mp3")
+
+	// Cross-provider proof: EL speaks, OpenAI listens. Needs an OpenAI VK too.
+	oaVK := requireEnv(t, "TEST_VK_OPENAI")
+	transcript := transcribe(t, oaVK, "openai/gpt-4o-transcribe", "el.mp3", audio)
+	t.Logf("elevenlabs->openai transcript: %q", transcript)
+	assertHeardTheFox(t, transcript)
+}
+
+func TestAudio_ElevenLabs_Transcription(t *testing.T) {
+	elVK := requireEnv(t, "TEST_VK_ELEVENLABS")
+	oaVK := requireEnv(t, "TEST_VK_OPENAI")
+
+	// OpenAI speaks, ElevenLabs listens (scribe_v1).
+	pcm := speak(t, oaVK, "openai/gpt-4o-mini-tts", "nova", "pcm")
+	transcript := transcribe(t, elVK, "elevenlabs/scribe_v1", "oa.wav", wavFromPCM(pcm, 24000))
+	t.Logf("openai->elevenlabs transcript: %q", transcript)
+	assertHeardTheFox(t, transcript)
+}

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -204,11 +204,15 @@ func TestAudio_ElevenLabs_SpeechToOpenAITranscription(t *testing.T) {
 		model = "eleven_flash_v2"
 	}
 
-	audio := speak(t, elVK, "elevenlabs/"+model, voice, "mp3")
+	// pcm on purpose: the gateway must ask ElevenLabs for pcm_24000 (every
+	// tier, OpenAI's 24kHz semantics), not Bifrost's default pcm_44100
+	// (Pro-tier-gated, wrong rate). Re-containering at 24kHz and having
+	// OpenAI STT still hear the sentence proves both halves.
+	audio := speak(t, elVK, "elevenlabs/"+model, voice, "pcm")
 
 	// Cross-provider proof: EL speaks, OpenAI listens. Needs an OpenAI VK too.
 	oaVK := requireEnv(t, "TEST_VK_OPENAI")
-	transcript := transcribe(t, oaVK, "openai/gpt-4o-transcribe", "el.mp3", audio)
+	transcript := transcribe(t, oaVK, "openai/gpt-4o-transcribe", "el.wav", wavFromPCM(audio, 24000))
 	t.Logf("elevenlabs->openai transcript: %q", transcript)
 	assertHeardTheFox(t, transcript)
 }

--- a/services/aigateway/tests/matrix/matrix_test.go
+++ b/services/aigateway/tests/matrix/matrix_test.go
@@ -1,4 +1,4 @@
-//go:build live_openai || live_anthropic || live_gemini || live_bedrock || live_azure || live_vertex || live_embeddings
+//go:build live_openai || live_anthropic || live_gemini || live_bedrock || live_azure || live_vertex || live_embeddings || live_audio
 
 // Package matrix runs the provider × scenario coverage matrix against a live
 // gateway + control plane + real provider credentials. Build-tagged per

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -1,0 +1,145 @@
+Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI and ElevenLabs
+  As a developer running voice agents (and as Scenario's own voice test harness)
+  I want the gateway to serve /v1/audio/speech and /v1/audio/transcriptions on a virtual key
+  So that voice traffic gets the same governance, observability, and cost tracking as chat
+  And so pointing an OpenAI SDK's base_url at the gateway is all a voice app needs to change
+
+  # The contract (§3) has declared both routes since v0.1: this feature makes
+  # them real. Bifrost v1.4.22 (already pinned) ships SpeechRequest and
+  # TranscriptionRequest with both an `openai` and an `elevenlabs` provider,
+  # so no Bifrost upgrade is required.
+
+  Background:
+    Given the gateway is running with a control plane
+    And a virtual key "vk-lw-test" bound to an organization with an OpenAI API key configured
+    And the organization also has an ElevenLabs API key configured
+
+  # ============================================================
+  # Group: Text to speech — POST /v1/audio/speech
+  # ============================================================
+
+  @integration
+  Scenario: OpenAI-shape TTS request returns binary audio
+    When the client POSTs /v1/audio/speech with the OpenAI wire shape
+      | field           | value                    |
+      | model           | openai/gpt-4o-mini-tts   |
+      | voice           | nova                     |
+      | input           | Hello from the gateway.  |
+      | response_format | mp3                      |
+    Then the response is 200 with binary audio bytes in the body
+    And the Content-Type is the audio MIME type for the requested format
+    And the body is NOT a JSON envelope — an OpenAI SDK's `client.audio.speech.create(...)` consumes it unchanged
+
+  @integration
+  Scenario: PCM response format passes through for realtime consumers
+    When the client requests response_format "pcm"
+    Then the raw PCM bytes are returned verbatim
+    And no JSON wrapping or base64 encoding is applied
+    # Scenario's voice harness consumes exactly this shape (pcm16/24000).
+
+  @integration
+  Scenario: ElevenLabs TTS through the same OpenAI wire shape
+    When the client POSTs /v1/audio/speech with model "elevenlabs/eleven_flash_v2" and a voice id in `voice`
+    Then the gateway routes the request through Bifrost's elevenlabs provider using the organization's ElevenLabs key
+    And the response is 200 with binary audio bytes
+
+  @unit
+  Scenario: A bare model name resolves like chat models do
+    When the client sends model "gpt-4o-mini-tts" with no provider prefix
+    Then model resolution applies the virtual key's aliases and allowlist exactly as /v1/chat/completions does
+    And the explicit "provider/model" form bypasses aliases, as everywhere else
+
+  # ============================================================
+  # Group: Speech to text — POST /v1/audio/transcriptions
+  # ============================================================
+
+  @integration
+  Scenario: OpenAI-shape multipart transcription returns the transcript JSON
+    When the client POSTs /v1/audio/transcriptions as multipart/form-data
+      | part  | value                       |
+      | file  | <a short WAV of speech>     |
+      | model | openai/gpt-4o-transcribe    |
+    Then the response is 200 with a JSON body carrying a non-empty "text" field
+    And an OpenAI SDK's `client.audio.transcriptions.create(...)` consumes it unchanged
+
+  @integration
+  Scenario: ElevenLabs transcription through the same multipart shape
+    When the multipart `model` part is "elevenlabs/scribe_v1"
+    Then the gateway routes through Bifrost's elevenlabs provider
+    And the response is 200 with the transcript in "text"
+
+  @unit
+  Scenario: Oversized uploads are rejected before provider dispatch
+    Given a multipart upload larger than the transcription size cap
+    When the request is parsed
+    Then the gateway responds 413 without contacting any provider
+    And the cap matches the largest upload OpenAI's own endpoint accepts (25 MB)
+
+  @unit
+  Scenario: A multipart request with no file part fails informatively
+    When the form has a model but no "file" part
+    Then the gateway responds 400 naming the missing "file" field
+    And no provider is contacted
+
+  # ============================================================
+  # Group: Governance — the same pipeline as chat
+  # ============================================================
+
+  @unit
+  Scenario: Audio requests authenticate exactly like chat
+    When a request carries no virtual key, or a revoked one
+    Then the response is the same 401 the chat endpoint returns
+
+  @unit
+  Scenario: The virtual key's model allowlist applies
+    Given a virtual key whose models_allowed does not include the requested audio model
+    When the client calls either audio endpoint with that model
+    Then the request is rejected with the standard model_not_allowed error
+
+  @unit
+  Scenario: A missing provider key is a clear terminal error
+    Given an organization with no ElevenLabs key configured
+    When a request targets "elevenlabs/eleven_flash_v2"
+    Then the response names the missing provider configuration
+    And it is the same no-provider-configured error shape chat returns
+
+  @unit
+  Scenario: Budgets and rate limits gate audio calls
+    Given a virtual key over its budget, or over its rate limit
+    When the client calls either audio endpoint
+    Then the request is blocked with the same error the chat endpoint emits
+    And an allowed call's spend is recorded against the same budget
+
+  @integration
+  Scenario: Upstream provider errors pass through transparently
+    When the provider rejects the request (e.g. an invalid voice, HTTP 400)
+    Then the gateway forwards the provider's status code and error body
+    And does not wrap it in an opaque gateway error
+    And a 4xx does not trigger credential fallback, per the standard retry classification
+
+  # ============================================================
+  # Group: Observability and cost
+  # ============================================================
+
+  @integration
+  Scenario: A TTS call lands as a trace with character usage
+    When a speech request completes
+    Then a gateway span is exported for the call with the resolved model
+    And the span carries the input character count as the usage measure TTS is priced by
+
+  @integration
+  Scenario: A transcription call lands as a trace with duration usage
+    When a transcription request completes
+    Then a gateway span is exported with the resolved model
+    And the span carries the audio duration (or the provider's token usage when reported) as the measure STT is priced by
+
+  # ============================================================
+  # Group: Dogfood — proven with the Scenario voice harness
+  # ============================================================
+
+  @e2e
+  Scenario: Scenario's voice tests run end to end through the gateway
+    Given OPENAI_BASE_URL pointing at the gateway and a virtual key as OPENAI_API_KEY
+    When a Scenario voice test synthesizes user turns (TTS) and the judge transcribes segments (STT)
+    Then the run completes with result.success without any direct provider call
+    And the gateway shows the audio usage for the run

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -144,7 +144,10 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
   # Group: Dogfood (proven with the Scenario voice harness)
   # ============================================================
 
-  @e2e
+  # Exercised live on PR #6168 (OpenAI-model and ElevenLabs-model runs, both
+  # success: True); automation is tracked in issue #6180 and lands when the
+  # Scenario repo's voice CI points at the deployed gateway.
+  @e2e @unimplemented
   Scenario: Scenario's voice tests run end to end through the gateway
     Given OPENAI_BASE_URL pointing at the gateway and a virtual key as OPENAI_API_KEY
     When a Scenario voice test synthesizes user turns (TTS) and the judge transcribes segments (STT)

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -37,6 +37,13 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
     And no JSON wrapping or base64 encoding is applied
     # Scenario's voice harness consumes exactly this shape (pcm16/24000).
 
+  @unit
+  Scenario: PCM means 24kHz on every provider, matching OpenAI semantics
+    When the client requests response_format "pcm" for an elevenlabs model
+    Then the gateway asks ElevenLabs for output_format "pcm_24000"
+    # Bifrost's own mapping picks pcm_44100, which is gated to the ElevenLabs
+    # Pro tier and is the wrong sample rate for the OpenAI pcm contract.
+
   @integration
   Scenario: ElevenLabs TTS through the same OpenAI wire shape
     When the client POSTs /v1/audio/speech with model "elevenlabs/eleven_flash_v2" and a voice id in `voice`

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -1,4 +1,4 @@
-Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI and ElevenLabs
+Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and ElevenLabs
   As a developer running voice agents (and as Scenario's own voice test harness)
   I want the gateway to serve /v1/audio/speech and /v1/audio/transcriptions on a virtual key
   So that voice traffic gets the same governance, observability, and cost tracking as chat
@@ -15,7 +15,7 @@ Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI an
     And the organization also has an ElevenLabs API key configured
 
   # ============================================================
-  # Group: Text to speech — POST /v1/audio/speech
+  # Group: Text to speech (POST /v1/audio/speech)
   # ============================================================
 
   @integration
@@ -28,7 +28,7 @@ Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI an
       | response_format | mp3                      |
     Then the response is 200 with binary audio bytes in the body
     And the Content-Type is the audio MIME type for the requested format
-    And the body is NOT a JSON envelope — an OpenAI SDK's `client.audio.speech.create(...)` consumes it unchanged
+    And the body is NOT a JSON envelope, so an OpenAI SDK's `client.audio.speech.create(...)` consumes it unchanged
 
   @integration
   Scenario: PCM response format passes through for realtime consumers
@@ -50,7 +50,7 @@ Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI an
     And the explicit "provider/model" form bypasses aliases, as everywhere else
 
   # ============================================================
-  # Group: Speech to text — POST /v1/audio/transcriptions
+  # Group: Speech to text (POST /v1/audio/transcriptions)
   # ============================================================
 
   @integration
@@ -82,7 +82,7 @@ Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI an
     And no provider is contacted
 
   # ============================================================
-  # Group: Governance — the same pipeline as chat
+  # Group: Governance (the same pipeline as chat)
   # ============================================================
 
   @unit
@@ -134,7 +134,7 @@ Feature: Gateway audio endpoints — OpenAI-compatible TTS and STT for OpenAI an
     And the span carries the audio duration (or the provider's token usage when reported) as the measure STT is priced by
 
   # ============================================================
-  # Group: Dogfood — proven with the Scenario voice harness
+  # Group: Dogfood (proven with the Scenario voice harness)
   # ============================================================
 
   @e2e


### PR DESCRIPTION
## What & why

We're dogfooding LangWatch itself for Scenario's voice testing, and the gateway 404'd on `/v1/audio/speech`. The contract (§3) has declared both audio routes since v0.1, but they were never implemented. This ships them for **OpenAI and ElevenLabs**: full TTS + STT with the same virtual-key governance as chat, verified live end to end.

No Bifrost upgrade needed: the pinned v1.4.22 already carries `SpeechRequest`/`TranscriptionRequest` and both providers.

## Gateway (Go)

- **`POST /v1/audio/speech`**: OpenAI wire shape in, **raw audio bytes out** with the right `audio/*` Content-Type. No JSON envelope, so `client.audio.speech.create(...)` works unchanged with `base_url` pointed at the gateway. ElevenLabs callers put their voice id in the same `voice` field.
- **`POST /v1/audio/transcriptions`**: multipart in the router (the only layer with the `*http.Request`), 26 MB cap → 413 before any provider is contacted, only known OpenAI form fields forwarded, standard JSON transcript out.
- Both ride the existing sync pipeline **untouched**: VK auth, model resolution + allowlists, budgets, rate limits, error transparency, and credential fallback all behave exactly as chat does.
- ElevenLabs slots in as a Bifrost-native provider: `ProviderID` maps verbatim onto Bifrost's enum, plain API key, zero changes to `mapProvider`/`credentialToBifrostKey`.
- Usage lands on the gateway span with the measures audio is priced by: token counts where reported (`gpt-4o-mini-tts`, `gpt-4o-transcribe`) plus `gen_ai.usage.input_chars` (TTS) and `gen_ai.usage.audio_seconds` (STT) for character/duration-priced providers.
- OpenAI `pcm` semantics enforced per provider: ElevenLabs is asked for `pcm_24000`. Bifrost's own mapping picks `pcm_44100`, which is gated to the ElevenLabs Pro tier and is the wrong sample rate for the OpenAI contract (24kHz).
- Found along the way: `ErrPayloadTooLarge` existed but was never registered with an HTTP status, so any 413 path would have surfaced as a 500. Registered.

## Control plane

- `elevenlabs` joins the model-provider registry (`ELEVENLABS_API_KEY`, with an icon), so the key lives in **Settings → Model Providers** like every other provider. The gateway materialiser's default `*_API_KEY` branch already carries it through, no materialiser changes.
- `scripts/dogfood/audio/seed-audio-vk.ts` mints the whole local setup in one shot: both provider rows, an org-default routing policy with **no chat-shaped model allowlist** (which would reject every audio model id), and a personal VK.

## Docs

`docs/ai-gateway/api/audio.mdx`: provider/model matrix, the raw-bytes response contract, the upload cap, usage attributes, and the not-yet list (streaming, realtime websockets).

## Spec & tests

- `specs/ai-gateway/audio-endpoints.feature` is the requirements file; the `@unit` scenarios bind in `adapters/httpapi/audio_test.go` (11 tests, including the guard that the speech body is never JSON-wrapped).
- The `@integration` scenarios are the new **live matrix cells** (`tests/matrix/audio_test.go`, build tag `live_audio`, wired into the gateway-matrix workflow defaults with inert-until-provisioned secrets). Their assertion is the strongest available: **TTS→STT round-trips** where the transcript must contain the spoken words.

## Live proof (no mocks)

Against a real local stack (app + this gateway + real provider keys):

```
TestAudio_OpenAI_SpeechToTranscriptionRoundTrip   openai transcript:            "The quick brown fox jumps over the lazy dog."  PASS
TestAudio_OpenAI_SpeechMP3                                                                                                      PASS
TestAudio_ElevenLabs_SpeechToOpenAITranscription  elevenlabs->openai transcript: "The quick brown fox jumps over the lazy dog." PASS
TestAudio_ElevenLabs_Transcription                openai->elevenlabs transcript: "The quick brown fox jumps over the lazy dog." PASS
```

And the **ultimate dogfood**: a full Scenario voice test (live ElevenLabs ConvAI agent + TTS'd user turns + judge STT + judge LLM) ran with `OPENAI_BASE_URL` pointed at this gateway and a virtual key as the API key: `success: True`, with every TTS, STT, and judge chat call served by the gateway (9 audio + 1 chat requests, zero direct OpenAI calls).

A second Scenario run swapped in **ElevenLabs models on both sides** through the gateway, using only Scenario's public hooks (`register_tts_provider` + `set_stt_provider`, zero SDK changes): user-turn TTS on `elevenlabs/eleven_flash_v2`, judge STT on `elevenlabs/scribe_v1`, judge LLM on the gateway chat route, agent = the live ElevenLabs ConvAI websocket. Result `success: True` with 2 speech + 3 transcription + 1 chat gateway calls. This run is what surfaced the `pcm_44100` tier gate the pcm fix above closes; the live EL matrix cell now requests `pcm` and round-trips at 24kHz so that regression stays covered.

## Follow-ups (not in this PR)

- Catalog pricing for audio models (the catalog's `mode` union and price fields are chat/embedding-shaped; needs per-char and per-second price support).
- Streaming TTS/STT.

## Deployment Impact

- New gateway routes only (`/v1/audio/speech`, `/v1/audio/transcriptions`): no database migrations, no changes to existing endpoints or wire shapes.
- The aigateway service must be redeployed to serve the routes; until then they keep returning 404. Rollback is equally clean: the previous binary restores the 404s with no data implications.
- Control plane ships a registry entry and icon with the normal app deploy; no new required environment variables. ElevenLabs is opt-in per organization via Settings -> Model Providers (`ELEVENLABS_API_KEY`).
- CI: the live audio matrix cells read two new optional org secrets (`MATRIX_TEST_VK_ELEVENLABS`, `MATRIX_ELEVENLABS_VOICE_ID`); until provisioned the cells skip and nothing fails.
- charts/ untouched.

## Screenshots

**ElevenLabs in Settings → Model Providers** (registry + icon):

![model providers list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6168/gateway-audio/01-model-providers-list.png)

**Add Model Provider menu**, ElevenLabs addable like any provider:

![add provider menu](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6168/gateway-audio/06-add-provider-menu.png)

**Provider config drawer**, plain `ELEVENLABS_API_KEY`, org scope:

![elevenlabs drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6168/gateway-audio/03-elevenlabs-config-open.png)

**Gateway audio traces in Trace Explorer**: `gen_ai.transcription` calls with origin Gateway, token usage, and computed cost, next to the Scenario-run simulation traces:

![gateway audio traces](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6168/gateway-audio/05-trace-open.png)

QA also caught and fixed one defect: the provider icon originally used a Tailwind-style `fill-foreground` class that does nothing in this app, so the row rendered without an icon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible `/v1/audio/speech` and `/v1/audio/transcriptions` endpoints.
  * Enabled ElevenLabs as an audio provider for TTS and STT, including model-based routing.
  * Extended live-audio testing coverage to validate end-to-end audio flows.
  * Updated API documentation navigation to include the audio API reference.
* **Bug Fixes**
  * Ensured speech responses return raw binary audio with the correct `Content-Type`.
  * Improved transcription validation and error handling for oversized uploads and malformed multipart requests.
* **Tests**
  * Added comprehensive unit tests, audio integration tests, and live-provider matrix scenarios for audio workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
