### PR TITLE
fix(automations): make the Slack channel picker searchable again

### DIFF
--- a/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -410,9 +410,9 @@ describe("SlackConfigForm channel picker", () => {
         );
         await user.tab();
 
-        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
-          channelId: "#adhoc",
-        });
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ channelId: "#adhoc" }),
+        );
       });
 
       it("carries the typed text into the slice on Enter", async () => {
@@ -425,9 +425,9 @@ describe("SlackConfigForm channel picker", () => {
           "#adhoc{Enter}",
         );
 
-        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
-          channelId: "#adhoc",
-        });
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ channelId: "#adhoc" }),
+        );
       });
     });
 
@@ -441,9 +441,30 @@ describe("SlackConfigForm channel picker", () => {
         await user.click(input);
         await user.click(await screen.findByText("#release-signoff"));
 
-        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
-          channelId: "C003",
-        });
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ channelId: "C003" }),
+        );
+        expect(input).toHaveValue("#release-signoff");
+      });
+
+      // Enter means two things in this field: commit what was typed, and
+      // accept the highlighted suggestion. Both handlers fire on the same
+      // keypress, so the one that lands LAST decides what gets saved — a
+      // suggestion the author deliberately highlighted must beat the search
+      // text they typed to find it.
+      it("keeps the highlighted channel, not the search text, when Enter accepts a suggestion", async () => {
+        const user = typist();
+        const onChangeSpy = vi.fn();
+        renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.type(input, "signoff");
+        await user.keyboard("{ArrowDown}{Enter}");
+
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ channelId: "C003" }),
+        );
         expect(input).toHaveValue("#release-signoff");
       });
     });

--- a/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -469,6 +469,56 @@ describe("SlackConfigForm channel picker", () => {
       });
     });
 
+    describe("when the author replaces a picked channel with a free-typed one", () => {
+      // The picked channel stays the combobox's selection until something
+      // moves it, so the list would keep a tick beside a channel that is no
+      // longer the field's value.
+      it("moves the tick off the channel it replaced", async () => {
+        const user = typist();
+        renderForm({ initial: botSlice({ channelId: "" }) });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.click(await screen.findByText("#release-signoff"));
+        await user.clear(input);
+        await user.type(input, "#adhoc");
+        await user.tab();
+        await user.click(input);
+
+        const checked = Array.from(
+          document.querySelectorAll(
+            '[data-scope="combobox"][data-part="item"][data-state="checked"]',
+          ),
+        ).map((el) => el.textContent);
+
+        // The typed channel is the value, so it may carry the tick; the
+        // channel it replaced must not.
+        expect(checked).toEqual(["#adhoc"]);
+      });
+
+      // ...and moving that selection must not take the typed text with it:
+      // the combobox rewrites its input from the selection, so CLEARING the
+      // selection outright is exactly the move that blanks the box. This is
+      // the guard on that — it fails if the fix regresses to setSelectedId("").
+      it("keeps the typed channel in the box and in the slice", async () => {
+        const user = typist();
+        const onChangeSpy = vi.fn();
+        renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.click(await screen.findByText("#release-signoff"));
+        await user.clear(input);
+        await user.type(input, "#adhoc");
+        await user.tab();
+
+        expect(input).toHaveValue("#adhoc");
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ channelId: "#adhoc" }),
+        );
+      });
+    });
+
     describe("given a saved automation whose channel id is already stored", () => {
       it("shows the channel name rather than the raw id", async () => {
         renderForm({ initial: botSlice({ channelId: "C003" }) });

--- a/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -13,13 +13,19 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFormCtx } from "~/features/automations/providers/types";
 
 vi.mock("@monaco-editor/react", () => ({ default: () => null }));
 vi.mock("~/components/ui/color-mode", () => ({
   useColorMode: () => ({ colorMode: "light" }),
 }));
+/** Channels the mocked listSlackChannels mutation has "already loaded". Tests
+ *  that care about the picker set this before rendering. */
+const listedChannels: { current: { id: string; name: string }[] | undefined } = {
+  current: undefined,
+};
+
 vi.mock("~/utils/api", () => ({
   api: {
     automation: {
@@ -29,7 +35,9 @@ vi.mock("~/utils/api", () => ({
       listSlackChannels: {
         useMutation: () => ({
           mutate: vi.fn(),
-          data: undefined,
+          data: listedChannels.current
+            ? { channels: listedChannels.current }
+            : undefined,
           isPending: false,
         }),
       },
@@ -325,6 +333,129 @@ describe("SlackConfigForm delivery method", () => {
           name: /use eval failure banner template/i,
         }),
       ).toBeEnabled();
+    });
+  });
+});
+
+describe("SlackConfigForm channel picker", () => {
+  afterEach(() => {
+    cleanup();
+    listedChannels.current = undefined;
+  });
+
+  describe("given a workspace whose channels have loaded", () => {
+    beforeEach(() => {
+      // A shared prefix ("support", "support-escalations") and a term that
+      // only bites late in the name ("signoff") are what a one-character
+      // search cannot separate — which is the bug this block pins.
+      listedChannels.current = [
+        { id: "C001", name: "alerts" },
+        { id: "C002", name: "build-status" },
+        { id: "C003", name: "release-signoff" },
+        { id: "C004", name: "support" },
+        { id: "C005", name: "support-escalations" },
+      ];
+    });
+
+    // Typed at a human cadence on purpose. The combobox resyncs the input
+    // element from a passive effect, so back-to-back synthetic keystrokes with
+    // no gap at all outrun React's effect flush and drop characters — a race no
+    // typist can win, and not the bug under test.
+    const typist = () => userEvent.setup({ delay: 10 });
+
+    describe("when the author types a channel name to search", () => {
+      it("keeps every typed character in the box", async () => {
+        const user = typist();
+        renderForm({ initial: botSlice({ channelId: "" }) });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.type(input, "signoff");
+
+        expect(input).toHaveValue("signoff");
+      });
+
+      it("narrows the list by the whole search term, not just the last letter", async () => {
+        const user = typist();
+        renderForm({ initial: botSlice({ channelId: "" }) });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.type(input, "signoff");
+
+        expect(screen.getByText("#release-signoff")).toBeInTheDocument();
+        expect(screen.queryByText("#support")).not.toBeInTheDocument();
+      });
+
+      // A long name is the case that broke: the box was rewritten on every
+      // keystroke, so only the last character ever survived.
+      it("keeps a long search term intact", async () => {
+        const user = typist();
+        renderForm({ initial: botSlice({ channelId: "" }) });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.type(input, "#adhoc");
+
+        expect(input).toHaveValue("#adhoc");
+      });
+
+      it("carries the typed text into the slice on blur, so a channel that isn't listed still saves", async () => {
+        const user = typist();
+        const onChangeSpy = vi.fn();
+        renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
+
+        await user.type(
+          screen.getByPlaceholderText(/#alerts or c0123/i),
+          "#adhoc",
+        );
+        await user.tab();
+
+        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
+          channelId: "#adhoc",
+        });
+      });
+
+      it("carries the typed text into the slice on Enter", async () => {
+        const user = typist();
+        const onChangeSpy = vi.fn();
+        renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
+
+        await user.type(
+          screen.getByPlaceholderText(/#alerts or c0123/i),
+          "#adhoc{Enter}",
+        );
+
+        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
+          channelId: "#adhoc",
+        });
+      });
+    });
+
+    describe("when the author picks a channel from the list", () => {
+      it("stores the channel id and shows its name", async () => {
+        const user = userEvent.setup();
+        const onChangeSpy = vi.fn();
+        renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
+        const input = screen.getByPlaceholderText(/#alerts or c0123/i);
+
+        await user.click(input);
+        await user.click(await screen.findByText("#release-signoff"));
+
+        expect(onChangeSpy.mock.calls.at(-1)![0]).toMatchObject({
+          channelId: "C003",
+        });
+        expect(input).toHaveValue("#release-signoff");
+      });
+    });
+
+    describe("given a saved automation whose channel id is already stored", () => {
+      it("shows the channel name rather than the raw id", async () => {
+        renderForm({ initial: botSlice({ channelId: "C003" }) });
+
+        expect(
+          await screen.findByDisplayValue("#release-signoff"),
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -265,8 +265,8 @@ function channelOption(channel: {
  * AUTOMATICALLY and drops in as filterable suggestions. Picking a suggestion
  * stores the channel ID (what `chat.postMessage` wants), while free typing is
  * kept verbatim so a custom / not-yet-listed channel still works — committed
- * when the author leaves the field, not on every keystroke. A missing scope
- * degrades to a hint, never a hard error.
+ * on blur or Enter, not on every keystroke. A missing scope degrades to a
+ * hint, never a hard error.
  */
 function SlackChannelField({
   projectId,
@@ -339,7 +339,7 @@ function SlackChannelField({
   const [selectedId, setSelectedId] = useState("");
   // Once the author starts typing, the field is theirs — nothing below may
   // reach in and rewrite what they are searching for.
-  const authorTyped = useRef(false);
+  const hasAuthorTyped = useRef(false);
 
   // Text typed but not yet committed to the slice. A ref, not state, and
   // deliberately NOT written through on every keystroke: writing the slice
@@ -360,7 +360,7 @@ function SlackChannelField({
   // Promoting it to a real selection once the list can resolve it lets the
   // combobox fill in the channel NAME, which is what the author recognises.
   useEffect(() => {
-    if (authorTyped.current) return;
+    if (hasAuthorTyped.current) return;
     const stored = (channelData ?? []).find((c) => c.id === slice.channelId);
     if (stored) setSelectedId(stored.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -421,7 +421,7 @@ function SlackChannelField({
           // Free entry (paste an ID / type a name that isn't listed) is held
           // until the author leaves the field — see `commitTypedChannel`.
           if (details.reason === "input-change") {
-            authorTyped.current = true;
+            hasAuthorTyped.current = true;
             pendingText.current = details.inputValue;
           }
         }}

--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -16,7 +16,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { ExternalLink } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { FaSlack } from "react-icons/fa";
 import { Link } from "~/components/ui/link";
 import { SegmentedControl } from "~/components/ui/segmented-control";
@@ -247,13 +247,26 @@ function UpgradeToBotBanner({ onUpgrade }: { onUpgrade: () => void }) {
   );
 }
 
+/** One channel as the picker shows it: the ID is stored, the name is read. */
+function channelOption(channel: {
+  id: string;
+  name: string;
+  isPrivate?: boolean;
+}) {
+  return {
+    value: channel.id,
+    label: `${channel.isPrivate ? "🔒 " : "#"}${channel.name}`,
+  };
+}
+
 /**
  * Channel field: a typeable combobox. Manual entry always works (type a name or
  * paste an ID); once a token is present the channel list is fetched
  * AUTOMATICALLY and drops in as filterable suggestions. Picking a suggestion
  * stores the channel ID (what `chat.postMessage` wants), while free typing is
- * kept verbatim so a custom / not-yet-listed channel still works. A missing
- * scope degrades to a hint, never a hard error.
+ * kept verbatim so a custom / not-yet-listed channel still works — committed
+ * when the author leaves the field, not on every keystroke. A missing scope
+ * degrades to a hint, never a hard error.
  */
 function SlackChannelField({
   projectId,
@@ -313,14 +326,45 @@ function SlackChannelField({
     value: string;
   }>({ initialItems: [], filter: contains });
   useEffect(() => {
-    set(
-      (channelData ?? []).map((c) => ({
-        value: c.id,
-        label: `${c.isPrivate ? "🔒 " : "#"}${c.name}`,
-      })),
-    );
+    set((channelData ?? []).map(channelOption));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelData]);
+
+  // The channel actually PICKED from the list — deliberately NOT
+  // `slice.channelId`, which also holds free-typed text. The combobox rewrites
+  // its own input to the selected item's label every time its `value` changes,
+  // so feeding half-typed text back as `value` wiped the box on every
+  // keystroke: the search never got past one character, and any channel that
+  // needed a longer search was unreachable.
+  const [selectedId, setSelectedId] = useState("");
+  // Once the author starts typing, the field is theirs — nothing below may
+  // reach in and rewrite what they are searching for.
+  const authorTyped = useRef(false);
+
+  // Text typed but not yet committed to the slice. A ref, not state, and
+  // deliberately NOT written through on every keystroke: writing the slice
+  // re-renders this whole form, and the combobox resyncs the input element
+  // from a PASSIVE effect, so the resync lands a render late and overwrites
+  // characters typed in between — "#adhoc" arrives as "#ahc". The search stays
+  // live on every keystroke; only the commit waits for the author to finish.
+  const pendingText = useRef<string | null>(null);
+  const commitTypedChannel = () => {
+    const typed = pendingText.current;
+    pendingText.current = null;
+    if (typed !== null && typed !== slice.channelId) {
+      onChange({ ...slice, channelId: typed });
+    }
+  };
+
+  // A saved automation stores the channel ID, so the box would read "C0123…".
+  // Promoting it to a real selection once the list can resolve it lets the
+  // combobox fill in the channel NAME, which is what the author recognises.
+  useEffect(() => {
+    if (authorTyped.current) return;
+    const stored = (channelData ?? []).find((c) => c.id === slice.channelId);
+    if (stored) setSelectedId(stored.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelData, slice.channelId]);
 
   const canLoad =
     typedToken.length > 0 || slice.botTokenAlreadySet || !!automationId;
@@ -361,16 +405,24 @@ function SlackChannelField({
         width="full"
         allowCustomValue
         openOnClick
-        value={slice.channelId ? [slice.channelId] : []}
-        onValueChange={(details) =>
-          onChange({ ...slice, channelId: details.value[0] ?? "" })
-        }
+        value={selectedId ? [selectedId] : []}
+        // The stored channel shows through immediately — as its ID at first,
+        // upgraded to its name by the effect above once the list resolves it.
+        defaultInputValue={slice.channelId}
+        onValueChange={(details) => {
+          // A pick beats whatever was half-typed, and stores the ID rather
+          // than the "#name" label the author sees.
+          pendingText.current = null;
+          setSelectedId(details.value[0] ?? "");
+          onChange({ ...slice, channelId: details.value[0] ?? "" });
+        }}
         onInputValueChange={(details) => {
-          filter(details.inputValue);
-          // Immediate free entry (paste an ID / type a name). A real pick is
-          // handled by onValueChange so we keep the channel ID, not its label.
+          startTransition(() => filter(details.inputValue));
+          // Free entry (paste an ID / type a name that isn't listed) is held
+          // until the author leaves the field — see `commitTypedChannel`.
           if (details.reason === "input-change") {
-            onChange({ ...slice, channelId: details.inputValue });
+            authorTyped.current = true;
+            pendingText.current = details.inputValue;
           }
         }}
         onOpenChange={(details) => {
@@ -382,6 +434,10 @@ function SlackChannelField({
             placeholder={
               list.isPending ? "Loading channels…" : "#alerts or C0123…"
             }
+            onBlur={commitTypedChannel}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitTypedChannel();
+            }}
           />
           <Combobox.IndicatorGroup>
             {list.isPending ? <Spinner size="xs" /> : null}

--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -325,10 +325,24 @@ function SlackChannelField({
     label: string;
     value: string;
   }>({ initialItems: [], filter: contains });
+  // A channel the bot can't list is still a real destination, so it gets its
+  // own entry once committed. That entry is what lets it be the combobox's
+  // SELECTION: the machine rewrites its input from the selected item's label,
+  // and an entry whose label is the typed text survives that rewrite unchanged.
+  const [customChannel, setCustomChannel] = useState("");
+  const listedIds = useMemo(
+    () => new Set((channelData ?? []).map((c) => c.id)),
+    [channelData],
+  );
   useEffect(() => {
-    set((channelData ?? []).map(channelOption));
+    const listed = (channelData ?? []).map(channelOption);
+    set(
+      customChannel && !listedIds.has(customChannel)
+        ? [...listed, { value: customChannel, label: customChannel }]
+        : listed,
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channelData]);
+  }, [channelData, customChannel]);
 
   // The channel actually PICKED from the list — deliberately NOT
   // `slice.channelId`, which also holds free-typed text. The combobox rewrites
@@ -352,6 +366,14 @@ function SlackChannelField({
     const typed = pendingText.current;
     pendingText.current = null;
     if (typed !== null && typed !== slice.channelId) {
+      // Typing over a picked channel replaces it, so the old pick must stop
+      // being the selection — otherwise the list keeps a tick beside a channel
+      // that is no longer this field's value. Clearing the selection outright
+      // would blank the box (the combobox rewrites its input from the selected
+      // item, and "nothing selected" stringifies to ""), so the typed channel
+      // becomes the selection instead, backed by its own collection entry.
+      if (!listedIds.has(typed)) setCustomChannel(typed);
+      setSelectedId(typed);
       onChange({ ...slice, channelId: typed });
     }
   };


### PR DESCRIPTION
## Why

Closes #6230

Typing in the **Channel** field of a Slack automation cleared the box on every keystroke. The dropdown visibly reacted to what was typed, but the input stayed empty — so the channel list could only ever be filtered by the *last single character*. In a workspace with a long channel list the field looks like a short, unsearchable dropdown, and the channel you actually want is unreachable.

Surfaced by a customer report. The initial reading — that the dropdown only lists a limited set of channels — is a symptom, not the cause. The dropdown renders every channel the server returned, and the server pages `conversations.list` up to 10 x 200 = 2000 channels before it truncates. What was broken is the search.

## What changed

`SlackChannelField` now keeps the channel the author **picked** separate from the text they are **typing**.

Before, both lived in the same place: `slice.channelId` holds a channel ID when you pick from the list *and* raw text when you type a channel the bot cannot list. That single value was handed straight back to the combobox as its selected value, so every keystroke looked like a new selection.

Three things follow from separating them:

- **The search survives.** Nothing rewrites the box while the author types, so the whole search term reaches the filter instead of just the last letter.
- **A saved automation shows its channel.** The stored value is an ID, resolved against a channel list that only arrives after mount. The box now shows the ID immediately and upgrades to the channel name as soon as the list can resolve it — previously it opened blank, so a perfectly configured automation looked unconfigured.
- **Free entry still works.** A channel the bot cannot list (private, or not yet joined) can still be typed by hand. It commits when the author leaves the field or presses Enter, rather than on every keystroke.

## How it works

The combobox is `@zag-js/combobox` (via Chakra). For a single-select combobox its `selectionBehavior` is `"replace"`, which means: whenever the machine's `value` changes, it rewrites its own input to the selected item's label — `collection.stringifyMany(value)`.

Feeding the typed text back as `value` therefore tripped that rewrite on every keystroke. Free text is not an item in the collection, so `stringifyMany` resolved to an empty string and the box was wiped. The filter had already run with the typed character before the rewrite landed, which is exactly why the list appeared to react while the box stayed blank.

The same rewrite also re-entered the input-change handler with an empty string and reason `input-change`, so it wiped the stored channel too — meaning a hand-typed channel could never be saved at all, only appear to be.

Two decisions worth flagging:

- **Free entry commits on blur / Enter, not per keystroke.** Writing the slice on every keystroke re-rendered the whole config form, and the combobox resyncs its input element from a *passive* effect — so the resync landed a render late and overwrote characters typed in between (`#adhoc` arrived as `#ahc`). Committing on blur removes the per-keystroke re-render of the preview, template gallery and editors as a bonus. A pick from the list still commits immediately, and beats any half-typed text.
- **Re-filtering runs in a `startTransition`.** Filtering a 2000-entry list is the expensive part of a keystroke; deferring it keeps the input on the urgent path.

## Test plan

10 new cases in `client.integration.test.tsx`. The first seven are one per symptom and all fail on `main`; the last three came out of review:

| Case | Fails without the fix as |
|---|---|
| keeps every typed character in the box | box is empty |
| keeps a long search term intact | `#adhoc` becomes `#ahc` |
| narrows the list by the whole search term, not just the last letter | non-matching channels still listed |
| carries the typed text into the slice on blur | `channelId` is `""` |
| carries the typed text into the slice on Enter | `channelId` is `""` |
| picking a channel stores the ID and shows the name | — (guards the fix) |
| a saved automation shows the channel name, not the raw ID | box is blank |
| Enter on a highlighted suggestion keeps the channel, not the search text | — (added in review; pins which of the two Enter handlers wins) |
| typing over a picked channel moves the tick off it | list keeps a tick on a channel that is no longer the value |
| ...and the typed text survives that | box blanks on blur (guards against clearing the selection to fix the row above) |

The typing cases drive a human cadence on purpose (`delay: 10`). Back-to-back synthetic keystrokes with no gap outrun React's effect flush and drop characters through the combobox's passive resync — a race no typist can win, and not the bug under test. That is called out in a comment next to the helper.

Run locally:

- `client.integration.test.tsx` — 27 passed, checked repeatedly for flake (5 clean runs before review, 3 after each review round).
- `src/features/automations` integration — 15 files, 131 passed.
- `src/features/automations` + `src/server/app-layer/automations` unit — 44 files, 619 passed.
- `pnpm typecheck` and `pnpm typecheck:tests` — both clean.

## Anything surprising?

- **The channel list is capped at 2000 and the dropdown renders all of it.** `listSlackChannels` walks 10 pages of 200 and logs a warning if it hits the cap; the popover then renders one DOM node per channel with no virtualisation. Both are pre-existing and neither is what caused this report — with search working they are far less pressing — but a workspace past 2000 channels will still silently miss some, and the popover is heavy. Worth a follow-up, deliberately out of scope here.
- **`biome` cannot run in this tree at all.** `biome.json` declares schema `2.4.14` against the pinned `2.5.1` binary, so `biome ci` bails on the configuration before it lints anything, on untouched files too. Pre-existing and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Slack channel picker’s combobox to better support searching by full terms, including long channel names.
  * Users can commit a manually typed channel name even if it isn’t in the loaded list.
  * Listed channel selections now consistently store the channel ID while showing the channel name, and restore properly for existing automations.

* **Bug Fixes**
  * Prevented user typing from being overwritten during filtering, including with delayed input.
  * When pressing Enter with a highlighted suggestion, the suggestion selection takes precedence over the typed search text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

