### PR TITLE
fix: distinguish Slack app (bot) destinations from webhooks in view drawer [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/langwatch/src/features/automations/ViewAutomationDrawer.tsx
+++ b/langwatch/src/features/automations/ViewAutomationDrawer.tsx
@@ -110,9 +110,21 @@ export function ViewAutomationDrawer({
   const destinationSummary = (): React.ReactNode => {
     if (!trigger) return null;
     switch (trigger.action) {
-      case "SEND_SLACK_MESSAGE":
-        // The webhook URL carries a secret token — mask it and surface the
-        // full URL only on hover, mirroring the list page's Slack cell.
+      case "SEND_SLACK_MESSAGE": {
+        // Distinguish the three ways a Slack automation can deliver:
+        // 1. Legacy webhook — `slackWebhook` holds the URL (mask it, surface
+        //    the full value only on hover to avoid leaking the token).
+        // 2. Slack app (bot) — `slackDelivery === "bot"` and the destination
+        //    is the picked channel (`slackChannelId`, e.g. "C0123" or "#name").
+        // 3. Fallback for untyped / legacy rows that carry neither flag.
+        if (actionParams.slackDelivery === "bot") {
+          const channel = actionParams.slackChannelId;
+          return (
+            <Text textStyle="sm" wordBreak="break-all">
+              {channel ? `Slack app · ${channel}` : "Slack app"}
+            </Text>
+          );
+        }
         return actionParams.slackWebhook ? (
           <Tooltip content={actionParams.slackWebhook}>
             <Text textStyle="sm" lineClamp={1} width="fit-content" cursor="help">
@@ -122,6 +134,7 @@ export function ViewAutomationDrawer({
         ) : (
           <Text textStyle="sm">Slack webhook</Text>
         );
+      }
       case "SEND_EMAIL":
         return actionParams.members?.length ? (
           <Text textStyle="sm" wordBreak="break-all">

--- a/langwatch/src/features/automations/__tests__/ViewAutomationDrawer.integration.test.tsx
+++ b/langwatch/src/features/automations/__tests__/ViewAutomationDrawer.integration.test.tsx
@@ -344,4 +344,77 @@ describe("ViewAutomationDrawer", () => {
       });
     });
   });
+
+  describe("given a Slack app (bot) automation", () => {
+    describe("when the picked channel is stored in slackChannelId", () => {
+      beforeEach(() => {
+        mockTriggerRow = {
+          id: "trigger_1",
+          name: "Errors to #alerts",
+          action: "SEND_SLACK_MESSAGE",
+          customGraphId: null,
+          filters: "{}",
+          actionParams: {
+            slackDelivery: "bot",
+            slackChannelId: "C012345",
+            slackBotTokenSet: true,
+          },
+        };
+        mockRecentFires = [];
+      });
+
+      it("labels the destination as a Slack app with the channel", () => {
+        renderDrawer();
+
+        expect(screen.getByText("Slack app · C012345")).toBeDefined();
+        expect(screen.queryByText("Slack webhook")).toBeNull();
+      });
+    });
+
+    describe("when no channel has been picked yet", () => {
+      beforeEach(() => {
+        mockTriggerRow = {
+          id: "trigger_1",
+          name: "Pending Slack app",
+          action: "SEND_SLACK_MESSAGE",
+          customGraphId: null,
+          filters: "{}",
+          actionParams: {
+            slackDelivery: "bot",
+            slackBotTokenSet: true,
+          },
+        };
+        mockRecentFires = [];
+      });
+
+      it("labels the destination as a Slack app without a channel", () => {
+        renderDrawer();
+
+        expect(screen.getByText("Slack app")).toBeDefined();
+        expect(screen.queryByText("Slack webhook")).toBeNull();
+      });
+    });
+  });
+
+  describe("given a legacy Slack automation with neither webhook nor bot flag", () => {
+    beforeEach(() => {
+      mockTriggerRow = {
+        id: "trigger_1",
+        name: "Legacy Slack",
+        action: "SEND_SLACK_MESSAGE",
+        customGraphId: null,
+        filters: "{}",
+        actionParams: {},
+      };
+      mockRecentFires = [];
+    });
+
+    describe("when the drawer renders", () => {
+      it("falls back to the generic webhook label", () => {
+        renderDrawer();
+
+        expect(screen.getByText("Slack webhook")).toBeDefined();
+      });
+    });
+  });
 });

--- a/langwatch/src/features/automations/logic/triggerActionParams.ts
+++ b/langwatch/src/features/automations/logic/triggerActionParams.ts
@@ -13,7 +13,9 @@ import type {
  * one place instead of three hand-maintained copies.
  */
 export interface TriggerActionParams {
+  slackDelivery?: "bot" | "webhook";
   slackWebhook?: string;
+  slackChannelId?: string;
   members?: string[];
   datasetId?: string;
   annotators?: { id: string; name: string }[];


### PR DESCRIPTION
## Summary

The read-only automation drawer currently labels every Slack automation's
destination as **"Slack webhook"**, including automations that deliver through
a Slack app (bot token + picked channel). It also never shows which channel
the message is sent to, so the drawer cannot answer the question it exists
to answer: *where does this automation post?*

This change branches on `actionParams.slackDelivery` inside the
`SEND_SLACK_MESSAGE` case of `destinationSummary()`:

- **Slack app (bot)** → renders `Slack app · <channel>` (e.g.
  `Slack app · C012345`), showing the picked destination channel.
- **Legacy webhook** (`slackWebhook` present) → keeps the existing masked
  label with a tooltip surfacing the full webhook URL (token stays hidden
  unless hovered).
- **Untyped legacy row** (neither flag) → falls back to the generic
  `Slack webhook` label, matching pre-existing behaviour.

`TriggerActionParams` is extended with the now-typed `slackDelivery` and
`slackChannelId` fields so the component compiles against the persisted
schema.

## Files changed

- `langwatch/src/features/automations/ViewAutomationDrawer.tsx` — branch on
  `slackDelivery === "bot"` and render the channel.
- `langwatch/src/features/automations/logic/triggerActionParams.ts` — add the
  two typed fields to the shared display interface.
- `langwatch/src/features/automations/__tests__/ViewAutomationDrawer.integration.test.tsx`
  — three new vitest cases: bot-with-channel, bot-without-channel, and
  legacy-fallback.

Fixes langwatch/langwatch#6244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack automation destinations now clearly identify whether messages are sent through the Slack app or a webhook.
  * Slack app destinations display the selected channel when available.
  * Destinations without a selected channel still show the Slack app label.

* **Bug Fixes**
  * Existing webhook-based Slack automations continue to display the appropriate webhook label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->