### PR TITLE
feat(analytics): capture signed_up and first_trace_integrated in posthog, instrument the coding-agent onboarding screen

### DIFF
--- a/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.analytics.unit.test.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.analytics.unit.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Analytics instrumentation on the coding-agent onboarding screen.
+ *
+ * The screen renders install commands and an MCP config that EMBED the
+ * project API key, so the property allowlist is a privacy property, not a
+ * tidiness one: every payload must stay a fixed identifier and must never
+ * carry the copied string.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const emitMock = vi.fn();
+const clipboardWriteMock = vi.fn<(text: string) => Promise<void>>();
+
+vi.mock("react-contextual-analytics", () => ({
+  useAnalytics: () => ({ emit: emitMock }),
+}));
+
+const API_KEY = "sk-lw-test-SUPERSECRET-000";
+
+vi.mock("../../contexts/ActiveProjectContext", () => ({
+  useActiveProject: () => ({
+    project: { id: "project-1", apiKey: API_KEY },
+  }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: { BASE_HOST: "https://app.langwatch.ai" } }),
+}));
+
+vi.mock("../../../../components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import { ViaClaudeCodeScreen } from "./ViaClaudeCodeScreen";
+
+type EmitCall = [string, string, Record<string, unknown> | undefined];
+
+function emitted(): EmitCall[] {
+  return emitMock.mock.calls as EmitCall[];
+}
+
+/**
+ * The emit calls padded so destructuring a missing call yields undefined
+ * rather than throwing, letting each test assert the count itself.
+ */
+function onlyEmit(): EmitCall {
+  return emitted()[0] ?? ["", "", undefined];
+}
+
+function renderScreen() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <ViaClaudeCodeScreen />
+    </ChakraProvider>,
+  );
+}
+
+/** An element on each tab, used to wait out the AnimatePresence swap. */
+const TAB_MARKER: Record<string, RegExp> = {
+  Prompt: /^Copy prompt$/,
+  Skill: /^Copy install command:/,
+  MCP: /^Copy config$/,
+};
+
+function copyButtons(): HTMLElement[] {
+  return screen
+    .queryAllByRole("button")
+    .filter((b) => (b.getAttribute("aria-label") ?? "").startsWith("Copy "));
+}
+
+function findCopyButton(pattern: RegExp): HTMLElement | undefined {
+  return copyButtons().find((b) =>
+    pattern.test(b.getAttribute("aria-label") ?? ""),
+  );
+}
+
+/**
+ * Switches tab and waits for its content to mount. The tab panels live in an
+ * `AnimatePresence mode="wait"`, so the incoming panel only mounts once the
+ * outgoing one has finished exiting; querying straight after the click finds
+ * the previous tab. Clears the `selected` event the switch itself emits.
+ */
+async function goToTab(name: keyof typeof TAB_MARKER | string): Promise<void> {
+  fireEvent.click(screen.getByRole("button", { name }));
+  const marker = TAB_MARKER[name];
+  if (marker) {
+    // Generous timeout: the swap is a real animation frame chain, and it
+    // runs well past the 1s default when the whole file executes together.
+    await waitFor(() => expect(findCopyButton(marker)).toBeDefined(), {
+      timeout: 10_000,
+    });
+  }
+  emitMock.mockClear();
+}
+
+/**
+ * Clicks every copyable control on every tab and returns everything emitted.
+ * The MCP tab is the point of the sweep: its quick commands and config JSON
+ * embed the raw API key.
+ */
+async function copyEverythingOnEveryTab(): Promise<EmitCall[]> {
+  const collected: EmitCall[] = [];
+  for (const tab of ["Prompt", "Skill", "MCP"]) {
+    await goToTab(tab);
+    for (const button of copyButtons()) fireEvent.click(button);
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    collected.push(...emitted());
+  }
+  return collected;
+}
+
+beforeEach(() => {
+  emitMock.mockClear();
+  clipboardWriteMock.mockReset();
+  clipboardWriteMock.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: clipboardWriteMock },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(cleanup);
+
+describe("when the user copies a skill prompt", () => {
+  /** @scenario Copying a prompt reports the skill it came from */
+  it("emits copied/prompt carrying only the skill id", async () => {
+    renderScreen();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Copy prompt" })[0]!);
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("prompt");
+    expect(Object.keys(properties ?? {})).toEqual(["skill"]);
+    expect(typeof properties?.skill).toBe("string");
+  });
+});
+
+describe("when the user copies a skill slash command", () => {
+  /** @scenario Copying a slash command reports the skill it came from */
+  it("emits copied/slash_command carrying only the skill id", async () => {
+    renderScreen();
+    await goToTab("Skill");
+
+    const slashButton = findCopyButton(/^Copy \//);
+    expect(slashButton).toBeDefined();
+    fireEvent.click(slashButton!);
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("slash_command");
+    expect(Object.keys(properties ?? {})).toEqual(["skill"]);
+  });
+});
+
+describe("when the user copies a skill install command", () => {
+  /** @scenario Copying a skill install command reports the skill it came from */
+  it("emits copied/install_command carrying only the skill id", async () => {
+    renderScreen();
+    await goToTab("Skill");
+
+    const installButton = findCopyButton(/^Copy install command:/);
+    expect(installButton).toBeDefined();
+    fireEvent.click(installButton!);
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("install_command");
+    expect(Object.keys(properties ?? {})).toEqual(["skill"]);
+  });
+});
+
+describe("when the user copies an agent quick command on the MCP tab", () => {
+  /** @scenario Copying an agent quick command reports the agent it configures */
+  it("emits copied/install_command carrying only the agent id", async () => {
+    renderScreen();
+    await goToTab("MCP");
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Copy command" })[0]!,
+    );
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("install_command");
+    expect(properties).toEqual({ agent: "claude-code" });
+  });
+
+  it("reports codex for the second quick command", async () => {
+    renderScreen();
+    await goToTab("MCP");
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Copy command" })[1]!,
+    );
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    expect(onlyEmit()[2]).toEqual({ agent: "codex" });
+  });
+});
+
+describe("when the user copies the MCP config", () => {
+  /** @scenario Copying the MCP config reports no further detail */
+  it("emits copied/mcp_config with no properties", async () => {
+    renderScreen();
+    await goToTab("MCP");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy config" }));
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("mcp_config");
+    expect(properties).toBeUndefined();
+  });
+});
+
+describe("when the user copies an editor config path", () => {
+  /** @scenario Copying an editor config path reports the editor */
+  it("emits copied/config_path carrying only the editor name", async () => {
+    renderScreen();
+    await goToTab("MCP");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy Cursor config path" }),
+    );
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalled());
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("copied");
+    expect(object).toBe("config_path");
+    expect(properties).toEqual({ editor: "Cursor" });
+  });
+});
+
+describe("when the user switches tabs", () => {
+  /** @scenario Switching tabs reports the tab selected */
+  it("emits selected/tab carrying only the tab key", () => {
+    renderScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skill" }));
+
+    expect(emitted()).toHaveLength(1);
+    const [action, object, properties] = onlyEmit();
+    expect(action).toBe("selected");
+    expect(object).toBe("tab");
+    expect(properties).toEqual({ tab: "skill" });
+  });
+});
+
+describe("when the clipboard write fails", () => {
+  /** @scenario A failed copy emits no analytics event */
+  it("emits no analytics event", async () => {
+    clipboardWriteMock.mockRejectedValue(new Error("denied"));
+    renderScreen();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Copy prompt" })[0]!);
+
+    await waitFor(() => expect(clipboardWriteMock).toHaveBeenCalled());
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("given the screen renders commands that embed the project API key", () => {
+  /** @scenario No onboarding analytics payload carries the project API key */
+  it("never puts the API key or the copied text in an analytics payload", async () => {
+    renderScreen();
+    const emittedAcrossTabs = await copyEverythingOnEveryTab();
+
+    // The copy paths really did handle the secret, so the assertions below
+    // are about the analytics payloads and not about an inert fixture.
+    const copiedTexts = clipboardWriteMock.mock.calls.map(([text]) => text);
+    expect(copiedTexts.some((text) => text.includes(API_KEY))).toBe(true);
+    expect(emittedAcrossTabs.length).toBeGreaterThan(0);
+
+    const payloads = emittedAcrossTabs.map(([, , properties]) =>
+      JSON.stringify(properties ?? {}),
+    );
+    expect(payloads.filter((p) => p.includes(API_KEY))).toEqual([]);
+    expect(
+      payloads.filter((p) => copiedTexts.some((t) => p.includes(t))),
+    ).toEqual([]);
+  });
+});

--- a/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.tsx
@@ -3,6 +3,7 @@ import { Check, Clipboard, Terminal } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type React from "react";
 import { useMemo, useState } from "react";
+import { useAnalytics } from "react-contextual-analytics";
 
 const MotionVStack = motion.create(VStack);
 
@@ -152,6 +153,7 @@ function glassCard(): Record<string, unknown> {
 
 function PromptRow({ skill }: { skill: SkillItem }): React.ReactElement {
   const [copied, setCopied] = useState(false);
+  const { emit } = useAnalytics();
 
   const handleCopy = async (): Promise<void> => {
     const ok = await copyToClipboard({
@@ -161,6 +163,7 @@ function PromptRow({ skill }: { skill: SkillItem }): React.ReactElement {
     if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      emit("copied", "prompt", { skill: skill.id });
     }
   };
 
@@ -207,6 +210,8 @@ function PromptRow({ skill }: { skill: SkillItem }): React.ReactElement {
 }
 
 function SkillRow({ skill }: { skill: SkillItem }): React.ReactElement {
+  const { emit } = useAnalytics();
+
   return (
     <VStack align="stretch" px={4} py={2.5} gap={1} {...glassCard()}>
       <HStack gap={2} align="baseline" minW={0}>
@@ -244,6 +249,8 @@ function SkillRow({ skill }: { skill: SkillItem }): React.ReactElement {
                 void copyToClipboard({
                   text: skill.slashCommand,
                   successMessage: `${skill.slashCommand} copied to clipboard`,
+                }).then((ok) => {
+                  if (ok) emit("copied", "slash_command", { skill: skill.id });
                 });
               }}
             >
@@ -280,6 +287,8 @@ function SkillRow({ skill }: { skill: SkillItem }): React.ReactElement {
               void copyToClipboard({
                 text: skill.installCommand,
                 successMessage: "Install command copied to clipboard",
+              }).then((ok) => {
+                if (ok) emit("copied", "install_command", { skill: skill.id });
               });
             }}
           >
@@ -323,13 +332,18 @@ function accentCredentialSegments(command: string): React.ReactNode[] {
 
 function QuickCommand({
   label,
+  agent,
   displayCommand,
   copyCommand,
 }: {
   label: string;
+  /** Stable agent id reported on the copy analytics event. */
+  agent: string;
   displayCommand: string;
   copyCommand: string;
 }): React.ReactElement {
+  const { emit } = useAnalytics();
+
   return (
     <HStack
       justify="space-between"
@@ -356,7 +370,11 @@ function QuickCommand({
           </Text>
         </VStack>
       </HStack>
-      <InlineCopyButton text={copyCommand} label="Command" />
+      <InlineCopyButton
+        text={copyCommand}
+        label="Command"
+        onCopied={() => emit("copied", "install_command", { agent })}
+      />
     </HStack>
   );
 }
@@ -376,6 +394,7 @@ function McpTab({
   endpoint: string | undefined;
   projectId: string | undefined;
 }): React.ReactElement {
+  const { emit } = useAnalytics();
   const isSelfHosted = endpoint && endpoint !== CLOUD_ENDPOINT;
   const endpointFlag = isSelfHosted ? ` --endpoint ${endpoint}` : "";
   const maskedEndpointFlag = isSelfHosted ? ` --endpoint ${endpoint}` : "";
@@ -399,11 +418,13 @@ function McpTab({
         </Text>
         <QuickCommand
           label="Claude Code"
+          agent="claude-code"
           displayCommand={`claude mcp add langwatch${projectIdEnvBefore} -- npx -y @langwatch/mcp-server --api-key ${maskedKey}${maskedEndpointFlag}`}
           copyCommand={`claude mcp add langwatch${projectIdEnvBefore} -- npx -y @langwatch/mcp-server --api-key ${apiKey}${endpointFlag}`}
         />
         <QuickCommand
           label="OpenAI Codex"
+          agent="codex"
           displayCommand={`codex mcp add langwatch --env LANGWATCH_API_KEY=${maskedKey}${projectIdEnvAfter}${isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : ""} -- npx -y @langwatch/mcp-server`}
           copyCommand={`codex mcp add langwatch --env LANGWATCH_API_KEY=${apiKey}${projectIdEnvAfter}${isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : ""} -- npx -y @langwatch/mcp-server`}
         />
@@ -432,7 +453,11 @@ function McpTab({
           highlightLines={findLangwatchEnvLines(displayConfigJson)}
         />
         <Box position="absolute" top={2.5} right={2.5}>
-          <InlineCopyButton text={mcpJson} label="Config" />
+          <InlineCopyButton
+            text={mcpJson}
+            label="Config"
+            onCopied={() => emit("copied", "mcp_config")}
+          />
         </Box>
       </Box>
 
@@ -464,6 +489,8 @@ function McpTab({
                 void copyToClipboard({
                   text: ep.path,
                   successMessage: `${ep.editor} config path copied`,
+                }).then((ok) => {
+                  if (ok) emit("copied", "config_path", { editor: ep.editor });
                 });
               }}
             >
@@ -538,6 +565,12 @@ export function ViaClaudeCodeScreen({
   const { project } = useActiveProject();
   const publicEnv = usePublicEnv();
   const [activeTab, setActiveTab] = useState<TabKey>("prompt");
+  const { emit } = useAnalytics();
+
+  const selectTab = (tab: TabKey): void => {
+    setActiveTab(tab);
+    emit("selected", "tab", { tab });
+  };
 
   const effectiveApiKey = project?.apiKey ?? "";
   const effectiveEndpoint = publicEnv.data?.BASE_HOST;
@@ -596,18 +629,18 @@ export function ViaClaudeCodeScreen({
           <TabButton
             label="Prompt"
             active={activeTab === "prompt"}
-            onClick={() => setActiveTab("prompt")}
+            onClick={() => selectTab("prompt")}
           />
           <TabButton
             label="Skill"
             active={activeTab === "skill"}
-            onClick={() => setActiveTab("skill")}
+            onClick={() => selectTab("skill")}
           />
           {showMcpTab && (
             <TabButton
               label="MCP"
               active={activeTab === "mcp"}
-              onClick={() => setActiveTab("mcp")}
+              onClick={() => selectTab("mcp")}
             />
           )}
         </HStack>

--- a/langwatch/src/features/onboarding/components/sections/shared/InlineCopyButton.tsx
+++ b/langwatch/src/features/onboarding/components/sections/shared/InlineCopyButton.tsx
@@ -8,9 +8,12 @@ import { copyToClipboard } from "./copy-to-clipboard";
 export function InlineCopyButton({
   text,
   label,
+  onCopied,
 }: {
   text: string;
   label: string;
+  /** Called after a successful copy, e.g. to emit an analytics event. */
+  onCopied?: () => void;
 }): React.ReactElement {
   const [copied, setCopied] = useState(false);
 
@@ -22,6 +25,7 @@ export function InlineCopyButton({
     if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      onCopied?.();
     }
   }
 

--- a/langwatch/src/features/traces-v2/onboarding/components/IntegrateDrawer.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/IntegrateDrawer.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid, HStack, Tabs, Text, VStack } from "@chakra-ui/react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
+import { AnalyticsBoundary } from "react-contextual-analytics";
 import { Kbd } from "~/components/ops/shared/Kbd";
 import { Drawer } from "~/components/ui/drawer";
 import { DocsLinks } from "~/features/onboarding/components/sections/observability/DocsLinks";
@@ -204,66 +205,70 @@ export function IntegrationContent({
   }, [enabled, onSegmentChange]);
 
   return (
-    <VStack align="stretch" gap={6}>
-      {/* API key generator at the top — minting a token is the first
-          step of integration. The lifted onboarding screens below
-          read the token via ActiveProjectProvider, so they
-          automatically pick up the freshly-scoped credential. */}
-      <ApiKeyIntegrationInfoCard
-        organizationId={organizationId}
-        projectId={projectId}
-        token={token}
-        onTokenGenerated={onTokenGenerated}
-      />
+    // Namespaces the analytics events the lifted onboarding sections emit
+    // (prompt/skill/config copies) when they render on this surface.
+    <AnalyticsBoundary name="traces_integrate">
+      <VStack align="stretch" gap={6}>
+        {/* API key generator at the top — minting a token is the first
+            step of integration. The lifted onboarding screens below
+            read the token via ActiveProjectProvider, so they
+            automatically pick up the freshly-scoped credential. */}
+        <ApiKeyIntegrationInfoCard
+          organizationId={organizationId}
+          projectId={projectId}
+          token={token}
+          onTokenGenerated={onTokenGenerated}
+        />
 
-      <Tabs.Root
-        value={segment}
-        onValueChange={(e) => onSegmentChange(e.value as Segment)}
-        variant="line"
-        size="sm"
-        colorPalette="orange"
-      >
-        <Text textStyle="xs" color="fg.muted" marginBottom={2}>
-          All four end up in the same explorer.
-        </Text>
-        <Tabs.List>
-          {SEGMENTS.map((s) => (
-            <Tabs.Trigger key={s.value} value={s.value}>
-              <HStack gap={1.5}>
-                <Box as="span">{s.label}</Box>
-                <Kbd>{s.shortcut}</Kbd>
-              </HStack>
-            </Tabs.Trigger>
-          ))}
-        </Tabs.List>
-
-        <Box paddingTop={3} paddingBottom={4}>
-          <Text
-            color="fg"
-            textStyle="md"
-            fontWeight="medium"
-            letterSpacing="-0.01em"
-            lineHeight="snug"
-          >
-            {activeSegmentDescription}
+        <Tabs.Root
+          value={segment}
+          onValueChange={(e) => onSegmentChange(e.value as Segment)}
+          variant="line"
+          size="sm"
+          colorPalette="orange"
+        >
+          <Text textStyle="xs" color="fg.muted" marginBottom={2}>
+            All four end up in the same explorer.
           </Text>
-        </Box>
+          <Tabs.List>
+            {SEGMENTS.map((s) => (
+              <Tabs.Trigger key={s.value} value={s.value}>
+                <HStack gap={1.5}>
+                  <Box as="span">{s.label}</Box>
+                  <Kbd>{s.shortcut}</Kbd>
+                </HStack>
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
 
-        <Tabs.Content value="mcp" padding={0}>
-          <ViaMcpClientScreen />
-        </Tabs.Content>
-        <Tabs.Content value="skill" padding={0}>
-          {/* Traces onboarding leads with tracing — that's the job here. */}
-          <SkillList primarySkillId={TRACING_SKILL_ID} />
-        </Tabs.Content>
-        <Tabs.Content value="prompt" padding={0}>
-          <PromptList primarySkillId={TRACING_SKILL_ID} />
-        </Tabs.Content>
-        <Tabs.Content value="sdk" padding={0}>
-          <ManualSetup />
-        </Tabs.Content>
-      </Tabs.Root>
-    </VStack>
+          <Box paddingTop={3} paddingBottom={4}>
+            <Text
+              color="fg"
+              textStyle="md"
+              fontWeight="medium"
+              letterSpacing="-0.01em"
+              lineHeight="snug"
+            >
+              {activeSegmentDescription}
+            </Text>
+          </Box>
+
+          <Tabs.Content value="mcp" padding={0}>
+            <ViaMcpClientScreen />
+          </Tabs.Content>
+          <Tabs.Content value="skill" padding={0}>
+            {/* Traces onboarding leads with tracing — that's the job here. */}
+            <SkillList primarySkillId={TRACING_SKILL_ID} />
+          </Tabs.Content>
+          <Tabs.Content value="prompt" padding={0}>
+            <PromptList primarySkillId={TRACING_SKILL_ID} />
+          </Tabs.Content>
+          <Tabs.Content value="sdk" padding={0}>
+            <ManualSetup />
+          </Tabs.Content>
+        </Tabs.Root>
+      </VStack>
+    </AnalyticsBoundary>
   );
 }
 

--- a/langwatch/src/server/api/routers/__tests__/user.register.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/user.register.unit.test.ts
@@ -68,6 +68,7 @@ describe("userRouter.register()", () => {
   };
 
   describe("when registration succeeds", () => {
+    /** @scenario Email-mode registration tracks the PostHog signed_up milestone exactly once */
     it("tracks the signed_up analytics event with the new user id", async () => {
       const result = await createCaller().register({
         name: "Alice",
@@ -85,6 +86,7 @@ describe("userRouter.register()", () => {
   });
 
   describe("when the user already exists", () => {
+    /** @scenario A rejected registration tracks no PostHog signed_up milestone */
     it("does not track signed_up", async () => {
       userFindUniqueMock.mockResolvedValue({ id: "user-1" });
 

--- a/langwatch/src/server/api/routers/__tests__/user.register.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/user.register.unit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for userRouter.register (email-mode signup).
+ *
+ * Verifies:
+ * - The signed_up analytics event fires once for a successful registration
+ * - No event fires when the user already exists
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInnerTRPCContext } from "../../trpc";
+import { userRouter } from "../user";
+
+vi.mock("../../../../env.mjs", () => ({
+  env: { NEXTAUTH_PROVIDER: "email" },
+}));
+
+const { mockTrackServerEvent } = vi.hoisted(() => ({
+  mockTrackServerEvent: vi.fn(),
+}));
+
+vi.mock("~/server/posthog", () => ({
+  trackServerEvent: mockTrackServerEvent,
+}));
+
+vi.mock("~/server/rateLimit", () => ({
+  rateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    skipPermissionCheck: ({ ctx, next }: any) => {
+      ctx.permissionChecked = true;
+      return next();
+    },
+  };
+});
+
+describe("userRouter.register()", () => {
+  let userFindUniqueMock: ReturnType<typeof vi.fn>;
+  let userCreateMock: ReturnType<typeof vi.fn>;
+  let accountCreateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userFindUniqueMock = vi.fn().mockResolvedValue(null);
+    userCreateMock = vi
+      .fn()
+      .mockResolvedValue({ id: "user-1", name: "Alice", email: "a@x.com" });
+    accountCreateMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  const createCaller = () => {
+    const ctx = createInnerTRPCContext({ session: null });
+    const prismaMock = {
+      user: { findUnique: userFindUniqueMock, create: userCreateMock },
+      account: { create: accountCreateMock },
+      $transaction: vi.fn(
+        async (cb: (tx: unknown) => unknown) =>
+          await cb({
+            user: { create: userCreateMock },
+            account: { create: accountCreateMock },
+          }),
+      ),
+    };
+    (ctx as any).prisma = prismaMock;
+    return userRouter.createCaller(ctx);
+  };
+
+  describe("when registration succeeds", () => {
+    it("tracks the signed_up analytics event with the new user id", async () => {
+      const result = await createCaller().register({
+        name: "Alice",
+        email: "a@x.com",
+        password: "supersecret",
+      });
+
+      expect(result).toEqual({ id: "user-1" });
+      expect(mockTrackServerEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user-1",
+        event: "signed_up",
+      });
+    });
+  });
+
+  describe("when the user already exists", () => {
+    it("does not track signed_up", async () => {
+      userFindUniqueMock.mockResolvedValue({ id: "user-1" });
+
+      await expect(
+        createCaller().register({
+          name: "Alice",
+          email: "a@x.com",
+          password: "supersecret",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -23,6 +23,7 @@ import { GatewayBudgetService } from "~/server/gateway/budget.service";
 import { sendBudgetIncreaseRequestEmail } from "~/server/mailer/budgetIncreaseRequestEmail";
 import { resolveOrgAdminEmail } from "~/server/organizations/resolveOrgAdminEmail";
 import { resolveSupportContact } from "~/server/organizations/resolveSupportContact";
+import { trackServerEvent } from "~/server/posthog";
 import { rateLimit } from "~/server/rateLimit";
 import { AvatarRateLimitedError } from "~/server/user-avatar/avatar";
 import { UserAvatarService } from "~/server/user-avatar/avatar.service";
@@ -154,6 +155,10 @@ export const userRouter = createTRPCRouter({
         });
         return created;
       });
+
+      // Email-mode signups bypass the BetterAuth user-create hooks, so the
+      // `signed_up` analytics event fires here instead.
+      trackServerEvent({ userId: newUser.id, event: "signed_up" });
 
       return { id: newUser.id };
     }),

--- a/langwatch/src/server/better-auth/__tests__/hooks.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/hooks.test.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("~/server/app-layer/app", () => ({
   getApp: () => ({
@@ -8,6 +8,14 @@ vi.mock("~/server/app-layer/app", () => ({
     },
     nurturing: null,
   }),
+}));
+
+const { mockTrackServerEvent } = vi.hoisted(() => ({
+  mockTrackServerEvent: vi.fn(),
+}));
+
+vi.mock("~/server/posthog", () => ({
+  trackServerEvent: mockTrackServerEvent,
 }));
 
 import {
@@ -85,6 +93,63 @@ describe("beforeUserCreate", () => {
 });
 
 describe("afterUserCreate", () => {
+  beforeEach(() => {
+    mockTrackServerEvent.mockClear();
+  });
+
+  describe("for every new user", () => {
+    it("tracks the signed_up analytics event with the user id", async () => {
+      const prisma = makePrismaMock();
+
+      await afterUserCreate({
+        prisma,
+        user: { id: "user_1", email: "u@other.com", name: "User" },
+      });
+
+      expect(mockTrackServerEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user_1",
+        event: "signed_up",
+      });
+    });
+
+    it("tracks signed_up even when the SSO auto-add path runs", async () => {
+      const prisma = makePrismaMock({
+        organization: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "org_1",
+            ssoDomain: "acme.com",
+          }),
+        },
+      });
+
+      await afterUserCreate({
+        prisma,
+        user: { id: "user_2", email: "new@acme.com", name: "New User" },
+      });
+
+      expect(mockTrackServerEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user_2",
+        event: "signed_up",
+      });
+    });
+
+    it("tracks signed_up even when the user has no parsable email domain", async () => {
+      const prisma = makePrismaMock();
+
+      await afterUserCreate({
+        prisma,
+        user: { id: "user_3", email: "", name: "User" },
+      });
+
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user_3",
+        event: "signed_up",
+      });
+    });
+  });
+
   describe("when the email domain matches an organization with ssoDomain", () => {
     /** @scenario New user with matching SSO domain joins the SSO org */
     it("adds the user to the organization as a MEMBER", async () => {

--- a/langwatch/src/server/better-auth/__tests__/hooks.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/hooks.test.ts
@@ -98,6 +98,7 @@ describe("afterUserCreate", () => {
   });
 
   describe("for every new user", () => {
+    /** @scenario BetterAuth signup tracks the PostHog signed_up milestone */
     it("tracks the signed_up analytics event with the user id", async () => {
       const prisma = makePrismaMock();
 
@@ -113,6 +114,7 @@ describe("afterUserCreate", () => {
       });
     });
 
+    /** @scenario PostHog signed_up still fires when the SSO auto-add path runs */
     it("tracks signed_up even when the SSO auto-add path runs", async () => {
       const prisma = makePrismaMock({
         organization: {
@@ -135,6 +137,7 @@ describe("afterUserCreate", () => {
       });
     });
 
+    /** @scenario PostHog signed_up still fires when the email has no parsable domain */
     it("tracks signed_up even when the user has no parsable email domain", async () => {
       const prisma = makePrismaMock();
 

--- a/langwatch/src/server/better-auth/hooks.ts
+++ b/langwatch/src/server/better-auth/hooks.ts
@@ -9,6 +9,7 @@ import {
 import { APIError } from "better-auth/api";
 import { getApp } from "~/server/app-layer/app";
 import { InviteService } from "~/server/invites/invite.service";
+import { trackServerEvent } from "~/server/posthog";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { fireSsoAutoAddNurturingCalls } from "../../../ee/billing/nurturing/hooks/ssoAutoAdd";
 import { captureException } from "../../utils/posthogErrorCapture";
@@ -83,8 +84,10 @@ export const beforeUserCreate = async ({
 };
 
 /**
- * Called after a new user is created. If the user's email domain matches an
- * organization with ssoDomain, auto-onboard the user:
+ * Called after a new user is created. Fires the `signed_up` analytics event
+ * for every new user (fire-and-forget, no-op without POSTHOG_KEY), then, if
+ * the user's email domain matches an organization with ssoDomain,
+ * auto-onboard the user:
  *
  *   - If a PENDING invite exists for (org, email), apply it — the invite's
  *     role and team assignments take precedence, and the invite is marked
@@ -115,6 +118,10 @@ export const afterUserCreate = async ({
   prisma: PrismaClient;
   user: { id: string; email: string; name: string };
 }): Promise<void> => {
+  // Same distinct_id posthog-js identifies with client-side (the user id),
+  // so this server event joins the browser person.
+  trackServerEvent({ userId: user.id, event: "signed_up" });
+
   const domain = extractEmailDomain(user.email);
   if (!domain) return;
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -11,6 +11,14 @@ vi.mock("@langwatch/observability", () => ({
   createLogger: () => logger,
 }));
 
+const { mockTrackServerEvent } = vi.hoisted(() => ({
+  mockTrackServerEvent: vi.fn(),
+}));
+
+vi.mock("~/server/posthog", () => ({
+  trackServerEvent: mockTrackServerEvent,
+}));
+
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
@@ -105,6 +113,11 @@ function createMockProjectService() {
     getWithTeam: vi.fn(),
     updateMetadata: vi.fn(),
     isFeatureEnabled: vi.fn(),
+    resolveOrgAdmin: vi.fn().mockResolvedValue({
+      userId: "admin-user-1",
+      organizationId: "org-1",
+      firstMessage: false,
+    }),
     repo: {} as any,
   };
 }
@@ -117,6 +130,7 @@ describe("createProjectMetadataReactor()", () => {
   beforeEach(() => {
     logger.error.mockClear();
     logger.warn.mockClear();
+    mockTrackServerEvent.mockClear();
     mockProjects = createMockProjectService();
     deps = {
       projects: mockProjects as any,
@@ -158,6 +172,60 @@ describe("createProjectMetadataReactor()", () => {
         id: tenantId,
         data: expect.objectContaining({ integrated: true }),
       });
+    });
+
+    it("tracks first_trace_integrated against the org admin", async () => {
+      const reactor = createProjectMetadataReactor(deps);
+      const event = createEvent(tenantId);
+      const foldState = createFoldState({
+        attributes: {
+          "sdk.language": "python",
+          "langwatch.sdk.framework": "openai",
+        },
+      });
+
+      await reactor.handle(event, createContext(tenantId, foldState));
+
+      expect(mockTrackServerEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "admin-user-1",
+        event: "first_trace_integrated",
+        properties: {
+          sdk_language: "python",
+          sdk_framework: "openai",
+        },
+        projectId: tenantId,
+      });
+    });
+
+    it("falls back to unknown sdk properties when attributes are absent", async () => {
+      const reactor = createProjectMetadataReactor(deps);
+      const event = createEvent(tenantId);
+
+      await reactor.handle(event, createContext(tenantId, createFoldState()));
+
+      expect(mockTrackServerEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: {
+            sdk_language: "unknown",
+            sdk_framework: "unknown",
+          },
+        }),
+      );
+    });
+
+    it("does not track first_trace_integrated when no admin user is found", async () => {
+      mockProjects.resolveOrgAdmin.mockResolvedValue({
+        userId: null,
+        organizationId: null,
+        firstMessage: false,
+      });
+      const reactor = createProjectMetadataReactor(deps);
+      const event = createEvent(tenantId);
+
+      await reactor.handle(event, createContext(tenantId, createFoldState()));
+
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
     });
   });
 
@@ -260,6 +328,16 @@ describe("createProjectMetadataReactor()", () => {
 
       expect(mockProjects.updateMetadata).not.toHaveBeenCalled();
     });
+
+    it("does not track first_trace_integrated again", async () => {
+      const reactor = createProjectMetadataReactor(deps);
+      const event = createEvent(tenantId);
+      const context = createContext(tenantId, createFoldState());
+
+      await reactor.handle(event, context);
+
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
+    });
   });
 
   describe("when project is not found", () => {
@@ -340,6 +418,17 @@ describe("createProjectMetadataReactor()", () => {
 
       // Must not throw
       await expect(reactor.handle(event, context)).resolves.toBeUndefined();
+    });
+
+    it("does not track first_trace_integrated for a failed write", async () => {
+      // The next trace retries the write and fires the event then.
+      const reactor = createProjectMetadataReactor(deps);
+      const event = createEvent(tenantId);
+      const context = createContext(tenantId, createFoldState());
+
+      await reactor.handle(event, context);
+
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
     });
   });
 
@@ -500,6 +589,20 @@ describe("createProjectMetadataReactor()", () => {
 
         expect(mockProjects.updateMetadata).toHaveBeenCalledTimes(1);
         expect(bootstrapTopicClustering).toHaveBeenCalledWith(tenantId);
+      });
+
+      it("does not track first_trace_integrated for the repeat write", async () => {
+        // The event is gated on the firstMessage transition, not on the
+        // metadata write: an integrated-flag repair must not re-fire it.
+        const reactor = createProjectMetadataReactor(deps);
+
+        await reactor.handle(
+          createEvent(tenantId),
+          createContext(tenantId, createFoldState()),
+        );
+
+        expect(mockProjects.updateMetadata).toHaveBeenCalledTimes(1);
+        expect(mockTrackServerEvent).not.toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -174,6 +174,7 @@ describe("createProjectMetadataReactor()", () => {
       });
     });
 
+    /** @scenario First trace tracks the PostHog integration milestone against the org admin */
     it("tracks first_trace_integrated against the org admin", async () => {
       const reactor = createProjectMetadataReactor(deps);
       const event = createEvent(tenantId);
@@ -198,6 +199,7 @@ describe("createProjectMetadataReactor()", () => {
       });
     });
 
+    /** @scenario PostHog integration milestone reports unknown when SDK attributes are absent */
     it("falls back to unknown sdk properties when attributes are absent", async () => {
       const reactor = createProjectMetadataReactor(deps);
       const event = createEvent(tenantId);
@@ -214,6 +216,7 @@ describe("createProjectMetadataReactor()", () => {
       );
     });
 
+    /** @scenario PostHog integration milestone is skipped when the project has no org admin */
     it("does not track first_trace_integrated when no admin user is found", async () => {
       mockProjects.resolveOrgAdmin.mockResolvedValue({
         userId: null,
@@ -329,6 +332,7 @@ describe("createProjectMetadataReactor()", () => {
       expect(mockProjects.updateMetadata).not.toHaveBeenCalled();
     });
 
+    /** @scenario PostHog integration milestone fires only on the firstMessage transition */
     it("does not track first_trace_integrated again", async () => {
       const reactor = createProjectMetadataReactor(deps);
       const event = createEvent(tenantId);
@@ -420,6 +424,7 @@ describe("createProjectMetadataReactor()", () => {
       await expect(reactor.handle(event, context)).resolves.toBeUndefined();
     });
 
+    /** @scenario PostHog integration milestone is not tracked when the metadata write fails */
     it("does not track first_trace_integrated for a failed write", async () => {
       // The next trace retries the write and fires the event then.
       const reactor = createProjectMetadataReactor(deps);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -53,6 +53,34 @@ function isRealFirstIngest(foldState: TraceSummaryData): boolean {
   return foldState.attributes?.["langwatch.origin"] !== "sample";
 }
 
+/**
+ * Tracks the project's first real trace as an integration milestone, against
+ * the org admin: that is the same distinct_id posthog-js identifies the user
+ * with in the browser, so this server event joins the browser person.
+ */
+async function trackFirstTraceIntegrated({
+  projects,
+  tenantId,
+  attrs,
+}: {
+  projects: ProjectService;
+  tenantId: string;
+  attrs: Record<string, string>;
+}): Promise<void> {
+  const { userId } = await projects.resolveOrgAdmin(tenantId);
+  if (!userId) return;
+
+  trackServerEvent({
+    userId,
+    event: "first_trace_integrated",
+    properties: {
+      sdk_language: attrs["sdk.language"] ?? "unknown",
+      sdk_framework: attrs["langwatch.sdk.framework"] ?? "unknown",
+    },
+    projectId: tenantId,
+  });
+}
+
 export function createProjectMetadataReactor(
   deps: ProjectMetadataReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
@@ -131,24 +159,14 @@ export function createProjectMetadataReactor(
           },
         });
 
-        // First real trace for this project: track the integration
-        // milestone against the org admin (the same distinct_id posthog-js
-        // identifies that user with in the browser). Fired after the
-        // metadata write commits so a failed write retries the event on the
-        // project's next trace instead of dropping it.
+        // Fired after the metadata write commits, so a failed write retries
+        // the event on the project's next trace instead of dropping it.
         if (!project.firstMessage) {
-          const { userId } = await deps.projects.resolveOrgAdmin(tenantId);
-          if (userId) {
-            trackServerEvent({
-              userId,
-              event: "first_trace_integrated",
-              properties: {
-                sdk_language: attrs["sdk.language"] ?? "unknown",
-                sdk_framework: attrs["langwatch.sdk.framework"] ?? "unknown",
-              },
-              projectId: tenantId,
-            });
-          }
+          await trackFirstTraceIntegrated({
+            projects: deps.projects,
+            tenantId,
+            attrs,
+          });
         }
       } catch (error) {
         logger.error(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@langwatch/observability";
 import type { ProjectService } from "~/server/app-layer/projects/project.service";
+import { trackServerEvent } from "~/server/posthog";
 import type {
   ReactorContext,
   ReactorDefinition,
@@ -33,7 +34,9 @@ export interface ProjectMetadataReactorDeps {
  * Reactor that marks the project as having received its first message.
  *
  * Sets project.firstMessage = true, project.integrated (unless optimization_studio),
- * and detects the SDK language from span resource attributes.
+ * and detects the SDK language from span resource attributes. On the
+ * firstMessage transition it also tracks the `first_trace_integrated`
+ * analytics event against the org admin.
  *
  * Uses a long dedup TTL so we only hit the database once per project in a given window.
  */
@@ -127,6 +130,26 @@ export function createProjectMetadataReactor(
             language,
           },
         });
+
+        // First real trace for this project: track the integration
+        // milestone against the org admin (the same distinct_id posthog-js
+        // identifies that user with in the browser). Fired after the
+        // metadata write commits so a failed write retries the event on the
+        // project's next trace instead of dropping it.
+        if (!project.firstMessage) {
+          const { userId } = await deps.projects.resolveOrgAdmin(tenantId);
+          if (userId) {
+            trackServerEvent({
+              userId,
+              event: "first_trace_integrated",
+              properties: {
+                sdk_language: attrs["sdk.language"] ?? "unknown",
+                sdk_framework: attrs["langwatch.sdk.framework"] ?? "unknown",
+              },
+              projectId: tenantId,
+            });
+          }
+        }
       } catch (error) {
         logger.error(
           {

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -20,12 +20,12 @@ const DEFAULT_FLAGS_POLLING_INTERVAL_MS = 5 * 60 * 1000;
 //
 // Constructing the client with local evaluation starts that background poller
 // immediately, regardless of whether any flag is ever evaluated. So the client
-// is built lazily on first use rather than at module load: a process that only
-// reads SYSTEM flags (workers, the event-sourcing pipeline — those resolve from
-// postgres and never touch PostHog) imports this module but never calls
+// is built lazily on first use rather than at module load: a process that
+// resolves only SYSTEM flags from postgres imports this module but never calls
 // getPostHogInstance, so it never starts the poller and never burns the
-// feature-flags quota. The web/API process builds it on its first PostHog flag
-// evaluation or analytics capture.
+// feature-flags quota. Each process builds it on its first PostHog flag
+// evaluation or analytics capture (the web/API process early on; the trace
+// worker only once a first-trace milestone event fires).
 //
 // `undefined` = not yet initialized, `null` = initialized with no POSTHOG_KEY.
 let _posthogInstance: PostHog | null | undefined;

--- a/specs/analytics/posthog-product-milestones.feature
+++ b/specs/analytics/posthog-product-milestones.feature
@@ -1,0 +1,125 @@
+Feature: PostHog product milestones
+  As a LangWatch operator
+  I want signup and first-integration milestones captured in PostHog with a stable identity and a narrow property set
+  So that the activation funnel is measurable without leaking anything about the user into an analytics vendor
+
+  Background:
+    Given the langwatch app captures server-side product events through trackServerEvent
+    And posthog-js identifies a browser person by the user id
+    And trackServerEvent uses that same user id as the distinct_id so both sides join
+
+  # ---------------------------------------------------------------------------
+  # signed_up — the two user-creation choke points
+  #
+  # BetterAuth creates users through its adapter, which runs the
+  # databaseHooks.user.create.after hook. The tRPC register route (email mode)
+  # inserts with Prisma directly and never reaches that adapter, so each path
+  # owns the event for the users it creates and neither can double-count.
+  #
+  # The Customer.io nurturing integration tracks its own separately named
+  # signed_up event; these scenarios are about the PostHog one.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: BetterAuth signup tracks the PostHog signed_up milestone
+    Given a new user is created through BetterAuth
+    When the after-user-create hook runs
+    Then exactly one "signed_up" PostHog event is tracked for that user id
+    And the event carries no properties
+
+  @unit
+  Scenario: PostHog signed_up still fires when the SSO auto-add path runs
+    Given a new user whose email domain matches an organization with an ssoDomain
+    When the after-user-create hook runs
+    Then exactly one "signed_up" PostHog event is tracked for that user id
+
+  @unit
+  Scenario: PostHog signed_up still fires when the email has no parsable domain
+    Given a new user whose email has no parsable domain
+    When the after-user-create hook runs
+    Then a "signed_up" PostHog event is tracked for that user id
+
+  @unit
+  Scenario: Email-mode registration tracks the PostHog signed_up milestone exactly once
+    Given the auth provider is email
+    When a registration succeeds through the register route
+    Then exactly one "signed_up" PostHog event is tracked for the created user id
+
+  @unit
+  Scenario: A rejected registration tracks no PostHog signed_up milestone
+    Given the auth provider is email
+    And a user already exists with that email
+    When the registration is attempted
+    Then no "signed_up" PostHog event is tracked
+
+  # ---------------------------------------------------------------------------
+  # Coding-agent onboarding screen instrumentation
+  #
+  # The screen renders install commands and an MCP config that EMBED the
+  # project API key, so the privacy property is not incidental: the payloads
+  # must stay fixed identifiers and never carry the copied string itself.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Copying a prompt reports the skill it came from
+    Given the coding-agent onboarding screen is on the prompt tab
+    When the user copies a skill prompt
+    Then a "copied" analytics event is emitted for object "prompt"
+    And its properties are exactly the skill id
+
+  @unit
+  Scenario: Copying a slash command reports the skill it came from
+    Given the coding-agent onboarding screen is on the skill tab
+    When the user copies a skill slash command
+    Then a "copied" analytics event is emitted for object "slash_command"
+    And its properties are exactly the skill id
+
+  @unit
+  Scenario: Copying a skill install command reports the skill it came from
+    Given the coding-agent onboarding screen is on the skill tab
+    When the user copies a skill install command
+    Then a "copied" analytics event is emitted for object "install_command"
+    And its properties are exactly the skill id
+
+  @unit
+  Scenario: Copying an agent quick command reports the agent it configures
+    Given the coding-agent onboarding screen is on the MCP tab
+    When the user copies the quick command for an agent
+    Then a "copied" analytics event is emitted for object "install_command"
+    And its properties are exactly that agent's stable id
+
+  @unit
+  Scenario: Copying the MCP config reports no further detail
+    Given the coding-agent onboarding screen is on the MCP tab
+    When the user copies the MCP config
+    Then a "copied" analytics event is emitted for object "mcp_config"
+    And the event carries no properties
+
+  @unit
+  Scenario: Copying an editor config path reports the editor
+    Given the coding-agent onboarding screen is on the MCP tab
+    When the user copies an editor's config path
+    Then a "copied" analytics event is emitted for object "config_path"
+    And its properties are exactly that editor's name
+
+  @unit
+  Scenario: Switching tabs reports the tab selected
+    Given the coding-agent onboarding screen is rendered
+    When the user switches to another tab
+    Then a "selected" analytics event is emitted for object "tab"
+    And its properties are exactly the tab key
+
+  @unit
+  Scenario: A failed copy emits no analytics event
+    Given the coding-agent onboarding screen is rendered
+    And the clipboard write fails
+    When the user attempts to copy
+    Then no analytics event is emitted
+
+  @unit
+  Scenario: No onboarding analytics payload carries the project API key
+    Given the coding-agent onboarding screen is rendered with a project API key
+    And the install commands and MCP config embed that API key
+    When the user copies every copyable element on every tab
+    Then no emitted analytics payload contains the API key
+    And no emitted analytics payload contains the copied text

--- a/specs/traces/project-metadata-onboarding.feature
+++ b/specs/traces/project-metadata-onboarding.feature
@@ -17,6 +17,48 @@ Feature: Project becomes integrated after first trace ingestion
     And project.integrated is set to true
     And project.language is detected from SDK attributes
 
+  # ---------------------------------------------------------------------------
+  # PostHog product analytics on the firstMessage transition
+  #
+  # The Customer.io nurturing integration tracks a separately named
+  # first_trace_integrated event from its own reactor; these scenarios are
+  # about the PostHog milestone fired by the projectMetadata reactor.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: First trace tracks the PostHog integration milestone against the org admin
+    Given a project with firstMessage set to false
+    When a trace is processed through the trace-processing pipeline
+    Then a "first_trace_integrated" PostHog event is tracked for the org admin user
+    And the event carries only sdk_language, sdk_framework and the project id
+
+  @unit
+  Scenario: PostHog integration milestone reports unknown when SDK attributes are absent
+    Given a project with firstMessage set to false
+    And the trace carries no sdk.language or langwatch.sdk.framework attribute
+    When a trace is processed through the trace-processing pipeline
+    Then the "first_trace_integrated" PostHog event reports both SDK properties as "unknown"
+
+  @unit
+  Scenario: PostHog integration milestone is skipped when the project has no org admin
+    Given a project with firstMessage set to false
+    And the project resolves no org admin user
+    When a trace is processed through the trace-processing pipeline
+    Then no "first_trace_integrated" PostHog event is tracked
+
+  @unit
+  Scenario: PostHog integration milestone fires only on the firstMessage transition
+    Given a project that already received its first message
+    When another trace is processed through the trace-processing pipeline
+    Then no "first_trace_integrated" PostHog event is tracked
+
+  @unit
+  Scenario: PostHog integration milestone is not tracked when the metadata write fails
+    Given a project with firstMessage set to false
+    And the project metadata write throws
+    When a trace is processed through the trace-processing pipeline
+    Then no "first_trace_integrated" PostHog event is tracked
+
   @integration @unimplemented
   Scenario: Messages page renders trace list for integrated projects
     Given a project with firstMessage = true


### PR DESCRIPTION
Closes three launch-critical PostHog gaps found in the analytics audit: signup and first-trace milestones were only reaching Customer.io, and the coding-agent onboarding screen had zero instrumentation.

## What changed

### 1. `signed_up` server event
Customer.io already receives `signed_up` from the nurturing hooks, PostHog received nothing. Now `trackServerEvent({ event: "signed_up" })` fires at both user-creation choke points, exactly once per new user:

- `afterUserCreate` (BetterAuth `databaseHooks.user.create.after`) covers every OAuth, Auth0 and BetterAuth email signup. The capture runs before the SSO early returns, so it fires for every new user, not just SSO domains.
- `user.register` tRPC mutation covers email-mode deployments, which create the user via Prisma directly and bypass the BetterAuth hooks.

The two paths are mutually exclusive per user, so there is no double fire.

### 2. `first_trace_integrated` server event
The audit pointed at `customerIoTraceSync.reactor.ts`, but that reactor is implemented and never registered (`pipelineRegistry.ts` has a TODO holding all Customer.io reactors back), so adding the capture there would ship an event that never fires. The capture went into the live first-trace choke point instead: the `projectMetadata` reactor, which flips `Project.firstMessage` on the first real trace.

- Guarded on the `!project.firstMessage` transition, so it fires exactly once per project, and never for repeat writes that only repair the `integrated` flag.
- Fired after the metadata write commits, so a failed write retries the event on the next trace instead of dropping it.
- Inherits the reactor's sample-trace guard: seeded sample traces do not count as an integration.
- Properties mirror the Customer.io event definition: `sdk_language`, `sdk_framework`, plus `projectId`.

### 3. Coding-agent onboarding screen instrumentation
`ViaClaudeCodeScreen` sits inside the existing `onboarding_product` / `via-claude-code` AnalyticsBoundary but emitted nothing. The audit described claude/codex/gemini/opencode agent tabs; the actual screen has Prompt / Skill / MCP tabs, with per-agent quick commands inside the MCP tab. Every interaction now emits, on successful copy only:

| Event (as captured in PostHog) | Properties |
|---|---|
| `onboarding_product.via-claude-code.selected.tab` | `tab`: prompt, skill, mcp |
| `onboarding_product.via-claude-code.copied.prompt` | `skill` id |
| `onboarding_product.via-claude-code.copied.install_command` | `skill` id (Skill tab) or `agent`: claude-code, codex (MCP quick setup) |
| `onboarding_product.via-claude-code.copied.slash_command` | `skill` id |
| `onboarding_product.via-claude-code.copied.mcp_config` | none |
| `onboarding_product.via-claude-code.copied.config_path` | `editor` |

`InlineCopyButton` gained an optional `onCopied` callback for this. The reused `PromptList` and `SkillList` on the traces empty state now render inside a `traces_integrate` AnalyticsBoundary so their events are namespaced on that surface too.

### Identity
All three captures use the internal user id as `distinct_id`, the same id `posthog.identify(userId)` uses client side (`usePostHogIdentify`), so server events join the browser person. `first_trace_integrated` resolves the org admin via `resolveOrgAdmin`, the same identity the Customer.io reactor uses.

One side effect worth knowing: the trace worker now builds the shared PostHog client on its first first-trace event, which starts the feature-flags local-evaluation poller in that process when `POSTHOG_FEATURE_FLAGS_KEY` is set. The stale comment in `posthog.ts` claiming workers never touch PostHog was updated.

## Tests

73 tests across the touched files, all passing (`pnpm test:unit`, no containers):

- `hooks.test.ts`: `signed_up` fires once with the user id for plain, SSO, and no-domain signups.
- `user.register.unit.test.ts` (new): `signed_up` fires once on successful registration, never when the user already exists.
- `projectMetadata.reactor.unit.test.ts`: `first_trace_integrated` fires once with the admin user id, sdk properties and projectId; falls back to `unknown` sdk values; does not fire for repeat traces, already-integrated projects, missing admins, or failed metadata writes.

`pnpm typecheck` and `pnpm typecheck:tests` are clean.

## QA evidence

Verified end to end against a local `pnpm dev` with the real PostHog project key: clicked through all three tabs and every copy affordance, watched the capture calls leave in the network panel (`POST https://eu.i.posthog.com/i/v0/e/` 200), and confirmed arrival in the PostHog project via SQL:

```
onboarding_product.via-claude-code.selected.tab            tab=prompt | skill | mcp
onboarding_product.via-claude-code.copied.prompt           skill=tracing
onboarding_product.via-claude-code.copied.install_command  skill=tracing
onboarding_product.via-claude-code.copied.slash_command    skill=tracing
onboarding_product.via-claude-code.copied.install_command  agent=claude-code
onboarding_product.via-claude-code.copied.install_command  agent=codex
onboarding_product.via-claude-code.copied.mcp_config
onboarding_product.via-claude-code.copied.config_path      editor=Cursor
```

One QA note: posthog-js drops events from automated browsers by default (`opt_out_useragent_filter`), so headless E2E runs will not pollute these metrics.

| Prompt tab | Skill tab (copy toast) | MCP tab |
|---|---|---|
| ![prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-launch-analytics/qa-onboarding-prompt-tab.png) | ![skill](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-launch-analytics/qa-onboarding-skill-tab.png) | ![mcp](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-launch-analytics/qa-onboarding-mcp-tab.png) |

## Deployment Impact

- No new environment variables, no migrations, no new infrastructure.
- Only three analytics captures: two fire-and-forget server-side `trackServerEvent` calls (`signed_up`, `first_trace_integrated`) and client-side emits on the onboarding screen.
- Events flow to the existing PostHog project through the already-configured `POSTHOG_KEY`; on deployments without it, the server captures no-op and the client provider is not registered.


## Coverage and specs

Brought up to the current bar after review. 19 scenarios, all bound via `@scenario`, and `check:feature-parity` goes from 3563 to 3582 enforced-and-bound.

**Where the scenarios live.** The first-trace milestone joins `specs/traces/project-metadata-onboarding.feature`, which already describes this reactor and previously said nothing about analytics. The signup milestone and the onboarding-screen instrumentation get `specs/analytics/posthog-product-milestones.feature`, next to the existing `posthog-cost-control.feature`. The titles all name PostHog on purpose: Customer.io already owns scenarios called "First trace fires first_trace_integrated event" and "New signup tracks signed_up event" for its own separate reactor, and the parity checker binds by title, so reusing them would have silently bound to the wrong tests.

**Server side** was already tested and is now specced: `signed_up` fires exactly once from the BetterAuth hook (including through the SSO auto-add path and with an unparsable email domain) and exactly once from the email-mode register route, and not at all on a rejected registration. `first_trace_integrated` fires on the `firstMessage` transition against the org admin, reports `unknown` for missing SDK attributes, and does not fire with no admin, on a repeat write, or after a failed metadata write.

**Frontend is newly covered.** `ViaClaudeCodeScreen.analytics.unit.test.tsx` drives all seven `emit(...)` call sites and the new `onCopied` callback through a stubbed `useAnalytics`, pinning each event name and its exact property keys, plus a negative for a failed clipboard write emitting nothing.

The case worth keeping permanently is the last one. It copies every control on every tab, first asserts the clipboard genuinely received the project API key (so the test cannot pass against an inert fixture), then asserts no analytics payload contains that key or any copied string. The quick commands and MCP config embed the key in the copied text, so the property allowlist is a privacy property, not a tidiness one, and it is now pinned rather than verified by reading.

**Deliberately not covered:** that the server `distinct_id` joins the browser person posthog-js identifies. Both sides use the user id, and a test for it would only assert that two mocks were handed the same string. Dogfooding the real PostHog project after merge proves it and a mock-heavy test does not, so it is left to that rather than papered over here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Analytics**
  - Improved tracking for onboarding actions, including copied setup commands, configuration details, and tab selections.
  - Added visibility into successful account sign-ups.
  - Added tracking for first-time project integrations to improve milestone reporting.
- **Testing**
  - Expanded automated coverage to verify signup and integration analytics across common scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
