### PR TITLE
fix(ci): correct the publish sanity check so 3.7.0 can actually ship

### DIFF
--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -218,8 +218,11 @@ jobs:
             # repo root).
             "package/feature-map.json"
             # The app's prepare step imports the skills front-matter helper
-            # (scripts/generate-langy-skills.ts) when a tree rebuilds.
-            "package/skills/_lib/frontmatter.js"
+            # (scripts/generate-langy-skills.ts) when a tree rebuilds. The
+            # source is .ts (tsx resolves the .js import specifier back to
+            # it); the tarball never ships a compiled .js, so asserting .js
+            # here always failed even on a correctly packaged tarball.
+            "package/skills/_lib/frontmatter.ts"
           )
           # Every workspace package in the checkout must ship: a missing one
           # leaves dangling pnpm links in the installed tree and the app dies
@@ -232,6 +235,13 @@ jobs:
           for pkgdir in langwatch/packages/*/ packages/*/; do
             pkgdir="${pkgdir%/}"
             [ -f "$pkgdir/package.json" ] || continue
+            # packages/server is this CLI itself, not a workspace dependency
+            # the app imports (langwatch's pnpm-workspace.yaml lists .,
+            # packages/*, ../mcp-server, ../packages/handled-error,
+            # ../packages/langy — never packages/server). Its package.json
+            # is deliberately excluded from files[]; only dist/ + templates/
+            # ship, already covered by the cli.cjs required path above.
+            [ "$pkgdir" = "packages/server" ] && continue
             required+=("package/$pkgdir/package.json")
           done
           forbidden=(


### PR DESCRIPTION
## The 3.7.0 npm publish failed

The release itself (tag `langwatch@v3.7.0`, GitHub release, aigateway binaries for all 4 platforms) published fine. The npm package did not — the workflow's own tarball completeness check failed before ever reaching `npm publish`, so `@langwatch/server` on npm is still at 3.6.0.

Two bugs in the sanity check, both introduced by me in the #6200/#6203 series:

1. **Wrong extension.** The required-paths list asserted `package/skills/_lib/frontmatter.js`, but the shipped file is `frontmatter.ts` (tsx resolves the `.js` import specifier back to the `.ts` source at runtime; the tarball never contains a compiled `.js`). This failed on every correctly packaged tarball — it's what broke this run.
2. **Latent, would have broken the next attempt.** The #6203 fix for CodeRabbit's hand-rolled-list finding made the workspace-completeness loop iterate `packages/*/` unconditionally, which also matches `packages/server` itself. But `packages/server` is the CLI's own package, not something the app imports, and its `package.json` is deliberately excluded from `files[]` (only `dist/` + `templates/` ship — already covered by the `cli.cjs` required-path check). Left alone, fixing bug 1 alone would have failed on this bug the very next run.

## Verified locally, end to end

Full production build on this branch, packed the tarball with `scripts/pack-npm.sh`, and ran the exact required/forbidden/workspace-completeness checks by hand against the real output:
- All required paths present, all forbidden paths absent
- 30MB (limit 300MB)
- Apache-2.0 LICENSE.md confirmed
- `packages/server`: 122 tests passing, typecheck clean

## After merge

The release/tag/binaries already exist — only npm needs the package. Plan is to dispatch `npx-server-publish.yml` manually against `main` (`workflow_dispatch` reads the version straight from `package.json`, no tag needed for that path), which re-packs with this fix and publishes 3.7.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package validation to correctly verify the included TypeScript source file.
  * Adjusted published package checks to handle the server package appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->