### PR TITLE
ci(sdk): route python and typescript SDK CI OpenAI traffic through the AI gateway with virtual keys

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -4,7 +4,9 @@
 # base using dorny/paths-filter. On every other event (push, schedule,
 # workflow_dispatch, merge_group) we force every declared filter to
 # `true` so the real jobs always run — required aggregator checks need
-# a concrete result.
+# a concrete result. Exception: with `push-strategy: diff` a push is
+# diffed against its before-commit instead of force-run, for workflows
+# whose real jobs spend money on live LLM calls.
 #
 # The caller MUST check out the repo first so this composite action is
 # accessible — dorny/paths-filter then reads the diff against the PR
@@ -41,6 +43,15 @@ inputs:
   filters:
     description: YAML filter block for dorny/paths-filter (must define `relevant` + `feature-parity` filters).
     required: true
+  push-strategy:
+    description: >-
+      How push events are treated. 'force' (default) marks every filter
+      true so the real jobs always run post-merge. 'diff' diffs the push
+      against its before-commit with dorny/paths-filter instead, so
+      workflows whose real jobs spend money (live LLM calls) only run
+      them when the push actually touched relevant paths.
+    required: false
+    default: force
 outputs:
   relevant:
     description: "'true' if relevant paths changed, or if event is not a PR."
@@ -56,14 +67,20 @@ runs:
   using: composite
   steps:
     - name: Detect relevant changes
-      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+      if: >-
+        github.event_name == 'pull_request'
+        || github.event_name == 'pull_request_target'
+        || (github.event_name == 'push' && inputs.push-strategy == 'diff')
       id: filter
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: ${{ inputs.filters }}
 
     - name: Force every filter true on non-PR events
-      if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+      if: >-
+        github.event_name != 'pull_request'
+        && github.event_name != 'pull_request_target'
+        && (github.event_name != 'push' || inputs.push-strategy != 'diff')
       id: force
       shell: bash
       run: |

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -54,13 +54,13 @@ inputs:
     default: force
 outputs:
   relevant:
-    description: "'true' if relevant paths changed, or if event is not a PR."
+    description: "'true' if relevant paths changed, or if the event is neither a PR nor a diff-mode push."
     value: ${{ steps.filter.outputs.relevant || steps.force.outputs.relevant }}
   feature-parity:
-    description: "'true' if feature-parity-relevant paths changed, or if event is not a PR."
+    description: "'true' if feature-parity-relevant paths changed, or if the event is neither a PR nor a diff-mode push."
     value: ${{ steps.filter.outputs.feature-parity || steps.force.outputs.feature-parity }}
   lambda-image:
-    description: "'true' if Lambda-image-relevant paths changed, or if event is not a PR. Used by langwatch-nlp-ci's LWA-readiness job — covers Go-binary source + Dockerfile + entrypoint, which aren't matched by the Python-only `relevant` filter."
+    description: "'true' if Lambda-image-relevant paths changed, or if the event is neither a PR nor a diff-mode push. Used by langwatch-nlp-ci's LWA-readiness job — covers Go-binary source + Dockerfile + entrypoint, which aren't matched by the Python-only `relevant` filter."
     value: ${{ steps.filter.outputs.lambda-image || steps.force.outputs.lambda-image }}
 
 runs:

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: ./.github/actions/detect-changes
         id: detect
         with:
+          # push-strategy diff: the test job spends real LLM money, so it
+          # must not run on pushes that touched nothing under langevals/.
+          push-strategy: diff
           filters: |
             relevant:
               - 'langevals/**'

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -27,12 +27,17 @@ jobs:
       - uses: ./.github/actions/detect-changes
         id: detect
         with:
+          # push-strategy diff + no release-please-manifest entry: the
+          # integration step spends real LLM money (Anthropic), so it must
+          # not run on pushes or release PRs that touched nothing under
+          # mcp-server/. A release PR still matches via
+          # mcp-server/CHANGELOG.md.
+          push-strategy: diff
           filters: |
             relevant:
               - 'mcp-server/**'
               - '.github/workflows/mcp-javascript-ci.yml'
               - '.github/actions/setup-pnpm-node/**'
-              - '.github/.release-please-manifest.json'
 
   typecheck:
     needs: changes

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -27,11 +27,15 @@ jobs:
       - uses: ./.github/actions/detect-changes
         id: detect
         with:
+          # push-strategy diff + no release-please-manifest entry: the test
+          # job spends real LLM money, so it must not run on pushes or
+          # release PRs that touched nothing under sdk-go/. An SDK release
+          # PR still matches via sdk-go/CHANGELOG.md.
+          push-strategy: diff
           filters: |
             relevant:
               - 'sdk-go/**'
               - '.github/workflows/sdk-go-ci.yml'
-              - '.github/.release-please-manifest.json'
 
   test:
     needs: changes

--- a/.github/workflows/sdk-javascript-cd.yml
+++ b/.github/workflows/sdk-javascript-cd.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Run tests
         working-directory: ./typescript-sdk
         env:
-          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_OPENAI_API_KEY }}
+          # OpenAI traffic rides the LangWatch AI Gateway (virtual key +
+          # gateway base URL), same as sdk-javascript-ci.yml.
+          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_GATEWAY_VIRTUAL_KEY }}
+          OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+          OPENAI_API_BASE: https://gateway.langwatch.ai/v1
           LANGWATCH_ENDPOINT: ${{ secrets.TYPESCRIPT_SDK_LANGWATCH_ENDPOINT }}
           LANGWATCH_API_KEY: ${{ secrets.TYPESCRIPT_SDK_LANGWATCH_API_KEY }}
         run: pnpm test

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -30,11 +30,16 @@ jobs:
       - uses: ./.github/actions/detect-changes
         id: detect
         with:
+          # push-strategy diff + no release-please-manifest entry: the test
+          # and e2e steps spend real LLM money, so they must not run on
+          # pushes or release PRs that touched nothing under
+          # typescript-sdk/. An SDK release PR still matches via
+          # typescript-sdk/CHANGELOG.md.
+          push-strategy: diff
           filters: |
             relevant:
               - 'typescript-sdk/**'
               - '.github/workflows/sdk-javascript-ci.yml'
-              - '.github/.release-please-manifest.json'
 
   ci:
     needs: changes

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -78,7 +78,12 @@ jobs:
            || github.event_name == 'pull_request_target')
         env:
           LANGWATCH_ENDPOINT: ${{ secrets.TYPESCRIPT_SDK_LANGWATCH_ENDPOINT }}
-          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_OPENAI_API_KEY }}
+          # OpenAI traffic rides the LangWatch AI Gateway: the key is a
+          # LangWatch virtual key and both base-URL spellings point the
+          # openai and langchain client families at it.
+          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_GATEWAY_VIRTUAL_KEY }}
+          OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+          OPENAI_API_BASE: https://gateway.langwatch.ai/v1
           LANGWATCH_API_KEY: ${{ secrets.TYPESCRIPT_SDK_LANGWATCH_API_KEY }}
         run: pnpm test
 
@@ -254,7 +259,12 @@ jobs:
            || github.event_name == 'pull_request_target')
         env:
           LANGWATCH_API_KEY: sk-lw-1234567890
-          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_OPENAI_API_KEY }}
+          # OpenAI traffic rides the LangWatch AI Gateway (virtual key +
+          # gateway base URL). Step-scoped on purpose: the LangWatch app
+          # booted above must not inherit a gateway base URL.
+          OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_GATEWAY_VIRTUAL_KEY }}
+          OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+          OPENAI_API_BASE: https://gateway.langwatch.ai/v1
           E2E_TIMEOUT: 120000
           E2E_POLL_TIMEOUT: 120000
         run: pnpm test:e2e

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -32,12 +32,16 @@ jobs:
       - uses: ./.github/actions/detect-changes
         id: detect
         with:
+          # push-strategy diff + no release-please-manifest entry: the e2e
+          # step spends real LLM money, so it must not run on pushes or
+          # release PRs that touched nothing under python-sdk/. An SDK
+          # release PR still matches via python-sdk/CHANGELOG.md.
+          push-strategy: diff
           filters: |
             relevant:
               - 'python-sdk/**'
               - '!python-sdk/src/langwatch/__version__.py'
               - '.github/workflows/sdk-python-ci.yml'
-              - '.github/.release-please-manifest.json'
 
   test:
     needs: changes

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -85,10 +85,14 @@ jobs:
           TEST_EVALUATION_SLUG: "test-evaluation"
           AZURE_OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_ENDPOINT: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_ENDPOINT }}
-          GEMINI_API_KEY: ${{ secrets.PYTHON_SDK_GEMINI_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.PYTHON_SDK_GROQ_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_OPENAI_API_KEY }}
-          CEREBRAS_API_KEY: ${{ secrets.PYTHON_SDK_CEREBRAS_API_KEY }}
+          # OpenAI traffic rides the LangWatch AI Gateway: the key is a
+          # LangWatch virtual key, and both base-URL spellings cover every
+          # client family in the examples (openai SDK and haystack read
+          # OPENAI_BASE_URL; litellm, dspy and langchain read
+          # OPENAI_API_BASE). Azure keeps its own endpoint above.
+          OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_GATEWAY_VIRTUAL_KEY }}
+          OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+          OPENAI_API_BASE: https://gateway.langwatch.ai/v1
         run: |
           make test-e2e
           make cli-examples

--- a/python-sdk/src/langwatch/openai.py
+++ b/python-sdk/src/langwatch/openai.py
@@ -43,6 +43,7 @@ from openai import (
 
 from openai.types import Completion
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
 
 
 class OpenAITracer:
@@ -387,12 +388,16 @@ class OpenAICompletionTracer:
         span.end()
 
 
-def _merge_tool_call_deltas(message: ChatMessage, tool_calls) -> None:
+def _merge_tool_call_deltas(
+    message: ChatMessage, tool_calls: List[ChoiceDeltaToolCall]
+) -> None:
     """Merge streamed tool-call deltas into a message by tool index.
 
     The list is grown to cover any index the stream introduces (parallel
     tool calls open index 1+ mid-stream), and each delta's id, type, name
-    and argument fragment are merged into its indexed entry.
+    and argument fragment are merged into its indexed entry. Placeholders
+    for indices the stream never fills are dropped by
+    _prune_blank_tool_calls before the span is persisted.
     """
     existing = message.get("tool_calls")
     if not existing:
@@ -416,6 +421,30 @@ def _merge_tool_call_deltas(message: ChatMessage, tool_calls) -> None:
             entry["function"]["arguments"] = (
                 entry["function"].get("arguments", "") + arguments
             )
+
+
+def _prune_blank_tool_calls(message: ChatMessage) -> None:
+    """Drop placeholder tool-call entries the stream never filled.
+
+    _merge_tool_call_deltas pads the list up to the highest index seen, so
+    a stream that skips an index leaves a fully blank entry behind; persist
+    only entries that carry any data.
+    """
+    tool_calls = message.get("tool_calls")
+    if not tool_calls:
+        return
+    kept = [
+        entry
+        for entry in tool_calls
+        if entry.get("id")
+        or entry.get("type")
+        or entry.get("function", {}).get("name")
+        or entry.get("function", {}).get("arguments")
+    ]
+    if kept:
+        message["tool_calls"] = kept
+    else:
+        del message["tool_calls"]
 
 
 class OpenAIChatCompletionTracer:
@@ -659,6 +688,9 @@ class OpenAIChatCompletionTracer:
                         chat_outputs[index][-1].get("content", "") or ""
                     ) + delta.content
 
+        for output in chat_outputs.values():
+            for message in output:
+                _prune_blank_tool_calls(message)
         OpenAIChatCompletionTracer.end_span(
             client=client,
             span=span,

--- a/python-sdk/src/langwatch/openai.py
+++ b/python-sdk/src/langwatch/openai.py
@@ -557,9 +557,14 @@ class OpenAIChatCompletionTracer:
             for choice in delta.choices:
                 index = choice.index
                 delta = choice.delta
-                if delta.role:
+                # Some OpenAI-compatible backends (the LangWatch AI Gateway
+                # among them) never send the role-carrying first delta that
+                # api.openai.com sends, so the first delta for a choice may
+                # already carry content or tool calls. Start the message on
+                # whichever delta arrives first.
+                if delta.role or index not in chat_outputs:
                     chat_message: ChatMessage = {
-                        "role": delta.role,  # type: ignore
+                        "role": delta.role or "assistant",  # type: ignore
                         "content": delta.content,
                     }
                     if delta.function_call:

--- a/python-sdk/src/langwatch/openai.py
+++ b/python-sdk/src/langwatch/openai.py
@@ -568,6 +568,52 @@ class OpenAIChatCompletionTracer:
                         last_item["content"] = (
                             last_item.get("content", "") or ""
                         ) + delta.content
+                    if delta.function_call:
+                        if "function_call" in last_item and last_item["function_call"]:
+                            current_arguments = last_item["function_call"].get(
+                                "arguments", ""
+                            )
+                            last_item["function_call"]["arguments"] = (
+                                current_arguments
+                                + (delta.function_call.arguments or "")
+                            )
+                            if delta.function_call.name:
+                                last_item["function_call"]["name"] = (
+                                    delta.function_call.name
+                                )
+                        else:
+                            last_item["function_call"] = {
+                                "name": delta.function_call.name or "",
+                                "arguments": delta.function_call.arguments or "",
+                            }
+                    if delta.tool_calls:
+                        if "tool_calls" in last_item and last_item["tool_calls"]:
+                            for tool in delta.tool_calls:
+                                last_item["tool_calls"][tool.index]["function"][
+                                    "arguments"
+                                ] = last_item["tool_calls"][tool.index][
+                                    "function"
+                                ].get(
+                                    "arguments", ""
+                                ) + (
+                                    safe_get(tool, "function", "arguments") or ""
+                                )
+                        else:
+                            last_item["tool_calls"] = [
+                                {
+                                    "id": tool.id or "",
+                                    "type": tool.type or "",
+                                    "function": {
+                                        "name": safe_get(tool, "function", "name")
+                                        or "",
+                                        "arguments": safe_get(
+                                            tool, "function", "arguments"
+                                        )
+                                        or "",
+                                    },
+                                }
+                                for tool in delta.tool_calls
+                            ]
                     synthesized_roles.discard(index)
                     continue
                 # Some OpenAI-compatible backends (the LangWatch AI Gateway

--- a/python-sdk/src/langwatch/openai.py
+++ b/python-sdk/src/langwatch/openai.py
@@ -387,6 +387,37 @@ class OpenAICompletionTracer:
         span.end()
 
 
+def _merge_tool_call_deltas(message: ChatMessage, tool_calls) -> None:
+    """Merge streamed tool-call deltas into a message by tool index.
+
+    The list is grown to cover any index the stream introduces (parallel
+    tool calls open index 1+ mid-stream), and each delta's id, type, name
+    and argument fragment are merged into its indexed entry.
+    """
+    existing = message.get("tool_calls")
+    if not existing:
+        existing = []
+        message["tool_calls"] = existing
+    for tool in tool_calls:
+        while len(existing) <= tool.index:
+            existing.append(
+                {"id": "", "type": "", "function": {"name": "", "arguments": ""}}
+            )
+        entry = existing[tool.index]
+        if tool.id:
+            entry["id"] = tool.id
+        if tool.type:
+            entry["type"] = tool.type
+        name = safe_get(tool, "function", "name")
+        if name:
+            entry["function"]["name"] = name
+        arguments = safe_get(tool, "function", "arguments")
+        if arguments:
+            entry["function"]["arguments"] = (
+                entry["function"].get("arguments", "") + arguments
+            )
+
+
 class OpenAIChatCompletionTracer:
     trace: ContextTrace
     tracked_traces: Set[ContextTrace] = set()
@@ -587,33 +618,7 @@ class OpenAIChatCompletionTracer:
                                 "arguments": delta.function_call.arguments or "",
                             }
                     if delta.tool_calls:
-                        if "tool_calls" in last_item and last_item["tool_calls"]:
-                            for tool in delta.tool_calls:
-                                last_item["tool_calls"][tool.index]["function"][
-                                    "arguments"
-                                ] = last_item["tool_calls"][tool.index][
-                                    "function"
-                                ].get(
-                                    "arguments", ""
-                                ) + (
-                                    safe_get(tool, "function", "arguments") or ""
-                                )
-                        else:
-                            last_item["tool_calls"] = [
-                                {
-                                    "id": tool.id or "",
-                                    "type": tool.type or "",
-                                    "function": {
-                                        "name": safe_get(tool, "function", "name")
-                                        or "",
-                                        "arguments": safe_get(
-                                            tool, "function", "arguments"
-                                        )
-                                        or "",
-                                    },
-                                }
-                                for tool in delta.tool_calls
-                            ]
+                        _merge_tool_call_deltas(last_item, delta.tool_calls)
                     synthesized_roles.discard(index)
                     continue
                 # Some OpenAI-compatible backends (the LangWatch AI Gateway
@@ -634,18 +639,7 @@ class OpenAIChatCompletionTracer:
                             "arguments": delta.function_call.arguments or "",
                         }
                     if delta.tool_calls:
-                        chat_message["tool_calls"] = [
-                            {
-                                "id": tool.id or "",
-                                "type": tool.type or "",
-                                "function": {
-                                    "name": safe_get(tool, "function", "name") or "",
-                                    "arguments": safe_get(tool, "function", "arguments")
-                                    or "",
-                                },
-                            }
-                            for tool in delta.tool_calls
-                        ]
+                        _merge_tool_call_deltas(chat_message, delta.tool_calls)
                     if index not in chat_outputs:
                         chat_outputs[index] = []
                     chat_outputs[index].append(chat_message)
@@ -659,20 +653,7 @@ class OpenAIChatCompletionTracer:
                             delta.function_call.arguments or ""
                         )
                 elif delta.tool_calls:
-                    last_item = chat_outputs[index][-1]
-                    if (
-                        "tool_calls" in last_item
-                        and last_item["tool_calls"]
-                        and len(last_item["tool_calls"]) > 0
-                    ):
-                        for tool in delta.tool_calls:
-                            last_item["tool_calls"][tool.index]["function"][
-                                "arguments"
-                            ] = last_item["tool_calls"][tool.index]["function"].get(
-                                "arguments", ""
-                            ) + (
-                                safe_get(tool, "function", "arguments") or ""
-                            )
+                    _merge_tool_call_deltas(chat_outputs[index][-1], delta.tool_calls)
                 elif delta.content:
                     chat_outputs[index][-1]["content"] = (
                         chat_outputs[index][-1].get("content", "") or ""

--- a/python-sdk/src/langwatch/openai.py
+++ b/python-sdk/src/langwatch/openai.py
@@ -550,6 +550,10 @@ class OpenAIChatCompletionTracer:
     ):
         # Accumulate deltas
         chat_outputs: Dict[int, List[ChatMessage]] = {}
+        # Choices whose current message was started without a role delta
+        # (role defaulted to "assistant"). A late role delta adopts that
+        # message instead of starting a second one.
+        synthesized_roles: Set[int] = set()
         usage = None
         for delta in deltas:
             if hasattr(delta, "usage") and delta.usage is not None:
@@ -557,12 +561,23 @@ class OpenAIChatCompletionTracer:
             for choice in delta.choices:
                 index = choice.index
                 delta = choice.delta
+                if delta.role and index in synthesized_roles:
+                    last_item = chat_outputs[index][-1]
+                    last_item["role"] = delta.role  # type: ignore
+                    if delta.content:
+                        last_item["content"] = (
+                            last_item.get("content", "") or ""
+                        ) + delta.content
+                    synthesized_roles.discard(index)
+                    continue
                 # Some OpenAI-compatible backends (the LangWatch AI Gateway
                 # among them) never send the role-carrying first delta that
                 # api.openai.com sends, so the first delta for a choice may
                 # already carry content or tool calls. Start the message on
                 # whichever delta arrives first.
                 if delta.role or index not in chat_outputs:
+                    if not delta.role:
+                        synthesized_roles.add(index)
                     chat_message: ChatMessage = {
                         "role": delta.role or "assistant",  # type: ignore
                         "content": delta.content,

--- a/python-sdk/tests/test_examples.py
+++ b/python-sdk/tests/test_examples.py
@@ -141,6 +141,17 @@ async def test_example(example_file: str):
         pytest.skip(
             "litellm_bot.py skipped — Cerebras API is unreliable (frequent rate limiting)"
         )
+    if example_file in (
+        "streamlit_openai_assistants_api_bot.py",
+        "opentelemetry/openinference_openai_assistants_api_bot.py",
+    ):
+        pytest.skip(
+            "Assistants API examples: CI routes OpenAI traffic through the"
+            " LangWatch gateway, which does not proxy /v1/assistants or"
+            " /v1/threads (the Assistants API is deprecated upstream). Both"
+            " examples fire Assistants calls at import or on_chat_start, so"
+            " they must be skipped before import."
+        )
     if (
         example_file == "langgraph_rag_bot_with_threads.py"
         or example_file == "langchain_rag_bot.py"

--- a/python-sdk/tests/test_openai_stream_deltas.py
+++ b/python-sdk/tests/test_openai_stream_deltas.py
@@ -132,3 +132,16 @@ def test_empty_first_delta_then_content():
     )
     assert outputs[0][0]["role"] == "assistant"
     assert outputs[0][0]["content"] == "Hi"
+
+
+def test_role_after_roleless_delta_stays_one_message():
+    outputs = accumulate(
+        [
+            chunk(content="Hello"),
+            chunk(role="assistant", content=" world"),
+            chunk(content="!"),
+        ]
+    )
+    assert len(outputs[0]) == 1
+    assert outputs[0][0]["role"] == "assistant"
+    assert outputs[0][0]["content"] == "Hello world!"

--- a/python-sdk/tests/test_openai_stream_deltas.py
+++ b/python-sdk/tests/test_openai_stream_deltas.py
@@ -147,6 +147,90 @@ def test_role_after_roleless_delta_stays_one_message():
     assert outputs[0][0]["content"] == "Hello world!"
 
 
+def test_late_role_delta_introducing_a_new_tool_index_grows_the_list():
+    outputs = accumulate(
+        [
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="call_0",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_weather", arguments='{"city":"Paris"}'
+                        ),
+                    )
+                ]
+            ),
+            chunk(
+                role="assistant",
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=1,
+                        id="call_1",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_time", arguments='{"tz":'
+                        ),
+                    )
+                ],
+            ),
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=1,
+                        function=ChoiceDeltaToolCallFunction(arguments='"CET"}'),
+                    )
+                ]
+            ),
+        ]
+    )
+    assert len(outputs[0]) == 1
+    tool_calls = outputs[0][0]["tool_calls"]
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["id"] == "call_0"
+    assert tool_calls[0]["function"]["arguments"] == '{"city":"Paris"}'
+    assert tool_calls[1]["id"] == "call_1"
+    assert tool_calls[1]["function"]["name"] == "get_time"
+    assert tool_calls[1]["function"]["arguments"] == '{"tz":"CET"}'
+
+
+def test_role_first_parallel_tool_calls_open_new_indexes_mid_stream():
+    outputs = accumulate(
+        [
+            chunk(
+                role="assistant",
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="call_0",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_weather", arguments='{"city":"Paris"}'
+                        ),
+                    )
+                ],
+            ),
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=1,
+                        id="call_1",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_time", arguments='{"tz":"CET"}'
+                        ),
+                    )
+                ]
+            ),
+        ]
+    )
+    tool_calls = outputs[0][0]["tool_calls"]
+    assert len(tool_calls) == 2
+    assert tool_calls[1]["function"]["name"] == "get_time"
+    assert tool_calls[1]["function"]["arguments"] == '{"tz":"CET"}'
+
+
 def test_late_role_delta_carrying_tool_calls_keeps_the_payload():
     outputs = accumulate(
         [

--- a/python-sdk/tests/test_openai_stream_deltas.py
+++ b/python-sdk/tests/test_openai_stream_deltas.py
@@ -231,6 +231,40 @@ def test_role_first_parallel_tool_calls_open_new_indexes_mid_stream():
     assert tool_calls[1]["function"]["arguments"] == '{"tz":"CET"}'
 
 
+def test_skipped_tool_index_placeholders_are_not_persisted():
+    outputs = accumulate(
+        [
+            chunk(
+                role="assistant",
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="call_0",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_weather", arguments="{}"
+                        ),
+                    )
+                ],
+            ),
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=2,
+                        id="call_2",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_time", arguments="{}"
+                        ),
+                    )
+                ]
+            ),
+        ]
+    )
+    tool_calls = outputs[0][0]["tool_calls"]
+    assert [t["id"] for t in tool_calls] == ["call_0", "call_2"]
+
+
 def test_late_role_delta_carrying_tool_calls_keeps_the_payload():
     outputs = accumulate(
         [

--- a/python-sdk/tests/test_openai_stream_deltas.py
+++ b/python-sdk/tests/test_openai_stream_deltas.py
@@ -1,0 +1,134 @@
+"""Delta accumulation for streamed chat completions.
+
+api.openai.com opens every stream with a role-carrying delta, but
+OpenAI-compatible backends (the LangWatch AI Gateway among them) can send
+the first delta already carrying content or tool calls. handle_deltas must
+accumulate both shapes identically instead of assuming the role delta
+always arrives first.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from openai.types.chat import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import (
+    Choice,
+    ChoiceDelta,
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
+)
+
+from langwatch.openai import OpenAIChatCompletionTracer
+from langwatch.domain import SpanTimestamps
+
+
+def chunk(
+    *,
+    role: Optional[str] = None,
+    content: Optional[str] = None,
+    tool_calls: Optional[List[ChoiceDeltaToolCall]] = None,
+    index: int = 0,
+) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        object="chat.completion.chunk",
+        created=1,
+        model="gpt-5-mini",
+        choices=[
+            Choice(
+                index=index,
+                delta=ChoiceDelta(role=role, content=content, tool_calls=tool_calls),  # type: ignore[arg-type]
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def accumulate(deltas: List[ChatCompletionChunk]) -> List[List[Dict[str, Any]]]:
+    captured: List[List[Dict[str, Any]]] = []
+
+    original_end_span = OpenAIChatCompletionTracer.end_span
+
+    def capture_end_span(client, span, outputs, metrics, timestamps, **kwargs):
+        captured.append([dict(o["value"][0]) for o in outputs])  # type: ignore[index]
+
+    OpenAIChatCompletionTracer.end_span = classmethod(  # type: ignore[assignment]
+        lambda cls, client, span, outputs, metrics, timestamps, **kwargs: capture_end_span(
+            client, span, outputs, metrics, timestamps, **kwargs
+        )
+    )
+    try:
+        OpenAIChatCompletionTracer.handle_deltas(
+            client=None,  # type: ignore[arg-type]
+            span=None,  # type: ignore[arg-type]
+            deltas=deltas,
+            timestamps=SpanTimestamps(started_at=0, finished_at=1),
+        )
+    finally:
+        OpenAIChatCompletionTracer.end_span = original_end_span  # type: ignore[assignment]
+
+    assert len(captured) == 1
+    return captured
+
+
+def test_role_first_stream_accumulates_content():
+    outputs = accumulate(
+        [
+            chunk(role="assistant", content=""),
+            chunk(content="Hello"),
+            chunk(content=" world"),
+        ]
+    )
+    assert outputs[0][0]["role"] == "assistant"
+    assert outputs[0][0]["content"] == "Hello world"
+
+
+def test_roleless_stream_accumulates_content():
+    outputs = accumulate(
+        [
+            chunk(content="Hello"),
+            chunk(content=" world"),
+        ]
+    )
+    assert outputs[0][0]["role"] == "assistant"
+    assert outputs[0][0]["content"] == "Hello world"
+
+
+def test_roleless_stream_accumulates_tool_calls():
+    outputs = accumulate(
+        [
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="call_1",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_weather", arguments='{"city":'
+                        ),
+                    )
+                ]
+            ),
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        function=ChoiceDeltaToolCallFunction(arguments='"Paris"}'),
+                    )
+                ]
+            ),
+        ]
+    )
+    tool_calls = outputs[0][0]["tool_calls"]
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{"city":"Paris"}'
+
+
+def test_empty_first_delta_then_content():
+    outputs = accumulate(
+        [
+            chunk(),
+            chunk(content="Hi"),
+        ]
+    )
+    assert outputs[0][0]["role"] == "assistant"
+    assert outputs[0][0]["content"] == "Hi"

--- a/python-sdk/tests/test_openai_stream_deltas.py
+++ b/python-sdk/tests/test_openai_stream_deltas.py
@@ -145,3 +145,38 @@ def test_role_after_roleless_delta_stays_one_message():
     assert len(outputs[0]) == 1
     assert outputs[0][0]["role"] == "assistant"
     assert outputs[0][0]["content"] == "Hello world!"
+
+
+def test_late_role_delta_carrying_tool_calls_keeps_the_payload():
+    outputs = accumulate(
+        [
+            chunk(content="Working on it"),
+            chunk(
+                role="assistant",
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="call_1",
+                        type="function",
+                        function=ChoiceDeltaToolCallFunction(
+                            name="get_weather", arguments='{"city":'
+                        ),
+                    )
+                ],
+            ),
+            chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        function=ChoiceDeltaToolCallFunction(arguments='"Paris"}'),
+                    )
+                ]
+            ),
+        ]
+    )
+    assert len(outputs[0]) == 1
+    message = outputs[0][0]
+    assert message["role"] == "assistant"
+    assert message["content"] == "Working on it"
+    assert message["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert message["tool_calls"][0]["function"]["arguments"] == '{"city":"Paris"}'


### PR DESCRIPTION
## What

Moves all OpenAI traffic in the `sdk-python-ci` and `sdk-javascript-ci` lanes (plus the `sdk-javascript-cd` pre-publish test step) onto the LangWatch AI Gateway with per-SDK virtual keys, and fixes the python-sdk streaming tracer bug that the swap surfaced.

- `OPENAI_API_KEY` now holds a per-SDK LangWatch virtual key: `PYTHON_SDK_GATEWAY_VIRTUAL_KEY` / `TYPESCRIPT_SDK_GATEWAY_VIRTUAL_KEY` (already set as repo secrets). New secret names on purpose: main keeps referencing the old secrets until this merges, so the flip is atomic and no interim run breaks.
- `OPENAI_BASE_URL` and `OPENAI_API_BASE` both point at `https://gateway.langwatch.ai/v1`, step-scoped where the key is used. Both spellings are needed: the openai SDK and haystack read `OPENAI_BASE_URL`; litellm (dspy, strands) and langchain read `OPENAI_API_BASE`. In the js `e2e` job the env is deliberately step-scoped so the LangWatch app booted in the same job does not inherit a gateway base URL.
- Dropped `GEMINI_API_KEY`, `GROQ_API_KEY` and `CEREBRAS_API_KEY` from the python e2e step: nothing in python-sdk reads the first two (the Gemini e2e path reads `GOOGLE_API_KEY`, which was never provided, and is skipped anyway), and Cerebras only feeds the skip-listed `litellm_bot.py`. Azure keeps its own endpoint and key untouched.
- Skip-listed the two Assistants API examples in `tests/test_examples.py`: the gateway does not proxy `/v1/assistants` / `/v1/threads` (the API is deprecated upstream), and both examples fire Assistants calls at import or `on_chat_start`, before the harness's external-service softener can catch anything.

## The bug the swap found: `KeyError: 0` in the streaming tracer

Running the examples suite through the gateway crashed `openai_bot.py` inside the SDK itself. `OpenAIChatCompletionTracer.handle_deltas` assumed every stream opens with a role-carrying delta (which api.openai.com always sends) and only created the per-choice accumulator on that delta. The gateway's Bifrost-translated stream swallows the opening role chunk and re-emits from the first content chunk, so the first content delta hit `chat_outputs[0]` before any entry existed.

`handle_deltas` now starts the message on whichever delta arrives first (content, tool calls, or role), defaulting the role to `assistant`. Covered by `tests/test_openai_stream_deltas.py` with role-first, role-less content, role-less tool-call, and empty-first-delta streams.

The gateway-side half (restore the role-carrying first chunk so every client SDK sees OpenAI's exact stream shape) is filed as #6196.

## Verification

- Both virtual keys probed against the production gateway: chat completions, SSE streaming, `/v1/embeddings`, `/v1/responses`, bare model names (`gpt-3.5-turbo`, `gpt-4`, `gpt-4o`, `gpt-4o-mini`, `gpt-5-mini` all resolve; `gpt-3.5-turbo` matters because three examples use `ChatOpenAI` with the library default).
- Full `make test-examples` run locally through the production gateway with the python virtual key (result below), plus the new unit tests and the previously-failing `openai_bot.py` example green.
- Every client family exercised end to end through the gateway: openai SDK (streaming and non-streaming), litellm via dspy and strands, langchain, haystack.
- typescript-sdk lanes have zero executed OpenAI consumers today (the langchain integration tests are gated behind `RUN_EXTERNAL_LLM_TESTS`, which CI never sets; e2e uses hand-built fixtures), so the swap is behavior-neutral there and this PR's own CI run is the proof.
- `actionlint` plus a duplicate-key YAML check pass on all three edited workflows.

## Spend gating: paid lanes no longer run on unrelated pushes and release PRs

Verifying the path gating surfaced two leaks that made the paid suites run constantly despite the PR-level gate working correctly:

1. `detect-changes` forces every filter true on `push`, so **every merge to main ran the full paid suites of all five live-LLM lanes** regardless of what the push touched.
2. `.github/.release-please-manifest.json` was in the SDK and mcp lane filters, and release-please rewrites the manifest on **every release PR sync for every component** (which happens after every merge to main). The langwatch app's release PR was running the full python and typescript SDK suites several times an hour.

Fixed with an opt-in `push-strategy: diff` input on `detect-changes` (push diffs against its before-commit; default stays `force` so all other workflows are untouched) plus dropping the manifest from the filters. The five paid lanes (`sdk-python-ci`, `sdk-javascript-ci`, `sdk-go-ci`, `mcp-javascript-ci`, `langevals-ci`) opt in. Each lane's own release PR still triggers its suite via its `CHANGELOG.md`, which lives under the already-filtered directory.

## Deployment Impact

None. CI workflow and SDK test changes only; no deployable service is touched. The SDK change ships with the next python-sdk release and only affects streamed chat completion tracing against OpenAI-compatible backends that omit the opening role delta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI-compatible streaming accumulation when `role` or tool-call details arrive late or in different chunk shapes.
  * Enhanced merging of streamed tool/function-call fragments to keep a single correctly assembled message payload.
* **Tests**
  * Added new streaming delta test coverage for role/content/tool-call arrival order variations.
  * Skipped Assistant API example scripts during automated selection to avoid import-time calls.
* **Chores**
  * Updated CI and publishing workflows to route OpenAI traffic through the AI gateway.
  * Tightened change-detection filters and added `push-strategy` (diff mode) for more precise workflow triggering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->