### PR TITLE
fix(deps): support Node 25 and 26 alongside 24

### DIFF
--- a/langwatch/.npmrc
+++ b/langwatch/.npmrc
@@ -1,2 +1,9 @@
 public-hoist-pattern[]=*import-in-the-middle*
 public-hoist-pattern[]=*require-in-the-middle*
+
+# node_modules is fully regenerable, so a purge never risks real data. Without
+# this, pnpm aborts non-interactively (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY)
+# instead of just reinstalling, which is exactly what a supported engine range
+# spanning several Node majors makes routine (native deps need a fresh build
+# per Node ABI).
+confirm-modules-purge=false

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -3,7 +3,7 @@
   "version": "3.7.0",
   "private": true,
   "engines": {
-    "node": "24.x",
+    "node": "24.x || 25.x || 26.x",
     "npm": ">=10.0.0"
   },
   "volta": {

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -335,14 +335,14 @@ if (
   (globalThis.localStorage == null ||
     typeof globalThis.localStorage.setItem !== "function")
 ) {
-  const noopStorage: Storage = {
+  const noopStorage = {
     length: 0,
     clear: () => {},
     getItem: () => null,
     key: () => null,
     removeItem: () => {},
     setItem: () => {},
-  };
+  } satisfies Storage;
   Object.defineProperty(globalThis, "localStorage", {
     value: noopStorage,
     configurable: true,

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -315,6 +315,41 @@ vi.mock("~/utils/compat/next-dynamic", () => ({
   },
 }));
 
+// Inside vitest's vm-sandboxed worker pool, Node 25 and 26 both define
+// `localStorage` as a global property even when `--localstorage-file` was
+// never passed, instead of leaving it genuinely absent the way plain Node
+// (and every other Node version) does. zustand's persist middleware defaults
+// to this bare global when no `storage` option is given: `createJSONStorage`
+// only falls back gracefully when READING the global throws (an absent
+// global does that), but here the property exists, so the read succeeds and
+// hands back either a broken stub missing `setItem`, or, in one of these
+// Node versions, the bare value `undefined`, which `typeof` can't tell
+// apart from the property being absent, so it still gets wrapped instead of
+// triggering the graceful fallback, and crashes the moment persist actually
+// calls `.setItem`. `in` distinguishes "property exists" from "genuinely
+// undeclared", and `defineProperty` (not assignment) replaces it even if the
+// existing property is a getter with no setter. Only touches a broken or
+// empty global, never jsdom's real, fully-functional `window.localStorage`.
+if (
+  "localStorage" in globalThis &&
+  (globalThis.localStorage == null ||
+    typeof globalThis.localStorage.setItem !== "function")
+) {
+  const noopStorage: Storage = {
+    length: 0,
+    clear: () => {},
+    getItem: () => null,
+    key: () => null,
+    removeItem: () => {},
+    setItem: () => {},
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: noopStorage,
+    configurable: true,
+    writable: true,
+  });
+}
+
 // Polyfill window.matchMedia for Vitest/JSDOM (not implemented by default).
 // Prevents "TypeError: window.matchMedia is not a function" when components
 // or hooks call matchMedia at module or render time.


### PR DESCRIPTION
## Summary

A customer report flagged that installing on Node 25 hits an engine warning and, separately, `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. Rather than assume the strict `24.x` pin was necessary, tested empirically: installed Node 25.6.0 and 26.5.0 via nvm and ran the real test suite against both.

Found one genuine incompatibility, not a dozen: inside vitest's vm-sandboxed worker pool, both Node 25 and 26 define a global `localStorage` even without `--localstorage-file`, instead of leaving it genuinely absent the way a bare Node process (and every other Node version) does. zustand's persist middleware (`useLangyStore`) defaults to this bare global when no `storage` option is given, and only falls back gracefully when *reading* it throws, not when it reads back something non-functional. Any node-environment test touching that store crashed the moment persist called `.setItem`.

- `langwatch/test-setup.ts` (shared by both the unit and integration vitest configs): replaces a broken or empty `localStorage` global with a working no-op `Storage` object. Only touches a broken/empty global, never jsdom's real, functional `window.localStorage`.
- `langwatch/package.json`: `engines.node` widened from `"24.x"` to `"24.x || 25.x || 26.x"`. Node 25 is itself already end-of-life (odd releases never reach LTS); Node 26 is Current until it reaches Active LTS in October. 24.x stays the default everywhere else (CI, the volta pin).
- `langwatch/.npmrc`: `confirm-modules-purge=false`. `node_modules` is fully regenerable, so skipping this confirmation is low-risk, and it's exactly what turns a Node-major switch into a hard, non-interactive abort instead of just a reinstall.

## Verification

- `pnpm typecheck` / `typecheck:tests` clean on Node 24.11.1, 25.6.0, and 26.5.0.
- Full `pnpm test:unit` suite: 1899/1907 passing (8 pre-existing skips), identical results on all three Node versions.
- Integration test spot-check clean on Node 26.
- `pnpm config get confirm-modules-purge` returns `false`, confirming the `.npmrc` key is recognized.

## Test plan

- [x] `pnpm typecheck` / `pnpm typecheck:tests` on Node 24, 25, 26
- [x] `pnpm test:unit run --watch=false` on Node 24, 25, 26 (1899/1907 passing, identical)
- [x] `pnpm test:integration` spot-check on Node 26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Expanded supported Node.js versions to include 25 and 26 (in addition to 24).
* **Reliability**
  * Improved non-interactive package installation behavior by disabling unnecessary purge confirmations.
  * Enhanced test environment compatibility for newer Node.js versions by adding a safe `localStorage` shim only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->