### PR TITLE
feat: launch day fixes: pre-provisioned tools, subscription-first CLI, first-trace redirect, opus-5 1m pricing, first-project affordance

### DIFF
--- a/docs/ai-governance/personal-portal/admin-catalog.mdx
+++ b/docs/ai-governance/personal-portal/admin-catalog.mdx
@@ -31,8 +31,10 @@ The provisioned set is org-scoped and editable like any other entry.
 You can reorder, scope, disable, or archive entries afterward.
 Auto-provisioning only ever runs on a catalog that has never had any
 entry, so a catalog you curated down to nothing stays empty. The
-**Import starter pack** CTA in the editor re-imports missing starter
-tiles whenever you want them back.
+**Import starter pack** button in the editor adds starter tiles the
+catalog never had, such as tiles added to the pack after your org was
+provisioned. Tiles you archived are respected as removed: import skips
+them, and **+ Add tile** recreates one if you want it back.
 
 ## Adding a tile
 

--- a/docs/ai-governance/personal-portal/admin-catalog.mdx
+++ b/docs/ai-governance/personal-portal/admin-catalog.mdx
@@ -17,19 +17,22 @@ every matching user's `/me` portal grid.
 
 ## Starter pack
 
-A fresh organization has an empty catalog. Your first visit shows an
-**Import starter pack** CTA, one click publishes a sensible default
-set:
+A fresh organization does not start empty: the standard catalog is
+provisioned automatically at signup (and on the portal's first load for
+organizations created before this behavior), so your members' `/me`
+portal renders tiles from day one:
 
-- Coding assistants: Claude Code, Copilot, Cursor, Codex
-- Model providers: OpenAI, Anthropic, Bedrock, Gemini
+- Coding assistants: Claude Code, Codex, Gemini CLI, opencode
+- Model providers: OpenAI, Anthropic, AWS Bedrock, Google AI
 - External tools: empty (admins fill these in per-org with internal
   links)
 
-The starter pack is org-scoped and editable like any other entry. You
-can reorder, scope to specific teams, or archive entries afterward.
-There's no penalty for skipping the starter pack and adding tiles
-manually if your org's allowed-AI list is narrower.
+The provisioned set is org-scoped and editable like any other entry.
+You can reorder, scope, disable, or archive entries afterward.
+Auto-provisioning only ever runs on a catalog that has never had any
+entry, so a catalog you curated down to nothing stays empty. The
+**Import starter pack** CTA in the editor re-imports missing starter
+tiles whenever you want them back.
 
 ## Adding a tile
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -16455,8 +16455,10 @@ The provisioned set is org-scoped and editable like any other entry.
 You can reorder, scope, disable, or archive entries afterward.
 Auto-provisioning only ever runs on a catalog that has never had any
 entry, so a catalog you curated down to nothing stays empty. The
-**Import starter pack** CTA in the editor re-imports missing starter
-tiles whenever you want them back.
+**Import starter pack** button in the editor adds starter tiles the
+catalog never had, such as tiles added to the pack after your org was
+provisioned. Tiles you archived are respected as removed: import skips
+them, and **+ Add tile** recreates one if you want it back.
 
 ## Adding a tile
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -16441,19 +16441,22 @@ every matching user's `/me` portal grid.
 
 ## Starter pack
 
-A fresh organization has an empty catalog. Your first visit shows an
-**Import starter pack** CTA, one click publishes a sensible default
-set:
+A fresh organization does not start empty: the standard catalog is
+provisioned automatically at signup (and on the portal's first load for
+organizations created before this behavior), so your members' `/me`
+portal renders tiles from day one:
 
-- Coding assistants: Claude Code, Copilot, Cursor, Codex
-- Model providers: OpenAI, Anthropic, Bedrock, Gemini
+- Coding assistants: Claude Code, Codex, Gemini CLI, opencode
+- Model providers: OpenAI, Anthropic, AWS Bedrock, Google AI
 - External tools: empty (admins fill these in per-org with internal
   links)
 
-The starter pack is org-scoped and editable like any other entry. You
-can reorder, scope to specific teams, or archive entries afterward.
-There's no penalty for skipping the starter pack and adding tiles
-manually if your org's allowed-AI list is narrower.
+The provisioned set is org-scoped and editable like any other entry.
+You can reorder, scope, disable, or archive entries afterward.
+Auto-provisioning only ever runs on a catalog that has never had any
+entry, so a catalog you curated down to nothing stays empty. The
+**Import starter pack** CTA in the editor re-imports missing starter
+tiles whenever you want them back.
 
 ## Adding a tile
 

--- a/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
@@ -511,6 +511,79 @@ describe("aiToolsRouter integration", () => {
     });
   });
 
+  describe("list auto-provisioning", () => {
+    // Hermetic fresh org: the suite org accumulates tiles from sibling
+    // tests (and gets auto-provisioned by their list calls), so pinning
+    // the exact default set needs a clean slate.
+    /** @scenario A member's first portal load of a zero-row organization returns the provisioned catalog */
+    it("provisions the standard catalog on a fresh org's very first list", async () => {
+      const fresh = `autoprov-${nanoid(8)}`;
+      const org = await prisma.organization.create({
+        data: { name: `Autoprov ${fresh}`, slug: `--ait-ap-${fresh}` },
+      });
+      const member = await prisma.user.create({
+        data: {
+          name: "Autoprov Member",
+          email: `ait-autoprov-${fresh}@example.com`,
+        },
+      });
+      await prisma.organizationUser.create({
+        data: {
+          userId: member.id,
+          organizationId: org.id,
+          role: OrganizationUserRole.MEMBER,
+        },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: org.id,
+          userId: member.id,
+          role: TeamUserRole.MEMBER,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: org.id,
+        },
+      });
+
+      try {
+        // No admin ever touched this org's catalog: the first list call
+        // itself provisions the standard set, so the portal's
+        // totalEnabled===0 empty state is unreachable for fresh orgs.
+        const list = await callerFor(member.id).aiTools.list({
+          organizationId: org.id,
+        });
+        expect(list.map((e) => e.slug).sort()).toEqual([
+          "anthropic",
+          "bedrock",
+          "claude-code",
+          "codex",
+          "gemini",
+          "google",
+          "openai",
+          "opencode",
+        ]);
+        expect(list.every((e) => e.enabled)).toBe(true);
+
+        // Second read is a plain read: nothing re-seeds or duplicates.
+        const again = await callerFor(member.id).aiTools.list({
+          organizationId: org.id,
+        });
+        expect(again).toHaveLength(8);
+      } finally {
+        await prisma.aiToolEntry.deleteMany({
+          where: { organizationId: org.id },
+        });
+        await prisma.roleBinding.deleteMany({
+          where: { organizationId: org.id },
+        });
+        await prisma.organizationUser.deleteMany({
+          where: { organizationId: org.id },
+        });
+        await prisma.organization.deleteMany({ where: { id: org.id } });
+        await prisma.user.deleteMany({ where: { id: member.id } });
+      }
+    });
+  });
+
   describe("Per-type config validation", () => {
     it("rejects coding_assistant entries missing setupCommand with BAD_REQUEST", async () => {
       await expect(

--- a/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
@@ -511,7 +511,7 @@ describe("aiToolsRouter integration", () => {
     });
   });
 
-  describe("list auto-provisioning", () => {
+  describe("when list reads hit organizations in different provisioning states", () => {
     // Hermetic fresh org: the suite org accumulates tiles from sibling
     // tests (and gets auto-provisioned by their list calls), so pinning
     // the exact default set needs a clean slate.
@@ -825,18 +825,18 @@ describe("aiToolsRouter integration", () => {
         expect(codexRows).toHaveLength(1);
         expect(codexRows[0]!.archivedAt).not.toBeNull();
       } finally {
-        await prisma.aiToolEntry
-          .deleteMany({ where: { organizationId: freshOrgId } })
-          .catch(() => undefined);
-        await prisma.roleBinding
-          .deleteMany({ where: { organizationId: freshOrgId } })
-          .catch(() => undefined);
-        await prisma.organizationUser
-          .deleteMany({ where: { organizationId: freshOrgId } })
-          .catch(() => undefined);
-        await prisma.organization
-          .deleteMany({ where: { id: freshOrgId } })
-          .catch(() => undefined);
+        await prisma.aiToolEntry.deleteMany({
+          where: { organizationId: freshOrgId },
+        });
+        await prisma.roleBinding.deleteMany({
+          where: { organizationId: freshOrgId },
+        });
+        await prisma.organizationUser.deleteMany({
+          where: { organizationId: freshOrgId },
+        });
+        await prisma.organization.deleteMany({
+          where: { id: freshOrgId },
+        });
       }
     });
 

--- a/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
@@ -761,6 +761,85 @@ describe("aiToolsRouter integration", () => {
       }
     });
 
+    /** @scenario "re-importing the starter pack adds only tiles the catalog never had" */
+    /** @scenario "an archived starter tile is not restored or duplicated by a re-import" */
+    it("adds only never-had tiles on re-import and leaves archived tiles archived", async () => {
+      const freshOrgId = `starter-org-${nanoid(8)}`;
+      await prisma.organization.create({
+        data: {
+          id: freshOrgId,
+          name: `Starter ${nanoid(4)}`,
+          slug: `starter-${nanoid(6)}`,
+        },
+      });
+      await prisma.organizationUser.create({
+        data: {
+          userId: adminUserId,
+          organizationId: freshOrgId,
+          role: OrganizationUserRole.ADMIN,
+        },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: freshOrgId,
+          userId: adminUserId,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: freshOrgId,
+        },
+      });
+
+      try {
+        await callerFor(adminUserId).aiTools.importStarterPack({
+          organizationId: freshOrgId,
+        });
+
+        // Curate: archive codex, and remove gemini entirely so it counts
+        // as a tile the catalog never had.
+        const codex = await prisma.aiToolEntry.findFirstOrThrow({
+          where: { organizationId: freshOrgId, slug: "codex" },
+        });
+        await prisma.aiToolEntry.update({
+          where: { id: codex.id },
+          data: { archivedAt: new Date() },
+        });
+        await prisma.aiToolEntry.deleteMany({
+          where: { organizationId: freshOrgId, slug: { in: ["gemini"] } },
+        });
+
+        const result = await callerFor(adminUserId).aiTools.importStarterPack({
+          organizationId: freshOrgId,
+        });
+        // Only the genuinely missing tile comes back; the archived one and
+        // the six untouched ones are treated as present.
+        expect(result.created).toBe(1);
+        expect(result.skipped).toBe(7);
+
+        const rows = await prisma.aiToolEntry.findMany({
+          where: { organizationId: freshOrgId },
+        });
+        expect(rows.filter((r) => r.slug === "gemini")).toHaveLength(1);
+        const codexRows = rows.filter(
+          (r) => r.id === codex.id || r.displayName === codex.displayName,
+        );
+        expect(codexRows).toHaveLength(1);
+        expect(codexRows[0]!.archivedAt).not.toBeNull();
+      } finally {
+        await prisma.aiToolEntry
+          .deleteMany({ where: { organizationId: freshOrgId } })
+          .catch(() => undefined);
+        await prisma.roleBinding
+          .deleteMany({ where: { organizationId: freshOrgId } })
+          .catch(() => undefined);
+        await prisma.organizationUser
+          .deleteMany({ where: { organizationId: freshOrgId } })
+          .catch(() => undefined);
+        await prisma.organization
+          .deleteMany({ where: { id: freshOrgId } })
+          .catch(() => undefined);
+      }
+    });
+
     it("rejects MEMBER callers - manage-permission required", async () => {
       await expect(
         callerFor(memberPlatformUserId).aiTools.importStarterPack({

--- a/langwatch/ee/governance/routers/aiTools.ts
+++ b/langwatch/ee/governance/routers/aiTools.ts
@@ -30,6 +30,7 @@ import {
 
 import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { captureException, toError } from "~/utils/posthogErrorCapture";
 
 const typeSchema = z.enum(
   SUPPORTED_TILE_TYPES as readonly [string, ...string[]],
@@ -65,12 +66,31 @@ export const aiToolsRouter = createTRPCRouter({
    * User-facing list - returns enabled, non-archived entries the
    * caller can see (org-scoped + their team-scoped, with team
    * overriding org by slug). Powers the /me portal grid.
+   *
+   * Lazily provisions the standard default catalog for orgs that never
+   * had any entry, so the first portal load of a fresh org renders
+   * tiles instead of the empty state (see ensureDefaultCatalog for the
+   * zero-row guard that keeps admin-curated-empty catalogs untouched).
    */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
     .use(checkOrganizationPermission("aiTools:view"))
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
+      try {
+        await service.ensureDefaultCatalog({
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        // Non-fatal: the list must keep serving whatever exists even if
+        // provisioning hiccups (it retries on the next load).
+        captureException(toError(error), {
+          extra: {
+            origin: "aiTools.list.ensureDefaultCatalog",
+            organizationId: input.organizationId,
+          },
+        });
+      }
       return await service.listForUser({
         organizationId: input.organizationId,
         userId: ctx.session.user.id,

--- a/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
@@ -225,4 +225,52 @@ describe("seedPlatformIngestionTemplates with no platform defaults", () => {
       }
     }
   });
+
+  /** @scenario An existing platform claude-cowork template is archived by the seeder */
+  it("archives every unarchived platform row for a retired slug, duplicates included", async () => {
+    // (organizationId, slug) has no unique backing when organizationId is
+    // NULL (Postgres treats NULL as not-equal-to-NULL), so duplicate
+    // platform rows for the same retired slug can exist. The retirement
+    // sweep must catch ALL of them in a single seeder run, not one per run.
+    const makeRow = () =>
+      prisma.ingestionTemplate.create({
+        data: {
+          organizationId: null,
+          slug: "claude_cowork",
+          sourceType: "claude_cowork",
+          displayName: "Claude cowork",
+          description: "duplicate legacy platform default",
+          iconAsset: "preset:claude_cowork",
+          credentialSchema: null,
+          ottlRules: "",
+          platformPublished: true,
+          enabled: true,
+        },
+      });
+    const first = await makeRow();
+    const second = await makeRow();
+
+    try {
+      const result = await seedPlatformIngestionTemplates(prisma);
+      expect(result.created).toBe(0);
+      expect(result.updated).toBe(0);
+
+      // Final state is the contract (not the archived counter: the rows
+      // are global, and a concurrently seeding suite may have archived
+      // some first) - after one seeder run, NO active platform cowork
+      // row remains, not even the duplicate beyond the first.
+      const rows = await prisma.ingestionTemplate.findMany({
+        where: { id: { in: [first.id, second.id] } },
+      });
+      expect(rows).toHaveLength(2);
+      for (const rowAfter of rows) {
+        expect(rowAfter.archivedAt).not.toBeNull();
+        expect(rowAfter.enabled).toBe(false);
+      }
+    } finally {
+      await prisma.ingestionTemplate.deleteMany({
+        where: { id: { in: [first.id, second.id] } },
+      });
+    }
+  });
 });

--- a/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
@@ -247,10 +247,14 @@ describe("seedPlatformIngestionTemplates with no platform defaults", () => {
           enabled: true,
         },
       });
-    const first = await makeRow();
-    const second = await makeRow();
-
+    // Collect ids as rows are created so a failure between the two creates
+    // still leaves the finally with the exact rows to delete (the in-array
+    // filter stays safe when only one, or neither, was created).
+    const createdIds: string[] = [];
     try {
+      createdIds.push((await makeRow()).id);
+      createdIds.push((await makeRow()).id);
+
       const result = await seedPlatformIngestionTemplates(prisma);
       expect(result.created).toBe(0);
       expect(result.updated).toBe(0);
@@ -260,7 +264,7 @@ describe("seedPlatformIngestionTemplates with no platform defaults", () => {
       // some first) - after one seeder run, NO active platform cowork
       // row remains, not even the duplicate beyond the first.
       const rows = await prisma.ingestionTemplate.findMany({
-        where: { id: { in: [first.id, second.id] } },
+        where: { id: { in: createdIds } },
       });
       expect(rows).toHaveLength(2);
       for (const rowAfter of rows) {
@@ -269,7 +273,7 @@ describe("seedPlatformIngestionTemplates with no platform defaults", () => {
       }
     } finally {
       await prisma.ingestionTemplate.deleteMany({
-        where: { id: { in: [first.id, second.id] } },
+        where: { id: { in: createdIds } },
       });
     }
   });

--- a/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * Zero-touch default catalog provisioning: every org gets the standard
+ * AI tool set automatically, so the /me portal never opens on the
+ * "Add your first tools" empty state for a fresh signup. The guard is
+ * strictly conservative - any existing AiToolEntry row (enabled,
+ * disabled, or archived) means an admin owns the catalog and
+ * provisioning keeps its hands off.
+ *
+ * Hits real Postgres through the real AiToolEntryService and the real
+ * platform-template seeder (no mocks). Requires: PostgreSQL (Prisma).
+ *
+ * Spec: specs/ai-governance/personal-portal/default-catalog.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+
+import {
+  AiToolEntryService,
+  STARTER_PACK_TILES,
+} from "../aiToolEntry.service";
+import { seedPlatformIngestionTemplates } from "../platformIngestionTemplates.seeds";
+
+const ns = `dfltcat-${nanoid(8)}`;
+const createdOrgIds: string[] = [];
+
+async function createOrg(label: string): Promise<string> {
+  const org = await prisma.organization.create({
+    data: {
+      name: `Default Catalog ${label} ${ns}`,
+      slug: `--dc-${label}-${ns}`,
+    },
+  });
+  createdOrgIds.push(org.id);
+  return org.id;
+}
+
+const service = AiToolEntryService.create(prisma);
+
+afterAll(async () => {
+  if (createdOrgIds.length > 0) {
+    await prisma.aiToolEntry.deleteMany({
+      where: { organizationId: { in: createdOrgIds } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: createdOrgIds } },
+    });
+  }
+});
+
+describe("AiToolEntryService.ensureDefaultCatalog", () => {
+  /** @scenario A fresh organization gets the full standard catalog with no admin action */
+  it("provisions all 8 standard tiles onto a zero-row org", async () => {
+    const organizationId = await createOrg("fresh");
+
+    const result = await service.ensureDefaultCatalog({ organizationId });
+    expect(result).toEqual({ seeded: true, created: 8 });
+
+    const rows = await prisma.aiToolEntry.findMany({
+      where: { organizationId },
+      orderBy: { order: "asc" },
+    });
+    expect(rows).toHaveLength(STARTER_PACK_TILES.length);
+    rows.forEach((row, index) => {
+      const tile = STARTER_PACK_TILES[index]!;
+      // Same shape an admin starter-pack import creates: verbatim slug,
+      // org-wide scope, enabled, config and icon straight from the pack.
+      expect(row.slug).toBe(tile.slug);
+      expect(row.displayName).toBe(tile.displayName);
+      expect(row.type).toBe(tile.type);
+      expect(row.iconAsset).toBe(tile.iconAsset);
+      expect(row.config).toEqual(tile.config);
+      expect(row.order).toBe(index);
+      expect(row.enabled).toBe(true);
+      expect(row.archivedAt).toBeNull();
+      expect(row.scope).toBe("organization");
+      expect(row.scopeId).toBe(organizationId);
+      // Platform-provisioned, not a user action.
+      expect(row.createdById).toBeNull();
+      expect(row.updatedById).toBeNull();
+    });
+  });
+
+  /** @scenario Default catalog provisioning is idempotent across repeated calls */
+  it("does nothing on an org that already has the catalog", async () => {
+    const organizationId = await createOrg("idem");
+    await service.ensureDefaultCatalog({ organizationId });
+
+    const second = await service.ensureDefaultCatalog({ organizationId });
+    expect(second).toEqual({ seeded: false, created: 0 });
+    expect(
+      await prisma.aiToolEntry.count({ where: { organizationId } }),
+    ).toBe(8);
+  });
+
+  /** @scenario An organization whose admin archived or disabled every entry is not re-seeded */
+  it("respects a curated-empty catalog (archived and disabled rows both count)", async () => {
+    const organizationId = await createOrg("curated");
+    // The admin's leftovers: one archived, one disabled. The portal list
+    // shows neither, but the org has HAD a catalog, so provisioning must
+    // not resurrect anything.
+    await prisma.aiToolEntry.createMany({
+      data: [
+        {
+          organizationId,
+          scope: "organization",
+          scopeId: organizationId,
+          type: "coding_assistant",
+          displayName: "Archived Claude",
+          slug: `archived-claude-${ns}`,
+          config: {
+            assistantKind: "claude_code",
+            setupCommand: "langwatch claude",
+          },
+          enabled: false,
+          archivedAt: new Date(),
+        },
+        {
+          organizationId,
+          scope: "organization",
+          scopeId: organizationId,
+          type: "model_provider",
+          displayName: "Disabled OpenAI",
+          slug: `disabled-openai-${ns}`,
+          config: { providerKey: "openai" },
+          enabled: false,
+        },
+      ],
+    });
+
+    const result = await service.ensureDefaultCatalog({ organizationId });
+    expect(result).toEqual({ seeded: false, created: 0 });
+
+    const rows = await prisma.aiToolEntry.findMany({
+      where: { organizationId },
+    });
+    expect(rows.map((r) => r.slug).sort()).toEqual(
+      [`archived-claude-${ns}`, `disabled-openai-${ns}`].sort(),
+    );
+  });
+
+  /** @scenario Concurrent provisioning attempts create exactly one catalog */
+  it("serialises concurrent provisioners via the per-org advisory lock", async () => {
+    const organizationId = await createOrg("race");
+
+    const [a, b] = await Promise.all([
+      service.ensureDefaultCatalog({ organizationId }),
+      service.ensureDefaultCatalog({ organizationId }),
+    ]);
+
+    // Exactly one call wins the advisory lock and inserts; the other
+    // re-checks under the lock (or trips the cheap pre-check) and backs
+    // off. There is no unique constraint on (organizationId, slug), so
+    // this lock is the only thing standing between us and duplicates.
+    expect([a, b].filter((r) => r.seeded)).toHaveLength(1);
+
+    const rows = await prisma.aiToolEntry.findMany({
+      where: { organizationId },
+      select: { slug: true },
+    });
+    expect(rows).toHaveLength(8);
+    expect(new Set(rows.map((r) => r.slug)).size).toBe(8);
+  });
+});
+
+describe("seedPlatformIngestionTemplates with no platform defaults", () => {
+  /** @scenario An existing platform claude-cowork template is archived by the seeder */
+  it("archives a pre-existing platform claude_cowork row and creates no defaults", async () => {
+    // A platform row (organizationId NULL) as earlier releases seeded it.
+    // The platform catalog is global, so reactivate an existing row
+    // instead of duplicating one if this shared test DB already has it.
+    const existing = await prisma.ingestionTemplate.findFirst({
+      where: { organizationId: null, slug: "claude_cowork" },
+      select: { id: true },
+    });
+    const row = existing
+      ? await prisma.ingestionTemplate.update({
+          where: { id: existing.id },
+          data: { enabled: true, archivedAt: null, platformPublished: true },
+        })
+      : await prisma.ingestionTemplate.create({
+          data: {
+            organizationId: null,
+            slug: "claude_cowork",
+            sourceType: "claude_cowork",
+            displayName: "Claude cowork",
+            description: "legacy platform default",
+            iconAsset: "preset:claude_cowork",
+            credentialSchema: null,
+            ottlRules: "",
+            platformPublished: true,
+            enabled: true,
+          },
+        });
+
+    try {
+      const result = await seedPlatformIngestionTemplates(prisma);
+      // The seed input is empty: nothing is created or updated, ever.
+      expect(result.created).toBe(0);
+      expect(result.updated).toBe(0);
+
+      // Final state is the contract (not the archived counter: the row is
+      // global, and a concurrently lazy-seeding suite may have archived
+      // it first) - after any seeder run, no active platform cowork row
+      // remains.
+      const after = await prisma.ingestionTemplate.findUniqueOrThrow({
+        where: { id: row.id },
+      });
+      expect(after.archivedAt).not.toBeNull();
+      expect(after.enabled).toBe(false);
+
+      // Idempotent: a second run has nothing left to archive.
+      const again = await seedPlatformIngestionTemplates(prisma);
+      expect(again).toEqual({ created: 0, updated: 0, archived: 0 });
+    } finally {
+      // Leave the DB converged (archived) when the row pre-existed;
+      // remove the row entirely when this test created it.
+      if (!existing) {
+        await prisma.ingestionTemplate.deleteMany({ where: { id: row.id } });
+      }
+    }
+  });
+});

--- a/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/aiToolEntry.defaultCatalog.integration.test.ts
@@ -59,7 +59,7 @@ describe("AiToolEntryService.ensureDefaultCatalog", () => {
     const organizationId = await createOrg("fresh");
 
     const result = await service.ensureDefaultCatalog({ organizationId });
-    expect(result).toEqual({ seeded: true, created: 8 });
+    expect(result).toEqual({ hasSeeded: true, created: 8 });
 
     const rows = await prisma.aiToolEntry.findMany({
       where: { organizationId },
@@ -92,7 +92,7 @@ describe("AiToolEntryService.ensureDefaultCatalog", () => {
     await service.ensureDefaultCatalog({ organizationId });
 
     const second = await service.ensureDefaultCatalog({ organizationId });
-    expect(second).toEqual({ seeded: false, created: 0 });
+    expect(second).toEqual({ hasSeeded: false, created: 0 });
     expect(
       await prisma.aiToolEntry.count({ where: { organizationId } }),
     ).toBe(8);
@@ -134,7 +134,7 @@ describe("AiToolEntryService.ensureDefaultCatalog", () => {
     });
 
     const result = await service.ensureDefaultCatalog({ organizationId });
-    expect(result).toEqual({ seeded: false, created: 0 });
+    expect(result).toEqual({ hasSeeded: false, created: 0 });
 
     const rows = await prisma.aiToolEntry.findMany({
       where: { organizationId },
@@ -157,7 +157,7 @@ describe("AiToolEntryService.ensureDefaultCatalog", () => {
     // re-checks under the lock (or trips the cheap pre-check) and backs
     // off. There is no unique constraint on (organizationId, slug), so
     // this lock is the only thing standing between us and duplicates.
-    expect([a, b].filter((r) => r.seeded)).toHaveLength(1);
+    expect([a, b].filter((r) => r.hasSeeded)).toHaveLength(1);
 
     const rows = await prisma.aiToolEntry.findMany({
       where: { organizationId },

--- a/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
@@ -29,7 +29,7 @@ const CODING_ASSISTANT_SLUGS = [
 ] as const;
 
 describe("PLATFORM_INGESTION_TEMPLATES", () => {
-  describe("given the platform seed input", () => {
+  describe("when the platform seed input is inspected", () => {
     /** @scenario The platform default template set ships no claude-cowork */
     it("ships no default template rows at all", () => {
       expect(PLATFORM_INGESTION_TEMPLATES).toEqual([]);
@@ -44,7 +44,7 @@ describe("PLATFORM_INGESTION_TEMPLATES", () => {
     });
   });
 
-  describe("given a dev DB that may hold rows from an earlier seed run", () => {
+  describe("when a dev DB still holds rows from an earlier seed run", () => {
     it("retires every coding-assistant slug so stale rows get archived", () => {
       for (const codingSlug of CODING_ASSISTANT_SLUGS) {
         expect(RETIRED_PLATFORM_TEMPLATE_SLUGS).toContain(codingSlug);

--- a/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
@@ -8,14 +8,17 @@ import {
 } from "../platformIngestionTemplates.seeds";
 
 /**
- * Regression guard for specs/ai-gateway/governance/ingestion-templates-catalog.feature
- * scenario "The platform-template seed produces no coding-assistant rows".
+ * Regression guard for
+ * specs/ai-gateway/governance/ingestion-templates-catalog.feature
+ * scenario "The platform-template seed produces no coding-assistant rows"
+ * and specs/ai-governance/personal-portal/default-catalog.feature
+ * scenario "The platform default template set ships no claude-cowork".
  *
- * The platform's coding assistants are owned by `langwatch <tool>` + the
- * receiver log-to-span conversion, so they are NOT seeded as ingestion
- * templates. There is no flag and no filter: they are simply absent from
- * the seed input. Any rows a previous seed created are archived via the
- * retired-slugs list so dev DBs converge to the v1 catalog.
+ * The platform ships NO default ingestion templates. The coding
+ * assistants are owned by `langwatch <tool>` + the receiver log-to-span
+ * conversion, and claude_cowork is retired from the default set. Any
+ * rows a previous seed created are archived via the retired-slugs list
+ * so dev DBs and production converge to the locked (empty) catalog.
  */
 const CODING_ASSISTANT_SLUGS = [
   "claude_code",
@@ -26,10 +29,10 @@ const CODING_ASSISTANT_SLUGS = [
 ] as const;
 
 describe("PLATFORM_INGESTION_TEMPLATES", () => {
-  describe("given the v1 platform seed input", () => {
-    it("seeds claude_cowork as the only platform coding-tool template", () => {
-      const slugs = PLATFORM_INGESTION_TEMPLATES.map((t) => t.slug);
-      expect(slugs).toEqual(["claude_cowork"]);
+  describe("given the platform seed input", () => {
+    /** @scenario The platform default template set ships no claude-cowork */
+    it("ships no default template rows at all", () => {
+      expect(PLATFORM_INGESTION_TEMPLATES).toEqual([]);
     });
 
     /** @scenario The platform-template seed produces no coding-assistant rows */
@@ -46,6 +49,11 @@ describe("PLATFORM_INGESTION_TEMPLATES", () => {
       for (const codingSlug of CODING_ASSISTANT_SLUGS) {
         expect(RETIRED_PLATFORM_TEMPLATE_SLUGS).toContain(codingSlug);
       }
+    });
+
+    /** @scenario The platform default template set ships no claude-cowork */
+    it("retires claude_cowork so existing platform rows get archived", () => {
+      expect(RETIRED_PLATFORM_TEMPLATE_SLUGS).toContain("claude_cowork");
     });
   });
 });

--- a/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/platformIngestionTemplates.seeds.unit.test.ts
@@ -30,7 +30,7 @@ const CODING_ASSISTANT_SLUGS = [
 
 describe("PLATFORM_INGESTION_TEMPLATES", () => {
   describe("when the platform seed input is inspected", () => {
-    /** @scenario The platform default template set ships no claude-cowork */
+    /** @scenario The platform-template seed produces no coding-assistant rows */
     it("ships no default template rows at all", () => {
       expect(PLATFORM_INGESTION_TEMPLATES).toEqual([]);
     });

--- a/langwatch/ee/governance/services/aiToolEntry.service.ts
+++ b/langwatch/ee/governance/services/aiToolEntry.service.ts
@@ -1049,8 +1049,12 @@ export class AiToolEntryService {
       },
       // Waiting on the advisory lock counts toward the interactive-txn
       // timeout; give a losing concurrent provisioner room to wait out
-      // the winner instead of aborting at Prisma's 5s default.
-      { timeout: 15_000 },
+      // the winner instead of aborting at Prisma's 5s default. maxWait is
+      // raised the same way dataset-lock.ts does it: the burst this lock
+      // exists for is several first-loads of one fresh org hitting the
+      // pool at once, and Prisma's 2s default can fail a provisioner on
+      // connection acquisition before it ever reaches the lock.
+      { timeout: 15_000, maxWait: 10_000 },
     );
   }
 

--- a/langwatch/ee/governance/services/aiToolEntry.service.ts
+++ b/langwatch/ee/governance/services/aiToolEntry.service.ts
@@ -1017,11 +1017,11 @@ export class AiToolEntryService {
     organizationId,
   }: {
     organizationId: string;
-  }): Promise<{ seeded: boolean; created: number }> {
+  }): Promise<{ hasSeeded: boolean; created: number }> {
     const existingCount = await this.prisma.aiToolEntry.count({
       where: { organizationId },
     });
-    if (existingCount > 0) return { seeded: false, created: 0 };
+    if (existingCount > 0) return { hasSeeded: false, created: 0 };
 
     return await this.prisma.$transaction(
       async (tx) => {
@@ -1032,7 +1032,7 @@ export class AiToolEntryService {
         const countUnderLock = await tx.aiToolEntry.count({
           where: { organizationId },
         });
-        if (countUnderLock > 0) return { seeded: false, created: 0 };
+        if (countUnderLock > 0) return { hasSeeded: false, created: 0 };
 
         await tx.aiToolEntry.createMany({
           data: STARTER_PACK_TILES.map((tile, index) =>
@@ -1045,7 +1045,7 @@ export class AiToolEntryService {
             }),
           ),
         });
-        return { seeded: true, created: STARTER_PACK_TILES.length };
+        return { hasSeeded: true, created: STARTER_PACK_TILES.length };
       },
       // Waiting on the advisory lock counts toward the interactive-txn
       // timeout; give a losing concurrent provisioner room to wait out

--- a/langwatch/ee/governance/services/aiToolEntry.service.ts
+++ b/langwatch/ee/governance/services/aiToolEntry.service.ts
@@ -957,6 +957,104 @@ export class AiToolEntryService {
   }
 
   /**
+   * The exact row shape a starter tile materialises as - shared by
+   * {@link seedStarterPack} (admin one-click import) and
+   * {@link ensureDefaultCatalog} (zero-touch provisioning) so both paths
+   * create identical rows: org-wide scope, enabled, slug written verbatim
+   * from the pack so later imports recognise the tile.
+   */
+  private starterTileCreateData({
+    organizationId,
+    tile,
+    order,
+    actorUserId,
+  }: {
+    organizationId: string;
+    tile: (typeof STARTER_PACK_TILES)[number];
+    order: number;
+    actorUserId?: string | null;
+  }): Prisma.AiToolEntryCreateManyInput {
+    return {
+      organizationId,
+      scope: "organization",
+      scopeId: organizationId,
+      type: tile.type,
+      displayName: tile.displayName,
+      slug: tile.slug,
+      iconAsset: tile.iconAsset,
+      order,
+      enabled: true,
+      config: tile.config as Prisma.InputJsonValue,
+      createdById: actorUserId ?? null,
+      updatedById: actorUserId ?? null,
+    };
+  }
+
+  /**
+   * Zero-touch default provisioning: an org that has NEVER had a catalog
+   * entry gets the full standard set ({@link STARTER_PACK_TILES}) so a
+   * fresh signup's /me portal renders tiles instead of the empty state.
+   * Wired into onboarding (org creation) and lazily into the aiTools.list
+   * read path, so the very first portal load of a zero-row org already
+   * returns the catalog.
+   *
+   * Strictly narrower than {@link seedStarterPack}: it only acts on an
+   * org with ZERO AiToolEntry rows - enabled, disabled, and archived all
+   * count as rows. Any existing row means an admin (or a previous
+   * provisioning run) owns the catalog, so an org whose admin archived or
+   * disabled everything is respected and NOT re-seeded; the portal empty
+   * state stays reachable only as that curated-empty fallback.
+   *
+   * Concurrency: there is no unique constraint on (organizationId, slug),
+   * so two concurrent first-loads could both observe zero rows and
+   * double-insert. A transaction-scoped Postgres advisory lock keyed per
+   * org serialises provisioners and the zero-row check re-runs under the
+   * lock (same pattern as modelDefaults.repository.ts#lockScope). The
+   * count outside the transaction keeps the hot path - every list call
+   * on an already-provisioned org - to one indexed count query.
+   */
+  async ensureDefaultCatalog({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<{ seeded: boolean; created: number }> {
+    const existingCount = await this.prisma.aiToolEntry.count({
+      where: { organizationId },
+    });
+    if (existingCount > 0) return { seeded: false, created: 0 };
+
+    return await this.prisma.$transaction(
+      async (tx) => {
+        // $executeRaw, not $queryRaw: pg_advisory_xact_lock returns void,
+        // which $queryRaw fails to deserialize. The lock releases at
+        // commit / rollback.
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${`ai-tool-default-catalog:${organizationId}`}, 0))`;
+        const countUnderLock = await tx.aiToolEntry.count({
+          where: { organizationId },
+        });
+        if (countUnderLock > 0) return { seeded: false, created: 0 };
+
+        await tx.aiToolEntry.createMany({
+          data: STARTER_PACK_TILES.map((tile, index) =>
+            this.starterTileCreateData({
+              organizationId,
+              tile,
+              order: index,
+              // Platform-provisioned, not a user action.
+              actorUserId: null,
+            }),
+          ),
+        });
+        return { seeded: true, created: STARTER_PACK_TILES.length };
+      },
+      // Waiting on the advisory lock counts toward the interactive-txn
+      // timeout; give a losing concurrent provisioner room to wait out
+      // the winner instead of aborting at Prisma's 5s default.
+      { timeout: 15_000 },
+    );
+  }
+
+  /**
    * Seed the documented starter pack onto an org's catalog (Phase 7
    * "fresh-org friction killer" per docs/ai-governance/personal-portal/
    * admin-catalog.mdx). Three-way idempotent merge:
@@ -1044,22 +1142,14 @@ export class AiToolEntryService {
       ),
       ...toCreate.map((tile, index) =>
         this.prisma.aiToolEntry.create({
-          data: {
+          data: this.starterTileCreateData({
             organizationId: input.organizationId,
-            scope: "organization",
-            scopeId: input.organizationId,
-            type: tile.type,
-            displayName: tile.displayName,
-            slug: tile.slug,
-            iconAsset: tile.iconAsset,
+            tile,
             // Append after any tiles the admin already created - keeps
             // their hand-curated order on top.
             order: existing.length + index,
-            enabled: true,
-            config: tile.config as Prisma.InputJsonValue,
-            createdById: input.actorUserId ?? null,
-            updatedById: input.actorUserId ?? null,
-          },
+            actorUserId: input.actorUserId,
+          }),
         }),
       ),
     ]);

--- a/langwatch/ee/governance/services/platformIngestionTemplates.seeds.ts
+++ b/langwatch/ee/governance/services/platformIngestionTemplates.seeds.ts
@@ -3,8 +3,9 @@
 /**
  * Platform-published default IngestionTemplate rows.
  *
- * v1 ships ONE real template (claude_cowork), `organizationId IS NULL`
- * so it appears in every org's catalog. The /me Trace Ingest tile
+ * The platform currently ships NO default templates: claude_cowork was
+ * the last one and is retired (archived on existing installs via
+ * RETIRED_PLATFORM_TEMPLATE_SLUGS below). The /me Trace Ingest tile
  * `raw_otlp_advanced` is a client-side discovery card — it deep-links to the personal OTLP endpoint panel
  * and does NOT mint an ingestion key, so it intentionally has no
  * IngestionTemplate row (see Andre PM call at 348936e4f).
@@ -20,9 +21,8 @@
  *
  * `ottlRules` is empty for v1 — the receiver applies no OTTL transform
  * for otlp_token templates v1; canonical gen_ai shaping is done by the
- * upstream tool's exporter (claude_cowork is already gen_ai-compliant).
- * The OTTL slot is wired so v2 templates can land per-template
- * normalization without a service refactor.
+ * upstream tool's exporter. The OTTL slot is wired so v2 templates can
+ * land per-template normalization without a service refactor.
  *
  * Spec:
  *   specs/ai-gateway/governance/ingestion-templates-catalog.feature
@@ -41,18 +41,11 @@ export interface PlatformTemplateSeed {
   ottlRules: string;
 }
 
-export const PLATFORM_INGESTION_TEMPLATES: readonly PlatformTemplateSeed[] = [
-  {
-    slug: "claude_cowork",
-    sourceType: "claude_cowork",
-    displayName: "Claude cowork",
-    description:
-      "Connect Claude cowork session telemetry. Spans land at /me/traces with gen_ai.usage.* + cost.usd populated automatically by the receiver.",
-    iconAsset: "preset:claude_cowork",
-    credentialSchema: null,
-    ottlRules: "",
-  },
-] as const;
+/// Platform templates currently ship no defaults. Org-authored templates
+/// and the client-side raw_otlp_advanced discovery card are the only
+/// tiles the /me Trace Ingest grid can render.
+export const PLATFORM_INGESTION_TEMPLATES: readonly PlatformTemplateSeed[] =
+  [] as const;
 
 /**
  * Slugs that previously had platform rows (e.g. during contract debate)
@@ -68,14 +61,19 @@ export const RETIRED_PLATFORM_TEMPLATE_SLUGS: readonly string[] = [
   "raw_otlp_advanced",
   // Platform coding assistants are owned by `langwatch <tool>` + receiver
   // log-to-span conversion, not ingestion templates. Earlier seed runs
-  // published them as rows; archive those so dev DBs converge to the v1
-  // catalog (claude_cowork only). They are surfaced as AiToolsPortal
-  // coding-assistant tiles instead.
+  // published them as rows; archive those so dev DBs converge to the
+  // locked catalog. They are surfaced as AiToolsPortal coding-assistant
+  // tiles instead.
   "claude_code",
   "codex",
   "cursor",
   "gemini",
   "opencode",
+  // Retired from the default set: platform templates currently ship no
+  // defaults at all. Existing installs get their platform cowork row
+  // archived; installed cowork IngestionSources keep ingesting (the
+  // receiver keys on the source, not the template).
+  "claude_cowork",
 ];
 
 /**

--- a/langwatch/ee/governance/services/platformIngestionTemplates.seeds.ts
+++ b/langwatch/ee/governance/services/platformIngestionTemplates.seeds.ts
@@ -137,20 +137,18 @@ export async function seedPlatformIngestionTemplates(
     }
   }
 
-  // Archive retired slugs (idempotent — already-archived rows stay
-  // archived; missing rows skip cleanly).
+  // Archive retired slugs (idempotent: already-archived rows stay
+  // archived; missing rows skip cleanly). updateMany sweeps EVERY
+  // unarchived platform row for the slug in one pass: (organizationId,
+  // slug) has no unique backing when organizationId is NULL (Postgres
+  // treats NULL as not-equal-to-NULL), so duplicate platform rows can
+  // exist and all of them must retire together.
   for (const slug of RETIRED_PLATFORM_TEMPLATE_SLUGS) {
-    const stale = await prisma.ingestionTemplate.findFirst({
+    const stale = await prisma.ingestionTemplate.updateMany({
       where: { organizationId: null, slug, archivedAt: null },
-      select: { id: true },
+      data: { archivedAt: new Date(), enabled: false },
     });
-    if (stale) {
-      await prisma.ingestionTemplate.update({
-        where: { id: stale.id },
-        data: { archivedAt: new Date(), enabled: false },
-      });
-      archived++;
-    }
+    archived += stale.count;
   }
 
   return { created, updated, archived };

--- a/langwatch/src/components/PersonalSidebar.tsx
+++ b/langwatch/src/components/PersonalSidebar.tsx
@@ -59,7 +59,11 @@ export const PersonalSidebar = React.memo(function PersonalSidebar({
     redirectToProjectOnboarding: false,
   });
   const personalProject = useMemo(
-    () => findPersonalProject(organizations, session.data?.user?.id),
+    () =>
+      findPersonalProject({
+        organizations,
+        userId: session.data?.user?.id,
+      }),
     [organizations, session.data?.user?.id],
   );
   const personalProjectSlug = personalProject?.slug ?? null;

--- a/langwatch/src/components/PersonalSidebar.tsx
+++ b/langwatch/src/components/PersonalSidebar.tsx
@@ -16,6 +16,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
+import { findPersonalProject } from "~/utils/personalProject";
 
 import { MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "./MainMenu";
 import { GovernSection } from "./sidebar/GovernSection";
@@ -57,19 +58,10 @@ export const PersonalSidebar = React.memo(function PersonalSidebar({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
-  const personalProject = useMemo(() => {
-    const userId = session.data?.user?.id;
-    if (!userId || !organizations) return null;
-    for (const org of organizations) {
-      for (const team of org.teams ?? []) {
-        if (team.isPersonal && team.ownerUserId === userId) {
-          const project = team.projects?.[0];
-          if (project) return { id: project.id, slug: project.slug };
-        }
-      }
-    }
-    return null;
-  }, [organizations, session.data?.user?.id]);
+  const personalProject = useMemo(
+    () => findPersonalProject(organizations, session.data?.user?.id),
+    [organizations, session.data?.user?.id],
+  );
   const personalProjectSlug = personalProject?.slug ?? null;
   const personalProjectId = personalProject?.id ?? null;
   const tracesHref = personalProjectSlug

--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -278,13 +278,18 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
     }
   }
 
-  // Hide teams with zero projects — they're navigation dead-ends in the
-  // dropdown (clicking the team name takes you to /settings/teams/<slug>
-  // which is admin-only). Empty teams are an org-admin curiosity, not a
-  // workspace-switcher target. Re-add later if rchaves wants team-level
-  // usage as a discoverable surface.
-  const teamsWithProjects = teams.filter(
-    (team) => (projectsByTeam.get(team.teamId) ?? []).length > 0,
+  // Teams with zero projects are navigation dead-ends for most viewers
+  // (clicking the team name takes you to /settings/teams/<slug> which is
+  // admin-only), so they are hidden — except when the viewer can create a
+  // project on them. A coding-usage (governance) signup starts with one
+  // empty shared team; hiding it would leave the dropdown with no create
+  // affordance at all, stranding them on personal usage with no path to a
+  // first shared project. For those viewers the row renders with its
+  // per-team "+" create button.
+  const visibleTeams = teams.filter(
+    (team) =>
+      (projectsByTeam.get(team.teamId) ?? []).length > 0 ||
+      (team.canCreateProject && !!onCreateProjectForTeam),
   );
 
   // Group teams by org so multi-org users see clear org boundaries instead
@@ -296,7 +301,7 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
     string,
     { orgName: string; orgSlug: string; teams: typeof teams }
   >();
-  for (const team of teamsWithProjects) {
+  for (const team of visibleTeams) {
     const bucket =
       teamsByOrg.get(team.orgId) ?? {
         orgName: team.orgName,

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -266,9 +266,7 @@ describe("WorkspaceSwitcher", () => {
       expect(screen.queryByText("Create project")).not.toBeInTheDocument();
 
       await user.hover(addButton);
-      expect(
-        await screen.findByText("Create project"),
-      ).toBeInTheDocument();
+      expect(await screen.findByText("Create project")).toBeInTheDocument();
 
       await user.unhover(addButton);
       await waitFor(() => {
@@ -288,54 +286,58 @@ describe("WorkspaceSwitcher", () => {
       subtitle: "Personal usage, personal budget",
     };
 
-    /** @scenario A coding-usage signup can always create their first shared project from the workspace menu */
-    it("renders the empty shared team with its create-project button and routes the click", async () => {
-      const user = userEvent.setup();
-      const onCreateProjectForTeam = vi.fn();
-      renderSwitcher({
-        personals: [orgPersonal],
-        teams: [{ ...teamA, canCreateProject: true }],
-        projects: [],
-        current: { kind: "personal" },
-        onCreateProjectForTeam,
-      });
+    describe("when the viewer can create a project on the team", () => {
+      /** @scenario A coding-usage signup can always create their first shared project from the workspace menu */
+      it("renders the empty shared team with its create-project button and routes the click", async () => {
+        const user = userEvent.setup();
+        const onCreateProjectForTeam = vi.fn();
+        renderSwitcher({
+          personals: [orgPersonal],
+          teams: [{ ...teamA, canCreateProject: true }],
+          projects: [],
+          current: { kind: "personal" },
+          onCreateProjectForTeam,
+        });
 
-      await user.click(
-        screen.getByRole("button", { name: /switch workspace/i }),
-      );
-      expect(await screen.findByText("Acme Engineering")).toBeInTheDocument();
+        await user.click(
+          screen.getByRole("button", { name: /switch workspace/i }),
+        );
+        expect(await screen.findByText("Acme Engineering")).toBeInTheDocument();
 
-      const addButton = await screen.findByRole("button", {
-        name: /create project in acme engineering/i,
-      });
-      await user.click(addButton);
+        const addButton = await screen.findByRole("button", {
+          name: /create project in acme engineering/i,
+        });
+        await user.click(addButton);
 
-      expect(onCreateProjectForTeam).toHaveBeenCalledWith({
-        teamId: "team_a",
-        orgId: "org_acme",
+        expect(onCreateProjectForTeam).toHaveBeenCalledWith({
+          teamId: "team_a",
+          orgId: "org_acme",
+        });
       });
     });
 
-    /** @scenario An empty team stays hidden from members who cannot create a project on it */
-    it("keeps hiding the empty team from viewers who cannot create a project on it", async () => {
-      const user = userEvent.setup();
-      renderSwitcher({
-        personals: [orgPersonal],
-        teams: [{ ...teamA, canCreateProject: false }],
-        projects: [],
-        current: { kind: "personal" },
-        onCreateProjectForTeam: vi.fn(),
-      });
+    describe("when the viewer cannot create a project on the team", () => {
+      /** @scenario An empty team stays hidden from members who cannot create a project on it */
+      it("keeps hiding the empty team from viewers who cannot create a project on it", async () => {
+        const user = userEvent.setup();
+        renderSwitcher({
+          personals: [orgPersonal],
+          teams: [{ ...teamA, canCreateProject: false }],
+          projects: [],
+          current: { kind: "personal" },
+          onCreateProjectForTeam: vi.fn(),
+        });
 
-      await user.click(
-        screen.getByRole("button", { name: /switch workspace/i }),
-      );
-      // The org header confirms the dropdown opened before we assert absence.
-      expect(await screen.findByText("Acme")).toBeInTheDocument();
-      expect(screen.queryByText("Acme Engineering")).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: /create project in/i }),
-      ).not.toBeInTheDocument();
+        await user.click(
+          screen.getByRole("button", { name: /switch workspace/i }),
+        );
+        // The org header confirms the dropdown opened before we assert absence.
+        expect(await screen.findByText("Acme")).toBeInTheDocument();
+        expect(screen.queryByText("Acme Engineering")).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole("button", { name: /create project in/i }),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -277,6 +277,68 @@ describe("WorkspaceSwitcher", () => {
     });
   });
 
+  describe("given a governance signup whose only shared team has no projects", () => {
+    const orgPersonal = {
+      kind: "personal" as const,
+      orgId: "org_acme",
+      orgName: "Acme",
+      orgSlug: "acme",
+      href: "/me",
+      label: "My Workspace",
+      subtitle: "Personal usage, personal budget",
+    };
+
+    /** @scenario A coding-usage signup can always create their first shared project from the workspace menu */
+    it("renders the empty shared team with its create-project button and routes the click", async () => {
+      const user = userEvent.setup();
+      const onCreateProjectForTeam = vi.fn();
+      renderSwitcher({
+        personals: [orgPersonal],
+        teams: [{ ...teamA, canCreateProject: true }],
+        projects: [],
+        current: { kind: "personal" },
+        onCreateProjectForTeam,
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      expect(await screen.findByText("Acme Engineering")).toBeInTheDocument();
+
+      const addButton = await screen.findByRole("button", {
+        name: /create project in acme engineering/i,
+      });
+      await user.click(addButton);
+
+      expect(onCreateProjectForTeam).toHaveBeenCalledWith({
+        teamId: "team_a",
+        orgId: "org_acme",
+      });
+    });
+
+    /** @scenario An empty team stays hidden from members who cannot create a project on it */
+    it("keeps hiding the empty team from viewers who cannot create a project on it", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personals: [orgPersonal],
+        teams: [{ ...teamA, canCreateProject: false }],
+        projects: [],
+        current: { kind: "personal" },
+        onCreateProjectForTeam: vi.fn(),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      // The org header confirms the dropdown opened before we assert absence.
+      expect(await screen.findByText("Acme")).toBeInTheDocument();
+      expect(screen.queryByText("Acme Engineering")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /create project in/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("personal entry governance gate", () => {
     /** @scenario The personal entry is hidden when no organization enables governance */
     it("does not render the My Workspace entry when personal is omitted", async () => {

--- a/langwatch/src/components/__tests__/WorkspaceSwitcherGovernanceSignup.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcherGovernanceSignup.integration.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers specs/ai-gateway/governance/workspace-switcher.feature, the
+ * empty-team create-affordance scenarios, through the REAL data derivation:
+ * the exact coding-usage signup org shape (personal team + one shared team
+ * with no projects) flows from the tRPC boundary through the real
+ * useWorkspaceData + useOrganizationTeamProject + useDrawer into the real
+ * WorkspaceSwitcher. Only the network boundary is mocked.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sessionRef } = vi.hoisted(() => ({
+  sessionRef: {
+    current: {
+      data: { user: { id: "user-1", email: "dev@example.com" } },
+      status: "authenticated" as const,
+    },
+  },
+}));
+
+vi.mock("~/utils/auth-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/auth-client")>();
+  return { ...actual, useSession: () => sessionRef.current };
+});
+
+// The founder-reported shape: governance signup, org ADMIN, personal team
+// provisioned, one shared team with zero projects.
+const organizationsFixture = [
+  {
+    id: "org-1",
+    name: "Acme Org",
+    slug: "acme-org",
+    members: [{ userId: "user-1", role: "ADMIN" }],
+    teams: [
+      {
+        id: "team-personal",
+        slug: "personal-team",
+        name: "Personal Workspace",
+        isPersonal: true,
+        ownerUserId: "user-1",
+        members: [{ userId: "user-1", role: "ADMIN" }],
+        projects: [
+          {
+            id: "proj-personal",
+            slug: "personal-proj",
+            name: "Personal project",
+            isPersonal: true,
+          },
+        ],
+      },
+      {
+        id: "team-shared",
+        slug: "acme-org-team",
+        name: "Acme Org Team",
+        isPersonal: false,
+        ownerUserId: null,
+        members: [{ userId: "user-1", role: "ADMIN" }],
+        projects: [],
+      },
+    ],
+  },
+];
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    publicEnv: { useQuery: () => ({ data: {}, isLoading: false }) },
+    sharedTrace: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+    },
+    organization: {
+      getAll: {
+        useQuery: () => ({
+          data: organizationsFixture,
+          isLoading: false,
+          isFetched: true,
+        }),
+      },
+    },
+    modelProvider: {
+      getAllForProject: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+    featureFlag: {
+      isEnabledForEachOrganization: {
+        useQuery: () => ({
+          data: { enabledByOrganizationId: { "org-1": true } },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+import { useRouter } from "~/utils/compat/next-router";
+import { WorkspaceSwitcher } from "../WorkspaceSwitcher";
+import { useWorkspaceData } from "../useWorkspaceData";
+
+const mockRouter = useRouter();
+
+function Harness() {
+  const data = useWorkspaceData();
+  return <WorkspaceSwitcher {...data} current={{ kind: "personal" }} />;
+}
+
+describe("workspace switcher for a coding-usage signup with an empty shared team", () => {
+  beforeEach(() => {
+    (mockRouter.push as unknown as Mock).mockClear();
+    mockRouter.pathname = "/me";
+    mockRouter.route = "/me";
+    mockRouter.asPath = "/me";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** @scenario A coding-usage signup can always create their first shared project from the workspace menu */
+  it("derives the empty shared team as creatable and opens the create-project drawer", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <Harness />
+      </ChakraProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /switch workspace/i }));
+
+    // The empty shared team renders, with its create affordance.
+    expect(await screen.findByText("Acme Org Team")).toBeInTheDocument();
+    const addButton = await screen.findByRole("button", {
+      name: /create project in acme org team/i,
+    });
+
+    // #6190 invariant: the personal team never appears as a switcher row.
+    expect(screen.queryByText("Personal Workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Personal project")).not.toBeInTheDocument();
+
+    await user.click(addButton);
+
+    // The click lands on the create-project drawer, scoped by URL params.
+    const pushedUrls = (mockRouter.push as unknown as Mock).mock.calls.map(
+      (call) => String(call[0]),
+    );
+    expect(
+      pushedUrls.some((url) => url.includes("drawer.open=createProject")),
+    ).toBe(true);
+  });
+});

--- a/langwatch/src/components/me/GovernanceGettingStartedBanner.tsx
+++ b/langwatch/src/components/me/GovernanceGettingStartedBanner.tsx
@@ -22,16 +22,20 @@ const MESH_COLORS_LIGHT = ["#b45309", "#ea580c", "#7c3aed", "#fff7ed"];
 const MESH_COLORS_DARK = ["#78350f", "#7c2d12", "#4c1d95", "#1a1206"];
 
 /**
- * Admin empty-state hero for the AI tools portal. Shown when the org has
- * published no tools yet and the viewer can manage the catalog. Reuses the
- * home-banner glass-card visual to make "set up governance" feel like a
- * first-class call to action rather than a bare empty list, and points
- * straight at the tool catalog where the starter pack lives.
+ * Admin empty-state hero for the AI tools portal. Shown when the catalog
+ * has zero enabled tiles and the viewer can manage it. Fresh orgs are
+ * auto-provisioned with the standard catalog, so this only renders for a
+ * catalog whose admin archived or disabled everything (the curated-empty
+ * fallback). Reuses the home-banner glass-card visual to make "set up
+ * governance" feel like a first-class call to action rather than a bare
+ * empty list, and points straight at the tool catalog where the starter
+ * pack lives.
  *
  * Not dismissible: it disappears on its own the moment the first tool is
  * published (the portal switches to the tile grid).
  *
- * Spec: specs/ai-governance/personal-portal/portal-empty-state.feature
+ * Spec: specs/ai-governance/personal-portal/portal-grid.feature
+ *       specs/ai-governance/personal-portal/default-catalog.feature
  */
 export function GovernanceGettingStartedBanner() {
   const reduceMotion = useReducedMotion();

--- a/langwatch/src/components/me/GovernanceGettingStartedBanner.tsx
+++ b/langwatch/src/components/me/GovernanceGettingStartedBanner.tsx
@@ -25,8 +25,9 @@ const MESH_COLORS_DARK = ["#78350f", "#7c2d12", "#4c1d95", "#1a1206"];
  * Admin empty-state hero for the AI tools portal. Shown when the catalog
  * has zero enabled tiles and the viewer can manage it. Fresh orgs are
  * auto-provisioned with the standard catalog, so this only renders for a
- * catalog whose admin archived or disabled everything (the curated-empty
- * fallback). Reuses the home-banner glass-card visual to make "set up
+ * catalog curated down to no enabled tools, whether by archiving,
+ * disabling, or deleting entries (the curated-empty fallback). Reuses
+ * the home-banner glass-card visual to make "set up
  * governance" feel like a first-class call to action rather than a bare
  * empty list, and points straight at the tool catalog where the starter
  * pack lives.

--- a/langwatch/src/components/me/TraceIngestSection.tsx
+++ b/langwatch/src/components/me/TraceIngestSection.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Bot, Check, Terminal, Users } from "lucide-react";
+import { Bot, Check, Terminal } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import {
@@ -22,13 +22,14 @@ import { usePublicEnv } from "~/hooks/usePublicEnv";
 import { api } from "~/utils/api";
 
 /**
- * /me Trace Ingest section — tile-grid for IngestionTemplate v1 catalog.
+ * /me Trace Ingest section, the tile-grid for the IngestionTemplate
+ * catalog.
  *
  * Tile metadata comes from `api.ingestionTemplates.list` (server is the
- * source of truth — admin can disable / org-author / archive). v1
- * platform-published rows are seeded by Sergey's seeders. Per-template
- * iconography is resolved client-side from a slug map since v1 platform
- * defaults ship with iconAsset=NULL.
+ * source of truth: admin can disable / org-author / archive). The
+ * platform ships NO default templates, so the whole section renders only
+ * when the org has at least one template of its own. A heading over an
+ * empty grid would read as a broken section on every fresh org's /me.
  *
  * Install fires `api.ingestionKey.install` mutation. The plaintext
  * sk-lw- token is shown ONCE in the drawer and stored in component state
@@ -38,7 +39,9 @@ import { api } from "~/utils/api";
  *
  * raw_otlp_advanced is rendered as a SEPARATE static tile (no
  * IngestionTemplate row, no install). It deep-links to
- * /me/configure#otlp — the BYO-OTLP fallback discovery card.
+ * /me/configure#otlp, the BYO-OTLP fallback discovery card. It renders
+ * only alongside real templates; the personal OTLP endpoint stays
+ * reachable via /me/configure regardless.
  *
  * The platform's coding assistants (claude_code, codex, cursor, gemini,
  * opencode) never appear in this grid because they are not seeded as
@@ -46,23 +49,13 @@ import { api } from "~/utils/api";
  * setup and the receiver converts their OTLP logs into canonical gen_ai
  * spans. Their entry points live on the AiToolsPortal "$ langwatch
  * <tool>" tiles. The grid simply renders whatever
- * `api.ingestionTemplates.list` returns (claude_cowork + any org-authored
- * templates) plus the raw_otlp_advanced discovery card — no slug filter.
+ * `api.ingestionTemplates.list` returns (org-authored templates) plus
+ * the raw_otlp_advanced discovery card, with no slug filter.
  *
  * Per the no-leak invariant in catalog.feature: this component MUST
  * NOT render under /[project] chrome — only on /me. Embedding lives on
  * /me/index.tsx.
  */
-const TILE_META: Record<
-  string,
-  { icon: ReactNode; subtitle: string }
-> = {
-  claude_cowork: {
-    icon: <Users size={20} />,
-    subtitle: "Multi-agent Claude sessions",
-  },
-};
-
 const FALLBACK_ICON = <Bot size={20} />;
 
 export function TraceIngestSection() {
@@ -120,6 +113,14 @@ export function TraceIngestSection() {
 
   /** Connected ingestion keys, keyed by the source they were minted for. */
   const keyBySourceType = new Map(keys.map((k) => [k.sourceType, k]));
+
+  // No templates, no section: the platform ships no defaults, so most
+  // orgs have nothing to install here. Rendering nothing (not even
+  // load skeletons) until the list resolves with at least one template
+  // keeps /me from flashing a section that then disappears. Installed
+  // sources keep ingesting regardless: the receiver keys on the
+  // IngestionSource, not on a listed template.
+  if (templates.length === 0) return null;
   const openTemplate = openSlug
     ? templates.find((t) => t.slug === openSlug) ?? null
     : null;
@@ -205,28 +206,17 @@ export function TraceIngestSection() {
       </VStack>
 
       <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} gap={3}>
-        {templatesQuery.isLoading
-          ? Array.from({ length: 3 }).map((_, idx) => (
-              <TileSkeleton key={`skeleton-${idx}`} />
-            ))
-          : templates.map((t) => {
-              const connected = keyBySourceType.has(t.sourceType);
-              const meta = TILE_META[t.slug] ?? {
-                icon: FALLBACK_ICON,
-                subtitle: t.description ?? t.sourceType,
-              };
-              return (
-                <InstallTile
-                  key={t.id}
-                  slug={t.slug}
-                  label={t.displayName}
-                  subtitle={meta.subtitle}
-                  icon={meta.icon}
-                  installed={connected}
-                  onClick={() => handleTileClick(t.sourceType, t.id, t.slug)}
-                />
-              );
-            })}
+        {templates.map((t) => (
+          <InstallTile
+            key={t.id}
+            slug={t.slug}
+            label={t.displayName}
+            subtitle={t.description ?? t.sourceType}
+            icon={FALLBACK_ICON}
+            installed={keyBySourceType.has(t.sourceType)}
+            onClick={() => handleTileClick(t.sourceType, t.id, t.slug)}
+          />
+        ))}
         <RawOtlpAdvancedTile />
       </SimpleGrid>
 
@@ -339,19 +329,6 @@ function InstallTile({
         </VStack>
       </HStack>
     </Box>
-  );
-}
-
-function TileSkeleton() {
-  return (
-    <Box
-      borderWidth="1px"
-      borderColor="border.muted"
-      borderRadius="md"
-      padding={3}
-      height="76px"
-      backgroundColor="bg.subtle"
-    />
   );
 }
 

--- a/langwatch/src/components/me/TraceIngestSection.tsx
+++ b/langwatch/src/components/me/TraceIngestSection.tsx
@@ -116,11 +116,15 @@ export function TraceIngestSection() {
 
   // No templates, no section: the platform ships no defaults, so most
   // orgs have nothing to install here. Rendering nothing (not even
-  // load skeletons) until the list resolves with at least one template
-  // keeps /me from flashing a section that then disappears. Installed
+  // load skeletons) while the list is in flight keeps /me from flashing
+  // a section that then disappears, and only a SUCCESSFUL empty list
+  // hides the section for good. A failed list is NOT an empty catalog:
+  // it falls through to the normal render (heading, grid, raw-OTLP
+  // fallback card) rather than silently hiding the section. Installed
   // sources keep ingesting regardless: the receiver keys on the
   // IngestionSource, not on a listed template.
-  if (templates.length === 0) return null;
+  if (!templatesQuery.isSuccess && !templatesQuery.isError) return null;
+  if (templatesQuery.isSuccess && templates.length === 0) return null;
   const openTemplate = openSlug
     ? templates.find((t) => t.slug === openSlug) ?? null
     : null;

--- a/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
+++ b/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
@@ -55,7 +55,7 @@ describe("<AiToolsPortal /> curated-empty fallback", () => {
     cleanup();
   });
 
-  describe("when every entry is archived or disabled and the viewer can manage the catalog", () => {
+  describe("when the catalog query returns no enabled tools and the viewer can manage the catalog", () => {
     beforeEach(() => {
       mockCanManage = true;
     });
@@ -81,7 +81,7 @@ describe("<AiToolsPortal /> curated-empty fallback", () => {
     });
   });
 
-  describe("when every entry is archived or disabled and the viewer is a member", () => {
+  describe("when the catalog query returns no enabled tools and the viewer is a member", () => {
     beforeEach(() => {
       mockCanManage = false;
     });

--- a/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
+++ b/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
@@ -27,8 +27,8 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 
 // Zero enabled entries: list resolves to [], availability to no configured
 // providers. Server-side auto-provisioning means a fresh org never actually
-// serves an empty list; this state is only reachable when the admin archived
-// or disabled every entry (the curated-empty fallback these tests pin).
+// serves an empty list; this state is only reachable when the catalog was
+// curated down to no enabled tools (the curated-empty fallback these pin).
 vi.mock("~/utils/api", () => ({
   api: {
     aiTools: {

--- a/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
+++ b/langwatch/src/components/me/__tests__/AiToolsPortal.integration.test.tsx
@@ -25,7 +25,10 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   })),
 }));
 
-// Empty catalog: list resolves to [], availability to no configured providers.
+// Zero enabled entries: list resolves to [], availability to no configured
+// providers. Server-side auto-provisioning means a fresh org never actually
+// serves an empty list; this state is only reachable when the admin archived
+// or disabled every entry (the curated-empty fallback these tests pin).
 vi.mock("~/utils/api", () => ({
   api: {
     aiTools: {
@@ -43,7 +46,7 @@ function renderWithProviders(ui: React.ReactElement) {
   return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
 }
 
-describe("<AiToolsPortal /> empty state", () => {
+describe("<AiToolsPortal /> curated-empty fallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -52,12 +55,12 @@ describe("<AiToolsPortal /> empty state", () => {
     cleanup();
   });
 
-  describe("when the catalog is empty and the viewer can manage it", () => {
+  describe("when every entry is archived or disabled and the viewer can manage the catalog", () => {
     beforeEach(() => {
       mockCanManage = true;
     });
 
-    /** @scenario brand-new org shows the getting-started banner to a catalog admin */
+    /** @scenario curated-empty catalog shows the getting-started banner to a catalog admin */
     it("renders the governance getting-started banner linking to the tool catalog", () => {
       renderWithProviders(<AiToolsPortal />);
 
@@ -78,12 +81,12 @@ describe("<AiToolsPortal /> empty state", () => {
     });
   });
 
-  describe("when the catalog is empty and the viewer is a member", () => {
+  describe("when every entry is archived or disabled and the viewer is a member", () => {
     beforeEach(() => {
       mockCanManage = false;
     });
 
-    /** @scenario brand-new org with no catalog shows a member empty-state note */
+    /** @scenario curated-empty catalog shows a member empty-state note */
     it("renders the member note and no getting-started banner or CLI card", () => {
       renderWithProviders(<AiToolsPortal />);
 

--- a/langwatch/src/components/settings/governance/ToolCatalogEditor.tsx
+++ b/langwatch/src/components/settings/governance/ToolCatalogEditor.tsx
@@ -164,6 +164,11 @@ export function ToolCatalogEditor({
   // A slug is selected unless the admin explicitly unchecks it, so the
   // checklist defaults to the full pack without waiting on the query.
   const [unchecked, setUnchecked] = useState<Record<string, boolean>>({});
+  // The import card is always reachable: open by default while the catalog
+  // is empty, behind a small toggle once tiles exist. The service skips
+  // tiles the org already has (archived ones included), so re-import only
+  // ever adds starter tiles the catalog never had.
+  const [showImport, setShowImport] = useState(false);
   const starterTiles = starterPackQuery.data ?? [];
   const selectedSlugs = starterTiles
     .filter((t) => !unchecked[t.slug])
@@ -238,7 +243,18 @@ export function ToolCatalogEditor({
 
   return (
     <VStack align="stretch" gap={6} width="full">
-      {isCatalogEmpty && (
+      {!isCatalogEmpty && (
+        <HStack justifyContent="flex-end">
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => setShowImport((v) => !v)}
+          >
+            <PackageOpen size={14} /> Import starter pack
+          </Button>
+        </HStack>
+      )}
+      {(isCatalogEmpty || showImport) && (
         <Box
           borderWidth="1px"
           borderColor="orange.300"
@@ -252,13 +268,18 @@ export function ToolCatalogEditor({
             </Box>
             <VStack align="start" gap={2} flex={1} minWidth={0}>
               <Text fontSize="sm" fontWeight="semibold">
-                Publish a starter pack to get going
+                {isCatalogEmpty
+                  ? "Publish a starter pack to get going"
+                  : "Import starter pack"}
               </Text>
               <Text fontSize="xs" color="fg.muted">
-                Pick the tools to publish at org scope so every member sees
-                them on /me. You can rename, reorder, disable, or remove
-                individual tiles afterwards. Re-running is safe; only new
-                slugs get added.
+                {isCatalogEmpty
+                  ? "Pick the tools to publish at org scope so every member " +
+                    "sees them on /me. You can rename, reorder, disable, or " +
+                    "remove individual tiles afterwards. Re-running is safe; " +
+                    "only new slugs get added."
+                  : "Adds starter tiles the catalog never had. Tiles already " +
+                    "present, archived ones included, are skipped."}
               </Text>
               <VStack align="start" gap={2} paddingTop={1} width="full">
                 {SECTION_ORDER.map((type) => {
@@ -295,10 +316,10 @@ export function ToolCatalogEditor({
                   loading={importStarterPackMutation.isPending}
                   disabled={selectedSlugs.length === 0}
                   onClick={() =>
-                    importStarterPackMutation.mutate({
-                      organizationId,
-                      slugs: selectedSlugs,
-                    })
+                    importStarterPackMutation.mutate(
+                      { organizationId, slugs: selectedSlugs },
+                      { onSuccess: () => setShowImport(false) },
+                    )
                   }
                 >
                   <PackageOpen size={14} /> Import selected (

--- a/langwatch/src/components/settings/governance/__tests__/ToolCatalogEditorStarterPack.integration.test.tsx
+++ b/langwatch/src/components/settings/governance/__tests__/ToolCatalogEditorStarterPack.integration.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers specs/ai-governance/personal-portal/admin-catalog-editor.feature,
+ * the ungated starter-pack import: with auto-provisioning, real catalogs
+ * are never empty, so the import affordance must stay reachable from a
+ * populated catalog. The real editor renders here; only the tRPC boundary
+ * is mocked.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const entriesFixture = [
+  {
+    id: "entry-1",
+    organizationId: "org-1",
+    slug: "claude-code",
+    type: "coding_assistant",
+    displayName: "Claude Code",
+    subtitle: "Coding assistant",
+    iconAsset: "preset:claude-code",
+    enabled: true,
+    order: 0,
+    scope: "organization",
+    scopeId: "org-1",
+    config: {},
+    archivedAt: null,
+  },
+];
+
+const starterTilesFixture = [
+  {
+    slug: "claude-code",
+    type: "coding_assistant",
+    displayName: "Claude Code",
+  },
+  { slug: "codex", type: "coding_assistant", displayName: "Codex" },
+  { slug: "openai", type: "model_provider", displayName: "OpenAI" },
+];
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      aiTools: { adminList: { invalidate: vi.fn(), setData: vi.fn() } },
+    }),
+    aiTools: {
+      adminList: {
+        useQuery: () => ({
+          data: entriesFixture,
+          isLoading: false,
+        }),
+      },
+      starterPackCatalog: {
+        useQuery: () => ({ data: starterTilesFixture, isLoading: false }),
+      },
+      setEnabled: { useMutation: () => ({ mutate: vi.fn() }) },
+      remove: { useMutation: () => ({ mutate: vi.fn() }) },
+      reorder: { useMutation: () => ({ mutate: vi.fn() }) },
+      importStarterPack: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    departments: {
+      list: { useQuery: () => ({ data: [], isLoading: false }) },
+    },
+  },
+}));
+
+import { ToolCatalogEditor } from "../ToolCatalogEditor";
+
+describe("<ToolCatalogEditor /> starter pack import", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the catalog already has entries", () => {
+    /** @scenario "a populated catalog still offers the starter pack import behind a toggle" */
+    it("shows the import button instead of the empty-state callout and reveals the checklist on click", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <ToolCatalogEditor
+            organizationId="org-1"
+            onAddTile={vi.fn()}
+            onEditTile={vi.fn()}
+          />
+        </ChakraProvider>,
+      );
+
+      expect(
+        screen.queryByText(/Publish a starter pack to get going/i),
+      ).not.toBeInTheDocument();
+      const toggle = screen.getByRole("button", {
+        name: /import starter pack/i,
+      });
+
+      await user.click(toggle);
+
+      expect(
+        await screen.findByText(/Adds starter tiles the catalog never had/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Codex")).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/pages/cli/FirstTraceRedirect.tsx
+++ b/langwatch/src/pages/cli/FirstTraceRedirect.tsx
@@ -62,6 +62,30 @@ export function resolveFirstTracePolling({
   return { enabled, refetchInterval };
 }
 
+/**
+ * Pure transition policy for a first-trace read landing: confirm the
+ * never-synced state, mark prior traces (which keeps the current behavior),
+ * or start the redirect. A response that lands after the watch timed out
+ * must not start a redirect, however late the network was.
+ */
+export function resolveFirstTraceTransition({
+  firstMessage,
+  hasSeenNeverSynced,
+  isTimedOut,
+}: {
+  firstMessage: boolean | undefined;
+  hasSeenNeverSynced: boolean;
+  isTimedOut: boolean;
+}): "none" | "confirm-never-synced" | "mark-prior-traces" | "redirect" {
+  if (firstMessage === undefined) return "none";
+  if (!firstMessage) {
+    return hasSeenNeverSynced ? "none" : "confirm-never-synced";
+  }
+  if (!hasSeenNeverSynced) return "mark-prior-traces";
+  if (isTimedOut) return "none";
+  return "redirect";
+}
+
 function useDocumentVisible(): boolean {
   const [isVisible, setIsVisible] = useState<boolean>(
     typeof document === "undefined"
@@ -92,7 +116,8 @@ function useFirstTraceWatch(): FirstTraceWatchState {
     redirectToOnboarding: false,
   });
   const personalProject = useMemo(
-    () => findPersonalProject(organizations, session?.user?.id),
+    () =>
+      findPersonalProject({ organizations, userId: session?.user?.id }),
     [organizations, session?.user?.id],
   );
 
@@ -132,20 +157,25 @@ function useFirstTraceWatch(): FirstTraceWatchState {
 
   useEffect(() => {
     const firstMessage = hasFirstMessage.data?.firstMessage;
-    if (firstMessage === undefined) return;
-    if (!hasResult) setHasResult(true);
-    if (!firstMessage) {
-      if (!hasSeenNeverSynced) setHasSeenNeverSynced(true);
-      return;
-    }
+    if (firstMessage !== undefined && !hasResult) setHasResult(true);
     // Users whose project already had traces keep the current behavior; only
-    // a false -> true transition observed on this page triggers the redirect.
-    if (!hasSeenNeverSynced) {
-      setHasPriorTraces(true);
-      return;
-    }
-    if (!isRedirecting) setIsRedirecting(true);
-  }, [hasFirstMessage.data, hasResult, hasSeenNeverSynced, isRedirecting]);
+    // a false -> true transition observed on this page, before the timeout,
+    // triggers the redirect.
+    const transition = resolveFirstTraceTransition({
+      firstMessage,
+      hasSeenNeverSynced,
+      isTimedOut,
+    });
+    if (transition === "confirm-never-synced") setHasSeenNeverSynced(true);
+    if (transition === "mark-prior-traces") setHasPriorTraces(true);
+    if (transition === "redirect" && !isRedirecting) setIsRedirecting(true);
+  }, [
+    hasFirstMessage.data,
+    hasResult,
+    hasSeenNeverSynced,
+    isRedirecting,
+    isTimedOut,
+  ]);
 
   useEffect(() => {
     if (!isRedirecting || !personalProject?.slug) return;

--- a/langwatch/src/pages/cli/FirstTraceRedirect.tsx
+++ b/langwatch/src/pages/cli/FirstTraceRedirect.tsx
@@ -31,10 +31,11 @@ const REDIRECT_DELAY_MS = 1_200;
  * Pure polling policy: the query runs only while there is a project to watch
  * and nothing has concluded the watch (redirect underway, timeout reached, or
  * the project already had traces). The refetch interval additionally requires
- * a visible tab, plus either a confirmed never-synced state or no result yet,
- * so a failed initial read keeps retrying until the timeout instead of
- * stalling, while a hidden tab or an already-synced project never ticks the
- * network.
+ * either a confirmed never-synced state or no result yet, so a failed
+ * initial read keeps retrying until the timeout instead of stalling.
+ * Hidden tabs are covered by react-query itself: with the default
+ * refetchIntervalInBackground (false), an interval query only ticks while
+ * the tab is focused per the focus manager's visibilitychange handling.
  */
 export function resolveFirstTracePolling({
   hasProject,
@@ -43,7 +44,6 @@ export function resolveFirstTracePolling({
   isTimedOut,
   hasPriorTraces,
   hasSeenNeverSynced,
-  isVisible,
 }: {
   hasProject: boolean;
   hasResult: boolean;
@@ -51,12 +51,11 @@ export function resolveFirstTracePolling({
   isTimedOut: boolean;
   hasPriorTraces: boolean;
   hasSeenNeverSynced: boolean;
-  isVisible: boolean;
 }): { enabled: boolean; refetchInterval: number | false } {
   const enabled =
     hasProject && !isRedirecting && !isTimedOut && !hasPriorTraces;
   const refetchInterval =
-    enabled && isVisible && (hasSeenNeverSynced || !hasResult)
+    enabled && (hasSeenNeverSynced || !hasResult)
       ? FIRST_TRACE_POLL_INTERVAL_MS
       : false;
   return { enabled, refetchInterval };
@@ -86,21 +85,6 @@ export function resolveFirstTraceTransition({
   return "redirect";
 }
 
-function useDocumentVisible(): boolean {
-  const [isVisible, setIsVisible] = useState<boolean>(
-    typeof document === "undefined"
-      ? true
-      : document.visibilityState === "visible",
-  );
-  useEffect(() => {
-    const onVisibility = () =>
-      setIsVisible(document.visibilityState === "visible");
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => document.removeEventListener("visibilitychange", onVisibility);
-  }, []);
-  return isVisible;
-}
-
 type FirstTraceWatchState = "hidden" | "waiting" | "redirecting";
 
 /**
@@ -121,7 +105,6 @@ function useFirstTraceWatch(): FirstTraceWatchState {
     [organizations, session?.user?.id],
   );
 
-  const isVisible = useDocumentVisible();
   const [hasResult, setHasResult] = useState(false);
   const [isTimedOut, setIsTimedOut] = useState(false);
   const [hasSeenNeverSynced, setHasSeenNeverSynced] = useState(false);
@@ -143,7 +126,6 @@ function useFirstTraceWatch(): FirstTraceWatchState {
     isTimedOut,
     hasPriorTraces,
     hasSeenNeverSynced,
-    isVisible,
   });
 
   const hasFirstMessage = api.project.getHasFirstMessage.useQuery(

--- a/langwatch/src/pages/cli/FirstTraceRedirect.tsx
+++ b/langwatch/src/pages/cli/FirstTraceRedirect.tsx
@@ -21,6 +21,7 @@ import { useSession } from "~/utils/auth-client";
 import { useRouter } from "~/utils/compat/next-router";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
+import { findPersonalProject } from "~/utils/personalProject";
 
 export const FIRST_TRACE_POLL_INTERVAL_MS = 3_000;
 export const FIRST_TRACE_POLL_TIMEOUT_MS = 10 * 60_000;
@@ -30,73 +31,81 @@ const REDIRECT_DELAY_MS = 1_200;
  * Pure polling policy: the query runs only while there is a project to watch
  * and nothing has concluded the watch (redirect underway, timeout reached, or
  * the project already had traces). The refetch interval additionally requires
- * that we have confirmed the never-synced state and that the tab is visible,
- * so a hidden tab or an already-synced project never ticks the network.
+ * a visible tab, plus either a confirmed never-synced state or no result yet,
+ * so a failed initial read keeps retrying until the timeout instead of
+ * stalling, while a hidden tab or an already-synced project never ticks the
+ * network.
  */
 export function resolveFirstTracePolling({
   hasProject,
-  redirecting,
-  timedOut,
-  alreadyHadTraces,
-  sawNeverSynced,
+  hasResult,
+  isRedirecting,
+  isTimedOut,
+  hasPriorTraces,
+  hasSeenNeverSynced,
   isVisible,
 }: {
   hasProject: boolean;
-  redirecting: boolean;
-  timedOut: boolean;
-  alreadyHadTraces: boolean;
-  sawNeverSynced: boolean;
+  hasResult: boolean;
+  isRedirecting: boolean;
+  isTimedOut: boolean;
+  hasPriorTraces: boolean;
+  hasSeenNeverSynced: boolean;
   isVisible: boolean;
 }): { enabled: boolean; refetchInterval: number | false } {
-  const enabled = hasProject && !redirecting && !timedOut && !alreadyHadTraces;
+  const enabled =
+    hasProject && !isRedirecting && !isTimedOut && !hasPriorTraces;
   const refetchInterval =
-    enabled && sawNeverSynced && isVisible ? FIRST_TRACE_POLL_INTERVAL_MS : false;
+    enabled && isVisible && (hasSeenNeverSynced || !hasResult)
+      ? FIRST_TRACE_POLL_INTERVAL_MS
+      : false;
   return { enabled, refetchInterval };
 }
 
-export function FirstTraceRedirect() {
-  const router = useRouter();
-  const { data: session } = useSession();
-  const { organizations } = useOrganizationTeamProject({
-    redirectToOnboarding: false,
-  });
-
-  // Same resolution PersonalSidebar uses: the personal team owned by the
-  // signed-in user carries exactly one personal project.
-  const personalProject = useMemo(() => {
-    const userId = session?.user?.id;
-    if (!userId || !organizations) return null;
-    for (const org of organizations) {
-      for (const team of org.teams ?? []) {
-        if (team.isPersonal && team.ownerUserId === userId) {
-          const project = team.projects?.[0];
-          if (project) return { id: project.id, slug: project.slug };
-        }
-      }
-    }
-    return null;
-  }, [organizations, session?.user?.id]);
-
+function useDocumentVisible(): boolean {
   const [isVisible, setIsVisible] = useState<boolean>(
     typeof document === "undefined"
       ? true
       : document.visibilityState === "visible",
   );
-  const [timedOut, setTimedOut] = useState(false);
-  const [sawNeverSynced, setSawNeverSynced] = useState(false);
-  const [alreadyHadTraces, setAlreadyHadTraces] = useState(false);
-  const [redirecting, setRedirecting] = useState(false);
-
   useEffect(() => {
     const onVisibility = () =>
       setIsVisible(document.visibilityState === "visible");
     document.addEventListener("visibilitychange", onVisibility);
     return () => document.removeEventListener("visibilitychange", onVisibility);
   }, []);
+  return isVisible;
+}
+
+type FirstTraceWatchState = "hidden" | "waiting" | "redirecting";
+
+/**
+ * Watches the personal project's first-trace flag and drives the redirect.
+ * "waiting" is the confirmed never-synced poll, "redirecting" the brief
+ * announcement before navigation; "hidden" covers every case that keeps the
+ * current close-this-tab behavior.
+ */
+function useFirstTraceWatch(): FirstTraceWatchState {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { organizations } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+  });
+  const personalProject = useMemo(
+    () => findPersonalProject(organizations, session?.user?.id),
+    [organizations, session?.user?.id],
+  );
+
+  const isVisible = useDocumentVisible();
+  const [hasResult, setHasResult] = useState(false);
+  const [isTimedOut, setIsTimedOut] = useState(false);
+  const [hasSeenNeverSynced, setHasSeenNeverSynced] = useState(false);
+  const [hasPriorTraces, setHasPriorTraces] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
     const timeout = setTimeout(
-      () => setTimedOut(true),
+      () => setIsTimedOut(true),
       FIRST_TRACE_POLL_TIMEOUT_MS,
     );
     return () => clearTimeout(timeout);
@@ -104,10 +113,11 @@ export function FirstTraceRedirect() {
 
   const polling = resolveFirstTracePolling({
     hasProject: !!personalProject?.id,
-    redirecting,
-    timedOut,
-    alreadyHadTraces,
-    sawNeverSynced,
+    hasResult,
+    isRedirecting,
+    isTimedOut,
+    hasPriorTraces,
+    hasSeenNeverSynced,
     isVisible,
   });
 
@@ -123,31 +133,39 @@ export function FirstTraceRedirect() {
   useEffect(() => {
     const firstMessage = hasFirstMessage.data?.firstMessage;
     if (firstMessage === undefined) return;
+    if (!hasResult) setHasResult(true);
     if (!firstMessage) {
-      if (!sawNeverSynced) setSawNeverSynced(true);
+      if (!hasSeenNeverSynced) setHasSeenNeverSynced(true);
       return;
     }
     // Users whose project already had traces keep the current behavior; only
     // a false -> true transition observed on this page triggers the redirect.
-    if (!sawNeverSynced) {
-      setAlreadyHadTraces(true);
+    if (!hasSeenNeverSynced) {
+      setHasPriorTraces(true);
       return;
     }
-    if (!redirecting) setRedirecting(true);
-  }, [hasFirstMessage.data, sawNeverSynced, redirecting]);
+    if (!isRedirecting) setIsRedirecting(true);
+  }, [hasFirstMessage.data, hasResult, hasSeenNeverSynced, isRedirecting]);
 
   useEffect(() => {
-    if (!redirecting || !personalProject?.slug) return;
+    if (!isRedirecting || !personalProject?.slug) return;
     const slug = personalProject.slug;
     const timeout = setTimeout(() => {
       void router.push(`/${slug}/traces`);
     }, REDIRECT_DELAY_MS);
     return () => clearTimeout(timeout);
-  }, [redirecting, personalProject?.slug, router]);
+  }, [isRedirecting, personalProject?.slug, router]);
 
-  if (!personalProject || alreadyHadTraces || timedOut) return null;
+  if (!personalProject || hasPriorTraces || isTimedOut) return "hidden";
+  if (isRedirecting) return "redirecting";
+  if (hasSeenNeverSynced) return "waiting";
+  return "hidden";
+}
 
-  if (redirecting) {
+export function FirstTraceRedirect() {
+  const watchState = useFirstTraceWatch();
+
+  if (watchState === "redirecting") {
     return (
       <HStack gap={2} role="status" aria-live="polite">
         <Icon as={CheckCircle2} boxSize={4} color="green.fg" />
@@ -158,7 +176,7 @@ export function FirstTraceRedirect() {
     );
   }
 
-  if (sawNeverSynced) {
+  if (watchState === "waiting") {
     return (
       <HStack gap={2} role="status" aria-live="polite">
         <Spinner size="sm" color="orange.400" />

--- a/langwatch/src/pages/cli/FirstTraceRedirect.tsx
+++ b/langwatch/src/pages/cli/FirstTraceRedirect.tsx
@@ -1,0 +1,173 @@
+/**
+ * Post-approval first-trace watcher for the CLI device-session flow.
+ *
+ * After the user approves a device session on /cli/auth, their next step in
+ * the terminal is running the wrapped tool (e.g. `langwatch claude`) for the
+ * first time. If their personal project has never received a trace, this
+ * component politely polls until the first trace lands and then redirects to
+ * the personal traces page, so the first thing they see is their own session.
+ *
+ * Behavior rules (specs/ai-governance/cli-onboarding/post-login-first-trace-redirect.feature):
+ * - Only the never-synced case watches: when the personal project already has
+ *   traces on first read, the page keeps the plain success card.
+ * - Polls every few seconds, only while the tab is visible, and gives up
+ *   after a timeout instead of polling forever.
+ * - Redirects with the SPA router to /<personal-project-slug>/traces.
+ */
+import { HStack, Icon, Spinner, Text } from "@chakra-ui/react";
+import { CheckCircle2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "~/utils/auth-client";
+import { useRouter } from "~/utils/compat/next-router";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { api } from "~/utils/api";
+
+export const FIRST_TRACE_POLL_INTERVAL_MS = 3_000;
+export const FIRST_TRACE_POLL_TIMEOUT_MS = 10 * 60_000;
+const REDIRECT_DELAY_MS = 1_200;
+
+/**
+ * Pure polling policy: the query runs only while there is a project to watch
+ * and nothing has concluded the watch (redirect underway, timeout reached, or
+ * the project already had traces). The refetch interval additionally requires
+ * that we have confirmed the never-synced state and that the tab is visible,
+ * so a hidden tab or an already-synced project never ticks the network.
+ */
+export function resolveFirstTracePolling({
+  hasProject,
+  redirecting,
+  timedOut,
+  alreadyHadTraces,
+  sawNeverSynced,
+  isVisible,
+}: {
+  hasProject: boolean;
+  redirecting: boolean;
+  timedOut: boolean;
+  alreadyHadTraces: boolean;
+  sawNeverSynced: boolean;
+  isVisible: boolean;
+}): { enabled: boolean; refetchInterval: number | false } {
+  const enabled = hasProject && !redirecting && !timedOut && !alreadyHadTraces;
+  const refetchInterval =
+    enabled && sawNeverSynced && isVisible ? FIRST_TRACE_POLL_INTERVAL_MS : false;
+  return { enabled, refetchInterval };
+}
+
+export function FirstTraceRedirect() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { organizations } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+  });
+
+  // Same resolution PersonalSidebar uses: the personal team owned by the
+  // signed-in user carries exactly one personal project.
+  const personalProject = useMemo(() => {
+    const userId = session?.user?.id;
+    if (!userId || !organizations) return null;
+    for (const org of organizations) {
+      for (const team of org.teams ?? []) {
+        if (team.isPersonal && team.ownerUserId === userId) {
+          const project = team.projects?.[0];
+          if (project) return { id: project.id, slug: project.slug };
+        }
+      }
+    }
+    return null;
+  }, [organizations, session?.user?.id]);
+
+  const [isVisible, setIsVisible] = useState<boolean>(
+    typeof document === "undefined"
+      ? true
+      : document.visibilityState === "visible",
+  );
+  const [timedOut, setTimedOut] = useState(false);
+  const [sawNeverSynced, setSawNeverSynced] = useState(false);
+  const [alreadyHadTraces, setAlreadyHadTraces] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
+
+  useEffect(() => {
+    const onVisibility = () =>
+      setIsVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setTimedOut(true),
+      FIRST_TRACE_POLL_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timeout);
+  }, []);
+
+  const polling = resolveFirstTracePolling({
+    hasProject: !!personalProject?.id,
+    redirecting,
+    timedOut,
+    alreadyHadTraces,
+    sawNeverSynced,
+    isVisible,
+  });
+
+  const hasFirstMessage = api.project.getHasFirstMessage.useQuery(
+    { projectId: personalProject?.id ?? "" },
+    {
+      enabled: polling.enabled,
+      refetchInterval: polling.refetchInterval,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  useEffect(() => {
+    const firstMessage = hasFirstMessage.data?.firstMessage;
+    if (firstMessage === undefined) return;
+    if (!firstMessage) {
+      if (!sawNeverSynced) setSawNeverSynced(true);
+      return;
+    }
+    // Users whose project already had traces keep the current behavior; only
+    // a false -> true transition observed on this page triggers the redirect.
+    if (!sawNeverSynced) {
+      setAlreadyHadTraces(true);
+      return;
+    }
+    if (!redirecting) setRedirecting(true);
+  }, [hasFirstMessage.data, sawNeverSynced, redirecting]);
+
+  useEffect(() => {
+    if (!redirecting || !personalProject?.slug) return;
+    const slug = personalProject.slug;
+    const timeout = setTimeout(() => {
+      void router.push(`/${slug}/traces`);
+    }, REDIRECT_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, [redirecting, personalProject?.slug, router]);
+
+  if (!personalProject || alreadyHadTraces || timedOut) return null;
+
+  if (redirecting) {
+    return (
+      <HStack gap={2} role="status" aria-live="polite">
+        <Icon as={CheckCircle2} boxSize={4} color="green.fg" />
+        <Text textStyle="sm" color="fg.muted">
+          First trace received. Taking you there now.
+        </Text>
+      </HStack>
+    );
+  }
+
+  if (sawNeverSynced) {
+    return (
+      <HStack gap={2} role="status" aria-live="polite">
+        <Spinner size="sm" color="orange.400" />
+        <Text textStyle="sm" color="fg.muted">
+          Waiting for your first trace. We will take you there when it arrives.
+        </Text>
+      </HStack>
+    );
+  }
+
+  return null;
+}

--- a/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -15,13 +15,23 @@ import userEvent from "@testing-library/user-event";
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchMock, sessionRef, firstMessageState, credentialTypeRef } =
-  vi.hoisted(() => {
+const {
+  fetchMock,
+  sessionRef,
+  firstMessageState,
+  credentialTypeRef,
+  lastFirstMessageQueryOptions,
+} = vi.hoisted(() => {
     const fetchMock = vi.fn();
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const listeners = new Set<() => void>();
     return {
       fetchMock,
+      lastFirstMessageQueryOptions: {
+        current: undefined as
+          | { enabled?: boolean; refetchIntervalInBackground?: boolean }
+          | undefined,
+      },
       sessionRef: {
         current: {
           data: { user: { id: "user-1", email: "dev@example.com" } },
@@ -121,8 +131,12 @@ vi.mock("~/utils/api", async () => {
         getHasFirstMessage: {
           useQuery: (
             _input: { projectId: string },
-            options?: { enabled?: boolean },
+            options?: {
+              enabled?: boolean;
+              refetchIntervalInBackground?: boolean;
+            },
           ) => {
+            lastFirstMessageQueryOptions.current = options;
             const value = useSyncExternalStore(
               (listener) => firstMessageState.subscribe(listener),
               () => firstMessageState.value,
@@ -213,6 +227,12 @@ describe("/cli/auth first-trace watch", () => {
       expect(screen.getByText(/Waiting for your first trace/i)).toBeDefined(),
     );
     expect(mockRouter.push).not.toHaveBeenCalled();
+
+    // Visible-tab-only polling rides react-query's default: the component
+    // must never override refetchIntervalInBackground.
+    expect(
+      lastFirstMessageQueryOptions.current?.refetchIntervalInBackground,
+    ).toBeUndefined();
 
     act(() => firstMessageState.set(true));
 

--- a/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -219,6 +219,7 @@ describe("/cli/auth first-trace watch", () => {
   };
 
   /** @scenario "Approving a device session before any trace has synced waits and then redirects to the personal traces page" */
+  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
   it("waits for the first trace, then redirects to the personal traces page", async () => {
     renderPage();
     await approveDeviceSession();

--- a/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/langwatch/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers specs/ai-governance/cli-onboarding/post-login-first-trace-redirect.feature.
+ *
+ * The real /cli/auth page runs here: the real approval flow, the real
+ * useOrganizationTeamProject, the real FirstTraceRedirect watcher. Only the
+ * network boundary is replaced: `fetch` answers like the CLI auth REST
+ * endpoints, and the tRPC hooks resolve fixtures, with getHasFirstMessage
+ * backed by a store the test flips to simulate the first trace landing.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, sessionRef, firstMessageState, credentialTypeRef } =
+  vi.hoisted(() => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const listeners = new Set<() => void>();
+    return {
+      fetchMock,
+      sessionRef: {
+        current: {
+          data: { user: { id: "user-1", email: "dev@example.com" } },
+          status: "authenticated" as const,
+        },
+      },
+      credentialTypeRef: {
+        current: "device_session" as "device_session" | "project_api_key",
+      },
+      firstMessageState: {
+        value: false,
+        listeners,
+        set(value: boolean) {
+          this.value = value;
+          for (const listener of listeners) listener();
+        },
+        subscribe(listener: () => void) {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+        snapshot: () => firstMessageState.value,
+      },
+    };
+  });
+
+vi.mock("~/utils/auth-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/auth-client")>();
+  return { ...actual, useSession: () => sessionRef.current };
+});
+
+const organizationsFixture = [
+  {
+    id: "org-1",
+    name: "Acme Org",
+    teams: [
+      {
+        id: "team-personal",
+        slug: "personal-team",
+        name: "Personal",
+        isPersonal: true,
+        ownerUserId: "user-1",
+        projects: [
+          {
+            id: "proj-personal",
+            slug: "personal-proj",
+            name: "Personal project",
+            isPersonal: true,
+            kind: "application",
+          },
+        ],
+      },
+      {
+        id: "team-shared",
+        slug: "shared-team",
+        name: "Engineering",
+        isPersonal: false,
+        ownerUserId: null,
+        projects: [
+          {
+            id: "proj-shared",
+            slug: "shared-proj",
+            name: "Shared project",
+            isPersonal: false,
+            kind: "application",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+vi.mock("~/utils/api", async () => {
+  const { useSyncExternalStore } = await import("react");
+  return {
+    api: {
+      publicEnv: {
+        useQuery: () => ({ data: {}, isLoading: false }),
+      },
+      sharedTrace: {
+        get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      },
+      organization: {
+        getAll: {
+          useQuery: () => ({
+            data: organizationsFixture,
+            isLoading: false,
+            isFetched: true,
+          }),
+        },
+      },
+      modelProvider: {
+        getAllForProject: {
+          useQuery: () => ({ data: undefined, isLoading: false }),
+        },
+      },
+      project: {
+        getHasFirstMessage: {
+          useQuery: (
+            _input: { projectId: string },
+            options?: { enabled?: boolean },
+          ) => {
+            const value = useSyncExternalStore(
+              (listener) => firstMessageState.subscribe(listener),
+              () => firstMessageState.value,
+            );
+            if (options?.enabled === false) {
+              return { data: undefined, isLoading: false };
+            }
+            return { data: { firstMessage: value }, isLoading: false };
+          },
+        },
+      },
+    },
+  };
+});
+
+import { useRouter } from "~/utils/compat/next-router";
+import CliAuthPage from "../auth";
+
+const mockRouter = useRouter();
+
+const serveCliAuthEndpoints = () => {
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/auth/cli/lookup")) {
+      return new Response(
+        JSON.stringify({
+          user_code: "WDJB-MJHT",
+          status: "pending",
+          expires_at: Date.now() + 10 * 60_000,
+          credential_type: credentialTypeRef.current,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.includes("/api/auth/cli/approve")) {
+      return new Response(
+        JSON.stringify({ ok: true, personal_vk_label: "default" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+};
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <CliAuthPage />
+    </ChakraProvider>,
+  );
+
+describe("/cli/auth first-trace watch", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    (mockRouter.push as unknown as Mock).mockClear();
+    (mockRouter.replace as unknown as Mock).mockClear();
+    mockRouter.query = { user_code: "WDJB-MJHT" };
+    credentialTypeRef.current = "device_session";
+    firstMessageState.value = false;
+    serveCliAuthEndpoints();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mockRouter.query = {};
+  });
+
+  const approveDeviceSession = async () => {
+    const user = userEvent.setup();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Approve" })).toBeDefined(),
+    );
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await waitFor(() =>
+      expect(screen.getByText(/You're signed in!/i)).toBeDefined(),
+    );
+  };
+
+  /** @scenario "Approving a device session before any trace has synced waits and then redirects to the personal traces page" */
+  it("waits for the first trace, then redirects to the personal traces page", async () => {
+    renderPage();
+    await approveDeviceSession();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Waiting for your first trace/i)).toBeDefined(),
+    );
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    act(() => firstMessageState.set(true));
+
+    await waitFor(() =>
+      expect(screen.getByText(/First trace received/i)).toBeDefined(),
+    );
+    await waitFor(
+      () =>
+        expect(mockRouter.push).toHaveBeenCalledWith("/personal-proj/traces"),
+      { timeout: 4_000 },
+    );
+  });
+
+  /** @scenario "Approving a device session when the personal project already has traces keeps the plain success card" */
+  it("keeps the plain success card when traces already exist", async () => {
+    firstMessageState.value = true;
+    renderPage();
+    await approveDeviceSession();
+
+    // Give the redirect delay window time to elapse before asserting nothing
+    // happened: an already-synced project must keep the close-this-tab card.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    expect(screen.queryByText(/Waiting for your first trace/i)).toBeNull();
+    expect(screen.queryByText(/First trace received/i)).toBeNull();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(screen.getByText(/You're signed in!/i)).toBeDefined();
+  });
+
+  /** @scenario "Generating a project API key does not start the first-trace watcher" */
+  it("does not watch for traces on the project API key flow", async () => {
+    credentialTypeRef.current = "project_api_key";
+    renderPage();
+
+    const user = userEvent.setup();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Generate API key" }),
+      ).toBeDefined(),
+    );
+    await user.click(screen.getByRole("button", { name: "Generate API key" }));
+    await waitFor(() =>
+      expect(screen.getByText(/API key generated!/i)).toBeDefined(),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(screen.queryByText(/Waiting for your first trace/i)).toBeNull();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+});

--- a/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  FIRST_TRACE_POLL_INTERVAL_MS,
+  resolveFirstTracePolling,
+} from "../FirstTraceRedirect";
+
+const base = {
+  hasProject: true,
+  redirecting: false,
+  timedOut: false,
+  alreadyHadTraces: false,
+  sawNeverSynced: true,
+  isVisible: true,
+};
+
+describe("resolveFirstTracePolling", () => {
+  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+  it("polls on the interval only while the tab is visible", () => {
+    expect(resolveFirstTracePolling(base)).toEqual({
+      enabled: true,
+      refetchInterval: FIRST_TRACE_POLL_INTERVAL_MS,
+    });
+    expect(resolveFirstTracePolling({ ...base, isVisible: false })).toEqual({
+      enabled: true,
+      refetchInterval: false,
+    });
+  });
+
+  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+  it("stops entirely at the timeout", () => {
+    expect(resolveFirstTracePolling({ ...base, timedOut: true })).toEqual({
+      enabled: false,
+      refetchInterval: false,
+    });
+  });
+
+  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+  it("never polls a project known to already have traces", () => {
+    expect(
+      resolveFirstTracePolling({
+        ...base,
+        sawNeverSynced: false,
+        alreadyHadTraces: true,
+      }),
+    ).toEqual({ enabled: false, refetchInterval: false });
+  });
+
+  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+  it("stops while the redirect is underway and never runs without a project", () => {
+    expect(resolveFirstTracePolling({ ...base, redirecting: true })).toEqual({
+      enabled: false,
+      refetchInterval: false,
+    });
+    expect(resolveFirstTracePolling({ ...base, hasProject: false })).toEqual({
+      enabled: false,
+      refetchInterval: false,
+    });
+    // Before the first read resolves we allow the single initial fetch but
+    // no interval yet.
+    expect(
+      resolveFirstTracePolling({ ...base, sawNeverSynced: false }),
+    ).toEqual({ enabled: true, refetchInterval: false });
+  });
+});

--- a/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
@@ -6,59 +6,82 @@ import {
 
 const base = {
   hasProject: true,
-  redirecting: false,
-  timedOut: false,
-  alreadyHadTraces: false,
-  sawNeverSynced: true,
+  hasResult: true,
+  isRedirecting: false,
+  isTimedOut: false,
+  hasPriorTraces: false,
+  hasSeenNeverSynced: true,
   isVisible: true,
 };
 
 describe("resolveFirstTracePolling", () => {
-  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
-  it("polls on the interval only while the tab is visible", () => {
-    expect(resolveFirstTracePolling(base)).toEqual({
-      enabled: true,
-      refetchInterval: FIRST_TRACE_POLL_INTERVAL_MS,
+  describe("when the never-synced state is confirmed", () => {
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("polls on the interval only while the tab is visible", () => {
+      expect(resolveFirstTracePolling(base)).toEqual({
+        enabled: true,
+        refetchInterval: FIRST_TRACE_POLL_INTERVAL_MS,
+      });
+      expect(resolveFirstTracePolling({ ...base, isVisible: false })).toEqual({
+        enabled: true,
+        refetchInterval: false,
+      });
     });
-    expect(resolveFirstTracePolling({ ...base, isVisible: false })).toEqual({
-      enabled: true,
-      refetchInterval: false,
+
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("stops entirely at the timeout", () => {
+      expect(resolveFirstTracePolling({ ...base, isTimedOut: true })).toEqual({
+        enabled: false,
+        refetchInterval: false,
+      });
     });
   });
 
-  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
-  it("stops entirely at the timeout", () => {
-    expect(resolveFirstTracePolling({ ...base, timedOut: true })).toEqual({
-      enabled: false,
-      refetchInterval: false,
+  describe("when the watch has concluded", () => {
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("never polls a project known to already have traces", () => {
+      expect(
+        resolveFirstTracePolling({
+          ...base,
+          hasSeenNeverSynced: false,
+          hasPriorTraces: true,
+        }),
+      ).toEqual({ enabled: false, refetchInterval: false });
+    });
+
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("stops while the redirect is underway and never runs without a project", () => {
+      expect(
+        resolveFirstTracePolling({ ...base, isRedirecting: true }),
+      ).toEqual({ enabled: false, refetchInterval: false });
+      expect(resolveFirstTracePolling({ ...base, hasProject: false })).toEqual({
+        enabled: false,
+        refetchInterval: false,
+      });
     });
   });
 
-  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
-  it("never polls a project known to already have traces", () => {
-    expect(
-      resolveFirstTracePolling({
-        ...base,
-        sawNeverSynced: false,
-        alreadyHadTraces: true,
-      }),
-    ).toEqual({ enabled: false, refetchInterval: false });
-  });
-
-  /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
-  it("stops while the redirect is underway and never runs without a project", () => {
-    expect(resolveFirstTracePolling({ ...base, redirecting: true })).toEqual({
-      enabled: false,
-      refetchInterval: false,
+  describe("when no result has arrived yet", () => {
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("keeps retrying the initial read until the timeout, so a failed fetch cannot stall the watch", () => {
+      expect(
+        resolveFirstTracePolling({
+          ...base,
+          hasResult: false,
+          hasSeenNeverSynced: false,
+        }),
+      ).toEqual({
+        enabled: true,
+        refetchInterval: FIRST_TRACE_POLL_INTERVAL_MS,
+      });
+      expect(
+        resolveFirstTracePolling({
+          ...base,
+          hasResult: false,
+          hasSeenNeverSynced: false,
+          isTimedOut: true,
+        }),
+      ).toEqual({ enabled: false, refetchInterval: false });
     });
-    expect(resolveFirstTracePolling({ ...base, hasProject: false })).toEqual({
-      enabled: false,
-      refetchInterval: false,
-    });
-    // Before the first read resolves we allow the single initial fetch but
-    // no interval yet.
-    expect(
-      resolveFirstTracePolling({ ...base, sawNeverSynced: false }),
-    ).toEqual({ enabled: true, refetchInterval: false });
   });
 });

--- a/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
@@ -12,20 +12,18 @@ const base = {
   isTimedOut: false,
   hasPriorTraces: false,
   hasSeenNeverSynced: true,
-  isVisible: true,
 } as const;
 
 describe("resolveFirstTracePolling", () => {
   describe("when the never-synced state is confirmed", () => {
     /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
-    it("polls on the interval only while the tab is visible", () => {
+    it("polls on the interval while the watch is live", () => {
+      // Visible-tab-only is react-query's own default: with
+      // refetchIntervalInBackground unset, interval refetches pause on a
+      // hidden tab. The RTL suite pins that the option is never overridden.
       expect(resolveFirstTracePolling(base)).toEqual({
         enabled: true,
         refetchInterval: FIRST_TRACE_POLL_INTERVAL_MS,
-      });
-      expect(resolveFirstTracePolling({ ...base, isVisible: false })).toEqual({
-        enabled: true,
-        refetchInterval: false,
       });
     });
 

--- a/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/firstTracePolling.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   FIRST_TRACE_POLL_INTERVAL_MS,
   resolveFirstTracePolling,
+  resolveFirstTraceTransition,
 } from "../FirstTraceRedirect";
 
 const base = {
@@ -12,7 +13,7 @@ const base = {
   hasPriorTraces: false,
   hasSeenNeverSynced: true,
   isVisible: true,
-};
+} as const;
 
 describe("resolveFirstTracePolling", () => {
   describe("when the never-synced state is confirmed", () => {
@@ -82,6 +83,62 @@ describe("resolveFirstTracePolling", () => {
           isTimedOut: true,
         }),
       ).toEqual({ enabled: false, refetchInterval: false });
+    });
+  });
+});
+
+describe("resolveFirstTraceTransition", () => {
+  describe("when reads land before the timeout", () => {
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("confirms never-synced once, keeps prior-trace projects on the current behavior, and redirects on the flip", () => {
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: false,
+          hasSeenNeverSynced: false,
+          isTimedOut: false,
+        }),
+      ).toBe("confirm-never-synced");
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: false,
+          hasSeenNeverSynced: true,
+          isTimedOut: false,
+        }),
+      ).toBe("none");
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: true,
+          hasSeenNeverSynced: false,
+          isTimedOut: false,
+        }),
+      ).toBe("mark-prior-traces");
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: true,
+          hasSeenNeverSynced: true,
+          isTimedOut: false,
+        }),
+      ).toBe("redirect");
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: undefined,
+          hasSeenNeverSynced: false,
+          isTimedOut: false,
+        }),
+      ).toBe("none");
+    });
+  });
+
+  describe("when a read lands after the watch timed out", () => {
+    /** @scenario "First-trace polling only runs while the page is visible and stops at the timeout" */
+    it("never starts a redirect, however late the response was", () => {
+      expect(
+        resolveFirstTraceTransition({
+          firstMessage: true,
+          hasSeenNeverSynced: true,
+          isTimedOut: true,
+        }),
+      ).toBe("none");
     });
   });
 });

--- a/langwatch/src/pages/cli/auth.tsx
+++ b/langwatch/src/pages/cli/auth.tsx
@@ -41,6 +41,7 @@ import { setAttributionIfAbsent } from "~/utils/attribution";
 import { OnboardingContainer } from "~/features/onboarding/components/containers/OnboardingContainer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { resolveCliAuthProjects } from "./cliAuthProjects";
+import { FirstTraceRedirect } from "./FirstTraceRedirect";
 import { ScopeChipPicker } from "~/components/settings/ScopeChipPicker";
 
 /**
@@ -603,16 +604,19 @@ export default function CliAuthPage() {
                       updated. You can close this tab.
                     </StatusCard>
                   ) : (
-                    <StatusCard
-                      palette="green"
-                      icon={CheckCircle2}
-                      title="You're signed in!"
-                    >
-                      LangWatch CLI is now authorized for{" "}
-                      <strong>{action.organizationName}</strong> using the{" "}
-                      <code>{action.vkLabel}</code> personal key. You can close
-                      this tab and return to your terminal.
-                    </StatusCard>
+                    <>
+                      <StatusCard
+                        palette="green"
+                        icon={CheckCircle2}
+                        title="You're signed in!"
+                      >
+                        LangWatch CLI is now authorized for{" "}
+                        <strong>{action.organizationName}</strong> using the{" "}
+                        <code>{action.vkLabel}</code> personal key. You can
+                        close this tab and return to your terminal.
+                      </StatusCard>
+                      <FirstTraceRedirect />
+                    </>
                   )}
                 </>
               )}

--- a/langwatch/src/server/api/routers/onboarding/__tests__/onboarding.personal-workspace.integration.test.ts
+++ b/langwatch/src/server/api/routers/onboarding/__tests__/onboarding.personal-workspace.integration.test.ts
@@ -17,7 +17,9 @@
  * PersonalWorkspaceService. Requires: PostgreSQL database (Prisma).
  *
  * Spec: specs/features/onboarding/intent-fork.feature
+ *       specs/ai-governance/personal-portal/default-catalog.feature
  */
+import { STARTER_PACK_TILES } from "@ee/governance/services/aiToolEntry.service";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -108,6 +110,7 @@ describe("onboarding.initializeOrganization personal workspace", () => {
         });
       }
       await prisma.project.deleteMany({ where: { team: { organizationId } } });
+      await prisma.aiToolEntry.deleteMany({ where: { organizationId } });
       await prisma.roleBinding.deleteMany({ where: { organizationId } });
       await prisma.teamUser.deleteMany({ where: { team: { organizationId } } });
       await prisma.team.deleteMany({ where: { organizationId } });
@@ -174,6 +177,21 @@ describe("onboarding.initializeOrganization personal workspace", () => {
       expect(await repository.getTeamCount(organizationId)).toBe(1);
     });
 
+    /** @scenario A fresh organization gets the full standard catalog with no admin action */
+    it("provisions the standard AI tool catalog", async () => {
+      const tiles = await prisma.aiToolEntry.findMany({
+        where: { organizationId },
+        orderBy: { order: "asc" },
+      });
+
+      expect(tiles.map((t) => t.slug)).toEqual(
+        STARTER_PACK_TILES.map((t) => t.slug),
+      );
+      expect(tiles.every((t) => t.enabled && t.archivedAt === null)).toBe(
+        true,
+      );
+    });
+
     /** @scenario The personal workspace does not spend the plan's allowance */
     it("is idempotent, so a later CLI login adds no second workspace", async () => {
       const { PersonalWorkspaceService } = await import(
@@ -226,6 +244,24 @@ describe("onboarding.initializeOrganization personal workspace", () => {
       });
 
       expect(sharedProjects).toHaveLength(1);
+    });
+
+    /** @scenario A fresh organization gets the full standard catalog with no admin action */
+    it("provisions the standard AI tool catalog for this intent too", async () => {
+      // The catalog is intent-independent: whichever door the org came in
+      // through, its members' /me portal must render tiles, not the
+      // empty state.
+      const tiles = await prisma.aiToolEntry.findMany({
+        where: { organizationId },
+        orderBy: { order: "asc" },
+      });
+
+      expect(tiles.map((t) => t.slug)).toEqual(
+        STARTER_PACK_TILES.map((t) => t.slug),
+      );
+      expect(tiles.every((t) => t.enabled && t.archivedAt === null)).toBe(
+        true,
+      );
     });
   });
 });

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
@@ -1,3 +1,4 @@
+import { AiToolEntryService } from "@ee/governance/services/aiToolEntry.service";
 import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -59,6 +60,27 @@ export const onboardingRouter = createTRPCRouter({
           throw new TRPCError({
             code: "INTERNAL_SERVER_ERROR",
             message: "Failed to create organization",
+          });
+        }
+
+        // Every new org gets the standard AI tool catalog at creation, for
+        // every intent: the /me portal must render tiles on its very first
+        // load instead of the "no tools yet" empty state.
+        //
+        // Non-fatal by design, same contract as the personal-workspace
+        // ensure below: a failure here must not cost the user the
+        // organization they just created, and the aiTools.list read path
+        // lazily provisions the same set on first portal load anyway.
+        try {
+          await AiToolEntryService.create(ctx.prisma).ensureDefaultCatalog({
+            organizationId: orgResult.organization.id,
+          });
+        } catch (error) {
+          captureException(toError(error), {
+            extra: {
+              origin: "onboarding.initializeOrganization.ensureDefaultCatalog",
+              organizationId: orgResult.organization.id,
+            },
           });
         }
 

--- a/langwatch/src/server/app-layer/traces/__tests__/long-context-model-cost.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/long-context-model-cost.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { getStaticModelCosts } from "../../../modelProviders/llmModelCost";
+import { matchModelCostWithFallbacks } from "../../../tracer/collector/cost";
+import { computeSpanCost } from "../model-cost-matching";
+
+/**
+ * Claude Code appends "[1m]" to the model id when the 1M-token context
+ * window is active. Registry regexes are prefix-anchored, so the suffix is
+ * absorbed by the base entry. Per Anthropic's published pricing
+ * (platform.claude.com docs/en/about-claude/pricing, "Long context
+ * pricing", retrieved 2026-07-27), Claude 4.6+ models bill the full 1M
+ * window at standard per-token rates with no premium above 200K input
+ * tokens, so the base entry's rates are the correct [1m] rates.
+ *
+ * The expected per-token rates below are Anthropic's Opus 5 price sheet
+ * (input $5/MTok, output $25/MTok, 5m cache write $6.25/MTok, cache read
+ * $0.50/MTok). If a registry sync changes them, re-verify against the
+ * pricing page before updating the constants.
+ */
+const OPUS_5_INPUT = 0.000005;
+const OPUS_5_OUTPUT = 0.000025;
+const OPUS_5_CACHE_WRITE = 0.00000625;
+const OPUS_5_CACHE_READ = 0.0000005;
+
+describe("long-context [1m] model cost matching", () => {
+  /** @scenario "A [1m] long-context model id resolves the base model's registry pricing" */
+  it("matches claude-opus-5[1m] to the anthropic/claude-opus-5 registry entry at standard rates", () => {
+    const match = matchModelCostWithFallbacks(
+      "claude-opus-5[1m]",
+      getStaticModelCosts(),
+    );
+
+    expect(match?.model).toBe("anthropic/claude-opus-5");
+    expect(match?.inputCostPerToken).toBe(OPUS_5_INPUT);
+    expect(match?.outputCostPerToken).toBe(OPUS_5_OUTPUT);
+    expect(match?.cacheCreationCostPerToken).toBe(OPUS_5_CACHE_WRITE);
+    expect(match?.cacheReadCostPerToken).toBe(OPUS_5_CACHE_READ);
+  });
+
+  /** @scenario "A Claude Code span on claude-opus-5[1m] with cache traffic gets a nonzero cost" */
+  it("computes a nonzero cost for the literal claude-opus-5[1m] with cache tokens", () => {
+    // The customer-reported span: model chip claude-opus-5[1m], cache read
+    // 20540 and cache write 22994 tokens, which showed no cost.
+    const result = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "claude-opus-5[1m]",
+        "gen_ai.usage.cache_read.input_tokens": 20540,
+        "gen_ai.usage.cache_creation.input_tokens": 22994,
+      },
+      promptTokens: 0,
+      completionTokens: 0,
+    });
+
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeCloseTo(
+      20540 * OPUS_5_CACHE_READ + 22994 * OPUS_5_CACHE_WRITE,
+      10,
+    );
+  });
+
+  /** @scenario "A Claude Code span on claude-opus-5[1m] with cache traffic gets a nonzero cost" */
+  it("adds fresh input and output tokens at the standard Opus 5 rates", () => {
+    const result = computeSpanCost({
+      attrs: {
+        "gen_ai.request.model": "claude-opus-5[1m]",
+        "gen_ai.usage.cache_read.input_tokens": 20540,
+        "gen_ai.usage.cache_creation.input_tokens": 22994,
+      },
+      promptTokens: 1000,
+      completionTokens: 500,
+    });
+
+    expect(result).toBeCloseTo(
+      1000 * OPUS_5_INPUT +
+        500 * OPUS_5_OUTPUT +
+        20540 * OPUS_5_CACHE_READ +
+        22994 * OPUS_5_CACHE_WRITE,
+      10,
+    );
+  });
+
+  /** @scenario "The [1m] suffix resolves registry pricing across the Claude model family" */
+  it("resolves the [1m] suffix for other Claude spellings too", () => {
+    const costs = getStaticModelCosts();
+
+    expect(
+      matchModelCostWithFallbacks("claude-sonnet-4-5[1m]", costs)?.model,
+    ).toBe("anthropic/claude-sonnet-4-5");
+    expect(
+      matchModelCostWithFallbacks("anthropic/claude-opus-5[1m]", costs)?.model,
+    ).toBe("anthropic/claude-opus-5");
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/long-context-model-cost.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/long-context-model-cost.unit.test.ts
@@ -23,7 +23,7 @@ const OPUS_5_CACHE_WRITE = 0.00000625;
 const OPUS_5_CACHE_READ = 0.0000005;
 
 describe("long-context [1m] model cost matching", () => {
-  /** @scenario "A [1m] long-context model id resolves the base model's registry pricing" */
+  /** @scenario "A [1m] long-context model id is priced as its base model" */
   it("matches claude-opus-5[1m] to the anthropic/claude-opus-5 registry entry at standard rates", () => {
     const match = matchModelCostWithFallbacks(
       "claude-opus-5[1m]",
@@ -79,7 +79,7 @@ describe("long-context [1m] model cost matching", () => {
     );
   });
 
-  /** @scenario "The [1m] suffix resolves registry pricing across the Claude model family" */
+  /** @scenario "The [1m] suffix is priced as the base model across the Claude family" */
   it("resolves the [1m] suffix for other Claude spellings too", () => {
     const costs = getStaticModelCosts();
 

--- a/langwatch/src/utils/personalProject.ts
+++ b/langwatch/src/utils/personalProject.ts
@@ -4,7 +4,10 @@
  * project. Shared by PersonalSidebar (personal nav links) and the /cli/auth
  * first-trace watcher, so the traversal lives in one place.
  */
-export function findPersonalProject(
+export function findPersonalProject({
+  organizations,
+  userId,
+}: {
   organizations:
     | Array<{
         teams?: Array<{
@@ -13,9 +16,9 @@ export function findPersonalProject(
           projects?: Array<{ id: string; slug: string }> | null;
         }> | null;
       }>
-    | undefined,
-  userId: string | null | undefined,
-): { id: string; slug: string } | null {
+    | undefined;
+  userId: string | null | undefined;
+}): { id: string; slug: string } | null {
   if (!userId || !organizations) return null;
   for (const org of organizations) {
     for (const team of org.teams ?? []) {

--- a/langwatch/src/utils/personalProject.ts
+++ b/langwatch/src/utils/personalProject.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves the signed-in user's personal project from the organizations
+ * payload: the personal team owned by the user carries exactly one personal
+ * project. Shared by PersonalSidebar (personal nav links) and the /cli/auth
+ * first-trace watcher, so the traversal lives in one place.
+ */
+export function findPersonalProject(
+  organizations:
+    | Array<{
+        teams?: Array<{
+          isPersonal?: boolean | null;
+          ownerUserId?: string | null;
+          projects?: Array<{ id: string; slug: string }> | null;
+        }> | null;
+      }>
+    | undefined,
+  userId: string | null | undefined,
+): { id: string; slug: string } | null {
+  if (!userId || !organizations) return null;
+  for (const org of organizations) {
+    for (const team of org.teams ?? []) {
+      if (team.isPersonal && team.ownerUserId === userId) {
+        const project = team.projects?.[0];
+        if (project) return { id: project.id, slug: project.slug };
+      }
+    }
+  }
+  return null;
+}

--- a/specs/ai-gateway/governance/ingestion-templates-catalog.feature
+++ b/specs/ai-gateway/governance/ingestion-templates-catalog.feature
@@ -37,9 +37,10 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
     And user "jane@acme.com" has a personal project "personal-jane"
     And the platform's coding assistants (claude_code, codex, cursor, gemini, opencode)
         are set up by `langwatch <tool>` and are NOT ingestion templates
-    And the platform ships these IngestionTemplate rows with organizationId IS NULL:
-      | slug          | sourceType    | credentialSchema | scope    |
-      | claude_cowork | claude_cowork | NULL             | platform |
+    And the platform ships NO default IngestionTemplate rows
+        (claude_cowork is retired; the seeder archives any existing platform
+        row for a retired slug, and installed cowork IngestionSources keep
+        ingesting because the receiver keys on the source, not the template)
     And the platform-template seed does NOT include any coding-assistant slug
         (claude_code / codex / cursor / gemini / opencode are never seeded)
     And a client-side **discovery card** "raw_otlp_advanced" renders alongside the
@@ -56,10 +57,11 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
 
   @bdd @ingestion-templates @catalog @user-visibility
   Scenario: User sees only non-coding-assistant templates on /me Trace Ingest
+    Given org "acme" has authored an IngestionTemplate "acme-router"
     When jane navigates to "/me" and scrolls to the "Trace Ingest" section
     Then she sees a tile-grid with exactly these items:
       | tile slug         | label                   | source                      |
-      | claude_cowork     | "Connect Claude cowork" | api.ingestionTemplates.list |
+      | acme-router       | "Acme router"           | api.ingestionTemplates.list |
       | raw_otlp_advanced | "Raw OTLP (advanced)"   | client-side discovery card  |
     And the install tile is sourced from `api.ingestionTemplates.list`
     And the raw_otlp_advanced card is rendered client-side (no server query)
@@ -67,6 +69,10 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
         (those are coding-assistant tiles on the AiToolsPortal, not ingestion templates)
     And the raw_otlp_advanced card is visually distinct from the install tiles
         (e.g. dashed border + subtle background per Lane-B Iter 2)
+    But when the org has no IngestionTemplate rows at all
+    Then the whole Trace Ingest section is hidden (no heading, no grid,
+        no raw_otlp_advanced card; the personal OTLP endpoint stays
+        reachable via /me/configure)
 
   @bdd @ingestion-templates @catalog @coding-assistant-not-a-template
   Scenario: A platform coding assistant never appears as an ingestion template
@@ -80,8 +86,9 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
 
   @bdd @ingestion-templates @catalog @copy-disambiguation
   Scenario: Catalog copy distinguishes auto-shape vs raw OTLP
-    When jane opens the install drawer for the claude_cowork tile
-    Then the drawer headline reads "Connect Claude cowork — auto-shaped"
+    Given org "acme" has authored an IngestionTemplate "Acme router"
+    When jane opens the install drawer for the acme-router tile
+    Then the drawer headline reads "Connect Acme router, auto-shaped"
     And the subcopy contains "Traces normalized into gen_ai.* canonical. Cost/tokens/model populated automatically."
     But when she opens the raw_otlp_advanced card
     Then the headline reads "Bring your own OTLP — raw shape"
@@ -97,7 +104,8 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
   Scenario: Platform-published templates (organizationId IS NULL) are visible to every org
     Given org "beta-corp" has not authored any IngestionTemplate rows
     When user "lisa@beta-corp.com" navigates to her /me Trace Ingest
-    Then she sees the same non-coding-assistant tiles as jane (claude_cowork + raw_otlp_advanced)
+    Then she sees any platform-published rows (organizationId IS NULL) that exist
+    And since the platform currently ships none, her Trace Ingest section is hidden
 
   @bdd @ingestion-templates @catalog @cross-org-isolation
   Scenario: Org-authored templates (organizationId NOT NULL) are scoped to that org only
@@ -120,8 +128,9 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
     # Existing P7-B6 ToolCatalogEditor surface (AiToolEntry catalog) gets a
     # second tab here. No new admin route v1.
     Then she sees the platform-default IngestionTemplate rows listed
-        (claude_cowork only — raw_otlp_advanced is a client-side card and does
-        NOT appear in the admin templates table)
+        (currently none: the platform ships no default rows, so only
+        org-authored templates appear; raw_otlp_advanced is a client-side
+        card and does NOT appear in the admin templates table)
     And she does NOT see rows for claude_code, codex, cursor, gemini, or opencode
         (they were never seeded as templates, so there is nothing to filter)
     And each template row has a "View OTTL" affordance opening a read-only modal
@@ -137,7 +146,8 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
   Scenario: The platform-template seed produces no coding-assistant rows
     When the platform IngestionTemplate seed runs
     Then no seeded row has a slug of claude_code, codex, cursor, gemini, or opencode
-    And claude_cowork is the only platform coding-tool template seeded
+    And no platform template rows are seeded at all (claude_cowork is retired
+        and archived on existing installs, see default-catalog.feature)
     # No flag, no filter constant: the coding assistants are absent from the seed
     # input itself, so the /me grid and the admin list never have a row to drop.
 

--- a/specs/ai-gateway/governance/ingestion-templates-catalog.feature
+++ b/specs/ai-gateway/governance/ingestion-templates-catalog.feature
@@ -37,10 +37,10 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
     And user "jane@acme.com" has a personal project "personal-jane"
     And the platform's coding assistants (claude_code, codex, cursor, gemini, opencode)
         are set up by `langwatch <tool>` and are NOT ingestion templates
-    And the platform ships NO default IngestionTemplate rows
-        (claude_cowork is retired; the seeder archives any existing platform
-        row for a retired slug, and installed cowork IngestionSources keep
-        ingesting because the receiver keys on the source, not the template)
+    And the platform ships NO built-in templates
+        (claude-cowork is retired: it no longer appears in any org's
+        catalog, even where an earlier release had offered it, and tools
+        already connected through it keep ingesting uninterrupted)
     And the platform-template seed does NOT include any coding-assistant slug
         (claude_code / codex / cursor / gemini / opencode are never seeded)
     And a client-side **discovery card** "raw_otlp_advanced" renders alongside the
@@ -57,22 +57,24 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
 
   @bdd @ingestion-templates @catalog @user-visibility
   Scenario: User sees only non-coding-assistant templates on /me Trace Ingest
-    Given org "acme" has authored an IngestionTemplate "acme-router"
+    Given org "acme" has authored a template "Acme router"
     When jane navigates to "/me" and scrolls to the "Trace Ingest" section
-    Then she sees a tile-grid with exactly these items:
-      | tile slug         | label                   | source                      |
-      | acme-router       | "Acme router"           | api.ingestionTemplates.list |
-      | raw_otlp_advanced | "Raw OTLP (advanced)"   | client-side discovery card  |
-    And the install tile is sourced from `api.ingestionTemplates.list`
-    And the raw_otlp_advanced card is rendered client-side (no server query)
+    Then she sees a tile-grid with exactly these tiles:
+      | tile              | label                 |
+      | acme-router       | "Acme router"         |
+      | raw_otlp_advanced | "Raw OTLP (advanced)" |
     And NO tile is shown for claude_code, codex, cursor, gemini, or opencode
         (those are coding-assistant tiles on the AiToolsPortal, not ingestion templates)
     And the raw_otlp_advanced card is visually distinct from the install tiles
         (e.g. dashed border + subtle background per Lane-B Iter 2)
-    But when the org has no IngestionTemplate rows at all
-    Then the whole Trace Ingest section is hidden (no heading, no grid,
-        no raw_otlp_advanced card; the personal OTLP endpoint stays
-        reachable via /me/configure)
+
+  @bdd @ingestion-templates @catalog @empty-catalog
+  Scenario: Trace Ingest section is hidden when the org has no templates
+    Given org "acme" has not authored any templates
+    When jane navigates to "/me"
+    Then no "Trace Ingest" section renders: no heading, no grid, and no
+        raw_otlp_advanced card
+    And the personal OTLP endpoint stays reachable via /me/configure
 
   @bdd @ingestion-templates @catalog @coding-assistant-not-a-template
   Scenario: A platform coding assistant never appears as an ingestion template
@@ -86,7 +88,7 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
 
   @bdd @ingestion-templates @catalog @copy-disambiguation
   Scenario: Catalog copy distinguishes auto-shape vs raw OTLP
-    Given org "acme" has authored an IngestionTemplate "Acme router"
+    Given org "acme" has authored a template "Acme router"
     When jane opens the install drawer for the acme-router tile
     Then the drawer headline reads "Connect Acme router, auto-shaped"
     And the subcopy contains "Traces normalized into gen_ai.* canonical. Cost/tokens/model populated automatically."
@@ -104,7 +106,7 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
   Scenario: Platform-published templates (organizationId IS NULL) are visible to every org
     Given org "beta-corp" has not authored any IngestionTemplate rows
     When user "lisa@beta-corp.com" navigates to her /me Trace Ingest
-    Then she sees any platform-published rows (organizationId IS NULL) that exist
+    Then she sees any templates the platform has published for every org
     And since the platform currently ships none, her Trace Ingest section is hidden
 
   @bdd @ingestion-templates @catalog @cross-org-isolation

--- a/specs/ai-gateway/governance/ingestion-templates-catalog.feature
+++ b/specs/ai-gateway/governance/ingestion-templates-catalog.feature
@@ -148,10 +148,11 @@ Feature: AI Gateway Governance — Ingestion Templates Catalog (personal-workspa
   Scenario: The platform-template seed produces no coding-assistant rows
     When the platform IngestionTemplate seed runs
     Then no seeded row has a slug of claude_code, codex, cursor, gemini, or opencode
-    And no platform template rows are seeded at all (claude_cowork is retired
-        and archived on existing installs, see default-catalog.feature)
-    # No flag, no filter constant: the coding assistants are absent from the seed
-    # input itself, so the /me grid and the admin list never have a row to drop.
+    And no platform template rows are seeded at all
+    # claude_cowork's retirement and archival on existing installs is covered
+    # by default-catalog.feature. No flag, no filter constant: the coding
+    # assistants are absent from the seed input itself, so the /me grid and
+    # the admin list never have a row to drop.
 
   # No-leak invariant: persona-aware-chrome layout component branches on
   # route shape to hide IngestionTemplate catalog under /[project]. No

--- a/specs/ai-gateway/governance/workspace-switcher.feature
+++ b/specs/ai-gateway/governance/workspace-switcher.feature
@@ -348,6 +348,29 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
     Then no "Create project" entry is rendered in team T's group
         (non-admins cannot create projects from this UI)
 
+  # A coding-usage (governance) signup provisions a personal workspace plus
+  # one shared team with no project. Empty teams are normally hidden as
+  # navigation dead-ends, but hiding the ONLY shared team removed the only
+  # create affordance in the dropdown, stranding these users on personal
+  # usage forever. The empty team therefore stays visible, with its "+"
+  # button, for viewers allowed to create a project on it. Personal teams
+  # stay excluded from the switcher and from ambient selection either way.
+  @bdd @ui @workspace-switcher @add-project @empty-team @integration
+  Scenario: A coding-usage signup can always create their first shared project from the workspace menu
+    Given the user signed up through the coding-usage path
+    And their organization has a personal workspace and one shared team with no projects
+    When the user opens the switcher
+    Then the empty shared team renders with its "Create project" button
+    And clicking it opens the CreateProject drawer scoped to that team
+    And the personal team still does not appear anywhere in the dropdown
+
+  @bdd @ui @workspace-switcher @add-project @empty-team @integration
+  Scenario: An empty team stays hidden from members who cannot create a project on it
+    Given the user is a regular member of a team with no projects
+    When the user opens the switcher
+    Then the empty team does not render
+        (it stays a navigation dead-end for non-creators)
+
   @bdd @ui @workspace-switcher @persistence @stage-2c
   Scenario: Picking a project from a non-project route persists selectedProjectSlug
     Given the user is on "/settings/teams/<team-slug>"

--- a/specs/ai-governance/cli-onboarding/post-login-first-trace-redirect.feature
+++ b/specs/ai-governance/cli-onboarding/post-login-first-trace-redirect.feature
@@ -1,0 +1,54 @@
+Feature: Post-login first-trace watch on the CLI authorize page
+  As a developer approving `langwatch login` in the browser
+  I want the authorize page to notice my very first trace arriving
+  So that right after my first Claude Code turn I land on my own traces
+  instead of a dead-end "you can close this tab" card
+
+  # Background
+  #
+  # The device-session flow ends on /cli/auth with a green success card. The
+  # user's next act is running the wrapped tool in the terminal; for a brand
+  # new account the wow moment is seeing that first session appear. The page
+  # therefore watches Project.firstMessage on the user's personal project
+  # (the project device-session traces land on) and redirects to
+  # /<personal-project-slug>/traces when it flips.
+  #
+  # The watch is polite: it only starts when the project has never synced a
+  # trace, polls on a seconds-scale interval only while the tab is visible,
+  # and gives up after a timeout rather than polling forever. Users whose
+  # project already has traces keep the existing close-this-tab behavior.
+
+  Background:
+    Given a signed-in user with a personal workspace
+    And the user completed the device-code approval on /cli/auth
+
+  @bdd @cli-onboarding @first-trace @integration
+  Scenario: Approving a device session before any trace has synced waits and then redirects to the personal traces page
+    Given the personal project has never received a trace
+    When the user approves the device session
+    Then the success card shows a "Waiting for your first trace" status line
+    And when the personal project receives its first trace
+    Then the page announces the trace arrived
+    And navigates to the personal project's traces page
+
+  @bdd @cli-onboarding @first-trace @integration
+  Scenario: Approving a device session when the personal project already has traces keeps the plain success card
+    Given the personal project has already received traces
+    When the user approves the device session
+    Then the success card renders without any waiting status line
+    And the page does not navigate away
+
+  @bdd @cli-onboarding @first-trace @integration
+  Scenario: Generating a project API key does not start the first-trace watcher
+    Given the CLI requested a project API key instead of a device session
+    When the user generates the key
+    Then the API key success card renders without any waiting status line
+    And the page does not navigate away
+
+  @bdd @cli-onboarding @first-trace @unit
+  Scenario: First-trace polling only runs while the page is visible and stops at the timeout
+    Given the watch confirmed the project has never synced a trace
+    Then the poll interval is active only while the tab is visible
+    And no polling happens after the timeout elapses
+    And no polling happens once the project is known to already have traces
+    And no polling happens while the redirect is underway

--- a/specs/ai-governance/cli-wrappers/wrap-path-choice.feature
+++ b/specs/ai-governance/cli-wrappers/wrap-path-choice.feature
@@ -9,10 +9,13 @@ Feature: CLI wrapper asks the user which path to run when both are allowed
   Two paths the wrapper can pick:
     - Path A "Gateway (virtual key)": LLM calls route through the LangWatch
       gateway via the user's personal virtual key. LLM usage is billed to the
-      gateway. (cfg.tool_mode = "gateway")
+      gateway. Offered in the prompt as "Using an API key".
+      (cfg.tool_mode = "gateway")
     - Path B "Direct OTLP": the tool calls its own provider with the user's own
       plan, and only OTLP telemetry is sent to LangWatch, authorized by the
-      user's personal ingest key. (cfg.tool_mode = "ingestion")
+      user's personal ingest key. Offered in the prompt with per-tool
+      subscription wording, e.g. "Using a Claude subscription" for claude.
+      (cfg.tool_mode = "ingestion")
 
   The remembered answer lives in cfg.tool_mode[tool] (the existing per-tool
   routing field). The wrapper only prompts when the answer is not already
@@ -29,19 +32,22 @@ Feature: CLI wrapper asks the user which path to run when both are allowed
 
   Rule: prompt only when both paths are allowed, on a TTY, with no remembered answer
 
+    # Launch-day users are mostly on Claude subscriptions, so the subscription (direct OTLP) choice is listed first and is the default.
+
     @unit
     Scenario: First interactive run with both paths allowed prompts for the path
       Given tool_mode.claude is unset
       And stdin and stdout are a TTY
       When the user runs `langwatch claude`
       Then the wrapper shows a select prompt asking how `langwatch claude` should run
-      And the prompt offers a "Gateway (virtual key)" choice and a "Direct OTLP" choice
+      And the prompt offers "Using a Claude subscription" first and "Using an API key" second
+      And the pre-selected default is "Using a Claude subscription"
 
     @unit
     Scenario: Choosing the gateway remembers it and does not prompt again
       Given tool_mode.claude is unset
       And stdin and stdout are a TTY
-      When the user runs `langwatch claude` and picks "Gateway (virtual key)"
+      When the user runs `langwatch claude` and picks "Using an API key"
       Then cfg.tool_mode.claude is saved as "gateway"
       And the wrapper prints a one-line tip explaining how to change it later
       When the user runs `langwatch claude` again
@@ -51,7 +57,7 @@ Feature: CLI wrapper asks the user which path to run when both are allowed
     Scenario: Choosing direct OTLP remembers it as ingestion
       Given tool_mode.claude is unset
       And stdin and stdout are a TTY
-      When the user runs `langwatch claude` and picks "Direct OTLP"
+      When the user runs `langwatch claude` and picks "Using a Claude subscription"
       Then cfg.tool_mode.claude is saved as "ingestion"
       And the wrapper proceeds in ingestion mode
 

--- a/specs/ai-governance/personal-portal/admin-catalog-editor.feature
+++ b/specs/ai-governance/personal-portal/admin-catalog-editor.feature
@@ -46,6 +46,33 @@ Feature: AI Tools Portal — Admin catalog editor at /settings/governance/tool-c
     And user "carol@acme.com" unchecks every starter tool
     Then the import action is disabled
 
+  # Auto-provisioning means real catalogs are never empty, so the import
+  # affordance cannot hide behind the empty state: it stays reachable from
+  # a populated catalog behind a compact toggle. Import only ever adds
+  # starter tiles the catalog never had: tiles already present are skipped,
+  # and archived tiles count as present, so a re-import never undoes
+  # curation (+ Add tile recreates an archived tile deliberately).
+  @bdd @admin-catalog @starter-pack @integration
+  Scenario: a populated catalog still offers the starter pack import behind a toggle
+    Given the org-scoped catalog already has entries
+    When user "carol@acme.com" loads "/settings/governance/tool-catalog"
+    Then an "Import starter pack" button is shown instead of the empty-state callout
+    And clicking it reveals the starter tool checklist
+
+  @bdd @admin-catalog @starter-pack @integration
+  Scenario: re-importing the starter pack adds only tiles the catalog never had
+    Given the catalog has most starter tiles but lacks one entirely
+    When the starter pack is imported again
+    Then only the missing starter tile is created
+    And the tiles already present are skipped untouched
+
+  @bdd @admin-catalog @starter-pack @integration
+  Scenario: an archived starter tile is not restored or duplicated by a re-import
+    Given the admin archived a starter tile
+    When the starter pack is imported again
+    Then the archived tile stays archived
+    And no duplicate row for it is created
+
   Scenario: admin sees populated catalog with scope badges
     Given the catalog has these admin-visible entries:
       | type             | displayName    | scope        | scopeId          | enabled |

--- a/specs/ai-governance/personal-portal/admin-catalog-editor.feature
+++ b/specs/ai-governance/personal-portal/admin-catalog-editor.feature
@@ -63,15 +63,15 @@ Feature: AI Tools Portal — Admin catalog editor at /settings/governance/tool-c
   Scenario: re-importing the starter pack adds only tiles the catalog never had
     Given the catalog has most starter tiles but lacks one entirely
     When the starter pack is imported again
-    Then only the missing starter tile is created
-    And the tiles already present are skipped untouched
+    Then the catalog gains only the tile it lacked
+    And the tiles already in the catalog stay exactly as they were
 
   @bdd @admin-catalog @starter-pack @integration
   Scenario: an archived starter tile is not restored or duplicated by a re-import
     Given the admin archived a starter tile
     When the starter pack is imported again
-    Then the archived tile stays archived
-    And no duplicate row for it is created
+    Then the archived tile does not reappear anywhere in the catalog
+    And the catalog does not gain a second copy of it
 
   Scenario: admin sees populated catalog with scope badges
     Given the catalog has these admin-visible entries:

--- a/specs/ai-governance/personal-portal/default-catalog.feature
+++ b/specs/ai-governance/personal-portal/default-catalog.feature
@@ -1,0 +1,80 @@
+Feature: AI Tools Portal - Default catalog provisioning
+  As a brand-new organization signing up to LangWatch
+  I want the standard set of AI tools provisioned for me automatically
+  So that my members' /me portal renders useful tiles on its very first
+  load instead of an "Add your first tools" empty state
+
+    Provisioning is zero-touch and strictly conservative: it only ever
+    acts on an organization that has NEVER had any AiToolEntry row.
+    Enabled, disabled, and archived rows all count as rows, so a catalog
+    an admin curated down to nothing stays empty. The portal empty state
+    remains reachable only as that curated-empty fallback (see
+    portal-grid.feature).
+
+    The standard set is the starter pack: 4 coding assistants
+    (Claude Code, Codex, Gemini CLI, opencode) and 4 model providers
+    (OpenAI, Anthropic, AWS Bedrock, Google AI), all org-scoped and
+    enabled, with slugs written verbatim so a later admin starter-pack
+    import recognises them instead of duplicating.
+
+    Two triggers, one guarantee:
+      - onboarding initializeOrganization provisions at org creation for
+        every signup intent (non-fatal: a provisioning failure never
+        costs the user their new organization)
+      - the aiTools.list read path provisions lazily before listing, so
+        even an org created before this behavior (or after an onboarding
+        hiccup) gets the catalog on its first portal load
+
+  Background:
+    Given a brand-new organization with zero AiToolEntry rows
+
+  @integration
+  Scenario: A fresh organization gets the full standard catalog with no admin action
+    When the default catalog is ensured for the organization
+    Then all 8 standard tiles exist on the organization's catalog
+    And each tile is org-scoped and enabled
+    And each tile carries the starter pack's verbatim slug, icon, and config
+    And no admin performed any catalog action
+
+  @integration
+  Scenario: Default catalog provisioning is idempotent across repeated calls
+    Given the default catalog was already ensured for the organization
+    When the default catalog is ensured again
+    Then no new rows are created and the catalog still has exactly 8 tiles
+
+  @integration
+  Scenario: An organization whose admin archived or disabled every entry is not re-seeded
+    Given the organization has only archived or disabled AiToolEntry rows
+    When the default catalog is ensured for the organization
+    Then no rows are created
+    And the admin's curated-empty catalog is preserved
+    # This is what keeps the portal empty state meaningful: it can only
+    # ever be the result of deliberate admin curation, never a fresh org.
+
+  @integration
+  Scenario: Concurrent provisioning attempts create exactly one catalog
+    When two provisioning calls race for the same organization
+    Then exactly one call seeds and the catalog ends with exactly 8 tiles
+    # There is no unique constraint on (organizationId, slug); a
+    # transaction-scoped per-org advisory lock serialises provisioners.
+
+  @integration
+  Scenario: A member's first portal load of a zero-row organization returns the provisioned catalog
+    Given a MEMBER of the brand-new organization
+    When the member's client calls aiTools.list for the first time
+    Then the list returns the 8 standard tiles, all enabled
+    And the /me portal therefore renders tile sections, never the empty state
+
+  @unit
+  Scenario: The platform default template set ships no claude-cowork
+    When the platform IngestionTemplate seed input is inspected
+    Then it contains no template rows at all
+    And "claude_cowork" is listed among the retired platform template slugs
+
+  @integration
+  Scenario: An existing platform claude-cowork template is archived by the seeder
+    Given a platform-published IngestionTemplate row with slug "claude_cowork" exists
+    When the platform IngestionTemplate seeder runs
+    Then the claude-cowork row is archived and disabled
+    And no new platform template rows are created
+    And installed claude-cowork IngestionSources keep ingesting unaffected

--- a/specs/ai-governance/personal-portal/default-catalog.feature
+++ b/specs/ai-governance/personal-portal/default-catalog.feature
@@ -26,55 +26,56 @@ Feature: AI Tools Portal - Default catalog provisioning
         hiccup) gets the catalog on its first portal load
 
   Background:
-    Given a brand-new organization with zero AiToolEntry rows
+    Given a brand-new organization whose catalog has never had a single entry
 
   @integration
   Scenario: A fresh organization gets the full standard catalog with no admin action
-    When the default catalog is ensured for the organization
-    Then all 8 standard tiles exist on the organization's catalog
-    And each tile is org-scoped and enabled
-    And each tile carries the starter pack's verbatim slug, icon, and config
+    When the standard tools are provisioned for the organization
+    Then the organization's catalog shows all 8 standard tiles
+    And each tile is available to the whole organization and enabled
+    And each tile matches its starter-pack original, so a later
+        starter-pack import recognises it instead of duplicating it
     And no admin performed any catalog action
 
   @integration
   Scenario: Default catalog provisioning is idempotent across repeated calls
-    Given the default catalog was already ensured for the organization
-    When the default catalog is ensured again
-    Then no new rows are created and the catalog still has exactly 8 tiles
+    Given the organization already received the standard catalog
+    When provisioning runs again for the organization
+    Then no new tiles appear and the catalog still has exactly 8 tiles
 
   @integration
   Scenario: An organization whose admin archived or disabled every entry is not re-seeded
-    Given the organization has only archived or disabled AiToolEntry rows
-    When the default catalog is ensured for the organization
-    Then no rows are created
+    Given the organization's admin archived or disabled every catalog entry
+    When provisioning runs for the organization
+    Then no tiles are added
     And the admin's curated-empty catalog is preserved
     # This is what keeps the portal empty state meaningful: it can only
     # ever be the result of deliberate admin curation, never a fresh org.
 
   @integration
   Scenario: Concurrent provisioning attempts create exactly one catalog
-    When two provisioning calls race for the same organization
-    Then exactly one call seeds and the catalog ends with exactly 8 tiles
+    When two provisioning attempts race for the same organization
+    Then the catalog ends with exactly 8 tiles and no duplicates
     # There is no unique constraint on (organizationId, slug); a
     # transaction-scoped per-org advisory lock serialises provisioners.
 
   @integration
   Scenario: A member's first portal load of a zero-row organization returns the provisioned catalog
     Given a MEMBER of the brand-new organization
-    When the member's client calls aiTools.list for the first time
-    Then the list returns the 8 standard tiles, all enabled
-    And the /me portal therefore renders tile sections, never the empty state
+    When the member opens their /me portal for the first time
+    Then the portal shows the 8 standard tiles, all enabled
+    And the member sees tile sections, never the empty state
 
   @unit
   Scenario: The platform default template set ships no claude-cowork
-    When the platform IngestionTemplate seed input is inspected
-    Then it contains no template rows at all
-    And "claude_cowork" is listed among the retired platform template slugs
+    When the platform's built-in template set is inspected
+    Then it offers no templates at all
+    And "claude_cowork" is marked as retired
 
   @integration
   Scenario: An existing platform claude-cowork template is archived by the seeder
-    Given a platform-published IngestionTemplate row with slug "claude_cowork" exists
-    When the platform IngestionTemplate seeder runs
-    Then the claude-cowork row is archived and disabled
-    And no new platform template rows are created
-    And installed claude-cowork IngestionSources keep ingesting unaffected
+    Given a platform-published "claude_cowork" template left over from an earlier release
+    When the platform template catalog is synced
+    Then every platform copy of the claude-cowork template is archived and disabled
+    And no new platform templates appear
+    And tools already connected through claude-cowork keep ingesting unaffected

--- a/specs/ai-governance/personal-portal/portal-grid.feature
+++ b/specs/ai-governance/personal-portal/portal-grid.feature
@@ -41,8 +41,12 @@ Feature: AI Tools Portal — Grid layout on /me
     And the "Internal tools" section heading does NOT render
     And the "Model providers" section renders normally
 
-  Scenario: brand-new org with no catalog shows a member empty-state note
-    Given the org-scoped catalog is empty
+  # A brand-new org never reaches this state: the standard catalog is
+  # auto-provisioned at signup and lazily on the first aiTools.list read
+  # (see default-catalog.feature). The empty state below is only the
+  # fallback for a catalog whose admin archived or disabled everything.
+  Scenario: curated-empty catalog shows a member empty-state note
+    Given the org's admin archived or disabled every catalog entry
     And no team-scoped entries are published for any of jane's teams
     And user "jane@acme.com" cannot manage the catalog (member, not admin)
     When user "jane@acme.com" loads "/me"
@@ -52,8 +56,8 @@ Feature: AI Tools Portal — Grid layout on /me
     And no tile sections render
     And the existing "My Usage" dashboard still renders below
 
-  Scenario: brand-new org shows the getting-started banner to a catalog admin
-    Given the org-scoped catalog is empty
+  Scenario: curated-empty catalog shows the getting-started banner to a catalog admin
+    Given the org's admin archived or disabled every catalog entry
     And user "alice@acme.com" can manage the catalog (aiTools:manage)
     When user "alice@acme.com" loads "/me"
     Then the AI-governance getting-started banner renders

--- a/specs/ai-governance/personal-portal/portal-grid.feature
+++ b/specs/ai-governance/personal-portal/portal-grid.feature
@@ -42,11 +42,11 @@ Feature: AI Tools Portal — Grid layout on /me
     And the "Model providers" section renders normally
 
   # A brand-new org never reaches this state: the standard catalog is
-  # auto-provisioned at signup and lazily on the first aiTools.list read
+  # auto-provisioned at signup and lazily on the first portal load
   # (see default-catalog.feature). The empty state below is only the
-  # fallback for a catalog whose admin archived or disabled everything.
+  # fallback for a catalog curated down to no enabled tools.
   Scenario: curated-empty catalog shows a member empty-state note
-    Given the org's admin archived or disabled every catalog entry
+    Given the org's catalog has no enabled tools left
     And no team-scoped entries are published for any of jane's teams
     And user "jane@acme.com" cannot manage the catalog (member, not admin)
     When user "jane@acme.com" loads "/me"
@@ -57,7 +57,7 @@ Feature: AI Tools Portal — Grid layout on /me
     And the existing "My Usage" dashboard still renders below
 
   Scenario: curated-empty catalog shows the getting-started banner to a catalog admin
-    Given the org's admin archived or disabled every catalog entry
+    Given the org's catalog has no enabled tools left
     And user "alice@acme.com" can manage the catalog (aiTools:manage)
     When user "alice@acme.com" loads "/me"
     Then the AI-governance getting-started banner renders

--- a/specs/trace-processing/long-context-model-cost.feature
+++ b/specs/trace-processing/long-context-model-cost.feature
@@ -27,20 +27,20 @@ Feature: Long-context [1m] model id cost matching
 
   @bdd @trace-processing @model-cost @unit
   Scenario: A [1m] long-context model id resolves the base model's registry pricing
-    Given the pricing registry has an entry for "anthropic/claude-opus-5"
-    When the cost for model "claude-opus-5[1m]" is matched
-    Then the "anthropic/claude-opus-5" registry entry is returned
-    And its rates equal the base entry's standard rates
+    Given Claude Opus 5 is a priced model on the platform
+    When a trace reports its model as "claude-opus-5[1m]"
+    Then the trace is priced as Claude Opus 5
+    And at the same standard per-token rates as traffic without the suffix
 
   @bdd @trace-processing @model-cost @cache-telemetry @unit
   Scenario: A Claude Code span on claude-opus-5[1m] with cache traffic gets a nonzero cost
-    Given an LLM span reporting model "claude-opus-5[1m]" with cache read and cache write tokens
-    When the span cost is computed
-    Then the cost is nonzero
-    And cache reads bill at the registry cache-read rate and cache writes at the cache-write rate
+    Given a Claude Code turn on "claude-opus-5[1m]" that mostly reads and writes prompt cache
+    When the turn's trace is processed
+    Then the trace shows a nonzero cost
+    And the cached share is billed at Claude's cache read and cache write prices, not the fresh-input price
 
   @bdd @trace-processing @model-cost @unit
   Scenario: The [1m] suffix resolves registry pricing across the Claude model family
-    Given the pricing registry has entries for the current Claude models
-    When costs for "claude-sonnet-4-5[1m]" and "anthropic/claude-opus-5[1m]" are matched
-    Then each resolves its base model's registry entry
+    Given the platform prices the current Claude models
+    When traces report "claude-sonnet-4-5[1m]" or "anthropic/claude-opus-5[1m]"
+    Then each is priced as its base model

--- a/specs/trace-processing/long-context-model-cost.feature
+++ b/specs/trace-processing/long-context-model-cost.feature
@@ -1,0 +1,46 @@
+Feature: Long-context [1m] model id cost matching
+  As a LangWatch user tracing Claude Code sessions
+  I want spans reporting a 1M-context model id like "claude-opus-5[1m]"
+  To resolve the platform's registry pricing for the underlying model
+  So that long-context Claude Code traffic is costed, cache tokens included
+
+  # Background
+  #
+  # Claude Code appends "[1m]" to the model id when the 1M-token context
+  # window is active for the session, e.g. claude-opus-5[1m] or
+  # claude-sonnet-4-5[1m]. The pricing registry keys models as
+  # <vendor>/<model> and matches with prefix-anchored regexes (no trailing
+  # anchor), so the "[1m]" suffix is absorbed by the base entry's pattern.
+  #
+  # Pricing policy: per Anthropic's published pricing (platform.claude.com,
+  # docs/en/about-claude/pricing, "Long context pricing", retrieved
+  # 2026-07-27), Claude 4.6 and later models include the full 1M-token
+  # context window at standard per-token rates; there is no premium tier
+  # above 200K input tokens for these models. The base registry entry's
+  # rates are therefore the correct rates for the [1m] variant, including
+  # the prompt-cache write (1.25x input) and cache read (0.1x input) rates.
+  #
+  # Regression context: a claude-opus-5[1m] trace with cache traffic showed
+  # no cost. The cause was the registry itself lagging behind the model
+  # launch (no claude-opus-5 entry in the deployed catalog), not the [1m]
+  # suffix; these scenarios pin both halves so neither regresses.
+
+  @bdd @trace-processing @model-cost @unit
+  Scenario: A [1m] long-context model id resolves the base model's registry pricing
+    Given the pricing registry has an entry for "anthropic/claude-opus-5"
+    When the cost for model "claude-opus-5[1m]" is matched
+    Then the "anthropic/claude-opus-5" registry entry is returned
+    And its rates equal the base entry's standard rates
+
+  @bdd @trace-processing @model-cost @cache-telemetry @unit
+  Scenario: A Claude Code span on claude-opus-5[1m] with cache traffic gets a nonzero cost
+    Given an LLM span reporting model "claude-opus-5[1m]" with cache read and cache write tokens
+    When the span cost is computed
+    Then the cost is nonzero
+    And cache reads bill at the registry cache-read rate and cache writes at the cache-write rate
+
+  @bdd @trace-processing @model-cost @unit
+  Scenario: The [1m] suffix resolves registry pricing across the Claude model family
+    Given the pricing registry has entries for the current Claude models
+    When costs for "claude-sonnet-4-5[1m]" and "anthropic/claude-opus-5[1m]" are matched
+    Then each resolves its base model's registry entry

--- a/specs/trace-processing/long-context-model-cost.feature
+++ b/specs/trace-processing/long-context-model-cost.feature
@@ -26,7 +26,7 @@ Feature: Long-context [1m] model id cost matching
   # suffix; these scenarios pin both halves so neither regresses.
 
   @bdd @trace-processing @model-cost @unit
-  Scenario: A [1m] long-context model id resolves the base model's registry pricing
+  Scenario: A [1m] long-context model id is priced as its base model
     Given Claude Opus 5 is a priced model on the platform
     When a trace reports its model as "claude-opus-5[1m]"
     Then the trace is priced as Claude Opus 5
@@ -40,7 +40,7 @@ Feature: Long-context [1m] model id cost matching
     And the cached share is billed at Claude's cache read and cache write prices, not the fresh-input price
 
   @bdd @trace-processing @model-cost @unit
-  Scenario: The [1m] suffix resolves registry pricing across the Claude model family
+  Scenario: The [1m] suffix is priced as the base model across the Claude family
     Given the platform prices the current Claude models
     When traces report "claude-sonnet-4-5[1m]" or "anthropic/claude-opus-5[1m]"
     Then each is priced as its base model

--- a/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
@@ -203,7 +203,7 @@ describe("resolveWrapperPath", () => {
         const promptArg = (prompt as unknown as ReturnType<typeof vi.fn>).mock
           .calls[0]![0] as {
           message: string;
-          choices: Array<{ title: string; value: string }>;
+          choices: Array<{ title: string; value: string; description?: string }>;
           initial: number;
         };
         expect(promptArg.message).toBe("How should `langwatch claude` run?");
@@ -214,6 +214,13 @@ describe("resolveWrapperPath", () => {
         const titles = promptArg.choices.map((c) => c.title).join(" | ");
         expect(titles).toContain("Using a Claude subscription");
         expect(titles).toContain("Using an API key");
+        // The secondary line carries the explanation, at the prompt boundary.
+        expect(promptArg.choices[0]!.description).toBe(
+          "keep your own plan, send only telemetry to LangWatch",
+        );
+        expect(promptArg.choices[1]!.description).toBe(
+          "route calls through LangWatch with a virtual key, billed per token",
+        );
         // Remembered for next time.
         expect(save).toHaveBeenCalledTimes(1);
         const persisted = save.mock.calls[0]![0] as GovernanceConfig;

--- a/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
@@ -426,6 +426,8 @@ describe("resolveWrapperPath", () => {
       expect(otlpChoiceTitle("codex")).toBe("Using a ChatGPT subscription");
       expect(otlpChoiceTitle("gemini")).toBe("Using a Gemini subscription");
       expect(otlpChoiceTitle("cursor")).toBe("Using a Cursor subscription");
+      // Inherited object keys must take the fallback, not the prototype.
+      expect(otlpChoiceTitle("toString")).toBe("Using your own toString plan");
       // opencode is a bring-your-own client with no single subscription.
       expect(otlpChoiceTitle("opencode")).toBe("Using your own opencode plan");
     });

--- a/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
@@ -15,7 +15,9 @@ import {
   resolveWrapperPath,
   pathChoiceMessage,
   gatewayChoiceTitle,
+  gatewayChoiceDescription,
   otlpChoiceTitle,
+  otlpChoiceDescription,
 } from "../wrapper-path-choice";
 
 function baseCfg(overrides: Partial<GovernanceConfig> = {}): GovernanceConfig {
@@ -196,18 +198,22 @@ describe("resolveWrapperPath", () => {
         });
         expect(out.mode).toBe("gateway");
         expect(out.prompted).toBe(true);
-        // The select asked how the tool should run and offered both paths.
+        // The select asked how the tool should run and offered both paths,
+        // subscription (OTLP) first and pre-selected as the default.
         const promptArg = (prompt as unknown as ReturnType<typeof vi.fn>).mock
           .calls[0]![0] as {
           message: string;
           choices: Array<{ title: string; value: string }>;
+          initial: number;
         };
         expect(promptArg.message).toBe("How should `langwatch claude` run?");
         const values = promptArg.choices.map((c) => c.value);
-        expect(values).toEqual(["gateway", "ingestion"]);
+        expect(values).toEqual(["ingestion", "gateway"]);
+        expect(promptArg.initial).toBe(0);
+        expect(promptArg.choices[promptArg.initial]!.value).toBe("ingestion");
         const titles = promptArg.choices.map((c) => c.title).join(" | ");
-        expect(titles).toContain("Gateway (virtual key)");
-        expect(titles).toContain("Direct OTLP");
+        expect(titles).toContain("Using a Claude subscription");
+        expect(titles).toContain("Using an API key");
         // Remembered for next time.
         expect(save).toHaveBeenCalledTimes(1);
         const persisted = save.mock.calls[0]![0] as GovernanceConfig;
@@ -397,14 +403,24 @@ describe("resolveWrapperPath", () => {
   });
 
   describe("prompt copy", () => {
-    it("asks how the tool should run and names both paths", () => {
+    it("asks how the tool should run and names both paths in human terms", () => {
       expect(pathChoiceMessage("claude")).toBe(
         "How should `langwatch claude` run?",
       );
-      expect(gatewayChoiceTitle()).toContain("Gateway (virtual key)");
-      expect(gatewayChoiceTitle()).toContain("billed per token");
-      expect(otlpChoiceTitle("claude")).toContain("Direct OTLP");
-      expect(otlpChoiceTitle("claude")).toContain("your own claude plan");
+      expect(otlpChoiceTitle("claude")).toBe("Using a Claude subscription");
+      expect(otlpChoiceDescription()).toBe(
+        "keep your own plan, send only telemetry to LangWatch",
+      );
+      expect(gatewayChoiceTitle()).toBe("Using an API key");
+      expect(gatewayChoiceDescription()).toContain("billed per token");
+    });
+
+    it("names the right subscription per tool, with a neutral fallback", () => {
+      expect(otlpChoiceTitle("codex")).toBe("Using a ChatGPT subscription");
+      expect(otlpChoiceTitle("gemini")).toBe("Using a Gemini subscription");
+      expect(otlpChoiceTitle("cursor")).toBe("Using a Cursor subscription");
+      // opencode is a bring-your-own client with no single subscription.
+      expect(otlpChoiceTitle("opencode")).toBe("Using your own opencode plan");
     });
   });
 });

--- a/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
+++ b/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
@@ -186,15 +186,18 @@ export function gatewayChoiceDescription(): string {
  * Tools without a well-known subscription (opencode is a bring-your-own
  * client) fall back to a neutral "your own <tool> plan".
  */
-const OTLP_TITLE_BY_TOOL: Record<string, string> = {
+const OTLP_TITLE_BY_TOOL = {
   claude: "Using a Claude subscription",
   codex: "Using a ChatGPT subscription",
   gemini: "Using a Gemini subscription",
   cursor: "Using a Cursor subscription",
-};
+} as const satisfies Record<string, string>;
 
 export function otlpChoiceTitle(tool: string): string {
-  return OTLP_TITLE_BY_TOOL[tool] ?? `Using your own ${tool} plan`;
+  if (tool in OTLP_TITLE_BY_TOOL) {
+    return OTLP_TITLE_BY_TOOL[tool as keyof typeof OTLP_TITLE_BY_TOOL];
+  }
+  return `Using your own ${tool} plan`;
 }
 
 export function otlpChoiceDescription(): string {

--- a/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
+++ b/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
@@ -194,7 +194,10 @@ const OTLP_TITLE_BY_TOOL = {
 } as const satisfies Record<string, string>;
 
 export function otlpChoiceTitle(tool: string): string {
-  if (tool in OTLP_TITLE_BY_TOOL) {
+  // Own-property check (not `in`) so inherited names like "toString" take
+  // the fallback path. hasOwnProperty.call keeps the SDK's pre-ES2022 lib
+  // target happy where Object.hasOwn does not typecheck.
+  if (Object.prototype.hasOwnProperty.call(OTLP_TITLE_BY_TOOL, tool)) {
     return OTLP_TITLE_BY_TOOL[tool as keyof typeof OTLP_TITLE_BY_TOOL];
   }
   return `Using your own ${tool} plan`;

--- a/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
+++ b/typescript-sdk/src/cli/utils/governance/wrapper-path-choice.ts
@@ -159,19 +159,46 @@ export interface ResolveWrapperPathResult {
 }
 
 /**
- * Human-readable copy for the interactive select. Kept as a constant so
- * tests can assert it and the wording stays in one place.
+ * Human-readable copy for the interactive select. Kept as exported
+ * helpers so tests can assert it and the wording stays in one place.
+ *
+ * The OTLP (ingestion) option is listed first and is the default: most
+ * users reaching this prompt already pay for the tool's own subscription
+ * and want LangWatch to observe their usage, not re-bill it. The gateway
+ * (API key) path is the explicit opt-in.
  */
 export function pathChoiceMessage(tool: string): string {
   return `How should \`langwatch ${tool}\` run?`;
 }
 
 export function gatewayChoiceTitle(): string {
-  return "Gateway (virtual key) - route LLM calls through LangWatch (usage billed per token)";
+  return "Using an API key";
 }
 
+export function gatewayChoiceDescription(): string {
+  return "route calls through LangWatch with a virtual key, billed per token";
+}
+
+/**
+ * Per-tool subscription noun for the OTLP (bring-your-own-plan) option:
+ * claude runs on a Claude subscription, codex on a ChatGPT subscription,
+ * gemini on a Gemini subscription, cursor on a Cursor subscription.
+ * Tools without a well-known subscription (opencode is a bring-your-own
+ * client) fall back to a neutral "your own <tool> plan".
+ */
+const OTLP_TITLE_BY_TOOL: Record<string, string> = {
+  claude: "Using a Claude subscription",
+  codex: "Using a ChatGPT subscription",
+  gemini: "Using a Gemini subscription",
+  cursor: "Using a Cursor subscription",
+};
+
 export function otlpChoiceTitle(tool: string): string {
-  return `Direct OTLP - use your own ${tool} plan, send only telemetry to LangWatch`;
+  return OTLP_TITLE_BY_TOOL[tool] ?? `Using your own ${tool} plan`;
+}
+
+export function otlpChoiceDescription(): string {
+  return "keep your own plan, send only telemetry to LangWatch";
 }
 
 /**
@@ -259,14 +286,19 @@ export async function resolveWrapperPath(
     type: "select",
     name: "path",
     message: pathChoiceMessage(tool),
+    // Subscription (OTLP) first and pre-selected; API key (gateway) is the
+    // explicit opt-in. Values stay "gateway"/"ingestion" - they are the
+    // persisted cfg.tool_mode vocabulary.
     choices: [
       {
-        title: gatewayChoiceTitle(),
-        value: "gateway",
+        title: otlpChoiceTitle(tool),
+        description: otlpChoiceDescription(),
+        value: "ingestion",
       },
       {
-        title: otlpChoiceTitle(tool),
-        value: "ingestion",
+        title: gatewayChoiceTitle(),
+        description: gatewayChoiceDescription(),
+        value: "gateway",
       },
     ],
     initial: 0,
@@ -292,9 +324,10 @@ export async function resolveWrapperPath(
     // Best-effort persist - a write failure shouldn't block the run.
   }
 
-  const label = chosen === "gateway" ? "gateway" : "otlp";
+  const label =
+    chosen === "gateway" ? "an API key (gateway)" : "your own plan (otlp)";
   writeImpl(
-    `${lwTag()} saved. \`${tool}\` will use the ${label} path. ` +
+    `${lwTag()} saved. \`${tool}\` will use ${label}. ` +
       `Override with --tool-mode=${chosen === "gateway" ? "otlp" : "gateway"}, ` +
       `or edit ~/.langwatch/config.json (tool_mode.${tool}).\n`,
   );


### PR DESCRIPTION
Five founder-priority fixes for today's launch, one per commit.

## 1. /me starts with the standard tools provisioned

Fresh signups saw a "configure your tools" step (the portal's add-your-first-tools empty state) instead of a working portal. Every org now gets the 8 standard tools (Claude Code, Codex, Gemini CLI, opencode, plus the OpenAI, Anthropic, Bedrock and Google provider tiles) seeded automatically: lazily on the first `aiTools.list` read, and at org creation for every onboarding intent. Seeding takes a per-org Postgres advisory lock and only runs for orgs that never had a catalog row, so concurrent requests cannot duplicate and admin-curated catalogs (archived or disabled entries) are never resurrected. The empty state remains only as the curated-empty fallback.

claude-cowork is removed from the default set via the existing platform-template retirement path: it no longer ships, and existing installs get the template archived on the next catalog read. Already-installed cowork ingestion sources keep working; only the default tile goes away.

## 2. CLI: subscription-first auth choice

The wrapper's gateway-vs-OTLP prompt listed the gateway first and preselected. Launch-day users are mostly devs on Claude subscriptions, so the OTLP path is now first and the default, titled "Using a Claude subscription" for claude (per-tool wording elsewhere: ChatGPT for codex, Gemini, Cursor), with the API-key/gateway path second as "Using an API key". Persisted `tool_mode` values, pinning semantics, and the non-interactive default (gateway) are unchanged.

## 3. Authorize page redirects to your first trace

Approving `langwatch login` used to dead-end on "you can close this tab". Now, when the personal project has never received a trace, the page watches `Project.firstMessage` (3s interval, only while the tab is visible, 10 minute cap) and redirects to `/<personal-project-slug>/traces` the moment the first trace lands, so the first Claude Code turn takes a fresh signup straight to their own session. Users whose project already has traces keep the current behavior, and the project-API-key flow is untouched.

## 4. claude-opus-5[1m] cost: root cause and fix

The founder asked which hypothesis was right. Neither, exactly:

- Hypothesis (b), the `[1m]` suffix breaking the matcher, is false. Registry regexes are prefix-anchored (`^(anthropic\/)?claude-opus-5` with no trailing anchor), so the suffix is absorbed; `claude-sonnet-4-5[1m]` already priced correctly in production.
- Hypothesis (a) is right in a modified form: it is a registry gap, but not because OpenRouter lacks the `[1m]` variant. The deployed catalog predates the claude-opus-5 launch entirely, so nothing matched. The registry sync on main (#6206) already carries `anthropic/claude-opus-5` at the correct rates; production picks it up when the SaaS submodule pin advances (see Deployment impact).

There is no long-context premium to encode: per Anthropic's published pricing (platform.claude.com, docs/en/about-claude/pricing, section "Long context pricing", retrieved 2026-07-27), Claude 4.6+ models bill the full 1M window at standard per-token rates, "a 900k-token request is billed at the same per-token rate as a 9k-token request". The correct `[1m]` prices are therefore the base entry's: $5/MTok input, $25/MTok output, $6.25/MTok cache write, $0.50/MTok cache read. New regression tests pin the literal `claude-opus-5[1m]` string with the exact reported cache traffic (20540 read + 22994 write = $0.1539825) through the real catalog and matcher, plus the `[1m]` family matching, so neither half can regress silently.

Historical traces stay unpriced: span cost is computed at ingest, and this PR does not attempt a backfill.

## 5. Empty shared team lost the create-project button

A coding-usage signup's org is a personal workspace plus one shared team with no project. The workspace switcher hides empty teams as navigation dead-ends, and the per-team "+" create button renders on the team row, so hiding the only shared team removed the only create affordance: those users could never move from Claude Code usage to LLMOps. The actual gating condition was the `teamsWithProjects` filter in `WorkspaceSwitcher.tsx`, not the personal-team exclusion. Empty teams now stay visible with their "+" button for viewers allowed to create a project on them, and stay hidden for everyone else. Personal teams remain excluded from the switcher and ambient selection (#6190 invariants untouched). The create drawer works with no ambient project: governance orgs carry `primaryIntent`, which exempts them from the onboarding bounce (ADR-038 v6), and the drawer receives explicit org and team ids.

## Specs and tests

Every behavior change is spec-bound (`pnpm check:feature-parity` green, 3081 scenarios):

- `specs/ai-governance/personal-portal/default-catalog.feature` (new) + portal-grid retitles; integration tests for seeding, idempotency, curation respect, the concurrency race, and cowork retirement
- `specs/ai-governance/cli-wrappers/wrap-path-choice.feature` + unit tests asserting order, default, and exact copy
- `specs/ai-governance/cli-onboarding/post-login-first-trace-redirect.feature` (new) + full-tree RTL test of /cli/auth (real page, real hooks, network boundary mocked) and a polling-policy unit test
- `specs/trace-processing/long-context-model-cost.feature` (new) + regression tests through the real static catalog
- `specs/ai-gateway/governance/workspace-switcher.feature` empty-team scenarios + props-level RTL tests and a full-tree test running the real `useWorkspaceData` on the exact signup org shape

`pnpm typecheck`, `pnpm typecheck:tests`, and the touched unit/integration suites are green.

## Deployment impact

- No migrations, no new env vars, no breaking API changes.
- Tool-catalog seeding writes 8 `AiToolEntry` rows per zero-row org, once, on first list read or org creation. No backfill job needed; existing orgs converge on their next /me visit.
- claude-cowork platform template is archived idempotently by the existing seeder on the next catalog read per org.
- Item 4 requires no deploy of this repo beyond the tests; the production fix for opus-5 pricing is the SaaS repo advancing its langwatch submodule past #6206 (which this PR's branch includes). Until that deploy, opus-5 traffic remains unpriced in production, and traces ingested before it stay unpriced (no backfill attempted).
- CLI change ships with the next `langwatch` npm release; no server dependency.

## QA

All five fixes were exercised end to end against a dev server: two brand-new accounts signed up through the coding-usage onboarding, the real `langwatch` CLI ran the device flow and a real Claude Code turn in a tmux TTY, and the first-trace redirect fired from that turn's own telemetry. The `claude-opus-5[1m]` trace below carries the exact cache traffic from the founder's report (20540 cache read + 22994 cache write) and stores cost 0.167982, the precise Opus 5 price-sheet sum.

### 1. /me pre-provisioned tools (fresh signup, no configure step, no cowork)

![me tools grid](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/me-tools-grid.png)

<details><summary>Mobile 390px</summary>

![me tools mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/me-tools-mobile-390.png)

</details>

### 2. CLI subscription-first choice (captured from the real CLI in tmux)

![cli prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/cli-subscription-first-prompt.png)

Raw pane capture:

```
? How should `langwatch claude` run? › - Use arrow-keys. Return to submit.
❯   Using a Claude subscription - keep your own plan, send only telemetry to LangWatch
    Using an API key
```

### 3. Authorize page waits for the first trace, then redirects

![authorize waiting](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/authorize-waiting-first-trace.png)

The watcher run against the real flow: approve, `Waiting for your first trace` appears, one `langwatch claude -p ...` turn later the page navigated itself to `/personal-.../traces`.

<details><summary>Mobile 390px</summary>

![authorize waiting mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/authorize-waiting-mobile-390.png)

</details>

### 4. claude-opus-5[1m] priced (the founder's exact cache traffic)

![traces with cost](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/personal-traces-opus5-1m-cost.png)

<details><summary>Mobile 390px</summary>

![traces mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/traces-mobile-390.png)

</details>

### 5. Empty shared team keeps its create-project affordance

![dropdown](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/workspace-dropdown-create-project.png)

![drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/create-project-drawer.png)

<details><summary>Mobile 390px</summary>

![dropdown mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6249/workspace-dropdown-mobile-390.png)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Tools starter catalog auto-provisions (org-scoped) at signup/first portal visit so tiles appear immediately.
  * CLI now watches for the first synced trace after approval and redirects once detected.
* **Bug Fixes**
  * Starter-pack re-import is idempotent: it only adds tiles the org never had and keeps archived tiles archived.
  * Long-context model cost matching correctly prices 1M-token Claude Code variants using cache rates.
* **Improvements**
  * Trace Ingest stays hidden until at least one ingestion template is available.
  * Workspace switcher preserves empty shared teams when users can create projects.
  * Updated governance/tool-catalog onboarding copy and editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->