### PR TITLE
feat(costs): price TTS per character and STT per second from the model catalog

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/audio-model-cost.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/audio-model-cost.unit.test.ts
@@ -10,7 +10,7 @@ const SCRIBE_PER_SECOND = 6.111e-5;
 const TRANSCRIBE_PER_SECOND = 1e-4;
 
 describe("audio model cost", () => {
-  /** @scenario a TTS span is priced from its character count */
+  /** @scenario a text-to-speech call is costed by the characters it spoke */
   it("prices a TTS span from gen_ai.usage.input_chars", () => {
     const result = computeSpanCost({
       attrs: {
@@ -23,7 +23,7 @@ describe("audio model cost", () => {
     expect(result).toBeCloseTo(1000 * FLASH_PER_CHAR, 10);
   });
 
-  /** @scenario an STT span is priced from its transcribed seconds */
+  /** @scenario a transcription call is costed by the audio it heard */
   it("prices an STT span from gen_ai.usage.audio_seconds", () => {
     const result = computeSpanCost({
       attrs: {
@@ -36,7 +36,7 @@ describe("audio model cost", () => {
     expect(result).toBeCloseTo(60 * SCRIBE_PER_SECOND, 10);
   });
 
-  /** @scenario audio usage alone unlocks the registry lookup */
+  /** @scenario an audio call with no token usage still gets a cost */
   it("consults the registry when only audio usage is present, and not when nothing is", () => {
     const withAudio = computeSpanCost({
       attrs: {
@@ -58,7 +58,7 @@ describe("audio model cost", () => {
     expect(withNothing).toBe(0);
   });
 
-  /** @scenario estimateCost prices per-character and per-second rates */
+  /** @scenario a model priced only by audio usage is never silently free */
   it("estimateCost handles per-character and per-second entries", () => {
     const ttsEntry = {
       projectId: "",
@@ -93,7 +93,7 @@ describe("audio model cost", () => {
     ).toBeUndefined();
   });
 
-  /** @scenario gpt-4o-transcribe matches its own explicit entry, not gpt-4o's */
+  /** @scenario gpt-4o-transcribe bills at its own audio rate, not gpt-4o's chat rate */
   it("prices gpt-4o-transcribe per second even when token usage is reported", () => {
     const result = computeSpanCost({
       attrs: {
@@ -109,7 +109,7 @@ describe("audio model cost", () => {
     expect(result).toBeCloseTo(60 * TRANSCRIBE_PER_SECOND, 10);
   });
 
-  /** @scenario audio-mode models are not offered as chat models */
+  /** @scenario speech and transcription models are not offered as chat models */
   it("keeps audio entries out of chat and embedding selectors", () => {
     const elevenChat = getProviderModelOptions("elevenlabs", "chat");
     const elevenEmbedding = getProviderModelOptions("elevenlabs", "embedding");

--- a/langwatch/src/server/app-layer/traces/__tests__/audio-model-cost.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/audio-model-cost.unit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { getProviderModelOptions } from "../../../modelProviders/registry";
+import { estimateCost } from "../../../tracer/collector/cost";
+import { computeSpanCost } from "../model-cost-matching";
+
+// Catalog rates under test (llmModels.overlay.json): flash v2 $0.05/1k chars,
+// scribe $0.22/hour, gpt-4o-transcribe $0.006/min.
+const FLASH_PER_CHAR = 5e-5;
+const SCRIBE_PER_SECOND = 6.111e-5;
+const TRANSCRIBE_PER_SECOND = 1e-4;
+
+describe("audio model cost", () => {
+  /** @scenario a TTS span is priced from its character count */
+  it("prices a TTS span from gen_ai.usage.input_chars", () => {
+    const result = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "elevenlabs/eleven_flash_v2",
+        "gen_ai.usage.input_chars": 1000,
+      },
+      promptTokens: null,
+      completionTokens: null,
+    });
+    expect(result).toBeCloseTo(1000 * FLASH_PER_CHAR, 10);
+  });
+
+  /** @scenario an STT span is priced from its transcribed seconds */
+  it("prices an STT span from gen_ai.usage.audio_seconds", () => {
+    const result = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "elevenlabs/scribe_v1",
+        "gen_ai.usage.audio_seconds": 60,
+      },
+      promptTokens: null,
+      completionTokens: null,
+    });
+    expect(result).toBeCloseTo(60 * SCRIBE_PER_SECOND, 10);
+  });
+
+  /** @scenario audio usage alone unlocks the registry lookup */
+  it("consults the registry when only audio usage is present, and not when nothing is", () => {
+    const withAudio = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "elevenlabs/eleven_flash_v2",
+        "gen_ai.usage.input_chars": 500,
+      },
+      promptTokens: 0,
+      completionTokens: 0,
+    });
+    expect(withAudio).toBeGreaterThan(0);
+
+    const withNothing = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "elevenlabs/eleven_flash_v2",
+      },
+      promptTokens: 0,
+      completionTokens: 0,
+    });
+    expect(withNothing).toBe(0);
+  });
+
+  /** @scenario estimateCost prices per-character and per-second rates */
+  it("estimateCost handles per-character and per-second entries", () => {
+    const ttsEntry = {
+      projectId: "",
+      model: "elevenlabs/eleven_flash_v2",
+      regex: "^(elevenlabs\\/)?eleven_flash_v2",
+      inputCostPerCharacter: FLASH_PER_CHAR,
+    };
+    expect(
+      estimateCost({ llmModelCost: ttsEntry, inputCharacters: 2000 }),
+    ).toBeCloseTo(2000 * FLASH_PER_CHAR, 10);
+
+    const sttEntry = {
+      projectId: "",
+      model: "elevenlabs/scribe_v1",
+      regex: "^(elevenlabs\\/)?scribe_v1",
+      inputCostPerSecond: SCRIBE_PER_SECOND,
+    };
+    expect(
+      estimateCost({ llmModelCost: sttEntry, audioSeconds: 3600 }),
+    ).toBeCloseTo(3600 * SCRIBE_PER_SECOND, 10);
+
+    // A rate-less entry still reports "cannot price" rather than zero.
+    expect(
+      estimateCost({
+        llmModelCost: {
+          projectId: "",
+          model: "x",
+          regex: "^x",
+        },
+        inputCharacters: 100,
+      }),
+    ).toBeUndefined();
+  });
+
+  /** @scenario gpt-4o-transcribe matches its own explicit entry, not gpt-4o's */
+  it("prices gpt-4o-transcribe per second even when token usage is reported", () => {
+    const result = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "openai/gpt-4o-transcribe",
+        "gen_ai.usage.audio_seconds": 60,
+      },
+      promptTokens: 100,
+      completionTokens: 20,
+    });
+    // The explicit transcribe entry carries zero token rates and a
+    // per-second rate; a gpt-4o prefix match would have priced the
+    // tokens at chat rates instead.
+    expect(result).toBeCloseTo(60 * TRANSCRIBE_PER_SECOND, 10);
+  });
+
+  /** @scenario audio-mode models are not offered as chat models */
+  it("keeps audio entries out of chat and embedding selectors", () => {
+    const elevenChat = getProviderModelOptions("elevenlabs", "chat");
+    const elevenEmbedding = getProviderModelOptions("elevenlabs", "embedding");
+    expect(elevenChat).toHaveLength(0);
+    expect(elevenEmbedding).toHaveLength(0);
+
+    const openaiChat = getProviderModelOptions("openai", "chat").map(
+      (o) => o.value,
+    );
+    for (const audioModel of [
+      "tts-1",
+      "tts-1-hd",
+      "gpt-4o-mini-tts",
+      "whisper-1",
+      "gpt-4o-transcribe",
+      "gpt-4o-mini-transcribe",
+    ]) {
+      expect(openaiChat).not.toContain(audioModel);
+    }
+  });
+});

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
@@ -232,6 +232,12 @@ export const ATTR_KEYS = {
     "gen_ai.usage.cache_creation.input_tokens",
   GEN_AI_USAGE_CACHED_INPUT_TOKENS: "gen_ai.usage.cached_input_tokens", // Mastra non-standard
 
+  // Audio usage measures the gateway emits: characters synthesized by a
+  // TTS call and seconds of audio transcribed by an STT call — the units
+  // character- and duration-priced audio models bill by.
+  GEN_AI_USAGE_INPUT_CHARS: "gen_ai.usage.input_chars",
+  GEN_AI_USAGE_AUDIO_SECONDS: "gen_ai.usage.audio_seconds",
+
   // Set by an extractor on a span whose token usage is a redundant copy of
   // another span's (e.g. codex emits one turn-rollup span AND a lower-level
   // response span carrying the SAME usage). The fold skips token/cost/cache

--- a/langwatch/src/server/app-layer/traces/model-cost-matching.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-matching.ts
@@ -51,6 +51,18 @@ export function computeSpanCost({
       0,
   );
 
+  // Audio usage: TTS spans carry the characters synthesized, STT spans the
+  // seconds transcribed. These are the billable units for audio models that
+  // report no token usage at all.
+  const inputCharacters = Math.max(
+    0,
+    coerceToNumber(attrs[ATTR_KEYS.GEN_AI_USAGE_INPUT_CHARS]) ?? 0,
+  );
+  const audioSeconds = Math.max(
+    0,
+    coerceToNumber(attrs[ATTR_KEYS.GEN_AI_USAGE_AUDIO_SECONDS]) ?? 0,
+  );
+
   // Priority 1: Custom cost rates from enrichment. A custom cost may carry
   // its own cache rates (customer override); when it does not, cache tokens
   // fall back to the input rate (counted, just not discounted).
@@ -102,7 +114,9 @@ export function computeSpanCost({
     (inputTokens > 0 ||
       outputTokens > 0 ||
       cacheReadTokens > 0 ||
-      cacheCreationTokens > 0)
+      cacheCreationTokens > 0 ||
+      inputCharacters > 0 ||
+      audioSeconds > 0)
   ) {
     const matched = matchModelCostWithFallbacks(
       resolvedModel,
@@ -115,6 +129,8 @@ export function computeSpanCost({
         outputTokens,
         cacheReadTokens,
         cacheCreationTokens,
+        inputCharacters,
+        audioSeconds,
       });
       if (computed !== undefined && computed > 0) return computed;
     }

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -314,6 +314,8 @@ describe("SpanStorageClickHouseRepository span-summary pages", () => {
     OutputTokens: "",
     CacheReadTokens: "",
     CacheCreationTokens: "",
+    InputChars: "",
+    AudioSeconds: "",
     CustomInputRate: "",
     CustomOutputRate: "",
     CustomCacheReadRate: "",
@@ -612,6 +614,8 @@ describe("mapSpanSummaryRow", () => {
     OutputTokens: "",
     CacheReadTokens: "",
     CacheCreationTokens: "",
+    InputChars: "",
+    AudioSeconds: "",
     CustomInputRate: "",
     CustomOutputRate: "",
     CustomCacheReadRate: "",
@@ -665,6 +669,8 @@ describe("mapSpanSummaryRow", () => {
           OutputTokens: "abc",
           CacheReadTokens: "NaN",
           CacheCreationTokens: "",
+          InputChars: "",
+          AudioSeconds: "",
         }),
       );
       expect(result.inputTokens).toBeNull();

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -214,6 +214,8 @@ const SUMMARY_SPAN_SELECT = `
   SpanAttributes['gen_ai.usage.output_tokens'] AS OutputTokens,
   SpanAttributes['gen_ai.usage.cache_read.input_tokens'] AS CacheReadTokens,
   SpanAttributes['gen_ai.usage.cache_creation.input_tokens'] AS CacheCreationTokens,
+  SpanAttributes['gen_ai.usage.input_chars'] AS InputChars,
+  SpanAttributes['gen_ai.usage.audio_seconds'] AS AudioSeconds,
   SpanAttributes['langwatch.model.inputCostPerToken'] AS CustomInputRate,
   SpanAttributes['langwatch.model.outputCostPerToken'] AS CustomOutputRate,
   SpanAttributes['langwatch.model.cacheReadCostPerToken'] AS CustomCacheReadRate,
@@ -356,6 +358,8 @@ export interface SpanSummaryQueryRow {
   OutputTokens: string;
   CacheReadTokens: string;
   CacheCreationTokens: string;
+  InputChars: string;
+  AudioSeconds: string;
   CustomInputRate: string;
   CustomOutputRate: string;
   CustomCacheReadRate: string;
@@ -408,6 +412,8 @@ export function mapSpanSummaryRow(row: SpanSummaryQueryRow): SpanSummaryRow {
           row.CacheReadTokens || undefined,
         [ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]:
           row.CacheCreationTokens || undefined,
+        [ATTR_KEYS.GEN_AI_USAGE_INPUT_CHARS]: row.InputChars || undefined,
+        [ATTR_KEYS.GEN_AI_USAGE_AUDIO_SECONDS]: row.AudioSeconds || undefined,
         [ATTR_KEYS.LANGWATCH_MODEL_INPUT_COST_PER_TOKEN]:
           row.CustomInputRate || undefined,
         [ATTR_KEYS.LANGWATCH_MODEL_OUTPUT_COST_PER_TOKEN]:

--- a/langwatch/src/server/modelProviders/llmModelCost.tsx
+++ b/langwatch/src/server/modelProviders/llmModelCost.tsx
@@ -22,6 +22,8 @@ const getImportedModelCosts = () => {
       outputCostPerToken: number;
       cacheReadCostPerToken?: number;
       cacheCreationCostPerToken?: number;
+      inputCostPerCharacter?: number;
+      inputCostPerSecond?: number;
     }
   > = {};
 
@@ -36,7 +38,9 @@ const getImportedModelCosts = () => {
     if (isCodexModel(modelId)) continue;
     if (
       model.pricing?.inputCostPerToken != null ||
-      model.pricing?.outputCostPerToken != null
+      model.pricing?.outputCostPerToken != null ||
+      model.pricing?.inputCostPerCharacter != null ||
+      model.pricing?.inputCostPerSecond != null
     ) {
       // Make vendor prefix optional in regex (e.g., both "gpt-4o" and "openai/gpt-4o" should match)
       const hasVendorPrefix = modelId.includes("/");
@@ -71,6 +75,8 @@ const getImportedModelCosts = () => {
         outputCostPerToken: model.pricing.outputCostPerToken ?? 0,
         cacheReadCostPerToken: model.pricing.inputCacheReadPerToken,
         cacheCreationCostPerToken: model.pricing.inputCacheWritePerToken,
+        inputCostPerCharacter: model.pricing.inputCostPerCharacter,
+        inputCostPerSecond: model.pricing.inputCostPerSecond,
       };
     }
   }
@@ -94,13 +100,18 @@ const getImportedModelCosts = () => {
         outputCostPerToken: model.outputCostPerToken,
         cacheReadCostPerToken: model.cacheReadCostPerToken,
         cacheCreationCostPerToken: model.cacheCreationCostPerToken,
+        inputCostPerCharacter: model.inputCostPerCharacter,
+        inputCostPerSecond: model.inputCostPerSecond,
       };
     });
 
   // Exclude models with no costs
   const paidModels = mergedModels.filter(
     (model) =>
-      model.inputCostPerToken != null || model.outputCostPerToken != null,
+      model.inputCostPerToken != null ||
+      model.outputCostPerToken != null ||
+      model.inputCostPerCharacter != null ||
+      model.inputCostPerSecond != null,
   );
 
   // Exclude some vendors (openrouter is already excluded as we're using their API)
@@ -129,6 +140,11 @@ export type MaybeStoredLLMModelCost = {
   // cache tokens fall back to the input rate (counted, just not discounted).
   cacheReadCostPerToken?: number;
   cacheCreationCostPerToken?: number;
+  // Audio rates: characters synthesized (TTS) and seconds transcribed
+  // (STT), matched against the gateway's gen_ai.usage.input_chars /
+  // gen_ai.usage.audio_seconds span attributes.
+  inputCostPerCharacter?: number;
+  inputCostPerSecond?: number;
   updatedAt?: Date;
   createdAt?: Date;
 };
@@ -154,6 +170,8 @@ export const getStaticModelCosts = (): MaybeStoredLLMModelCost[] => {
         outputCostPerToken: value.outputCostPerToken,
         cacheReadCostPerToken: value.cacheReadCostPerToken,
         cacheCreationCostPerToken: value.cacheCreationCostPerToken,
+        inputCostPerCharacter: value.inputCostPerCharacter,
+        inputCostPerSecond: value.inputCostPerSecond,
       }))
       // Sort by the matched model suffix, not raw registry key length,
       // because vendor prefixes are optional in the generated regex.

--- a/langwatch/src/server/modelProviders/llmModels.overlay.json
+++ b/langwatch/src/server/modelProviders/llmModels.overlay.json
@@ -106,6 +106,237 @@
       "supportsAudioInput": false,
       "supportsImageOutput": false,
       "supportsAudioOutput": false
+    },
+    "openai/tts-1": {
+      "id": "openai/tts-1",
+      "name": "OpenAI: TTS-1",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 1.5e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "OpenAI speech synthesis, standard latency-optimized tier. Priced per input character ($15 per 1M characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "openai/tts-1-hd": {
+      "id": "openai/tts-1-hd",
+      "name": "OpenAI: TTS-1 HD",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 3e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "OpenAI speech synthesis, high-definition tier. Priced per input character ($30 per 1M characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "openai/gpt-4o-mini-tts": {
+      "id": "openai/gpt-4o-mini-tts",
+      "name": "OpenAI: GPT-4o mini TTS",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 1.667e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "OpenAI speech synthesis on the GPT-4o mini engine. Priced per input character, derived from OpenAI's published $0.015-per-minute estimate at a standard speech rate.",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "openai/whisper-1": {
+      "id": "openai/whisper-1",
+      "name": "OpenAI: Whisper",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerSecond": 0.0001
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "audio->text",
+      "mode": "audio",
+      "description": "OpenAI speech-to-text. Priced per second of audio ($0.006 per minute).",
+      "supportsImageInput": false,
+      "supportsAudioInput": true,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
+    },
+    "openai/gpt-4o-transcribe": {
+      "id": "openai/gpt-4o-transcribe",
+      "name": "OpenAI: GPT-4o Transcribe",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerSecond": 0.0001
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "audio->text",
+      "mode": "audio",
+      "description": "OpenAI speech-to-text on the GPT-4o engine. Priced per second of audio ($0.006 per minute). An explicit entry so it stops prefix-matching gpt-4o's text-token rates.",
+      "supportsImageInput": false,
+      "supportsAudioInput": true,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
+    },
+    "openai/gpt-4o-mini-transcribe": {
+      "id": "openai/gpt-4o-mini-transcribe",
+      "name": "OpenAI: GPT-4o mini Transcribe",
+      "provider": "openai",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerSecond": 5e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "audio->text",
+      "mode": "audio",
+      "description": "OpenAI speech-to-text on the GPT-4o mini engine. Priced per second of audio ($0.003 per minute). An explicit entry so it stops prefix-matching gpt-4o-mini's text-token rates.",
+      "supportsImageInput": false,
+      "supportsAudioInput": true,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
+    },
+    "elevenlabs/eleven_multilingual_v2": {
+      "id": "elevenlabs/eleven_multilingual_v2",
+      "name": "ElevenLabs: Multilingual v2",
+      "provider": "elevenlabs",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 0.0001
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "ElevenLabs' quality-tier speech synthesis. Priced per input character ($0.10 per 1k characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "elevenlabs/eleven_flash_v2": {
+      "id": "elevenlabs/eleven_flash_v2",
+      "name": "ElevenLabs: Flash v2",
+      "provider": "elevenlabs",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 5e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "ElevenLabs' low-latency speech synthesis. Priced per input character ($0.05 per 1k characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "elevenlabs/eleven_flash_v2_5": {
+      "id": "elevenlabs/eleven_flash_v2_5",
+      "name": "ElevenLabs: Flash v2.5",
+      "provider": "elevenlabs",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 5e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "ElevenLabs' low-latency multilingual speech synthesis. Priced per input character ($0.05 per 1k characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "elevenlabs/eleven_turbo_v2_5": {
+      "id": "elevenlabs/eleven_turbo_v2_5",
+      "name": "ElevenLabs: Turbo v2.5",
+      "provider": "elevenlabs",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerCharacter": 5e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "text->audio",
+      "mode": "audio",
+      "description": "ElevenLabs' balanced quality/latency speech synthesis. Priced per input character ($0.05 per 1k characters).",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": true
+    },
+    "elevenlabs/scribe_v1": {
+      "id": "elevenlabs/scribe_v1",
+      "name": "ElevenLabs: Scribe v1",
+      "provider": "elevenlabs",
+      "pricing": {
+        "inputCostPerToken": 0,
+        "outputCostPerToken": 0,
+        "inputCostPerSecond": 6.111e-05
+      },
+      "contextLength": 0,
+      "maxCompletionTokens": null,
+      "supportedParameters": [],
+      "defaultParameters": null,
+      "modality": "audio->text",
+      "mode": "audio",
+      "description": "ElevenLabs speech-to-text. Priced per second of audio ($0.22 per hour).",
+      "supportsImageInput": false,
+      "supportsAudioInput": true,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
     }
   }
 }

--- a/langwatch/src/server/modelProviders/llmModels.types.ts
+++ b/langwatch/src/server/modelProviders/llmModels.types.ts
@@ -23,6 +23,13 @@ export type LLMModelPricing = {
   audioCostPerToken?: number;
   internalReasoningCostPerToken?: number;
   webSearchCostPerQuery?: number;
+  // Audio pricing: TTS models bill per input character synthesized,
+  // STT models per second of audio transcribed. Matched against the
+  // gen_ai.usage.input_chars / gen_ai.usage.audio_seconds span attrs
+  // the gateway emits. Hand-curated in llmModels.overlay.json — the
+  // OpenRouter sync has no per-character/per-second price data.
+  inputCostPerCharacter?: number;
+  inputCostPerSecond?: number;
 };
 
 // ============================================================================
@@ -78,8 +85,8 @@ export type LLMModelEntry = {
   defaultParameters: Record<string, unknown> | null;
   /** Raw modality string, e.g. "text->text" */
   modality: string;
-  /** Derived mode: "chat" or "embedding" */
-  mode: "chat" | "embedding";
+  /** Derived mode: "chat", "embedding", or "audio" (TTS/STT) */
+  mode: "chat" | "embedding" | "audio";
   /** Model description (optional) */
   description?: string;
   // Multimodal support flags

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -509,7 +509,10 @@ export function hasVariantSuffix(modelId: string): boolean {
  * Maps to the new registry format
  * Excludes models with variant suffixes (:free, :thinking, etc.)
  */
-export const allLitellmModels: Record<string, { mode: "chat" | "embedding" }> =
+export const allLitellmModels: Record<
+  string,
+  { mode: "chat" | "embedding" | "audio" }
+> =
   Object.fromEntries(
     Object.entries(llmModels.models)
       .filter(([id]) => !hasVariantSuffix(id))

--- a/langwatch/src/server/tracer/collector/cost.ts
+++ b/langwatch/src/server/tracer/collector/cost.ts
@@ -16,6 +16,8 @@ export function estimateCost({
   outputTokens,
   cacheReadTokens,
   cacheCreationTokens,
+  inputCharacters,
+  audioSeconds,
 }: {
   llmModelCost: MaybeStoredLLMModelCost;
   inputTokens?: number;
@@ -28,9 +30,18 @@ export function estimateCost({
   // is never costed as free.
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
+  // Audio usage: characters synthesized by TTS and seconds transcribed by
+  // STT, billed at their own per-character / per-second rates. Sourced
+  // from the gateway's gen_ai.usage.input_chars / gen_ai.usage.audio_seconds
+  // span attributes.
+  inputCharacters?: number;
+  audioSeconds?: number;
 }): number | undefined {
   const hasAnyRate =
-    !!llmModelCost?.inputCostPerToken || !!llmModelCost?.outputCostPerToken;
+    !!llmModelCost?.inputCostPerToken ||
+    !!llmModelCost?.outputCostPerToken ||
+    !!llmModelCost?.inputCostPerCharacter ||
+    !!llmModelCost?.inputCostPerSecond;
   if (!hasAnyRate) return undefined;
 
   const inputRate = llmModelCost.inputCostPerToken ?? 0;
@@ -41,7 +52,9 @@ export function estimateCost({
     (inputTokens ?? 0) * inputRate +
     (outputTokens ?? 0) * (llmModelCost.outputCostPerToken ?? 0) +
     (cacheReadTokens ?? 0) * cacheReadRate +
-    (cacheCreationTokens ?? 0) * cacheCreationRate
+    (cacheCreationTokens ?? 0) * cacheCreationRate +
+    (inputCharacters ?? 0) * (llmModelCost.inputCostPerCharacter ?? 0) +
+    (audioSeconds ?? 0) * (llmModelCost.inputCostPerSecond ?? 0)
   );
 }
 

--- a/pkg/customertracebridge/attrs.go
+++ b/pkg/customertracebridge/attrs.go
@@ -13,6 +13,13 @@ const (
 	AttrGenAIUsageCacheCreate = "gen_ai.usage.cache_creation.input_tokens"
 	AttrGenAIConversationID   = "gen_ai.conversation.id"
 
+	// Audio usage measures (no upstream semconv exists yet for either):
+	// characters synthesized by a TTS call and seconds of audio transcribed
+	// by an STT call, the units character- and duration-priced audio
+	// providers bill by. The cost pipeline prices audio spans from these.
+	AttrGenAIUsageInputChars   = "gen_ai.usage.input_chars"
+	AttrGenAIUsageAudioSeconds = "gen_ai.usage.audio_seconds"
+
 	// AttrLabels carries the VK's tags; the trace pipeline ingests this
 	// exact key into metadata.labels (otel.traces.ts), which the Trace
 	// Explorer filters as "Label".

--- a/pkg/customertracebridge/emitter.go
+++ b/pkg/customertracebridge/emitter.go
@@ -282,6 +282,15 @@ func (e *Emitter) EndSpan(ctx context.Context, params domain.AITraceParams) {
 	if params.Usage.CacheCreationTokens > 0 {
 		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheCreate, params.Usage.CacheCreationTokens))
 	}
+	// Audio usage: TTS reports the characters synthesized, STT the seconds
+	// transcribed. Character- and duration-priced audio models have no token
+	// usage, so these attrs are what the cost pipeline prices them from.
+	if params.Usage.InputChars > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageInputChars, params.Usage.InputChars))
+	}
+	if params.Usage.AudioSeconds > 0 {
+		attrs = append(attrs, attribute.Float64(AttrGenAIUsageAudioSeconds, params.Usage.AudioSeconds))
+	}
 	// VK id + request id let the control plane's trace-processing pipeline
 	// identify gateway traces and fold idempotent budget debits into ClickHouse.
 	// See specs/ai-gateway/_shared/contract.md §4.5.

--- a/pkg/customertracebridge/emitter_test.go
+++ b/pkg/customertracebridge/emitter_test.go
@@ -305,11 +305,52 @@ func TestEmitter_SpeechSpanIsNotSuppressedAsProbe(t *testing.T) {
 	case body := <-received:
 		// span reached the wire: not suppressed, and it carries the
 		// character count the cost pipeline prices TTS by.
-		require.Contains(t, string(body), AttrGenAIUsageInputChars,
-			"speech span must carry gen_ai.usage.input_chars")
+		require.Equal(t, int64(5), intAttrFromExport(t, body, AttrGenAIUsageInputChars),
+			"speech span must carry gen_ai.usage.input_chars with the synthesized count")
 	case <-time.After(3 * time.Second):
 		t.Fatal("speech span was suppressed by the zero-cost probe filter")
 	}
+}
+
+// intAttrFromExport unmarshals an OTLP export and returns the named int
+// attribute from the first span carrying it, failing the test if absent.
+func intAttrFromExport(t *testing.T, body []byte, key string) int64 {
+	t.Helper()
+	var req coltracepb.ExportTraceServiceRequest
+	require.NoError(t, proto.Unmarshal(body, &req))
+	for _, rs := range req.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				for _, attr := range span.Attributes {
+					if attr.GetKey() == key {
+						return attr.GetValue().GetIntValue()
+					}
+				}
+			}
+		}
+	}
+	t.Fatalf("attribute %s not found on any exported span", key)
+	return 0
+}
+
+// doubleAttrFromExport is intAttrFromExport's float twin.
+func doubleAttrFromExport(t *testing.T, body []byte, key string) float64 {
+	t.Helper()
+	var req coltracepb.ExportTraceServiceRequest
+	require.NoError(t, proto.Unmarshal(body, &req))
+	for _, rs := range req.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				for _, attr := range span.Attributes {
+					if attr.GetKey() == key {
+						return attr.GetValue().GetDoubleValue()
+					}
+				}
+			}
+		}
+	}
+	t.Fatalf("attribute %s not found on any exported span", key)
+	return 0
 }
 
 // @scenario "A transcription call lands as a trace with duration usage"
@@ -350,8 +391,8 @@ func TestEmitter_TranscriptionSpanCarriesAudioSeconds(t *testing.T) {
 
 	select {
 	case body := <-received:
-		require.Contains(t, string(body), AttrGenAIUsageAudioSeconds,
-			"transcription span must carry gen_ai.usage.audio_seconds")
+		require.InDelta(t, 4.2, doubleAttrFromExport(t, body, AttrGenAIUsageAudioSeconds), 1e-9,
+			"transcription span must carry gen_ai.usage.audio_seconds with the transcribed duration")
 	case <-time.After(3 * time.Second):
 		t.Fatal("transcription span did not reach the exporter")
 	}

--- a/pkg/customertracebridge/emitter_test.go
+++ b/pkg/customertracebridge/emitter_test.go
@@ -288,8 +288,9 @@ func TestEmitter_SpeechSpanIsNotSuppressedAsProbe(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = e.Shutdown(context.Background()) })
 
-	// A successful TTS call: zero completion tokens, zero cost (no catalog
-	// pricing yet), binary response body so no extractable output.
+	// A successful TTS call: zero completion tokens, zero provider-reported
+	// cost, binary response body so no extractable output. The character
+	// count is the usage measure the cost pipeline prices TTS by.
 	spanCtx, _ := e.BeginSpan(ctx, "proj-1", domain.RequestTypeSpeech)
 	e.EndSpan(spanCtx, domain.AITraceParams{
 		Model:        "gpt-4o-mini-tts",
@@ -301,10 +302,58 @@ func TestEmitter_SpeechSpanIsNotSuppressedAsProbe(t *testing.T) {
 	require.NoError(t, e.tp.ForceFlush(context.Background()))
 
 	select {
-	case <-received:
-		// span reached the wire: not suppressed
+	case body := <-received:
+		// span reached the wire: not suppressed, and it carries the
+		// character count the cost pipeline prices TTS by.
+		require.Contains(t, string(body), AttrGenAIUsageInputChars,
+			"speech span must carry gen_ai.usage.input_chars")
 	case <-time.After(3 * time.Second):
 		t.Fatal("speech span was suppressed by the zero-cost probe filter")
+	}
+}
+
+// @scenario "A transcription call lands as a trace with duration usage"
+func TestEmitter_TranscriptionSpanCarriesAudioSeconds(t *testing.T) {
+	received := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case received <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	registry := NewRegistry()
+	require.NoError(t, registry.Set("proj-1", srv.URL, nil))
+
+	ctx := contexts.SetServiceInfo(context.Background(), contexts.ServiceInfo{
+		Service: "langwatch-service-aigateway",
+		Version: "test",
+	})
+	e, err := NewEmitter(ctx, EmitterOptions{
+		Registry:     registry,
+		BatchTimeout: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Shutdown(context.Background()) })
+
+	spanCtx, _ := e.BeginSpan(ctx, "proj-1", domain.RequestTypeTranscription)
+	e.EndSpan(spanCtx, domain.AITraceParams{
+		Model:        "scribe_v1",
+		RequestType:  domain.RequestTypeTranscription,
+		ResponseBody: []byte(`{"text":"hello world"}`),
+		Usage:        domain.Usage{AudioSeconds: 4.2},
+	})
+	require.NoError(t, e.tp.ForceFlush(context.Background()))
+
+	select {
+	case body := <-received:
+		require.Contains(t, string(body), AttrGenAIUsageAudioSeconds,
+			"transcription span must carry gen_ai.usage.audio_seconds")
+	case <-time.After(3 * time.Second):
+		t.Fatal("transcription span did not reach the exporter")
 	}
 }
 

--- a/specs/trace-processing/audio-model-cost.feature
+++ b/specs/trace-processing/audio-model-cost.feature
@@ -1,0 +1,56 @@
+Feature: Audio model cost computation
+  TTS models bill per input character synthesized and STT models per second
+  of audio transcribed — units that carry no token usage at all. The gateway
+  records them on audio spans as gen_ai.usage.input_chars and
+  gen_ai.usage.audio_seconds, and the catalog's audio entries carry matching
+  inputCostPerCharacter / inputCostPerSecond rates in llmModels.overlay.json
+  (hand-curated: the OpenRouter price sync has no per-character or
+  per-second data, and it overwrites the base llmModels.json wholesale).
+
+  Background:
+    Given the model catalog carries audio entries for openai and elevenlabs
+    And the gateway stamps audio usage attributes on gen_ai.speech and gen_ai.transcription spans
+
+  Rule: Character- and second-priced usage produces a non-zero span cost
+
+    @unit
+    Scenario: a TTS span is priced from its character count
+      Given a span for model "elevenlabs/eleven_flash_v2" carrying gen_ai.usage.input_chars = 1000
+      And the span reports zero token usage
+      When the span cost is computed
+      Then the cost is 1000 times the model's per-character rate
+
+    @unit
+    Scenario: an STT span is priced from its transcribed seconds
+      Given a span for model "elevenlabs/scribe_v1" carrying gen_ai.usage.audio_seconds = 60
+      And the span reports zero token usage
+      When the span cost is computed
+      Then the cost is 60 times the model's per-second rate
+
+    @unit
+    Scenario: audio usage alone unlocks the registry lookup
+      Given a span with zero tokens and zero cache counts but positive audio usage
+      When the span cost is computed
+      Then the static registry is still consulted instead of short-circuiting to zero
+
+    @unit
+    Scenario: estimateCost prices per-character and per-second rates
+      Given a registry entry carrying only inputCostPerCharacter or inputCostPerSecond
+      When estimateCost runs with inputCharacters or audioSeconds usage
+      Then it returns usage times rate instead of undefined
+
+  Rule: Transcribe models stop borrowing chat-model token rates
+
+    @unit
+    Scenario: gpt-4o-transcribe matches its own explicit entry, not gpt-4o's
+      Given the catalog carries an explicit "openai/gpt-4o-transcribe" entry priced per second
+      When a span for "openai/gpt-4o-transcribe" is matched against the registry
+      Then the explicit transcribe entry wins over the gpt-4o prefix match
+
+  Rule: Audio catalog entries stay out of chat and embedding selectors
+
+    @unit
+    Scenario: audio-mode models are not offered as chat models
+      Given the catalog's audio entries carry mode "audio"
+      When provider model options are listed for mode "chat"
+      Then no TTS or STT model appears in the list

--- a/specs/trace-processing/audio-model-cost.feature
+++ b/specs/trace-processing/audio-model-cost.feature
@@ -1,56 +1,55 @@
 Feature: Audio model cost computation
-  TTS models bill per input character synthesized and STT models per second
-  of audio transcribed — units that carry no token usage at all. The gateway
-  records them on audio spans as gen_ai.usage.input_chars and
-  gen_ai.usage.audio_seconds, and the catalog's audio entries carry matching
-  inputCostPerCharacter / inputCostPerSecond rates in llmModels.overlay.json
-  (hand-curated: the OpenRouter price sync has no per-character or
-  per-second data, and it overwrites the base llmModels.json wholesale).
+  Speech synthesis is billed by how much text was spoken and transcription
+  by how much audio was heard, not by tokens. A customer running TTS or STT
+  through the gateway sees each call's real cost on its trace, computed
+  from the model catalog's audio rates. Audio rates are hand-curated: the
+  upstream price source only carries token prices.
 
   Background:
-    Given the model catalog carries audio entries for openai and elevenlabs
-    And the gateway stamps audio usage attributes on gen_ai.speech and gen_ai.transcription spans
+    Given the model catalog carries audio pricing for openai and elevenlabs models
+    And audio calls through the gateway land as traces with their usage recorded
 
-  Rule: Character- and second-priced usage produces a non-zero span cost
-
-    @unit
-    Scenario: a TTS span is priced from its character count
-      Given a span for model "elevenlabs/eleven_flash_v2" carrying gen_ai.usage.input_chars = 1000
-      And the span reports zero token usage
-      When the span cost is computed
-      Then the cost is 1000 times the model's per-character rate
+  Rule: Audio calls show their real cost, not zero
 
     @unit
-    Scenario: an STT span is priced from its transcribed seconds
-      Given a span for model "elevenlabs/scribe_v1" carrying gen_ai.usage.audio_seconds = 60
-      And the span reports zero token usage
-      When the span cost is computed
-      Then the cost is 60 times the model's per-second rate
+    Scenario: a text-to-speech call is costed by the characters it spoke
+      Given a text-to-speech call that synthesized 1000 characters
+      When its trace is processed
+      Then the span cost equals 1000 times the model's per-character rate
 
     @unit
-    Scenario: audio usage alone unlocks the registry lookup
-      Given a span with zero tokens and zero cache counts but positive audio usage
-      When the span cost is computed
-      Then the static registry is still consulted instead of short-circuiting to zero
+    Scenario: a transcription call is costed by the audio it heard
+      Given a transcription call that transcribed 60 seconds of audio
+      When its trace is processed
+      Then the span cost equals 60 times the model's per-second rate
 
     @unit
-    Scenario: estimateCost prices per-character and per-second rates
-      Given a registry entry carrying only inputCostPerCharacter or inputCostPerSecond
-      When estimateCost runs with inputCharacters or audioSeconds usage
-      Then it returns usage times rate instead of undefined
+    Scenario: an audio call with no token usage still gets a cost
+      Given an audio call reporting zero tokens but real audio usage
+      When its trace is processed
+      Then a non-zero cost is computed
+      And a call with no usage of any kind still costs nothing
+
+    @unit
+    Scenario: a model priced only by audio usage is never silently free
+      Given a catalog entry carrying only an audio rate and no token rates
+      When a cost estimate runs with audio usage
+      Then it produces usage times rate
+      And an entry with no rates at all reports that it cannot price the call
 
   Rule: Transcribe models stop borrowing chat-model token rates
 
     @unit
-    Scenario: gpt-4o-transcribe matches its own explicit entry, not gpt-4o's
-      Given the catalog carries an explicit "openai/gpt-4o-transcribe" entry priced per second
-      When a span for "openai/gpt-4o-transcribe" is matched against the registry
-      Then the explicit transcribe entry wins over the gpt-4o prefix match
+    Scenario: gpt-4o-transcribe bills at its own audio rate, not gpt-4o's chat rate
+      Given a transcription call on gpt-4o-transcribe that also reports token usage
+      When its trace is processed
+      Then the cost comes from the transcribe model's per-second rate
+      And none of it comes from gpt-4o's chat token rates
 
-  Rule: Audio catalog entries stay out of chat and embedding selectors
+  Rule: Audio models stay out of chat and embedding pickers
 
     @unit
-    Scenario: audio-mode models are not offered as chat models
-      Given the catalog's audio entries carry mode "audio"
-      When provider model options are listed for mode "chat"
-      Then no TTS or STT model appears in the list
+    Scenario: speech and transcription models are not offered as chat models
+      Given the catalog's audio entries
+      When a user picks a chat or embedding model for a provider
+      Then no speech or transcription model appears among the options


### PR DESCRIPTION
## What

Audio model calls through the gateway stop showing $0 cost. TTS is priced per input character and STT per second of audio, end to end: gateway span attrs -> catalog rates -> span and trace cost -> Trace Explorer.

This is the catalog pricing follow-up from #6168.

## How

Three layers, matching where the data lives:

1. **Gateway bridge** (`pkg/customertracebridge`): customer-facing audio spans now carry `gen_ai.usage.input_chars` (TTS) and `gen_ai.usage.audio_seconds` (STT). The values already flowed through `domain.Usage` and the internal operational span; the customer span dropped them.
2. **Catalog** (`llmModels.types.ts` + `llmModels.overlay.json`): pricing gains `inputCostPerCharacter` / `inputCostPerSecond`, `mode` widens to `"audio"`, and eleven hand-curated entries land in the overlay at published prices: OpenAI tts-1 ($15/1M chars), tts-1-hd ($30/1M), gpt-4o-mini-tts (derived from OpenAI's published $0.015/min estimate), whisper-1 ($0.006/min), gpt-4o-transcribe ($0.006/min), gpt-4o-mini-transcribe ($0.003/min); ElevenLabs multilingual v2 ($0.10/1k chars), flash v2 / v2.5 / turbo v2.5 ($0.05/1k), scribe_v1 ($0.22/hour). Overlay on purpose: the weekly OpenRouter sync rewrites `llmModels.json` wholesale and OpenRouter carries no TTS/STT prices, so `~/langwatch-saas`'s sync script needs **no changes** (it imports the schema from this repo and never touches the overlay).
3. **Cost path**: `estimateCost` and `computeSpanCost` price the two new usage measures, audio usage alone unlocks the registry lookup (previously gated on token counts), and the waterfall's per-span recompute selects the two attrs so the drawer agrees with the trace list. Budgets get fixed for free: virtual-key debits fold from the same span costs.

Also fixes an accidental billing bug: `gpt-4o-transcribe` / `gpt-4o-mini-transcribe` were prefix-matching `gpt-4o` / `gpt-4o-mini` and billing their audio tokens at chat text-token rates. They now have explicit per-second entries that shadow the prefix match.

Audio-mode entries stay out of chat and embedding selectors (`getProviderModelOptions` filters by mode).

## Verification

- Spec-first: `specs/trace-processing/audio-model-cost.feature` (6 scenarios) plus the two audio observability scenarios in `specs/ai-gateway/audio-endpoints.feature` now assert the customer span carries the usage attrs. All bound; feature-parity checker green (3028 scenarios).
- 6 new unit tests over the cost path + 2 extended Go emitter tests; full cost suites green (110 tests), `go test ./pkg/... ./services/aigateway/...` green, tsgo typecheck green.
- Dogfooded live with a local gateway + app + workers: ElevenLabs flash TTS and scribe STT calls landed in ClickHouse with `Cost` 0.00315 (63 chars x $0.05/1k) and 0.000182 (2.979s x $0.22/hr) — exact to the rate math — and the Trace Explorer renders both (screenshots below).

### TTS priced in the Trace Explorer

![TTS cost](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6199/audio-pricing/tts-cost.png)

### STT priced in the Trace Explorer

![STT cost](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6199/audio-pricing/stt-cost.png)

## Deployment Impact

Gateway (`services/aigateway` via `pkg/customertracebridge`) and the langwatch app both change. No schema or chart changes; new catalog fields are optional so the SaaS model-registry sync is unaffected. Existing token pricing is untouched (all 110 existing cost tests pass unchanged). Costs apply to spans processed after deploy; historical audio spans keep their stored null cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recording of TTS input character usage and STT audio duration in traces, and ensured these values are exported.
  * Expanded model catalog and pricing to cover audio-mode models (character- and second-based).
  * Added audio-model cost estimation using the new usage attributes.
  * Extended span summary storage to include the new audio usage fields.
* **Bug Fixes**
  * Corrected transcription pricing to use model-specific per-second rates.
* **Tests**
  * Added and updated unit/integration and end-to-end specifications to validate audio cost computation and attribute propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->