### PR TITLE
fix(licensing): personal workspaces no longer consume plan limits

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/project.create.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.planLimit.integration.test.ts
@@ -30,11 +30,7 @@ import {
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-// TEST_CLICKHOUSE_URL indicates testcontainers mode without full infrastructure
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)(
+describe(
   "project.create plan limit enforcement",
   () => {
     const testNamespace = `proj-limit-${nanoid(8)}`;
@@ -255,7 +251,7 @@ describe.skipIf(isTestcontainersOnly)(
 // Regression: BetterAuth uses RoleBinding for team membership — TeamUser is never populated.
 // A user must be able to create a project with only a RoleBinding, no TeamUser row.
 // Previously project.create checked teamUser.findFirst which always returned null, causing a 403.
-describe.skipIf(isTestcontainersOnly)(
+describe(
   "project.create with RoleBinding-only membership (no TeamUser)",
   () => {
     const testNamespace = `proj-rb-${nanoid(8)}`;

--- a/langwatch/src/server/api/routers/__tests__/team.createTeamWithMembers.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.createTeamWithMembers.planLimit.integration.test.ts
@@ -6,7 +6,11 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -30,11 +34,7 @@ import {
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-// TEST_CLICKHOUSE_URL indicates testcontainers mode without full infrastructure
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)(
+describe(
   "team.createTeamWithMembers plan limit enforcement",
   () => {
     const testNamespace = `team-limit-${nanoid(8)}`;
@@ -65,6 +65,18 @@ describe.skipIf(isTestcontainersOnly)(
           userId: user.id,
           organizationId: organization.id,
           role: OrganizationUserRole.ADMIN,
+        },
+      });
+
+      // `organization:manage` resolves through an ORGANIZATION-scoped
+      // RoleBinding; OrganizationUser.role alone never grants it.
+      await prisma.roleBinding.create({
+        data: {
+          userId: user.id,
+          organizationId: organization.id,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organization.id,
         },
       });
 
@@ -106,6 +118,11 @@ describe.skipIf(isTestcontainersOnly)(
     });
 
     afterAll(async () => {
+      await prisma.roleBinding
+        .deleteMany({
+          where: { organization: { slug: `--test-org-${testNamespace}` } },
+        })
+        .catch(() => {});
       await prisma.teamUser
         .deleteMany({
           where: {

--- a/langwatch/src/server/api/routers/limits.ts
+++ b/langwatch/src/server/api/routers/limits.ts
@@ -43,11 +43,3 @@ export const limitsRouter = createTRPCRouter({
       };
     }),
 });
-
-export const getOrganizationProjectsCount = async (organizationId: string) => {
-  return await prisma.project.count({
-    where: {
-      team: { organizationId },
-    },
-  });
-};

--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
@@ -47,6 +47,7 @@ const createMockPrisma = () => ({
   },
   team: {
     findMany: vi.fn().mockResolvedValue([]),
+    count: vi.fn().mockResolvedValue(0),
   },
   teamUser: {
     findMany: vi.fn().mockResolvedValue([]),
@@ -184,13 +185,18 @@ describe("LicenseEnforcementRepository", () => {
   describe("getProjectCount", () => {
     /** @scenario Counts projects across all teams */
     /** @scenario Counts only non-archived projects toward limit */
-    it("queries non-archived projects with organization filter that traverses every team", async () => {
+    /** @scenario Personal projects do not count toward the project limit */
+    it("queries non-archived, non-personal projects with organization filter that traverses every team", async () => {
       mockPrisma.project.count.mockResolvedValue(4);
 
       const result = await repository.getProjectCount(organizationId);
 
       expect(mockPrisma.project.count).toHaveBeenCalledWith({
-        where: { team: { organizationId }, archivedAt: null },
+        where: {
+          team: { organizationId },
+          archivedAt: null,
+          isPersonal: false,
+        },
       });
       expect(result).toBe(4);
     });
@@ -199,6 +205,28 @@ describe("LicenseEnforcementRepository", () => {
       mockPrisma.project.count.mockResolvedValue(0);
 
       const result = await repository.getProjectCount(organizationId);
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("getTeamCount", () => {
+    /** @scenario Personal teams do not count toward the team limit */
+    it("queries non-personal teams in the organization", async () => {
+      mockPrisma.team.count.mockResolvedValue(3);
+
+      const result = await repository.getTeamCount(organizationId);
+
+      expect(mockPrisma.team.count).toHaveBeenCalledWith({
+        where: { organizationId, isPersonal: false },
+      });
+      expect(result).toBe(3);
+    });
+
+    it("returns zero when no teams exist", async () => {
+      mockPrisma.team.count.mockResolvedValue(0);
+
+      const result = await repository.getTeamCount(organizationId);
 
       expect(result).toBe(0);
     });

--- a/langwatch/src/server/license-enforcement/__tests__/personal-workspaces-excluded.integration.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/personal-workspaces-excluded.integration.test.ts
@@ -1,0 +1,371 @@
+/**
+ * @vitest-environment node
+ *
+ * Personal workspaces must not consume an organization's plan allowance.
+ *
+ * Every person on the free plan should be able to track their own coding-agent
+ * usage, which needs a personal workspace. That workspace cannot spend the
+ * projects the customer bought for real work.
+ *
+ * The enforcement path, the usage page, and the license status panel all read
+ * their project and team counts from LicenseEnforcementRepository, so this
+ * suite asserts all three agree. A count excluded in one place and included in
+ * another is worse than excluding it nowhere, because the number a customer
+ * sees stops matching the number that blocks them.
+ *
+ * Requires: PostgreSQL database (Prisma)
+ */
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { prisma } from "../../db";
+import { FREE_PLAN } from "../../../../ee/licensing/constants";
+import type { PlanInfo } from "../../../../ee/licensing/planInfo";
+import { globalForApp, resetApp } from "../../app-layer/app";
+import { createTestApp } from "../../app-layer/presets";
+import {
+  type PlanProvider,
+  PlanProviderService,
+} from "../../app-layer/subscription/plan-provider";
+import { appRouter } from "../../api/root";
+import { createInnerTRPCContext } from "../../api/trpc";
+import { LicenseEnforcementRepository } from "../license-enforcement.repository";
+import { LicenseEnforcementService } from "../license-enforcement.service";
+import {
+  type ITraceUsageService,
+  type IUsageUnitResolver,
+  UsageStatsService,
+} from "../usage-stats.service";
+
+const testNamespace = `personal-limits-${nanoid(8)}`;
+
+/** Real (non-personal) workspaces the fixture creates. */
+const REAL_TEAMS = 1;
+const REAL_PROJECTS = 2;
+/**
+ * Personal workspaces the fixture creates, which must stay invisible to limits.
+ * One per (organization, user) is all the schema allows, so this mirrors the
+ * free plan's two members each tracking their own coding-agent usage.
+ */
+const PERSONAL_TEAMS = 2;
+const PERSONAL_PROJECTS = 2;
+
+describe("given an organization with both personal and real workspaces", () => {
+  let organizationId: string;
+  let realTeamId: string;
+  let userId: string;
+  let memberUserIds: string[];
+  let repository: LicenseEnforcementRepository;
+  let mockGetActivePlan: ReturnType<typeof vi.fn>;
+
+  const freePlanWith = (overrides: Partial<PlanInfo> = {}): PlanInfo => ({
+    ...FREE_PLAN,
+    overrideAddingLimitations: false,
+    ...overrides,
+  });
+
+  const enforcementFor = (plan: PlanInfo) =>
+    new LicenseEnforcementService(
+      repository,
+      PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue(plan),
+      }),
+    );
+
+  const usageStatsFor = (plan: PlanInfo) =>
+    new UsageStatsService(
+      repository,
+      {
+        getCurrentMonthCount: vi.fn().mockResolvedValue(0),
+        getCurrentMonthCountForDisplay: vi.fn().mockResolvedValue(0),
+      } satisfies ITraceUsageService,
+      PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue(plan),
+      }),
+      {
+        getResolvedUsageUnit: vi.fn().mockResolvedValue("traces"),
+      } satisfies IUsageUnitResolver,
+    );
+
+  const createCaller = () =>
+    appRouter.createCaller(
+      createInnerTRPCContext({
+        session: { user: { id: userId }, expires: "1" },
+      }),
+    );
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Test Organization", slug: `--test-org-${testNamespace}` },
+    });
+    organizationId = organization.id;
+
+    memberUserIds = [];
+    for (let index = 0; index < PERSONAL_TEAMS; index++) {
+      const member = await prisma.user.create({
+        data: {
+          name: `Test User ${index}`,
+          email: `test-${testNamespace}-${index}@example.com`,
+        },
+      });
+      memberUserIds.push(member.id);
+
+      await prisma.organizationUser.create({
+        data: {
+          userId: member.id,
+          organizationId,
+          role: OrganizationUserRole.ADMIN,
+        },
+      });
+    }
+    userId = memberUserIds[0]!;
+
+    const createTeam = ({
+      index,
+      isPersonal,
+    }: {
+      index: number;
+      isPersonal: boolean;
+    }) =>
+      prisma.team.create({
+        data: {
+          name: isPersonal ? `Personal Team ${index}` : `Team ${index}`,
+          slug: `--test-team-${testNamespace}-${isPersonal ? "personal" : "real"}-${index}`,
+          organizationId,
+          isPersonal,
+          ...(isPersonal ? { ownerUserId: memberUserIds[index] } : {}),
+        },
+      });
+
+    const createProject = ({
+      teamId,
+      index,
+      isPersonal,
+    }: {
+      teamId: string;
+      index: number;
+      isPersonal: boolean;
+    }) =>
+      prisma.project.create({
+        data: {
+          name: isPersonal ? `Personal Project ${index}` : `Project ${index}`,
+          slug: `--test-proj-${testNamespace}-${isPersonal ? "personal" : "real"}-${index}`,
+          apiKey: `sk-lw-test-${nanoid()}`,
+          teamId,
+          language: "en",
+          framework: "test",
+          isPersonal,
+          ...(isPersonal ? { ownerUserId: memberUserIds[index] } : {}),
+        },
+      });
+
+    const realTeam = await createTeam({ index: 0, isPersonal: false });
+    realTeamId = realTeam.id;
+    for (let index = 0; index < REAL_PROJECTS; index++) {
+      await createProject({ teamId: realTeam.id, index, isPersonal: false });
+    }
+
+    // Membership on the real team so the create-project RBAC guard passes.
+    await prisma.teamUser.create({
+      data: { userId, teamId: realTeam.id, role: TeamUserRole.ADMIN },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        userId,
+        organizationId,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: realTeam.id,
+        role: TeamUserRole.ADMIN,
+      },
+    });
+
+    for (let index = 0; index < PERSONAL_TEAMS; index++) {
+      const personalTeam = await createTeam({ index, isPersonal: true });
+      if (index < PERSONAL_PROJECTS) {
+        await createProject({
+          teamId: personalTeam.id,
+          index,
+          isPersonal: true,
+        });
+      }
+    }
+
+    repository = new LicenseEnforcementRepository(prisma);
+  });
+
+  beforeEach(async () => {
+    await resetApp();
+    mockGetActivePlan = vi.fn();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+  });
+
+  afterAll(async () => {
+    const fixtureProjects = { team: { organizationId } };
+    await prisma.projectSecret
+      .deleteMany({ where: { project: fixtureProjects } })
+      .catch(() => {});
+    await prisma.project.deleteMany({ where: fixtureProjects }).catch(() => {});
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({
+        where: { team: { slug: { startsWith: `--test-team-${testNamespace}` } } },
+      })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({
+        where: { slug: { startsWith: `--test-team-${testNamespace}` } },
+      })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { slug: `--test-org-${testNamespace}` } })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { email: { startsWith: `test-${testNamespace}-` } },
+      })
+      .catch(() => {});
+  });
+
+  describe("when counting resources for plan enforcement", () => {
+    it("excludes personal projects from the project count", async () => {
+      await expect(repository.getProjectCount(organizationId)).resolves.toBe(
+        REAL_PROJECTS,
+      );
+    });
+
+    it("excludes personal teams from the team count", async () => {
+      await expect(repository.getTeamCount(organizationId)).resolves.toBe(
+        REAL_TEAMS,
+      );
+    });
+  });
+
+  describe("when only personal workspaces would push the organization over", () => {
+    it("allows another project because personal ones do not count", async () => {
+      const service = enforcementFor(
+        freePlanWith({ maxProjects: REAL_PROJECTS + PERSONAL_PROJECTS }),
+      );
+
+      await expect(
+        service.checkLimit(organizationId, "projects"),
+      ).resolves.toMatchObject({ allowed: true, current: REAL_PROJECTS });
+    });
+
+    it("allows another team because personal ones do not count", async () => {
+      const service = enforcementFor(
+        freePlanWith({ maxTeams: REAL_TEAMS + PERSONAL_TEAMS }),
+      );
+
+      await expect(
+        service.checkLimit(organizationId, "teams"),
+      ).resolves.toMatchObject({ allowed: true, current: REAL_TEAMS });
+    });
+  });
+
+  describe("when real projects have already filled the free allowance", () => {
+    it("still blocks a new project", async () => {
+      const service = enforcementFor(
+        freePlanWith({ maxProjects: REAL_PROJECTS }),
+      );
+
+      await expect(
+        service.checkLimit(organizationId, "projects"),
+      ).resolves.toMatchObject({
+        allowed: false,
+        current: REAL_PROJECTS,
+        max: REAL_PROJECTS,
+      });
+    });
+
+    it("rejects project.create with FORBIDDEN", async () => {
+      mockGetActivePlan.mockResolvedValue(
+        freePlanWith({ maxProjects: REAL_PROJECTS }),
+      );
+
+      await expect(
+        createCaller().project.create({
+          organizationId,
+          teamId: realTeamId,
+          name: "One Too Many",
+          language: "en",
+          framework: "test",
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        message: "You have reached the maximum number of projects",
+      });
+    });
+  });
+
+  describe("when the customer looks at the usage page", () => {
+    it("reports the same counts that enforcement blocks on", async () => {
+      const plan = freePlanWith();
+      const usage = await usageStatsFor(plan).getUsageStats(organizationId, {
+        id: userId,
+      });
+
+      expect(usage.projectsCount).toBe(REAL_PROJECTS);
+      expect(usage.teamsCount).toBe(REAL_TEAMS);
+
+      const service = enforcementFor(plan);
+      const projectLimit = await service.checkLimit(organizationId, "projects");
+      const teamLimit = await service.checkLimit(organizationId, "teams");
+
+      expect(projectLimit.current).toBe(usage.projectsCount);
+      expect(teamLimit.current).toBe(usage.teamsCount);
+    });
+  });
+
+  // Runs last: it adds a real project, which shifts the counts the
+  // assertions above pin.
+  describe("when a free organization still has real allowance left", () => {
+    it("creates the project even though personal projects exist", async () => {
+      mockGetActivePlan.mockResolvedValue(
+        freePlanWith({ maxProjects: REAL_PROJECTS + 1 }),
+      );
+
+      const result = await createCaller().project.create({
+        organizationId,
+        teamId: realTeamId,
+        name: "Real Work",
+        language: "en",
+        framework: "test",
+      });
+
+      expect(result).toMatchObject({ success: true });
+      await expect(repository.getProjectCount(organizationId)).resolves.toBe(
+        REAL_PROJECTS + 1,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/license-enforcement/__tests__/personal-workspaces-excluded.integration.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/personal-workspaces-excluded.integration.test.ts
@@ -293,6 +293,7 @@ describe("given an organization with both personal and real workspaces", () => {
   });
 
   describe("when real projects have already filled the free allowance", () => {
+    /** @scenario Real projects still reach the limit alongside personal projects */
     it("still blocks a new project", async () => {
       const service = enforcementFor(
         freePlanWith({ maxProjects: REAL_PROJECTS }),
@@ -327,7 +328,24 @@ describe("given an organization with both personal and real workspaces", () => {
     });
   });
 
+  describe("when real teams have already filled the team allowance", () => {
+    /** @scenario Real teams still reach the limit alongside personal teams */
+    it("still blocks a new team", async () => {
+      const service = enforcementFor(freePlanWith({ maxTeams: REAL_TEAMS }));
+
+      await expect(
+        service.checkLimit(organizationId, "teams"),
+      ).resolves.toMatchObject({
+        allowed: false,
+        current: REAL_TEAMS,
+        max: REAL_TEAMS,
+      });
+    });
+  });
+
   describe("when the customer looks at the usage page", () => {
+    /** @scenario The reported project usage excludes personal projects */
+    /** @scenario The reported team usage excludes personal teams */
     it("reports the same counts that enforcement blocks on", async () => {
       const plan = freePlanWith();
       const usage = await usageStatsFor(plan).getUsageStats(organizationId, {
@@ -349,6 +367,7 @@ describe("given an organization with both personal and real workspaces", () => {
   // Runs last: it adds a real project, which shifts the counts the
   // assertions above pin.
   describe("when a free organization still has real allowance left", () => {
+    /** @scenario A free organization keeps its full project allowance after provisioning a personal workspace */
     it("creates the project even though personal projects exist", async () => {
       mockGetActivePlan.mockResolvedValue(
         freePlanWith({ maxProjects: REAL_PROJECTS + 1 }),

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -123,20 +123,30 @@ export class LicenseEnforcementRepository
   }
 
   /**
-   * Counts non-archived projects in organization.
+   * Counts non-archived projects in organization, excluding personal ones.
+   *
+   * A personal workspace belongs to a person, not to the organization that
+   * pays, so it never spends the project allowance bought for real work.
+   * See the "Personal Workspaces" scenarios in
+   * specs/licensing/enforcement-projects.feature.
    */
   async getProjectCount(organizationId: string): Promise<number> {
     return this.prisma.project.count({
-      where: { team: { organizationId }, archivedAt: null },
+      where: { team: { organizationId }, archivedAt: null, isPersonal: false },
     });
   }
 
   /**
-   * Counts teams in organization.
+   * Counts teams in organization, excluding personal ones.
+   *
+   * A personal team is provisioned for a user rather than requested by the
+   * organization, so it never spends the team allowance.
+   * See the "Personal Workspaces" scenarios in
+   * specs/licensing/enforcement-resources.feature.
    */
   async getTeamCount(organizationId: string): Promise<number> {
     return this.prisma.team.count({
-      where: { organizationId },
+      where: { organizationId, isPersonal: false },
     });
   }
 

--- a/specs/licensing/enforcement-projects.feature
+++ b/specs/licensing/enforcement-projects.feature
@@ -76,3 +76,43 @@ Feature: Project Limit Enforcement with License
     And team "team-789" has 1 project
     When I create a project named "New Project"
     Then the request fails with FORBIDDEN
+
+  # ============================================================================
+  # Personal Workspaces
+  # ============================================================================
+  #
+  # Everyone on the free plan should be able to track their own coding-agent
+  # usage, which needs a personal workspace. A personal workspace must not
+  # spend any of the projects the customer gets for real work.
+  #
+  # The same count backs enforcement, the usage page, and the license status
+  # panel, so a personal project is invisible to all three or to none of them.
+
+  @integration
+  Scenario: Personal projects do not count toward the project limit
+    Given the organization has a license with maxProjects 2
+    And the organization has 2 personal projects
+    When I create a project named "New Project"
+    Then the project is created successfully
+
+  @integration
+  Scenario: Real projects still reach the limit alongside personal projects
+    Given the organization has a license with maxProjects 2
+    And the organization has 2 projects
+    And the organization has 1 personal project
+    When I create a project named "New Project"
+    Then the request fails with FORBIDDEN
+
+  @integration
+  Scenario: A free organization keeps its full project allowance after provisioning a personal workspace
+    Given the organization is on the free plan allowing 2 projects
+    And every member has a personal workspace
+    When I create 2 projects for real work
+    Then both projects are created successfully
+
+  @integration
+  Scenario: The reported project usage excludes personal projects
+    Given the organization has 2 projects
+    And the organization has 1 personal project
+    When I view the organization usage
+    Then the reported project count is 2

--- a/specs/licensing/enforcement-projects.feature
+++ b/specs/licensing/enforcement-projects.feature
@@ -88,14 +88,12 @@ Feature: Project Limit Enforcement with License
   # The same count backs enforcement, the usage page, and the license status
   # panel, so a personal project is invisible to all three or to none of them.
 
-  @integration
   Scenario: Personal projects do not count toward the project limit
     Given the organization has a license with maxProjects 2
     And the organization has 2 personal projects
     When I create a project named "New Project"
     Then the project is created successfully
 
-  @integration
   Scenario: Real projects still reach the limit alongside personal projects
     Given the organization has a license with maxProjects 2
     And the organization has 2 projects
@@ -103,14 +101,12 @@ Feature: Project Limit Enforcement with License
     When I create a project named "New Project"
     Then the request fails with FORBIDDEN
 
-  @integration
   Scenario: A free organization keeps its full project allowance after provisioning a personal workspace
     Given the organization is on the free plan allowing 2 projects
     And every member has a personal workspace
-    When I create 2 projects for real work
-    Then both projects are created successfully
+    When I create a project for real work
+    Then the project is created successfully
 
-  @integration
   Scenario: The reported project usage excludes personal projects
     Given the organization has 2 projects
     And the organization has 1 personal project

--- a/specs/licensing/enforcement-resources.feature
+++ b/specs/licensing/enforcement-resources.feature
@@ -189,6 +189,34 @@ Feature: Resource Limit Enforcement (Workflows, Prompts, Evaluators, Scenarios, 
     Then the request fails with FORBIDDEN
     And the error message contains "maximum number of teams"
 
+  # A personal workspace is provisioned for a user, not asked for by the
+  # organization, so it must never spend the organization's team allowance.
+  # The same count backs enforcement, the usage page, and the license status
+  # panel, so a personal team is invisible to all three or to none of them.
+
+  @integration
+  Scenario: Personal teams do not count toward the team limit
+    Given the organization has a license with maxTeams 1
+    And the organization has 3 personal teams
+    When I create a team in the organization
+    Then the team is created successfully
+
+  @integration
+  Scenario: Real teams still reach the limit alongside personal teams
+    Given the organization has a license with maxTeams 1
+    And the organization has 1 team
+    And the organization has 1 personal team
+    When I create a team in the organization
+    Then the request fails with FORBIDDEN
+    And the error message contains "maximum number of teams"
+
+  @integration
+  Scenario: The reported team usage excludes personal teams
+    Given the organization has 1 team
+    And the organization has 1 personal team
+    When I view the organization usage
+    Then the reported team count is 1
+
   # ============================================================================
   # UI: Click-then-Modal Pattern (All Resources)
   # ============================================================================


### PR DESCRIPTION
## What

Personal workspaces no longer consume an organization's plan allowance.

Every person on the free plan should be able to track their own coding-agent usage. That needs a personal workspace, and a personal workspace was spending the allowance the customer bought for real work.

A free organization gets 2 projects and 1 team. Provisioning a personal workspace consumed one of each, so a user with a personal workspace and a single real project was already at 2/2 and could not create a second. On the governance signup path the personal team also pushed the org straight to its team limit.

## Changes

**`getProjectCount` and `getTeamCount` now exclude `isPersonal` rows.**

Both are the single source that the enforcement path, the usage page, and the license status panel read, so this keeps them consistent by construction. A count excluded in one place and included in another would be worse than excluding it nowhere, because the number a customer sees would stop matching the number that blocks them.

**Plan limits themselves are unchanged.** Free still allows 2 projects and its current team limit. No plan numbers were touched.

**Removed `getOrganizationProjectsCount`**, a zero-caller export in `limits.ts` that counted org projects without either the archived or the personal filter. It was the exact divergence trap this change is guarding against.

### Where the exclusion stops, deliberately

Resources created *inside* a personal project (datasets, workflows, prompts, agents) still count toward the organization's limits. Personal workspaces are capped at one per (organization, user) by a partial unique index, so excluding them is bounded and cannot be used to evade quota. The resources inside them are not bounded, so exempting those would open an unbounded hole: park every workflow in a personal project and it is free. Flagging this as a judgement call rather than an oversight.

## Tests

New `personal-workspaces-excluded.integration.test.ts` runs against real Postgres and asserts the repository counts, the enforcement service, the tRPC `project.create` route, and `UsageStatsService` all agree that personal workspaces are invisible and that real projects still hit the cap.

**Teeth:** reverting just the two `isPersonal: false` filters fails 7 of its 8 tests, with the expected numbers (`expected 4 to be 2` for projects, `expected 3 to be 1` for teams).

### These suites were not running at all (#6187)

`project.create.planLimit` and `team.createTeamWithMembers.planLimit` both guarded on `describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)`. `setup.ts` sets that variable on every run, including the native path where Postgres is present, so both suites skipped unconditionally. Verified before touching them: `Test Files 1 skipped (1) | Tests 4 skipped (4)`.

Guard dropped on the files touched here. That exposed a stale fixture in the team suite: it had gone stale behind the skip after the RoleBinding migration and failed with `UNAUTHORIZED`, because `organization:manage` resolves through an ORGANIZATION-scoped `RoleBinding` and `OrganizationUser.role = ADMIN` alone never grants it. Fixture fixed.

Result: 15 integration tests passing across the three suites, 173 unit tests in `license-enforcement`, typecheck clean including test files (which `pnpm typecheck` excludes by default).

## QA

Signed up on a free organization, provisioned a personal workspace, then used the full project allowance for real work.

Final state: **3 projects and 2 teams exist, but only 2 projects and 1 team count.**

Free plan active on the organization:

![Free plan active](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-free-plan-limits/1-free-plan-active.png)

Personal workspace provisioned, tracking coding-agent usage on the free org:

![Personal workspace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-free-plan-limits/2-personal-workspace.png)

Full allowance still available for real work: two real projects alongside the personal workspace. Before this change the second project was blocked.

![Full allowance plus personal workspace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-free-plan-limits/4-full-allowance-plus-personal.png)

Free still stops at two real projects, and reports `2 / 2` rather than counting the personal project into the number:

![Limit still stops at two](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-free-plan-limits/3-limit-still-stops-at-two.png)

No UI changed, so there are no light/dark or breakpoint variants to show. The screenshots are behavioural evidence.

## Still open, not addressed here

`useOrganizationTeamProject` selects the current team with `teams.find((team) => team.projects.length > 0)` and no `isPersonal` filter (`langwatch/src/hooks/useOrganizationTeamProject.ts:245-269`). A personal team always has exactly one project, so it can win that selection, and `project` then becomes the personal project that the model-provider settings page hands to its write path. That would file org-scoped credentials into a personal workspace.

This is pre-existing and orthogonal: this PR changes counting only and provisions nothing, so it does not make the selection any more likely to land on a personal team. It does need fixing before personal-workspace provisioning is extended to the coding-agents onboarding path. Left for its own PR rather than mixed into a counting change, since it touches the core navigation hook app-wide.

`specs/features/onboarding/intent-fork.feature` is untouched for the same reason: this PR does not extend provisioning, so ADR-038 v6's reservation of personal-workspace provisioning for CLI login still holds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal workspaces and their projects no longer count toward organization team and project limits.
  * Usage reporting now excludes personal workspace resources, providing more accurate plan usage information.
* **Bug Fixes**
  * Free-plan organizations retain their available resource allowance when personal workspaces are created.
  * Plan enforcement continues to apply correctly when non-personal projects or teams reach their limits.
  * License-limit notifications now provide clearer delivery status details and are restricted to authorized organization managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->