### PR TITLE
fix(server): ship the workspace packages the app imports, and boot smoke from the packed tarball

### DIFF
--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -213,7 +213,22 @@ jobs:
             # crashes loading "@langwatch/mcp-server/create-mcp-server".
             "package/mcp-server/package.json"
             "package/mcp-server/dist/create-mcp-server.js"
+            # Langy reads the platform feature map at runtime
+            # (langwatch/src/shared/langy/featureMap.ts imports it from the
+            # repo root).
+            "package/feature-map.json"
           )
+          # Every workspace package in the checkout must ship: a missing one
+          # leaves dangling pnpm links in the installed tree and the app dies
+          # with MODULE_NOT_FOUND at first boot — 3.6.0 shipped exactly that
+          # way (.npmignore still excluded langwatch/packages/ after runtime
+          # packages moved in). Derived from the directory listing so a new
+          # package is covered the day it appears.
+          for pkgdir in langwatch/packages/*/ packages/handled-error/ packages/langy/; do
+            pkgdir="${pkgdir%/}"
+            [ -f "$pkgdir/package.json" ] || continue
+            required+=("package/$pkgdir/package.json")
+          done
           forbidden=(
             "package/langwatch/node_modules"
             "package/langwatch/.next/cache"

--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -217,6 +217,9 @@ jobs:
             # (langwatch/src/shared/langy/featureMap.ts imports it from the
             # repo root).
             "package/feature-map.json"
+            # The app's prepare step imports the skills front-matter helper
+            # (scripts/generate-langy-skills.ts) when a tree rebuilds.
+            "package/skills/_lib/frontmatter.js"
           )
           # Every workspace package in the checkout must ship: a missing one
           # leaves dangling pnpm links in the installed tree and the app dies

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -173,22 +173,27 @@ jobs:
           # window meant a boot that outlived the first window was then
           # sought on ports it never bound, turning a slow build into a
           # guaranteed 3x-window failure.
-          for i in $(seq 1 360); do
+          SECONDS=0
+          i=0
+          while [ "$SECONDS" -lt 1800 ]; do
+            i=$((i + 1))
             for shift in 0 10 20; do
               url="http://127.0.0.1:$((base + shift))/api/health"
-              if curl -fsS "$url" >/dev/null 2>&1; then
-                echo "✓ $url is healthy after $((i*5))s"
+              # -m bounds each probe: a half-open listener must not be able
+              # to hang the loop past the advertised budget.
+              if curl -fsS -m 5 "$url" >/dev/null 2>&1; then
+                echo "✓ $url is healthy after ${SECONDS}s"
                 echo "RESOLVED_BASE=$((base + shift))" >> "$GITHUB_ENV"
                 exit 0
               fi
             done
             if [ $((i % 24)) -eq 0 ]; then
-              echo "  …still waiting at $((i*5))s — last cli.log lines:"
+              echo "  …still waiting at ${SECONDS}s — last cli.log lines:"
               tail -n 10 "$GITHUB_WORKSPACE/_smoke.log" 2>/dev/null | sed 's/^/    /' || true
             fi
             sleep 5
           done
-          echo "✗ langwatch never reported healthy on any port slot"
+          echo "✗ langwatch never reported healthy on any port slot within ${SECONDS}s"
           exit 1
 
       - name: Probe service health endpoints

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -377,15 +377,10 @@ jobs:
     steps:
       - name: Decide on aggregate status
         run: |
-          # Smoke is informational until it's been running clean for a week —
-          # only fail the aggregator on workflow_dispatch + scheduled runs.
+          # The smoke boots the packed artifact — the thing npm users run —
+          # so a red smoke is a shippability signal on every trigger, not an
+          # informational one. Reporting success over failed or cancelled
+          # matrix jobs is how a broken artifact reads as green.
           status='${{ needs.smoke.result }}'
           echo "smoke status: $status"
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "$status" != "success" ]; then
-            exit 1
-          fi
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "$status" != "success" ]; then
-            exit 1
-          fi
-          # On push, never fail — let humans decide.
-          exit 0
+          [ "$status" = "success" ] || exit 1

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -137,9 +137,18 @@ jobs:
         run: |
           set -e
           mkdir -p "$LANGWATCH_HOME"
-          # `node packages/server/dist/cli.cjs` reproduces what `npx <tarball>` would
-          # do, but doesn't depend on a working npm registry. Faster + more stable.
-          node packages/server/dist/cli.cjs start \
+          # Boot from the EXTRACTED TARBALL, laid out the way npx lays it out
+          # (node_modules/@langwatch/server), so the run exercises the same
+          # relocation + install path npm users get and the app tree is
+          # exactly the published artifact. Booting the checkout instead
+          # masks packaging gaps: 3.6.0 shipped without langwatch/packages/*
+          # (both .npmignore files still excluded the dir after runtime
+          # packages moved in), every install died at first boot with
+          # MODULE_NOT_FOUND — and every checkout-based smoke run passed.
+          install_dir="$GITHUB_WORKSPACE/_pack/node_modules/@langwatch/server"
+          mkdir -p "$install_dir"
+          tar -xzf "${{ steps.pack.outputs.tarball }}" -C "$install_dir" --strip-components=1
+          node "$install_dir/packages/server/dist/cli.cjs" start \
             --yes \
             --no-open \
             --port-base "$PORT_BASE" \

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -111,6 +111,19 @@ jobs:
       - name: Build @langwatch/server CLI
         run: pnpm --filter @langwatch/server-cli build
 
+      # Same prebuild as npx-server-publish.yml: every published artifact
+      # ships langwatch/dist + mcp-server/dist (the publish sanity check
+      # asserts both), so the artifact THIS job boots must carry them too —
+      # otherwise the smoke exercises a tree shape no npm user ever receives
+      # and pays a full on-runner vite build for it inside the health budget.
+      - name: Install langwatch app deps
+        run: pnpm -C langwatch install --frozen-lockfile --prod=false
+
+      - name: Build langwatch app (vite + scenario + mcp + generated types)
+        run: pnpm -C langwatch run build
+        env:
+          NODE_ENV: production
+
       - name: Pack the npm tarball
         id: pack
         # Use the same wrapper as npx-server-publish.yml so the smoke tarball

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -156,37 +156,39 @@ jobs:
           echo "$!" > "$GITHUB_WORKSPACE/_smoke.pid"
           echo "Started CLI in background (pid $(cat $GITHUB_WORKSPACE/_smoke.pid))"
 
-      - name: Wait for /api/health (up to 18 minutes)
+      - name: Wait for /api/health (up to 30 minutes)
         run: |
           set -e
           base=${PORT_BASE}
           # CI runners have nothing cached — predep download (postgres ~80MB,
           # clickhouse ~100MB, redis tarball, uv installer) + uv venv install
-          # for langevals + aigateway/nlpgo monobinary download + pnpm
-          # install + vite build of the langwatch app together can take 8-12
-          # minutes on a cold runner. Be generous so the smoke isn't flaky on
-          # the initial provisioning window. Subsequent runs hit the cached
-          # ~/.langwatch and finish in <1 min.
+          # for langevals + aigateway/nlpgo monobinary download + relocation
+          # of the extracted tarball + pnpm install + vite build of the
+          # langwatch app together can take 15-25 minutes on a cold runner.
+          # Be generous so the smoke isn't flaky on the initial provisioning
+          # window. Subsequent runs hit the cached ~/.langwatch and finish
+          # in <1 min.
           #
-          # Auto-shift is unlikely on a fresh CI runner (5560 should be free)
-          # so the inner timeout is what matters; outer shift is a safety net.
-          for shift in 0 10 20; do
-            url="http://127.0.0.1:$((base + shift))/api/health"
-            echo "==> probing $url for up to 18min"
-            for i in $(seq 1 216); do
+          # Every port slot is probed in the SAME loop: probing one slot per
+          # window meant a boot that outlived the first window was then
+          # sought on ports it never bound, turning a slow build into a
+          # guaranteed 3x-window failure.
+          for i in $(seq 1 360); do
+            for shift in 0 10 20; do
+              url="http://127.0.0.1:$((base + shift))/api/health"
               if curl -fsS "$url" >/dev/null 2>&1; then
                 echo "✓ $url is healthy after $((i*5))s"
                 echo "RESOLVED_BASE=$((base + shift))" >> "$GITHUB_ENV"
                 exit 0
               fi
-              if [ $((i % 12)) -eq 0 ]; then
-                echo "  …still waiting at $((i*5))s — last cli.log lines:"
-                tail -n 10 "$GITHUB_WORKSPACE/_smoke.log" 2>/dev/null | sed 's/^/    /' || true
-              fi
-              sleep 5
             done
+            if [ $((i % 24)) -eq 0 ]; then
+              echo "  …still waiting at $((i*5))s — last cli.log lines:"
+              tail -n 10 "$GITHUB_WORKSPACE/_smoke.log" 2>/dev/null | sed 's/^/    /' || true
+            fi
+            sleep 5
           done
-          echo "✗ langwatch never reported healthy on any port-shift"
+          echo "✗ langwatch never reported healthy on any port slot"
           exit 1
 
       - name: Probe service health endpoints

--- a/.npmignore
+++ b/.npmignore
@@ -8,10 +8,11 @@
 # .github/workflows/npx-server-publish.yml so end users skip the runtime
 # `vite build` step.
 
-# Internal dev tooling — used only during langwatch development, never at
-# runtime by `npx @langwatch/server`. Keeping these out cuts the tarball
-# in half (deja-view alone is ~1MB).
-langwatch/packages/
+# langwatch/packages/ is intentionally INCLUDED. Its members are runtime
+# workspace dependencies of the app (@langwatch/observability, automations,
+# react-rum, redaction, ssrf, api) — excluding them ships an app whose
+# `workspace:*` links dangle and whose first import dies with
+# MODULE_NOT_FOUND. All members together are under 1MB of source.
 
 # Jupyter notebooks — exploration artifacts, not runtime code.
 langwatch_nlp/notebooks/

--- a/langwatch/.npmignore
+++ b/langwatch/.npmignore
@@ -17,10 +17,10 @@ node_modules/
 .turbo/
 .vercel/
 
-# Internal dev tooling — used only during langwatch development, never at
-# runtime by `npx @langwatch/server`. Keeping these out matters; deja-view
-# alone is ~1MB.
-packages/
+# packages/ is intentionally INCLUDED: these are runtime workspace
+# dependencies of the app (@langwatch/observability and friends), declared
+# `workspace:*` in package.json. Excluding them leaves dangling node_modules
+# links in the shipped tree and the app dies at its first import.
 
 # Test artifacts.
 coverage/

--- a/langwatch/scripts/build-mcp-server.sh
+++ b/langwatch/scripts/build-mcp-server.sh
@@ -13,9 +13,14 @@ printf 'building mcp server... '
 # is nothing to build from, and the shipped dist is the thing to use. Only
 # a tree that carries the build config gets rebuilt.
 mcp_root="$(cd "$(dirname "$0")/../.." && pwd)/mcp-server"
-if [ ! -f "$mcp_root/tsup.config.ts" ] && [ -f "$mcp_root/dist/create-mcp-server.js" ]; then
-  printf 'prebuilt in published artifact, skipping\n'
-  exit 0
+if [ ! -f "$mcp_root/tsup.config.ts" ]; then
+  if [ -f "$mcp_root/dist/create-mcp-server.js" ]; then
+    printf 'prebuilt in published artifact, skipping\n'
+    exit 0
+  fi
+  printf 'FAILED\n'
+  printf 'mcp-server has neither its build config nor a prebuilt dist — the artifact is incomplete (packaging bug in @langwatch/server).\n'
+  exit 1
 fi
 # process.stdout.write, not console.log: under `pnpm dev` concurrently sets
 # FORCE_COLOR, and console.log wraps numbers in ANSI colour codes even when

--- a/langwatch/scripts/build-mcp-server.sh
+++ b/langwatch/scripts/build-mcp-server.sh
@@ -7,6 +7,16 @@
 set -eo pipefail
 
 printf 'building mcp server... '
+
+# The published @langwatch/server artifact ships mcp-server PRE-BUILT and
+# deliberately excludes its build config (see mcp-server/.npmignore): there
+# is nothing to build from, and the shipped dist is the thing to use. Only
+# a tree that carries the build config gets rebuilt.
+mcp_root="$(cd "$(dirname "$0")/../.." && pwd)/mcp-server"
+if [ ! -f "$mcp_root/tsup.config.ts" ] && [ -f "$mcp_root/dist/create-mcp-server.js" ]; then
+  printf 'prebuilt in published artifact, skipping\n'
+  exit 0
+fi
 # process.stdout.write, not console.log: under `pnpm dev` concurrently sets
 # FORCE_COLOR, and console.log wraps numbers in ANSI colour codes even when
 # piped — which then get interpolated into the elapsed-time eval below.

--- a/langwatch/scripts/generate-langy-skills.ts
+++ b/langwatch/scripts/generate-langy-skills.ts
@@ -187,6 +187,16 @@ export function deriveSkills(repoRoot: string): GeneratedSkill[] {
 
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
+  // The published @langwatch/server artifact ships the committed catalogue and
+  // deliberately excludes Dockerfile.langyagent (nothing to derive from). The
+  // committed output IS the catalogue there; only a tree that can regenerate
+  // does. A tree with neither still fails loudly below.
+  if (!fs.existsSync(DOCKERFILE) && fs.existsSync(OUT)) {
+    console.log(
+      "Dockerfile.langyagent not in this tree (published artifact) — keeping the committed Langy skill catalogue.",
+    );
+    process.exit(0);
+  }
   const skills = deriveSkills(REPO_ROOT);
   fs.writeFileSync(OUT, JSON.stringify(skills, null, 2) + "\n");
   const counts = skills.reduce<Record<string, number>>((acc, s) => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "python-sdk/",
     "mcp-server/",
     "scripts/",
+    "skills/",
     "feature-map.json",
     "README.md",
     "LICENSE.md"

--- a/package.json
+++ b/package.json
@@ -33,11 +33,14 @@
   "files": [
     "packages/server/dist/",
     "packages/server/templates/",
+    "packages/handled-error/",
+    "packages/langy/",
     "langwatch/",
     "langevals/",
     "python-sdk/",
     "mcp-server/",
     "scripts/",
+    "feature-map.json",
     "README.md",
     "LICENSE.md"
   ],

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,251 +1,317 @@
-import { Command } from "commander";
-import chalk from "chalk";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import chalk from "chalk";
+import { Command } from "commander";
 import prompts from "prompts";
 import { printBanner } from "./animation/banner.ts";
-import { openBrowser } from "./animation/open-browser.ts";
+import {
+	isInstallEvent,
+	makeInstallPanelRouter,
+	renderInstallPanels,
+} from "./animation/install-panels.ts";
 import { streamEventsToTTY } from "./animation/log-tee.ts";
-import { isInstallEvent, makeInstallPanelRouter, renderInstallPanels } from "./animation/install-panels.ts";
-import { runPredeps } from "./predeps/runner.ts";
-import { inspectPredeps, printDoctorTable } from "./predeps/detect-only.ts";
+import { openBrowser } from "./animation/open-browser.ts";
 import { resolvePortConflicts } from "./port-conflict/resolve.ts";
-import { paths } from "./shared/paths.ts";
-import { allocatePorts, PORT_BASE_DEFAULT } from "./shared/ports.ts";
-import { detectPlatform } from "./shared/platform.ts";
+import { inspectPredeps, printDoctorTable } from "./predeps/detect-only.ts";
+import { runPredeps } from "./predeps/runner.ts";
 import { captureUserEnv, scaffoldEnvFile } from "./shared/env.ts";
-import { placeholderRuntime, type RuntimeApi, type RuntimeContext, type ServiceHandle } from "./shared/runtime-placeholder.ts";
+import { paths } from "./shared/paths.ts";
+import { detectPlatform } from "./shared/platform.ts";
+import { allocatePorts, PORT_BASE_DEFAULT } from "./shared/ports.ts";
+import {
+	placeholderRuntime,
+	type RuntimeApi,
+	type RuntimeContext,
+	type ServiceHandle,
+} from "./shared/runtime-placeholder.ts";
 
 declare const __LANGWATCH_VERSION__: string;
-const VERSION = typeof __LANGWATCH_VERSION__ !== "undefined" ? __LANGWATCH_VERSION__ : "0.0.0-dev";
+const VERSION =
+	typeof __LANGWATCH_VERSION__ !== "undefined"
+		? __LANGWATCH_VERSION__
+		: "0.0.0-dev";
 
 async function loadRuntime(): Promise<RuntimeApi> {
-  try {
-    // services/runtime.ts is julia's lane — see specs/npx-installer/03-services.feature.
-    const real = await import("./services/runtime.ts" as any);
-    if (real?.runtime) return real.runtime;
-    console.warn(chalk.yellow("⚠ services/runtime.ts loaded but does not export `runtime` — falling back to placeholder"));
-    return placeholderRuntime;
-  } catch (err) {
-    console.warn(chalk.yellow(`⚠ failed to load services/runtime.ts: ${(err as Error).message}`));
-    return placeholderRuntime;
-  }
+	try {
+		// services/runtime.ts is julia's lane — see specs/npx-installer/03-services.feature.
+		const real = await import("./services/runtime.ts" as any);
+		if (real?.runtime) return real.runtime;
+		console.warn(
+			chalk.yellow(
+				"⚠ services/runtime.ts loaded but does not export `runtime` — falling back to placeholder",
+			),
+		);
+		return placeholderRuntime;
+	} catch (err) {
+		console.warn(
+			chalk.yellow(
+				`⚠ failed to load services/runtime.ts: ${(err as Error).message}`,
+			),
+		);
+		return placeholderRuntime;
+	}
 }
 
-function ensureEnvFile(ctx: RuntimeContext): { written: boolean; path: string } {
-  return scaffoldEnvFile({ ports: ctx.ports, path: ctx.paths.envFile });
+function ensureEnvFile(
+	ctx: RuntimeContext,
+	{ reconcilePorts = false }: { reconcilePorts?: boolean } = {},
+): { written: boolean; path: string; reconciledKeys: string[] } {
+	return scaffoldEnvFile({
+		ports: ctx.ports,
+		path: ctx.paths.envFile,
+		reconcilePorts,
+	});
 }
 
 const program = new Command();
 
 program
-  .name("langwatch-server")
-  .description("Run LangWatch locally — postgres, redis, clickhouse, langwatch app, langevals, ai-gateway")
-  .version(VERSION, "-v, --version");
+	.name("langwatch-server")
+	.description(
+		"Run LangWatch locally — postgres, redis, clickhouse, langwatch app, langevals, ai-gateway",
+	)
+	.version(VERSION, "-v, --version");
 
 program
-  .command("start", { isDefault: true })
-  .description("install missing predeps, scaffold .env, start every service, open the browser")
-  .option("--port-base <n>", "first port slot to use", String(PORT_BASE_DEFAULT))
-  .option("-y, --yes", "skip every confirmation prompt", false)
-  .option("--no-open", "do not auto-open the browser when ready")
-  .option("--dry-run","print what would be done and exit (no installs, no env, no services)", false)
-  .action(async (opts) => {
-    detectPlatform();
-    printBanner(VERSION);
+	.command("start", { isDefault: true })
+	.description(
+		"install missing predeps, scaffold .env, start every service, open the browser",
+	)
+	.option(
+		"--port-base <n>",
+		"first port slot to use",
+		String(PORT_BASE_DEFAULT),
+	)
+	.option("-y, --yes", "skip every confirmation prompt", false)
+	.option("--no-open", "do not auto-open the browser when ready")
+	.option(
+		"--dry-run",
+		"print what would be done and exit (no installs, no env, no services)",
+		false,
+	)
+	.action(async (opts) => {
+		detectPlatform();
+		printBanner(VERSION);
 
-    if (opts.dryRun) {
-      const base = Number.parseInt(opts.portBase, 10);
-      const ports = allocatePorts(base);
-      console.log(chalk.bold("dry-run — no work performed"));
-      console.log("");
-      console.log(chalk.bold("port-base:"), base);
-      console.log(chalk.bold("ports:"));
-      for (const [k, v] of Object.entries(ports)) {
-        if (k === "base") continue;
-        console.log(`  ${k.padEnd(18)} ${v}`);
-      }
-      console.log("");
-      console.log(chalk.bold("paths:"));
-      for (const [k, v] of Object.entries(paths)) console.log(`  ${k.padEnd(18)} ${v}`);
-      process.exit(0);
-    }
+		if (opts.dryRun) {
+			const base = Number.parseInt(opts.portBase, 10);
+			const ports = allocatePorts(base);
+			console.log(chalk.bold("dry-run — no work performed"));
+			console.log("");
+			console.log(chalk.bold("port-base:"), base);
+			console.log(chalk.bold("ports:"));
+			for (const [k, v] of Object.entries(ports)) {
+				if (k === "base") continue;
+				console.log(`  ${k.padEnd(18)} ${v}`);
+			}
+			console.log("");
+			console.log(chalk.bold("paths:"));
+			for (const [k, v] of Object.entries(paths))
+				console.log(`  ${k.padEnd(18)} ${v}`);
+			process.exit(0);
+		}
 
-    const base = Number.parseInt(opts.portBase, 10);
-    const { base: resolvedBase } = await resolvePortConflicts({ base, yes: opts.yes });
-    const ports = allocatePorts(resolvedBase);
+		const base = Number.parseInt(opts.portBase, 10);
+		const { base: resolvedBase } = await resolvePortConflicts({
+			base,
+			yes: opts.yes,
+		});
+		const ports = allocatePorts(resolvedBase);
 
-    // First-run signpost — predep tarballs + langwatch app deps are cached
-    // after the initial install, so warm starts complete in <30s. Cold
-    // first-run can take 3-5 min (clickhouse 178MB download, uv venv
-    // builds, pnpm install). Tell the user up front so the wait isn't
-    // silent. Both gates have to be empty: paths.bin holds the predep
-    // binaries, install-manifest.json is written after the langwatch app
-    // relocation completes.
-    if (!existsSync(paths.bin) && !existsSync(paths.installManifest)) {
-      console.log("");
-      console.log(chalk.dim("Setting up ~/.langwatch for the first time, this may take a few minutes."));
-      console.log(chalk.dim("Next runs will be much faster."));
-      console.log("");
-    }
+		// First-run signpost — predep tarballs + langwatch app deps are cached
+		// after the initial install, so warm starts complete in <30s. Cold
+		// first-run can take 3-5 min (clickhouse 178MB download, uv venv
+		// builds, pnpm install). Tell the user up front so the wait isn't
+		// silent. Both gates have to be empty: paths.bin holds the predep
+		// binaries, install-manifest.json is written after the langwatch app
+		// relocation completes.
+		if (!existsSync(paths.bin) && !existsSync(paths.installManifest)) {
+			console.log("");
+			console.log(
+				chalk.dim(
+					"Setting up ~/.langwatch for the first time, this may take a few minutes.",
+				),
+			);
+			console.log(chalk.dim("Next runs will be much faster."));
+			console.log("");
+		}
 
-    const predeps = await runPredeps({ yes: opts.yes, version: VERSION });
+		const predeps = await runPredeps({ yes: opts.yes, version: VERSION });
 
-    const runtime = await loadRuntime();
-    const ctx: RuntimeContext = {
-      ports,
-      paths,
-      predeps,
-      envFile: paths.envFile,
-      version: VERSION,
-      userEnv: captureUserEnv(),
-    };
+		const runtime = await loadRuntime();
+		const ctx: RuntimeContext = {
+			ports,
+			paths,
+			predeps,
+			envFile: paths.envFile,
+			version: VERSION,
+			userEnv: captureUserEnv(),
+		};
 
-    ensureEnvFile(ctx);
+		const envResult = ensureEnvFile(ctx, { reconcilePorts: true });
+		if (envResult.reconciledKeys.length > 0) {
+			console.log(
+				chalk.yellow(
+					`→ ports moved to ${ports.base} — updated ${envResult.reconciledKeys.join(", ")} in ${envResult.path}`,
+				),
+			);
+		}
 
-    // Drain runtime events from the start. The same async stream feeds two
-    // renderers:
-    //   - install-phase events → docker-buildx-style bounded panels
-    //     (one per service, last 5 lines visible) via the router below.
-    //   - everything else → `concurrently`-style prefixed scroll lines
-    //     in animation/log-tee.ts.
-    // The router buffers events that arrive before listr2's task subscribes
-    // (typical race: prepare:app emits 'starting' before the panels render
-    // resolves the task callbacks).
-    const installRouter = makeInstallPanelRouter();
-    const panelsPromise = renderInstallPanels(installRouter);
-    const eventsStream = streamEventsToTTY(runtime.events(ctx), {
-      intercept: (ev) => {
-        if (!isInstallEvent(ev)) return false;
-        installRouter.feed(ev);
-        return true;
-      },
-    });
+		// Drain runtime events from the start. The same async stream feeds two
+		// renderers:
+		//   - install-phase events → docker-buildx-style bounded panels
+		//     (one per service, last 5 lines visible) via the router below.
+		//   - everything else → `concurrently`-style prefixed scroll lines
+		//     in animation/log-tee.ts.
+		// The router buffers events that arrive before listr2's task subscribes
+		// (typical race: prepare:app emits 'starting' before the panels render
+		// resolves the task callbacks).
+		const installRouter = makeInstallPanelRouter();
+		const panelsPromise = renderInstallPanels(installRouter);
+		const eventsStream = streamEventsToTTY(runtime.events(ctx), {
+			intercept: (ev) => {
+				if (!isInstallEvent(ev)) return false;
+				installRouter.feed(ev);
+				return true;
+			},
+		});
 
-    // Register the shutdown handler BEFORE installServices/startAll so a
-    // Ctrl+C during install or boot still tears down anything we've
-    // already spawned. The handles array is populated by `startAll` after
-    // each service comes up; until then the handler closes the events
-    // stream and exits cleanly. Without an early registration, SIGINT
-    // during boot would orphan supervised children (they get reparented
-    // to launchd/init and keep running) and leak postgres/redis/clickhouse
-    // ports across runs.
-    let handles: ServiceHandle[] = [];
-    let shuttingDown = false;
-    const onShutdown = async () => {
-      if (shuttingDown) return;
-      shuttingDown = true;
-      console.log(chalk.yellow("\n  ⏻ shutting down LangWatch..."));
-      installRouter.installFinished();
-      if (handles.length > 0) {
-        await runtime.stopAll(handles).catch(() => undefined);
-      }
-      await eventsStream.catch(() => undefined);
-      process.exit(0);
-    };
-    process.on("SIGINT", onShutdown);
-    process.on("SIGTERM", onShutdown);
+		// Register the shutdown handler BEFORE installServices/startAll so a
+		// Ctrl+C during install or boot still tears down anything we've
+		// already spawned. The handles array is populated by `startAll` after
+		// each service comes up; until then the handler closes the events
+		// stream and exits cleanly. Without an early registration, SIGINT
+		// during boot would orphan supervised children (they get reparented
+		// to launchd/init and keep running) and leak postgres/redis/clickhouse
+		// ports across runs.
+		let handles: ServiceHandle[] = [];
+		let shuttingDown = false;
+		const onShutdown = async () => {
+			if (shuttingDown) return;
+			shuttingDown = true;
+			console.log(chalk.yellow("\n  ⏻ shutting down LangWatch..."));
+			installRouter.installFinished();
+			if (handles.length > 0) {
+				await runtime.stopAll(handles).catch(() => undefined);
+			}
+			await eventsStream.catch(() => undefined);
+			process.exit(0);
+		};
+		process.on("SIGINT", onShutdown);
+		process.on("SIGTERM", onShutdown);
 
-    try {
-      await runtime.installServices(ctx);
-    } finally {
-      // Signal panels for cached steps to skip and any pending tasks to
-      // close. Even if installServices throws mid-step, we don't want
-      // panels left hanging on the screen during error reporting.
-      installRouter.installFinished();
-    }
-    await panelsPromise;
+		try {
+			await runtime.installServices(ctx);
+		} finally {
+			// Signal panels for cached steps to skip and any pending tasks to
+			// close. Even if installServices throws mid-step, we don't want
+			// panels left hanging on the screen during error reporting.
+			installRouter.installFinished();
+		}
+		await panelsPromise;
 
-    handles = await runtime.startAll(ctx);
-    await runtime.waitForHealth(ctx, { timeoutMs: 60_000 });
+		handles = await runtime.startAll(ctx);
+		await runtime.waitForHealth(ctx, { timeoutMs: 60_000 });
 
-    const url = `http://localhost:${ports.langwatch}`;
-    if (opts.open !== false && !process.env.CI) await openBrowser(url);
+		const url = `http://localhost:${ports.langwatch}`;
+		if (opts.open !== false && !process.env.CI) await openBrowser(url);
 
-    // Block forever — drained by the events tee above. SIGINT exits via
-    // `onShutdown`; an uncaught crash event in renderEvent ends the
-    // iterator and returns control here.
-    await eventsStream;
-  });
-
-program
-  .command("doctor")
-  .description("check which predeps and services are installed; do not change anything")
-  .option("--port-base <n>", "report the resolved ports for this base", String(PORT_BASE_DEFAULT))
-  .action(async (opts) => {
-    detectPlatform();
-    printBanner(VERSION);
-    const rows = await inspectPredeps({ version: VERSION });
-    printDoctorTable(rows);
-    const base = Number.parseInt(opts.portBase, 10);
-    const ports = allocatePorts(base);
-    const { detectConflicts } = await import("./port-conflict/detect.ts");
-    const conflicts = await detectConflicts(base);
-    console.log(chalk.bold(`Ports (port-base=${base})`));
-    for (const [k, v] of Object.entries(ports)) {
-      if (k === "base") continue;
-      const conflict = conflicts.conflicts.find((c) => c.port === v);
-      const marker = conflict ? chalk.red("✗") : chalk.green("✓");
-      console.log(`  ${marker} ${k.padEnd(18)} ${v}`);
-      if (conflict) {
-        console.log(chalk.dim(`      held by pid ${conflict.pid}: ${conflict.command}`));
-      }
-    }
-    console.log("");
-    const missing = rows.filter((r) => !r.installed).length;
-    const exitCode = missing === 0 && conflicts.conflicts.length === 0 ? 0 : 1;
-    process.exit(exitCode);
-  });
+		// Block forever — drained by the events tee above. SIGINT exits via
+		// `onShutdown`; an uncaught crash event in renderEvent ends the
+		// iterator and returns control here.
+		await eventsStream;
+	});
 
 program
-  .command("install")
-  .description("install missing predeps and services without starting anything")
-  .option("-y, --yes", "skip confirmation", false)
-  .action(async (opts) => {
-    detectPlatform();
-    printBanner(VERSION);
-    await runPredeps({ yes: opts.yes, version: VERSION });
-    const runtime = await loadRuntime();
-    const base = PORT_BASE_DEFAULT;
-    const ports = allocatePorts(base);
-    const ctx: RuntimeContext = {
-      ports,
-      paths,
-      predeps: {},
-      envFile: paths.envFile,
-      version: VERSION,
-      userEnv: captureUserEnv(),
-    };
-    ensureEnvFile(ctx);
-    await runtime.installServices(ctx);
-    console.log(chalk.green("✓ install complete — run `npx @langwatch/server` to start"));
-  });
+	.command("doctor")
+	.description(
+		"check which predeps and services are installed; do not change anything",
+	)
+	.option(
+		"--port-base <n>",
+		"report the resolved ports for this base",
+		String(PORT_BASE_DEFAULT),
+	)
+	.action(async (opts) => {
+		detectPlatform();
+		printBanner(VERSION);
+		const rows = await inspectPredeps({ version: VERSION });
+		printDoctorTable(rows);
+		const base = Number.parseInt(opts.portBase, 10);
+		const ports = allocatePorts(base);
+		const { detectConflicts } = await import("./port-conflict/detect.ts");
+		const conflicts = await detectConflicts(base);
+		console.log(chalk.bold(`Ports (port-base=${base})`));
+		for (const [k, v] of Object.entries(ports)) {
+			if (k === "base") continue;
+			const conflict = conflicts.conflicts.find((c) => c.port === v);
+			const marker = conflict ? chalk.red("✗") : chalk.green("✓");
+			console.log(`  ${marker} ${k.padEnd(18)} ${v}`);
+			if (conflict) {
+				console.log(
+					chalk.dim(`      held by pid ${conflict.pid}: ${conflict.command}`),
+				);
+			}
+		}
+		console.log("");
+		const missing = rows.filter((r) => !r.installed).length;
+		const exitCode = missing === 0 && conflicts.conflicts.length === 0 ? 0 : 1;
+		process.exit(exitCode);
+	});
 
 program
-  .command("reset")
-  .description("delete ~/.langwatch (binaries, data, env) so the next run is a clean install")
-  .action(async () => {
-    const { confirmed } = await prompts(
-      {
-        type: "confirm",
-        name: "confirmed",
-        message: `Permanently delete ${paths.root} (binaries, postgres data, redis data, clickhouse data, env)?`,
-        initial: false,
-      },
-      { onCancel: () => process.exit(130) }
-    );
-    if (!confirmed) {
-      console.log(chalk.yellow("Aborted."));
-      process.exit(0);
-    }
-    const { rmSync } = await import("node:fs");
-    rmSync(paths.root, { recursive: true, force: true });
-    console.log(chalk.green(`✓ removed ${paths.root}`));
-  });
+	.command("install")
+	.description("install missing predeps and services without starting anything")
+	.option("-y, --yes", "skip confirmation", false)
+	.action(async (opts) => {
+		detectPlatform();
+		printBanner(VERSION);
+		await runPredeps({ yes: opts.yes, version: VERSION });
+		const runtime = await loadRuntime();
+		const base = PORT_BASE_DEFAULT;
+		const ports = allocatePorts(base);
+		const ctx: RuntimeContext = {
+			ports,
+			paths,
+			predeps: {},
+			envFile: paths.envFile,
+			version: VERSION,
+			userEnv: captureUserEnv(),
+		};
+		ensureEnvFile(ctx);
+		await runtime.installServices(ctx);
+		console.log(
+			chalk.green("✓ install complete — run `npx @langwatch/server` to start"),
+		);
+	});
+
+program
+	.command("reset")
+	.description(
+		"delete ~/.langwatch (binaries, data, env) so the next run is a clean install",
+	)
+	.action(async () => {
+		const { confirmed } = await prompts(
+			{
+				type: "confirm",
+				name: "confirmed",
+				message: `Permanently delete ${paths.root} (binaries, postgres data, redis data, clickhouse data, env)?`,
+				initial: false,
+			},
+			{ onCancel: () => process.exit(130) },
+		);
+		if (!confirmed) {
+			console.log(chalk.yellow("Aborted."));
+			process.exit(0);
+		}
+		const { rmSync } = await import("node:fs");
+		rmSync(paths.root, { recursive: true, force: true });
+		console.log(chalk.green(`✓ removed ${paths.root}`));
+	});
 
 program.parseAsync(process.argv).catch((err) => {
-  console.error(chalk.red(`✗ ${err.message ?? err}`));
-  process.exit(1);
+	console.error(chalk.red(`✗ ${err.message ?? err}`));
+	process.exit(1);
 });
 
 // Pull resolve to silence "unused import" if commander is configured oddly.

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
 import prompts from "prompts";
@@ -54,12 +53,12 @@ async function loadRuntime(): Promise<RuntimeApi> {
 
 function ensureEnvFile(
 	ctx: RuntimeContext,
-	{ reconcilePorts = false }: { reconcilePorts?: boolean } = {},
+	{ shouldReconcilePorts = false }: { shouldReconcilePorts?: boolean } = {},
 ): { written: boolean; path: string; reconciledKeys: string[] } {
 	return scaffoldEnvFile({
 		ports: ctx.ports,
 		path: ctx.paths.envFile,
-		reconcilePorts,
+		shouldReconcilePorts,
 	});
 }
 
@@ -148,7 +147,7 @@ program
 			userEnv: captureUserEnv(),
 		};
 
-		const envResult = ensureEnvFile(ctx, { reconcilePorts: true });
+		const envResult = ensureEnvFile(ctx, { shouldReconcilePorts: true });
 		if (envResult.reconciledKeys.length > 0) {
 			console.log(
 				chalk.yellow(
@@ -313,6 +312,3 @@ program.parseAsync(process.argv).catch((err) => {
 	console.error(chalk.red(`✗ ${err.message ?? err}`));
 	process.exit(1);
 });
-
-// Pull resolve to silence "unused import" if commander is configured oddly.
-void resolve;

--- a/packages/server/src/services/app-dir.ts
+++ b/packages/server/src/services/app-dir.ts
@@ -1,7 +1,14 @@
-import { execa } from "execa";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { execa } from "execa";
 import { paths } from "../shared/paths.ts";
 import type { RuntimeContext } from "../shared/runtime-contract.ts";
 import type { EventBus } from "./event-bus.ts";
@@ -17,25 +24,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * So `dirname(cli.cjs)/../../..` == package root in both.
  */
 function locatePackageSource(): string | null {
-  // Walk up rather than counting levels: the bundled entrypoint sits at
-  // packages/server/dist/cli.cjs and this module at packages/server/src/
-  // services/app-dir.ts, which are different depths. A fixed `../../..`
-  // resolves correctly from the bundle and one directory short from source,
-  // so running the CLI from a checkout (`tsx src/cli.ts`) died with "could
-  // not locate @langwatch/server package source" after every predep had
-  // already been downloaded.
-  let dir = __dirname;
-  for (let i = 0; i < 6; i++) {
-    if (existsSync(join(dir, "langwatch", "package.json"))) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return null;
+	// Walk up rather than counting levels: the bundled entrypoint sits at
+	// packages/server/dist/cli.cjs and this module at packages/server/src/
+	// services/app-dir.ts, which are different depths. A fixed `../../..`
+	// resolves correctly from the bundle and one directory short from source,
+	// so running the CLI from a checkout (`tsx src/cli.ts`) died with "could
+	// not locate @langwatch/server package source" after every predep had
+	// already been downloaded.
+	let dir = __dirname;
+	for (let i = 0; i < 6; i++) {
+		if (existsSync(join(dir, "langwatch", "package.json"))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return null;
 }
 
 function isUnderNodeModules(p: string): boolean {
-  return p.split(/[\\/]/).includes("node_modules");
+	return p.split(/[\\/]/).includes("node_modules");
 }
 
 /**
@@ -57,55 +64,93 @@ function isUnderNodeModules(p: string): boolean {
  * directly in the relocated dir. Idempotent via a .installed-version
  * marker — same version → no-op.
  */
-export async function ensureAppDir(ctx: RuntimeContext, bus: EventBus): Promise<void> {
-  const src = locatePackageSource();
-  if (!src) throw new Error("could not locate @langwatch/server package source");
+export async function ensureAppDir(
+	ctx: RuntimeContext,
+	bus: EventBus,
+): Promise<void> {
+	const src = locatePackageSource();
+	if (!src)
+		throw new Error("could not locate @langwatch/server package source");
 
-  // Dev mode: source is checked out at a regular path (no node_modules
-  // ancestor). The tsx guard doesn't fire and editing in-place is part of
-  // the dev loop — relocating would break that. appRoot() handles this
-  // case by returning the source path directly.
-  if (!isUnderNodeModules(src)) return;
+	// Dev mode: source is checked out at a regular path (no node_modules
+	// ancestor). The tsx guard doesn't fire and editing in-place is part of
+	// the dev loop — relocating would break that. appRoot() handles this
+	// case by returning the source path directly.
+	if (!isUnderNodeModules(src)) return;
 
-  const dst = ctx.paths.app;
-  const versionMarker = join(dst, ".installed-version");
+	const dst = ctx.paths.app;
+	const versionMarker = join(dst, ".installed-version");
 
-  if (existsSync(versionMarker)) {
-    const installed = readFileSync(versionMarker, "utf8").trim();
-    if (installed === ctx.version) return;
-  }
+	if (existsSync(versionMarker)) {
+		const installed = readFileSync(versionMarker, "utf8").trim();
+		if (installed === ctx.version) return;
+	}
 
-  bus.emit({ type: "starting", service: "prepare:app" as never });
-  const start = Date.now();
+	bus.emit({ type: "starting", service: "prepare:app" as never });
+	const start = Date.now();
 
-  mkdirSync(dst, { recursive: true });
+	mkdirSync(dst, { recursive: true });
 
-  // Prefer rsync — handles --exclude for node_modules and --delete for
-  // version upgrades in one pass. Falls back to a tar pipe (universally
-  // available) if rsync is missing on the host.
-  const rsyncProbe = await execa("which", ["rsync"], { reject: false });
-  if (rsyncProbe.exitCode === 0) {
-    await execa(
-      "rsync",
-      [
-        "-a",
-        "--delete",
-        "--exclude=node_modules",
-        "--exclude=.installed-version",
-        "--exclude=.git",
-        `${src}/`,
-        `${dst}/`,
-      ],
-      { stdio: "pipe" },
-    );
-  } else {
-    // tar | tar avoids cp -R's quirks across BSD vs GNU and gives us
-    // exclude support. Stream so memory stays flat for large trees.
-    await execa("sh", ["-c", `tar -cf - --exclude=node_modules --exclude=.git -C "${src}" . | tar -xf - -C "${dst}"`]);
-  }
+	// Prefer rsync — handles --exclude for node_modules and --delete for
+	// version upgrades in one pass. Falls back to a tar pipe (universally
+	// available) if rsync is missing on the host.
+	const rsyncProbe = await execa("which", ["rsync"], { reject: false });
+	if (rsyncProbe.exitCode === 0) {
+		await execa(
+			"rsync",
+			[
+				"-a",
+				"--delete",
+				"--exclude=node_modules",
+				"--exclude=.installed-version",
+				"--exclude=.git",
+				`${src}/`,
+				`${dst}/`,
+			],
+			{ stdio: "pipe" },
+		);
+	} else {
+		// tar | tar avoids cp -R's quirks across BSD vs GNU and gives us
+		// exclude support. Stream so memory stays flat for large trees.
+		await execa("sh", [
+			"-c",
+			`tar -cf - --exclude=node_modules --exclude=.git -C "${src}" . | tar -xf - -C "${dst}"`,
+		]);
+	}
 
-  writeFileSync(versionMarker, ctx.version);
-  bus.emit({ type: "healthy", service: "prepare:app" as never, durationMs: Date.now() - start });
+	// pnpm pack normalizes file modes, so every shell script in the published
+	// artifact arrives without its executable bit — and the app's build chain
+	// invokes some of them directly (`pnpm run build` → ./scripts/build-mcp-server.sh
+	// died with exit 126 on exactly this). Restore the bit on the relocated copy.
+	restoreShellScriptBits(dst);
+
+	writeFileSync(versionMarker, ctx.version);
+	bus.emit({
+		type: "healthy",
+		service: "prepare:app" as never,
+		durationMs: Date.now() - start,
+	});
+}
+
+/**
+ * Marks every *.sh in the tree executable (skipping node_modules). Exported
+ * for tests.
+ */
+export function restoreShellScriptBits(root: string): number {
+	let restored = 0;
+	const walk = (dir: string) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === "node_modules" || entry.name === ".git") continue;
+			const p = join(dir, entry.name);
+			if (entry.isDirectory()) walk(p);
+			else if (entry.isFile() && entry.name.endsWith(".sh")) {
+				chmodSync(p, 0o755);
+				restored++;
+			}
+		}
+	};
+	walk(root);
+	return restored;
 }
 
 /**
@@ -114,14 +159,17 @@ export async function ensureAppDir(ctx: RuntimeContext, bus: EventBus): Promise<
  * that don't go through installServices).
  */
 export function appRoot(): string {
-  // Prefer the relocated tree when ensureAppDir has actually relocated
-  // (i.e. there's a version marker). Otherwise fall back to the source —
-  // either dev mode (no relocation needed) or pre-relocation lookup
-  // during the install phase itself.
-  if (existsSync(join(paths.app, ".installed-version"))) {
-    return paths.app;
-  }
-  const src = locatePackageSource();
-  if (!src) throw new Error("@langwatch/server tree not found (neither relocated nor in source layout)");
-  return src;
+	// Prefer the relocated tree when ensureAppDir has actually relocated
+	// (i.e. there's a version marker). Otherwise fall back to the source —
+	// either dev mode (no relocation needed) or pre-relocation lookup
+	// during the install phase itself.
+	if (existsSync(join(paths.app, ".installed-version"))) {
+		return paths.app;
+	}
+	const src = locatePackageSource();
+	if (!src)
+		throw new Error(
+			"@langwatch/server tree not found (neither relocated nor in source layout)",
+		);
+	return src;
 }

--- a/packages/server/src/services/env.ts
+++ b/packages/server/src/services/env.ts
@@ -1,12 +1,20 @@
-import type { RuntimeContext } from "../shared/runtime-contract.ts";
 import { scaffoldEnvFile } from "../shared/env.ts";
+import type { RuntimeContext } from "../shared/runtime-contract.ts";
 
 /**
  * `runtime.scaffoldEnv` thin wrapper. Idempotent — if `~/.langwatch/.env`
- * exists we leave it alone so the user's saved OPENAI_API_KEY/etc. survive
- * across runs. The CLI's `[2/4] env` phase calls this; the runtime calls
- * it again before `installServices` as a safety net.
+ * exists, user-owned values (OPENAI_API_KEY etc.) survive across runs and
+ * only the port-bound URLs are reconciled to this run's allocation (the
+ * ctx here always carries a real, conflict-checked port table).
  */
-export function scaffoldEnv(ctx: RuntimeContext): { written: boolean; path: string } {
-  return scaffoldEnvFile({ ports: ctx.ports, path: ctx.envFile });
+export function scaffoldEnv(ctx: RuntimeContext): {
+	written: boolean;
+	path: string;
+	reconciledKeys: string[];
+} {
+	return scaffoldEnvFile({
+		ports: ctx.ports,
+		path: ctx.envFile,
+		reconcilePorts: true,
+	});
 }

--- a/packages/server/src/services/env.ts
+++ b/packages/server/src/services/env.ts
@@ -15,6 +15,6 @@ export function scaffoldEnv(ctx: RuntimeContext): {
 	return scaffoldEnvFile({
 		ports: ctx.ports,
 		path: ctx.envFile,
-		reconcilePorts: true,
+		shouldReconcilePorts: true,
 	});
 }

--- a/packages/server/src/services/node-deps.ts
+++ b/packages/server/src/services/node-deps.ts
@@ -1,11 +1,18 @@
-import { execa } from "execa";
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, sep } from "node:path";
-import { appRoot } from "./app-dir.ts";
-import type { EventBus } from "./event-bus.ts";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, relative, sep } from "node:path";
+import { execa } from "execa";
 import type { LangwatchPaths } from "../shared/paths.ts";
 import { execAndPipe } from "./_pipe-to-bus.ts";
+import { appRoot } from "./app-dir.ts";
+import type { EventBus } from "./event-bus.ts";
 
 /**
  * Ensure langwatch/node_modules exists + start:prepare:files has run, both of
@@ -14,138 +21,268 @@ import { execAndPipe } from "./_pipe-to-bus.ts";
  * Runs INSIDE the relocated app tree (LANGWATCH_HOME/app/langwatch/) — see
  * services/app-dir.ts for why we relocate out of node_modules.
  */
-export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: EventBus): Promise<void> {
-  const langwatchDir = locateLangwatchDir();
-  if (!langwatchDir) throw new Error("langwatch app dir not found");
+export async function ensureLangwatchDeps(
+	ctx: { paths: LangwatchPaths },
+	bus: EventBus,
+): Promise<void> {
+	const langwatchDir = locateLangwatchDir();
+	if (!langwatchDir) throw new Error("langwatch app dir not found");
 
-  const nodeModulesPath = join(langwatchDir, "node_modules");
-  const distPath = join(langwatchDir, "dist");
-  const lockfilePath = join(langwatchDir, "pnpm-lock.yaml");
-  const hashFile = join(nodeModulesPath, ".install-hash");
+	const nodeModulesPath = join(langwatchDir, "node_modules");
+	const distPath = join(langwatchDir, "dist");
+	const lockfilePath = join(langwatchDir, "pnpm-lock.yaml");
+	const hashFile = join(nodeModulesPath, ".install-hash");
 
-  const distAlreadyBuilt = existsSync(join(distPath, "client"));
-  // Hash key combines the lockfile + package.json — either changing means
-  // we need to re-run install. Use sha256 (not just mtime) because rsync
-  // during ensureAppDir resets mtimes. The sequence tag versions the whole
-  // install recipe: bumping it re-runs the cycle on existing installs, which
-  // is how trees installed before the prod-prune step existed get pruned.
-  const installKey = `${computeInstallKey(lockfilePath, join(langwatchDir, "package.json"))}|seq2-prod-pruned`;
+	const distAlreadyBuilt = existsSync(join(distPath, "client"));
+	// Hash key combines the lockfile + package.json — either changing means
+	// we need to re-run install. Use sha256 (not just mtime) because rsync
+	// during ensureAppDir resets mtimes. The sequence tag versions the whole
+	// install recipe: bumping it re-runs the cycle on existing installs, which
+	// is how trees installed before the prod-prune step existed get pruned.
+	// seq3: re-run on installs whose tree predates the tarball shipping the
+	// workspace packages (3.6.0) — their pnpm links dangled and the member
+	// packages' own dependencies were never installed.
+	const installKey = `${computeInstallKey(lockfilePath, join(langwatchDir, "package.json"))}|seq3-workspace-packages`;
 
-  // Top-level symlinks are the strongest "install completed" signal:
-  // pnpm creates `.bin/` and direct package entries LAST after populating
-  // `.pnpm/`. If a previous install was interrupted between those two
-  // phases (CTRL-C, OOM, fs flush mid-write), `.pnpm/` looks fine but
-  // `.bin/prisma` is missing — and `pnpm prisma migrate deploy` then
-  // dies with `Command "prisma" not found`. Including this in the
-  // skip-gate keeps that whole class of bug from re-armoring.
-  const topLevelLinksOk = existsSync(join(nodeModulesPath, ".bin", "prisma"));
-  const cachedHash = existsSync(hashFile) ? readFileSync(hashFile, "utf8").trim() : null;
-  const installFresh = topLevelLinksOk && cachedHash === installKey;
+	// Top-level symlinks are the strongest "install completed" signal:
+	// pnpm creates `.bin/` and direct package entries LAST after populating
+	// `.pnpm/`. If a previous install was interrupted between those two
+	// phases (CTRL-C, OOM, fs flush mid-write), `.pnpm/` looks fine but
+	// `.bin/prisma` is missing — and `pnpm prisma migrate deploy` then
+	// dies with `Command "prisma" not found`. Including this in the
+	// skip-gate keeps that whole class of bug from re-armoring.
+	const topLevelLinksOk = existsSync(join(nodeModulesPath, ".bin", "prisma"));
+	const cachedHash = existsSync(hashFile)
+		? readFileSync(hashFile, "utf8").trim()
+		: null;
+	const installFresh = topLevelLinksOk && cachedHash === installKey;
 
-  if (installFresh && prismaClientGenerated(nodeModulesPath) && distAlreadyBuilt) {
-    return;
-  }
+	if (
+		installFresh &&
+		prismaClientGenerated(nodeModulesPath) &&
+		distAlreadyBuilt
+	) {
+		return;
+	}
 
-  bus.emit({ type: "starting", service: "prepare:langwatch" as never });
-  const start = Date.now();
+	bus.emit({ type: "starting", service: "prepare:langwatch" as never });
+	const start = Date.now();
 
-  // We use `pnpm -C <dir>` instead of `cwd: langwatchDir` because pnpm's
-  // workspace-aware mode resolves the workspace ROOT package.json when
-  // invoked through corepack (or sometimes plain pnpm too) — leading to
-  // "Missing script: build. Did you mean pnpm run build:cli?" because
-  // build:cli is on root. `-C` is the official "change to package dir
-  // and only that dir" flag.
-  //
-  // For the binary, prefer `pnpm` directly on PATH when present (CI via
-  // pnpm/action-setup, end users via corepack-shimmed PATH) and fall back
-  // to `corepack pnpm`. corepack is *not* the primary because `corepack
-  // pnpm -C <dir>` swallows the `-C` flag in some cases and pnpm
-  // re-resolves cwd to its own dir, defeating the workspace-isolation
-  // intent above. See resolvePnpm() below.
-  const pnpm = await resolvePnpm(ctx.paths);
+	// We use `pnpm -C <dir>` instead of `cwd: langwatchDir` because pnpm's
+	// workspace-aware mode resolves the workspace ROOT package.json when
+	// invoked through corepack (or sometimes plain pnpm too) — leading to
+	// "Missing script: build. Did you mean pnpm run build:cli?" because
+	// build:cli is on root. `-C` is the official "change to package dir
+	// and only that dir" flag.
+	//
+	// For the binary, prefer `pnpm` directly on PATH when present (CI via
+	// pnpm/action-setup, end users via corepack-shimmed PATH) and fall back
+	// to `corepack pnpm`. corepack is *not* the primary because `corepack
+	// pnpm -C <dir>` swallows the `-C` flag in some cases and pnpm
+	// re-resolves cwd to its own dir, defeating the workspace-isolation
+	// intent above. See resolvePnpm() below.
+	const pnpm = await resolvePnpm(ctx.paths);
 
-  if (!installFresh) {
-    // Install everything, dev dependencies included, because the steps that
-    // follow genuinely need them: prisma generate needs the prisma CLI's
-    // build tooling and the full build needs vite. Installing with `--prod`
-    // up front was tried once and broke exactly those two steps. The dev
-    // dependencies come OUT again below (prune --prod, after the build),
-    // which is the same order the production Dockerfile uses — the pruned
-    // tree it produces is what every helm and docker deployment runs.
-    await execAndPipe(
-      bus,
-      "prepare:langwatch",
-      pnpm.command,
-      [...pnpm.args, "-C", langwatchDir, "install", "--prod=false", "--frozen-lockfile"],
-    );
-  }
+	// npm pack unconditionally drops .npmrc from published artifacts (it often
+	// carries auth tokens), so the repo's langwatch/.npmrc never reaches an
+	// npx install. Recreate it before the first install: without these hoists
+	// OpenTelemetry's ESM loader shims land deep in the virtual store and its
+	// instrumentation cannot patch them.
+	const npmrcPath = join(langwatchDir, ".npmrc");
+	if (!existsSync(npmrcPath)) {
+		writeFileSync(
+			npmrcPath,
+			[
+				"# Recreated by @langwatch/server (npm pack always strips .npmrc).",
+				"# Mirrors the repo's langwatch/.npmrc.",
+				"public-hoist-pattern[]=*import-in-the-middle*",
+				"public-hoist-pattern[]=*require-in-the-middle*",
+				"",
+			].join("\n"),
+		);
+	}
 
-  // Skip the build step entirely when dist/client/ is already present.
-  // Published npm tarballs ship dist/ pre-built (see
-  // .github/workflows/npx-server-publish.yml), so end users hit `pnpm install`
-  // + `prisma generate` and nothing else. The build only runs for
-  // `pnpm pack`-driven local dogfood and dev checkouts where dist/
-  // doesn't exist yet.
-  if (!distAlreadyBuilt) {
-    // Full prod build: start:prepare:files → build:scenario-child-process → vite build.
-    // start:prepare:files generates Prisma client, Zod types, SDK versions,
-    // langevals types (from the source committed in langevals/ts-integration/),
-    // and the mcp-server bundle. vite build emits dist/client/ for static serving.
-    // Without dist/client/, every UI route returns 404 and only /api/* works.
-    await execAndPipe(
-      bus,
-      "prepare:langwatch",
-      pnpm.command,
-      [...pnpm.args, "-C", langwatchDir, "run", "build"],
-      {
-        env: {
-          ...process.env,
-          NODE_ENV: "production",
-        },
-      },
-    );
-  }
+	if (!installFresh) {
+		// Install everything, dev dependencies included, because the steps that
+		// follow genuinely need them: prisma generate needs the prisma CLI's
+		// build tooling and the full build needs vite. Installing with `--prod`
+		// up front was tried once and broke exactly those two steps. The dev
+		// dependencies come OUT again below (prune --prod, after the build),
+		// which is the same order the production Dockerfile uses — the pruned
+		// tree it produces is what every helm and docker deployment runs.
+		await execAndPipe(bus, "prepare:langwatch", pnpm.command, [
+			...pnpm.args,
+			"-C",
+			langwatchDir,
+			"install",
+			"--prod=false",
+			"--frozen-lockfile",
+		]);
+	}
 
-  // Take the dev dependencies back out, the way the production Dockerfile
-  // does after ITS build (install → build → prune --prod → prisma generate).
-  // This is what drops vite, vitest, playwright, biome and the rest of the
-  // build tooling from the tree the server actually runs — on the order of a
-  // gigabyte — while tsx and prisma stay, because they are runtime
-  // dependencies here (the server boots through tsx, migrations run through
-  // the prisma CLI) and are declared as such.
-  //
-  // ONLY on the relocated copy under LANGWATCH_HOME. A dev checkout runs the
-  // CLI against its own working tree, and pruning that would strip the
-  // developer's test and build tooling out from under them.
-  if (shouldPruneToProd(langwatchDir, ctx.paths)) {
-    await execAndPipe(
-      bus,
-      "prepare:langwatch",
-      pnpm.command,
-      [...pnpm.args, "-C", langwatchDir, "prune", "--prod"],
-      { env: { ...process.env, CI: "true" } },
-    );
-  }
+	// Skip the build step entirely when dist/client/ is already present.
+	// Published npm tarballs ship dist/ pre-built (see
+	// .github/workflows/npx-server-publish.yml), so end users hit `pnpm install`
+	// + `prisma generate` and nothing else. The build only runs for
+	// `pnpm pack`-driven local dogfood and dev checkouts where dist/
+	// doesn't exist yet.
+	if (!distAlreadyBuilt) {
+		// Full prod build: start:prepare:files → build:scenario-child-process → vite build.
+		// start:prepare:files generates Prisma client, Zod types, SDK versions,
+		// langevals types (from the source committed in langevals/ts-integration/),
+		// and the mcp-server bundle. vite build emits dist/client/ for static serving.
+		// Without dist/client/, every UI route returns 404 and only /api/* works.
+		await execAndPipe(
+			bus,
+			"prepare:langwatch",
+			pnpm.command,
+			[...pnpm.args, "-C", langwatchDir, "run", "build"],
+			{
+				env: {
+					...process.env,
+					NODE_ENV: "production",
+				},
+			},
+		);
+	}
 
-  // pnpm install does not auto-generate the prisma client, and prune removes
-  // a generated one (it is not a declared dependency, so prune sees it as
-  // extraneous — the Dockerfile regenerates after pruning for the same
-  // reason). One post-prune generate covers every path that needs it.
-  if (!prismaClientGenerated(nodeModulesPath)) {
-    await execAndPipe(
-      bus,
-      "prepare:langwatch",
-      pnpm.command,
-      [...pnpm.args, "-C", langwatchDir, "exec", "prisma", "generate"],
-    );
-  }
+	// Take the dev dependencies back out, the way the production Dockerfile
+	// does after ITS build (install → build → prune --prod → prisma generate).
+	// This is what drops vite, vitest, playwright, biome and the rest of the
+	// build tooling from the tree the server actually runs — on the order of a
+	// gigabyte — while tsx and prisma stay, because they are runtime
+	// dependencies here (the server boots through tsx, migrations run through
+	// the prisma CLI) and are declared as such.
+	//
+	// ONLY on the relocated copy under LANGWATCH_HOME. A dev checkout runs the
+	// CLI against its own working tree, and pruning that would strip the
+	// developer's test and build tooling out from under them.
+	if (shouldPruneToProd(langwatchDir, ctx.paths)) {
+		await execAndPipe(
+			bus,
+			"prepare:langwatch",
+			pnpm.command,
+			[...pnpm.args, "-C", langwatchDir, "prune", "--prod"],
+			{ env: { ...process.env, CI: "true" } },
+		);
+	}
 
-  // Written LAST so an interrupted run never records success: any of the
-  // steps above dying leaves the old key (or none) and the next boot redoes
-  // the cycle.
-  writeFileSync(hashFile, installKey);
+	// pnpm install does not auto-generate the prisma client, and prune removes
+	// a generated one (it is not a declared dependency, so prune sees it as
+	// extraneous — the Dockerfile regenerates after pruning for the same
+	// reason). One post-prune generate covers every path that needs it.
+	if (!prismaClientGenerated(nodeModulesPath)) {
+		await execAndPipe(bus, "prepare:langwatch", pnpm.command, [
+			...pnpm.args,
+			"-C",
+			langwatchDir,
+			"exec",
+			"prisma",
+			"generate",
+		]);
+	}
 
-  bus.emit({ type: "healthy", service: "prepare:langwatch" as never, durationMs: Date.now() - start });
+	// Workspace members living OUTSIDE langwatch/ (mcp-server, packages/*)
+	// cannot reach langwatch/node_modules by walking up, so their declared
+	// peerDependencies resolve nowhere in the relocated tree. Materialize
+	// each peer as a member-local link to the app's resolved instance —
+	// the "consumer provides the peer" contract made explicit on disk.
+	// Only on the relocated copy: a dev checkout resolves these through its
+	// own root-workspace install.
+	if (shouldPruneToProd(langwatchDir, ctx.paths)) {
+		linkExternalMemberPeers(appRoot());
+	}
+
+	// pnpm quietly tolerates a workspace member listed in the lockfile whose
+	// directory is absent: install exits 0 and leaves dangling @langwatch/*
+	// links, and the first runtime import dies minutes later inside a
+	// migration. Turn that into an install-time failure that names the
+	// packaging gap. (Exactly how 3.6.0 shipped: both .npmignore files still
+	// excluded langwatch/packages/ after runtime packages moved in.)
+	assertWorkspaceLinksResolve(nodeModulesPath);
+
+	// Written LAST so an interrupted run never records success: any of the
+	// steps above dying leaves the old key (or none) and the next boot redoes
+	// the cycle.
+	writeFileSync(hashFile, installKey);
+
+	bus.emit({
+		type: "healthy",
+		service: "prepare:langwatch" as never,
+		durationMs: Date.now() - start,
+	});
+}
+
+/**
+ * For every app-workspace member outside langwatch/, link its declared
+ * peerDependencies to the app's own resolved instances. Runtime imports in
+ * those members (zod in @langwatch/langy, @opentelemetry/api in
+ * @langwatch/handled-error) are peers on purpose: both packages must share
+ * the CONSUMER's instance — a second copy of either breaks it (zod schemas
+ * from two majors cannot merge; a second otel api loses the global
+ * registrations). The links make the relocated tree resolve them the way
+ * every other deployment already does. Idempotent; skips peers the app
+ * doesn't carry. Exported for tests.
+ */
+export function linkExternalMemberPeers(appRootDir: string): string[] {
+	const appNodeModules = join(appRootDir, "langwatch", "node_modules");
+	const memberDirs = [join(appRootDir, "mcp-server"), ...listDirs(join(appRootDir, "packages"))];
+	const linked: string[] = [];
+	for (const memberDir of memberDirs) {
+		const pkgPath = join(memberDir, "package.json");
+		if (!existsSync(pkgPath)) continue;
+		let peers: string[] = [];
+		try {
+			const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+				peerDependencies?: Record<string, string>;
+			};
+			peers = Object.keys(pkg.peerDependencies ?? {});
+		} catch {
+			continue;
+		}
+		for (const name of peers) {
+			const target = join(appNodeModules, ...name.split("/"));
+			if (!existsSync(target)) continue;
+			const linkPath = join(memberDir, "node_modules", ...name.split("/"));
+			if (existsSync(linkPath)) continue;
+			mkdirSync(dirname(linkPath), { recursive: true });
+			symlinkSync(relative(dirname(linkPath), target), linkPath);
+			linked.push(`${basename(memberDir)}:${name}`);
+		}
+	}
+	return linked;
+}
+
+function listDirs(dir: string): string[] {
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.map((entry) => join(dir, entry))
+		.filter((p) => existsSync(join(p, "package.json")));
+}
+
+/**
+ * Every @langwatch/* entry in node_modules must resolve to a real directory.
+ * A dangling link means the app tree is missing a workspace package the
+ * lockfile promised — a packaging bug in the published artifact, not
+ * something a retry can fix. Exported for tests.
+ */
+export function assertWorkspaceLinksResolve(nodeModulesPath: string): void {
+	const scopeDir = join(nodeModulesPath, "@langwatch");
+	if (!existsSync(scopeDir)) return;
+	const dangling: string[] = [];
+	for (const entry of readdirSync(scopeDir)) {
+		// existsSync follows symlinks: false for a link whose target is gone.
+		if (!existsSync(join(scopeDir, entry, "package.json"))) {
+			dangling.push(`@langwatch/${entry}`);
+		}
+	}
+	if (dangling.length > 0) {
+		throw new Error(
+			`app tree is missing workspace packages: ${dangling.join(", ")}. ` +
+				`The published artifact did not ship them — this is a packaging bug in @langwatch/server; ` +
+				`please report it at https://github.com/langwatch/langwatch/issues`,
+		);
+	}
 }
 
 /**
@@ -158,22 +295,22 @@ export async function ensureLangwatchDeps(ctx: { paths: LangwatchPaths }, bus: E
  * believing the client was missing. Exported for tests.
  */
 export function prismaClientGenerated(nodeModulesPath: string): boolean {
-  if (existsSync(join(nodeModulesPath, ".prisma", "client", "index.js"))) {
-    return true;
-  }
-  const pnpmDir = join(nodeModulesPath, ".pnpm");
-  if (!existsSync(pnpmDir)) return false;
-  for (const entry of readdirSync(pnpmDir)) {
-    if (!entry.startsWith("@prisma+client@")) continue;
-    if (
-      existsSync(
-        join(pnpmDir, entry, "node_modules", ".prisma", "client", "index.js"),
-      )
-    ) {
-      return true;
-    }
-  }
-  return false;
+	if (existsSync(join(nodeModulesPath, ".prisma", "client", "index.js"))) {
+		return true;
+	}
+	const pnpmDir = join(nodeModulesPath, ".pnpm");
+	if (!existsSync(pnpmDir)) return false;
+	for (const entry of readdirSync(pnpmDir)) {
+		if (!entry.startsWith("@prisma+client@")) continue;
+		if (
+			existsSync(
+				join(pnpmDir, entry, "node_modules", ".prisma", "client", "index.js"),
+			)
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**
@@ -181,19 +318,19 @@ export function prismaClientGenerated(nodeModulesPath: string): boolean {
  * tests; the path comparison is the entire decision.
  */
 export function shouldPruneToProd(
-  langwatchDir: string,
-  paths: Pick<LangwatchPaths, "app">,
+	langwatchDir: string,
+	paths: Pick<LangwatchPaths, "app">,
 ): boolean {
-  return langwatchDir === paths.app || langwatchDir.startsWith(paths.app + sep);
+	return langwatchDir === paths.app || langwatchDir.startsWith(paths.app + sep);
 }
 
 function computeInstallKey(...files: string[]): string {
-  const h = createHash("sha256");
-  for (const f of files) {
-    if (existsSync(f)) h.update(readFileSync(f));
-    h.update("\n--\n");
-  }
-  return h.digest("hex");
+	const h = createHash("sha256");
+	for (const f of files) {
+		if (existsSync(f)) h.update(readFileSync(f));
+		h.update("\n--\n");
+	}
+	return h.digest("hex");
 }
 
 /**
@@ -219,21 +356,25 @@ function computeInstallKey(...files: string[]): string {
  * Pass `paths` from any caller that has runtime context; callers who
  * don't (legacy ensureLangwatchDeps before predeps run) skip step 1.
  */
-export async function resolvePnpm(paths?: LangwatchPaths): Promise<{ command: string; args: string[] }> {
-  if (paths) {
-    const bundled = join(paths.bin, "pnpm");
-    if (existsSync(bundled)) return { command: bundled, args: [] };
-  }
-  const direct = await execa("pnpm", ["--version"], { reject: false });
-  if (direct.exitCode === 0) return { command: "pnpm", args: [] };
-  const { exitCode } = await execa("corepack", ["--version"], { reject: false });
-  if (exitCode === 0) return { command: "corepack", args: ["pnpm"] };
-  throw new Error("pnpm not found in <bin>/pnpm, on PATH, or via corepack");
+export async function resolvePnpm(
+	paths?: LangwatchPaths,
+): Promise<{ command: string; args: string[] }> {
+	if (paths) {
+		const bundled = join(paths.bin, "pnpm");
+		if (existsSync(bundled)) return { command: bundled, args: [] };
+	}
+	const direct = await execa("pnpm", ["--version"], { reject: false });
+	if (direct.exitCode === 0) return { command: "pnpm", args: [] };
+	const { exitCode } = await execa("corepack", ["--version"], {
+		reject: false,
+	});
+	if (exitCode === 0) return { command: "corepack", args: ["pnpm"] };
+	throw new Error("pnpm not found in <bin>/pnpm, on PATH, or via corepack");
 }
 
 export function locateLangwatchDir(): string | null {
-  // appRoot() returns the relocated tree (LANGWATCH_HOME/app) once
-  // ensureAppDir has run, or the dev workspace fallback otherwise.
-  const dir = join(appRoot(), "langwatch");
-  return existsSync(join(dir, "package.json")) ? dir : null;
+	// appRoot() returns the relocated tree (LANGWATCH_HOME/app) once
+	// ensureAppDir has run, or the dev workspace fallback otherwise.
+	const dir = join(appRoot(), "langwatch");
+	return existsSync(join(dir, "package.json")) ? dir : null;
 }

--- a/packages/server/src/services/node-deps.ts
+++ b/packages/server/src/services/node-deps.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import {
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
 	symlinkSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, relative, sep } from "node:path";
@@ -226,7 +228,10 @@ export async function ensureLangwatchDeps(
  */
 export function linkExternalMemberPeers(appRootDir: string): string[] {
 	const appNodeModules = join(appRootDir, "langwatch", "node_modules");
-	const memberDirs = [join(appRootDir, "mcp-server"), ...listDirs(join(appRootDir, "packages"))];
+	const memberDirs = [
+		join(appRootDir, "mcp-server"),
+		...listDirs(join(appRootDir, "packages")),
+	];
 	const linked: string[] = [];
 	for (const memberDir of memberDirs) {
 		const pkgPath = join(memberDir, "package.json");
@@ -244,7 +249,17 @@ export function linkExternalMemberPeers(appRootDir: string): string[] {
 			const target = join(appNodeModules, ...name.split("/"));
 			if (!existsSync(target)) continue;
 			const linkPath = join(memberDir, "node_modules", ...name.split("/"));
-			if (existsSync(linkPath)) continue;
+			// existsSync follows symlinks, so it says false for a dangling link
+			// whose directory entry is still there — and symlinkSync would then
+			// die with EEXIST. lstat sees the entry itself: keep it when it
+			// resolves, replace it when it dangles (a re-install after an app
+			// tree wipe leaves exactly that).
+			if (lstatSafely(linkPath)) {
+				if (existsSync(linkPath)) continue;
+				// unlinkSync, not rmSync: rm stats the TARGET, and on a dangling
+				// link it silently does nothing — unlink removes the entry itself.
+				unlinkSync(linkPath);
+			}
 			mkdirSync(dirname(linkPath), { recursive: true });
 			symlinkSync(relative(dirname(linkPath), target), linkPath);
 			linked.push(`${basename(memberDir)}:${name}`);
@@ -258,6 +273,15 @@ function listDirs(dir: string): string[] {
 	return readdirSync(dir)
 		.map((entry) => join(dir, entry))
 		.filter((p) => existsSync(join(p, "package.json")));
+}
+
+function lstatSafely(path: string): boolean {
+	try {
+		lstatSync(path);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -1,11 +1,12 @@
 // julia's lane: orchestrator that implements RuntimeApi.
 // Wired up by the CLI via dynamic import — see shared/runtime-placeholder.ts.
 
+import { featureEnv, resolveEffectiveFeatures } from "../shared/features.ts";
 import type {
-  RuntimeApi,
-  RuntimeContext,
-  RuntimeEvent,
-  ServiceHandle,
+	RuntimeApi,
+	RuntimeContext,
+	RuntimeEvent,
+	ServiceHandle,
 } from "../shared/runtime-contract.ts";
 import { startAigateway } from "./aigateway.ts";
 import { ensureAppDir } from "./app-dir.ts";
@@ -16,205 +17,222 @@ import { EventBus } from "./event-bus.ts";
 import { startLangevals } from "./langevals.ts";
 import { startLangwatch } from "./langwatch.ts";
 import { startLangwatchWorkers } from "./langwatch-workers.ts";
-import { monobinarySupportsLangyagent, startLangyagent } from "./langyagent.ts";
 import { ensureLangyCli } from "./langy-cli.ts";
-import { startNlpgo } from "./nlpgo.ts";
-import { featureEnv, resolveEffectiveFeatures } from "../shared/features.ts";
+import { monobinarySupportsLangyagent, startLangyagent } from "./langyagent.ts";
 import { runMigrations } from "./migrate.ts";
+import { startNlpgo } from "./nlpgo.ts";
 import { ensureLangwatchDeps } from "./node-deps.ts";
 import { startPostgres } from "./postgres.ts";
 import { startRedis } from "./redis.ts";
-import { syncVenvs } from "./venvs.ts";
 import type { SupervisedHandle } from "./spawn.ts";
+import { syncVenvs } from "./venvs.ts";
 
 // One bus per RuntimeContext. The CLI calls events(ctx) before startAll
 // (via the [3/4] services phase) and the same bus is used throughout.
 const buses = new WeakMap<RuntimeContext, EventBus>();
 
 function busFor(ctx: RuntimeContext): EventBus {
-  let bus = buses.get(ctx);
-  if (!bus) {
-    bus = new EventBus();
-    buses.set(ctx, bus);
-  }
-  return bus;
+	let bus = buses.get(ctx);
+	if (!bus) {
+		bus = new EventBus();
+		buses.set(ctx, bus);
+	}
+	return bus;
 }
 
 const runtimeImpl: RuntimeApi = {
-  async scaffoldEnv(ctx) {
-    return scaffoldEnv(ctx);
-  },
+	async scaffoldEnv(ctx) {
+		return scaffoldEnv(ctx);
+	},
 
-  async installServices(ctx) {
-    const bus = busFor(ctx);
-    // Relocate the @langwatch/server tree out of node_modules first —
-    // every downstream step (uv sync, pnpm install, migrations, app boot)
-    // resolves files via app-dir.ts#appRoot() and needs the relocation
-    // to have completed. See app-dir.ts for the tsx/node_modules guard
-    // root cause.
-    await ensureAppDir(ctx, bus);
+	async installServices(ctx) {
+		const bus = busFor(ctx);
+		// Relocate the @langwatch/server tree out of node_modules first —
+		// every downstream step (uv sync, pnpm install, migrations, app boot)
+		// resolves files via app-dir.ts#appRoot() and needs the relocation
+		// to have completed. See app-dir.ts for the tsx/node_modules guard
+		// root cause.
+		await ensureAppDir(ctx, bus);
 
-    // uv sync + langwatch node_modules + prepare:files run in parallel.
-    // Each helper is idempotent and prints "already cached" + early-returns
-    // when its lockfile hash matches the previous run.
-    const features = resolveEffectiveFeatures(ctx.envFile);
-    await Promise.all([
-      syncVenvs(ctx, bus),
-      ensureLangwatchDeps(ctx, bus),
-      // The assistant's CLI: only an install running it needs the download.
-      ...(features.isLangyEnabled ? [ensureLangyCli(ctx, bus)] : []),
-    ]);
-  },
+		// uv sync + langwatch node_modules + prepare:files run in parallel.
+		// Each helper is idempotent and prints "already cached" + early-returns
+		// when its lockfile hash matches the previous run.
+		const features = resolveEffectiveFeatures(ctx.envFile);
+		await Promise.all([
+			syncVenvs(ctx, bus),
+			ensureLangwatchDeps(ctx, bus),
+			// The assistant's CLI: only an install running it needs the download.
+			...(features.isLangyEnabled ? [ensureLangyCli(ctx, bus)] : []),
+		]);
+	},
 
-  async startAll(ctx) {
-    const bus = busFor(ctx);
-    const envFromFile = readEnvFile(ctx.envFile);
-    const handles: SupervisedHandle[] = [];
+	async startAll(ctx) {
+		const bus = busFor(ctx);
+		const envFromFile = readEnvFile(ctx.envFile);
+		const handles: SupervisedHandle[] = [];
 
-    // Phase 1: infrastructure (postgres, redis, clickhouse) in parallel.
-    // Each helper waits for its own health probe so by the time Promise.all
-    // resolves every infra service is reachable.
-    const [pg, redis, ch] = await Promise.all([
-      startPostgres(ctx, bus),
-      startRedis(ctx, bus),
-      startClickhouse(ctx, bus),
-    ]);
-    handles.push(pg, redis, ch);
+		// Phase 1: infrastructure (postgres, redis, clickhouse) in parallel.
+		// Each helper waits for its own health probe so by the time Promise.all
+		// resolves every infra service is reachable.
+		const [pg, redis, ch] = await Promise.all([
+			startPostgres(ctx, bus),
+			startRedis(ctx, bus),
+			startClickhouse(ctx, bus),
+		]);
+		handles.push(pg, redis, ch);
 
-    // Phase 2: migrations (Prisma + ClickHouse goose). Both shell out to
-    // the langwatch app's existing pnpm scripts so we stay in lockstep with
-    // helm/docker.
-    try {
-      await runMigrations(ctx, bus, envFromFile);
-    } catch (err) {
-      await stopHandles(handles);
-      throw err;
-    }
+		// Phase 2: migrations (Prisma + ClickHouse goose). Both shell out to
+		// the langwatch app's existing pnpm scripts so we stay in lockstep with
+		// helm/docker.
+		try {
+			await runMigrations(ctx, bus, envFromFile);
+		} catch (err) {
+			await stopHandles(handles);
+			throw err;
+		}
 
-    // Phase 3: app-tier services in parallel. The langwatch app receives
-    // userEnv overlay so the user's provider keys (OPENAI_API_KEY etc.)
-    // win over the blank .env entries written by scaffoldEnvFile. The
-    // resolved feature toggles ride along explicitly (see featureEnv) so the
-    // app describes exactly the install this process just built.
-    const features = resolveEffectiveFeatures(ctx.envFile);
-    // The assistant is OPTIONAL: nothing else depends on it, so no failure of
-    // its own may take the install down. It boots (or declines to) BEFORE the
-    // app tier, because the app must be told the truth about it: an agent URL
-    // with no agent behind it turns every send into a hang. Two ways it
-    // declines, each with its own notice:
-    //   - the mono-binary predates the langyagent service (the npm package
-    //     and the release binary move in lockstep, but a smoke run of an
-    //     unreleased CLI, or an install mid release-window, gets the previous
-    //     release's binary, which answers "unknown service");
-    //   - it started but never reached healthy.
-    let isLangyRunnable = features.isLangyEnabled;
-    let langyHandle: SupervisedHandle | null = null;
-    if (isLangyRunnable) {
-      const binary = ctx.predeps.aigateway?.resolvedPath;
-      isLangyRunnable = !!binary && (await monobinarySupportsLangyagent(binary));
-      if (!isLangyRunnable) {
-        bus.emit({
-          type: "log",
-          service: "langyagent",
-          stream: "stderr",
-          line:
-            "langy assistant disabled: the installed ai-gateway binary predates it. The next release's binary includes it and will be picked up automatically.",
-        });
-      }
-    }
-    if (isLangyRunnable) {
-      try {
-        langyHandle = await startLangyagent(ctx, bus, {
-          ...envFromFile,
-          ...ctx.userEnv,
-        });
-        handles.push(langyHandle);
-      } catch (err) {
-        isLangyRunnable = false;
-        bus.emit({
-          type: "log",
-          service: "langyagent",
-          stream: "stderr",
-          line: `langy assistant disabled: it failed to start (${err instanceof Error ? err.message : String(err)}). Everything else continues without it.`,
-        });
-      }
-    }
-    const effective = { ...features, isLangyEnabled: isLangyRunnable };
-    const childEnv: Record<string, string> = {
-      ...envFromFile,
-      ...ctx.userEnv,
-      ...featureEnv(effective),
-    };
-    if (!effective.isLangyEnabled) {
-      // With the assistant off, the app must not think it exists: an agent
-      // URL with no agent behind it turns every send into a hang, and the
-      // forced rollout flag would render the panel. The .env keeps its lines
-      // (they are the user's knobs); only the running processes lose them.
-      delete childEnv.OPENCODE_AGENT_URL;
-      const forced = (childEnv.FEATURE_FLAG_FORCE_ENABLE ?? "")
-        .split(",")
-        .map((f) => f.trim())
-        .filter((f) => f && f !== "release_langy_enabled");
-      if (forced.length > 0) childEnv.FEATURE_FLAG_FORCE_ENABLE = forced.join(",");
-      else delete childEnv.FEATURE_FLAG_FORCE_ENABLE;
-    }
+		// Phase 3: app-tier services in parallel. The langwatch app receives
+		// userEnv overlay so the user's provider keys (OPENAI_API_KEY etc.)
+		// win over the blank .env entries written by scaffoldEnvFile. The
+		// resolved feature toggles ride along explicitly (see featureEnv) so the
+		// app describes exactly the install this process just built.
+		const features = resolveEffectiveFeatures(ctx.envFile);
+		// The assistant is OPTIONAL: nothing else depends on it, so no failure of
+		// its own may take the install down. It boots (or declines to) BEFORE the
+		// app tier, because the app must be told the truth about it: an agent URL
+		// with no agent behind it turns every send into a hang. Two ways it
+		// declines, each with its own notice:
+		//   - the mono-binary predates the langyagent service (the npm package
+		//     and the release binary move in lockstep, but a smoke run of an
+		//     unreleased CLI, or an install mid release-window, gets the previous
+		//     release's binary, which answers "unknown service");
+		//   - it started but never reached healthy.
+		let isLangyRunnable = features.isLangyEnabled;
+		let langyHandle: SupervisedHandle | null = null;
+		if (isLangyRunnable) {
+			const binary = ctx.predeps.aigateway?.resolvedPath;
+			isLangyRunnable =
+				!!binary && (await monobinarySupportsLangyagent(binary));
+			if (!isLangyRunnable) {
+				bus.emit({
+					type: "log",
+					service: "langyagent",
+					stream: "stderr",
+					line: "langy assistant disabled: the installed ai-gateway binary predates it. The next release's binary includes it and will be picked up automatically.",
+				});
+			}
+		}
+		if (isLangyRunnable) {
+			try {
+				langyHandle = await startLangyagent(ctx, bus, {
+					...envFromFile,
+					...ctx.userEnv,
+				});
+				handles.push(langyHandle);
+			} catch (err) {
+				isLangyRunnable = false;
+				bus.emit({
+					type: "log",
+					service: "langyagent",
+					stream: "stderr",
+					line: `langy assistant disabled: it failed to start (${err instanceof Error ? err.message : String(err)}). Everything else continues without it.`,
+				});
+			}
+		}
+		const effective = { ...features, isLangyEnabled: isLangyRunnable };
+		const childEnv: Record<string, string> = {
+			...envFromFile,
+			...ctx.userEnv,
+			...featureEnv(effective),
+		};
+		if (!effective.isLangyEnabled) {
+			// With the assistant off, the app must not think it exists: an agent
+			// URL with no agent behind it turns every send into a hang, and the
+			// forced rollout flag would render the panel. The .env keeps its lines
+			// (they are the user's knobs); only the running processes lose them.
+			delete childEnv.OPENCODE_AGENT_URL;
+			const forced = (childEnv.FEATURE_FLAG_FORCE_ENABLE ?? "")
+				.split(",")
+				.map((f) => f.trim())
+				.filter((f) => f && f !== "release_langy_enabled");
+			if (forced.length > 0)
+				childEnv.FEATURE_FLAG_FORCE_ENABLE = forced.join(",");
+			else delete childEnv.FEATURE_FLAG_FORCE_ENABLE;
+		}
 
-    try {
-      // nlpgo is the only NLP runtime — the Go service from the aigateway
-      // monobinary, dispatched as `nlpgo`. It binds to ctx.ports.nlp; the
-      // langwatch app's /studio/* routing always targets /go/*.
-      const [nlp, langevals, gw, lw] = await Promise.all([
-        startNlpgo(ctx, bus, childEnv),
-        startLangevals(ctx, bus, childEnv),
-        startAigateway(ctx, bus, envFromFile),
-        startLangwatch(ctx, bus, childEnv),
-      ]);
-      handles.push(nlp, langevals, gw, lw);
+		// nlpgo is the only NLP runtime — the Go service from the aigateway
+		// monobinary, dispatched as `nlpgo`. It binds to ctx.ports.nlp; the
+		// langwatch app's /studio/* routing always targets /go/*.
+		//
+		// allSettled, not all: with all(), one service failing its health probe
+		// rejects the combinator and DISCARDS the handles of the services that
+		// had already started — stopHandles never sees them, and every partial
+		// boot leaks live nlpgo/gateway processes that then squat the port slot
+		// and force the next run to auto-shift.
+		const results = await Promise.allSettled([
+			startNlpgo(ctx, bus, childEnv),
+			startLangevals(ctx, bus, childEnv),
+			startAigateway(ctx, bus, envFromFile),
+			startLangwatch(ctx, bus, childEnv),
+		]);
+		for (const r of results) {
+			if (r.status === "fulfilled") handles.push(r.value);
+		}
+		const failure = results.find(
+			(r): r is PromiseRejectedResult => r.status === "rejected",
+		);
+		if (failure) {
+			await stopHandles(handles);
+			throw failure.reason;
+		}
 
-      // Phase 3b: workers. Spawned AFTER the app is healthy so it can
-      // share the same boot env (Redis + Prisma already migrated, app
-      // listening). Without these, the BullMQ collector/evaluations/
-      // track-event/topic-clustering queues fill up with no consumer and
-      // the UI sits forever on "Waiting for first trace…". The await is
-      // for resolvePnpm() inside startLangwatchWorkers — the spawn itself
-      // is non-blocking; lifecycle is inferred from process state.
-      const workers = await startLangwatchWorkers(ctx, bus, childEnv);
-      handles.push(workers);
-    } catch (err) {
-      await stopHandles(handles);
-      throw err;
-    }
+		try {
+			// Phase 3b: workers. Spawned AFTER the app is healthy so it can
+			// share the same boot env (Redis + Prisma already migrated, app
+			// listening). Without these, the BullMQ collector/evaluations/
+			// track-event/topic-clustering queues fill up with no consumer and
+			// the UI sits forever on "Waiting for first trace…". The await is
+			// for resolvePnpm() inside startLangwatchWorkers — the spawn itself
+			// is non-blocking; lifecycle is inferred from process state.
+			const workers = await startLangwatchWorkers(ctx, bus, childEnv);
+			handles.push(workers);
+		} catch (err) {
+			await stopHandles(handles);
+			throw err;
+		}
 
-    return handles.map(toServiceHandle);
-  },
+		return handles.map(toServiceHandle);
+	},
 
-  async waitForHealth() {
-    // startAll already gates on every individual health probe. Keep this
-    // as a no-op cross-check so the CLI's [4/4] phase has somewhere to land.
-  },
+	async waitForHealth() {
+		// startAll already gates on every individual health probe. Keep this
+		// as a no-op cross-check so the CLI's [4/4] phase has somewhere to land.
+	},
 
-  async stopAll(handles) {
-    await stopHandles(handles);
-  },
+	async stopAll(handles) {
+		await stopHandles(handles);
+	},
 
-  events(ctx) {
-    return busFor(ctx);
-  },
+	events(ctx) {
+		return busFor(ctx);
+	},
 };
 
-async function stopHandles(handles: { stop(): Promise<void> }[]): Promise<void> {
-  // Reverse start order so app services drain before infra goes down.
-  for (const h of [...handles].reverse()) {
-    try {
-      await h.stop();
-    } catch {
-      // Swallow — we still want to stop the rest.
-    }
-  }
+async function stopHandles(
+	handles: { stop(): Promise<void> }[],
+): Promise<void> {
+	// Reverse start order so app services drain before infra goes down.
+	for (const h of [...handles].reverse()) {
+		try {
+			await h.stop();
+		} catch {
+			// Swallow — we still want to stop the rest.
+		}
+	}
 }
 
 function toServiceHandle(h: SupervisedHandle): ServiceHandle {
-  return { name: h.name, pid: h.pid, stop: h.stop };
+	return { name: h.name, pid: h.pid, stop: h.stop };
 }
 
 export const runtime = runtimeImpl;

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -218,7 +218,7 @@ export function buildEnv({
  * .env file stays free of user secrets. See 04-validation.feature.
  */
 export function scaffoldEnvFile(
-	input: EnvScaffoldInput & { path: string; reconcilePorts?: boolean },
+	input: EnvScaffoldInput & { path: string; shouldReconcilePorts?: boolean },
 ): { written: boolean; path: string; reconciledKeys: string[] } {
 	const secretsPath = join(dirname(input.path), "secrets.json");
 
@@ -240,7 +240,9 @@ export function scaffoldEnvFile(
 		// real, conflict-checked allocation ask for this — a default-port guess
 		// (the bare `install` command) must not rewrite a shifted install
 		// backwards.
-		const reconciledKeys = input.reconcilePorts ? reconcileEnvFile(input) : [];
+		const reconciledKeys = input.shouldReconcilePorts
+			? reconcileEnvFile(input)
+			: [];
 		return { written: false, path: input.path, reconciledKeys };
 	}
 

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -6,9 +6,9 @@ import type { PortAllocation } from "./ports.ts";
 export type EnvOverrides = Partial<Record<string, string>>;
 
 export type EnvScaffoldInput = {
-  ports: PortAllocation;
-  baseHost?: string;
-  overrides?: EnvOverrides;
+	ports: PortAllocation;
+	baseHost?: string;
+	overrides?: EnvOverrides;
 };
 
 // Keys whose generated value MUST be stable across .env regenerations —
@@ -23,19 +23,80 @@ export type EnvScaffoldInput = {
 // because rotating the gateway pepper invalidates every issued virtual
 // key.
 const PERSISTENT_SECRET_KEYS = [
-  "NEXTAUTH_SECRET",
-  "CREDENTIALS_SECRET",
-  "API_TOKEN_JWT_SECRET",
-  "LW_VIRTUAL_KEY_PEPPER",
-  "LW_GATEWAY_INTERNAL_SECRET",
-  "LW_GATEWAY_JWT_SECRET",
-  // The app and the Langy agent authenticate to each other with this; a
-  // regenerated value on one side and not the other makes every turn 401.
-  "LANGY_INTERNAL_SECRET",
+	"NEXTAUTH_SECRET",
+	"CREDENTIALS_SECRET",
+	"API_TOKEN_JWT_SECRET",
+	"LW_VIRTUAL_KEY_PEPPER",
+	"LW_GATEWAY_INTERNAL_SECRET",
+	"LW_GATEWAY_JWT_SECRET",
+	// The app and the Langy agent authenticate to each other with this; a
+	// regenerated value on one side and not the other makes every turn 401.
+	"LANGY_INTERNAL_SECRET",
 ] as const;
 
 const hex = (bytes: number) => randomBytes(bytes).toString("hex");
 const b64 = (bytes: number) => randomBytes(bytes).toString("base64");
+
+type PortBoundEnvEntry = {
+	/** The value the current port allocation calls for. */
+	expected: string;
+	/**
+	 * What a scaffold-written value looks like for ANY port base. Reconcile
+	 * only rewrites a value that still matches this shape: a user who pointed
+	 * the key somewhere else on purpose (a LAN hostname, an external store)
+	 * never matches, so their edit survives every port shift.
+	 */
+	scaffoldShape: RegExp;
+};
+
+const LOCALHOST_URL_SHAPE = /^http:\/\/localhost:\d+$/;
+
+/**
+ * Every .env key whose value embeds an allocated port, with the value the
+ * given allocation expects. buildEnv writes these on first scaffold and
+ * reconcileEnvFile rewrites them when a later run lands on a different port
+ * base (a stray process on one port of the old slot is enough) — without
+ * this, the .env keeps the old slot's URLs and the app dials data stores
+ * that this very run started somewhere else.
+ */
+export function portBoundEnv(ports: PortAllocation) {
+	const host = `http://localhost:${ports.langwatch}`;
+	return {
+		BASE_HOST: { expected: host, scaffoldShape: LOCALHOST_URL_SHAPE },
+		NEXTAUTH_URL: { expected: host, scaffoldShape: LOCALHOST_URL_SHAPE },
+		PORT: { expected: String(ports.langwatch), scaffoldShape: /^\d+$/ },
+		DATABASE_URL: {
+			expected: `postgresql://langwatch@localhost:${ports.postgres}/langwatch_db?schema=langwatch_db&connection_limit=5`,
+			scaffoldShape:
+				/^postgresql:\/\/langwatch@localhost:\d+\/langwatch_db\?schema=langwatch_db&connection_limit=5$/,
+		},
+		REDIS_URL: {
+			expected: `redis://localhost:${ports.redis}/0`,
+			scaffoldShape: /^redis:\/\/localhost:\d+\/0$/,
+		},
+		CLICKHOUSE_URL: {
+			expected: `http://localhost:${ports.clickhouseHttp}/langwatch`,
+			scaffoldShape: /^http:\/\/localhost:\d+\/langwatch$/,
+		},
+		LANGWATCH_NLP_SERVICE: {
+			expected: `http://localhost:${ports.nlp}`,
+			scaffoldShape: LOCALHOST_URL_SHAPE,
+		},
+		LANGEVALS_ENDPOINT: {
+			expected: `http://localhost:${ports.langevals}`,
+			scaffoldShape: LOCALHOST_URL_SHAPE,
+		},
+		LANGWATCH_ENDPOINT: { expected: host, scaffoldShape: LOCALHOST_URL_SHAPE },
+		LW_GATEWAY_BASE_URL: {
+			expected: `http://localhost:${ports.aigateway}`,
+			scaffoldShape: LOCALHOST_URL_SHAPE,
+		},
+		OPENCODE_AGENT_URL: {
+			expected: `http://localhost:${ports.langyagent}`,
+			scaffoldShape: LOCALHOST_URL_SHAPE,
+		},
+	} satisfies Record<string, PortBoundEnvEntry>;
+}
 
 /**
  * Builds the .env body for ~/.langwatch/.env. Mirrors the helm chart's
@@ -45,103 +106,105 @@ const b64 = (bytes: number) => randomBytes(bytes).toString("base64");
  * allocated port table so a `--port-base 5570` shift cascades to every
  * service consistently.
  */
-export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput): string {
-  const host = baseHost ?? `http://localhost:${ports.langwatch}`;
-  const lines: string[] = [];
-  const set = (key: string, value: string) => {
-    lines.push(`${key}=${value}`);
-  };
-  const sectionBreak = (title: string) => {
-    lines.push("", `# ${title}`);
-  };
+export function buildEnv({
+	ports,
+	baseHost,
+	overrides = {},
+}: EnvScaffoldInput): string {
+	const host = baseHost ?? `http://localhost:${ports.langwatch}`;
+	const portBound = portBoundEnv(ports);
+	const lines: string[] = [];
+	const set = (key: string, value: string) => {
+		lines.push(`${key}=${value}`);
+	};
+	const sectionBreak = (title: string) => {
+		lines.push("", `# ${title}`);
+	};
 
-  sectionBreak("BASIC CONFIGURATION");
-  set("NODE_ENV", "production");
-  set("BASE_HOST", host);
-  set("NEXTAUTH_URL", host);
-  set("PORT", String(ports.langwatch));
-  set("DEBUG", "langwatch:*");
+	sectionBreak("BASIC CONFIGURATION");
+	set("NODE_ENV", "production");
+	set("BASE_HOST", host);
+	set("NEXTAUTH_URL", host);
+	set("PORT", portBound.PORT.expected);
+	set("DEBUG", "langwatch:*");
 
-  sectionBreak("AUTHENTICATION");
-  set("NEXTAUTH_PROVIDER", "email");
-  set("NEXTAUTH_SECRET", b64(32));
-  set("CREDENTIALS_SECRET", hex(32));
-  set("API_TOKEN_JWT_SECRET", hex(32));
+	sectionBreak("AUTHENTICATION");
+	set("NEXTAUTH_PROVIDER", "email");
+	set("NEXTAUTH_SECRET", b64(32));
+	set("CREDENTIALS_SECRET", hex(32));
+	set("API_TOKEN_JWT_SECRET", hex(32));
 
-  sectionBreak("DATA STORES (provisioned locally by @langwatch/server)");
-  set(
-    "DATABASE_URL",
-    `postgresql://langwatch@localhost:${ports.postgres}/langwatch_db?schema=langwatch_db&connection_limit=5`
-  );
-  set("REDIS_URL", `redis://localhost:${ports.redis}/0`);
-  set("CLICKHOUSE_URL", `http://localhost:${ports.clickhouseHttp}/langwatch`);
+	sectionBreak("DATA STORES (provisioned locally by @langwatch/server)");
+	set("DATABASE_URL", portBound.DATABASE_URL.expected);
+	set("REDIS_URL", portBound.REDIS_URL.expected);
+	set("CLICKHOUSE_URL", portBound.CLICKHOUSE_URL.expected);
 
-  sectionBreak("LANGWATCH INTERNAL SERVICES");
-  set("LANGWATCH_NLP_SERVICE", `http://localhost:${ports.nlp}`);
-  set("LANGEVALS_ENDPOINT", `http://localhost:${ports.langevals}`);
-  // The engine reads `LANGWATCH_ENDPOINT` to decide where to POST evaluator
-  // runs and dataset uploads. The default is https://app.langwatch.ai
-  // (cloud) — which is wrong for self-host: callbacks then 401 against the
-  // hosted API, evaluators produce no scores, and the experiments workbench
-  // just shows the evaluator title with no value. Pinning to our local
-  // langwatch app routes those callbacks to the running stack.
-  set("LANGWATCH_ENDPOINT", host);
+	sectionBreak("LANGWATCH INTERNAL SERVICES");
+	set("LANGWATCH_NLP_SERVICE", portBound.LANGWATCH_NLP_SERVICE.expected);
+	set("LANGEVALS_ENDPOINT", portBound.LANGEVALS_ENDPOINT.expected);
+	// The engine reads `LANGWATCH_ENDPOINT` to decide where to POST evaluator
+	// runs and dataset uploads. The default is https://app.langwatch.ai
+	// (cloud) — which is wrong for self-host: callbacks then 401 against the
+	// hosted API, evaluators produce no scores, and the experiments workbench
+	// just shows the evaluator title with no value. Pinning to our local
+	// langwatch app routes those callbacks to the running stack.
+	set("LANGWATCH_ENDPOINT", host);
 
-  sectionBreak("AI GATEWAY");
-  set("LW_VIRTUAL_KEY_PEPPER", hex(32));
-  set("LW_GATEWAY_INTERNAL_SECRET", hex(32));
-  set("LW_GATEWAY_JWT_SECRET", hex(32));
-  // Where the gateway is, from the app's point of view. The gateway process
-  // reads this same name to mean the opposite direction (where the CONTROL
-  // PLANE is) and services/aigateway.ts sets it explicitly in that child's
-  // env, so this value only ever reaches the app — which uses it to hand
-  // Langy's workers, and CLI users, an OpenAI-compatible base URL. Pointed at
-  // the app itself, every one of those callers dialled a server with no /v1
-  // surface.
-  set("LW_GATEWAY_BASE_URL", `http://localhost:${ports.aigateway}`);
+	sectionBreak("AI GATEWAY");
+	set("LW_VIRTUAL_KEY_PEPPER", hex(32));
+	set("LW_GATEWAY_INTERNAL_SECRET", hex(32));
+	set("LW_GATEWAY_JWT_SECRET", hex(32));
+	// Where the gateway is, from the app's point of view. The gateway process
+	// reads this same name to mean the opposite direction (where the CONTROL
+	// PLANE is) and services/aigateway.ts sets it explicitly in that child's
+	// env, so this value only ever reaches the app — which uses it to hand
+	// Langy's workers, and CLI users, an OpenAI-compatible base URL. Pointed at
+	// the app itself, every one of those callers dialled a server with no /v1
+	// surface.
+	set("LW_GATEWAY_BASE_URL", portBound.LW_GATEWAY_BASE_URL.expected);
 
-  sectionBreak("LANGY ASSISTANT");
-  // Shared bearer between the app and the agent; see PERSISTENT_SECRET_KEYS.
-  set("LANGY_INTERNAL_SECRET", hex(32));
-  set("OPENCODE_AGENT_URL", `http://localhost:${ports.langyagent}`);
-  // Langy's rollout flag is SYSTEM-scoped and defaults off so the hosted
-  // product can open it one cohort at a time. A laptop install is a cohort of
-  // one, and it just installed the assistant on purpose.
-  set("FEATURE_FLAG_FORCE_ENABLE", "release_langy_enabled");
+	sectionBreak("LANGY ASSISTANT");
+	// Shared bearer between the app and the agent; see PERSISTENT_SECRET_KEYS.
+	set("LANGY_INTERNAL_SECRET", hex(32));
+	set("OPENCODE_AGENT_URL", portBound.OPENCODE_AGENT_URL.expected);
+	// Langy's rollout flag is SYSTEM-scoped and defaults off so the hosted
+	// product can open it one cohort at a time. A laptop install is a cohort of
+	// one, and it just installed the assistant on purpose.
+	set("FEATURE_FLAG_FORCE_ENABLE", "release_langy_enabled");
 
-  sectionBreak("OPTIONAL PIECES — flip one of these and restart the server");
-  // These are read by the installer AND by the app, so the same line decides
-  // what gets downloaded and what the product says about it.
-  set("LANGWATCH_ENABLE_LANGY", "true");
-  // The PII detection evaluator ships a ~670MB language model — larger than
-  // the rest of the evaluator environment put together. Off by default; the
-  // product points anyone who reaches for that evaluator back at this line.
-  set("LANGWATCH_ENABLE_PRESIDIO", "false");
-  // The language detection evaluator: ~95MB of language models, same deal.
-  set("LANGWATCH_ENABLE_LINGUA", "false");
-  // The deprecated legacy evaluators (old Ragas API), kept only so
-  // evaluations saved years ago keep running. When off they are hidden from
-  // the product entirely, not just disabled.
-  set("LANGWATCH_ENABLE_LEGACY_EVALUATORS", "false");
+	sectionBreak("OPTIONAL PIECES — flip one of these and restart the server");
+	// These are read by the installer AND by the app, so the same line decides
+	// what gets downloaded and what the product says about it.
+	set("LANGWATCH_ENABLE_LANGY", "true");
+	// The PII detection evaluator ships a ~670MB language model — larger than
+	// the rest of the evaluator environment put together. Off by default; the
+	// product points anyone who reaches for that evaluator back at this line.
+	set("LANGWATCH_ENABLE_PRESIDIO", "false");
+	// The language detection evaluator: ~95MB of language models, same deal.
+	set("LANGWATCH_ENABLE_LINGUA", "false");
+	// The deprecated legacy evaluators (old Ragas API), kept only so
+	// evaluations saved years ago keep running. When off they are hidden from
+	// the product entirely, not just disabled.
+	set("LANGWATCH_ENABLE_LEGACY_EVALUATORS", "false");
 
-  sectionBreak("ENVIRONMENT");
-  set("ENVIRONMENT", "local");
+	sectionBreak("ENVIRONMENT");
+	set("ENVIRONMENT", "local");
 
-  sectionBreak("MODELS — fill in any provider you want to evaluate against");
-  set("OPENAI_API_KEY", "");
-  set("ANTHROPIC_API_KEY", "");
-  set("AZURE_OPENAI_ENDPOINT", "");
-  set("AZURE_OPENAI_API_KEY", "");
-  set("GROQ_API_KEY", "");
+	sectionBreak("MODELS — fill in any provider you want to evaluate against");
+	set("OPENAI_API_KEY", "");
+	set("ANTHROPIC_API_KEY", "");
+	set("AZURE_OPENAI_ENDPOINT", "");
+	set("AZURE_OPENAI_API_KEY", "");
+	set("GROQ_API_KEY", "");
 
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) continue;
-    const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
-    if (idx >= 0) lines[idx] = `${key}=${value}`;
-    else set(key, value);
-  }
+	for (const [key, value] of Object.entries(overrides)) {
+		if (value === undefined) continue;
+		const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+		if (idx >= 0) lines[idx] = `${key}=${value}`;
+		else set(key, value);
+	}
 
-  return lines.join("\n") + "\n";
+	return lines.join("\n") + "\n";
 }
 
 /**
@@ -154,89 +217,132 @@ export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput):
  * NOT honoured here — those propagate via RuntimeContext.userEnv so the
  * .env file stays free of user secrets. See 04-validation.feature.
  */
-export function scaffoldEnvFile(input: EnvScaffoldInput & { path: string }): { written: boolean; path: string } {
-  const secretsPath = join(dirname(input.path), "secrets.json");
+export function scaffoldEnvFile(
+	input: EnvScaffoldInput & { path: string; reconcilePorts?: boolean },
+): { written: boolean; path: string; reconciledKeys: string[] } {
+	const secretsPath = join(dirname(input.path), "secrets.json");
 
-  if (existsSync(input.path)) {
-    // .env already exists. Backfill secrets.json from it if the sidecar
-    // hasn't been written yet — this covers users upgrading from a prior
-    // beta that didn't ship the secret-persistence path. Without this,
-    // their existing CREDENTIALS_SECRET stays in the .env but the
-    // sidecar is empty, so the next `rm ~/.langwatch/.env` rotates the
-    // secret and orphans encrypted ModelProvider rows.
-    if (!existsSync(secretsPath)) {
-      writePersistedSecrets(secretsPath, readFileSync(input.path, "utf8"));
-    }
-    return { written: false, path: input.path };
-  }
+	if (existsSync(input.path)) {
+		// .env already exists. Backfill secrets.json from it if the sidecar
+		// hasn't been written yet — this covers users upgrading from a prior
+		// beta that didn't ship the secret-persistence path. Without this,
+		// their existing CREDENTIALS_SECRET stays in the .env but the
+		// sidecar is empty, so the next `rm ~/.langwatch/.env` rotates the
+		// secret and orphans encrypted ModelProvider rows.
+		if (!existsSync(secretsPath)) {
+			writePersistedSecrets(secretsPath, readFileSync(input.path, "utf8"));
+		}
+		// The file stays the user's — except the port-bound URLs, which belong
+		// to whatever allocation THIS run got. A run that auto-shifted (one
+		// stray process on the old slot is enough) otherwise boots services on
+		// the new slot while the app reads the old slot's URLs from here and
+		// dials data stores that aren't there. Only callers whose ports are a
+		// real, conflict-checked allocation ask for this — a default-port guess
+		// (the bare `install` command) must not rewrite a shifted install
+		// backwards.
+		const reconciledKeys = input.reconcilePorts ? reconcileEnvFile(input) : [];
+		return { written: false, path: input.path, reconciledKeys };
+	}
 
-  mkdirSync(dirname(input.path), { recursive: true });
+	mkdirSync(dirname(input.path), { recursive: true });
 
-  // Read previously persisted secrets (from a prior scaffold) and overlay
-  // them so a `rm ~/.langwatch/.env; npx ...` doesn't rotate
-  // CREDENTIALS_SECRET out from under encrypted postgres rows. The first
-  // scaffold writes the sidecar; every later scaffold reuses it.
-  const persistedSecrets = readPersistedSecrets(secretsPath);
-  const overlay = { ...input.overrides, ...persistedSecrets };
+	// Read previously persisted secrets (from a prior scaffold) and overlay
+	// them so a `rm ~/.langwatch/.env; npx ...` doesn't rotate
+	// CREDENTIALS_SECRET out from under encrypted postgres rows. The first
+	// scaffold writes the sidecar; every later scaffold reuses it.
+	const persistedSecrets = readPersistedSecrets(secretsPath);
+	const overlay = { ...input.overrides, ...persistedSecrets };
 
-  const body = buildEnv({ ...input, overrides: overlay });
-  writeFileSync(input.path, body, { mode: 0o600 });
-  writePersistedSecrets(secretsPath, body);
-  return { written: true, path: input.path };
+	const body = buildEnv({ ...input, overrides: overlay });
+	writeFileSync(input.path, body, { mode: 0o600 });
+	writePersistedSecrets(secretsPath, body);
+	return { written: true, path: input.path, reconciledKeys: [] };
+}
+
+/**
+ * Rewrites the port-bound URLs of an existing .env to the given allocation.
+ * Only values still in their scaffold shape are touched (see portBoundEnv);
+ * anything a user pointed elsewhere is kept, and the rest of the file —
+ * secrets, model keys, toggles, comments — is preserved byte for byte.
+ * Returns the keys it rewrote.
+ */
+export function reconcileEnvFile(input: {
+	ports: PortAllocation;
+	path: string;
+}): string[] {
+	if (!existsSync(input.path)) return [];
+	const entries = portBoundEnv(input.ports);
+	const lines = readFileSync(input.path, "utf8").split("\n");
+	const reconciledKeys: string[] = [];
+	for (const [key, entry] of Object.entries(entries)) {
+		const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+		if (idx < 0) continue;
+		const value = (lines[idx] as string).slice(key.length + 1);
+		if (value === entry.expected) continue;
+		if (!entry.scaffoldShape.test(value)) continue;
+		lines[idx] = `${key}=${entry.expected}`;
+		reconciledKeys.push(key);
+	}
+	if (reconciledKeys.length > 0) {
+		writeFileSync(input.path, lines.join("\n"), { mode: 0o600 });
+	}
+	return reconciledKeys;
 }
 
 function readPersistedSecrets(path: string): Record<string, string> {
-  if (!existsSync(path)) return {};
-  try {
-    const raw = readFileSync(path, "utf8");
-    const parsed = JSON.parse(raw) as Record<string, string>;
-    const out: Record<string, string> = {};
-    for (const key of PERSISTENT_SECRET_KEYS) {
-      const v = parsed[key];
-      if (typeof v === "string" && v.length > 0) out[key] = v;
-    }
-    return out;
-  } catch {
-    return {};
-  }
+	if (!existsSync(path)) return {};
+	try {
+		const raw = readFileSync(path, "utf8");
+		const parsed = JSON.parse(raw) as Record<string, string>;
+		const out: Record<string, string> = {};
+		for (const key of PERSISTENT_SECRET_KEYS) {
+			const v = parsed[key];
+			if (typeof v === "string" && v.length > 0) out[key] = v;
+		}
+		return out;
+	} catch {
+		return {};
+	}
 }
 
 function writePersistedSecrets(path: string, envBody: string): void {
-  const found: Record<string, string> = {};
-  for (const line of envBody.split("\n")) {
-    const m = line.match(/^([^=]+)=(.*)$/);
-    if (!m) continue;
-    const [, key, value] = m as unknown as [string, string, string];
-    if ((PERSISTENT_SECRET_KEYS as readonly string[]).includes(key)) {
-      found[key] = value;
-    }
-  }
-  if (Object.keys(found).length === 0) return;
-  writeFileSync(path, JSON.stringify(found, null, 2), { mode: 0o600 });
+	const found: Record<string, string> = {};
+	for (const line of envBody.split("\n")) {
+		const m = line.match(/^([^=]+)=(.*)$/);
+		if (!m) continue;
+		const [, key, value] = m as unknown as [string, string, string];
+		if ((PERSISTENT_SECRET_KEYS as readonly string[]).includes(key)) {
+			found[key] = value;
+		}
+	}
+	if (Object.keys(found).length === 0) return;
+	writeFileSync(path, JSON.stringify(found, null, 2), { mode: 0o600 });
 }
 
 const PASSTHROUGH_ENV_KEYS = [
-  "OPENAI_API_KEY",
-  "AZURE_OPENAI_ENDPOINT",
-  "AZURE_OPENAI_API_KEY",
-  "ANTHROPIC_API_KEY",
-  "GROQ_API_KEY",
-  "GOOGLE_APPLICATION_CREDENTIALS",
-  "VERTEXAI_PROJECT",
-  "VERTEXAI_LOCATION",
-  "SENDGRID_API_KEY",
-  "SENTRY_DSN",
+	"OPENAI_API_KEY",
+	"AZURE_OPENAI_ENDPOINT",
+	"AZURE_OPENAI_API_KEY",
+	"ANTHROPIC_API_KEY",
+	"GROQ_API_KEY",
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"VERTEXAI_PROJECT",
+	"VERTEXAI_LOCATION",
+	"SENDGRID_API_KEY",
+	"SENTRY_DSN",
 ] as const;
 
 /**
  * Snapshot the user's process.env for the keys we propagate to children.
  * Empty values are dropped so they don't override .env defaults.
  */
-export function captureUserEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const key of PASSTHROUGH_ENV_KEYS) {
-    const value = env[key];
-    if (value && value.length > 0) out[key] = value;
-  }
-  return out;
+export function captureUserEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const key of PASSTHROUGH_ENV_KEYS) {
+		const value = env[key];
+		if (value && value.length > 0) out[key] = value;
+	}
+	return out;
 }

--- a/packages/server/test/env.test.ts
+++ b/packages/server/test/env.test.ts
@@ -125,17 +125,27 @@ describe("reconcileEnvFile", () => {
 
 		it("keeps everything that is not a port-bound URL byte for byte", async () => {
 			const { envPath } = await scaffoldAt(5560);
-			const before = readFileSync(envPath, "utf8");
-			const secret = before.match(/CREDENTIALS_SECRET=(.*)/)?.[1];
 			writeFileSync(
 				envPath,
-				before.replace("OPENAI_API_KEY=", "OPENAI_API_KEY=sk-test-123"),
+				readFileSync(envPath, "utf8").replace(
+					"OPENAI_API_KEY=",
+					"OPENAI_API_KEY=sk-test-123",
+				),
 			);
-			reconcileEnvFile({ ports: allocatePorts(5580), path: envPath });
-			const after = readFileSync(envPath, "utf8");
-			expect(after).toContain(`CREDENTIALS_SECRET=${secret}`);
+			const before = readFileSync(envPath, "utf8").split("\n");
+			const reconciled = reconcileEnvFile({
+				ports: allocatePorts(5580),
+				path: envPath,
+			});
+			const after = readFileSync(envPath, "utf8").split("\n");
+			// Same line count, same order, and every line that differs is one
+			// of the keys reconcile reported — nothing else moved at all.
+			expect(after).toHaveLength(before.length);
+			for (let i = 0; i < before.length; i++) {
+				if (before[i] === after[i]) continue;
+				expect(reconciled).toContain((before[i] ?? "").split("=")[0]);
+			}
 			expect(after).toContain("OPENAI_API_KEY=sk-test-123");
-			expect(after).toContain("# LANGY ASSISTANT");
 		});
 
 		it("is a no-op when the allocation already matches", async () => {
@@ -184,7 +194,7 @@ describe("reconcileEnvFile", () => {
 			const asked = scaffoldEnvFile({
 				ports: allocatePorts(5560),
 				path: envPath,
-				reconcilePorts: true,
+				shouldReconcilePorts: true,
 			});
 			expect(asked.reconciledKeys).toContain("REDIS_URL");
 			expect(readFileSync(envPath, "utf8")).toContain(

--- a/packages/server/test/env.test.ts
+++ b/packages/server/test/env.test.ts
@@ -1,74 +1,195 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+	buildEnv,
+	reconcileEnvFile,
+	scaffoldEnvFile,
+} from "../src/shared/env.ts";
 import { allocatePorts } from "../src/shared/ports.ts";
-import { buildEnv } from "../src/shared/env.ts";
 
 describe("buildEnv", () => {
-  describe("when given the default port base", () => {
-    const env = buildEnv({ ports: allocatePorts(5560) });
+	describe("when given the default port base", () => {
+		const env = buildEnv({ ports: allocatePorts(5560) });
 
-    it("targets every URL at the matching port (app tier 5560-3, infra tier 6560-3)", () => {
-      expect(env).toContain("BASE_HOST=http://localhost:5560");
-      expect(env).toContain("DATABASE_URL=postgresql://langwatch@localhost:6560");
-      expect(env).toContain("REDIS_URL=redis://localhost:6561/0");
-      expect(env).toContain("CLICKHOUSE_URL=http://localhost:6562/langwatch");
-      expect(env).toContain("LANGWATCH_NLP_SERVICE=http://localhost:5561");
-      expect(env).toContain("LANGEVALS_ENDPOINT=http://localhost:5562");
-      // The gateway's own port, not the app's: this value is what the app
-      // hands Langy's workers and CLI users as an OpenAI-compatible base URL.
-      // The gateway process reads the same name to mean the opposite direction
-      // and gets its value from services/aigateway.ts, not from here.
-      expect(env).toContain("LW_GATEWAY_BASE_URL=http://localhost:5563");
-      expect(env).toContain("OPENCODE_AGENT_URL=http://localhost:5564");
-    });
+		it("targets every URL at the matching port (app tier 5560-3, infra tier 6560-3)", () => {
+			expect(env).toContain("BASE_HOST=http://localhost:5560");
+			expect(env).toContain(
+				"DATABASE_URL=postgresql://langwatch@localhost:6560",
+			);
+			expect(env).toContain("REDIS_URL=redis://localhost:6561/0");
+			expect(env).toContain("CLICKHOUSE_URL=http://localhost:6562/langwatch");
+			expect(env).toContain("LANGWATCH_NLP_SERVICE=http://localhost:5561");
+			expect(env).toContain("LANGEVALS_ENDPOINT=http://localhost:5562");
+			// The gateway's own port, not the app's: this value is what the app
+			// hands Langy's workers and CLI users as an OpenAI-compatible base URL.
+			// The gateway process reads the same name to mean the opposite direction
+			// and gets its value from services/aigateway.ts, not from here.
+			expect(env).toContain("LW_GATEWAY_BASE_URL=http://localhost:5563");
+			expect(env).toContain("OPENCODE_AGENT_URL=http://localhost:5564");
+		});
 
-    it("populates every secret with a fresh random value", () => {
-      const env2 = buildEnv({ ports: allocatePorts(5560) });
-      const secret = (text: string, key: string) =>
-        text.split("\n").find((line) => line.startsWith(`${key}=`))?.split("=")[1];
-      expect(secret(env, "NEXTAUTH_SECRET")).not.toBe(secret(env2, "NEXTAUTH_SECRET"));
-      expect(secret(env, "CREDENTIALS_SECRET")).toMatch(/^[a-f0-9]{64}$/);
-      expect(secret(env, "API_TOKEN_JWT_SECRET")).toMatch(/^[a-f0-9]{64}$/);
-      expect(secret(env, "LW_VIRTUAL_KEY_PEPPER")).toMatch(/^[a-f0-9]{64}$/);
-      expect(secret(env, "LW_GATEWAY_INTERNAL_SECRET")).toMatch(/^[a-f0-9]{64}$/);
-      expect(secret(env, "LW_GATEWAY_JWT_SECRET")).toMatch(/^[a-f0-9]{64}$/);
-    });
+		it("populates every secret with a fresh random value", () => {
+			const env2 = buildEnv({ ports: allocatePorts(5560) });
+			const secret = (text: string, key: string) =>
+				text
+					.split("\n")
+					.find((line) => line.startsWith(`${key}=`))
+					?.split("=")[1];
+			expect(secret(env, "NEXTAUTH_SECRET")).not.toBe(
+				secret(env2, "NEXTAUTH_SECRET"),
+			);
+			expect(secret(env, "CREDENTIALS_SECRET")).toMatch(/^[a-f0-9]{64}$/);
+			expect(secret(env, "API_TOKEN_JWT_SECRET")).toMatch(/^[a-f0-9]{64}$/);
+			expect(secret(env, "LW_VIRTUAL_KEY_PEPPER")).toMatch(/^[a-f0-9]{64}$/);
+			expect(secret(env, "LW_GATEWAY_INTERNAL_SECRET")).toMatch(
+				/^[a-f0-9]{64}$/,
+			);
+			expect(secret(env, "LW_GATEWAY_JWT_SECRET")).toMatch(/^[a-f0-9]{64}$/);
+		});
 
-    it("leaves model API keys empty for the user to fill in", () => {
-      expect(env).toContain("OPENAI_API_KEY=\n");
-      expect(env).toContain("ANTHROPIC_API_KEY=\n");
-    });
-  });
+		it("leaves model API keys empty for the user to fill in", () => {
+			expect(env).toContain("OPENAI_API_KEY=\n");
+			expect(env).toContain("ANTHROPIC_API_KEY=\n");
+		});
+	});
 
-  describe("when given an override", () => {
-    it("replaces the value in place rather than appending a duplicate", () => {
-      const env = buildEnv({
-        ports: allocatePorts(5560),
-        overrides: { OPENAI_API_KEY: "sk-test-123" },
-      });
-      const lines = env.split("\n").filter((l) => l.startsWith("OPENAI_API_KEY="));
-      expect(lines).toEqual(["OPENAI_API_KEY=sk-test-123"]);
-    });
-  });
+	describe("when given an override", () => {
+		it("replaces the value in place rather than appending a duplicate", () => {
+			const env = buildEnv({
+				ports: allocatePorts(5560),
+				overrides: { OPENAI_API_KEY: "sk-test-123" },
+			});
+			const lines = env
+				.split("\n")
+				.filter((l) => l.startsWith("OPENAI_API_KEY="));
+			expect(lines).toEqual(["OPENAI_API_KEY=sk-test-123"]);
+		});
+	});
 
-  describe("when given a custom port base", () => {
-    it("shifts every URL to the new slot in lockstep across both tiers", () => {
-      const env = buildEnv({ ports: allocatePorts(5610) });
-      expect(env).toContain("BASE_HOST=http://localhost:5610");
-      expect(env).toContain("DATABASE_URL=postgresql://langwatch@localhost:6610");
-      expect(env).toContain("REDIS_URL=redis://localhost:6611/0");
-    });
-  });
+	describe("when given a custom port base", () => {
+		it("shifts every URL to the new slot in lockstep across both tiers", () => {
+			const env = buildEnv({ ports: allocatePorts(5610) });
+			expect(env).toContain("BASE_HOST=http://localhost:5610");
+			expect(env).toContain(
+				"DATABASE_URL=postgresql://langwatch@localhost:6610",
+			);
+			expect(env).toContain("REDIS_URL=redis://localhost:6611/0");
+		});
+	});
 
-  describe("when scaffolding NLP wiring", () => {
-    const env = buildEnv({ ports: allocatePorts(5560) });
+	describe("when scaffolding NLP wiring", () => {
+		const env = buildEnv({ ports: allocatePorts(5560) });
 
-    it("points LANGWATCH_NLP_SERVICE at the nlpgo port", () => {
-      expect(env).toContain("LANGWATCH_NLP_SERVICE=http://localhost:5561");
-    });
+		it("points LANGWATCH_NLP_SERVICE at the nlpgo port", () => {
+			expect(env).toContain("LANGWATCH_NLP_SERVICE=http://localhost:5561");
+		});
 
-    it("does not force the removed Go-engine feature flag (routing is unconditional)", () => {
-      expect(env).not.toContain("release_nlp_go_engine_enabled");
-      expect(env).not.toContain("LANGWATCH_NPX_NLP");
-    });
-  });
+		it("does not force the removed Go-engine feature flag (routing is unconditional)", () => {
+			expect(env).not.toContain("release_nlp_go_engine_enabled");
+			expect(env).not.toContain("LANGWATCH_NPX_NLP");
+		});
+	});
+});
+
+describe("reconcileEnvFile", () => {
+	async function scaffoldAt(
+		base: number,
+	): Promise<{ dir: string; envPath: string }> {
+		const dir = await mkdtemp(join(tmpdir(), "langwatch-reconcile-"));
+		const envPath = join(dir, ".env");
+		scaffoldEnvFile({ ports: allocatePorts(base), path: envPath });
+		return { dir, envPath };
+	}
+
+	describe("when a later run lands on a different port slot", () => {
+		it("rewrites every port-bound URL to the new slot", async () => {
+			const { envPath } = await scaffoldAt(5560);
+			const reconciled = reconcileEnvFile({
+				ports: allocatePorts(5580),
+				path: envPath,
+			});
+			const body = readFileSync(envPath, "utf8");
+			expect(reconciled).toContain("REDIS_URL");
+			expect(reconciled).toContain("DATABASE_URL");
+			expect(body).toContain("REDIS_URL=redis://localhost:6581/0");
+			expect(body).toContain(
+				"DATABASE_URL=postgresql://langwatch@localhost:6580",
+			);
+			expect(body).toContain("BASE_HOST=http://localhost:5580");
+			expect(body).toContain("OPENCODE_AGENT_URL=http://localhost:5584");
+			expect(body).toContain("PORT=5580");
+		});
+
+		it("keeps everything that is not a port-bound URL byte for byte", async () => {
+			const { envPath } = await scaffoldAt(5560);
+			const before = readFileSync(envPath, "utf8");
+			const secret = before.match(/CREDENTIALS_SECRET=(.*)/)?.[1];
+			writeFileSync(
+				envPath,
+				before.replace("OPENAI_API_KEY=", "OPENAI_API_KEY=sk-test-123"),
+			);
+			reconcileEnvFile({ ports: allocatePorts(5580), path: envPath });
+			const after = readFileSync(envPath, "utf8");
+			expect(after).toContain(`CREDENTIALS_SECRET=${secret}`);
+			expect(after).toContain("OPENAI_API_KEY=sk-test-123");
+			expect(after).toContain("# LANGY ASSISTANT");
+		});
+
+		it("is a no-op when the allocation already matches", async () => {
+			const { envPath } = await scaffoldAt(5560);
+			const before = readFileSync(envPath, "utf8");
+			const reconciled = reconcileEnvFile({
+				ports: allocatePorts(5560),
+				path: envPath,
+			});
+			expect(reconciled).toEqual([]);
+			expect(readFileSync(envPath, "utf8")).toBe(before);
+		});
+	});
+
+	describe("when the user pointed a URL somewhere else on purpose", () => {
+		it("keeps the user's value and only updates the still-scaffold-shaped ones", async () => {
+			const { envPath } = await scaffoldAt(5560);
+			const custom = readFileSync(envPath, "utf8").replace(
+				"BASE_HOST=http://localhost:5560",
+				"BASE_HOST=https://langwatch.lan.example",
+			);
+			writeFileSync(envPath, custom);
+			const reconciled = reconcileEnvFile({
+				ports: allocatePorts(5580),
+				path: envPath,
+			});
+			const body = readFileSync(envPath, "utf8");
+			expect(body).toContain("BASE_HOST=https://langwatch.lan.example");
+			expect(reconciled).not.toContain("BASE_HOST");
+			expect(body).toContain("REDIS_URL=redis://localhost:6581/0");
+		});
+	});
+
+	describe("when scaffoldEnvFile runs over an existing file", () => {
+		it("reconciles only when asked to (a default-port guess must not rewrite a shifted install)", async () => {
+			const { envPath } = await scaffoldAt(5580);
+			const untouched = scaffoldEnvFile({
+				ports: allocatePorts(5560),
+				path: envPath,
+			});
+			expect(untouched.reconciledKeys).toEqual([]);
+			expect(readFileSync(envPath, "utf8")).toContain(
+				"REDIS_URL=redis://localhost:6581/0",
+			);
+
+			const asked = scaffoldEnvFile({
+				ports: allocatePorts(5560),
+				path: envPath,
+				reconcilePorts: true,
+			});
+			expect(asked.reconciledKeys).toContain("REDIS_URL");
+			expect(readFileSync(envPath, "utf8")).toContain(
+				"REDIS_URL=redis://localhost:6561/0",
+			);
+		});
+	});
 });

--- a/packages/server/test/services/app-dir.test.ts
+++ b/packages/server/test/services/app-dir.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { restoreShellScriptBits } from "../../src/services/app-dir.ts";
+
+describe("shell script bits after relocation", () => {
+	async function makeTree(): Promise<string> {
+		const root = await mkdtemp(join(tmpdir(), "langwatch-appdir-"));
+		mkdirSync(join(root, "langwatch", "scripts"), { recursive: true });
+		mkdirSync(join(root, "node_modules", "dep"), { recursive: true });
+		// pnpm pack normalizes modes: scripts arrive 0644.
+		writeFileSync(
+			join(root, "langwatch", "scripts", "build-mcp-server.sh"),
+			"#!/bin/sh\n",
+			{
+				mode: 0o644,
+			},
+		);
+		writeFileSync(
+			join(root, "langwatch", "scripts", "helper.ts"),
+			"export {};\n",
+			{
+				mode: 0o644,
+			},
+		);
+		writeFileSync(join(root, "node_modules", "dep", "hook.sh"), "#!/bin/sh\n", {
+			mode: 0o644,
+		});
+		return root;
+	}
+
+	describe("when the extracted artifact carries scripts without their bit", () => {
+		it("makes every *.sh executable so the app's build chain can invoke them", async () => {
+			// `pnpm run build` calls ./scripts/build-mcp-server.sh directly; a
+			// 0644 script dies with exit 126 and the boot never reaches healthy.
+			const root = await makeTree();
+			const restored = restoreShellScriptBits(root);
+			expect(restored).toBe(1);
+			const mode = statSync(
+				join(root, "langwatch", "scripts", "build-mcp-server.sh"),
+			).mode;
+			expect(mode & 0o111).not.toBe(0);
+		});
+
+		it("leaves non-scripts and node_modules alone", async () => {
+			const root = await makeTree();
+			restoreShellScriptBits(root);
+			expect(
+				statSync(join(root, "langwatch", "scripts", "helper.ts")).mode & 0o111,
+			).toBe(0);
+			expect(
+				statSync(join(root, "node_modules", "dep", "hook.sh")).mode & 0o111,
+			).toBe(0);
+		});
+	});
+});

--- a/packages/server/test/services/app-dir.test.ts
+++ b/packages/server/test/services/app-dir.test.ts
@@ -1,13 +1,20 @@
-import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { restoreShellScriptBits } from "../../src/services/app-dir.ts";
 
 describe("shell script bits after relocation", () => {
+	const roots: string[] = [];
+	afterEach(() => {
+		for (const root of roots.splice(0))
+			rmSync(root, { recursive: true, force: true });
+	});
+
 	async function makeTree(): Promise<string> {
 		const root = await mkdtemp(join(tmpdir(), "langwatch-appdir-"));
+		roots.push(root);
 		mkdirSync(join(root, "langwatch", "scripts"), { recursive: true });
 		mkdirSync(join(root, "node_modules", "dep"), { recursive: true });
 		// pnpm pack normalizes modes: scripts arrive 0644.

--- a/packages/server/test/services/node-deps.test.ts
+++ b/packages/server/test/services/node-deps.test.ts
@@ -99,12 +99,20 @@ describe("workspace link integrity", () => {
 describe("external member peer links", () => {
 	async function makeAppTree(): Promise<string> {
 		const appRoot = await mkdtemp(join(tmpdir(), "langwatch-peers-"));
-		mkdirSync(join(appRoot, "langwatch", "node_modules", "zod"), { recursive: true });
-		writeFileSync(join(appRoot, "langwatch", "node_modules", "zod", "package.json"), "{}");
+		mkdirSync(join(appRoot, "langwatch", "node_modules", "zod"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(appRoot, "langwatch", "node_modules", "zod", "package.json"),
+			"{}",
+		);
 		mkdirSync(join(appRoot, "packages", "langy"), { recursive: true });
 		writeFileSync(
 			join(appRoot, "packages", "langy", "package.json"),
-			JSON.stringify({ name: "@langwatch/langy", peerDependencies: { zod: ">=3.25.0 <5", "left-pad": "*" } }),
+			JSON.stringify({
+				name: "@langwatch/langy",
+				peerDependencies: { zod: ">=3.25.0 <5", "left-pad": "*" },
+			}),
 		);
 		return appRoot;
 	}
@@ -116,7 +124,14 @@ describe("external member peer links", () => {
 			const appRoot = await makeAppTree();
 			const linked = linkExternalMemberPeers(appRoot);
 			expect(linked).toContain("langy:zod");
-			const linkPath = join(appRoot, "packages", "langy", "node_modules", "zod", "package.json");
+			const linkPath = join(
+				appRoot,
+				"packages",
+				"langy",
+				"node_modules",
+				"zod",
+				"package.json",
+			);
 			expect(existsSync(linkPath)).toBe(true);
 		});
 
@@ -124,6 +139,21 @@ describe("external member peer links", () => {
 			const appRoot = await makeAppTree();
 			linkExternalMemberPeers(appRoot);
 			expect(linkExternalMemberPeers(appRoot)).toEqual([]);
+		});
+	});
+
+	describe("when a previous link at the peer path dangles", () => {
+		it("replaces it instead of dying with EEXIST", async () => {
+			// existsSync follows symlinks and reports false for a dangling one,
+			// but the directory entry still blocks symlinkSync. An app-tree wipe
+			// leaves exactly this state behind.
+			const root = await makeAppTree();
+			const memberNm = join(root, "packages", "langy", "node_modules");
+			mkdirSync(memberNm, { recursive: true });
+			symlinkSync(join(root, "not-there"), join(memberNm, "zod"));
+			const linked = linkExternalMemberPeers(root);
+			expect(linked).toContain("langy:zod");
+			expect(existsSync(join(memberNm, "zod", "package.json"))).toBe(true);
 		});
 	});
 

--- a/packages/server/test/services/node-deps.test.ts
+++ b/packages/server/test/services/node-deps.test.ts
@@ -1,24 +1,137 @@
+import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { shouldPruneToProd } from "../../src/services/node-deps.ts";
+import {
+	assertWorkspaceLinksResolve,
+	linkExternalMemberPeers,
+	shouldPruneToProd,
+} from "../../src/services/node-deps.ts";
 
 describe("pruning to production dependencies", () => {
-  const paths = { app: "/home/u/.langwatch/app" };
+	const paths = { app: "/home/u/.langwatch/app" };
 
-  describe("when the app tree is the relocated copy", () => {
-    it("prunes", () => {
-      expect(shouldPruneToProd("/home/u/.langwatch/app/langwatch", paths)).toBe(true);
-    });
-  });
+	describe("when the app tree is the relocated copy", () => {
+		it("prunes", () => {
+			expect(shouldPruneToProd("/home/u/.langwatch/app/langwatch", paths)).toBe(
+				true,
+			);
+		});
+	});
 
-  describe("when the app tree is a developer checkout", () => {
-    it("leaves it alone", () => {
-      // Pruning a working tree would strip the developer's own test and
-      // build tooling out from under them.
-      expect(shouldPruneToProd("/home/u/Projects/langwatch/langwatch", paths)).toBe(false);
-    });
+	describe("when the app tree is a developer checkout", () => {
+		it("leaves it alone", () => {
+			// Pruning a working tree would strip the developer's own test and
+			// build tooling out from under them.
+			expect(
+				shouldPruneToProd("/home/u/Projects/langwatch/langwatch", paths),
+			).toBe(false);
+		});
 
-    it("is not fooled by a sibling directory sharing the prefix", () => {
-      expect(shouldPruneToProd("/home/u/.langwatch/apple/langwatch", paths)).toBe(false);
-    });
-  });
+		it("is not fooled by a sibling directory sharing the prefix", () => {
+			expect(
+				shouldPruneToProd("/home/u/.langwatch/apple/langwatch", paths),
+			).toBe(false);
+		});
+	});
+});
+
+describe("workspace link integrity", () => {
+	async function makeTree(): Promise<{
+		nodeModules: string;
+		scope: string;
+		root: string;
+	}> {
+		const root = await mkdtemp(join(tmpdir(), "langwatch-links-"));
+		const nodeModules = join(root, "node_modules");
+		const scope = join(nodeModules, "@langwatch");
+		mkdirSync(scope, { recursive: true });
+		return { nodeModules, scope, root };
+	}
+
+	function addPackage(root: string, scope: string, name: string): void {
+		const target = join(root, "packages", name);
+		mkdirSync(target, { recursive: true });
+		writeFileSync(
+			join(target, "package.json"),
+			`{"name":"@langwatch/${name}"}`,
+		);
+		symlinkSync(target, join(scope, name));
+	}
+
+	describe("when every @langwatch link resolves", () => {
+		it("passes silently", async () => {
+			const { nodeModules, scope, root } = await makeTree();
+			addPackage(root, scope, "observability");
+			addPackage(root, scope, "langy");
+			expect(() => assertWorkspaceLinksResolve(nodeModules)).not.toThrow();
+		});
+	});
+
+	describe("when a link points at a package that does not exist", () => {
+		it("fails naming the missing packages and calling it a packaging bug", async () => {
+			// pnpm exits 0 in exactly this state (workspace member in the lockfile,
+			// directory absent from the shipped artifact) and the app then dies
+			// minutes later inside a migration with a bare MODULE_NOT_FOUND.
+			const { nodeModules, scope, root } = await makeTree();
+			addPackage(root, scope, "langy");
+			symlinkSync(
+				join(root, "packages", "observability"),
+				join(scope, "observability"),
+			);
+			expect(() => assertWorkspaceLinksResolve(nodeModules)).toThrow(
+				/@langwatch\/observability.*packaging bug/s,
+			);
+		});
+	});
+
+	describe("when the tree has no @langwatch scope at all", () => {
+		it("passes (nothing to verify)", async () => {
+			const root = await mkdtemp(join(tmpdir(), "langwatch-links-"));
+			const nodeModules = join(root, "node_modules");
+			mkdirSync(nodeModules, { recursive: true });
+			expect(() => assertWorkspaceLinksResolve(nodeModules)).not.toThrow();
+		});
+	});
+});
+
+describe("external member peer links", () => {
+	async function makeAppTree(): Promise<string> {
+		const appRoot = await mkdtemp(join(tmpdir(), "langwatch-peers-"));
+		mkdirSync(join(appRoot, "langwatch", "node_modules", "zod"), { recursive: true });
+		writeFileSync(join(appRoot, "langwatch", "node_modules", "zod", "package.json"), "{}");
+		mkdirSync(join(appRoot, "packages", "langy"), { recursive: true });
+		writeFileSync(
+			join(appRoot, "packages", "langy", "package.json"),
+			JSON.stringify({ name: "@langwatch/langy", peerDependencies: { zod: ">=3.25.0 <5", "left-pad": "*" } }),
+		);
+		return appRoot;
+	}
+
+	describe("when a member declares a peer the app carries", () => {
+		it("links the member to the app's instance so both share one copy", async () => {
+			// Two zod instances cannot merge each other's schemas; two otel
+			// apis lose the global registrations. The link IS the peer contract.
+			const appRoot = await makeAppTree();
+			const linked = linkExternalMemberPeers(appRoot);
+			expect(linked).toContain("langy:zod");
+			const linkPath = join(appRoot, "packages", "langy", "node_modules", "zod", "package.json");
+			expect(existsSync(linkPath)).toBe(true);
+		});
+
+		it("is idempotent", async () => {
+			const appRoot = await makeAppTree();
+			linkExternalMemberPeers(appRoot);
+			expect(linkExternalMemberPeers(appRoot)).toEqual([]);
+		});
+	});
+
+	describe("when a member declares a peer the app does not carry", () => {
+		it("skips it", async () => {
+			const appRoot = await makeAppTree();
+			const linked = linkExternalMemberPeers(appRoot);
+			expect(linked.some((l) => l.includes("left-pad"))).toBe(false);
+		});
+	});
 });

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -1,29 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeContext, RuntimeEvent } from "../../src/shared/runtime-contract.ts";
 import type { SupervisedHandle } from "../../src/services/spawn.ts";
+import type {
+	RuntimeContext,
+	RuntimeEvent,
+} from "../../src/shared/runtime-contract.ts";
 
 // Track call order across all mocked service modules. Each fn pushes its own
 // label on entry so we can assert phase ordering without coupling to timing.
 const callLog: string[] = [];
 
 function makeStub(name: string, durationMs = 1) {
-  return {
-    fn: vi.fn(async (_ctx: RuntimeContext, bus: { emit(e: RuntimeEvent): void }) => {
-      callLog.push(`start:${name}`);
-      bus.emit({ type: "starting", service: name });
-      bus.emit({ type: "healthy", service: name, durationMs });
-      const handle: SupervisedHandle = {
-        name,
-        pid: callLog.length,
-        // The runtime never reads .child, only .stop().
-        child: null as never,
-        stop: vi.fn(async () => {
-          callLog.push(`stop:${name}`);
-        }),
-      };
-      return handle;
-    }),
-  };
+	return {
+		fn: vi.fn(
+			async (_ctx: RuntimeContext, bus: { emit(e: RuntimeEvent): void }) => {
+				callLog.push(`start:${name}`);
+				bus.emit({ type: "starting", service: name });
+				bus.emit({ type: "healthy", service: name, durationMs });
+				const handle: SupervisedHandle = {
+					name,
+					pid: callLog.length,
+					// The runtime never reads .child, only .stop().
+					child: null as never,
+					stop: vi.fn(async () => {
+						callLog.push(`stop:${name}`);
+					}),
+				};
+				return handle;
+			},
+		),
+	};
 }
 
 const postgresStub = makeStub("postgres");
@@ -36,334 +41,394 @@ const langwatchStub = makeStub("langwatch");
 const langyStub = makeStub("langyagent");
 
 const migrateFn = vi.fn(async () => {
-  callLog.push("migrate");
+	callLog.push("migrate");
 });
 const venvsFn = vi.fn(async () => {
-  callLog.push("venvs");
+	callLog.push("venvs");
 });
 const nodeDepsFn = vi.fn(async () => {
-  callLog.push("node-deps");
+	callLog.push("node-deps");
 });
 const ensureAppDirFn = vi.fn(async () => {
-  callLog.push("app-dir");
+	callLog.push("app-dir");
 });
 const langyCliFn = vi.fn(async () => {
-  callLog.push("langy-cli");
+	callLog.push("langy-cli");
 });
 
-vi.mock("../../src/services/postgres.ts", () => ({ startPostgres: postgresStub.fn }));
+vi.mock("../../src/services/postgres.ts", () => ({
+	startPostgres: postgresStub.fn,
+}));
 vi.mock("../../src/services/redis.ts", () => ({ startRedis: redisStub.fn }));
-vi.mock("../../src/services/clickhouse.ts", () => ({ startClickhouse: clickhouseStub.fn }));
+vi.mock("../../src/services/clickhouse.ts", () => ({
+	startClickhouse: clickhouseStub.fn,
+}));
 vi.mock("../../src/services/nlpgo.ts", () => ({ startNlpgo: nlpStub.fn }));
-vi.mock("../../src/services/langevals.ts", () => ({ startLangevals: langevalsStub.fn }));
-vi.mock("../../src/services/aigateway.ts", () => ({ startAigateway: gatewayStub.fn }));
-vi.mock("../../src/services/langwatch.ts", () => ({ startLangwatch: langwatchStub.fn }));
+vi.mock("../../src/services/langevals.ts", () => ({
+	startLangevals: langevalsStub.fn,
+}));
+vi.mock("../../src/services/aigateway.ts", () => ({
+	startAigateway: gatewayStub.fn,
+}));
+vi.mock("../../src/services/langwatch.ts", () => ({
+	startLangwatch: langwatchStub.fn,
+}));
 let langyBinarySupported = true;
 vi.mock("../../src/services/langyagent.ts", () => ({
-  startLangyagent: langyStub.fn,
-  monobinarySupportsLangyagent: vi.fn(async () => langyBinarySupported),
+	startLangyagent: langyStub.fn,
+	monobinarySupportsLangyagent: vi.fn(async () => langyBinarySupported),
 }));
-vi.mock("../../src/services/langy-cli.ts", () => ({ ensureLangyCli: langyCliFn }));
+vi.mock("../../src/services/langy-cli.ts", () => ({
+	ensureLangyCli: langyCliFn,
+}));
 vi.mock("../../src/services/langwatch-workers.ts", () => ({
-  startLangwatchWorkers: () => ({
-    name: "workers",
-    pid: 0,
-    stop: async () => {
-      callLog.push("stop:workers");
-    },
-  }),
+	startLangwatchWorkers: () => ({
+		name: "workers",
+		pid: 0,
+		stop: async () => {
+			callLog.push("stop:workers");
+		},
+	}),
 }));
 vi.mock("../../src/services/migrate.ts", () => ({ runMigrations: migrateFn }));
 vi.mock("../../src/services/venvs.ts", () => ({ syncVenvs: venvsFn }));
 vi.mock("../../src/services/node-deps.ts", () => ({
-  ensureLangwatchDeps: nodeDepsFn,
-  locateLangwatchDir: () => "/tmp/.langwatch-test/app/langwatch",
+	ensureLangwatchDeps: nodeDepsFn,
+	locateLangwatchDir: () => "/tmp/.langwatch-test/app/langwatch",
 }));
 vi.mock("../../src/services/app-dir.ts", () => ({
-  ensureAppDir: ensureAppDirFn,
-  appRoot: () => "/tmp/.langwatch-test/app",
+	ensureAppDir: ensureAppDirFn,
+	appRoot: () => "/tmp/.langwatch-test/app",
 }));
 let envFileContent: Record<string, string> = {};
-vi.mock("../../src/services/env-file.ts", () => ({ readEnvFile: () => envFileContent }));
+vi.mock("../../src/services/env-file.ts", () => ({
+	readEnvFile: () => envFileContent,
+}));
 
 // Import AFTER vi.mock so the runtime resolves the stubs.
 const { runtime } = await import("../../src/services/runtime.ts");
 
 function fakeCtx(): RuntimeContext {
-  return {
-    ports: {
-      base: 5560,
-      langwatch: 5560,
-      nlp: 5561,
-      langevals: 5562,
-      aigateway: 5563,
-      langyagent: 5564,
-      postgres: 6560,
-      redis: 6561,
-      clickhouseHttp: 6562,
-      clickhouseNative: 6563,
-    },
-    paths: {
-      root: "/tmp/.langwatch-test",
-      bin: "/tmp/.langwatch-test/bin",
-      app: "/tmp/.langwatch-test/app",
-      data: "/tmp/.langwatch-test/data",
-      redisData: "/tmp/.langwatch-test/data/redis",
-      postgresData: "/tmp/.langwatch-test/data/postgres",
-      clickhouseData: "/tmp/.langwatch-test/data/clickhouse",
-      logs: "/tmp/.langwatch-test/logs",
-      pidFile: "/tmp/.langwatch-test/run/langwatch.pid",
-      lockFile: "/tmp/.langwatch-test/run/langwatch.lock",
-      envFile: "/tmp/.langwatch-test/.env",
-      installManifest: "/tmp/.langwatch-test/install-manifest.json",
-    },
-    predeps: { aigateway: { version: "test", resolvedPath: "/fake/bin/aigateway", preInstalled: false } },
-    envFile: "/tmp/.langwatch-test/.env",
-    version: "test",
-    userEnv: {},
-  };
+	return {
+		ports: {
+			base: 5560,
+			langwatch: 5560,
+			nlp: 5561,
+			langevals: 5562,
+			aigateway: 5563,
+			langyagent: 5564,
+			postgres: 6560,
+			redis: 6561,
+			clickhouseHttp: 6562,
+			clickhouseNative: 6563,
+		},
+		paths: {
+			root: "/tmp/.langwatch-test",
+			bin: "/tmp/.langwatch-test/bin",
+			app: "/tmp/.langwatch-test/app",
+			data: "/tmp/.langwatch-test/data",
+			redisData: "/tmp/.langwatch-test/data/redis",
+			postgresData: "/tmp/.langwatch-test/data/postgres",
+			clickhouseData: "/tmp/.langwatch-test/data/clickhouse",
+			logs: "/tmp/.langwatch-test/logs",
+			pidFile: "/tmp/.langwatch-test/run/langwatch.pid",
+			lockFile: "/tmp/.langwatch-test/run/langwatch.lock",
+			envFile: "/tmp/.langwatch-test/.env",
+			installManifest: "/tmp/.langwatch-test/install-manifest.json",
+		},
+		predeps: {
+			aigateway: {
+				version: "test",
+				resolvedPath: "/fake/bin/aigateway",
+				preInstalled: false,
+			},
+		},
+		envFile: "/tmp/.langwatch-test/.env",
+		version: "test",
+		userEnv: {},
+	};
 }
 
 describe("services/runtime", () => {
-  beforeEach(() => {
-    langyBinarySupported = true;
-    callLog.length = 0;
-    [
-      postgresStub.fn,
-      redisStub.fn,
-      clickhouseStub.fn,
-      nlpStub.fn,
-      langevalsStub.fn,
-      gatewayStub.fn,
-      langwatchStub.fn,
-      migrateFn,
-      venvsFn,
-      nodeDepsFn,
-      ensureAppDirFn,
-    ].forEach((fn) => fn.mockClear());
-  });
+	beforeEach(() => {
+		langyBinarySupported = true;
+		callLog.length = 0;
+		[
+			postgresStub.fn,
+			redisStub.fn,
+			clickhouseStub.fn,
+			nlpStub.fn,
+			langevalsStub.fn,
+			gatewayStub.fn,
+			langwatchStub.fn,
+			migrateFn,
+			venvsFn,
+			nodeDepsFn,
+			ensureAppDirFn,
+		].forEach((fn) => fn.mockClear());
+	});
 
-  describe("when installServices is called", () => {
-    it("runs uv venv sync and langwatch node-deps in parallel", async () => {
-      await runtime.installServices(fakeCtx());
-      expect(venvsFn).toHaveBeenCalledTimes(1);
-      expect(nodeDepsFn).toHaveBeenCalledTimes(1);
-      expect(callLog).toContain("venvs");
-      expect(callLog).toContain("node-deps");
-    });
+	describe("when installServices is called", () => {
+		it("runs uv venv sync and langwatch node-deps in parallel", async () => {
+			await runtime.installServices(fakeCtx());
+			expect(venvsFn).toHaveBeenCalledTimes(1);
+			expect(nodeDepsFn).toHaveBeenCalledTimes(1);
+			expect(callLog).toContain("venvs");
+			expect(callLog).toContain("node-deps");
+		});
 
-    it("relocates the @langwatch/server tree before venv/node-deps run", async () => {
-      // Order matters: venvs + node-deps both resolve paths via appRoot(),
-      // which only points at LANGWATCH_HOME/app once ensureAppDir has run.
-      await runtime.installServices(fakeCtx());
-      expect(ensureAppDirFn).toHaveBeenCalledTimes(1);
-      const appDirIdx = callLog.indexOf("app-dir");
-      const venvsIdx = callLog.indexOf("venvs");
-      const nodeDepsIdx = callLog.indexOf("node-deps");
-      expect(appDirIdx).toBeGreaterThanOrEqual(0);
-      expect(appDirIdx).toBeLessThan(venvsIdx);
-      expect(appDirIdx).toBeLessThan(nodeDepsIdx);
-    });
-  });
+		it("relocates the @langwatch/server tree before venv/node-deps run", async () => {
+			// Order matters: venvs + node-deps both resolve paths via appRoot(),
+			// which only points at LANGWATCH_HOME/app once ensureAppDir has run.
+			await runtime.installServices(fakeCtx());
+			expect(ensureAppDirFn).toHaveBeenCalledTimes(1);
+			const appDirIdx = callLog.indexOf("app-dir");
+			const venvsIdx = callLog.indexOf("venvs");
+			const nodeDepsIdx = callLog.indexOf("node-deps");
+			expect(appDirIdx).toBeGreaterThanOrEqual(0);
+			expect(appDirIdx).toBeLessThan(venvsIdx);
+			expect(appDirIdx).toBeLessThan(nodeDepsIdx);
+		});
+	});
 
-  describe("when startAll is called", () => {
-    it("starts infra (pg+redis+clickhouse) → migrates → starts app tier (nlp+langevals+gateway+langwatch+langyagent+workers)", async () => {
-      const ctx = fakeCtx();
-      const handles = await runtime.startAll(ctx);
-      expect(handles).toHaveLength(9);
-      const positions: Record<string, number> = {};
-      callLog.forEach((entry, idx) => {
-        if (!(entry in positions)) positions[entry] = idx;
-      });
-      // Infra phase 1.
-      const infraEnd = Math.max(
-        positions["start:postgres"]!,
-        positions["start:redis"]!,
-        positions["start:clickhouse"]!,
-      );
-      // Migrations strictly after infra healthy.
-      expect(positions["migrate"]).toBeGreaterThan(infraEnd);
-      // App tier strictly after migrations.
-      expect(positions["start:nlpgo"]).toBeGreaterThan(positions["migrate"]!);
-      expect(positions["start:langevals"]).toBeGreaterThan(positions["migrate"]!);
-      expect(positions["start:aigateway"]).toBeGreaterThan(positions["migrate"]!);
-      expect(positions["start:langwatch"]).toBeGreaterThan(positions["migrate"]!);
-    });
+	describe("when startAll is called", () => {
+		it("starts infra (pg+redis+clickhouse) → migrates → starts app tier (nlp+langevals+gateway+langwatch+langyagent+workers)", async () => {
+			const ctx = fakeCtx();
+			const handles = await runtime.startAll(ctx);
+			expect(handles).toHaveLength(9);
+			const positions: Record<string, number> = {};
+			callLog.forEach((entry, idx) => {
+				if (!(entry in positions)) positions[entry] = idx;
+			});
+			// Infra phase 1.
+			const infraEnd = Math.max(
+				positions["start:postgres"]!,
+				positions["start:redis"]!,
+				positions["start:clickhouse"]!,
+			);
+			// Migrations strictly after infra healthy.
+			expect(positions["migrate"]).toBeGreaterThan(infraEnd);
+			// App tier strictly after migrations.
+			expect(positions["start:nlpgo"]).toBeGreaterThan(positions["migrate"]!);
+			expect(positions["start:langevals"]).toBeGreaterThan(
+				positions["migrate"]!,
+			);
+			expect(positions["start:aigateway"]).toBeGreaterThan(
+				positions["migrate"]!,
+			);
+			expect(positions["start:langwatch"]).toBeGreaterThan(
+				positions["migrate"]!,
+			);
+		});
 
-    it("starts the assistant alongside the rest of the app tier", async () => {
-      await runtime.startAll(fakeCtx());
-      expect(callLog).toContain("start:langyagent");
-    });
+		it("starts the assistant alongside the rest of the app tier", async () => {
+			await runtime.startAll(fakeCtx());
+			expect(callLog).toContain("start:langyagent");
+		});
 
-    it("returns ServiceHandle objects with name + pid + stop()", async () => {
-      const handles = await runtime.startAll(fakeCtx());
-      for (const h of handles) {
-        expect(typeof h.name).toBe("string");
-        expect(typeof h.pid).toBe("number");
-        expect(typeof h.stop).toBe("function");
-      }
-    });
-  });
+		it("returns ServiceHandle objects with name + pid + stop()", async () => {
+			const handles = await runtime.startAll(fakeCtx());
+			for (const h of handles) {
+				expect(typeof h.name).toBe("string");
+				expect(typeof h.pid).toBe("number");
+				expect(typeof h.stop).toBe("function");
+			}
+		});
+	});
 
-  describe("when the assistant is turned off", () => {
-    it("does not start it, and does not fetch what only it needs", async () => {
-      process.env.LANGWATCH_ENABLE_LANGY = "false";
-      try {
-        await runtime.installServices(fakeCtx());
-        const handles = await runtime.startAll(fakeCtx());
-        expect(callLog).not.toContain("start:langyagent");
-        expect(callLog).not.toContain("langy-cli");
-        // Everything else is untouched.
-        expect(handles).toHaveLength(8);
-        expect(callLog).toContain("start:langwatch");
-        expect(callLog).toContain("venvs");
-      } finally {
-        delete process.env.LANGWATCH_ENABLE_LANGY;
-      }
-    });
+	describe("when one app-tier service never becomes healthy", () => {
+		it("stops the siblings that did start instead of leaking them", async () => {
+			// Promise.all rejects on the first failure and DISCARDS the resolved
+			// handles, so the started siblings never reached stopHandles: every
+			// partial boot leaked live processes that squatted the port slot and
+			// forced the next run to auto-shift.
+			langwatchStub.fn.mockImplementationOnce(async () => {
+				callLog.push("start:langwatch");
+				throw new Error("langwatch did not become healthy: timed out");
+			});
 
-    it("strips the assistant out of the app's env so nothing points at a service that is not there", async () => {
-      process.env.LANGWATCH_ENABLE_LANGY = "false";
-      // Simulate a .env scaffolded while the assistant was on: the file keeps
-      // its lines (they are the user's knobs), the processes must not see them.
-      envFileContent = {
-        OPENCODE_AGENT_URL: "http://localhost:5564",
-        FEATURE_FLAG_FORCE_ENABLE: "release_langy_enabled,other_flag",
-      };
-      try {
-        await runtime.startAll(fakeCtx());
-        const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
-        expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
-        expect(childEnv.FEATURE_FLAG_FORCE_ENABLE).toBe("other_flag");
-        expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
-      } finally {
-        envFileContent = {};
-        delete process.env.LANGWATCH_ENABLE_LANGY;
-      }
-    });
+			await expect(runtime.startAll(fakeCtx())).rejects.toThrow(
+				"did not become healthy",
+			);
 
-  });
+			for (const sibling of ["nlpgo", "langevals", "aigateway"]) {
+				expect(callLog).toContain(`stop:${sibling}`);
+			}
+			// Infra + the assistant come down with them.
+			for (const infra of ["postgres", "redis", "clickhouse", "langyagent"]) {
+				expect(callLog).toContain(`stop:${infra}`);
+			}
+		});
+	});
 
-  describe("when the release binary predates the assistant", () => {
-    it("comes up without it, and says so", async () => {
-      langyBinarySupported = false;
-      const events: unknown[] = [];
-      const ctx = fakeCtx();
-      const bus = runtime.events(ctx) as { emit(e: unknown): void };
-      const origEmit = bus.emit.bind(bus);
-      bus.emit = (e: unknown) => {
-        events.push(e);
-        origEmit(e);
-      };
-      const handles = await runtime.startAll(ctx);
-      // The whole install still boots; only the assistant is absent.
-      expect(callLog).not.toContain("start:langyagent");
-      expect(callLog).toContain("start:langwatch");
-      expect(handles).toHaveLength(8);
-      // The app is told the assistant is off, not left pointing at a corpse.
-      const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
-      expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
-      expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
-      // And the person running the install is told why.
-      const warning = events.find(
-        (e) =>
-          (e as { type?: string; line?: string }).type === "log" &&
-          ((e as { line?: string }).line ?? "").includes("langy assistant disabled"),
-      );
-      expect(warning).toBeDefined();
-    });
+	describe("when the assistant is turned off", () => {
+		it("does not start it, and does not fetch what only it needs", async () => {
+			process.env.LANGWATCH_ENABLE_LANGY = "false";
+			try {
+				await runtime.installServices(fakeCtx());
+				const handles = await runtime.startAll(fakeCtx());
+				expect(callLog).not.toContain("start:langyagent");
+				expect(callLog).not.toContain("langy-cli");
+				// Everything else is untouched.
+				expect(handles).toHaveLength(8);
+				expect(callLog).toContain("start:langwatch");
+				expect(callLog).toContain("venvs");
+			} finally {
+				delete process.env.LANGWATCH_ENABLE_LANGY;
+			}
+		});
 
-  });
+		it("strips the assistant out of the app's env so nothing points at a service that is not there", async () => {
+			process.env.LANGWATCH_ENABLE_LANGY = "false";
+			// Simulate a .env scaffolded while the assistant was on: the file keeps
+			// its lines (they are the user's knobs), the processes must not see them.
+			envFileContent = {
+				OPENCODE_AGENT_URL: "http://localhost:5564",
+				FEATURE_FLAG_FORCE_ENABLE: "release_langy_enabled,other_flag",
+			};
+			try {
+				await runtime.startAll(fakeCtx());
+				const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<
+					string,
+					string
+				>;
+				expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
+				expect(childEnv.FEATURE_FLAG_FORCE_ENABLE).toBe("other_flag");
+				expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
+			} finally {
+				envFileContent = {};
+				delete process.env.LANGWATCH_ENABLE_LANGY;
+			}
+		});
+	});
 
-  describe("when nothing is toggled", () => {
-    it("tells the app exactly which evaluators this install skipped", async () => {
-      await runtime.startAll(fakeCtx());
-      const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<string, string>;
-      // Explicit values, so an install whose .env predates a toggle still
-      // gets the truth rather than the app's assume-available default.
-      expect(childEnv.LANGWATCH_ENABLE_PRESIDIO).toBe("false");
-      expect(childEnv.LANGWATCH_ENABLE_LINGUA).toBe("false");
-      expect(childEnv.LANGWATCH_ENABLE_LEGACY_EVALUATORS).toBe("false");
-    });
-  });
+	describe("when the release binary predates the assistant", () => {
+		it("comes up without it, and says so", async () => {
+			langyBinarySupported = false;
+			const events: unknown[] = [];
+			const ctx = fakeCtx();
+			const bus = runtime.events(ctx) as { emit(e: unknown): void };
+			const origEmit = bus.emit.bind(bus);
+			bus.emit = (e: unknown) => {
+				events.push(e);
+				origEmit(e);
+			};
+			const handles = await runtime.startAll(ctx);
+			// The whole install still boots; only the assistant is absent.
+			expect(callLog).not.toContain("start:langyagent");
+			expect(callLog).toContain("start:langwatch");
+			expect(handles).toHaveLength(8);
+			// The app is told the assistant is off, not left pointing at a corpse.
+			const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<
+				string,
+				string
+			>;
+			expect(childEnv.LANGWATCH_ENABLE_LANGY).toBe("false");
+			expect(childEnv.OPENCODE_AGENT_URL).toBeUndefined();
+			// And the person running the install is told why.
+			const warning = events.find(
+				(e) =>
+					(e as { type?: string; line?: string }).type === "log" &&
+					((e as { line?: string }).line ?? "").includes(
+						"langy assistant disabled",
+					),
+			);
+			expect(warning).toBeDefined();
+		});
+	});
 
-  describe("when stopAll is called", () => {
-    it("stops handles in reverse start order", async () => {
-      const handles = await runtime.startAll(fakeCtx());
-      callLog.length = 0; // reset to count only stops
-      await runtime.stopAll(handles);
-      const stopOrder = callLog.filter((entry) => entry.startsWith("stop:"));
-      expect(stopOrder).toHaveLength(9);
-      // First stopped should be langwatch (last started); last stopped should be one of the infra.
-      const firstStopped = stopOrder[0]!.replace("stop:", "");
-      const lastStopped = stopOrder[stopOrder.length - 1]!.replace("stop:", "");
-      expect(firstStopped).toBe("workers");
-      expect(["postgres", "redis", "clickhouse"]).toContain(lastStopped);
-    });
+	describe("when nothing is toggled", () => {
+		it("tells the app exactly which evaluators this install skipped", async () => {
+			await runtime.startAll(fakeCtx());
+			const childEnv = langwatchStub.fn.mock.calls.at(-1)![2] as Record<
+				string,
+				string
+			>;
+			// Explicit values, so an install whose .env predates a toggle still
+			// gets the truth rather than the app's assume-available default.
+			expect(childEnv.LANGWATCH_ENABLE_PRESIDIO).toBe("false");
+			expect(childEnv.LANGWATCH_ENABLE_LINGUA).toBe("false");
+			expect(childEnv.LANGWATCH_ENABLE_LEGACY_EVALUATORS).toBe("false");
+		});
+	});
 
-    it("does not throw when individual stop() throws", async () => {
-      const handles = await runtime.startAll(fakeCtx());
-      handles[0]!.stop = vi.fn(async () => {
-        throw new Error("boom");
-      });
-      await expect(runtime.stopAll(handles)).resolves.toBeUndefined();
-    });
-  });
+	describe("when stopAll is called", () => {
+		it("stops handles in reverse start order", async () => {
+			const handles = await runtime.startAll(fakeCtx());
+			callLog.length = 0; // reset to count only stops
+			await runtime.stopAll(handles);
+			const stopOrder = callLog.filter((entry) => entry.startsWith("stop:"));
+			expect(stopOrder).toHaveLength(9);
+			// First stopped should be langwatch (last started); last stopped should be one of the infra.
+			const firstStopped = stopOrder[0]!.replace("stop:", "");
+			const lastStopped = stopOrder[stopOrder.length - 1]!.replace("stop:", "");
+			expect(firstStopped).toBe("workers");
+			expect(["postgres", "redis", "clickhouse"]).toContain(lastStopped);
+		});
 
-  describe("when events() is called", () => {
-    it("returns the same AsyncIterable across calls within a single ctx", () => {
-      const ctx = fakeCtx();
-      const a = runtime.events(ctx);
-      const b = runtime.events(ctx);
-      expect(a).toBe(b);
-    });
+		it("does not throw when individual stop() throws", async () => {
+			const handles = await runtime.startAll(fakeCtx());
+			handles[0]!.stop = vi.fn(async () => {
+				throw new Error("boom");
+			});
+			await expect(runtime.stopAll(handles)).resolves.toBeUndefined();
+		});
+	});
 
-    it("emits starting+healthy events for every service that starts", async () => {
-      const ctx = fakeCtx();
-      const events = runtime.events(ctx);
-      const collected: RuntimeEvent[] = [];
-      const collector = (async () => {
-        for await (const ev of events) {
-          collected.push(ev);
-          if (collected.filter((e) => e.type === "healthy").length >= 8) break;
-        }
-      })();
-      await runtime.startAll(ctx);
-      // Watchdog: if a regression makes one of the supervised services
-      // skip its "healthy" emit, the collector loop above will block
-      // forever waiting for the 7th event. Race against a 5s timeout so
-      // the test fails loud instead of hanging the runner.
-      await Promise.race([
-        collector,
-        new Promise<void>((_, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  `runtime.events collector did not see 8 healthy events within 5s — got ${
-                    collected.filter((e) => e.type === "healthy").length
-                  }`,
-                ),
-              ),
-            5_000,
-          ),
-        ),
-      ]);
-      const startingServices = collected
-        .filter((e) => e.type === "starting")
-        .map((e) => (e as { service: string }).service);
-      expect(startingServices).toEqual(
-        expect.arrayContaining([
-          "postgres",
-          "redis",
-          "clickhouse",
-          "langyagent",
-          "nlpgo",
-          "langevals",
-          "aigateway",
-          "langwatch",
-        ]),
-      );
-    });
-  });
+	describe("when events() is called", () => {
+		it("returns the same AsyncIterable across calls within a single ctx", () => {
+			const ctx = fakeCtx();
+			const a = runtime.events(ctx);
+			const b = runtime.events(ctx);
+			expect(a).toBe(b);
+		});
+
+		it("emits starting+healthy events for every service that starts", async () => {
+			const ctx = fakeCtx();
+			const events = runtime.events(ctx);
+			const collected: RuntimeEvent[] = [];
+			const collector = (async () => {
+				for await (const ev of events) {
+					collected.push(ev);
+					if (collected.filter((e) => e.type === "healthy").length >= 8) break;
+				}
+			})();
+			await runtime.startAll(ctx);
+			// Watchdog: if a regression makes one of the supervised services
+			// skip its "healthy" emit, the collector loop above will block
+			// forever waiting for the 7th event. Race against a 5s timeout so
+			// the test fails loud instead of hanging the runner.
+			await Promise.race([
+				collector,
+				new Promise<void>((_, reject) =>
+					setTimeout(
+						() =>
+							reject(
+								new Error(
+									`runtime.events collector did not see 8 healthy events within 5s — got ${
+										collected.filter((e) => e.type === "healthy").length
+									}`,
+								),
+							),
+						5_000,
+					),
+				),
+			]);
+			const startingServices = collected
+				.filter((e) => e.type === "starting")
+				.map((e) => (e as { service: string }).service);
+			expect(startingServices).toEqual(
+				expect.arrayContaining([
+					"postgres",
+					"redis",
+					"clickhouse",
+					"langyagent",
+					"nlpgo",
+					"langevals",
+					"aigateway",
+					"langwatch",
+				]),
+			);
+		});
+	});
 });

--- a/packages/server/test/services/runtime.test.ts
+++ b/packages/server/test/services/runtime.test.ts
@@ -165,6 +165,7 @@ describe("services/runtime", () => {
 			venvsFn,
 			nodeDepsFn,
 			ensureAppDirFn,
+			langyCliFn,
 		].forEach((fn) => fn.mockClear());
 	});
 

--- a/specs/npx-installer/03-services.feature
+++ b/specs/npx-installer/03-services.feature
@@ -132,6 +132,7 @@ Feature: Service orchestration after pre-deps are installed
   Scenario: Explicit --port flag wins over auto-shift
     When the user runs `npx @langwatch/server --port 6660`
     Then port-base is 6660
+    And no auto-shift occurs even if 6660 is in use (instead, the CLI errors loudly)
 
   Scenario: A run that lands on a different port slot updates the install's URLs
     Given an install whose .env was scaffolded on the 5560 slot
@@ -146,7 +147,6 @@ Feature: Service orchestration after pre-deps are installed
     When a later run auto-shifts to a different port slot
     Then BASE_HOST still carries the user's hostname
     And only values still in their scaffolded localhost shape were updated
-    And no auto-shift occurs even if 6660 is in use (instead, the CLI errors loudly)
 
   # =========================================================================
   # Browser auto-open

--- a/specs/npx-installer/03-services.feature
+++ b/specs/npx-installer/03-services.feature
@@ -97,6 +97,15 @@ Feature: Service orchestration after pre-deps are installed
     And the CLI calls `runtime.stopAll(handles)` to bring down everything else
     And the CLI exits with code 1
 
+  Scenario: A service failing its health probe takes the already-started ones down with it
+    Given the app tier starts several services at once
+    When one of them never reports healthy
+    But its siblings started fine
+    Then the boot fails naming the unhealthy service
+    And every sibling that did start is stopped, none is left running
+    # A leaked sibling squats its port, so the NEXT run auto-shifts to a new
+    # slot and boots services the .env's URLs don't point at.
+
   Scenario: Ctrl+C cleanly stops every service
     Given all services are running
     When the user sends SIGINT to the CLI process
@@ -123,6 +132,20 @@ Feature: Service orchestration after pre-deps are installed
   Scenario: Explicit --port flag wins over auto-shift
     When the user runs `npx @langwatch/server --port 6660`
     Then port-base is 6660
+
+  Scenario: A run that lands on a different port slot updates the install's URLs
+    Given an install whose .env was scaffolded on the 5560 slot
+    And a stray process now holds one port of that slot
+    When the next run auto-shifts to 5570
+    Then the .env's service URLs point at the 5570 slot
+    And the CLI says which keys it updated
+    And the app reaches the data stores this run actually started
+
+  Scenario: A URL the user pointed elsewhere survives every port shift
+    Given the user replaced BASE_HOST with a LAN hostname in the .env
+    When a later run auto-shifts to a different port slot
+    Then BASE_HOST still carries the user's hostname
+    And only values still in their scaffolded localhost shape were updated
     And no auto-shift occurs even if 6660 is in use (instead, the CLI errors loudly)
 
   # =========================================================================

--- a/specs/npx-installer/05-publish.feature
+++ b/specs/npx-installer/05-publish.feature
@@ -22,6 +22,27 @@ Feature: CI smoke + publish for `@langwatch/server`
       | ubuntu-22.04         |
       | ubuntu-22.04-arm     |
 
+  Scenario: Smoke boots the packed tarball, never the checkout
+    Given the smoke job packed the npm tarball
+    When it starts the server
+    Then the CLI it runs is the one extracted from that tarball
+    And the extraction is laid out like an npx install (node_modules/@langwatch/server)
+    And the app tree that boots is the tarball's contents, not the repository's
+    # A checkout boot masks packaging gaps: an over-broad .npmignore breaks
+    # only the released artifact, which no CI step would otherwise execute.
+
+  Scenario: The tarball ships every workspace package the app imports
+    When the publish job builds the tarball
+    Then for every workspace package directory in the checkout there is a package.json in the tarball
+    And the platform feature map ships at the tarball root
+    And a fresh install from the tarball resolves every @langwatch/* module at boot
+
+  Scenario: An install missing a workspace package fails at install time, not at boot
+    Given an app tree whose node_modules carries a link to a package that does not exist
+    When the installer prepares the app's dependencies
+    Then it fails naming the missing packages
+    And the message says the published artifact is the problem and where to report it
+
   Scenario: Smoke job uploads logs as artifact on failure
     Given a smoke job step fails
     Then "~/.langwatch/logs/" is uploaded as workflow artifact "logs-<runner>-<sha>.tar.gz"

--- a/specs/npx-installer/05-publish.feature
+++ b/specs/npx-installer/05-publish.feature
@@ -22,26 +22,25 @@ Feature: CI smoke + publish for `@langwatch/server`
       | ubuntu-22.04         |
       | ubuntu-22.04-arm     |
 
-  Scenario: Smoke boots the packed tarball, never the checkout
+  Scenario: Smoke proves the artifact npm users receive, never the checkout
     Given the smoke job packed the npm tarball
-    When it starts the server
-    Then the CLI it runs is the one extracted from that tarball
-    And the extraction is laid out like an npx install (node_modules/@langwatch/server)
-    And the app tree that boots is the tarball's contents, not the repository's
-    # A checkout boot masks packaging gaps: an over-broad .npmignore breaks
+    When the smoke boots the server
+    Then everything that runs came from that tarball
+    And a file missing from the artifact fails the smoke even though the checkout has it
+    # A checkout boot masks packaging gaps: an over-broad exclusion breaks
     # only the released artifact, which no CI step would otherwise execute.
 
-  Scenario: The tarball ships every workspace package the app imports
-    When the publish job builds the tarball
-    Then for every workspace package directory in the checkout there is a package.json in the tarball
-    And the platform feature map ships at the tarball root
-    And a fresh install from the tarball resolves every @langwatch/* module at boot
+  Scenario: A fresh install from the published artifact boots with nothing missing
+    When a user installs from the published artifact
+    Then the server reaches healthy with every module the app imports present
+    And the publish job refuses to ship an artifact that would not
 
-  Scenario: An install missing a workspace package fails at install time, not at boot
-    Given an app tree whose node_modules carries a link to a package that does not exist
-    When the installer prepares the app's dependencies
-    Then it fails naming the missing packages
-    And the message says the published artifact is the problem and where to report it
+  Scenario: An incomplete artifact fails at install time, not minutes later at boot
+    Given a published artifact missing packages the app needs
+    When the installer prepares the app
+    Then it fails during install, before any service starts
+    And the failure names the missing packages and says the artifact itself is at fault
+    And it points at the issue tracker instead of leaving the user to debug a bare module error
 
   Scenario: Smoke job uploads logs as artifact on failure
     Given a smoke job step fails


### PR DESCRIPTION
# fix(server): ship the workspace packages the app imports, and boot smoke from the packed tarball

## The 3.6.0 release is broken for `npx @langwatch/server`

A fresh `npx @langwatch/server@3.6.0` install dies at first boot:

```
Error: Cannot find module '@langwatch/observability'
Require stack: .../app/langwatch/src/task.ts
```

Both `.npmignore` files still exclude `langwatch/packages/` from the era when that directory held only dev tooling. Runtime workspace packages have since moved in (`@langwatch/observability`, `automations`, `react-rum`, `redaction`, `ssrf`, `api`), and the root-level members `packages/handled-error` and `packages/langy` plus `feature-map.json` (read by Langy at runtime) were never in `files[]` either. pnpm exits 0 when a lockfile importer's directory is missing, so the install "succeeds" with dangling `@langwatch/*` links and the app dies minutes later inside the first migration. This needs a 3.6.1 patch release.

## Why CI never saw it

The smoke workflow packs the tarball but boots the **checkout**, where all the packages exist. The packed artifact, the only thing npm users ever run, was never executed by any CI step. (Local dogfooding had the same blind spot: an extraction inside the repo resolves modules from the repo's own node_modules by walk-up. The relocated `~/.langwatch/app` tree is the honest environment, and it fails.)

## What this PR changes

**Packaging, the release fix:**
- Drop the `langwatch/packages/` exclusion from both `.npmignore` files (all members together are under 1MB of source)
- Add `packages/handled-error/`, `packages/langy/`, `feature-map.json` to `files[]`
- Publish sanity-check now requires every workspace package present in the checkout to exist in the tarball, derived from the directory listing so the next new package is covered the day it appears

**Smoke now tests the real artifact:**
- The smoke job extracts the packed tarball into a `node_modules/@langwatch/server` layout and boots that, exercising the same relocation and app tree npm users get. This exact class of bug now fails PRs instead of releases.

**Install-time guards in the CLI:**
- After install, every `@langwatch/*` link must resolve; a dangling one fails immediately with a message naming the missing packages and calling it a packaging bug, instead of a bare MODULE_NOT_FOUND mid-migration
- Members living outside `langwatch/` (mcp-server, `packages/*`) can't reach `langwatch/node_modules` by walk-up, so their declared `peerDependencies` (zod for `@langwatch/langy`, `@opentelemetry/api` for `@langwatch/handled-error`) are now linked to the app's own resolved instances post-install. Links rather than `dependencies` entries on purpose: both packages must share the consumer's instance (zod schemas from two majors can't merge; a second otel api loses global registrations), and a `dependencies` entry resolves per-workspace, which pulled zod 4 in next to the app's zod 3 and broke every Langy turn with `merging._def.shape is not a function`
- npm pack strips `.npmrc` unconditionally, so the repo's `langwatch/.npmrc` hoist patterns (`*import-in-the-middle*`, `*require-in-the-middle*`, needed by OTel's ESM loader hooks) never ship; the installer recreates them before the first install
- installKey sequence bumped so existing 3.6.0 victims get one repairing re-install on upgrade

**Two boot-lifecycle bugs the rehearsal surfaced, both fixed:**
- A service failing its health probe rejected the app-tier `Promise.all` and discarded the handles of siblings that had already started. Every partial boot leaked live `nlpgo`/`aigateway`/langevals processes, which then squatted the port slot and forced the next run to auto-shift. Startup now collects handles via `allSettled` and stops everything that started
- A rerun that auto-shifts port slots kept the old slot's URLs in `.env`, so the app dialed data stores this very run had started elsewhere (Redis ECONNREFUSED crash loops). Scaffolding now reconciles port-bound `.env` URLs to the current allocation, only touching values still in their scaffolded localhost shape so hand-edited ones survive, and prints which keys it updated

## Verified end to end on the fixed tarball

Full wipe of `~/.langwatch`, packed tarball extracted into an npx-faithful `node_modules/@langwatch/server` layout, booted with the **released v3.6.0 binaries**. All five services healthy, then dogfooded in a real browser with a fresh account:

Fresh workspace after signup + onboarding:

![fresh workspace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/npx-langy-light/npx-fresh-workspace.png)

Langy answered a real turn (manager on the released monobinary, opencode worker, gateway, OpenAI): "I'm Langy, your LangWatch assistant. I can help with traces, evaluations, prompts, scenarios, datasets, and monitoring." Gateway proven separately with a personal virtual key minted by `langwatch login --endpoint` against the local install:

![gateway trace detail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/npx-langy-light/npx-gateway-trace-detail.png)

`langwatch claude` session tracked into the local install, all three origins side by side (Coding Agent, Gateway, Langy):

![traces three origins](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/npx-langy-light/npx-traces-three-origins.png)

Usage accounting picked all of it up (coding-agent session cost, by-tool spend, recent activity):

![usage all origins](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/npx-langy-light/npx-usage-all-origins.png)

## Findings filed separately

- Workers process killed under memory pressure (exit 137) stays down; the CLI has no restart policy for crashed services
- `langwatch claude` in OTLP mode is silently overridden by a pre-existing `~/.claude/settings.json` env block pointing at another endpoint (claude applies user-level settings env over process env), so telemetry lands on the previous install; the wrapper should pin a project-level `.claude/settings.local.json` in the workdir

## Tests

- `packages/server`: 97 tests passing (new: env reconcile shape-guard suite, workspace-link integrity, external-member peer links, allSettled leak regression)
- Specs updated: `03-services.feature` (partial-boot teardown, port-shift reconcile), `05-publish.feature` (tarball completeness, smoke-from-tarball)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup so if any app-tier service fails to become healthy, the boot process fails with the unhealthy service name and stops all already-started siblings.
  * Enhanced `.env` handling to reconcile port-dependent URL settings on reruns while preserving user-customized values (including LAN `BASE_HOST`).
* **Packaging**
  * Updated the published server artifact to include required workspace packages and `feature-map.json`, fixing runtime module resolution.
* **CI / Release Validation**
  * Strengthened smoke and tarball sanity checks to boot strictly from the published artifact and fail fast when artifacts are incomplete.
* **Testing**
  * Expanded coverage for env reconciliation, dependency/link integrity, and runtime orchestration.
* **Chores**
  * Added artifact-awareness and executable-bit restoration for relocated app content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->