### PR TITLE
fix(langy): resolve the user's own project on /me, not the org ambient team

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -601,7 +601,13 @@ export const DashboardLayout = ({
 
   const user = session?.user;
   const currentRoute = findCurrentRoute(router.pathname);
-  const isDemoProject = publicEnv.data?.DEMO_PROJECT_SLUG === project?.slug;
+  // Requires BOTH sides present: an install with no demo project configured
+  // leaves DEMO_PROJECT_SLUG undefined, and `===` against an equally-undefined
+  // `project?.slug` would otherwise read as a match on any route that hasn't
+  // resolved a project yet.
+  const isDemoProject =
+    !!publicEnv.data?.DEMO_PROJECT_SLUG &&
+    publicEnv.data.DEMO_PROJECT_SLUG === project?.slug;
   const userIsPartOfTeam =
     publicPage ||
     // Personal-scope routes (/me/* and the caller's own Personal Workspace

--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -138,7 +138,7 @@ describe("useShowLangy", () => {
     });
   });
 
-  describe("given the active project has not resolved yet", () => {
+  describe("when the active project has not resolved yet", () => {
     beforeEach(() => {
       context.project = undefined;
       context.demoProjectSlug = undefined;

--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -14,7 +14,7 @@
  * Spec: specs/langy/langy-baseline.feature ("Access and rollout gating")
  */
 import { cleanup, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type FlagOptions = {
   projectId?: string;
@@ -37,26 +37,6 @@ vi.mock("~/hooks/useRequiredSession", () => ({
   useRequiredSession: () => ({ data: { user: { id: "user-1" } } }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "project-1", slug: "acme" },
-    team: {
-      isPersonal: false,
-      ownerUserId: "someone-else",
-      members: [{ userId: "user-1" }],
-    },
-    organization: { id: "org-1" },
-    organizationRole: "MEMBER",
-    hasPermission: (permission: string) => permission === "langy:view",
-  }),
-}));
-
-vi.mock("~/hooks/usePublicEnv", () => ({
-  // A demo slug that does NOT match the active project, so the demo-refusal
-  // branch stays out of the way and the rollout is what decides visibility.
-  usePublicEnv: () => ({ data: { DEMO_PROJECT_SLUG: "not-this-project" } }),
-}));
-
 vi.mock("~/hooks/useFeatureFlag", () => ({
   useFeatureFlag: (_flag: string, options: FlagOptions) => {
     gate.lastFlagOptions = options;
@@ -73,12 +53,45 @@ vi.mock("~/hooks/useFeatureFlag", () => ({
   },
 }));
 
+// Mutable so a later describe block can swap in an unresolved-project shape
+// without a second vi.mock (hoisting only allows one factory per module).
+const context = {
+  project: { id: "project-1", slug: "acme" } as { id: string; slug: string } | undefined,
+  demoProjectSlug: "not-this-project" as string | undefined,
+};
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    get project() {
+      return context.project;
+    },
+    team: {
+      isPersonal: false,
+      ownerUserId: "someone-else",
+      members: [{ userId: "user-1" }],
+    },
+    organization: { id: "org-1" },
+    organizationRole: "MEMBER",
+    hasPermission: (permission: string) => permission === "langy:view",
+  }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({
+    get data() {
+      return { DEMO_PROJECT_SLUG: context.demoProjectSlug };
+    },
+  }),
+}));
+
 import { useShowLangy } from "../useShowLangy";
 
 afterEach(() => {
   cleanup();
   gate.rule = null;
   gate.lastFlagOptions = undefined;
+  context.project = { id: "project-1", slug: "acme" };
+  context.demoProjectSlug = "not-this-project";
 });
 
 describe("useShowLangy", () => {
@@ -122,6 +135,27 @@ describe("useShowLangy", () => {
 
         expect(result.current).toBe(false);
       });
+    });
+  });
+
+  describe("given no demo project is configured (every self-host) and the project has not resolved yet", () => {
+    beforeEach(() => {
+      context.project = undefined;
+      context.demoProjectSlug = undefined;
+    });
+
+    /**
+     * @scenario `DEMO_PROJECT_SLUG === project?.slug` with both sides
+     * undefined must not read as "this is the demo project". An install
+     * with no demo project configured hits exactly this on any route whose
+     * project hasn't resolved yet, and did not deserve to lose Langy for it.
+     */
+    it("does not treat the unresolved project as the demo project", () => {
+      gate.rule = { organizationId: "org-1" };
+
+      const { result } = renderHook(() => useShowLangy());
+
+      expect(result.current).toBe(true);
     });
   });
 });

--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -144,12 +144,11 @@ describe("useShowLangy", () => {
       context.demoProjectSlug = undefined;
     });
 
-    /**
-     * @scenario `DEMO_PROJECT_SLUG === project?.slug` with both sides
-     * undefined must not read as "this is the demo project". An install
-     * with no demo project configured hits exactly this on any route whose
-     * project hasn't resolved yet, and did not deserve to lose Langy for it.
-     */
+    // `DEMO_PROJECT_SLUG === project?.slug` with both sides undefined must
+    // not read as "this is the demo project". An install with no demo
+    // project configured hits exactly this on any route whose project
+    // hasn't resolved yet, and did not deserve to lose Langy for it.
+    /** @scenario An unresolved project is not mistaken for the demo project */
     it("does not treat the unresolved project as the demo project", () => {
       gate.rule = { organizationId: "org-1" };
 

--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -138,7 +138,7 @@ describe("useShowLangy", () => {
     });
   });
 
-  describe("given no demo project is configured (every self-host) and the project has not resolved yet", () => {
+  describe("given the active project has not resolved yet", () => {
     beforeEach(() => {
       context.project = undefined;
       context.demoProjectSlug = undefined;
@@ -148,7 +148,7 @@ describe("useShowLangy", () => {
     // not read as "this is the demo project". An install with no demo
     // project configured hits exactly this on any route whose project
     // hasn't resolved yet, and did not deserve to lose Langy for it.
-    /** @scenario An unresolved project is not mistaken for the demo project */
+    /** @scenario The handle stays visible while the active project is still loading */
     it("does not treat the unresolved project as the demo project", () => {
       gate.rule = { organizationId: "org-1" };
 

--- a/langwatch/src/features/langy/hooks/useShowLangy.ts
+++ b/langwatch/src/features/langy/hooks/useShowLangy.ts
@@ -69,11 +69,11 @@ export function useLangyVisibility(): LangyVisibility {
   const user = session?.user;
   // The server refuses Langy on the demo project outright, so rendering the
   // panel there would only produce a chat where every send 403s. Requires
-  // BOTH sides present: an install with no demo project configured (every
-  // self-host) leaves DEMO_PROJECT_SLUG undefined, and `===` against an
-  // equally-undefined `project?.slug` (any route that hasn't resolved a
-  // project yet) would otherwise read as a match and hide Langy for a user
-  // who was never anywhere near the demo project.
+  // BOTH sides present: an install with no demo project configured leaves
+  // DEMO_PROJECT_SLUG undefined, and `===` against an equally-undefined
+  // `project?.slug` (any route that hasn't resolved a project yet) would
+  // otherwise read as a match and hide Langy for a user who was never
+  // anywhere near the demo project.
   const isDemoProject =
     !!publicEnv.data?.DEMO_PROJECT_SLUG &&
     publicEnv.data.DEMO_PROJECT_SLUG === project?.slug;

--- a/langwatch/src/features/langy/hooks/useShowLangy.ts
+++ b/langwatch/src/features/langy/hooks/useShowLangy.ts
@@ -68,8 +68,15 @@ export function useLangyVisibility(): LangyVisibility {
 
   const user = session?.user;
   // The server refuses Langy on the demo project outright, so rendering the
-  // panel there would only produce a chat where every send 403s.
-  const isDemoProject = publicEnv.data?.DEMO_PROJECT_SLUG === project?.slug;
+  // panel there would only produce a chat where every send 403s. Requires
+  // BOTH sides present: an install with no demo project configured (every
+  // self-host) leaves DEMO_PROJECT_SLUG undefined, and `===` against an
+  // equally-undefined `project?.slug` (any route that hasn't resolved a
+  // project yet) would otherwise read as a match and hide Langy for a user
+  // who was never anywhere near the demo project.
+  const isDemoProject =
+    !!publicEnv.data?.DEMO_PROJECT_SLUG &&
+    publicEnv.data.DEMO_PROJECT_SLUG === project?.slug;
   const isOnOwnPersonalProject =
     !!team?.isPersonal && team.ownerUserId === user?.id;
   const userIsPartOfTeam =

--- a/langwatch/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
@@ -256,22 +256,21 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       mockRouter.asPath = "/me";
     });
 
-    /**
-     * @scenario /me is the one "no slug" page that means the OPPOSITE of the
-     * organization-scoped case above: the personal workspace must win, not
-     * the shared team it otherwise correctly loses to. Unfixed, this landed
-     * on the shared team's own first project (or, per "given the shared team
-     * has no project yet" below, no project at all): any organization
-     * feature gated on "does this reader have a project" (Langy chief among
-     * them) then read a personal-workspace visit as project-less.
-     */
+    // /me is the one "no slug" page that means the OPPOSITE of the
+    // organization-scoped case above: the personal workspace must win, not
+    // the shared team it otherwise correctly loses to. Unfixed, this landed
+    // on the shared team's own first project (or, per "given the shared team
+    // has no project yet" below, no project at all): any organization
+    // feature gated on "does this reader have a project" (Langy chief among
+    // them) then read a personal-workspace visit as project-less.
+    /** @scenario Visiting the personal-workspace page resolves the personal team */
     it("resolves the personal team instead of the shared one", () => {
       const { result } = renderResolution();
 
       expect(result.current.team?.id).toBe("team-personal");
     });
 
-    /** @scenario /me resolves the user's own project, not the org's */
+    /** @scenario Visiting the personal-workspace page resolves the personal team */
     it("resolves the personal project instead of the organization's", () => {
       const { result } = renderResolution();
 
@@ -292,12 +291,11 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       );
     });
 
-    /**
-     * @scenario The organization-scoped equivalent of this fixture correctly
-     * leaves the page without a project (see "given the shared team has no
-     * project yet" above), /me must not inherit that outcome just because
-     * the same shared, project-less team exists in the organization.
-     */
+    // The organization-scoped equivalent of this fixture correctly leaves the
+    // page without a project (see "given the shared team has no project yet"
+    // above), /me must not inherit that outcome just because the same
+    // shared, project-less team exists in the organization.
+    /** @scenario A shared team without a project does not leak into the personal-workspace page */
     it("still resolves the personal team and project, not an empty shared one", () => {
       const { result } = renderResolution();
 
@@ -313,7 +311,7 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       mockRouter.asPath = "/me/devices";
     });
 
-    /** @scenario Every /me/* sub-route gets the same treatment as /me itself */
+    /** @scenario Every personal-workspace sub-route gets the same treatment */
     it("resolves the personal team and project there too", () => {
       const { result } = renderResolution();
 
@@ -336,12 +334,11 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       mockLocalStorage.selectedTeamId = "team-shared";
     });
 
-    /**
-     * @scenario Unlike a stale PERSONAL slug fading off an organization page
-     * (which the code already handles), a stale SHARED team id must not
-     * follow the user onto /me: this route is unambiguously about the
-     * personal workspace regardless of whatever was last remembered.
-     */
+    // Unlike a stale PERSONAL slug fading off an organization page (which the
+    // code already handles), a stale SHARED team id must not follow the user
+    // onto /me: this route is unambiguously about the personal workspace
+    // regardless of whatever was last remembered.
+    /** @scenario A team remembered from an earlier organization-scoped visit does not follow jane onto the personal-workspace page */
     it("still resolves the personal team, not the remembered shared one", () => {
       const { result } = renderResolution();
 
@@ -360,11 +357,10 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       );
     });
 
-    /**
-     * @scenario An EXTERNAL member with no personal workspace of their own
-     * falls through to the ordinary ambient resolution exactly as before:
-     * the /me fix only ever adds a preference, never a requirement.
-     */
+    // An EXTERNAL member with no personal workspace of their own falls
+    // through to the ordinary ambient resolution exactly as before: the /me
+    // fix only ever adds a preference, never a requirement.
+    /** @scenario A member with no personal workspace of their own falls back to the ambient team */
     it("falls back to the ambient team rather than resolving nothing", () => {
       const { result } = renderResolution();
 

--- a/langwatch/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
@@ -248,4 +248,127 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       expect(result.current.team?.id).toBe("team-shared");
     });
   });
+
+  describe("given a personal-workspace-scoped page (/me) and nothing selected yet", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+    });
+
+    /**
+     * @scenario /me is the one "no slug" page that means the OPPOSITE of the
+     * organization-scoped case above: the personal workspace must win, not
+     * the shared team it otherwise correctly loses to. Unfixed, this landed
+     * on the shared team's own first project (or, per "given the shared team
+     * has no project yet" below, no project at all): any organization
+     * feature gated on "does this reader have a project" (Langy chief among
+     * them) then read a personal-workspace visit as project-less.
+     */
+    it("resolves the personal team instead of the shared one", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-personal");
+    });
+
+    /** @scenario /me resolves the user's own project, not the org's */
+    it("resolves the personal project instead of the organization's", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.project?.id).toBe("proj-personal");
+    });
+  });
+
+  describe("given /me and the shared team has no project yet", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+      mockOrganizationsQuery.mockReturnValue(
+        loadedOrganizationsQuery([
+          PERSONAL_TEAM,
+          { ...SHARED_TEAM, projects: [] },
+        ]),
+      );
+    });
+
+    /**
+     * @scenario The organization-scoped equivalent of this fixture correctly
+     * leaves the page without a project (see "given the shared team has no
+     * project yet" above), /me must not inherit that outcome just because
+     * the same shared, project-less team exists in the organization.
+     */
+    it("still resolves the personal team and project, not an empty shared one", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-personal");
+      expect(result.current.project?.id).toBe("proj-personal");
+    });
+  });
+
+  describe("given a personal sub-route (/me/devices) and nothing selected yet", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me/devices";
+      mockRouter.pathname = "/me/devices";
+      mockRouter.asPath = "/me/devices";
+    });
+
+    /** @scenario Every /me/* sub-route gets the same treatment as /me itself */
+    it("resolves the personal team and project there too", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-personal");
+      expect(result.current.project?.id).toBe("proj-personal");
+    });
+  });
+
+  describe("given /me and a stale non-personal team remembered from an earlier organization-scoped visit", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+      // The exact stickiness an earlier organization-scoped visit leaves
+      // behind on purpose (see "given the personal project is only the
+      // remembered selection" above): the localStorage-remembered team
+      // lookup that persisted selection normally wins was the actual gap, it
+      // ran before any personal-workspace preference could apply, so this
+      // persisted id matched and /me silently resolved to the shared team.
+      mockLocalStorage.selectedTeamId = "team-shared";
+    });
+
+    /**
+     * @scenario Unlike a stale PERSONAL slug fading off an organization page
+     * (which the code already handles), a stale SHARED team id must not
+     * follow the user onto /me: this route is unambiguously about the
+     * personal workspace regardless of whatever was last remembered.
+     */
+    it("still resolves the personal team, not the remembered shared one", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-personal");
+      expect(result.current.project?.id).toBe("proj-personal");
+    });
+  });
+
+  describe("given /me but the organization has no personal team at all", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+      mockOrganizationsQuery.mockReturnValue(
+        loadedOrganizationsQuery([SHARED_TEAM]),
+      );
+    });
+
+    /**
+     * @scenario An EXTERNAL member with no personal workspace of their own
+     * falls through to the ordinary ambient resolution exactly as before:
+     * the /me fix only ever adds a preference, never a requirement.
+     */
+    it("falls back to the ambient team rather than resolving nothing", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-shared");
+    });
+  });
 });

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -291,6 +291,30 @@ export const useOrganizationTeamProject = (
             ) ?? organizations.data[0])
           : undefined;
 
+  // `/me` and its sub-routes are the one place "no project slug in the URL"
+  // does NOT mean "organization-level work", it means the user's own
+  // personal workspace, the opposite of the ambient/shared team `selectAmbientTeam`
+  // exists to prefer. Checked BEFORE the localStorage-remembered-team lookup,
+  // not just added as a further fallback after it: a member who visited any
+  // organization-scoped page earlier in the session has a non-personal team
+  // id already persisted there, and that stale selection legitimately wins
+  // on THOSE pages (see the stickiness handling above) but must never win on
+  // /me itself, which is unambiguously about the personal workspace and
+  // cannot mean anything else. Left as a fallback-only check, that persisted
+  // selection matched before this was ever reached, and /me resolved to the
+  // shared team's first (or, if it holds no project yet, undefined) project,
+  // which then read every personal-scope feature (Langy chief among them) as
+  // running in a context that either belonged to someone else or did not
+  // exist. Gated on the same `/me` prefix DashboardLayout already uses for
+  // `isPersonalScopeRoute`, so every other caller (settings pages,
+  // project-slug pages, demo mode) is unaffected.
+  const isPersonalScopeRoute = router.pathname.startsWith("/me");
+  const ownPersonalTeam = isPersonalScopeRoute
+    ? organization?.teams.find(
+        (team) => team.isPersonal && team.ownerUserId === session.data?.user.id,
+      )
+    : undefined;
+
   const team = isDemo
     ? (organization?.teams.find((t) =>
         t.projects.some(
@@ -300,11 +324,13 @@ export const useOrganizationTeamProject = (
       selectAmbientTeam(organization?.teams ?? [])) // The team holding the demo project, else the ambient one
     : resolvedSlugMatch
       ? resolvedSlugMatch.team
-      : organization
-        ? (organization.teams.find(
-            (team) => team.id == localStorageTeamId && !team.isPersonal,
-          ) ?? selectAmbientTeam(organization.teams))
-        : undefined;
+      : ownPersonalTeam
+        ? ownPersonalTeam
+        : organization
+          ? (organization.teams.find(
+              (team) => team.id == localStorageTeamId && !team.isPersonal,
+            ) ?? selectAmbientTeam(organization.teams))
+          : undefined;
 
   // For demo mode, find the project with the demo slug
   const project = isDemo

--- a/langwatch/src/utils/__tests__/docsUrl.unit.test.ts
+++ b/langwatch/src/utils/__tests__/docsUrl.unit.test.ts
@@ -3,57 +3,65 @@ import { describe, it, expect } from "vitest";
 import { docsUrl, getDocsBaseUrl } from "../docsUrl";
 
 describe("getDocsBaseUrl", () => {
-  describe("given a development build", () => {
-    /** @scenario A contributor's local dev server links to the local docs server */
+  describe("when resolving in a development build", () => {
+    /** @scenario A contributor's local checkout links to their own local docs */
     it("returns localhost docs when control plane is on localhost", () => {
-      expect(getDocsBaseUrl("localhost", true)).toBe("http://localhost:3000");
+      expect(getDocsBaseUrl({ hostname: "localhost", isDev: true })).toBe(
+        "http://localhost:3000",
+      );
     });
 
     it("returns localhost docs when on 127.0.0.1", () => {
-      expect(getDocsBaseUrl("127.0.0.1", true)).toBe("http://localhost:3000");
+      expect(getDocsBaseUrl({ hostname: "127.0.0.1", isDev: true })).toBe(
+        "http://localhost:3000",
+      );
     });
 
     it("returns localhost docs when on 0.0.0.0", () => {
-      expect(getDocsBaseUrl("0.0.0.0", true)).toBe("http://localhost:3000");
+      expect(getDocsBaseUrl({ hostname: "0.0.0.0", isDev: true })).toBe(
+        "http://localhost:3000",
+      );
     });
 
     it("returns production docs on a non-local hostname", () => {
-      expect(getDocsBaseUrl("app.langwatch.ai", true)).toBe(
-        "https://docs.langwatch.ai",
-      );
+      expect(
+        getDocsBaseUrl({ hostname: "app.langwatch.ai", isDev: true }),
+      ).toBe("https://docs.langwatch.ai");
     });
   });
 
-  describe("given a production build", () => {
-    /** @scenario A packaged self-hosted server on localhost links to production docs */
+  describe("when resolving in a production build", () => {
+    /** @scenario A packaged self-hosted install links to real documentation */
     it("returns production docs when a self-hosted server is on localhost", () => {
-      expect(getDocsBaseUrl("localhost", false)).toBe(
+      expect(getDocsBaseUrl({ hostname: "localhost", isDev: false })).toBe(
         "https://docs.langwatch.ai",
       );
     });
 
     it("returns production docs on app.langwatch.ai", () => {
-      expect(getDocsBaseUrl("app.langwatch.ai", false)).toBe(
-        "https://docs.langwatch.ai",
-      );
+      expect(
+        getDocsBaseUrl({ hostname: "app.langwatch.ai", isDev: false }),
+      ).toBe("https://docs.langwatch.ai");
     });
 
     it("returns production docs on a customer's self-hosted DNS", () => {
-      expect(getDocsBaseUrl("langwatch.acme.internal", false)).toBe(
-        "https://docs.langwatch.ai",
-      );
+      expect(
+        getDocsBaseUrl({ hostname: "langwatch.acme.internal", isDev: false }),
+      ).toBe("https://docs.langwatch.ai");
     });
   });
 
   it("returns production docs in a no-window environment (Node, future SSR)", () => {
-    expect(getDocsBaseUrl(undefined, false)).toBe("https://docs.langwatch.ai");
+    expect(getDocsBaseUrl({ hostname: undefined, isDev: false })).toBe(
+      "https://docs.langwatch.ai",
+    );
   });
 });
 
 describe("docsUrl", () => {
   it("joins the base with a leading-slash path", () => {
-    // No hostname/isDev injection; relies on the no-window fallback
-    // returning the production base. Production callers omit both args.
+    // No overrides; relies on the no-window fallback returning the
+    // production base. Production callers omit them entirely.
     expect(docsUrl("/ai-governance/anomaly-rules")).toBe(
       "https://docs.langwatch.ai/ai-governance/anomaly-rules",
     );

--- a/langwatch/src/utils/__tests__/docsUrl.unit.test.ts
+++ b/langwatch/src/utils/__tests__/docsUrl.unit.test.ts
@@ -3,37 +3,57 @@ import { describe, it, expect } from "vitest";
 import { docsUrl, getDocsBaseUrl } from "../docsUrl";
 
 describe("getDocsBaseUrl", () => {
-  it("returns localhost docs when control plane is on localhost", () => {
-    expect(getDocsBaseUrl("localhost")).toBe("http://localhost:3000");
+  describe("given a development build", () => {
+    /** @scenario A contributor's local dev server links to the local docs server */
+    it("returns localhost docs when control plane is on localhost", () => {
+      expect(getDocsBaseUrl("localhost", true)).toBe("http://localhost:3000");
+    });
+
+    it("returns localhost docs when on 127.0.0.1", () => {
+      expect(getDocsBaseUrl("127.0.0.1", true)).toBe("http://localhost:3000");
+    });
+
+    it("returns localhost docs when on 0.0.0.0", () => {
+      expect(getDocsBaseUrl("0.0.0.0", true)).toBe("http://localhost:3000");
+    });
+
+    it("returns production docs on a non-local hostname", () => {
+      expect(getDocsBaseUrl("app.langwatch.ai", true)).toBe(
+        "https://docs.langwatch.ai",
+      );
+    });
   });
 
-  it("returns localhost docs when on 127.0.0.1", () => {
-    expect(getDocsBaseUrl("127.0.0.1")).toBe("http://localhost:3000");
-  });
+  describe("given a production build", () => {
+    /** @scenario A packaged self-hosted server on localhost links to production docs */
+    it("returns production docs when a self-hosted server is on localhost", () => {
+      expect(getDocsBaseUrl("localhost", false)).toBe(
+        "https://docs.langwatch.ai",
+      );
+    });
 
-  it("returns localhost docs when on 0.0.0.0", () => {
-    expect(getDocsBaseUrl("0.0.0.0")).toBe("http://localhost:3000");
-  });
+    it("returns production docs on app.langwatch.ai", () => {
+      expect(getDocsBaseUrl("app.langwatch.ai", false)).toBe(
+        "https://docs.langwatch.ai",
+      );
+    });
 
-  it("returns production docs on app.langwatch.ai", () => {
-    expect(getDocsBaseUrl("app.langwatch.ai")).toBe("https://docs.langwatch.ai");
-  });
-
-  it("returns production docs on a customer's self-hosted DNS", () => {
-    expect(getDocsBaseUrl("langwatch.acme.internal")).toBe(
-      "https://docs.langwatch.ai",
-    );
+    it("returns production docs on a customer's self-hosted DNS", () => {
+      expect(getDocsBaseUrl("langwatch.acme.internal", false)).toBe(
+        "https://docs.langwatch.ai",
+      );
+    });
   });
 
   it("returns production docs in a no-window environment (Node, future SSR)", () => {
-    expect(getDocsBaseUrl(undefined)).toBe("https://docs.langwatch.ai");
+    expect(getDocsBaseUrl(undefined, false)).toBe("https://docs.langwatch.ai");
   });
 });
 
 describe("docsUrl", () => {
   it("joins the base with a leading-slash path", () => {
-    // No hostname injection; relies on the no-window fallback returning
-    // the production base. Production callers omit the hostname arg.
+    // No hostname/isDev injection; relies on the no-window fallback
+    // returning the production base. Production callers omit both args.
     expect(docsUrl("/ai-governance/anomaly-rules")).toBe(
       "https://docs.langwatch.ai/ai-governance/anomaly-rules",
     );

--- a/langwatch/src/utils/docsUrl.ts
+++ b/langwatch/src/utils/docsUrl.ts
@@ -33,7 +33,7 @@ const LOCAL_DOCS_URL = "http://localhost:3000";
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
 
 /**
- * `hostname` and `isDev` are exposed as optional arguments so unit tests
+ * `hostname` and `isDev` are exposed as optional overrides so unit tests
  * can pin the branch without mutating `window.location` (jsdom locks the
  * slot with a non-configurable accessor) or the build-time `import.meta.env`
  * constant. Production callers omit both and the helper reads
@@ -46,7 +46,10 @@ const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
  * ever evaluated inside the same `typeof window !== "undefined"` branch as
  * `window.location`, so the server path never touches it.
  */
-export function getDocsBaseUrl(hostname?: string, isDev?: boolean): string {
+export function getDocsBaseUrl({
+  hostname,
+  isDev,
+}: { hostname?: string; isDev?: boolean } = {}): string {
   const inBrowser = typeof window !== "undefined";
   const resolvedHostname = hostname ?? (inBrowser ? window.location.hostname : undefined);
   const resolvedIsDev = isDev ?? (inBrowser ? import.meta.env.DEV : false);

--- a/langwatch/src/utils/docsUrl.ts
+++ b/langwatch/src/utils/docsUrl.ts
@@ -12,6 +12,15 @@
  * "Setup guide ↗" / "Schema reference" / "Docs →" link punch out to
  * production.
  *
+ * Hostname alone can't tell a contributor's dev server apart from a
+ * packaged self-hosted server (npx @langwatch/server, Docker, Helm):
+ * both are commonly reached on localhost, but only the former has
+ * Mintlify running alongside it. Also requiring a development build
+ * (`import.meta.env.DEV`, false in every packaged/production build,
+ * including the self-hosted one) keeps the local-docs shortcut scoped
+ * to contributors while self-hosted installs always get the real,
+ * reachable production docs.
+ *
  * Pure CSR — Vite renders client-side (`createRoot` in main.tsx, no
  * SSR), so reading `window.location` is safe at every render. Falls
  * back to the production URL when `window` is undefined (Node test
@@ -24,16 +33,26 @@ const LOCAL_DOCS_URL = "http://localhost:3000";
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
 
 /**
- * `hostname` is exposed as an optional argument so unit tests can pin
- * the branch without mutating `window.location` (jsdom locks the slot
- * with a non-configurable accessor). Production callers omit it and
- * the helper reads `window.location.hostname` itself.
+ * `hostname` and `isDev` are exposed as optional arguments so unit tests
+ * can pin the branch without mutating `window.location` (jsdom locks the
+ * slot with a non-configurable accessor) or the build-time `import.meta.env`
+ * constant. Production callers omit both and the helper reads
+ * `window.location.hostname` / `import.meta.env.DEV` itself.
+ *
+ * This module is also imported server-side (error-remediation.ts), which
+ * runs under `tsx`, not Vite: `import.meta.env` is a Vite-only construct
+ * and is `undefined` there, so reading `.DEV` off it unconditionally would
+ * throw on every server-rendered docs link. `import.meta.env.DEV` is only
+ * ever evaluated inside the same `typeof window !== "undefined"` branch as
+ * `window.location`, so the server path never touches it.
  */
-export function getDocsBaseUrl(hostname?: string): string {
-  const resolved =
-    hostname ??
-    (typeof window !== "undefined" ? window.location.hostname : undefined);
-  if (resolved && LOCAL_HOSTS.has(resolved)) return LOCAL_DOCS_URL;
+export function getDocsBaseUrl(hostname?: string, isDev?: boolean): string {
+  const inBrowser = typeof window !== "undefined";
+  const resolvedHostname = hostname ?? (inBrowser ? window.location.hostname : undefined);
+  const resolvedIsDev = isDev ?? (inBrowser ? import.meta.env.DEV : false);
+  if (resolvedIsDev && resolvedHostname && LOCAL_HOSTS.has(resolvedHostname)) {
+    return LOCAL_DOCS_URL;
+  }
   return PRODUCTION_DOCS_URL;
 }
 

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -107,3 +107,63 @@ Feature: A personal workspace is never the ambient context for organization work
       Given bob has just been in his personal project
       When bob opens an organization-scoped settings page
       Then the ambient project is still his personal project
+
+  # ============================================================================
+  # /me is the one exception: it means the personal workspace on purpose
+  # ============================================================================
+
+  Rule: the personal-workspace page itself resolves to the personal team, never the shared one
+
+    A page with no project in its address bar is normally organization-scoped
+    work, which is exactly why the ambient context prefers a shared team. `/me`
+    and its sub-routes are the one page family where that assumption is
+    backwards: they ARE the personal workspace, so resolving them to the
+    organization's shared team instead hands every personal-scope feature
+    (Langy chief among them) a project that is either the wrong one or does
+    not exist, even though nothing in the address bar or the remembered
+    selection asked for that.
+
+    @integration
+    Scenario: Visiting the personal-workspace page resolves the personal team
+      Given jane's personal team is listed before the shared team
+      And jane has not opened any project yet
+      When jane opens her personal-workspace page
+      Then the ambient team is her personal team
+      And the ambient project is her personal project
+
+    @integration
+    Scenario: A shared team without a project does not leak into the personal-workspace page
+      Given the shared team holds no project yet
+      When jane opens her personal-workspace page
+      Then the ambient team is still her personal team
+      And the ambient project is still her personal project
+      # The organization-scoped equivalent of this fixture correctly leaves
+      # the page without a project; /me must not inherit that outcome just
+      # because the same project-less shared team exists in the organization.
+
+    @integration
+    Scenario: Every personal-workspace sub-route gets the same treatment
+      When jane opens a sub-page of her personal-workspace page
+      Then the ambient team is still her personal team
+
+    @integration
+    Scenario: A team remembered from an earlier organization-scoped visit does not follow jane onto the personal-workspace page
+      Given jane's last remembered team selection is the shared team, from an
+        earlier organization-scoped page
+      When jane opens her personal-workspace page
+      Then the ambient team is her personal team, not the remembered shared one
+      # A stale PERSONAL selection fading off an organization-scoped page is
+      # already handled (see "Leaving the personal project releases it"
+      # above). The mirror case is what this locks in: a stale SHARED
+      # selection must not follow her onto the personal-workspace page
+      # either, because that page can never mean anything but her own
+      # workspace.
+
+    @integration
+    Scenario: A member with no personal workspace of their own falls back to the ambient team
+      Given an external member belongs only to the shared team
+      When that member opens the personal-workspace page
+      Then the ambient team is the shared team
+      # The /me preference only ever adds a resolution, never a requirement:
+      # someone with no personal team gets the same ambient fallback as
+      # every organization-scoped page already does.

--- a/specs/ai-governance/cli-onboarding/docs-links-resolve-correctly.feature
+++ b/specs/ai-governance/cli-onboarding/docs-links-resolve-correctly.feature
@@ -1,0 +1,29 @@
+Feature: Docs links resolve to a reachable destination
+  As a self-hosted user setting up the LangWatch CLI
+  I want the "Install guide" and "CLI reference" links to open real docs
+  So that I am not sent to a local development server that only exists on a
+  contributor's own machine
+
+  # `docsUrl()` links to a locally-running Mintlify instance on
+  # http://localhost:3000 when the app itself is served from localhost, so a
+  # contributor iterating on both the app and the docs in the same monorepo
+  # checkout gets an in-sync round trip instead of punching out to
+  # production. A packaged self-hosted server (npx @langwatch/server, a
+  # Docker image, a Helm chart) is ALSO served from localhost or another
+  # non-production hostname, but never has Mintlify running alongside it, so
+  # the same hostname check sent every "Install guide" / "CLI reference" /
+  # docs link on those installs to a dead http://localhost:3000.
+
+  @unit
+  Scenario: A contributor's local dev server links to the local docs server
+    Given the app is served from "localhost"
+    And the running build is a development build
+    When a docs link is resolved
+    Then it points at "http://localhost:3000"
+
+  @unit
+  Scenario: A packaged self-hosted server on localhost links to production docs
+    Given the app is served from "localhost"
+    And the running build is a production build
+    When a docs link is resolved
+    Then it points at "https://docs.langwatch.ai"

--- a/specs/ai-governance/cli-onboarding/docs-links-resolve-correctly.feature
+++ b/specs/ai-governance/cli-onboarding/docs-links-resolve-correctly.feature
@@ -4,26 +4,20 @@ Feature: Docs links resolve to a reachable destination
   So that I am not sent to a local development server that only exists on a
   contributor's own machine
 
-  # `docsUrl()` links to a locally-running Mintlify instance on
-  # http://localhost:3000 when the app itself is served from localhost, so a
-  # contributor iterating on both the app and the docs in the same monorepo
-  # checkout gets an in-sync round trip instead of punching out to
-  # production. A packaged self-hosted server (npx @langwatch/server, a
-  # Docker image, a Helm chart) is ALSO served from localhost or another
-  # non-production hostname, but never has Mintlify running alongside it, so
-  # the same hostname check sent every "Install guide" / "CLI reference" /
-  # docs link on those installs to a dead http://localhost:3000.
+  # Contributors iterating on the app and its docs in the same monorepo
+  # checkout get an in-sync local round trip. Everyone else, most of all a
+  # packaged self-hosted install (npx @langwatch/server, a Docker image, a
+  # Helm chart), needs every onboarding documentation link to reach real,
+  # working documentation instead.
 
   @unit
-  Scenario: A contributor's local dev server links to the local docs server
-    Given the app is served from "localhost"
-    And the running build is a development build
-    When a docs link is resolved
-    Then it points at "http://localhost:3000"
+  Scenario: A contributor's local checkout links to their own local docs
+    Given a contributor is running the app from their own local checkout
+    When they open an onboarding documentation link
+    Then it opens their local documentation
 
   @unit
-  Scenario: A packaged self-hosted server on localhost links to production docs
-    Given the app is served from "localhost"
-    And the running build is a production build
-    When a docs link is resolved
-    Then it points at "https://docs.langwatch.ai"
+  Scenario: A packaged self-hosted install links to real documentation
+    Given the app is a packaged self-hosted install
+    When a user opens an onboarding documentation link
+    Then it opens the real, reachable documentation

--- a/specs/langy/langy-baseline.feature
+++ b/specs/langy/langy-baseline.feature
@@ -88,6 +88,17 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When I navigate to any "/[project]/*" route in project "demo"
     Then the Langy handle is not visible
 
+  # An install with no demo project configured (every self-host) leaves
+  # DEMO_PROJECT_SLUG undefined. Comparing it against an equally unresolved
+  # project, on any route where project context hasn't loaded yet, must not
+  # read as a match, hiding the handle for a rollout that already applies.
+  Scenario: An unresolved project is not mistaken for the demo project
+    Given Langy has been rolled out to my organization
+    And no demo project is configured on this install
+    And the active project has not resolved yet
+    When I navigate to any "/[project]/*" route
+    Then the Langy handle is visible
+
   # ============================================================================
   # Read-only tools (information retrieval)
   # ============================================================================

--- a/specs/langy/langy-baseline.feature
+++ b/specs/langy/langy-baseline.feature
@@ -88,15 +88,12 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When I navigate to any "/[project]/*" route in project "demo"
     Then the Langy handle is not visible
 
-  # An install with no demo project configured (every self-host) leaves
-  # DEMO_PROJECT_SLUG undefined. Comparing it against an equally unresolved
-  # project, on any route where project context hasn't loaded yet, must not
-  # read as a match, hiding the handle for a rollout that already applies.
-  Scenario: An unresolved project is not mistaken for the demo project
+  # Nothing about the active project is known yet while it is still loading,
+  # so nothing about it can be compared against. That must not be treated as
+  # a reason to hide the handle for a rollout that already applies.
+  Scenario: The handle stays visible while the active project is still loading
     Given Langy has been rolled out to my organization
-    And no demo project is configured on this install
-    And the active project has not resolved yet
-    When I navigate to any "/[project]/*" route
+    When I navigate to any "/[project]/*" route before its project finishes loading
     Then the Langy handle is visible
 
   # ============================================================================


### PR DESCRIPTION
## Summary

Fresh `npx @langwatch/server@latest` install (3.7.0) showed the Langy launcher completely missing on `/me`. Root cause: `useOrganizationTeamProject` funnels every route through `selectAmbientTeam`, which correctly prefers a shared team over a personal one on organization-scoped pages (settings etc, so org-wide settings never land in one member's private workspace), but `/me` is unambiguously the personal workspace and was wrongly sent through that same ambient logic.

- `useOrganizationTeamProject.ts`: on `/me` and its sub-routes, resolve the user's own personal team first, before the localStorage-remembered-team lookup runs. A team id persisted from an earlier organization-scoped visit legitimately wins on those pages but must never follow the user onto `/me` (caught via live debugging: an earlier version of this fix put the personal-team check after the localStorage lookup instead of before it, so a stale remembered team still won).
- `useShowLangy.ts` and `DashboardLayout.tsx`: fixed a `DEMO_PROJECT_SLUG === project?.slug` equality trap that read as true when both sides are `undefined` (any self-host with no demo project configured, on any route with an unresolved project), wrongly treating the user as being on the demo project and hiding Langy.

## Verification

- 23 integration tests added/updated across `useOrganizationTeamProject.personal-workspace.integration.test.tsx` and `useShowLangy.integration.test.tsx`, all passing, including one confirmed to genuinely fail without the fix (reverted and reran before restoring).
- `pnpm typecheck` and `pnpm typecheck:tests` both clean.
- New BDD scenarios in `specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature`.
- Live end-to-end proof on the real released 3.7.0 package: rebuilt the relocated install tree with the fix, restarted it, and confirmed via headless browser that the Langy launcher now renders on `/me` (previously absent), the composer enables once a real model provider is configured, and Langy replies for real to a genuine conversation.

Langy panel open and enabled on `/me`, after the fix:

![Langy panel visible on /me](https://raw.githubusercontent.com/langwatch/pr-screenshots/458fb93afb2aa44349884552e1a3b5c466ac5b50/pr-6262/langy-panel-visible-on-me.png)

A real conversation completing, with the resulting trace showing up in usage:

![Langy real reply and trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/458fb93afb2aa44349884552e1a3b5c466ac5b50/pr-6262/langy-real-reply-and-trace.png)

## Also fixed: docs links pointed at a local Mintlify on self-hosted installs

Found while dogfooding the same install: `getDocsBaseUrl` assumed any app served from `localhost` has a contributor's Mintlify running on `:3000`, so the "Install guide" / "CLI reference" / other docs links on a packaged self-hosted server (npx, Docker, Helm) pointed at a dead local port instead of the real docs, since those installs are also commonly reached on `localhost`.

Now also requires a development build (`import.meta.env.DEV`, false in every packaged production build) before taking the local-docs shortcut, checked only inside the existing browser-only branch since this module is also imported server-side under `tsx`, where `import.meta.env` does not exist.

- 9 unit tests added/updated in `docsUrl.unit.test.ts`, all passing.
- New BDD scenarios in `specs/ai-governance/cli-onboarding/docs-links-resolve-correctly.feature`.

## Test plan

- [x] `pnpm test:integration run src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx --watch=false`
- [x] `pnpm test:unit run src/utils/__tests__/docsUrl.unit.test.ts --watch=false`
- [x] `pnpm typecheck` / `pnpm typecheck:tests`
- [x] `pnpm check:feature-parity`
- [x] Live dogfood on a rebuilt `npx @langwatch/server@latest` install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Personal workspace routes (`/me` and sub-routes) now consistently resolve to the user’s personal team/project, avoiding stale shared selections and ambient context leakage.
  * Langy visibility no longer incorrectly hides/matches when the active project or demo project slug hasn’t resolved yet.
  * Documentation links now correctly distinguish contributor dev servers from production self-hosted instances.
* **Tests**
  * Expanded integration and governance coverage for personal-workspace routing and Langy loading edge cases.
  * Added CLI onboarding link resolution specs for self-hosted setups.
  * Updated unit tests for docs base URL resolution across development and production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->