### PR TITLE
ci: unblock main and the release PR from three checks that fail on correct code

### DIFF
--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -25,6 +25,11 @@ permissions:
 
 jobs:
   check:
+    # Release PRs are exempt. release-please writes their description itself
+    # from the changelog, so there is no author to fill the section in, and the
+    # operator impact of everything the release carries was already stated on
+    # the PRs that composed it.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify deployment-impact section in PR description

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -29,7 +29,14 @@ jobs:
     # from the changelog, so there is no author to fill the section in, and the
     # operator impact of everything the release carries was already stated on
     # the PRs that composed it.
-    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    #
+    # Same-repo only: a fork can name its branch anything, and the branch name
+    # alone would let it opt out of the gate. release-please only ever opens
+    # PRs from inside the upstream repo, matching the guard in
+    # release-please-chart-lock-sync.yml.
+    if: |
+      !(github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.head_ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
       - name: Verify deployment-impact section in PR description

--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -195,7 +195,12 @@ jobs:
 
       - name: Assert gateway subchart renders under the umbrella
         run: |
-          if ! grep -q "app.kubernetes.io/name: gateway" /tmp/umbrella.yaml; then
+          # Assert on the Source marker helm stamps on every rendered file, not on
+          # the gateway's pod label: sibling charts legitimately SELECT that label
+          # (langyagent's NetworkPolicy has an egress rule to the gateway), so a
+          # label grep answers "does anything mention the gateway", not "did the
+          # subchart render".
+          if ! grep -q "^# Source: langwatch/charts/gateway/" /tmp/umbrella.yaml; then
             echo "umbrella chart did NOT include the gateway subchart — dependency broken?"
             exit 1
           fi
@@ -211,7 +216,7 @@ jobs:
 
       - name: Assert opt-out drops the gateway
         run: |
-          if grep -q "app.kubernetes.io/name: gateway" /tmp/umbrella-no-gw.yaml; then
+          if grep -q "^# Source: langwatch/charts/gateway/" /tmp/umbrella-no-gw.yaml; then
             echo "gateway.chartManaged=false should suppress the subchart"
             exit 1
           fi

--- a/typescript-sdk/src/observability-sdk/__tests__/e2e/real-llm-interactions.e2e.test.ts
+++ b/typescript-sdk/src/observability-sdk/__tests__/e2e/real-llm-interactions.e2e.test.ts
@@ -151,8 +151,9 @@ describe("Real LLM Interactions E2E", () => {
     expect(span!.name).toBe("streaming-generation");
     expect(span!.type).toBe("llm");
     expectSpanAttribute(span!, "test.scenario", "streaming");
-    // ClickHouse stores all span attributes as strings
-    expectSpanAttribute(span!, "langwatch.gen_ai.streaming", "true");
+    // ClickHouse stores span attributes JSON-encoded in a Map(String, String);
+    // the read path decodes them, so a boolean arrives back as a boolean.
+    expectSpanAttribute(span!, "langwatch.gen_ai.streaming", true);
     expect(span!.input).toBeTruthy();
     expect(span!.output).toBeTruthy();
   }, E2E_CONFIG.timeout);


### PR DESCRIPTION
Main is red, and so is the open release PR (#5212). This fixes it.

## What broke

The `helm` job in `go-services.yaml` proved "the gateway subchart rendered" by grepping the rendered umbrella for `app.kubernetes.io/name: gateway`. That string is not evidence of the subchart. Sibling charts legitimately **select** that label, and langyagent's NetworkPolicy carries an egress rule to the gateway:

```yaml
# AI gateway — OpenCode LLM traffic (OPENAI_BASE_URL).
- to:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: gateway
```

Before #6106 the agent was off by default, so that policy never rendered on a default install and the grep happened to mean what it claimed. Now that Langy ships enabled, it renders, and the opt-out assertion fails on a chart that suppressed the gateway perfectly correctly:

```
gateway.chartManaged=false should suppress the subchart
```

I confirmed the suppression itself is fine: with `gateway.chartManaged=false` the gateway subchart renders **zero** files. Only the assertion was wrong.

## The same hole pointed the other way

The positive assertion ("umbrella chart did NOT include the gateway subchart — dependency broken?") had the identical flaw in reverse: langyagent's egress rule supplies that label whether or not the gateway rendered, so it would have **passed on a genuinely broken dependency**. That one has been vacuous since #6106 merged, which is worse than the failure that made us look.

## The fix

Both assertions now grep the `# Source:` marker helm stamps on every rendered file, which is the actual question being asked:

```bash
grep -q "^# Source: langwatch/charts/gateway/" ...
```

Note the path is `charts/gateway/`, not `charts/langwatch-gateway/`: the dependency is aliased, and helm's Source marker uses the alias. I got that wrong on the first attempt and caught it by running both directions locally.

## Verified

Ran the whole `helm` job locally against latest main:

| Check | Result |
|---|---|
| gateway on: subchart files rendered | 6 |
| gateway off: subchart files rendered | 0 |
| `targetPort: 5563` under the umbrella | present |
| gateway chart lint | passes |
| netpol renders when enabled / absent by default | both correct |

## Also: release PRs are exempt from `deployment-impact-check`

Same class of problem, found while checking why #5212 was red on two checks instead of one. `deployment-impact-check` fires on `charts/**`, and a release PR always bumps chart versions, so it fires on every release. But release-please writes the PR description itself from the changelog, and it will never contain a `## Also: main's SDK e2e has been red since #4735

Third check failing on the release PR, and it is failing on main too, since `9b51945ce` ("fix(traces): deserialize stored span attributes on trace read paths"). Last green run on main was `7f103eb62`.

That commit made the trace read path run `deserializeAttributes`, which turns the JSON-encoded `"true"` ClickHouse holds back into a real boolean. That is the whole point of it: "params/timestamps stop leaking JSON-encoded strings". The SDK e2e test sets the attribute as a boolean:

```ts
"langwatch.gen_ai.streaming": true,
```

and then asserted it came back as the string, with a comment stating the old lossy behaviour as a fact:

```ts
// ClickHouse stores all span attributes as strings
expectSpanAttribute(span!, "langwatch.gen_ai.streaming", "true");
```

So the test was pinning the bug that got fixed. It now expects the boolean. One occurrence in the suite, no other assertion depends on the stringified form.

Note on the PR type. This repo squash-merges with the PR title as the commit subject, so the title is what release-please reads. `fix(ci):` on a squash that touches `typescript-sdk/**` would open a spurious SDK patch release for a test-only change, hence `ci:`, which bumps nothing. The root `langwatch` component excludes both `.github` and `typescript-sdk`, so this merge does not alter #5212's contents either.

## Deployment Impact` heading. There is no author to add one and no edit that survives the next force-push.

So the job now skips PRs that are release-please's, matched by head branch and restricted to this repository:

```yaml
if: |
  !(github.event.pull_request.head.repo.full_name == github.repository &&
    startsWith(github.head_ref, 'release-please--'))
```

The same-repo half matters: a fork can name its branch anything, so the branch prefix on its own would let any PR opt out of the gate by claiming it. Same guard as `release-please-chart-lock-sync.yml` already uses, written the same way. Caught by CodeRabbit.

This is not a hole in the gate. Everything a release carries already went through this check on the PR that introduced it; the release PR is a version bump plus a changelog. Skipping at the job level rather than the trigger keeps the check reporting (a job skipped by a conditional counts as passing), which matters for the plan to make this a required check on main.

It is a job-level condition, so it takes effect once this merges and release-please next syncs its branch off main.

## Deployment Impact

No operator impact. This changes CI and one test assertion only: no chart template, value, default, env var or rendered manifest changes, so a `helm install` with no overrides produces byte-identical output before and after. No BYOC dataplane impact. It unblocks main and the pending `langwatch@v3.6.0` release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated Helm umbrella chart rendering checks to confirm gateway inclusion/exclusion using Helm-rendered “Source” markers.
  - Updated the real LLM streaming e2e test to assert the streaming span attribute value as boolean `true` (not the string `"true"`).
- **Chores**
  - Adjusted the deployment-impact validation workflow to skip the `check` job for release-automation-generated PRs, while preserving existing PR body/section requirements in other cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
