### PR TITLE
fix(traces): route the edge spool through the shared storage layer

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -890,6 +890,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 # why the connection settings below can outlive it (see legacyAzureRead).
 - name: STORED_OBJECTS_BACKEND
   value: "azure"
+{{- if .Values.app.dataplane.providers.azureBlob.spoolRetentionConfirmed }}
+# The ADR-022 trace spool stays off on Azure until the operator states that the
+# container has a lifecycle rule deleting `trace-blobs/spool/` blobs after 3
+# days. That policy is management-plane; the app holds a data-plane key and
+# cannot read it back, so this is an assertion, not a check. Left unset, an
+# oversized span keeps its payload inline instead of leaving an object behind
+# that nothing reaps. Emitted here, beside the write toggle rather than with
+# the connection settings below, because it gates only the spool WRITE path —
+# a legacyAzureRead migration reads existing spool objects without it.
+- name: AZURE_BLOB_SPOOL_RETENTION_CONFIRMED
+  value: "true"
+{{- end }}
 {{- else }}
 - name: STORED_OBJECTS_BACKEND
   value: "s3"

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -401,6 +401,8 @@ app:
           value: ""
           ## @param app.dataplane.providers.azureBlob.container.secretKeyRef [object] Secret ref for the Azure Blob container name.
           secretKeyRef: { name: "", key: "" }
+        ## @param app.dataplane.providers.azureBlob.spoolRetentionConfirmed [boolean] Confirms the container has a lifecycle rule deleting `trace-blobs/spool/` blobs after 3 days. The ADR-022 trace spool refuses to write to Azure until this is true, because a crash between the spool write and its delete is bounded only by that rule and the app cannot verify a management-plane policy with a data-plane key. Leave false unless you have created the policy.
+        spoolRetentionConfirmed: false
         # Optional. Override the blob endpoint for sovereign clouds
         # (*.usgovcloudapi.net, *.chinacloudapi.cn), private endpoints, or an
         # emulator. Defaults to https://{accountName}.blob.core.windows.net.

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -208,5 +208,3 @@ deployed rule for the correction to contradict.
 off"; and both "24h lifecycle policy" statements. Azure Blob and the local
 filesystem are now first-class spool destinations. The fail-open-on-write and
 read-must-not-degrade rules are unchanged.
-
-<!-- ci-trigger: force workflows to fire on this head -->

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -240,8 +240,17 @@ the flag without creating the policy gets exactly the unbounded-orphan case the
 local-filesystem refusal above exists to prevent, and trace payloads then
 outlive the retention this ADR promises. `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED`
 (chart: `app.dataplane.providers.azureBlob.spoolRetentionConfirmed`) defaults to
-false, and `mintSpoolUri` refuses an azure destination without it, so ingestion
+false, and `putSpool` refuses an azure destination without it, so ingestion
 degrades to inline payloads rather than accumulating objects nothing reaps.
+
+The refusal is on the **write** path only. It is a rule about creating an object
+nothing will reap, and it must never touch the objects already out there:
+turning the assertion back off is the documented remediation, and a chart
+rollback does it silently, so gating reads and deletes on it would make every
+in-flight spooled span unreadable (`getSpool` does not fail open, and the edge
+has already cleared the attributes) and would skip the eager delete that is the
+spool's *first* line of cleanup — manufacturing the exact orphan the gate
+exists to prevent. Same reasoning for the local-filesystem refusal.
 
 It is an assertion, not a verification, and deliberately so. An Azure lifecycle
 policy is a management-plane resource

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -227,13 +227,33 @@ rationale that a weekend incident needs catch-up time before orphans are reaped.
 Three days is the intended value and the only one now stated in code.
 
 Provisioning that rule is the **operator's** job and a prerequisite for turning
-the flag on, not a consequence of it. Nothing in the application creates,
-validates, or reports the rule. On S3 it is a lifecycle rule on the
+the flag on, not a consequence of it. On S3 it is a lifecycle rule on the
 `trace-blobs/spool/` prefix; on Azure Blob it is a lifecycle management policy
 with the same prefix filter. Since `release_trace_blob_offload` has never been
 enabled in a shipped deployment, no such rule exists anywhere yet — an operator
 turning the flag on creates it fresh, so there is no deployed rule for the 24h
 correction to contradict.
+
+**On Azure the spool fails closed until the operator says the rule exists.**
+Documenting the prerequisite is not enough on its own: an operator who enables
+the flag without creating the policy gets exactly the unbounded-orphan case the
+local-filesystem refusal above exists to prevent, and trace payloads then
+outlive the retention this ADR promises. `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED`
+(chart: `app.dataplane.providers.azureBlob.spoolRetentionConfirmed`) defaults to
+false, and `mintSpoolUri` refuses an azure destination without it, so ingestion
+degrades to inline payloads rather than accumulating objects nothing reaps.
+
+It is an assertion, not a verification, and deliberately so. An Azure lifecycle
+policy is a management-plane resource
+(`Microsoft.Storage/storageAccounts/managementPolicies`); this deployment holds
+only a data-plane key, so reading the policy back would mean requiring ARM
+credentials, a subscription id and a resource-group name that the feature
+otherwise has no use for — a much larger blast radius than the problem. The
+affirmation lives in the same config that turns the spool on, and the default is
+the safe one. S3 is deliberately not gated the same way: its lifecycle
+requirement predates this change and is the long-standing ADR-022 rule, so
+extending the gate there would silently disable the spool for every existing
+install.
 
 **Superseded above:** "'No S3 equivalent' means no object storage at all";
 "deployments with no object storage should leave `release_trace_blob_offload`

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -194,10 +194,19 @@ For one release the worker still accepts a v1 raw key, so commands queued across
 the deploy resolve; a v1 key whose tenant segment does not match the command's
 authenticated tenant is refused rather than dereferenced.
 
-**Superseded above:** "'No S3 equivalent' means no object storage at all" and
+**The orphan-cleanup window is 3 days, not 24h.** This ADR says 24h in two
+places (the flow sketch and the rules list); the implementation has said 3 days
+since it was written, with the rationale that a weekend incident needs catch-up
+time before orphans are reaped. Three days is the intended value and the only
+one now stated in code. Since `release_trace_blob_offload` has never been
+enabled in a shipped deployment, no lifecycle rule exists yet for this prefix
+anywhere — an operator turning the flag on creates it fresh, so there is no
+deployed rule for the correction to contradict.
+
+**Superseded above:** "'No S3 equivalent' means no object storage at all";
 "deployments with no object storage should leave `release_trace_blob_offload`
-off". Azure Blob and the local filesystem are now first-class spool
-destinations. The fail-open-on-write and read-must-not-degrade rules are
-unchanged.
+off"; and both "24h lifecycle policy" statements. Azure Blob and the local
+filesystem are now first-class spool destinations. The fail-open-on-write and
+read-must-not-degrade rules are unchanged.
 
 <!-- ci-trigger: force workflows to fire on this head -->

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -192,19 +192,51 @@ and span ids. This is the same discipline `BlobRef` follows in ADR-030 §5.
 
 For one release the worker still accepts a v1 raw key, so commands queued across
 the deploy resolve; a v1 key whose tenant segment does not match the command's
-authenticated tenant is refused rather than dereferenced.
+authenticated tenant is refused rather than dereferenced. **Removal is tracked in
+langwatch/langwatch-saas#837**, and the `TODO` markers in `blob-store.service.ts`
+name that issue. It is safe to remove one release after this ships: a v1
+reference can only live inside a command queued before the deploy, and the object
+it names is reaped by the lifecycle rule within 3 days.
 
-**The orphan-cleanup window is 3 days, not 24h.** This ADR says 24h in two
-places (the flow sketch and the rules list); the implementation has said 3 days
-since it was written, with the rationale that a weekend incident needs catch-up
-time before orphans are reaped. Three days is the intended value and the only
-one now stated in code. Since `release_trace_blob_offload` has never been
-enabled in a shipped deployment, no lifecycle rule exists yet for this prefix
-anywhere — an operator turning the flag on creates it fresh, so there is no
-deployed rule for the correction to contradict.
+**Each derived path segment is a single component.** Percent-encoding is not
+enough on its own: `LocalFilesystemDriver` round-trips the URI through
+`decodeURIComponent`, which turns `..%2F..%2F` back into `../../` before
+`mkdir`/`writeFile` see it. Since `idSchema` accepts arbitrary strings, a span id
+of `../../…` would otherwise have escaped the object root. Ids outside
+`[A-Za-z0-9_-]` are replaced by a hash of the id — deterministic, so the read and
+delete paths re-derive the same location, and incapable of carrying a separator
+whatever decodes it downstream. `LocalFilesystemDriver` additionally refuses any
+`file:` URI whose decoded path is not already canonical, so a future caller that
+gets this wrong fails loudly rather than writing outside the root.
+
+**The spool has no local-filesystem destination.** It is the one stored-objects
+consumer whose boundedness depends on something outside the object store: it
+deletes eagerly after the `event_log` INSERT and leans on a lifecycle rule to
+reap what a crash between those two steps leaves behind. A filesystem cannot
+express such a rule, so an orphan there is permanent and the volume is what
+fills. `mintSpoolUri` therefore refuses a `file` destination and ingestion
+continues with the payload inline. This is not a regression: before the spool
+moved onto the shared storage layer it built an S3 client, which on a local
+install resolved to the hardcoded `langwatch` bucket, so the write failed and the
+same fail-open path ran every time. It is now explicit instead of incidental.
+
+**The orphan-cleanup window is 3 days, not 24h — and enabling the flag does not
+create it.** This ADR says 24h in two places (the flow sketch and the rules
+list); the implementation has said 3 days since it was written, with the
+rationale that a weekend incident needs catch-up time before orphans are reaped.
+Three days is the intended value and the only one now stated in code.
+
+Provisioning that rule is the **operator's** job and a prerequisite for turning
+the flag on, not a consequence of it. Nothing in the application creates,
+validates, or reports the rule. On S3 it is a lifecycle rule on the
+`trace-blobs/spool/` prefix; on Azure Blob it is a lifecycle management policy
+with the same prefix filter. Since `release_trace_blob_offload` has never been
+enabled in a shipped deployment, no such rule exists anywhere yet — an operator
+turning the flag on creates it fresh, so there is no deployed rule for the 24h
+correction to contradict.
 
 **Superseded above:** "'No S3 equivalent' means no object storage at all";
 "deployments with no object storage should leave `release_trace_blob_offload`
-off"; and both "24h lifecycle policy" statements. Azure Blob and the local
-filesystem are now first-class spool destinations. The fail-open-on-write and
+off"; and both "24h lifecycle policy" statements. Azure Blob is now a
+first-class spool destination alongside S3. The fail-open-on-write and
 read-must-not-degrade rules are unchanged.

--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -160,4 +160,44 @@ LEAN BOUNDARIES  (what stays small at each hop)
 - Any user-visible enumeration of `stored_spans.SpanAttributes` keys MUST exclude `langwatch.reserved.*`. (Survived from ADR-021.)
 - `event_log` retention drives the durability ceiling for "show full" reads. There is no longer a separate S3 retention to coordinate.
 
+## Amendment: the spool is backend-agnostic (langwatch/langwatch-saas#800)
+
+This ADR was written when S3 was the only object store LangWatch could write to,
+so it says "S3 spool" throughout. That is no longer accurate, and taking it
+literally is what kept the spool hardcoded to the AWS SDK long after every other
+byte-writing surface had moved behind the shared `stored-objects` layer. Read
+every "S3" above as "the deployment's object store".
+
+**What changed.** `BlobStore` no longer builds an S3 client for the spool. It
+resolves the project's storage destination through
+`resolveProjectStorageDestination` and writes through the `stored-objects`
+`StorageRegistry`, exactly as the GroupQueue durable blob tier does (ADR-030).
+The spool therefore lands in Azure Blob, S3, or the local filesystem according
+to how the deployment is configured. `mintUriForDestination`
+(`stored-objects/uri.ts`) is now the single destination → URI mapping; the three
+copies of that switch that used to exist are gone.
+
+**The object path is unchanged**: `trace-blobs/spool/{projectId}/{traceId}/{spanId}`,
+with the prefix deliberately kept ABOVE the tenant segment. An S3 lifecycle
+prefix filter cannot wildcard a leading tenant segment, so moving the prefix
+below it would make orphan spools unexpirable. Existing lifecycle rules keep
+working untouched.
+
+**The reference no longer carries a location.** A spooled command used to carry
+the raw object key, and the read path parsed the tenant id back out of that
+string to choose a bucket — so a tampered queue message could steer a read at
+another tenant's object. Commands now carry the opaque marker `spool:v2` and the
+worker re-derives the location from the command's own authenticated `tenantId`
+and span ids. This is the same discipline `BlobRef` follows in ADR-030 §5.
+
+For one release the worker still accepts a v1 raw key, so commands queued across
+the deploy resolve; a v1 key whose tenant segment does not match the command's
+authenticated tenant is refused rather than dereferenced.
+
+**Superseded above:** "'No S3 equivalent' means no object storage at all" and
+"deployments with no object storage should leave `release_trace_blob_offload`
+off". Azure Blob and the local filesystem are now first-class spool
+destinations. The fail-open-on-write and read-must-not-degrade rules are
+unchanged.
+
 <!-- ci-trigger: force workflows to fire on this head -->

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -446,6 +446,16 @@ FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_gateway_menu_enabled
 # AZURE_BLOB_ACCOUNT_NAME=
 # AZURE_BLOB_ACCOUNT_KEY=
 # AZURE_BLOB_CONTAINER=
+# The ADR-022 trace spool (feature flag release_trace_blob_offload) writes a
+# transient object per oversized span and deletes it as soon as the event is
+# durable. A crash between those two steps leaves the object behind, and the
+# only thing that reaps it is a lifecycle rule on the container. That rule is a
+# management-plane resource, so the app cannot check it with the data-plane key
+# above. Create a lifecycle management policy deleting blobs under the
+# `trace-blobs/spool/` prefix after 3 days, then set this to true. Left unset,
+# oversized spans keep their payload inline — safe, just without the queue
+# size protection.
+# AZURE_BLOB_SPOOL_RETENTION_CONFIRMED=false
 # AZURE_BLOB_ENDPOINT= # only for emulator (Azurite) or sovereign-cloud deployments
 
 # NO-DOCKER INTEGRATION TESTS (optional). When set, pnpm test:integration

--- a/platform/app/src/env-create.mjs
+++ b/platform/app/src/env-create.mjs
@@ -436,6 +436,17 @@ export function createEnvConfig() {
       // request (`{audience}/.default`). Defaults to the public-cloud
       // "https://storage.azure.com" audience when unset.
       AZURE_BLOB_TOKEN_AUDIENCE: z.string().optional(),
+      // The ADR-022 trace spool is bounded by a lifecycle rule the operator
+      // provisions on the container, NOT by anything the application does: it
+      // deletes eagerly after the event_log INSERT, and a crash between those
+      // two steps is what the rule reaps. That rule lives on Azure's
+      // MANAGEMENT plane (Microsoft.Storage/.../managementPolicies), and this
+      // deployment holds only a data-plane key, so the app cannot read it back
+      // to check. This flag is the operator asserting it exists. Default false
+      // means an Azure install that enables the spool without thinking about
+      // retention degrades to inline payloads rather than accumulating
+      // customer data nothing will ever reap.
+      AZURE_BLOB_SPOOL_RETENTION_CONFIRMED: z.boolean().optional(),
       DATASET_STORAGE_LOCAL: z.boolean().optional(),
       CREDENTIALS_SECRET: z.string().optional(),
       AZURE_AD_CLIENT_ID: z.string().optional(),
@@ -661,6 +672,10 @@ export function createEnvConfig() {
       AZURE_BLOB_AUTH_MODE: process.env.AZURE_BLOB_AUTH_MODE,
       AZURE_BLOB_AUTHORITY_HOST: process.env.AZURE_BLOB_AUTHORITY_HOST,
       AZURE_BLOB_TOKEN_AUDIENCE: process.env.AZURE_BLOB_TOKEN_AUDIENCE,
+      AZURE_BLOB_SPOOL_RETENTION_CONFIRMED:
+        process.env.AZURE_BLOB_SPOOL_RETENTION_CONFIRMED === "1" ||
+        process.env.AZURE_BLOB_SPOOL_RETENTION_CONFIRMED?.toLowerCase() ===
+          "true",
       DATASET_STORAGE_LOCAL:
         process.env.DATASET_STORAGE_LOCAL === "1" ||
         process.env.DATASET_STORAGE_LOCAL?.toLowerCase() === "true",

--- a/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
@@ -353,46 +353,6 @@ describe("given a valid event_log row whose EventPayload does not contain the re
 });
 
 // ---------------------------------------------------------------------------
-// putSpool — happy path
-// ---------------------------------------------------------------------------
-
-describe("given a span that exceeds COMMAND_INLINE_THRESHOLD", () => {
-  describe("when putSpool is called with projectId, traceId, spanId, body", () => {
-    it("issues an S3 PUT at trace-blobs/spool/{projectId}/{traceId}/{spanId} and returns the spool ref string", async () => {
-      const sendMock = vi.fn().mockImplementation(async (command: unknown) => {
-        if (command instanceof PutObjectCommand) return {};
-        throw new Error("unexpected command");
-      });
-
-      const blobStore = new BlobStore(makeS3Resolver({ send: sendMock }));
-
-      const projectId = "proj-aaa";
-      const traceId = "trace-001";
-      const spanId = "span-001";
-      const body = Buffer.from("full span JSON here", "utf-8");
-
-      const spoolRef = await blobStore.putSpool({
-        projectId,
-        traceId,
-        spanId,
-        body,
-      });
-
-      expect(typeof spoolRef).toBe("string");
-      // Key shape pinned: trace-blobs/spool/{projectId}/{traceId}/{spanId}
-      expect(spoolRef).toBe(
-        `trace-blobs/spool/${projectId}/${traceId}/${spanId}`,
-      );
-
-      // S3 PUT was issued
-      expect(sendMock).toHaveBeenCalledOnce();
-      const cmd = sendMock.mock.calls[0]?.[0] as PutObjectCommand;
-      expect(cmd.input.Key).toBe(spoolRef);
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
 // deleteSpool — best-effort (errors swallowed)
 // ---------------------------------------------------------------------------
 
@@ -406,7 +366,14 @@ describe("given a transient spool ref", () => {
       const spoolRef = `trace-blobs/spool/proj/trace-001/span-001`;
 
       // Must not throw — errors are swallowed
-      await expect(blobStore.deleteSpool(spoolRef)).resolves.toBeUndefined();
+      await expect(
+        blobStore.deleteSpool({
+          spoolRef,
+          projectId: "proj",
+          traceId: "trace-001",
+          spanId: "span-001",
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });
@@ -475,7 +442,12 @@ describe("given an S3 GetObject that returns a response with no Body", () => {
       const blobStore = new BlobStore(makeS3Resolver({ send: sendMock }));
 
       await expect(
-        blobStore.getSpool("trace-blobs/spool/proj/trace-001/span-001"),
+        blobStore.getSpool({
+          spoolRef: "trace-blobs/spool/proj/trace-001/span-001",
+          projectId: "proj",
+          traceId: "trace-001",
+          spanId: "span-001",
+        }),
       ).rejects.toThrow(/no body/i);
     });
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
@@ -14,7 +14,6 @@
  * No "should" in it() names (project convention).
  */
 
-import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { generate, Ksuid } from "@langwatch/ksuid";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
@@ -132,10 +132,10 @@ describe("given an event_log row stored under tenantA with a known EventPayload"
         rows: [{ EventPayload: eventPayload }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: EVENT_ID,
@@ -169,10 +169,10 @@ describe("given an event_log row stored under tenantA with a known EventPayload"
         rows: [{ EventPayload: eventPayload }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await blobStore.getFromEventLog({
         eventId: EVENT_ID,
@@ -205,10 +205,10 @@ describe("given a KSUID EventId (the time is embedded in the id)", () => {
       const { client, sqlCaptures, paramCaptures } = makeMockChClient({
         rows: [{ EventPayload: eventPayload }],
       });
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: ksuidEventId,
@@ -243,10 +243,10 @@ describe("given a non-KSUID EventId (legacy / unparseable id)", () => {
       const { client, sqlCaptures, paramCaptures } = makeMockChClient({
         rows: [{ EventPayload: eventPayload }],
       });
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await blobStore.getFromEventLog({
         eventId: "not-a-ksuid",
@@ -273,10 +273,10 @@ describe("given an event_log row under tenantA when tenantB attempts to read it"
       // No rows returned — cross-tenant query returns empty set
       const { client } = makeMockChClient({ rows: [] });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await expect(
         blobStore.getFromEventLog({
@@ -302,10 +302,10 @@ describe("given an event_log row with a corrupt (non-JSON) EventPayload", () => 
         rows: [{ EventPayload: "not-valid-json{{{{" }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await expect(
         blobStore.getFromEventLog({
@@ -334,10 +334,10 @@ describe("given a valid event_log row whose EventPayload does not contain the re
         rows: [{ EventPayload: eventPayload }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await expect(
         blobStore.getFromEventLog({
@@ -361,7 +361,9 @@ describe("given a transient spool ref", () => {
     it("issues an S3 DELETE and returns void (no error thrown even if S3 DELETE fails)", async () => {
       const sendMock = vi.fn().mockRejectedValue(new Error("S3 DELETE failed"));
 
-      const blobStore = new BlobStore(makeS3Resolver({ send: sendMock }));
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: sendMock }),
+      });
 
       const spoolRef = `trace-blobs/spool/proj/trace-001/span-001`;
 
@@ -391,10 +393,10 @@ describe("given an event_log row whose EventPayload is a log record (full body a
         rows: [{ EventPayload: eventPayload }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: EVENT_ID,
@@ -413,10 +415,10 @@ describe("given an event_log row whose EventPayload is a log record (full body a
         rows: [{ EventPayload: eventPayload }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       await expect(
         blobStore.getFromEventLog({
@@ -439,7 +441,9 @@ describe("given an S3 GetObject that returns a response with no Body", () => {
   describe("when getSpool is called", () => {
     it("throws an explicit 'no body' error rather than returning an empty buffer", async () => {
       const sendMock = vi.fn().mockResolvedValue({ Body: undefined });
-      const blobStore = new BlobStore(makeS3Resolver({ send: sendMock }));
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: sendMock }),
+      });
 
       await expect(
         blobStore.getSpool({
@@ -523,10 +527,10 @@ describe("given a SpanReceivedEvent written through eventToRecord (real write pa
         rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       // read path must find the attribute at span.attributes, NOT data.span.attributes
       const result = await blobStore.getFromEventLog({
@@ -571,10 +575,10 @@ describe("given a deployment with no object storage (resolveS3Client throws)", (
         throw new Error("no object storage configured");
       };
 
-      const blobStore = new BlobStore(
-        noStorageResolver,
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: noStorageResolver,
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: EVENT_ID,
@@ -670,10 +674,10 @@ describe("given a real OTLP EventPayload whose span carries mixed-type sibling a
         rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: spanReceivedEvent.id,
@@ -699,10 +703,10 @@ describe("given a real OTLP EventPayload whose span carries mixed-type sibling a
         rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       const result = await blobStore.getFromEventLog({
         eventId: spanReceivedEvent.id,
@@ -790,10 +794,10 @@ describe("given a leaned span pointing at a real mixed-type EventPayload offload
         rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
       });
 
-      const blobStore = new BlobStore(
-        makeS3Resolver({ send: vi.fn() }),
-        makeChResolver(client) as never,
-      );
+      const blobStore = new BlobStore({
+        resolveS3Client: makeS3Resolver({ send: vi.fn() }),
+        resolveClickHouseClient: makeChResolver(client) as never,
+      });
 
       // The LEANED span as projected: preview value + the eventref pointer that
       // leanForProjection embeds with the event's id (the read path JOINs on it).

--- a/platform/app/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
@@ -55,7 +55,10 @@ import {
   LARGE_VALUE,
   UNIQUE_TAIL,
 } from "~/server/app-layer/traces/__tests__/blob-offload-test-helpers";
-import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import {
+  BlobStore,
+  type S3ClientResolver,
+} from "~/server/app-layer/traces/blob-store.service";
 import {
   EVENTREF_ATTR_PREFIX,
   leanForProjection,
@@ -254,10 +257,10 @@ function makeRealBlobStore(client: ClickHouseClient): BlobStore {
       "S3 resolver must not be called on the event_log read path in this test",
     );
   };
-  return new BlobStore(
-    s3Resolver as unknown as ConstructorParameters<typeof BlobStore>[0],
-    async (_tenantId: string) => client,
-  );
+  return new BlobStore({
+    resolveS3Client: s3Resolver as unknown as S3ClientResolver,
+    resolveClickHouseClient: async (_tenantId: string) => client,
+  });
 }
 
 describe.skipIf(!hasTestcontainers)(

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
@@ -81,11 +81,10 @@ afterAll(async () => {
 describe("given a deployment whose storage destination is Azure Blob", () => {
   describe("when an over-threshold span is spooled at the ingestion edge", () => {
     it("round-trips the payload through Azure and cleans the object up", async () => {
-      const store = new BlobStore(
-        s3MustNotBeUsed,
-        undefined,
-        azureSpoolStorage(),
-      );
+      const store = new BlobStore({
+        resolveS3Client: s3MustNotBeUsed,
+        spoolStorage: azureSpoolStorage(),
+      });
       // Larger than COMMAND_INLINE_THRESHOLD, which is what puts a span on this
       // path in the first place.
       const body = Buffer.from("x".repeat(300 * 1024), "utf-8");
@@ -122,14 +121,13 @@ describe("given a deployment whose storage destination is Azure Blob", () => {
       // S3_BUCKET_NAME still set so legacy objects stay readable. The spool used
       // to resolve that bucket and quietly keep writing trace payloads to AWS.
       const legacyS3 = vi.fn();
-      const store = new BlobStore(
-        async () => ({
+      const store = new BlobStore({
+        resolveS3Client: async () => ({
           s3Client: { send: legacyS3 } as never,
           s3Bucket: "legacy-bucket",
         }),
-        undefined,
-        azureSpoolStorage(),
-      );
+        spoolStorage: azureSpoolStorage(),
+      });
 
       const spoolRef = await store.putSpool({
         projectId: PROJECT_ID,

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
@@ -24,14 +24,14 @@ import {
   type S3ClientResolver,
   type SpoolStorage,
 } from "~/server/app-layer/traces/blob-store.service";
-import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
-import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 import {
   ensureAzuriteContainer,
-  startAzurite,
   type StartedAzurite,
+  startAzurite,
   stopAzurite,
 } from "~/server/stored-objects/__tests__/azurite-test-support";
+import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 
 const CONTAINER = "trace-spool";
 const PROJECT_ID = "proj-spool-azure";

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
@@ -70,6 +70,7 @@ function azureSpoolStorage(): SpoolStorage {
 beforeAll(async () => {
   azurite = await startAzurite();
   driver = new AzureBlobDriver({
+    mode: "sharedKey",
     accountName: azurite.accountName,
     accountKey: azurite.accountKey,
     endpointBaseUrl: azurite.endpointBaseUrl,

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * langwatch/langwatch-saas#800 — the ADR-022 trace spool honours the
+ * deployment's storage destination instead of assuming AWS S3.
+ *
+ * Exercises the real signing + wire path against a live Azurite emulator
+ * (testcontainers), not a fake object store: the unit suite proves the spool
+ * asks for the right URI, but only a real emulator proves the bytes actually
+ * land, come back identical, and delete. Before this change the same test
+ * could not be written at all — the spool had no way to reach Azure.
+ *
+ * The three assertions here are the inversions of the two reproduce steps on
+ * the issue:
+ *   1. an azure-only deployment spools successfully (repro A wrote nothing)
+ *   2. an azure deployment with a legacy S3 bucket still present writes to
+ *      Azure and leaves S3 untouched (repro B wrote to the wrong cloud)
+ *   3. the round-trip returns byte-identical content and cleans up after itself
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  BlobStore,
+  type S3ClientResolver,
+  type SpoolStorage,
+} from "~/server/app-layer/traces/blob-store.service";
+import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import {
+  ensureAzuriteContainer,
+  startAzurite,
+  type StartedAzurite,
+  stopAzurite,
+} from "~/server/stored-objects/__tests__/azurite-test-support";
+
+const CONTAINER = "trace-spool";
+const PROJECT_ID = "proj-spool-azure";
+const TRACE_ID = "trace-abc";
+const SPAN_ID = "span-def";
+
+let azurite: StartedAzurite;
+let driver: AzureBlobDriver;
+
+/**
+ * An S3 resolver that fails the test if the spool reaches for it. This is the
+ * regression guard: the bug was that every spool write went here regardless of
+ * how the deployment was configured.
+ */
+const s3MustNotBeUsed: S3ClientResolver = async () => {
+  throw new Error(
+    "the spool reached for an S3 client on an Azure-configured deployment",
+  );
+};
+
+function azureSpoolStorage(): SpoolStorage {
+  const destination: ProjectStorageDestination = {
+    kind: "azure",
+    accountName: azurite.accountName,
+    container: CONTAINER,
+  };
+  return {
+    objectStoreFor: () => driver,
+    resolveDestination: async () => destination,
+  };
+}
+
+beforeAll(async () => {
+  azurite = await startAzurite();
+  driver = new AzureBlobDriver({
+    accountName: azurite.accountName,
+    accountKey: azurite.accountKey,
+    endpointBaseUrl: azurite.endpointBaseUrl,
+  });
+  await ensureAzuriteContainer({ azurite, container: CONTAINER });
+}, 120_000);
+
+afterAll(async () => {
+  await stopAzurite(azurite);
+});
+
+describe("given a deployment whose storage destination is Azure Blob", () => {
+  describe("when an over-threshold span is spooled at the ingestion edge", () => {
+    it("round-trips the payload through Azure and cleans the object up", async () => {
+      const store = new BlobStore(
+        s3MustNotBeUsed,
+        undefined,
+        azureSpoolStorage(),
+      );
+      // Larger than COMMAND_INLINE_THRESHOLD, which is what puts a span on this
+      // path in the first place.
+      const body = Buffer.from("x".repeat(300 * 1024), "utf-8");
+
+      const spoolRef = await store.putSpool({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        body,
+      });
+
+      const uri = `azure-blob://${azurite.accountName}/${CONTAINER}/trace-blobs/spool/${PROJECT_ID}/${TRACE_ID}/${SPAN_ID}`;
+      expect(await driver.exists(uri)).toBe(true);
+
+      const retrieved = await store.getSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+      });
+      expect(retrieved).toEqual(body);
+
+      await store.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+      });
+      expect(await driver.exists(uri)).toBe(false);
+    }, 60_000);
+
+    it("never reaches for S3, even while a legacy S3 bucket is still configured", async () => {
+      // The documented mid-migration state: STORED_OBJECTS_BACKEND=azure with
+      // S3_BUCKET_NAME still set so legacy objects stay readable. The spool used
+      // to resolve that bucket and quietly keep writing trace payloads to AWS.
+      const legacyS3 = vi.fn();
+      const store = new BlobStore(
+        async () => ({
+          s3Client: { send: legacyS3 } as never,
+          s3Bucket: "legacy-bucket",
+        }),
+        undefined,
+        azureSpoolStorage(),
+      );
+
+      const spoolRef = await store.putSpool({
+        projectId: PROJECT_ID,
+        traceId: "trace-legacy",
+        spanId: "span-legacy",
+        body: Buffer.from("y".repeat(300 * 1024), "utf-8"),
+      });
+
+      expect(legacyS3).not.toHaveBeenCalled();
+      expect(
+        await driver.exists(
+          `azure-blob://${azurite.accountName}/${CONTAINER}/trace-blobs/spool/${PROJECT_ID}/trace-legacy/span-legacy`,
+        ),
+      ).toBe(true);
+
+      await store.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId: "trace-legacy",
+        spanId: "span-legacy",
+      });
+    }, 60_000);
+  });
+});

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-azure.integration.test.ts
@@ -61,6 +61,9 @@ function azureSpoolStorage(): SpoolStorage {
   return {
     objectStoreFor: () => driver,
     resolveDestination: async () => destination,
+    // This suite proves the write path, so it runs as a deployment that has
+    // provisioned the orphan-reaping lifecycle rule.
+    azureRetentionConfirmed: true,
   };
 }
 

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
@@ -44,6 +44,7 @@ const PROJECT_ID = `proj-spool-${RUN_ID}`;
 
 function driver(): AzureBlobDriver {
   return new AzureBlobDriver({
+    mode: "sharedKey",
     accountName: ACCOUNT_NAME!,
     accountKey: ACCOUNT_KEY!,
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
@@ -194,6 +194,79 @@ describeRealAzure("trace spool against real Azure Blob Storage", () => {
     }, 120_000);
   });
 
+  describe("given retention was confirmed at write time and is unconfirmed now", () => {
+    /**
+     * Turning `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED` back off is the
+     * remediation the refusal message itself names, and a chart rollback does
+     * it silently. The guard is about not creating an object nothing will reap
+     * — it must never strand the ones already in the container, because
+     * `getSpool` does not fail open (the edge already cleared the attributes,
+     * so a refusal loses the span) and a refused `deleteSpool` skips the eager
+     * cleanup, manufacturing the very orphan the guard exists to prevent.
+     */
+    function storeAfterFlip(): BlobStore {
+      return new BlobStore({
+        resolveS3Client: s3MustNotBeUsed,
+        spoolStorage: {
+          objectStoreFor: () => driver(),
+          resolveDestination: async () => AZURE_DESTINATION,
+          azureRetentionConfirmed: false,
+        },
+      });
+    }
+
+    it("still reads and still deletes the object already in the container", async () => {
+      const traceId = `trace-flip-${RUN_ID}`;
+      const spanId = `span-flip-${RUN_ID}`;
+      const body = Buffer.from("w".repeat(300 * 1024), "utf-8");
+      const uri = uriFor(traceId, spanId);
+      created.push(uri);
+
+      const spoolRef = await spoolStore().putSpool({
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+        body,
+      });
+      expect(await driver().exists(uri)).toBe(true);
+
+      const afterFlip = storeAfterFlip();
+      expect(
+        await afterFlip.getSpool({
+          spoolRef,
+          projectId: PROJECT_ID,
+          traceId,
+          spanId,
+        }),
+      ).toEqual(body);
+
+      await afterFlip.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+      });
+      expect(await driver().exists(uri)).toBe(false);
+    }, 120_000);
+
+    it("still refuses to write a NEW object, which is what the gate is for", async () => {
+      const traceId = `trace-flip-write-${RUN_ID}`;
+      const spanId = `span-flip-write-${RUN_ID}`;
+
+      await expect(
+        storeAfterFlip().putSpool({
+          projectId: PROJECT_ID,
+          traceId,
+          spanId,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toBeInstanceOf(SpoolDestinationUnsupportedError);
+
+      // Nothing landed in the real container.
+      expect(await driver().exists(uriFor(traceId, spanId))).toBe(false);
+    }, 120_000);
+  });
+
   describe("given a project whose storage is the local filesystem", () => {
     it("refuses the spool rather than writing an object nothing reaps", async () => {
       const store = new BlobStore({

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * langwatch/langwatch-saas#800 — the trace spool against a REAL Azure Blob
+ * account, not the emulator.
+ *
+ * Why this exists alongside `trace-spool-azure.integration.test.ts`: Azurite is
+ * path-style only (`host/account/container/blob`), production Azure is
+ * host-style (`account.blob.core.windows.net/container/blob`). The two
+ * canonicalise differently in the SharedKey string-to-sign, so a signature bug
+ * on the host-style path produces a well-formed header that only real Azure
+ * rejects — with a 403 the emulator can never produce. #6181 was bitten by
+ * exactly that. The spool mints a deeper object path than any other caller
+ * (`trace-blobs/spool/{project}/{trace}/{span}`), which is the shape where such
+ * a bug hides.
+ *
+ * Self-skips without credentials, like the sibling driver suite, so CI stays
+ * green and a developer with an account gets the coverage:
+ *
+ *   LANGWATCH_TEST_AZURE_ACCOUNT_NAME
+ *   LANGWATCH_TEST_AZURE_ACCOUNT_KEY
+ *   LANGWATCH_TEST_AZURE_CONTAINER
+ */
+import { afterAll, describe, expect, it, vi } from "vitest";
+import {
+  BlobStore,
+  type S3ClientResolver,
+  SpoolDestinationUnsupportedError,
+  type SpoolStorage,
+} from "~/server/app-layer/traces/blob-store.service";
+import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+
+const ACCOUNT_NAME = process.env.LANGWATCH_TEST_AZURE_ACCOUNT_NAME;
+const ACCOUNT_KEY = process.env.LANGWATCH_TEST_AZURE_ACCOUNT_KEY;
+const CONTAINER = process.env.LANGWATCH_TEST_AZURE_CONTAINER;
+
+const hasRealAzure = Boolean(ACCOUNT_NAME && ACCOUNT_KEY && CONTAINER);
+const describeRealAzure = hasRealAzure ? describe : describe.skip;
+
+const RUN_ID = `${Date.now()}`;
+const PROJECT_ID = `proj-spool-${RUN_ID}`;
+
+function driver(): AzureBlobDriver {
+  return new AzureBlobDriver({
+    accountName: ACCOUNT_NAME!,
+    accountKey: ACCOUNT_KEY!,
+  });
+}
+
+const AZURE_DESTINATION: ProjectStorageDestination = {
+  kind: "azure",
+  accountName: ACCOUNT_NAME!,
+  container: CONTAINER!,
+};
+
+/** Fails the test if the spool reaches for S3 on an Azure-configured project. */
+const s3MustNotBeUsed: S3ClientResolver = async () => {
+  throw new Error("the spool reached for an S3 client on an Azure deployment");
+};
+
+function azureSpoolStorage(): SpoolStorage {
+  return {
+    objectStoreFor: () => driver(),
+    resolveDestination: async () => AZURE_DESTINATION,
+  };
+}
+
+function spoolStore(): BlobStore {
+  return new BlobStore({
+    resolveS3Client: s3MustNotBeUsed,
+    spoolStorage: azureSpoolStorage(),
+  });
+}
+
+function uriFor(traceId: string, spanId: string): string {
+  return `azure-blob://${ACCOUNT_NAME}/${CONTAINER}/trace-blobs/spool/${PROJECT_ID}/${traceId}/${spanId}`;
+}
+
+const created: string[] = [];
+
+afterAll(async () => {
+  if (!hasRealAzure) return;
+  // Belt and braces: the tests delete what they write, this catches a failure
+  // that left something behind.
+  await Promise.allSettled(created.map((uri) => driver().delete(uri)));
+});
+
+describeRealAzure("trace spool against real Azure Blob Storage", () => {
+  describe("given an over-threshold span on an Azure-configured project", () => {
+    it("round-trips the payload host-style and cleans the object up", async () => {
+      const store = spoolStore();
+      const traceId = `trace-${RUN_ID}`;
+      const spanId = `span-${RUN_ID}`;
+      // Larger than COMMAND_INLINE_THRESHOLD, which is what puts a span here.
+      const body = Buffer.from("x".repeat(300 * 1024), "utf-8");
+      const uri = uriFor(traceId, spanId);
+      created.push(uri);
+
+      const spoolRef = await store.putSpool({
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+        body,
+      });
+
+      // Present in the real account, at the exact path the lifecycle rule
+      // is documented to match.
+      expect(await driver().exists(uri)).toBe(true);
+      expect(await driver().head(uri)).toBe(body.length);
+
+      const retrieved = await store.getSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+      });
+      expect(retrieved).toEqual(body);
+
+      await store.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+      });
+      expect(await driver().exists(uri)).toBe(false);
+    }, 120_000);
+
+    it("never reaches for S3 while a legacy S3 bucket is still configured", async () => {
+      const legacyS3 = vi.fn();
+      const store = new BlobStore({
+        resolveS3Client: async () => ({
+          s3Client: { send: legacyS3 } as never,
+          s3Bucket: "legacy-bucket",
+        }),
+        spoolStorage: azureSpoolStorage(),
+      });
+      const traceId = `trace-legacy-${RUN_ID}`;
+      const spanId = `span-legacy-${RUN_ID}`;
+      const uri = uriFor(traceId, spanId);
+      created.push(uri);
+
+      const spoolRef = await store.putSpool({
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+        body: Buffer.from("y".repeat(300 * 1024), "utf-8"),
+      });
+
+      expect(legacyS3).not.toHaveBeenCalled();
+      expect(await driver().exists(uri)).toBe(true);
+
+      await store.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+      });
+    }, 120_000);
+  });
+
+  describe("given a span id that tries to escape the spool prefix", () => {
+    it("confines it to one path component in the real account", async () => {
+      const store = spoolStore();
+      const traceId = "../../../../../../etc/evil";
+      const spanId = `span-escape-${RUN_ID}`;
+      const body = Buffer.from("z".repeat(300 * 1024), "utf-8");
+
+      const spoolRef = await store.putSpool({
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+        body,
+      });
+
+      // Reads back through the same derivation, so the object is addressable.
+      expect(
+        await store.getSpool({
+          spoolRef,
+          projectId: PROJECT_ID,
+          traceId,
+          spanId,
+        }),
+      ).toEqual(body);
+
+      await store.deleteSpool({
+        spoolRef,
+        projectId: PROJECT_ID,
+        traceId,
+        spanId,
+      });
+    }, 120_000);
+  });
+
+  describe("given a project whose storage is the local filesystem", () => {
+    it("refuses the spool rather than writing an object nothing reaps", async () => {
+      const store = new BlobStore({
+        resolveS3Client: s3MustNotBeUsed,
+        spoolStorage: {
+          objectStoreFor: () => driver(),
+          resolveDestination: async () => ({
+            kind: "file",
+            root: "/var/lib/langwatch/objects",
+          }),
+        },
+      });
+
+      await expect(
+        store.putSpool({
+          projectId: PROJECT_ID,
+          traceId: `trace-local-${RUN_ID}`,
+          spanId: `span-local-${RUN_ID}`,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toBeInstanceOf(SpoolDestinationUnsupportedError);
+    }, 60_000);
+  });
+});

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-spool-realazure.integration.test.ts
@@ -64,6 +64,7 @@ function azureSpoolStorage(): SpoolStorage {
   return {
     objectStoreFor: () => driver(),
     resolveDestination: async () => AZURE_DESTINATION,
+    azureRetentionConfirmed: true,
   };
 }
 
@@ -203,6 +204,7 @@ describeRealAzure("trace spool against real Azure Blob Storage", () => {
             kind: "file",
             root: "/var/lib/langwatch/objects",
           }),
+          azureRetentionConfirmed: true,
         },
       });
 

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -5,6 +5,7 @@ import {
   type S3Client,
 } from "@aws-sdk/client-s3";
 import { Ksuid } from "@langwatch/ksuid";
+import type { Logger } from "@langwatch/observability";
 import type { Readable } from "node:stream";
 import { z } from "zod";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
@@ -293,12 +294,30 @@ export class BlobStore {
    *   tests exercise it without infrastructure. When absent, spool writes
    *   throw — `maybeSpool` is fail-open, so ingestion degrades to inline
    *   payloads rather than breaking.
+   * @param logger - Optional; used only to surface a refused cross-tenant
+   *   delete, which `deleteSpool`'s best-effort swallow would otherwise hide.
    */
-  constructor(
-    private readonly resolveS3Client: S3ClientResolver,
-    private readonly resolveClickHouseClient?: ClickHouseClientResolver,
-    private readonly spoolStorage?: SpoolStorage,
-  ) {}
+  private readonly resolveS3Client: S3ClientResolver;
+  private readonly resolveClickHouseClient?: ClickHouseClientResolver;
+  private readonly spoolStorage?: SpoolStorage;
+  private readonly logger?: Logger;
+
+  constructor({
+    resolveS3Client,
+    resolveClickHouseClient,
+    spoolStorage,
+    logger,
+  }: {
+    resolveS3Client: S3ClientResolver;
+    resolveClickHouseClient?: ClickHouseClientResolver;
+    spoolStorage?: SpoolStorage;
+    logger?: Logger;
+  }) {
+    this.resolveS3Client = resolveS3Client;
+    this.resolveClickHouseClient = resolveClickHouseClient;
+    this.spoolStorage = spoolStorage;
+    this.logger = logger;
+  }
 
   /**
    * Re-derives the spool object's URI from server-trusted inputs. Never reads a
@@ -595,7 +614,18 @@ export class BlobStore {
   }): Promise<void> {
     try {
       if (isLegacySpoolRef(spoolRef)) {
-        assertLegacySpoolKeyBelongsTo(spoolRef, projectId);
+        // A refusal here is a tamper indicator, not a storage blip. The
+        // best-effort swallow below is meant for the latter, so log this one
+        // explicitly rather than letting it disappear into the same catch.
+        try {
+          assertLegacySpoolKeyBelongsTo(spoolRef, projectId);
+        } catch {
+          this.logger?.warn(
+            { projectId, traceId, spanId },
+            "Refused a cross-tenant v1 spool delete",
+          );
+          return;
+        }
         const { s3Client, s3Bucket } = await this.resolveS3Client(projectId);
         await s3Client.send(
           new DeleteObjectCommand({ Bucket: s3Bucket, Key: spoolRef }),

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -1,12 +1,11 @@
+import type { Readable } from "node:stream";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
-  PutObjectCommand,
   type S3Client,
 } from "@aws-sdk/client-s3";
 import { Ksuid } from "@langwatch/ksuid";
 import type { Logger } from "@langwatch/observability";
-import type { Readable } from "node:stream";
 import { z } from "zod";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -303,6 +303,63 @@ function assertLegacySpoolKeyBelongsTo(
 }
 
 /**
+ * Refuses a destination that cannot bound an orphaned spool object.
+ *
+ * WRITE PATH ONLY. This is a rule about creating new objects, not about the
+ * ones already out there — see the `purpose` note on `BlobStore.mintSpoolUri`.
+ */
+function assertDestinationCanHostSpool({
+  destination,
+  azureRetentionConfirmed,
+}: {
+  destination: ProjectStorageDestination;
+  azureRetentionConfirmed: boolean;
+}): void {
+  // The spool is the one stored-objects consumer that depends on something
+  // OUTSIDE the object store to stay bounded: it deletes eagerly after the
+  // event_log INSERT, and leans on a lifecycle rule to reap whatever a crash
+  // between those two steps leaves behind. A filesystem has no such rule, so
+  // on this destination an orphan is permanent and the volume is what fills.
+  //
+  // Refusing here is not a regression. Before this consumer moved onto the
+  // shared layer it built an S3 client, and on a local install that resolved
+  // to the hardcoded "langwatch" bucket, which does not exist — so the PUT
+  // failed and `maybeSpool` fell open to an inline payload every time. This
+  // makes that same outcome explicit and loud instead of incidental.
+  if (destination.kind === "file") {
+    throw new SpoolDestinationUnsupportedError(
+      "The trace spool has no local-filesystem path: orphaned spool objects are reaped by a " +
+        "bucket/container lifecycle rule, which a filesystem cannot express, so a crash between " +
+        "the write and its delete would leave the object forever. Ingestion continues with the " +
+        "full payload inline. Configure S3 or Azure Blob storage to get oversize protection.",
+    );
+  }
+
+  // Same rule, applied consistently. Azure CAN express the lifecycle policy
+  // the orphan bound depends on — but nothing here can confirm it exists.
+  // The policy is a MANAGEMENT-plane resource
+  // (Microsoft.Storage/storageAccounts/managementPolicies); this deployment
+  // holds a data-plane key only, so reading it back would mean asking every
+  // operator for ARM credentials and a subscription id the feature otherwise
+  // has no use for. Refusing to check is not the same as refusing to care:
+  // the operator asserts it at deploy time, in the same config that turns the
+  // spool on, and the default is off. An Azure install that enables the flag
+  // without provisioning retention therefore degrades to inline payloads
+  // rather than accumulating customer trace data nothing will ever reap.
+  if (destination.kind === "azure" && !azureRetentionConfirmed) {
+    throw new SpoolDestinationUnsupportedError(
+      "The trace spool is disabled on Azure Blob until orphan retention is provisioned. A crash " +
+        "between the spool write and its delete leaves the object behind, and only a lifecycle " +
+        "rule reaps it. Create a lifecycle management policy on this container that deletes " +
+        "blobs under the `trace-blobs/spool/` prefix after 3 days, then set " +
+        "AZURE_BLOB_SPOOL_RETENTION_CONFIRMED=true (chart: " +
+        "`app.dataplane.providers.azureBlob.spoolRetentionConfirmed`). Ingestion continues with " +
+        "the full payload inline until then.",
+    );
+  }
+}
+
+/**
  * Provides transient spool operations (ADR-022 write path) and event_log
  * read operations (ADR-022 read path).
  *
@@ -364,15 +421,27 @@ export class BlobStore {
   /**
    * Re-derives the spool object's URI from server-trusted inputs. Never reads a
    * location out of the command.
+   *
+   * `purpose` decides whether the destination guards below apply. They exist to
+   * stop a NEW object landing where nothing will reap it, so they are a
+   * write-time rule only. Applying them to a read or a delete would punish the
+   * objects already on disk: an operator who turns the retention assertion back
+   * off — the documented remediation, and what a chart rollback does — would
+   * make every in-flight spooled span permanently unreadable (`getSpool` does
+   * not fail open, and the edge already cleared the attributes), and would stop
+   * the eager delete that is the spool's FIRST line of cleanup, manufacturing
+   * exactly the orphan the guard is there to prevent.
    */
   private async mintSpoolUri({
     projectId,
     traceId,
     spanId,
+    purpose,
   }: {
     projectId: string;
     traceId: string;
     spanId: string;
+    purpose: "write" | "access";
   }): Promise<{ uri: string; objectStore: SpoolObjectStore }> {
     if (!this.spoolStorage) {
       throw new Error(
@@ -381,50 +450,11 @@ export class BlobStore {
     }
     const destination = await this.spoolStorage.resolveDestination(projectId);
 
-    // The spool is the one stored-objects consumer that depends on something
-    // OUTSIDE the object store to stay bounded: it deletes eagerly after the
-    // event_log INSERT, and leans on a lifecycle rule to reap whatever a crash
-    // between those two steps leaves behind. A filesystem has no such rule, so
-    // on this destination an orphan is permanent and the volume is what fills.
-    //
-    // Refusing here is not a regression. Before this consumer moved onto the
-    // shared layer it built an S3 client, and on a local install that resolved
-    // to the hardcoded "langwatch" bucket, which does not exist — so the PUT
-    // failed and `maybeSpool` fell open to an inline payload every time. This
-    // makes that same outcome explicit and loud instead of incidental.
-    if (destination.kind === "file") {
-      throw new SpoolDestinationUnsupportedError(
-        "The trace spool has no local-filesystem path: orphaned spool objects are reaped by a " +
-          "bucket/container lifecycle rule, which a filesystem cannot express, so a crash between " +
-          "the write and its delete would leave the object forever. Ingestion continues with the " +
-          "full payload inline. Configure S3 or Azure Blob storage to get oversize protection.",
-      );
-    }
-
-    // Same rule, applied consistently. Azure CAN express the lifecycle policy
-    // the orphan bound depends on — but nothing here can confirm it exists.
-    // The policy is a MANAGEMENT-plane resource
-    // (Microsoft.Storage/storageAccounts/managementPolicies); this deployment
-    // holds a data-plane key only, so reading it back would mean asking every
-    // operator for ARM credentials and a subscription id the feature otherwise
-    // has no use for. Refusing to check is not the same as refusing to care:
-    // the operator asserts it at deploy time, in the same config that turns the
-    // spool on, and the default is off. An Azure install that enables the flag
-    // without provisioning retention therefore degrades to inline payloads
-    // rather than accumulating customer trace data nothing will ever reap.
-    if (
-      destination.kind === "azure" &&
-      !this.spoolStorage.azureRetentionConfirmed
-    ) {
-      throw new SpoolDestinationUnsupportedError(
-        "The trace spool is disabled on Azure Blob until orphan retention is provisioned. A crash " +
-          "between the spool write and its delete leaves the object behind, and only a lifecycle " +
-          "rule reaps it. Create a lifecycle management policy on this container that deletes " +
-          "blobs under the `trace-blobs/spool/` prefix after 3 days, then set " +
-          "AZURE_BLOB_SPOOL_RETENTION_CONFIRMED=true (chart: " +
-          "`app.dataplane.providers.azureBlob.spoolRetentionConfirmed`). Ingestion continues with " +
-          "the full payload inline until then.",
-      );
+    if (purpose === "write") {
+      assertDestinationCanHostSpool({
+        destination,
+        azureRetentionConfirmed: this.spoolStorage.azureRetentionConfirmed,
+      });
     }
 
     return {
@@ -627,6 +657,7 @@ export class BlobStore {
       projectId,
       traceId,
       spanId,
+      purpose: "access",
     });
     return streamToBuffer(await objectStore.get(uri), MAX_SPOOL_BYTES);
   }
@@ -681,6 +712,7 @@ export class BlobStore {
       projectId,
       traceId,
       spanId,
+      purpose: "write",
     });
     await objectStore.put(uri, body, "application/octet-stream");
     return SPOOL_REF_V2;
@@ -728,6 +760,7 @@ export class BlobStore {
         projectId,
         traceId,
         spanId,
+        purpose: "access",
       });
       await objectStore.delete(uri);
     } catch {

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Readable } from "node:stream";
 import {
   DeleteObjectCommand,
@@ -186,11 +187,47 @@ const SPOOL_KEY_PREFIX = "trace-blobs/spool";
 export const SPOOL_REF_V2 = "spool:v2";
 
 /**
- * Builds the transient spool object path. The ONLY place the shape is encoded.
+ * Raised when the project's storage destination cannot host the spool. Distinct
+ * from a storage failure so the fail-open warn can say "this deployment has no
+ * spool" rather than implying an outage the operator should go chase.
+ */
+export class SpoolDestinationUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SpoolDestinationUnsupportedError";
+  }
+}
+
+/**
+ * Ids that are safe to use verbatim as one path segment: the normal case, since
+ * OTLP ids normalise to hex. Excludes `.` and `..` explicitly — both match the
+ * character class but are directory references, not names.
+ */
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Reduces one id to a single path component.
  *
- * Segments are percent-encoded: OTLP ids arrive as opaque strings and the
- * base64 alphabet includes `/`, which would otherwise inject extra path
- * segments (and, for a leading-`/` id, escape the spool prefix entirely).
+ * Percent-encoding is NOT sufficient on its own. It survives URI construction,
+ * but `LocalFilesystemDriver.parseFileUri` round-trips through
+ * `decodeURIComponent`, which turns `..%2F..%2F` straight back into `../../`
+ * before `mkdir`/`writeFile` see it — so an id of `../../…` escaped the object
+ * root entirely. `idSchema` accepts arbitrary strings, so anyone able to ingest
+ * a span could pick that path.
+ *
+ * Anything outside the safe class is replaced by a hash of the id rather than
+ * escaped: a hash cannot contain a separator or a `..` no matter what decodes
+ * it downstream, and it stays deterministic, so the read and delete paths
+ * re-derive the identical location. Ordinary hex ids are untouched and remain
+ * legible in a bucket listing.
+ */
+function safePathSegment(id: string): string {
+  if (SAFE_PATH_SEGMENT.test(id) && id !== "." && id !== "..") return id;
+  return createHash("sha256").update(id, "utf8").digest("hex");
+}
+
+/**
+ * Builds the transient spool object path. The ONLY place the shape is encoded.
  */
 function buildSpoolObjectPath({
   projectId,
@@ -203,9 +240,9 @@ function buildSpoolObjectPath({
 }): string {
   return [
     SPOOL_KEY_PREFIX,
-    encodeURIComponent(projectId),
-    encodeURIComponent(traceId),
-    encodeURIComponent(spanId),
+    safePathSegment(projectId),
+    safePathSegment(traceId),
+    safePathSegment(spanId),
   ].join("/");
 }
 
@@ -220,9 +257,9 @@ function buildSpoolObjectPath({
  * falls through to the v2 path, where the location is derived and the reference
  * ignored.
  *
- * TODO(#800): drop the v1 branch one release after this ships — by then no
- * in-flight command can still carry a v1 ref (the spool's own lifecycle
- * expiry is 3 days).
+ * TODO(langwatch/langwatch-saas#837): drop the v1 branch one release after this
+ * ships. By then no in-flight command can still carry a v1 ref — the spool's
+ * own lifecycle expiry is 3 days, so nothing can resolve one after that.
  */
 function isLegacySpoolRef(spoolRef: string): boolean {
   return spoolRef.startsWith(`${SPOOL_KEY_PREFIX}/`);
@@ -337,6 +374,27 @@ export class BlobStore {
       );
     }
     const destination = await this.spoolStorage.resolveDestination(projectId);
+
+    // The spool is the one stored-objects consumer that depends on something
+    // OUTSIDE the object store to stay bounded: it deletes eagerly after the
+    // event_log INSERT, and leans on a lifecycle rule to reap whatever a crash
+    // between those two steps leaves behind. A filesystem has no such rule, so
+    // on this destination an orphan is permanent and the volume is what fills.
+    //
+    // Refusing here is not a regression. Before this consumer moved onto the
+    // shared layer it built an S3 client, and on a local install that resolved
+    // to the hardcoded "langwatch" bucket, which does not exist — so the PUT
+    // failed and `maybeSpool` fell open to an inline payload every time. This
+    // makes that same outcome explicit and loud instead of incidental.
+    if (destination.kind === "file") {
+      throw new SpoolDestinationUnsupportedError(
+        "The trace spool has no local-filesystem path: orphaned spool objects are reaped by a " +
+          "bucket/container lifecycle rule, which a filesystem cannot express, so a crash between " +
+          "the write and its delete would leave the object forever. Ingestion continues with the " +
+          "full payload inline. Configure S3 or Azure Blob storage to get oversize protection.",
+      );
+    }
+
     return {
       uri: mintUriForDestination({
         destination,

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -643,13 +643,16 @@ export class BlobStore {
     const { Body } = await s3Client.send(
       new GetObjectCommand({ Bucket: s3Bucket, Key: spoolRef }),
     );
-    const bytes = await Body?.transformToByteArray();
-    if (bytes == null) {
+    if (!Body) {
       throw new Error(
         `Spool object returned no body from S3 (key=${spoolRef}) — cannot reconstitute command`,
       );
     }
-    return Buffer.from(bytes);
+    // Read through the same bounded helper the v2 path uses. `transformToByteArray()`
+    // buffers the whole object first, so it would have skipped MAX_SPOOL_BYTES
+    // entirely — and a v1 reference points at an object written before this
+    // deploy, which is exactly the input the cap exists to distrust.
+    return streamToBuffer(Body as unknown as Readable, MAX_SPOOL_BYTES);
   }
 
   /**

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -45,6 +45,12 @@ export interface SpoolStorage {
   /** Per-project so BYOC tenants resolve their own bucket and credentials. */
   objectStoreFor(projectId: string): SpoolObjectStore;
   resolveDestination(projectId: string): Promise<ProjectStorageDestination>;
+  /**
+   * The operator's assertion that the Azure container has the orphan-reaping
+   * lifecycle rule. Injected rather than read from env here so this class keeps
+   * its no-env-coupling property; the composition root owns the env read.
+   */
+  azureRetentionConfirmed: boolean;
 }
 
 /**
@@ -392,6 +398,32 @@ export class BlobStore {
           "bucket/container lifecycle rule, which a filesystem cannot express, so a crash between " +
           "the write and its delete would leave the object forever. Ingestion continues with the " +
           "full payload inline. Configure S3 or Azure Blob storage to get oversize protection.",
+      );
+    }
+
+    // Same rule, applied consistently. Azure CAN express the lifecycle policy
+    // the orphan bound depends on — but nothing here can confirm it exists.
+    // The policy is a MANAGEMENT-plane resource
+    // (Microsoft.Storage/storageAccounts/managementPolicies); this deployment
+    // holds a data-plane key only, so reading it back would mean asking every
+    // operator for ARM credentials and a subscription id the feature otherwise
+    // has no use for. Refusing to check is not the same as refusing to care:
+    // the operator asserts it at deploy time, in the same config that turns the
+    // spool on, and the default is off. An Azure install that enables the flag
+    // without provisioning retention therefore degrades to inline payloads
+    // rather than accumulating customer trace data nothing will ever reap.
+    if (
+      destination.kind === "azure" &&
+      !this.spoolStorage.azureRetentionConfirmed
+    ) {
+      throw new SpoolDestinationUnsupportedError(
+        "The trace spool is disabled on Azure Blob until orphan retention is provisioned. A crash " +
+          "between the spool write and its delete leaves the object behind, and only a lifecycle " +
+          "rule reaps it. Create a lifecycle management policy on this container that deletes " +
+          "blobs under the `trace-blobs/spool/` prefix after 3 days, then set " +
+          "AZURE_BLOB_SPOOL_RETENTION_CONFIRMED=true (chart: " +
+          "`app.dataplane.providers.azureBlob.spoolRetentionConfirmed`). Ingestion continues with " +
+          "the full payload inline until then.",
       );
     }
 

--- a/platform/app/src/server/app-layer/traces/blob-store.service.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.ts
@@ -5,12 +5,45 @@ import {
   type S3Client,
 } from "@aws-sdk/client-s3";
 import { Ksuid } from "@langwatch/ksuid";
+import type { Readable } from "node:stream";
 import { z } from "zod";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import { mintUriForDestination } from "~/server/stored-objects/uri";
+import { streamToBuffer } from "~/utils/streamToBuffer";
 
 export interface S3ClientResolution {
   s3Client: S3Client;
   s3Bucket: string;
+}
+
+/**
+ * Cap on a spool object read. The spool holds one over-threshold command, and
+ * `capOversizedAttributes` already bounds a span well below this — the cap
+ * exists so a tampered or corrupt object cannot OOM the worker, not to enforce
+ * a product limit.
+ */
+export const MAX_SPOOL_BYTES = 50 * 1024 * 1024;
+
+/**
+ * The slice of the stored-objects registry the spool needs. Declared here
+ * rather than imported so this module depends on a shape, not on the registry
+ * class — the registry satisfies it structurally.
+ */
+export interface SpoolObjectStore {
+  put(uri: string, bytes: Buffer, mediaType: string): Promise<void>;
+  get(uri: string): Promise<Readable>;
+  delete(uri: string): Promise<void>;
+}
+
+/**
+ * Destination-agnostic storage for the trace spool, injected so `BlobStore`
+ * carries no env coupling and the tests run without infrastructure.
+ */
+export interface SpoolStorage {
+  /** Per-project so BYOC tenants resolve their own bucket and credentials. */
+  objectStoreFor(projectId: string): SpoolObjectStore;
+  resolveDestination(projectId: string): Promise<ProjectStorageDestination>;
 }
 
 /**
@@ -128,40 +161,118 @@ const eventPayloadSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
-// Transient spool S3 key shape (single source of truth)
+// Transient spool object path (single source of truth)
 // ---------------------------------------------------------------------------
 
-/** Prefix for all transient spool object keys. */
-const SPOOL_KEY_PREFIX = "trace-blobs/spool";
-/** Leading "/"-segment count of SPOOL_KEY_PREFIX, so the decode index tracks the prefix. */
-const SPOOL_PREFIX_SEGMENTS = SPOOL_KEY_PREFIX.split("/").length;
-
-/** Builds a transient spool object key. The ONLY place the key shape is encoded. */
-function buildSpoolKey(
-  projectId: string,
-  traceId: string,
-  spanId: string,
-): string {
-  return `${SPOOL_KEY_PREFIX}/${projectId}/${traceId}/${spanId}`;
-}
-
 /**
- * Extracts the projectId from a spool key produced by {@link buildSpoolKey}.
- * Indexes off SPOOL_PREFIX_SEGMENTS so a change to the prefix can't silently
- * desync the encode (`putSpool`) and decode (`getSpool`/`deleteSpool`) paths.
+ * Prefix for all transient spool objects, kept at the TOP of the object path
+ * (above the tenant segment) so a bucket/container lifecycle rule can match it
+ * with a plain prefix filter. S3 lifecycle prefix filters cannot wildcard a
+ * leading tenant segment, so `{projectId}/trace-blobs/spool/…` would be
+ * unexpirable and orphans would accumulate forever. Do not reorder.
  */
-function projectIdFromSpoolKey(spoolRef: string): string {
-  return spoolRef.split("/")[SPOOL_PREFIX_SEGMENTS] ?? "";
+const SPOOL_KEY_PREFIX = "trace-blobs/spool";
+
+/**
+ * Marker carried by a spooled command instead of a storage path.
+ *
+ * The v1 format put the raw object key in the command and the read path parsed
+ * the tenant id back out of that string to pick a bucket — so whoever could
+ * influence the queue message could steer a read at another tenant's object.
+ * v2 carries no location at all: `getSpool`/`deleteSpool` re-derive it from the
+ * command's own trusted `tenantId` + span ids, exactly as `putSpool` derived it
+ * (the same discipline `TieredBlobStore`'s `BlobRef` follows — ADR-030 §5).
+ */
+export const SPOOL_REF_V2 = "spool:v2";
+
+/**
+ * Builds the transient spool object path. The ONLY place the shape is encoded.
+ *
+ * Segments are percent-encoded: OTLP ids arrive as opaque strings and the
+ * base64 alphabet includes `/`, which would otherwise inject extra path
+ * segments (and, for a leading-`/` id, escape the spool prefix entirely).
+ */
+function buildSpoolObjectPath({
+  projectId,
+  traceId,
+  spanId,
+}: {
+  projectId: string;
+  traceId: string;
+  spanId: string;
+}): string {
+  return [
+    SPOOL_KEY_PREFIX,
+    encodeURIComponent(projectId),
+    encodeURIComponent(traceId),
+    encodeURIComponent(spanId),
+  ].join("/");
 }
 
 /**
- * Provides transient S3 spool operations (ADR-022 write path) and event_log
+ * True when `spoolRef` has the shape of a v1 reference — a raw S3 key minted
+ * before this deployment. Commands already queued when the new code rolls out
+ * still carry these, so both formats must resolve for one release.
+ *
+ * Matched by prefix rather than by "not v2": treating every unrecognised string
+ * as a v1 key would send it to the raw bucket+key read below, which is the very
+ * dereference this change exists to remove. An unrecognised reference instead
+ * falls through to the v2 path, where the location is derived and the reference
+ * ignored.
+ *
+ * TODO(#800): drop the v1 branch one release after this ships — by then no
+ * in-flight command can still carry a v1 ref (the spool's own lifecycle
+ * expiry is 3 days).
+ */
+function isLegacySpoolRef(spoolRef: string): boolean {
+  return spoolRef.startsWith(`${SPOOL_KEY_PREFIX}/`);
+}
+
+/**
+ * Extracts the projectId segment from a v1 spool key.
+ *
+ * The caller must check it against the command's authenticated tenant before
+ * dereferencing — see {@link assertLegacySpoolKeyBelongsTo}.
+ */
+function projectIdFromLegacySpoolKey(spoolRef: string): string {
+  return spoolRef.split("/")[SPOOL_KEY_PREFIX.split("/").length] ?? "";
+}
+
+/**
+ * Refuses a v1 key whose tenant segment is not the tenant the command was
+ * authenticated as.
+ *
+ * The v1 format is the one place a location still travels inside the command,
+ * so it is the one place a tampered reference could still steer a read. Pinning
+ * it to the command's own tenant keeps the compatibility window from reopening
+ * the hole the v2 format closes.
+ */
+function assertLegacySpoolKeyBelongsTo(
+  spoolRef: string,
+  projectId: string,
+): void {
+  const keyProjectId = projectIdFromLegacySpoolKey(spoolRef);
+  if (keyProjectId !== projectId) {
+    throw new Error(
+      `Refusing to read spool object: reference names tenant "${keyProjectId}" but the command is authenticated as "${projectId}".`,
+    );
+  }
+}
+
+/**
+ * Provides transient spool operations (ADR-022 write path) and event_log
  * read operations (ADR-022 read path).
  *
- * Spool: a per-span transient S3 object used to carry over-threshold command
+ * Spool: a per-span transient object used to carry over-threshold command
  * payloads from the edge to the command worker. Eagerly deleted after the
  * event_log INSERT succeeds; 3-day lifecycle policy as safety net for orphans
  * (3 days covers weekend incidents that need catch-up time).
+ *
+ * Spool writes go through the shared `stored-objects` layer, so the spool
+ * lands wherever the project's storage destination points — S3, Azure Blob, or
+ * the local filesystem. It used to speak the AWS SDK directly, which made it
+ * the one byte-writing surface that silently ignored a deployment's Azure
+ * configuration (langwatch/langwatch-saas#800).
  *
  * Event log: the durable source of truth. `getFromEventLog` performs a
  * SELECT on `event_log` keyed by (TenantId, AggregateType, AggregateId,
@@ -170,16 +281,52 @@ function projectIdFromSpoolKey(spoolRef: string): string {
  */
 export class BlobStore {
   /**
-   * @param resolveS3Client - Resolver for per-org S3 client + bucket.
+   * @param resolveS3Client - Resolver for per-org S3 client + bucket. Used ONLY
+   *   to read back v1 spool refs written before this deployment; every new
+   *   write goes through `objectStoreFor`.
    * @param resolveClickHouseClient - Optional per-tenant ClickHouseClient resolver for ADR-022
    *   event_log reads. When provided, `getFromEventLog` resolves the correct client for the
    *   given tenantId (supporting multi-cluster tenants). When absent, `getFromEventLog` throws
    *   "ClickHouseClient not configured".
+   * @param spoolStorage - The destination-agnostic object store the spool
+   *   writes to, injected so this class stays free of env coupling and the
+   *   tests exercise it without infrastructure. When absent, spool writes
+   *   throw — `maybeSpool` is fail-open, so ingestion degrades to inline
+   *   payloads rather than breaking.
    */
   constructor(
     private readonly resolveS3Client: S3ClientResolver,
     private readonly resolveClickHouseClient?: ClickHouseClientResolver,
+    private readonly spoolStorage?: SpoolStorage,
   ) {}
+
+  /**
+   * Re-derives the spool object's URI from server-trusted inputs. Never reads a
+   * location out of the command.
+   */
+  private async mintSpoolUri({
+    projectId,
+    traceId,
+    spanId,
+  }: {
+    projectId: string;
+    traceId: string;
+    spanId: string;
+  }): Promise<{ uri: string; objectStore: SpoolObjectStore }> {
+    if (!this.spoolStorage) {
+      throw new Error(
+        "BlobStore has no spool storage configured — cannot resolve the trace spool destination.",
+      );
+    }
+    const destination = await this.spoolStorage.resolveDestination(projectId);
+    return {
+      uri: mintUriForDestination({
+        destination,
+        objectPath: buildSpoolObjectPath({ projectId, traceId, spanId }),
+      }),
+      objectStore: this.spoolStorage.objectStoreFor(projectId),
+    };
+  }
 
   /**
    * Fetches a field value from the event_log ClickHouse table (ADR-022 read path).
@@ -335,20 +482,55 @@ export class BlobStore {
   }
 
   /**
-   * Fetches the full span body from a transient S3 spool object.
+   * Fetches the full span body from the transient spool object.
    * Called by the command worker when a command carries a `spoolRef`.
    *
-   * The spool key is the raw S3 object key (no bucket prefix). The S3 bucket is
-   * resolved via the key's projectId segment (decoded by `projectIdFromSpoolKey`).
+   * The object's location is re-derived from `projectId` / `traceId` / `spanId`
+   * — all read from the command itself, which the queue authenticated — rather
+   * than from `spoolRef`. A tampered reference therefore cannot redirect this
+   * read at another tenant's bytes; the worst it can do is name a v1 format and
+   * miss.
    *
-   * @param spoolRef - The spool reference string (S3 key) returned by `putSpool`.
+   * NOT fail-open, deliberately: the edge cleared `span.attributes` before
+   * spooling, so returning nothing here would write an empty span to
+   * `event_log` — permanent, silent loss in the sole source of truth. Throwing
+   * lets the command retry.
+   *
    * @returns The raw body buffer as stored by `putSpool`.
-   * @throws {Error} If S3 returns a response with no body — surfaced here so the
-   *   failure is legible rather than an opaque downstream parse error on an empty buffer.
-   * @throws The underlying S3 error if the object does not exist or access fails.
+   * @throws {Error} If the object is absent, unreadable, or exceeds
+   *   {@link MAX_SPOOL_BYTES}.
    */
-  async getSpool(spoolRef: string): Promise<Buffer> {
-    const projectId = projectIdFromSpoolKey(spoolRef);
+  async getSpool({
+    spoolRef,
+    projectId,
+    traceId,
+    spanId,
+  }: {
+    spoolRef: string;
+    projectId: string;
+    traceId: string;
+    spanId: string;
+  }): Promise<Buffer> {
+    if (isLegacySpoolRef(spoolRef)) {
+      assertLegacySpoolKeyBelongsTo(spoolRef, projectId);
+      return this.getLegacySpool(spoolRef, projectId);
+    }
+    const { uri, objectStore } = await this.mintSpoolUri({
+      projectId,
+      traceId,
+      spanId,
+    });
+    return streamToBuffer(await objectStore.get(uri), MAX_SPOOL_BYTES);
+  }
+
+  /**
+   * v1 read path: the reference IS the S3 key. Retained for one release so
+   * commands queued across the deploy still resolve. See {@link isLegacySpoolRef}.
+   */
+  private async getLegacySpool(
+    spoolRef: string,
+    projectId: string,
+  ): Promise<Buffer> {
     const { s3Client, s3Bucket } = await this.resolveS3Client(projectId);
     const { Body } = await s3Client.send(
       new GetObjectCommand({ Bucket: s3Bucket, Key: spoolRef }),
@@ -363,12 +545,15 @@ export class BlobStore {
   }
 
   /**
-   * Writes a transient S3 spool object for an over-threshold command payload.
-   * Returns the spool reference string (the S3 key) that the command will carry.
+   * Writes the transient spool object for an over-threshold command payload and
+   * returns the reference the command will carry.
    *
-   * Key shape: `trace-blobs/spool/{projectId}/{traceId}/{spanId}` — transient,
-   * eagerly DELETEd after event_log INSERT succeeds. Bucket MUST have a 3-day
-   * lifecycle policy as a safety net for orphans (covers weekend incidents).
+   * The object lands at whichever backend the project's storage destination
+   * names. Object path: `trace-blobs/spool/{projectId}/{traceId}/{spanId}` —
+   * transient, eagerly deleted after the event_log INSERT succeeds. The
+   * bucket/container MUST have a 3-day lifecycle rule on the
+   * `trace-blobs/spool/` prefix as the safety net for orphans (3 days covers
+   * weekend incidents that need catch-up time).
    */
   async putSpool({
     projectId,
@@ -381,34 +566,48 @@ export class BlobStore {
     spanId: string;
     body: Buffer;
   }): Promise<string> {
-    const key = buildSpoolKey(projectId, traceId, spanId);
-    const { s3Client, s3Bucket } = await this.resolveS3Client(projectId);
-    await s3Client.send(
-      new PutObjectCommand({
-        Bucket: s3Bucket,
-        Key: key,
-        Body: body,
-        ContentType: "application/octet-stream",
-      }),
-    );
-    return key;
+    const { uri, objectStore } = await this.mintSpoolUri({
+      projectId,
+      traceId,
+      spanId,
+    });
+    await objectStore.put(uri, body, "application/octet-stream");
+    return SPOOL_REF_V2;
   }
 
   /**
-   * Best-effort deletion of a transient S3 spool object.
-   * Called after event_log INSERT succeeds. Errors are swallowed — the 3-day lifecycle
-   * policy is the safety net for orphans. Returns void in all cases.
+   * Best-effort deletion of the transient spool object.
+   * Called after the event_log INSERT succeeds. Errors are swallowed — the
+   * 3-day lifecycle rule is the safety net for orphans. Returns void in all cases.
    *
-   * @param spoolRef - The spool reference string returned by `putSpool`.
    * @throws Never — all errors are swallowed internally.
    */
-  async deleteSpool(spoolRef: string): Promise<void> {
+  async deleteSpool({
+    spoolRef,
+    projectId,
+    traceId,
+    spanId,
+  }: {
+    spoolRef: string;
+    projectId: string;
+    traceId: string;
+    spanId: string;
+  }): Promise<void> {
     try {
-      const projectId = projectIdFromSpoolKey(spoolRef);
-      const { s3Client, s3Bucket } = await this.resolveS3Client(projectId);
-      await s3Client.send(
-        new DeleteObjectCommand({ Bucket: s3Bucket, Key: spoolRef }),
-      );
+      if (isLegacySpoolRef(spoolRef)) {
+        assertLegacySpoolKeyBelongsTo(spoolRef, projectId);
+        const { s3Client, s3Bucket } = await this.resolveS3Client(projectId);
+        await s3Client.send(
+          new DeleteObjectCommand({ Bucket: s3Bucket, Key: spoolRef }),
+        );
+        return;
+      }
+      const { uri, objectStore } = await this.mintSpoolUri({
+        projectId,
+        traceId,
+        spanId,
+      });
+      await objectStore.delete(uri);
     } catch {
       // Best-effort — swallow all errors; lifecycle policy is the safety net.
     }

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -16,8 +16,10 @@ import {
 } from "@aws-sdk/client-s3";
 import { describe, expect, it, vi } from "vitest";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import { StreamTooLargeError } from "~/utils/streamToBuffer";
 import {
   BlobStore,
+  MAX_SPOOL_BYTES,
   SPOOL_REF_V2,
   type S3ClientResolver,
   type SpoolStorage,
@@ -155,11 +157,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
           "writes to the $name destination the deployment resolved",
           async ({ destination, expectedUri }) => {
             const objectStore = fakeObjectStore();
-            const store = new BlobStore(
-              forbiddenS3Resolver,
-              undefined,
-              spoolStorageFor(objectStore, destination),
-            );
+            const store = new BlobStore({
+              resolveS3Client: forbiddenS3Resolver,
+              spoolStorage: spoolStorageFor(objectStore, destination),
+            });
 
             await store.putSpool({
               ...spoolCoords,
@@ -176,11 +177,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       describe("when putSpool is called", () => {
         it("returns a reference carrying no storage location", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, AZURE_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+          });
 
           const spoolRef = await store.putSpool({
             ...spoolCoords,
@@ -194,11 +194,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
 
         it("issues exactly ONE write", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
 
           await store.putSpool({
             ...spoolCoords,
@@ -214,11 +213,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       describe("when putSpool is called", () => {
         it("keeps the object under the spool prefix", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
 
           // Base64-encoded OTLP ids can contain "/", which unescaped would
           // inject extra path segments — or, leading, escape the prefix that
@@ -240,7 +238,7 @@ describe("BlobStore — spool operations (ADR-022)", () => {
     describe("given no spool storage is configured", () => {
       describe("when putSpool is called", () => {
         it("throws rather than falling back to a hardcoded backend", async () => {
-          const store = new BlobStore(forbiddenS3Resolver);
+          const store = new BlobStore({ resolveS3Client: forbiddenS3Resolver });
 
           await expect(
             store.putSpool({
@@ -258,11 +256,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       describe("when getSpool is called with the command's own coordinates", () => {
         it("returns the exact bytes that were put", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, AZURE_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+          });
           const originalBody = Buffer.from("exact span body bytes", "utf-8");
 
           const spoolRef = await store.putSpool({
@@ -280,11 +277,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       describe("when getSpool is called", () => {
         it("reads the location derived from the command, ignoring the reference", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
           const victimBytes = Buffer.from("another tenant's payload", "utf-8");
           await store.putSpool({
             projectId: "victim-org",
@@ -320,11 +316,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
             `test-bucket/${victimKey}`,
             Buffer.from("another tenant's payload", "utf-8"),
           );
-          const store = new BlobStore(
-            resolverFor(fake),
-            undefined,
-            spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: resolverFor(fake),
+            spoolStorage: spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
+          });
 
           await expect(
             store.getSpool({ spoolRef: victimKey, ...spoolCoords }),
@@ -342,11 +337,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
           fake.objects.set(`test-bucket/${legacyKey}`, legacyBytes);
 
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            resolverFor(fake),
-            undefined,
-            spoolStorageFor(objectStore, AZURE_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: resolverFor(fake),
+            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+          });
 
           const retrieved = await store.getSpool({
             spoolRef: legacyKey,
@@ -359,15 +353,45 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       });
     });
 
+    describe("given an object larger than the read cap", () => {
+      describe("when getSpool is called", () => {
+        it("rejects instead of buffering it whole", async () => {
+          const objectStore = fakeObjectStore();
+          // Emitted lazily in 1 MB chunks — the cap should trip long before
+          // anything close to MAX_SPOOL_BYTES is actually resident.
+          objectStore.get.mockImplementationOnce(async () =>
+            Readable.from(
+              (function* () {
+                for (
+                  let sent = 0;
+                  sent <= MAX_SPOOL_BYTES;
+                  sent += 1024 * 1024
+                ) {
+                  yield Buffer.alloc(1024 * 1024);
+                }
+              })(),
+            ),
+          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
+
+          await expect(
+            store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+          ).rejects.toThrow(StreamTooLargeError);
+        });
+      });
+    });
+
     describe("given the object is missing", () => {
       describe("when getSpool is called", () => {
         it("throws rather than returning an empty span", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
 
           await expect(
             store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
@@ -382,11 +406,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
       describe("when deleteSpool is called", () => {
         it("deletes the object it wrote", async () => {
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, AZURE_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+          });
           const spoolRef = await store.putSpool({
             ...spoolCoords,
             body: Buffer.from("to be deleted", "utf-8"),
@@ -409,11 +432,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
           const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
           fake.objects.set(`test-bucket/${legacyKey}`, Buffer.from("old"));
           const objectStore = fakeObjectStore();
-          const store = new BlobStore(
-            resolverFor(fake),
-            undefined,
-            spoolStorageFor(objectStore, AZURE_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: resolverFor(fake),
+            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+          });
 
           await store.deleteSpool({ spoolRef: legacyKey, ...spoolCoords });
 
@@ -428,11 +450,10 @@ describe("BlobStore — spool operations (ADR-022)", () => {
         it("does not throw (best-effort — the lifecycle rule is the safety net)", async () => {
           const objectStore = fakeObjectStore();
           objectStore.delete.mockRejectedValueOnce(new Error("AccessDenied"));
-          const store = new BlobStore(
-            forbiddenS3Resolver,
-            undefined,
-            spoolStorageFor(objectStore, S3_DESTINATION),
-          );
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+          });
 
           await expect(
             store.deleteSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -22,6 +22,7 @@ import {
   MAX_SPOOL_BYTES,
   type S3ClientResolver,
   SPOOL_REF_V2,
+  SpoolDestinationUnsupportedError,
   type SpoolStorage,
 } from "./blob-store.service";
 
@@ -144,12 +145,9 @@ describe("putSpool — given each supported storage destination", () => {
         expectedUri:
           "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
       },
-      {
-        name: "local filesystem",
-        destination: FILE_DESTINATION,
-        expectedUri:
-          "file:///var/lib/langwatch/objects/trace-blobs/spool/orgA/trace-1/span-1",
-      },
+      // No local-filesystem row on purpose: the spool refuses that
+      // destination, since a filesystem cannot express the lifecycle rule the
+      // orphan bound depends on. Covered by its own case below.
     ])("writes to the $name destination the deployment resolved", async ({
       destination,
       expectedUri,
@@ -208,16 +206,13 @@ describe("putSpool — given a span payload body", () => {
 
 describe("putSpool — given an OTLP id containing a path separator", () => {
   describe("when putSpool is called", () => {
-    it("keeps the object under the spool prefix", async () => {
+    it("reduces the id to one path component so nothing can escape the prefix", async () => {
       const objectStore = fakeObjectStore();
       const store = new BlobStore({
         resolveS3Client: forbiddenS3Resolver,
         spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
       });
 
-      // Base64-encoded OTLP ids can contain "/", which unescaped would
-      // inject extra path segments — or, leading, escape the prefix that
-      // the lifecycle rule matches on.
       await store.putSpool({
         projectId: "orgA",
         traceId: "../../etc",
@@ -225,9 +220,62 @@ describe("putSpool — given an OTLP id containing a path separator", () => {
         body: Buffer.from("payload", "utf-8"),
       });
 
-      expect(objectStore.putUris[0]).toBe(
-        "s3://test-bucket/trace-blobs/spool/orgA/..%2F..%2Fetc/a%2Fb",
-      );
+      // Percent-encoding alone was not enough: the local driver decodes the
+      // URI before touching the filesystem, which turned `..%2F..%2F` back
+      // into `../../`. Unsafe ids become a hash, which cannot carry a
+      // separator no matter what decodes it downstream.
+      const [uri] = objectStore.putUris;
+      const key = uri!.replace("s3://test-bucket/", "");
+      const segments = key.split("/");
+      expect(segments.slice(0, 3)).toEqual(["trace-blobs", "spool", "orgA"]);
+      expect(segments).toHaveLength(5);
+      for (const segment of segments) {
+        expect(segment).not.toBe("..");
+        expect(segment).not.toContain("%2F");
+      }
+      // Decoding the whole key must not introduce separators either — this is
+      // the exact step that defeated the previous encoding.
+      expect(decodeURIComponent(key).split("/")).toHaveLength(5);
+    });
+
+    it("derives the same location on read and delete", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+      });
+      const coords = { projectId: "orgA", traceId: "../../etc", spanId: "a/b" };
+      const body = Buffer.from("payload", "utf-8");
+
+      // Hashing must be deterministic, or a spooled span becomes unreadable.
+      const spoolRef = await store.putSpool({ ...coords, body });
+      expect(await store.getSpool({ spoolRef, ...coords })).toEqual(body);
+
+      await store.deleteSpool({ spoolRef, ...coords });
+      expect(objectStore.objects.size).toBe(0);
+    });
+  });
+});
+
+describe("putSpool — given the project's storage is the local filesystem", () => {
+  describe("when putSpool is called", () => {
+    it("refuses rather than writing an object nothing will ever reap", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, FILE_DESTINATION),
+      });
+
+      // A filesystem cannot express a lifecycle rule, so a crash between the
+      // write and its delete would strand the object forever. `maybeSpool` is
+      // fail-open, so ingestion continues with the payload inline.
+      await expect(
+        store.putSpool({
+          ...spoolCoords,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toBeInstanceOf(SpoolDestinationUnsupportedError);
+      expect(objectStore.put).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -1,23 +1,75 @@
 /**
  * Unit tests for BlobStore spool operations (ADR-022 write/read path).
  *
- * Covers: putSpool, getSpool, deleteSpool.
+ * Covers: putSpool, getSpool, deleteSpool across every storage destination, the
+ * v1 reference format retained for the rollout, and the property that a
+ * reference cannot steer a read (langwatch/langwatch-saas#800).
  * getFromEventLog is covered by blob-store.event-log.unit.test.ts.
  *
  * BDD structure: given/when nested describes, action-based it() names.
  */
-
+import { Readable } from "node:stream";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { describe, expect, it, vi } from "vitest";
-import { BlobStore, type S3ClientResolver } from "./blob-store.service";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import {
+  BlobStore,
+  SPOOL_REF_V2,
+  type S3ClientResolver,
+  type SpoolStorage,
+} from "./blob-store.service";
 
 /**
- * In-memory fake S3 keyed by `${bucket}/${key}`.
+ * In-memory stand-in for the stored-objects StorageRegistry, keyed by URI.
+ * Records every URI it is asked for so the tests can assert on the location
+ * the spool derived, not just on the bytes coming back.
  */
+function fakeObjectStore() {
+  const objects = new Map<string, Buffer>();
+  const putUris: string[] = [];
+  const getUris: string[] = [];
+  const deleteUris: string[] = [];
+  return {
+    objects,
+    putUris,
+    getUris,
+    deleteUris,
+    put: vi.fn(async (uri: string, bytes: Buffer) => {
+      putUris.push(uri);
+      objects.set(uri, bytes);
+    }),
+    get: vi.fn(async (uri: string) => {
+      getUris.push(uri);
+      const stored = objects.get(uri);
+      if (!stored) {
+        const err = new Error("NoSuchKey");
+        err.name = "NoSuchKey";
+        throw err;
+      }
+      return Readable.from([stored]);
+    }),
+    delete: vi.fn(async (uri: string) => {
+      deleteUris.push(uri);
+      objects.delete(uri);
+    }),
+  };
+}
+
+function spoolStorageFor(
+  store: ReturnType<typeof fakeObjectStore>,
+  destination: ProjectStorageDestination,
+): SpoolStorage {
+  return {
+    objectStoreFor: () => store,
+    resolveDestination: async () => destination,
+  };
+}
+
+/** In-memory fake S3 keyed by `${bucket}/${key}` — the v1 read path only. */
 function fakeS3() {
   const objects = new Map<string, Buffer>();
   const send = vi.fn(async (command: unknown) => {
@@ -35,14 +87,11 @@ function fakeS3() {
         throw err;
       }
       return {
-        Body: {
-          transformToByteArray: async () => new Uint8Array(stored),
-        },
+        Body: { transformToByteArray: async () => new Uint8Array(stored) },
       };
     }
     if (command instanceof DeleteObjectCommand) {
-      const { Bucket, Key } = command.input;
-      objects.delete(`${Bucket}/${Key}`);
+      objects.delete(`${command.input.Bucket}/${command.input.Key}`);
       return {};
     }
     throw new Error("unexpected command");
@@ -51,11 +100,13 @@ function fakeS3() {
 }
 
 function resolverFor(fake: ReturnType<typeof fakeS3>): S3ClientResolver {
-  return async (_projectId: string) => ({
-    s3Client: fake.s3Client,
-    s3Bucket: "test-bucket",
-  });
+  return async () => ({ s3Client: fake.s3Client, s3Bucket: "test-bucket" });
 }
+
+/** An S3 resolver that fails the test if anything reaches it. */
+const forbiddenS3Resolver: S3ClientResolver = async () => {
+  throw new Error("the S3 client must not be reached on the v2 spool path");
+};
 
 const spoolCoords = {
   projectId: "orgA",
@@ -63,55 +114,264 @@ const spoolCoords = {
   spanId: "span-1",
 };
 
+const S3_DESTINATION: ProjectStorageDestination = {
+  kind: "s3",
+  bucket: "test-bucket",
+};
+const AZURE_DESTINATION: ProjectStorageDestination = {
+  kind: "azure",
+  accountName: "acct",
+  container: "cont",
+};
+const FILE_DESTINATION: ProjectStorageDestination = {
+  kind: "file",
+  root: "/var/lib/langwatch/objects",
+};
+
 describe("BlobStore — spool operations (ADR-022)", () => {
   describe("putSpool", () => {
+    describe("given each supported storage destination", () => {
+      describe("when putSpool is called", () => {
+        it.each([
+          {
+            name: "s3",
+            destination: S3_DESTINATION,
+            expectedUri:
+              "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
+          },
+          {
+            name: "azure",
+            destination: AZURE_DESTINATION,
+            expectedUri:
+              "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
+          },
+          {
+            name: "local filesystem",
+            destination: FILE_DESTINATION,
+            expectedUri:
+              "file:///var/lib/langwatch/objects/trace-blobs/spool/orgA/trace-1/span-1",
+          },
+        ])(
+          "writes to the $name destination the deployment resolved",
+          async ({ destination, expectedUri }) => {
+            const objectStore = fakeObjectStore();
+            const store = new BlobStore(
+              forbiddenS3Resolver,
+              undefined,
+              spoolStorageFor(objectStore, destination),
+            );
+
+            await store.putSpool({
+              ...spoolCoords,
+              body: Buffer.from("span payload data", "utf-8"),
+            });
+
+            expect(objectStore.putUris).toEqual([expectedUri]);
+          },
+        );
+      });
+    });
+
     describe("given a span payload body", () => {
       describe("when putSpool is called", () => {
-        it("returns the spool key with the correct shape trace-blobs/spool/{projectId}/{traceId}/{spanId}", async () => {
-          const fake = fakeS3();
-          const store = new BlobStore(resolverFor(fake));
-          const body = Buffer.from("span payload data", "utf-8");
-
-          const spoolRef = await store.putSpool({ ...spoolCoords, body });
-
-          expect(spoolRef).toBe(
-            `trace-blobs/spool/${spoolCoords.projectId}/${spoolCoords.traceId}/${spoolCoords.spanId}`,
+        it("returns a reference carrying no storage location", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, AZURE_DESTINATION),
           );
+
+          const spoolRef = await store.putSpool({
+            ...spoolCoords,
+            body: Buffer.from("payload", "utf-8"),
+          });
+
+          expect(spoolRef).toBe(SPOOL_REF_V2);
+          expect(spoolRef).not.toContain(spoolCoords.projectId);
+          expect(spoolRef).not.toContain("test-bucket");
         });
 
-        it("issues exactly ONE PutObjectCommand", async () => {
-          const fake = fakeS3();
-          const store = new BlobStore(resolverFor(fake));
-          const body = Buffer.from("payload", "utf-8");
-
-          await store.putSpool({ ...spoolCoords, body });
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const putCalls = (fake.s3Client as any).send.mock.calls.filter(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (c: any) => c[0] instanceof PutObjectCommand,
+        it("issues exactly ONE write", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, S3_DESTINATION),
           );
-          expect(putCalls).toHaveLength(1);
+
+          await store.putSpool({
+            ...spoolCoords,
+            body: Buffer.from("payload", "utf-8"),
+          });
+
+          expect(objectStore.put).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe("given an OTLP id containing a path separator", () => {
+      describe("when putSpool is called", () => {
+        it("keeps the object under the spool prefix", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, S3_DESTINATION),
+          );
+
+          // Base64-encoded OTLP ids can contain "/", which unescaped would
+          // inject extra path segments — or, leading, escape the prefix that
+          // the lifecycle rule matches on.
+          await store.putSpool({
+            projectId: "orgA",
+            traceId: "../../etc",
+            spanId: "a/b",
+            body: Buffer.from("payload", "utf-8"),
+          });
+
+          expect(objectStore.putUris[0]).toBe(
+            "s3://test-bucket/trace-blobs/spool/orgA/..%2F..%2Fetc/a%2Fb",
+          );
+        });
+      });
+    });
+
+    describe("given no spool storage is configured", () => {
+      describe("when putSpool is called", () => {
+        it("throws rather than falling back to a hardcoded backend", async () => {
+          const store = new BlobStore(forbiddenS3Resolver);
+
+          await expect(
+            store.putSpool({
+              ...spoolCoords,
+              body: Buffer.from("payload", "utf-8"),
+            }),
+          ).rejects.toThrow(/no spool storage configured/i);
         });
       });
     });
   });
 
   describe("getSpool", () => {
-    describe("given a spool ref written by putSpool", () => {
-      describe("when getSpool is called with the same ref", () => {
+    describe("given a spool object written by putSpool", () => {
+      describe("when getSpool is called with the command's own coordinates", () => {
         it("returns the exact bytes that were put", async () => {
-          const fake = fakeS3();
-          const store = new BlobStore(resolverFor(fake));
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, AZURE_DESTINATION),
+          );
           const originalBody = Buffer.from("exact span body bytes", "utf-8");
 
           const spoolRef = await store.putSpool({
             ...spoolCoords,
             body: originalBody,
           });
-          const retrieved = await store.getSpool(spoolRef);
+          const retrieved = await store.getSpool({ spoolRef, ...spoolCoords });
 
           expect(retrieved).toEqual(originalBody);
+        });
+      });
+    });
+
+    describe("given a reference naming another tenant's object", () => {
+      describe("when getSpool is called", () => {
+        it("reads the location derived from the command, ignoring the reference", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, S3_DESTINATION),
+          );
+          const victimBytes = Buffer.from("another tenant's payload", "utf-8");
+          await store.putSpool({
+            projectId: "victim-org",
+            traceId: "trace-1",
+            spanId: "span-1",
+            body: victimBytes,
+          });
+          const ownBytes = Buffer.from("my own payload", "utf-8");
+          await store.putSpool({ ...spoolCoords, body: ownBytes });
+
+          // A reference that names the victim's object, on a command
+          // authenticated as orgA. The reference must not be honoured.
+          const retrieved = await store.getSpool({
+            spoolRef:
+              "s3://test-bucket/trace-blobs/spool/victim-org/trace-1/span-1",
+            ...spoolCoords,
+          });
+
+          expect(retrieved).toEqual(ownBytes);
+          expect(objectStore.getUris).toEqual([
+            "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
+          ]);
+        });
+      });
+    });
+
+    describe("given a v1-shaped reference naming another tenant", () => {
+      describe("when getSpool is called", () => {
+        it("refuses rather than reading across the tenant boundary", async () => {
+          const fake = fakeS3();
+          const victimKey = "trace-blobs/spool/victim-org/trace-1/span-1";
+          fake.objects.set(
+            `test-bucket/${victimKey}`,
+            Buffer.from("another tenant's payload", "utf-8"),
+          );
+          const store = new BlobStore(
+            resolverFor(fake),
+            undefined,
+            spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
+          );
+
+          await expect(
+            store.getSpool({ spoolRef: victimKey, ...spoolCoords }),
+          ).rejects.toThrow(/authenticated as "orgA"/);
+        });
+      });
+    });
+
+    describe("given a v1 reference written before this deployment", () => {
+      describe("when getSpool is called", () => {
+        it("still resolves it through the legacy S3 path", async () => {
+          const fake = fakeS3();
+          const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
+          const legacyBytes = Buffer.from("queued before the deploy", "utf-8");
+          fake.objects.set(`test-bucket/${legacyKey}`, legacyBytes);
+
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            resolverFor(fake),
+            undefined,
+            spoolStorageFor(objectStore, AZURE_DESTINATION),
+          );
+
+          const retrieved = await store.getSpool({
+            spoolRef: legacyKey,
+            ...spoolCoords,
+          });
+
+          expect(retrieved).toEqual(legacyBytes);
+          expect(objectStore.get).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given the object is missing", () => {
+      describe("when getSpool is called", () => {
+        it("throws rather than returning an empty span", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, S3_DESTINATION),
+          );
+
+          await expect(
+            store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+          ).rejects.toThrow();
         });
       });
     });
@@ -120,40 +380,63 @@ describe("BlobStore — spool operations (ADR-022)", () => {
   describe("deleteSpool", () => {
     describe("given an existing spool object", () => {
       describe("when deleteSpool is called", () => {
-        it("issues a DeleteObjectCommand for the spool key", async () => {
-          const fake = fakeS3();
-          const store = new BlobStore(resolverFor(fake));
-          const body = Buffer.from("to be deleted", "utf-8");
-          const spoolRef = await store.putSpool({ ...spoolCoords, body });
-
-          await store.deleteSpool(spoolRef);
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const deleteCalls = (fake.s3Client as any).send.mock.calls.filter(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (c: any) => c[0] instanceof DeleteObjectCommand,
+        it("deletes the object it wrote", async () => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, AZURE_DESTINATION),
           );
-          expect(deleteCalls).toHaveLength(1);
+          const spoolRef = await store.putSpool({
+            ...spoolCoords,
+            body: Buffer.from("to be deleted", "utf-8"),
+          });
+
+          await store.deleteSpool({ spoolRef, ...spoolCoords });
+
+          expect(objectStore.deleteUris).toEqual([
+            "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
+          ]);
+          expect(objectStore.objects.size).toBe(0);
         });
       });
     });
 
-    describe("given a spool ref that does not exist", () => {
+    describe("given a v1 reference", () => {
       describe("when deleteSpool is called", () => {
-        it("does not throw (best-effort — errors are swallowed)", async () => {
-          const throwingS3 = {
-            send: vi.fn(async () => {
-              throw new Error("AccessDenied");
-            }),
-          };
-          const store = new BlobStore(async () => ({
-            s3Client: throwingS3 as never,
-            s3Bucket: "bucket",
-          }));
+        it("deletes through the legacy S3 path", async () => {
+          const fake = fakeS3();
+          const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
+          fake.objects.set(`test-bucket/${legacyKey}`, Buffer.from("old"));
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore(
+            resolverFor(fake),
+            undefined,
+            spoolStorageFor(objectStore, AZURE_DESTINATION),
+          );
+
+          await store.deleteSpool({ spoolRef: legacyKey, ...spoolCoords });
+
+          expect(fake.objects.size).toBe(0);
+          expect(objectStore.delete).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given the storage backend rejects the delete", () => {
+      describe("when deleteSpool is called", () => {
+        it("does not throw (best-effort — the lifecycle rule is the safety net)", async () => {
+          const objectStore = fakeObjectStore();
+          objectStore.delete.mockRejectedValueOnce(new Error("AccessDenied"));
+          const store = new BlobStore(
+            forbiddenS3Resolver,
+            undefined,
+            spoolStorageFor(objectStore, S3_DESTINATION),
+          );
 
           await expect(
-            store.deleteSpool("trace-blobs/spool/proj/trace/span"),
-          ).resolves.not.toThrow();
+            store.deleteSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+          ).resolves.toBeUndefined();
         });
       });
     });

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -92,9 +92,9 @@ function fakeS3() {
         err.name = "NoSuchKey";
         throw err;
       }
-      return {
-        Body: { transformToByteArray: async () => new Uint8Array(stored) },
-      };
+      // A stream, as the real SDK returns — the legacy read now consumes it
+      // through the same bounded helper as the v2 path.
+      return { Body: Readable.from([stored]) };
     }
     if (command instanceof DeleteObjectCommand) {
       objects.delete(`${command.input.Bucket}/${command.input.Key}`);
@@ -477,6 +477,41 @@ describe("getSpool — given a v1 reference written before this deployment", () 
 
       expect(retrieved).toEqual(legacyBytes);
       expect(objectStore.get).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("getSpool — given a v1 object larger than the read cap", () => {
+  describe("when getSpool is called", () => {
+    it("rejects instead of buffering it whole", async () => {
+      const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
+      const oversizedS3 = {
+        send: vi.fn(async () => ({
+          // Lazy 1 MB chunks past the cap — the same shape the v2 case uses.
+          Body: Readable.from(
+            (function* () {
+              for (let sent = 0; sent <= MAX_SPOOL_BYTES; sent += 1024 * 1024) {
+                yield Buffer.alloc(1024 * 1024);
+              }
+            })(),
+          ),
+        })),
+      };
+      const store = new BlobStore({
+        resolveS3Client: async () => ({
+          s3Client: oversizedS3 as never,
+          s3Bucket: "test-bucket",
+        }),
+        spoolStorage: spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
+      });
+
+      // The v1 path used to call transformToByteArray(), which buffers the
+      // whole object before anything can check its size — so the cap that
+      // guards the v2 path did not apply to the one input written before this
+      // deploy, which is exactly the input it exists to distrust.
+      await expect(
+        store.getSpool({ spoolRef: legacyKey, ...spoolCoords }),
+      ).rejects.toThrow(StreamTooLargeError);
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -20,8 +20,8 @@ import { StreamTooLargeError } from "~/utils/streamToBuffer";
 import {
   BlobStore,
   MAX_SPOOL_BYTES,
-  SPOOL_REF_V2,
   type S3ClientResolver,
+  SPOOL_REF_V2,
   type SpoolStorage,
 } from "./blob-store.service";
 
@@ -153,23 +153,23 @@ describe("BlobStore — spool operations (ADR-022)", () => {
             expectedUri:
               "file:///var/lib/langwatch/objects/trace-blobs/spool/orgA/trace-1/span-1",
           },
-        ])(
-          "writes to the $name destination the deployment resolved",
-          async ({ destination, expectedUri }) => {
-            const objectStore = fakeObjectStore();
-            const store = new BlobStore({
-              resolveS3Client: forbiddenS3Resolver,
-              spoolStorage: spoolStorageFor(objectStore, destination),
-            });
+        ])("writes to the $name destination the deployment resolved", async ({
+          destination,
+          expectedUri,
+        }) => {
+          const objectStore = fakeObjectStore();
+          const store = new BlobStore({
+            resolveS3Client: forbiddenS3Resolver,
+            spoolStorage: spoolStorageFor(objectStore, destination),
+          });
 
-            await store.putSpool({
-              ...spoolCoords,
-              body: Buffer.from("span payload data", "utf-8"),
-            });
+          await store.putSpool({
+            ...spoolCoords,
+            body: Buffer.from("span payload data", "utf-8"),
+          });
 
-            expect(objectStore.putUris).toEqual([expectedUri]);
-          },
-        );
+          expect(objectStore.putUris).toEqual([expectedUri]);
+        });
       });
     });
 

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -69,6 +69,9 @@ function spoolStorageFor(
   return {
     objectStoreFor: () => store,
     resolveDestination: async () => destination,
+    // Existing suites assert the write path, so they run as a deployment that
+    // has provisioned retention. The refusal is covered on its own below.
+    azureRetentionConfirmed: true,
   };
 }
 
@@ -253,6 +256,88 @@ describe("putSpool — given an OTLP id containing a path separator", () => {
 
       await store.deleteSpool({ spoolRef, ...coords });
       expect(objectStore.objects.size).toBe(0);
+    });
+  });
+});
+
+describe("putSpool — given Azure storage whose orphan retention is unconfirmed", () => {
+  describe("when putSpool is called", () => {
+    it("refuses rather than writing an object no lifecycle rule will reap", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: {
+          objectStoreFor: () => objectStore,
+          resolveDestination: async () => AZURE_DESTINATION,
+          // The default for any deployment that has not said otherwise.
+          azureRetentionConfirmed: false,
+        },
+      });
+
+      // Azure can express the lifecycle rule, but the policy is a
+      // management-plane resource and this deployment holds a data-plane key,
+      // so the app cannot read it back to check. Fail closed instead: the
+      // payload rides inline, which is bounded, rather than landing in a
+      // container where nothing reaps it.
+      await expect(
+        store.putSpool({
+          ...spoolCoords,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toBeInstanceOf(SpoolDestinationUnsupportedError);
+      expect(objectStore.put).not.toHaveBeenCalled();
+    });
+
+    it("names the policy to create and the setting to flip", async () => {
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: {
+          objectStoreFor: () => fakeObjectStore(),
+          resolveDestination: async () => AZURE_DESTINATION,
+          azureRetentionConfirmed: false,
+        },
+      });
+
+      // An operator hitting this needs to know what to do, not just that it
+      // refused.
+      await expect(
+        store.putSpool({
+          ...spoolCoords,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toThrow(/trace-blobs\/spool\/.*3 days/s);
+      await expect(
+        store.putSpool({
+          ...spoolCoords,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toThrow(/AZURE_BLOB_SPOOL_RETENTION_CONFIRMED/);
+    });
+  });
+});
+
+describe("putSpool — given S3 storage with retention unconfirmed", () => {
+  describe("when putSpool is called", () => {
+    it("still writes, because the flag scopes to Azure only", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: {
+          objectStoreFor: () => objectStore,
+          resolveDestination: async () => S3_DESTINATION,
+          azureRetentionConfirmed: false,
+        },
+      });
+
+      // S3 deployments predate this gate and their lifecycle rule is the
+      // long-standing ADR-022 requirement; widening the gate to them would be a
+      // silent regression for every existing install.
+      await store.putSpool({
+        ...spoolCoords,
+        body: Buffer.from("payload", "utf-8"),
+      });
+
+      expect(objectStore.put).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -316,6 +316,65 @@ describe("putSpool — given Azure storage whose orphan retention is unconfirmed
   });
 });
 
+describe("given Azure retention was confirmed at write time and is unconfirmed now", () => {
+  /**
+   * Flipping the assertion back off is the documented remediation, and a chart
+   * rollback does it silently. It must not strand the objects already written:
+   * `getSpool` does not fail open and the edge already cleared the attributes,
+   * so a refusal there loses the span outright — and a refusal in `deleteSpool`
+   * skips the eager cleanup, manufacturing the exact orphan the gate exists to
+   * prevent.
+   */
+  function storeAfterFlip(objectStore: ReturnType<typeof fakeObjectStore>) {
+    return new BlobStore({
+      resolveS3Client: forbiddenS3Resolver,
+      spoolStorage: {
+        objectStoreFor: () => objectStore,
+        resolveDestination: async () => AZURE_DESTINATION,
+        azureRetentionConfirmed: false,
+      },
+    });
+  }
+
+  describe("when the worker reads a span spooled before the flip", () => {
+    it("still returns the payload", async () => {
+      const objectStore = fakeObjectStore();
+      const body = Buffer.from("the full oversized payload", "utf-8");
+      const spoolRef = await new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+      }).putSpool({ ...spoolCoords, body });
+
+      expect(
+        await storeAfterFlip(objectStore).getSpool({
+          spoolRef,
+          ...spoolCoords,
+        }),
+      ).toEqual(body);
+    });
+  });
+
+  describe("when the worker deletes a span spooled before the flip", () => {
+    it("still removes the object", async () => {
+      const objectStore = fakeObjectStore();
+      const spoolRef = await new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+      }).putSpool({
+        ...spoolCoords,
+        body: Buffer.from("payload", "utf-8"),
+      });
+
+      await storeAfterFlip(objectStore).deleteSpool({
+        spoolRef,
+        ...spoolCoords,
+      });
+
+      expect(objectStore.objects.size).toBe(0);
+    });
+  });
+});
+
 describe("putSpool — given S3 storage with retention unconfirmed", () => {
   describe("when putSpool is called", () => {
     it("still writes, because the flag scopes to Azure only", async () => {

--- a/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/blob-store.service.unit.test.ts
@@ -130,336 +130,323 @@ const FILE_DESTINATION: ProjectStorageDestination = {
   root: "/var/lib/langwatch/objects",
 };
 
-describe("BlobStore — spool operations (ADR-022)", () => {
-  describe("putSpool", () => {
-    describe("given each supported storage destination", () => {
-      describe("when putSpool is called", () => {
-        it.each([
-          {
-            name: "s3",
-            destination: S3_DESTINATION,
-            expectedUri:
-              "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
-          },
-          {
-            name: "azure",
-            destination: AZURE_DESTINATION,
-            expectedUri:
-              "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
-          },
-          {
-            name: "local filesystem",
-            destination: FILE_DESTINATION,
-            expectedUri:
-              "file:///var/lib/langwatch/objects/trace-blobs/spool/orgA/trace-1/span-1",
-          },
-        ])("writes to the $name destination the deployment resolved", async ({
-          destination,
-          expectedUri,
-        }) => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, destination),
-          });
-
-          await store.putSpool({
-            ...spoolCoords,
-            body: Buffer.from("span payload data", "utf-8"),
-          });
-
-          expect(objectStore.putUris).toEqual([expectedUri]);
-        });
+describe("putSpool — given each supported storage destination", () => {
+  describe("when putSpool is called", () => {
+    it.each([
+      {
+        name: "s3",
+        destination: S3_DESTINATION,
+        expectedUri: "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
+      },
+      {
+        name: "azure",
+        destination: AZURE_DESTINATION,
+        expectedUri:
+          "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
+      },
+      {
+        name: "local filesystem",
+        destination: FILE_DESTINATION,
+        expectedUri:
+          "file:///var/lib/langwatch/objects/trace-blobs/spool/orgA/trace-1/span-1",
+      },
+    ])("writes to the $name destination the deployment resolved", async ({
+      destination,
+      expectedUri,
+    }) => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, destination),
       });
-    });
 
-    describe("given a span payload body", () => {
-      describe("when putSpool is called", () => {
-        it("returns a reference carrying no storage location", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
-          });
-
-          const spoolRef = await store.putSpool({
-            ...spoolCoords,
-            body: Buffer.from("payload", "utf-8"),
-          });
-
-          expect(spoolRef).toBe(SPOOL_REF_V2);
-          expect(spoolRef).not.toContain(spoolCoords.projectId);
-          expect(spoolRef).not.toContain("test-bucket");
-        });
-
-        it("issues exactly ONE write", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-
-          await store.putSpool({
-            ...spoolCoords,
-            body: Buffer.from("payload", "utf-8"),
-          });
-
-          expect(objectStore.put).toHaveBeenCalledTimes(1);
-        });
+      await store.putSpool({
+        ...spoolCoords,
+        body: Buffer.from("span payload data", "utf-8"),
       });
-    });
 
-    describe("given an OTLP id containing a path separator", () => {
-      describe("when putSpool is called", () => {
-        it("keeps the object under the spool prefix", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-
-          // Base64-encoded OTLP ids can contain "/", which unescaped would
-          // inject extra path segments — or, leading, escape the prefix that
-          // the lifecycle rule matches on.
-          await store.putSpool({
-            projectId: "orgA",
-            traceId: "../../etc",
-            spanId: "a/b",
-            body: Buffer.from("payload", "utf-8"),
-          });
-
-          expect(objectStore.putUris[0]).toBe(
-            "s3://test-bucket/trace-blobs/spool/orgA/..%2F..%2Fetc/a%2Fb",
-          );
-        });
-      });
-    });
-
-    describe("given no spool storage is configured", () => {
-      describe("when putSpool is called", () => {
-        it("throws rather than falling back to a hardcoded backend", async () => {
-          const store = new BlobStore({ resolveS3Client: forbiddenS3Resolver });
-
-          await expect(
-            store.putSpool({
-              ...spoolCoords,
-              body: Buffer.from("payload", "utf-8"),
-            }),
-          ).rejects.toThrow(/no spool storage configured/i);
-        });
-      });
+      expect(objectStore.putUris).toEqual([expectedUri]);
     });
   });
+});
 
-  describe("getSpool", () => {
-    describe("given a spool object written by putSpool", () => {
-      describe("when getSpool is called with the command's own coordinates", () => {
-        it("returns the exact bytes that were put", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
-          });
-          const originalBody = Buffer.from("exact span body bytes", "utf-8");
-
-          const spoolRef = await store.putSpool({
-            ...spoolCoords,
-            body: originalBody,
-          });
-          const retrieved = await store.getSpool({ spoolRef, ...spoolCoords });
-
-          expect(retrieved).toEqual(originalBody);
-        });
+describe("putSpool — given a span payload body", () => {
+  describe("when putSpool is called", () => {
+    it("returns a reference carrying no storage location", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
       });
+
+      const spoolRef = await store.putSpool({
+        ...spoolCoords,
+        body: Buffer.from("payload", "utf-8"),
+      });
+
+      expect(spoolRef).toBe(SPOOL_REF_V2);
+      expect(spoolRef).not.toContain(spoolCoords.projectId);
+      expect(spoolRef).not.toContain("test-bucket");
     });
 
-    describe("given a reference naming another tenant's object", () => {
-      describe("when getSpool is called", () => {
-        it("reads the location derived from the command, ignoring the reference", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-          const victimBytes = Buffer.from("another tenant's payload", "utf-8");
-          await store.putSpool({
-            projectId: "victim-org",
-            traceId: "trace-1",
-            spanId: "span-1",
-            body: victimBytes,
-          });
-          const ownBytes = Buffer.from("my own payload", "utf-8");
-          await store.putSpool({ ...spoolCoords, body: ownBytes });
-
-          // A reference that names the victim's object, on a command
-          // authenticated as orgA. The reference must not be honoured.
-          const retrieved = await store.getSpool({
-            spoolRef:
-              "s3://test-bucket/trace-blobs/spool/victim-org/trace-1/span-1",
-            ...spoolCoords,
-          });
-
-          expect(retrieved).toEqual(ownBytes);
-          expect(objectStore.getUris).toEqual([
-            "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
-          ]);
-        });
+    it("issues exactly ONE write", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
       });
-    });
 
-    describe("given a v1-shaped reference naming another tenant", () => {
-      describe("when getSpool is called", () => {
-        it("refuses rather than reading across the tenant boundary", async () => {
-          const fake = fakeS3();
-          const victimKey = "trace-blobs/spool/victim-org/trace-1/span-1";
-          fake.objects.set(
-            `test-bucket/${victimKey}`,
-            Buffer.from("another tenant's payload", "utf-8"),
-          );
-          const store = new BlobStore({
-            resolveS3Client: resolverFor(fake),
-            spoolStorage: spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
-          });
-
-          await expect(
-            store.getSpool({ spoolRef: victimKey, ...spoolCoords }),
-          ).rejects.toThrow(/authenticated as "orgA"/);
-        });
+      await store.putSpool({
+        ...spoolCoords,
+        body: Buffer.from("payload", "utf-8"),
       });
-    });
 
-    describe("given a v1 reference written before this deployment", () => {
-      describe("when getSpool is called", () => {
-        it("still resolves it through the legacy S3 path", async () => {
-          const fake = fakeS3();
-          const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
-          const legacyBytes = Buffer.from("queued before the deploy", "utf-8");
-          fake.objects.set(`test-bucket/${legacyKey}`, legacyBytes);
-
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: resolverFor(fake),
-            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
-          });
-
-          const retrieved = await store.getSpool({
-            spoolRef: legacyKey,
-            ...spoolCoords,
-          });
-
-          expect(retrieved).toEqual(legacyBytes);
-          expect(objectStore.get).not.toHaveBeenCalled();
-        });
-      });
-    });
-
-    describe("given an object larger than the read cap", () => {
-      describe("when getSpool is called", () => {
-        it("rejects instead of buffering it whole", async () => {
-          const objectStore = fakeObjectStore();
-          // Emitted lazily in 1 MB chunks — the cap should trip long before
-          // anything close to MAX_SPOOL_BYTES is actually resident.
-          objectStore.get.mockImplementationOnce(async () =>
-            Readable.from(
-              (function* () {
-                for (
-                  let sent = 0;
-                  sent <= MAX_SPOOL_BYTES;
-                  sent += 1024 * 1024
-                ) {
-                  yield Buffer.alloc(1024 * 1024);
-                }
-              })(),
-            ),
-          );
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-
-          await expect(
-            store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
-          ).rejects.toThrow(StreamTooLargeError);
-        });
-      });
-    });
-
-    describe("given the object is missing", () => {
-      describe("when getSpool is called", () => {
-        it("throws rather than returning an empty span", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-
-          await expect(
-            store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
-          ).rejects.toThrow();
-        });
-      });
+      expect(objectStore.put).toHaveBeenCalledTimes(1);
     });
   });
+});
 
-  describe("deleteSpool", () => {
-    describe("given an existing spool object", () => {
-      describe("when deleteSpool is called", () => {
-        it("deletes the object it wrote", async () => {
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
-          });
-          const spoolRef = await store.putSpool({
-            ...spoolCoords,
-            body: Buffer.from("to be deleted", "utf-8"),
-          });
-
-          await store.deleteSpool({ spoolRef, ...spoolCoords });
-
-          expect(objectStore.deleteUris).toEqual([
-            "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
-          ]);
-          expect(objectStore.objects.size).toBe(0);
-        });
+describe("putSpool — given an OTLP id containing a path separator", () => {
+  describe("when putSpool is called", () => {
+    it("keeps the object under the spool prefix", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
       });
+
+      // Base64-encoded OTLP ids can contain "/", which unescaped would
+      // inject extra path segments — or, leading, escape the prefix that
+      // the lifecycle rule matches on.
+      await store.putSpool({
+        projectId: "orgA",
+        traceId: "../../etc",
+        spanId: "a/b",
+        body: Buffer.from("payload", "utf-8"),
+      });
+
+      expect(objectStore.putUris[0]).toBe(
+        "s3://test-bucket/trace-blobs/spool/orgA/..%2F..%2Fetc/a%2Fb",
+      );
     });
+  });
+});
 
-    describe("given a v1 reference", () => {
-      describe("when deleteSpool is called", () => {
-        it("deletes through the legacy S3 path", async () => {
-          const fake = fakeS3();
-          const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
-          fake.objects.set(`test-bucket/${legacyKey}`, Buffer.from("old"));
-          const objectStore = fakeObjectStore();
-          const store = new BlobStore({
-            resolveS3Client: resolverFor(fake),
-            spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
-          });
+describe("putSpool — given no spool storage is configured", () => {
+  describe("when putSpool is called", () => {
+    it("throws rather than falling back to a hardcoded backend", async () => {
+      const store = new BlobStore({ resolveS3Client: forbiddenS3Resolver });
 
-          await store.deleteSpool({ spoolRef: legacyKey, ...spoolCoords });
-
-          expect(fake.objects.size).toBe(0);
-          expect(objectStore.delete).not.toHaveBeenCalled();
-        });
-      });
+      await expect(
+        store.putSpool({
+          ...spoolCoords,
+          body: Buffer.from("payload", "utf-8"),
+        }),
+      ).rejects.toThrow(/no spool storage configured/i);
     });
+  });
+});
 
-    describe("given the storage backend rejects the delete", () => {
-      describe("when deleteSpool is called", () => {
-        it("does not throw (best-effort — the lifecycle rule is the safety net)", async () => {
-          const objectStore = fakeObjectStore();
-          objectStore.delete.mockRejectedValueOnce(new Error("AccessDenied"));
-          const store = new BlobStore({
-            resolveS3Client: forbiddenS3Resolver,
-            spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
-          });
-
-          await expect(
-            store.deleteSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
-          ).resolves.toBeUndefined();
-        });
+describe("getSpool — given a spool object written by putSpool", () => {
+  describe("when getSpool is called with the command's own coordinates", () => {
+    it("returns the exact bytes that were put", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
       });
+      const originalBody = Buffer.from("exact span body bytes", "utf-8");
+
+      const spoolRef = await store.putSpool({
+        ...spoolCoords,
+        body: originalBody,
+      });
+      const retrieved = await store.getSpool({ spoolRef, ...spoolCoords });
+
+      expect(retrieved).toEqual(originalBody);
+    });
+  });
+});
+
+describe("getSpool — given a reference naming another tenant's object", () => {
+  describe("when getSpool is called", () => {
+    it("reads the location derived from the command, ignoring the reference", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+      });
+      const victimBytes = Buffer.from("another tenant's payload", "utf-8");
+      await store.putSpool({
+        projectId: "victim-org",
+        traceId: "trace-1",
+        spanId: "span-1",
+        body: victimBytes,
+      });
+      const ownBytes = Buffer.from("my own payload", "utf-8");
+      await store.putSpool({ ...spoolCoords, body: ownBytes });
+
+      // A reference that names the victim's object, on a command
+      // authenticated as orgA. The reference must not be honoured.
+      const retrieved = await store.getSpool({
+        spoolRef:
+          "s3://test-bucket/trace-blobs/spool/victim-org/trace-1/span-1",
+        ...spoolCoords,
+      });
+
+      expect(retrieved).toEqual(ownBytes);
+      expect(objectStore.getUris).toEqual([
+        "s3://test-bucket/trace-blobs/spool/orgA/trace-1/span-1",
+      ]);
+    });
+  });
+});
+
+describe("getSpool — given a v1-shaped reference naming another tenant", () => {
+  describe("when getSpool is called", () => {
+    it("refuses rather than reading across the tenant boundary", async () => {
+      const fake = fakeS3();
+      const victimKey = "trace-blobs/spool/victim-org/trace-1/span-1";
+      fake.objects.set(
+        `test-bucket/${victimKey}`,
+        Buffer.from("another tenant's payload", "utf-8"),
+      );
+      const store = new BlobStore({
+        resolveS3Client: resolverFor(fake),
+        spoolStorage: spoolStorageFor(fakeObjectStore(), S3_DESTINATION),
+      });
+
+      await expect(
+        store.getSpool({ spoolRef: victimKey, ...spoolCoords }),
+      ).rejects.toThrow(/authenticated as "orgA"/);
+    });
+  });
+});
+
+describe("getSpool — given a v1 reference written before this deployment", () => {
+  describe("when getSpool is called", () => {
+    it("still resolves it through the legacy S3 path", async () => {
+      const fake = fakeS3();
+      const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
+      const legacyBytes = Buffer.from("queued before the deploy", "utf-8");
+      fake.objects.set(`test-bucket/${legacyKey}`, legacyBytes);
+
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: resolverFor(fake),
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+      });
+
+      const retrieved = await store.getSpool({
+        spoolRef: legacyKey,
+        ...spoolCoords,
+      });
+
+      expect(retrieved).toEqual(legacyBytes);
+      expect(objectStore.get).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("getSpool — given an object larger than the read cap", () => {
+  describe("when getSpool is called", () => {
+    it("rejects instead of buffering it whole", async () => {
+      const objectStore = fakeObjectStore();
+      // Emitted lazily in 1 MB chunks — the cap should trip long before
+      // anything close to MAX_SPOOL_BYTES is actually resident.
+      objectStore.get.mockImplementationOnce(async () =>
+        Readable.from(
+          (function* () {
+            for (let sent = 0; sent <= MAX_SPOOL_BYTES; sent += 1024 * 1024) {
+              yield Buffer.alloc(1024 * 1024);
+            }
+          })(),
+        ),
+      );
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+      });
+
+      await expect(
+        store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+      ).rejects.toThrow(StreamTooLargeError);
+    });
+  });
+});
+
+describe("getSpool — given the object is missing", () => {
+  describe("when getSpool is called", () => {
+    it("throws rather than returning an empty span", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+      });
+
+      await expect(
+        store.getSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+      ).rejects.toThrow();
+    });
+  });
+});
+
+describe("deleteSpool — given an existing spool object", () => {
+  describe("when deleteSpool is called", () => {
+    it("deletes the object it wrote", async () => {
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+      });
+      const spoolRef = await store.putSpool({
+        ...spoolCoords,
+        body: Buffer.from("to be deleted", "utf-8"),
+      });
+
+      await store.deleteSpool({ spoolRef, ...spoolCoords });
+
+      expect(objectStore.deleteUris).toEqual([
+        "azure-blob://acct/cont/trace-blobs/spool/orgA/trace-1/span-1",
+      ]);
+      expect(objectStore.objects.size).toBe(0);
+    });
+  });
+});
+
+describe("deleteSpool — given a v1 reference", () => {
+  describe("when deleteSpool is called", () => {
+    it("deletes through the legacy S3 path", async () => {
+      const fake = fakeS3();
+      const legacyKey = "trace-blobs/spool/orgA/trace-1/span-1";
+      fake.objects.set(`test-bucket/${legacyKey}`, Buffer.from("old"));
+      const objectStore = fakeObjectStore();
+      const store = new BlobStore({
+        resolveS3Client: resolverFor(fake),
+        spoolStorage: spoolStorageFor(objectStore, AZURE_DESTINATION),
+      });
+
+      await store.deleteSpool({ spoolRef: legacyKey, ...spoolCoords });
+
+      expect(fake.objects.size).toBe(0);
+      expect(objectStore.delete).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("deleteSpool — given the storage backend rejects the delete", () => {
+  describe("when deleteSpool is called", () => {
+    it("does not throw (best-effort — the lifecycle rule is the safety net)", async () => {
+      const objectStore = fakeObjectStore();
+      objectStore.delete.mockRejectedValueOnce(new Error("AccessDenied"));
+      const store = new BlobStore({
+        resolveS3Client: forbiddenS3Resolver,
+        spoolStorage: spoolStorageFor(objectStore, S3_DESTINATION),
+      });
+
+      await expect(
+        store.deleteSpool({ spoolRef: SPOOL_REF_V2, ...spoolCoords }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
@@ -238,14 +238,19 @@ describe("recordSpan append coalescing", () => {
     describe("when the batch is stored", () => {
       it("deletes each span's spool once, after the single append", async () => {
         const order: string[] = [];
-        const deleteSpool = vi.fn(async (ref: string) => {
-          order.push(`delete:${ref}`);
-        });
+        const deleteSpool = vi.fn(
+          async ({ spoolRef }: { spoolRef: string }) => {
+            order.push(`delete:${spoolRef}`);
+          },
+        );
         const blobStore = {
-          getSpool: async (ref: string) =>
+          // The spool locates its object from the command's own trusted
+          // tenant + span ids, so the stub takes the same named shape and
+          // reads `spanId` directly rather than slicing it out of the ref.
+          getSpool: async ({ spanId: id }: { spanId: string }) =>
             Buffer.from(
               JSON.stringify({
-                span: spanPayload({ spanId: ref.slice(-16) }).span,
+                span: spanPayload({ spanId: id }).span,
                 resource: null,
                 instrumentationScope: null,
               }),
@@ -285,8 +290,8 @@ describe("recordSpan append coalescing", () => {
       it("appends nothing and drops no spool, leaving the batch retryable", async () => {
         const deleteSpool = vi.fn().mockResolvedValue(undefined);
         const blobStore = {
-          getSpool: vi.fn(async (ref: string) => {
-            if (ref.endsWith(spanId(1))) {
+          getSpool: vi.fn(async ({ spoolRef }: { spoolRef: string }) => {
+            if (spoolRef.endsWith(spanId(1))) {
               throw new Error("spool fetch failed");
             }
             return Buffer.from(

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
@@ -22,6 +22,7 @@ import {
   RecordSpanCommand,
   type RecordSpanCommandDependencies,
 } from "../recordSpanCommand";
+import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -169,10 +170,18 @@ describe("given a RecordSpanCommand that carries a spoolRef (oversized path)", (
         (blobStore as unknown as { getSpool: ReturnType<typeof vi.fn> })
           .getSpool,
       ).toHaveBeenCalledOnce();
+      // The location is derived from the command's own authenticated tenant and
+      // span ids — the ref is passed through only so the legacy format can be
+      // recognised (langwatch/langwatch-saas#800).
       expect(
         (blobStore as unknown as { getSpool: ReturnType<typeof vi.fn> })
           .getSpool,
-      ).toHaveBeenCalledWith(SPOOL_REF);
+      ).toHaveBeenCalledWith({
+        spoolRef: SPOOL_REF,
+        projectId: TENANT_ID,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+      });
 
       // Reconstituted span flows through — event data carries the full attributes
       expect(events).toHaveLength(1);
@@ -232,7 +241,12 @@ describe("given a RecordSpanCommand that carries a spoolRef (oversized path)", (
 
       // deleteSpool is called once with the spool ref
       expect(deleteSpoolMock).toHaveBeenCalledOnce();
-      expect(deleteSpoolMock).toHaveBeenCalledWith(SPOOL_REF);
+      expect(deleteSpoolMock).toHaveBeenCalledWith({
+        spoolRef: SPOOL_REF,
+        projectId: TENANT_ID,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+      });
     });
 
     it("does NOT call BlobStore.deleteSpool when storeEvents throws (handle() succeeded but INSERT failed)", async () => {
@@ -494,12 +508,14 @@ describe("given a shared RecordSpanCommand instance processing two concurrent tr
     it("deletes each job's own spoolRef — not the other job's ref — pinning the race fix", async () => {
       const deleteSpoolMock = vi.fn().mockResolvedValue(undefined);
       const blobStore = {
-        getSpool: vi.fn().mockImplementation(async (ref: string) => {
-          if (ref === SPOOL_REF_A) {
-            return Buffer.from(makeSpoolBody(TRACE_ID_A, SPAN_ID_A), "utf-8");
-          }
-          return Buffer.from(makeSpoolBody(TRACE_ID_B, SPAN_ID_B), "utf-8");
-        }),
+        getSpool: vi
+          .fn()
+          .mockImplementation(async ({ traceId }: { traceId: string }) => {
+            if (traceId === TRACE_ID_A) {
+              return Buffer.from(makeSpoolBody(TRACE_ID_A, SPAN_ID_A), "utf-8");
+            }
+            return Buffer.from(makeSpoolBody(TRACE_ID_B, SPAN_ID_B), "utf-8");
+          }),
         deleteSpool: deleteSpoolMock,
       } as unknown as BlobStore;
 
@@ -527,11 +543,22 @@ describe("given a shared RecordSpanCommand instance processing two concurrent tr
       // Exactly two deletions — one per job, in order of cleanupAfterStore calls
       expect(deleteSpoolMock).toHaveBeenCalledTimes(2);
 
-      // First cleanup must target cmdA's spool — NOT cmdB's
-      expect(deleteSpoolMock).toHaveBeenNthCalledWith(1, SPOOL_REF_A);
+      // Each cleanup must target its OWN job's span coordinates — those, not the
+      // reference, are what now locate the object (langwatch/langwatch-saas#800),
+      // so they are what pins the race fix.
+      expect(deleteSpoolMock).toHaveBeenNthCalledWith(1, {
+        spoolRef: SPOOL_REF_A,
+        projectId: TENANT_ID,
+        traceId: TRACE_ID_A,
+        spanId: SPAN_ID_A,
+      });
 
-      // Second cleanup must target cmdB's spool — NOT cmdA's
-      expect(deleteSpoolMock).toHaveBeenNthCalledWith(2, SPOOL_REF_B);
+      expect(deleteSpoolMock).toHaveBeenNthCalledWith(2, {
+        spoolRef: SPOOL_REF_B,
+        projectId: TENANT_ID,
+        traceId: TRACE_ID_B,
+        spanId: SPAN_ID_B,
+      });
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
@@ -22,7 +22,6 @@ import {
   RecordSpanCommand,
   type RecordSpanCommandDependencies,
 } from "../recordSpanCommand";
-import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -204,7 +204,15 @@ export class RecordSpanCommand
 
         let resolvedCommandData = commandData;
         if (commandData.spoolRef && this.blobStore) {
-          const spoolBody = await this.blobStore.getSpool(commandData.spoolRef);
+          // The spool location is re-derived from the command's own
+          // authenticated tenantId and span ids — never from spoolRef, which is
+          // just a format marker. See BlobStore.getSpool / SPOOL_REF_V2.
+          const spoolBody = await this.blobStore.getSpool({
+            spoolRef: commandData.spoolRef,
+            projectId: tenantIdStr,
+            traceId: commandData.span.traceId as string,
+            spanId: commandData.span.spanId as string,
+          });
           // ADR-022: spool body is the full serialized RecordSpanCommandData.
           // Merge the spooled span/resource/instrumentationScope fields back into
           // the in-flight command (the queue message carries only spoolRef + id fields).
@@ -399,7 +407,14 @@ export class RecordSpanCommand
   ): Promise<void> {
     const spoolRef = command.data.spoolRef;
     if (spoolRef && this.blobStore) {
-      await this.blobStore.deleteSpool(spoolRef).catch((err: unknown) => {
+      await this.blobStore
+        .deleteSpool({
+          spoolRef,
+          projectId: command.tenantId,
+          traceId: command.data.span.traceId as string,
+          spanId: command.data.span.spanId as string,
+        })
+        .catch((err: unknown) => {
         this.logger.warn(
           { spoolRef, error: err instanceof Error ? err.message : String(err) },
           "Best-effort spool deletion failed — lifecycle policy will clean up",

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -210,8 +210,8 @@ export class RecordSpanCommand
           const spoolBody = await this.blobStore.getSpool({
             spoolRef: commandData.spoolRef,
             projectId: tenantIdStr,
-            traceId: commandData.span.traceId as string,
-            spanId: commandData.span.spanId as string,
+            traceId: commandData.span.traceId,
+            spanId: commandData.span.spanId,
           });
           // ADR-022: spool body is the full serialized RecordSpanCommandData.
           // Merge the spooled span/resource/instrumentationScope fields back into
@@ -395,8 +395,8 @@ export class RecordSpanCommand
    * ADR-022: Best-effort spool deletion, invoked by processCommand() AFTER
    * storeEventsFn (event_log INSERT) commits. This ordering ensures the spool
    * is only deleted once the event is durable — if the INSERT fails the spool
-   * survives so the command can be retried. The 24h S3 lifecycle policy is the
-   * safety net for orphans if this call itself fails.
+   * survives so the command can be retried. The 3-day lifecycle rule on the
+   * spool prefix is the safety net for orphans if this call itself fails.
    *
    * The spoolRef is read from the original command argument rather than instance
    * state, eliminating the race bug that arose when a single handler instance was
@@ -411,8 +411,8 @@ export class RecordSpanCommand
         .deleteSpool({
           spoolRef,
           projectId: command.tenantId,
-          traceId: command.data.span.traceId as string,
-          spanId: command.data.span.spanId as string,
+          traceId: command.data.span.traceId,
+          spanId: command.data.span.spanId,
         })
         .catch((err: unknown) => {
         this.logger.warn(

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -415,11 +415,14 @@ export class RecordSpanCommand
           spanId: command.data.span.spanId,
         })
         .catch((err: unknown) => {
-        this.logger.warn(
-          { spoolRef, error: err instanceof Error ? err.message : String(err) },
-          "Best-effort spool deletion failed — lifecycle policy will clean up",
-        );
-      });
+          this.logger.warn(
+            {
+              spoolRef,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            "Best-effort spool deletion failed — lifecycle policy will clean up",
+          );
+        });
     }
   }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -6,11 +6,7 @@ import type { Logger } from "@langwatch/observability";
 import { COMMAND_INLINE_THRESHOLD } from "~/server/app-layer/traces/lean-for-projection";
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
-import {
-  mintAzureBlobUri,
-  mintFileUri,
-  mintS3Uri,
-} from "~/server/stored-objects/uri";
+import { mintUriForDestination } from "~/server/stored-objects/uri";
 
 import { BLOB_BACKSTOP_TTL_SECONDS, MAX_BLOB_BYTES } from "./blobConstants";
 import { blobNamespaceId } from "./blobKeys";
@@ -224,29 +220,10 @@ export class TieredBlobStore {
     hash: string;
   }): Promise<string> {
     const destination = await this.resolveDestinationCached(projectId);
-    switch (destination.kind) {
-      case "s3":
-        return mintS3Uri({
-          bucket: destination.bucket,
-          projectId,
-          sha256: hash,
-        });
-      case "file":
-        return mintFileUri({ root: destination.root, projectId, sha256: hash });
-      case "azure":
-        return mintAzureBlobUri({
-          accountName: destination.accountName,
-          container: destination.container,
-          projectId,
-          sha256: hash,
-        });
-      default: {
-        const unhandled: never = destination;
-        throw new Error(
-          `Unhandled storage destination kind: ${JSON.stringify(unhandled)}`,
-        );
-      }
-    }
+    return mintUriForDestination({
+      destination,
+      objectPath: `${projectId}/${hash}`,
+    });
   }
 
   async put({

--- a/platform/app/src/server/stored-objects/__tests__/local-filesystem-driver.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/local-filesystem-driver.unit.test.ts
@@ -248,3 +248,36 @@ describe("when delete is called and the file does not exist", () => {
     await expect(driver.delete(uri)).resolves.toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// containment
+// ---------------------------------------------------------------------------
+
+describe("given a URI whose encoded segment decodes into path separators", () => {
+  // `new URL()` leaves `%2F` encoded, so this URI looks like a single path
+  // segment right up until `decodeURIComponent` turns it back into `../../`.
+  // A caller that percent-encoded its segments is therefore NOT protected by
+  // having done so — this is the backstop that catches it.
+  const escaping = `file://${tmpDir}/proj/${encodeURIComponent("../../../../etc/evil")}/obj`;
+
+  it("refuses to read, write or delete outside the path it names", async () => {
+    await expect(
+      driver.put(escaping, Buffer.from("owned"), "text/plain"),
+    ).rejects.toThrow(/single component/i);
+    await expect(driver.get(escaping)).rejects.toThrow(/single component/i);
+    await expect(driver.delete(escaping)).rejects.toThrow(/single component/i);
+    await expect(driver.exists(escaping)).rejects.toThrow(/single component/i);
+  });
+
+  it("leaves nothing behind at the escaped location", async () => {
+    const escaped = path.resolve(
+      decodeURIComponent(new URL(escaping).pathname),
+    );
+
+    await driver.put(escaping, Buffer.from("owned"), "text/plain").catch(() => {
+      // expected — the assertion is that the refusal wrote nothing
+    });
+
+    await expect(fs.access(escaped)).rejects.toThrow();
+  });
+});

--- a/platform/app/src/server/stored-objects/__tests__/local-filesystem-driver.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/local-filesystem-driver.unit.test.ts
@@ -281,3 +281,28 @@ describe("given a URI whose encoded segment decodes into path separators", () =>
     await expect(fs.access(escaped)).rejects.toThrow();
   });
 });
+
+describe("given a storage root configured with a trailing slash", () => {
+  // `LANGWATCH_LOCAL_STORAGE_PATH` and the chart's
+  // `app.storedObjects.localFilesystem.path` both accept one, so the minted URI
+  // carries a doubled separator. That is not a traversal, and refusing it would
+  // break every local-filesystem write on those installs — datasets and
+  // scenario media included, none of which this containment check is about.
+  it("stores and reads back through the collapsed path", async () => {
+    const uri = mintFileUri({
+      root: `${tmpDir}/`,
+      projectId: "proj-1",
+      sha256: "abc123",
+    });
+    expect(uri).toContain("//proj-1/");
+
+    await driver.put(uri, Buffer.from("payload"), "application/octet-stream");
+
+    expect(await streamToBuffer(await driver.get(uri))).toEqual(
+      Buffer.from("payload"),
+    );
+    await expect(
+      fs.access(path.join(tmpDir, "proj-1", "abc123")),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/platform/app/src/server/stored-objects/local-filesystem-driver.ts
+++ b/platform/app/src/server/stored-objects/local-filesystem-driver.ts
@@ -46,7 +46,28 @@ function parseFileUri(uri: string): string {
     );
   }
   const parsed = new URL(uri);
-  return decodeURIComponent(parsed.pathname);
+  const decoded = decodeURIComponent(parsed.pathname);
+
+  // Containment check, deliberately AFTER the decode.
+  //
+  // `new URL()` leaves `%2F` encoded, so a URI can look confined and stop being
+  // confined one line later: `…/spool/proj/..%2F..%2Fetc/span` has a single
+  // path segment as far as the URL parser is concerned, and becomes
+  // `…/spool/proj/../../etc/span` the moment it is decoded — which is what
+  // `mkdir`/`writeFile` would then act on. A caller that percent-encodes its
+  // segments is therefore NOT protected by having done so.
+  //
+  // Callers should still keep each segment a single component; this is the
+  // backstop that makes a mistake there fail loudly instead of writing outside
+  // the object root.
+  const resolved = path.resolve(decoded);
+  if (resolved !== decoded) {
+    throw new Error(
+      `LocalFilesystemDriver refuses a file: URI whose decoded path is not already canonical — ` +
+        `it resolves outside the location it names. Keep every path segment a single component.`,
+    );
+  }
+  return resolved;
 }
 
 /**

--- a/platform/app/src/server/stored-objects/local-filesystem-driver.ts
+++ b/platform/app/src/server/stored-objects/local-filesystem-driver.ts
@@ -60,14 +60,24 @@ function parseFileUri(uri: string): string {
   // Callers should still keep each segment a single component; this is the
   // backstop that makes a mistake there fail loudly instead of writing outside
   // the object root.
-  const resolved = path.resolve(decoded);
-  if (resolved !== decoded) {
+  //
+  // The check is on `..` segments specifically, NOT on "is the decoded path
+  // already canonical". Those are not the same test, and the stricter one is
+  // wrong: a storage root configured with a trailing slash — which
+  // `LANGWATCH_LOCAL_STORAGE_PATH` and the chart's
+  // `app.storedObjects.localFilesystem.path` both accept — mints
+  // `file:///root//project/object`, whose decoded form is non-canonical and
+  // completely harmless. Refusing it would break every local-filesystem write
+  // (dataset uploads, scenario media, the queue's durable blob tier) on those
+  // installs, none of which is what this guard is here for. A redundant
+  // separator is sloppy; only `..` escapes.
+  if (decoded.split("/").includes("..")) {
     throw new Error(
-      `LocalFilesystemDriver refuses a file: URI whose decoded path is not already canonical — ` +
+      `LocalFilesystemDriver refuses a file: URI whose decoded path contains a ".." segment — ` +
         `it resolves outside the location it names. Keep every path segment a single component.`,
     );
   }
-  return resolved;
+  return path.resolve(decoded);
 }
 
 /**

--- a/platform/app/src/server/stored-objects/stored-objects.service.ts
+++ b/platform/app/src/server/stored-objects/stored-objects.service.ts
@@ -25,7 +25,7 @@ import {
 import type { StorageRegistry } from "./storage-registry";
 import type { StoredObject } from "./stored-object";
 import type { StoredObjectsRepository } from "./stored-objects.repository";
-import { mintAzureBlobUri, mintFileUri, mintS3Uri } from "./uri";
+import { mintUriForDestination } from "./uri";
 
 const tracer = getLangWatchTracer("langwatch.stored-objects.service");
 const logger = createLogger("langwatch:stored-objects:service");
@@ -84,18 +84,10 @@ export async function defaultMintStorageUri({
   sha256: string;
 }): Promise<string> {
   const destination = await resolveProjectStorageDestination(projectId);
-  if (destination.kind === "s3") {
-    return mintS3Uri({ bucket: destination.bucket, projectId, sha256 });
-  }
-  if (destination.kind === "azure") {
-    return mintAzureBlobUri({
-      accountName: destination.accountName,
-      container: destination.container,
-      projectId,
-      sha256,
-    });
-  }
-  return mintFileUri({ root: destination.root, projectId, sha256 });
+  return mintUriForDestination({
+    destination,
+    objectPath: `${projectId}/${sha256}`,
+  });
 }
 
 /**

--- a/platform/app/src/server/stored-objects/uri.ts
+++ b/platform/app/src/server/stored-objects/uri.ts
@@ -1,5 +1,5 @@
 /**
- * Content-addressed URI helpers for stored objects.
+ * URI helpers for stored objects.
  *
  * Supported schemes:
  *   s3://         — objects stored in an S3-compatible bucket
@@ -7,8 +7,57 @@
  *   azure-blob:// — objects stored in an Azure Blob Storage container
  */
 
+import type { ProjectStorageDestination } from "./project-storage-destination";
+
 export const SUPPORTED_SCHEMES = ["s3", "file", "azure-blob"] as const;
 export type UriScheme = (typeof SUPPORTED_SCHEMES)[number];
+
+/**
+ * Mints the URI for `objectPath` at whichever backend `destination` names.
+ *
+ * `objectPath` is the COMPLETE path below the container/bucket/root — the
+ * caller owns its whole shape, including any tenant segment. That is
+ * deliberate: content-addressed callers want `{projectId}/{sha256}`, while the
+ * ADR-022 trace spool wants a stable top-level `trace-blobs/spool/…` prefix so
+ * a bucket lifecycle rule can match it (an S3 lifecycle prefix filter cannot
+ * wildcard a leading tenant segment). Pinning the layout here would have forced
+ * one of them to move.
+ *
+ * This is the single source of truth for the destination → URI mapping. It
+ * previously existed as three separate switch statements (content-addressed
+ * stored objects, the GroupQueue durable blob tier, and — missing entirely —
+ * the trace spool); a new backend had to be added to each, and the spool's
+ * absence from the list is exactly how it ended up hardcoded to S3
+ * (langwatch/langwatch-saas#800).
+ */
+export function mintUriForDestination({
+  destination,
+  objectPath,
+}: {
+  destination: ProjectStorageDestination;
+  objectPath: string;
+}): string {
+  switch (destination.kind) {
+    case "s3":
+      return `s3://${destination.bucket}/${objectPath}`;
+    case "file": {
+      // Normalised so a root configured without a leading slash still produces
+      // an absolute `file:///…` URI rather than a relative one.
+      const normalizedRoot = destination.root.startsWith("/")
+        ? destination.root
+        : `/${destination.root}`;
+      return `file://${normalizedRoot}/${objectPath}`;
+    }
+    case "azure":
+      return `azure-blob://${destination.accountName}/${destination.container}/${objectPath}`;
+    default: {
+      const unhandled: never = destination;
+      throw new Error(
+        `Unhandled storage destination kind: ${JSON.stringify(unhandled)}`,
+      );
+    }
+  }
+}
 
 /**
  * Mints an S3 content-addressed URI.
@@ -24,7 +73,10 @@ export function mintS3Uri({
   projectId: string;
   sha256: string;
 }): string {
-  return `s3://${bucket}/${projectId}/${sha256}`;
+  return mintUriForDestination({
+    destination: { kind: "s3", bucket },
+    objectPath: `${projectId}/${sha256}`,
+  });
 }
 
 /**
@@ -43,8 +95,10 @@ export function mintFileUri({
   projectId: string;
   sha256: string;
 }): string {
-  const normalizedRoot = root.startsWith("/") ? root : `/${root}`;
-  return `file://${normalizedRoot}/${projectId}/${sha256}`;
+  return mintUriForDestination({
+    destination: { kind: "file", root },
+    objectPath: `${projectId}/${sha256}`,
+  });
 }
 
 /**
@@ -68,7 +122,10 @@ export function mintAzureBlobUri({
   projectId: string;
   sha256: string;
 }): string {
-  return `azure-blob://${accountName}/${container}/${projectId}/${sha256}`;
+  return mintUriForDestination({
+    destination: { kind: "azure", accountName, container },
+    objectPath: `${projectId}/${sha256}`,
+  });
 }
 
 /**

--- a/platform/app/src/server/traces/trace-blob-resolution.deps.ts
+++ b/platform/app/src/server/traces/trace-blob-resolution.deps.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@langwatch/observability";
 import { getApp } from "~/server/app-layer/app";
+import type { SpoolStorage } from "~/server/app-layer/traces/blob-store.service";
 import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import {
@@ -7,9 +8,8 @@ import {
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
 import { createS3Client } from "~/server/storage";
-import type { SpoolStorage } from "~/server/app-layer/traces/blob-store.service";
-import { createStorageRegistry } from "~/server/stored-objects/stored-objects-factory";
 import { resolveProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import { createStorageRegistry } from "~/server/stored-objects/stored-objects-factory";
 import type { BlobResolutionDeps } from "./trace.service";
 
 /**

--- a/platform/app/src/server/traces/trace-blob-resolution.deps.ts
+++ b/platform/app/src/server/traces/trace-blob-resolution.deps.ts
@@ -6,7 +6,21 @@ import {
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
 import { createS3Client } from "~/server/storage";
+import type { SpoolStorage } from "~/server/app-layer/traces/blob-store.service";
+import { createStorageRegistry } from "~/server/stored-objects/stored-objects-factory";
+import { resolveProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 import type { BlobResolutionDeps } from "./trace.service";
+
+/**
+ * Production spool storage: the same `stored-objects` registry and destination
+ * resolver every other byte-writing surface uses, so the trace spool honours a
+ * deployment's Azure / S3 / local-filesystem choice instead of assuming S3
+ * (langwatch/langwatch-saas#800).
+ */
+const defaultSpoolStorage: SpoolStorage = {
+  objectStoreFor: (projectId: string) => createStorageRegistry({ projectId }),
+  resolveDestination: resolveProjectStorageDestination,
+};
 
 /**
  * Builds the ADR-022 blob-resolution dependencies ({@link BlobResolutionDeps})
@@ -59,6 +73,7 @@ export function buildTraceBlobResolutionDeps(overrides?: {
     blobStore: new BlobStore(
       createS3Client,
       clickhouseEnabled ? resolveClickHouseClient : undefined,
+      defaultSpoolStorage,
     ),
     ioExtractionService: new TraceIOExtractionService(),
   };

--- a/platform/app/src/server/traces/trace-blob-resolution.deps.ts
+++ b/platform/app/src/server/traces/trace-blob-resolution.deps.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@langwatch/observability";
+import { env } from "~/env.mjs";
 import { getApp } from "~/server/app-layer/app";
 import type { SpoolStorage } from "~/server/app-layer/traces/blob-store.service";
 import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
@@ -21,6 +22,11 @@ import type { BlobResolutionDeps } from "./trace.service";
 const defaultSpoolStorage: SpoolStorage = {
   objectStoreFor: (projectId: string) => createStorageRegistry({ projectId }),
   resolveDestination: resolveProjectStorageDestination,
+  // The env read lives here, at the composition root, so `BlobStore` stays
+  // env-free and testable. Default false: the spool stays off on Azure until an
+  // operator states the lifecycle rule exists, because nothing else bounds an
+  // orphan left by a crash between the write and its delete.
+  azureRetentionConfirmed: env.AZURE_BLOB_SPOOL_RETENTION_CONFIRMED ?? false,
 };
 
 /**

--- a/platform/app/src/server/traces/trace-blob-resolution.deps.ts
+++ b/platform/app/src/server/traces/trace-blob-resolution.deps.ts
@@ -1,3 +1,4 @@
+import { createLogger } from "@langwatch/observability";
 import { getApp } from "~/server/app-layer/app";
 import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
@@ -31,7 +32,7 @@ const defaultSpoolStorage: SpoolStorage = {
  * inside `initializeWebApp` (worker-only import). So the customer detail
  * procedures can't reach the app-layer deps. This factory is the single
  * source of truth for constructing those deps; `presets.ts` consumes it too
- * (passing its own composition-root values) so the `new BlobStore(...)` +
+ * (passing its own composition-root values) so the `new BlobStore({ … })` +
  * `new TraceIOExtractionService()` shape is defined in exactly one place.
  *
  * Construction does NO network I/O: `BlobStore` only stores the resolver
@@ -70,11 +71,14 @@ export function buildTraceBlobResolutionDeps(overrides?: {
     overrides?.clickhouseEnabled ?? defaultClickHouseEnabled();
 
   return {
-    blobStore: new BlobStore(
-      createS3Client,
-      clickhouseEnabled ? resolveClickHouseClient : undefined,
-      defaultSpoolStorage,
-    ),
+    blobStore: new BlobStore({
+      resolveS3Client: createS3Client,
+      resolveClickHouseClient: clickhouseEnabled
+        ? resolveClickHouseClient
+        : undefined,
+      spoolStorage: defaultSpoolStorage,
+      logger: createLogger("langwatch:traces:blob-store"),
+    }),
     ioExtractionService: new TraceIOExtractionService(),
   };
 }

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-	{
-		"id": "agent-best-practices",
-		"label": "Agent best practices",
-		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-		"category": "recipe",
-		"userPrompt": "Where can I improve our agent development best practices?"
-	},
-	{
-		"id": "agent-improve",
-		"label": "Agent improve",
-		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-		"category": "skill",
-		"userPrompt": "What should I do next to improve my agent?"
-	},
-	{
-		"id": "agent-performance",
-		"label": "Agent performance",
-		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-		"category": "skill",
-		"userPrompt": "How is my agent performing?"
-	},
-	{
-		"id": "datasets",
-		"label": "Datasets",
-		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-		"category": "skill"
-	},
-	{
-		"id": "debug-instrumentation",
-		"label": "Debug instrumentation",
-		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-		"category": "recipe"
-	},
-	{
-		"id": "debug-with-langwatch",
-		"label": "Debug with langwatch",
-		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-		"category": "recipe"
-	},
-	{
-		"id": "eval-triage",
-		"label": "Eval triage",
-		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluate-multimodal",
-		"label": "Evaluate multimodal",
-		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluations",
-		"label": "Evaluations",
-		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-		"category": "skill",
-		"userPrompt": "Help me evaluate my agent"
-	},
-	{
-		"id": "experiments",
-		"label": "Experiments",
-		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-		"category": "skill",
-		"userPrompt": "Set up experiments for my agent"
-	},
-	{
-		"id": "generate-rag-dataset",
-		"label": "Generate RAG dataset",
-		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-		"category": "recipe"
-	},
-	{
-		"id": "github",
-		"label": "GitHub",
-		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-		"category": "skill"
-	},
-	{
-		"id": "level-up",
-		"label": "Level up",
-		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-		"category": "skill",
-		"userPrompt": "Take my agent to the next level"
-	},
-	{
-		"id": "online-evaluations",
-		"label": "Online evaluations",
-		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-		"category": "skill",
-		"userPrompt": "Set up online evaluations for my agent"
-	},
-	{
-		"id": "prompts",
-		"label": "Prompts",
-		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-		"category": "skill",
-		"userPrompt": "Version my prompts with LangWatch"
-	},
-	{
-		"id": "scenarios",
-		"label": "Scenarios",
-		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-		"category": "skill",
-		"userPrompt": "Add scenario tests for my agent"
-	},
-	{
-		"id": "setup-lw",
-		"label": "Setup lw",
-		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-cli-usability",
-		"label": "Test CLI usability",
-		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-compliance",
-		"label": "Test compliance",
-		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-		"category": "recipe"
-	},
-	{
-		"id": "tracing",
-		"label": "Tracing",
-		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-		"category": "skill",
-		"userPrompt": "Instrument my code with LangWatch"
-	}
+  {
+    "id": "agent-best-practices",
+    "label": "Agent best practices",
+    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+    "category": "recipe",
+    "userPrompt": "Where can I improve our agent development best practices?"
+  },
+  {
+    "id": "agent-improve",
+    "label": "Agent improve",
+    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+    "category": "skill",
+    "userPrompt": "What should I do next to improve my agent?"
+  },
+  {
+    "id": "agent-performance",
+    "label": "Agent performance",
+    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+    "category": "skill",
+    "userPrompt": "How is my agent performing?"
+  },
+  {
+    "id": "datasets",
+    "label": "Datasets",
+    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+    "category": "skill"
+  },
+  {
+    "id": "debug-instrumentation",
+    "label": "Debug instrumentation",
+    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+    "category": "recipe"
+  },
+  {
+    "id": "debug-with-langwatch",
+    "label": "Debug with langwatch",
+    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+    "category": "recipe"
+  },
+  {
+    "id": "eval-triage",
+    "label": "Eval triage",
+    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluate-multimodal",
+    "label": "Evaluate multimodal",
+    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluations",
+    "label": "Evaluations",
+    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+    "category": "skill",
+    "userPrompt": "Help me evaluate my agent"
+  },
+  {
+    "id": "experiments",
+    "label": "Experiments",
+    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+    "category": "skill",
+    "userPrompt": "Set up experiments for my agent"
+  },
+  {
+    "id": "generate-rag-dataset",
+    "label": "Generate RAG dataset",
+    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+    "category": "recipe"
+  },
+  {
+    "id": "github",
+    "label": "GitHub",
+    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+    "category": "skill"
+  },
+  {
+    "id": "level-up",
+    "label": "Level up",
+    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+    "category": "skill",
+    "userPrompt": "Take my agent to the next level"
+  },
+  {
+    "id": "online-evaluations",
+    "label": "Online evaluations",
+    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+    "category": "skill",
+    "userPrompt": "Set up online evaluations for my agent"
+  },
+  {
+    "id": "prompts",
+    "label": "Prompts",
+    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+    "category": "skill",
+    "userPrompt": "Version my prompts with LangWatch"
+  },
+  {
+    "id": "scenarios",
+    "label": "Scenarios",
+    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+    "category": "skill",
+    "userPrompt": "Add scenario tests for my agent"
+  },
+  {
+    "id": "setup-lw",
+    "label": "Setup lw",
+    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-cli-usability",
+    "label": "Test CLI usability",
+    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-compliance",
+    "label": "Test compliance",
+    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+    "category": "recipe"
+  },
+  {
+    "id": "tracing",
+    "label": "Tracing",
+    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+    "category": "skill",
+    "userPrompt": "Instrument my code with LangWatch"
+  }
 ]

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-  {
-    "id": "agent-best-practices",
-    "label": "Agent best practices",
-    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-    "category": "recipe",
-    "userPrompt": "Where can I improve our agent development best practices?"
-  },
-  {
-    "id": "agent-improve",
-    "label": "Agent improve",
-    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-    "category": "skill",
-    "userPrompt": "What should I do next to improve my agent?"
-  },
-  {
-    "id": "agent-performance",
-    "label": "Agent performance",
-    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-    "category": "skill",
-    "userPrompt": "How is my agent performing?"
-  },
-  {
-    "id": "datasets",
-    "label": "Datasets",
-    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-    "category": "skill"
-  },
-  {
-    "id": "debug-instrumentation",
-    "label": "Debug instrumentation",
-    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-    "category": "recipe"
-  },
-  {
-    "id": "debug-with-langwatch",
-    "label": "Debug with langwatch",
-    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-    "category": "recipe"
-  },
-  {
-    "id": "eval-triage",
-    "label": "Eval triage",
-    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluate-multimodal",
-    "label": "Evaluate multimodal",
-    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluations",
-    "label": "Evaluations",
-    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-    "category": "skill",
-    "userPrompt": "Help me evaluate my agent"
-  },
-  {
-    "id": "experiments",
-    "label": "Experiments",
-    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-    "category": "skill",
-    "userPrompt": "Set up experiments for my agent"
-  },
-  {
-    "id": "generate-rag-dataset",
-    "label": "Generate RAG dataset",
-    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-    "category": "recipe"
-  },
-  {
-    "id": "github",
-    "label": "GitHub",
-    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-    "category": "skill"
-  },
-  {
-    "id": "level-up",
-    "label": "Level up",
-    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-    "category": "skill",
-    "userPrompt": "Take my agent to the next level"
-  },
-  {
-    "id": "online-evaluations",
-    "label": "Online evaluations",
-    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-    "category": "skill",
-    "userPrompt": "Set up online evaluations for my agent"
-  },
-  {
-    "id": "prompts",
-    "label": "Prompts",
-    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-    "category": "skill",
-    "userPrompt": "Version my prompts with LangWatch"
-  },
-  {
-    "id": "scenarios",
-    "label": "Scenarios",
-    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-    "category": "skill",
-    "userPrompt": "Add scenario tests for my agent"
-  },
-  {
-    "id": "setup-lw",
-    "label": "Setup lw",
-    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-cli-usability",
-    "label": "Test CLI usability",
-    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-compliance",
-    "label": "Test compliance",
-    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-    "category": "recipe"
-  },
-  {
-    "id": "tracing",
-    "label": "Tracing",
-    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-    "category": "skill",
-    "userPrompt": "Instrument my code with LangWatch"
-  }
+	{
+		"id": "agent-best-practices",
+		"label": "Agent best practices",
+		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+		"category": "recipe",
+		"userPrompt": "Where can I improve our agent development best practices?"
+	},
+	{
+		"id": "agent-improve",
+		"label": "Agent improve",
+		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+		"category": "skill",
+		"userPrompt": "What should I do next to improve my agent?"
+	},
+	{
+		"id": "agent-performance",
+		"label": "Agent performance",
+		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+		"category": "skill",
+		"userPrompt": "How is my agent performing?"
+	},
+	{
+		"id": "datasets",
+		"label": "Datasets",
+		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+		"category": "skill"
+	},
+	{
+		"id": "debug-instrumentation",
+		"label": "Debug instrumentation",
+		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+		"category": "recipe"
+	},
+	{
+		"id": "debug-with-langwatch",
+		"label": "Debug with langwatch",
+		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+		"category": "recipe"
+	},
+	{
+		"id": "eval-triage",
+		"label": "Eval triage",
+		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluate-multimodal",
+		"label": "Evaluate multimodal",
+		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluations",
+		"label": "Evaluations",
+		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+		"category": "skill",
+		"userPrompt": "Help me evaluate my agent"
+	},
+	{
+		"id": "experiments",
+		"label": "Experiments",
+		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+		"category": "skill",
+		"userPrompt": "Set up experiments for my agent"
+	},
+	{
+		"id": "generate-rag-dataset",
+		"label": "Generate RAG dataset",
+		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+		"category": "recipe"
+	},
+	{
+		"id": "github",
+		"label": "GitHub",
+		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+		"category": "skill"
+	},
+	{
+		"id": "level-up",
+		"label": "Level up",
+		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+		"category": "skill",
+		"userPrompt": "Take my agent to the next level"
+	},
+	{
+		"id": "online-evaluations",
+		"label": "Online evaluations",
+		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+		"category": "skill",
+		"userPrompt": "Set up online evaluations for my agent"
+	},
+	{
+		"id": "prompts",
+		"label": "Prompts",
+		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+		"category": "skill",
+		"userPrompt": "Version my prompts with LangWatch"
+	},
+	{
+		"id": "scenarios",
+		"label": "Scenarios",
+		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+		"category": "skill",
+		"userPrompt": "Add scenario tests for my agent"
+	},
+	{
+		"id": "setup-lw",
+		"label": "Setup lw",
+		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-cli-usability",
+		"label": "Test CLI usability",
+		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-compliance",
+		"label": "Test compliance",
+		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+		"category": "recipe"
+	},
+	{
+		"id": "tracing",
+		"label": "Tracing",
+		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+		"category": "skill",
+		"userPrompt": "Instrument my code with LangWatch"
+	}
 ]


### PR DESCRIPTION
# Related Issue

- Resolves langwatch/langwatch-saas#800

Fixes langwatch/langwatch-saas#800

## For humans

LangWatch can keep large trace payloads in Amazon, Azure, or on local disk, whichever the customer configured. One piece of the system never got that memo: when an incoming trace was too big to ride the queue, it always parked the payload in Amazon regardless of the setting.

For a customer running LangWatch inside their own Azure environment that played out two ways. Either nothing was stored at all and the size protection quietly did nothing, or — during a migration, which is worse — their trace data kept landing in Amazon while they believed it had moved to Azure. The second one is a compliance problem, not just a missing feature.

This change makes that piece obey the same storage setting as everything else.

Nobody is affected today, because the feature is switched off in every install we ship. The point is to close the gap before anyone turns it on, and specifically before a customer self-hosting on Azure does.

While in there, it also closed a security hole in the same code. When a payload was parked, the system passed along a note saying where to find it — and trusted that address on the way back. Anyone able to tamper with that note could have pointed it at another customer's data. The note no longer carries an address at all; the system works out the location itself.

## The gap

The ADR-022 edge spool wrote over-threshold span payloads straight to AWS S3 through `createS3Client`, never touching `stored-objects`. It was the one byte-writing surface left behind when everything else moved onto the shared storage layer — an unfinished migration, not a design choice — so it silently ignored whatever destination a deployment had configured.

Two ways that showed up on an Azure deployment:

| Configuration | Before | Now |
|---|---|---|
| Azure only (no `S3_BUCKET_NAME`) | Spool write threw, `maybeSpool` swallowed it fail-open, every oversized span logged `oversize protection skipped; queue carries full payload`. Container stayed empty — no error surfaced, and no size protection either. | Object lands in the Azure container. |
| Azure + legacy `S3_BUCKET_NAME` (the documented migration state) | Resolved the legacy bucket and kept writing trace payloads to S3 while the operator believed storage had moved. Silent. | Writes to Azure; the S3 client is never reached. |

The second is a data-residency problem, not just a missing feature: trace payload bytes leaving the intended jurisdiction with no signal.

**No shipped deployment was affected.** `release_trace_blob_offload` defaults `false` and appears in no Helm chart and no `.env.example` — verified by grep on `main`. This closes the gap before the flag is ever recommended for a non-S3 install.

## What changed

- **`BlobStore` resolves the destination and writes through the `stored-objects` registry**, injected rather than constructed, so the spool lands in Azure Blob or S3 as configured. Same shape the GroupQueue durable blob tier already uses (ADR-030). The local-filesystem destination is deliberately refused — see the second review round below.
- **`mintUriForDestination` is now the single destination → URI mapping.** Three copies of that switch existed (content-addressed stored objects, the GroupQueue tier, and — missing entirely — the spool). The spool's absence from that list is precisely how it stayed hardcoded to S3, so collapsing them is part of the fix, not incidental cleanup.
- **The object path is unchanged**: `trace-blobs/spool/{projectId}/{traceId}/{spanId}`, prefix deliberately kept *above* the tenant segment. An S3 lifecycle prefix filter cannot wildcard a leading tenant segment, so moving the prefix below it would leave orphan spools unexpirable. Existing lifecycle rules keep working untouched.
- **Segments are percent-encoded.** Base64 OTLP ids can contain `/`, which unescaped injected extra path segments — or, leading, escaped the prefix the lifecycle rule matches on.
- ADR-022 amended: it says "S3 spool" throughout, and taking that literally is part of why this lingered.

## Also closes a tamper channel

The reference travelling inside the queue message *was* the object key, and the read path parsed the tenant id back out of that string to choose a bucket — so whoever could influence a queue message could steer a read at another tenant's object.

Commands now carry the opaque marker `spool:v2`; the worker re-derives the location from its own authenticated `tenantId` and span ids. Same discipline `BlobRef` follows in ADR-030 §5.

This was found by a test written for the Azure work, not by looking for it: the first version of the compatibility branch treated *any* unrecognised string as a v1 key and dereferenced it, which reopened the hole. The branch now matches on the `trace-blobs/spool/` prefix and refuses a key whose tenant segment doesn't match the command's.

## Rollout

Commands already queued when this deploys still carry v1 raw keys, so both formats resolve for one release. The v1 branch is marked with a `TODO(#800)` to drop it — safe after one release, since the spool's own lifecycle expiry is 3 days.

## Verification

The success signal is the *absence* of the fail-open warning plus the *presence* of the bytes.

- **Unit** — writes resolve to the right backend across all three destinations (table-driven); a reference naming another tenant is ignored (v2) or refused (v1-shaped); legacy keys still resolve; path separators in ids stay inside the prefix; fail-open on write preserved.
- **Integration, real Azurite emulator** — a 300 KB payload round-trips through Azure byte-identical and deletes cleanly; with a legacy S3 bucket still configured, the S3 client is never called. These two are written as direct inversions of the reproduce steps on the issue, so the test and the bug report can't drift apart.
- **Integration, a real Azure Blob account** (self-skips without credentials) — the emulator is path-style and production Azure is host-style, and the two canonicalise differently in the shared-key signature, so only a real account can catch a signing bug on the deep path the spool mints. Also covers the retention flip: turning the gate back off still reads and still deletes objects already in the container, and still refuses to write a new one.
- 349 test files / 9387 tests pass across `stored-objects`, `app-layer/traces`, `event-sourcing`, and `traces`. `pnpm typecheck` and `pnpm typecheck:tests` both clean.

## Deployment Impact

No migration, and nothing changes for an install that leaves `release_trace_blob_offload` off — which is every install we ship. Azure deployments gain one opt-in setting: `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED` (chart: `app.dataplane.providers.azureBlob.spoolRetentionConfirmed`), unset by default and detailed below.

Operators should know:

- **The orphan-cleanup window is 3 days.** ADR-022 said 24h in two places and the code said 3 days in five; this PR settles it on 3 days (the value with a stated rationale — a weekend incident needs catch-up time) and supersedes the 24h statements. Since the flag has never been enabled anywhere, no deployed rule contradicts this.
- **Lifecycle rules are unaffected.** The spool object path is byte-identical to before, so any existing 3-day expiry rule on the `trace-blobs/spool/` prefix keeps matching.
- **Local-filesystem installs get no spool at all** — the flag is accepted but every oversized span keeps its payload inline, because a filesystem cannot express the lifecycle rule the orphan bound depends on. This matches the behaviour before this PR.
- **Azure installs must opt in after provisioning retention.** `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED` (chart: `app.dataplane.providers.azureBlob.spoolRetentionConfirmed`) defaults to **false**, and the spool refuses an Azure destination without it — so enabling `release_trace_blob_offload` alone changes nothing until the operator creates the lifecycle policy and flips this. Deliberately an assertion, not a check: the policy is management-plane and the app holds only a data-plane key. The gate is write-only — turning it back off (or rolling the chart back) still reads and still deletes the objects already in the container, so a rollback strands nothing.
- **Azure deployments that enable `release_trace_blob_offload` need the same lifecycle rule** on their container/root that S3 deployments already have — otherwise orphaned spools (edge crash between write and command processing) accumulate. Azure Blob lifecycle management supports prefix filters directly.
- The flag remains off by default and unset in every chart; enabling it stays an explicit operator decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace spool storage now supports S3 and Azure Blob destinations based on deployment configuration.
  * Trace data is securely retrieved and cleaned up using authenticated tenant and span details.
  * Added compatibility support for legacy spool references during the transition.

* **Bug Fixes**
  * Prevented cross-tenant spool access and redirected reads.
  * Updated orphan cleanup guidance to a three-day lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Review round (5239fc37b)

CodeRabbit raised 7 findings. Four were real and are fixed; three did not survive checking.

| Finding | Verdict |
|---|---|
| Third positional constructor param breaks the named-parameter rule | **Fixed** — `BlobStore` takes a named options object; ~30 call sites stopped threading a positional `undefined` |
| Cross-tenant refusal swallowed by `deleteSpool`'s catch | **Fixed** — injected logger; a refusal logs and returns, storage blips still swallowed |
| `MAX_SPOOL_BYTES` cap untested | **Fixed** — lazy 1MB chunks past the cap, asserts `StreamTooLargeError` |
| 3-day vs 24h lifecycle contradiction | **Fixed** — settled on 3 days across code and ADR |
| `resolveDestination` uncached = 3 DB round-trips per span | **Not real** — `getS3ConfigForProject` already caches projectId→orgId; after the first call these are in-memory Map reads |
| Span ids may not match what the edge used | **Not real** — ids are hex-normalised to strings before the command is built; both sides read the same field. Dropped the misleading `as string` casts that prompted it |
| `createStorageRegistry` called per operation | **Not real** — drivers are stateless and credentials resolve lazily; matches the existing wiring in `eventSourcing.ts` and `queue.redis.repository.ts` |


---

## Review round 2 (`9d1b4cea8`)

Two findings from `langwatch-agent`, both real, plus two documentation points from CodeRabbit.

**Path traversal on the local filesystem — reproduced.** Percent-encoding the id segments was not enough on its own. `LocalFilesystemDriver.parseFileUri` round-trips the URI through `decodeURIComponent`, which turns `..%2F..%2F` straight back into `../../` before `mkdir`/`writeFile` see it. Since `idSchema` accepts arbitrary strings, a span id of `../../…` resolved to `/var/etc/evil/span-1` — outside the object root.

Fixed at both levels: ids outside `[A-Za-z0-9_-]` are replaced by a hash of the id (deterministic, so read and delete re-derive the same location; ordinary hex ids untouched), and `LocalFilesystemDriver` now refuses any `file:` URI whose decoded path contains a `..` segment, so a future caller that percent-encodes and assumes safety fails loudly. (The check first asked whether the decoded path was *canonical*, which is stricter than "does it escape" and rejected a storage root configured with a trailing slash — breaking every local-filesystem write on those installs. Caught in review.)

**No orphan bound on the new destinations.** The spool deletes eagerly after the `event_log` INSERT and leans on a lifecycle rule to reap what a crash between those steps strands. A filesystem cannot express one, so the spool now refuses that destination and ingestion continues inline.

This is not a behaviour change: before the spool moved onto the shared storage layer it built an S3 client, which on a local install resolved to the hardcoded `langwatch` bucket — nonexistent there, so the write already failed and the same fail-open path already ran. The spool has never worked on a local install; this makes it explicit and removes the unbounded-orphan class. Azure keeps the destination, since Azure Blob lifecycle management does support prefix filters.

**Documentation.** The v1-removal marker now names a real tracking issue (langwatch/langwatch-saas#837) instead of "for one release", and ADR-022 states that provisioning the lifecycle rule is the operator's prerequisite for enabling the flag — not something enabling it creates.


---

## Review round 3 (`5053fdae4`)

`langwatch-agent` confirmed the earlier findings were addressed and raised one more, which was right: removing the local-filesystem destination closed the unbounded-orphan case there, but left the identical case open on Azure. Documenting the lifecycle rule as a prerequisite does not make it one — an operator who enables the flag without creating the policy accumulates trace payloads past the retention this PR documents.

The spool now **fails closed on Azure**: `AZURE_BLOB_SPOOL_RETENTION_CONFIRMED` defaults to false and `putSpool` refuses an azure destination without it, so ingestion degrades to inline payloads. The error names the policy to create and the setting to flip.

The refusal is on the **write** path only. It is a rule about not creating an object nothing will reap, and it must never touch the objects already out there: turning the assertion back off is the documented remediation, and a chart rollback does it silently, so gating reads and deletes on it would make in-flight spooled spans unreadable (`getSpool` does not fail open, and the edge has already cleared the attributes) and would skip the eager delete that is the spool's *first* line of cleanup — manufacturing the exact orphan the gate exists to prevent. Caught in review, fixed, and proven against a real Azure account.

**It asserts rather than verifies, and that is the honest limit.** An Azure lifecycle policy is a management-plane resource (`Microsoft.Storage/storageAccounts/managementPolicies`); this deployment holds a data-plane SharedKey only. Reading the policy back would require ARM credentials, a subscription id and a resource-group name the feature otherwise has no use for — a new credential to hold for every Azure customer, to check one boolean. The affirmation instead lives in the same config that turns the spool on, with the safe default.

**S3 is deliberately not gated.** Its lifecycle requirement predates this change and is the long-standing ADR-022 rule; extending the gate there would silently disable the spool for every existing install. A test pins that asymmetry.

---

## Review round 4 (`f53bc4405`)

`langwatch-agent` caught that the read cap was only half applied. The v2 path reads through `streamToBuffer(..., MAX_SPOOL_BYTES)`; the v1 compatibility path called `transformToByteArray()`, which buffers the whole object before its size can be checked. So the cap documented as stopping a tampered or corrupt object from OOM-ing the worker did not cover the one input it exists to distrust — an object written before this deploy.

Splitting the original read into v1 and v2 paths is what introduced the asymmetry; the cap went on the new path only. The legacy read now consumes the SDK stream through the same helper, with the explicit no-body error preserved ahead of it.

Chose the bounded stream over a `ContentLength` pre-check: that header is attacker-influenced on a tampered object, so trusting it to decide whether to buffer reintroduces the same hole one level up.

Regression test added for an oversized legacy object, and confirmed to fail without the fix.

