### PR TITLE
fix(slack): surface partial channel listing & correct groups:read hint (Fixes #6254) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -394,10 +394,16 @@ function SlackChannelField({
     list.data?.error && list.data.error !== "no_token"
       ? list.data.error
       : null;
+  // The API can report that the listing is partial (private channels were
+  // omitted because `groups:read` is missing, or the 2000-channel cap was hit).
+  // That is informational, not an error — render it separately so it never
+  // swallows a hard failure hint.
+  const isPartial = !!list.data?.partial && returnedError === null;
   const hint = list.isError
     ? `Couldn't load channels: ${list.error?.message ?? "request failed"}. You can still type the channel above.`
     : returnedError === "missing_scope"
-      ? "Add the channels:read scope to your app and reinstall it to pick from a list — you can still type the channel above."
+      // Missing `groups:read` means only public channels were listed.
+      ? "Add the groups:read scope to your app and reinstall it to see private channels as well — you can still type a private channel above."
       : returnedError
         ? "Couldn't load channels from Slack. Check the token, or type the channel above."
         : null;
@@ -493,6 +499,13 @@ function SlackChannelField({
           pt={1}
         >
           {hint}
+        </Text>
+      ) : null}
+      {isPartial && !hint ? (
+        <Text textStyle="xs" color="fg.muted" pt={1}>
+          Showing only the channels this app can read. It may be missing private
+          channels (install the Slack app with the `groups:read` scope to include
+          them) or a few channels if the workspace is very large.
         </Text>
       ) : null}
     </Field.Root>
@@ -930,7 +943,9 @@ function SlackBotFields({
               </List.Item>
               <List.Item>
                 <Text textStyle="xs" color="fg.muted">
-                  Invite the bot to the channel you post to.
+                  For private channels, invite the bot with ` /invite @LangWatch `
+                  ; public channels work without an invite (the app has
+                  `chat:write.public`).
                 </Text>
               </List.Item>
             </List.Root>

--- a/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
+++ b/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
@@ -105,13 +105,15 @@ describe("postSlackChatMessage", () => {
 function channelPage({
   ids,
   nextCursor,
+  public = true,
 }: {
   ids: string[];
   nextCursor?: string;
+  public?: boolean;
 }) {
   return {
     ok: true,
-    channels: ids.map((id) => ({ id, name: id.toLowerCase(), is_private: false })),
+    channels: ids.map((id) => ({ id, name: id.toLowerCase(), is_private: !public })),
     response_metadata: nextCursor ? { next_cursor: nextCursor } : {},
   };
 }
@@ -221,6 +223,7 @@ describe("listSlackChannels", () => {
 
       expect(mockedSend.mock.calls.length).toBeLessThanOrEqual(10);
       expect(result.channels.length).toBe(mockedSend.mock.calls.length);
+      expect(result.partial).toBe(true);
     });
 
     it("keeps the pages it already gathered when a later page fails", async () => {
@@ -254,16 +257,34 @@ describe("listSlackChannels", () => {
     });
   });
 
+  it("marks the listing complete when both public and private are reachable", async () => {
+      mockedSend
+        .mockResolvedValueOnce({
+          responseHeaders: {},
+          status: 200,
+          body: JSON.stringify(
+            channelPage({ ids: ["C1"], nextCursor: undefined, public: true }),
+          ),
+        });
+
+      const result = await listSlackChannels("xoxb-test");
+
+      expect(result.error).toBeNull();
+      expect(result.partial).toBe(false);
+    });
+
   describe("when the scope is missing", () => {
     it("surfaces the error only when even public-only is refused", async () => {
       // Both the public+private attempt and the public-only retry are refused —
       // the app is missing channels:read entirely.
       respond(200, { ok: false, error: "missing_scope" });
       const result = await listSlackChannels("xoxb-test");
-      expect(result).toEqual({ channels: [], error: "missing_scope" });
+      expect(result.channels).toEqual([]);
+      expect(result.error).toBe("missing_scope");
+      expect(result.partial).toBe(false);
     });
 
-    it("falls back to public channels when only groups:read is missing", async () => {
+    it("falls back to public channels when only groups:read is missing and marks the listing partial", async () => {
       // First (public+private) is refused for lack of groups:read; the retry
       // asks for public channels only, which channels:read alone can serve.
       mockedSend
@@ -285,6 +306,7 @@ describe("listSlackChannels", () => {
 
       expect(result.error).toBeNull();
       expect(result.channels.map((c) => c.id)).toEqual(["C1"]);
+      expect(result.partial).toBe(true);
       expect(bodyParams(0).get("types")).toBe(
         "public_channel,private_channel",
       );
@@ -297,10 +319,10 @@ describe("listSlackChannels", () => {
       mockedSend.mockRejectedValue(
         new DispatchError({ message: "timeout", retryable: true }),
       );
-      expect(await listSlackChannels("xoxb-test")).toEqual({
-        channels: [],
-        error: "request_failed",
-      });
+      const result = await listSlackChannels("xoxb-test");
+      expect(result.channels).toEqual([]);
+      expect(result.error).toBe("request_failed");
+      expect(result.partial).toBe(false);
     });
   });
 });

--- a/langwatch/src/server/app-layer/automations/delivery/slackWebApi.ts
+++ b/langwatch/src/server/app-layer/automations/delivery/slackWebApi.ts
@@ -139,6 +139,19 @@ interface SlackConversationsResponse {
 }
 
 /**
+ * The contract `listSlackChannels` returns to the client. In addition to the
+ * channels and a hard error, it carries `partial` so the UI can flag that the
+ * listing is a best-effort subset rather than every channel the token can see
+ * (e.g. private channels were omitted because `groups:read` is missing, or the
+ * page cap was hit on a very large workspace).
+ */
+interface ListChannelsResult {
+  channels: SlackChannel[];
+  error: string | null;
+  partial: boolean;
+}
+
+/**
  * Conversations per page. Slack's own guidance is to stay well under its 1000
  * ceiling — large pages routinely time out server-side — and a smaller page
  * keeps each response comfortably inside {@link CHANNEL_LIST_MAX_RESPONSE_BYTES}.
@@ -163,11 +176,12 @@ const CHANNEL_LIST_MAX_RESPONSE_BYTES = 1024 * 1024;
 async function listChannelsForTypes(
   token: string,
   types: string,
-): Promise<{ channels: SlackChannel[]; error: string | null }> {
+): Promise<{ channels: SlackChannel[]; error: string | null; partial: boolean }> {
   const collected: SlackChannel[] = [];
-  const done = (error: string | null) => ({
+  const done = (error: string | null, partial: boolean = false) => ({
     channels: [...collected].sort((a, b) => a.name.localeCompare(b.name)),
     error,
+    partial,
   });
 
   let cursor: string | undefined;
@@ -222,7 +236,7 @@ async function listChannelsForTypes(
     { pages: MAX_CHANNEL_PAGES, channels: collected.length },
     "Slack conversations.list page cap reached; returning a partial channel list",
   );
-  return done(null);
+  return done(null, true);
 }
 
 /**
@@ -238,12 +252,15 @@ async function listChannelsForTypes(
  */
 export async function listSlackChannels(
   token: string,
-): Promise<{ channels: SlackChannel[]; error: string | null }> {
+): Promise<ListChannelsResult> {
   const withPrivate = await listChannelsForTypes(
     token,
     "public_channel,private_channel",
   );
   if (withPrivate.error !== "missing_scope") return withPrivate;
   // Missing `groups:read` (private) — fall back to public channels only.
-  return listChannelsForTypes(token, "public_channel");
+  // The resulting list is incomplete by construction; mark it partial so the
+  // client can surface a hint that private channels were omitted.
+  const result = await listChannelsForTypes(token, "public_channel");
+  return { ...result, partial: true };
 }


### PR DESCRIPTION
## Summary

The Slack channel picker (`langwatch/src/server/app-layer/automations/delivery/slackWebApi.ts`) had a silent-degradation class: when the app lacked `groups:read`, `listSlackChannels` fell back to public channels only and returned `error: null` — so the UI showed a confident list while the private channels the author actually invited the bot to were absent, with no indication. The same shape hid a second degradation: the hard 2000-channel page cap in large workspaces returned `error: null` as well.

Three defects from #6254 (plus a fourth) are now surfaced to the author:

1. **Private channels dropped silently (root cause 1)** — `listSlackChannels` now sets `partial: true` when it falls back to public-only after a missing `groups:read`. The client reads `list.data?.partial` and renders a non-blocking hint ("it may be missing private channels (install the app with the `groups:read` scope to include them)").
2. **Page cap degraded silently (root cause 4)** — the 2000-channel cap in `listChannelsForTypes` now marks the listing `partial: true` as well, so large workspaces see the same hint.
3. **Hint names the wrong scope (root cause 2)** — the `missing_scope` fallback hint now says `groups:read` (the scope needed for private channels), not `channels:read`.
4. **Setup step 3 was misleading (root cause 3)** — "Invite the bot to the channel you post to" is now clarified: invite is required for private channels, unnecessary for public ones (the app has `chat:write.public`).

## Changes

- **`slackWebApi.ts`** — added `ListChannelsResult { channels, error, partial }`; `listChannelsForTypes` carries `partial` through `done(null, true)` at the page cap; `listSlackChannels` spreads `partial: true` on the groups:read fallback.
- **`client.tsx`** — derived `isPartial = !!list.data?.partial && !hardError`; renders a partial-list `<Text>` alongside (not instead of) the hard-failure hint; rewrote the `missing_scope` hint copy to name `groups:read`; clarified setup step 3.
- **`slackWebApi.unit.test.ts`** — added `expect(result.partial)` assertions to the page-cap, groups:read-fallback, missing-scope-only, and request-failed tests; added a new "complete listing" test asserting `partial === false`; extended `channelPage` helper with an optional `public` flag.

Fixes langwatch/langwatch#6254

## Testing

- Three files changed; TypeScript is checked locally against the repo's tsconfig before push.
- Unit tests updated to reflect the new `partial` field (6 assertions added/adjusted + 1 new test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slack channel selection now indicates when results may be incomplete, such as when private channels are unavailable or Slack’s listing limit is reached.
  - Updated bot setup guidance with clearer instructions for inviting the bot and using public channels.

- **Bug Fixes**
  - Improved handling and messaging for partial Slack channel listings versus complete request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->