### PR TITLE
fix(charts): let the gateway find the control plane of its own install

### DIFF
--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -209,6 +209,42 @@ jobs:
             exit 1
           fi
 
+      - name: Assert the gateway follows the release name to the control plane
+        working-directory: charts/langwatch
+        run: |
+          # A fixed control-plane address resolves only on an install named the
+          # same as ours, and the failure is silent: every pod healthy, then
+          # every virtual-key request refused. Render under a release name that
+          # is deliberately NOT "langwatch" so a hardcoded default cannot pass.
+          helm template lw . --set autogen.enabled=true --dry-run > /tmp/umbrella-lw.yaml
+          if ! grep -q 'LW_GATEWAY_BASE_URL: "http://lw-app:5560"' /tmp/umbrella-lw.yaml; then
+            echo "gateway control-plane URL does not follow the release name:"
+            grep "LW_GATEWAY_BASE_URL" /tmp/umbrella-lw.yaml || echo "  (not rendered at all)"
+            exit 1
+          fi
+
+          # An address the operator set is theirs, not a starting point.
+          helm template lw . --set autogen.enabled=true \
+            --set gateway.controlPlane.baseUrl=http://elsewhere.internal:9000 --dry-run \
+            > /tmp/umbrella-cp-override.yaml
+          if ! grep -q 'LW_GATEWAY_BASE_URL: "http://elsewhere.internal:9000"' /tmp/umbrella-cp-override.yaml; then
+            echo "an explicit gateway.controlPlane.baseUrl was overridden by the derived one"
+            exit 1
+          fi
+
+          # The derivation can only assume the default app port, so an app moved
+          # off it has to be refused rather than silently dialled.
+          if helm template lw . --set autogen.enabled=true --set app.service.port=8080 --dry-run \
+            > /tmp/umbrella-cp-port.yaml 2>&1; then
+            echo "a non-default app.service.port with no gateway.controlPlane.baseUrl should fail to render"
+            exit 1
+          fi
+          if ! grep -q "gateway.controlPlane.baseUrl" /tmp/umbrella-cp-port.yaml; then
+            echo "the refusal does not name the value that fixes it:"
+            cat /tmp/umbrella-cp-port.yaml
+            exit 1
+          fi
+
       - name: helm template (umbrella gateway disabled)
         working-directory: charts/langwatch
         run: |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -68,7 +68,7 @@ self-hosting. The values you most often override:
 | Path                          | Purpose                                                              |
 |-------------------------------|----------------------------------------------------------------------|
 | `image.tag`                   | Image tag override (defaults to `Chart.AppVersion`)                  |
-| `controlPlane.baseUrl`        | URL of your LangWatch app — e.g. `http://langwatch-app:5560`         |
+| `controlPlane.baseUrl`        | URL of your LangWatch app. Empty resolves to `<release>-app:5560`     |
 | `secrets.existingSecretName`  | Name of the Secret created above (default `gateway-runtime-secrets`) |
 | `ingress.host`                | Customer-facing hostname for the gateway                             |
 | `ingress.tls.secretName`      | TLS Secret managed by cert-manager (or BYO)                          |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -12,7 +12,13 @@ data:
   # them avoids misleading operators into thinking they're tuning behavior.
   SERVER_ADDR: ":5563"
   LOG_LEVEL: {{ .Values.logging.level | quote }}
-  LW_GATEWAY_BASE_URL: {{ .Values.controlPlane.baseUrl | quote }}
+  {{/* The route back to the control plane. Derived from the release name,
+       because that is what the cluster names the app Service after: a fixed
+       address resolves only on an install called the same as ours, and the
+       breakage is silent and late — every pod healthy, every probe green,
+       and nothing wrong until a request arrives carrying a virtual key that
+       then cannot be resolved. */}}
+  LW_GATEWAY_BASE_URL: {{ .Values.controlPlane.baseUrl | default (printf "http://%s-app:5560" .Release.Name) | quote }}
   {{- if .Values.otel.endpoint }}
   # Official OpenTelemetry name, plus the deprecated LangWatch-only name so
   # older gateway images keep reading their endpoint during upgrades. The

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -67,11 +67,18 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 
-# Control-plane connection (LangWatch app). Port 5560 matches the
-# langwatch Helm chart's main-app Service (consistent with the local-
-# dev port: app=5560, nlp=5561, langevals=5562, gateway=5563).
+# Control-plane connection (LangWatch app). Left empty, this resolves to the
+# app Service of the install the gateway is part of, `<release>-app:5560` —
+# the cluster names that Service after the release, so a fixed address would
+# only resolve on an install that happens to share ours. Port 5560 is the
+# langwatch chart's main-app Service (consistent with the local-dev port:
+# app=5560, nlp=5561, langevals=5562, gateway=5563).
+#
+# Set it when the control plane is somewhere the derivation cannot reach: a
+# gateway installed on its own rather than as part of the umbrella chart, an
+# app served on another port, or a split topology where the two live apart.
 controlPlane:
-  baseUrl: http://langwatch-app:5560
+  baseUrl: ""
   requestTimeout: 2s
   longPollTimeout: 25s
 

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -432,6 +432,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if ne $gwSecretName $appSecretName }}
     {{- $errors = append $errors (printf "gateway.secrets.existingSecretName (%q) must equal the app Secret name (%q). this release collapsed gateway-auth into the app Secret so both langwatch-app and the gateway pod mount the same Secret. Either drop the secrets.existingSecret / autogen.secretNames.app override to use the langwatch-app-secrets default, or set gateway.secrets.existingSecretName to %q so both pods agree." $gwSecretName $appSecretName $appSecretName) }}
   {{- end }}
+
+  {{/* The gateway derives its route to the control plane as
+       `<release>-app:5560` when nothing is set. The release half always
+       matches, since the app Service is named after it. The port half is a
+       constant the subchart cannot see past, so an app moved to another port
+       would leave the gateway dialling a closed one — a install that comes up
+       entirely healthy and then refuses every request that carries a virtual
+       key. Stop instead, and name the value that fixes it. */}}
+  {{- $gwBaseUrl := (($gw.controlPlane) | default dict).baseUrl | default "" }}
+  {{- $appPort := ((.Values.app.service) | default dict).port | default 5560 }}
+  {{- if and (not $gwBaseUrl) (ne (int $appPort) 5560) }}
+    {{- $errors = append $errors (printf "app.service.port is %v, but the gateway works out where the control plane is on its own and can only assume the default port 5560. It would dial http://%s-app:5560 and get nothing, and the install would come up healthy while refusing every request that carries a virtual key. Set gateway.controlPlane.baseUrl to http://%s-app:%v." $appPort .Release.Name .Release.Name $appPort) }}
+  {{- end }}
 {{- end }}
 
 {{/* Validate Langy agent secret wiring.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1603,9 +1603,9 @@ gateway:
   # PDB, SecurityContext) live in charts/gateway/values.yaml. Common
   # umbrella-level overrides below; everything else inherits.
 
-  ## @param gateway.controlPlane.baseUrl [string, default: http://langwatch-app:5560] URL the gateway uses to reach langwatch-app. Defaults assume release name `langwatch`.
+  ## @param gateway.controlPlane.baseUrl [string, default: ""] URL the gateway uses to reach the app. Empty resolves to this install's own app Service, `<release>-app:5560`. Set it for a control plane outside this install, or an app served on another port.
   controlPlane:
-    baseUrl: http://langwatch-app:5560
+    baseUrl: ""
 
   ## @param gateway.secrets.existingSecretName [string, default: langwatch-app-secrets] Name of the Secret the gateway pod mounts for LW_GATEWAY_INTERNAL_SECRET + LW_GATEWAY_JWT_SECRET. this release collapsed gateway-auth into the umbrella's app Secret so both langwatch-app and the gateway pod mount the SAME Secret. Default matches the autogen app-secret name when release name is `langwatch`. If you override the release name OR set `autogen.secretNames.app` / `secrets.existingSecret`, set this to the same Secret name so the gateway subchart bridges to it.
   secrets:

--- a/docs/ai-gateway/self-hosting/post-install-checklist.mdx
+++ b/docs/ai-gateway/self-hosting/post-install-checklist.mdx
@@ -74,10 +74,11 @@ kubectl -n langwatch logs -l app.kubernetes.io/name=langwatch-gateway --tail 50
 ```
 
 If the gateway can't reach the control plane, it logs
-`auth_upstream_unavailable` and returns 503 for every VK call. The
-fix is almost always `gateway.controlPlane.baseUrl`, defaults to
-`http://langwatch-app:5560` on the assumption your release name is
-`langwatch`. Adjust on a different release name or split-domain.
+`auth_upstream_unavailable` and returns 503 for every VK call. Left
+unset, `gateway.controlPlane.baseUrl` resolves to this install's own
+app Service, `<release>-app:5560`, so a release name of your choosing
+needs no adjustment. Set it for a split-domain deployment, or when the
+control plane lives outside this install.
 
 ## 5. Expose the gateway and set its public URL
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11351,10 +11351,11 @@ kubectl -n langwatch logs -l app.kubernetes.io/name=langwatch-gateway --tail 50
 ```
 
 If the gateway can't reach the control plane, it logs
-`auth_upstream_unavailable` and returns 503 for every VK call. The
-fix is almost always `gateway.controlPlane.baseUrl`, defaults to
-`http://langwatch-app:5560` on the assumption your release name is
-`langwatch`. Adjust on a different release name or split-domain.
+`auth_upstream_unavailable` and returns 503 for every VK call. Left
+unset, `gateway.controlPlane.baseUrl` resolves to this install's own
+app Service, `<release>-app:5560`, so a release name of your choosing
+needs no adjustment. Set it for a split-domain deployment, or when the
+control plane lives outside this install.
 
 ## 5. Expose the gateway and set its public URL
 

--- a/specs/ai-gateway/self-hosting/gateway-finds-its-control-plane.feature
+++ b/specs/ai-gateway/self-hosting/gateway-finds-its-control-plane.feature
@@ -1,0 +1,43 @@
+Feature: The gateway finds its control plane whatever the install is called
+  As someone self-hosting LangWatch,
+  I want the AI Gateway to work whatever I name my install,
+  so that picking a name is not a decision that quietly breaks the product.
+
+  # Cross-references:
+  #   specs/ai-gateway/self-hosting/personal-keys-deployment.feature — the
+  #   rest of the self-hosted gateway path.
+  #
+  # Context. Every address the chart hands one component for reaching another
+  # is derived from the install's own name, because that is what the cluster
+  # names the services after. The gateway's route back to the control plane
+  # was the one exception: it carried a fixed address that only resolved on
+  # installs that happened to be named the same as ours.
+  #
+  # The failure it produced is silent and late. Every pod starts, every probe
+  # is green, and nothing goes wrong until someone actually sends traffic:
+  # the key cannot be resolved, the request is refused, and no usage is
+  # recorded. Nothing in the install says why, and the operator's only clue
+  # is that it works in the documentation and not on their cluster.
+
+  Scenario: An install named something else still has a working gateway
+    Given an operator installs LangWatch under a name of their own choosing
+    When the gateway needs to reach the control plane
+    Then it reaches the control plane of that same install
+    And a request presented with a virtual key is served
+
+  Scenario: An operator pointing the gateway elsewhere keeps that address
+    Given an operator runs the gateway against a control plane outside this install
+    When they tell the chart where that control plane is
+    Then the gateway uses the address they gave
+    And nothing the chart works out for itself overrides it
+
+  # The derived address can only be right about the port if the port is the
+  # one the chart serves the control plane on. Rather than derive an address
+  # that resolves to a closed door, the install stops and says which value
+  # the operator has to fill in.
+  Scenario: An install that moves the control plane off its usual port is told to say where it went
+    Given an operator serves the control plane on a port of their own choosing
+    And they have not told the gateway where the control plane is
+    When they install
+    Then the install refuses to render
+    And the refusal names the value they need to set


### PR DESCRIPTION
Found while setting up the gateway half of the 3.6.0 dogfood. The AI Gateway only reaches the control plane if you name your Helm release `langwatch`.

## What breaks

`charts/gateway/values.yaml` pinned the address:

```yaml
controlPlane:
  baseUrl: http://langwatch-app:5560
```

and the subchart's ConfigMap used it verbatim. Rendered under two release names off `main`:

| `helm install <name> langwatch/langwatch` | app Service | `LW_GATEWAY_BASE_URL` | |
|---|---|---|---|
| `langwatch` | `langwatch-app` | `http://langwatch-app:5560` | correct |
| `lw` | `lw-app` | `http://langwatch-app:5560` | points at nothing |

That env var is what sets `cfg.ControlPlane.BaseURL` (`services/aigateway/config.go:202`). The gateway calls `/api/internal/gateway/resolve-key`, `/config`, `/changes` and `/guardrail-check` against it synchronously, so on a differently-named install no virtual key resolves and no usage is reported.

The failure mode is the bad kind: nothing crashes. Every pod starts, every probe is green, the install looks finished. It only shows up when real traffic arrives, as 503s and `auth_upstream_unavailable` in the gateway log, and nothing in the install points at the cause. Our own docs all say `helm install langwatch langwatch/langwatch`, which is exactly why this survived: the documented path is the one name that works.

Every other cross-service address in this chart family already derives from the release name. This was the one that did not.

## The fix

The subchart derives it, and an address you set is still yours:

```yaml
LW_GATEWAY_BASE_URL: {{ .Values.controlPlane.baseUrl | default (printf "http://%s-app:5560" .Release.Name) | quote }}
```

Same shape the langyagent subchart already uses for its mirror endpoint, so the two read alike.

## The port half

The release name is always right, because the cluster names the Service after it. The port is a constant the subchart cannot see past: it has no visibility into the parent's `app.service.port`. Deriving an address that resolves to a closed port would rebuild the same silent failure one layer down, so an app moved off 5560 with no `baseUrl` set is refused at render time instead:

```
app.service.port is 8080, but the gateway works out where the control plane is
on its own and can only assume the default port 5560. It would dial
http://lw-app:5560 and get nothing, and the install would come up healthy while
refusing every request that carries a virtual key. Set gateway.controlPlane.baseUrl
to http://lw-app:8080.
```

## Verified

Rendered locally against every branch of the behaviour:

| Case | Result |
|---|---|
| release `langwatch` | `http://langwatch-app:5560` (unchanged) |
| release `lw` | `http://lw-app:5560` |
| explicit `baseUrl` | `http://elsewhere.internal:9000`, derivation does not override |
| `app.service.port=8080`, no `baseUrl` | render refused, message names the value |
| `app.service.port=8080` + explicit `baseUrl` | renders, `http://lw-app:8080` |
| gateway subchart standalone | `http://mygw-app:5560` |
| `helm lint` both charts | passes |

## Regression guard

The existing CI assertions all render under the release name `langwatch`, which is precisely the one name that cannot catch this. The new step in `go-services.yaml` renders under `lw` and asserts all three behaviours: derivation follows the release name, an explicit value wins, and a moved app port is refused with a message that names the fix. Ran the whole block locally, four for four.

## Spec

`specs/ai-gateway/self-hosting/gateway-finds-its-control-plane.feature`, alongside the existing `personal-keys-deployment.feature`.

## Deployment Impact

**Env vars:** none added or removed. `LW_GATEWAY_BASE_URL` keeps its name and meaning; only the value the chart computes for it changes.

**Helm values:** `gateway.controlPlane.baseUrl` default changes from `http://langwatch-app:5560` to `""`, at both the umbrella and subchart surface. Empty means "derive from the release name", which is why the default is empty rather than a literal.

**Default `helm install` with no overrides:** byte-identical for the documented release name `langwatch`, since the derivation produces exactly the address that was hardcoded. Changes only for installs named something else, where it goes from broken to working.

**Upgrades:** an existing install that set `gateway.controlPlane.baseUrl` explicitly keeps its value. An install that relied on the old default and is named `langwatch` sees no change. An install named something else and running with a broken gateway starts working on upgrade.

**New render-time refusal:** an install with `app.service.port` set to something other than 5560 **and** no `gateway.controlPlane.baseUrl` will now fail to render rather than deploy a gateway that cannot reach the app. That combination was already broken at runtime, so this converts a silent runtime failure into a loud install-time one, with the fix in the message.

**BYOC dataplane:** no impact. The dataplane does not run the gateway subchart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway deployments now automatically discover the control plane using the installation’s release name.
  * Explicit control-plane URLs remain supported for external or split-domain deployments.
  * Deployments using a non-default application port now provide a clear configuration error when the control-plane URL is not set.

* **Documentation**
  * Updated configuration references and troubleshooting guidance to explain the new default behavior and override options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->