### PR TITLE
fix(automations): expose page-cap and missing-scope gaps in Slack channel listings

### DIFF
--- a/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/langwatch/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -25,6 +25,8 @@ vi.mock("~/components/ui/color-mode", () => ({
 const listedChannels: { current: { id: string; name: string }[] | undefined } = {
   current: undefined,
 };
+/** Why the listing is short of the workspace, as the server would report it. */
+const listedGaps: { current: string[] } = { current: [] };
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -36,7 +38,7 @@ vi.mock("~/utils/api", () => ({
         useMutation: () => ({
           mutate: vi.fn(),
           data: listedChannels.current
-            ? { channels: listedChannels.current }
+            ? { channels: listedChannels.current, gaps: listedGaps.current }
             : undefined,
           isPending: false,
         }),
@@ -341,6 +343,7 @@ describe("SlackConfigForm channel picker", () => {
   afterEach(() => {
     cleanup();
     listedChannels.current = undefined;
+    listedGaps.current = [];
   });
 
   describe("given a workspace whose channels have loaded", () => {
@@ -516,6 +519,93 @@ describe("SlackConfigForm channel picker", () => {
         expect(onChangeSpy).toHaveBeenLastCalledWith(
           expect.objectContaining({ channelId: "#adhoc" }),
         );
+      });
+    });
+
+    // A short list that looks complete is the failure mode being fixed: the
+    // author scrolls, doesn't find their channel, and concludes the whole
+    // integration is broken. Every way the list can come back short has to say
+    // so, and point at the way through.
+    describe("when the workspace has more channels than the fetch can return", () => {
+      beforeEach(() => {
+        listedGaps.current = ["page_cap"];
+      });
+
+      it("tells the author the list is incomplete", async () => {
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        expect(
+          await screen.findByText(/more channels than we can list/i),
+        ).toBeInTheDocument();
+      });
+
+      it("points the author at entering the channel themselves", async () => {
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        expect(
+          await screen.findByText(/type the channel name or paste its id/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    // Reachable: an app with no groups:read whose public channels then outrun
+    // the page budget. Ranking the two would have the author fix the scope and
+    // still come up short.
+    describe("when the list is short for more than one reason", () => {
+      beforeEach(() => {
+        listedGaps.current = ["page_cap", "private_channels_hidden"];
+      });
+
+      it("names every reason, not just the first", async () => {
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        const hint = await screen.findByText(/private channels aren't listed/i);
+
+        expect(hint).toHaveTextContent(/more channels than we can list/i);
+      });
+    });
+
+    describe("when the app cannot see private channels", () => {
+      beforeEach(() => {
+        listedGaps.current = ["private_channels_hidden"];
+      });
+
+      it("names the permission that would show them", async () => {
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        const hint = await screen.findByText(/private channels aren't listed/i);
+
+        expect(hint).toHaveTextContent(/groups:read/);
+      });
+    });
+
+    describe("when the list covers the whole workspace", () => {
+      it("says nothing about the list being short", () => {
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        expect(
+          screen.queryByText(/more channels than we can list/i),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/private channels aren't listed/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    // The manifest grants chat:write.public, so public channels need no invite
+    // and private ones do. Telling the author only "invite the bot" sends them
+    // to do the one thing that doesn't help for a public channel, and doesn't
+    // mention the case where it is required.
+    describe("when the author reads the setup steps", () => {
+      it("says public channels need no invite and private ones do", async () => {
+        const user = userEvent.setup();
+        renderForm({ initial: botSlice({ channelId: "" }) });
+
+        await user.click(screen.getByText(/setup steps/i));
+
+        expect(
+          await screen.findByText(/public channels work straight away/i),
+        ).toHaveTextContent(/private channel, add the app to that channel/i);
       });
     });
 

--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -394,13 +394,32 @@ function SlackChannelField({
     list.data?.error && list.data.error !== "no_token"
       ? list.data.error
       : null;
+  // A listing can succeed and still be short of the workspace. Saying nothing
+  // is the worst option: the author scrolls a list that looks complete, doesn't
+  // find their channel, and concludes the integration is broken.
+  // Both gaps can apply at once — an app without `groups:read` whose public
+  // channels then outrun the page budget — so they are listed, not ranked.
+  // Showing only the first would have the author fix one cause and still not
+  // find their channel.
+  const gaps = list.data?.gaps ?? [];
+  const gapHints = [
+    gaps.includes("private_channels_hidden")
+      ? "Private channels aren't listed — your Slack app needs the groups:read permission. Reinstall it with the manifest above."
+      : null,
+    gaps.includes("page_cap")
+      ? "This workspace has more channels than we can list here, so some are missing."
+      : null,
+  ].filter((line): line is string => line !== null);
+  const gapHint = gapHints.length
+    ? `${gapHints.join(" ")} Type the channel name or paste its ID above to use one that isn't shown.`
+    : null;
   const hint = list.isError
     ? `Couldn't load channels: ${list.error?.message ?? "request failed"}. You can still type the channel above.`
     : returnedError === "missing_scope"
-      ? "Add the channels:read scope to your app and reinstall it to pick from a list — you can still type the channel above."
+      ? "Add the channels:read permission to your Slack app and reinstall it to pick from a list — you can still type the channel above."
       : returnedError
         ? "Couldn't load channels from Slack. Check the token, or type the channel above."
-        : null;
+        : gapHint;
 
   return (
     <Field.Root>
@@ -930,7 +949,8 @@ function SlackBotFields({
               </List.Item>
               <List.Item>
                 <Text textStyle="xs" color="fg.muted">
-                  Invite the bot to the channel you post to.
+                  Public channels work straight away. To post to a private
+                  channel, add the app to that channel first.
                 </Text>
               </List.Item>
             </List.Root>

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -606,7 +606,9 @@ export const automationRouter = createTRPCRouter({
    * picker (ADR-041). Uses the freshly-typed token, or the saved automation's
    * stored token (decrypted server-side, never returned). A missing
    * `channels:read` scope comes back as `{ error: "missing_scope" }` so the UI
-   * degrades to manual entry instead of failing.
+   * degrades to manual entry instead of failing. A listing that succeeded but
+   * does not cover the whole workspace carries `gaps` saying why, so the picker
+   * can tell the author rather than presenting a short list as complete.
    */
   listSlackChannels: protectedProcedure
     .input(
@@ -630,7 +632,8 @@ export const automationRouter = createTRPCRouter({
           (saved?.actionParams ?? {}) as SlackActionParams,
         );
       }
-      if (!token) return { channels: [], error: "no_token" as string };
+      if (!token)
+        return { channels: [], error: "no_token" as string, gaps: [] };
       return listSlackChannels(token);
     }),
   updateTriggerFilters: protectedProcedure

--- a/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
+++ b/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
@@ -210,9 +210,9 @@ describe("listSlackChannels", () => {
 
     // Slack returns "fewer than the requested number of items ... even if the
     // end of the list hasn't been reached", so a workspace exhausts the page
-    // budget long before it exhausts its channels. Reproduced against a
-    // stand-in Slack serving 40 per page: 400 of 601 channels came back with
-    // nothing to say the other 201 existed.
+    // budget long before it exhausts its channels. This mock takes that to its
+    // extreme — one channel per page, a cursor that never ends — so the cap is
+    // the only thing that can stop the walk.
     it("stops at the page cap rather than spinning on an endless cursor", async () => {
       mockedSend.mockResolvedValue({
         responseHeaders: {},

--- a/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
+++ b/langwatch/src/server/app-layer/automations/delivery/__tests__/slackWebApi.unit.test.ts
@@ -208,6 +208,11 @@ describe("listSlackChannels", () => {
       expect(bodyParams(1).get("cursor")).toBe("dGVhbTpDMDYx");
     });
 
+    // Slack returns "fewer than the requested number of items ... even if the
+    // end of the list hasn't been reached", so a workspace exhausts the page
+    // budget long before it exhausts its channels. Reproduced against a
+    // stand-in Slack serving 40 per page: 400 of 601 channels came back with
+    // nothing to say the other 201 existed.
     it("stops at the page cap rather than spinning on an endless cursor", async () => {
       mockedSend.mockResolvedValue({
         responseHeaders: {},
@@ -221,6 +226,36 @@ describe("listSlackChannels", () => {
 
       expect(mockedSend.mock.calls.length).toBeLessThanOrEqual(10);
       expect(result.channels.length).toBe(mockedSend.mock.calls.length);
+    });
+
+    it("reports the listing as capped so the caller can say the list is short", async () => {
+      mockedSend.mockResolvedValue({
+        responseHeaders: {},
+        status: 200,
+        body: JSON.stringify(
+          channelPage({ ids: ["C1"], nextCursor: "never-ends" }),
+        ),
+      });
+
+      const result = await listSlackChannels("xoxb-test");
+
+      // Not an error — the call succeeded. It is just not the whole workspace,
+      // and that difference has to survive the return trip.
+      expect(result.error).toBeNull();
+      expect(result.gaps).toContain("page_cap");
+    });
+
+    it("reports no gaps when the walk reaches the end of the workspace", async () => {
+      mockedSend.mockResolvedValueOnce({
+        responseHeaders: {},
+        status: 200,
+        body: JSON.stringify(channelPage({ ids: ["C1", "C2"] })),
+      });
+
+      const result = await listSlackChannels("xoxb-test");
+
+      expect(result.error).toBeNull();
+      expect(result.gaps).toEqual([]);
     });
 
     it("keeps the pages it already gathered when a later page fails", async () => {
@@ -250,7 +285,7 @@ describe("listSlackChannels", () => {
 
       const result = await listSlackChannels("xoxb-test");
 
-      expect(result).toEqual({ channels: [], error: "bad_response" });
+      expect(result).toEqual({ channels: [], error: "bad_response", gaps: [] });
     });
   });
 
@@ -260,7 +295,7 @@ describe("listSlackChannels", () => {
       // the app is missing channels:read entirely.
       respond(200, { ok: false, error: "missing_scope" });
       const result = await listSlackChannels("xoxb-test");
-      expect(result).toEqual({ channels: [], error: "missing_scope" });
+      expect(result).toEqual({ channels: [], error: "missing_scope", gaps: [] });
     });
 
     it("falls back to public channels when only groups:read is missing", async () => {
@@ -283,7 +318,10 @@ describe("listSlackChannels", () => {
 
       const result = await listSlackChannels("xoxb-test");
 
+      // The retry succeeds, so there is no error to report — but the listing is
+      // missing every private channel and the caller has to be able to say so.
       expect(result.error).toBeNull();
+      expect(result.gaps).toContain("private_channels_hidden");
       expect(result.channels.map((c) => c.id)).toEqual(["C1"]);
       expect(bodyParams(0).get("types")).toBe(
         "public_channel,private_channel",
@@ -300,6 +338,7 @@ describe("listSlackChannels", () => {
       expect(await listSlackChannels("xoxb-test")).toEqual({
         channels: [],
         error: "request_failed",
+        gaps: [],
       });
     });
   });

--- a/langwatch/src/server/app-layer/automations/delivery/slackWebApi.ts
+++ b/langwatch/src/server/app-layer/automations/delivery/slackWebApi.ts
@@ -131,6 +131,30 @@ export interface SlackChannel {
   isPrivate: boolean;
 }
 
+/**
+ * Why a channel listing is short of the workspace. A listing can succeed and
+ * still be incomplete, and the two are indistinguishable to the caller unless
+ * we say so — which is the whole reason this type exists.
+ *
+ *   - `page_cap` — the walk stopped before Slack ran out of channels. Slack
+ *     documents that "it's possible to receive fewer results than your
+ *     specified limit, even when there are additional results to retrieve", so
+ *     a page can carry a fraction of what we ask for. The real ceiling is
+ *     therefore well under `pages x limit`, varies by workspace, and cannot be
+ *     predicted from the page size — which is why the cap has to be reported
+ *     rather than reasoned about.
+ *   - `private_channels_hidden` — the app has no `groups:read`, so the listing
+ *     fell back to public channels only.
+ */
+export type SlackChannelListGap = "page_cap" | "private_channels_hidden";
+
+export interface SlackChannelListing {
+  channels: SlackChannel[];
+  error: string | null;
+  /** Empty when the listing covers the whole workspace. */
+  gaps: SlackChannelListGap[];
+}
+
 interface SlackConversationsResponse {
   ok: boolean;
   error?: string;
@@ -163,11 +187,19 @@ const CHANNEL_LIST_MAX_RESPONSE_BYTES = 1024 * 1024;
 async function listChannelsForTypes(
   token: string,
   types: string,
-): Promise<{ channels: SlackChannel[]; error: string | null }> {
+): Promise<SlackChannelListing> {
   const collected: SlackChannel[] = [];
-  const done = (error: string | null) => ({
+  // Sorting happens here, AFTER any truncation, so a capped walk yields a list
+  // that reads as alphabetical and complete while missing entries throughout.
+  // That is why a silent cap is so misleading: the holes look like absence, not
+  // truncation.
+  const done = (
+    error: string | null,
+    gaps: SlackChannelListGap[] = [],
+  ): SlackChannelListing => ({
     channels: [...collected].sort((a, b) => a.name.localeCompare(b.name)),
     error,
+    gaps,
   });
 
   let cursor: string | undefined;
@@ -222,7 +254,7 @@ async function listChannelsForTypes(
     { pages: MAX_CHANNEL_PAGES, channels: collected.length },
     "Slack conversations.list page cap reached; returning a partial channel list",
   );
-  return done(null);
+  return done(null, ["page_cap"]);
 }
 
 /**
@@ -238,12 +270,21 @@ async function listChannelsForTypes(
  */
 export async function listSlackChannels(
   token: string,
-): Promise<{ channels: SlackChannel[]; error: string | null }> {
+): Promise<SlackChannelListing> {
   const withPrivate = await listChannelsForTypes(
     token,
     "public_channel,private_channel",
   );
   if (withPrivate.error !== "missing_scope") return withPrivate;
-  // Missing `groups:read` (private) — fall back to public channels only.
-  return listChannelsForTypes(token, "public_channel");
+  // Missing `groups:read` (private) — fall back to public channels only. The
+  // retry succeeds, so without recording the gap the caller would see a clean
+  // listing and no reason to doubt it.
+  const publicOnly = await listChannelsForTypes(token, "public_channel");
+  // Only a listing that came back is missing something. If the retry failed too
+  // there is no list to be partial, and the error is the whole story.
+  if (publicOnly.error !== null) return publicOnly;
+  return {
+    ...publicOnly,
+    gaps: [...publicOnly.gaps, "private_channels_hidden"],
+  };
 }

--- a/specs/automations/authoring-drawer.feature
+++ b/specs/automations/authoring-drawer.feature
@@ -96,7 +96,7 @@ Feature: Staged automation authoring drawer
 
     Scenario: The app cannot see private channels
       Given the user is configuring a Slack notification
-      And the Slack app was installed without permission to read private channels
+      And the Slack app cannot see the workspace's private channels
       Then the public channels are still offered
       And the author is told private channels are missing and which permission adds them
 

--- a/specs/automations/authoring-drawer.feature
+++ b/specs/automations/authoring-drawer.feature
@@ -68,14 +68,49 @@ Feature: Staged automation authoring drawer
       Then the recipient is accepted
       And it is shown with an "External" warning badge
 
-    Scenario: A Slack notification configures a webhook and a message template
+    Scenario: A Slack notification configures a destination and a message template
       Given the user is configuring a Slack notification
-      Then the user sets the webhook and the message template
+      Then the user sets the channel and the message template
 
     Scenario: A dataset action configures the destination only
       Given the user is configuring an add-to-dataset action
       Then the user selects the target dataset
       And no template section is shown
+
+  Rule: The Slack channel list never claims to be complete when it isn't
+
+    The picker is populated from what the bot token can see, and there are
+    several ways that view comes back partial: a scope the app was never
+    granted, and a workspace with more channels than the picker can list. A
+    partial list that looks complete is worse than no list — the author scrolls
+    past the channel they wanted, concludes the integration is broken, and has
+    nothing to act on. Whenever the list is short of the workspace, the author
+    is told so and given the way through.
+
+    Scenario: The workspace has more channels than the picker can list
+      Given the user is configuring a Slack notification
+      And the workspace has more channels than the picker can list
+      Then the channels that were retrieved are offered
+      And the author is told the list is incomplete
+      And the author is told they can enter the channel directly instead
+
+    Scenario: The app cannot see private channels
+      Given the user is configuring a Slack notification
+      And the Slack app was installed without permission to read private channels
+      Then the public channels are still offered
+      And the author is told private channels are missing and which permission adds them
+
+    Scenario: The whole workspace fits in the list
+      Given the user is configuring a Slack notification
+      And the workspace has few enough channels for the picker to list them all
+      Then every channel is offered
+      And no incompleteness notice is shown
+
+    Scenario: A channel the list never returned can still be used
+      Given the user is configuring a Slack notification
+      And the channel they want is absent from the list
+      When the author enters the channel themselves
+      Then it is accepted as the destination
 
   Rule: Cadence and debounce apply per trigger
 


### PR DESCRIPTION
# Related Issue

- Resolves #6254

## Why

Closes #6254

The Slack channel picker could return a fraction of a workspace's channels and look complete doing it. An author scrolls a tidy alphabetical list, doesn't find the channel they want — often one they had just added the app to — and reasonably concludes the integration is broken.

Reproduced against a stand-in Slack that pages the way the real one does: **400 of 601 channels came back, the private channel the bot belonged to was gone, and `error` was `null`.**

## What changed

A channel listing can now say it is short of the workspace, and why.

Previously the contract was `{ channels, error }`, which can express *worked* or *failed* but not *"worked, but this is not all of it"*. Every way the list came back partial collapsed into `error: null`, so the picker had nothing to show and no way to know. Listings now carry `gaps` naming what made them short, and the picker tells the author which ones apply and how to reach a channel that isn't listed.

Two pieces of copy that actively misdirected people are corrected too:

- The scope hint named `channels:read` — the permission for *public* channels — when the problem was private ones.
- The setup steps said only "invite the bot to the channel you post to". The manifest we hand out grants `chat:write.public`, so that is unnecessary for public channels and required for private ones. Saying neither is why the flow reads as contradictory: test messages land in channels the app was never invited to, while the channel someone deliberately added it to doesn't appear.

## How it works

Two behaviours combined to make the list short and silent.

**The page walk ends before the workspace does.** Slack documents that "it's possible to receive fewer results than your specified limit, even when there are additional results to retrieve". We ask for 200 and walk 10 pages, but a page can carry far less, so the real ceiling is well under what the page size implies, varies per workspace, and cannot be predicted from it. That is why the cap has to be *reported* rather than reasoned about.

**The list is sorted after it is truncated.** Channels are collected in Slack's order, cut at the page cap, then sorted alphabetically. The result reads as an orderly complete list with entries missing throughout, rather than as a list that was obviously cut short — which is exactly why it fools people.

A listing can be short for more than one reason at once (an app without `groups:read` whose public channels then outrun the page budget), so gaps are listed rather than ranked. Showing only the first would have the author fix one cause and still come up empty.

One deliberate asymmetry: a listing that *failed* carries no gaps. There is no partial list to describe, and the error is the whole story.

## Test plan

Two existing tests pinned the silent behaviour as intended and had to be rewritten — worth a reviewer's attention, because it means this could never have surfaced as a regression:

- `slackWebApi.unit.test.ts` previously asserted `expect(result.error).toBeNull()` on the private-channel fallback.
- The page-cap test asserted only that the walk stopped, never that the caller was told.

Added:

| Test | Pins |
|---|---|
| capped walk reports `page_cap` | truncation is visible to the caller |
| complete walk reports no gaps | no false alarm when the list is whole |
| public-only fallback reports `private_channels_hidden` | the scope gap survives a successful retry |
| picker says the list is incomplete | the truncation reaches the author |
| picker names the permission for private channels | `groups:read`, not `channels:read` |
| picker names every reason when several apply | reachable case, verified by execution |
| picker stays silent when the list is whole | no notice on a healthy workspace |
| setup steps distinguish public from private | the copy that misdirected people |

Green locally: 33 picker integration, 19 server unit, 621 automations unit, 136 automations integration, `pnpm typecheck` and `pnpm typecheck:tests`.

Specs: `specs/automations/authoring-drawer.feature` had **no channel-picker scenarios at all**, which is why none of this was caught. Added a rule covering the partial-list cases; its existing Slack scenario also still described the retired webhook flow and now describes the channel.

## Anything surprising?

- **The "2000-channel cap" in the original report is fiction.** 10 pages x 200 is the request, not the result. In the reproduction the real ceiling was 400.
- **A missing scope was not needed to explain the symptom.** Truncation alone drops private channels the bot belongs to, so "the app is in this channel but the channel isn't listed" does not imply a permissions problem — which is where the old copy pointed people.
- **One path still returns a partial list without a gap:** a page failing mid-walk returns what was collected plus an error, so the picker lists partial channels while saying it couldn't load them. Pre-existing and unchanged by this PR; flagged rather than folded in.
- **Related:** #6244 (the view drawer labels every bot automation "Slack webhook") is untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Slack channel picker guidance when results are incomplete (including pagination truncation).
  - Supports manual entry of a channel name or ID when the desired channel isn’t returned.
  - Clarifies permission messaging when private channels can’t be listed.
  - Updated “Copy app manifest” setup steps: public channels work immediately; private channels require adding the app first.
- **Bug Fixes**
  - Slack channel listing now correctly communicates “incomplete” vs “complete” results, including hidden private channels, instead of implying the list is exhaustive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->