### PR TITLE
fix(gateway): chat streams open with the role-carrying delta OpenAI sends

### DIFF
--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -1476,6 +1476,10 @@ type bifrostStreamIterator struct {
 	// right parser at iterator-construction time. When nil, the
 	// iterator skips usage extraction (final Usage() reports zeros).
 	parseUsage func([]byte) (domain.Usage, bool)
+	// roleSeenByChoice tracks which chat choice indices have emitted their
+	// first delta, driving the leading-role repair in ensureLeadingRoleDelta
+	// (see chat_stream_role.go). Lazily allocated on the first chat chunk.
+	roleSeenByChoice map[int]bool
 }
 
 func (it *bifrostStreamIterator) Next(ctx context.Context) bool {
@@ -1498,6 +1502,7 @@ func (it *bifrostStreamIterator) Next(ctx context.Context) bool {
 			return false
 		}
 		if chunk.BifrostChatResponse != nil {
+			it.ensureLeadingRoleDelta(chunk.BifrostChatResponse)
 			data, _ := sonic.Marshal(chunk.BifrostChatResponse)
 			it.current = data
 			if chunk.BifrostChatResponse.Usage != nil {

--- a/services/aigateway/adapters/providers/chat_stream_role.go
+++ b/services/aigateway/adapters/providers/chat_stream_role.go
@@ -1,0 +1,59 @@
+package providers
+
+import (
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// chatDeltaRoleAssistant is the role OpenAI stamps on the first delta of every
+// streamed chat completion choice.
+const chatDeltaRoleAssistant = "assistant"
+
+// ensureLeadingRoleDelta restores the role-carrying first delta on a streamed
+// chat completion.
+//
+// api.openai.com opens every streamed choice with
+// `"delta":{"role":"assistant","content":""}` before any content arrives.
+// Bifrost's stream handler forwards a chunk only when its delta carries
+// content, reasoning, audio or tool calls, so that opening chunk matches
+// nothing and is consumed internally; the first chunk the gateway emits is a
+// content delta with no role. Clients that key their accumulator off the
+// opening role delta then index a message that was never created (the
+// python-sdk streaming tracer died with KeyError: 0 on exactly this).
+//
+// The repair happens here, in the gateway's own iterator layer, on the first
+// delta-carrying chunk observed per choice index: if that delta has no role,
+// it gains `"role":"assistant"`. Per choice, not per stream, because n>1
+// requests interleave choices and each one opens independently. A provider
+// that does send the role itself (self-hosted OpenAI-compatible servers often
+// do) passes through untouched: the role is present, so nothing is injected,
+// and later chunks are never inspected again for that choice, so no second
+// role can appear.
+//
+// Everything else is deliberately out of reach. Usage-only final chunks carry
+// no choices and fall straight through, chunks whose choice has no delta
+// object are not given one (only the delta of the first chunk per choice may
+// gain a field), and after every choice has been seen the per-chunk cost is a
+// map lookup per choice.
+func (it *bifrostStreamIterator) ensureLeadingRoleDelta(resp *bfschemas.BifrostChatResponse) {
+	if resp == nil {
+		return
+	}
+	for i := range resp.Choices {
+		choice := &resp.Choices[i]
+		// The nil check on the embedded pointer is load-bearing: promoted
+		// field access through a nil embedded struct panics.
+		if choice.ChatStreamResponseChoice == nil || choice.Delta == nil {
+			continue
+		}
+		if it.roleSeenByChoice == nil {
+			it.roleSeenByChoice = make(map[int]bool, 1)
+		}
+		if it.roleSeenByChoice[choice.Index] {
+			continue
+		}
+		it.roleSeenByChoice[choice.Index] = true
+		if choice.Delta.Role == nil {
+			choice.Delta.Role = bfschemas.Ptr(chatDeltaRoleAssistant)
+		}
+	}
+}

--- a/services/aigateway/adapters/providers/chat_stream_role_test.go
+++ b/services/aigateway/adapters/providers/chat_stream_role_test.go
@@ -1,0 +1,427 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// These tests drive the real dispatch path: NewBifrostRouter, DispatchStream,
+// and a local upstream replaying the exact SSE shape api.openai.com sends,
+// opening role chunk included. Bifrost's stream handler forwards a chunk only
+// when its delta carries content, reasoning, audio or tool calls, so the
+// opening `"delta":{"role":"assistant","content":""}` chunk is consumed before
+// it ever reaches the gateway's iterator. That consumption is the bug's
+// mechanism, and running the real pipeline is what makes these tests observe
+// it instead of assuming it.
+//
+// Spec: specs/ai-gateway/streaming.feature
+
+// chatChunkJSON is one parsed `data:` payload from the gateway's stream.
+type chatChunkJSON struct {
+	raw     map[string]any
+	choices []map[string]any
+}
+
+func (c chatChunkJSON) delta(i int) map[string]any {
+	for _, ch := range c.choices {
+		if idx, ok := ch["index"].(float64); ok && int(idx) == i {
+			if d, ok := ch["delta"].(map[string]any); ok {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// collectChatStream drains the iterator and parses each emitted chunk.
+func collectChatStream(t *testing.T, iter domain.StreamIterator) []chatChunkJSON {
+	t.Helper()
+	var chunks []chatChunkJSON
+	for iter.Next(context.Background()) {
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(iter.Chunk(), &raw),
+			"every emitted chunk must be valid JSON")
+		c := chatChunkJSON{raw: raw}
+		if arr, ok := raw["choices"].([]any); ok {
+			for _, e := range arr {
+				if m, ok := e.(map[string]any); ok {
+					c.choices = append(c.choices, m)
+				}
+			}
+		}
+		chunks = append(chunks, c)
+	}
+	require.NoError(t, iter.Err())
+	return chunks
+}
+
+// firstDeltaPerChoice returns the first chunk that carries a delta for the
+// given choice index, plus every later delta for it.
+func deltasForChoice(chunks []chatChunkJSON, idx int) []map[string]any {
+	var out []map[string]any
+	for _, c := range chunks {
+		if d := c.delta(idx); d != nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func openAISSEBackend(t *testing.T, script string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(script))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func openAIRouter(t *testing.T, backendURL string) *BifrostRouter {
+	t.Helper()
+	router, err := NewBifrostRouter(context.Background(), BifrostOptions{
+		Logger:           zap.NewNop(),
+		OpenAIBackendURL: backendURL,
+	})
+	require.NoError(t, err)
+	t.Cleanup(router.Close)
+	return router
+}
+
+func chatStreamRequest() *domain.Request {
+	return &domain.Request{
+		Type:  domain.RequestTypeChat,
+		Model: "openai/gpt-5.6-luna",
+		Body:  []byte(`{"model":"gpt-5.6-luna","messages":[{"role":"user","content":"count to 3"}],"stream":true}`),
+	}
+}
+
+func openAICred() domain.Credential {
+	return domain.Credential{ID: "cred-oai", ProviderID: domain.ProviderOpenAI, APIKey: "sk-test"}
+}
+
+// oaChunk renders one api.openai.com-shaped SSE chunk.
+func oaChunk(choices string) string {
+	return `data: {"id":"chatcmpl-role1","object":"chat.completion.chunk","created":1730000000,"model":"gpt-5.6-luna","system_fingerprint":"fp_test","choices":[` + choices + `]}` + "\n\n"
+}
+
+// openAICaptureScript is the shape api.openai.com actually streams: the
+// role-carrying opening chunk, content deltas, a finish chunk, a usage-only
+// chunk with empty choices, and the [DONE] sentinel.
+const roleOpening = `{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}`
+
+func openAICaptureScript() string {
+	return oaChunk(roleOpening) +
+		oaChunk(`{"index":0,"delta":{"content":"1, "},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{"content":"2, 3"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}`) +
+		`data: {"id":"chatcmpl-role1","object":"chat.completion.chunk","created":1730000000,"model":"gpt-5.6-luna","system_fingerprint":"fp_test","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":5,"total_tokens":17}}` + "\n\n" +
+		"data: [DONE]\n\n"
+}
+
+// The stream engine consumes OpenAI's opening role chunk, so without the
+// repair the gateway's first delta is a bare content delta. The contract is
+// OpenAI's: the first delta per choice carries the assistant role.
+//
+// @scenario "the first emitted delta of a chat completion stream carries the assistant role"
+func TestChatStreamRole_OpenAI_FirstDeltaCarriesRole(t *testing.T) {
+	backend := openAISSEBackend(t, openAICaptureScript())
+	router := openAIRouter(t, backend.URL)
+
+	iter, err := router.DispatchStream(context.Background(), chatStreamRequest(), openAICred())
+	require.NoError(t, err)
+
+	chunks := collectChatStream(t, iter)
+	require.NotEmpty(t, chunks)
+
+	deltas := deltasForChoice(chunks, 0)
+	require.NotEmpty(t, deltas, "the stream must carry deltas for choice 0")
+
+	role, ok := deltas[0]["role"].(string)
+	require.True(t, ok,
+		"the first delta must carry a role; clients key their message accumulator off it")
+	assert.Equal(t, "assistant", role)
+	assert.Equal(t, "1, ", deltas[0]["content"],
+		"the role rides on the first real delta; no synthetic chunk is invented")
+
+	// The repair is first-chunk-per-choice only: every later delta is
+	// emitted without a role, exactly as the upstream sent it.
+	for i, d := range deltas[1:] {
+		_, hasRole := d["role"]
+		assert.False(t, hasRole, "delta %d must not gain a role; only the first may", i+1)
+	}
+
+	// The rest of the first chunk is untouched: id, model and fingerprint
+	// come through as the upstream sent them.
+	first := chunks[0]
+	assert.Equal(t, "chatcmpl-role1", first.raw["id"])
+	assert.Equal(t, "gpt-5.6-luna", first.raw["model"])
+	assert.Equal(t, "fp_test", first.raw["system_fingerprint"])
+
+	// Content survives reassembly.
+	var content strings.Builder
+	for _, d := range deltas {
+		if s, ok := d["content"].(string); ok {
+			content.WriteString(s)
+		}
+	}
+	assert.Equal(t, "1, 2, 3", content.String())
+
+	// Usage still reaches billing.
+	assert.Equal(t, 12, iter.Usage().PromptTokens)
+	assert.Equal(t, 5, iter.Usage().CompletionTokens)
+}
+
+// A tool-call-first turn: OpenAI sends the role chunk (consumed), then
+// tool_calls deltas with no content. Claude-style agent loops are all
+// tool-call-first, so this is the common case, not the exotic one.
+//
+// @scenario "a turn that opens with a tool call still carries the role"
+func TestChatStreamRole_ToolCallFirstTurn_StillGetsRole(t *testing.T) {
+	script := oaChunk(roleOpening) +
+		oaChunk(`{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":""}}]},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":\"x\"}"}}]},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}`) +
+		"data: [DONE]\n\n"
+
+	backend := openAISSEBackend(t, script)
+	router := openAIRouter(t, backend.URL)
+
+	iter, err := router.DispatchStream(context.Background(), chatStreamRequest(), openAICred())
+	require.NoError(t, err)
+
+	deltas := deltasForChoice(collectChatStream(t, iter), 0)
+	require.NotEmpty(t, deltas)
+
+	assert.Equal(t, "assistant", deltas[0]["role"],
+		"a tool-call-first delta must still carry the role")
+	calls, ok := deltas[0]["tool_calls"].([]any)
+	require.True(t, ok, "the tool call must ride the same delta the role was injected into")
+	require.NotEmpty(t, calls)
+
+	for i, d := range deltas[1:] {
+		_, hasRole := d["role"]
+		assert.False(t, hasRole, "delta %d must not gain a role", i+1)
+	}
+}
+
+// n>1 interleaves choices, and each choice opens independently on the wire,
+// so the repair must track per choice index rather than per stream.
+//
+// @scenario "every choice of a multi-choice stream opens with its own role delta"
+func TestChatStreamRole_MultiChoice_RolePerChoiceIndex(t *testing.T) {
+	script := oaChunk(roleOpening) +
+		oaChunk(`{"index":1,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{"content":"alpha"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":1,"delta":{"content":"bravo"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{"content":" one"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":1,"delta":{"content":" two"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}`) +
+		oaChunk(`{"index":1,"delta":{},"logprobs":null,"finish_reason":"stop"}`) +
+		"data: [DONE]\n\n"
+
+	backend := openAISSEBackend(t, script)
+	router := openAIRouter(t, backend.URL)
+
+	iter, err := router.DispatchStream(context.Background(), chatStreamRequest(), openAICred())
+	require.NoError(t, err)
+
+	chunks := collectChatStream(t, iter)
+	for _, idx := range []int{0, 1} {
+		deltas := deltasForChoice(chunks, idx)
+		require.NotEmpty(t, deltas, "choice %d must have deltas", idx)
+		assert.Equal(t, "assistant", deltas[0]["role"],
+			"choice %d must open with its own role delta", idx)
+		for i, d := range deltas[1:] {
+			_, hasRole := d["role"]
+			assert.False(t, hasRole, "choice %d delta %d must not gain a role", idx, i+1)
+		}
+	}
+}
+
+// Self-hosted OpenAI-compatible servers often stamp the role on their first
+// content-carrying chunk, which the stream engine forwards as-is. When the
+// role is already there, the stream must pass through untouched: no second
+// role, no mutation.
+//
+// @scenario "a provider that sends its own role delta passes through untouched"
+func TestChatStreamRole_ProviderSendsOwnRole_PassesThroughUntouched(t *testing.T) {
+	script := oaChunk(`{"index":0,"delta":{"role":"assistant","content":"Hello"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{"content":" world"},"logprobs":null,"finish_reason":null}`) +
+		oaChunk(`{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}`) +
+		"data: [DONE]\n\n"
+
+	backend := openAISSEBackend(t, script)
+	router := newTestRouterForRole(t)
+
+	iter, err := router.DispatchStream(context.Background(), chatStreamRequest(), customEndpointCredential(backend.URL))
+	require.NoError(t, err)
+
+	deltas := deltasForChoice(collectChatStream(t, iter), 0)
+	require.NotEmpty(t, deltas)
+
+	roleCount := 0
+	for _, d := range deltas {
+		if _, ok := d["role"]; ok {
+			roleCount++
+		}
+	}
+	assert.Equal(t, 1, roleCount, "exactly one role in the stream; the provider's own, never a second")
+	assert.Equal(t, "assistant", deltas[0]["role"])
+	assert.Equal(t, "Hello", deltas[0]["content"],
+		"the provider's own first chunk must come through unmodified")
+}
+
+// Azure and self-hosted OpenAI-compatible endpoints stream through the same
+// shared handler and the same gateway iterator. Confirmed here with a real
+// dispatch through the openai-compat provider rather than assumed from
+// reading the code.
+//
+// @scenario "OpenAI-compatible providers inherit the role repair"
+func TestChatStreamRole_OpenAICompat_InheritsRepair(t *testing.T) {
+	backend := openAISSEBackend(t, openAICaptureScript())
+	router := newTestRouterForRole(t)
+
+	iter, err := router.DispatchStream(context.Background(), chatStreamRequest(), customEndpointCredential(backend.URL))
+	require.NoError(t, err)
+
+	deltas := deltasForChoice(collectChatStream(t, iter), 0)
+	require.NotEmpty(t, deltas)
+	assert.Equal(t, "assistant", deltas[0]["role"],
+		"the openai-compat lane shares the iterator and must inherit the repair")
+}
+
+// The wrapper itself, fed the exact chunk sequence Bifrost hands the gateway:
+// roleless content deltas, then a usage-only chunk with no choices. Terminal
+// chunks must pass through with no choices invented, and the [DONE] sentinel
+// the writer appends must stay exactly `data: [DONE]`.
+//
+// @scenario "terminal chunks are not reshaped by the role repair"
+func TestChatStreamRole_TerminalChunks_PassThroughUntouched(t *testing.T) {
+	ch := make(chan *bfschemas.BifrostStreamChunk, 3)
+	content := "hi"
+	ch <- &bfschemas.BifrostStreamChunk{BifrostChatResponse: &bfschemas.BifrostChatResponse{
+		ID:     "chatcmpl-t",
+		Object: "chat.completion.chunk",
+		Model:  "gpt-5.6-luna",
+		Choices: []bfschemas.BifrostResponseChoice{{
+			Index: 0,
+			ChatStreamResponseChoice: &bfschemas.ChatStreamResponseChoice{
+				Delta: &bfschemas.ChatStreamResponseChoiceDelta{Content: &content},
+			},
+		}},
+	}}
+	// The usage-only terminal chunk as OpenAI sends it: empty choices array.
+	ch <- &bfschemas.BifrostStreamChunk{BifrostChatResponse: &bfschemas.BifrostChatResponse{
+		ID:      "chatcmpl-t",
+		Object:  "chat.completion.chunk",
+		Model:   "gpt-5.6-luna",
+		Choices: []bfschemas.BifrostResponseChoice{},
+		Usage:   &bfschemas.BifrostLLMUsage{PromptTokens: 3, CompletionTokens: 1, TotalTokens: 4},
+	}}
+	close(ch)
+
+	iter := &bifrostStreamIterator{ch: ch}
+
+	// The writer appends the standard `data: [DONE]` sentinel exactly when the
+	// iterator does not claim raw framing; the repair must not change that.
+	assert.False(t, iter.RawFraming(),
+		"chat streams must stay on the writer's standard framing, [DONE] included")
+
+	var frames []map[string]any
+	for iter.Next(context.Background()) {
+		var frame map[string]any
+		require.NoError(t, json.Unmarshal(iter.Chunk(), &frame))
+		frames = append(frames, frame)
+	}
+	require.NoError(t, iter.Err())
+	require.Len(t, frames, 2)
+
+	// First frame: the content delta gained the role.
+	choices := frames[0]["choices"].([]any)
+	delta := choices[0].(map[string]any)["delta"].(map[string]any)
+	assert.Equal(t, "assistant", delta["role"])
+
+	// Usage-only frame: choices stays an empty array, nothing invented.
+	usageChoices, ok := frames[1]["choices"].([]any)
+	require.True(t, ok, "the usage-only chunk must keep its choices array")
+	assert.Empty(t, usageChoices, "no choice may be invented on a usage-only chunk")
+	assert.NotNil(t, frames[1]["usage"], "usage must survive untouched")
+	deltaRoleCount := 0
+	for _, f := range frames {
+		if cs, ok := f["choices"].([]any); ok {
+			for _, c := range cs {
+				if d, ok := c.(map[string]any)["delta"].(map[string]any); ok {
+					if _, has := d["role"]; has {
+						deltaRoleCount++
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, 1, deltaRoleCount, "exactly one role in the whole stream")
+}
+
+// A choice whose chunk carries no delta object must not be given one: only
+// the delta of the first chunk per choice may gain a field, never the chunk
+// itself.
+//
+// @scenario "terminal chunks are not reshaped by the role repair"
+func TestChatStreamRole_ChoiceWithoutDelta_NotGivenOne(t *testing.T) {
+	ch := make(chan *bfschemas.BifrostStreamChunk, 1)
+	reason := "stop"
+	ch <- &bfschemas.BifrostStreamChunk{BifrostChatResponse: &bfschemas.BifrostChatResponse{
+		ID:     "chatcmpl-nd",
+		Object: "chat.completion.chunk",
+		Choices: []bfschemas.BifrostResponseChoice{{
+			Index:        0,
+			FinishReason: &reason,
+		}},
+	}}
+	close(ch)
+
+	iter := &bifrostStreamIterator{ch: ch}
+	require.True(t, iter.Next(context.Background()))
+
+	var chunk map[string]any
+	require.NoError(t, json.Unmarshal(iter.Chunk(), &chunk))
+	choice := chunk["choices"].([]any)[0].(map[string]any)
+	_, hasDelta := choice["delta"]
+	assert.False(t, hasDelta, "a delta object must never be invented on a chunk that had none")
+}
+
+// newTestRouterForRole builds a bare router for openai-compat dispatches.
+func newTestRouterForRole(t *testing.T) *BifrostRouter {
+	t.Helper()
+	router, err := NewBifrostRouter(context.Background(), BifrostOptions{Logger: zap.NewNop()})
+	require.NoError(t, err)
+	t.Cleanup(router.Close)
+	return router
+}
+
+// customEndpointCredential points a credential at a local OpenAI-compatible
+// upstream, the production shape for self-hosted vLLM and LiteLLM servers.
+func customEndpointCredential(url string) domain.Credential {
+	return domain.Credential{
+		ID:         "cred-compat",
+		ProviderID: domain.ProviderCustom,
+		APIKey:     "sk-test",
+		Extra:      map[string]string{"base_url": url},
+	}
+}

--- a/services/aigateway/adapters/providers/chat_stream_role_test.go
+++ b/services/aigateway/adapters/providers/chat_stream_role_test.go
@@ -66,8 +66,8 @@ func collectChatStream(t *testing.T, iter domain.StreamIterator) []chatChunkJSON
 	return chunks
 }
 
-// firstDeltaPerChoice returns the first chunk that carries a delta for the
-// given choice index, plus every later delta for it.
+// deltasForChoice returns every delta emitted for the given choice index, in
+// stream order.
 func deltasForChoice(chunks []chatChunkJSON, idx int) []map[string]any {
 	var out []map[string]any
 	for _, c := range chunks {
@@ -382,7 +382,7 @@ func TestChatStreamRole_TerminalChunks_PassThroughUntouched(t *testing.T) {
 // the delta of the first chunk per choice may gain a field, never the chunk
 // itself.
 //
-// @scenario "terminal chunks are not reshaped by the role repair"
+// @scenario "a choice with no delta is not given one"
 func TestChatStreamRole_ChoiceWithoutDelta_NotGivenOne(t *testing.T) {
 	ch := make(chan *bfschemas.BifrostStreamChunk, 1)
 	reason := "stop"

--- a/specs/ai-gateway/streaming.feature
+++ b/specs/ai-gateway/streaming.feature
@@ -170,7 +170,7 @@ Feature: SSE streaming — exact byte preservation post-first-chunk
 
     @unit
     Scenario: the first emitted delta of a chat completion stream carries the assistant role
-      Given a chat completion stream whose upstream opening role chunk was consumed by the stream engine
+      Given a chat completion stream that would otherwise reach the client with no role on any delta
       When the gateway emits the stream
       Then the first delta of the stream carries "role":"assistant"
       And every later chunk of the stream is emitted unchanged
@@ -200,6 +200,12 @@ Feature: SSE streaming — exact byte preservation post-first-chunk
       When the gateway emits the stream
       Then the usage-only chunk passes through with no choices invented
       And the [DONE] sentinel is unchanged
+
+    @unit
+    Scenario: a choice with no delta is not given one
+      Given a chat completion chunk whose choice carries a finish reason and no delta
+      When the gateway emits the stream
+      Then the chunk passes through without a delta object being invented
 
     @unit
     Scenario: OpenAI-compatible providers inherit the role repair

--- a/specs/ai-gateway/streaming.feature
+++ b/specs/ai-gateway/streaming.feature
@@ -155,3 +155,54 @@ Feature: SSE streaming — exact byte preservation post-first-chunk
       Then the OTel span attached to the trace has gen_ai.usage.input_tokens > 0
       And gen_ai.usage.output_tokens > 0
       And the gateway does NOT emit the success_no_usage soft warning for this request
+
+  Rule: Chat completion streams open with a role-carrying delta, matching OpenAI's contract
+
+    # api.openai.com opens every streamed choice with
+    # "delta":{"role":"assistant","content":""} before any content arrives.
+    # The gateway's stream engine consumes that opening chunk internally and
+    # re-emits starting from the first content delta, so clients that key
+    # their accumulator off the opening role delta index a message that was
+    # never created (our own python-sdk streaming tracer crashed with
+    # KeyError: 0 on every streamed chat completion through the gateway).
+    # The gateway therefore guarantees the role on the first delta it emits
+    # per choice, whatever the upstream engine swallowed.
+
+    @unit
+    Scenario: the first emitted delta of a chat completion stream carries the assistant role
+      Given a chat completion stream whose upstream opening role chunk was consumed by the stream engine
+      When the gateway emits the stream
+      Then the first delta of the stream carries "role":"assistant"
+      And every later chunk of the stream is emitted unchanged
+
+    @unit
+    Scenario: a turn that opens with a tool call still carries the role
+      Given a chat completion stream whose first delta carries tool calls and no content
+      When the gateway emits the stream
+      Then that first delta carries "role":"assistant" alongside its tool calls
+
+    @unit
+    Scenario: every choice of a multi-choice stream opens with its own role delta
+      Given a chat completion request with n greater than 1
+      When the gateway emits the stream
+      Then the first delta of each choice index carries "role":"assistant"
+
+    @unit
+    Scenario: a provider that sends its own role delta passes through untouched
+      Given a chat completion stream whose upstream already opens with a role-carrying delta
+      When the gateway emits the stream
+      Then the stream is emitted unchanged
+      And no chunk gains a second role
+
+    @unit
+    Scenario: terminal chunks are not reshaped by the role repair
+      Given a chat completion stream that ends with a usage-only chunk and the [DONE] sentinel
+      When the gateway emits the stream
+      Then the usage-only chunk passes through with no choices invented
+      And the [DONE] sentinel is unchanged
+
+    @unit
+    Scenario: OpenAI-compatible providers inherit the role repair
+      Given a chat completion stream served through a self-hosted OpenAI-compatible endpoint
+      When the gateway emits the stream
+      Then the first delta of the stream carries "role":"assistant"


### PR DESCRIPTION
# Related Issue

- Resolves #6196

Fixes #6196

## What

Chat completion streams served by the gateway never opened with the role-carrying first delta that api.openai.com sends. The stream engine forwards a chunk only when its delta carries content, reasoning, audio or tool calls, so OpenAI's opening `"delta":{"role":"assistant","content":""}` chunk matches nothing and is consumed internally; the first chunk the gateway emitted was a bare content delta.

Clients that key their accumulator off the opening role delta then index a message that was never created. Our own python-sdk streaming tracer crashed with `KeyError: 0` on every streamed chat completion through the gateway (made shape-tolerant in #6197, but the gateway contract stayed wrong for any customer accumulator with the same pattern).

## The fix

In the gateway's own stream iterator layer, not vendored Bifrost: on the first delta-carrying chunk observed per choice index, a delta with no role gains `"role":"assistant"`.

- **Per choice index, not per stream**, so `n>1` requests get a role on each choice's opening delta.
- **First-chunk-per-choice only**: after a choice is seen, its chunks are never inspected again, so the steady-state cost is one map lookup per choice and later deltas never gain a role.
- **Presence-checked**: a provider that sends its own role delta (self-hosted OpenAI-compatible servers often stamp the role on their first content chunk) passes through untouched, and no second role can appear.
- **Nothing else is reshaped**: chunks whose choice has no delta object are not given one, usage-only terminal chunks pass through with no choices invented, and the `[DONE]` sentinel is unchanged. Only the delta object of the first chunk per choice may gain a field.

Azure and self-hosted OpenAI-compatible endpoints stream through the same shared handler and the same iterator, so they inherit the repair; pinned by a test through the openai-compat dispatch path rather than assumed.

## Live evidence

Local gateway (this branch), real virtual key routing to OpenAI, `curl -N`:

```
data: {"id":"chatcmpl-E5xylC1dVRG3YBDwZjX31YqfQe9x5","choices":[{"index":0,"delta":{"role":"assistant","content":"1"}}],"created":1785090907,"model":"gpt-5.6-luna","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"","usage":null,"extra_fields":{"request_type":"chat_comp...
data: {"id":"chatcmpl-E5xylC1dVRG3YBDwZjX31YqfQe9x5","choices":[{"index":0,"delta":{"content":" "}}],"created":1785090907,"model":"gpt-5.6-luna","object":"chat.completion.chunk","service_tier":"default","system_fingerpri...
```

Direct api.openai.com, same model, side by side:

```
data: {"id":"chatcmpl-E5xvik1KC957oGaXZEyGDX0S1xUr5","object":"chat.completion.chunk","created":1785090718,"model":"gpt-5.6-luna","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}],"obfuscation":"5r...
data: {"id":"chatcmpl-E5xvik1KC957oGaXZEyGDX0S1xUr5","object":"chat.completion.chunk","created":1785090718,"model":"gpt-5.6-luna","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content...
```

Both streams open with a role-carrying delta and carry it exactly once; the gateway now matches OpenAI's shape. The gateway capture ends with the untouched `data: [DONE]` sentinel.

## Testing

Seven Go tests, six driving the real dispatch path (`NewBifrostRouter` + `DispatchStream` against a local upstream replaying api.openai.com's exact SSE shape, opening role chunk included) so the engine's chunk consumption is observed rather than assumed:

- first delta carries the role, later deltas never gain one, id/model/fingerprint untouched, usage still reaches billing
- tool-call-first turns get the role on the same delta as the tool call
- multi-choice `n>1`: role per choice index
- a provider that sends its own role: exactly one role, byte-preserved first chunk
- openai-compat lane inherits the repair (real dispatch through the custom-endpoint provider)
- terminal chunks: usage-only chunk keeps its empty choices array, no delta object is ever invented on a delta-less chunk

Teeth verified by reverting the fix: exactly the five injection tests fail, and the two no-mutation tests keep passing, which is the correct split.

New spec rule in `specs/ai-gateway/streaming.feature` (6 scenarios, all bound, `check:feature-parity` green). `golangci-lint` clean on CI's exact five-path target set; full `-race` suite green.

## Deployment Impact

No migrations, no config, no new environment variables, no API surface change. Behaviour changes only for streamed `/v1/chat/completions` responses: the first delta per choice now carries `"role":"assistant"` when the upstream engine consumed the provider's own role chunk, which restores the shape api.openai.com sends. Clients that already tolerate the missing role (openai SDK, litellm, langchain) see a strictly more standard stream; clients that broke on it stop breaking.

Rollback is a plain revert.

Known overlap: #6207 touches the same iterator file; whichever merges second rebases and re-runs the full battery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streamed chat completions so the first emitted delta for each choice includes the correct `assistant` role.
  * Preserved correct role behavior for tool-call-first turns and multi-choice responses.
  * Prevented duplicate role injection when providers already include `delta.role`.
  * Kept usage-only chunks, empty choices, and stream termination markers unchanged.

* **Tests**
  * Added end-to-end streaming coverage for standard, tool-call, multi-choice, compatibility, and edge/terminal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->