### PR TITLE
fix(docs): make the agents footer link readable on desktop

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1299,8 +1299,8 @@
         "header": "For agents",
         "items": [
           {
-            "label": "Report an issue: npx langwatch report",
-            "href": "https://langwatch.ai/docs/support#reporting-issues-from-coding-agents"
+            "label": "For agents: report an issue",
+            "href": "https://langwatch.ai/docs/support"
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1299,7 +1299,7 @@
         "header": "For agents",
         "items": [
           {
-            "label": "For agents: report an issue",
+            "label": "For agents: report an issue using npx langwatch report",
             "href": "https://langwatch.ai/docs/support"
           }
         ]

--- a/docs/style.css
+++ b/docs/style.css
@@ -445,3 +445,15 @@ code {
 .dark .lw-accordion-action[data-copied] { background: rgba(5, 150, 105, 0.15); border-color: rgba(5, 150, 105, 0.4); }
 .dark .lw-accordion-chevron { color: #6b7280; }
 .dark .lw-slash-command { color: #fe9a00; }
+
+/* Footer link for agents.
+   The theme gives footer links `max-w-36` plus `truncate` from md up, which
+   clips any label longer than about 18 characters mid-word. The single link
+   sits alone in a column several hundred pixels wide, so let it use the room
+   it already has. Keyed on the href, which docs.json owns; the pairing is
+   pinned by scripts/__tests__/bug-report-discovery.unit.test.ts. */
+footer a[href="https://langwatch.ai/docs/support"] {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+}

--- a/langwatch/scripts/__tests__/bug-report-discovery.unit.test.ts
+++ b/langwatch/scripts/__tests__/bug-report-discovery.unit.test.ts
@@ -60,16 +60,29 @@ describe("agent report discovery notices", () => {
         .find((item) => item.label.includes("report an issue"));
 
       expect(link, "the docs footer lost the agent report link").toBeDefined();
+      // The theme renders no group header for a single group, so the label
+      // carries the framing, and the command is the point of the note.
+      expect(link!.label).toMatch(/^For agents:/);
+      expect(link!.label).toContain("npx langwatch report");
       // The theme truncates footer labels at `max-w-36` (144px) from md up;
-      // style.css lifts that for this href, and the column it lives in is
-      // ~500px wide at 1440px, so the label has to stay well inside that.
-      expect(link!.label.length).toBeLessThanOrEqual(40);
+      // style.css lifts that for this href, leaving the ~500px column as the
+      // real budget. The current label measures 361px, so cap the length with
+      // room to spare rather than letting it grow into a wrap on desktop.
+      expect(link!.label.length).toBeLessThanOrEqual(60);
       // Mintlify strips the fragment from footer hrefs, so a `#section` deep
       // link here silently lands on the page top. Keep the plain page URL.
       expect(link!.href).not.toContain("#");
-      expect(read("docs/style.css")).toContain(
-        `footer a[href="${link!.href}"]`,
-      );
+
+      // The override has to still DO something: a surviving selector with the
+      // declarations removed would silently restore the clipping.
+      const escapedHref = link!.href.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const rule = new RegExp(
+        `footer a\\[href="${escapedHref}"\\]\\s*\\{([^}]*)\\}`,
+      ).exec(read("docs/style.css"));
+      expect(rule, "style.css lost the footer link override").not.toBeNull();
+      expect(rule![1]).toContain("max-width: none");
+      expect(rule![1]).toContain("overflow: visible");
+      expect(rule![1]).toContain("text-overflow: clip");
     });
   });
 

--- a/langwatch/scripts/__tests__/bug-report-discovery.unit.test.ts
+++ b/langwatch/scripts/__tests__/bug-report-discovery.unit.test.ts
@@ -49,6 +49,30 @@ describe("agent report discovery notices", () => {
     });
   });
 
+  describe("given the docs footer", () => {
+    /** @scenario "The docs footer note for agents reads in full" */
+    it("keeps the label short enough and un-clipped by the theme", () => {
+      const config = JSON.parse(read("docs/docs.json")) as {
+        footer: { links: { items: { label: string; href: string }[] }[] };
+      };
+      const link = config.footer.links
+        .flatMap((group) => group.items)
+        .find((item) => item.label.includes("report an issue"));
+
+      expect(link, "the docs footer lost the agent report link").toBeDefined();
+      // The theme truncates footer labels at `max-w-36` (144px) from md up;
+      // style.css lifts that for this href, and the column it lives in is
+      // ~500px wide at 1440px, so the label has to stay well inside that.
+      expect(link!.label.length).toBeLessThanOrEqual(40);
+      // Mintlify strips the fragment from footer hrefs, so a `#section` deep
+      // link here silently lands on the page top. Keep the plain page URL.
+      expect(link!.href).not.toContain("#");
+      expect(read("docs/style.css")).toContain(
+        `footer a[href="${link!.href}"]`,
+      );
+    });
+  });
+
   describe("given the support documentation", () => {
     /** @scenario "The docs have a page documenting the report command" */
     it("documents the report modes and the redaction guarantees", () => {

--- a/specs/support/agent-report-discovery.feature
+++ b/specs/support/agent-report-discovery.feature
@@ -23,6 +23,12 @@ Feature: Agent Report Discovery Across Access Points
     Then a small "For agents" note says issues found while following the page can be reported with "npx langwatch report"
 
   @unit
+  Scenario: The docs footer note for agents reads in full
+    When a reader reaches the footer of a docs page on a desktop screen
+    Then the note for agents reads in full instead of being clipped mid-word
+    And following it lands on the support documentation
+
+  @unit
   Scenario: The docs have a page documenting the report command
     When a reader opens the support documentation
     Then it documents how agents and users report issues, the two report modes, and the redaction guarantees


### PR DESCRIPTION
Follow-up to #6101. The "for agents" note in the docs footer rendered badly on desktop: the label was clipped mid-word to `Report an issue: np...`.

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6193/docs-footer/before-desktop.png)

## What was actually broken

Driving the footer in a real browser turned up three separate defects from that one config block, not just the visible one:

1. **The label was clipped.** The theme gives every footer link `max-w-36` (144px) plus `truncate` from `md` up. The label needed 251px, so it was cut at 144px. Anything longer than about 18 characters gets clipped there.
2. **The deep link never worked.** Mintlify strips the fragment from footer hrefs, in both relative and absolute form, so `#reporting-issues-from-coding-agents` silently landed readers on the top of the support page. Confirmed against production, where the rendered href is a bare `/docs/support`.
3. **The "For agents" header never rendered.** The theme only renders group headers when there are two or more link groups. With a single group it switches to an inline centered row and drops the header, so the framing the note was supposed to carry was invisible.

## The fix

`style.css` lifts the width cap for this one link, keyed on the href, following the same targeted-override pattern already used there for the nav GitHub link. With the cap gone the label has room for both the framing the header cannot render and the command that is the point of the note: **For agents: report an issue using npx langwatch report**. The fragment is dropped, because it never survived.

A test pins the framing prefix, the command, the label length, the fragment-free href, and the CSS rule including the declarations that do the un-clipping, so neither a copy change nor an emptied rule can silently bring the clipping back. Verified by gutting the rule body and watching the test fail.

## Verified in a browser

Measured and screenshotted at 1024, 1280, 1440 and 1920: one line, 361px inside a 500px column, `scrollWidth == clientWidth` so nothing is clipped, no overflow past the column. Light and dark, plus mobile at 390px where the label wraps onto two lines in its grid cell. Clicking it lands on the support page with the "Reporting Issues from Coding Agents" section present.

Desktop, light and dark:

![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6193/docs-footer/after-desktop.png)

![after dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6193/docs-footer/after-desktop-dark.png)

Mobile:

![after mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6193/docs-footer/after-mobile.png)

`mintlify broken-links` passes, and the docs-ci generated-file check is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “For agents” footer support link label to “For agents: report an issue,” and adjusted the destination to remove the fragment.
* **User Experience / Styling**
  * Improved footer link styling to prevent label clipping and ensure the full note is readable.
* **Bug Fixes**
  * Added coverage to confirm the “For agents” footer note displays fully and that the link navigates to the correct support page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->