### PR TITLE
fix(server): restart crashed services with bounded backoff

### DIFF
--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -223,11 +223,13 @@ jobs:
           )
           # Every workspace package in the checkout must ship: a missing one
           # leaves dangling pnpm links in the installed tree and the app dies
-          # with MODULE_NOT_FOUND at first boot — 3.6.0 shipped exactly that
+          # with MODULE_NOT_FOUND at first boot; 3.6.0 shipped exactly that
           # way (.npmignore still excluded langwatch/packages/ after runtime
-          # packages moved in). Derived from the directory listing so a new
-          # package is covered the day it appears.
-          for pkgdir in langwatch/packages/*/ packages/handled-error/ packages/langy/; do
+          # packages moved in). Both root packages/* and langwatch/packages/*
+          # are derived from a directory listing rather than named one by one,
+          # so a new package on either side is covered by this gate the day
+          # it appears, with nothing to remember to add here.
+          for pkgdir in langwatch/packages/*/ packages/*/; do
             pkgdir="${pkgdir%/}"
             [ -f "$pkgdir/package.json" ] || continue
             required+=("package/$pkgdir/package.json")

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -60,7 +60,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
     env:
-      LANGWATCH_HOME: ${{ github.workspace }}/.langwatch-smoke
+      # Outside $GITHUB_WORKSPACE on purpose (see the "Run npx @langwatch/server
+      # in a sandbox" step below): Node walks every ancestor directory looking
+      # for a node_modules, and the checkout's own workspace install would sit
+      # on that ancestor chain if LANGWATCH_HOME or the extracted tarball lived
+      # under the workspace.
+      LANGWATCH_HOME: ${{ runner.temp }}/.langwatch-smoke
       PORT_BASE: ${{ inputs.port_base || '5560' }}
       CI: "true"
 
@@ -157,8 +162,19 @@ jobs:
           # masks packaging gaps: 3.6.0 shipped without langwatch/packages/*
           # (both .npmignore files still excluded the dir after runtime
           # packages moved in), every install died at first boot with
-          # MODULE_NOT_FOUND — and every checkout-based smoke run passed.
-          install_dir="$GITHUB_WORKSPACE/_pack/node_modules/@langwatch/server"
+          # MODULE_NOT_FOUND, and every checkout-based smoke run passed.
+          #
+          # Extracted under $RUNNER_TEMP, not $GITHUB_WORKSPACE: Node's module
+          # resolution walks every ancestor directory looking for a
+          # node_modules to check, and the "Install pnpm dependencies
+          # (workspace)" step above left $GITHUB_WORKSPACE/node_modules on
+          # disk. An install_dir nested under $GITHUB_WORKSPACE would still
+          # have carried that as an ancestor and could silently satisfy a
+          # module the tarball forgot to ship, masking the exact tsx
+          # alias-skip bug this job exists to catch. $RUNNER_TEMP is a
+          # sibling of the checkout, matching what a real npx cache dir
+          # looks like.
+          install_dir="$RUNNER_TEMP/npx-server-smoke/node_modules/@langwatch/server"
           mkdir -p "$install_dir"
           tar -xzf "${{ steps.pack.outputs.tarball }}" -C "$install_dir" --strip-components=1
           node "$install_dir/packages/server/dist/cli.cjs" start \

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -60,18 +60,23 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
     env:
-      # Outside $GITHUB_WORKSPACE on purpose (see the "Run npx @langwatch/server
-      # in a sandbox" step below): Node walks every ancestor directory looking
-      # for a node_modules, and the checkout's own workspace install would sit
-      # on that ancestor chain if LANGWATCH_HOME or the extracted tarball lived
-      # under the workspace.
-      LANGWATCH_HOME: ${{ runner.temp }}/.langwatch-smoke
       PORT_BASE: ${{ inputs.port_base || '5560' }}
       CI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Set LANGWATCH_HOME outside the workspace
+        # Outside $GITHUB_WORKSPACE on purpose (see the "Run npx @langwatch/server
+        # in a sandbox" step below): Node walks every ancestor directory looking
+        # for a node_modules, and the checkout's own workspace install would sit
+        # on that ancestor chain if LANGWATCH_HOME or the extracted tarball lived
+        # under the workspace. jobs.<job_id>.env only allows the github, inputs,
+        # matrix, needs, secrets, strategy and vars expression contexts, not
+        # runner, so $RUNNER_TEMP is resolved here as a shell variable instead
+        # and exported to every later step via $GITHUB_ENV.
+        run: echo "LANGWATCH_HOME=$RUNNER_TEMP/.langwatch-smoke" >> "$GITHUB_ENV"
 
       - name: Identify runner
         run: |

--- a/packages/server/src/animation/log-tee.ts
+++ b/packages/server/src/animation/log-tee.ts
@@ -61,7 +61,7 @@ export function renderEvent(ev: RuntimeEvent): string | null {
 		}
 		case "crashed":
 			return `${chalk.red("✗")} ${paint(ev.service)} ${chalk.red(
-				`crashed (exit ${ev.code}), see ${serviceLogPath(ev.service)}`,
+				`crashed (${exitCause(ev)}), see ${serviceLogPath(ev.service)}`,
 			)}`;
 		case "stopped":
 			return `${chalk.yellow("⏻")} ${paint(ev.service)} ${chalk.dim("stopped")}`;

--- a/packages/server/src/animation/log-tee.ts
+++ b/packages/server/src/animation/log-tee.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import chalk from "chalk";
 import { paths } from "../shared/paths.ts";
-import type { RuntimeEvent } from "../shared/runtime-contract.ts";
+import { exitCause, type RuntimeEvent } from "../shared/runtime-contract.ts";
 
 const COLORS: Record<string, (s: string) => string> = {
 	langwatch: chalk.green,
@@ -34,10 +34,6 @@ function serviceLogPath(service: string): string {
 	const full = join(paths.logs, `${service}.log`);
 	const home = homedir();
 	return full.startsWith(home) ? `~${full.slice(home.length)}` : full;
-}
-
-function exitCause(ev: { code: number; signal?: NodeJS.Signals }): string {
-	return ev.signal ? `signal ${ev.signal}` : `code ${ev.code}`;
 }
 
 /**
@@ -73,7 +69,7 @@ export function renderEvent(ev: RuntimeEvent): string | null {
 /**
  * Drain the runtime's event stream to the user's TTY, never blocking the
  * CLI's main flow. Returns an awaitable that resolves once the stream
- * closes — typically after `runtime.stopAll` is called and every
+ * closes, typically after `runtime.stopAll` is called and every
  * supervised child has exited.
  */
 export async function streamEventsToTTY(

--- a/packages/server/src/animation/log-tee.ts
+++ b/packages/server/src/animation/log-tee.ts
@@ -1,20 +1,23 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import chalk from "chalk";
+import { paths } from "../shared/paths.ts";
 import type { RuntimeEvent } from "../shared/runtime-contract.ts";
 
 const COLORS: Record<string, (s: string) => string> = {
-  langwatch: chalk.green,
-  workers: chalk.bold.green,
-  nlpgo: chalk.cyan,
-  langevals: chalk.magenta,
-  aigateway: chalk.yellow,
-  postgres: chalk.dim,
-  redis: chalk.dim,
-  clickhouse: chalk.dim,
-  "prepare:app": chalk.blue,
-  "prepare:langwatch": chalk.green,
-  "prepare:langevals": chalk.magenta,
-  "migrate:prisma": chalk.dim,
-  "migrate:clickhouse": chalk.dim,
+	langwatch: chalk.green,
+	workers: chalk.bold.green,
+	nlpgo: chalk.cyan,
+	langevals: chalk.magenta,
+	aigateway: chalk.yellow,
+	postgres: chalk.dim,
+	redis: chalk.dim,
+	clickhouse: chalk.dim,
+	"prepare:app": chalk.blue,
+	"prepare:langwatch": chalk.green,
+	"prepare:langevals": chalk.magenta,
+	"migrate:prisma": chalk.dim,
+	"migrate:clickhouse": chalk.dim,
 };
 
 // Wide enough to fit `prepare:langevals` without breaking alignment when
@@ -23,8 +26,18 @@ const COLORS: Record<string, (s: string) => string> = {
 const LABEL_WIDTH = 22;
 
 function paint(service: string): string {
-  const fn = COLORS[service] ?? chalk.white;
-  return fn(service.padEnd(LABEL_WIDTH));
+	const fn = COLORS[service] ?? chalk.white;
+	return fn(service.padEnd(LABEL_WIDTH));
+}
+
+function serviceLogPath(service: string): string {
+	const full = join(paths.logs, `${service}.log`);
+	const home = homedir();
+	return full.startsWith(home) ? `~${full.slice(home.length)}` : full;
+}
+
+function exitCause(ev: { code: number; signal?: NodeJS.Signals }): string {
+	return ev.signal ? `signal ${ev.signal}` : `code ${ev.code}`;
 }
 
 /**
@@ -32,20 +45,29 @@ function paint(service: string): string {
  * style so the user feels at home if they've ever run `pnpm dev`.
  */
 export function renderEvent(ev: RuntimeEvent): string | null {
-  switch (ev.type) {
-    case "starting":
-      return `${chalk.dim("⋯")} ${paint(ev.service)} ${chalk.dim("starting…")}`;
-    case "healthy":
-      return `${chalk.green("✓")} ${paint(ev.service)} ${chalk.dim(`healthy in ${ev.durationMs}ms`)}`;
-    case "log":
-      return `${chalk.dim("│")} ${paint(ev.service)} ${ev.line.replace(/\r?\n$/, "")}`;
-    case "crashed":
-      return `${chalk.red("✗")} ${paint(ev.service)} ${chalk.red(`crashed (exit ${ev.code})`)}`;
-    case "stopped":
-      return `${chalk.yellow("⏻")} ${paint(ev.service)} ${chalk.dim("stopped")}`;
-    default:
-      return null;
-  }
+	switch (ev.type) {
+		case "starting":
+			return `${chalk.dim("⋯")} ${paint(ev.service)} ${chalk.dim("starting…")}`;
+		case "healthy":
+			return `${chalk.green("✓")} ${paint(ev.service)} ${chalk.dim(`healthy in ${ev.durationMs}ms`)}`;
+		case "log":
+			return `${chalk.dim("│")} ${paint(ev.service)} ${ev.line.replace(/\r?\n$/, "")}`;
+		case "restarting": {
+			const delay =
+				ev.delayMs % 1000 === 0 ? `${ev.delayMs / 1000}s` : `${ev.delayMs}ms`;
+			return `${chalk.yellow("↻")} ${paint(ev.service)} ${chalk.yellow(
+				`exited (${exitCause(ev)}), restarting in ${delay} (attempt ${ev.attempt}/${ev.maxAttempts})`,
+			)}`;
+		}
+		case "crashed":
+			return `${chalk.red("✗")} ${paint(ev.service)} ${chalk.red(
+				`crashed (exit ${ev.code}), see ${serviceLogPath(ev.service)}`,
+			)}`;
+		case "stopped":
+			return `${chalk.yellow("⏻")} ${paint(ev.service)} ${chalk.dim("stopped")}`;
+		default:
+			return null;
+	}
 }
 
 /**
@@ -55,17 +77,17 @@ export function renderEvent(ev: RuntimeEvent): string | null {
  * supervised child has exited.
  */
 export async function streamEventsToTTY(
-  events: AsyncIterable<RuntimeEvent>,
-  options: { intercept?: (ev: RuntimeEvent) => boolean } = {},
+	events: AsyncIterable<RuntimeEvent>,
+	options: { intercept?: (ev: RuntimeEvent) => boolean } = {},
 ): Promise<void> {
-  const { intercept } = options;
-  for await (const ev of events) {
-    // Interceptor returns true to claim the event (e.g. routed into the
-    // install-phase panel renderer) and skip the default scrolling render.
-    if (intercept && intercept(ev)) continue;
-    const line = renderEvent(ev);
-    if (line) {
-      process.stdout.write(`${line}\n`);
-    }
-  }
+	const { intercept } = options;
+	for await (const ev of events) {
+		// Interceptor returns true to claim the event (e.g. routed into the
+		// install-phase panel renderer) and skip the default scrolling render.
+		if (intercept?.(ev)) continue;
+		const line = renderEvent(ev);
+		if (line) {
+			process.stdout.write(`${line}\n`);
+		}
+	}
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -281,7 +281,11 @@ program
 			version: VERSION,
 			userEnv: captureUserEnv(),
 		};
-		await ensureEnvFile(runtime, ctx);
+		// No conflict resolution has run for this port table (unlike "start",
+		// which calls resolvePortConflicts first): base is just
+		// PORT_BASE_DEFAULT. Reconciling now would rewrite a real install's
+		// .env to that guess; leave existing port-bound URLs alone.
+		await ensureEnvFile(runtime, ctx, { shouldReconcilePorts: false });
 		await runtime.installServices(ctx);
 		console.log(
 			chalk.green("✓ install complete — run `npx @langwatch/server` to start"),

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -13,7 +13,7 @@ import { openBrowser } from "./animation/open-browser.ts";
 import { resolvePortConflicts } from "./port-conflict/resolve.ts";
 import { inspectPredeps, printDoctorTable } from "./predeps/detect-only.ts";
 import { runPredeps } from "./predeps/runner.ts";
-import { captureUserEnv, scaffoldEnvFile } from "./shared/env.ts";
+import { captureUserEnv } from "./shared/env.ts";
 import { paths } from "./shared/paths.ts";
 import { detectPlatform } from "./shared/platform.ts";
 import { allocatePorts, PORT_BASE_DEFAULT } from "./shared/ports.ts";
@@ -51,15 +51,17 @@ async function loadRuntime(): Promise<RuntimeApi> {
 	}
 }
 
-function ensureEnvFile(
+/**
+ * Routed through `RuntimeApi.scaffoldEnv` rather than calling `shared/env.ts`
+ * directly, so the CLI stays behind the same contract `services/runtime.ts`
+ * implements (and the placeholder stands in for, before it exists).
+ */
+async function ensureEnvFile(
+	runtime: RuntimeApi,
 	ctx: RuntimeContext,
-	{ shouldReconcilePorts = false }: { shouldReconcilePorts?: boolean } = {},
-): { written: boolean; path: string; reconciledKeys: string[] } {
-	return scaffoldEnvFile({
-		ports: ctx.ports,
-		path: ctx.paths.envFile,
-		shouldReconcilePorts,
-	});
+	opts: { shouldReconcilePorts?: boolean } = {},
+): Promise<{ written: boolean; path: string; reconciledKeys: string[] }> {
+	return runtime.scaffoldEnv(ctx, opts);
 }
 
 const program = new Command();
@@ -147,7 +149,9 @@ program
 			userEnv: captureUserEnv(),
 		};
 
-		const envResult = ensureEnvFile(ctx, { shouldReconcilePorts: true });
+		const envResult = await ensureEnvFile(runtime, ctx, {
+			shouldReconcilePorts: true,
+		});
 		if (envResult.reconciledKeys.length > 0) {
 			console.log(
 				chalk.yellow(
@@ -277,7 +281,7 @@ program
 			version: VERSION,
 			userEnv: captureUserEnv(),
 		};
-		ensureEnvFile(ctx);
+		await ensureEnvFile(runtime, ctx);
 		await runtime.installServices(ctx);
 		console.log(
 			chalk.green("✓ install complete — run `npx @langwatch/server` to start"),

--- a/packages/server/src/services/env.ts
+++ b/packages/server/src/services/env.ts
@@ -2,12 +2,20 @@ import { scaffoldEnvFile } from "../shared/env.ts";
 import type { RuntimeContext } from "../shared/runtime-contract.ts";
 
 /**
- * `runtime.scaffoldEnv` thin wrapper. Idempotent — if `~/.langwatch/.env`
+ * `runtime.scaffoldEnv` thin wrapper. Idempotent: if `~/.langwatch/.env`
  * exists, user-owned values (OPENAI_API_KEY etc.) survive across runs and
  * only the port-bound URLs are reconciled to this run's allocation (the
  * ctx here always carries a real, conflict-checked port table).
+ *
+ * `shouldReconcilePorts` defaults to true (the "start" flow's need) but the
+ * "install" flow, which writes .env before any port conflict has been
+ * resolved for this run, passes false so it does not rewrite URLs to a
+ * guess that the actual start-up might not honor.
  */
-export function scaffoldEnv(ctx: RuntimeContext): {
+export function scaffoldEnv(
+	ctx: RuntimeContext,
+	{ shouldReconcilePorts = true }: { shouldReconcilePorts?: boolean } = {},
+): {
 	written: boolean;
 	path: string;
 	reconciledKeys: string[];
@@ -15,6 +23,6 @@ export function scaffoldEnv(ctx: RuntimeContext): {
 	return scaffoldEnvFile({
 		ports: ctx.ports,
 		path: ctx.envFile,
-		shouldReconcilePorts: true,
+		shouldReconcilePorts,
 	});
 }

--- a/packages/server/src/services/event-bus.ts
+++ b/packages/server/src/services/event-bus.ts
@@ -10,43 +10,62 @@ import type { RuntimeEvent } from "../shared/runtime-contract.ts";
  * logs from a single iterator. If we ever need fan-out we tee at the consumer.
  */
 export class EventBus implements AsyncIterable<RuntimeEvent> {
-  private readonly buffer: RuntimeEvent[] = [];
-  private readonly waiters: Array<(result: IteratorResult<RuntimeEvent>) => void> = [];
-  private done = false;
+	private readonly buffer: RuntimeEvent[] = [];
+	private readonly waiters: Array<
+		(result: IteratorResult<RuntimeEvent>) => void
+	> = [];
+	private readonly taps = new Set<(event: RuntimeEvent) => void>();
+	private done = false;
 
-  emit(event: RuntimeEvent): void {
-    if (this.done) return;
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      waiter({ value: event, done: false });
-      return;
-    }
-    this.buffer.push(event);
-  }
+	/**
+	 * Observe every event synchronously at emit time without consuming the
+	 * single-consumer iterator. Supervision uses this to notice its own
+	 * service's "healthy" event (emitted by the start helpers) so it knows a
+	 * later crash happened in steady state, not during boot. Returns an
+	 * unsubscribe function. Events emitted after end() are not observed.
+	 */
+	tap(listener: (event: RuntimeEvent) => void): () => void {
+		this.taps.add(listener);
+		return () => {
+			this.taps.delete(listener);
+		};
+	}
 
-  end(): void {
-    if (this.done) return;
-    this.done = true;
-    while (this.waiters.length > 0) {
-      const waiter = this.waiters.shift();
-      waiter?.({ value: undefined as never, done: true });
-    }
-  }
+	emit(event: RuntimeEvent): void {
+		if (this.done) return;
+		for (const tap of this.taps) tap(event);
+		const waiter = this.waiters.shift();
+		if (waiter) {
+			waiter({ value: event, done: false });
+			return;
+		}
+		this.buffer.push(event);
+	}
 
-  [Symbol.asyncIterator](): AsyncIterator<RuntimeEvent> {
-    return {
-      next: () => this.nextValue(),
-      return: async () => {
-        this.end();
-        return { value: undefined as never, done: true };
-      },
-    };
-  }
+	end(): void {
+		if (this.done) return;
+		this.done = true;
+		while (this.waiters.length > 0) {
+			const waiter = this.waiters.shift();
+			waiter?.({ value: undefined as never, done: true });
+		}
+	}
 
-  private nextValue(): Promise<IteratorResult<RuntimeEvent>> {
-    const buffered = this.buffer.shift();
-    if (buffered) return Promise.resolve({ value: buffered, done: false });
-    if (this.done) return Promise.resolve({ value: undefined as never, done: true });
-    return new Promise((resolve) => this.waiters.push(resolve));
-  }
+	[Symbol.asyncIterator](): AsyncIterator<RuntimeEvent> {
+		return {
+			next: () => this.nextValue(),
+			return: async () => {
+				this.end();
+				return { value: undefined as never, done: true };
+			},
+		};
+	}
+
+	private nextValue(): Promise<IteratorResult<RuntimeEvent>> {
+		const buffered = this.buffer.shift();
+		if (buffered) return Promise.resolve({ value: buffered, done: false });
+		if (this.done)
+			return Promise.resolve({ value: undefined as never, done: true });
+		return new Promise((resolve) => this.waiters.push(resolve));
+	}
 }

--- a/packages/server/src/services/event-bus.ts
+++ b/packages/server/src/services/event-bus.ts
@@ -6,7 +6,7 @@ import type { RuntimeEvent } from "../shared/runtime-contract.ts";
  * which buffers if no consumer is currently awaiting `next()`. Once `bus.end()`
  * is called every pending consumer wakes up with `{ done: true }`.
  *
- * Multi-consumer is intentionally not supported — the CLI animates and tees
+ * Multi-consumer is intentionally not supported: the CLI animates and tees
  * logs from a single iterator. If we ever need fan-out we tee at the consumer.
  */
 export class EventBus implements AsyncIterable<RuntimeEvent> {
@@ -33,7 +33,13 @@ export class EventBus implements AsyncIterable<RuntimeEvent> {
 
 	emit(event: RuntimeEvent): void {
 		if (this.done) return;
-		for (const tap of this.taps) tap(event);
+		for (const tap of this.taps) {
+			try {
+				tap(event);
+			} catch {
+				// A misbehaving tap must not break delivery to other taps or the iterator.
+			}
+		}
 		const waiter = this.waiters.shift();
 		if (waiter) {
 			waiter({ value: event, done: false });

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -41,8 +41,8 @@ function busFor(ctx: RuntimeContext): EventBus {
 }
 
 const runtimeImpl: RuntimeApi = {
-	async scaffoldEnv(ctx) {
-		return scaffoldEnv(ctx);
+	async scaffoldEnv(ctx, opts) {
+		return scaffoldEnv(ctx, opts);
 	},
 
 	async installServices(ctx) {

--- a/packages/server/src/services/spawn.ts
+++ b/packages/server/src/services/spawn.ts
@@ -1,30 +1,45 @@
 import { type ChildProcess, spawn as nodeSpawn } from "node:child_process";
-import { createInterface } from "node:readline";
 import {
-  createWriteStream,
-  existsSync,
-  mkdirSync,
-  unlinkSync,
-  writeFileSync,
-  type WriteStream,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	unlinkSync,
+	type WriteStream,
+	writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import type { ServiceName, ServicePaths } from "./paths.ts";
+import { createInterface } from "node:readline";
 import type { EventBus } from "./event-bus.ts";
+import type { ServiceName, ServicePaths } from "./paths.ts";
 
 export type SpawnSpec = {
-  name: ServiceName;
-  command: string;
-  args: string[];
-  env: NodeJS.ProcessEnv;
-  cwd?: string;
+	name: ServiceName;
+	command: string;
+	args: string[];
+	env: NodeJS.ProcessEnv;
+	cwd?: string;
 };
 
 export type SupervisedHandle = {
-  name: string;
-  pid: number;
-  child: ChildProcess;
-  stop(): Promise<void>;
+	name: string;
+	pid: number;
+	child: ChildProcess;
+	stop(): Promise<void>;
+};
+
+export type RestartPolicy = {
+	/** Restarts granted to a service that crashes after having been healthy. */
+	maxRestarts: number;
+	/** Delay before each restart attempt; the last entry repeats if the list is shorter than maxRestarts. */
+	backoffMs: readonly number[];
+	/** Uptime after which the restart counter resets to zero. */
+	steadyUptimeMs: number;
+};
+
+export const DEFAULT_RESTART_POLICY: RestartPolicy = {
+	maxRestarts: 3,
+	backoffMs: [1_000, 5_000, 15_000],
+	steadyUptimeMs: 5 * 60_000,
 };
 
 /**
@@ -32,117 +47,230 @@ export type SupervisedHandle = {
  * AND emit "log" events on the bus so the CLI can render to TTY. Writes a
  * pidfile so a stale process can be detected on the next CLI run.
  *
+ * Crash policy: a crash before the service's first "healthy" event is a boot
+ * failure and fails fast with a "crashed" event, exactly once. A crash after
+ * the service has been healthy is retried in place with bounded backoff
+ * (announced via "restarting" events); staying up for `steadyUptimeMs`
+ * refills the budget. When the budget is exhausted the crash falls through
+ * to the "crashed" event. Supervision learns about "healthy" by observing
+ * the bus; the health probes live in each service's start helper.
+ *
  * The returned handle's `stop()` sends SIGTERM, waits up to 10s for clean
- * exit, then SIGKILLs. Idempotent.
+ * exit, then SIGKILLs. It also cancels any pending restart. Idempotent.
+ * `pid` and `child` always reflect the current (most recently spawned)
+ * process.
  */
 export function supervise({
-  spec,
-  paths,
-  bus,
+	spec,
+	paths,
+	bus,
+	restartPolicy = DEFAULT_RESTART_POLICY,
 }: {
-  spec: SpawnSpec;
-  paths: ServicePaths;
-  bus: EventBus;
+	spec: SpawnSpec;
+	paths: ServicePaths;
+	bus: EventBus;
+	restartPolicy?: RestartPolicy;
 }): SupervisedHandle {
-  const logPath = paths.log(spec.name);
-  const pidPath = paths.pid(spec.name);
-  mkdirSync(dirname(logPath), { recursive: true });
-  mkdirSync(dirname(pidPath), { recursive: true });
-  const logStream = createWriteStream(logPath, { flags: "a" });
+	const logPath = paths.log(spec.name);
+	const pidPath = paths.pid(spec.name);
+	mkdirSync(dirname(logPath), { recursive: true });
+	mkdirSync(dirname(pidPath), { recursive: true });
 
-  const child = nodeSpawn(spec.command, spec.args, {
-    env: spec.env,
-    cwd: spec.cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: false,
-  });
+	let currentChild!: ChildProcess;
+	let stopped = false;
+	let hasBeenHealthy = false;
+	let restartCount = 0;
+	let backoffTimer: NodeJS.Timeout | null = null;
+	let steadyTimer: NodeJS.Timeout | null = null;
 
-  if (typeof child.pid === "number") {
-    writeFileSync(pidPath, String(child.pid));
-  }
+	const untap = bus.tap((ev) => {
+		if (ev.type === "healthy" && ev.service === spec.name)
+			hasBeenHealthy = true;
+	});
 
-  // Track stdout + stderr "end" events so we can drain any buffered lines
-  // BEFORE closing the log file. If we end() the logStream synchronously
-  // on child 'exit', the readline transformer may still be flushing the
-  // last chunk and we lose tail data — caught by spawn.integration.test
-  // intermittently failing on the 'row-2' assertion. Wait for both pipes
-  // to finish before closing.
-  const pipesDrained: Promise<void>[] = [
-    pipeLines(child, "stdout", spec.name, logStream, bus),
-    pipeLines(child, "stderr", spec.name, logStream, bus),
-  ];
+	const clearSteadyTimer = (): void => {
+		if (steadyTimer) {
+			clearTimeout(steadyTimer);
+			steadyTimer = null;
+		}
+	};
 
-  let stopped = false;
-  let exited = false;
+	const handleExit = ({
+		code,
+		signal,
+		logStream,
+	}: {
+		code: number | null;
+		signal: NodeJS.Signals | null;
+		logStream: WriteStream;
+	}): void => {
+		const isCrash = !stopped && (code !== 0 || signal !== null);
+		if (!isCrash) {
+			logStream.end();
+			untap();
+			bus.emit({ type: "stopped", service: spec.name });
+			return;
+		}
 
-  child.on("exit", (code, signal) => {
-    exited = true;
-    safeUnlink(pidPath);
+		const cause = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+		if (hasBeenHealthy && restartCount < restartPolicy.maxRestarts) {
+			restartCount += 1;
+			const attempt = restartCount;
+			const delayMs =
+				restartPolicy.backoffMs[
+					Math.min(attempt, restartPolicy.backoffMs.length) - 1
+				] ?? 1_000;
+			logStream.write(
+				`[supervisor] ${spec.name} exited (${cause}), restarting in ${delayMs}ms (attempt ${attempt}/${restartPolicy.maxRestarts})\n`,
+			);
+			logStream.end();
+			bus.emit({
+				type: "restarting",
+				service: spec.name,
+				code: code ?? -1,
+				signal: signal ?? undefined,
+				attempt,
+				maxAttempts: restartPolicy.maxRestarts,
+				delayMs,
+			});
+			backoffTimer = setTimeout(() => {
+				backoffTimer = null;
+				if (stopped) return;
+				spawnAttempt();
+			}, delayMs);
+			return;
+		}
 
-    void Promise.all(pipesDrained).then(() => {
-      logStream.end();
-      if (!stopped && (code !== 0 || signal !== null)) {
-        bus.emit({
-          type: "crashed",
-          service: spec.name,
-          code: code ?? -1,
-          signal: signal ?? undefined,
-        });
-      } else {
-        bus.emit({ type: "stopped", service: spec.name });
-      }
-    });
-  });
+		const reason = hasBeenHealthy
+			? "restart budget exhausted"
+			: "died before first healthy";
+		logStream.write(
+			`[supervisor] ${spec.name} exited (${cause}), ${reason}, not restarting\n`,
+		);
+		logStream.end();
+		untap();
+		bus.emit({
+			type: "crashed",
+			service: spec.name,
+			code: code ?? -1,
+			signal: signal ?? undefined,
+		});
+	};
 
-  const stop = async (): Promise<void> => {
-    if (stopped || exited) return;
-    stopped = true;
-    if (!child.pid || child.killed) return;
-    child.kill("SIGTERM");
-    const exit = waitForExit(child, 10_000);
-    if (await exit) return;
-    child.kill("SIGKILL");
-    await waitForExit(child, 5_000);
-  };
+	const spawnAttempt = (): void => {
+		const logStream = createWriteStream(logPath, { flags: "a" });
+		const child = nodeSpawn(spec.command, spec.args, {
+			env: spec.env,
+			cwd: spec.cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: false,
+		});
+		currentChild = child;
 
-  return { name: spec.name, pid: child.pid ?? -1, child, stop };
+		if (typeof child.pid === "number") {
+			writeFileSync(pidPath, String(child.pid));
+		}
+
+		// Track stdout + stderr "end" events so we can drain any buffered lines
+		// BEFORE closing the log file. If we end() the logStream synchronously
+		// on child 'exit', the readline transformer may still be flushing the
+		// last chunk and we lose tail data, caught by spawn.integration.test
+		// intermittently failing on the 'row-2' assertion. Wait for both pipes
+		// to finish before closing.
+		const pipesDrained: Promise<void>[] = [
+			pipeLines(child, "stdout", spec.name, logStream, bus),
+			pipeLines(child, "stderr", spec.name, logStream, bus),
+		];
+
+		clearSteadyTimer();
+		steadyTimer = setTimeout(() => {
+			steadyTimer = null;
+			restartCount = 0;
+		}, restartPolicy.steadyUptimeMs);
+
+		child.on("exit", (code, signal) => {
+			safeUnlink(pidPath);
+			clearSteadyTimer();
+			void Promise.all(pipesDrained).then(() =>
+				handleExit({ code, signal, logStream }),
+			);
+		});
+	};
+
+	spawnAttempt();
+
+	const stop = async (): Promise<void> => {
+		if (stopped) return;
+		stopped = true;
+		untap();
+		if (backoffTimer) {
+			// The child already exited and a respawn is pending: cancel it. No
+			// process is running, so this is the service's terminal event.
+			clearTimeout(backoffTimer);
+			backoffTimer = null;
+			clearSteadyTimer();
+			bus.emit({ type: "stopped", service: spec.name });
+			return;
+		}
+		clearSteadyTimer();
+		const child = currentChild;
+		const hasExited = child.exitCode !== null || child.signalCode !== null;
+		if (hasExited || !child.pid || child.killed) return;
+		child.kill("SIGTERM");
+		const exit = waitForExit(child, 10_000);
+		if (await exit) return;
+		child.kill("SIGKILL");
+		await waitForExit(child, 5_000);
+	};
+
+	return {
+		name: spec.name,
+		get pid() {
+			return currentChild.pid ?? -1;
+		},
+		get child() {
+			return currentChild;
+		},
+		stop,
+	};
 }
 
 function pipeLines(
-  child: ChildProcess,
-  streamName: "stdout" | "stderr",
-  service: ServiceName,
-  logStream: WriteStream,
-  bus: EventBus,
+	child: ChildProcess,
+	streamName: "stdout" | "stderr",
+	service: ServiceName,
+	logStream: WriteStream,
+	bus: EventBus,
 ): Promise<void> {
-  const stream = child[streamName];
-  if (!stream) return Promise.resolve();
-  const rl = createInterface({ input: stream });
-  rl.on("line", (line) => {
-    logStream.write(`${line}\n`);
-    bus.emit({ type: "log", service, stream: streamName, line });
-  });
-  // Resolve when readline finishes draining the pipe (stream EOF). The
-  // child's 'exit' handler awaits this before closing the logStream so
-  // the last lines aren't truncated.
-  return new Promise<void>((resolve) => rl.once("close", () => resolve()));
+	const stream = child[streamName];
+	if (!stream) return Promise.resolve();
+	const rl = createInterface({ input: stream });
+	rl.on("line", (line) => {
+		logStream.write(`${line}\n`);
+		bus.emit({ type: "log", service, stream: streamName, line });
+	});
+	// Resolve when readline finishes draining the pipe (stream EOF). The
+	// child's 'exit' handler awaits this before closing the logStream so
+	// the last lines aren't truncated.
+	return new Promise<void>((resolve) => rl.once("close", () => resolve()));
 }
 
 function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
-  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => resolve(false), timeoutMs);
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve(true);
-    });
-  });
+	if (child.exitCode !== null || child.signalCode !== null)
+		return Promise.resolve(true);
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(false), timeoutMs);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve(true);
+		});
+	});
 }
 
 function safeUnlink(path: string): void {
-  try {
-    if (existsSync(path)) unlinkSync(path);
-  } catch {
-    // ignore
-  }
+	try {
+		if (existsSync(path)) unlinkSync(path);
+	} catch {
+		// ignore
+	}
 }

--- a/packages/server/src/services/spawn.ts
+++ b/packages/server/src/services/spawn.ts
@@ -42,6 +42,28 @@ export const DEFAULT_RESTART_POLICY: RestartPolicy = {
 	steadyUptimeMs: 5 * 60_000,
 };
 
+type ExitInfo = {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	logStream: WriteStream;
+};
+
+/** Mutable bookkeeping for one supervised service, threaded through the helpers below. */
+type SupervisionState = {
+	spec: SpawnSpec;
+	bus: EventBus;
+	restartPolicy: RestartPolicy;
+	logPath: string;
+	pidPath: string;
+	currentChild: ChildProcess;
+	stopped: boolean;
+	hasBeenHealthy: boolean;
+	restartCount: number;
+	backoffTimer: NodeJS.Timeout | null;
+	steadyTimer: NodeJS.Timeout | null;
+	untap: () => void;
+};
+
 /**
  * Spawn a child process under supervision: tee stdout/stderr to its log file
  * AND emit "log" events on the bus so the CLI can render to TTY. Writes a
@@ -76,163 +98,217 @@ export function supervise({
 	mkdirSync(dirname(logPath), { recursive: true });
 	mkdirSync(dirname(pidPath), { recursive: true });
 
-	let currentChild!: ChildProcess;
-	let stopped = false;
-	let hasBeenHealthy = false;
-	let restartCount = 0;
-	let backoffTimer: NodeJS.Timeout | null = null;
-	let steadyTimer: NodeJS.Timeout | null = null;
-
-	const untap = bus.tap((ev) => {
-		if (ev.type === "healthy" && ev.service === spec.name)
-			hasBeenHealthy = true;
+	const state = makeSupervisionState({
+		spec,
+		bus,
+		restartPolicy,
+		logPath,
+		pidPath,
 	});
-
-	const clearSteadyTimer = (): void => {
-		if (steadyTimer) {
-			clearTimeout(steadyTimer);
-			steadyTimer = null;
-		}
-	};
-
-	const handleExit = ({
-		code,
-		signal,
-		logStream,
-	}: {
-		code: number | null;
-		signal: NodeJS.Signals | null;
-		logStream: WriteStream;
-	}): void => {
-		const isCrash = !stopped && (code !== 0 || signal !== null);
-		if (!isCrash) {
-			logStream.end();
-			untap();
-			bus.emit({ type: "stopped", service: spec.name });
-			return;
-		}
-
-		const cause = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
-		if (hasBeenHealthy && restartCount < restartPolicy.maxRestarts) {
-			restartCount += 1;
-			const attempt = restartCount;
-			const delayMs =
-				restartPolicy.backoffMs[
-					Math.min(attempt, restartPolicy.backoffMs.length) - 1
-				] ?? 1_000;
-			logStream.write(
-				`[supervisor] ${spec.name} exited (${cause}), restarting in ${delayMs}ms (attempt ${attempt}/${restartPolicy.maxRestarts})\n`,
-			);
-			logStream.end();
-			bus.emit({
-				type: "restarting",
-				service: spec.name,
-				code: code ?? -1,
-				signal: signal ?? undefined,
-				attempt,
-				maxAttempts: restartPolicy.maxRestarts,
-				delayMs,
-			});
-			backoffTimer = setTimeout(() => {
-				backoffTimer = null;
-				if (stopped) return;
-				spawnAttempt();
-			}, delayMs);
-			return;
-		}
-
-		const reason = hasBeenHealthy
-			? "restart budget exhausted"
-			: "died before first healthy";
-		logStream.write(
-			`[supervisor] ${spec.name} exited (${cause}), ${reason}, not restarting\n`,
-		);
-		logStream.end();
-		untap();
-		bus.emit({
-			type: "crashed",
-			service: spec.name,
-			code: code ?? -1,
-			signal: signal ?? undefined,
-		});
-	};
-
-	const spawnAttempt = (): void => {
-		const logStream = createWriteStream(logPath, { flags: "a" });
-		const child = nodeSpawn(spec.command, spec.args, {
-			env: spec.env,
-			cwd: spec.cwd,
-			stdio: ["ignore", "pipe", "pipe"],
-			detached: false,
-		});
-		currentChild = child;
-
-		if (typeof child.pid === "number") {
-			writeFileSync(pidPath, String(child.pid));
-		}
-
-		// Track stdout + stderr "end" events so we can drain any buffered lines
-		// BEFORE closing the log file. If we end() the logStream synchronously
-		// on child 'exit', the readline transformer may still be flushing the
-		// last chunk and we lose tail data, caught by spawn.integration.test
-		// intermittently failing on the 'row-2' assertion. Wait for both pipes
-		// to finish before closing.
-		const pipesDrained: Promise<void>[] = [
-			pipeLines(child, "stdout", spec.name, logStream, bus),
-			pipeLines(child, "stderr", spec.name, logStream, bus),
-		];
-
-		clearSteadyTimer();
-		steadyTimer = setTimeout(() => {
-			steadyTimer = null;
-			restartCount = 0;
-		}, restartPolicy.steadyUptimeMs);
-
-		child.on("exit", (code, signal) => {
-			safeUnlink(pidPath);
-			clearSteadyTimer();
-			void Promise.all(pipesDrained).then(() =>
-				handleExit({ code, signal, logStream }),
-			);
-		});
-	};
-
-	spawnAttempt();
-
-	const stop = async (): Promise<void> => {
-		if (stopped) return;
-		stopped = true;
-		untap();
-		if (backoffTimer) {
-			// The child already exited and a respawn is pending: cancel it. No
-			// process is running, so this is the service's terminal event.
-			clearTimeout(backoffTimer);
-			backoffTimer = null;
-			clearSteadyTimer();
-			bus.emit({ type: "stopped", service: spec.name });
-			return;
-		}
-		clearSteadyTimer();
-		const child = currentChild;
-		const hasExited = child.exitCode !== null || child.signalCode !== null;
-		if (hasExited || !child.pid || child.killed) return;
-		child.kill("SIGTERM");
-		const exit = waitForExit(child, 10_000);
-		if (await exit) return;
-		child.kill("SIGKILL");
-		await waitForExit(child, 5_000);
-	};
+	spawnAttempt(state);
 
 	return {
 		name: spec.name,
 		get pid() {
-			return currentChild.pid ?? -1;
+			return state.currentChild.pid ?? -1;
 		},
 		get child() {
-			return currentChild;
+			return state.currentChild;
 		},
-		stop,
+		stop: () => stopSupervised(state),
 	};
+}
+
+function makeSupervisionState({
+	spec,
+	bus,
+	restartPolicy,
+	logPath,
+	pidPath,
+}: {
+	spec: SpawnSpec;
+	bus: EventBus;
+	restartPolicy: RestartPolicy;
+	logPath: string;
+	pidPath: string;
+}): SupervisionState {
+	const state: SupervisionState = {
+		spec,
+		bus,
+		restartPolicy,
+		logPath,
+		pidPath,
+		currentChild: null as unknown as ChildProcess,
+		stopped: false,
+		hasBeenHealthy: false,
+		restartCount: 0,
+		backoffTimer: null,
+		steadyTimer: null,
+		untap: () => {},
+	};
+	// Supervision learns "this service was healthy" by observing the bus
+	// rather than being told directly; the health probes live in each
+	// service's start helper (langwatch.ts, postgres.ts, ...), not here.
+	state.untap = bus.tap((ev) => {
+		if (ev.type === "healthy" && ev.service === spec.name)
+			state.hasBeenHealthy = true;
+	});
+	return state;
+}
+
+/** Launch (or relaunch, on restart) the child and wire its exit to `handleExit`. */
+function spawnAttempt(state: SupervisionState): void {
+	const logStream = createWriteStream(state.logPath, { flags: "a" });
+	const child = nodeSpawn(state.spec.command, state.spec.args, {
+		env: state.spec.env,
+		cwd: state.spec.cwd,
+		stdio: ["ignore", "pipe", "pipe"],
+		detached: false,
+	});
+	state.currentChild = child;
+
+	if (typeof child.pid === "number") {
+		writeFileSync(state.pidPath, String(child.pid));
+	}
+
+	// Track stdout + stderr "end" events so we can drain any buffered lines
+	// BEFORE closing the log file. If we end() the logStream synchronously
+	// on child 'exit', the readline transformer may still be flushing the
+	// last chunk and we lose tail data, caught by spawn.integration.test
+	// intermittently failing on the 'row-2' assertion. Wait for both pipes
+	// to finish before closing.
+	const pipesDrained: Promise<void>[] = [
+		pipeLines(child, "stdout", state.spec.name, logStream, state.bus),
+		pipeLines(child, "stderr", state.spec.name, logStream, state.bus),
+	];
+
+	restartSteadyTimer(state);
+
+	child.on("exit", (code, signal) => {
+		safeUnlink(state.pidPath);
+		clearSteadyTimer(state);
+		void Promise.all(pipesDrained).then(() =>
+			handleExit(state, { code, signal, logStream }),
+		);
+	});
+}
+
+function clearSteadyTimer(state: SupervisionState): void {
+	if (state.steadyTimer) {
+		clearTimeout(state.steadyTimer);
+		state.steadyTimer = null;
+	}
+}
+
+/** Restarts the countdown to "this service has proven itself stable again". */
+function restartSteadyTimer(state: SupervisionState): void {
+	clearSteadyTimer(state);
+	state.steadyTimer = setTimeout(() => {
+		state.steadyTimer = null;
+		state.restartCount = 0;
+	}, state.restartPolicy.steadyUptimeMs);
+}
+
+function exitCause(code: number | null, signal: NodeJS.Signals | null): string {
+	return signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+}
+
+/** Dispatch a child's exit: a clean/requested stop, a restart, or a terminal crash. */
+function handleExit(state: SupervisionState, info: ExitInfo): void {
+	const isCrash = !state.stopped && (info.code !== 0 || info.signal !== null);
+	if (!isCrash) {
+		info.logStream.end();
+		state.untap();
+		state.bus.emit({ type: "stopped", service: state.spec.name });
+		return;
+	}
+	if (
+		state.hasBeenHealthy &&
+		state.restartCount < state.restartPolicy.maxRestarts
+	) {
+		scheduleRestart(state, info);
+		return;
+	}
+	emitCrashed(state, info);
+}
+
+/** Announce the crash, back off, then relaunch, budget permitting. */
+function scheduleRestart(
+	state: SupervisionState,
+	{ code, signal, logStream }: ExitInfo,
+): void {
+	state.restartCount += 1;
+	const attempt = state.restartCount;
+	const delayMs =
+		state.restartPolicy.backoffMs[
+			Math.min(attempt, state.restartPolicy.backoffMs.length) - 1
+		] ?? 1_000;
+	logStream.write(
+		`[supervisor] ${state.spec.name} exited (${exitCause(code, signal)}), restarting in ${delayMs}ms (attempt ${attempt}/${state.restartPolicy.maxRestarts})\n`,
+	);
+	logStream.end();
+	state.bus.emit({
+		type: "restarting",
+		service: state.spec.name,
+		code: code ?? -1,
+		signal: signal ?? undefined,
+		attempt,
+		maxAttempts: state.restartPolicy.maxRestarts,
+		delayMs,
+	});
+	state.backoffTimer = setTimeout(() => {
+		state.backoffTimer = null;
+		if (state.stopped) return;
+		spawnAttempt(state);
+	}, delayMs);
+}
+
+/** Restart budget exhausted (or the service never reached healthy): today's terminal behavior. */
+function emitCrashed(
+	state: SupervisionState,
+	{ code, signal, logStream }: ExitInfo,
+): void {
+	const reason = state.hasBeenHealthy
+		? "restart budget exhausted"
+		: "died before first healthy";
+	logStream.write(
+		`[supervisor] ${state.spec.name} exited (${exitCause(code, signal)}), ${reason}, not restarting\n`,
+	);
+	logStream.end();
+	state.untap();
+	state.bus.emit({
+		type: "crashed",
+		service: state.spec.name,
+		code: code ?? -1,
+		signal: signal ?? undefined,
+	});
+}
+
+async function stopSupervised(state: SupervisionState): Promise<void> {
+	if (state.stopped) return;
+	state.stopped = true;
+	state.untap();
+	if (state.backoffTimer) {
+		// The child already exited and a respawn is pending: cancel it. No
+		// process is running, so this is the service's terminal event.
+		clearTimeout(state.backoffTimer);
+		state.backoffTimer = null;
+		clearSteadyTimer(state);
+		state.bus.emit({ type: "stopped", service: state.spec.name });
+		return;
+	}
+	clearSteadyTimer(state);
+	await killWithEscalation(state.currentChild);
+}
+
+async function killWithEscalation(child: ChildProcess): Promise<void> {
+	const hasExited = child.exitCode !== null || child.signalCode !== null;
+	if (hasExited || !child.pid || child.killed) return;
+	child.kill("SIGTERM");
+	const exited = await waitForExit(child, 10_000);
+	if (exited) return;
+	child.kill("SIGKILL");
+	await waitForExit(child, 5_000);
 }
 
 function pipeLines(

--- a/packages/server/src/services/spawn.ts
+++ b/packages/server/src/services/spawn.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
+import { exitCause } from "../shared/runtime-contract.ts";
 import type { EventBus } from "./event-bus.ts";
 import type { ServiceName, ServicePaths } from "./paths.ts";
 
@@ -156,7 +157,7 @@ function makeSupervisionState({
 	return state;
 }
 
-/** Launch (or relaunch, on restart) the child and wire its exit to `handleExit`. */
+/** Launch (or relaunch, on restart) the child and wire its termination to `handleExit`. */
 function spawnAttempt(state: SupervisionState): void {
 	const logStream = createWriteStream(state.logPath, { flags: "a" });
 	const child = nodeSpawn(state.spec.command, state.spec.args, {
@@ -183,14 +184,45 @@ function spawnAttempt(state: SupervisionState): void {
 	];
 
 	restartSteadyTimer(state);
+	wireChildTermination(state, child, logStream, pipesDrained);
+}
 
-	child.on("exit", (code, signal) => {
+/**
+ * A child ends its life one of two ways: it exits (cleanly or a crash), or
+ * it never really started at all ("error": ENOENT/EACCES/EPERM spawning the
+ * command). Both funnel into the same handleExit dispatch, gated by a
+ * settle-once guard so only whichever fires first is processed. Node does
+ * not reliably follow a failed spawn with "exit", so relying on "exit"
+ * alone leaves that failure completely unhandled, and an unhandled "error"
+ * event throws and takes down the whole CLI process, restart logic or not.
+ */
+function wireChildTermination(
+	state: SupervisionState,
+	child: ChildProcess,
+	logStream: WriteStream,
+	pipesDrained: Promise<void>[],
+): void {
+	let settled = false;
+	const settleOnce = (
+		code: number | null,
+		signal: NodeJS.Signals | null,
+	): void => {
+		if (settled) return;
+		settled = true;
 		safeUnlink(state.pidPath);
 		clearSteadyTimer(state);
 		void Promise.all(pipesDrained).then(() =>
 			handleExit(state, { code, signal, logStream }),
 		);
+	};
+
+	child.on("error", (err) => {
+		logStream.write(
+			`[supervisor] ${state.spec.name} failed to spawn: ${err.message}\n`,
+		);
+		settleOnce(null, null);
 	});
+	child.on("exit", (code, signal) => settleOnce(code, signal));
 }
 
 function clearSteadyTimer(state: SupervisionState): void {
@@ -207,10 +239,6 @@ function restartSteadyTimer(state: SupervisionState): void {
 		state.steadyTimer = null;
 		state.restartCount = 0;
 	}, state.restartPolicy.steadyUptimeMs);
-}
-
-function exitCause(code: number | null, signal: NodeJS.Signals | null): string {
-	return signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
 }
 
 /** Dispatch a child's exit: a clean/requested stop, a restart, or a terminal crash. */
@@ -244,7 +272,7 @@ function scheduleRestart(
 			Math.min(attempt, state.restartPolicy.backoffMs.length) - 1
 		] ?? 1_000;
 	logStream.write(
-		`[supervisor] ${state.spec.name} exited (${exitCause(code, signal)}), restarting in ${delayMs}ms (attempt ${attempt}/${state.restartPolicy.maxRestarts})\n`,
+		`[supervisor] ${state.spec.name} exited (${exitCause({ code, signal })}), restarting in ${delayMs}ms (attempt ${attempt}/${state.restartPolicy.maxRestarts})\n`,
 	);
 	logStream.end();
 	state.bus.emit({
@@ -272,7 +300,7 @@ function emitCrashed(
 		? "restart budget exhausted"
 		: "died before first healthy";
 	logStream.write(
-		`[supervisor] ${state.spec.name} exited (${exitCause(code, signal)}), ${reason}, not restarting\n`,
+		`[supervisor] ${state.spec.name} exited (${exitCause({ code, signal })}), ${reason}, not restarting\n`,
 	);
 	logStream.end();
 	state.untap();

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -1,5 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import type { PortAllocation } from "./ports.ts";
 
@@ -286,7 +292,12 @@ export function reconcileEnvFile(input: {
 		reconciledKeys.push(key);
 	}
 	if (reconciledKeys.length > 0) {
+		// { mode } on writeFileSync only applies when the OS creates a new
+		// file; rewriting an existing one leaves its current permissions
+		// untouched. The .env holds secrets, so chmod explicitly rather than
+		// trust whatever mode the file already had.
 		writeFileSync(input.path, lines.join("\n"), { mode: 0o600 });
+		chmodSync(input.path, 0o600);
 	}
 	return reconciledKeys;
 }

--- a/packages/server/src/shared/runtime-contract.ts
+++ b/packages/server/src/shared/runtime-contract.ts
@@ -1,7 +1,7 @@
 // Contract module shared between the CLI flow (smith) and the runtime
 // implementation (julia). The CLI calls these functions; julia owns the
-// implementation in services/runtime.ts. Keep this file backward compatible
-// — adding fields is fine, removing or renaming is a coordinated change.
+// implementation in services/runtime.ts. Keep this file backward compatible:
+// adding fields is fine, removing or renaming is a coordinated change.
 
 import type { PredepResult } from "../predeps/runner.ts";
 import type { LangwatchPaths } from "../shared/paths.ts";
@@ -29,7 +29,7 @@ export type ServiceHandle = {
  * and to tee log lines to TTY (with stable per-service prefix + color).
  *
  * The stream stays open from the moment `events(ctx)` is called until
- * `stopAll(handles)` resolves. Multiple consumers are not supported — call
+ * `stopAll(handles)` resolves. Multiple consumers are not supported: call
  * `events(ctx)` exactly once per CLI run.
  */
 export type RuntimeEvent =
@@ -54,7 +54,10 @@ export type RuntimeEvent =
 	| { type: "stopped"; service: string };
 
 export type RuntimeApi = {
-	scaffoldEnv(ctx: RuntimeContext): Promise<{ written: boolean; path: string }>;
+	scaffoldEnv(
+		ctx: RuntimeContext,
+		opts?: { shouldReconcilePorts?: boolean },
+	): Promise<{ written: boolean; path: string; reconciledKeys: string[] }>;
 	installServices(ctx: RuntimeContext): Promise<void>;
 	startAll(ctx: RuntimeContext): Promise<ServiceHandle[]>;
 	waitForHealth(

--- a/packages/server/src/shared/runtime-contract.ts
+++ b/packages/server/src/shared/runtime-contract.ts
@@ -53,6 +53,22 @@ export type RuntimeEvent =
 	| { type: "crashed"; service: string; code: number; signal?: NodeJS.Signals }
 	| { type: "stopped"; service: string };
 
+/**
+ * Format a process exit the same way everywhere it is reported: the
+ * supervisor's log-file marker lines (spawn.ts) and the CLI's TTY render
+ * (log-tee.ts) must read identically, so both call this instead of keeping
+ * their own copy.
+ */
+export function exitCause({
+	code,
+	signal,
+}: {
+	code: number | null;
+	signal?: NodeJS.Signals | null;
+}): string {
+	return signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+}
+
 export type RuntimeApi = {
 	scaffoldEnv(
 		ctx: RuntimeContext,

--- a/packages/server/src/shared/runtime-contract.ts
+++ b/packages/server/src/shared/runtime-contract.ts
@@ -3,24 +3,24 @@
 // implementation in services/runtime.ts. Keep this file backward compatible
 // — adding fields is fine, removing or renaming is a coordinated change.
 
-import type { PortAllocation } from "../shared/ports.ts";
-import type { LangwatchPaths } from "../shared/paths.ts";
 import type { PredepResult } from "../predeps/runner.ts";
+import type { LangwatchPaths } from "../shared/paths.ts";
+import type { PortAllocation } from "../shared/ports.ts";
 
 export type RuntimeContext = {
-  ports: PortAllocation;
-  paths: LangwatchPaths;
-  predeps: PredepResult;
-  envFile: string;
-  version: string;
-  /** Pass-through env from the user shell (OPENAI_API_KEY, …) — propagated to children, never persisted. */
-  userEnv: Record<string, string>;
+	ports: PortAllocation;
+	paths: LangwatchPaths;
+	predeps: PredepResult;
+	envFile: string;
+	version: string;
+	/** Pass-through env from the user shell (OPENAI_API_KEY, …), propagated to children, never persisted. */
+	userEnv: Record<string, string>;
 };
 
 export type ServiceHandle = {
-  name: string;
-  pid: number;
-  stop(): Promise<void>;
+	name: string;
+	pid: number;
+	stop(): Promise<void>;
 };
 
 /**
@@ -33,17 +33,34 @@ export type ServiceHandle = {
  * `events(ctx)` exactly once per CLI run.
  */
 export type RuntimeEvent =
-  | { type: "starting"; service: string }
-  | { type: "healthy"; service: string; durationMs: number }
-  | { type: "log"; service: string; stream: "stdout" | "stderr"; line: string }
-  | { type: "crashed"; service: string; code: number; signal?: NodeJS.Signals }
-  | { type: "stopped"; service: string };
+	| { type: "starting"; service: string }
+	| { type: "healthy"; service: string; durationMs: number }
+	| { type: "log"; service: string; stream: "stdout" | "stderr"; line: string }
+	/**
+	 * A previously-healthy service crashed and the supervisor is bringing it
+	 * back after `delayMs`. Emitted instead of "crashed" while restart budget
+	 * remains; when the budget runs out the crash falls through to "crashed".
+	 */
+	| {
+			type: "restarting";
+			service: string;
+			code: number;
+			signal?: NodeJS.Signals;
+			attempt: number;
+			maxAttempts: number;
+			delayMs: number;
+	  }
+	| { type: "crashed"; service: string; code: number; signal?: NodeJS.Signals }
+	| { type: "stopped"; service: string };
 
 export type RuntimeApi = {
-  scaffoldEnv(ctx: RuntimeContext): Promise<{ written: boolean; path: string }>;
-  installServices(ctx: RuntimeContext): Promise<void>;
-  startAll(ctx: RuntimeContext): Promise<ServiceHandle[]>;
-  waitForHealth(ctx: RuntimeContext, opts: { timeoutMs: number }): Promise<void>;
-  stopAll(handles: ServiceHandle[]): Promise<void>;
-  events(ctx: RuntimeContext): AsyncIterable<RuntimeEvent>;
+	scaffoldEnv(ctx: RuntimeContext): Promise<{ written: boolean; path: string }>;
+	installServices(ctx: RuntimeContext): Promise<void>;
+	startAll(ctx: RuntimeContext): Promise<ServiceHandle[]>;
+	waitForHealth(
+		ctx: RuntimeContext,
+		opts: { timeoutMs: number },
+	): Promise<void>;
+	stopAll(handles: ServiceHandle[]): Promise<void>;
+	events(ctx: RuntimeContext): AsyncIterable<RuntimeEvent>;
 };

--- a/packages/server/test/env.test.ts
+++ b/packages/server/test/env.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -200,6 +200,16 @@ describe("reconcileEnvFile", () => {
 			expect(readFileSync(envPath, "utf8")).toContain(
 				"REDIS_URL=redis://localhost:6561/0",
 			);
+		});
+	});
+
+	describe("when the existing file has looser permissions than 0600", () => {
+		it("tightens them back down on rewrite, since the file holds secrets", async () => {
+			const { envPath } = await scaffoldAt(5560);
+			chmodSync(envPath, 0o644);
+			reconcileEnvFile({ ports: allocatePorts(5580), path: envPath });
+			const mode = statSync(envPath).mode & 0o777;
+			expect(mode).toBe(0o600);
 		});
 	});
 });

--- a/packages/server/test/log-tee.test.ts
+++ b/packages/server/test/log-tee.test.ts
@@ -89,6 +89,17 @@ describe("renderEvent", () => {
 			expect(out).toContain("clickhouse.log");
 			expect(out).toContain("see ");
 		});
+
+		it("names the signal when the child was killed rather than exiting", () => {
+			const out = renderEvent({
+				type: "crashed",
+				service: "clickhouse",
+				code: -1,
+				signal: "SIGKILL",
+			});
+			expect(out).toContain("crashed (signal SIGKILL)");
+			expect(out).not.toContain("exit -1");
+		});
 	});
 
 	describe("when given a stopped event", () => {

--- a/packages/server/test/log-tee.test.ts
+++ b/packages/server/test/log-tee.test.ts
@@ -2,46 +2,100 @@ import { describe, expect, it } from "vitest";
 import { renderEvent } from "../src/animation/log-tee.ts";
 
 describe("renderEvent", () => {
-  describe("when given a starting event", () => {
-    it("paints with a 'starting…' suffix", () => {
-      const out = renderEvent({ type: "starting", service: "postgres" });
-      expect(out).not.toBeNull();
-      expect(out).toContain("postgres");
-      expect(out).toContain("starting");
-    });
-  });
+	describe("when given a starting event", () => {
+		it("paints with a 'starting…' suffix", () => {
+			const out = renderEvent({ type: "starting", service: "postgres" });
+			expect(out).not.toBeNull();
+			expect(out).toContain("postgres");
+			expect(out).toContain("starting");
+		});
+	});
 
-  describe("when given a healthy event", () => {
-    it("paints with the duration in ms", () => {
-      const out = renderEvent({ type: "healthy", service: "redis", durationMs: 1234 });
-      expect(out).toContain("redis");
-      expect(out).toContain("1234ms");
-    });
-  });
+	describe("when given a healthy event", () => {
+		it("paints with the duration in ms", () => {
+			const out = renderEvent({
+				type: "healthy",
+				service: "redis",
+				durationMs: 1234,
+			});
+			expect(out).toContain("redis");
+			expect(out).toContain("1234ms");
+		});
+	});
 
-  describe("when given a log event", () => {
-    it("strips trailing newlines so listr lines never double-spaced", () => {
-      const out = renderEvent({ type: "log", service: "langwatch", stream: "stdout", line: "Listening on :5560\n" });
-      expect(out).toContain("langwatch");
-      expect(out).toContain("Listening on :5560");
-      expect(out).not.toContain("\n\n");
-    });
-  });
+	describe("when given a log event", () => {
+		it("strips trailing newlines so listr lines never double-spaced", () => {
+			const out = renderEvent({
+				type: "log",
+				service: "langwatch",
+				stream: "stdout",
+				line: "Listening on :5560\n",
+			});
+			expect(out).toContain("langwatch");
+			expect(out).toContain("Listening on :5560");
+			expect(out).not.toContain("\n\n");
+		});
+	});
 
-  describe("when given a crashed event", () => {
-    it("paints in red with the exit code", () => {
-      const out = renderEvent({ type: "crashed", service: "clickhouse", code: 137 });
-      expect(out).toContain("clickhouse");
-      expect(out).toContain("137");
-      expect(out).toMatch(/crashed/);
-    });
-  });
+	describe("when given a restarting event", () => {
+		it("announces the exit cause, the delay, and the attempt budget", () => {
+			const out = renderEvent({
+				type: "restarting",
+				service: "workers",
+				code: 137,
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 1000,
+			});
+			expect(out).toContain("workers");
+			expect(out).toContain("exited (code 137)");
+			expect(out).toContain("restarting in 1s");
+			expect(out).toContain("(attempt 1/3)");
+		});
 
-  describe("when given a stopped event", () => {
-    it("paints with the power-off glyph", () => {
-      const out = renderEvent({ type: "stopped", service: "aigateway" });
-      expect(out).toContain("aigateway");
-      expect(out).toContain("stopped");
-    });
-  });
+		it("names the signal when the child was killed rather than exiting", () => {
+			const out = renderEvent({
+				type: "restarting",
+				service: "workers",
+				code: -1,
+				signal: "SIGKILL",
+				attempt: 2,
+				maxAttempts: 3,
+				delayMs: 5000,
+			});
+			expect(out).toContain("exited (signal SIGKILL)");
+			expect(out).toContain("(attempt 2/3)");
+		});
+	});
+
+	describe("when given a crashed event", () => {
+		it("paints in red with the exit code", () => {
+			const out = renderEvent({
+				type: "crashed",
+				service: "clickhouse",
+				code: 137,
+			});
+			expect(out).toContain("clickhouse");
+			expect(out).toContain("137");
+			expect(out).toMatch(/crashed/);
+		});
+
+		it("points at the service's log file", () => {
+			const out = renderEvent({
+				type: "crashed",
+				service: "clickhouse",
+				code: 137,
+			});
+			expect(out).toContain("clickhouse.log");
+			expect(out).toContain("see ");
+		});
+	});
+
+	describe("when given a stopped event", () => {
+		it("paints with the power-off glyph", () => {
+			const out = renderEvent({ type: "stopped", service: "aigateway" });
+			expect(out).toContain("aigateway");
+			expect(out).toContain("stopped");
+		});
+	});
 });

--- a/packages/server/test/services/event-bus.test.ts
+++ b/packages/server/test/services/event-bus.test.ts
@@ -81,6 +81,23 @@ describe("EventBus", () => {
 		});
 	});
 
+	describe("when a tap throws", () => {
+		it("still delivers the event to other taps and to the iterator", async () => {
+			const bus = new EventBus();
+			const seen: string[] = [];
+			bus.tap(() => {
+				throw new Error("boom");
+			});
+			bus.tap((ev) => seen.push(ev.type));
+
+			bus.emit({ type: "starting", service: "postgres" });
+
+			expect(seen).toEqual(["starting"]);
+			const it = bus[Symbol.asyncIterator]();
+			expect((await it.next()).value).toMatchObject({ type: "starting" });
+		});
+	});
+
 	describe("when an iterator's return() is called", () => {
 		it("ends the bus and unblocks every other waiter", async () => {
 			const bus = new EventBus();

--- a/packages/server/test/services/event-bus.test.ts
+++ b/packages/server/test/services/event-bus.test.ts
@@ -2,60 +2,93 @@ import { describe, expect, it } from "vitest";
 import { EventBus } from "../../src/services/event-bus.ts";
 
 describe("EventBus", () => {
-  describe("when events are emitted before iteration starts", () => {
-    it("buffers them and replays in order on the first iterator pass", async () => {
-      const bus = new EventBus();
-      bus.emit({ type: "starting", service: "postgres" });
-      bus.emit({ type: "starting", service: "redis" });
+	describe("when events are emitted before iteration starts", () => {
+		it("buffers them and replays in order on the first iterator pass", async () => {
+			const bus = new EventBus();
+			bus.emit({ type: "starting", service: "postgres" });
+			bus.emit({ type: "starting", service: "redis" });
 
-      const it = bus[Symbol.asyncIterator]();
-      expect((await it.next()).value).toMatchObject({ type: "starting", service: "postgres" });
-      expect((await it.next()).value).toMatchObject({ type: "starting", service: "redis" });
-    });
-  });
+			const it = bus[Symbol.asyncIterator]();
+			expect((await it.next()).value).toMatchObject({
+				type: "starting",
+				service: "postgres",
+			});
+			expect((await it.next()).value).toMatchObject({
+				type: "starting",
+				service: "redis",
+			});
+		});
+	});
 
-  describe("when a consumer is awaiting next() before the producer emits", () => {
-    it("delivers the event directly to the waiter", async () => {
-      const bus = new EventBus();
-      const it = bus[Symbol.asyncIterator]();
-      const pending = it.next();
+	describe("when a consumer is awaiting next() before the producer emits", () => {
+		it("delivers the event directly to the waiter", async () => {
+			const bus = new EventBus();
+			const it = bus[Symbol.asyncIterator]();
+			const pending = it.next();
 
-      bus.emit({ type: "healthy", service: "postgres", durationMs: 1200 });
-      const result = await pending;
-      expect(result.done).toBe(false);
-      expect(result.value).toMatchObject({ type: "healthy", durationMs: 1200 });
-    });
-  });
+			bus.emit({ type: "healthy", service: "postgres", durationMs: 1200 });
+			const result = await pending;
+			expect(result.done).toBe(false);
+			expect(result.value).toMatchObject({ type: "healthy", durationMs: 1200 });
+		});
+	});
 
-  describe("when end() is called", () => {
-    it("resolves every pending consumer with done:true", async () => {
-      const bus = new EventBus();
-      const it = bus[Symbol.asyncIterator]();
-      const pending = it.next();
+	describe("when end() is called", () => {
+		it("resolves every pending consumer with done:true", async () => {
+			const bus = new EventBus();
+			const it = bus[Symbol.asyncIterator]();
+			const pending = it.next();
 
-      bus.end();
-      const result = await pending;
-      expect(result.done).toBe(true);
-    });
+			bus.end();
+			const result = await pending;
+			expect(result.done).toBe(true);
+		});
 
-    it("makes subsequent emits no-op", async () => {
-      const bus = new EventBus();
-      bus.end();
-      bus.emit({ type: "starting", service: "postgres" });
-      const it = bus[Symbol.asyncIterator]();
-      const result = await it.next();
-      expect(result.done).toBe(true);
-    });
-  });
+		it("makes subsequent emits no-op", async () => {
+			const bus = new EventBus();
+			bus.end();
+			bus.emit({ type: "starting", service: "postgres" });
+			const it = bus[Symbol.asyncIterator]();
+			const result = await it.next();
+			expect(result.done).toBe(true);
+		});
+	});
 
-  describe("when an iterator's return() is called", () => {
-    it("ends the bus and unblocks every other waiter", async () => {
-      const bus = new EventBus();
-      const it = bus[Symbol.asyncIterator]();
-      const pending = it.next();
-      await it.return?.();
-      const result = await pending;
-      expect(result.done).toBe(true);
-    });
-  });
+	describe("when a tap listener is registered", () => {
+		it("observes every event at emit time without consuming the iterator", async () => {
+			const bus = new EventBus();
+			const seen: string[] = [];
+			bus.tap((ev) => seen.push(ev.type));
+
+			bus.emit({ type: "starting", service: "postgres" });
+			bus.emit({ type: "healthy", service: "postgres", durationMs: 5 });
+			expect(seen).toEqual(["starting", "healthy"]);
+
+			const it = bus[Symbol.asyncIterator]();
+			expect((await it.next()).value).toMatchObject({ type: "starting" });
+			expect((await it.next()).value).toMatchObject({ type: "healthy" });
+		});
+
+		it("stops observing once the returned unsubscribe is called", () => {
+			const bus = new EventBus();
+			const seen: string[] = [];
+			const untap = bus.tap((ev) => seen.push(ev.type));
+
+			bus.emit({ type: "starting", service: "postgres" });
+			untap();
+			bus.emit({ type: "stopped", service: "postgres" });
+			expect(seen).toEqual(["starting"]);
+		});
+	});
+
+	describe("when an iterator's return() is called", () => {
+		it("ends the bus and unblocks every other waiter", async () => {
+			const bus = new EventBus();
+			const it = bus[Symbol.asyncIterator]();
+			const pending = it.next();
+			await it.return?.();
+			const result = await pending;
+			expect(result.done).toBe(true);
+		});
+	});
 });

--- a/packages/server/test/services/node-deps.test.ts
+++ b/packages/server/test/services/node-deps.test.ts
@@ -1,7 +1,13 @@
-import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readlinkSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	assertWorkspaceLinksResolve,
@@ -139,6 +145,18 @@ describe("external member peer links", () => {
 			const appRoot = await makeAppTree();
 			linkExternalMemberPeers(appRoot);
 			expect(linkExternalMemberPeers(appRoot)).toEqual([]);
+		});
+
+		it("links relatively so the tree survives relocation", async () => {
+			// An absolute target would break the moment ~/.langwatch/app moves
+			// (a fresh install, a version bump); relative is what makes the
+			// symlink keep resolving after the whole tree is relocated.
+			const appRoot = await makeAppTree();
+			linkExternalMemberPeers(appRoot);
+			const target = readlinkSync(
+				join(appRoot, "packages", "langy", "node_modules", "zod"),
+			);
+			expect(isAbsolute(target)).toBe(false);
 		});
 	});
 

--- a/packages/server/test/services/spawn-restart.test.ts
+++ b/packages/server/test/services/spawn-restart.test.ts
@@ -82,6 +82,20 @@ function childAt(index: number): FakeChild {
 	return child;
 }
 
+/** rmSync can lose a benign race against a real log write still landing (see afterEach). */
+async function removeDirWithRetry(
+	path: string,
+	attemptsLeft = 5,
+): Promise<void> {
+	try {
+		rmSync(path, { recursive: true, force: true });
+	} catch (err) {
+		if (attemptsLeft <= 1) throw err;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		await removeDirWithRetry(path, attemptsLeft - 1);
+	}
+}
+
 describe("supervise restart policy", () => {
 	let root: string;
 	let bus: EventBus;
@@ -118,9 +132,16 @@ describe("supervise restart policy", () => {
 		bus.tap((ev) => events.push(ev));
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.useRealTimers();
-		rmSync(root, { recursive: true, force: true });
+		// Every spawnAttempt() opens a real log-file write stream; fake-timer
+		// advances resolve the assertions long before that real, unfaked disk
+		// I/O necessarily finishes. Give it a moment before the recursive
+		// rmSync below, and retry rmSync itself, so a write that is still
+		// landing does not race the directory out from under it (ENOENT/
+		// ENOTEMPTY) and fail a later, unrelated test instead of this one.
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		await removeDirWithRetry(root);
 	});
 
 	describe("given a service that already reported healthy", () => {

--- a/packages/server/test/services/spawn-restart.test.ts
+++ b/packages/server/test/services/spawn-restart.test.ts
@@ -67,6 +67,11 @@ function exitChild(
 	child.emit("exit", code, signal);
 }
 
+/** Fail a spawn the way Node does for ENOENT/EACCES/EPERM: an "error" event, usually with no "exit" follow-up. */
+function failToSpawn(child: FakeChild, err: NodeJS.ErrnoException): void {
+	child.emit("error", err);
+}
+
 /** Let the exit handler's pipe-drain microtasks run without moving the clock. */
 async function flushMicrotasks(): Promise<void> {
 	await vi.advanceTimersByTimeAsync(0);
@@ -302,6 +307,41 @@ describe("supervise restart policy", () => {
 				expect(spawnedChildren).toHaveLength(1);
 			});
 		});
+
+		describe("when its process fails to respawn mid-life", () => {
+			it("treats a spawn error the same as any other crash, restarting with backoff", async () => {
+				boot();
+				markHealthy();
+				const err = Object.assign(new Error("spawn workers EACCES"), {
+					code: "EACCES",
+				});
+				failToSpawn(childAt(0), err);
+				await flushMicrotasks();
+
+				expect(restartingEvents()).toHaveLength(1);
+				expect(restartingEvents()[0]).toMatchObject({
+					service: "workers",
+					attempt: 1,
+					maxAttempts: 3,
+					delayMs: 1_000,
+				});
+			});
+		});
+
+		describe("when a spawn both errors and (on some platforms) still exits", () => {
+			it("only dispatches once, keyed off whichever event arrives first", async () => {
+				boot();
+				markHealthy();
+				const err = Object.assign(new Error("spawn workers ENOENT"), {
+					code: "ENOENT",
+				});
+				failToSpawn(childAt(0), err);
+				exitChild(childAt(0), { code: 1 });
+				await flushMicrotasks();
+
+				expect(restartingEvents()).toHaveLength(1);
+			});
+		});
 	});
 
 	describe("given a service that never reported healthy", () => {
@@ -318,6 +358,41 @@ describe("supervise restart policy", () => {
 
 				await vi.advanceTimersByTimeAsync(120_000);
 				expect(spawnedChildren).toHaveLength(1);
+			});
+		});
+
+		describe("when the command fails to spawn at all", () => {
+			it("emits crashed instead of crashing the CLI process", async () => {
+				boot();
+				const err = Object.assign(new Error("spawn workers ENOENT"), {
+					code: "ENOENT",
+				});
+				failToSpawn(childAt(0), err);
+				await flushMicrotasks();
+
+				expect(events.some((e) => e.type === "restarting")).toBe(false);
+				const crashes = events.filter((e) => e.type === "crashed");
+				expect(crashes).toHaveLength(1);
+				expect(crashes[0]).toMatchObject({ service: "workers" });
+
+				await vi.advanceTimersByTimeAsync(120_000);
+				expect(spawnedChildren).toHaveLength(1);
+			});
+
+			it("writes the spawn error into the service log", async () => {
+				boot();
+				const err = Object.assign(new Error("spawn workers ENOENT"), {
+					code: "ENOENT",
+				});
+				failToSpawn(childAt(0), err);
+				await flushMicrotasks();
+
+				vi.useRealTimers();
+				await vi.waitFor(() => {
+					expect(readFileSync(sp.log("workers"), "utf8")).toContain(
+						"[supervisor] workers failed to spawn: spawn workers ENOENT",
+					);
+				});
 			});
 		});
 	});

--- a/packages/server/test/services/spawn-restart.test.ts
+++ b/packages/server/test/services/spawn-restart.test.ts
@@ -1,0 +1,303 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/services/event-bus.ts";
+import { servicePaths } from "../../src/services/paths.ts";
+import { supervise } from "../../src/services/spawn.ts";
+import type { RuntimeEvent } from "../../src/shared/runtime-contract.ts";
+
+class FakeChild extends EventEmitter {
+	pid: number;
+	exitCode: number | null = null;
+	signalCode: NodeJS.Signals | null = null;
+	killed = false;
+	stdout = null;
+	stderr = null;
+
+	constructor(pid: number) {
+		super();
+		this.pid = pid;
+	}
+
+	kill(): boolean {
+		this.killed = true;
+		return true;
+	}
+}
+
+const spawnedChildren: FakeChild[] = [];
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn(() => {
+		const child = new FakeChild(1000 + spawnedChildren.length);
+		spawnedChildren.push(child);
+		return child;
+	}),
+}));
+
+function makePaths(root: string) {
+	return servicePaths({
+		root,
+		bin: join(root, "bin"),
+		app: join(root, "app"),
+		data: join(root, "data"),
+		redisData: join(root, "data", "redis"),
+		postgresData: join(root, "data", "postgres"),
+		clickhouseData: join(root, "data", "clickhouse"),
+		logs: join(root, "logs"),
+		pidFile: join(root, "run", "langwatch.pid"),
+		lockFile: join(root, "run", "langwatch.lock"),
+		envFile: join(root, ".env"),
+		installManifest: join(root, "install-manifest.json"),
+	});
+}
+
+/** Set the exit fields the way a real ChildProcess does before firing 'exit'. */
+function exitChild(
+	child: FakeChild,
+	{
+		code,
+		signal = null,
+	}: { code: number | null; signal?: NodeJS.Signals | null },
+): void {
+	child.exitCode = code;
+	child.signalCode = signal;
+	child.emit("exit", code, signal);
+}
+
+/** Let the exit handler's pipe-drain microtasks run without moving the clock. */
+async function flushMicrotasks(): Promise<void> {
+	await vi.advanceTimersByTimeAsync(0);
+}
+
+function childAt(index: number): FakeChild {
+	const child = spawnedChildren[index];
+	if (!child) {
+		throw new Error(
+			`expected a child at index ${index}, only ${spawnedChildren.length} spawned`,
+		);
+	}
+	return child;
+}
+
+describe("supervise restart policy", () => {
+	let root: string;
+	let bus: EventBus;
+	let events: RuntimeEvent[];
+	let sp: ReturnType<typeof makePaths>;
+
+	function boot() {
+		const handle = supervise({
+			spec: { name: "workers", command: "node", args: [], env: {} },
+			paths: sp,
+			bus,
+		});
+		return handle;
+	}
+
+	function markHealthy(): void {
+		bus.emit({ type: "healthy", service: "workers", durationMs: 0 });
+	}
+
+	function restartingEvents() {
+		return events.filter(
+			(e): e is Extract<RuntimeEvent, { type: "restarting" }> =>
+				e.type === "restarting",
+		);
+	}
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		spawnedChildren.length = 0;
+		root = mkdtempSync(join(tmpdir(), "lw-spawn-restart-"));
+		sp = makePaths(root);
+		bus = new EventBus();
+		events = [];
+		bus.tap((ev) => events.push(ev));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	describe("given a service that already reported healthy", () => {
+		describe("when its process crashes", () => {
+			it("emits a restarting event instead of crashed", async () => {
+				boot();
+				markHealthy();
+				exitChild(childAt(0), { code: 137 });
+				await flushMicrotasks();
+
+				expect(restartingEvents()).toHaveLength(1);
+				expect(restartingEvents()[0]).toMatchObject({
+					service: "workers",
+					code: 137,
+					attempt: 1,
+					maxAttempts: 3,
+					delayMs: 1_000,
+				});
+				expect(events.some((e) => e.type === "crashed")).toBe(false);
+			});
+
+			it("respawns after the first backoff delay with a fresh pidfile", async () => {
+				const handle = boot();
+				markHealthy();
+				exitChild(childAt(0), { code: 137 });
+				await flushMicrotasks();
+
+				expect(spawnedChildren).toHaveLength(1);
+				await vi.advanceTimersByTimeAsync(999);
+				expect(spawnedChildren).toHaveLength(1);
+				await vi.advanceTimersByTimeAsync(1);
+				expect(spawnedChildren).toHaveLength(2);
+				expect(handle.pid).toBe(childAt(1).pid);
+				expect(readFileSync(sp.pid("workers"), "utf8")).toBe(
+					String(childAt(1).pid),
+				);
+			});
+
+			it("writes a supervisor marker line into the service log", async () => {
+				boot();
+				markHealthy();
+				exitChild(childAt(0), { code: 137 });
+				await flushMicrotasks();
+
+				vi.useRealTimers();
+				await vi.waitFor(() => {
+					expect(readFileSync(sp.log("workers"), "utf8")).toContain(
+						"[supervisor] workers exited (code 137), restarting in 1000ms (attempt 1/3)",
+					);
+				});
+			});
+		});
+
+		describe("when the process is killed by a signal", () => {
+			it("carries the signal on the restarting event", async () => {
+				boot();
+				markHealthy();
+				exitChild(childAt(0), { code: null, signal: "SIGKILL" });
+				await flushMicrotasks();
+
+				expect(restartingEvents()[0]).toMatchObject({
+					service: "workers",
+					signal: "SIGKILL",
+					attempt: 1,
+				});
+			});
+		});
+
+		describe("when the process keeps crashing after every restart", () => {
+			it("backs off 1s then 5s then 15s and gives up with a crashed event", async () => {
+				boot();
+				markHealthy();
+
+				exitChild(childAt(0), { code: 137 });
+				await flushMicrotasks();
+				await vi.advanceTimersByTimeAsync(1_000);
+				expect(spawnedChildren).toHaveLength(2);
+
+				exitChild(childAt(1), { code: 137 });
+				await flushMicrotasks();
+				await vi.advanceTimersByTimeAsync(4_999);
+				expect(spawnedChildren).toHaveLength(2);
+				await vi.advanceTimersByTimeAsync(1);
+				expect(spawnedChildren).toHaveLength(3);
+
+				exitChild(childAt(2), { code: 137 });
+				await flushMicrotasks();
+				await vi.advanceTimersByTimeAsync(15_000);
+				expect(spawnedChildren).toHaveLength(4);
+
+				exitChild(childAt(3), { code: 137 });
+				await flushMicrotasks();
+
+				expect(restartingEvents().map((e) => e.attempt)).toEqual([1, 2, 3]);
+				expect(restartingEvents().map((e) => e.delayMs)).toEqual([
+					1_000, 5_000, 15_000,
+				]);
+				const crashes = events.filter((e) => e.type === "crashed");
+				expect(crashes).toHaveLength(1);
+				expect(crashes[0]).toMatchObject({ service: "workers", code: 137 });
+
+				await vi.advanceTimersByTimeAsync(120_000);
+				expect(spawnedChildren).toHaveLength(4);
+			});
+		});
+
+		describe("when a restarted process stays up past the steady-state window", () => {
+			it("earns back the full restart budget", async () => {
+				boot();
+				markHealthy();
+
+				exitChild(childAt(0), { code: 1 });
+				await flushMicrotasks();
+				await vi.advanceTimersByTimeAsync(1_000);
+				expect(spawnedChildren).toHaveLength(2);
+
+				await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+				exitChild(childAt(1), { code: 1 });
+				await flushMicrotasks();
+
+				expect(restartingEvents().map((e) => e.attempt)).toEqual([1, 1]);
+			});
+		});
+
+		describe("when stop() is called during the backoff wait", () => {
+			it("cancels the pending respawn and emits stopped", async () => {
+				const handle = boot();
+				markHealthy();
+				exitChild(childAt(0), { code: 137 });
+				await flushMicrotasks();
+
+				await handle.stop();
+				expect(events.at(-1)).toMatchObject({
+					type: "stopped",
+					service: "workers",
+				});
+
+				await vi.advanceTimersByTimeAsync(120_000);
+				expect(spawnedChildren).toHaveLength(1);
+				expect(events.some((e) => e.type === "crashed")).toBe(false);
+			});
+		});
+
+		describe("when the process exits cleanly", () => {
+			it("emits stopped without restarting", async () => {
+				boot();
+				markHealthy();
+				exitChild(childAt(0), { code: 0 });
+				await flushMicrotasks();
+
+				expect(events.some((e) => e.type === "restarting")).toBe(false);
+				expect(events.at(-1)).toMatchObject({
+					type: "stopped",
+					service: "workers",
+				});
+				await vi.advanceTimersByTimeAsync(120_000);
+				expect(spawnedChildren).toHaveLength(1);
+			});
+		});
+	});
+
+	describe("given a service that never reported healthy", () => {
+		describe("when its process dies during boot", () => {
+			it("emits crashed immediately and never restarts", async () => {
+				boot();
+				exitChild(childAt(0), { code: 1 });
+				await flushMicrotasks();
+
+				expect(events.some((e) => e.type === "restarting")).toBe(false);
+				const crashes = events.filter((e) => e.type === "crashed");
+				expect(crashes).toHaveLength(1);
+				expect(crashes[0]).toMatchObject({ service: "workers", code: 1 });
+
+				await vi.advanceTimersByTimeAsync(120_000);
+				expect(spawnedChildren).toHaveLength(1);
+			});
+		});
+	});
+});

--- a/specs/npx-installer/03-services.feature
+++ b/specs/npx-installer/03-services.feature
@@ -89,13 +89,44 @@ Feature: Service orchestration after pre-deps are installed
     And `runtime.events(ctx)` emits "log" events with "service" ∈ {postgres, redis, clickhouse, langwatch_nlp, langevals, ai-gateway, langwatch}
     And the CLI renders each log line to TTY with a stable prefix+color (langwatch=green, nlp=cyan, langevals=magenta, gateway=yellow, postgres=blue, redis=red, clickhouse=dim)
 
-  Scenario: A crashing service emits a "crashed" event and the CLI tears down
+  Scenario: A service that crashes after being healthy is restarted with backoff
     Given all services are running
-    When "redis" exits with code 137
+    And "workers" already reported healthy
+    When the "workers" process is killed with exit code 137 under memory pressure
+    Then the supervisor schedules a restart instead of giving up
+    And `runtime.events(ctx)` emits { type: "restarting", service: "workers", code: 137, attempt: 1 }
+    And the CLI prints "workers exited (code 137), restarting in 1s (attempt 1/3)"
+    And no "crashed" event is emitted for that exit
+    And after the backoff delay a fresh "workers" process is spawned with a new pidfile
+    And the BullMQ queues get their consumer back without a manual restart
+
+  Scenario: Repeated crashes back off and the budget is bounded
+    Given "workers" already reported healthy
+    When its process dies again right after each restart
+    Then the supervisor waits 1s before attempt 1, 5s before attempt 2, and 15s before attempt 3
+    And no further restart is attempted after attempt 3
+
+  Scenario: Staying up repays the restart budget
+    Given "workers" was restarted after a crash
+    When the new process stays up for the steady-state window
+    Then the restart counter resets
+    And a later crash is retried from attempt 1 again
+
+  Scenario: A crashed service with no restart budget left emits "crashed" and the CLI tears down
+    Given all services are running
+    And "redis" has used up its restart budget
+    When "redis" exits with code 137 once more
     Then `runtime.events(ctx)` emits { type: "crashed", service: "redis", code: 137 }
-    And the CLI prints "redis exited unexpectedly (code 137) — see ~/.langwatch/logs/redis.log"
+    And the CLI prints "redis crashed (exit 137), see ~/.langwatch/logs/redis.log"
     And the CLI calls `runtime.stopAll(handles)` to bring down everything else
     And the CLI exits with code 1
+
+  Scenario: A service that dies during initial boot is not restarted
+    Given "clickhouse" never reported healthy
+    When its process exits during boot
+    Then no restart is attempted
+    And `runtime.events(ctx)` emits { type: "crashed", service: "clickhouse" }
+    And the boot fails fast naming the service, as before
 
   Scenario: A service failing its health probe takes the already-started ones down with it
     Given the app tier starts several services at once

--- a/specs/npx-installer/_shared/contract.md
+++ b/specs/npx-installer/_shared/contract.md
@@ -209,14 +209,16 @@ type RuntimeEvent =
   | { type: "starting"; service: string }
   | { type: "healthy"; service: string; durationMs: number }
   | { type: "log"; service: string; stream: "stdout" | "stderr"; line: string }
-  | { type: "crashed"; service: string; code: number };
+  | { type: "restarting"; service: string; code: number; attempt: number; maxAttempts: number; delayMs: number }
+  | { type: "crashed"; service: string; code: number }
+  | { type: "stopped"; service: string };
 ```
 
 The CLI consumes events to render the listr2 status grid and tee log lines to TTY (prefixed + colored). No synchronous coupling between runtime and CLI animation.
 
 `Ctrl+C` triggers `stopAll(handles)`: SIGTERM each handle in reverse start order, 10s grace, then SIGKILL. `~/.langwatch/run/<service>.pid` files are removed on clean exit. The supervisor pidfile (`~/.langwatch/run/langwatch.pid`) doubles as a re-entry guard — second concurrent `npx @langwatch/server` invocations refuse to start with a clear "already running" error.
 
-Crash policy: any non-langwatch service crash emits `{ type: "crashed", code }` and the CLI calls `stopAll(handles)` followed by exit 1. The langwatch app (in-proc workers) is allowed up to 3 restarts in 60s before the same fate.
+Crash policy: a service that dies before its first `healthy` event is a boot failure and fails fast: `{ type: "crashed", code }` is emitted with no retry and the boot error path takes it from there. A service that dies after having been healthy is restarted in place, up to 3 attempts with 1s / 5s / 15s backoff, each announced as `{ type: "restarting", attempt }` on the bus and as a `[supervisor]` line in the service's log file. Staying up for 5 minutes resets the budget. When the budget is exhausted the crash falls through to `{ type: "crashed", code }`, the CLI prints the log-file pointer, calls `stopAll(handles)` and exits 1.
 
 ---
 


### PR DESCRIPTION
Fixes #6201

> Stacked on #6200 (`fix/npx-tarball-workspace-packages`): this branch was cut from it because both touch the runtime startup path, so its commits show in this diff until #6200 merges into main. Only `5afef0e` is this PR's change.

## The incident

On a `npx @langwatch/server` install, the separate `workers` process was SIGKILLed by the OOM killer (exit 137) while a heavy install phase was running. The CLI printed `workers crashed (exit 137)` and kept everything else up, but nothing ever restarted the process. The UI stayed reachable while the BullMQ collector/evaluations/track-event queues had no consumer, so the product sat on "Waiting for first trace..." forever. Any supervised service had the same failure mode: one crash and it stayed dead for the life of the run.

## The policy

Supervision (`packages/server/src/services/spawn.ts`) now distinguishes boot failures from steady-state crashes:

- **Dies before its first `healthy` event**: boot failure, fails fast exactly as before. One `crashed` event, no retry, the boot error path (health-probe timeout, sibling teardown) takes it from there.
- **Dies after having been healthy**: restarted in place with bounded backoff. Up to 3 attempts at 1s / 5s / 15s, each announced on the event bus as a new `restarting` event (rendered as `workers  exited (code 137), restarting in 1s (attempt 1/3)`) and as a `[supervisor]` marker line in `~/.langwatch/logs/<service>.log`. Staying up for 5 minutes refills the budget, so a rare crash a day never exhausts it, while a tight crash loop still gives up quickly.
- **Budget exhausted**: falls through to today's behavior, a `crashed` event, and the CLI's crash line now points at the log file: `workers crashed (exit 137), see ~/.langwatch/logs/workers.log`.

Supervision learns "this service was healthy" by observing the bus (new `EventBus.tap()` synchronous observer), since the health probes live in each service's start helper. That keeps the change contained to `spawn.ts` with zero churn in `runtime.ts` or the nine start helpers. `stop()` cancels any pending respawn, and the handle's `pid`/`child` always reflect the current process, so pidfiles and teardown stay correct across respawns.

## Changes

- `specs/npx-installer/03-services.feature`: crash scenarios refined first (restart with backoff, bounded budget, steady-state reset, boot deaths still fail fast); `_shared/contract.md` §7 crash policy updated to match.
- `packages/server/src/shared/runtime-contract.ts`: new `restarting` runtime event (additive).
- `packages/server/src/services/event-bus.ts`: `tap()` observer, does not consume the single-consumer iterator.
- `packages/server/src/services/spawn.ts`: the restart state machine described above; per-attempt log stream, pidfile rewrite, supervisor marker lines.
- `packages/server/src/animation/log-tee.ts`: renders `restarting`, and `crashed` now includes the log-file pointer.
- Tests: `test/services/spawn-restart.test.ts` (unit, fake timers, mocked `child_process`, no real ports or processes), plus new cases in `event-bus.test.ts` and `log-tee.test.ts`.

## Test results

`pnpm test` in `packages/server/`: 16 files, 112 tests passed (98 baseline + 14 new). `pnpm typecheck` clean, `pnpm build` clean, touched files formatted with biome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Services that crash after becoming healthy now restart automatically with progressive backoff (up to three attempts), resetting after sustained stability, and report restart progress via runtime events.
  - Restart delay/attempt details are surfaced in logs, and terminal crashes now include a “see service log” hint.
- **Bug Fixes**
  - Pending restarts are properly canceled on shutdown, and supervisor log streaming avoids truncating tail output.
  - Improved crash/restart messaging for both exit codes and signals.
- **Documentation**
  - Updated the service supervision and runtime event contract to include the new `restarting` behavior.
- **Chores**
  - `.env` rewrites now reliably re-apply restrictive permissions (0600), and CLI env scaffolding respects install vs start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->