### PR TITLE
feat(gateway): a public status-page health endpoint for the AI gateway

### DIFF
--- a/charts/gateway/INSTALL-LW-DEV.md
+++ b/charts/gateway/INSTALL-LW-DEV.md
@@ -158,8 +158,9 @@ curl -sSf http://localhost:5563/readyz | jq .
 # /health: public status-page verdict, process + control-plane connectivity.
 # 200 with {"status":"ok"} when the signed probe to
 # /api/internal/gateway/health has succeeded within the last 60s; 503 with
-# {"status":"degraded"} on a sustained control-plane outage.
-curl -sSf http://localhost:5563/health | jq .
+# {"status":"degraded"} on a sustained control-plane outage. No -f here:
+# it would swallow the degraded body, which is the half worth reading.
+curl -sS http://localhost:5563/health | jq .
 
 # /v1/models — 401 without auth, 200 with a valid VK
 curl -si http://localhost:5563/v1/models
@@ -219,7 +220,7 @@ kubectl -n langwatch delete pdb gateway-smoke-langwatch-gateway --ignore-not-fou
 - **ImagePullBackOff**: EKS node role needs ECR pull permission. The `lw-dev` cluster's node role already has `AmazonEC2ContainerRegistryReadOnly` attached; if a new node group lacks it, `kubectl describe pod` will show the auth error and the fix is to extend the role policy.
 - **CrashLoopBackOff with `LW_GATEWAY_INTERNAL_SECRET is required`**: step 2 secret is missing or the env var key in the Secret doesn't match `secrets.internalSecretKey` (default `LW_GATEWAY_INTERNAL_SECRET`).
 - **401 `invalid_api_key` on every /v1/* request**: INTERNAL_SECRET on the gateway side doesn't match the control plane's. Re-run step 2 and roll both deploys.
-- **503 on `/health` with `control_plane: unreachable for Ns`**: the gateway's background probe can't reach the app's `/api/internal/gateway/health` (or the shared INTERNAL_SECRET mismatches, which 401s the probe). Check `kubectl -n langwatch get svc` shows the app Service the ConfigMap's control-plane URL points at, and see the `statusprobe_control_plane_unreachable` log line for the real dial error. `/readyz` stays 200 through this on purpose: pulling pods from the LB on a control-plane blip would kill the warm-cache traffic that still serves fine.
+- **503 on `/health` with `control_plane: unreachable for Ns`**: the gateway's background probe can't reach the app's `/api/internal/gateway/health` (or the shared INTERNAL_SECRET mismatches, which 401s the probe). Check `kubectl -n langwatch get svc` shows the app Service the ConfigMap's control-plane URL points at, and see the `statusprobe_control_plane_unreachable` log line for the underlying probe failure. `/readyz` stays 200 through this on purpose: pulling pods from the LB on a control-plane blip would kill the warm-cache traffic that still serves fine.
 
 ## Not covered
 

--- a/charts/gateway/INSTALL-LW-DEV.md
+++ b/charts/gateway/INSTALL-LW-DEV.md
@@ -152,10 +152,10 @@ curl -sSf http://localhost:5563/healthz | jq .
 # /startupz — 200 once MarkStarted; 503 before
 curl -sSf http://localhost:5563/startupz | jq .
 
-# /readyz — 200 unless the pod is draining (deliberately dependency-free)
+# /readyz: 200 unless the pod is draining (deliberately dependency-free)
 curl -sSf http://localhost:5563/readyz | jq .
 
-# /health — public status-page verdict: process + control-plane connectivity.
+# /health: public status-page verdict, process + control-plane connectivity.
 # 200 with {"status":"ok"} when the signed probe to
 # /api/internal/gateway/health has succeeded within the last 60s; 503 with
 # {"status":"degraded"} on a sustained control-plane outage.

--- a/charts/gateway/INSTALL-LW-DEV.md
+++ b/charts/gateway/INSTALL-LW-DEV.md
@@ -152,9 +152,14 @@ curl -sSf http://localhost:5563/healthz | jq .
 # /startupz — 200 once MarkStarted; 503 before
 curl -sSf http://localhost:5563/startupz | jq .
 
-# /readyz — 200 only when all registered readiness checks pass
+# /readyz — 200 unless the pod is draining (deliberately dependency-free)
 curl -sSf http://localhost:5563/readyz | jq .
-# → Note: `auth_cache_warm` will be failing until at least one VK resolves
+
+# /health — public status-page verdict: process + control-plane connectivity.
+# 200 with {"status":"ok"} when the signed probe to
+# /api/internal/gateway/health has succeeded within the last 60s; 503 with
+# {"status":"degraded"} on a sustained control-plane outage.
+curl -sSf http://localhost:5563/health | jq .
 
 # /v1/models — 401 without auth, 200 with a valid VK
 curl -si http://localhost:5563/v1/models
@@ -214,8 +219,7 @@ kubectl -n langwatch delete pdb gateway-smoke-langwatch-gateway --ignore-not-fou
 - **ImagePullBackOff**: EKS node role needs ECR pull permission. The `lw-dev` cluster's node role already has `AmazonEC2ContainerRegistryReadOnly` attached; if a new node group lacks it, `kubectl describe pod` will show the auth error and the fix is to extend the role policy.
 - **CrashLoopBackOff with `LW_GATEWAY_INTERNAL_SECRET is required`**: step 2 secret is missing or the env var key in the Secret doesn't match `secrets.internalSecretKey` (default `LW_GATEWAY_INTERNAL_SECRET`).
 - **401 `invalid_api_key` on every /v1/* request**: INTERNAL_SECRET on the gateway side doesn't match the control plane's. Re-run step 2 and roll both deploys.
-- **503 on `/readyz` with `auth_cache_warm: cache has not observed any revision yet`**: normal until the first VK resolves. Hit `/v1/models` once with a valid VK.
-- **503 on `/readyz` with `control_plane_reachable`**: the gateway can't reach `http://langwatch-app:5560/api/internal/gateway/health`. Check `kubectl -n langwatch get svc langwatch-app` is on `:5560`. NetworkPolicy off by default so this shouldn't be kube-level.
+- **503 on `/health` with `control_plane: unreachable for Ns`**: the gateway's background probe can't reach the app's `/api/internal/gateway/health` (or the shared INTERNAL_SECRET mismatches, which 401s the probe). Check `kubectl -n langwatch get svc` shows the app Service the ConfigMap's control-plane URL points at, and see the `statusprobe_control_plane_unreachable` log line for the real dial error. `/readyz` stays 200 through this on purpose: pulling pods from the LB on a control-plane blip would kill the warm-cache traffic that still serves fine.
 
 ## Not covered
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -98,6 +98,18 @@ listener (port `5563`, named `http`):
 Response shape and tuning are documented in
 [Health Checks](https://docs.langwatch.ai/ai-gateway/self-hosting/health-checks).
 
+## Status-page endpoint
+
+`GET /health` (also `HEAD`) is the public status-page surface, exposed
+through the ingress as an Exact path when `ingress.healthPath.enabled`
+(default `true`); point an uptime monitor at `https://<ingress.host>/health`.
+It reports the gateway process plus the control-plane connectivity
+verdict that a background probe refreshes every 15 s over the signed
+internal channel: HTTP 200 healthy, 503 once the control plane has been
+unreachable for over 60 s. It never contacts a model provider, so an
+OpenAI or Anthropic outage cannot turn it red, and a poll never fans
+out anywhere. Distinct from the k8s probes above, which stay in-cluster.
+
 ## Streaming / SSE
 
 The default ingress annotations (`charts/gateway/values.yaml: ingress.annotations`)

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -27,8 +27,10 @@ spec:
                   number: {{ .Values.service.port }}
           {{- if and .Values.ingress.healthPath .Values.ingress.healthPath.enabled }}
           {{- /*
-            Status-page health endpoint. Exact so only GET/HEAD /health
-            is public; the k8s probes and /metrics stay in-cluster.
+            Status-page health endpoint. Exact publishes this one path and
+            nothing else, so the k8s probes, /metrics and /internal stay
+            in-cluster. It does not bound the method: the gateway route
+            registers only GET and HEAD, and chi answers 405 otherwise.
           */}}
           - path: {{ .Values.ingress.healthPath.path }}
             pathType: Exact

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
                 name: {{ include "gateway.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
-          {{- if .Values.ingress.healthPath.enabled }}
+          {{- if and .Values.ingress.healthPath .Values.ingress.healthPath.enabled }}
           {{- /*
             Status-page health endpoint. Exact so only GET/HEAD /health
             is public; the k8s probes and /metrics stay in-cluster.

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -25,4 +25,17 @@ spec:
                 name: {{ include "gateway.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
+          {{- if .Values.ingress.healthPath.enabled }}
+          {{- /*
+            Status-page health endpoint. Exact so only GET/HEAD /health
+            is public; the k8s probes and /metrics stay in-cluster.
+          */}}
+          - path: {{ .Values.ingress.healthPath.path }}
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "gateway.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+          {{- end }}
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -57,8 +57,10 @@ ingress:
   host: gateway.langwatch.ai
   path: /v1
   pathType: Prefix
-  # Public status-page surface. Exposes exactly GET/HEAD /health (Exact
-  # match, so /healthz, /readyz, /metrics and /internal stay in-cluster).
+  # Public status-page surface. An Exact match publishes this one path and
+  # nothing else, so /healthz, /readyz, /metrics and /internal stay
+  # in-cluster. Methods are bounded by the gateway route, which serves GET
+  # and HEAD and answers 405 otherwise, not by the ingress.
   # The endpoint is unauthenticated by design: it reports the gateway
   # process plus the control-plane connectivity verdict cached by a
   # background probe, returns no tenant data, makes no upstream call per

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -57,6 +57,16 @@ ingress:
   host: gateway.langwatch.ai
   path: /v1
   pathType: Prefix
+  # Public status-page surface. Exposes exactly GET/HEAD /health (Exact
+  # match, so /healthz, /readyz, /metrics and /internal stay in-cluster).
+  # The endpoint is unauthenticated by design: it reports the gateway
+  # process plus the control-plane connectivity verdict cached by a
+  # background probe, returns no tenant data, makes no upstream call per
+  # poll, and can never go red from a model-provider outage. Point the
+  # status-page HTTP monitor at https://<ingress.host>/health.
+  healthPath:
+    enabled: true
+    path: /health
   tls:
     enabled: true
     secretName: gateway-tls

--- a/docs/ai-gateway/self-hosting/health-checks.mdx
+++ b/docs/ai-gateway/self-hosting/health-checks.mdx
@@ -1,21 +1,24 @@
 ---
 title: Health Checks
-description: Liveness, readiness, and startup probes for the LangWatch AI Gateway.
+description: Kubernetes probes and the public status endpoint for the LangWatch AI Gateway.
 sidebarTitle: Health Checks
 ---
 
-The gateway exposes three HTTP endpoints for Kubernetes probes, all on the same port the API listens on (`5563` by default, referenced as the named container port `http` in the chart). Each is deliberately scoped, `/readyz` flipping to 503 must mean "this replica should not serve customer traffic right now", and nothing more.
+The gateway exposes three HTTP endpoints for Kubernetes probes plus one public status endpoint, all on the same port the API listens on (`5563` by default, referenced as the named container port `http` in the chart). Each is deliberately scoped, `/readyz` flipping to 503 must mean "this replica should not serve customer traffic right now", and nothing more.
 
 ## Endpoint summary
 
 | Endpoint   | Used by                                | Returns 200 when                                                    |
 |------------|----------------------------------------|---------------------------------------------------------------------|
 | `/healthz` | Kubernetes `livenessProbe`             | The Go process is responsive (no registered checks fail)            |
-| `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining and all readiness checks pass               |
-| `/startupz`| Kubernetes `startupProbe`              | Bootstrap (auth-cache warm-up) has completed, then mirrors `/readyz`|
+| `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining                                             |
+| `/startupz`| Kubernetes `startupProbe`              | Startup is marked complete, then mirrors `/readyz`                  |
+| `/health`  | Your status page / uptime monitor      | The process is up and the control plane is reachable                |
 | `/metrics` | Prometheus                              | Always, counter + histogram surface (see [Observability](/ai-gateway/observability)) |
 
-All three return the same JSON shape:
+The three probes are in-cluster signals. `/health` is the one meant to be reachable from outside; the chart publishes it through the ingress and leaves the rest internal.
+
+The three probes return the same JSON shape:
 
 ```json
 {
@@ -26,7 +29,7 @@ All three return the same JSON shape:
 }
 ```
 
-`checks` is omitted when there are no registered checks AND the status is `ok`. Today the gateway registers `MarkStarted` (after the auth-cache bootstrap completes) and `MarkDraining` (on `SIGTERM`), but no per-dependency liveness or readiness checks, the probes are intentionally lightweight signals about process state and lifecycle, not external-dependency health. Dependency health is reported via per-request error codes and the OTel trace surface, not the probes.
+`checks` is omitted when there are no registered checks AND the status is `ok`. The gateway registers `MarkStarted` (at boot) and `MarkDraining` (on `SIGTERM`), but no per-dependency liveness or readiness checks. The probes are intentionally lightweight signals about process state and lifecycle, not external-dependency health. Dependency health is reported on `/health`, per-request error codes, and the OTel trace surface, never on the probes.
 
 ## `/healthz` (liveness)
 
@@ -77,10 +80,11 @@ readinessProbe:
 ### What `/readyz` does NOT check
 
 - **Per-provider live health.** If OpenAI is rate-limiting, the gateway still serves and falls back per the VK's configured chain. Reporting `not_ready` for one upstream would amplify the incident.
+- **The control plane.** A control-plane blip is a degradation the auth cache is built to absorb: warm keys keep serving from the in-process cache. Failing readiness on it would drop every replica from the load balancer at once and turn that degradation into a total outage. Control-plane reachability is reported on `/health` instead, where it informs a status page rather than gating traffic.
 - **Redis L2.** The current gateway has no Redis client; the auth cache is in-process LRU.
 - **PostgreSQL.** The gateway never talks to Postgres directly; the control plane mediates persistence.
 
-The blast-radius of readiness is specifically: "is this pod still meant to serve traffic?", and the only conditions today are `MarkDraining` and (transitively, via `/startupz` mirroring `/readyz` once started) the auth-cache bootstrap.
+The blast-radius of readiness is specifically: "is this pod still meant to serve traffic?", and the only condition today is `MarkDraining`.
 
 ## `/startupz` (startup)
 
@@ -94,7 +98,7 @@ GET /startupz
 { "status": "ok", "version": "git-a1412a4", "uptime_s": 12.48 }
 ```
 
-The bootstrap step is the auth-cache warm-up: the gateway calls the control plane's `/api/internal/gateway/keys/changes` once on boot to fill the L1 cache before taking traffic. Tenants with 50K+ virtual keys take 2–3 seconds; the failure threshold gives ~60 s of room before the kubelet declares the pod failed and restarts it (chart default `failureThreshold: 30 × periodSeconds: 2 = 60 s` of bootstrap time).
+There is no blocking bootstrap step today: the gateway marks itself started as soon as its dependencies are constructed, so `/startupz` goes 200 within the first probe interval and the `starting` state is only ever observed if the process dies during construction. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
 
 ```yaml
 startupProbe:
@@ -105,6 +109,53 @@ startupProbe:
 ```
 
 Once `/startupz` first returns 200, Kubernetes stops calling it; readiness + liveness take over.
+
+## `/health` (public status endpoint)
+
+This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` is answered identically to `GET`, and responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict.
+
+```
+GET /health
+→ 200 OK
+{ "status": "ok", "checks": { "gateway": "ok", "control_plane": "ok" } }
+```
+
+```
+GET /health
+→ 503 Service Unavailable
+{ "status": "degraded", "checks": { "gateway": "ok", "control_plane": "unreachable for 65s" } }
+```
+
+The body is deliberately smaller than the probes': no `version`, no `uptime_s`. This endpoint is polled by the public internet, and restart cadence and build identity are not something to publish.
+
+### What it covers, and what it never will
+
+The verdict covers the gateway process and the dependencies you own: the control plane. It is structurally independent of model providers.
+
+- **A provider outage cannot turn it red.** Nothing on the verdict path reads dispatch state, so if OpenAI and Anthropic are both down, completions fail while `/health` stays 200. That is the providers' status page's news, not yours, and a gateway that goes red on someone else's outage trains people to ignore the page.
+- **A poll never triggers an upstream call.** A background monitor probes the control plane every 15 s and `/health` serves the cached verdict, so poll rate and control-plane load are unrelated. On an unauthenticated public endpoint, fanning out per poll would be an amplification and cost bug.
+
+### Control-plane semantics
+
+The monitor probes the control plane's `/api/internal/gateway/health` over the same HMAC-signed internal channel every request uses. That is the point of the design: a 200 proves DNS, TCP/TLS, the app being up, **and** the shared `LW_GATEWAY_INTERNAL_SECRET` matching. A mismatched secret is the misconfiguration where every pod looks green while every virtual-key resolve is refused, and this is the only signal that catches it.
+
+Unreachability shorter than 60 s stays 200: warm keys keep serving from the auth cache through a blip, and a page that flaps on what customers cannot feel is worse than no page. Past 60 s, cold-cache requests are failing with `auth_upstream_unavailable` and the page should say so. A booting pod is given one full 60 s window before it can report red, so a rolling deploy never blinks the page.
+
+Because the tolerance is 60 s and the probe interval is 15 s, a monitor polling every 30 to 60 s sees a sustained outage within about two minutes of onset.
+
+### Exposure
+
+The chart publishes exactly this one path through the ingress, as an `Exact` match, so `/healthz`, `/readyz`, `/startupz`, `/metrics` and `/internal` stay in-cluster:
+
+```yaml
+ingress:
+  host: gateway.your-corp.com
+  healthPath:
+    enabled: true   # default
+    path: /health
+```
+
+Point the monitor at `https://gateway.your-corp.com/health`. Set `ingress.healthPath.enabled: false` if you would rather not publish it at all; the endpoint still answers in-cluster.
 
 ## Graceful shutdown
 
@@ -131,7 +182,7 @@ lifecycle:
 
 ## End-to-end synthetic check
 
-`/readyz` validates lifecycle state but not the request path. For real-traffic confidence, run a synthetic completion every 30 s:
+Neither the probes nor `/health` exercise the request path, and `/health` will not tell you a provider is down, on purpose. For real-traffic confidence, run a synthetic completion every 30 s. Keep it on an internal alert rather than on the public status page, so a provider incident does not read as a LangWatch incident:
 
 ```bash
 curl --fail --max-time 5 \
@@ -153,6 +204,7 @@ On alert:
 | Symptom                                                         | Likely cause                                           | First step                                                         |
 |-----------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------------------|
 | `/healthz` 200, `/v1/chat/completions` returns 500 `auth_upstream_unavailable` | Gateway can't reach control plane (`LW_GATEWAY_BASE_URL` wrong/missing) | Check the env var on the pod; confirm Service, DNS resolves       |
-| `/startupz` fails 30× in a row, pod CrashLoopBackOff             | Control plane unreachable on boot, or auth secret mismatch | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods |
+| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the real dial error |
+| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Nothing to do on the gateway; fix the control plane. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
 | `/readyz` flips to 503 mid-life                                  | Pod received `SIGTERM` (rolling deploy, eviction, OOMKill) | `kubectl describe pod` for the termination reason                   |
 | 502 from LB for a small window during rolling deploy             | LB hasn't yet removed the draining replica             | Add a `preStop: sleep 3` lifecycle hook (see Graceful shutdown above) |

--- a/docs/ai-gateway/self-hosting/health-checks.mdx
+++ b/docs/ai-gateway/self-hosting/health-checks.mdx
@@ -13,7 +13,7 @@ The gateway exposes three HTTP endpoints for Kubernetes probes plus one public s
 | `/healthz` | Kubernetes `livenessProbe`             | The Go process is responsive (no registered checks fail)            |
 | `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining                                             |
 | `/startupz`| Kubernetes `startupProbe`              | Startup is marked complete, then mirrors `/readyz`                  |
-| `/health`  | Your status page / uptime monitor      | The process is up and the control plane is reachable                |
+| `/health`  | Your status page / uptime monitor      | The process is up and the control plane has answered within the last 60s |
 | `/metrics` | Prometheus                              | Always, counter + histogram surface (see [Observability](/ai-gateway/observability)) |
 
 The three probes are in-cluster signals. `/health` is the one meant to be reachable from outside; the chart publishes it through the ingress and leaves the rest internal.

--- a/docs/ai-gateway/self-hosting/health-checks.mdx
+++ b/docs/ai-gateway/self-hosting/health-checks.mdx
@@ -98,7 +98,7 @@ GET /startupz
 { "status": "ok", "version": "git-a1412a4", "uptime_s": 12.48 }
 ```
 
-There is no blocking bootstrap step today: the gateway marks itself started as soon as its dependencies are constructed, so `/startupz` goes 200 within the first probe interval and the `starting` state is only ever observed if the process dies during construction. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
+There is no blocking bootstrap step today: `MarkStarted` is called while dependencies are being constructed, which finishes before the HTTP listener opens, so `/startupz` is already 200 on the first request it can possibly receive and the `starting` state is unobservable over HTTP. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
 
 ```yaml
 startupProbe:
@@ -112,7 +112,7 @@ Once `/startupz` first returns 200, Kubernetes stops calling it; readiness + liv
 
 ## `/health` (public status endpoint)
 
-This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` is answered identically to `GET`, and responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict.
+This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` returns the same status and headers with no body, as HTTP requires, so a monitor that probes with `HEAD` reads the same verdict. Responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict. Any other method is 405: the ingress publishes the path, the gateway bounds the methods.
 
 ```
 GET /health
@@ -204,7 +204,7 @@ On alert:
 | Symptom                                                         | Likely cause                                           | First step                                                         |
 |-----------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------------------|
 | `/healthz` 200, `/v1/chat/completions` returns 500 `auth_upstream_unavailable` | Gateway can't reach control plane (`LW_GATEWAY_BASE_URL` wrong/missing) | Check the env var on the pod; confirm Service, DNS resolves       |
-| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the real dial error |
-| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Nothing to do on the gateway; fix the control plane. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
+| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the underlying probe failure |
+| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Confirm it is a real outage and not a secret mismatch (row above, which reads identically), then fix whichever side is wrong. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
 | `/readyz` flips to 503 mid-life                                  | Pod received `SIGTERM` (rolling deploy, eviction, OOMKill) | `kubectl describe pod` for the termination reason                   |
 | 502 from LB for a small window during rolling deploy             | LB hasn't yet removed the draining replica             | Add a `preStop: sleep 3` lifecycle hook (see Graceful shutdown above) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10645,7 +10645,7 @@ The gateway exposes three HTTP endpoints for Kubernetes probes plus one public s
 | `/healthz` | Kubernetes `livenessProbe`             | The Go process is responsive (no registered checks fail)            |
 | `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining                                             |
 | `/startupz`| Kubernetes `startupProbe`              | Startup is marked complete, then mirrors `/readyz`                  |
-| `/health`  | Your status page / uptime monitor      | The process is up and the control plane is reachable                |
+| `/health`  | Your status page / uptime monitor      | The process is up and the control plane has answered within the last 60s |
 | `/metrics` | Prometheus                              | Always, counter + histogram surface (see [Observability](/ai-gateway/observability)) |
 
 The three probes are in-cluster signals. `/health` is the one meant to be reachable from outside; the chart publishes it through the ingress and leaves the rest internal.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10632,22 +10632,25 @@ The last call traces end-to-end through auth, blocked-pattern enforcement, budge
 
 ---
 title: Health Checks
-description: Liveness, readiness, and startup probes for the LangWatch AI Gateway.
+description: Kubernetes probes and the public status endpoint for the LangWatch AI Gateway.
 sidebarTitle: Health Checks
 ---
 
-The gateway exposes three HTTP endpoints for Kubernetes probes, all on the same port the API listens on (`5563` by default, referenced as the named container port `http` in the chart). Each is deliberately scoped, `/readyz` flipping to 503 must mean "this replica should not serve customer traffic right now", and nothing more.
+The gateway exposes three HTTP endpoints for Kubernetes probes plus one public status endpoint, all on the same port the API listens on (`5563` by default, referenced as the named container port `http` in the chart). Each is deliberately scoped, `/readyz` flipping to 503 must mean "this replica should not serve customer traffic right now", and nothing more.
 
 ## Endpoint summary
 
 | Endpoint   | Used by                                | Returns 200 when                                                    |
 |------------|----------------------------------------|---------------------------------------------------------------------|
 | `/healthz` | Kubernetes `livenessProbe`             | The Go process is responsive (no registered checks fail)            |
-| `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining and all readiness checks pass               |
-| `/startupz`| Kubernetes `startupProbe`              | Bootstrap (auth-cache warm-up) has completed, then mirrors `/readyz`|
+| `/readyz`  | Kubernetes `readinessProbe` + LB       | The pod is not draining                                             |
+| `/startupz`| Kubernetes `startupProbe`              | Startup is marked complete, then mirrors `/readyz`                  |
+| `/health`  | Your status page / uptime monitor      | The process is up and the control plane is reachable                |
 | `/metrics` | Prometheus                              | Always, counter + histogram surface (see [Observability](/ai-gateway/observability)) |
 
-All three return the same JSON shape:
+The three probes are in-cluster signals. `/health` is the one meant to be reachable from outside; the chart publishes it through the ingress and leaves the rest internal.
+
+The three probes return the same JSON shape:
 
 ```json
 {
@@ -10658,7 +10661,7 @@ All three return the same JSON shape:
 }
 ```
 
-`checks` is omitted when there are no registered checks AND the status is `ok`. Today the gateway registers `MarkStarted` (after the auth-cache bootstrap completes) and `MarkDraining` (on `SIGTERM`), but no per-dependency liveness or readiness checks, the probes are intentionally lightweight signals about process state and lifecycle, not external-dependency health. Dependency health is reported via per-request error codes and the OTel trace surface, not the probes.
+`checks` is omitted when there are no registered checks AND the status is `ok`. The gateway registers `MarkStarted` (at boot) and `MarkDraining` (on `SIGTERM`), but no per-dependency liveness or readiness checks. The probes are intentionally lightweight signals about process state and lifecycle, not external-dependency health. Dependency health is reported on `/health`, per-request error codes, and the OTel trace surface, never on the probes.
 
 ## `/healthz` (liveness)
 
@@ -10709,10 +10712,11 @@ readinessProbe:
 ### What `/readyz` does NOT check
 
 - **Per-provider live health.** If OpenAI is rate-limiting, the gateway still serves and falls back per the VK's configured chain. Reporting `not_ready` for one upstream would amplify the incident.
+- **The control plane.** A control-plane blip is a degradation the auth cache is built to absorb: warm keys keep serving from the in-process cache. Failing readiness on it would drop every replica from the load balancer at once and turn that degradation into a total outage. Control-plane reachability is reported on `/health` instead, where it informs a status page rather than gating traffic.
 - **Redis L2.** The current gateway has no Redis client; the auth cache is in-process LRU.
 - **PostgreSQL.** The gateway never talks to Postgres directly; the control plane mediates persistence.
 
-The blast-radius of readiness is specifically: "is this pod still meant to serve traffic?", and the only conditions today are `MarkDraining` and (transitively, via `/startupz` mirroring `/readyz` once started) the auth-cache bootstrap.
+The blast-radius of readiness is specifically: "is this pod still meant to serve traffic?", and the only condition today is `MarkDraining`.
 
 ## `/startupz` (startup)
 
@@ -10726,7 +10730,7 @@ GET /startupz
 { "status": "ok", "version": "git-a1412a4", "uptime_s": 12.48 }
 ```
 
-The bootstrap step is the auth-cache warm-up: the gateway calls the control plane's `/api/internal/gateway/keys/changes` once on boot to fill the L1 cache before taking traffic. Tenants with 50K+ virtual keys take 2–3 seconds; the failure threshold gives ~60 s of room before the kubelet declares the pod failed and restarts it (chart default `failureThreshold: 30 × periodSeconds: 2 = 60 s` of bootstrap time).
+There is no blocking bootstrap step today: the gateway marks itself started as soon as its dependencies are constructed, so `/startupz` goes 200 within the first probe interval and the `starting` state is only ever observed if the process dies during construction. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
 
 ```yaml
 startupProbe:
@@ -10737,6 +10741,53 @@ startupProbe:
 ```
 
 Once `/startupz` first returns 200, Kubernetes stops calling it; readiness + liveness take over.
+
+## `/health` (public status endpoint)
+
+This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` is answered identically to `GET`, and responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict.
+
+```
+GET /health
+→ 200 OK
+{ "status": "ok", "checks": { "gateway": "ok", "control_plane": "ok" } }
+```
+
+```
+GET /health
+→ 503 Service Unavailable
+{ "status": "degraded", "checks": { "gateway": "ok", "control_plane": "unreachable for 65s" } }
+```
+
+The body is deliberately smaller than the probes': no `version`, no `uptime_s`. This endpoint is polled by the public internet, and restart cadence and build identity are not something to publish.
+
+### What it covers, and what it never will
+
+The verdict covers the gateway process and the dependencies you own: the control plane. It is structurally independent of model providers.
+
+- **A provider outage cannot turn it red.** Nothing on the verdict path reads dispatch state, so if OpenAI and Anthropic are both down, completions fail while `/health` stays 200. That is the providers' status page's news, not yours, and a gateway that goes red on someone else's outage trains people to ignore the page.
+- **A poll never triggers an upstream call.** A background monitor probes the control plane every 15 s and `/health` serves the cached verdict, so poll rate and control-plane load are unrelated. On an unauthenticated public endpoint, fanning out per poll would be an amplification and cost bug.
+
+### Control-plane semantics
+
+The monitor probes the control plane's `/api/internal/gateway/health` over the same HMAC-signed internal channel every request uses. That is the point of the design: a 200 proves DNS, TCP/TLS, the app being up, **and** the shared `LW_GATEWAY_INTERNAL_SECRET` matching. A mismatched secret is the misconfiguration where every pod looks green while every virtual-key resolve is refused, and this is the only signal that catches it.
+
+Unreachability shorter than 60 s stays 200: warm keys keep serving from the auth cache through a blip, and a page that flaps on what customers cannot feel is worse than no page. Past 60 s, cold-cache requests are failing with `auth_upstream_unavailable` and the page should say so. A booting pod is given one full 60 s window before it can report red, so a rolling deploy never blinks the page.
+
+Because the tolerance is 60 s and the probe interval is 15 s, a monitor polling every 30 to 60 s sees a sustained outage within about two minutes of onset.
+
+### Exposure
+
+The chart publishes exactly this one path through the ingress, as an `Exact` match, so `/healthz`, `/readyz`, `/startupz`, `/metrics` and `/internal` stay in-cluster:
+
+```yaml
+ingress:
+  host: gateway.your-corp.com
+  healthPath:
+    enabled: true   # default
+    path: /health
+```
+
+Point the monitor at `https://gateway.your-corp.com/health`. Set `ingress.healthPath.enabled: false` if you would rather not publish it at all; the endpoint still answers in-cluster.
 
 ## Graceful shutdown
 
@@ -10763,7 +10814,7 @@ lifecycle:
 
 ## End-to-end synthetic check
 
-`/readyz` validates lifecycle state but not the request path. For real-traffic confidence, run a synthetic completion every 30 s:
+Neither the probes nor `/health` exercise the request path, and `/health` will not tell you a provider is down, on purpose. For real-traffic confidence, run a synthetic completion every 30 s. Keep it on an internal alert rather than on the public status page, so a provider incident does not read as a LangWatch incident:
 
 ```bash
 curl --fail --max-time 5 \
@@ -10785,7 +10836,8 @@ On alert:
 | Symptom                                                         | Likely cause                                           | First step                                                         |
 |-----------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------------------|
 | `/healthz` 200, `/v1/chat/completions` returns 500 `auth_upstream_unavailable` | Gateway can't reach control plane (`LW_GATEWAY_BASE_URL` wrong/missing) | Check the env var on the pod; confirm Service, DNS resolves       |
-| `/startupz` fails 30× in a row, pod CrashLoopBackOff             | Control plane unreachable on boot, or auth secret mismatch | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods |
+| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the real dial error |
+| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Nothing to do on the gateway; fix the control plane. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
 | `/readyz` flips to 503 mid-life                                  | Pod received `SIGTERM` (rolling deploy, eviction, OOMKill) | `kubectl describe pod` for the termination reason                   |
 | 502 from LB for a small window during rolling deploy             | LB hasn't yet removed the draining replica             | Add a `preStop: sleep 3` lifecycle hook (see Graceful shutdown above) |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10730,7 +10730,7 @@ GET /startupz
 { "status": "ok", "version": "git-a1412a4", "uptime_s": 12.48 }
 ```
 
-There is no blocking bootstrap step today: the gateway marks itself started as soon as its dependencies are constructed, so `/startupz` goes 200 within the first probe interval and the `starting` state is only ever observed if the process dies during construction. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
+There is no blocking bootstrap step today: `MarkStarted` is called while dependencies are being constructed, which finishes before the HTTP listener opens, so `/startupz` is already 200 on the first request it can possibly receive and the `starting` state is unobservable over HTTP. The auth cache warms organically on the first request per virtual key; an unwarmed gateway costs a cold-cache request one extra control-plane round trip, which is the correct behavior for a fresh deployment. The chart's generous failure threshold is headroom kept for a future bootstrap-pull, not a window the gateway currently uses.
 
 ```yaml
 startupProbe:
@@ -10744,7 +10744,7 @@ Once `/startupz` first returns 200, Kubernetes stops calling it; readiness + liv
 
 ## `/health` (public status endpoint)
 
-This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` is answered identically to `GET`, and responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict.
+This is the endpoint to point a status page or uptime monitor at. Plain HTTP monitor semantics: 200 healthy, 503 not. `HEAD` returns the same status and headers with no body, as HTTP requires, so a monitor that probes with `HEAD` reads the same verdict. Responses carry `Cache-Control: no-store` so a CDN cannot serve a stale verdict. Any other method is 405: the ingress publishes the path, the gateway bounds the methods.
 
 ```
 GET /health
@@ -10836,8 +10836,8 @@ On alert:
 | Symptom                                                         | Likely cause                                           | First step                                                         |
 |-----------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------------------|
 | `/healthz` 200, `/v1/chat/completions` returns 500 `auth_upstream_unavailable` | Gateway can't reach control plane (`LW_GATEWAY_BASE_URL` wrong/missing) | Check the env var on the pod; confirm Service, DNS resolves       |
-| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the real dial error |
-| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Nothing to do on the gateway; fix the control plane. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
+| `/health` 503 with `control_plane: unreachable for Ns`           | Control plane down, unroutable, or the shared internal secret does not match (a mismatch 401s the probe and reads the same) | Compare `LW_GATEWAY_INTERNAL_SECRET` byte-for-byte between gateway and control-plane pods, then check the Service and DNS. The `statusprobe_control_plane_unreachable` log line carries the underlying probe failure |
+| `/health` 503 while completions still succeed                    | Expected during a control-plane outage longer than 60 s: warm keys keep serving from the auth cache, cold ones do not | Confirm it is a real outage and not a secret mismatch (row above, which reads identically), then fix whichever side is wrong. `/readyz` stays 200 on purpose so warm traffic keeps flowing |
 | `/readyz` flips to 503 mid-life                                  | Pod received `SIGTERM` (rolling deploy, eviction, OOMKill) | `kubectl describe pod` for the termination reason                   |
 | 502 from LB for a small window during rolling deploy             | LB hasn't yet removed the draining replica             | Add a `preStop: sleep 3` lifecycle hook (see Graceful shutdown above) |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -436,7 +436,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Post-install checklist](https://langwatch.ai/docs/ai-gateway/self-hosting/post-install-checklist.md): What to do after `helm install` to get personal keys, the AI Gateway, and the unified `langwatch` CLI working end-to-end.
 - [Config](https://langwatch.ai/docs/ai-gateway/self-hosting/config.md): Environment variables and configuration for self-hosted LangWatch AI Gateway deployments.
 - [DNS and TLS](https://langwatch.ai/docs/ai-gateway/self-hosting/dns-and-tls.md): Point a public hostname at the AI Gateway, AWS ELB, NLB + Cloudflare + cert-manager.
-- [Health Checks](https://langwatch.ai/docs/ai-gateway/self-hosting/health-checks.md): Liveness, readiness, and startup probes for the LangWatch AI Gateway.
+- [Health Checks](https://langwatch.ai/docs/ai-gateway/self-hosting/health-checks.md): Kubernetes probes and the public status endpoint for the LangWatch AI Gateway.
 - [Scaling](https://langwatch.ai/docs/ai-gateway/self-hosting/scaling.md): Horizontal scaling, autoscaling, capacity, and benchmarks for the LangWatch AI Gateway.
 
 ## Cookbooks

--- a/langwatch/src/server/routes/__tests__/gateway-internal.health-route.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/gateway-internal.health-route.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment node
+ *
+ * GET /api/internal/gateway/health is the control-plane half of the
+ * gateway's status-page health endpoint. The Go gateway's statusprobe
+ * monitor calls this on its own clock and serves the cached verdict on
+ * the public GET /health route (specs/ai-gateway/gateway-health.feature).
+ *
+ * Hits the real Hono app so the HMAC verifySecret chain is exercised
+ * end-to-end: the probe must succeed only over the signed channel, since
+ * proving the shared secret matches is the reason the probe exists.
+ */
+import { createHash, createHmac } from "crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { app } from "../gateway-internal";
+
+const SECRET = "0123456789abcdef0123456789abcdef";
+const PATH = "/api/internal/gateway/health";
+
+function signedRequest(path: string, overrides?: { signature?: string }) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const bodyHash = createHash("sha256").update("").digest("hex");
+  const canonical = `GET\n${path}\n${timestamp}\n${bodyHash}`;
+  const signature =
+    overrides?.signature ??
+    createHmac("sha256", SECRET).update(canonical).digest("hex");
+  return new Request(`http://localhost${path}`, {
+    method: "GET",
+    headers: {
+      "X-LangWatch-Gateway-Signature": signature,
+      "X-LangWatch-Gateway-Timestamp": timestamp,
+    },
+  });
+}
+
+describe("GET /api/internal/gateway/health", () => {
+  let previousSecret: string | undefined;
+
+  beforeAll(() => {
+    previousSecret = process.env.LW_GATEWAY_INTERNAL_SECRET;
+    process.env.LW_GATEWAY_INTERNAL_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    if (previousSecret === undefined) {
+      delete process.env.LW_GATEWAY_INTERNAL_SECRET;
+    } else {
+      process.env.LW_GATEWAY_INTERNAL_SECRET = previousSecret;
+    }
+  });
+
+  /** @scenario "control plane answers the gateway's signed health probe" */
+  it("returns 200 with a static ok body for a signed probe", async () => {
+    const res = await app.request(signedRequest(PATH));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  /** @scenario "unsigned health probes to the control plane are rejected" */
+  it("rejects a probe without signature headers", async () => {
+    const res = await app.request(PATH, { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a probe with a wrong signature", async () => {
+    const res = await app.request(
+      signedRequest(PATH, { signature: "0".repeat(64) }),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/langwatch/src/server/routes/gateway-internal.ts
+++ b/langwatch/src/server/routes/gateway-internal.ts
@@ -271,6 +271,21 @@ function notImplemented(c: Context) {
 // ── routes ──────────────────────────────────────────────────────────────
 
 /**
+ * §4.7: connectivity probe for the gateway's public /health endpoint.
+ *
+ * The Go gateway's statusprobe monitor calls this on its own clock
+ * (default every 15s per gateway pod) and serves the cached verdict to
+ * the status page. Riding the signed channel is the point: a 200 proves
+ * not just that the app is up but that the shared HMAC secret matches,
+ * the misconfig where every pod looks green while every virtual-key
+ * resolve is refused. Body deliberately static; the gateway only reads
+ * the status code.
+ */
+secured.access(gatewayPolicy()).get("/health", (c) => {
+  return c.json({ status: "ok" });
+});
+
+/**
  * §4.1 — resolve a raw virtual key to a signed JWT + current revision.
  *
  * Request:  { key_presented: "vk-lw-01HZX...", gateway_node_id: "gw-eks-abc" }

--- a/services/aigateway/adapters/controlplane/client.go
+++ b/services/aigateway/adapters/controlplane/client.go
@@ -285,6 +285,36 @@ func (c *Client) FetchConfig(ctx context.Context, vkID string) (domain.BundleCon
 	return wire.toDomain(), nil
 }
 
+// Health performs the signed control-plane connectivity probe backing the
+// gateway's public /health status endpoint (adapters/statusprobe). It hits
+// the HMAC-protected /api/internal/gateway/health route rather than a
+// public liveness path on purpose: a success proves the whole channel the
+// gateway depends on to serve traffic: DNS, TCP/TLS, the app being up,
+// AND the shared internal secret matching. A wrong secret is the exact
+// misconfig where every pod looks green while every virtual-key resolve
+// is refused, and this is the only probe that catches it.
+func (c *Client) Health(ctx context.Context) error {
+	endpoint, _ := url.JoinPath(c.baseURL, "/api/internal/gateway/health")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	c.setCommonHeaders(req)
+	c.sign(req, nil)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Drain the small body so the pooled connection is reusable.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("control plane health returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // --- Internal helpers ---
 
 // Claims are the gateway-relevant fields extracted from a control-plane JWT.

--- a/services/aigateway/adapters/controlplane/health_test.go
+++ b/services/aigateway/adapters/controlplane/health_test.go
@@ -1,0 +1,92 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/jwtverify"
+)
+
+func healthTestClient(t *testing.T, srv *httptest.Server, secret string) *Client {
+	t.Helper()
+	signer, err := NewSigner(secret, "node-1")
+	require.NoError(t, err)
+	return NewClient(ClientOptions{
+		BaseURL:    srv.URL,
+		Sign:       signer.Sign,
+		Verifier:   jwtverify.NewJWTVerifier("jwt-secret", ""),
+		HTTPClient: srv.Client(),
+	})
+}
+
+// @scenario "the connectivity probe is HMAC-signed like every internal call"
+// The server side recomputes the signature over the same canonical string
+// the control plane's verifier uses (METHOD\nPATH\nTS\nhex(sha256(body))),
+// so a drift in how Health signs its empty-body GET fails here before it
+// fails in production.
+func TestClientHealth_SendsSignedGet(t *testing.T) {
+	const secret = "test-secret"
+	var (
+		gotMethod, gotPath string
+		sigOK              bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+
+		ts := r.Header.Get("X-LangWatch-Gateway-Timestamp")
+		presented := r.Header.Get("X-LangWatch-Gateway-Signature")
+		bodyHash := sha256.Sum256(nil)
+		canonical := fmt.Sprintf("%s\n%s\n%s\n%s", r.Method, r.URL.Path, ts, hex.EncodeToString(bodyHash[:]))
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(canonical))
+		sigOK = presented != "" && hmac.Equal([]byte(hex.EncodeToString(mac.Sum(nil))), []byte(presented))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	cp := healthTestClient(t, srv, secret)
+
+	require.NoError(t, cp.Health(context.Background()))
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/api/internal/gateway/health", gotPath)
+	assert.True(t, sigOK, "probe must carry a valid HMAC signature over the canonical string")
+}
+
+func TestClientHealth_Non200IsFailure(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			cp := healthTestClient(t, srv, "test-secret")
+
+			err := cp.Health(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprint(status))
+		})
+	}
+}
+
+func TestClientHealth_TransportFailureIsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	client := healthTestClient(t, srv, "test-secret")
+	srv.Close()
+
+	assert.Error(t, client.Health(context.Background()))
+}

--- a/services/aigateway/adapters/controlplane/health_test.go
+++ b/services/aigateway/adapters/controlplane/health_test.go
@@ -28,7 +28,7 @@ func healthTestClient(t *testing.T, srv *httptest.Server, secret string) *Client
 	})
 }
 
-// @scenario "the connectivity probe is HMAC-signed like every internal call"
+// @scenario "a mismatched internal secret shows up as a control-plane failure"
 // The server side recomputes the signature over the same canonical string
 // the control plane's verifier uses (METHOD\nPATH\nTS\nhex(sha256(body))),
 // so a drift in how Health signs its empty-body GET fails here before it
@@ -64,6 +64,10 @@ func TestClientHealth_SendsSignedGet(t *testing.T) {
 	assert.True(t, sigOK, "probe must carry a valid HMAC signature over the canonical string")
 }
 
+// @scenario "a mismatched internal secret shows up as a control-plane failure"
+// 401 is the secret-mismatch case specifically: the control plane is up and
+// answering, it just refuses this gateway. It must read as a failed probe,
+// not as a reachable control plane.
 func TestClientHealth_Non200IsFailure(t *testing.T) {
 	for _, status := range []int{http.StatusUnauthorized, http.StatusInternalServerError, http.StatusServiceUnavailable} {
 		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {

--- a/services/aigateway/adapters/gatewaymetrics/http.go
+++ b/services/aigateway/adapters/gatewaymetrics/http.go
@@ -94,6 +94,9 @@ var operationalPaths = map[string]bool{
 	"/healthz":  true,
 	"/readyz":   true,
 	"/startupz": true,
+	// The public status-page monitor's poll target. Same reasoning as the
+	// probes: it always answers and would dilute the error-rate ratio.
+	"/health": true,
 }
 
 // Middleware counts and times every request, and tracks how many are in

--- a/services/aigateway/adapters/gatewaymetrics/metrics_test.go
+++ b/services/aigateway/adapters/gatewaymetrics/metrics_test.go
@@ -462,7 +462,7 @@ func TestMiddleware_SkipsProbesAndScrapes(t *testing.T) {
 	r := New()
 	router := chi.NewRouter()
 	router.Use(Middleware(r))
-	for _, path := range []string{"/healthz", "/readyz", "/startupz", "/metrics"} {
+	for _, path := range []string{"/healthz", "/readyz", "/startupz", "/metrics", "/health"} {
 		router.Get(path, func(w http.ResponseWriter, _ *http.Request) {
 			// The gauge must stay flat even while the operational request
 			// is being served, so a drain watcher sees customer work only.
@@ -471,7 +471,7 @@ func TestMiddleware_SkipsProbesAndScrapes(t *testing.T) {
 		})
 	}
 
-	for _, path := range []string{"/healthz", "/readyz", "/startupz", "/metrics"} {
+	for _, path := range []string{"/healthz", "/readyz", "/startupz", "/metrics", "/health"} {
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 		require.Equal(t, http.StatusOK, rec.Code)

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -67,6 +67,10 @@ type RouterDeps struct {
 	// config.DefaultNonStreamingHeartbeatInterval (45s); negative disables
 	// heartbeating entirely.
 	HeartbeatInterval time.Duration
+	// Status backs the public GET /health status-page endpoint
+	// (specs/ai-gateway/gateway-health.feature). Optional; when nil the
+	// endpoint reports the process-level component only.
+	Status StatusReporter
 }
 
 // NewRouter creates the chi router with all gateway routes mounted.
@@ -93,6 +97,15 @@ func NewRouter(deps RouterDeps) http.Handler {
 		r.Get("/readyz", deps.Health.Readiness)
 		r.Get("/startupz", deps.Health.Startup)
 	}
+
+	// Public status-page surface, distinct from the k8s probes above: the
+	// probes gate pod lifecycle in-cluster, while /health is exposed
+	// through the ingress for status.langwatch.ai. HEAD is registered
+	// explicitly because chi does not fall HEAD back to GET, and uptime
+	// monitors commonly probe with HEAD.
+	statusRoute := statusHandler(deps.Status)
+	r.Get("/health", statusRoute)
+	r.Head("/health", statusRoute)
 
 	// Unauthenticated like the probes: the cluster's scraper has no
 	// virtual key, and the endpoint is kept off the public ingress by the

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -68,8 +68,10 @@ type RouterDeps struct {
 	// heartbeating entirely.
 	HeartbeatInterval time.Duration
 	// Status backs the public GET /health status-page endpoint
-	// (specs/ai-gateway/gateway-health.feature). Optional; when nil the
-	// endpoint reports the process-level component only.
+	// (specs/ai-gateway/gateway-health.feature). Optional in the type so a
+	// router can be built without it, but a nil reporter makes /health
+	// answer 503: a gateway that cannot observe its control plane must not
+	// report itself healthy to a public status page.
 	Status StatusReporter
 }
 

--- a/services/aigateway/adapters/httpapi/statushealth.go
+++ b/services/aigateway/adapters/httpapi/statushealth.go
@@ -6,8 +6,8 @@ import (
 )
 
 // StatusReporter answers the dependency section of the public GET /health
-// status-page endpoint. Implemented by statusprobe.Monitor; nil leaves the
-// response with the process-level component only.
+// status-page endpoint. Implemented by statusprobe.Monitor; nil reports the
+// control plane as unconfigured, which is a degraded verdict.
 type StatusReporter interface {
 	// ControlPlane reports the cached control-plane verdict. The detail is
 	// written verbatim into the public response body, so implementations
@@ -38,17 +38,20 @@ type statusResponse struct {
 // pulls a draining pod out of the load balancer, so by the time a public
 // poll could observe it the pod is gone from rotation; reporting it here
 // would flap the status page on every routine rollout.
+//
+// A nil reporter fails closed, matching statusprobe's behavior with no
+// Pinger: a gateway that cannot observe its control plane has no grounds
+// to call itself healthy, and answering 200 would pin the public status
+// page green on a half-wired deployment. Every response therefore carries
+// both components, so the shape does not change with the wiring.
 func statusHandler(status StatusReporter) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		checks := map[string]string{"gateway": "ok"}
-		healthy := true
+		ok, detail := false, "not configured"
 		if status != nil {
-			ok, detail := status.ControlPlane()
-			if !ok {
-				healthy = false
-			}
-			checks["control_plane"] = detail
+			ok, detail = status.ControlPlane()
 		}
+		checks := map[string]string{"gateway": "ok", "control_plane": detail}
+		healthy := ok
 
 		code := http.StatusOK
 		word := "ok"

--- a/services/aigateway/adapters/httpapi/statushealth.go
+++ b/services/aigateway/adapters/httpapi/statushealth.go
@@ -1,0 +1,65 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// StatusReporter answers the dependency section of the public GET /health
+// status-page endpoint. Implemented by statusprobe.Monitor; nil leaves the
+// response with the process-level component only.
+type StatusReporter interface {
+	// ControlPlane reports the cached control-plane verdict. The detail is
+	// written verbatim into the public response body, so implementations
+	// must keep it free of hostnames, URLs, and error internals.
+	ControlPlane() (ok bool, detail string)
+}
+
+// statusResponse is the public /health body. Deliberately minimal: overall
+// status plus a component map, mirroring pkg/health's probe vocabulary
+// ("ok" / "degraded", per-check "ok" or a short detail) without the
+// version and uptime fields: this endpoint is polled by the public
+// internet, and restart cadence and build identity are nobody's business.
+type statusResponse struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks"`
+}
+
+// statusHandler serves GET/HEAD /health for the public status page.
+//
+// Semantics the status page consumes: HTTP 200 healthy, 503 unhealthy.
+// The verdict covers the gateway process and the dependencies LangWatch
+// owns (the control plane, via the background statusprobe monitor). It is
+// structurally independent of model providers: no dispatch state feeds it
+// and no upstream call is made per poll, so an OpenAI or Anthropic outage
+// can never turn it red. That is their status page's job.
+//
+// Pod-lifecycle state (draining) is deliberately ignored: /readyz already
+// pulls a draining pod out of the load balancer, so by the time a public
+// poll could observe it the pod is gone from rotation; reporting it here
+// would flap the status page on every routine rollout.
+func statusHandler(status StatusReporter) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		checks := map[string]string{"gateway": "ok"}
+		healthy := true
+		if status != nil {
+			ok, detail := status.ControlPlane()
+			if !ok {
+				healthy = false
+			}
+			checks["control_plane"] = detail
+		}
+
+		code := http.StatusOK
+		word := "ok"
+		if !healthy {
+			code = http.StatusServiceUnavailable
+			word = "degraded"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Every poll must observe the current verdict, not an edge cache's.
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(statusResponse{Status: word, Checks: checks})
+	}
+}

--- a/services/aigateway/adapters/httpapi/statushealth_test.go
+++ b/services/aigateway/adapters/httpapi/statushealth_test.go
@@ -1,0 +1,251 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/services/aigateway/adapters/statusprobe"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// statusClock mirrors the statusprobe test clock: verdict windows are
+// exercised by moving time, not by sleeping.
+type statusClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *statusClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *statusClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// statusPinger counts control-plane probes so tests can prove none were
+// triggered by public polls.
+type statusPinger struct {
+	calls atomic.Int64
+}
+
+func (p *statusPinger) Health(context.Context) error {
+	p.calls.Add(1)
+	return nil
+}
+
+func buildRouterWithStatus(status StatusReporter, opts ...app.Option) http.Handler {
+	reg := health.New("test")
+	reg.MarkStarted()
+	return NewRouter(RouterDeps{
+		App:    app.New(opts...),
+		Logger: zap.NewNop(),
+		Health: reg,
+		Status: status,
+	})
+}
+
+func getHealth(t *testing.T, router http.Handler) (*httptest.ResponseRecorder, statusBody) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	var body statusBody
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	return rec, body
+}
+
+type statusBody struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks"`
+}
+
+// @scenario "healthy gateway reports ok with a component breakdown"
+func TestHealthEndpoint_HealthyReportsComponents(t *testing.T) {
+	// A real monitor, fresh from construction: last successful contact is
+	// "now", which is exactly the state after a recent successful probe.
+	mon := statusprobe.New(statusprobe.Options{})
+	router := buildRouterWithStatus(mon)
+
+	rec, body := getHealth(t, router)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "ok", body.Status)
+	assert.Equal(t, "ok", body.Checks["gateway"])
+	assert.Equal(t, "ok", body.Checks["control_plane"])
+}
+
+// @scenario "a total model provider outage never turns gateway health red"
+// The guarantee the status page depends on: with every provider dispatch
+// failing (OpenAI and Anthropic both down, as far as the gateway can
+// tell), completions return 5xx while /health stays 200. Third-party
+// outage is their status, not ours.
+func TestHealthEndpoint_ProviderOutageStays200(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			return nil, &domain.UpstreamError{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "upstream provider is melting down",
+			}
+		},
+	}
+	mon := statusprobe.New(statusprobe.Options{})
+	router := buildRouterWithStatus(mon, app.WithAuth(auth), app.WithProviders(provider))
+
+	// The provider outage is user-visible on the dispatch path...
+	for range 3 {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+		req.Header.Set("Authorization", "Bearer vk-lw-test")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.GreaterOrEqual(t, rec.Code, 500, "dispatch should be failing in this simulation")
+	}
+
+	// ...and invisible to the status verdict.
+	rec, body := getHealth(t, router)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", body.Status)
+	assert.Equal(t, "ok", body.Checks["control_plane"])
+}
+
+// @scenario "status polls never fan out to providers or the control plane"
+// The monitor is built but never started: its ticker is the only thing
+// allowed to probe, so with no ticker running, any probe observed here
+// would have been triggered by a public poll, an amplification bug.
+func TestHealthEndpoint_PollsDoNotFanOut(t *testing.T) {
+	pinger := &statusPinger{}
+	mon := statusprobe.New(statusprobe.Options{Pinger: pinger})
+
+	var dispatches atomic.Int64
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatches.Add(1)
+			return successResponse(), nil
+		},
+	}
+	router := buildRouterWithStatus(mon, app.WithProviders(provider))
+
+	for range 50 {
+		rec, body := getHealth(t, router)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "ok", body.Status)
+	}
+
+	assert.Zero(t, pinger.calls.Load(), "a /health poll must never probe the control plane")
+	assert.Zero(t, dispatches.Load(), "a /health poll must never dispatch to a provider")
+}
+
+// @scenario "sustained control plane outage flips health to 503"
+func TestHealthEndpoint_ControlPlaneOutageFlips503(t *testing.T) {
+	clock := &statusClock{t: time.Unix(1_700_000_000, 0)}
+	mon := statusprobe.New(statusprobe.Options{Now: clock.Now})
+	router := buildRouterWithStatus(mon)
+
+	clock.Advance(statusprobe.DefaultUnhealthyAfter + 33*time.Second)
+
+	rec, body := getHealth(t, router)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "degraded", body.Status)
+	assert.Equal(t, "ok", body.Checks["gateway"], "the process itself is still up")
+	assert.Contains(t, body.Checks["control_plane"], "unreachable")
+}
+
+// @scenario "health response carries no tenant data or internal endpoints"
+// Asserted in both verdicts, since the degraded detail string is the only
+// dynamic content and the most likely place for an error string carrying
+// the control plane's URL to leak.
+func TestHealthEndpoint_BodyIsPublicSafe(t *testing.T) {
+	clock := &statusClock{t: time.Unix(1_700_000_000, 0)}
+	mon := statusprobe.New(statusprobe.Options{Now: clock.Now})
+	router := buildRouterWithStatus(mon)
+
+	assertPublicSafe := func(t *testing.T) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		raw := rec.Body.String()
+
+		var generic map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &generic))
+		assert.ElementsMatch(t, []string{"status", "checks"}, mapKeys(generic), "body must stay minimal")
+
+		checks, ok := generic["checks"].(map[string]any)
+		require.True(t, ok)
+		assert.Subset(t, []string{"gateway", "control_plane"}, mapKeys(checks))
+
+		for _, needle := range []string{"http://", "https://", "localhost", "5560", "vk-", "proj", "org", "team"} {
+			assert.NotContains(t, raw, needle)
+		}
+		assert.NotRegexp(t, `[a-z0-9-]+\.[a-z]{2,}`, raw, "no hostname-shaped token in the public body")
+	}
+
+	assertPublicSafe(t)
+	clock.Advance(statusprobe.DefaultUnhealthyAfter + time.Hour)
+	assertPublicSafe(t)
+}
+
+// @scenario "HEAD polls get the same verdict as GET"
+func TestHealthEndpoint_HeadMatchesGet(t *testing.T) {
+	t.Run("healthy", func(t *testing.T) {
+		mon := statusprobe.New(statusprobe.Options{})
+		router := buildRouterWithStatus(mon)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/health", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("degraded", func(t *testing.T) {
+		clock := &statusClock{t: time.Unix(1_700_000_000, 0)}
+		mon := statusprobe.New(statusprobe.Options{Now: clock.Now})
+		clock.Advance(statusprobe.DefaultUnhealthyAfter + time.Minute)
+		router := buildRouterWithStatus(mon)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/health", nil))
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+}
+
+// Without a reporter wired (nil Status), the endpoint still answers with
+// the process-level component so a partially wired deployment fails open
+// rather than 404ing the monitor.
+func TestHealthEndpoint_NilReporterServesProcessComponent(t *testing.T) {
+	router := buildRouter()
+
+	rec, body := getHealth(t, router)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", body.Status)
+	assert.Equal(t, map[string]string{"gateway": "ok"}, body.Checks)
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/services/aigateway/adapters/httpapi/statushealth_test.go
+++ b/services/aigateway/adapters/httpapi/statushealth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -41,13 +42,18 @@ func (c *statusClock) Advance(d time.Duration) {
 }
 
 // statusPinger counts control-plane probes so tests can prove none were
-// triggered by public polls.
+// triggered by public polls, and can fail with the shape of error a dead
+// control plane really produces, host and port included.
 type statusPinger struct {
 	calls atomic.Int64
+	fail  atomic.Bool
 }
 
 func (p *statusPinger) Health(context.Context) error {
 	p.calls.Add(1)
+	if p.fail.Load() {
+		return errors.New("dial tcp 10.0.0.1:5560: connection refused")
+	}
 	return nil
 }
 
@@ -180,7 +186,21 @@ func TestHealthEndpoint_ControlPlaneOutageFlips503(t *testing.T) {
 // the control plane's URL to leak.
 func TestHealthEndpoint_BodyIsPublicSafe(t *testing.T) {
 	clock := &statusClock{t: time.Unix(1_700_000_000, 0)}
-	mon := statusprobe.New(statusprobe.Options{Now: clock.Now})
+	// A monitor whose probes really fail, so the degraded body is produced
+	// downstream of an actual transport error rather than of a monitor that
+	// never dialed anything: an implementation that formatted the error
+	// into the detail would look clean against a monitor with no pinger.
+	pinger := &statusPinger{}
+	pinger.fail.Store(true)
+	mon := statusprobe.New(statusprobe.Options{Pinger: pinger, Now: clock.Now, Interval: time.Millisecond})
+	t.Cleanup(mon.Stop)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	mon.Start(ctx)
+	require.Eventually(t, func() bool {
+		return pinger.calls.Load() >= 2
+	}, 2*time.Second, time.Millisecond, "the monitor should have observed real failures")
+
 	router := buildRouterWithStatus(mon)
 
 	assertPublicSafe := func(t *testing.T) {

--- a/services/aigateway/adapters/httpapi/statushealth_test.go
+++ b/services/aigateway/adapters/httpapi/statushealth_test.go
@@ -138,7 +138,7 @@ func TestHealthEndpoint_ProviderOutageStays200(t *testing.T) {
 	assert.Equal(t, "ok", body.Checks["control_plane"])
 }
 
-// @scenario "status polls never fan out to providers or the control plane"
+// @scenario "polling the status endpoint puts no load on anything else"
 // The monitor is built but never started: its ticker is the only thing
 // allowed to probe, so with no ticker running, any probe observed here
 // would have been triggered by a public poll, an amplification bug.
@@ -250,16 +250,29 @@ func TestHealthEndpoint_HeadMatchesGet(t *testing.T) {
 	})
 }
 
-// Without a reporter wired (nil Status), the endpoint still answers with
-// the process-level component so a partially wired deployment fails open
-// rather than 404ing the monitor.
-func TestHealthEndpoint_NilReporterServesProcessComponent(t *testing.T) {
+// The chart publishes /health as an Exact ingress path, which bounds the
+// path but not the method. The method guarantee lives here, so the chart
+// comment that says so stays true.
+func TestHealthEndpoint_RejectsOtherMethods(t *testing.T) {
+	router := buildRouterWithStatus(statusprobe.New(statusprobe.Options{}))
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(method, "/health", nil))
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "%s /health", method)
+	}
+}
+
+// Without a reporter wired (nil Status), the endpoint answers rather than
+// 404ing the monitor, but it fails closed: a gateway that cannot observe
+// its control plane must not pin the public status page green.
+func TestHealthEndpoint_NilReporterFailsClosed(t *testing.T) {
 	router := buildRouter()
 
 	rec, body := getHealth(t, router)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "ok", body.Status)
-	assert.Equal(t, map[string]string{"gateway": "ok"}, body.Checks)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "degraded", body.Status)
+	assert.Equal(t, map[string]string{"gateway": "ok", "control_plane": "not configured"}, body.Checks)
 }
 
 func mapKeys(m map[string]any) []string {

--- a/services/aigateway/adapters/httpapi/statushealth_test.go
+++ b/services/aigateway/adapters/httpapi/statushealth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -57,6 +58,29 @@ func (p *statusPinger) Health(context.Context) error {
 	return nil
 }
 
+// healthyMonitor returns a monitor that is healthy because a probe really
+// succeeded, not because it was just constructed. Fresh construction also
+// reads healthy (the boot grace window), but using that as the healthy
+// fixture would mean these tests never exercise a successful probe and
+// would keep passing if probing broke entirely.
+func healthyMonitor(t *testing.T) *statusprobe.Monitor {
+	t.Helper()
+	pinger := &statusPinger{}
+	mon := statusprobe.New(statusprobe.Options{Pinger: pinger, Interval: time.Millisecond})
+	t.Cleanup(mon.Stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	mon.Start(ctx)
+	require.Eventually(t, func() bool {
+		return pinger.calls.Load() >= 1
+	}, 2*time.Second, time.Millisecond, "the monitor should have completed a probe")
+
+	ok, _ := mon.ControlPlane()
+	require.True(t, ok, "a successful probe must read healthy")
+	return mon
+}
+
 func buildRouterWithStatus(status StatusReporter, opts ...app.Option) http.Handler {
 	reg := health.New("test")
 	reg.MarkStarted()
@@ -85,10 +109,7 @@ type statusBody struct {
 
 // @scenario "healthy gateway reports ok with a component breakdown"
 func TestHealthEndpoint_HealthyReportsComponents(t *testing.T) {
-	// A real monitor, fresh from construction: last successful contact is
-	// "now", which is exactly the state after a recent successful probe.
-	mon := statusprobe.New(statusprobe.Options{})
-	router := buildRouterWithStatus(mon)
+	router := buildRouterWithStatus(healthyMonitor(t))
 
 	rec, body := getHealth(t, router)
 
@@ -119,8 +140,7 @@ func TestHealthEndpoint_ProviderOutageStays200(t *testing.T) {
 			}
 		},
 	}
-	mon := statusprobe.New(statusprobe.Options{})
-	router := buildRouterWithStatus(mon, app.WithAuth(auth), app.WithProviders(provider))
+	router := buildRouterWithStatus(healthyMonitor(t), app.WithAuth(auth), app.WithProviders(provider))
 
 	// The provider outage is user-visible on the dispatch path...
 	for range 3 {
@@ -232,8 +252,7 @@ func TestHealthEndpoint_BodyIsPublicSafe(t *testing.T) {
 // @scenario "HEAD polls get the same verdict as GET"
 func TestHealthEndpoint_HeadMatchesGet(t *testing.T) {
 	t.Run("healthy", func(t *testing.T) {
-		mon := statusprobe.New(statusprobe.Options{})
-		router := buildRouterWithStatus(mon)
+		router := buildRouterWithStatus(healthyMonitor(t))
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/health", nil))
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -250,11 +269,40 @@ func TestHealthEndpoint_HeadMatchesGet(t *testing.T) {
 	})
 }
 
+// @scenario "HEAD polls get the same verdict as GET"
+// Over a real server rather than a recorder, because that is where the
+// difference shows. net/http discards the body of a HEAD response while
+// still reporting the Content-Length the GET would have carried, which is
+// what RFC 9110 asks for. Guarding the encode with `r.Method == HEAD`
+// looks tidier and is worse: measured against a real server it drops
+// Content-Length entirely and adds `Connection: close`, so a status
+// monitor polling with HEAD would pay a fresh handshake every time.
+func TestHealthEndpoint_HeadOnTheWireHasNoBodyButKeepsContentLength(t *testing.T) {
+	srv := httptest.NewServer(buildRouterWithStatus(healthyMonitor(t)))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/health", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, body, "HEAD must not carry a body on the wire")
+	assert.Positive(t, resp.ContentLength, "HEAD must still report the length GET would have sent")
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+	assert.NotEqual(t, "close", resp.Header.Get("Connection"), "HEAD polls should reuse the connection")
+}
+
 // The chart publishes /health as an Exact ingress path, which bounds the
 // path but not the method. The method guarantee lives here, so the chart
 // comment that says so stays true.
 func TestHealthEndpoint_RejectsOtherMethods(t *testing.T) {
-	router := buildRouterWithStatus(statusprobe.New(statusprobe.Options{}))
+	router := buildRouterWithStatus(healthyMonitor(t))
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
 		rec := httptest.NewRecorder()

--- a/services/aigateway/adapters/httpapi/statushealth_test.go
+++ b/services/aigateway/adapters/httpapi/statushealth_test.go
@@ -59,25 +59,37 @@ func (p *statusPinger) Health(context.Context) error {
 }
 
 // healthyMonitor returns a monitor that is healthy because a probe really
-// succeeded, not because it was just constructed. Fresh construction also
-// reads healthy (the boot grace window), but using that as the healthy
-// fixture would mean these tests never exercise a successful probe and
-// would keep passing if probing broke entirely.
+// succeeded, not because it was just constructed.
+//
+// Construction seeds lastSuccess with "now" for the boot grace window, so
+// a freshly built monitor reads healthy whether or not anything answered.
+// Waiting for a probe to be attempted is not enough either: the verdict
+// would still be sitting on that seed. This starts from a deliberately
+// stale seed, asserts the monitor is unhealthy first, and then waits for
+// it to flip. Only a probe that returned nil can do that, so if Health
+// started failing this helper fails rather than handing out a monitor
+// that is healthy for the wrong reason.
 func healthyMonitor(t *testing.T) *statusprobe.Monitor {
 	t.Helper()
-	pinger := &statusPinger{}
-	mon := statusprobe.New(statusprobe.Options{Pinger: pinger, Interval: time.Millisecond})
+	clock := &statusClock{t: time.Unix(1_700_000_000, 0)}
+	mon := statusprobe.New(statusprobe.Options{
+		Pinger:   &statusPinger{},
+		Now:      clock.Now,
+		Interval: time.Millisecond,
+	})
 	t.Cleanup(mon.Stop)
+
+	clock.Advance(statusprobe.DefaultUnhealthyAfter + time.Minute)
+	ok, _ := mon.ControlPlane()
+	require.False(t, ok, "the construction-time seed must be stale before probing starts")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	mon.Start(ctx)
 	require.Eventually(t, func() bool {
-		return pinger.calls.Load() >= 1
-	}, 2*time.Second, time.Millisecond, "the monitor should have completed a probe")
-
-	ok, _ := mon.ControlPlane()
-	require.True(t, ok, "a successful probe must read healthy")
+		ok, _ := mon.ControlPlane()
+		return ok
+	}, 2*time.Second, time.Millisecond, "a successful probe must move the verdict to healthy")
 	return mon
 }
 

--- a/services/aigateway/adapters/statusprobe/monitor.go
+++ b/services/aigateway/adapters/statusprobe/monitor.go
@@ -55,6 +55,11 @@ const (
 
 // Options configures a Monitor.
 type Options struct {
+	// Pinger performs the probe. A nil Pinger disables probing, which the
+	// verdict then reads as a sustained outage once the tolerance elapses:
+	// a monitor with no way to reach the control plane has no grounds to
+	// call the gateway healthy, so this fails closed rather than pinning
+	// the status page green on a half-wired deployment.
 	Pinger Pinger
 	Logger *zap.Logger
 	// Interval between background probes. 0 uses DefaultInterval.

--- a/services/aigateway/adapters/statusprobe/monitor.go
+++ b/services/aigateway/adapters/statusprobe/monitor.go
@@ -1,0 +1,176 @@
+// Package statusprobe watches the gateway's owned dependencies in the
+// background and answers the public GET /health status-page endpoint.
+//
+// The public status page (status.langwatch.ai) polls /health as a plain
+// HTTP monitor: 200 means the gateway is healthy, anything else means it
+// is not. Two properties are load-bearing:
+//
+//   - Only dependencies LangWatch owns are watched. A model provider
+//     outage (OpenAI, Anthropic, ...) is that provider's status, never
+//     ours, so nothing in this package touches the dispatch path.
+//   - The endpoint is public and unauthenticated, so a poll must never
+//     fan out to anything. The monitor probes on its own clock and the
+//     handler only reads the cached verdict; hammering /health costs the
+//     gateway a mutex read, not a control-plane round-trip.
+//
+// The single owned dependency is the control plane: the gateway needs it
+// for virtual-key resolution and config fetch on every cache miss. The
+// auth cache's stale-while-error machinery keeps warm traffic serving
+// through a short control-plane blip (soft bumps up to the hard grace
+// cap), so the verdict tolerates UnhealthyAfter of unreachability before
+// flipping: within the window the fleet is still serving normally, past
+// it cold-cache requests are failing with auth_upstream errors and the
+// status page should show it.
+package statusprobe
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Pinger performs one connectivity probe against the control plane.
+// Implemented by the controlplane.Client via its signed health call, so a
+// success also proves the shared HMAC secret matches: the misconfig where
+// every pod looks green while every virtual-key resolve is refused.
+type Pinger interface {
+	Health(ctx context.Context) error
+}
+
+const (
+	// DefaultInterval is how often the background probe runs.
+	DefaultInterval = 15 * time.Second
+	// DefaultUnhealthyAfter is how long the control plane may be
+	// unreachable before the verdict flips. Sized to ride out a blip that
+	// warm-cache serving absorbs (a rolling app deploy, a transient
+	// network drop) while still reporting a sustained outage within one
+	// status-page poll cycle or two.
+	DefaultUnhealthyAfter = 60 * time.Second
+	// DefaultProbeTimeout bounds a single probe attempt.
+	DefaultProbeTimeout = 5 * time.Second
+)
+
+// Options configures a Monitor.
+type Options struct {
+	Pinger Pinger
+	Logger *zap.Logger
+	// Interval between background probes. 0 uses DefaultInterval.
+	Interval time.Duration
+	// UnhealthyAfter is the unreachability tolerance. 0 uses
+	// DefaultUnhealthyAfter.
+	UnhealthyAfter time.Duration
+	// ProbeTimeout bounds one probe attempt. 0 uses DefaultProbeTimeout.
+	ProbeTimeout time.Duration
+	// Now is a clock seam for tests. nil uses time.Now.
+	Now func() time.Time
+}
+
+// Monitor runs the background probe loop and caches the latest verdict.
+type Monitor struct {
+	pinger         Pinger
+	logger         *zap.Logger
+	interval       time.Duration
+	unhealthyAfter time.Duration
+	probeTimeout   time.Duration
+	now            func() time.Time
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+
+	mu sync.Mutex
+	// lastSuccess starts at construction time, not zero: a booting pod is
+	// given one full UnhealthyAfter window to reach the control plane
+	// before it reports unhealthy, so a rolling deploy does not blink the
+	// public status page while the first probe is still in flight.
+	lastSuccess time.Time
+}
+
+// New builds a Monitor. It does not start probing until Start.
+func New(opts Options) *Monitor {
+	if opts.Logger == nil {
+		opts.Logger = zap.NewNop()
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = DefaultInterval
+	}
+	if opts.UnhealthyAfter <= 0 {
+		opts.UnhealthyAfter = DefaultUnhealthyAfter
+	}
+	if opts.ProbeTimeout <= 0 {
+		opts.ProbeTimeout = DefaultProbeTimeout
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Monitor{
+		pinger:         opts.Pinger,
+		logger:         opts.Logger,
+		interval:       opts.Interval,
+		unhealthyAfter: opts.UnhealthyAfter,
+		probeTimeout:   opts.ProbeTimeout,
+		now:            opts.Now,
+		stopCh:         make(chan struct{}),
+		lastSuccess:    opts.Now(),
+	}
+}
+
+// Start launches the probe loop. Matches the lifecycle.Worker shape.
+func (m *Monitor) Start(ctx context.Context) {
+	go m.loop(ctx)
+}
+
+// Stop signals the probe loop to exit. Safe to call more than once.
+func (m *Monitor) Stop() {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+}
+
+// ControlPlane reports the cached control-plane verdict. The detail string
+// is written verbatim into the public /health response body, so it names
+// the condition and its duration only, never the error text, which can
+// carry the control plane's URL or other internals.
+func (m *Monitor) ControlPlane() (ok bool, detail string) {
+	m.mu.Lock()
+	last := m.lastSuccess
+	m.mu.Unlock()
+	elapsed := m.now().Sub(last)
+	if elapsed <= m.unhealthyAfter {
+		return true, "ok"
+	}
+	return false, fmt.Sprintf("unreachable for %ds", int(elapsed.Seconds()))
+}
+
+func (m *Monitor) loop(ctx context.Context) {
+	m.probe(ctx)
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.probe(ctx)
+		}
+	}
+}
+
+func (m *Monitor) probe(ctx context.Context) {
+	if m.pinger == nil {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, m.probeTimeout)
+	defer cancel()
+	if err := m.pinger.Health(probeCtx); err != nil {
+		// The public detail string stays generic; the operator log gets
+		// the real cause.
+		m.logger.Warn("statusprobe_control_plane_unreachable", zap.Error(err))
+		return
+	}
+	m.mu.Lock()
+	m.lastSuccess = m.now()
+	m.mu.Unlock()
+}

--- a/services/aigateway/adapters/statusprobe/monitor_test.go
+++ b/services/aigateway/adapters/statusprobe/monitor_test.go
@@ -144,6 +144,23 @@ func TestMonitor_PublicDetailNeverCarriesTheProbeError(t *testing.T) {
 	}
 }
 
+// A half-wired monitor fails closed. With no Pinger nothing can ever
+// refresh the verdict, so it must go unhealthy at the tolerance rather
+// than pin the public status page green forever.
+func TestMonitor_WithoutAPingerFailsClosed(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := New(Options{Now: clock.Now})
+
+	ok, _ := m.ControlPlane()
+	require.True(t, ok, "the boot grace window still applies")
+
+	clock.Advance(DefaultUnhealthyAfter + time.Second)
+
+	ok, detail := m.ControlPlane()
+	assert.False(t, ok)
+	assert.Contains(t, detail, "unreachable")
+}
+
 // The loop probes on its own clock and Stop halts it. The endpoint's
 // no-fan-out property depends on the ticker being the only probe driver.
 func TestMonitor_ProbesOnItsOwnClockAndStops(t *testing.T) {

--- a/services/aigateway/adapters/statusprobe/monitor_test.go
+++ b/services/aigateway/adapters/statusprobe/monitor_test.go
@@ -146,18 +146,34 @@ func TestMonitor_PublicDetailNeverCarriesTheProbeError(t *testing.T) {
 
 // A half-wired monitor fails closed. With no Pinger nothing can ever
 // refresh the verdict, so it must go unhealthy at the tolerance rather
-// than pin the public status page green forever.
+// than pin the public status page green forever. The loop runs on a fast
+// ticker throughout, so a probe that treated "no pinger" as success would
+// keep stamping lastSuccess and pull the verdict back to healthy.
 func TestMonitor_WithoutAPingerFailsClosed(t *testing.T) {
 	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
-	m := New(Options{Now: clock.Now})
+	m := New(Options{Now: clock.Now, Interval: time.Millisecond})
+	t.Cleanup(m.Stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m.Start(ctx)
 
 	ok, _ := m.ControlPlane()
 	require.True(t, ok, "the boot grace window still applies")
 
 	clock.Advance(DefaultUnhealthyAfter + time.Second)
 
+	// Never, not Eventually: the verdict is already unhealthy the instant
+	// the clock moves, so Eventually would pass on the first read, before
+	// the loop had run at all. Holding it unhealthy across ~200 ticks is
+	// what proves the loop cannot talk itself back to healthy.
+	require.Never(t, func() bool {
+		ok, _ := m.ControlPlane()
+		return ok
+	}, 200*time.Millisecond, time.Millisecond, "a monitor with no pinger must not refresh its own verdict")
+
 	ok, detail := m.ControlPlane()
-	assert.False(t, ok)
+	require.False(t, ok)
 	assert.Contains(t, detail, "unreachable")
 }
 

--- a/services/aigateway/adapters/statusprobe/monitor_test.go
+++ b/services/aigateway/adapters/statusprobe/monitor_test.go
@@ -115,6 +115,35 @@ func TestMonitor_RecoversAfterSuccessfulProbe(t *testing.T) {
 	}, 2*time.Second, 5*time.Millisecond, "verdict should recover after a successful probe")
 }
 
+// @scenario "health response carries no tenant data or internal endpoints"
+// Monitor-level half of the scenario, against a probe that really failed:
+// the transport error a dead control plane produces embeds its host and
+// port, and that string must not reach the public detail. Asserted here
+// rather than only on a monitor that never probed, since a detail built
+// from the error would otherwise look clean in every test.
+func TestMonitor_PublicDetailNeverCarriesTheProbeError(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	pinger := &countingPinger{}
+	pinger.fail.Store(true)
+
+	m := New(Options{Pinger: pinger, Now: clock.Now, Interval: time.Millisecond})
+	t.Cleanup(m.Stop)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return pinger.calls.Load() >= 2
+	}, 2*time.Second, time.Millisecond, "the loop should have observed real failures")
+	clock.Advance(DefaultUnhealthyAfter + time.Minute)
+
+	ok, detail := m.ControlPlane()
+	require.False(t, ok)
+	for _, leak := range []string{"dial", "tcp", "10.0.0.1", "5560", "connection refused"} {
+		assert.NotContains(t, detail, leak, "probe error internals must stay out of the public body")
+	}
+}
+
 // The loop probes on its own clock and Stop halts it. The endpoint's
 // no-fan-out property depends on the ticker being the only probe driver.
 func TestMonitor_ProbesOnItsOwnClockAndStops(t *testing.T) {

--- a/services/aigateway/adapters/statusprobe/monitor_test.go
+++ b/services/aigateway/adapters/statusprobe/monitor_test.go
@@ -1,0 +1,153 @@
+package statusprobe
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock is a mutable clock seam so verdict windows are exercised
+// deterministically instead of with sleeps.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// countingPinger fails or succeeds on command and counts probe attempts.
+type countingPinger struct {
+	calls atomic.Int64
+	fail  atomic.Bool
+}
+
+func (p *countingPinger) Health(context.Context) error {
+	p.calls.Add(1)
+	if p.fail.Load() {
+		return errors.New("dial tcp 10.0.0.1:5560: connection refused")
+	}
+	return nil
+}
+
+// @scenario "control plane blip within the warm-cache window stays healthy"
+// A short stretch of failed probes must not flip the verdict: warm-cache
+// traffic is unaffected during a blip and the public status page must not
+// flap on what customers cannot feel.
+func TestMonitor_BlipWithinToleranceStaysHealthy(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := New(Options{Now: clock.Now})
+
+	clock.Advance(30 * time.Second)
+
+	ok, detail := m.ControlPlane()
+	assert.True(t, ok)
+	assert.Equal(t, "ok", detail)
+}
+
+// @scenario "sustained control plane outage flips health to 503"
+// Monitor-level half of the scenario: past the tolerance the component
+// verdict goes unhealthy with a duration-only detail. The route-level 503
+// mapping is covered in httpapi's statushealth_test.go.
+func TestMonitor_SustainedOutageGoesUnhealthy(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := New(Options{Now: clock.Now})
+
+	clock.Advance(DefaultUnhealthyAfter + 30*time.Second)
+
+	ok, detail := m.ControlPlane()
+	assert.False(t, ok)
+	assert.Contains(t, detail, "unreachable")
+	// The public detail must never carry error internals: probe failures
+	// embed the control plane's host and port in their error strings.
+	assert.NotContains(t, detail, "http")
+	assert.NotContains(t, detail, "5560")
+	assert.NotContains(t, detail, ":")
+}
+
+// @scenario "recovery after an outage returns health to 200"
+// Once the control plane answers again, the next background probe restores
+// the healthy verdict without a restart.
+func TestMonitor_RecoversAfterSuccessfulProbe(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	pinger := &countingPinger{}
+	pinger.fail.Store(true)
+
+	m := New(Options{
+		Pinger:   pinger,
+		Now:      clock.Now,
+		Interval: 2 * time.Millisecond,
+	})
+	t.Cleanup(m.Stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m.Start(ctx)
+
+	// Outage: probes fail while the clock moves past the tolerance.
+	clock.Advance(DefaultUnhealthyAfter + time.Minute)
+	require.Eventually(t, func() bool {
+		ok, _ := m.ControlPlane()
+		return !ok
+	}, 2*time.Second, 5*time.Millisecond, "verdict should flip after the tolerance")
+
+	// Control plane comes back; the loop's next probe succeeds and stamps
+	// lastSuccess with the current clock.
+	pinger.fail.Store(false)
+	require.Eventually(t, func() bool {
+		ok, _ := m.ControlPlane()
+		return ok
+	}, 2*time.Second, 5*time.Millisecond, "verdict should recover after a successful probe")
+}
+
+// The loop probes on its own clock and Stop halts it. The endpoint's
+// no-fan-out property depends on the ticker being the only probe driver.
+func TestMonitor_ProbesOnItsOwnClockAndStops(t *testing.T) {
+	pinger := &countingPinger{}
+	m := New(Options{Pinger: pinger, Interval: 2 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return pinger.calls.Load() >= 3
+	}, 2*time.Second, time.Millisecond, "loop should keep probing on the ticker")
+
+	m.Stop()
+	// Idempotent stop must not panic.
+	m.Stop()
+
+	settled := pinger.calls.Load()
+	time.Sleep(20 * time.Millisecond)
+	assert.LessOrEqual(t, pinger.calls.Load(), settled+1, "probing should halt after Stop")
+}
+
+// Reading the verdict never triggers a probe: ControlPlane is a cached
+// read, whatever the poll rate.
+func TestMonitor_VerdictReadsDoNotProbe(t *testing.T) {
+	pinger := &countingPinger{}
+	m := New(Options{Pinger: pinger})
+
+	for range 100 {
+		ok, detail := m.ControlPlane()
+		assert.True(t, ok)
+		assert.NotContains(t, detail, "unreachable")
+	}
+	assert.Zero(t, pinger.calls.Load())
+}

--- a/services/aigateway/serve.go
+++ b/services/aigateway/serve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langwatch/langwatch/pkg/lifecycle"
 	"github.com/langwatch/langwatch/services/aigateway/adapters/httpapi"
 	"github.com/langwatch/langwatch/services/aigateway/adapters/ottlserver"
+	"github.com/langwatch/langwatch/services/aigateway/adapters/statusprobe"
 	"github.com/langwatch/langwatch/services/aigateway/app"
 )
 
@@ -24,6 +25,13 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 	if err != nil {
 		return fmt.Errorf("ottlserver init: %w", err)
 	}
+
+	// Backs the public GET /health status-page endpoint: probes the
+	// control plane on its own clock so a poll never fans out.
+	statusMon := statusprobe.New(statusprobe.Options{
+		Pinger: deps.ControlPlane,
+		Logger: deps.Logger,
+	})
 
 	info := contexts.MustGetServiceInfo(ctx)
 	handler := httpapi.NewRouter(httpapi.RouterDeps{
@@ -38,6 +46,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		InternalSecret:        cfg.ControlPlane.InternalSecret,
 		MaxRequestBodyBytes:   cfg.Server.MaxRequestBodyBytes,
 		HeartbeatInterval:     time.Duration(cfg.NonStreamingHeartbeatIntervalSeconds) * time.Second,
+		Status:                statusMon,
 	})
 
 	srv := &http.Server{Handler: handler, Addr: cfg.Server.Addr, ReadHeaderTimeout: 10 * time.Second}
@@ -50,6 +59,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		lifecycle.Closer("otel", deps.OTel.Shutdown),
 		lifecycle.Closer("customer-trace-bridge", deps.TraceBridge.Shutdown),
 		lifecycle.Worker("auth", deps.Auth.Start, deps.Auth.Stop),
+		lifecycle.Worker("statusprobe", statusMon.Start, statusMon.Stop),
 		lifecycle.ListenServer("http", srv),
 	)
 	return g.Run(ctx)

--- a/specs/ai-gateway/_shared/contract.md
+++ b/specs/ai-gateway/_shared/contract.md
@@ -403,6 +403,19 @@ Response:
 
 Gateway applies modifications **before** dispatch (request direction) or **before** returning to client (response/stream_chunk).
 
+### 4.7 `GET /api/internal/gateway/health`
+
+Connectivity probe backing the gateway's public `GET /health` status-page endpoint (`specs/ai-gateway/gateway-health.feature`). The gateway's statusprobe monitor calls this on its own clock (default every 15s per gateway node) and serves the cached verdict to public polls, so status-page traffic never reaches the control plane.
+
+Riding the signed channel is the point: a 200 proves DNS/TCP/TLS, the app being up, and the shared HMAC secret matching. The gateway only reads the status code.
+
+Response (200):
+```json
+{ "status": "ok" }
+```
+
+Any non-200 (including 401 on a secret mismatch) marks the probe failed.
+
 ---
 
 ## 5. Error envelope

--- a/specs/ai-gateway/gateway-health.feature
+++ b/specs/ai-gateway/gateway-health.feature
@@ -1,0 +1,125 @@
+Feature: Gateway status-page health endpoint
+
+  # GET /health on the Go gateway (services/aigateway) is the public
+  # surface the LangWatch status page (status.langwatch.ai) polls, the
+  # gateway's sibling of the app's /api/health/* subsystem monitors.
+  # Plain HTTP monitor semantics: 200 healthy, 503 unhealthy.
+  #
+  # Distinct from the k8s probes in health-checks.feature: /healthz,
+  # /readyz and /startupz gate pod lifecycle in-cluster, while /health is
+  # exposed through the ingress and reports the service as a whole.
+  #
+  # The load-bearing property: the verdict covers the gateway process and
+  # the dependencies LangWatch owns (the control plane, reached over the
+  # HMAC-signed internal channel). Model providers are deliberately
+  # excluded, in both directions: dispatch outcomes never feed the
+  # verdict, and a poll never triggers an upstream call. OpenAI or
+  # Anthropic being down is their status page's news, not ours, and a
+  # public unauthenticated endpoint that fanned out per poll would be an
+  # amplification and cost bug besides.
+  #
+  # Control-plane semantics: a background monitor probes the signed
+  # /api/internal/gateway/health route on its own clock (default every
+  # 15s) and /health serves the cached verdict. Unreachability shorter
+  # than the tolerance (default 60s) stays 200 because the auth cache's
+  # stale-while-error machinery keeps warm traffic serving through a
+  # blip; sustained unreachability flips 503 because cold-cache requests
+  # are by then failing with auth_upstream errors.
+
+  Background:
+    Given the Go gateway service is running
+
+  Rule: The verdict is independent of model providers
+
+    @unit
+    Scenario: a total model provider outage never turns gateway health red
+      Given every model provider dispatch fails as if OpenAI and Anthropic are down
+      And completion requests through the gateway are returning 5xx
+      When I GET "/health"
+      Then the response status is 200
+      And the response JSON has "status" == "ok"
+
+    @unit
+    Scenario: status polls never fan out to providers or the control plane
+      Given the background monitor is not ticking
+      When I GET "/health" 50 times
+      Then every response is 200
+      And no model provider dispatch was triggered
+      And no control-plane probe was triggered by the polls
+
+  Rule: The verdict covers the dependencies LangWatch owns
+
+    @unit
+    Scenario: healthy gateway reports ok with a component breakdown
+      Given the control-plane monitor has a recent successful probe
+      When I GET "/health"
+      Then the response status is 200
+      And the response JSON has "checks.gateway" == "ok"
+      And the response JSON has "checks.control_plane" == "ok"
+
+    @unit
+    Scenario: control plane blip within the warm-cache window stays healthy
+      Given the control plane has been unreachable for 30 seconds
+      When the monitor evaluates the control-plane component
+      Then the component is healthy
+      # Warm-cache traffic is unaffected during a short blip, and the
+      # status page must not flap on what customers cannot feel.
+
+    @unit
+    Scenario: sustained control plane outage flips health to 503
+      Given the control plane has been unreachable for longer than the tolerance
+      When I GET "/health"
+      Then the response status is 503
+      And the response JSON has "status" == "degraded"
+      And the response JSON "checks.control_plane" contains "unreachable"
+
+    @unit
+    Scenario: recovery after an outage returns health to 200
+      Given the control plane was unreachable for longer than the tolerance
+      When the control plane becomes reachable again
+      And the background monitor completes a successful probe
+      Then the control-plane component is healthy again
+
+  Rule: The response is safe for public polling
+
+    @unit
+    Scenario: health response carries no tenant data or internal endpoints
+      When I GET "/health" in both healthy and degraded states
+      Then the response JSON has exactly the keys "status" and "checks"
+      And no URL, hostname, or port appears anywhere in the body
+      And no tenant, project, or key identifier appears anywhere in the body
+
+    @unit
+    Scenario: HEAD polls get the same verdict as GET
+      When I HEAD "/health"
+      Then the response status matches the GET verdict
+      And the response has no body
+
+  Rule: The control-plane probe rides the signed internal channel
+
+    # A successful probe proves the whole channel the gateway needs to
+    # serve traffic: DNS, TCP/TLS, the app being up, and the shared HMAC
+    # secret matching. A wrong secret is the misconfig where every pod
+    # looks green while every virtual-key resolve is refused; this probe
+    # is what catches it.
+
+    @unit
+    Scenario: the connectivity probe is HMAC-signed like every internal call
+      When the gateway probes the control plane
+      Then the request is GET "/api/internal/gateway/health"
+      And it carries the X-LangWatch-Gateway-Signature and timestamp headers
+      And a 200 marks the probe successful
+      And a non-200 marks the probe failed
+
+    @integration
+    Scenario: control plane answers the gateway's signed health probe
+      Given a request signed with the shared internal secret
+      When the control plane receives GET "/api/internal/gateway/health"
+      Then the response status is 200
+      And the response JSON has "status" == "ok"
+
+    @integration
+    Scenario: unsigned health probes to the control plane are rejected
+      Given a request without signature headers
+      When the control plane receives GET "/api/internal/gateway/health"
+      Then the response status is 401

--- a/specs/ai-gateway/gateway-health.feature
+++ b/specs/ai-gateway/gateway-health.feature
@@ -40,12 +40,15 @@ Feature: Gateway status-page health endpoint
       And the response JSON has "status" == "ok"
 
     @unit
-    Scenario: status polls never fan out to providers or the control plane
-      Given the background monitor is not ticking
+    Scenario: polling the status endpoint puts no load on anything else
+      Given a status page free to poll as hard as it likes
       When I GET "/health" 50 times
       Then every response is 200
-      And no model provider dispatch was triggered
-      And no control-plane probe was triggered by the polls
+      And no model provider was called
+      And the control plane was not called
+      # Poll rate and the cost of answering are unrelated. On a public
+      # unauthenticated endpoint, anything else is an amplification and a
+      # bill someone else gets to write.
 
   Rule: The verdict covers the dependencies LangWatch owns
 
@@ -104,12 +107,14 @@ Feature: Gateway status-page health endpoint
     # is what catches it.
 
     @unit
-    Scenario: the connectivity probe is HMAC-signed like every internal call
+    Scenario: a mismatched internal secret shows up as a control-plane failure
+      Given the gateway and the control plane hold different internal secrets
       When the gateway probes the control plane
-      Then the request is GET "/api/internal/gateway/health"
-      And it carries the X-LangWatch-Gateway-Signature and timestamp headers
-      And a 200 marks the probe successful
-      And a non-200 marks the probe failed
+      Then the control plane refuses the probe
+      And the gateway records the probe as failed
+      # The whole reason the probe rides the signed channel. An unsigned
+      # liveness ping would report green while every virtual-key resolve
+      # is being refused.
 
     @integration
     Scenario: control plane answers the gateway's signed health probe

--- a/specs/ai-gateway/health-checks.feature
+++ b/specs/ai-gateway/health-checks.feature
@@ -4,6 +4,9 @@ Feature: Gateway health checks
   # (/healthz, /readyz, /startupz) implemented in the Go gateway
   # service. Out of scope for the TS parity check — verified via Go
   # tests in services/aigateway/.
+  #
+  # The public status-page endpoint (GET /health) is a separate surface
+  # with different consequences, see gateway-health.feature.
 
   Kubernetes uses three probe endpoints to distinguish transient
   dependency hiccups from a dead pod. Each has distinct semantics.
@@ -28,39 +31,34 @@ Feature: Gateway health checks
       Then the probe times out
       And kubernetes will kill the pod
 
-  Rule: /readyz gates traffic on real dependencies
+  Rule: /readyz gates traffic on pod state, never on dependencies
+
+    # Deliberately dependency-free, two hard lessons deep. An
+    # `auth_cache_warm` readiness check dead-locked cold starts: K8s
+    # would not route traffic until /readyz went 200, but the cache
+    # could only warm from routed traffic (see the note in
+    # services/aigateway/deps.go). And a `control_plane_reachable`
+    # readiness check would turn a control-plane blip into a total
+    # gateway outage: every pod would drop from the load balancer at
+    # once, killing exactly the warm-cache traffic the auth cache's
+    # stale-while-error machinery is designed to keep serving.
+    # Dependency health is reported on the public GET /health
+    # status-page endpoint instead (gateway-health.feature), where a
+    # red verdict informs a status page rather than gating traffic.
 
     @integration @unimplemented
-    Scenario: all dependencies healthy returns 200 with each check reported
-      Given the control plane responds 200 to /api/health
-      And the auth cache has observed at least one revision
-      And redis (if configured) responds PONG
+    Scenario: readyz reflects only pod lifecycle
+      Given the control plane is unreachable
+      And the pod is not draining
       When I GET "/readyz"
       Then the response status is 200
-      And the response JSON has "checks.control_plane_reachable" == "ok"
-      And the response JSON has "checks.auth_cache_warm" == "ok"
+      And warm-cache traffic keeps serving through the blip
 
     @integration @unimplemented
-    Scenario: control plane 5xx flips readyz to 503
-      Given the control plane returns 503 to /api/health
-      When I GET "/readyz"
-      Then the response status is 503
-      And the JSON body contains "checks.control_plane_reachable" with an error detail
-      And kubernetes removes this pod from the service endpoints
-      And the pod is NOT killed (liveness still passes)
-
-    @integration @unimplemented
-    Scenario: auth cache cold flips readyz to 503
-      Given the gateway has just started and no resolve-key / changes poll has returned yet
-      When I GET "/readyz"
-      Then the response status is 503
-      And the JSON body contains "checks.auth_cache_warm" with "auth cache has not observed any revision yet"
-
-    @integration @unimplemented
-    Scenario: readyz is cheap (<50ms) even when all dependencies are healthy
+    Scenario: readyz is cheap (<50ms) and makes no upstream calls
       When I GET "/readyz" 10 times sequentially
       Then every response completes within 50ms
-      And the cumulative upstream control-plane calls are ≤ 10
+      And the cumulative upstream control-plane calls are 0
 
   Rule: /startupz blocks until initial warmup completes
 


### PR DESCRIPTION
## Why

status.langwatch.ai has nothing to point at for the AI gateway. The gateway already carries the three Kubernetes probes, but none of them is a statement about whether the service is actually serving, and none of them is reachable from outside the cluster.

This adds `GET /health`, the public status-page surface, and publishes exactly that one path through the ingress.

**The path to point the status-page monitor at: `https://gateway.langwatch.ai/health`** (in general `https://<ingress.host>/health`). Plain HTTP monitor, 200 healthy, 503 not. `HEAD` works identically if your monitor prefers it.

## What I found about the existing convention (read this before wiring the monitor)

I surveyed what the other services do, and the short version is that the existing probes are not usable as a status-page target, for reasons that are deliberate rather than accidental.

**The gateway's three probes are lifecycle signals, not health.** `pkg/health` gives every Go service `/healthz`, `/readyz`, `/startupz` with a shared JSON shape. In the gateway, `/healthz` answers as long as the process is alive; `/readyz` reports one thing, whether the pod is draining; `/startupz` mirrors `/readyz` once started. **The gateway registers zero dependency checks on any of them.** Pointing a status page at `/healthz` would have produced a page that is green during a total control-plane outage.

**That is not an oversight, it is two scars.** An `auth_cache_warm` readiness check dead-locked cold starts: Kubernetes will not route traffic until `/readyz` is 200, and the cache could only warm from routed traffic, so pods never went ready. And a `control_plane_reachable` readiness check would be worse in production: a control-plane blip would pull every gateway pod out of the load balancer at once, turning a degradation the auth cache is specifically built to absorb into a total outage. So dependency health had nowhere to live. This PR gives it a home where a red verdict informs a status page instead of removing pods from rotation.

**Three docs were describing a gateway we do not ship.** `specs/ai-gateway/health-checks.feature` specified a `/readyz` that checks the control plane, the auth cache and redis (all scenarios `@unimplemented`, so nothing caught the drift). `docs/ai-gateway/self-hosting/health-checks.mdx` said the same, plus that `/startupz` blocks on an auth-cache bootstrap that calls the control plane. There is no such bootstrap: startup is marked complete as soon as dependencies are constructed, which makes the "startupz fails 30x, CrashLoopBackOff" row in that page's failures table describe an impossible failure. All three are corrected here to the shipped behavior.

**The app-side "health checks" are mostly not health checks, and this is the one thing to know before wiring any monitor.** `GET /api/health` on the app is a genuine 204 liveness ping (GET and HEAD, no auth) and is a fine status-page target for the app. But the five sub-endpoints under `/api/health/*` are a different animal entirely:

| Endpoint | What one hit actually does |
|---|---|
| `/api/health/collector` | sends canary traces over REST and OTLP |
| `/api/health/processor` | sends canary traces, then polls until they are processed |
| `/api/health/evaluations` | runs a real PII evaluation |
| `/api/health/workflows` | runs one of the tenant's real workflows via `POST /api/workflows/:id/run` |
| `/api/health/triggers` | queries whether a trigger fired in the last hour |

Every one of them requires a project API key in the handler, writes tenant data, and costs real money per poll. `/api/health/workflows` executes a customer workflow, so its LLM nodes call model providers with that tenant's credentials: **it goes red when OpenAI goes down, and it bills the customer for every poll.** These are deep diagnostic tools, correctly built, and they are the exact opposite of what a public status page should poll. Nothing in their naming says so.

So there was no convention to copy for the gateway, and copying the nearest-looking one would have produced a status page that bills us to be told OpenAI is down. That is why `/health` is a new shape: unauthenticated, zero tenant data, no work per hit, provider-independent by construction.

## What changed

`GET /health` (and `HEAD`) on the gateway returns:

```json
{ "status": "ok", "checks": { "gateway": "ok", "control_plane": "ok" } }
```

with 200, or 503 with `{"status":"degraded","checks":{"gateway":"ok","control_plane":"unreachable for 65s"}}`.

Two properties are structural rather than conventions to be careful about:

- **A model provider outage can never turn it red.** Nothing on the verdict path reads dispatch state, so with OpenAI and Anthropic both down, completions 5xx while `/health` stays 200. A gateway that goes red on someone else's outage trains people to ignore the status page, and it is not our incident to report.
- **A poll never fans out.** The endpoint is public and unauthenticated, so a per-poll upstream call would be an amplification and cost bug wearing a health check's clothes. A background monitor (`adapters/statusprobe`) probes on its own 15s clock and the handler reads a cached verdict under a mutex. Poll rate and control-plane load are unrelated.

The single owned dependency watched is the control plane, and the probe rides the HMAC-signed internal channel (new `GET /api/internal/gateway/health`, contract §4.7) rather than a public liveness path. That is the point of the design: a 200 proves DNS, TCP/TLS, the app being up, **and** the shared `LW_GATEWAY_INTERNAL_SECRET` matching. A mismatched secret is the misconfiguration where every pod looks green while every virtual-key resolve is refused, and this is the only signal that catches it.

**Where provider visibility lives, since it is deliberately not here:** the gateway already publishes `gateway_circuit_state` on `/metrics`, a per-credential gauge the breaker updates from dispatch outcomes it has already observed. That is passively derived, costs nothing extra, and sits on a scrape endpoint that stays in-cluster and has no path to the `/health` status code. I did not add a second provider surface; the right one already exists.

**Which side of 200 the in-between state falls on:** unreachability shorter than 60s stays **200**. Warm keys keep serving from the auth cache through a blip (its stale-while-error machinery is built for exactly this), and a page that flaps on what customers cannot feel is worse than no page. Past 60s it flips to **503**, because by then cold-cache requests are failing with `auth_upstream_unavailable` and it is customer-visible. A booting pod gets one full 60s window before it can report red, so a rolling deploy never blinks the page.

It fails closed in both directions: a monitor with no way to reach the control plane, and a router built without the monitor wired, both report 503 rather than a green lie. A gateway that cannot observe its control plane has no grounds to call itself healthy.

The body is smaller than the probes' on purpose: no `version`, no `uptime_s`. This is polled by the public internet and restart cadence and build identity are not something to publish. The degraded detail carries a duration only, never the probe error, which embeds the control plane's host and port.

## Deployment Impact

- **Env vars added or changed:** none. The probe reuses `LW_GATEWAY_BASE_URL` and `LW_GATEWAY_INTERNAL_SECRET`, which the gateway already requires. Interval (15s), tolerance (60s) and probe timeout (5s) are constants in `adapters/statusprobe`, not configuration.
- **Helm values added:** `ingress.healthPath.enabled` (default `true`) and `ingress.healthPath.path` (default `/health`), both under the existing `ingress` block. No other values touched. Set `enabled: false` to keep the endpoint in-cluster only.
- **Default behavior on a vanilla `helm install` with no overrides:** when `ingress.enabled` is true, the ingress gains one `pathType: Exact` rule for `/health` alongside the existing `/v1` prefix rule. `Exact` is load-bearing: it will not match `/healthz`, and it does not open a prefix, so the k8s probes, `/metrics` and `/internal` stay in-cluster. When `ingress.enabled` is false nothing changes. Rendering verified both ways with `helm template`, plus `helm lint`.
- **Methods:** the ingress `Exact` match bounds the path only. The gateway route registers GET and HEAD and answers 405 to everything else, which is asserted by a test so the chart comment cannot drift from the router.
- **Runtime cost:** one additional goroutine per gateway pod issuing one signed GET to the control plane every 15s. At any realistic fleet size that is noise next to virtual-key resolution traffic.
- **Control plane:** one new route, `GET /api/internal/gateway/health`, behind the same `gatewayPolicy()` HMAC guard as every other internal gateway route. It is not reachable without a valid signature, returns a static body, and touches no database.
- **BYOC dataplane:** the new route is served by the dataplane's own gateway and app; the probe never leaves the dataplane, and no tenant data is in the response. A BYOC customer can point their own status page at their own gateway host with the same path.
- **Rollout ordering:** deploy the app before the gateway, or the gateway's probe 404s until the app catches up and the page reads degraded after 60s. This is the normal ordering already, and `/readyz` is unaffected, so traffic keeps flowing either way.
- **Migrations:** none.

## Test plan

Go: `go build`, `go test -race ./services/aigateway/...`, `gofmt`, `golangci-lint run ./services/aigateway/... ./pkg/... ./cmd/...` (0 issues). TS: `pnpm typecheck`, `pnpm typecheck:tests`, `pnpm check:feature-parity` (all 11 scenarios in the new feature file bound), and the new control-plane route integration test. Chart: `helm lint` plus `helm template` with the health path on and off.

### The guards have teeth (each mutation was run, the listed tests fail, nothing else does)

| Mutation | Fails |
|---|---|
| Remove the `/health` route | all 7 endpoint tests |
| Verdict can never go unhealthy (drop the tolerance) | `..._ControlPlaneOutageFlips503`, `..._HeadMatchesGet/degraded`, `TestMonitor_SustainedOutageGoesUnhealthy`, `TestMonitor_RecoversAfterSuccessfulProbe` |
| Format the probe error into the public detail | `..._BodyIsPublicSafe`, `TestMonitor_SustainedOutageGoesUnhealthy`, `TestMonitor_PublicDetailNeverCarriesTheProbeError` |
| Probe the control plane on each verdict read (fan-out) | `..._PollsDoNotFanOut`, `TestMonitor_VerdictReadsDoNotProbe` |
| Feed observed dispatch failures into the verdict | `..._ProviderOutageStays200` |

That third row found a real hole while I was checking: both public-safety assertions ran against a monitor that had never probed, so an implementation leaking the error text passed them. Both now run the loop against a pinger failing with `dial tcp <host>:<port>: connection refused` before reading the degraded verdict, and the same mutation now fails them. That is the separate `test(gateway):` commit.

### Live evidence, gateway running natively against the real control plane

Re-captured after rebasing onto latest main, so this is the code in the PR.

Healthy, gateway on `:5573` pointed at the app on `:5560` with the real shared secret:

```
$ curl -si http://localhost:5573/health
HTTP/1.1 200 OK
Cache-Control: no-store
Content-Type: application/json

{"status":"ok","checks":{"control_plane":"ok","gateway":"ok"}}

$ curl -sI http://localhost:5573/health
HTTP/1.1 200 OK          # HEAD: same status and headers, no body

$ for m in POST PUT PATCH DELETE; do curl -s -o /dev/null -w "$m -> %{http_code}\n" -X $m http://localhost:5573/health; done
POST -> 405
PUT -> 405
PATCH -> 405
DELETE -> 405
```

Unhealthy, control plane unreachable (gateway pointed at a dead port), after the 60s tolerance:

```
$ curl -si http://localhost:5583/health
HTTP/1.1 503 Service Unavailable
Cache-Control: no-store

{"status":"degraded","checks":{"control_plane":"unreachable for 64s","gateway":"ok"}}

$ curl -o /dev/null -w '%{http_code}\n' http://localhost:5583/healthz    # 200
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:5583/readyz     # 200
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:5583/startupz   # 200
```

Unhealthy for the reason that matters most, a mismatched `LW_GATEWAY_INTERNAL_SECRET` against a control plane that is up, reachable, and on the correct URL:

```
$ curl -si http://localhost:5601/health
HTTP/1.1 503 Service Unavailable

{"status":"degraded","checks":{"control_plane":"unreachable for 62s","gateway":"ok"}}
```

Both failure modes answered 200 for the first 60s after boot, confirming the grace window: a rolling deploy does not blink the page.

No fan-out, measured rather than asserted. A stub control plane counting hits on `/api/internal/gateway/health`:

```
probes before: 1        # the boot probe
500 polls of /health
probes after : 1        # unchanged
```

An earlier run left idle for another 35s took the count from 1 to 4: the 15s ticker is the only thing that ever probes.

## Anything surprising?

- **`/readyz` is dependency-free and must stay that way.** The temptation on reading this PR is "why not just add the control-plane check to `/readyz` and point the status page there". Because that pulls every pod from the load balancer on a control-plane blip and converts a survivable degradation into a full outage. The reasoning is now recorded in both the spec and the docs so the next person does not rediscover it in production.
- **`/health` can be 503 while the gateway is still serving most traffic.** That is intended: warm keys keep resolving from the auth cache. It means a red status page during a control-plane outage is honest about "some requests are failing" rather than "everything is down". If we later want to distinguish those, the component map already has room for it without changing the status code contract.
- **Interval and tolerance are constants, not values.** 15s/60s are sensible for our topology and I did not want to add config surface nobody asked for. If a self-hoster with a slow control plane needs a longer tolerance, promoting them to `ControlPlaneConfig` is a small follow-up.
- **Do not point the status page at `/api/health/workflows` or `/api/health/evaluations`**, whatever their names suggest. See the table above: they need a project API key, they run real customer work per hit, and the workflows one goes red on a model provider outage while billing the tenant for the privilege. `GET /api/health` (204) is the right target for the app, `GET /health` is the right target for the gateway.
- **Rebased onto latest main** and the full battery re-run on the rebased tree: Go build, `go test -race`, gofmt, golangci-lint (0 issues), `pnpm typecheck`, `pnpm typecheck:tests`, `pnpm check:feature-parity`, `helm lint`, and the live curls above. No conflicts; the only file both sides touched was the generated `docs/llms-full.txt`, and regenerating it after the rebase produced no diff.
- **Pre-existing local test failures, unrelated:** `src/server/routes/__tests__/trpc-empty-body.test.ts` and `hono-bridge-streaming.test.ts` fail on a clean `origin/main` in my worktree with `Cannot find package '@langwatch/mcp-server/config'`, which needs the `mcp-server` workspace built locally. Not a code failure, and confirmed by reverting my only TS source change and re-running. CI builds the workspace, so it does not reproduce there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `GET/HEAD /health` status endpoint (ingress-configurable) returning `200` when healthy and `503` when degraded.
  * Reports `gateway` + `control_plane` status in a minimal JSON payload, with `Cache-Control: no-store`.
  * Introduced signed internal connectivity checks and background monitoring to back `/health`.

* **Documentation**
  * Updated health-check and troubleshooting guidance to make `/readyz` lifecycle-only and move dependency health reporting to `/health`.

* **Tests**
  * Added integration and unit coverage for signed health, `/health` HTTP semantics, and caching/probe fan-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->