### PR TITLE
fix(security): let ALLOWED_PROXY_HOSTS reach on-premise .local hosts

### DIFF
--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -374,7 +374,8 @@ LW_GATEWAY_SPEND_ENABLED=1
 #   "llm.corp.local,10.0.5.3". Also lifts the default .local / .localhost
 #   block for that exact host, so an on-prem deployment can reach internal
 #   services by name. Cloud metadata endpoints and cloud internal domains
-#   (.amazonaws.com, .compute.internal, .internal, ...) can never be listed.
+#   (.amazonaws.com, .compute.internal, .internal, ...) can never be reached
+#   through this allowlist — listing one has no effect.
 # - REQUIRE_HTTPS_CUSTOM_ENDPOINTS=true: rejects non-HTTPS customer-configured
 #   AI Gateway endpoints. Keep false for local and self-hosted HTTP endpoints.
 # - unset/false: only cloud metadata is blocked; local destinations allowed.

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -370,6 +370,11 @@ LW_GATEWAY_SPEND_ENABLED=1
 # - BLOCK_LOCAL_HTTP_CALLS=true: blocks private IPs / localhost / hostnames
 #   that resolve to private IPs (cloud metadata is always blocked regardless).
 #   Use ALLOWED_PROXY_HOSTS to allow specific hostnames when blocking is on.
+# - ALLOWED_PROXY_HOSTS: comma-separated literal hostnames, e.g.
+#   "llm.corp.local,10.0.5.3". Also lifts the default .local / .localhost
+#   block for that exact host, so an on-prem deployment can reach internal
+#   services by name. Cloud metadata endpoints and cloud internal domains
+#   (.amazonaws.com, .compute.internal, .internal, ...) can never be listed.
 # - REQUIRE_HTTPS_CUSTOM_ENDPOINTS=true: rejects non-HTTPS customer-configured
 #   AI Gateway endpoints. Keep false for local and self-hosted HTTP endpoints.
 # - unset/false: only cloud metadata is blocked; local destinations allowed.

--- a/platform/app/src/utils/__tests__/ssrfProtection.test.ts
+++ b/platform/app/src/utils/__tests__/ssrfProtection.test.ts
@@ -241,6 +241,93 @@ describe("createSSRFValidator (dependency injection)", () => {
     ).rejects.toThrow("cloud provider internal domains");
   });
 
+  it("cloud internal domain is not allowlistable via repeated .local suffixes", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["metadata.google.internal.local.local"],
+    });
+
+    // After every trailing on-premise label is gone, .internal is still
+    // there, so the on-premise exemption does not apply.
+    await expect(
+      validator(
+        "http://metadata.google.internal.local.local/computeMetadata/v1/",
+      ),
+    ).rejects.toThrow("cloud provider internal domains");
+  });
+
+  it("cloud internal domain is not allowlistable via mixed on-premise suffixes", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["s3.amazonaws.com.localhost.local"],
+    });
+
+    // Mixing .localhost and .local must not hide the amazonaws.com name.
+    await expect(
+      validator("http://s3.amazonaws.com.localhost.local/bucket"),
+    ).rejects.toThrow("cloud provider internal domains");
+  });
+
+  it("cloud internal domain is not allowlistable via mixed suffixes in reverse order", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["s3.amazonaws.com.local.localhost"],
+    });
+
+    // The stripping must not depend on suffix order. A single pass over the
+    // suffix list handled .localhost.local but let .local.localhost through.
+    await expect(
+      validator("http://s3.amazonaws.com.local.localhost/bucket"),
+    ).rejects.toThrow("cloud provider internal domains");
+  });
+
+  it("blocks a cloud internal domain spelled as a trailing-dot FQDN", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: [],
+    });
+
+    // DNS treats "s3.amazonaws.com." and "s3.amazonaws.com" as the same
+    // host. The suffix checks must not be fooled by the trailing dot.
+    await expect(validator("http://s3.amazonaws.com./bucket")).rejects.toThrow(
+      "cloud provider internal domains",
+    );
+  });
+
+  it("blocks the GCP metadata domain spelled as a trailing-dot FQDN", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: [],
+    });
+
+    await expect(
+      validator("http://metadata.google.internal./"),
+    ).rejects.toThrow("cloud provider internal domains");
+  });
+
+  it("blocks a .local cloud smuggle spelled as a trailing-dot FQDN", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: [],
+    });
+
+    // A trailing dot must not reopen the .local smuggling path.
+    await expect(
+      validator("http://metadata.google.internal.local./"),
+    ).rejects.toThrow("cloud provider internal domains");
+  });
+
+  it("blocks the bare metadata host spelled as a trailing-dot FQDN", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: [],
+    });
+
+    await expect(validator("http://metadata./")).rejects.toThrow(
+      "cloud metadata endpoints",
+    );
+  });
+
   it("permissive mode allows private IPs without an allowlist", async () => {
     const validator = createSSRFValidator({
       blockLocal: false,

--- a/platform/app/src/utils/__tests__/ssrfProtection.test.ts
+++ b/platform/app/src/utils/__tests__/ssrfProtection.test.ts
@@ -195,13 +195,50 @@ describe("createSSRFValidator (dependency injection)", () => {
   it("allowlisted host that is also a cloud domain pattern is still blocked", async () => {
     const validator = createSSRFValidator({
       blockLocal: true,
-      allowedHosts: ["myhost.local"],
+      allowedHosts: ["s3.amazonaws.com"],
     });
 
-    // myhost.local matches the .local cloud-domain block — that ALWAYS wins.
-    await expect(validator("http://myhost.local/api")).rejects.toThrow(
+    // Cloud internal domains are rejected before the allowlist is consulted.
+    await expect(validator("http://s3.amazonaws.com/bucket")).rejects.toThrow(
       "cloud provider internal domains",
     );
+  });
+
+  it("allowlisted on-premise .local host is reachable", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["llm.corp.local"],
+    });
+
+    // .local names on-premise infrastructure, so an operator may re-enable a
+    // specific host through ALLOWED_PROXY_HOSTS.
+    const result = await validator("http://llm.corp.local/v1/chat");
+    expect(result.type).toBe("allowlisted");
+  });
+
+  it("non-allowlisted .local host stays blocked", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["llm.corp.local"],
+    });
+
+    // Deferring the cloud-domain check past the allowlist must not open up
+    // every .local host.
+    await expect(validator("http://other.corp.local/api")).rejects.toThrow(
+      "cloud provider internal domains",
+    );
+  });
+
+  it("cloud internal domain is not allowlistable via a .local suffix", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["metadata.google.internal.local"],
+    });
+
+    // Matches .internal as well, so the on-premise exemption does not apply.
+    await expect(
+      validator("http://metadata.google.internal.local/computeMetadata/v1/"),
+    ).rejects.toThrow("cloud provider internal domains");
   });
 
   it("permissive mode allows private IPs without an allowlist", async () => {

--- a/platform/app/src/utils/ssrfConstants.ts
+++ b/platform/app/src/utils/ssrfConstants.ts
@@ -50,9 +50,33 @@ export const BLOCKED_CLOUD_DOMAINS = [
 
   // Generic internal domains (catch-all for misconfigured services)
   ".internal",
+
+  // On-premise suffixes. Blocked by default, but unlike the cloud domains
+  // above these MAY be lifted per-host via ALLOWED_PROXY_HOSTS — see
+  // ALLOWLISTABLE_LOCAL_SUFFIXES below.
   ".local",
   ".localhost",
 ];
+
+/**
+ * Suffixes an operator may re-enable for a specific hostname through the
+ * ALLOWED_PROXY_HOSTS allowlist.
+ *
+ * `.local` (mDNS) and `.localhost` name on-premise infrastructure, not cloud
+ * infrastructure: they carry no ambient credentials the way a cloud metadata
+ * service or an internal cloud endpoint does. An operator running LangWatch
+ * inside their own datacentre needs to reach `llm.corp.local`, and today the
+ * cloud-domain block rejects it even when they name that exact host in
+ * ALLOWED_PROXY_HOSTS.
+ *
+ * Everything else in BLOCKED_CLOUD_DOMAINS stays unconditional. Allowlisting
+ * `metadata.google.internal` or `s3.amazonaws.com` must keep failing —
+ * those are the SSRF targets the block exists for.
+ *
+ * Narrow by design: extend only with suffixes that are meaningless outside a
+ * private network.
+ */
+export const ALLOWLISTABLE_LOCAL_SUFFIXES = [".local", ".localhost"];
 
 /**
  * Cloud metadata endpoint hostnames and IPs to block.

--- a/platform/app/src/utils/ssrfConstants.ts
+++ b/platform/app/src/utils/ssrfConstants.ts
@@ -70,8 +70,14 @@ export const BLOCKED_CLOUD_DOMAINS = [
  * ALLOWED_PROXY_HOSTS.
  *
  * Everything else in BLOCKED_CLOUD_DOMAINS stays unconditional. Allowlisting
- * `metadata.google.internal` or `s3.amazonaws.com` must keep failing —
- * those are the SSRF targets the block exists for.
+ * `metadata.google.internal` or `s3.amazonaws.com` must keep failing.
+ * Those are the SSRF targets the block exists for.
+ *
+ * A host whose name also matches a cloud pattern once these suffixes are
+ * stripped stays blocked no matter what. `grafana.internal.local` reduces to
+ * `grafana.internal`, which hits `.internal`, so it can never be allowlisted.
+ * An on-premise DNS zone that collides with `.internal` is unreachable by
+ * design. Rename the zone or front it with a name that does not.
  *
  * Narrow by design: extend only with suffixes that are meaningless outside a
  * private network.

--- a/platform/app/src/utils/ssrfProtection.ts
+++ b/platform/app/src/utils/ssrfProtection.ts
@@ -225,6 +225,14 @@ export function isBlockedCloudDomain(hostname: string): boolean {
 }
 
 /**
+ * On-premise DNS labels ("local", "localhost") that may be stripped off the
+ * end of a hostname before the cloud patterns are tested.
+ */
+const strippableLabels = new Set(
+  ALLOWLISTABLE_LOCAL_SUFFIXES.map((suffix) => suffix.slice(1)),
+);
+
+/**
  * Whether a blocked hostname is blocked *only* because of an on-premise
  * suffix (`.local`, `.localhost`) and may therefore be re-enabled for that
  * exact host via ALLOWED_PROXY_HOSTS.
@@ -240,14 +248,19 @@ function isAllowlistableLocalDomain(hostname: string): boolean {
   );
   if (!matchesLocalSuffix) return false;
 
-  // Strip the on-premise suffix before testing the cloud patterns, so a
-  // hostname cannot smuggle a cloud label past the check by appending
-  // ".local" — "metadata.google.internal.local" still reads as ".internal".
-  const withoutLocalSuffix = ALLOWLISTABLE_LOCAL_SUFFIXES.reduce(
-    (name, suffix) =>
-      name.endsWith(suffix) ? name.slice(0, -suffix.length) : name,
-    lowerHostname,
-  );
+  // Strip trailing on-premise labels one by one until none is left, then
+  // test the cloud patterns on what remains. Repeated or mixed suffixes
+  // cannot smuggle a cloud name past the check:
+  // "metadata.google.internal.local.local" reduces to
+  // "metadata.google.internal".
+  const labels = lowerHostname.split(".");
+  while (
+    labels.length > 1 &&
+    strippableLabels.has(labels[labels.length - 1]!)
+  ) {
+    labels.pop();
+  }
+  const withoutLocalSuffix = labels.join(".");
 
   const matchesCloudDomain = BLOCKED_CLOUD_DOMAINS.filter(
     (domain) => !ALLOWLISTABLE_LOCAL_SUFFIXES.includes(domain),
@@ -427,7 +440,10 @@ export function createSSRFValidator(config: SSRFConfig) {
       );
     }
 
-    const hostname = parsedUrl.hostname.toLowerCase();
+    // Drop the trailing dot of a fully-qualified name ("s3.amazonaws.com.").
+    // DNS treats both spellings as the same host, so every check below must
+    // see the dotless form or the dot walks the name past the suffix checks.
+    const hostname = parsedUrl.hostname.toLowerCase().replace(/\.$/, "");
     const port = parsedUrl.port
       ? parseInt(parsedUrl.port, 10)
       : parsedUrl.protocol === "https:"

--- a/platform/app/src/utils/ssrfProtection.ts
+++ b/platform/app/src/utils/ssrfProtection.ts
@@ -7,6 +7,12 @@
  * - Cloud metadata endpoints (see ssrfConstants.ts for full list)
  * - Cloud provider internal domains (configured for AWS, see ssrfConstants.ts to extend)
  *
+ * ## What's Blocked by default but allowlistable (ALLOWED_PROXY_HOSTS)
+ * - On-premise suffixes .local / .localhost. They name private infrastructure
+ *   rather than a cloud service handing out ambient credentials, so an operator
+ *   may re-enable one exact host. Everything above stays unconditional — a
+ *   cloud internal domain is never reachable by listing it.
+ *
  * ## What's Blocked (only when BLOCK_LOCAL_HTTP_CALLS is true)
  * Every non-globally-routable address, as classified by the shared
  * `@langwatch/ssrf` rule set (one table, shared byte-for-byte with the Go
@@ -89,7 +95,11 @@ import {
   fetch as undiciFetch,
 } from "undici";
 import { env } from "../env.mjs";
-import { BLOCKED_CLOUD_DOMAINS, BLOCKED_METADATA_HOSTS } from "./ssrfConstants";
+import {
+  ALLOWLISTABLE_LOCAL_SUFFIXES,
+  BLOCKED_CLOUD_DOMAINS,
+  BLOCKED_METADATA_HOSTS,
+} from "./ssrfConstants";
 
 const logger = createLogger("langwatch:ssrfProtection");
 
@@ -212,6 +222,42 @@ export function isBlockedCloudDomain(hostname: string): boolean {
     (domain) =>
       lowerHostname === domain.slice(1) || lowerHostname.endsWith(domain),
   );
+}
+
+/**
+ * Whether a blocked hostname is blocked *only* because of an on-premise
+ * suffix (`.local`, `.localhost`) and may therefore be re-enabled for that
+ * exact host via ALLOWED_PROXY_HOSTS.
+ *
+ * A hostname that also matches a real cloud pattern is never allowlistable:
+ * `metadata.google.internal.local` hits `.internal` too, so it stays blocked.
+ */
+function isAllowlistableLocalDomain(hostname: string): boolean {
+  const lowerHostname = hostname.toLowerCase();
+
+  const matchesLocalSuffix = ALLOWLISTABLE_LOCAL_SUFFIXES.some((suffix) =>
+    lowerHostname.endsWith(suffix),
+  );
+  if (!matchesLocalSuffix) return false;
+
+  // Strip the on-premise suffix before testing the cloud patterns, so a
+  // hostname cannot smuggle a cloud label past the check by appending
+  // ".local" — "metadata.google.internal.local" still reads as ".internal".
+  const withoutLocalSuffix = ALLOWLISTABLE_LOCAL_SUFFIXES.reduce(
+    (name, suffix) =>
+      name.endsWith(suffix) ? name.slice(0, -suffix.length) : name,
+    lowerHostname,
+  );
+
+  const matchesCloudDomain = BLOCKED_CLOUD_DOMAINS.filter(
+    (domain) => !ALLOWLISTABLE_LOCAL_SUFFIXES.includes(domain),
+  ).some(
+    (domain) =>
+      withoutLocalSuffix === domain.slice(1) ||
+      withoutLocalSuffix.endsWith(domain),
+  );
+
+  return !matchesCloudDomain;
 }
 
 // ============================================================================
@@ -398,13 +444,22 @@ export function createSSRFValidator(config: SSRFConfig) {
       config,
     };
 
-    // Always validate metadata and cloud domains (critical security)
+    // Always validate metadata endpoints (critical security, never allowlistable)
     validateNotMetadataEndpoint(ctx);
-    validateNotBlockedCloudDomain(ctx);
+
+    // Cloud provider internal domains are rejected before the allowlist is even
+    // consulted, so they can never be allowlisted. The exception is the
+    // on-premise suffixes (.local / .localhost), which an operator may re-enable
+    // for a specific host below — they name private infrastructure, not a cloud
+    // service handing out ambient credentials.
+    if (!isAllowlistableLocalDomain(hostname)) {
+      validateNotBlockedCloudDomain(ctx);
+    }
 
     // Allowlist (literal hostname match, case-insensitive) — bypasses
-    // private-IP / localhost blocking. Cloud metadata was already rejected
-    // above, so it can never be allowlisted.
+    // private-IP / localhost blocking, and the .local/.localhost block for
+    // on-premise hosts. Cloud metadata and cloud internal domains were already
+    // rejected above, so neither can ever be allowlisted.
     if (config.allowedHosts.length > 0) {
       const normalizedAllowed = config.allowedHosts.map((h) =>
         h.trim().toLowerCase(),
@@ -421,6 +476,11 @@ export function createSSRFValidator(config: SSRFConfig) {
         );
       }
     }
+
+    // An on-premise host that was deferred past the cloud-domain check but did
+    // NOT match the allowlist is still blocked — deferring the check must not
+    // become a way to reach every .local host.
+    validateNotBlockedCloudDomain(ctx);
 
     // Handle IP literals
     const ipVersion = isIP(hostname);

--- a/specs/security/ssrf-blocking.feature
+++ b/specs/security/ssrf-blocking.feature
@@ -96,7 +96,8 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
 
   Rule: ALLOWED_PROXY_HOSTS is a literal hostname allowlist evaluated regardless of NODE_ENV
     Match is case-insensitive on hostname only (port is ignored). Matches bypass
-    private-IP/localhost checks. Cloud metadata is NEVER bypassed.
+    private-IP/localhost checks, and the .local/.localhost block for on-premise
+    hosts. Cloud metadata and cloud internal domains are NEVER bypassed.
 
     @unit
     Scenario Outline: <impl> allows allowlisted host even when BLOCK_LOCAL_HTTP_CALLS is "true"
@@ -134,6 +135,45 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
         | impl   |
         | TS     |
         | Python |
+
+  # ============================================================================
+  # On-premise hosts — blocked by default, allowlistable per host
+  # ============================================================================
+
+  Rule: An operator can reach a specific on-premise .local host via ALLOWED_PROXY_HOSTS
+    LangWatch running inside a customer datacentre has to call services named
+    under .local / .localhost. Those suffixes are blocked by default, but unlike
+    cloud internal domains they name private infrastructure that hands out no
+    ambient credentials, so an operator may re-enable one exact host. Naming a
+    cloud internal domain in the allowlist still fails.
+
+    @unit
+    Scenario: TS allows an allowlisted on-premise .local host
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "llm.corp.local"
+      When TS validates "http://llm.corp.local/v1/chat"
+      Then the validation passes
+
+    @unit
+    Scenario: TS still blocks a .local host that is not allowlisted
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "llm.corp.local"
+      When TS validates "http://other.corp.local/api"
+      Then the validation fails with an SSRF block error
+
+    @unit
+    Scenario: TS refuses to allowlist a cloud internal domain
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "s3.amazonaws.com"
+      When TS validates "http://s3.amazonaws.com/bucket"
+      Then the validation fails with an SSRF block error
+
+    @unit
+    Scenario: TS refuses a cloud internal domain dressed up with a .local suffix
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "metadata.google.internal.local"
+      When TS validates "http://metadata.google.internal.local/computeMetadata/v1/"
+      Then the validation fails with an SSRF block error
 
   # ============================================================================
   # Cloud metadata — ALWAYS blocked, no escape


### PR DESCRIPTION
## The problem

`ALLOWED_PROXY_HOSTS` lifts the private-IP block for a named host, but it does not lift the cloud-domain block — and `BLOCKED_CLOUD_DOMAINS` carries `.local` and `.localhost` next to the genuine cloud patterns:

```ts
// ssrfConstants.ts
export const BLOCKED_CLOUD_DOMAINS = [
  ".amazonaws.com",
  ".aws.amazon.com",
  ".compute.internal",
  ".internal",
  ".local",       // ← on-premise, not cloud
  ".localhost",   // ← on-premise, not cloud
];
```

`validateNotBlockedCloudDomain` runs *before* the allowlist is consulted, so an operator running LangWatch inside their own datacentre cannot reach `llm.corp.local` even after naming that exact host in `ALLOWED_PROXY_HOSTS`. The request is rejected before the allowlist is read, and no combination of `BLOCK_LOCAL_HTTP_CALLS` / `ALLOWED_PROXY_HOSTS` makes it work.

This is a gap between the documented contract and the behaviour: `.env.example` presents `ALLOWED_PROXY_HOSTS` as the way to "allow specific hostnames when blocking is on", and the on-premise default is described as permissive so operators "can reach internal services" — but internal services named under `.local` are exactly the ones it cannot reach.

## Why the contract had to change

The obvious fix — move `validateNotBlockedCloudDomain` after the allowlist — is the wrong one, and worth spelling out because it looks correct.

`BLOCKED_CLOUD_DOMAINS` is not only on-premise suffixes. Deferring the whole check past the allowlist would make `.amazonaws.com`, `.compute.internal` and `.internal` allowlistable too. `metadata.google.internal` is a **hostname**, and the unconditional metadata guard matches on `BLOCKED_METADATA_HOSTS` — IPs plus the bare label `metadata` — so it would not catch it. Allowlisting `metadata.google.internal` would start resolving, which is precisely the SSRF target the block exists for.

So instead of reordering one check, this splits the suffixes by what they actually name:

- `.local` / `.localhost` describe private infrastructure that hands out no ambient credentials. Blocked by default; an operator may re-enable **one exact host** through the allowlist.
- Everything else in `BLOCKED_CLOUD_DOMAINS` is still rejected before the allowlist is read, so it can never be listed.
- Cloud metadata endpoints were already unconditional and are untouched.

New `ALLOWLISTABLE_LOCAL_SUFFIXES` constant, deliberately narrow — extend only with suffixes that are meaningless outside a private network.

## Two ways this could have widened the hole

Both closed, each with a test:

1. **A `.local` host that is not in the allowlist.** Deferring the check must not open up every `.local` host, so the cloud-domain check runs again after the allowlist misses.
2. **A cloud label wearing an on-premise suffix.** `metadata.google.internal.local` ends in `.local`, so a naive suffix test treats it as on-premise while it still matches `.internal`. The on-premise suffix is stripped before the cloud patterns are matched. This one was caught by the test, not by review — the first implementation let it through.

## What is unchanged

- Cloud metadata endpoints: unconditional, never allowlistable.
- Cloud internal domains: rejected before the allowlist, never allowlistable.
- `.local` / `.localhost` with no allowlist entry: blocked exactly as before.
- Private-IP / `BLOCK_LOCAL_HTTP_CALLS` behaviour: untouched.
- No new configuration — this is the existing `ALLOWED_PROXY_HOSTS` contract doing what its documentation already implies.

## Tests

| Suite | Result |
|---|---|
| `ssrfProtection` + 8 consumers (TS) | 188/188 |
| `packages/ssrf` (shared classification) | 164/164 |
| `pkg/ssrf` (Go, shared vectors) | ok |
| `pnpm typecheck` on touched files | clean |

Four new scenarios: allowlisted `.local` passes; non-allowlisted `.local` blocks; cloud internal domain is not allowlistable; cloud internal domain with a `.local` suffix blocks.

One existing test changed. `"allowlisted host that is also a cloud domain pattern is still blocked"` used `myhost.local` to assert cloud-domain always wins over the allowlist. Its intent — a cloud domain cannot be allowlisted — is preserved, restated with `s3.amazonaws.com`, which is what the assertion was really about.

`specs/security/ssrf-blocking.feature` gains a rule covering the on-premise contract, and `.env.example` documents what `ALLOWED_PROXY_HOSTS` does and does not lift.

## Scope

TypeScript only. If `langwatch_server` (Python) performs the same hostname-suffix validation, it will still reject on-premise `.local` hosts and an operator would see the two planes disagree — worth confirming, and happy to follow up in a separate PR if so. The shared `packages/ssrf` and `pkg/ssrf` layers classify at IP level and carry no hostname-suffix logic, so TS and Go do not diverge here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allowlisted on-premises `.local` and `.localhost` hosts can now be accessed through the proxy.
  * Cloud metadata and internal cloud domains remain blocked, even when allowlisted or modified with local suffixes.
* **Bug Fixes**
  * Unallowlisted private infrastructure hosts continue to be rejected.
* **Documentation**
  * Added configuration guidance for hostname allowlisting and its security restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->