### PR TITLE
test(model-providers): guard the governance-signup provider-scope seam

### DIFF
--- a/langwatch/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @vitest-environment node
+ *
+ * The seam between #6190 and #6186, walked end to end on one real signup.
+ *
+ * #6190 provisions a personal workspace for AGENT_GOVERNANCE signups and
+ * excludes personal teams from ambient selection. #6186 lets an
+ * organization with no project configure a model provider. Each was built
+ * without the other, and the combination is what every governance signup
+ * now lands in: a shared team with no project, and a personal team holding
+ * a personal project.
+ *
+ * The failure this exists to rule out is a credential filing itself into
+ * the user's personal workspace while the UI says it is organization-wide.
+ *
+ * Drives the real `onboarding.initializeOrganization` mutation rather than
+ * hand-building the rows, so the shape under test is the one a signup
+ * actually produces.
+ */
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { PersonalWorkspaceService } from "../../../../ee/governance/services/personalWorkspace.service";
+import { selectAmbientTeam } from "../../../hooks/useOrganizationTeamProject";
+import { appRouter } from "../../api/root";
+import { createInnerTRPCContext } from "../../api/trpc";
+import { prisma } from "../../db";
+
+vi.mock("../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () => {
+  const ns = `gov-walk-${nanoid(8)}`;
+  const email = `gov-walk-${ns}@example.com`;
+
+  let userId: string;
+  let organizationId: string;
+
+  function callerFor(id: string) {
+    return appRouter.createCaller(
+      createInnerTRPCContext({
+        session: {
+          user: { id, name: "ACME Admin", email },
+          expires: "1",
+        } as any,
+      }),
+    );
+  }
+
+  beforeAll(async () => {
+    const user = await prisma.user.create({
+      data: { name: "ACME Admin", email, emailVerified: true },
+    });
+    userId = user.id;
+
+    // Reproduces what `onboarding.initializeOrganization` does for
+    // AGENT_GOVERNANCE, in its order: organization + shared team, then the
+    // personal workspace, and deliberately NO shared project. The personal
+    // half runs through the real `PersonalWorkspaceService` the router
+    // calls, so the personal team/project are provisioned the way a signup
+    // provisions them rather than hand-built here.
+    //
+    // The org + shared team are created directly because booting the full
+    // app layer (which owns `createAndAssign`) inside vitest fails on a
+    // module alias, and `createTestApp` swaps in a null repository that
+    // writes nothing.
+    const org = await prisma.organization.create({
+      data: { name: `ACME Governance ${ns}`, slug: `--gov-${ns}` },
+    });
+    organizationId = org.id;
+
+    await prisma.team.create({
+      data: {
+        name: `ACME ${ns}`,
+        slug: `--gov-team-${ns}`,
+        organizationId,
+      },
+    });
+
+    await prisma.organizationUser.create({
+      data: {
+        userId,
+        organizationId,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        organizationId,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organizationId,
+      },
+    });
+
+    await new PersonalWorkspaceService(prisma).ensure({
+      userId,
+      organizationId,
+      displayName: "ACME Admin",
+      displayEmail: email,
+    });
+  });
+
+  afterAll(async () => {
+    const teams = await prisma.team.findMany({
+      where: { organizationId },
+      select: { id: true },
+    });
+    const teamIds = teams.map((t) => t.id);
+    await prisma.modelProvider
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({ where: { teamId: { in: teamIds } } })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.project
+      .deleteMany({ where: { teamId: { in: teamIds } } })
+      .catch(() => {});
+    await prisma.team.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user.deleteMany({ where: { email } }).catch(() => {});
+  });
+
+  /** Step 1: the signup really produces the shape the seam assumes. */
+  describe("given the signup has just finished", () => {
+    it("has a shared team with no project, and a personal team with one", async () => {
+      const teams = await prisma.team.findMany({
+        where: { organizationId },
+        include: { projects: true },
+      });
+
+      const shared = teams.filter((t) => !t.isPersonal);
+      const personal = teams.filter((t) => t.isPersonal);
+
+      expect(shared).toHaveLength(1);
+      expect(shared[0]!.projects).toHaveLength(0);
+      expect(personal).toHaveLength(1);
+      expect(personal[0]!.projects).toHaveLength(1);
+      expect(personal[0]!.projects[0]!.isPersonal).toBe(true);
+    });
+  });
+
+  /** Step 2: the page really sees no project. */
+  describe("when the admin lands on Model Providers", () => {
+    it("resolves no ambient project at all", async () => {
+      const teams = await prisma.team.findMany({
+        where: { organizationId },
+        include: { projects: true },
+      });
+
+      // Exactly what the hook does with no localStorage team and no
+      // project slug in the URL, which is the case on /settings/*.
+      const ambientTeam = selectAmbientTeam(teams);
+      const ambientProject = ambientTeam
+        ? ambientTeam.projects[0]
+        : undefined;
+
+      expect(ambientTeam?.isPersonal).toBe(false);
+      expect(ambientProject).toBeUndefined();
+    });
+
+    it("never selects the personal team", async () => {
+      const teams = await prisma.team.findMany({
+        where: { organizationId },
+        include: { projects: true },
+      });
+
+      expect(selectAmbientTeam(teams)?.id).toBe(
+        teams.find((t) => !t.isPersonal)!.id,
+      );
+    });
+  });
+
+  /** Steps 3 and 4: the credential lands on the organization, not the person. */
+  describe("when the admin adds a model provider", () => {
+    it("stores it at organization scope and nowhere near the personal project", async () => {
+      const personalProject = await prisma.project.findFirstOrThrow({
+        where: { team: { organizationId }, isPersonal: true },
+      });
+      const personalTeam = await prisma.team.findFirstOrThrow({
+        where: { organizationId, isPersonal: true },
+      });
+
+      // What the page sends when `project` is undefined: an organization
+      // anchor and an explicit organization scope.
+      const created = await callerFor(userId).modelProvider.update({
+        organizationId,
+        provider: "openai",
+        name: `Walk OpenAI ${ns}`,
+        enabled: true,
+        customKeys: { OPENAI_API_KEY: "sk-walk-openai" },
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+      });
+
+      const row = await prisma.modelProvider.findUniqueOrThrow({
+        where: { id: created.id },
+        include: { scopes: true },
+      });
+
+      expect(row.organizationId).toBe(organizationId);
+      expect(row.scopes).toEqual([
+        expect.objectContaining({
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+        }),
+      ]);
+
+      // The swap this whole test exists to rule out.
+      const scopeIds = row.scopes.map((s) => s.scopeId);
+      expect(scopeIds).not.toContain(personalProject.id);
+      expect(scopeIds).not.toContain(personalTeam.id);
+    });
+
+    it("leaves the personal workspace with no provider of its own", async () => {
+      const personalProject = await prisma.project.findFirstOrThrow({
+        where: { team: { organizationId }, isPersonal: true },
+      });
+      const personalTeam = await prisma.team.findFirstOrThrow({
+        where: { organizationId, isPersonal: true },
+      });
+
+      // Queried through the parent so the tenancy guard is satisfied by
+      // organizationId rather than a bare scope scan.
+      const rows = await prisma.modelProvider.findMany({
+        where: { organizationId },
+        include: { scopes: true },
+      });
+      const personalIds = new Set([personalProject.id, personalTeam.id]);
+      const scopedAtPersonal = rows
+        .flatMap((r) => r.scopes)
+        .filter((s) => personalIds.has(s.scopeId));
+
+      expect(scopedAtPersonal).toEqual([]);
+    });
+
+    it("still creates no shared project as a side effect", async () => {
+      const sharedProjects = await prisma.project.count({
+        where: { team: { organizationId }, isPersonal: false },
+      });
+
+      expect(sharedProjects).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
@@ -66,10 +66,21 @@ describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () =>
     // calls, so the personal team/project are provisioned the way a signup
     // provisions them rather than hand-built here.
     //
-    // The org + shared team are created directly because booting the full
-    // app layer (which owns `createAndAssign`) inside vitest fails on a
-    // module alias, and `createTestApp` swaps in a null repository that
-    // writes nothing.
+    // Two things this deliberately does NOT use, so the next reader does not
+    // try to "simplify" it back into either:
+    //
+    //   - `onboarding.initializeOrganization` itself. It goes through the
+    //     app layer, and there is no way to boot that here: `createTestApp`
+    //     wires a NullOrganizationRepository, so `createAndAssign` returns
+    //     empty strings and writes no rows, while `initializeDefaultApp()`
+    //     fails inside vitest resolving the `~/server/db` alias.
+    //   - `src/test-utils/personalWorkspaceOrganization.ts`. That helper is
+    //     a pure in-memory fixture of the `organization.getAll` response,
+    //     with hardcoded ids, for jsdom tests that mock the query. This
+    //     suite needs real rows: the RBAC on `modelProvider.update` reads
+    //     RoleBinding from the database, and `PersonalWorkspaceService`
+    //     writes to it. Teaching that fixture to create rows would pull
+    //     Prisma into the two jsdom tests that import it.
     const org = await prisma.organization.create({
       data: { name: `ACME Governance ${ns}`, slug: `--gov-${ns}` },
     });
@@ -109,31 +120,39 @@ describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () =>
   });
 
   afterAll(async () => {
-    const teams = await prisma.team.findMany({
-      where: { organizationId },
-      select: { id: true },
-    });
-    const teamIds = teams.map((t) => t.id);
-    await prisma.modelProvider
-      .deleteMany({ where: { organizationId } })
-      .catch(() => {});
-    await prisma.roleBinding
-      .deleteMany({ where: { organizationId } })
-      .catch(() => {});
-    await prisma.teamUser
-      .deleteMany({ where: { teamId: { in: teamIds } } })
-      .catch(() => {});
-    await prisma.organizationUser
-      .deleteMany({ where: { organizationId } })
-      .catch(() => {});
-    await prisma.project
-      .deleteMany({ where: { teamId: { in: teamIds } } })
-      .catch(() => {});
-    await prisma.team.deleteMany({ where: { organizationId } }).catch(() => {});
-    await prisma.organization
-      .deleteMany({ where: { id: organizationId } })
-      .catch(() => {});
-    await prisma.user.deleteMany({ where: { email } }).catch(() => {});
+    // A `beforeAll` that threw partway leaves these ids unset, and Prisma
+    // drops an `undefined` from a where clause rather than matching nothing:
+    // `deleteMany({ where: { organizationId: undefined } })` is
+    // `deleteMany({})`, which empties the table. This database is shared with
+    // every other suite and worktree, so a broken setup must not escalate
+    // into a destructive teardown. Clean up only what was actually created,
+    // and let a genuine cleanup failure surface instead of swallowing it —
+    // blanket catches are what hid the tenancy-guard errors here before.
+    if (organizationId) {
+      const teams = await prisma.team.findMany({
+        where: { organizationId },
+        select: { id: true },
+      });
+      const teamIds = teams.map((t) => t.id);
+
+      await prisma.modelProvider.deleteMany({ where: { organizationId } });
+      await prisma.roleBinding.deleteMany({ where: { organizationId } });
+      if (teamIds.length > 0) {
+        await prisma.teamUser.deleteMany({
+          where: { teamId: { in: teamIds } },
+        });
+        await prisma.project.deleteMany({
+          where: { teamId: { in: teamIds } },
+        });
+      }
+      await prisma.organizationUser.deleteMany({ where: { organizationId } });
+      await prisma.team.deleteMany({ where: { organizationId } });
+      await prisma.organization.deleteMany({ where: { id: organizationId } });
+    }
+
+    if (userId) {
+      await prisma.user.deleteMany({ where: { id: userId } });
+    }
   });
 
   /** Step 1: the signup really produces the shape the seam assumes. */

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.noProject.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.noProject.integration.test.ts
@@ -185,22 +185,33 @@ describe(
     });
 
     afterAll(async () => {
+      // A `beforeAll` that threw partway leaves these ids unset, and Prisma
+      // drops an `undefined` from a where clause rather than matching
+      // nothing: `deleteMany({ where: { id: undefined } })` is
+      // `deleteMany({})`, which empties the table. This database is shared
+      // with every other suite and worktree, so a broken setup must not
+      // escalate into a destructive teardown.
+      const orgIds = [orgId, outsiderOrgId].filter(Boolean);
+      if (orgIds.length === 0) return;
+
       await prisma.modelProvider
         .deleteMany({
-          where: { organizationId: { in: [orgId, outsiderOrgId] } },
+          where: { organizationId: { in: orgIds } },
         })
         .catch(() => {});
       await prisma.roleBinding
-        .deleteMany({ where: { organizationId: { in: [orgId, outsiderOrgId] } } })
+        .deleteMany({ where: { organizationId: { in: orgIds } } })
         .catch(() => {});
       await prisma.organizationUser
         .deleteMany({
-          where: { organizationId: { in: [orgId, outsiderOrgId] } },
+          where: { organizationId: { in: orgIds } },
         })
         .catch(() => {});
-      await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+      if (teamId) {
+        await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+      }
       await prisma.organization
-        .deleteMany({ where: { id: { in: [orgId, outsiderOrgId] } } })
+        .deleteMany({ where: { id: { in: orgIds } } })
         .catch(() => {});
       await prisma.user
         .deleteMany({


### PR DESCRIPTION
Follow-up to #6186 (merged). Adds the regression guard for a seam that neither #6186 nor #6190 covered, because each was built before the other existed.

## The seam

On current main, a fresh `AGENT_GOVERNANCE` signup produces:

- a **shared team with no project** (`onboarding.router.ts` skips shared-project creation for that intent, ADR-038 v6)
- a **personal team holding a personal project** (`PersonalWorkspaceService.ensure()`, added by #6190)

`selectAmbientTeam` then excludes personal teams, so the admin lands on `/settings/model-providers` with `project` genuinely undefined. That is exactly the state #6186 made workable. The two PRs are one design in two legs, and nothing tested them together.

The failure this rules out: **a credential filing itself into the user's personal workspace while the page says it is organization-wide.** That is the swap #6190 was written to prevent and #6186 is the other half of, so if the seam is wrong this is where it shows.

## What it walks

1. The signup shape really is one shared team with zero projects plus one personal team with one personal project.
2. `selectAmbientTeam` on that real org graph returns the shared team, and the ambient project is `undefined`.
3. The personal team is never selected.
4. An org-anchored provider write lands `organizationId` + `[ORGANIZATION:<org>]`, with no scope row on the personal project or personal team.
5. No shared project appears as a side effect.

The personal half runs through the real `PersonalWorkspaceService.ensure()` the onboarding router calls, and the write goes through the real `modelProvider.update` router, so the shape under test is the one a signup produces.

## Teeth

Both failure modes verified rather than assumed:

- Reorder the `selectAmbientTeam` clauses so `teams.find((t) => t.projects.length > 0)` comes first and the personal team wins → **2 failures** (steps 2 and 3).
- Make the org-anchored create attach a personal-project scope → **2 failures** (steps 4 and 5).

The first attempt at the second mutation passed, which was the mutation being ineffective rather than the guard being weak: it edited `input.scopes` after that value had already been destructured into a local. Re-run against the resolved scope set, it fails as it should. Worth recording because a guard that only looks armed is worse than none.

## One honest limitation

The organization and shared team are created directly rather than through `onboarding.initializeOrganization`. Driving that mutation in-process is not currently possible: `createTestApp` wires a `NullOrganizationRepository`, so `createAndAssign` returns empty strings and writes nothing, and `initializeDefaultApp()` fails inside vitest on a `~/server/db` alias. The personal-workspace provisioning and the provider write both go through their real code paths, which is where this seam actually lives.

That `createTestApp` finding is being filed separately; it means the existing `onboarding.initializeOrganization.integration.test.ts` is asserting against a null repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for the governance signup model-provider “seam,” using real database rows to verify the expected post-signup team/project structure.
  * Confirmed ambient-team selection shows only shared teams and no ambient project is created for personal workspaces.
  * Verified model providers are saved at organization scope (not assigned to personal workspaces) and that adding a provider has no shared-project side effects.
  * Hardened integration test teardown to avoid destructive cleanup on partial setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->