### PR TITLE
fix(model-providers): ElevenLabs key validation uses xi-api-key instead of failing with a fake network error

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/providerValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/providerValidation.unit.test.ts
@@ -75,6 +75,61 @@ describe("validateProviderApiKey", () => {
     });
   });
 
+  describe("ElevenLabs validation", () => {
+    /** @scenario "ElevenLabs keys validate with the xi-api-key header" */
+    it("uses xi-api-key header against the ElevenLabs models endpoint", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+      const result = await validateProviderApiKey("elevenlabs", {
+        ELEVENLABS_API_KEY: "sk_test",
+      });
+
+      expect(result).toEqual({ valid: true });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.elevenlabs.io/v1/models",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "xi-api-key": "sk_test" }),
+        }),
+      );
+    });
+
+    it("reports an invalid key on 401, not a network problem", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+      const result = await validateProviderApiKey("elevenlabs", {
+        ELEVENLABS_API_KEY: "sk_wrong",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Invalid API key");
+      expect(result.error).not.toContain("network");
+    });
+
+    it("reports a network error only when the fetch itself fails", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      const result = await validateProviderApiKey("elevenlabs", {
+        ELEVENLABS_API_KEY: "sk_test",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("network");
+    });
+  });
+
+  describe("Providers without a validation endpoint", () => {
+    /** @scenario "Providers with no known validation endpoint skip validation" */
+    it("skips validation instead of fetching a relative URL", async () => {
+      const result = await validateProviderApiKey("voyage", {
+        VOYAGE_API_KEY: "pa-test",
+      });
+
+      expect(result).toEqual({ valid: true });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Bearer token validation (OpenAI)", () => {
     it("returns valid when API key is accepted", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/langwatch/src/server/api/routers/providerValidation.ts
+++ b/langwatch/src/server/api/routers/providerValidation.ts
@@ -12,8 +12,9 @@ export type ValidationResult = { valid: boolean; error?: string };
  * - `bearer`: Uses `Authorization: Bearer {key}` header (OpenAI-compatible) - DEFAULT
  * - `anthropic`: Uses `x-api-key` header with `anthropic-version`
  * - `gemini`: Uses query parameter `?key=`
+ * - `elevenlabs`: Uses `xi-api-key` header
  */
-type AuthStrategy = "bearer" | "anthropic" | "gemini";
+type AuthStrategy = "bearer" | "anthropic" | "gemini" | "elevenlabs";
 
 /**
  * Providers that use non-standard auth. All others default to bearer auth.
@@ -21,10 +22,21 @@ type AuthStrategy = "bearer" | "anthropic" | "gemini";
 const PROVIDER_AUTH_OVERRIDES: Partial<Record<string, AuthStrategy>> = {
   anthropic: "anthropic",
   gemini: "gemini",
+  elevenlabs: "elevenlabs",
 };
 
 /** Providers with complex auth (AWS, gcloud, etc.) that skip validation */
 const SKIP_VALIDATION = new Set(["bedrock", "vertex_ai", "azure"]);
+
+/**
+ * Validation endpoints for providers that are not part of the onboarding
+ * registry (which is what feeds `providerDefaultBaseUrls`). ElevenLabs is an
+ * audio-only provider added directly in Settings, so its models endpoint
+ * lives here.
+ */
+const VALIDATION_ONLY_BASE_URLS: Record<string, string> = {
+  elevenlabs: "https://api.elevenlabs.io/v1",
+};
 
 /**
  * Builds the models endpoint URL by normalizing and appending /models if needed.
@@ -121,6 +133,44 @@ async function validateWithAnthropicAuth(
       headers: {
         "x-api-key": apiKey,
         "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return handleHttpError(response);
+    }
+
+    return { valid: true };
+  } catch {
+    return {
+      valid: false,
+      error:
+        "Failed to validate API key. Please check your network connection.",
+    };
+  }
+}
+
+/**
+ * Validates using ElevenLabs' xi-api-key header authentication.
+ *
+ * @param apiKey - The API key to validate
+ * @param baseUrl - The user-provided base URL (may be empty)
+ * @param defaultBaseUrl - The default base URL for ElevenLabs
+ * @returns Promise resolving to validation result
+ */
+async function validateWithElevenLabsAuth(
+  apiKey: string,
+  baseUrl: string,
+  defaultBaseUrl: string,
+): Promise<ValidationResult> {
+  const url = buildModelsEndpointUrl(baseUrl, defaultBaseUrl);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "xi-api-key": apiKey,
         "Content-Type": "application/json",
       },
     });
@@ -304,7 +354,18 @@ export async function validateProviderApiKey(
 
   // Get auth strategy (default to bearer) and base URL
   const authStrategy = PROVIDER_AUTH_OVERRIDES[provider] ?? "bearer";
-  const defaultBaseUrl = providerDefaultBaseUrls[provider] ?? "";
+  const defaultBaseUrl =
+    providerDefaultBaseUrls[provider] ??
+    VALIDATION_ONLY_BASE_URLS[provider] ??
+    "";
+
+  // No endpoint to probe (e.g. voyage, which has no models listing): skip
+  // rather than fetch a relative URL, which would always throw and surface
+  // as a misleading "check your network connection" error. The key is
+  // exercised on the first real call instead.
+  if (!baseUrl && !defaultBaseUrl) {
+    return { valid: true };
+  }
 
   switch (authStrategy) {
     case "bearer":
@@ -313,6 +374,8 @@ export async function validateProviderApiKey(
       return validateWithAnthropicAuth(apiKey, baseUrl, defaultBaseUrl);
     case "gemini":
       return validateWithGeminiAuth(apiKey, defaultBaseUrl);
+    case "elevenlabs":
+      return validateWithElevenLabsAuth(apiKey, baseUrl, defaultBaseUrl);
     default:
       return { valid: true };
   }

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -196,3 +196,18 @@ Feature: Credential Validation
     When I call validateProviderApiKey with "HAS_KEY••••••••••••••••••••••••"
     Then validation is skipped
     And the result is valid
+
+  @unit
+  Scenario: ElevenLabs keys validate with the xi-api-key header
+    Given I am validating an ElevenLabs API key
+    When I call validateProviderApiKey with an ELEVENLABS_API_KEY
+    Then the models endpoint at api.elevenlabs.io is probed with the xi-api-key header
+    And a 200 marks the key valid
+    And a 401 reports an invalid API key, not a network problem
+
+  @unit
+  Scenario: Providers with no known validation endpoint skip validation
+    Given a registered provider that has no default validation base URL and no custom endpoint
+    When I call validateProviderApiKey for it
+    Then validation is skipped instead of probing a relative URL
+    And no misleading network-connection error is shown


### PR DESCRIPTION
## What and why

Saving an ElevenLabs API key in Settings -> Model Providers fails on prod with "Failed to validate API key. Please check your network connection and base URL." even for a perfectly valid key. Found while onboarding the first ElevenLabs voice traffic onto the freshly deployed gateway audio endpoints (#6168).

Two real defects stacked:

1. `elevenlabs` has no entry in `providerDefaultBaseUrls` (that map is generated from the onboarding registry, and ElevenLabs is an audio-only provider added directly in Settings). Validation therefore called `fetch("/models")`, a relative URL that always throws, and the catch-all reported a network problem that does not exist.
2. Even with a base URL, the default bearer strategy would 401: ElevenLabs authenticates with the `xi-api-key` header (live-verified: bearer 401s, `xi-api-key` 200s with the same key).

## Fix

- New `elevenlabs` auth strategy probing `https://api.elevenlabs.io/v1/models` with `xi-api-key`.
- `VALIDATION_ONLY_BASE_URLS` for providers that are validatable but absent from the onboarding registry.
- Class guard: a provider with no known validation endpoint and no custom URL now **skips** validation (like the complex-auth providers do) instead of throwing on a relative URL. This also fixes `voyage`, which was silently broken the same way (it has no `/models` endpoint at all).

## Tests and proof

- `credential-validation.feature` gets two bound scenarios; 4 new unit tests (24/24 passing): xi-api-key header shape, 401 -> "Invalid API key" (not "network"), fetch failure -> network message, voyage -> skip without fetch.
- Live probe of `validateProviderApiKey` with the real production key: `{"valid":true}`; wrong key: `{"valid":false,"error":"Invalid API key. Please check your API key and try again."}`; voyage: skip.
- Browser QA of the exact failing drawer flow (screenshots below).

Prod smoke while here: the deployed gateway is already serving audio (`POST /v1/audio/speech` returned 200 `audio/mpeg` through gateway.langwatch.ai with a virtual key), so this validation fix is the last blocker for ElevenLabs keys on prod.

## Deployment Impact

- App-only change to the key-validation path; no schema, gateway, or chart changes. Normal app deploy picks it up.
- Behavior change: providers with no known validation endpoint skip validation instead of erroring; the key is exercised on the first real call.

## Screenshots

(browser QA in progress, embedded before review)