### PR TITLE
fix(gateway): stop transient config-fetch failures from answering (and caching) no_provider_configured

### DIFF
--- a/services/aigateway/adapters/authresolver/config_fail_closed_test.go
+++ b/services/aigateway/adapters/authresolver/config_fail_closed_test.go
@@ -110,7 +110,7 @@ func TestResolve_StaleEntryAtHardCap_ConfigFetchFailure_FailsRetryable(t *testin
 		cfgErr: errors.New("config fetch returned 503"),
 	}
 	fetcher.returns = []resolverReturn{
-		{bundle: freshBundle("vk_capped", time.Now().Add(10 * time.Minute))},
+		{bundle: freshBundle("vk_capped", time.Now().Add(10*time.Minute))},
 	}
 	svc, _ := newService(t, Options{
 		Resolver:      &fetcher.fakeResolver,

--- a/services/aigateway/adapters/authresolver/config_fail_closed_test.go
+++ b/services/aigateway/adapters/authresolver/config_fail_closed_test.go
@@ -1,0 +1,139 @@
+package authresolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// bundleWithCreds builds a bundle carrying one credential, the shape a
+// healthy org resolves to.
+func bundleWithCreds(vkID string, exp time.Time, credID string) *domain.Bundle {
+	b := freshBundle(vkID, exp)
+	b.Credentials = []domain.Credential{{ID: credID}}
+	return b
+}
+
+// @scenario "config fetch fails on a cold miss -> retryable error, nothing cached"
+func TestResolve_ColdMiss_ConfigFetchFailure_FailsClosedAndCachesNothing(t *testing.T) {
+	fetcher := &fakeConfigFetcher{
+		cfg:    domain.BundleConfig{Credentials: []domain.Credential{{ID: "cred-good"}}},
+		cfgErr: errors.New("config fetch returned 502"),
+	}
+	fetcher.returns = []resolverReturn{
+		{bundle: freshBundle("vk_cold", time.Now().Add(10*time.Minute))},
+	}
+	svc, _ := newService(t, Options{Resolver: &fetcher.fakeResolver, ConfigFetcher: fetcher})
+
+	_, err := svc.Resolve(context.Background(), "vk-lw-cold")
+	if err == nil {
+		t.Fatal("expected a failure when the config fetch fails on a cold miss")
+	}
+	if !errors.Is(err, domain.ErrAuthUpstream) {
+		t.Fatalf("expected auth_upstream_unavailable (retryable), got %v", err)
+	}
+	if svc.l1.Len() != 0 {
+		t.Fatalf("a config-less bundle must not be cached; L1 holds %d entries", svc.l1.Len())
+	}
+
+	// Control plane recovers: the retry succeeds and serves real credentials.
+	fetcher.cfgErr = nil
+	bundle, err := svc.Resolve(context.Background(), "vk-lw-cold")
+	if err != nil {
+		t.Fatalf("expected recovery once the config fetch works: %v", err)
+	}
+	if len(bundle.Credentials) != 1 || bundle.Credentials[0].ID != "cred-good" {
+		t.Fatalf("expected the recovered bundle to carry credentials, got %+v", bundle.Credentials)
+	}
+}
+
+// @scenario "config fetch succeeds with zero credentials -> the real no-provider answer stands"
+func TestResolve_ColdMiss_EmptyCredentialsFromControlPlane_IsCachedAndServed(t *testing.T) {
+	fetcher := &fakeConfigFetcher{cfg: domain.BundleConfig{}}
+	fetcher.returns = []resolverReturn{
+		{bundle: freshBundle("vk_noprov", time.Now().Add(10*time.Minute))},
+	}
+	svc, _ := newService(t, Options{Resolver: &fetcher.fakeResolver, ConfigFetcher: fetcher})
+
+	bundle, err := svc.Resolve(context.Background(), "vk-lw-noprov")
+	if err != nil {
+		t.Fatalf("a successfully fetched empty config is a valid resolution: %v", err)
+	}
+	if len(bundle.Credentials) != 0 {
+		t.Fatalf("expected zero credentials, got %+v", bundle.Credentials)
+	}
+	if svc.l1.Len() != 1 {
+		t.Fatalf("the legitimately empty bundle should be cached; L1 holds %d entries", svc.l1.Len())
+	}
+}
+
+// @scenario "config fetch fails during a stale-entry refresh -> stale credentials keep serving"
+func TestResolve_StaleEntry_ConfigFetchFailure_ServesStaleCredentials(t *testing.T) {
+	fetcher := &fakeConfigFetcher{
+		cfgErr: errors.New("config fetch returned 503"),
+	}
+	fetcher.returns = []resolverReturn{
+		{bundle: freshBundle("vk_stale", time.Now().Add(10*time.Minute))},
+	}
+	svc, _ := newService(t, Options{Resolver: &fetcher.fakeResolver, ConfigFetcher: fetcher})
+
+	rawKey := "vk-lw-stale"
+	h := hashKey(rawKey)
+	svc.storeL1(h, bundleWithCreds("vk_stale", time.Now().Add(-30*time.Second), "cred-old"))
+
+	bundle, err := svc.Resolve(context.Background(), rawKey)
+	if err != nil {
+		t.Fatalf("expected the stale bundle to serve: %v", err)
+	}
+	if len(bundle.Credentials) != 1 || bundle.Credentials[0].ID != "cred-old" {
+		t.Fatalf("expected the stale credentials to keep serving, got %+v", bundle.Credentials)
+	}
+
+	e, ok := svc.l1.Get(h)
+	if !ok {
+		t.Fatal("expected the stale entry to remain in L1")
+	}
+	if len(e.bundle.Credentials) != 1 || e.bundle.Credentials[0].ID != "cred-old" {
+		t.Fatalf("the config-less fresh bundle must not replace the entry; L1 now holds %+v", e.bundle.Credentials)
+	}
+}
+
+// @scenario "config fetch fails during a proactive background refresh -> the healthy entry survives"
+func TestRefreshBackground_ConfigFetchFailure_KeepsExistingEntry(t *testing.T) {
+	fetcher := &fakeConfigFetcher{
+		cfg:    domain.BundleConfig{Credentials: []domain.Credential{{ID: "cred-new"}}},
+		cfgErr: errors.New("config fetch timed out"),
+	}
+	fetcher.returns = []resolverReturn{
+		{bundle: freshBundle("vk_bg", time.Now().Add(10*time.Minute))},
+	}
+	svc, _ := newService(t, Options{Resolver: &fetcher.fakeResolver, ConfigFetcher: fetcher})
+
+	rawKey := "vk-lw-bg"
+	h := hashKey(rawKey)
+	svc.storeL1(h, bundleWithCreds("vk_bg", time.Now().Add(5*time.Minute), "cred-old"))
+
+	svc.refreshBackground(rawKey, h)
+
+	e, ok := svc.l1.Get(h)
+	if !ok {
+		t.Fatal("expected the healthy entry to survive the failed refresh")
+	}
+	if len(e.bundle.Credentials) != 1 || e.bundle.Credentials[0].ID != "cred-old" {
+		t.Fatalf("the config-less bundle must not replace the healthy entry, got %+v", e.bundle.Credentials)
+	}
+
+	// Control plane recovers: the next refresh replaces the entry for real.
+	fetcher.cfgErr = nil
+	svc.refreshBackground(rawKey, h)
+	e, ok = svc.l1.Get(h)
+	if !ok {
+		t.Fatal("expected the refreshed entry in L1")
+	}
+	if len(e.bundle.Credentials) != 1 || e.bundle.Credentials[0].ID != "cred-new" {
+		t.Fatalf("expected the recovered refresh to install fresh credentials, got %+v", e.bundle.Credentials)
+	}
+}

--- a/services/aigateway/adapters/authresolver/config_fail_closed_test.go
+++ b/services/aigateway/adapters/authresolver/config_fail_closed_test.go
@@ -101,10 +101,11 @@ func TestResolve_StaleEntry_ConfigFetchFailure_ServesStaleCredentials(t *testing
 	}
 }
 
-// The hard-cap tail of the same scenario: when the stale entry has burnt
-// its whole grace window and the config fetch still fails, the caller gets
-// the retryable auth_upstream_unavailable, not the ResolveKey nil error.
-// @scenario "config fetch fails during a stale-entry refresh -> stale credentials keep serving"
+// The hard-cap tail of the stale-refresh path: when the stale entry has
+// burnt its whole grace window and the config fetch still fails, the
+// caller gets the retryable auth_upstream_unavailable, not the ResolveKey
+// nil error. Unbound on purpose: the bound scenario above describes the
+// keep-serving outcome, and this test asserts the opposite tail of it.
 func TestResolve_StaleEntryAtHardCap_ConfigFetchFailure_FailsRetryable(t *testing.T) {
 	fetcher := &fakeConfigFetcher{
 		cfgErr: errors.New("config fetch returned 503"),

--- a/services/aigateway/adapters/authresolver/config_fail_closed_test.go
+++ b/services/aigateway/adapters/authresolver/config_fail_closed_test.go
@@ -101,6 +101,35 @@ func TestResolve_StaleEntry_ConfigFetchFailure_ServesStaleCredentials(t *testing
 	}
 }
 
+// The hard-cap tail of the same scenario: when the stale entry has burnt
+// its whole grace window and the config fetch still fails, the caller gets
+// the retryable auth_upstream_unavailable, not the ResolveKey nil error.
+// @scenario "config fetch fails during a stale-entry refresh -> stale credentials keep serving"
+func TestResolve_StaleEntryAtHardCap_ConfigFetchFailure_FailsRetryable(t *testing.T) {
+	fetcher := &fakeConfigFetcher{
+		cfgErr: errors.New("config fetch returned 503"),
+	}
+	fetcher.returns = []resolverReturn{
+		{bundle: freshBundle("vk_capped", time.Now().Add(10 * time.Minute))},
+	}
+	svc, _ := newService(t, Options{
+		Resolver:      &fetcher.fakeResolver,
+		ConfigFetcher: fetcher,
+		HardGrace:     1 * time.Nanosecond,
+	})
+
+	rawKey := "vk-lw-capped"
+	seedExpiredEntry(t, svc, rawKey, "vk_capped", 30*time.Second)
+
+	_, err := svc.Resolve(context.Background(), rawKey)
+	if err == nil {
+		t.Fatal("expected a failure once the hard grace cap is exhausted")
+	}
+	if !errors.Is(err, domain.ErrAuthUpstream) {
+		t.Fatalf("expected auth_upstream_unavailable (retryable), got %v", err)
+	}
+}
+
 // @scenario "config fetch fails during a proactive background refresh -> the healthy entry survives"
 func TestRefreshBackground_ConfigFetchFailure_KeepsExistingEntry(t *testing.T) {
 	fetcher := &fakeConfigFetcher{

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -499,6 +499,12 @@ func (s *Service) serveStaleAfterFailure(ctx context.Context, h [64]byte, stale 
 		}
 		return nil, cause
 	}
+	// classNone here means the auth succeeded and the CONFIG fetch failed;
+	// log that instead of a misleading "none" error class.
+	classLabel := cls.String()
+	if cls == classNone {
+		classLabel = "config_fetch_failed"
+	}
 	s.logger.Warn("auth_cache_refresh_transport_failure",
 		zap.String("vk_id", vkID),
 		zap.Time("new_soft_expires_at", newSoft),
@@ -509,7 +515,7 @@ func (s *Service) serveStaleAfterFailure(ctx context.Context, h [64]byte, stale 
 		zap.String("vk_id", vkID),
 		zap.Duration("stale_for", time.Since(staleBundle.ExpiresAt)),
 		zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
-		zap.String("refresh_error_class", cls.String()),
+		zap.String("refresh_error_class", classLabel),
 	)
 	return staleBundle, nil
 }

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -428,7 +428,11 @@ func (s *Service) resolveFresh(ctx context.Context, rawKey string, h [64]byte) (
 	if err != nil {
 		return nil, err
 	}
-	s.populateConfig(ctx, bundle)
+	if cfgErr := s.populateConfig(ctx, bundle); cfgErr != nil {
+		// Cold miss: no stale entry to fall back on. Cache nothing — a
+		// bundle without its config is not a resolution result.
+		return nil, errConfigUnavailable(ctx, cfgErr)
+	}
 	s.storeL1(h, bundle)
 	if s.l2 != nil {
 		s.l2.Set(ctx, string(h[:]), bundle)
@@ -449,7 +453,14 @@ func (s *Service) refreshOrServeStale(ctx context.Context, rawKey string, h [64]
 
 	switch cls {
 	case classNone:
-		s.populateConfig(ctx, bundle)
+		if cfgErr := s.populateConfig(ctx, bundle); cfgErr != nil {
+			// The control plane authenticated the key but could not hand
+			// over its provider config. Serving the fresh, config-less
+			// bundle would surface as no_provider_configured for an org
+			// whose keys are fine — treat it as a transport failure and
+			// serve the stale entry's known-good credentials instead.
+			return s.serveStaleAfterFailure(ctx, h, stale, staleBundle, vkID, hardExpiresAt, cls, cfgErr)
+		}
 		s.storeL1(h, bundle)
 		if s.l2 != nil {
 			s.l2.Set(ctx, string(h[:]), bundle)
@@ -466,46 +477,71 @@ func (s *Service) refreshOrServeStale(ctx context.Context, rawKey string, h [64]
 		return nil, err
 
 	default:
-		newSoft, bumped := stale.bumpSoft(s.softBump)
-		if !bumped {
-			s.l1.Remove(h)
-			s.logger.Error("auth_cache_hard_evict",
-				zap.String("vk_id", vkID),
-				zap.String("reason", "hard_cap_exceeded"),
-				zap.Error(err),
-			)
-			return nil, err
-		}
-		s.logger.Warn("auth_cache_refresh_transport_failure",
-			zap.String("vk_id", vkID),
-			zap.Time("new_soft_expires_at", newSoft),
-			zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
-			zap.Error(err),
-		)
-		s.logger.Info("auth_cache_serve_stale",
-			zap.String("vk_id", vkID),
-			zap.Duration("stale_for", time.Since(staleBundle.ExpiresAt)),
-			zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
-			zap.String("refresh_error_class", cls.String()),
-		)
-		return staleBundle, nil
+		return s.serveStaleAfterFailure(ctx, h, stale, staleBundle, vkID, hardExpiresAt, cls, err)
 	}
 }
 
+// serveStaleAfterFailure is the transport-failure tail of refreshOrServeStale:
+// bump the stale entry's soft expiry and keep serving it, or evict and fail
+// once the hard grace cap is exhausted. `cause` is what stopped the refresh —
+// a ResolveKey transport error or a config fetch failure after a good auth.
+func (s *Service) serveStaleAfterFailure(ctx context.Context, h [64]byte, stale *entry, staleBundle *domain.Bundle, vkID string, hardExpiresAt time.Time, cls refreshErrorClass, cause error) (*domain.Bundle, error) {
+	newSoft, bumped := stale.bumpSoft(s.softBump)
+	if !bumped {
+		s.l1.Remove(h)
+		s.logger.Error("auth_cache_hard_evict",
+			zap.String("vk_id", vkID),
+			zap.String("reason", "hard_cap_exceeded"),
+			zap.Error(cause),
+		)
+		if cls == classNone {
+			return nil, errConfigUnavailable(ctx, cause)
+		}
+		return nil, cause
+	}
+	s.logger.Warn("auth_cache_refresh_transport_failure",
+		zap.String("vk_id", vkID),
+		zap.Time("new_soft_expires_at", newSoft),
+		zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
+		zap.Error(cause),
+	)
+	s.logger.Info("auth_cache_serve_stale",
+		zap.String("vk_id", vkID),
+		zap.Duration("stale_for", time.Since(staleBundle.ExpiresAt)),
+		zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
+		zap.String("refresh_error_class", cls.String()),
+	)
+	return staleBundle, nil
+}
+
 // populateConfig eagerly fetches the bundle's config and merges it into the
-// bundle. Failure here is non-fatal — the bundle still serves with empty
-// config.Credentials, and downstream resolution will surface its own error.
-func (s *Service) populateConfig(ctx context.Context, bundle *domain.Bundle) {
+// bundle. A failure leaves the bundle without credentials, so callers must
+// not cache or serve the bundle as-is: dispatch would answer the terminal
+// no_provider_configured ("add a provider API key in Settings") for an org
+// whose keys are fine, and a cached config-less bundle keeps giving that
+// answer until it expires — on every node that shares the L2 cache.
+func (s *Service) populateConfig(ctx context.Context, bundle *domain.Bundle) error {
 	if bundle == nil {
-		return
+		return nil
 	}
 	cfg, err := s.configFetcher.FetchConfig(ctx, bundle.VirtualKeyID)
 	if err != nil {
 		s.logger.Warn("config_fetch_failed", zap.String("vk_id", bundle.VirtualKeyID), zap.Error(err))
-		return
+		return err
 	}
 	bundle.Config = cfg
 	bundle.Credentials = cfg.Credentials
+	return nil
+}
+
+// errConfigUnavailable is the fail-closed answer when the control plane
+// authenticated the key but could not hand over its provider config and no
+// stale entry exists to serve instead. Transport-class on purpose: the
+// client should retry, not go check its provider settings.
+func errConfigUnavailable(ctx context.Context, err error) error {
+	return herr.New(ctx, domain.ErrAuthUpstream, herr.M{
+		"message": "control plane unavailable while loading this key's provider configuration — retry shortly",
+	}, err)
 }
 
 // Start launches the background refresh loop and (when configured) the
@@ -686,7 +722,14 @@ func (s *Service) refreshBackground(rawKey string, h [64]byte) {
 
 	switch cls {
 	case classNone:
-		s.populateConfig(ctx, bundle)
+		if cfgErr := s.populateConfig(ctx, bundle); cfgErr != nil {
+			// Keep the existing entry serving its known-good credentials.
+			// Replacing it with a config-less bundle would proactively
+			// poison a perfectly healthy cache entry into answering
+			// no_provider_configured until expiry.
+			s.bumpEntryAfterTransportFailure(h, cfgErr)
+			return
+		}
 		s.storeL1(h, bundle)
 		if s.l2 != nil {
 			s.l2.Set(ctx, string(h[:]), bundle)
@@ -706,22 +749,30 @@ func (s *Service) refreshBackground(rawKey string, h [64]byte) {
 		)
 
 	default:
-		e, ok := s.l1.Get(h)
-		if !ok {
-			return
-		}
-		newSoft, bumped := e.bumpSoft(s.softBump)
-		if !bumped {
-			return
-		}
-		_, _, hardExpiresAt := e.snapshot()
-		s.logger.Warn("auth_cache_refresh_transport_failure",
-			zap.String("vk_id", e.bundle.VirtualKeyID),
-			zap.Time("new_soft_expires_at", newSoft),
-			zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
-			zap.Error(err),
-		)
+		s.bumpEntryAfterTransportFailure(h, err)
 	}
+}
+
+// bumpEntryAfterTransportFailure extends the soft expiry of an existing L1
+// entry after a background refresh failed for transport-class reasons (the
+// resolve call itself, or the config fetch after a good auth), keeping the
+// entry serving instead of letting it lapse.
+func (s *Service) bumpEntryAfterTransportFailure(h [64]byte, cause error) {
+	e, ok := s.l1.Get(h)
+	if !ok {
+		return
+	}
+	newSoft, bumped := e.bumpSoft(s.softBump)
+	if !bumped {
+		return
+	}
+	_, _, hardExpiresAt := e.snapshot()
+	s.logger.Warn("auth_cache_refresh_transport_failure",
+		zap.String("vk_id", e.bundle.VirtualKeyID),
+		zap.Time("new_soft_expires_at", newSoft),
+		zap.Duration("hard_grace_remaining", time.Until(hardExpiresAt)),
+		zap.Error(cause),
+	)
 }
 
 // refreshConfigBackground re-fetches only the bundle's config (not auth)

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -1091,4 +1091,7 @@ func registerErrorStatuses() {
 	herr.RegisterStatus(domain.ErrNotFound, http.StatusNotFound)
 	herr.RegisterStatus(domain.ErrInternal, http.StatusInternalServerError)
 	herr.RegisterStatus(domain.ErrNoProviderConfigured, http.StatusBadRequest)
+	// Retryable by contract: the control plane failed us, not the caller.
+	// A 5xx keeps client SDKs retrying instead of bubbling a config error.
+	herr.RegisterStatus(domain.ErrAuthUpstream, http.StatusServiceUnavailable)
 }

--- a/specs/ai-gateway/auth-cache.feature
+++ b/specs/ai-gateway/auth-cache.feature
@@ -104,6 +104,50 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
         | 404 Not Found         | invalid_api_key       |
         | 403 Forbidden         | virtual_key_revoked   |
 
+  Rule: A config fetch failure never manufactures a "no provider configured" answer
+    resolve-key authenticates the key; the /config fetch carries the org's
+    provider credentials. If the config fetch fails, a bundle with zero
+    credentials must never be cached or served: dispatch would answer the
+    terminal no_provider_configured 400 — telling an org with perfectly good
+    keys to go add a provider API key — and the poisoned bundle would keep
+    that answer alive until expiry, on every node sharing the cache.
+
+    @unit
+    Scenario: config fetch fails on a cold miss -> retryable error, nothing cached
+      Given the control plane resolves the key successfully
+      But the config fetch fails with a transport error
+      When I send a request with that VK
+      Then the request is rejected with error.type "auth_upstream_unavailable" (503, retryable)
+      And no bundle is cached in L1 or L2
+      And the next request retries the control plane and succeeds once it recovers
+
+    @unit
+    Scenario: config fetch succeeds with zero credentials -> the real no-provider answer stands
+      Given the control plane resolves the key successfully
+      And the config fetch succeeds carrying an empty credential list
+      When I send a request with that VK
+      Then the bundle is cached and served with zero credentials
+      And dispatch answers no_provider_configured (the org genuinely has no provider key)
+
+    @unit
+    Scenario: config fetch fails during a stale-entry refresh -> stale credentials keep serving
+      Given the cache holds a soft-expired entry whose bundle carries known-good credentials
+      And the control plane resolves the key successfully
+      But the config fetch fails with a transport error
+      When I send a request with that VK
+      Then the stale bundle with its credentials is served
+      And its soft expiry is bumped, transport-failure style
+      And the config-less fresh bundle is not cached
+
+    @unit
+    Scenario: config fetch fails during a proactive background refresh -> the healthy entry survives
+      Given the cache holds a fresh entry near its soft expiry with known-good credentials
+      And the control plane resolves the key successfully
+      But the config fetch fails with a transport error
+      When the proactive background refresh runs
+      Then the existing entry keeps serving its credentials
+      And the config-less fresh bundle does not replace it
+
     @unit @unimplemented
     Scenario: hard expiry cap stops the stale-while-error chain
       Given the cache holds an entry stale-extended past the LW_GATEWAY_AUTH_CACHE_HARD_GRACE cap (default 6h)


### PR DESCRIPTION
## What

Fixes the intermittent `no_provider_configured` 400s that orgs with perfectly configured provider keys have been hitting through the gateway today (seen failing the python-sdk CI lane on #6197 and langwatch/scenario#856's examples, and reproduced locally 2 out of 3 runs).

## Root cause

`/resolve-key` authenticates the key; the separate `/config/:vk_id` fetch carries the org's provider credentials. `populateConfig` swallowed config-fetch failures ("Failure here is non-fatal") and let the bundle proceed with zero credentials. Dispatch then answers the terminal `no_provider_configured` 400: "add a provider API key in Settings → Model Providers" for an org whose keys are fine.

It gets worse: all three call sites cached or kept the poisoned bundle.

1. Cold miss (`resolveFresh`): the config-less bundle was stored in L1 and L2, so the wrong 400 kept serving until expiry, on every node sharing Redis.
2. Stale-entry refresh (`refreshOrServeStale`): a good auth plus a failed config fetch replaced a stale-but-credentialed entry with a config-less one.
3. Proactive background refresh (`refreshBackground`): the nastiest one — a still-healthy, still-fresh entry was proactively replaced by a config-less bundle near soft expiry.

The background ConfigTTL refresh path already did the right thing (keep stale config on failure); the other three did not.

## The fix

- `populateConfig` now returns the error.
- Cold miss: retryable `auth_upstream_unavailable` and nothing cached; the next request retries the control plane.
- Stale-entry refresh: config-fetch failure is treated as a transport failure — the stale bundle's known-good credentials keep serving with the usual soft-expiry bump.
- Background refresh: the existing healthy entry survives; the config-less bundle never replaces it.
- `auth_upstream_unavailable` now maps to HTTP 503 (it previously fell through to a generic 500), so client SDKs classify it as retryable. `faults.go` already attributes it to the platform.

A config fetch that **succeeds** with a genuinely empty credential list still caches and answers `no_provider_configured` — that distinction is the point of the fix.

## Verification

- 4 new unit tests bound to 4 new scenarios in `specs/ai-gateway/auth-cache.feature` (cold-miss fail-closed + instant recovery, legit-empty-credentials unchanged, stale-serving on refresh failure, background refresh keeps the healthy entry). Full `authresolver` suite green, full `./services/aigateway/... ./pkg/...` green, golangci-lint clean, feature-parity checker green.
- Dogfooded live: local gateway pointed at a selective-failure proxy that forwards `/resolve-key` but 503s only `/api/internal/gateway/config/*`. With the outage injected, cold-cache requests answer 503 `auth_upstream_unavailable` (previously: 400 `no_provider_configured`). The **first** request after clearing the outage serves a real completion — previously the poisoned bundle kept answering the wrong 400 from cache until expiry.

## Deployment Impact

Gateway only (`services/aigateway`, `pkg/herr` untouched). Behavior change: transient control-plane failures during config fetch now surface as retryable 503s instead of definitive 400s, and never poison the auth cache. No config, schema, or chart changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced fail-closed behavior when the gateway’s `/config` fetch fails after `resolve-key`, avoiding creation/caching of config-less empty-credential results.
  - Preserved existing cached credentials during refresh/background config-fetch failures, continuing to serve stale where applicable (and bumping soft expiry).
  - Mapped `ErrAuthUpstream` to **503 Service Unavailable** as a retryable outcome.
- **Tests**
  - Added new test coverage for cold-miss failures, empty-config caching, stale serving during failures, hard grace cap handling, and background refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->