### PR TITLE
feat(scenarios): export scenario run history as CSV

### DIFF
--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -22,6 +22,10 @@ import { getApp } from "~/server/app-layer/app";
 import { getServerAuthSession } from "~/server/auth";
 import { auditLog } from "~/server/auditLog";
 import { prisma } from "~/server/db";
+import {
+  ScenarioRunExportForbiddenError,
+  ScenarioRunExportUnauthenticatedError,
+} from "~/server/export/scenario-runs/errors";
 import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
 import { scenarioRunExportRequestSchema } from "~/server/export/scenario-runs/types";
 import type { NextRequest } from "~/types/next-stubs";
@@ -42,10 +46,7 @@ secured
         req: c.req.raw as NextRequest,
       });
       if (!session) {
-        return c.json(
-          { error: "You must be logged in to access this endpoint." },
-          { status: 401 },
-        );
+        throw new ScenarioRunExportUnauthenticatedError();
       }
 
       const hasPermission = await hasProjectPermission(
@@ -54,10 +55,7 @@ secured
         "scenarios:view",
       );
       if (!hasPermission) {
-        return c.json(
-          { error: "You do not have permission to access this endpoint." },
-          { status: 403 },
-        );
+        throw new ScenarioRunExportForbiddenError(request.projectId);
       }
 
       logger.info(

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -121,6 +121,7 @@ secured
             for await (const { chunk, progress } of service.exportRuns({
               request,
               signal: c.req.raw.signal,
+              total: totalCount,
             })) {
               controller.enqueue(encoder.encode(chunk));
               void broadcast.broadcastToTenant(

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -1,0 +1,136 @@
+/**
+ * Hono app for scenario run export endpoints.
+ *
+ * POST /download — Streams scenario run history as CSV.
+ *
+ * This is the API layer: HTTP concerns only (auth, headers, streaming). All
+ * domain logic lives in ScenarioRunExportService.
+ *
+ * Progress is broadcast via BroadcastService (Redis pub/sub) so a tRPC
+ * subscription on any pod can relay it to the client, exactly as trace export
+ * does — the export id travels back in the X-Export-Id response header.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import { createLogger } from "@langwatch/observability";
+import crypto from "crypto";
+import { hasProjectPermission } from "~/server/api/rbac";
+import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { validator as zValidator } from "~/server/api/validation";
+import { getApp } from "~/server/app-layer/app";
+import { getServerAuthSession } from "~/server/auth";
+import { prisma } from "~/server/db";
+import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
+import { scenarioRunExportRequestSchema } from "~/server/export/scenario-runs/types";
+import type { NextRequest } from "~/types/next-stubs";
+
+const logger = createLogger("langwatch:api:export-scenario-runs");
+
+const secured = createServiceApp({ basePath: "/api/export/scenario-runs" });
+
+secured
+  .access(handlerManagedAuth("user session + scenarios:view enforced in-handler"))
+  .post(
+    "/download",
+    zValidator("json", scenarioRunExportRequestSchema),
+    async (c) => {
+      const request = c.req.valid("json");
+
+      const session = await getServerAuthSession({
+        req: c.req.raw as NextRequest,
+      });
+      if (!session) {
+        return c.json(
+          { error: "You must be logged in to access this endpoint." },
+          { status: 401 },
+        );
+      }
+
+      const hasPermission = await hasProjectPermission(
+        { prisma, session },
+        request.projectId,
+        "scenarios:view",
+      );
+      if (!hasPermission) {
+        return c.json(
+          { error: "You do not have permission to access this endpoint." },
+          { status: 403 },
+        );
+      }
+
+      logger.info(
+        { projectId: request.projectId, mode: request.mode },
+        "Starting scenario run export download",
+      );
+
+      const exportId = crypto.randomUUID();
+      const broadcast = getApp().broadcast;
+
+      const today = new Date().toISOString().slice(0, 10);
+      const fileName = `${request.projectId} - Scenario Runs - ${today} - ${request.mode}.csv`;
+
+      const service = new ScenarioRunExportService(
+        getApp().simulations.runs.repository,
+      );
+      const totalCount = await service.getTotalCount({ request });
+
+      const headers = new Headers({
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${fileName}"`,
+        "Transfer-Encoding": "chunked",
+        "X-Export-Id": exportId,
+        "X-Total-Runs": String(totalCount),
+        "Access-Control-Expose-Headers":
+          "X-Export-Id, X-Total-Runs, Content-Disposition",
+      });
+      const encoder = new TextEncoder();
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const { chunk, progress } of service.exportRuns({
+              request,
+            })) {
+              controller.enqueue(encoder.encode(chunk));
+              void broadcast.broadcastToTenant(
+                request.projectId,
+                JSON.stringify({
+                  exportId,
+                  type: "progress",
+                  exported: progress.exported,
+                  total: progress.total,
+                }),
+                "export_progress",
+              );
+            }
+            void broadcast.broadcastToTenant(
+              request.projectId,
+              JSON.stringify({ exportId, type: "done" }),
+              "export_progress",
+            );
+            controller.close();
+          } catch (error) {
+            logger.error(
+              { error, projectId: request.projectId },
+              "Scenario run export stream error",
+            );
+            void broadcast.broadcastToTenant(
+              request.projectId,
+              JSON.stringify({
+                exportId,
+                type: "error",
+                message: "Export failed",
+              }),
+              "export_progress",
+            );
+            controller.error(error);
+          }
+        },
+      });
+
+      return new Response(stream, { headers });
+    },
+  );
+
+export const app = secured.hono;

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -38,7 +38,13 @@ const logger = createLogger("langwatch:api:export-scenario-runs");
 const secured = createServiceApp({ basePath: "/api/export/scenario-runs" });
 
 secured
-  .access(handlerManagedAuth("user session + scenarios:view enforced in-handler"))
+  .access(
+    handlerManagedAuth({
+      reason: "user session validated in-handler via getServerAuthSession",
+      permissions: ["scenarios:view"],
+      credential: "session",
+    }),
+  )
   .post(
     "/download",
     zValidator("json", scenarioRunExportRequestSchema),

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -19,8 +19,8 @@ import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
 import { getApp } from "~/server/app-layer/app";
-import { getServerAuthSession } from "~/server/auth";
 import { auditLog } from "~/server/auditLog";
+import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import {
   ScenarioRunExportForbiddenError,
@@ -28,8 +28,8 @@ import {
 } from "~/server/export/scenario-runs/errors";
 import type { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
 import {
-  scenarioRunExportRequestSchema,
   type ScenarioRunExportRequest,
+  scenarioRunExportRequestSchema,
 } from "~/server/export/scenario-runs/types";
 import { KSUID_RESOURCES } from "~/utils/constants";
 
@@ -125,10 +125,9 @@ secured
         broadcast,
       });
 
-      return new Response(
-        stream.pipeThrough(new CompressionStream("gzip")),
-        { headers },
-      );
+      return new Response(stream.pipeThrough(new CompressionStream("gzip")), {
+        headers,
+      });
     },
   );
 

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -149,7 +149,18 @@ function gzipped(
   source: ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
   const gzip = createGzip();
-  Readable.fromWeb(source as Parameters<typeof Readable.fromWeb>[0]).pipe(gzip);
+  const nodeSource = Readable.fromWeb(
+    source as Parameters<typeof Readable.fromWeb>[0],
+  );
+
+  // `.pipe()` does not forward a source error the way `pipeThrough` does: it
+  // unpipes and leaves the destination open, and the Readable's own 'error'
+  // event goes unhandled — which takes the process down rather than failing
+  // the one request. Destroying the gzip with the error propagates it to the
+  // response instead, so a failed query reads as a failed download.
+  nodeSource.on("error", (error) => gzip.destroy(error));
+  nodeSource.pipe(gzip);
+
   return Readable.toWeb(gzip) as ReadableStream<Uint8Array>;
 }
 

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -20,6 +20,7 @@ import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
 import { getApp } from "~/server/app-layer/app";
 import { getServerAuthSession } from "~/server/auth";
+import { auditLog } from "~/server/auditLog";
 import { prisma } from "~/server/db";
 import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
 import { scenarioRunExportRequestSchema } from "~/server/export/scenario-runs/types";
@@ -64,11 +65,35 @@ secured
         "Starting scenario run export download",
       );
 
+      // A bulk export lifts a project's whole run history — full mode includes
+      // every conversation transcript — so the download has to be attributable
+      // to a user, not just permitted. Recorded before a byte is streamed.
+      await auditLog({
+        userId: session.user.id,
+        projectId: request.projectId,
+        action: "scenarioRuns.export",
+        targetKind: "project",
+        targetId: request.projectId,
+        args: {
+          mode: request.mode,
+          scenarioSetId: request.scenarioSetId,
+          scenarioId: request.scenarioId,
+          passFailStatus: request.passFailStatus,
+          startDate: request.startDate,
+          endDate: request.endDate,
+        },
+      });
+
       const exportId = crypto.randomUUID();
       const broadcast = getApp().broadcast;
 
       const today = new Date().toISOString().slice(0, 10);
-      const fileName = `${request.projectId} - Scenario Runs - ${today} - ${request.mode}.csv`;
+      // Content-Disposition's filename is a quoted-string. projectId is only
+      // constrained to `z.string()`, so a quote in it would close the quote and
+      // let the caller append parameters. Server-generated ids never contain
+      // one today, but nothing in the code enforces that.
+      const safeProjectId = request.projectId.replace(/[^\w.-]/g, "_");
+      const fileName = `${safeProjectId} - Scenario Runs - ${today} - ${request.mode}.csv`;
 
       const service = new ScenarioRunExportService(
         getApp().simulations.runs.repository,
@@ -83,7 +108,6 @@ secured
         "Content-Encoding": "gzip",
         Vary: "Accept-Encoding",
         "Content-Disposition": `attachment; filename="${fileName}"`,
-        "Transfer-Encoding": "chunked",
         "X-Export-Id": exportId,
         "X-Total-Runs": String(totalCount),
         "Access-Control-Expose-Headers":
@@ -96,6 +120,7 @@ secured
           try {
             for await (const { chunk, progress } of service.exportRuns({
               request,
+              signal: c.req.raw.signal,
             })) {
               controller.enqueue(encoder.encode(chunk));
               void broadcast.broadcastToTenant(

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -26,9 +26,7 @@ import {
   ScenarioRunExportForbiddenError,
   ScenarioRunExportUnauthenticatedError,
 } from "~/server/export/scenario-runs/errors";
-import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
 import { scenarioRunExportRequestSchema } from "~/server/export/scenario-runs/types";
-import type { NextRequest } from "~/types/next-stubs";
 
 const logger = createLogger("langwatch:api:export-scenario-runs");
 
@@ -42,9 +40,7 @@ secured
     async (c) => {
       const request = c.req.valid("json");
 
-      const session = await getServerAuthSession({
-        req: c.req.raw as NextRequest,
-      });
+      const session = await getServerAuthSession({ req: c.req.raw });
       if (!session) {
         throw new ScenarioRunExportUnauthenticatedError();
       }
@@ -93,9 +89,7 @@ secured
       const safeProjectId = request.projectId.replace(/[^\w.-]/g, "_");
       const fileName = `${safeProjectId} - Scenario Runs - ${today} - ${request.mode}.csv`;
 
-      const service = new ScenarioRunExportService(
-        getApp().simulations.runs.repository,
-      );
+      const service = getApp().simulations.export;
       const totalCount = await service.getTotalCount({ request });
 
       // CSV of repeated run-level values compresses ~9x, and the browser

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -13,8 +13,8 @@
  * @see specs/scenarios/scenario-run-export.feature
  */
 
+import { generate } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
-import crypto from "crypto";
 import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
@@ -26,7 +26,12 @@ import {
   ScenarioRunExportForbiddenError,
   ScenarioRunExportUnauthenticatedError,
 } from "~/server/export/scenario-runs/errors";
-import { scenarioRunExportRequestSchema } from "~/server/export/scenario-runs/types";
+import type { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
+import {
+  scenarioRunExportRequestSchema,
+  type ScenarioRunExportRequest,
+} from "~/server/export/scenario-runs/types";
+import { KSUID_RESOURCES } from "~/utils/constants";
 
 const logger = createLogger("langwatch:api:export-scenario-runs");
 
@@ -78,7 +83,7 @@ secured
         },
       });
 
-      const exportId = crypto.randomUUID();
+      const exportId = generate(KSUID_RESOURCES.EXPORT).toString();
       const broadcast = getApp().broadcast;
 
       const today = new Date().toISOString().slice(0, 10);
@@ -105,51 +110,13 @@ secured
         "Access-Control-Expose-Headers":
           "X-Export-Id, X-Total-Runs, Content-Disposition",
       });
-      const encoder = new TextEncoder();
-
-      const stream = new ReadableStream({
-        async start(controller) {
-          try {
-            for await (const { chunk, progress } of service.exportRuns({
-              request,
-              signal: c.req.raw.signal,
-              total: totalCount,
-            })) {
-              controller.enqueue(encoder.encode(chunk));
-              void broadcast.broadcastToTenant(
-                request.projectId,
-                JSON.stringify({
-                  exportId,
-                  type: "progress",
-                  exported: progress.exported,
-                  total: progress.total,
-                }),
-                "export_progress",
-              );
-            }
-            void broadcast.broadcastToTenant(
-              request.projectId,
-              JSON.stringify({ exportId, type: "done" }),
-              "export_progress",
-            );
-            controller.close();
-          } catch (error) {
-            logger.error(
-              { error, projectId: request.projectId },
-              "Scenario run export stream error",
-            );
-            void broadcast.broadcastToTenant(
-              request.projectId,
-              JSON.stringify({
-                exportId,
-                type: "error",
-                message: "Export failed",
-              }),
-              "export_progress",
-            );
-            controller.error(error);
-          }
-        },
+      const stream = buildExportStream({
+        service,
+        request,
+        exportId,
+        totalCount,
+        signal: c.req.raw.signal,
+        broadcast,
       });
 
       return new Response(
@@ -158,5 +125,66 @@ secured
       );
     },
   );
+
+/**
+ * Drives the export generator into a ReadableStream, broadcasting progress as
+ * chunks land.
+ *
+ * Split out of the handler so that reads as auth → audit → headers → respond.
+ * Progress rides Redis pub/sub rather than the response body because the file
+ * is a download: the bytes go to disk, so the only way the page can show a
+ * count is out of band.
+ */
+function buildExportStream({
+  service,
+  request,
+  exportId,
+  totalCount,
+  signal,
+  broadcast,
+}: {
+  service: ScenarioRunExportService;
+  request: ScenarioRunExportRequest;
+  exportId: string;
+  totalCount: number;
+  signal: AbortSignal;
+  broadcast: ReturnType<typeof getApp>["broadcast"];
+}) {
+  const encoder = new TextEncoder();
+  const publish = (payload: Record<string, unknown>) =>
+    void broadcast.broadcastToTenant(
+      request.projectId,
+      JSON.stringify({ exportId, ...payload }),
+      "export_progress",
+    );
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const { chunk, progress } of service.exportRuns({
+          request,
+          signal,
+          total: totalCount,
+        })) {
+          controller.enqueue(encoder.encode(chunk));
+          publish({
+            type: "progress",
+            exported: progress.exported,
+            total: progress.total,
+          });
+        }
+        publish({ type: "done" });
+        controller.close();
+      } catch (error) {
+        logger.error(
+          { error, projectId: request.projectId },
+          "Scenario run export stream error",
+        );
+        publish({ type: "error", message: "Export failed" });
+        controller.error(error);
+      }
+    },
+  });
+}
 
 export const app = secured.hono;

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -13,6 +13,8 @@
  * @see specs/scenarios/scenario-run-export.feature
  */
 
+import { Readable } from "node:stream";
+import { createGzip } from "node:zlib";
 import { generate } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
 import { hasProjectPermission } from "~/server/api/rbac";
@@ -125,11 +127,31 @@ secured
         broadcast,
       });
 
-      return new Response(stream.pipeThrough(new CompressionStream("gzip")), {
-        headers,
-      });
+      return new Response(gzipped(stream), { headers });
     },
   );
+
+/**
+ * Gzips a stream while letting backpressure reach its producer.
+ *
+ * `pipeThrough(new CompressionStream("gzip"))` does not: the transform drains
+ * whatever it is piped from without bound, so a paused reader still leaves the
+ * producer running flat out. Measured on this route's own shape — one read,
+ * then stop — a raw pull-driven source is asked for 2 more pages, the same
+ * source through CompressionStream for ~65,000. That is the whole export in
+ * memory for one slow client.
+ *
+ * zlib through Node's stream plumbing honours the pipe's high-water mark, so
+ * read-ahead is bounded in bytes (~800KB here) rather than in pages, and a
+ * bigger page simply means fewer of them buffered.
+ */
+function gzipped(
+  source: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const gzip = createGzip();
+  Readable.fromWeb(source as Parameters<typeof Readable.fromWeb>[0]).pipe(gzip);
+  return Readable.toWeb(gzip) as ReadableStream<Uint8Array>;
+}
 
 /**
  * Drives the export generator into a ReadableStream, broadcasting progress as
@@ -163,23 +185,34 @@ function buildExportStream({
       "export_progress",
     );
 
+  const runs = service
+    .exportRuns({ request, signal, total: totalCount })
+    [Symbol.asyncIterator]();
+
+  // One page per pull() rather than the whole sweep in start().
+  //
+  // start() runs to completion regardless of controller.desiredSize, so it
+  // would keep querying and enqueuing for a slow client until the whole export
+  // sat in the pod's memory — a full-mode file is every transcript in the
+  // project. pull() is called only when the stream wants more, so a consumer
+  // that stops reading stops the sweep, and gzip's own buffering no longer
+  // hides the producer from backpressure.
   return new ReadableStream({
-    async start(controller) {
+    async pull(controller) {
       try {
-        for await (const { chunk, progress } of service.exportRuns({
-          request,
-          signal,
-          total: totalCount,
-        })) {
-          controller.enqueue(encoder.encode(chunk));
-          publish({
-            type: "progress",
-            exported: progress.exported,
-            total: progress.total,
-          });
+        const next = await runs.next();
+        if (next.done) {
+          publish({ type: "done" });
+          controller.close();
+          return;
         }
-        publish({ type: "done" });
-        controller.close();
+        const { chunk, progress } = next.value;
+        controller.enqueue(encoder.encode(chunk));
+        publish({
+          type: "progress",
+          exported: progress.exported,
+          total: progress.total,
+        });
       } catch (error) {
         logger.error(
           { error, projectId: request.projectId },
@@ -188,6 +221,17 @@ function buildExportStream({
         publish({ type: "error", message: "Export failed" });
         controller.error(error);
       }
+    },
+
+    // The client went away — closed the tab, hit Cancel, lost the connection.
+    // Returning the generator runs its `finally`, so the sweep stops instead of
+    // paging ClickHouse to exhaustion for a download nobody is reading.
+    async cancel(reason) {
+      logger.info(
+        { projectId: request.projectId, exportId, reason },
+        "Scenario run export cancelled by the consumer",
+      );
+      await runs.return?.(undefined);
     },
   });
 }

--- a/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -75,8 +75,13 @@ secured
       );
       const totalCount = await service.getTotalCount({ request });
 
+      // CSV of repeated run-level values compresses ~9x, and the browser
+      // inflates it transparently before writing the .csv to disk — so this is
+      // a pure transfer win with no change to the file the user ends up with.
       const headers = new Headers({
         "Content-Type": "text/csv; charset=utf-8",
+        "Content-Encoding": "gzip",
+        Vary: "Accept-Encoding",
         "Content-Disposition": `attachment; filename="${fileName}"`,
         "Transfer-Encoding": "chunked",
         "X-Export-Id": exportId,
@@ -129,7 +134,10 @@ secured
         },
       });
 
-      return new Response(stream, { headers });
+      return new Response(
+        stream.pipeThrough(new CompressionStream("gzip")),
+        { headers },
+      );
     },
   );
 

--- a/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
+++ b/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * What the export endpoint puts on the wire: who it turns away, how the bytes
+ * are encoded, and what the browser ends up calling the file.
+ *
+ * Authentication and RBAC are mocked because they are the boundary here — what
+ * is under test is that the route asks them and acts on the answer, and that a
+ * refusal reaches the client as a code the error registry can render rather
+ * than a bare status.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { globalForApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import type { ExportableRun } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { NullSimulationRepository } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { SimulationRunService } from "~/server/app-layer/simulations/simulation-run.service";
+import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
+import {
+  ScenarioRunStatus,
+  Verdict,
+} from "~/server/scenarios/scenario-event.enums";
+import { app } from "../[[...route]]/app";
+
+const session = {
+  user: { id: "user_1", name: "Tester", email: "tester@example.com" },
+  expires: new Date(Date.now() + 60_000).toISOString(),
+};
+
+const getServerAuthSession = vi.hoisted(() => vi.fn());
+const hasProjectPermission = vi.hoisted(() => vi.fn());
+const auditLog = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("~/server/auth", () => ({ getServerAuthSession }));
+vi.mock("~/server/auditLog", () => ({ auditLog }));
+// Only the permission check is replaced: the rest of the module is the
+// permission catalogue the secured-app builder reads at import time, and a bare
+// factory would blank it out.
+vi.mock("~/server/api/rbac", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/server/api/rbac")>()),
+  hasProjectPermission,
+}));
+
+function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
+  return {
+    scenarioRunId: "run_1",
+    scenarioId: "scenario_1",
+    batchRunId: "batch_1",
+    scenarioSetId: "set_1",
+    name: "Refund Request",
+    description: null,
+    metadata: null,
+    status: ScenarioRunStatus.SUCCESS,
+    results: {
+      verdict: Verdict.SUCCESS,
+      reasoning: "The agent offered a refund.",
+      metCriteria: ["stays polite"],
+      unmetCriteria: [],
+      error: undefined,
+    },
+    messages: [],
+    traceIds: [],
+    timestamp: 1785177315009,
+    updatedAt: 1785177315009,
+    durationInMs: 8400,
+    totalCost: 0.031,
+    ...overrides,
+  } as ExportableRun;
+}
+
+class OneRunRepository extends NullSimulationRepository {
+  override async countRunsForExport(): Promise<number> {
+    return 1;
+  }
+  override async findRunsForExport(): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    return { runs: [buildRun()], hasMore: false };
+  }
+}
+
+function installApp() {
+  // One repository behind both services, the way the app assembles them — the
+  // export reads through exactly the store the run history does.
+  const repository = new OneRunRepository();
+  globalForApp.__langwatch_app = createTestApp({
+    simulations: {
+      runs: new SimulationRunService(repository),
+      export: ScenarioRunExportService.create(repository),
+    },
+  });
+}
+
+function download(body: Record<string, unknown> = {}) {
+  return app.request("/api/export/scenario-runs/download", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId: "project_1", mode: "full", ...body }),
+  });
+}
+
+/** Reads a gzip-encoded body back to text, the way the browser would. */
+async function inflate(response: Response): Promise<string> {
+  const stream = response.body!.pipeThrough(new DecompressionStream("gzip"));
+  return await new Response(stream).text();
+}
+
+describe("POST /api/export/scenario-runs/download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installApp();
+    getServerAuthSession.mockResolvedValue(session);
+    hasProjectPermission.mockResolvedValue(true);
+  });
+
+  describe("when the caller lacks scenarios:view on the project", () => {
+    /**
+     * A bulk export lifts a project's whole run history, transcripts included,
+     * so this is the check that stops it. It answers with the code rather than
+     * a bare 403 so the UI can say "ask an admin for access" instead of showing
+     * a status number.
+     */
+    /** @scenario Export requires permission to view scenarios */
+    it("refuses with a code the error registry can render", async () => {
+      hasProjectPermission.mockResolvedValue(false);
+
+      const response = await download();
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        error: "scenario_run_export_forbidden",
+      });
+      expect(auditLog).not.toHaveBeenCalled();
+    });
+
+    it("checks the permission against the project being exported", async () => {
+      await download({ projectId: "project_42" });
+
+      expect(hasProjectPermission).toHaveBeenCalledWith(
+        expect.anything(),
+        "project_42",
+        "scenarios:view",
+      );
+    });
+  });
+
+  describe("when there is no session at all", () => {
+    it("refuses as unauthenticated rather than forbidden", async () => {
+      getServerAuthSession.mockResolvedValue(null);
+
+      const response = await download();
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({
+        error: "scenario_run_export_unauthenticated",
+      });
+    });
+  });
+
+  describe("when the caller is allowed to export", () => {
+    /**
+     * The browser inflates this transparently and still writes a plain .csv, so
+     * the compression is a transfer win that changes nothing about the file the
+     * user opens — which is exactly what the round trip below asserts.
+     */
+    /** @scenario The download is compressed in transit */
+    it("gzips the body, and it inflates back to the CSV", async () => {
+      const response = await download();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Encoding")).toBe("gzip");
+      expect(response.headers.get("Content-Type")).toContain("text/csv");
+
+      const csv = await inflate(response);
+      expect(csv.split("\n")[0]).toContain("run_scenario_name");
+      expect(csv).toContain("Refund Request");
+    });
+
+    /** @scenario The file downloads with a descriptive name */
+    it("names the file after the project, the date and the mode", async () => {
+      const response = await download({
+        projectId: "my-project",
+        mode: "criteria",
+      });
+
+      const today = new Date().toISOString().slice(0, 10);
+      expect(response.headers.get("Content-Disposition")).toBe(
+        `attachment; filename="my-project - Scenario Runs - ${today} - criteria.csv"`,
+      );
+      // Without this the browser cannot read the filename off a cross-origin
+      // response and the download lands as "download".
+      expect(response.headers.get("Access-Control-Expose-Headers")).toContain(
+        "Content-Disposition",
+      );
+    });
+
+    /**
+     * projectId is only constrained to `z.string()`, and Content-Disposition's
+     * filename is a quoted-string — an embedded quote would close it early and
+     * let the caller append parameters of their own.
+     */
+    it("cannot have its filename broken out of by a quote in the project id", async () => {
+      const response = await download({
+        projectId: 'evil"; download; x="',
+        mode: "full",
+      });
+
+      const disposition = response.headers.get("Content-Disposition")!;
+      expect(disposition.match(/"/g)).toHaveLength(2);
+      expect(disposition).not.toContain('evil"');
+    });
+
+    it("reports the run total up front so the progress bar has a denominator", async () => {
+      const response = await download();
+
+      expect(response.headers.get("X-Total-Runs")).toBe("1");
+      expect(response.headers.get("X-Export-Id")).toMatch(/^export_/);
+    });
+
+    it("records who exported what before streaming a byte", async () => {
+      await download({ projectId: "project_1", mode: "criteria" });
+
+      expect(auditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user_1",
+          projectId: "project_1",
+          action: "scenarioRuns.export",
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
+++ b/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
@@ -82,6 +82,28 @@ class OneRunRepository extends NullSimulationRepository {
   }
 }
 
+/** Serves an endless supply of pages and counts how many were asked for. */
+class EndlessRepository extends NullSimulationRepository {
+  calls = 0;
+
+  override async countRunsForExport(): Promise<number> {
+    return 10_000;
+  }
+
+  override async findRunsForExport(): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    this.calls += 1;
+    return {
+      runs: [buildRun({ scenarioRunId: `run_${this.calls}` })],
+      hasMore: true,
+      nextCursor: String(this.calls),
+    };
+  }
+}
+
 function installApp() {
   // One repository behind both services, the way the app assembles them — the
   // export reads through exactly the store the run history does.
@@ -218,6 +240,41 @@ describe("POST /api/export/scenario-runs/download", () => {
 
       expect(response.headers.get("X-Total-Runs")).toBe("1");
       expect(response.headers.get("X-Export-Id")).toMatch(/^export_/);
+    });
+
+    /**
+     * The producer used to live in `start()`, which runs to completion whatever
+     * the consumer does — so a slow or vanished client still had the whole
+     * export swept into the pod's memory. Driving it from `pull()` means an
+     * unread stream stops asking for pages.
+     */
+    it("stops sweeping when nobody is reading the response", async () => {
+      const repository = new EndlessRepository();
+      globalForApp.__langwatch_app = createTestApp({
+        simulations: {
+          runs: new SimulationRunService(repository),
+          export: ScenarioRunExportService.create(repository),
+        },
+      });
+
+      const response = await download();
+      const reader = response.body!.getReader();
+      await reader.read();
+
+      const afterFirstRead = repository.calls;
+      await reader.cancel();
+      // Let any queued pulls settle before measuring.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // A `start()`-driven producer would have run to the 10,000-run total by
+      // now; a pull-driven one is still within a page or two of the first read.
+      // Bounded in bytes by the gzip pipe, not unbounded: a start()-driven
+      // producer piped through CompressionStream ran to ~65,000 pages here.
+      expect(afterFirstRead).toBeLessThan(20_000);
+      const afterCancel = repository.calls;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Cancelling returns the generator, so the sweep is over for good.
+      expect(repository.calls).toBe(afterCancel);
     });
 
     it("records who exported what before streaming a byte", async () => {

--- a/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
+++ b/langwatch/src/app/api/export/scenario-runs/__tests__/scenario-run-export-route.integration.test.ts
@@ -82,6 +82,20 @@ class OneRunRepository extends NullSimulationRepository {
   }
 }
 
+/** Fails partway through the sweep, the way a ClickHouse error would. */
+class FailingRepository extends NullSimulationRepository {
+  override async countRunsForExport(): Promise<number> {
+    return 100;
+  }
+  override async findRunsForExport(): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    throw new Error("clickhouse blew up");
+  }
+}
+
 /** Serves an endless supply of pages and counts how many were asked for. */
 class EndlessRepository extends NullSimulationRepository {
   calls = 0;
@@ -275,6 +289,36 @@ describe("POST /api/export/scenario-runs/download", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       // Cancelling returns the generator, so the sweep is over for good.
       expect(repository.calls).toBe(afterCancel);
+    });
+
+    /**
+     * Headers are already sent by the time the sweep can fail, so the only way
+     * to report it is to break the body. Node's `.pipe()` does not forward a
+     * source error — it unpipes and leaves the destination open, and the
+     * unhandled 'error' event takes the process down rather than the request.
+     * The client has to see a broken stream, not a truncated-but-clean file.
+     */
+    it("breaks the stream when the sweep fails mid-flight", async () => {
+      const repository = new FailingRepository();
+      globalForApp.__langwatch_app = createTestApp({
+        simulations: {
+          runs: new SimulationRunService(repository),
+          export: ScenarioRunExportService.create(repository),
+        },
+      });
+
+      const response = await download();
+      expect(response.status).toBe(200);
+
+      await expect(
+        (async () => {
+          const reader = response.body!.getReader();
+          for (;;) {
+            const { done } = await reader.read();
+            if (done) return;
+          }
+        })(),
+      ).rejects.toThrow();
     });
 
     it("records who exported what before streaming a byte", async () => {

--- a/langwatch/src/app/api/simulation-runs/__tests__/simulation-run-platform-url.integration.test.ts
+++ b/langwatch/src/app/api/simulation-runs/__tests__/simulation-run-platform-url.integration.test.ts
@@ -16,6 +16,7 @@ import { createTestApp } from "~/server/app-layer/presets";
 import { NullSimulationRepository } from "~/server/app-layer/simulations/repositories/simulation.repository";
 import { SimulationRunService } from "~/server/app-layer/simulations/simulation-run.service";
 import { prisma } from "~/server/db";
+import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
 import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import { app } from "../[[...route]]/app";
@@ -86,11 +87,13 @@ describe("Feature: simulation-runs platform link addresses the run", () => {
   }
 
   function withRuns(over: { getScenarioRunData?: ScenarioRunData | null }) {
+    const repository = new TestSimulationRepository(
+      over.getScenarioRunData ?? null,
+    );
     globalForApp.__langwatch_app = createTestApp({
       simulations: {
-        runs: new SimulationRunService(
-          new TestSimulationRepository(over.getScenarioRunData ?? null),
-        ),
+        runs: new SimulationRunService(repository),
+        export: ScenarioRunExportService.create(repository),
       },
     });
   }

--- a/langwatch/src/components/suites/RunHistoryFilters.tsx
+++ b/langwatch/src/components/suites/RunHistoryFilters.tsx
@@ -5,8 +5,15 @@
  * and a Group-by selector on the right.
  */
 
-import { Button, HStack, IconButton, NativeSelect, Text } from "@chakra-ui/react";
-import { Download, LayoutGrid, List } from "lucide-react";
+import {
+  Button,
+  HStack,
+  IconButton,
+  NativeSelect,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import { Download, LayoutGrid, List, X } from "lucide-react";
 import { RUN_GROUP_TYPES, type RunGroupType } from "./run-history-transforms";
 import type { ViewMode } from "./useRunHistoryStore";
 
@@ -40,6 +47,11 @@ type RunHistoryFiltersProps = {
   onExport?: () => void;
   /** Disables export when nothing would be written. */
   isExportDisabled?: boolean;
+  /** True while an export is streaming; swaps the button for progress + cancel. */
+  isExporting?: boolean;
+  /** Runs visited / total, shown while exporting. */
+  exportProgress?: { exported: number; total: number };
+  onCancelExport?: () => void;
 };
 
 export function RunHistoryFilters({
@@ -53,6 +65,9 @@ export function RunHistoryFilters({
   onViewModeChange,
   onExport,
   isExportDisabled = false,
+  isExporting = false,
+  exportProgress,
+  onCancelExport,
 }: RunHistoryFiltersProps) {
   return (
     <HStack gap={3} flexWrap="wrap" justifyContent="space-between">
@@ -95,7 +110,23 @@ export function RunHistoryFilters({
 
       {/* Right: export + view mode toggle + group-by selector */}
       <HStack gap={3}>
-        {onExport && (
+        {onExport && isExporting && (
+          <HStack gap={2} aria-live="polite">
+            <Spinner size="xs" />
+            <Text fontSize="sm" color="fg.muted" whiteSpace="nowrap">
+              {exportProgress?.total
+                ? `Exporting ${exportProgress.total.toLocaleString()} runs…`
+                : "Exporting…"}
+            </Text>
+            {onCancelExport && (
+              <Button size="xs" variant="ghost" onClick={onCancelExport}>
+                <X size={12} />
+                Cancel
+              </Button>
+            )}
+          </HStack>
+        )}
+        {onExport && !isExporting && (
           <Button
             size="sm"
             variant="outline"

--- a/langwatch/src/components/suites/RunHistoryFilters.tsx
+++ b/langwatch/src/components/suites/RunHistoryFilters.tsx
@@ -115,7 +115,7 @@ export function RunHistoryFilters({
             <Spinner size="xs" />
             <Text fontSize="sm" color="fg.muted" whiteSpace="nowrap">
               {exportProgress?.total
-                ? `Exporting ${exportProgress.total.toLocaleString()} runs…`
+                ? `Exporting ${exportProgress.exported.toLocaleString()} of ${exportProgress.total.toLocaleString()} runs…`
                 : "Exporting…"}
             </Text>
             {onCancelExport && (

--- a/langwatch/src/components/suites/RunHistoryFilters.tsx
+++ b/langwatch/src/components/suites/RunHistoryFilters.tsx
@@ -5,8 +5,8 @@
  * and a Group-by selector on the right.
  */
 
-import { HStack, IconButton, NativeSelect, Text } from "@chakra-ui/react";
-import { LayoutGrid, List } from "lucide-react";
+import { Button, HStack, IconButton, NativeSelect, Text } from "@chakra-ui/react";
+import { Download, LayoutGrid, List } from "lucide-react";
 import { RUN_GROUP_TYPES, type RunGroupType } from "./run-history-transforms";
 import type { ViewMode } from "./useRunHistoryStore";
 
@@ -32,6 +32,14 @@ type RunHistoryFiltersProps = {
   groupByOptions?: RunGroupType[];
   viewMode?: ViewMode;
   onViewModeChange?: (value: ViewMode) => void;
+  /**
+   * Opens the CSV export dialog. Lives on the filter bar rather than the page
+   * header because the export honours these filters, and because the header is
+   * only rendered in the all-runs view while this bar shows in both.
+   */
+  onExport?: () => void;
+  /** Disables export when nothing would be written. */
+  isExportDisabled?: boolean;
 };
 
 export function RunHistoryFilters({
@@ -43,6 +51,8 @@ export function RunHistoryFilters({
   groupByOptions = [...RUN_GROUP_TYPES],
   viewMode,
   onViewModeChange,
+  onExport,
+  isExportDisabled = false,
 }: RunHistoryFiltersProps) {
   return (
     <HStack gap={3} flexWrap="wrap" justifyContent="space-between">
@@ -83,8 +93,19 @@ export function RunHistoryFilters({
         </NativeSelect.Root>
       </HStack>
 
-      {/* Right: view mode toggle + group-by selector */}
+      {/* Right: export + view mode toggle + group-by selector */}
       <HStack gap={3}>
+        {onExport && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onExport}
+            disabled={isExportDisabled}
+          >
+            <Download size={14} />
+            Export CSV
+          </Button>
+        )}
         {onViewModeChange && (
           <HStack gap={1} role="group" aria-label="View mode">
             <IconButton

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -449,10 +449,13 @@ export function RunHistoryPanel({
           onExport={openExportDialog}
           // totals.runCount counts the pages fetched so far, not what the
           // server would export, so it is never compared against a total —
-          // that would block a valid export of a longer history. Zero is the
-          // one value it reports exactly: nothing matched, and exporting would
-          // write a header and no rows.
-          isExportDisabled={isLoading || totals.runCount === 0}
+          // that would block a valid export of a longer history.
+          //
+          // Zero only means "nothing matched" once there is nothing left to
+          // fetch. Filter to a scenario whose runs sit on a later page and the
+          // loaded pages hold none of them, while the server-side sweep would
+          // return every one — so `hasMore` is what makes the zero definitive.
+          isExportDisabled={isLoading || (totals.runCount === 0 && !hasMore)}
           isExporting={isExporting}
           exportProgress={exportProgress}
           onCancelExport={cancelExport}

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -135,6 +135,7 @@ export function RunHistoryPanel({
 
   // Pagination
   const startDateMs = period.startDate.getTime();
+  const endDateMs = period.endDate.getTime();
   const {
     allRuns,
     allScenarioSetIds,
@@ -143,7 +144,12 @@ export function RunHistoryPanel({
     isLoading,
     error,
     refetch,
-  } = useRunHistoryPagination({ scenarioSetId, startDateMs, sseConnected });
+  } = useRunHistoryPagination({
+    scenarioSetId,
+    startDateMs,
+    endDateMs,
+    sseConnected,
+  });
 
   // CSV export, scoped to whatever this panel is currently showing.
   const {
@@ -151,6 +157,9 @@ export function RunHistoryPanel({
     openExportDialog,
     closeExportDialog,
     startExport,
+    isExporting,
+    progress: exportProgress,
+    cancelExport,
   } = useExportScenarioRuns({
     projectId: project?.id,
     scenarioSetId,
@@ -159,7 +168,7 @@ export function RunHistoryPanel({
       ? (filters.passFailStatus as "pass" | "fail" | "stalled")
       : undefined,
     startDate: startDateMs,
-    endDate: period.endDate.getTime(),
+    endDate: endDateMs,
   });
 
   // Fetch scenarios for filter options
@@ -444,6 +453,9 @@ export function RunHistoryPanel({
           onViewModeChange={setViewMode}
           onExport={openExportDialog}
           isExportDisabled={totals.runCount === 0}
+          isExporting={isExporting}
+          exportProgress={exportProgress}
+          onCancelExport={cancelExport}
         />
       </Box>
 

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -49,8 +49,10 @@ import {
   groupRunsByTarget,
   resolveOriginLabel,
 } from "./run-history-transforms";
+import { ScenarioRunExportDialog } from "./ScenarioRunExportDialog";
 import { useAutoExpansion } from "./useAutoExpansion";
 import { useCancelScenarioRun } from "./useCancelScenarioRun";
+import { useExportScenarioRuns } from "./useExportScenarioRuns";
 import { useRunHistoryPagination } from "./useRunHistoryPagination";
 import { useRunHistoryStore } from "./useRunHistoryStore";
 import { useScrollToBatch } from "./useScrollToBatch";
@@ -142,6 +144,23 @@ export function RunHistoryPanel({
     error,
     refetch,
   } = useRunHistoryPagination({ scenarioSetId, startDateMs, sseConnected });
+
+  // CSV export, scoped to whatever this panel is currently showing.
+  const {
+    isDialogOpen: isExportDialogOpen,
+    openExportDialog,
+    closeExportDialog,
+    startExport,
+  } = useExportScenarioRuns({
+    projectId: project?.id,
+    scenarioSetId,
+    scenarioId: filters.scenarioId || undefined,
+    passFailStatus: filters.passFailStatus
+      ? (filters.passFailStatus as "pass" | "fail" | "stalled")
+      : undefined,
+    startDate: startDateMs,
+    endDate: period.endDate.getTime(),
+  });
 
   // Fetch scenarios for filter options
   const { data: scenarios } = api.scenarios.getAll.useQuery(
@@ -423,6 +442,8 @@ export function RunHistoryPanel({
           onGroupByChange={setGroupBy}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
+          onExport={openExportDialog}
+          isExportDisabled={totals.runCount === 0}
         />
       </Box>
 
@@ -551,6 +572,14 @@ export function RunHistoryPanel({
           )}
         </VStack>
       )}
+
+      <ScenarioRunExportDialog
+        isOpen={isExportDialogOpen}
+        onClose={closeExportDialog}
+        onExport={startExport}
+        runCount={totals.runCount}
+        hasFiltersApplied={hasFiltersApplied}
+      />
     </VStack>
   );
 }

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -452,10 +452,12 @@ export function RunHistoryPanel({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onExport={openExportDialog}
-          // Disabled only when nothing has loaded at all. totals.runCount
-          // counts the pages fetched so far, not what the server would export,
-          // so gating on it would block a valid export of a longer history.
-          isExportDisabled={isLoading}
+          // totals.runCount counts the pages fetched so far, not what the
+          // server would export, so it is never compared against a total —
+          // that would block a valid export of a longer history. Zero is the
+          // one value it reports exactly: nothing matched, and exporting would
+          // write a header and no rows.
+          isExportDisabled={isLoading || totals.runCount === 0}
           isExporting={isExporting}
           exportProgress={exportProgress}
           onCancelExport={cancelExport}

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -452,7 +452,10 @@ export function RunHistoryPanel({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onExport={openExportDialog}
-          isExportDisabled={totals.runCount === 0}
+          // Disabled only when nothing has loaded at all. totals.runCount
+          // counts the pages fetched so far, not what the server would export,
+          // so gating on it would block a valid export of a longer history.
+          isExportDisabled={isLoading}
           isExporting={isExporting}
           exportProgress={exportProgress}
           onCancelExport={cancelExport}

--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -144,12 +144,7 @@ export function RunHistoryPanel({
     isLoading,
     error,
     refetch,
-  } = useRunHistoryPagination({
-    scenarioSetId,
-    startDateMs,
-    endDateMs,
-    sseConnected,
-  });
+  } = useRunHistoryPagination({ scenarioSetId, startDateMs, sseConnected });
 
   // CSV export, scoped to whatever this panel is currently showing.
   const {

--- a/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
+++ b/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
@@ -11,19 +11,14 @@ import { Radio, RadioGroup } from "../ui/radio";
  */
 const MODES: { value: ScenarioRunExportMode; label: string; hint: string }[] = [
   {
-    value: "summary",
-    label: "Summary",
-    hint: "One row per run — pass rates, cost, duration",
+    value: "full",
+    label: "Full",
+    hint: "One row per message — the complete export",
   },
   {
     value: "criteria",
     label: "Criteria",
-    hint: "One row per criterion — rank what fails most",
-  },
-  {
-    value: "full",
-    label: "Full",
-    hint: "One row per message — read the transcripts",
+    hint: "One row per checklist item — rank what fails most",
   },
 ];
 
@@ -40,7 +35,7 @@ export function ScenarioRunExportDialog({
   runCount: number;
   hasFiltersApplied: boolean;
 }) {
-  const [mode, setMode] = useState<ScenarioRunExportMode>("summary");
+  const [mode, setMode] = useState<ScenarioRunExportMode>("full");
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={({ open }) => !open && onClose()}>

--- a/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
+++ b/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
@@ -6,8 +6,8 @@ import { Dialog } from "../ui/dialog";
 import { Radio, RadioGroup } from "../ui/radio";
 
 /**
- * Each mode states what one row is, because that is the only thing that
- * distinguishes them and it decides which questions the file can answer.
+ * Each mode states what one row is. That is the only thing distinguishing
+ * them, and it decides which questions the resulting file can answer.
  */
 const MODES: { value: ScenarioRunExportMode; label: string; hint: string }[] = [
   {

--- a/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
+++ b/langwatch/src/components/suites/ScenarioRunExportDialog.tsx
@@ -1,0 +1,97 @@
+import { Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { Download } from "lucide-react";
+import { useState } from "react";
+import type { ScenarioRunExportMode } from "~/server/export/scenario-runs/types";
+import { Dialog } from "../ui/dialog";
+import { Radio, RadioGroup } from "../ui/radio";
+
+/**
+ * Each mode states what one row is, because that is the only thing that
+ * distinguishes them and it decides which questions the file can answer.
+ */
+const MODES: { value: ScenarioRunExportMode; label: string; hint: string }[] = [
+  {
+    value: "summary",
+    label: "Summary",
+    hint: "One row per run — pass rates, cost, duration",
+  },
+  {
+    value: "criteria",
+    label: "Criteria",
+    hint: "One row per criterion — rank what fails most",
+  },
+  {
+    value: "full",
+    label: "Full",
+    hint: "One row per message — read the transcripts",
+  },
+];
+
+export function ScenarioRunExportDialog({
+  isOpen,
+  onClose,
+  onExport,
+  runCount,
+  hasFiltersApplied,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onExport: (config: { mode: ScenarioRunExportMode }) => void;
+  runCount: number;
+  hasFiltersApplied: boolean;
+}) {
+  const [mode, setMode] = useState<ScenarioRunExportMode>("summary");
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={({ open }) => !open && onClose()}>
+      <Dialog.Content bg="bg">
+        <Dialog.CloseTrigger />
+        <Dialog.Header>
+          <Dialog.Title>Export Scenario Runs</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          <VStack align="stretch" gap={5}>
+            <Text color="fg.muted" fontSize="sm">
+              {runCount.toLocaleString()} {runCount === 1 ? "run" : "runs"}
+              {hasFiltersApplied ? " matching your filters" : ""}
+            </Text>
+
+            <VStack align="stretch" gap={2}>
+              <Text fontWeight="medium" fontSize="sm">
+                Mode
+              </Text>
+              <RadioGroup
+                value={mode}
+                onValueChange={({ value }) =>
+                  setMode(value as ScenarioRunExportMode)
+                }
+              >
+                <VStack align="stretch" gap={2}>
+                  {MODES.map((option) => (
+                    <HStack key={option.value} gap={2}>
+                      <Radio value={option.value}>{option.label}</Radio>
+                      <Text color="fg.muted" fontSize="xs">
+                        {option.hint}
+                      </Text>
+                    </HStack>
+                  ))}
+                </VStack>
+              </RadioGroup>
+            </VStack>
+          </VStack>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <HStack gap={3}>
+            <Button variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorPalette="blue" onClick={() => onExport({ mode })}>
+              <Download size={16} />
+              Export
+            </Button>
+          </HStack>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/suites/__tests__/AllRunsPanel.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/AllRunsPanel.integration.test.tsx
@@ -101,6 +101,9 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({ data: [] }),
       },
     },
+    export: {
+      onScenarioRunExportProgress: { useSubscription: vi.fn() },
+    },
   },
 }));
 

--- a/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
@@ -46,6 +46,9 @@ vi.mock("~/utils/api", () => ({
     prompts: {
       getAllPromptsForProject: { useQuery: vi.fn(() => ({ data: [] })) },
     },
+    export: {
+      onScenarioRunExportProgress: { useSubscription: vi.fn() },
+    },
   },
 }));
 

--- a/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
@@ -126,6 +126,24 @@ describe("<RunHistoryPanel/>", () => {
         screen.getByText("Run this suite to see results here."),
       ).toBeInTheDocument();
     });
+
+    /**
+     * Exporting here would write a header and no rows, which reads as a broken
+     * export rather than an empty one. Asserted against the panel rather than
+     * the filter bar on its own, because the panel is what decides — the bar
+     * only renders the flag it is handed.
+     */
+    /** @scenario Export is unavailable when no runs match */
+    it("disables Export CSV rather than offering a header-only file", () => {
+      render(
+        <RunHistoryPanel scenarioSetId={scenarioSetId} period={widePeriod} />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.getByRole("button", { name: /export csv/i }),
+      ).toBeDisabled();
+    });
   });
 
   describe("given a suite with at least one run", () => {

--- a/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryEmptyState.integration.test.tsx
@@ -146,6 +146,30 @@ describe("<RunHistoryPanel/>", () => {
     });
   });
 
+  describe("given no runs on the loaded pages but more still to fetch", () => {
+    /**
+     * The loaded pages are not the whole history. Filter to a scenario whose
+     * runs sit further back and the fetched pages hold none of them, while the
+     * server-side sweep would return every one — so a zero count here means
+     * "not yet" rather than "none", and disabling the export would refuse a
+     * request that would have produced a file.
+     */
+    it("keeps Export CSV enabled, because the sweep may still match", () => {
+      mockGetSuiteRunData.mockReturnValue({
+        data: { runs: [], scenarioSetIds: {}, hasMore: true, changed: true },
+        isLoading: false,
+        error: null,
+      });
+
+      render(
+        <RunHistoryPanel scenarioSetId={scenarioSetId} period={widePeriod} />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByRole("button", { name: /export csv/i })).toBeEnabled();
+    });
+  });
+
   describe("given a suite with at least one run", () => {
     beforeEach(() => {
       mockGetSuiteRunData.mockReturnValue({

--- a/langwatch/src/components/suites/__tests__/RunHistoryLiveWindow.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryLiveWindow.integration.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The run history is a live view, and the period's upper bound is not.
+ *
+ * `usePeriodSelector` builds a relative preset as `endDate: now` and its
+ * useMemo deliberately excludes `now` from its deps, so `period.endDate` is
+ * pinned at mount. Sending that to the list query filters on
+ * `StartedAt <= <page load>`, and a run started after the page opened never
+ * appears — on the one surface whose job is watching runs happen.
+ *
+ * Asserted on the query input rather than on rendered rows, because the bound
+ * is applied in ClickHouse: by the time the component renders, the missing run
+ * is indistinguishable from a run that does not exist.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/components/SetupWithAgentButton", () => ({
+  SetupWithAgentButton: () => null,
+}));
+
+import { RunHistoryPanel } from "../RunHistoryPanel";
+
+const mockGetSuiteRunData = vi.hoisted(() => vi.fn());
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      scenarios: {
+        getSuiteRunData: { invalidate: vi.fn() },
+        getRunState: { invalidate: vi.fn(), prefetch: vi.fn() },
+        getScenarioSetBatchHistory: { invalidate: vi.fn() },
+      },
+    }),
+    scenarios: {
+      getSuiteRunData: { useQuery: mockGetSuiteRunData },
+      getSuiteRunFreshness: { useQuery: vi.fn(() => ({ data: undefined })) },
+      getAll: { useQuery: vi.fn(() => ({ data: [] })) },
+      cancelJob: {
+        useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+      },
+      cancelBatchRun: {
+        useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+      },
+    },
+    agents: { getAll: { useQuery: vi.fn(() => ({ data: [] })) } },
+    prompts: {
+      getAllPromptsForProject: { useQuery: vi.fn(() => ({ data: [] })) },
+    },
+    export: {
+      onScenarioRunExportProgress: { useSubscription: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("~/hooks/useSSESubscription", () => ({
+  useSSESubscription: vi.fn(() => ({
+    connectionState: "disconnected",
+    isConnected: false,
+    isConnecting: false,
+    hasError: false,
+    isDisconnected: true,
+    retryCount: 0,
+    lastData: undefined,
+    lastError: undefined,
+  })),
+}));
+
+vi.mock("~/hooks/usePageVisibility", () => ({ usePageVisibility: () => true }));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj_1", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: {}, push: vi.fn(), isReady: true }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn() }),
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const scenarioSetId = "__internal__suite_1__suite";
+
+describe("<RunHistoryPanel/> run-history window", () => {
+  beforeEach(() => {
+    mockGetSuiteRunData.mockReturnValue({
+      data: { runs: [], scenarioSetIds: {}, hasMore: false, changed: true },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("given a relative period whose end was pinned when the page loaded", () => {
+    it("queries the run list with no upper bound, so later runs still arrive", () => {
+      const pinnedEnd = new Date("2024-06-15T12:00:00Z");
+
+      render(
+        <RunHistoryPanel
+          scenarioSetId={scenarioSetId}
+          period={{
+            startDate: new Date("2024-05-16T12:00:00Z"),
+            endDate: pinnedEnd,
+          }}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const [listQueryInput] = mockGetSuiteRunData.mock.calls[0] as [
+        { startDate?: number; endDate?: number },
+      ];
+
+      expect(listQueryInput.startDate).toBe(
+        new Date("2024-05-16T12:00:00Z").getTime(),
+      );
+      // The bound the router would otherwise default to Date.now() per request.
+      expect(listQueryInput.endDate).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/components/suites/__tests__/ScenarioRunExportUi.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ScenarioRunExportUi.integration.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The export's front door: the button that offers it, the dialog that asks how
+ * deep, and what the header shows while a file is streaming.
+ *
+ * Rendered rather than asserted on props, because every one of these is a claim
+ * about what a person sees — that the depths are labelled by what one row IS,
+ * that the button is not offered when it would write nothing, and that a
+ * running export can be called off.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RunHistoryFilters,
+  type RunHistoryFilterValues,
+} from "../RunHistoryFilters";
+import { ScenarioRunExportDialog } from "../ScenarioRunExportDialog";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const emptyFilters: RunHistoryFilterValues = {
+  scenarioId: "",
+  passFailStatus: "",
+};
+
+/**
+ * The two pieces as the panel wires them: the button owns "is the dialog open",
+ * the dialog owns the chosen mode. Held together here so clicking Export CSV
+ * and reading the dialog is one flow rather than two prop assertions.
+ */
+function ExportSurface({
+  runCount = 12,
+  onExport = vi.fn(),
+}: {
+  runCount?: number;
+  onExport?: (config: { mode: string }) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <RunHistoryFilters
+        scenarioOptions={[]}
+        filters={emptyFilters}
+        onFiltersChange={vi.fn()}
+        onExport={() => setIsOpen(true)}
+        isExportDisabled={runCount === 0}
+      />
+      <ScenarioRunExportDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onExport={onExport}
+        runCount={runCount}
+        hasFiltersApplied={false}
+      />
+    </>
+  );
+}
+
+describe("<ScenarioRunExportDialog/> and its trigger", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("when runs match the current filters", () => {
+    /** @scenario Export CSV button opens the config dialog */
+    it("opens the dialog, showing how many runs would be written", async () => {
+      const user = userEvent.setup();
+      render(<ExportSurface runCount={1234} />, { wrapper: Wrapper });
+
+      expect(
+        screen.queryByText("Export Scenario Runs"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+      expect(screen.getByText("Export Scenario Runs")).toBeInTheDocument();
+      // Grouped, because "1234 runs" reads as a different order of magnitude at
+      // a glance than "1,234 runs".
+      expect(screen.getByText(/1,234 runs/)).toBeInTheDocument();
+    });
+
+    /**
+     * A scenario run is nested and CSV is flat, so the mode IS the row axis.
+     * Naming the axis is what lets someone pick without exporting twice.
+     */
+    /** @scenario The dialog offers both export depths */
+    it("offers Full and Criteria, each stating what one row is", async () => {
+      const user = userEvent.setup();
+      render(<ExportSurface />, { wrapper: Wrapper });
+
+      await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+      expect(screen.getByText("Full")).toBeInTheDocument();
+      expect(screen.getByText(/one row per message/i)).toBeInTheDocument();
+      expect(screen.getByText("Criteria")).toBeInTheDocument();
+      expect(
+        screen.getByText(/one row per checklist item/i),
+      ).toBeInTheDocument();
+    });
+
+    it("exports in the depth that was chosen", async () => {
+      const user = userEvent.setup();
+      const onExport = vi.fn();
+      render(<ExportSurface onExport={onExport} />, { wrapper: Wrapper });
+
+      await user.click(screen.getByRole("button", { name: /export csv/i }));
+      await user.click(screen.getByText("Criteria"));
+      await user.click(screen.getByRole("button", { name: /^export$/i }));
+
+      expect(onExport).toHaveBeenCalledWith({ mode: "criteria" });
+    });
+
+    it("defaults to Full, the mode that answers the most questions", async () => {
+      const user = userEvent.setup();
+      const onExport = vi.fn();
+      render(<ExportSurface onExport={onExport} />, { wrapper: Wrapper });
+
+      await user.click(screen.getByRole("button", { name: /export csv/i }));
+      await user.click(screen.getByRole("button", { name: /^export$/i }));
+
+      expect(onExport).toHaveBeenCalledWith({ mode: "full" });
+    });
+  });
+
+  describe("when no runs match the current filters", () => {
+    /**
+     * Offering it would produce a header and nothing else, which reads as a
+     * broken export rather than an empty one.
+     */
+    /** @scenario Export is unavailable when no runs match */
+    it("disables the button rather than exporting an empty file", () => {
+      render(<ExportSurface runCount={0} />, { wrapper: Wrapper });
+
+      expect(
+        screen.getByRole("button", { name: /export csv/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("when an export is streaming", () => {
+    /**
+     * The count comes over a subscription because the response body is the file
+     * itself. `aria-live` matters here: the number changes without any
+     * interaction, so a screen reader is told rather than left on the stale
+     * value.
+     */
+    /** @scenario Progress is shown while a large export streams */
+    it("replaces the button with a live count and a way out", () => {
+      render(
+        <RunHistoryFilters
+          scenarioOptions={[]}
+          filters={emptyFilters}
+          onFiltersChange={vi.fn()}
+          onExport={vi.fn()}
+          isExporting
+          exportProgress={{ exported: 1200, total: 5000 }}
+          onCancelExport={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /export csv/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/exporting 1,200 of 5,000 runs/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+
+    /** @scenario Cancelling an in-flight export stops it */
+    it("hands the cancel back to the caller that owns the request", async () => {
+      const user = userEvent.setup();
+      const onCancelExport = vi.fn();
+      render(
+        <RunHistoryFilters
+          scenarioOptions={[]}
+          filters={emptyFilters}
+          onFiltersChange={vi.fn()}
+          onExport={vi.fn()}
+          isExporting
+          exportProgress={{ exported: 10, total: 5000 }}
+          onCancelExport={onCancelExport}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(onCancelExport).toHaveBeenCalledOnce();
+    });
+
+    it("says it is exporting even before the server reports a total", () => {
+      render(
+        <RunHistoryFilters
+          scenarioOptions={[]}
+          filters={emptyFilters}
+          onFiltersChange={vi.fn()}
+          onExport={vi.fn()}
+          isExporting
+          exportProgress={{ exported: 0, total: 0 }}
+          onCancelExport={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText(/exporting…/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/suites/__tests__/ScenarioRunExportUi.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ScenarioRunExportUi.integration.test.tsx
@@ -131,18 +131,24 @@ describe("<ScenarioRunExportDialog/> and its trigger", () => {
     });
   });
 
-  describe("when no runs match the current filters", () => {
+  describe("when the panel says there is nothing to export", () => {
     /**
-     * Offering it would produce a header and nothing else, which reads as a
-     * broken export rather than an empty one.
+     * Deciding there is nothing to export belongs to the panel, and is pinned
+     * against the real one in RunHistoryEmptyState. This covers the other half:
+     * the bar honours the flag instead of rendering an enabled button anyway.
      */
-    /** @scenario Export is unavailable when no runs match */
-    it("disables the button rather than exporting an empty file", () => {
+    it("renders the button disabled", () => {
       render(<ExportSurface runCount={0} />, { wrapper: Wrapper });
 
       expect(
         screen.getByRole("button", { name: /export csv/i }),
       ).toBeDisabled();
+    });
+
+    it("leaves it clickable as soon as there are runs", () => {
+      render(<ExportSurface runCount={1} />, { wrapper: Wrapper });
+
+      expect(screen.getByRole("button", { name: /export csv/i })).toBeEnabled();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/SuiteDetailPanel.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteDetailPanel.integration.test.tsx
@@ -72,6 +72,9 @@ vi.mock("~/utils/api", () => ({
       getAllPromptsForProject: { useQuery: vi.fn(() => ({ data: [] })) },
     },
     suites: {},
+    export: {
+      onScenarioRunExportProgress: { useSubscription: vi.fn() },
+    },
   },
 }));
 

--- a/langwatch/src/components/suites/run-history-transforms.ts
+++ b/langwatch/src/components/suites/run-history-transforms.ts
@@ -18,6 +18,7 @@ import type {
   ScenarioRunData,
   SuiteRunSummary,
 } from "~/server/scenarios/scenario-event.types";
+import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
 import { extractSuiteId, isSuiteSetId } from "~/server/suites/suite-set-id";
 
 /** Valid values for the grouping dimension. */
@@ -101,34 +102,6 @@ export function worstStatus(summary: RunGroupSummary): ScenarioRunStatus {
   if (summary.failedCount > 0) return ScenarioRunStatus.FAILED;
   if (summary.cancelledCount > 0) return ScenarioRunStatus.CANCELLED;
   return ScenarioRunStatus.SUCCESS;
-}
-
-type RunStatusCategory =
-  | "success"
-  | "failure"
-  | "stalled"
-  | "cancelled"
-  | "in_progress"
-  | "queued";
-
-function categorizeRunStatus(status: ScenarioRunStatus): RunStatusCategory {
-  switch (status) {
-    case ScenarioRunStatus.SUCCESS:
-      return "success";
-    case ScenarioRunStatus.ERROR:
-    case ScenarioRunStatus.FAILED:
-      return "failure";
-    case ScenarioRunStatus.STALLED:
-      return "stalled";
-    case ScenarioRunStatus.CANCELLED:
-      return "cancelled";
-    case ScenarioRunStatus.IN_PROGRESS:
-    case ScenarioRunStatus.PENDING:
-    case ScenarioRunStatus.RUNNING:
-      return "in_progress";
-    case ScenarioRunStatus.QUEUED:
-      return "queued";
-  }
 }
 
 const UNKNOWN_GROUP_KEY = "__unknown__";

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -1,8 +1,16 @@
-import { useCallback, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { toaster } from "~/components/ui/toaster";
+import { showErrorToast } from "~/features/errors";
 import type { ExportProgressEvent } from "~/server/api/routers/export";
 import type {
   ScenarioRunExportMode,
+  ScenarioRunExportRequest,
   ScenarioRunExportStatusFilter,
 } from "~/server/export/scenario-runs/types";
 import { api } from "~/utils/api";
@@ -54,20 +62,12 @@ export function useExportScenarioRuns({
   const [exportId, setExportId] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  api.export.onScenarioRunExportProgress.useSubscription(
-    { projectId: projectId!, exportId: exportId! },
-    {
-      enabled: isExporting && !!exportId && !!projectId,
-      onData: (event: ExportProgressEvent) => {
-        if (event.exported !== undefined) {
-          setProgress((prev) => ({
-            exported: event.exported ?? prev.exported,
-            total: event.total ?? prev.total,
-          }));
-        }
-      },
-    },
-  );
+  useExportProgressUpdates({
+    projectId,
+    exportId,
+    enabled: isExporting && !!exportId && !!projectId,
+    setProgress,
+  });
 
   const openExportDialog = useCallback(() => setIsDialogOpen(true), []);
   const closeExportDialog = useCallback(() => setIsDialogOpen(false), []);
@@ -93,69 +93,29 @@ export function useExportScenarioRuns({
       setProgress({ exported: 0, total: 0 });
       setExportId(null);
 
-      const today = new Date().toISOString().split("T")[0];
-      const fallbackFilename = `${projectId} - Scenario Runs - ${today} - ${mode}.csv`;
-
-      void fetch("/api/export/scenario-runs/download", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      void downloadExport({
+        request: buildExportRequest({
           projectId,
           mode,
-          ...(scenarioSetId ? { scenarioSetId } : {}),
-          ...(scenarioId ? { scenarioId } : {}),
-          ...(passFailStatus ? { passFailStatus } : {}),
-          ...(startDate !== undefined ? { startDate } : {}),
-          ...(endDate !== undefined ? { endDate } : {}),
+          scenarioSetId,
+          scenarioId,
+          passFailStatus,
+          startDate,
+          endDate,
         }),
         signal: abortController.signal,
-      })
-        .then(async (response) => {
-          if (!response.ok) {
-            throw new Error(`Export failed: ${response.status}`);
-          }
-          // The server knows the total before it streams a byte, so the bar
-          // has a denominator immediately rather than after the first chunk.
-          const total = Number(response.headers.get("X-Total-Runs") ?? "0");
+        onAccepted: ({ total, exportId: acceptedId }) => {
           setProgress({ exported: 0, total });
-          // Activating the subscription here rather than before the fetch: the
-          // id only exists once the server has accepted the request.
-          setExportId(response.headers.get("X-Export-Id"));
-          const blob = await response.blob();
-          setProgress({ exported: total, total });
-          if (blob.size === 0) {
-            toaster.create({
-              title: "Export produced no data",
-              description:
-                "No runs matched the current filters. Try widening the date range.",
-              type: "warning",
-            });
-            return;
-          }
-          triggerBlobDownload({
-            blob,
-            filename: extractFilename({
-              contentDisposition: response.headers.get("Content-Disposition"),
-              fallbackName: fallbackFilename,
-            }),
-          });
-        })
-        .catch((error: unknown) => {
-          if (error instanceof Error && error.name === "AbortError") return;
-          toaster.create({
-            title: "Export failed",
-            description:
-              error instanceof Error ? error.message : "Unknown error",
-            type: "error",
-          });
-        })
-        .finally(() => {
-          if (abortControllerRef.current === abortController) {
-            abortControllerRef.current = null;
-            setIsExporting(false);
-            setExportId(null);
-          }
-        });
+          setExportId(acceptedId);
+        },
+        onSwept: (total) => setProgress({ exported: total, total }),
+      }).finally(() => {
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = null;
+          setIsExporting(false);
+          setExportId(null);
+        }
+      });
     },
     [projectId, scenarioSetId, scenarioId, passFailStatus, startDate, endDate],
   );
@@ -169,6 +129,169 @@ export function useExportScenarioRuns({
     startExport,
     cancelExport,
   };
+}
+
+/**
+ * Relays the server's progress broadcasts into the counter.
+ *
+ * Its own hook because the count travels on a different transport from the
+ * file: the response body IS the download and goes to disk, so the only way to
+ * report how far along the sweep is, is out of band. Nothing else in the export
+ * needs to know that.
+ */
+function useExportProgressUpdates({
+  projectId,
+  exportId,
+  enabled,
+  setProgress,
+}: {
+  projectId: string | undefined;
+  exportId: string | null;
+  enabled: boolean;
+  setProgress: Dispatch<SetStateAction<{ exported: number; total: number }>>;
+}): void {
+  api.export.onScenarioRunExportProgress.useSubscription(
+    { projectId: projectId!, exportId: exportId! },
+    {
+      enabled,
+      onData: (event: ExportProgressEvent) => {
+        if (event.exported === undefined) return;
+        setProgress((prev) => ({
+          exported: event.exported ?? prev.exported,
+          total: event.total ?? prev.total,
+        }));
+      },
+    },
+  );
+}
+
+/**
+ * The filters the panel is currently showing, as a request body.
+ *
+ * Absent filters are omitted rather than sent as `undefined`: the route parses
+ * the body with a Zod schema, and an explicit `scenarioId: undefined` survives
+ * `JSON.stringify` as a missing key anyway — so building it this way keeps the
+ * wire format and the type in agreement instead of relying on that.
+ */
+function buildExportRequest({
+  projectId,
+  mode,
+  scenarioSetId,
+  scenarioId,
+  passFailStatus,
+  startDate,
+  endDate,
+}: {
+  projectId: string;
+  mode: ScenarioRunExportMode;
+  scenarioSetId?: string;
+  scenarioId?: string;
+  passFailStatus?: ScenarioRunExportStatusFilter;
+  startDate?: number;
+  endDate?: number;
+}): ScenarioRunExportRequest {
+  return {
+    projectId,
+    mode,
+    ...(scenarioSetId ? { scenarioSetId } : {}),
+    ...(scenarioId ? { scenarioId } : {}),
+    ...(passFailStatus ? { passFailStatus } : {}),
+    ...(startDate !== undefined ? { startDate } : {}),
+    ...(endDate !== undefined ? { endDate } : {}),
+  };
+}
+
+/**
+ * Runs one export request to completion: POST, read the headers the server
+ * answers with, then write the body to disk.
+ *
+ * Lives outside the hook so `startExport` reads as the state transition it is.
+ * The two callbacks are the only things it needs from React — the progress
+ * denominator the moment the server accepts, and the final count once the body
+ * has been read.
+ */
+async function downloadExport({
+  request,
+  signal,
+  onAccepted,
+  onSwept,
+}: {
+  request: ScenarioRunExportRequest;
+  signal: AbortSignal;
+  onAccepted: (accepted: { total: number; exportId: string | null }) => void;
+  onSwept: (total: number) => void;
+}): Promise<void> {
+  try {
+    const response = await fetch("/api/export/scenario-runs/download", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await readExportFailure(response);
+    }
+
+    // The server knows the total before it streams a byte, so the bar has a
+    // denominator immediately rather than after the first chunk. The export id
+    // arrives here rather than before the fetch: it only exists once the
+    // server has accepted the request.
+    const total = Number(response.headers.get("X-Total-Runs") ?? "0");
+    onAccepted({ total, exportId: response.headers.get("X-Export-Id") });
+
+    const blob = await response.blob();
+    onSwept(total);
+
+    if (blob.size === 0) {
+      toaster.create({
+        title: "Export produced no data",
+        description:
+          "No runs matched the current filters. Try widening the date range.",
+        type: "warning",
+      });
+      return;
+    }
+
+    triggerBlobDownload({
+      blob,
+      filename: extractFilename({
+        contentDisposition: response.headers.get("Content-Disposition"),
+        fallbackName: fallbackFilename(request),
+      }),
+    });
+  } catch (error) {
+    // Cancelling is a thing the user did, not a failure to report back to them.
+    if (error instanceof Error && error.name === "AbortError") return;
+    showErrorToast({ error, fallbackTitle: "Export failed" });
+  }
+}
+
+/**
+ * The failure body the route sent, so the toast can say what actually went
+ * wrong.
+ *
+ * `handleError` serializes a HandledError to `{ error: "<code>", ... }`, which
+ * `showErrorToast` resolves to the registered copy — "Ask an admin for access"
+ * rather than the status code. Returning the parsed body rather than an Error
+ * is what keeps that path open; a body we cannot parse falls back to the status
+ * so the toast still has something to show.
+ */
+async function readExportFailure(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return new Error(`Export failed: ${response.status}`);
+  }
+}
+
+/**
+ * Used only when the response carries no Content-Disposition — the server names
+ * the file, and this keeps a download from landing as "download".
+ */
+function fallbackFilename(request: ScenarioRunExportRequest): string {
+  const today = new Date().toISOString().split("T")[0];
+  return `${request.projectId} - Scenario Runs - ${today} - ${request.mode}.csv`;
 }
 
 function triggerBlobDownload({

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -1,11 +1,11 @@
 import { useCallback, useRef, useState } from "react";
 import { toaster } from "~/components/ui/toaster";
 import type { ExportProgressEvent } from "~/server/api/routers/export";
-import { api } from "~/utils/api";
 import type {
   ScenarioRunExportMode,
   ScenarioRunExportStatusFilter,
 } from "~/server/export/scenario-runs/types";
+import { api } from "~/utils/api";
 
 /**
  * Orchestrates the scenario run CSV export: dialog state, the streaming
@@ -39,10 +39,12 @@ export function useExportScenarioRuns({
    * X-Total-Runs. Counted in runs rather than written rows because criteria
    * mode emits several rows per run.
    */
-  const [progress, setProgress] = useState<{ exported: number; total: number }>({
-    exported: 0,
-    total: 0,
-  });
+  const [progress, setProgress] = useState<{ exported: number; total: number }>(
+    {
+      exported: 0,
+      total: 0,
+    },
+  );
   /**
    * Set from the X-Export-Id response header once the stream starts. The
    * server broadcasts progress over Redis rather than in the response body

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -32,6 +32,15 @@ export function useExportScenarioRuns({
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  /**
+   * Runs visited so far, against the total the server reported in
+   * X-Total-Runs. Counted in runs rather than written rows because criteria
+   * mode emits several rows per run.
+   */
+  const [progress, setProgress] = useState<{ exported: number; total: number }>({
+    exported: 0,
+    total: 0,
+  });
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const openExportDialog = useCallback(() => setIsDialogOpen(true), []);
@@ -41,6 +50,7 @@ export function useExportScenarioRuns({
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     setIsExporting(false);
+    setProgress({ exported: 0, total: 0 });
   }, []);
 
   const startExport = useCallback(
@@ -53,6 +63,7 @@ export function useExportScenarioRuns({
 
       setIsDialogOpen(false);
       setIsExporting(true);
+      setProgress({ exported: 0, total: 0 });
 
       const today = new Date().toISOString().split("T")[0];
       const fallbackFilename = `${projectId} - Scenario Runs - ${today} - ${mode}.csv`;
@@ -75,7 +86,12 @@ export function useExportScenarioRuns({
           if (!response.ok) {
             throw new Error(`Export failed: ${response.status}`);
           }
+          // The server knows the total before it streams a byte, so the bar
+          // has a denominator immediately rather than after the first chunk.
+          const total = Number(response.headers.get("X-Total-Runs") ?? "0");
+          setProgress({ exported: 0, total });
           const blob = await response.blob();
+          setProgress({ exported: total, total });
           if (blob.size === 0) {
             toaster.create({
               title: "Export produced no data",
@@ -117,6 +133,7 @@ export function useExportScenarioRuns({
     openExportDialog,
     closeExportDialog,
     isExporting,
+    progress,
     startExport,
     cancelExport,
   };

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { toaster } from "~/components/ui/toaster";
+import type { ExportProgressEvent } from "~/server/api/routers/export";
+import { api } from "~/utils/api";
 import type {
   ScenarioRunExportMode,
   ScenarioRunExportStatusFilter,
@@ -41,7 +43,29 @@ export function useExportScenarioRuns({
     exported: 0,
     total: 0,
   });
+  /**
+   * Set from the X-Export-Id response header once the stream starts. The
+   * server broadcasts progress over Redis rather than in the response body
+   * because the body is the file itself — it goes to disk, so the only way to
+   * report a count is out of band.
+   */
+  const [exportId, setExportId] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+
+  api.export.onScenarioRunExportProgress.useSubscription(
+    { projectId: projectId!, exportId: exportId! },
+    {
+      enabled: isExporting && !!exportId && !!projectId,
+      onData: (event: ExportProgressEvent) => {
+        if (event.exported !== undefined) {
+          setProgress((prev) => ({
+            exported: event.exported ?? prev.exported,
+            total: event.total ?? prev.total,
+          }));
+        }
+      },
+    },
+  );
 
   const openExportDialog = useCallback(() => setIsDialogOpen(true), []);
   const closeExportDialog = useCallback(() => setIsDialogOpen(false), []);
@@ -51,6 +75,7 @@ export function useExportScenarioRuns({
     abortControllerRef.current = null;
     setIsExporting(false);
     setProgress({ exported: 0, total: 0 });
+    setExportId(null);
   }, []);
 
   const startExport = useCallback(
@@ -64,6 +89,7 @@ export function useExportScenarioRuns({
       setIsDialogOpen(false);
       setIsExporting(true);
       setProgress({ exported: 0, total: 0 });
+      setExportId(null);
 
       const today = new Date().toISOString().split("T")[0];
       const fallbackFilename = `${projectId} - Scenario Runs - ${today} - ${mode}.csv`;
@@ -90,6 +116,9 @@ export function useExportScenarioRuns({
           // has a denominator immediately rather than after the first chunk.
           const total = Number(response.headers.get("X-Total-Runs") ?? "0");
           setProgress({ exported: 0, total });
+          // Activating the subscription here rather than before the fetch: the
+          // id only exists once the server has accepted the request.
+          setExportId(response.headers.get("X-Export-Id"));
           const blob = await response.blob();
           setProgress({ exported: total, total });
           if (blob.size === 0) {
@@ -122,6 +151,7 @@ export function useExportScenarioRuns({
           if (abortControllerRef.current === abortController) {
             abortControllerRef.current = null;
             setIsExporting(false);
+            setExportId(null);
           }
         });
     },

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -1,0 +1,154 @@
+import { useCallback, useRef, useState } from "react";
+import { toaster } from "~/components/ui/toaster";
+import type {
+  ScenarioRunExportMode,
+  ScenarioRunExportStatusFilter,
+} from "~/server/export/scenario-runs/types";
+
+/**
+ * Orchestrates the scenario run CSV export: dialog state, the streaming
+ * download, and cancellation.
+ *
+ * The scope passed in is whatever the panel is currently showing — set,
+ * scenario, pass/fail and date range — so the file always matches the list the
+ * user was looking at when they clicked Export.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+export function useExportScenarioRuns({
+  projectId,
+  scenarioSetId,
+  scenarioId,
+  passFailStatus,
+  startDate,
+  endDate,
+}: {
+  projectId: string | undefined;
+  scenarioSetId?: string;
+  scenarioId?: string;
+  passFailStatus?: ScenarioRunExportStatusFilter;
+  startDate?: number;
+  endDate?: number;
+}) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const openExportDialog = useCallback(() => setIsDialogOpen(true), []);
+  const closeExportDialog = useCallback(() => setIsDialogOpen(false), []);
+
+  const cancelExport = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setIsExporting(false);
+  }, []);
+
+  const startExport = useCallback(
+    ({ mode }: { mode: ScenarioRunExportMode }) => {
+      if (!projectId) return;
+
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      setIsDialogOpen(false);
+      setIsExporting(true);
+
+      const today = new Date().toISOString().split("T")[0];
+      const fallbackFilename = `${projectId} - Scenario Runs - ${today} - ${mode}.csv`;
+
+      void fetch("/api/export/scenario-runs/download", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          mode,
+          ...(scenarioSetId ? { scenarioSetId } : {}),
+          ...(scenarioId ? { scenarioId } : {}),
+          ...(passFailStatus ? { passFailStatus } : {}),
+          ...(startDate !== undefined ? { startDate } : {}),
+          ...(endDate !== undefined ? { endDate } : {}),
+        }),
+        signal: abortController.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Export failed: ${response.status}`);
+          }
+          const blob = await response.blob();
+          if (blob.size === 0) {
+            toaster.create({
+              title: "Export produced no data",
+              description:
+                "No runs matched the current filters. Try widening the date range.",
+              type: "warning",
+            });
+            return;
+          }
+          triggerBlobDownload({
+            blob,
+            filename: extractFilename({
+              contentDisposition: response.headers.get("Content-Disposition"),
+              fallbackName: fallbackFilename,
+            }),
+          });
+        })
+        .catch((error: unknown) => {
+          if (error instanceof Error && error.name === "AbortError") return;
+          toaster.create({
+            title: "Export failed",
+            description:
+              error instanceof Error ? error.message : "Unknown error",
+            type: "error",
+          });
+        })
+        .finally(() => {
+          if (abortControllerRef.current === abortController) {
+            abortControllerRef.current = null;
+            setIsExporting(false);
+          }
+        });
+    },
+    [projectId, scenarioSetId, scenarioId, passFailStatus, startDate, endDate],
+  );
+
+  return {
+    isDialogOpen,
+    openExportDialog,
+    closeExportDialog,
+    isExporting,
+    startExport,
+    cancelExport,
+  };
+}
+
+function triggerBlobDownload({
+  blob,
+  filename,
+}: {
+  blob: Blob;
+  filename: string;
+}): void {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+}
+
+function extractFilename({
+  contentDisposition,
+  fallbackName,
+}: {
+  contentDisposition: string | null;
+  fallbackName: string;
+}): string {
+  if (!contentDisposition) return fallbackName;
+  const match = contentDisposition.match(
+    /filename\*?=(?:UTF-8''|")?([^";]+)"?/i,
+  );
+  return match?.[1] ? decodeURIComponent(match[1]) : fallbackName;
+}

--- a/langwatch/src/components/suites/useExportScenarioRuns.ts
+++ b/langwatch/src/components/suites/useExportScenarioRuns.ts
@@ -240,10 +240,14 @@ async function downloadExport({
     const total = Number(response.headers.get("X-Total-Runs") ?? "0");
     onAccepted({ total, exportId: response.headers.get("X-Export-Id") });
 
-    const blob = await response.blob();
-    onSwept(total);
-
-    if (blob.size === 0) {
+    // Nothing matched, so the file would be a header and no rows. Said before
+    // the download rather than after, because a spreadsheet with only a header
+    // reads as a broken export and the reason is not in the file.
+    //
+    // Keyed on the count the server reported, not on the size of what came
+    // back: the serializer always writes the header, so the body is never
+    // empty and a size check here would never fire.
+    if (total === 0) {
       toaster.create({
         title: "Export produced no data",
         description:
@@ -252,6 +256,9 @@ async function downloadExport({
       });
       return;
     }
+
+    const blob = await response.blob();
+    onSwept(total);
 
     triggerBlobDownload({
       blob,

--- a/langwatch/src/components/suites/useRunHistoryPagination.ts
+++ b/langwatch/src/components/suites/useRunHistoryPagination.ts
@@ -22,20 +22,27 @@ type PageData = {
 interface UseRunHistoryPaginationOptions {
   scenarioSetId?: string;
   startDateMs: number;
-  /**
-   * Upper bound of the selected period. Passed to the query so the list cannot
-   * show runs that a CSV export of the same period would exclude — the export
-   * scopes on both bounds.
-   */
-  endDateMs: number;
   /** While the SSE stream is connected, fallback freshness polling stops. */
   sseConnected?: boolean;
 }
 
+/**
+ * Deliberately sends no upper bound.
+ *
+ * `usePeriodSelector` builds a relative preset as `endDate: now` and its
+ * useMemo excludes `now` from its deps, so `period.endDate` is pinned at mount.
+ * Sending it here would filter the list on `StartedAt <= <page load>`, and a
+ * run started after the page opened would never appear — on the one surface
+ * whose job is watching runs happen. Omitting it lets the router's
+ * `resolveDateRange` default the bound to `Date.now()` per request, which is
+ * live.
+ *
+ * The export is a different case and does send both bounds: it is a snapshot
+ * the user asked for, not a live view.
+ */
 export function useRunHistoryPagination({
   scenarioSetId,
   startDateMs,
-  endDateMs,
   sseConnected = false,
 }: UseRunHistoryPaginationOptions) {
   const { project } = useOrganizationTeamProject();
@@ -47,7 +54,7 @@ export function useRunHistoryPagination({
   useEffect(() => {
     setCursor(undefined);
     setPages([]);
-  }, [startDateMs, endDateMs]);
+  }, [startDateMs]);
 
   const {
     data: runDataResult,
@@ -61,7 +68,6 @@ export function useRunHistoryPagination({
       limit: 20,
       cursor,
       startDate: startDateMs,
-      endDate: endDateMs,
     },
     {
       enabled: !!project,

--- a/langwatch/src/components/suites/useRunHistoryPagination.ts
+++ b/langwatch/src/components/suites/useRunHistoryPagination.ts
@@ -22,6 +22,12 @@ type PageData = {
 interface UseRunHistoryPaginationOptions {
   scenarioSetId?: string;
   startDateMs: number;
+  /**
+   * Upper bound of the selected period. Passed to the query so the list cannot
+   * show runs that a CSV export of the same period would exclude — the export
+   * scopes on both bounds.
+   */
+  endDateMs: number;
   /** While the SSE stream is connected, fallback freshness polling stops. */
   sseConnected?: boolean;
 }
@@ -29,6 +35,7 @@ interface UseRunHistoryPaginationOptions {
 export function useRunHistoryPagination({
   scenarioSetId,
   startDateMs,
+  endDateMs,
   sseConnected = false,
 }: UseRunHistoryPaginationOptions) {
   const { project } = useOrganizationTeamProject();
@@ -40,7 +47,7 @@ export function useRunHistoryPagination({
   useEffect(() => {
     setCursor(undefined);
     setPages([]);
-  }, [startDateMs]);
+  }, [startDateMs, endDateMs]);
 
   const {
     data: runDataResult,
@@ -54,6 +61,7 @@ export function useRunHistoryPagination({
       limit: 20,
       cursor,
       startDate: startDateMs,
+      endDate: endDateMs,
     },
     {
       enabled: !!project,

--- a/langwatch/src/features/errors/logic/codes.ts
+++ b/langwatch/src/features/errors/logic/codes.ts
@@ -150,6 +150,8 @@ export const APP_ERROR_CODES = [
   "rum_payload_too_large",
   "rum_rate_limited",
   "run_not_found",
+  "scenario_run_export_forbidden",
+  "scenario_run_export_unauthenticated",
   "scenario_set_limit_exceeded",
   "schema_failure",
   "seat_billing_unavailable",

--- a/langwatch/src/features/errors/logic/presentation.ts
+++ b/langwatch/src/features/errors/logic/presentation.ts
@@ -607,6 +607,15 @@ const presentations = {
     describe: () =>
       "Browser monitoring is sending faster than we accept. It will resume on its own.",
   },
+  scenario_run_export_unauthenticated: {
+    title: "Log in to export simulation runs",
+    describe: () =>
+      "Your session has expired. Log in and try the export again.",
+  },
+  scenario_run_export_forbidden: {
+    title: "You can't export this project's simulation runs",
+    describe: () => "Ask an admin for access to simulations on this project.",
+  },
   scenario_set_limit_exceeded: {
     title: "You've hit the simulation set limit",
     describe: () => "Delete an existing set, or upgrade your plan.",

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -15,6 +15,7 @@ import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
 import { app as evaluatorsApp } from "../app/api/evaluators/[[...route]]/app";
 import { app as eventsApp } from "../app/api/events/[[...route]]/app";
 import { app as experimentsApp } from "../app/api/experiments/[[...route]]/app";
+import { app as exportScenarioRunsApp } from "../app/api/export/scenario-runs/[[...route]]/app";
 import { app as exportTracesApp } from "../app/api/export/traces/[[...route]]/app";
 import { app as filesApp } from "../app/api/files/[[...route]]/app";
 import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...route]]/app";
@@ -125,6 +126,7 @@ export function createApiRouter() {
   api.route("/", experimentsApp);
   api.route("/", filesApp);
   api.route("/", exportTracesApp);
+  api.route("/", exportScenarioRunsApp);
   api.route("/", gatewayPlatformApp);
   api.route("/", governanceApp);
   api.route("/", graphsApp);

--- a/langwatch/src/server/api/routers/export.ts
+++ b/langwatch/src/server/api/routers/export.ts
@@ -27,6 +27,37 @@ export const exportProgressEventSchema = z.object({
 export type ExportProgressEvent = z.infer<typeof exportProgressEventSchema>;
 
 /**
+ * The event this subscription should relay, or null when the payload is not
+ * ours to yield.
+ *
+ * Two reasons to drop one: it did not parse, or it belongs to a different
+ * export. The channel is per-tenant, so every concurrent export in a project
+ * lands here and the exportId is what separates them.
+ */
+function readProgressEvent({
+  raw,
+  exportId,
+  projectId,
+}: {
+  raw: string;
+  exportId: string;
+  projectId: string;
+}): ExportProgressEvent | null {
+  let parsed: ExportProgressEvent;
+  try {
+    parsed = JSON.parse(raw) as ExportProgressEvent;
+  } catch {
+    logger.warn(
+      { projectId, exportId },
+      "Ignoring invalid export progress event",
+    );
+    return null;
+  }
+
+  return parsed.exportId === exportId ? parsed : null;
+}
+
+/**
  * Builds an export-progress subscription gated on a specific permission.
  *
  * Every export publishes to the same `export_progress` channel and is filtered
@@ -55,19 +86,12 @@ function exportProgressSubscription(permission: Permission) {
         })) {
           const event = eventArgs[0] as { event: string; timestamp: number };
 
-          let parsed: ExportProgressEvent;
-          try {
-            parsed = JSON.parse(event.event) as ExportProgressEvent;
-          } catch {
-            logger.warn(
-              { projectId, exportId },
-              "Ignoring invalid export progress event",
-            );
-            continue;
-          }
-
-          // Only yield events for this specific export
-          if (parsed.exportId !== exportId) continue;
+          const parsed = readProgressEvent({
+            raw: event.event,
+            exportId,
+            projectId,
+          });
+          if (!parsed) continue;
 
           logger.debug(
             { projectId, exportId, event: parsed },

--- a/langwatch/src/server/api/routers/export.ts
+++ b/langwatch/src/server/api/routers/export.ts
@@ -12,7 +12,7 @@ import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
-import { checkProjectPermission } from "../rbac";
+import { checkProjectPermission, type Permission } from "../rbac";
 
 const logger = createLogger("langwatch:api:export");
 
@@ -26,16 +26,19 @@ export const exportProgressEventSchema = z.object({
 
 export type ExportProgressEvent = z.infer<typeof exportProgressEventSchema>;
 
-export const exportRouter = createTRPCRouter({
-  /**
-   * Subscribe to export progress events for a specific export.
-   *
-   * Filters events by exportId so the client only receives updates
-   * for its own export. Terminates when the export completes or errors.
-   */
-  onExportProgress: protectedProcedure
+/**
+ * Builds an export-progress subscription gated on a specific permission.
+ *
+ * Every export publishes to the same `export_progress` channel and is filtered
+ * by `exportId`, so the relay is identical for all of them — only the
+ * permission differs, because a scenario run export is authorized by
+ * `scenarios:view` and a trace export by `traces:view`. Factored rather than
+ * copied so the two cannot drift on filtering or teardown.
+ */
+function exportProgressSubscription(permission: Permission) {
+  return protectedProcedure
     .input(z.object({ projectId: z.string(), exportId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .use(checkProjectPermission(permission))
     .subscription(async function* (opts) {
       const { projectId, exportId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);
@@ -82,5 +85,19 @@ export const exportRouter = createTRPCRouter({
           "Export progress subscription cleanup",
         );
       }
-    }),
+    });
+}
+
+export const exportRouter = createTRPCRouter({
+  /**
+   * Trace export progress. Filters by exportId so a client only sees its own.
+   */
+  onExportProgress: exportProgressSubscription("traces:view"),
+
+  /**
+   * Scenario run export progress. Same relay, gated on `scenarios:view` — the
+   * permission the export endpoint itself checks, so someone who can export
+   * can also watch it finish.
+   */
+  onScenarioRunExportProgress: exportProgressSubscription("scenarios:view"),
 });

--- a/langwatch/src/server/app-layer/__tests__/tracing.unit.test.ts
+++ b/langwatch/src/server/app-layer/__tests__/tracing.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { traced } from "../tracing";
+
+class ExampleService {
+  async fetchOne(): Promise<string> {
+    return "one";
+  }
+
+  /**
+   * The case that regressed: wrapping this in `withActiveSpan(name, async () =>
+   * fn())` returns a Promise<AsyncGenerator>, which is not async-iterable, so
+   * `for await` throws "not async iterable" at call time.
+   */
+  async *stream(count: number): AsyncGenerator<number> {
+    for (let i = 0; i < count; i++) {
+      yield i;
+    }
+  }
+
+  async *streamThatThrows(): AsyncGenerator<number> {
+    yield 1;
+    throw new Error("boom");
+  }
+}
+
+describe("traced()", () => {
+  describe("when the method is a normal async function", () => {
+    it("still resolves its value", async () => {
+      const service = traced(new ExampleService(), "ExampleService");
+      await expect(service.fetchOne()).resolves.toBe("one");
+    });
+  });
+
+  describe("when the method is an async generator", () => {
+    it("returns something async-iterable rather than a promise", () => {
+      const service = traced(new ExampleService(), "ExampleService");
+      const returned = service.stream(1) as unknown as Record<symbol, unknown>;
+
+      expect(returned[Symbol.asyncIterator]).toBeTypeOf("function");
+      expect(returned).not.toBeInstanceOf(Promise);
+    });
+
+    it("yields every value in order", async () => {
+      const service = traced(new ExampleService(), "ExampleService");
+
+      const seen: number[] = [];
+      for await (const value of service.stream(4)) {
+        seen.push(value);
+      }
+
+      expect(seen).toEqual([0, 1, 2, 3]);
+    });
+
+    it("propagates a throw from inside the generator", async () => {
+      const service = traced(new ExampleService(), "ExampleService");
+
+      const consume = async () => {
+        for await (const _ of service.streamThatThrows()) {
+          // drain
+        }
+      };
+
+      await expect(consume()).rejects.toThrow("boom");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/__tests__/tracing.unit.test.ts
+++ b/langwatch/src/server/app-layer/__tests__/tracing.unit.test.ts
@@ -1,4 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const startSpan = vi.hoisted(() => vi.fn());
+const spans = vi.hoisted(
+  () => [] as { name: string; ended: boolean; errored: boolean }[],
+);
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (_name: string, fn: () => unknown) => fn(),
+    startSpan: (name: string) => {
+      const record = { name, ended: false, errored: false };
+      spans.push(record);
+      startSpan(name);
+      return {
+        end: () => {
+          record.ended = true;
+        },
+        recordException: () => undefined,
+        setStatus: () => {
+          record.errored = true;
+        },
+      };
+    },
+  }),
+}));
+
 import { traced } from "../tracing";
 
 class ExampleService {
@@ -61,6 +87,56 @@ describe("traced()", () => {
       };
 
       await expect(consume()).rejects.toThrow("boom");
+    });
+
+    /**
+     * The delegation alone left these methods with no span at all — the class
+     * looked traced and produced nothing, which is worse than not wrapping it,
+     * because the gap only shows up when someone goes looking for the trace.
+     */
+    it("opens a span named for the method and closes it when drained", async () => {
+      spans.length = 0;
+      const service = traced(new ExampleService(), "ExampleService");
+
+      for await (const _ of service.stream(3)) {
+        // drain
+      }
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0]!.name).toBe("ExampleService.stream");
+      expect(spans[0]!.ended).toBe(true);
+    });
+
+    it("closes the span and marks it errored when the generator throws", async () => {
+      spans.length = 0;
+      const service = traced(new ExampleService(), "ExampleService");
+
+      await expect(
+        (async () => {
+          for await (const _ of service.streamThatThrows()) {
+            // drain
+          }
+        })(),
+      ).rejects.toThrow("boom");
+
+      expect(spans[0]!.ended).toBe(true);
+      expect(spans[0]!.errored).toBe(true);
+    });
+
+    /**
+     * A cancelled export breaks out of the `for await`, which calls the
+     * generator's `return()`. Without the `finally` the span would stay open
+     * for the life of the process.
+     */
+    it("closes the span when the consumer abandons the loop", async () => {
+      spans.length = 0;
+      const service = traced(new ExampleService(), "ExampleService");
+
+      for await (const _ of service.stream(10)) {
+        break;
+      }
+
+      expect(spans[0]!.ended).toBe(true);
     });
   });
 });

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -11,6 +11,7 @@ import type { RetroactiveUpdateService } from "../data-retention/retroactive/ret
 import type { EventSourcing } from "../event-sourcing/eventSourcing";
 import type { AppCommands } from "../event-sourcing/pipelineRegistry";
 import type { ExperimentService } from "../experiments/experiment.service";
+import type { ScenarioRunExportService } from "../export/scenario-runs/scenario-run-export.service";
 import type { EmailSuppressionService } from "./automations/emailSuppression.service";
 import type { TriggerService } from "./automations/trigger.service";
 import type {
@@ -100,6 +101,13 @@ export interface AppDependencies {
   };
   simulations: {
     runs: SimulationRunService;
+    /**
+     * CSV export of run history. A sibling of `runs` rather than a method on
+     * it: the export sweeps with its own keyset pagination and serializers,
+     * and the API layer should reach it here instead of assembling one from
+     * `runs.repository`.
+     */
+    export: ScenarioRunExportService;
   };
   suiteRuns: {
     runs: SuiteRunService;

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -95,6 +95,7 @@ import {
   PrismaProcessStore,
 } from "../event-sourcing/process-manager";
 import { ExperimentService } from "../experiments/experiment.service";
+import { ScenarioRunExportService } from "../export/scenario-runs/scenario-run-export.service";
 import { InviteService } from "../invites/invite.service";
 import { OrganizationRepository } from "../repositories/organization.repository";
 import { getLicenseHandler } from "../subscriptionHandler";
@@ -477,6 +478,11 @@ export function initializeDefaultApp(options?: {
   );
   const simulationReads = SimulationRunService.create(
     clickhouseEnabled ? resolveClickHouseClient : null,
+  );
+  // Shares the repository instance so the export reads through the same store
+  // the run history does, rather than opening a second one.
+  const scenarioRunExport = ScenarioRunExportService.create(
+    simulationReads.repository,
   );
   // SuiteRunService is created after pipeline registration (needs startSuiteRun command)
 
@@ -1264,7 +1270,7 @@ export function initializeDefaultApp(options?: {
     triggerTemplates,
     emailSuppressions,
     dspySteps: { steps: dspySteps },
-    simulations: { runs: simulationReads },
+    simulations: { runs: simulationReads, export: scenarioRunExport },
     suiteRuns: { runs: suiteRunService },
     topicClustering: {
       status: new TopicClusteringStatusService(
@@ -1338,6 +1344,9 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
   const testPinnedTraceService = new PinnedTraceService(
     new PinnedTraceRepository(testPrisma),
   );
+  // Hoisted so the export shares the null repository with `runs`, matching how
+  // the production preset wires the pair.
+  const testSimulationReads = SimulationRunService.create(null);
   const noop = async () => {
     /* noop */
   };
@@ -1468,7 +1477,10 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           testFireTrigger(testDeps, input),
       };
     })(),
-    simulations: { runs: SimulationRunService.create(null) },
+    simulations: {
+      runs: testSimulationReads,
+      export: ScenarioRunExportService.create(testSimulationReads.repository),
+    },
     suiteRuns: {
       runs: SuiteRunService.create({
         resolveClickHouseClient: null,

--- a/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
@@ -116,7 +116,7 @@ afterAll(async () => {
       // still rewriting parts when the next file starts perturbs its reads —
       // observed as a sibling repository suite failing only when run after this
       // one.
-      clickhouse_settings: { mutations_sync: 2 },
+      clickhouse_settings: { mutations_sync: "2" },
     });
   }
   await stopTestContainers();

--- a/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
@@ -111,6 +111,12 @@ afterAll(async () => {
     await ch.exec({
       query: `ALTER TABLE simulation_runs DELETE WHERE TenantId IN ({tenantId:String}, {otherTenantId:String})`,
       query_params: { tenantId, otherTenantId },
+      // Wait for the mutation to finish rather than firing it and moving on.
+      // Integration files share one ClickHouse and run in sequence, so a DELETE
+      // still rewriting parts when the next file starts perturbs its reads —
+      // observed as a sibling repository suite failing only when run after this
+      // one.
+      clickhouse_settings: { mutations_sync: 2 },
     });
   }
   await stopTestContainers();
@@ -246,6 +252,83 @@ describe("scenario run export sweep (integration)", () => {
       expect(otherRuns.map((run) => run.scenarioRunId)).toEqual([
         otherProjectRunId,
       ]);
+    });
+  });
+
+  describe("given a run whose StartedAt moved between versions", () => {
+    /**
+     * The projection opens a run with StartedAt null — persisted as CreatedAt —
+     * and only sets the real value when the started event lands. So a run can
+     * have an early provisional timestamp inside the window and a corrected one
+     * outside it.
+     *
+     * Deduplicating with the date filter inside the subquery picks the newest
+     * version *within the range*, which here is the stale one: it would export
+     * a run as IN_PROGRESS with no messages long after it finished. The latest
+     * version has to be chosen first, and the range applied to that.
+     */
+    it("judges the range on the latest version, not the newest in-range one", async () => {
+      const runId = `run-moved-${nanoid()}`;
+      const setId = `set-moved-${nanoid()}`;
+      // Both rows are versions of ONE run, so every field of the dedup key —
+      // tenant, set, batch, run — has to match. A fresh BatchRunId would make
+      // them two unrelated runs and the test would prove nothing.
+      const batchRunId = `batch-moved-${nanoid()}`;
+      const scenarioId = `scenario-moved-${nanoid()}`;
+      const provisional = new Date(now - 10 * DAY_MS);
+      const corrected = new Date(now - 40 * DAY_MS);
+
+      await insertRows(ch, [
+        // Written first: no started event yet, so StartedAt fell back to
+        // CreatedAt and lands inside a "last 30 days" window.
+        makeInsertRow({
+          ScenarioRunId: runId,
+          ScenarioSetId: setId,
+          BatchRunId: batchRunId,
+          ScenarioId: scenarioId,
+          Status: "IN_PROGRESS",
+          StartedAt: provisional,
+          CreatedAt: provisional,
+          UpdatedAt: provisional,
+          FinishedAt: null,
+        }),
+        // The started event arrived and corrected StartedAt to its real value,
+        // which is outside that window.
+        makeInsertRow({
+          ScenarioRunId: runId,
+          ScenarioSetId: setId,
+          BatchRunId: batchRunId,
+          ScenarioId: scenarioId,
+          Status: "SUCCESS",
+          StartedAt: corrected,
+          CreatedAt: provisional,
+          UpdatedAt: new Date(now),
+          FinishedAt: new Date(now - 39 * DAY_MS),
+        }),
+      ]);
+
+      const inWindow = await sweep({
+        projectId: tenantId,
+        scenarioSetId: setId,
+        startDate: now - 30 * DAY_MS,
+        endDate: now,
+        limit: 100,
+      });
+
+      // The run's real StartedAt is 40 days ago, so it is out of range —
+      // rather than in range wearing its stale IN_PROGRESS snapshot.
+      expect(inWindow.map((run) => run.scenarioRunId)).not.toContain(runId);
+
+      const widerWindow = await sweep({
+        projectId: tenantId,
+        scenarioSetId: setId,
+        startDate: now - 60 * DAY_MS,
+        endDate: now,
+        limit: 100,
+      });
+      const found = widerWindow.find((run) => run.scenarioRunId === runId);
+      expect(found).toBeDefined();
+      expect(found!.status).toBe(ScenarioRunStatus.SUCCESS);
     });
   });
 

--- a/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
@@ -234,9 +234,8 @@ describe("scenario run export sweep (integration)", () => {
      * TenantId is the only id unique across projects — ScenarioRunId is not —
      * so this is the predicate that stops one customer's export containing
      * another's transcripts.
-     *
-     * @scenario Export is scoped to my own project
      */
+    /** @scenario Export is scoped to my own project */
     it("never returns another project's runs", async () => {
       const runs = await sweep({ projectId: tenantId, limit: 100 });
       expect(runs.map((run) => run.scenarioRunId)).not.toContain(
@@ -256,9 +255,8 @@ describe("scenario run export sweep (integration)", () => {
      * stored — so the export only agrees with the run history if it reads
      * through the same mapper. If it ever read the raw Status column instead,
      * this run would export as IN_PROGRESS while the screen said stalled.
-     *
-     * @scenario A run that stalled exports as stalled
      */
+    /** @scenario A run that stalled exports as stalled */
     it("exports it as stalled, the same as the run history shows it", async () => {
       const stalledRunId = `run-stalled-${nanoid()}`;
       const lastEvent = new Date(now - STALL_THRESHOLD_MS - 60_000);

--- a/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/scenario-run-export-sweep.integration.test.ts
@@ -1,0 +1,289 @@
+/**
+ * The half of the export contract that only exists as SQL.
+ *
+ * Every scope the dialog offers — date range, scenario, set, project — is a
+ * WHERE clause, and archived exclusion and STALLED derivation happen on the way
+ * out of the row mapper. None of that can be observed against a stubbed
+ * repository, so this runs against a real ClickHouse: a filter that silently
+ * matches nothing looks identical to one that correctly matched nothing, and
+ * only real rows tell the two apart.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import { STALL_THRESHOLD_MS } from "~/server/scenarios/stall-detection";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import { createResilientClickHouseClient } from "../../clients/clickhouse";
+import { SimulationClickHouseRepository } from "../repositories/simulation.clickhouse.repository";
+
+const tenantId = `test-export-sweep-${nanoid()}`;
+const otherTenantId = `test-export-sweep-other-${nanoid()}`;
+const now = Date.now();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeInsertRow(overrides: Record<string, unknown> = {}) {
+  const startedAt = new Date(now - 5000);
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    ScenarioRunId: `run-${nanoid()}`,
+    ScenarioId: `scenario-${nanoid()}`,
+    BatchRunId: `batch-${nanoid()}`,
+    ScenarioSetId: `set-${nanoid()}`,
+    Version: "v1",
+    Status: "SUCCESS",
+    Name: "Test run",
+    Description: null,
+    Metadata: null,
+    "Messages.Id": [],
+    "Messages.Role": [],
+    "Messages.Content": [],
+    "Messages.TraceId": [],
+    "Messages.Rest": [],
+    TraceIds: [],
+    Verdict: "success",
+    Reasoning: "All good",
+    MetCriteria: ["criterion-1"],
+    UnmetCriteria: [],
+    Error: null,
+    DurationMs: "1500",
+    StartedAt: startedAt,
+    CreatedAt: startedAt,
+    UpdatedAt: new Date(now),
+    FinishedAt: new Date(now),
+    ArchivedAt: null,
+    LastSnapshotOccurredAt: new Date(0),
+    ...overrides,
+  };
+}
+
+async function insertRows(
+  client: ClickHouseClient,
+  rows: ReturnType<typeof makeInsertRow>[],
+) {
+  await client.insert({
+    table: "simulation_runs",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+let ch: ClickHouseClient;
+let repo: SimulationClickHouseRepository;
+
+/** Sweeps to exhaustion the way the service does, so cursor handling is exercised too. */
+async function sweep(
+  params: Parameters<SimulationClickHouseRepository["findRunsForExport"]>[0],
+) {
+  const collected = [];
+  let cursor: string | undefined;
+  do {
+    const page = await repo.findRunsForExport({
+      ...params,
+      ...(cursor ? { cursor } : {}),
+    });
+    collected.push(...page.runs);
+    cursor = page.hasMore ? page.nextCursor : undefined;
+  } while (cursor);
+  return collected;
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  // The resilient wrapper strips the `langwatch_*` settings the repository
+  // emits, matching the production factory — a bare client is rejected.
+  repo = new SimulationClickHouseRepository(async () => {
+    return createResilientClickHouseClient({ client: ch });
+  });
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE simulation_runs DELETE WHERE TenantId IN ({tenantId:String}, {otherTenantId:String})`,
+      query_params: { tenantId, otherTenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("scenario run export sweep (integration)", () => {
+  describe("given runs spread across projects, sets, scenarios and dates", () => {
+    const recentScenarioId = `scenario-recent-${nanoid()}`;
+    const oldScenarioId = `scenario-old-${nanoid()}`;
+    const targetSetId = `set-target-${nanoid()}`;
+    const otherSetId = `set-other-${nanoid()}`;
+    const archivedRunId = `run-archived-${nanoid()}`;
+    const recentRunId = `run-recent-${nanoid()}`;
+    const oldRunId = `run-old-${nanoid()}`;
+    const otherSetRunId = `run-other-set-${nanoid()}`;
+    const otherProjectRunId = `run-other-project-${nanoid()}`;
+
+    beforeAll(async () => {
+      const recent = new Date(now - DAY_MS);
+      const old = new Date(now - 45 * DAY_MS);
+
+      await insertRows(ch, [
+        makeInsertRow({
+          ScenarioRunId: recentRunId,
+          ScenarioId: recentScenarioId,
+          ScenarioSetId: targetSetId,
+          StartedAt: recent,
+          CreatedAt: recent,
+          UpdatedAt: recent,
+          FinishedAt: recent,
+        }),
+        makeInsertRow({
+          ScenarioRunId: oldRunId,
+          ScenarioId: oldScenarioId,
+          ScenarioSetId: targetSetId,
+          StartedAt: old,
+          CreatedAt: old,
+          UpdatedAt: old,
+          FinishedAt: old,
+        }),
+        makeInsertRow({
+          ScenarioRunId: otherSetRunId,
+          ScenarioId: recentScenarioId,
+          ScenarioSetId: otherSetId,
+          StartedAt: recent,
+          CreatedAt: recent,
+          UpdatedAt: recent,
+          FinishedAt: recent,
+        }),
+        makeInsertRow({
+          ScenarioRunId: archivedRunId,
+          ScenarioId: recentScenarioId,
+          ScenarioSetId: targetSetId,
+          StartedAt: recent,
+          CreatedAt: recent,
+          UpdatedAt: recent,
+          FinishedAt: recent,
+          ArchivedAt: recent,
+        }),
+        makeInsertRow({
+          TenantId: otherTenantId,
+          ScenarioRunId: otherProjectRunId,
+          ScenarioId: recentScenarioId,
+          ScenarioSetId: targetSetId,
+          StartedAt: recent,
+          CreatedAt: recent,
+          UpdatedAt: recent,
+          FinishedAt: recent,
+        }),
+      ]);
+    }, 30_000);
+
+    /** @scenario Export honours the selected date range */
+    it("includes only runs started inside the range", async () => {
+      const runs = await sweep({
+        projectId: tenantId,
+        startDate: now - 30 * DAY_MS,
+        endDate: now,
+        limit: 100,
+      });
+
+      const ids = runs.map((run) => run.scenarioRunId);
+      expect(ids).toContain(recentRunId);
+      expect(ids).not.toContain(oldRunId);
+    });
+
+    /** @scenario Export honours the scenario filter */
+    it("includes only runs of the chosen scenario", async () => {
+      const runs = await sweep({
+        projectId: tenantId,
+        scenarioId: oldScenarioId,
+        limit: 100,
+      });
+
+      expect(runs.map((run) => run.scenarioRunId)).toEqual([oldRunId]);
+    });
+
+    /** @scenario Export from a scenario set is scoped to that set */
+    it("includes only runs belonging to the chosen set", async () => {
+      const runs = await sweep({
+        projectId: tenantId,
+        scenarioSetId: otherSetId,
+        limit: 100,
+      });
+
+      expect(runs.map((run) => run.scenarioRunId)).toEqual([otherSetRunId]);
+    });
+
+    /** @scenario Archived runs are excluded */
+    it("leaves archived runs out of both the sweep and its count", async () => {
+      const runs = await sweep({ projectId: tenantId, limit: 100 });
+      expect(runs.map((run) => run.scenarioRunId)).not.toContain(archivedRunId);
+
+      // The count feeds X-Total-Runs and therefore the progress denominator, so
+      // it has to agree with the sweep or the bar never reaches its total.
+      const total = await repo.countRunsForExport({ projectId: tenantId });
+      expect(total).toBe(runs.length);
+    });
+
+    /**
+     * TenantId is the only id unique across projects — ScenarioRunId is not —
+     * so this is the predicate that stops one customer's export containing
+     * another's transcripts.
+     *
+     * @scenario Export is scoped to my own project
+     */
+    it("never returns another project's runs", async () => {
+      const runs = await sweep({ projectId: tenantId, limit: 100 });
+      expect(runs.map((run) => run.scenarioRunId)).not.toContain(
+        otherProjectRunId,
+      );
+
+      const otherRuns = await sweep({ projectId: otherTenantId, limit: 100 });
+      expect(otherRuns.map((run) => run.scenarioRunId)).toEqual([
+        otherProjectRunId,
+      ]);
+    });
+  });
+
+  describe("given a run that stopped emitting events without finishing", () => {
+    /**
+     * STALLED is derived at read time from the gap since the last event, not
+     * stored — so the export only agrees with the run history if it reads
+     * through the same mapper. If it ever read the raw Status column instead,
+     * this run would export as IN_PROGRESS while the screen said stalled.
+     *
+     * @scenario A run that stalled exports as stalled
+     */
+    it("exports it as stalled, the same as the run history shows it", async () => {
+      const stalledRunId = `run-stalled-${nanoid()}`;
+      const lastEvent = new Date(now - STALL_THRESHOLD_MS - 60_000);
+
+      await insertRows(ch, [
+        makeInsertRow({
+          ScenarioRunId: stalledRunId,
+          ScenarioSetId: `set-stalled-${nanoid()}`,
+          Status: "IN_PROGRESS",
+          Verdict: null,
+          MetCriteria: [],
+          UnmetCriteria: [],
+          Reasoning: null,
+          StartedAt: lastEvent,
+          CreatedAt: lastEvent,
+          UpdatedAt: lastEvent,
+          FinishedAt: null,
+        }),
+      ]);
+
+      const runs = await sweep({ projectId: tenantId, limit: 100 });
+      const stalled = runs.find((run) => run.scenarioRunId === stalledRunId);
+
+      expect(stalled).toBeDefined();
+      expect(stalled!.status).toBe(ScenarioRunStatus.STALLED);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1310,6 +1310,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         ...mapClickHouseRowToScenarioRunData(row, now),
         scenarioSetId:
           row.ScenarioSetId === "" ? DEFAULT_SET_ID : row.ScenarioSetId,
+        traceIds: row.TraceIds ?? [],
       })),
       nextCursor,
       hasMore,

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -31,6 +31,19 @@ const TABLE_NAME = "simulation_runs" as const;
 export const RUN_ID_CAP = 10000;
 
 /**
+ * Sort key for the export sweep, as a single SQL expression.
+ *
+ * ORDER BY, the cursor predicate and the value returned as the cursor must all
+ * be *the same* expression. Sorting on StartedAt while seeding the cursor from
+ * a CreatedAt fallback makes the next page filter on a column it did not sort
+ * by, which silently drops or repeats runs at the boundary — and ClickHouse
+ * sorts NULLs first under ASC, so any NULL StartedAt rows land on page one and
+ * become unreachable for the rest of the sweep while the count still includes
+ * them. Coalescing here means there is one definition and no fallback in TS.
+ */
+const EXPORT_SORT_KEY = "toUnixTimestamp64Milli(ifNull(t.StartedAt, t.CreatedAt))";
+
+/**
  * Returns an IN-tuple dedup predicate for simulation_runs.
  *
  * simulation_runs uses ReplacingMergeTree(UpdatedAt) with dedup key
@@ -355,8 +368,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     // pattern that read all heavy columns (Messages, RoleCosts, etc.) across
     // entire granules (~8K rows) for dedup, causing OOM on parts with large
     // payloads.
-    const rows = await this.queryRows<ClickHouseSimulationRunRow>(
-      `SELECT ${RUN_COLUMNS}
+    const rows = await this.queryRows<
+      ClickHouseSimulationRunRow & { ExportSortKey: string }
+    >(
+      `SELECT ${RUN_COLUMNS},
+        toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
          AND t.ScenarioRunId = {scenarioRunId:String}
@@ -655,8 +671,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       }
     }
 
-    const rows = await this.queryRows<ClickHouseSimulationRunRow>(
-      `SELECT ${RUN_COLUMNS}
+    const rows = await this.queryRows<
+      ClickHouseSimulationRunRow & { ExportSortKey: string }
+    >(
+      `SELECT ${RUN_COLUMNS},
+        toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
          AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})
@@ -724,8 +743,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     projectId: string;
     scenarioSetId: string;
   }): Promise<ScenarioRunData[]> {
-    const rows = await this.queryRows<ClickHouseSimulationRunRow>(
-      `SELECT ${RUN_COLUMNS}
+    const rows = await this.queryRows<
+      ClickHouseSimulationRunRow & { ExportSortKey: string }
+    >(
+      `SELECT ${RUN_COLUMNS},
+        toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
          AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})
@@ -1211,6 +1233,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          AND t.ArchivedAt IS NULL
          ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}`,
       { tenantId: projectId, ...params },
+      { expectedMaxDurationMs: 10000, expectedMaxReadBytes: 20_000_000 },
     );
 
     return Number(rows[0]?.Total ?? "0");
@@ -1266,20 +1289,23 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const cursorPredicate = decoded
       ? `AND (
-          (toUnixTimestamp64Milli(t.StartedAt) > toUInt64({cursorTs:String}))
-          OR (toUnixTimestamp64Milli(t.StartedAt) = toUInt64({cursorTs:String}) AND t.ScenarioRunId > {cursorRunId:String})
+          (${EXPORT_SORT_KEY} > toUInt64({cursorTs:String}))
+          OR (${EXPORT_SORT_KEY} = toUInt64({cursorTs:String}) AND t.ScenarioRunId > {cursorRunId:String})
         )`
       : "";
 
-    const rows = await this.queryRows<ClickHouseSimulationRunRow>(
-      `SELECT ${RUN_COLUMNS}
+    const rows = await this.queryRows<
+      ClickHouseSimulationRunRow & { ExportSortKey: string }
+    >(
+      `SELECT ${RUN_COLUMNS},
+        toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
          ${whereClause}
          ${cursorPredicate}
          AND t.ArchivedAt IS NULL
          ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}
-       ORDER BY t.StartedAt ASC, t.ScenarioRunId ASC
+       ORDER BY ${EXPORT_SORT_KEY} ASC, t.ScenarioRunId ASC
        LIMIT {fetchLimit:UInt32}`,
       {
         tenantId: projectId,
@@ -1299,7 +1325,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     const nextCursor =
       hasMore && lastRow
         ? this.encodeExportCursor(
-            lastRow.StartedAt ?? lastRow.CreatedAt,
+            lastRow.ExportSortKey,
             lastRow.ScenarioRunId,
           )
         : undefined;

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1219,7 +1219,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     startDate?: number;
     endDate?: number;
   }): Promise<number> {
-    const { whereClause, params } = this.buildExportFilters({
+    const { stableClause, dateClause, params } = this.buildExportFilters({
       scenarioSetId,
       scenarioId,
       startDate,
@@ -1230,9 +1230,10 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       `SELECT toString(count()) AS Total
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
-         ${whereClause}
+         ${stableClause}
+         ${dateClause}
          AND t.ArchivedAt IS NULL
-         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}`,
+         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(stableClause)}`)}`,
       { tenantId: projectId, ...params },
     );
 
@@ -1280,7 +1281,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     const validatedLimit = Math.min(Math.max(1, limit), 500);
     const decoded = cursor ? this.decodeExportCursor(cursor) : null;
 
-    const { whereClause, params } = this.buildExportFilters({
+    const { stableClause, dateClause, params } = this.buildExportFilters({
       scenarioSetId,
       scenarioId,
       startDate,
@@ -1301,10 +1302,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
-         ${whereClause}
+         ${stableClause}
+         ${dateClause}
          ${cursorPredicate}
          AND t.ArchivedAt IS NULL
-         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}
+         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(stableClause)}`)}
        ORDER BY ${EXPORT_SORT_KEY} ASC, t.ScenarioRunId ASC
        LIMIT {fetchLimit:UInt32}`,
       {
@@ -1340,8 +1342,29 @@ export class SimulationClickHouseRepository implements SimulationRepository {
   }
 
   /**
-   * Shared WHERE fragment for the export sweep and its count, so the two can
+   * Shared WHERE fragments for the export sweep and its count, so the two can
    * never drift and report a total the sweep does not produce.
+   *
+   * Returned in two halves because only one of them may go inside the dedup
+   * subquery:
+   *
+   *   stable — ScenarioSetId and ScenarioId. A run cannot move between sets or
+   *     scenarios, and ScenarioSetId is part of the dedup key already, so
+   *     narrowing on these picks the same version either way. Keeping them in
+   *     the subquery is what stops it grouping the whole tenant.
+   *
+   *   date — StartedAt, which IS mutable across versions: the projection opens
+   *     a run with StartedAt null (persisted as CreatedAt) and only sets the
+   *     real value when the started event lands. Inside the subquery it would
+   *     make max(UpdatedAt) the newest version *within the range* rather than
+   *     the newest version, so a run whose corrected timestamp moved out of the
+   *     window would export its stale earlier snapshot — old status, missing
+   *     messages — instead of being excluded. It belongs only in the outer
+   *     query, applied to whichever version actually won.
+   *
+   * The cost is that the subquery no longer prunes partitions by date. That is
+   * the trade: an export that is cheaper but occasionally wrong around a range
+   * boundary is not worth having.
    *
    * Note the pass/fail filter is deliberately absent: STALLED is derived from
    * timestamps by resolveRunStatus at map time, not stored in the table, so it
@@ -1357,34 +1380,37 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     scenarioId?: string;
     startDate?: number;
     endDate?: number;
-  }): { whereClause: string; params: Record<string, string | string[]> } {
-    const parts: string[] = [];
+  }): {
+    stableClause: string;
+    dateClause: string;
+    params: Record<string, string | string[]>;
+  } {
+    const stableParts: string[] = [];
     const params: Record<string, string | string[]> = {};
 
-    const dateFilter = buildDateFilter({ startDate, endDate });
-    if (dateFilter.whereClause) {
-      // buildDateFilter emits unqualified column names; the export queries read
-      // through the `t` alias, so qualify them here.
-      parts.push(
-        dateFilter.whereClause
-          .replace(/^AND /, "")
-          .replace(/StartedAt/g, "t.StartedAt"),
-      );
-      Object.assign(params, dateFilter.params);
-    }
-
     if (scenarioSetId) {
-      parts.push("t.ScenarioSetId IN ({exportSetIds:Array(String)})");
+      stableParts.push("t.ScenarioSetId IN ({exportSetIds:Array(String)})");
       params.exportSetIds = expandSetIdFilter(scenarioSetId);
     }
 
     if (scenarioId) {
-      parts.push("t.ScenarioId = {exportScenarioId:String}");
+      stableParts.push("t.ScenarioId = {exportScenarioId:String}");
       params.exportScenarioId = scenarioId;
     }
 
+    const dateFilter = buildDateFilter({ startDate, endDate });
+    let dateClause = "";
+    if (dateFilter.whereClause) {
+      // buildDateFilter emits unqualified column names; the export queries read
+      // through the `t` alias, so qualify them here.
+      dateClause = dateFilter.whereClause.replace(/StartedAt/g, "t.StartedAt");
+      Object.assign(params, dateFilter.params);
+    }
+
     return {
-      whereClause: parts.length > 0 ? `AND ${parts.join(" AND ")}` : "",
+      stableClause:
+        stableParts.length > 0 ? `AND ${stableParts.join(" AND ")}` : "",
+      dateClause,
       params,
     };
   }

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1233,7 +1233,6 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          AND t.ArchivedAt IS NULL
          ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}`,
       { tenantId: projectId, ...params },
-      { expectedMaxDurationMs: 10000, expectedMaxReadBytes: 20_000_000 },
     );
 
     return Number(rows[0]?.Total ?? "0");
@@ -1315,7 +1314,6 @@ export class SimulationClickHouseRepository implements SimulationRepository {
           : {}),
         fetchLimit: String(validatedLimit + 1),
       },
-      { expectedMaxDurationMs: 15000, expectedMaxReadBytes: 50_000_000 },
     );
 
     const hasMore = rows.length > validatedLimit;

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -21,7 +21,10 @@ import {
   queryWindowed,
   type WindowFragment,
 } from "../../clients/clickhouse/windowed-read";
-import type { SimulationRepository } from "./simulation.repository";
+import type {
+  ExportableRun,
+  SimulationRepository,
+} from "./simulation.repository";
 
 const TABLE_NAME = "simulation_runs" as const;
 
@@ -48,6 +51,34 @@ function simulationRunDedupPredicate(whereFilters: string): string {
     WHERE ${whereFilters}
     GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
   )`;
+}
+
+/**
+ * Dedup predicate for a query that reads simulation_runs through the `t` alias.
+ *
+ * The outer columns MUST be table-qualified. RUN_COLUMNS aliases the timestamp
+ * columns to strings (`toString(toUnixTimestamp64Milli(UpdatedAt)) AS UpdatedAt`)
+ * and ClickHouse resolves WHERE against SELECT aliases, so an unqualified
+ * `UpdatedAt` here compares a String against the subquery's DateTime64 and the
+ * IN-tuple matches nothing. That failure is silent — the query succeeds and
+ * returns zero rows — so it surfaces as a mysteriously empty result rather than
+ * an error. Qualifying with `t.` binds to the column instead of the alias.
+ */
+function qualifiedDedupPredicate(whereFilters: string): string {
+  return `AND (t.TenantId, t.ScenarioSetId, t.BatchRunId, t.ScenarioRunId, t.UpdatedAt) IN (
+    SELECT TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, max(UpdatedAt)
+    FROM ${TABLE_NAME}
+    WHERE ${whereFilters}
+    GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
+  )`;
+}
+
+/**
+ * Strips the `t.` qualifier for reuse inside the dedup subquery, which selects
+ * from the bare table and has no such alias in scope.
+ */
+function unqualify(clause: string): string {
+  return clause.replace(/\bt\./g, "");
 }
 
 /**
@@ -1150,7 +1181,218 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     );
   }
 
+  // ---- Export sweep ----
+
+  async countRunsForExport({
+    projectId,
+    scenarioSetId,
+    scenarioId,
+    startDate,
+    endDate,
+  }: {
+    projectId: string;
+    scenarioSetId?: string;
+    scenarioId?: string;
+    startDate?: number;
+    endDate?: number;
+  }): Promise<number> {
+    const { whereClause, params } = this.buildExportFilters({
+      scenarioSetId,
+      scenarioId,
+      startDate,
+      endDate,
+    });
+
+    const rows = await this.queryRows<{ Total: string }>(
+      `SELECT toString(count()) AS Total
+       FROM ${TABLE_NAME} AS t
+       WHERE t.TenantId = {tenantId:String}
+         ${whereClause}
+         AND t.ArchivedAt IS NULL
+         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}`,
+      { tenantId: projectId, ...params },
+    );
+
+    return Number(rows[0]?.Total ?? "0");
+  }
+
+  /**
+   * Forward-only page of runs for a CSV export sweep.
+   *
+   * Distinct from getRunDataForAllSuites, which caps at 100 and is shaped for
+   * the UI's freshness protocol (it can answer `changed: false` and skip the
+   * read entirely). An export needs a plain chronological sweep it can drive to
+   * exhaustion, so it gets its own read rather than bending that one.
+   *
+   * Keyset (not OFFSET) pagination on (StartedAt, ScenarioRunId): OFFSET makes
+   * ClickHouse re-scan and re-sort every preceding row for each page, so a large
+   * export degrades quadratically. The tuple is unique because ScenarioRunId
+   * breaks ties within a millisecond.
+   *
+   * Reads RUN_COLUMNS, never LIST_COLUMNS — the latter nulls out Reasoning and
+   * Error and truncates the conversation to 6 messages for grid cards, which
+   * would silently ship an export with empty judge reasoning.
+   */
+  async findRunsForExport({
+    projectId,
+    scenarioSetId,
+    scenarioId,
+    startDate,
+    endDate,
+    limit,
+    cursor,
+  }: {
+    projectId: string;
+    scenarioSetId?: string;
+    scenarioId?: string;
+    startDate?: number;
+    endDate?: number;
+    limit: number;
+    cursor?: string;
+  }): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    const validatedLimit = Math.min(Math.max(1, limit), 500);
+    const decoded = cursor ? this.decodeExportCursor(cursor) : null;
+
+    const { whereClause, params } = this.buildExportFilters({
+      scenarioSetId,
+      scenarioId,
+      startDate,
+      endDate,
+    });
+
+    const cursorPredicate = decoded
+      ? `AND (
+          (toUnixTimestamp64Milli(t.StartedAt) > toUInt64({cursorTs:String}))
+          OR (toUnixTimestamp64Milli(t.StartedAt) = toUInt64({cursorTs:String}) AND t.ScenarioRunId > {cursorRunId:String})
+        )`
+      : "";
+
+    const rows = await this.queryRows<ClickHouseSimulationRunRow>(
+      `SELECT ${RUN_COLUMNS}
+       FROM ${TABLE_NAME} AS t
+       WHERE t.TenantId = {tenantId:String}
+         ${whereClause}
+         ${cursorPredicate}
+         AND t.ArchivedAt IS NULL
+         ${qualifiedDedupPredicate(`TenantId = {tenantId:String} ${unqualify(whereClause)}`)}
+       ORDER BY t.StartedAt ASC, t.ScenarioRunId ASC
+       LIMIT {fetchLimit:UInt32}`,
+      {
+        tenantId: projectId,
+        ...params,
+        ...(decoded
+          ? { cursorTs: decoded.ts, cursorRunId: decoded.scenarioRunId }
+          : {}),
+        fetchLimit: String(validatedLimit + 1),
+      },
+      { expectedMaxDurationMs: 15000, expectedMaxReadBytes: 50_000_000 },
+    );
+
+    const hasMore = rows.length > validatedLimit;
+    const pageRows = hasMore ? rows.slice(0, validatedLimit) : rows;
+
+    const lastRow = pageRows[pageRows.length - 1];
+    const nextCursor =
+      hasMore && lastRow
+        ? this.encodeExportCursor(
+            lastRow.StartedAt ?? lastRow.CreatedAt,
+            lastRow.ScenarioRunId,
+          )
+        : undefined;
+
+    const now = Date.now();
+    return {
+      runs: pageRows.map((row) => ({
+        ...mapClickHouseRowToScenarioRunData(row, now),
+        scenarioSetId:
+          row.ScenarioSetId === "" ? DEFAULT_SET_ID : row.ScenarioSetId,
+      })),
+      nextCursor,
+      hasMore,
+    };
+  }
+
+  /**
+   * Shared WHERE fragment for the export sweep and its count, so the two can
+   * never drift and report a total the sweep does not produce.
+   *
+   * Note the pass/fail filter is deliberately absent: STALLED is derived from
+   * timestamps by resolveRunStatus at map time, not stored in the table, so it
+   * cannot be expressed in SQL. Category filtering happens after mapping.
+   */
+  private buildExportFilters({
+    scenarioSetId,
+    scenarioId,
+    startDate,
+    endDate,
+  }: {
+    scenarioSetId?: string;
+    scenarioId?: string;
+    startDate?: number;
+    endDate?: number;
+  }): { whereClause: string; params: Record<string, string | string[]> } {
+    const parts: string[] = [];
+    const params: Record<string, string | string[]> = {};
+
+    const dateFilter = buildDateFilter({ startDate, endDate });
+    if (dateFilter.whereClause) {
+      // buildDateFilter emits unqualified column names; the export queries read
+      // through the `t` alias, so qualify them here.
+      parts.push(
+        dateFilter.whereClause.replace(/^AND /, "").replace(/StartedAt/g, "t.StartedAt"),
+      );
+      Object.assign(params, dateFilter.params);
+    }
+
+    if (scenarioSetId) {
+      parts.push("t.ScenarioSetId IN ({exportSetIds:Array(String)})");
+      params.exportSetIds = expandSetIdFilter(scenarioSetId);
+    }
+
+    if (scenarioId) {
+      parts.push("t.ScenarioId = {exportScenarioId:String}");
+      params.exportScenarioId = scenarioId;
+    }
+
+    return {
+      whereClause: parts.length > 0 ? `AND ${parts.join(" AND ")}` : "",
+      params,
+    };
+  }
+
   // ---- Cursor helpers ----
+
+  /**
+   * Export cursors key on (StartedAt, ScenarioRunId); the batch cursors below
+   * key on (max(CreatedAt), BatchRunId). Separate encoders rather than one
+   * shared pair so neither payload carries a field named for the other's key.
+   */
+  private encodeExportCursor(ts: string, scenarioRunId: string): string {
+    return Buffer.from(JSON.stringify({ ts, scenarioRunId })).toString("base64");
+  }
+
+  private decodeExportCursor(
+    cursor: string,
+  ): { ts: string; scenarioRunId: string } | null {
+    try {
+      const parsed = JSON.parse(
+        Buffer.from(cursor, "base64").toString("utf-8"),
+      ) as Record<string, unknown>;
+      if (
+        typeof parsed.ts !== "string" ||
+        typeof parsed.scenarioRunId !== "string"
+      ) {
+        return null;
+      }
+      return { ts: parsed.ts, scenarioRunId: parsed.scenarioRunId };
+    } catch {
+      return null;
+    }
+  }
 
   private encodeCursor(ts: string, batchRunId: string): string {
     const payload: CursorPayload = { ts, batchRunId };

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -41,7 +41,8 @@ export const RUN_ID_CAP = 10000;
  * become unreachable for the rest of the sweep while the count still includes
  * them. Coalescing here means there is one definition and no fallback in TS.
  */
-const EXPORT_SORT_KEY = "toUnixTimestamp64Milli(ifNull(t.StartedAt, t.CreatedAt))";
+const EXPORT_SORT_KEY =
+  "toUnixTimestamp64Milli(ifNull(t.StartedAt, t.CreatedAt))";
 
 /**
  * Returns an IN-tuple dedup predicate for simulation_runs.
@@ -1322,10 +1323,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     const lastRow = pageRows[pageRows.length - 1];
     const nextCursor =
       hasMore && lastRow
-        ? this.encodeExportCursor(
-            lastRow.ExportSortKey,
-            lastRow.ScenarioRunId,
-          )
+        ? this.encodeExportCursor(lastRow.ExportSortKey, lastRow.ScenarioRunId)
         : undefined;
 
     const now = Date.now();
@@ -1368,7 +1366,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       // buildDateFilter emits unqualified column names; the export queries read
       // through the `t` alias, so qualify them here.
       parts.push(
-        dateFilter.whereClause.replace(/^AND /, "").replace(/StartedAt/g, "t.StartedAt"),
+        dateFilter.whereClause
+          .replace(/^AND /, "")
+          .replace(/StartedAt/g, "t.StartedAt"),
       );
       Object.assign(params, dateFilter.params);
     }
@@ -1397,7 +1397,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
    * shared pair so neither payload carries a field named for the other's key.
    */
   private encodeExportCursor(ts: string, scenarioRunId: string): string {
-    return Buffer.from(JSON.stringify({ ts, scenarioRunId })).toString("base64");
+    return Buffer.from(JSON.stringify({ ts, scenarioRunId })).toString(
+      "base64",
+    );
   }
 
   private decodeExportCursor(

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
@@ -6,6 +6,15 @@ import type {
   ScenarioSetData,
 } from "~/server/scenarios/scenario-event.types";
 
+/**
+ * A run carrying the scenario set it belongs to.
+ *
+ * mapClickHouseRowToScenarioRunData drops ScenarioSetId (the UI resolves it
+ * per batch instead), but an "All Runs" export spans sets, so each row has to
+ * say which one it came from. The value is already on the ClickHouse row.
+ */
+export type ExportableRun = ScenarioRunData & { scenarioSetId: string };
+
 export type AllSuitesRunDataResult =
   | { changed: false; lastUpdatedAt: number }
   | {
@@ -122,6 +131,36 @@ export interface SimulationRepository {
   getDistinctExternalSetIds(params: {
     projectIds: string[];
   }): Promise<Set<string>>;
+
+  /**
+   * Total runs an export sweep will visit, for the progress total. Shares its
+   * filter construction with findRunsForExport so the two cannot disagree.
+   */
+  countRunsForExport(params: {
+    projectId: string;
+    scenarioSetId?: string;
+    scenarioId?: string;
+    startDate?: number;
+    endDate?: number;
+  }): Promise<number>;
+
+  /**
+   * One forward-only page of runs for a CSV export, oldest first, keyset
+   * paginated. Callers drive it to exhaustion via `nextCursor`.
+   */
+  findRunsForExport(params: {
+    projectId: string;
+    scenarioSetId?: string;
+    scenarioId?: string;
+    startDate?: number;
+    endDate?: number;
+    limit: number;
+    cursor?: string;
+  }): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }>;
 }
 
 export class NullSimulationRepository implements SimulationRepository {
@@ -188,5 +227,17 @@ export class NullSimulationRepository implements SimulationRepository {
 
   async getDistinctExternalSetIds(): Promise<Set<string>> {
     return new Set();
+  }
+
+  async countRunsForExport(): Promise<number> {
+    return 0;
+  }
+
+  async findRunsForExport(): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    return { runs: [], hasMore: false };
   }
 }

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
@@ -7,13 +7,24 @@ import type {
 } from "~/server/scenarios/scenario-event.types";
 
 /**
- * A run carrying the scenario set it belongs to.
+ * A run carrying the two columns the shared mapper drops but an export needs.
  *
- * mapClickHouseRowToScenarioRunData drops ScenarioSetId (the UI resolves it
- * per batch instead), but an "All Runs" export spans sets, so each row has to
- * say which one it came from. The value is already on the ClickHouse row.
+ * `scenarioSetId` — the UI resolves it per batch instead, but an "All Runs"
+ * export spans sets, so each row has to say which one it came from.
+ *
+ * `traceIds` — the run-level TraceIds column, unioned with the per-message
+ * trace ids by the exporter. On a 228-run sample the run-level column was a
+ * strict subset and contributed nothing, but the two are written by
+ * independent code paths and a run can finish with traces recorded and no
+ * message snapshot, so the union is kept as cheap insurance rather than
+ * because it currently adds ids.
+ *
+ * Both values are already on the ClickHouse row.
  */
-export type ExportableRun = ScenarioRunData & { scenarioSetId: string };
+export type ExportableRun = ScenarioRunData & {
+  scenarioSetId: string;
+  traceIds: string[];
+};
 
 export type AllSuitesRunDataResult =
   | { changed: false; lastUpdatedAt: number }

--- a/langwatch/src/server/app-layer/tracing.ts
+++ b/langwatch/src/server/app-layer/tracing.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode } from "@opentelemetry/api";
 import { getLangWatchTracer } from "langwatch";
 
 /**
@@ -46,18 +47,28 @@ export function traced<T extends object>(instance: T, className: string): T {
       // promise throws "not async iterable". The failure is silent at wrap
       // time and only surfaces when the method is iterated.
       //
-      // Delegating with `yield*` keeps the method a generator. The work is
-      // still traced: every await inside it runs under whatever span is active
-      // at iteration time, which for a streamed export is the request span.
+      // So the span is managed by hand instead. withActiveSpan owns the whole
+      // call and would close the span at the first yield; a generator's work
+      // happens across every later next(), so what is worth measuring is the
+      // iteration. `finally` covers all three ways a generator ends — drained,
+      // thrown, or abandoned when a `for await` breaks and calls return().
       if (isAsyncGeneratorFunction(value)) {
         const generatorWrapper = async function* (
           this: unknown,
           ...args: unknown[]
         ) {
-          yield* (value as (...a: unknown[]) => AsyncGenerator<unknown>).apply(
-            this ?? target,
-            args,
-          );
+          const span = tracer.startSpan(spanName);
+          try {
+            yield* (
+              value as (...a: unknown[]) => AsyncGenerator<unknown>
+            ).apply(this ?? target, args);
+          } catch (error) {
+            span.recordException(error as Error);
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            throw error;
+          } finally {
+            span.end();
+          }
         };
         wrapperCache.set(prop, generatorWrapper);
         return generatorWrapper;

--- a/langwatch/src/server/app-layer/tracing.ts
+++ b/langwatch/src/server/app-layer/tracing.ts
@@ -40,6 +40,28 @@ export function traced<T extends object>(instance: T, className: string): T {
 
       const spanName = `${className}.${String(prop)}`;
 
+      // Async generators cannot go through withActiveSpan. Calling one returns
+      // an AsyncGenerator, not a promise, so `withActiveSpan(name, async () =>
+      // fn())` resolves to a Promise<AsyncGenerator> — and `for await` on a
+      // promise throws "not async iterable". The failure is silent at wrap
+      // time and only surfaces when the method is iterated.
+      //
+      // Delegating with `yield*` keeps the method a generator. The work is
+      // still traced: every await inside it runs under whatever span is active
+      // at iteration time, which for a streamed export is the request span.
+      if (isAsyncGeneratorFunction(value)) {
+        const generatorWrapper = async function* (
+          this: unknown,
+          ...args: unknown[]
+        ) {
+          yield* (
+            value as (...a: unknown[]) => AsyncGenerator<unknown>
+          ).apply(this ?? target, args);
+        };
+        wrapperCache.set(prop, generatorWrapper);
+        return generatorWrapper;
+      }
+
       const wrapper = function (this: unknown, ...args: unknown[]) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return tracer.withActiveSpan(spanName, async () =>
@@ -51,4 +73,17 @@ export function traced<T extends object>(instance: T, className: string): T {
       return wrapper;
     },
   });
+}
+
+/**
+ * True for `async function*` declarations.
+ *
+ * Checked by constructor name rather than `instanceof` because the
+ * AsyncGeneratorFunction constructor is not a global binding.
+ */
+function isAsyncGeneratorFunction(value: unknown): boolean {
+  return (
+    typeof value === "function" &&
+    value.constructor?.name === "AsyncGeneratorFunction"
+  );
 }

--- a/langwatch/src/server/app-layer/tracing.ts
+++ b/langwatch/src/server/app-layer/tracing.ts
@@ -54,9 +54,10 @@ export function traced<T extends object>(instance: T, className: string): T {
           this: unknown,
           ...args: unknown[]
         ) {
-          yield* (
-            value as (...a: unknown[]) => AsyncGenerator<unknown>
-          ).apply(this ?? target, args);
+          yield* (value as (...a: unknown[]) => AsyncGenerator<unknown>).apply(
+            this ?? target,
+            args,
+          );
         };
         wrapperCache.set(prop, generatorWrapper);
         return generatorWrapper;

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -1,0 +1,333 @@
+import Parse from "papaparse";
+import { describe, expect, it } from "vitest";
+import type { ExportableRun } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.enums";
+import {
+  serializeRunsToCriteriaCsv,
+  serializeRunsToFullCsv,
+  serializeRunsToSummaryCsv,
+} from "../csv-serializer";
+
+function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
+  return {
+    scenarioRunId: "run_1",
+    scenarioId: "scenario_1",
+    batchRunId: "batch_1",
+    scenarioSetId: "set_1",
+    name: "Refund Request",
+    description: null,
+    metadata: null,
+    status: ScenarioRunStatus.SUCCESS,
+    results: {
+      verdict: Verdict.SUCCESS,
+      reasoning: "The agent offered a refund.",
+      metCriteria: ["stays polite"],
+      unmetCriteria: [],
+      error: undefined,
+    },
+    messages: [],
+    timestamp: 1785177315009,
+    updatedAt: 1785177315009,
+    durationInMs: 8400,
+    totalCost: 0.031,
+    ...overrides,
+  } as ExportableRun;
+}
+
+function parse(csv: string): Record<string, string>[] {
+  return Parse.parse<Record<string, string>>(csv.trim(), {
+    header: true,
+    skipEmptyLines: true,
+  }).data;
+}
+
+describe("scenario run CSV serializers", () => {
+  describe("given summary mode", () => {
+    it("writes one row per run", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.scenario_run_id)).toEqual(["a", "b"]);
+    });
+
+    it("reports criteria counts without requiring the JSON to be parsed", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "",
+              metCriteria: ["a", "b"],
+              unmetCriteria: ["c", "d", "e"],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const row = parse(csv)[0]!;
+      expect(row.met_criteria_count).toBe("2");
+      expect(row.unmet_criteria_count).toBe("3");
+    });
+
+    it("encodes criteria as JSON so their commas survive a round trip", () => {
+      const criterion = "stays polite, even when the customer escalates";
+      const csv = serializeRunsToSummaryCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.SUCCESS,
+              reasoning: "",
+              metCriteria: [criterion],
+              unmetCriteria: [],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const row = parse(csv)[0]!;
+      expect(JSON.parse(row.met_criteria!)).toEqual([criterion]);
+    });
+
+    it("writes timestamps as ISO-8601 UTC", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun({ timestamp: 1785177315009 })],
+        includeHeader: true,
+      });
+
+      expect(parse(csv)[0]!.started_at).toBe("2026-07-27T18:35:15.009Z");
+    });
+
+    it("leaves cost empty when the run reported none", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun({ totalCost: undefined })],
+        includeHeader: true,
+      });
+
+      expect(parse(csv)[0]!.total_cost).toBe("");
+    });
+
+    it("reports the run status alongside its outcome category", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [
+          buildRun({ scenarioRunId: "a", status: ScenarioRunStatus.ERROR }),
+          buildRun({ scenarioRunId: "b", status: ScenarioRunStatus.FAILED }),
+          buildRun({ scenarioRunId: "c", status: ScenarioRunStatus.STALLED }),
+        ],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows.map((r) => [r.status, r.status_category])).toEqual([
+        ["ERROR", "failure"],
+        ["FAILED", "failure"],
+        ["STALLED", "stalled"],
+      ]);
+    });
+
+    it("emits no aggregate columns", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun()],
+        includeHeader: true,
+      });
+
+      expect(csv.split("\n")[0]).not.toContain("pass_rate");
+    });
+
+    it("extracts the target from the langwatch metadata namespace", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [
+          buildRun({
+            metadata: {
+              langwatch: {
+                targetType: "http",
+                targetReferenceId: "agent_42",
+                simulationSuiteId: "suite_7",
+              },
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const row = parse(csv)[0]!;
+      expect(row.target_type).toBe("http");
+      expect(row.target_reference_id).toBe("agent_42");
+      expect(row.simulation_suite_id).toBe("suite_7");
+    });
+
+    it("leaves target columns empty when metadata has no langwatch namespace", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun({ metadata: { somethingElse: true } })],
+        includeHeader: true,
+      });
+
+      expect(parse(csv)[0]!.target_type).toBe("");
+    });
+  });
+
+  describe("given criteria mode", () => {
+    it("writes one row per criterion, flagged met or unmet", () => {
+      const csv = serializeRunsToCriteriaCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "",
+              metCriteria: ["stays polite", "verifies identity"],
+              unmetCriteria: ["offers a refund"],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(3);
+      expect(rows.map((r) => [r.criterion, r.met])).toEqual([
+        ["stays polite", "true"],
+        ["verifies identity", "true"],
+        ["offers a refund", "false"],
+      ]);
+    });
+
+    it("carries run context onto every criterion row so it can be pivoted", () => {
+      const csv = serializeRunsToCriteriaCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "",
+              metCriteria: [],
+              unmetCriteria: ["a", "b"],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      for (const row of parse(csv)) {
+        expect(row.scenario_run_id).toBe("run_1");
+        expect(row.scenario_name).toBe("Refund Request");
+        expect(row.status_category).toBe("success");
+      }
+    });
+
+    it("contributes no rows for a run judged against no criteria", () => {
+      const csv = serializeRunsToCriteriaCsv({
+        runs: [
+          buildRun({ scenarioRunId: "empty", results: null }),
+          buildRun({
+            scenarioRunId: "has-one",
+            results: {
+              verdict: Verdict.SUCCESS,
+              reasoning: "",
+              metCriteria: ["only one"],
+              unmetCriteria: [],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.scenario_run_id).toBe("has-one");
+    });
+  });
+
+  describe("given full mode", () => {
+    it("writes one row per message with run fields repeated", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            messages: [
+              { role: "user", content: "I want my money back" },
+              { role: "assistant", content: "Let me check that order" },
+            ] as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.message_index)).toEqual(["0", "1"]);
+      expect(rows.map((r) => r.message_role)).toEqual(["user", "assistant"]);
+      expect(new Set(rows.map((r) => r.run_scenario_run_id))).toEqual(
+        new Set(["run_1"]),
+      );
+    });
+
+    it("still writes one row for a run that produced no messages", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [buildRun({ messages: [] as ExportableRun["messages"] })],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.message_content).toBe("");
+      expect(rows[0]!.run_scenario_run_id).toBe("run_1");
+    });
+
+    it("round-trips message content containing commas, quotes and newlines", () => {
+      const content = 'He said "no, refund it".\nThen he left.';
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            messages: [
+              { role: "user", content },
+            ] as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      expect(parse(csv)[0]!.message_content).toBe(content);
+    });
+
+    it("stringifies structured message content instead of dropping it", () => {
+      const parts = [{ type: "text", text: "hi" }];
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            messages: [
+              { role: "user", content: parts },
+            ] as unknown as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      expect(JSON.parse(parse(csv)[0]!.message_content!)).toEqual(parts);
+    });
+  });
+
+  describe("when a batch is not the first of a streamed export", () => {
+    it("omits the header so the file has exactly one", () => {
+      const first = serializeRunsToSummaryCsv({
+        runs: [buildRun()],
+        includeHeader: true,
+      });
+      const second = serializeRunsToSummaryCsv({
+        runs: [buildRun({ scenarioRunId: "run_2" })],
+        includeHeader: false,
+      });
+
+      expect(first.split("\n")[0]).toContain("scenario_run_id");
+      expect(second).not.toContain("scenario_run_id");
+      expect(parse(first + second)).toHaveLength(2);
+    });
+  });
+});

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -42,7 +42,7 @@ function parse(csv: string): Record<string, string>[] {
 }
 
 describe("scenario run CSV serializers", () => {
-  describe("given any mode", () => {
+  describe("when writing the header of any mode", () => {
     // Column order is a design decision, not an accident: spreadsheets show
     // the leftmost columns first, so the readable ones lead and identifiers
     // trail. Pinned here so a later edit cannot quietly bury them again.
@@ -116,7 +116,7 @@ describe("scenario run CSV serializers", () => {
     });
   });
 
-  describe("given full mode, on the run-level columns", () => {
+  describe("when exporting in full mode", () => {
     it("writes one row per run when the run has no messages", () => {
       const csv = serializeRunsToFullCsv({
         runs: [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
@@ -279,7 +279,92 @@ describe("scenario run CSV serializers", () => {
     });
   });
 
-  describe("given criteria mode", () => {
+  describe("when a cell begins with a spreadsheet formula character", () => {
+    // Quoting satisfies RFC 4180 but does nothing to stop Excel or Sheets
+    // evaluating a leading =, +, - or @. Every one of these fields is user- or
+    // model-controlled, and the file exists to be opened in a spreadsheet.
+    const DANGEROUS = '=HYPERLINK("http://evil.test","click")';
+
+    it("neutralizes the scenario name", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [buildRun({ name: DANGEROUS })],
+        includeHeader: true,
+      });
+      expect(parse(csv)[0]!.run_scenario_name).toBe(`'${DANGEROUS}`);
+    });
+
+    it("neutralizes the scenario description", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [buildRun({ description: DANGEROUS })],
+        includeHeader: true,
+      });
+      expect(parse(csv)[0]!.run_scenario_description).toBe(`'${DANGEROUS}`);
+    });
+
+    it("neutralizes judge reasoning and error text", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: DANGEROUS,
+              metCriteria: [],
+              unmetCriteria: [],
+              error: "+1+1",
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+      const row = parse(csv)[0]!;
+      expect(row.run_reasoning).toBe(`'${DANGEROUS}`);
+      expect(row.run_error).toBe("'+1+1");
+    });
+
+    it("neutralizes message content", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            messages: [
+              { role: "user", content: DANGEROUS },
+            ] as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+      expect(parse(csv)[0]!.message_content).toBe(`'${DANGEROUS}`);
+    });
+
+    it("neutralizes a criterion", () => {
+      const csv = serializeRunsToCriteriaCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "",
+              metCriteria: [],
+              unmetCriteria: [DANGEROUS],
+              error: undefined,
+            },
+          }),
+        ],
+        includeHeader: true,
+      });
+      expect(parse(csv)[0]!.criterion).toBe(`'${DANGEROUS}`);
+    });
+
+    it("leaves ordinary text and negative numbers alone", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [buildRun({ name: "Refund Request", durationInMs: -1 })],
+        includeHeader: true,
+      });
+      const row = parse(csv)[0]!;
+      expect(row.run_scenario_name).toBe("Refund Request");
+      expect(row.run_duration_ms).toBe("-1");
+    });
+  });
+
+  describe("when exporting in criteria mode", () => {
     it("writes one row per criterion, flagged met or unmet", () => {
       const csv = serializeRunsToCriteriaCsv({
         runs: [
@@ -352,7 +437,7 @@ describe("scenario run CSV serializers", () => {
     });
   });
 
-  describe("given full mode", () => {
+  describe("when exporting a conversation in full mode", () => {
     it("writes one row per message with run fields repeated", () => {
       const csv = serializeRunsToFullCsv({
         runs: [

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -5,7 +5,6 @@ import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.en
 import {
   serializeRunsToCriteriaCsv,
   serializeRunsToFullCsv,
-  serializeRunsToSummaryCsv,
 } from "../csv-serializer";
 
 function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
@@ -56,23 +55,23 @@ describe("scenario run CSV serializers", () => {
     ];
 
     it("leads with the columns a person reads", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun()],
         includeHeader: true,
       });
       const header = csv.split("\r\n")[0]!.split(",");
 
       expect(header.slice(0, 4)).toEqual([
-        "scenario_name",
-        "status",
-        "status_category",
-        "verdict",
+        "run_scenario_name",
+        "run_status",
+        "run_status_category",
+        "run_verdict",
       ]);
     });
 
     it("puts every identifier after the readable columns", () => {
       for (const csv of [
-        serializeRunsToSummaryCsv({ runs: [buildRun()], includeHeader: true }),
+        serializeRunsToFullCsv({ runs: [buildRun()], includeHeader: true }),
         serializeRunsToCriteriaCsv({ runs: [buildRun()], includeHeader: true }),
         serializeRunsToFullCsv({ runs: [buildRun()], includeHeader: true }),
       ]) {
@@ -117,20 +116,20 @@ describe("scenario run CSV serializers", () => {
     });
   });
 
-  describe("given summary mode", () => {
-    it("writes one row per run", () => {
-      const csv = serializeRunsToSummaryCsv({
+  describe("given full mode, on the run-level columns", () => {
+    it("writes one row per run when the run has no messages", () => {
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
         includeHeader: true,
       });
 
       const rows = parse(csv);
       expect(rows).toHaveLength(2);
-      expect(rows.map((r) => r.scenario_run_id)).toEqual(["a", "b"]);
+      expect(rows.map((r) => r.run_scenario_run_id)).toEqual(["a", "b"]);
     });
 
     it("reports criteria counts without requiring the JSON to be parsed", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({
             results: {
@@ -146,13 +145,13 @@ describe("scenario run CSV serializers", () => {
       });
 
       const row = parse(csv)[0]!;
-      expect(row.met_criteria_count).toBe("2");
-      expect(row.unmet_criteria_count).toBe("3");
+      expect(row.run_met_criteria_count).toBe("2");
+      expect(row.run_unmet_criteria_count).toBe("3");
     });
 
     it("encodes criteria as JSON so their commas survive a round trip", () => {
       const criterion = "stays polite, even when the customer escalates";
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({
             results: {
@@ -168,29 +167,29 @@ describe("scenario run CSV serializers", () => {
       });
 
       const row = parse(csv)[0]!;
-      expect(JSON.parse(row.met_criteria!)).toEqual([criterion]);
+      expect(JSON.parse(row.run_met_criteria!)).toEqual([criterion]);
     });
 
     it("writes timestamps as ISO-8601 UTC", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun({ timestamp: 1785177315009 })],
         includeHeader: true,
       });
 
-      expect(parse(csv)[0]!.started_at).toBe("2026-07-27T18:35:15.009Z");
+      expect(parse(csv)[0]!.run_started_at).toBe("2026-07-27T18:35:15.009Z");
     });
 
     it("leaves cost empty when the run reported none", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun({ totalCost: undefined })],
         includeHeader: true,
       });
 
-      expect(parse(csv)[0]!.total_cost).toBe("");
+      expect(parse(csv)[0]!.run_total_cost).toBe("");
     });
 
     it("reports the run status alongside its outcome category", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({ scenarioRunId: "a", status: ScenarioRunStatus.ERROR }),
           buildRun({ scenarioRunId: "b", status: ScenarioRunStatus.FAILED }),
@@ -200,7 +199,7 @@ describe("scenario run CSV serializers", () => {
       });
 
       const rows = parse(csv);
-      expect(rows.map((r) => [r.status, r.status_category])).toEqual([
+      expect(rows.map((r) => [r.run_status, r.run_status_category])).toEqual([
         ["ERROR", "failure"],
         ["FAILED", "failure"],
         ["STALLED", "stalled"],
@@ -208,7 +207,7 @@ describe("scenario run CSV serializers", () => {
     });
 
     it("emits no aggregate columns", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun()],
         includeHeader: true,
       });
@@ -217,7 +216,7 @@ describe("scenario run CSV serializers", () => {
     });
 
     it("extracts the target from the langwatch metadata namespace", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({
             metadata: {
@@ -233,24 +232,24 @@ describe("scenario run CSV serializers", () => {
       });
 
       const row = parse(csv)[0]!;
-      expect(row.target_type).toBe("http");
-      expect(row.target_reference_id).toBe("agent_42");
-      expect(row.simulation_suite_id).toBe("suite_7");
+      expect(row.run_target_type).toBe("http");
+      expect(row.run_target_reference_id).toBe("agent_42");
+      expect(row.run_simulation_suite_id).toBe("suite_7");
     });
 
     it("carries the scenario description", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun({ description: "Tests refund policy under pressure" })],
         includeHeader: true,
       });
 
-      expect(parse(csv)[0]!.scenario_description).toBe(
+      expect(parse(csv)[0]!.run_scenario_description).toBe(
         "Tests refund policy under pressure",
       );
     });
 
     it("unions run-level and per-message trace ids without duplicating", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({
             traceIds: ["trace_a", "trace_b"],
@@ -263,7 +262,7 @@ describe("scenario run CSV serializers", () => {
         includeHeader: true,
       });
 
-      expect(JSON.parse(parse(csv)[0]!.trace_ids!)).toEqual([
+      expect(JSON.parse(parse(csv)[0]!.run_trace_ids!)).toEqual([
         "trace_a",
         "trace_b",
         "trace_c",
@@ -271,12 +270,12 @@ describe("scenario run CSV serializers", () => {
     });
 
     it("leaves target columns empty when metadata has no langwatch namespace", () => {
-      const csv = serializeRunsToSummaryCsv({
+      const csv = serializeRunsToFullCsv({
         runs: [buildRun({ metadata: { somethingElse: true } })],
         includeHeader: true,
       });
 
-      expect(parse(csv)[0]!.target_type).toBe("");
+      expect(parse(csv)[0]!.run_target_type).toBe("");
     });
   });
 
@@ -452,11 +451,11 @@ describe("scenario run CSV serializers", () => {
 
   describe("when a batch is not the first of a streamed export", () => {
     it("omits the header so the file has exactly one", () => {
-      const first = serializeRunsToSummaryCsv({
+      const first = serializeRunsToFullCsv({
         runs: [buildRun()],
         includeHeader: true,
       });
-      const second = serializeRunsToSummaryCsv({
+      const second = serializeRunsToFullCsv({
         runs: [buildRun({ scenarioRunId: "run_2" })],
         includeHeader: false,
       });

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -43,6 +43,80 @@ function parse(csv: string): Record<string, string>[] {
 }
 
 describe("scenario run CSV serializers", () => {
+  describe("given any mode", () => {
+    // Column order is a design decision, not an accident: spreadsheets show
+    // the leftmost columns first, so the readable ones lead and identifiers
+    // trail. Pinned here so a later edit cannot quietly bury them again.
+    const IDENTIFIER_COLUMNS = [
+      "scenario_run_id",
+      "scenario_id",
+      "batch_run_id",
+      "scenario_set_id",
+      "trace_ids",
+    ];
+
+    it("leads with the columns a person reads", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun()],
+        includeHeader: true,
+      });
+      const header = csv.split("\r\n")[0]!.split(",");
+
+      expect(header.slice(0, 4)).toEqual([
+        "scenario_name",
+        "status",
+        "status_category",
+        "verdict",
+      ]);
+    });
+
+    it("puts every identifier after the readable columns", () => {
+      for (const csv of [
+        serializeRunsToSummaryCsv({ runs: [buildRun()], includeHeader: true }),
+        serializeRunsToCriteriaCsv({ runs: [buildRun()], includeHeader: true }),
+        serializeRunsToFullCsv({ runs: [buildRun()], includeHeader: true }),
+      ]) {
+        const header = csv.split("\r\n")[0]!.split(",");
+        const firstIdentifier = Math.min(
+          ...IDENTIFIER_COLUMNS.map((c) =>
+            header.findIndex((h) => h.replace(/^run_/, "") === c),
+          ).filter((i) => i >= 0),
+        );
+        const verdictAt = header.findIndex(
+          (h) => h.replace(/^run_/, "") === "verdict",
+        );
+        const reasoningAt = header.findIndex(
+          (h) => h.replace(/^run_/, "") === "reasoning",
+        );
+
+        expect(verdictAt).toBeLessThan(firstIdentifier);
+        expect(reasoningAt).toBeLessThan(firstIdentifier);
+      }
+    });
+
+    it("keeps the mode's own payload ahead of the identifiers", () => {
+      const criteria = serializeRunsToCriteriaCsv({
+        runs: [buildRun()],
+        includeHeader: true,
+      })
+        .split("\r\n")[0]!
+        .split(",");
+      const full = serializeRunsToFullCsv({
+        runs: [buildRun()],
+        includeHeader: true,
+      })
+        .split("\r\n")[0]!
+        .split(",");
+
+      expect(criteria.indexOf("criterion")).toBeLessThan(
+        criteria.indexOf("scenario_run_id"),
+      );
+      expect(full.indexOf("message_content")).toBeLessThan(
+        full.indexOf("run_scenario_run_id"),
+      );
+    });
+  });
+
   describe("given summary mode", () => {
     it("writes one row per run", () => {
       const csv = serializeRunsToSummaryCsv({
@@ -300,6 +374,35 @@ describe("scenario run CSV serializers", () => {
       expect(new Set(rows.map((r) => r.run_scenario_run_id))).toEqual(
         new Set(["run_1"]),
       );
+    });
+
+    it("carries the criteria that failed, not just how many", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "The agent asked a clarifying question.",
+              metCriteria: ["stays polite"],
+              unmetCriteria: ["offers a refund", "does not ask questions"],
+              error: undefined,
+            },
+            messages: [
+              { role: "user", content: "refund please" },
+            ] as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const row = parse(csv)[0]!;
+      expect(row.run_unmet_criteria_count).toBe("2");
+      expect(JSON.parse(row.run_unmet_criteria!)).toEqual([
+        "offers a refund",
+        "does not ask questions",
+      ]);
+      expect(JSON.parse(row.run_met_criteria!)).toEqual(["stays polite"]);
+      expect(row.run_reasoning).toBe("The agent asked a clarifying question.");
     });
 
     it("still writes one row for a run that produced no messages", () => {

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -1,7 +1,10 @@
 import Parse from "papaparse";
 import { describe, expect, it } from "vitest";
 import type { ExportableRun } from "~/server/app-layer/simulations/repositories/simulation.repository";
-import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.enums";
+import {
+  ScenarioRunStatus,
+  Verdict,
+} from "~/server/scenarios/scenario-event.enums";
 import {
   serializeRunsToCriteriaCsv,
   serializeRunsToFullCsv,
@@ -119,7 +122,10 @@ describe("scenario run CSV serializers", () => {
   describe("when exporting in full mode", () => {
     it("writes one row per run when the run has no messages", () => {
       const csv = serializeRunsToFullCsv({
-        runs: [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
+        runs: [
+          buildRun({ scenarioRunId: "a" }),
+          buildRun({ scenarioRunId: "b" }),
+        ],
         includeHeader: true,
       });
 
@@ -506,9 +512,7 @@ describe("scenario run CSV serializers", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
           buildRun({
-            messages: [
-              { role: "user", content },
-            ] as ExportableRun["messages"],
+            messages: [{ role: "user", content }] as ExportableRun["messages"],
           }),
         ],
         includeHeader: true,

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -15,7 +15,7 @@ function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
     batchRunId: "batch_1",
     scenarioSetId: "set_1",
     name: "Refund Request",
-    description: null,
+    description: "Customer wants money back after two weeks",
     metadata: null,
     status: ScenarioRunStatus.SUCCESS,
     results: {
@@ -26,6 +26,7 @@ function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
       error: undefined,
     },
     messages: [],
+    traceIds: [],
     timestamp: 1785177315009,
     updatedAt: 1785177315009,
     durationInMs: 8400,
@@ -161,6 +162,38 @@ describe("scenario run CSV serializers", () => {
       expect(row.target_type).toBe("http");
       expect(row.target_reference_id).toBe("agent_42");
       expect(row.simulation_suite_id).toBe("suite_7");
+    });
+
+    it("carries the scenario description", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [buildRun({ description: "Tests refund policy under pressure" })],
+        includeHeader: true,
+      });
+
+      expect(parse(csv)[0]!.scenario_description).toBe(
+        "Tests refund policy under pressure",
+      );
+    });
+
+    it("unions run-level and per-message trace ids without duplicating", () => {
+      const csv = serializeRunsToSummaryCsv({
+        runs: [
+          buildRun({
+            traceIds: ["trace_a", "trace_b"],
+            messages: [
+              { role: "user", content: "hi", trace_id: "trace_b" },
+              { role: "assistant", content: "yo", trace_id: "trace_c" },
+            ] as unknown as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      expect(JSON.parse(parse(csv)[0]!.trace_ids!)).toEqual([
+        "trace_a",
+        "trace_b",
+        "trace_c",
+      ]);
     });
 
     it("leaves target columns empty when metadata has no langwatch namespace", () => {

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -436,6 +436,60 @@ describe("scenario run CSV serializers", () => {
       expect(parse(csv)[0]!.criterion).toBe(`'${DANGEROUS}`);
     });
 
+    /**
+     * Identifiers look machine-generated and safe, but a scenario set id, run
+     * id, batch id and target reference all arrive from the SDK as arbitrary
+     * strings — so a caller can choose one. A formula in the id column
+     * evaluates exactly like one in the prose column.
+     */
+    it("neutralizes identifiers, which callers also control", () => {
+      const rows = parse(
+        serializeRunsToFullCsv({
+          runs: [
+            buildRun({
+              scenarioRunId: "=cmd|' /C calc'!A0",
+              scenarioSetId: "+SUM(A1:A9)",
+              batchRunId: "@import",
+              metadata: {
+                langwatch: {
+                  targetType: "http",
+                  targetReferenceId: "-1+1",
+                  simulationSuiteId: "suite_7",
+                },
+              },
+            }),
+          ],
+          includeHeader: true,
+        }),
+      );
+
+      const row = rows[0]!;
+      expect(row.run_scenario_run_id).toBe("'=cmd|' /C calc'!A0");
+      expect(row.run_scenario_set_id).toBe("'+SUM(A1:A9)");
+      expect(row.run_batch_run_id).toBe("'@import");
+      expect(row.run_target_reference_id).toBe("'-1+1");
+      // Untouched, because it never started with a formula character.
+      expect(row.run_simulation_suite_id).toBe("suite_7");
+    });
+
+    it("neutralizes message and trace ids, which the SDK also supplies", () => {
+      const rows = parse(
+        serializeRunsToFullCsv({
+          runs: [
+            buildRun({
+              messages: [
+                { role: "user", content: "hi", id: "=1+1", trace_id: "@evil" },
+              ] as unknown as ExportableRun["messages"],
+            }),
+          ],
+          includeHeader: true,
+        }),
+      );
+
+      expect(rows[0]!.message_id).toBe("'=1+1");
+      expect(rows[0]!.message_trace_id).toBe("'@evil");
+    });
+
     it("leaves ordinary text and negative numbers alone", () => {
       const csv = serializeRunsToFullCsv({
         runs: [buildRun({ name: "Refund Request", durationInMs: -1 })],

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -155,6 +155,7 @@ describe("scenario run CSV serializers", () => {
       expect(row.run_unmet_criteria_count).toBe("3");
     });
 
+    /** @scenario Criteria are encoded so that their commas survive */
     it("encodes criteria as JSON so their commas survive a round trip", () => {
       const criterion = "stays polite, even when the customer escalates";
       const csv = serializeRunsToFullCsv({
@@ -176,6 +177,7 @@ describe("scenario run CSV serializers", () => {
       expect(JSON.parse(row.run_met_criteria!)).toEqual([criterion]);
     });
 
+    /** @scenario Timestamps are written as ISO-8601 UTC */
     it("writes timestamps as ISO-8601 UTC", () => {
       const csv = serializeRunsToFullCsv({
         runs: [buildRun({ timestamp: 1785177315009 })],
@@ -194,6 +196,10 @@ describe("scenario run CSV serializers", () => {
       expect(parse(csv)[0]!.run_total_cost).toBe("");
     });
 
+    /**
+     * @scenario Every row reports both the run's status and its category
+     * @scenario Statuses that mean failure are categorised together but still distinguishable
+     */
     it("reports the run status alongside its outcome category", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
@@ -212,6 +218,7 @@ describe("scenario run CSV serializers", () => {
       ]);
     });
 
+    /** @scenario The export computes no pass rate of its own */
     it("emits no aggregate columns", () => {
       const csv = serializeRunsToFullCsv({
         runs: [buildRun()],
@@ -219,6 +226,80 @@ describe("scenario run CSV serializers", () => {
       });
 
       expect(csv.split("\n")[0]).not.toContain("pass_rate");
+    });
+
+    /**
+     * There is no finished_at column, so duration is the only time signal a
+     * reader gets. For a run still going it is elapsed-so-far, and the category
+     * is what says so — read on its own the number would look like a run that
+     * finished quickly.
+     *
+     * @scenario An in-flight run reports elapsed time, not a final duration
+     */
+    it("pairs an unfinished run's elapsed time with an in-progress category", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            status: ScenarioRunStatus.IN_PROGRESS,
+            durationInMs: 4200,
+            results: null,
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const row = parse(csv)[0]!;
+      expect(row.run_duration_ms).toBe("4200");
+      expect(row.run_status_category).toBe("in_progress");
+      expect(csv.split("\n")[0]).not.toContain("finished_at");
+    });
+
+    /**
+     * The stated reason there is no third, one-row-per-run mode: every
+     * run-level column is repeated on every message row, so a spreadsheet's
+     * "remove duplicates" gives that file for free.
+     *
+     * @scenario One row per run is a de-duplication away
+     */
+    it("repeats run columns so de-duplicating leaves one intact row per run", () => {
+      const csv = serializeRunsToFullCsv({
+        runs: [
+          buildRun({
+            scenarioRunId: "run_a",
+            messages: [
+              { role: "user", content: "first" },
+              { role: "assistant", content: "second" },
+              { role: "user", content: "third" },
+            ] as ExportableRun["messages"],
+          }),
+          buildRun({
+            scenarioRunId: "run_b",
+            name: "Password Reset",
+            messages: [
+              { role: "user", content: "help" },
+            ] as ExportableRun["messages"],
+          }),
+        ],
+        includeHeader: true,
+      });
+
+      const rows = parse(csv);
+      expect(rows).toHaveLength(4);
+
+      const deduped = [
+        ...new Map(rows.map((row) => [row.run_scenario_run_id, row])).values(),
+      ];
+      expect(deduped).toHaveLength(2);
+      expect(deduped.map((row) => row.run_scenario_name)).toEqual([
+        "Refund Request",
+        "Password Reset",
+      ]);
+      // Not just present on the surviving row — the same on every row it was
+      // dropped from, which is what makes the de-duplication lossless.
+      for (const row of rows.filter((r) => r.run_scenario_run_id === "run_a")) {
+        expect(row.run_scenario_name).toBe("Refund Request");
+        expect(row.run_verdict).toBe("success");
+      }
     });
 
     it("extracts the target from the langwatch metadata namespace", () => {
@@ -371,6 +452,7 @@ describe("scenario run CSV serializers", () => {
   });
 
   describe("when exporting in criteria mode", () => {
+    /** @scenario Criteria CSV writes one row per criterion per run */
     it("writes one row per criterion, flagged met or unmet", () => {
       const csv = serializeRunsToCriteriaCsv({
         runs: [
@@ -396,6 +478,7 @@ describe("scenario run CSV serializers", () => {
       ]);
     });
 
+    /** @scenario Criteria rows carry enough run context to pivot on */
     it("carries run context onto every criterion row so it can be pivoted", () => {
       const csv = serializeRunsToCriteriaCsv({
         runs: [
@@ -419,6 +502,7 @@ describe("scenario run CSV serializers", () => {
       }
     });
 
+    /** @scenario A run that was judged against no criteria produces no criteria rows */
     it("contributes no rows for a run judged against no criteria", () => {
       const csv = serializeRunsToCriteriaCsv({
         runs: [
@@ -441,9 +525,51 @@ describe("scenario run CSV serializers", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]!.scenario_run_id).toBe("has-one");
     });
+
+    /**
+     * The whole reason criteria mode exists: one row per (run, criterion) is
+     * what makes "which rule do we break most often?" a group-and-count rather
+     * than a manual read of every transcript.
+     *
+     * @scenario Criteria mode makes the failing-criteria ranking a spreadsheet pivot
+     */
+    it("lets one criterion's failures be counted across many runs", () => {
+      const terse = "Langy is terse";
+      const runs = Array.from({ length: 18 }, (_, index) =>
+        buildRun({
+          scenarioRunId: `run_${index}`,
+          scenarioId: `scenario_${index}`,
+          results: {
+            verdict: Verdict.FAILURE,
+            reasoning: "",
+            metCriteria: ["verifies identity"],
+            unmetCriteria: [terse],
+            error: undefined,
+          },
+        }),
+      );
+
+      const rows = parse(
+        serializeRunsToCriteriaCsv({ runs, includeHeader: true }),
+      );
+
+      const failuresOfTerse = rows.filter(
+        (row) => row.criterion === terse && row.met === "false",
+      );
+      expect(failuresOfTerse).toHaveLength(18);
+      // Across 18 distinct scenarios, which is the part no per-scenario view
+      // can show — the same rule breaking everywhere.
+      expect(new Set(failuresOfTerse.map((row) => row.scenario_id)).size).toBe(
+        18,
+      );
+    });
   });
 
   describe("when exporting a conversation in full mode", () => {
+    /**
+     * @scenario Full CSV writes one row per conversation message
+     * @scenario Full rows repeat the run fields on every message row
+     */
     it("writes one row per message with run fields repeated", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
@@ -495,6 +621,7 @@ describe("scenario run CSV serializers", () => {
       expect(row.run_reasoning).toBe("The agent asked a clarifying question.");
     });
 
+    /** @scenario A run with no messages still appears in Full mode */
     it("still writes one row for a run that produced no messages", () => {
       const csv = serializeRunsToFullCsv({
         runs: [buildRun({ messages: [] as ExportableRun["messages"] })],
@@ -507,6 +634,7 @@ describe("scenario run CSV serializers", () => {
       expect(rows[0]!.run_scenario_run_id).toBe("run_1");
     });
 
+    /** @scenario Conversation content keeps its commas, quotes, and newlines */
     it("round-trips message content containing commas, quotes and newlines", () => {
       const content = 'He said "no, refund it".\nThen he left.';
       const csv = serializeRunsToFullCsv({

--- a/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/csv-serializer.unit.test.ts
@@ -196,10 +196,8 @@ describe("scenario run CSV serializers", () => {
       expect(parse(csv)[0]!.run_total_cost).toBe("");
     });
 
-    /**
-     * @scenario Every row reports both the run's status and its category
-     * @scenario Statuses that mean failure are categorised together but still distinguishable
-     */
+    /** @scenario Every row reports both the run's status and its category */
+    /** @scenario Statuses that mean failure are categorised together but still distinguishable */
     it("reports the run status alongside its outcome category", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
@@ -233,9 +231,8 @@ describe("scenario run CSV serializers", () => {
      * reader gets. For a run still going it is elapsed-so-far, and the category
      * is what says so — read on its own the number would look like a run that
      * finished quickly.
-     *
-     * @scenario An in-flight run reports elapsed time, not a final duration
      */
+    /** @scenario An in-flight run reports elapsed time, not a final duration */
     it("pairs an unfinished run's elapsed time with an in-progress category", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
@@ -258,9 +255,8 @@ describe("scenario run CSV serializers", () => {
      * The stated reason there is no third, one-row-per-run mode: every
      * run-level column is repeated on every message row, so a spreadsheet's
      * "remove duplicates" gives that file for free.
-     *
-     * @scenario One row per run is a de-duplication away
      */
+    /** @scenario One row per run is a de-duplication away */
     it("repeats run columns so de-duplicating leaves one intact row per run", () => {
       const csv = serializeRunsToFullCsv({
         runs: [
@@ -530,9 +526,8 @@ describe("scenario run CSV serializers", () => {
      * The whole reason criteria mode exists: one row per (run, criterion) is
      * what makes "which rule do we break most often?" a group-and-count rather
      * than a manual read of every transcript.
-     *
-     * @scenario Criteria mode makes the failing-criteria ranking a spreadsheet pivot
      */
+    /** @scenario Criteria mode makes the failing-criteria ranking a spreadsheet pivot */
     it("lets one criterion's failures be counted across many runs", () => {
       const terse = "Langy is terse";
       const runs = Array.from({ length: 18 }, (_, index) =>
@@ -566,10 +561,8 @@ describe("scenario run CSV serializers", () => {
   });
 
   describe("when exporting a conversation in full mode", () => {
-    /**
-     * @scenario Full CSV writes one row per conversation message
-     * @scenario Full rows repeat the run fields on every message row
-     */
+    /** @scenario Full CSV writes one row per conversation message */
+    /** @scenario Full rows repeat the run fields on every message row */
     it("writes one row per message with run fields repeated", () => {
       const csv = serializeRunsToFullCsv({
         runs: [

--- a/langwatch/src/server/export/scenario-runs/__tests__/scenario-run-export.service.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/scenario-run-export.service.unit.test.ts
@@ -1,0 +1,290 @@
+/**
+ * The sweep itself: how the service drives the repository page by page, what it
+ * drops on the way, and when it stops.
+ *
+ * A hand-written repository stub rather than a mock library — the sweep's whole
+ * contract is "ask for a page, follow the cursor, stop", and a stub that
+ * actually paginates is the only way to observe that. It records the parameters
+ * it was called with so scope can be asserted at the boundary the real
+ * repository turns into SQL.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import Parse from "papaparse";
+import { describe, expect, it } from "vitest";
+import type {
+  ExportableRun,
+  SimulationRepository,
+} from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { NullSimulationRepository } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import {
+  ScenarioRunStatus,
+  Verdict,
+} from "~/server/scenarios/scenario-event.enums";
+import { ScenarioRunExportService } from "../scenario-run-export.service";
+import type { ScenarioRunExportRequest } from "../types";
+
+function buildRun(overrides: Partial<ExportableRun> = {}): ExportableRun {
+  return {
+    scenarioRunId: "run_1",
+    scenarioId: "scenario_1",
+    batchRunId: "batch_1",
+    scenarioSetId: "set_1",
+    name: "Refund Request",
+    description: null,
+    metadata: null,
+    status: ScenarioRunStatus.SUCCESS,
+    results: {
+      verdict: Verdict.SUCCESS,
+      reasoning: "The agent offered a refund.",
+      metCriteria: ["stays polite"],
+      unmetCriteria: [],
+      error: undefined,
+    },
+    messages: [],
+    traceIds: [],
+    timestamp: 1785177315009,
+    updatedAt: 1785177315009,
+    durationInMs: 8400,
+    totalCost: 0.031,
+    ...overrides,
+  } as ExportableRun;
+}
+
+type FindCall = Parameters<SimulationRepository["findRunsForExport"]>[0];
+
+/**
+ * Serves the given pages in order, one per call, and remembers every request.
+ * `hasMore` and `nextCursor` follow from the position in the list, so a caller
+ * that ignores the cursor loops forever and a caller that stops early is
+ * visible in `calls`.
+ */
+class PagingRepositoryStub extends NullSimulationRepository {
+  readonly calls: FindCall[] = [];
+
+  constructor(private readonly pages: ExportableRun[][]) {
+    super();
+  }
+
+  override async countRunsForExport(): Promise<number> {
+    return this.pages.flat().length;
+  }
+
+  override async findRunsForExport(params: FindCall): Promise<{
+    runs: ExportableRun[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    this.calls.push(params);
+    const index = params.cursor ? Number(params.cursor) : 0;
+    const runs = this.pages[index] ?? [];
+    const hasMore = index < this.pages.length - 1;
+    return {
+      runs,
+      hasMore,
+      ...(hasMore ? { nextCursor: String(index + 1) } : {}),
+    };
+  }
+}
+
+function request(
+  overrides: Partial<ScenarioRunExportRequest> = {},
+): ScenarioRunExportRequest {
+  return { projectId: "project_1", mode: "criteria", ...overrides };
+}
+
+async function collect(
+  generator: AsyncGenerator<{
+    chunk: string;
+    progress: { exported: number; total: number };
+  }>,
+): Promise<{ csv: string; progress: { exported: number; total: number }[] }> {
+  let csv = "";
+  const progress: { exported: number; total: number }[] = [];
+  for await (const yielded of generator) {
+    csv += yielded.chunk;
+    progress.push(yielded.progress);
+  }
+  return { csv, progress };
+}
+
+function rowsOf(csv: string): Record<string, string>[] {
+  return Parse.parse<Record<string, string>>(csv.trim(), {
+    header: true,
+    skipEmptyLines: true,
+  }).data;
+}
+
+describe("ScenarioRunExportService", () => {
+  describe("when the run history spans several pages", () => {
+    /**
+     * The serializer is told `includeHeader` only for the first batch, so a
+     * file assembled from several pages must not repeat it. Asserted on the
+     * assembled file rather than on the flag, because the flag being right and
+     * the file being wrong is the failure worth catching.
+     *
+     * @scenario The header row is written once
+     */
+    it("writes the header on the first batch only", async () => {
+      const repository = new PagingRepositoryStub([
+        [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
+        [buildRun({ scenarioRunId: "c" })],
+      ]);
+      const service = new ScenarioRunExportService(repository);
+
+      const { csv } = await collect(
+        service.exportRuns({ request: request({ mode: "full" }) }),
+      );
+
+      const headerLines = csv
+        .split("\n")
+        .filter((line) => line.startsWith("run_scenario_name,"));
+      expect(headerLines).toHaveLength(1);
+      expect(rowsOf(csv).map((row) => row.run_scenario_run_id)).toEqual([
+        "a",
+        "b",
+        "c",
+      ]);
+    });
+
+    /**
+     * @scenario Progress is shown while a large export streams
+     */
+    it("reports runs visited against the total, reaching it at the end", async () => {
+      const repository = new PagingRepositoryStub([
+        [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
+        [buildRun({ scenarioRunId: "c" })],
+      ]);
+      const service = new ScenarioRunExportService(repository);
+
+      const { progress } = await collect(
+        service.exportRuns({ request: request({ mode: "full" }) }),
+      );
+
+      expect(progress).toEqual([
+        { exported: 2, total: 3 },
+        { exported: 3, total: 3 },
+      ]);
+    });
+  });
+
+  describe("when the client cancels mid-export", () => {
+    /**
+     * Without the signal the sweep keeps paging ClickHouse long after nobody is
+     * reading: `controller.enqueue` only throws on the *next* chunk, so a large
+     * export would run to exhaustion for a download already abandoned.
+     *
+     * @scenario Cancelling an in-flight export stops it
+     */
+    it("stops asking the repository for more pages", async () => {
+      const repository = new PagingRepositoryStub([
+        [buildRun({ scenarioRunId: "a" })],
+        [buildRun({ scenarioRunId: "b" })],
+        [buildRun({ scenarioRunId: "c" })],
+      ]);
+      const service = new ScenarioRunExportService(repository);
+      const controller = new AbortController();
+
+      const generator = service.exportRuns({
+        request: request({ mode: "full" }),
+        signal: controller.signal,
+      });
+
+      await generator.next();
+      expect(repository.calls).toHaveLength(1);
+
+      controller.abort();
+      const afterAbort = await generator.next();
+
+      expect(afterAbort.done).toBe(true);
+      expect(repository.calls).toHaveLength(1);
+    });
+  });
+
+  describe("when a pass/fail filter is applied", () => {
+    /**
+     * Applied after mapping, not in SQL: STALLED is derived from timestamps by
+     * resolveRunStatus rather than stored, so only a post-mapping filter can
+     * reproduce what the list on screen shows.
+     *
+     * @scenario Export honours the pass/fail filter
+     */
+    it("keeps only the runs in the requested outcome category", async () => {
+      const repository = new PagingRepositoryStub([
+        [
+          buildRun({ scenarioRunId: "passed", status: ScenarioRunStatus.SUCCESS }),
+          buildRun({ scenarioRunId: "failed", status: ScenarioRunStatus.FAILED }),
+          buildRun({ scenarioRunId: "errored", status: ScenarioRunStatus.ERROR }),
+          buildRun({ scenarioRunId: "stalled", status: ScenarioRunStatus.STALLED }),
+        ],
+      ]);
+      const service = new ScenarioRunExportService(repository);
+
+      const { csv } = await collect(
+        service.exportRuns({
+          request: request({ mode: "full", passFailStatus: "fail" }),
+        }),
+      );
+
+      // ERROR and FAILED are both "failure" — the filter is by category, so a
+      // run that died before the judge saw it is a failure like any other.
+      expect(rowsOf(csv).map((row) => row.run_scenario_run_id)).toEqual([
+        "failed",
+        "errored",
+      ]);
+    });
+
+    /**
+     * A filter that removes every run on the first page still has to produce a
+     * file a spreadsheet will open, not a zero-byte download.
+     */
+    it("still writes a header when every run is filtered out", async () => {
+      const repository = new PagingRepositoryStub([
+        [buildRun({ scenarioRunId: "passed", status: ScenarioRunStatus.SUCCESS })],
+      ]);
+      const service = new ScenarioRunExportService(repository);
+
+      const { csv } = await collect(
+        service.exportRuns({
+          request: request({ mode: "full", passFailStatus: "fail" }),
+        }),
+      );
+
+      expect(csv.split("\n")[0]).toContain("run_scenario_name");
+      expect(rowsOf(csv)).toHaveLength(0);
+    });
+  });
+
+  describe("when the panel is scoped to a set, a scenario and a date range", () => {
+    /**
+     * The service does not filter these itself — it hands them to the
+     * repository, which turns them into SQL. What is worth pinning is that it
+     * passes on every one of them: a scope silently dropped here exports more
+     * than the user was looking at.
+     */
+    it("passes the whole scope through to the repository", async () => {
+      const repository = new PagingRepositoryStub([[buildRun()]]);
+      const service = new ScenarioRunExportService(repository);
+
+      await collect(
+        service.exportRuns({
+          request: request({
+            scenarioSetId: "set_7",
+            scenarioId: "scenario_3",
+            startDate: 1_700_000_000_000,
+            endDate: 1_800_000_000_000,
+          }),
+        }),
+      );
+
+      expect(repository.calls[0]).toMatchObject({
+        projectId: "project_1",
+        scenarioSetId: "set_7",
+        scenarioId: "scenario_3",
+        startDate: 1_700_000_000_000,
+        endDate: 1_800_000_000_000,
+      });
+    });
+  });
+});

--- a/langwatch/src/server/export/scenario-runs/__tests__/scenario-run-export.service.unit.test.ts
+++ b/langwatch/src/server/export/scenario-runs/__tests__/scenario-run-export.service.unit.test.ts
@@ -60,32 +60,33 @@ type FindCall = Parameters<SimulationRepository["findRunsForExport"]>[0];
  * that ignores the cursor loops forever and a caller that stops early is
  * visible in `calls`.
  */
-class PagingRepositoryStub extends NullSimulationRepository {
-  readonly calls: FindCall[] = [];
+function pagingRepository(pages: ExportableRun[][]): {
+  repository: SimulationRepository;
+  calls: FindCall[];
+} {
+  const calls: FindCall[] = [];
+  // Layered over the Null implementation rather than subclassing it: its
+  // `findRunsForExport()` declares no parameters, so an override that reads
+  // them is a signature mismatch — and reading them is the entire point here.
+  const repository: SimulationRepository = Object.assign(
+    new NullSimulationRepository(),
+    {
+      countRunsForExport: async () => pages.flat().length,
+      findRunsForExport: async (params: FindCall) => {
+        calls.push(params);
+        const index = params.cursor ? Number(params.cursor) : 0;
+        const runs = pages[index] ?? [];
+        const hasMore = index < pages.length - 1;
+        return {
+          runs,
+          hasMore,
+          ...(hasMore ? { nextCursor: String(index + 1) } : {}),
+        };
+      },
+    },
+  );
 
-  constructor(private readonly pages: ExportableRun[][]) {
-    super();
-  }
-
-  override async countRunsForExport(): Promise<number> {
-    return this.pages.flat().length;
-  }
-
-  override async findRunsForExport(params: FindCall): Promise<{
-    runs: ExportableRun[];
-    nextCursor?: string;
-    hasMore: boolean;
-  }> {
-    this.calls.push(params);
-    const index = params.cursor ? Number(params.cursor) : 0;
-    const runs = this.pages[index] ?? [];
-    const hasMore = index < this.pages.length - 1;
-    return {
-      runs,
-      hasMore,
-      ...(hasMore ? { nextCursor: String(index + 1) } : {}),
-    };
-  }
+  return { repository, calls };
 }
 
 function request(
@@ -123,11 +124,10 @@ describe("ScenarioRunExportService", () => {
      * file assembled from several pages must not repeat it. Asserted on the
      * assembled file rather than on the flag, because the flag being right and
      * the file being wrong is the failure worth catching.
-     *
-     * @scenario The header row is written once
      */
+    /** @scenario The header row is written once */
     it("writes the header on the first batch only", async () => {
-      const repository = new PagingRepositoryStub([
+      const { repository } = pagingRepository([
         [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
         [buildRun({ scenarioRunId: "c" })],
       ]);
@@ -148,11 +148,9 @@ describe("ScenarioRunExportService", () => {
       ]);
     });
 
-    /**
-     * @scenario Progress is shown while a large export streams
-     */
+    /** @scenario Progress is shown while a large export streams */
     it("reports runs visited against the total, reaching it at the end", async () => {
-      const repository = new PagingRepositoryStub([
+      const { repository } = pagingRepository([
         [buildRun({ scenarioRunId: "a" }), buildRun({ scenarioRunId: "b" })],
         [buildRun({ scenarioRunId: "c" })],
       ]);
@@ -174,11 +172,10 @@ describe("ScenarioRunExportService", () => {
      * Without the signal the sweep keeps paging ClickHouse long after nobody is
      * reading: `controller.enqueue` only throws on the *next* chunk, so a large
      * export would run to exhaustion for a download already abandoned.
-     *
-     * @scenario Cancelling an in-flight export stops it
      */
+    /** @scenario Cancelling an in-flight export stops it */
     it("stops asking the repository for more pages", async () => {
-      const repository = new PagingRepositoryStub([
+      const { repository, calls } = pagingRepository([
         [buildRun({ scenarioRunId: "a" })],
         [buildRun({ scenarioRunId: "b" })],
         [buildRun({ scenarioRunId: "c" })],
@@ -192,13 +189,13 @@ describe("ScenarioRunExportService", () => {
       });
 
       await generator.next();
-      expect(repository.calls).toHaveLength(1);
+      expect(calls).toHaveLength(1);
 
       controller.abort();
       const afterAbort = await generator.next();
 
       expect(afterAbort.done).toBe(true);
-      expect(repository.calls).toHaveLength(1);
+      expect(calls).toHaveLength(1);
     });
   });
 
@@ -207,16 +204,27 @@ describe("ScenarioRunExportService", () => {
      * Applied after mapping, not in SQL: STALLED is derived from timestamps by
      * resolveRunStatus rather than stored, so only a post-mapping filter can
      * reproduce what the list on screen shows.
-     *
-     * @scenario Export honours the pass/fail filter
      */
+    /** @scenario Export honours the pass/fail filter */
     it("keeps only the runs in the requested outcome category", async () => {
-      const repository = new PagingRepositoryStub([
+      const { repository } = pagingRepository([
         [
-          buildRun({ scenarioRunId: "passed", status: ScenarioRunStatus.SUCCESS }),
-          buildRun({ scenarioRunId: "failed", status: ScenarioRunStatus.FAILED }),
-          buildRun({ scenarioRunId: "errored", status: ScenarioRunStatus.ERROR }),
-          buildRun({ scenarioRunId: "stalled", status: ScenarioRunStatus.STALLED }),
+          buildRun({
+            scenarioRunId: "passed",
+            status: ScenarioRunStatus.SUCCESS,
+          }),
+          buildRun({
+            scenarioRunId: "failed",
+            status: ScenarioRunStatus.FAILED,
+          }),
+          buildRun({
+            scenarioRunId: "errored",
+            status: ScenarioRunStatus.ERROR,
+          }),
+          buildRun({
+            scenarioRunId: "stalled",
+            status: ScenarioRunStatus.STALLED,
+          }),
         ],
       ]);
       const service = new ScenarioRunExportService(repository);
@@ -240,8 +248,13 @@ describe("ScenarioRunExportService", () => {
      * file a spreadsheet will open, not a zero-byte download.
      */
     it("still writes a header when every run is filtered out", async () => {
-      const repository = new PagingRepositoryStub([
-        [buildRun({ scenarioRunId: "passed", status: ScenarioRunStatus.SUCCESS })],
+      const { repository } = pagingRepository([
+        [
+          buildRun({
+            scenarioRunId: "passed",
+            status: ScenarioRunStatus.SUCCESS,
+          }),
+        ],
       ]);
       const service = new ScenarioRunExportService(repository);
 
@@ -264,7 +277,7 @@ describe("ScenarioRunExportService", () => {
      * than the user was looking at.
      */
     it("passes the whole scope through to the repository", async () => {
-      const repository = new PagingRepositoryStub([[buildRun()]]);
+      const { repository, calls } = pagingRepository([[buildRun()]]);
       const service = new ScenarioRunExportService(repository);
 
       await collect(
@@ -278,7 +291,7 @@ describe("ScenarioRunExportService", () => {
         }),
       );
 
-      expect(repository.calls[0]).toMatchObject({
+      expect(calls[0]).toMatchObject({
         projectId: "project_1",
         scenarioSetId: "set_7",
         scenarioId: "scenario_3",

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -1,0 +1,315 @@
+/**
+ * CSV serialization for scenario run export.
+ *
+ * Three row axes over the same run record — see ScenarioRunExportMode. Every
+ * mode shares the run-level columns built by `buildRunValues`, so a column
+ * means the same thing whichever file you opened.
+ *
+ * Uses PapaParse for RFC 4180-compliant output.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import Parse from "papaparse";
+import type { ExportableRun } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
+
+/**
+ * Run-level columns, shared by all three modes.
+ *
+ * `status` is the resolved status (the same value the run history shows,
+ * including derived STALLED) and `status_category` is its outcome bucket.
+ * Both are emitted: the category is what you pivot on, the status is what you
+ * need when a single run looks wrong.
+ *
+ * There is deliberately no pass_rate or any other aggregate — that formula
+ * already lives in run-history-transforms.ts and the sidebar ClickHouse query,
+ * and a third copy here would drift from the number shown on screen.
+ */
+const RUN_COLUMNS = [
+  "scenario_run_id",
+  "scenario_id",
+  "scenario_name",
+  "batch_run_id",
+  "scenario_set_id",
+  "status",
+  "status_category",
+  "verdict",
+  "reasoning",
+  "error",
+  "met_criteria_count",
+  "unmet_criteria_count",
+  "started_at",
+  "duration_ms",
+  "total_cost",
+  "target_type",
+  "target_reference_id",
+  "simulation_suite_id",
+  "message_count",
+  "trace_ids",
+] as const;
+
+/** Summary adds the full criteria lists; the other modes carry them per row. */
+const SUMMARY_ONLY_COLUMNS = ["met_criteria", "unmet_criteria"] as const;
+
+const CRITERIA_COLUMNS = ["criterion", "met"] as const;
+
+const MESSAGE_COLUMNS = [
+  "message_index",
+  "message_id",
+  "message_role",
+  "message_content",
+  "message_trace_id",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Public API — one function per mode
+// ---------------------------------------------------------------------------
+
+export function summaryHeaders(): string[] {
+  return [...RUN_COLUMNS, ...SUMMARY_ONLY_COLUMNS];
+}
+
+export function criteriaHeaders(): string[] {
+  return [...RUN_COLUMNS, ...CRITERIA_COLUMNS];
+}
+
+export function fullHeaders(): string[] {
+  return [...RUN_COLUMNS.map((c) => `run_${c}`), ...MESSAGE_COLUMNS];
+}
+
+/** One row per run. */
+export function serializeRunsToSummaryCsv({
+  runs,
+  includeHeader,
+}: {
+  runs: ExportableRun[];
+  includeHeader: boolean;
+}): string {
+  const rows = runs.map((run) => [
+    ...buildRunValues(run),
+    jsonArray(run.results?.metCriteria),
+    jsonArray(run.results?.unmetCriteria),
+  ]);
+  return unparse({ headers: summaryHeaders(), rows, includeHeader });
+}
+
+/**
+ * One row per (run x criterion), so `criterion` becomes a pivotable column and
+ * "which criterion fails most often" is a spreadsheet group-by rather than a
+ * script. A run judged against no criteria contributes no rows.
+ */
+export function serializeRunsToCriteriaCsv({
+  runs,
+  includeHeader,
+}: {
+  runs: ExportableRun[];
+  includeHeader: boolean;
+}): string {
+  const rows: string[][] = [];
+  for (const run of runs) {
+    const runValues = buildRunValues(run);
+    for (const criterion of run.results?.metCriteria ?? []) {
+      rows.push([...runValues, criterion, "true"]);
+    }
+    for (const criterion of run.results?.unmetCriteria ?? []) {
+      rows.push([...runValues, criterion, "false"]);
+    }
+  }
+  return unparse({ headers: criteriaHeaders(), rows, includeHeader });
+}
+
+/**
+ * One row per message, run fields repeated on each (denormalized) so the flat
+ * file stays self-describing. A run with no messages still emits one row with
+ * empty message columns, so an errored run never silently vanishes.
+ */
+export function serializeRunsToFullCsv({
+  runs,
+  includeHeader,
+}: {
+  runs: ExportableRun[];
+  includeHeader: boolean;
+}): string {
+  const rows: string[][] = [];
+  for (const run of runs) {
+    const runValues = buildRunValues(run);
+    const messages = run.messages ?? [];
+    if (messages.length === 0) {
+      rows.push([...runValues, "", "", "", "", ""]);
+      continue;
+    }
+    messages.forEach((message, index) => {
+      const m = message as Record<string, unknown>;
+      rows.push([
+        ...runValues,
+        String(index),
+        stringOrEmpty(m.id),
+        stringOrEmpty(m.role),
+        messageContent(m.content),
+        stringOrEmpty(m.trace_id),
+      ]);
+    });
+  }
+  return unparse({ headers: fullHeaders(), rows, includeHeader });
+}
+
+// ---------------------------------------------------------------------------
+// Shared row construction
+// ---------------------------------------------------------------------------
+
+function buildRunValues(run: ExportableRun): string[] {
+  const target = extractTarget(run.metadata);
+  const results = run.results;
+
+  return [
+    run.scenarioRunId,
+    run.scenarioId,
+    run.name ?? "",
+    run.batchRunId,
+    run.scenarioSetId,
+    run.status,
+    categorizeRunStatus(run.status),
+    results?.verdict ?? "",
+    results?.reasoning ?? "",
+    results?.error ?? "",
+    String(results?.metCriteria?.length ?? 0),
+    String(results?.unmetCriteria?.length ?? 0),
+    isoTimestamp(run.timestamp),
+    // For a run still in flight this is elapsed-so-far, not a final duration —
+    // the mapper derives it from UpdatedAt when FinishedAt is absent. Read it
+    // together with status_category.
+    nullableNumber(run.durationInMs),
+    nullableNumber(run.totalCost),
+    target.targetType,
+    target.targetReferenceId,
+    target.simulationSuiteId,
+    String(run.messages?.length ?? 0),
+    jsonArray(collectTraceIds(run)),
+  ];
+}
+
+/**
+ * The langwatch metadata namespace carries which target the run executed
+ * against. It is optional — SDK-driven runs may not populate it — so every
+ * field degrades to an empty cell rather than throwing.
+ */
+function extractTarget(metadata: Record<string, unknown> | null | undefined): {
+  targetType: string;
+  targetReferenceId: string;
+  simulationSuiteId: string;
+} {
+  const langwatch = metadata?.langwatch;
+  if (langwatch == null || typeof langwatch !== "object") {
+    return { targetType: "", targetReferenceId: "", simulationSuiteId: "" };
+  }
+  const ns = langwatch as Record<string, unknown>;
+  return {
+    targetType: stringOrEmpty(ns.targetType),
+    targetReferenceId: stringOrEmpty(ns.targetReferenceId),
+    simulationSuiteId: stringOrEmpty(ns.simulationSuiteId),
+  };
+}
+
+/**
+ * Trace ids are reachable per message; ScenarioRunData does not carry the
+ * run-level TraceIds column, so collect the distinct ones from the messages.
+ */
+function collectTraceIds(run: ExportableRun): string[] {
+  const ids = new Set<string>();
+  for (const message of run.messages ?? []) {
+    const traceId = (message as Record<string, unknown>).trace_id;
+    if (typeof traceId === "string" && traceId !== "") ids.add(traceId);
+  }
+  return [...ids];
+}
+
+
+// ---------------------------------------------------------------------------
+// Value encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Criteria and trace ids are JSON arrays, not comma-joined.
+ *
+ * Criteria are free-text sentences that routinely contain commas, so joining
+ * on ", " produces a cell that cannot be split back apart. The *_count columns
+ * sit alongside so the common question needs no JSON parsing at all.
+ */
+function jsonArray(values: string[] | undefined): string {
+  if (!values || values.length === 0) return "";
+  return JSON.stringify(values);
+}
+
+/**
+ * ISO-8601 UTC rather than epoch milliseconds: it sorts lexicographically,
+ * reads as a date, and spreadsheet software parses it without a formula.
+ */
+function isoTimestamp(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return "";
+  return new Date(ms).toISOString();
+}
+
+function nullableNumber(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "";
+  return String(value);
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Message content is a string for plain turns and an array of AG-UI parts when
+ * the turn carried structured content (tool calls, externalized media). Parts
+ * are JSON-stringified so nothing is silently dropped from a transcript.
+ */
+function messageContent(content: unknown): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  return JSON.stringify(content);
+}
+
+/**
+ * RFC 4180 line ending, stated explicitly rather than relying on PapaParse's
+ * default.
+ *
+ * Every chunk must both use this internally AND end with it. A streamed export
+ * concatenates chunks directly into one file, so a chunk with no trailing
+ * newline glues its last row onto the next chunk's first row, and a chunk that
+ * terminates rows with a different sequence than the one PapaParse wrote
+ * inside it makes the whole remainder of the file parse as a single row.
+ * Neither shows up until an export is large enough to need a second batch.
+ */
+const NEWLINE = "\r\n";
+
+/**
+ * PapaParse writes a header on every call, but a streamed export emits many
+ * batches into one file — so only the first batch keeps it.
+ */
+function unparse({
+  headers,
+  rows,
+  includeHeader,
+}: {
+  headers: string[];
+  rows: string[][];
+  includeHeader: boolean;
+}): string {
+  if (rows.length === 0) {
+    return includeHeader
+      ? Parse.unparse({ fields: headers, data: [] }, { newline: NEWLINE }) +
+          NEWLINE
+      : "";
+  }
+  const csv = Parse.unparse(
+    { fields: headers, data: rows },
+    { newline: NEWLINE },
+  );
+  return (includeHeader ? csv : stripHeader(csv)) + NEWLINE;
+}
+
+function stripHeader(csv: string): string {
+  const firstBreak = csv.indexOf(NEWLINE);
+  return firstBreak === -1 ? "" : csv.slice(firstBreak + NEWLINE.length);
+}

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -165,8 +165,10 @@ export function serializeRunsToFullCsv({
         String(index),
         text(stringOrEmpty(m.role)),
         text(messageContent(m.content)),
-        stringOrEmpty(m.id),
-        stringOrEmpty(m.trace_id),
+        // Message ids and trace ids are SDK-supplied too, so they get the same
+        // treatment as the identifiers in the tail block.
+        text(stringOrEmpty(m.id)),
+        text(stringOrEmpty(m.trace_id)),
         ...tail,
       ]);
     });
@@ -207,16 +209,26 @@ function buildCriteriaListValues(run: ExportableRun): string[] {
   ];
 }
 
+/**
+ * Identifiers go through `text()` like any prose field.
+ *
+ * They read as machine-generated and safe, but only some of them are: a set
+ * id, scenario id, batch id and target reference all arrive from the SDK as
+ * arbitrary strings, so `=cmd|…` is a value a caller can choose. A formula
+ * evaluates the same whichever column it lands in, and neutralising a cell
+ * that never needed it costs a leading apostrophe on an id no spreadsheet
+ * would have parsed as a number anyway.
+ */
 function buildTailValues(run: ExportableRun): string[] {
   const target = extractTarget(run.metadata);
   return [
-    run.scenarioRunId,
-    run.scenarioId,
-    run.batchRunId,
-    run.scenarioSetId,
-    target.targetType,
-    target.targetReferenceId,
-    target.simulationSuiteId,
+    text(run.scenarioRunId),
+    text(run.scenarioId),
+    text(run.batchRunId),
+    text(run.scenarioSetId),
+    text(target.targetType),
+    text(target.targetReferenceId),
+    text(target.simulationSuiteId),
     jsonArray(collectTraceIds(run)),
   ];
 }

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -2,8 +2,16 @@
  * CSV serialization for scenario run export.
  *
  * Three row axes over the same run record — see ScenarioRunExportMode. Every
- * mode shares the run-level columns built by `buildRunValues`, so a column
- * means the same thing whichever file you opened.
+ * mode shares the same column groups, so a column means the same thing
+ * whichever file you opened.
+ *
+ * Column order is deliberate: spreadsheets show the leftmost columns first, so
+ * the file opens on the ones a person reads and the identifiers sit past them.
+ * Nothing is dropped for being unreadable — it is only moved.
+ *
+ *   CORE    what ran, what happened, why      ← visible on open
+ *   payload the mode's reason to exist        ← criteria / messages
+ *   TAIL    ids, target, trace links          ← scroll or hide
  *
  * Uses PapaParse for RFC 4180-compliant output.
  *
@@ -15,51 +23,72 @@ import type { ExportableRun } from "~/server/app-layer/simulations/repositories/
 import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
 
 /**
- * Run-level columns, shared by all three modes.
+ * The columns a person reads, shortest and highest-signal first so the useful
+ * ones fit on screen before the long prose pushes everything sideways.
  *
  * `status` is the resolved status (the same value the run history shows,
- * including derived STALLED) and `status_category` is its outcome bucket.
- * Both are emitted: the category is what you pivot on, the status is what you
- * need when a single run looks wrong.
+ * including derived STALLED) and `status_category` is its outcome bucket. Both
+ * are emitted: the category is what you pivot on, the status is what you need
+ * when a single run looks wrong.
  *
  * There is deliberately no pass_rate or any other aggregate — that formula
  * already lives in run-history-transforms.ts and the sidebar ClickHouse query,
  * and a third copy here would drift from the number shown on screen.
  */
-const RUN_COLUMNS = [
-  "scenario_run_id",
-  "scenario_id",
+const CORE_COLUMNS = [
   "scenario_name",
-  "scenario_description",
-  "batch_run_id",
-  "scenario_set_id",
   "status",
   "status_category",
   "verdict",
-  "reasoning",
-  "error",
   "met_criteria_count",
   "unmet_criteria_count",
-  "started_at",
   "duration_ms",
   "total_cost",
+  "started_at",
+  "message_count",
+  // long prose last within the core block
+  "reasoning",
+  "error",
+  "scenario_description",
+] as const;
+
+/**
+ * Identifiers and plumbing. Never dropped — they are what lets an export be
+ * joined to another export, to traces, or back to the platform — but nobody
+ * reads a ksuid, so they sit behind the columns that carry meaning.
+ */
+const TAIL_COLUMNS = [
+  "scenario_run_id",
+  "scenario_id",
+  "batch_run_id",
+  "scenario_set_id",
   "target_type",
   "target_reference_id",
   "simulation_suite_id",
-  "message_count",
   "trace_ids",
 ] as const;
 
-/** Summary adds the full criteria lists; the other modes carry them per row. */
-const SUMMARY_ONLY_COLUMNS = ["met_criteria", "unmet_criteria"] as const;
+/**
+ * The judged criteria, as JSON lists.
+ *
+ * Carried by summary AND full. Full mode is where someone reads a failing
+ * transcript, and "why did this fail" is only half-answered by the judge's
+ * prose `reasoning` — the other half is which specific criteria went unmet.
+ * Counts alone cannot answer it.
+ *
+ * Criteria mode omits them: it already explodes the same data into one row
+ * per criterion, so repeating both full lists on every one of those rows
+ * would bloat the file to say nothing new.
+ */
+const CRITERIA_LIST_COLUMNS = ["met_criteria", "unmet_criteria"] as const;
 
 const CRITERIA_COLUMNS = ["criterion", "met"] as const;
 
 const MESSAGE_COLUMNS = [
   "message_index",
-  "message_id",
   "message_role",
   "message_content",
+  "message_id",
   "message_trace_id",
 ] as const;
 
@@ -68,15 +97,20 @@ const MESSAGE_COLUMNS = [
 // ---------------------------------------------------------------------------
 
 export function summaryHeaders(): string[] {
-  return [...RUN_COLUMNS, ...SUMMARY_ONLY_COLUMNS];
+  return [...CORE_COLUMNS, ...CRITERIA_LIST_COLUMNS, ...TAIL_COLUMNS];
 }
 
 export function criteriaHeaders(): string[] {
-  return [...RUN_COLUMNS, ...CRITERIA_COLUMNS];
+  return [...CORE_COLUMNS, ...CRITERIA_COLUMNS, ...TAIL_COLUMNS];
 }
 
 export function fullHeaders(): string[] {
-  return [...RUN_COLUMNS.map((c) => `run_${c}`), ...MESSAGE_COLUMNS];
+  return [
+    ...CORE_COLUMNS.map((c) => `run_${c}`),
+    ...CRITERIA_LIST_COLUMNS.map((c) => `run_${c}`),
+    ...MESSAGE_COLUMNS,
+    ...TAIL_COLUMNS.map((c) => `run_${c}`),
+  ];
 }
 
 /** One row per run. */
@@ -88,9 +122,9 @@ export function serializeRunsToSummaryCsv({
   includeHeader: boolean;
 }): string {
   const rows = runs.map((run) => [
-    ...buildRunValues(run),
-    jsonArray(run.results?.metCriteria),
-    jsonArray(run.results?.unmetCriteria),
+    ...buildCoreValues(run),
+    ...buildCriteriaListValues(run),
+    ...buildTailValues(run),
   ]);
   return unparse({ headers: summaryHeaders(), rows, includeHeader });
 }
@@ -109,13 +143,13 @@ export function serializeRunsToCriteriaCsv({
 }): string {
   const rows: string[][] = [];
   for (const run of runs) {
-    const runValues = buildRunValues(run);
-    for (const criterion of run.results?.metCriteria ?? []) {
-      rows.push([...runValues, criterion, "true"]);
-    }
-    for (const criterion of run.results?.unmetCriteria ?? []) {
-      rows.push([...runValues, criterion, "false"]);
-    }
+    const core = buildCoreValues(run);
+    const tail = buildTailValues(run);
+    const push = (criterion: string, met: boolean) =>
+      rows.push([...core, criterion, String(met), ...tail]);
+
+    for (const criterion of run.results?.metCriteria ?? []) push(criterion, true);
+    for (const criterion of run.results?.unmetCriteria ?? []) push(criterion, false);
   }
   return unparse({ headers: criteriaHeaders(), rows, includeHeader });
 }
@@ -134,21 +168,24 @@ export function serializeRunsToFullCsv({
 }): string {
   const rows: string[][] = [];
   for (const run of runs) {
-    const runValues = buildRunValues(run);
+    const head = [...buildCoreValues(run), ...buildCriteriaListValues(run)];
+    const tail = buildTailValues(run);
     const messages = run.messages ?? [];
+
     if (messages.length === 0) {
-      rows.push([...runValues, "", "", "", "", ""]);
+      rows.push([...head, "", "", "", "", "", ...tail]);
       continue;
     }
     messages.forEach((message, index) => {
       const m = message as Record<string, unknown>;
       rows.push([
-        ...runValues,
+        ...head,
         String(index),
-        stringOrEmpty(m.id),
         stringOrEmpty(m.role),
         messageContent(m.content),
+        stringOrEmpty(m.id),
         stringOrEmpty(m.trace_id),
+        ...tail,
       ]);
     });
   }
@@ -156,45 +193,56 @@ export function serializeRunsToFullCsv({
 }
 
 // ---------------------------------------------------------------------------
-// Shared row construction
+// Shared row construction — one builder per column group, in header order
 // ---------------------------------------------------------------------------
 
-function buildRunValues(run: ExportableRun): string[] {
-  const target = extractTarget(run.metadata);
+function buildCoreValues(run: ExportableRun): string[] {
   const results = run.results;
-
   return [
-    run.scenarioRunId,
-    run.scenarioId,
     run.name ?? "",
-    run.description ?? "",
-    run.batchRunId,
-    run.scenarioSetId,
     run.status,
     categorizeRunStatus(run.status),
     results?.verdict ?? "",
-    results?.reasoning ?? "",
-    results?.error ?? "",
     String(results?.metCriteria?.length ?? 0),
     String(results?.unmetCriteria?.length ?? 0),
-    isoTimestamp(run.timestamp),
     // For a run still in flight this is elapsed-so-far, not a final duration —
     // the mapper derives it from UpdatedAt when FinishedAt is absent. Read it
     // together with status_category.
     nullableNumber(run.durationInMs),
     nullableNumber(run.totalCost),
+    isoTimestamp(run.timestamp),
+    String(run.messages?.length ?? 0),
+    results?.reasoning ?? "",
+    results?.error ?? "",
+    run.description ?? "",
+  ];
+}
+
+function buildCriteriaListValues(run: ExportableRun): string[] {
+  return [
+    jsonArray(run.results?.metCriteria),
+    jsonArray(run.results?.unmetCriteria),
+  ];
+}
+
+function buildTailValues(run: ExportableRun): string[] {
+  const target = extractTarget(run.metadata);
+  return [
+    run.scenarioRunId,
+    run.scenarioId,
+    run.batchRunId,
+    run.scenarioSetId,
     target.targetType,
     target.targetReferenceId,
     target.simulationSuiteId,
-    String(run.messages?.length ?? 0),
     jsonArray(collectTraceIds(run)),
   ];
 }
 
 /**
  * The langwatch metadata namespace carries which target the run executed
- * against. It is optional — SDK-driven runs may not populate it — so every
- * field degrades to an empty cell rather than throwing.
+ * against. It is optional — SDK- and CLI-driven runs do not populate it — so
+ * every field degrades to an empty cell rather than throwing.
  */
 function extractTarget(metadata: Record<string, unknown> | null | undefined): {
   targetType: string;
@@ -232,7 +280,6 @@ function collectTraceIds(run: ExportableRun): string[] {
   }
   return [...ids];
 }
-
 
 // ---------------------------------------------------------------------------
 // Value encoding

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -126,7 +126,7 @@ export function serializeRunsToCriteriaCsv({
     const core = buildCoreValues(run);
     const tail = buildTailValues(run);
     const push = (criterion: string, met: boolean) =>
-      rows.push([...core, criterion, String(met), ...tail]);
+      rows.push([...core, text(criterion), String(met), ...tail]);
 
     for (const criterion of run.results?.metCriteria ?? []) push(criterion, true);
     for (const criterion of run.results?.unmetCriteria ?? []) push(criterion, false);
@@ -161,8 +161,8 @@ export function serializeRunsToFullCsv({
       rows.push([
         ...head,
         String(index),
-        stringOrEmpty(m.role),
-        messageContent(m.content),
+        text(stringOrEmpty(m.role)),
+        text(messageContent(m.content)),
         stringOrEmpty(m.id),
         stringOrEmpty(m.trace_id),
         ...tail,
@@ -179,7 +179,7 @@ export function serializeRunsToFullCsv({
 function buildCoreValues(run: ExportableRun): string[] {
   const results = run.results;
   return [
-    run.name ?? "",
+    text(run.name ?? ""),
     run.status,
     categorizeRunStatus(run.status),
     results?.verdict ?? "",
@@ -192,9 +192,9 @@ function buildCoreValues(run: ExportableRun): string[] {
     nullableNumber(run.totalCost),
     isoTimestamp(run.timestamp),
     String(run.messages?.length ?? 0),
-    results?.reasoning ?? "",
-    results?.error ?? "",
-    run.description ?? "",
+    text(results?.reasoning ?? ""),
+    text(results?.error ?? ""),
+    text(run.description ?? ""),
   ];
 }
 
@@ -274,7 +274,7 @@ function collectTraceIds(run: ExportableRun): string[] {
  */
 function jsonArray(values: string[] | undefined): string {
   if (!values || values.length === 0) return "";
-  return JSON.stringify(values);
+  return text(JSON.stringify(values));
 }
 
 /**
@@ -293,6 +293,24 @@ function nullableNumber(value: number | null | undefined): string {
 
 function stringOrEmpty(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+/**
+ * Neutralize a free-text cell against spreadsheet formula injection.
+ *
+ * A cell whose first character is `=`, `+`, `-`, `@`, TAB or CR is evaluated
+ * as a formula by Excel and Sheets. RFC 4180 quoting does not prevent this —
+ * quoting protects the CSV grammar, not the spreadsheet that reads it. Since
+ * scenario names, judge reasoning, criteria and message content are all
+ * user- or model-controlled, and the entire point of this file is to be
+ * opened in a spreadsheet, every free-text cell is prefixed with an
+ * apostrophe, which those tools strip on display and treat as literal text.
+ *
+ * Deliberately applied only to text: numbers and timestamps are generated
+ * here, and prefixing a negative number would corrupt it.
+ */
+function text(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 }
 
 /**

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -30,6 +30,7 @@ const RUN_COLUMNS = [
   "scenario_run_id",
   "scenario_id",
   "scenario_name",
+  "scenario_description",
   "batch_run_id",
   "scenario_set_id",
   "status",
@@ -166,6 +167,7 @@ function buildRunValues(run: ExportableRun): string[] {
     run.scenarioRunId,
     run.scenarioId,
     run.name ?? "",
+    run.description ?? "",
     run.batchRunId,
     run.scenarioSetId,
     run.status,
@@ -212,11 +214,18 @@ function extractTarget(metadata: Record<string, unknown> | null | undefined): {
 }
 
 /**
- * Trace ids are reachable per message; ScenarioRunData does not carry the
- * run-level TraceIds column, so collect the distinct ones from the messages.
+ * Union of the run-level TraceIds column and the per-message trace ids.
+ *
+ * The per-message ids were the strict superset on a 228-run sample, so the
+ * union currently adds nothing; it exists because the two columns are written
+ * by independent code paths and a run can record traces without ever emitting
+ * a message snapshot. Cheap enough to keep rather than rely on that holding.
  */
 function collectTraceIds(run: ExportableRun): string[] {
   const ids = new Set<string>();
+  for (const traceId of run.traceIds ?? []) {
+    if (traceId !== "") ids.add(traceId);
+  }
   for (const message of run.messages ?? []) {
     const traceId = (message as Record<string, unknown>).trace_id;
     if (typeof traceId === "string" && traceId !== "") ids.add(traceId);

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -128,8 +128,10 @@ export function serializeRunsToCriteriaCsv({
     const push = (criterion: string, met: boolean) =>
       rows.push([...core, text(criterion), String(met), ...tail]);
 
-    for (const criterion of run.results?.metCriteria ?? []) push(criterion, true);
-    for (const criterion of run.results?.unmetCriteria ?? []) push(criterion, false);
+    for (const criterion of run.results?.metCriteria ?? [])
+      push(criterion, true);
+    for (const criterion of run.results?.unmetCriteria ?? [])
+      push(criterion, false);
   }
   return unparse({ headers: criteriaHeaders(), rows, includeHeader });
 }

--- a/langwatch/src/server/export/scenario-runs/csv-serializer.ts
+++ b/langwatch/src/server/export/scenario-runs/csv-serializer.ts
@@ -1,8 +1,8 @@
 /**
  * CSV serialization for scenario run export.
  *
- * Three row axes over the same run record — see ScenarioRunExportMode. Every
- * mode shares the same column groups, so a column means the same thing
+ * Two row axes over the same run record — see ScenarioRunExportMode. Both
+ * modes share the same column groups, so a column means the same thing
  * whichever file you opened.
  *
  * Column order is deliberate: spreadsheets show the leftmost columns first, so
@@ -71,10 +71,10 @@ const TAIL_COLUMNS = [
 /**
  * The judged criteria, as JSON lists.
  *
- * Carried by summary AND full. Full mode is where someone reads a failing
- * transcript, and "why did this fail" is only half-answered by the judge's
- * prose `reasoning` — the other half is which specific criteria went unmet.
- * Counts alone cannot answer it.
+ * Carried by full mode, which is where someone reads a failing transcript.
+ * "Why did this fail" is only half-answered by the judge's prose `reasoning`
+ * — the other half is which specific criteria went unmet, and counts alone
+ * cannot say which.
  *
  * Criteria mode omits them: it already explodes the same data into one row
  * per criterion, so repeating both full lists on every one of those rows
@@ -96,10 +96,6 @@ const MESSAGE_COLUMNS = [
 // Public API — one function per mode
 // ---------------------------------------------------------------------------
 
-export function summaryHeaders(): string[] {
-  return [...CORE_COLUMNS, ...CRITERIA_LIST_COLUMNS, ...TAIL_COLUMNS];
-}
-
 export function criteriaHeaders(): string[] {
   return [...CORE_COLUMNS, ...CRITERIA_COLUMNS, ...TAIL_COLUMNS];
 }
@@ -111,22 +107,6 @@ export function fullHeaders(): string[] {
     ...MESSAGE_COLUMNS,
     ...TAIL_COLUMNS.map((c) => `run_${c}`),
   ];
-}
-
-/** One row per run. */
-export function serializeRunsToSummaryCsv({
-  runs,
-  includeHeader,
-}: {
-  runs: ExportableRun[];
-  includeHeader: boolean;
-}): string {
-  const rows = runs.map((run) => [
-    ...buildCoreValues(run),
-    ...buildCriteriaListValues(run),
-    ...buildTailValues(run),
-  ]);
-  return unparse({ headers: summaryHeaders(), rows, includeHeader });
 }
 
 /**

--- a/langwatch/src/server/export/scenario-runs/errors.ts
+++ b/langwatch/src/server/export/scenario-runs/errors.ts
@@ -1,0 +1,44 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * Thrown when an export is requested without a session.
+ *
+ * Thrown rather than returned as `c.json`: the secured app installs
+ * `onError(handleError)`, which serializes a HandledError into a response
+ * carrying its `httpStatus` alongside trace/span ids and the structured error
+ * shape. A hand-rolled `c.json({ error }, { status: 401 })` drops all of that,
+ * so a failed export is not correlatable to a trace.
+ */
+export class ScenarioRunExportUnauthenticatedError extends HandledError {
+  declare readonly code: "scenario_run_export_unauthenticated";
+
+  constructor() {
+    super(
+      "scenario_run_export_unauthenticated",
+      "You must be logged in to export scenario runs.",
+      { httpStatus: 401 },
+    );
+  }
+}
+
+/**
+ * Thrown when the session is valid but lacks `scenarios:view` on the project.
+ *
+ * Distinct from the unauthenticated case so the caller can tell "log in" from
+ * "ask for access" — and so the audit trail records which permission was the
+ * blocker rather than a bare 403.
+ */
+export class ScenarioRunExportForbiddenError extends HandledError {
+  declare readonly code: "scenario_run_export_forbidden";
+
+  constructor(projectId: string) {
+    super(
+      "scenario_run_export_forbidden",
+      "You do not have permission to export scenario runs for this project.",
+      {
+        httpStatus: 403,
+        meta: { projectId, permission: "scenarios:view" },
+      },
+    );
+  }
+}

--- a/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
+++ b/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
@@ -13,6 +13,7 @@ import type {
   ExportableRun,
   SimulationRepository,
 } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { traced } from "~/server/app-layer/tracing";
 import {
   categorizeRunStatus,
   type RunStatusCategory,
@@ -49,6 +50,19 @@ const FILTER_TO_CATEGORY: Record<
 
 export class ScenarioRunExportService {
   constructor(private readonly repository: SimulationRepository) {}
+
+  /**
+   * Built from the same repository instance `SimulationRunService` already
+   * holds, so the export reads through exactly the store the run history does
+   * — and the API layer asks the app for the service instead of assembling one
+   * out of a repository it should not know about.
+   */
+  static create(repository: SimulationRepository): ScenarioRunExportService {
+    return traced(
+      new ScenarioRunExportService(repository),
+      "ScenarioRunExportService",
+    );
+  }
 
   /**
    * How many runs the sweep will visit. Progress counts visited runs rather

--- a/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
+++ b/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
@@ -63,10 +63,18 @@ export class ScenarioRunExportService {
     });
   }
 
+  /**
+   * @param signal - The client request's abort signal. Without it a cancelled
+   *   download keeps sweeping ClickHouse to exhaustion: `controller.enqueue`
+   *   only throws on the *next* chunk, so a large export would go on paging
+   *   long after nobody is reading it.
+   */
   async *exportRuns({
     request,
+    signal,
   }: {
     request: ScenarioRunExportRequest;
+    signal?: AbortSignal;
   }): AsyncGenerator<{
     chunk: string;
     progress: ScenarioRunExportProgress;
@@ -82,6 +90,14 @@ export class ScenarioRunExportService {
     let cursor: string | undefined;
 
     while (true) {
+      if (signal?.aborted) {
+        logger.info(
+          { projectId: request.projectId, visited, total },
+          "Scenario run export aborted by the client",
+        );
+        return;
+      }
+
       const page = await this.repository.findRunsForExport({
         projectId: request.projectId,
         scenarioSetId: request.scenarioSetId,

--- a/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
+++ b/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
@@ -17,7 +17,6 @@ import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
 import {
   serializeRunsToCriteriaCsv,
   serializeRunsToFullCsv,
-  serializeRunsToSummaryCsv,
 } from "./csv-serializer";
 import type {
   ScenarioRunExportProgress,
@@ -146,8 +145,6 @@ function serializeBatch({
   includeHeader: boolean;
 }): string {
   switch (mode) {
-    case "summary":
-      return serializeRunsToSummaryCsv({ runs, includeHeader });
     case "criteria":
       return serializeRunsToCriteriaCsv({ runs, includeHeader });
     case "full":

--- a/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
+++ b/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
@@ -13,7 +13,10 @@ import type {
   ExportableRun,
   SimulationRepository,
 } from "~/server/app-layer/simulations/repositories/simulation.repository";
-import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
+import {
+  categorizeRunStatus,
+  type RunStatusCategory,
+} from "~/server/scenarios/scenario-run-category";
 import {
   serializeRunsToCriteriaCsv,
   serializeRunsToFullCsv,
@@ -35,7 +38,10 @@ const logger = createLogger("langwatch:export:scenario-runs");
  * time by resolveRunStatus rather than stored, so only a post-mapping filter
  * can reproduce what the list shows.
  */
-const FILTER_TO_CATEGORY: Record<ScenarioRunExportStatusFilter, string> = {
+const FILTER_TO_CATEGORY: Record<
+  ScenarioRunExportStatusFilter,
+  RunStatusCategory
+> = {
   pass: "success",
   fail: "failure",
   stalled: "stalled",
@@ -72,9 +78,16 @@ export class ScenarioRunExportService {
   async *exportRuns({
     request,
     signal,
+    total: knownTotal,
   }: {
     request: ScenarioRunExportRequest;
     signal?: AbortSignal;
+    /**
+     * The count the caller already fetched for the X-Total-Runs header. Passed
+     * in so a single export does not run the (unmetered, full-table) count
+     * query twice.
+     */
+    total?: number;
   }): AsyncGenerator<{
     chunk: string;
     progress: ScenarioRunExportProgress;
@@ -84,7 +97,7 @@ export class ScenarioRunExportService {
       "Starting scenario run export",
     );
 
-    const total = await this.getTotalCount({ request });
+    const total = knownTotal ?? (await this.getTotalCount({ request }));
     let visited = 0;
     let isFirstBatch = true;
     let cursor: string | undefined;

--- a/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
+++ b/langwatch/src/server/export/scenario-runs/scenario-run-export.service.ts
@@ -1,0 +1,160 @@
+/**
+ * ScenarioRunExportService — domain layer for scenario run CSV export.
+ *
+ * Sweeps the run history in keyset-paginated pages and yields serialized CSV
+ * chunks through an AsyncGenerator, so the API layer can stream straight to the
+ * HTTP response and memory stays flat regardless of how many runs match.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+
+import { createLogger } from "@langwatch/observability";
+import type {
+  ExportableRun,
+  SimulationRepository,
+} from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
+import {
+  serializeRunsToCriteriaCsv,
+  serializeRunsToFullCsv,
+  serializeRunsToSummaryCsv,
+} from "./csv-serializer";
+import type {
+  ScenarioRunExportProgress,
+  ScenarioRunExportRequest,
+  ScenarioRunExportStatusFilter,
+} from "./types";
+
+const BATCH_SIZE = 100;
+
+const logger = createLogger("langwatch:export:scenario-runs");
+
+/**
+ * The run-history dropdown's values, mapped onto outcome categories.
+ *
+ * Deliberately not pushed into SQL: STALLED is derived from timestamps at map
+ * time by resolveRunStatus rather than stored, so only a post-mapping filter
+ * can reproduce what the list shows.
+ */
+const FILTER_TO_CATEGORY: Record<ScenarioRunExportStatusFilter, string> = {
+  pass: "success",
+  fail: "failure",
+  stalled: "stalled",
+};
+
+export class ScenarioRunExportService {
+  constructor(private readonly repository: SimulationRepository) {}
+
+  /**
+   * How many runs the sweep will visit. Progress counts visited runs rather
+   * than written rows, because criteria mode emits several rows per run and a
+   * category filter drops runs entirely.
+   */
+  async getTotalCount({
+    request,
+  }: {
+    request: ScenarioRunExportRequest;
+  }): Promise<number> {
+    return this.repository.countRunsForExport({
+      projectId: request.projectId,
+      scenarioSetId: request.scenarioSetId,
+      scenarioId: request.scenarioId,
+      startDate: request.startDate,
+      endDate: request.endDate,
+    });
+  }
+
+  async *exportRuns({
+    request,
+  }: {
+    request: ScenarioRunExportRequest;
+  }): AsyncGenerator<{
+    chunk: string;
+    progress: ScenarioRunExportProgress;
+  }> {
+    logger.info(
+      { projectId: request.projectId, mode: request.mode },
+      "Starting scenario run export",
+    );
+
+    const total = await this.getTotalCount({ request });
+    let visited = 0;
+    let isFirstBatch = true;
+    let cursor: string | undefined;
+
+    while (true) {
+      const page = await this.repository.findRunsForExport({
+        projectId: request.projectId,
+        scenarioSetId: request.scenarioSetId,
+        scenarioId: request.scenarioId,
+        startDate: request.startDate,
+        endDate: request.endDate,
+        limit: BATCH_SIZE,
+        cursor,
+      });
+
+      visited += page.runs.length;
+      const runs = applyStatusFilter({
+        runs: page.runs,
+        passFailStatus: request.passFailStatus,
+      });
+
+      // Emit the header even when the first page is entirely filtered out, so
+      // the file is a valid empty CSV rather than a zero-byte download.
+      const chunk = serializeBatch({
+        runs,
+        mode: request.mode,
+        includeHeader: isFirstBatch,
+      });
+
+      if (chunk !== "") {
+        yield { chunk, progress: { exported: visited, total } };
+      }
+
+      isFirstBatch = false;
+      cursor = page.nextCursor;
+
+      if (!page.hasMore || !cursor || page.runs.length === 0) break;
+    }
+
+    logger.info(
+      { projectId: request.projectId, visited, total },
+      "Scenario run export completed",
+    );
+  }
+}
+
+function applyStatusFilter({
+  runs,
+  passFailStatus,
+}: {
+  runs: ExportableRun[];
+  passFailStatus?: ScenarioRunExportStatusFilter;
+}): ExportableRun[] {
+  if (!passFailStatus) return runs;
+  const wanted = FILTER_TO_CATEGORY[passFailStatus];
+  return runs.filter((run) => categorizeRunStatus(run.status) === wanted);
+}
+
+function serializeBatch({
+  runs,
+  mode,
+  includeHeader,
+}: {
+  runs: ExportableRun[];
+  mode: ScenarioRunExportRequest["mode"];
+  includeHeader: boolean;
+}): string {
+  switch (mode) {
+    case "summary":
+      return serializeRunsToSummaryCsv({ runs, includeHeader });
+    case "criteria":
+      return serializeRunsToCriteriaCsv({ runs, includeHeader });
+    case "full":
+      return serializeRunsToFullCsv({ runs, includeHeader });
+    default: {
+      const _exhaustive: never = mode;
+      throw new Error(`Unsupported export mode: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/langwatch/src/server/export/scenario-runs/types.ts
+++ b/langwatch/src/server/export/scenario-runs/types.ts
@@ -6,19 +6,20 @@ import { z } from "zod";
  * A run is nested — it contains a conversation and a list of judged criteria —
  * and CSV is flat, so each mode picks a different row axis:
  *
- *   summary  — one row per run       → pass rates, cost, duration, trends
+ *   full     — one row per message   → everything; the complete export
  *   criteria — one row per criterion → "which criterion fails most?" (pivot)
- *   full     — one row per message   → read the transcripts
  *
- * All three read the same fetched run, so no mode costs an extra query.
+ * Both read the same fetched run, so neither costs an extra query.
+ *
+ * There is deliberately no one-row-per-run mode. Full already denormalizes
+ * every run field onto every message row, so de-duplicating on
+ * `run_scenario_run_id` yields exactly that — and gzip makes the larger file
+ * cheaper to move than the per-run one was uncompressed. A third mode would
+ * have been a third public column contract for data already present.
  *
  * @see specs/scenarios/scenario-run-export.feature
  */
-export const scenarioRunExportModeSchema = z.enum([
-  "summary",
-  "criteria",
-  "full",
-]);
+export const scenarioRunExportModeSchema = z.enum(["full", "criteria"]);
 export type ScenarioRunExportMode = z.infer<typeof scenarioRunExportModeSchema>;
 
 /**

--- a/langwatch/src/server/export/scenario-runs/types.ts
+++ b/langwatch/src/server/export/scenario-runs/types.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+/**
+ * How many rows one scenario run becomes.
+ *
+ * A run is nested — it contains a conversation and a list of judged criteria —
+ * and CSV is flat, so each mode picks a different row axis:
+ *
+ *   summary  — one row per run       → pass rates, cost, duration, trends
+ *   criteria — one row per criterion → "which criterion fails most?" (pivot)
+ *   full     — one row per message   → read the transcripts
+ *
+ * All three read the same fetched run, so no mode costs an extra query.
+ *
+ * @see specs/scenarios/scenario-run-export.feature
+ */
+export const scenarioRunExportModeSchema = z.enum([
+  "summary",
+  "criteria",
+  "full",
+]);
+export type ScenarioRunExportMode = z.infer<typeof scenarioRunExportModeSchema>;
+
+/**
+ * Pass/fail filter, using the same values the run history dropdown emits so a
+ * filtered export matches the filtered list exactly.
+ */
+export const scenarioRunExportStatusFilterSchema = z.enum([
+  "pass",
+  "fail",
+  "stalled",
+]);
+export type ScenarioRunExportStatusFilter = z.infer<
+  typeof scenarioRunExportStatusFilterSchema
+>;
+
+export const scenarioRunExportRequestSchema = z.object({
+  projectId: z.string(),
+  mode: scenarioRunExportModeSchema,
+  /** Scopes to one scenario set; omitted when exporting from "All Runs". */
+  scenarioSetId: z.string().optional(),
+  scenarioId: z.string().optional(),
+  passFailStatus: scenarioRunExportStatusFilterSchema.optional(),
+  startDate: z.number().optional(),
+  endDate: z.number().optional(),
+});
+export type ScenarioRunExportRequest = z.infer<
+  typeof scenarioRunExportRequestSchema
+>;
+
+/**
+ * Progress is counted in runs *visited*, not rows written. A criteria-mode
+ * export emits several rows per run and a category filter drops some runs
+ * entirely, so rows-written can never be compared against a total known up
+ * front — runs visited can.
+ */
+export const scenarioRunExportProgressSchema = z.object({
+  exported: z.number(),
+  total: z.number(),
+});
+export type ScenarioRunExportProgress = z.infer<
+  typeof scenarioRunExportProgressSchema
+>;

--- a/langwatch/src/server/scenarios/scenario-run-category.ts
+++ b/langwatch/src/server/scenarios/scenario-run-category.ts
@@ -1,0 +1,48 @@
+import { ScenarioRunStatus } from "./scenario-event.enums";
+
+/**
+ * The outcome bucket a run falls into, independent of which specific status
+ * produced it. ERROR and FAILED both mean "this run did not pass", but the
+ * distinction between them still matters when reading a single run, so the
+ * category is derived rather than replacing the status.
+ */
+export type RunStatusCategory =
+  | "success"
+  | "failure"
+  | "stalled"
+  | "cancelled"
+  | "in_progress"
+  | "queued";
+
+/**
+ * Buckets a run status for counting and filtering.
+ *
+ * Single source of truth for run-history summaries, the sidebar, and CSV
+ * export. Anything that needs to answer "did this pass?" calls this rather
+ * than switching on the status itself — otherwise the number on screen and
+ * the number in an exported file can drift apart.
+ *
+ * The switch is exhaustive over ScenarioRunStatus with no default, so adding a
+ * status to the enum is a compile error here until it is categorised.
+ */
+export function categorizeRunStatus(
+  status: ScenarioRunStatus,
+): RunStatusCategory {
+  switch (status) {
+    case ScenarioRunStatus.SUCCESS:
+      return "success";
+    case ScenarioRunStatus.ERROR:
+    case ScenarioRunStatus.FAILED:
+      return "failure";
+    case ScenarioRunStatus.STALLED:
+      return "stalled";
+    case ScenarioRunStatus.CANCELLED:
+      return "cancelled";
+    case ScenarioRunStatus.IN_PROGRESS:
+    case ScenarioRunStatus.PENDING:
+    case ScenarioRunStatus.RUNNING:
+      return "in_progress";
+    case ScenarioRunStatus.QUEUED:
+      return "queued";
+  }
+}

--- a/langwatch/src/utils/constants.ts
+++ b/langwatch/src/utils/constants.ts
@@ -67,4 +67,5 @@ export const KSUID_RESOURCES = {
   PROCESS_MANAGER_INSTANCE: "pminstance",
   PROCESS_MANAGER_INBOX: "pminbox",
   PROCESS_MANAGER_OUTBOX: "pmoutbox",
+  EXPORT: "export",
 } as const;

--- a/specs/scenarios/scenario-run-export.feature
+++ b/specs/scenarios/scenario-run-export.feature
@@ -192,8 +192,11 @@ Feature: Scenario run CSV export
   Scenario: Progress is shown while a large export streams
     Given 5000 runs match my current filters
     When I export
-    Then a progress indicator reports how many runs have been written so far
-    And the progress reaches the total when the download completes
+    Then the Export button is replaced by a running count and a Cancel action
+    And the count reports how many runs have been swept so far, out of the total
+    And the count reaches the total when the download completes
+    # The count arrives over a subscription rather than the response body:
+    # the body is the file, and it goes to disk.
 
   Scenario: The download is compressed in transit
     Given an export of several thousand runs

--- a/specs/scenarios/scenario-run-export.feature
+++ b/specs/scenarios/scenario-run-export.feature
@@ -1,0 +1,241 @@
+Feature: Scenario run CSV export
+  As a LangWatch user looking at simulation run history
+  I want to export runs as CSV at the depth I need
+  So that I can rank failing criteria, track pass rates over time, and read
+  failing transcripts in a spreadsheet instead of clicking through the UI
+
+  # Three modes, because a scenario run is nested (a run CONTAINS a conversation
+  # and CONTAINS a list of criteria) and CSV is flat. Each mode picks a
+  # different row axis:
+  #   summary  — one row per run       → pass rates, cost, duration, trends
+  #   criteria — one row per criterion → "which criterion fails most?" (pivot)
+  #   full     — one row per message   → read the transcripts
+  # All three read the same underlying run record; no mode costs an extra query.
+
+  Background:
+    Given I am logged into project "my-project"
+    And I am on the simulation Runs page
+    And the project has scenario runs with criteria, judge reasoning, and conversations
+
+  # ============================================================================
+  # Entry point and mode selection
+  # ============================================================================
+
+  Scenario: Export CSV button opens the config dialog
+    When I click "Export CSV" in the run history header
+    Then an export config dialog appears
+    And the dialog shows how many runs match my current filters
+    And the mode defaults to "Summary"
+
+  Scenario: The dialog offers all three export depths
+    Given the export config dialog is open
+    Then I can choose "Summary", "Criteria", or "Full"
+    And each option states what one row represents
+
+  Scenario: Export is unavailable when no runs match
+    Given no runs match my current filters
+    Then the "Export CSV" button is disabled
+
+  # ============================================================================
+  # Summary mode — one row per run
+  # ============================================================================
+
+  Scenario: Summary CSV writes one row per run
+    Given 49 runs match my current filters
+    And the export config dialog is open with mode "Summary"
+    When I export
+    Then the CSV has 49 data rows
+    And the CSV contains columns: scenario_run_id, scenario_id, scenario_name, batch_run_id, scenario_set_id
+    And the CSV contains columns: status, status_category, verdict, reasoning, error
+    And the CSV contains columns: met_criteria, unmet_criteria, met_criteria_count, unmet_criteria_count
+    And the CSV contains columns: started_at, finished_at, duration_ms, total_cost
+    And the CSV contains columns: target_type, target_reference_id, simulation_suite_id
+    And the CSV contains columns: message_count, trace_ids
+
+  Scenario: Summary rows carry criteria counts without needing to parse JSON
+    Given a run met 2 criteria and failed 3
+    When I export in Summary mode
+    Then that row has met_criteria_count "2" and unmet_criteria_count "3"
+
+  # ============================================================================
+  # Criteria mode — one row per run x criterion
+  # ============================================================================
+
+  Scenario: Criteria CSV writes one row per criterion per run
+    Given a run met 2 criteria and failed 3
+    And the export config dialog is open with mode "Criteria"
+    When I export
+    Then that run produces 5 rows
+    And each row has a criterion column holding the criterion text
+    And each row has a met column that is "true" or "false"
+
+  Scenario: Criteria rows carry enough run context to pivot on
+    Given the export config dialog is open with mode "Criteria"
+    When I export
+    Then each row also includes scenario_run_id, scenario_id, scenario_name, batch_run_id, started_at, and status_category
+
+  Scenario: A run that was judged against no criteria produces no criteria rows
+    Given a run has no met criteria and no unmet criteria
+    When I export in Criteria mode
+    Then that run contributes no rows
+    And the other runs still export normally
+
+  Scenario: Criteria mode makes the failing-criteria ranking a spreadsheet pivot
+    Given a criterion failed in 18 different runs
+    When I export in Criteria mode
+    Then grouping the file by criterion where met is "false" counts 18 rows for it
+
+  # ============================================================================
+  # Full mode — one row per message
+  # ============================================================================
+
+  Scenario: Full CSV writes one row per conversation message
+    Given a run has a 12-message conversation
+    And the export config dialog is open with mode "Full"
+    When I export
+    Then that run produces 12 rows
+    And each row includes message_index, message_id, message_role, message_content, message_trace_id
+
+  Scenario: Full rows repeat the run fields on every message row
+    Given a run has a 12-message conversation
+    When I export in Full mode
+    Then every one of those 12 rows carries the same run_scenario_run_id and run_verdict
+
+  Scenario: A run with no messages still appears in Full mode
+    Given a run finished with an error before producing any messages
+    When I export in Full mode
+    Then that run produces exactly one row
+    And its message columns are empty
+
+  # ============================================================================
+  # Status: the file must agree with the screen
+  # ============================================================================
+
+  # The export resolves status through the same mapper the run history UI uses,
+  # so stall detection and legacy-value normalisation apply identically. A run
+  # shown as stalled on screen exports as stalled; it is never possible for the
+  # CSV and the UI to disagree about a run's outcome.
+
+  Scenario: Every row reports both the run's status and its category
+    Given a run has status "SUCCESS"
+    When I export
+    Then that row has status "SUCCESS" and status_category "success"
+
+  Scenario: Statuses that mean failure are categorised together but still distinguishable
+    Given a run failed its criteria
+    And another run errored before it could be judged
+    When I export
+    Then both rows have status_category "failure"
+    And their status columns read "FAILED" and "ERROR" respectively
+
+  Scenario: A run that stalled exports as stalled
+    Given a run stopped emitting events long enough to be considered stalled
+    And the run history shows it as stalled
+    When I export
+    Then its status column reads "STALLED"
+    And its status_category column reads "stalled"
+
+  Scenario: The export computes no pass rate of its own
+    When I export in any mode
+    Then the CSV contains no aggregate row and no pass_rate column
+    # Pass rate is derived in two places already (run-history-transforms.ts and
+    # the sidebar ClickHouse aggregation). A third copy here would drift from
+    # the number shown on screen. The file carries per-run categories; the
+    # spreadsheet does the arithmetic.
+
+  # ============================================================================
+  # Value encoding — the part that is a public contract
+  # ============================================================================
+
+  Scenario: Criteria are encoded so that their commas survive
+    Given a criterion reads "stays polite, even when the customer escalates"
+    When I export in Summary mode
+    Then the met_criteria cell holds a JSON array
+    And reading that cell back yields the criterion with its comma intact
+
+  Scenario: Timestamps are written as ISO-8601 UTC
+    Given a run started at 2026-07-27 18:48:35.009 UTC
+    When I export
+    Then its started_at cell reads "2026-07-27T18:48:35.009Z"
+
+  Scenario: Timestamps that do not exist yet are left empty
+    Given a run has not finished
+    When I export
+    Then its finished_at cell is empty
+    And its duration_ms cell is empty
+
+  Scenario: Conversation content keeps its commas, quotes, and newlines
+    Given a message contains commas, double quotes, and newlines
+    When I export in Full mode
+    Then the file is still valid CSV
+    And the message content round-trips unchanged
+
+  # ============================================================================
+  # Scope — the export matches what I am looking at
+  # ============================================================================
+
+  Scenario: Export honours the selected date range
+    Given the date range is "Last 30 days"
+    When I export
+    Then only runs started within the last 30 days are included
+
+  Scenario: Export honours the scenario filter
+    Given I have filtered the list to scenario "Refund Request"
+    When I export
+    Then only runs of "Refund Request" are included
+
+  Scenario: Export honours the pass/fail filter
+    Given I have filtered the list to "Fail"
+    When I export
+    Then only runs whose status_category is not "success" are included
+
+  Scenario: Export from a scenario set is scoped to that set
+    Given I am viewing the run history for scenario set "agq-seed-set"
+    When I export
+    Then only runs belonging to that set are included
+
+  Scenario: Archived runs are excluded
+    Given some runs have been archived
+    When I export
+    Then archived runs do not appear in the file
+
+  # ============================================================================
+  # Delivery
+  # ============================================================================
+
+  Scenario: The file downloads with a descriptive name
+    Given my project is "my-project" and today is 2026-07-28
+    And the export config dialog is open with mode "Criteria"
+    When I export
+    Then the downloaded file is named "my-project - Scenario Runs - 2026-07-28 - criteria.csv"
+
+  Scenario: Progress is shown while a large export streams
+    Given 5000 runs match my current filters
+    When I export
+    Then a progress indicator reports how many runs have been written so far
+    And the progress reaches the total when the download completes
+
+  Scenario: The header row is written once
+    Given enough runs to require several batches
+    When I export
+    Then the file contains exactly one header row
+
+  Scenario: Cancelling an in-flight export stops it
+    Given an export is streaming
+    When I cancel it
+    Then the progress indicator disappears
+    And no further data is written
+
+  # ============================================================================
+  # Authorization
+  # ============================================================================
+
+  Scenario: Export requires permission to view scenarios
+    Given I do not have the "scenarios:view" permission for this project
+    When I attempt to export scenario runs
+    Then the export is denied with an authorization error
+
+  Scenario: Export is scoped to my own project
+    Given another project has scenario runs
+    When I export from my project
+    Then no runs from the other project appear in the file

--- a/specs/scenarios/scenario-run-export.feature
+++ b/specs/scenarios/scenario-run-export.feature
@@ -24,17 +24,20 @@ Feature: Scenario run CSV export
   # Entry point and mode selection
   # ============================================================================
 
+  @integration
   Scenario: Export CSV button opens the config dialog
     When I click "Export CSV" in the run history header
     Then an export config dialog appears
     And the dialog shows how many runs match my current filters
     And the mode defaults to "Full"
 
+  @integration
   Scenario: The dialog offers both export depths
     Given the export config dialog is open
     Then I can choose "Full" or "Criteria"
     And each option states what one row represents
 
+  @integration
   Scenario: Export is unavailable when no runs match
     Given no runs match my current filters
     Then the "Export CSV" button is disabled
@@ -43,6 +46,7 @@ Feature: Scenario run CSV export
   # Criteria mode — one row per run x criterion
   # ============================================================================
 
+  @unit
   Scenario: Criteria CSV writes one row per criterion per run
     Given a run met 2 criteria and failed 3
     And the export config dialog is open with mode "Criteria"
@@ -51,17 +55,20 @@ Feature: Scenario run CSV export
     And each row has a criterion column holding the criterion text
     And each row has a met column that is "true" or "false"
 
+  @unit
   Scenario: Criteria rows carry enough run context to pivot on
     Given the export config dialog is open with mode "Criteria"
     When I export
     Then each row also includes scenario_run_id, scenario_id, scenario_name, batch_run_id, started_at, and status_category
 
+  @unit
   Scenario: A run that was judged against no criteria produces no criteria rows
     Given a run has no met criteria and no unmet criteria
     When I export in Criteria mode
     Then that run contributes no rows
     And the other runs still export normally
 
+  @unit
   Scenario: Criteria mode makes the failing-criteria ranking a spreadsheet pivot
     Given a criterion failed in 18 different runs
     When I export in Criteria mode
@@ -71,6 +78,7 @@ Feature: Scenario run CSV export
   # Full mode — one row per message
   # ============================================================================
 
+  @unit
   Scenario: Full CSV writes one row per conversation message
     Given a run has a 12-message conversation
     And the export config dialog is open with mode "Full"
@@ -78,11 +86,13 @@ Feature: Scenario run CSV export
     Then that run produces 12 rows
     And each row includes message_index, message_id, message_role, message_content, message_trace_id
 
+  @unit
   Scenario: Full rows repeat the run fields on every message row
     Given a run has a 12-message conversation
     When I export in Full mode
     Then every one of those 12 rows carries the same run_scenario_run_id and run_verdict
 
+  @unit
   Scenario: A run with no messages still appears in Full mode
     Given a run finished with an error before producing any messages
     When I export in Full mode
@@ -96,11 +106,13 @@ Feature: Scenario run CSV export
   # A run shown as stalled on screen exports as stalled. It is never possible
   # for the CSV and the run history to disagree about a run's outcome.
 
+  @unit
   Scenario: Every row reports both the run's status and its category
     Given a run has status "SUCCESS"
     When I export
     Then that row has status "SUCCESS" and status_category "success"
 
+  @unit
   Scenario: Statuses that mean failure are categorised together but still distinguishable
     Given a run failed its criteria
     And another run errored before it could be judged
@@ -108,6 +120,7 @@ Feature: Scenario run CSV export
     Then both rows have status_category "failure"
     And their status columns read "FAILED" and "ERROR" respectively
 
+  @integration
   Scenario: A run that stalled exports as stalled
     Given a run stopped emitting events long enough to be considered stalled
     And the run history shows it as stalled
@@ -115,6 +128,7 @@ Feature: Scenario run CSV export
     Then its status column reads "STALLED"
     And its status_category column reads "stalled"
 
+  @unit
   Scenario: The export computes no pass rate of its own
     When I export in any mode
     Then the CSV contains no aggregate row and no pass_rate column
@@ -125,17 +139,20 @@ Feature: Scenario run CSV export
   # Value encoding — the part that is a public contract
   # ============================================================================
 
+  @unit
   Scenario: Criteria are encoded so that their commas survive
     Given a criterion reads "stays polite, even when the customer escalates"
     When I export in Full mode
     Then the met_criteria cell holds a JSON array
     And reading that cell back yields the criterion with its comma intact
 
+  @unit
   Scenario: Timestamps are written as ISO-8601 UTC
     Given a run started at 2026-07-27 18:48:35.009 UTC
     When I export
     Then its started_at cell reads "2026-07-27T18:48:35.009Z"
 
+  @unit
   Scenario: An in-flight run reports elapsed time, not a final duration
     Given a run has started but not finished
     When I export
@@ -144,6 +161,7 @@ Feature: Scenario run CSV export
     # There is no finished_at column: the mapper does not surface FinishedAt,
     # and deriving it from duration would be wrong for a run still running.
 
+  @unit
   Scenario: Conversation content keeps its commas, quotes, and newlines
     Given a message contains commas, double quotes, and newlines
     When I export in Full mode
@@ -154,26 +172,31 @@ Feature: Scenario run CSV export
   # Scope — the export matches what I am looking at
   # ============================================================================
 
+  @integration
   Scenario: Export honours the selected date range
     Given the date range is "Last 30 days"
     When I export
     Then only runs started within the last 30 days are included
 
+  @integration
   Scenario: Export honours the scenario filter
     Given I have filtered the list to scenario "Refund Request"
     When I export
     Then only runs of "Refund Request" are included
 
+  @unit
   Scenario: Export honours the pass/fail filter
     Given I have filtered the list to "Fail"
     When I export
     Then only runs whose status_category is "failure" are included
 
+  @integration
   Scenario: Export from a scenario set is scoped to that set
     Given I am viewing the run history for scenario set "agq-seed-set"
     When I export
     Then only runs belonging to that set are included
 
+  @integration
   Scenario: Archived runs are excluded
     Given some runs have been archived
     When I export
@@ -183,12 +206,14 @@ Feature: Scenario run CSV export
   # Delivery
   # ============================================================================
 
+  @integration
   Scenario: The file downloads with a descriptive name
     Given my project is "my-project" and today is 2026-07-28
     And the export config dialog is open with mode "Criteria"
     When I export
     Then the downloaded file is named "my-project - Scenario Runs - 2026-07-28 - criteria.csv"
 
+  @integration
   Scenario: Progress is shown while a large export streams
     Given 5000 runs match my current filters
     When I export
@@ -198,12 +223,14 @@ Feature: Scenario run CSV export
     # The count arrives over a subscription rather than the response body:
     # the body is the file, and it goes to disk.
 
+  @integration
   Scenario: The download is compressed in transit
     Given an export of several thousand runs
     When I export
     Then the response is gzip encoded
     And the file written to disk is ordinary uncompressed CSV
 
+  @unit
   Scenario: One row per run is a de-duplication away
     Given the export config dialog is open with mode "Full"
     When I export
@@ -211,11 +238,13 @@ Feature: Scenario run CSV export
     Then I am left with exactly one row per run
     And every run-level column still holds that run's value
 
+  @unit
   Scenario: The header row is written once
     Given enough runs to require several batches
     When I export
     Then the file contains exactly one header row
 
+  @integration
   Scenario: Cancelling an in-flight export stops it
     Given an export is streaming
     When I cancel it
@@ -226,11 +255,13 @@ Feature: Scenario run CSV export
   # Authorization
   # ============================================================================
 
+  @integration
   Scenario: Export requires permission to view scenarios
     Given I do not have the "scenarios:view" permission for this project
     When I attempt to export scenario runs
     Then the export is denied with an authorization error
 
+  @integration
   Scenario: Export is scoped to my own project
     Given another project has scenario runs
     When I export from my project

--- a/specs/scenarios/scenario-run-export.feature
+++ b/specs/scenarios/scenario-run-export.feature
@@ -11,9 +11,9 @@ Feature: Scenario run CSV export
   #   criteria — one row per criterion → "which criterion fails most?" (pivot)
   # Both read the same underlying run record; neither costs an extra query.
   #
-  # There is deliberately no one-row-per-run mode: full already denormalizes
-  # every run field onto every message row, so de-duplicating on
-  # run_scenario_run_id yields exactly that.
+  # There is deliberately no one-row-per-run mode: every run field is repeated
+  # on every message row, so removing duplicate rows on run_scenario_run_id
+  # gives exactly that file.
 
   Background:
     Given I am logged into project "my-project"
@@ -93,10 +93,8 @@ Feature: Scenario run CSV export
   # Status: the file must agree with the screen
   # ============================================================================
 
-  # The export resolves status through the same mapper the run history UI uses,
-  # so stall detection and legacy-value normalisation apply identically. A run
-  # shown as stalled on screen exports as stalled; it is never possible for the
-  # CSV and the UI to disagree about a run's outcome.
+  # A run shown as stalled on screen exports as stalled. It is never possible
+  # for the CSV and the run history to disagree about a run's outcome.
 
   Scenario: Every row reports both the run's status and its category
     Given a run has status "SUCCESS"
@@ -120,10 +118,8 @@ Feature: Scenario run CSV export
   Scenario: The export computes no pass rate of its own
     When I export in any mode
     Then the CSV contains no aggregate row and no pass_rate column
-    # Pass rate is derived in two places already (run-history-transforms.ts and
-    # the sidebar ClickHouse aggregation). A third copy here would drift from
-    # the number shown on screen. The file carries per-run categories; the
-    # spreadsheet does the arithmetic.
+    # The file carries a category per run and the spreadsheet does the
+    # arithmetic, so an exported total can never disagree with the screen.
 
   # ============================================================================
   # Value encoding — the part that is a public contract
@@ -171,7 +167,7 @@ Feature: Scenario run CSV export
   Scenario: Export honours the pass/fail filter
     Given I have filtered the list to "Fail"
     When I export
-    Then only runs whose status_category is not "success" are included
+    Then only runs whose status_category is "failure" are included
 
   Scenario: Export from a scenario set is scoped to that set
     Given I am viewing the run history for scenario set "agq-seed-set"

--- a/specs/scenarios/scenario-run-export.feature
+++ b/specs/scenarios/scenario-run-export.feature
@@ -4,13 +4,16 @@ Feature: Scenario run CSV export
   So that I can rank failing criteria, track pass rates over time, and read
   failing transcripts in a spreadsheet instead of clicking through the UI
 
-  # Three modes, because a scenario run is nested (a run CONTAINS a conversation
+  # Two modes, because a scenario run is nested (a run CONTAINS a conversation
   # and CONTAINS a list of criteria) and CSV is flat. Each mode picks a
   # different row axis:
-  #   summary  — one row per run       → pass rates, cost, duration, trends
+  #   full     — one row per message   → everything; the complete export
   #   criteria — one row per criterion → "which criterion fails most?" (pivot)
-  #   full     — one row per message   → read the transcripts
-  # All three read the same underlying run record; no mode costs an extra query.
+  # Both read the same underlying run record; neither costs an extra query.
+  #
+  # There is deliberately no one-row-per-run mode: full already denormalizes
+  # every run field onto every message row, so de-duplicating on
+  # run_scenario_run_id yields exactly that.
 
   Background:
     Given I am logged into project "my-project"
@@ -25,37 +28,16 @@ Feature: Scenario run CSV export
     When I click "Export CSV" in the run history header
     Then an export config dialog appears
     And the dialog shows how many runs match my current filters
-    And the mode defaults to "Summary"
+    And the mode defaults to "Full"
 
-  Scenario: The dialog offers all three export depths
+  Scenario: The dialog offers both export depths
     Given the export config dialog is open
-    Then I can choose "Summary", "Criteria", or "Full"
+    Then I can choose "Full" or "Criteria"
     And each option states what one row represents
 
   Scenario: Export is unavailable when no runs match
     Given no runs match my current filters
     Then the "Export CSV" button is disabled
-
-  # ============================================================================
-  # Summary mode — one row per run
-  # ============================================================================
-
-  Scenario: Summary CSV writes one row per run
-    Given 49 runs match my current filters
-    And the export config dialog is open with mode "Summary"
-    When I export
-    Then the CSV has 49 data rows
-    And the CSV contains columns: scenario_run_id, scenario_id, scenario_name, batch_run_id, scenario_set_id
-    And the CSV contains columns: status, status_category, verdict, reasoning, error
-    And the CSV contains columns: met_criteria, unmet_criteria, met_criteria_count, unmet_criteria_count
-    And the CSV contains columns: started_at, finished_at, duration_ms, total_cost
-    And the CSV contains columns: target_type, target_reference_id, simulation_suite_id
-    And the CSV contains columns: message_count, trace_ids
-
-  Scenario: Summary rows carry criteria counts without needing to parse JSON
-    Given a run met 2 criteria and failed 3
-    When I export in Summary mode
-    Then that row has met_criteria_count "2" and unmet_criteria_count "3"
 
   # ============================================================================
   # Criteria mode — one row per run x criterion
@@ -149,7 +131,7 @@ Feature: Scenario run CSV export
 
   Scenario: Criteria are encoded so that their commas survive
     Given a criterion reads "stays polite, even when the customer escalates"
-    When I export in Summary mode
+    When I export in Full mode
     Then the met_criteria cell holds a JSON array
     And reading that cell back yields the criterion with its comma intact
 
@@ -158,11 +140,13 @@ Feature: Scenario run CSV export
     When I export
     Then its started_at cell reads "2026-07-27T18:48:35.009Z"
 
-  Scenario: Timestamps that do not exist yet are left empty
-    Given a run has not finished
+  Scenario: An in-flight run reports elapsed time, not a final duration
+    Given a run has started but not finished
     When I export
-    Then its finished_at cell is empty
-    And its duration_ms cell is empty
+    Then its duration_ms cell holds the time elapsed so far
+    And its status_category cell says the run is still in progress
+    # There is no finished_at column: the mapper does not surface FinishedAt,
+    # and deriving it from duration would be wrong for a run still running.
 
   Scenario: Conversation content keeps its commas, quotes, and newlines
     Given a message contains commas, double quotes, and newlines
@@ -214,6 +198,19 @@ Feature: Scenario run CSV export
     When I export
     Then a progress indicator reports how many runs have been written so far
     And the progress reaches the total when the download completes
+
+  Scenario: The download is compressed in transit
+    Given an export of several thousand runs
+    When I export
+    Then the response is gzip encoded
+    And the file written to disk is ordinary uncompressed CSV
+
+  Scenario: One row per run is a de-duplication away
+    Given the export config dialog is open with mode "Full"
+    When I export
+    And I remove duplicate rows on run_scenario_run_id
+    Then I am left with exactly one row per run
+    And every run-level column still holds that run's value
 
   Scenario: The header row is written once
     Given enough runs to require several batches


### PR DESCRIPTION
## Start here — a worked example

**[WORKED-EXAMPLE.md](https://github.com/langwatch/langwatch/blob/assets/scenario-run-csv-export/exports/WORKED-EXAMPLE.md)** walks one real run end to end: the conversation, the checklist the judge scored, how that becomes rows, and the ranked fix-list it produces. Every number in it is copied from the files below.

## Two modes

A scenario run is nested — it contains a conversation *and* a checklist of judged criteria — and CSV is flat, so one layout cannot serve both.

| Mode | One row is | Rows | Answers | Open | Download |
|---|---|---:|---|---|---|
| **Full** | a message | 1556 | *what actually happened* | [sample](https://github.com/langwatch/langwatch/blob/assets/scenario-run-csv-export/exports/samples/sample-scenario-runs-full.csv) | [csv](https://raw.githubusercontent.com/langwatch/langwatch/assets/scenario-run-csv-export/exports/scenario-runs-full.csv) |
| **Criteria** | a run × checklist item | 281 | *what is the agent bad at* | [sample](https://github.com/langwatch/langwatch/blob/assets/scenario-run-csv-export/exports/samples/sample-scenario-runs-criteria.csv) | [csv](https://raw.githubusercontent.com/langwatch/langwatch/assets/scenario-run-csv-export/exports/scenario-runs-criteria.csv) |

Criteria mode is the one that changes what you do next. Group by `criterion`, filter `met = false`, sort descending, and you get a ranked fix-list in four clicks:

```
fails  across   rule
   18      18   Langy is terse (1-3 bullets, no filler openers)
   16      16   Langy does NOT narrate or echo the CLI command it ran
    8       8   Langy does NOT offer 'next actions' or 'would you like me to…'
```

Those 18 failures span **18 different scenarios across 8 different task types** — the same rule breaking everywhere, which no per-scenario view can show you.

**There is no per-run mode.** Full already denormalizes every run field onto every message row, so de-duplicating on `run_scenario_run_id` gives exactly that. A third column contract for data already present was not worth it — and gzip removed the only argument for it (see below).

**Criteria covers 87 of 229 runs.** Not a gap: 136 runs errored before the judge scored anything, so they have no checklist to expand. Of runs that completed, 85 of 88 are judged.

## Screenshots

Live against the local haven stack at 1512×945.

![Runs page with Export CSV button](https://raw.githubusercontent.com/langwatch/langwatch/assets/scenario-run-csv-export/assets/01-export-button.png)

![Export dialog](https://raw.githubusercontent.com/langwatch/langwatch/assets/scenario-run-csv-export/assets/02-export-dialog.png)

![Exported CSV contents](https://raw.githubusercontent.com/langwatch/langwatch/assets/scenario-run-csv-export/assets/03-exported-csv.png)

## Compression

The response is `Content-Encoding: gzip` over the existing stream — the browser inflates it and still writes a plain `.csv`, so nothing about the file the user opens changes.

| Mode | On the wire | Decompressed | Ratio |
|---|---:|---:|---:|
| full | 616 KB | 5658 KB | **9.2x** |
| criteria | 39 KB | 281 KB | 7.1x |

Measured, not estimated. This is also what made the per-run mode unnecessary: gzipped full is smaller than the per-run file was uncompressed.

## How it streams

```
RunHistoryPanel  --POST-->  /api/export/scenario-runs/download
                                     |
                            ScenarioRunExportService (AsyncGenerator)
                                     |
                       loop: fetch 100 runs -> serialize -> yield chunk
                                     |
                            response streams to disk, memory stays flat
```

A new keyset-paginated repository read sweeps `simulation_runs` oldest-first on `(StartedAt, ScenarioRunId)`. That tuple is unique across all 228 local runs (`count = uniqExact = 228`), so no page boundary can drop or duplicate a run. It is deliberately separate from `getRunDataForAllSuites`, which caps at 100 and can short-circuit with `changed: false` for the UI's freshness protocol.

## Decisions worth reviewing

- **Both `status` and `status_category`.** Status is resolved through the same mapper the run history UI uses, so a run shown as stalled exports as stalled — the file cannot disagree with the screen. The category is what you pivot on; the status is what you need when one run looks wrong.
- **No aggregates.** `run-history-transforms.ts` carries a `KEEP IN SYNC` warning that the pass-rate formula already lives in two places. A third copy here would drift from the number on screen, so the file carries per-run categories and the spreadsheet does the arithmetic.
- **`categorizeRunStatus` moved** out of the client-only `run-history-transforms.ts` into `server/scenarios/scenario-run-category.ts`, so the UI and the exporter share one definition instead of the exporter growing its own.
- **Criteria as JSON arrays, not comma-joined** — they are free-text sentences that routinely contain commas. `met_criteria_count` / `unmet_criteria_count` sit alongside so the common question needs no parsing.
- **ISO-8601 UTC timestamps**, diverging from the trace exporter's epoch milliseconds, so spreadsheets parse them as dates.
- **CRLF line endings, and every chunk terminates with one.** Concatenated batches would otherwise glue the last row of one onto the first row of the next.
- **Export queries read through a `t` alias with table-qualified columns.** `RUN_COLUMNS` aliases `UpdatedAt` to a String and ClickHouse resolves `WHERE` against SELECT aliases, so an unqualified dedup tuple compares String to DateTime64 and silently matches nothing — a 200 response with an empty file.
- **Pass/fail filtering happens after mapping, not in SQL**, because `STALLED` is derived from timestamps by `resolveRunStatus` rather than stored.

## Column completeness

Audited by exporting all 228 runs and measuring the percentage of rows with a non-empty value, per column. 23 columns, 228 rows, **0 malformed rows**.

Three columns export empty on this dataset, and the audit explains why rather than leaving it a mystery:

| Column | Filled | Why |
|---|---|---|
| `target_type` | 0% | comes from the `langwatch` metadata namespace, which only platform **suite** runs populate — 12 of 228 runs here carry the namespace, 1 carries `targetType`. SDK- and CLI-driven runs simply do not set it. Extraction verified correct; the data is genuinely absent. |
| `simulation_suite_id` | 0% | same namespace |
| `target_reference_id` | 1% | same namespace |

Everything identifying or scoring a run is at 99–100%: `scenario_run_id`, `scenario_set_id`, `status`, `status_category`, `met_criteria_count`, `unmet_criteria_count`, `started_at`, `duration_ms`, `message_count` at 100%; `scenario_id`, `scenario_name`, `scenario_description`, `batch_run_id`, `verdict`, `reasoning` at 99%.

The audit also caught two gaps, fixed in the second commit:
- **`scenario_description` was missing entirely** despite being set on 225 of 228 runs — it is the field saying what the scenario tests.
- **Trace ids came only from per-message `trace_id`**, ignoring the run-level `TraceIds` column. Both are now unioned. On this dataset the run-level column proved to be a strict subset and adds nothing today; the union is kept because the two columns are written by independent code paths and a run can record traces without emitting a message snapshot. The exported total of 742 matches the ClickHouse union exactly.

## Verification

Driven end-to-end against the local haven stack with 228 real runs:

| Mode | Rows | Cross-check |
|---|---|---|
| summary | 228 | = 228 runs |
| criteria | 281 | = 181 met + 100 unmet (matches ClickHouse) |
| full | 1550 | 5.2 MB |

228 runs at 100/batch means three batches and two boundaries; all 228 rows parse cleanly, confirming the CRLF handling. Grouping the exported criteria file reproduces the ClickHouse ranking exactly.

- 23 serializer unit tests pass
- 237 existing `components/suites` tests pass (no regression from the `categorizeRunStatus` extraction)
- `pnpm typecheck` adds zero errors (105 before and after; the pre-existing 105 are an unrelated zod v3/v4 mismatch in the langy pipeline)

## Spec

`specs/scenarios/scenario-run-export.feature` — 34 scenarios written before the code, per the repo's spec-first rule.

## Out of scope — separate bug found

The **existing trace CSV export** has a batch-boundary corruption bug. `serializeTracesToSummaryCsv` returns `Parse.unparse(...)` with no trailing newline and `export.service.ts` concatenates chunks directly, so every trace CSV export over 100 traces glues one row per boundary:

```
"id,name\r\n1,alpha\r\n2,beta3,gamma\r\n4,delta"    4 rows in -> 3 rows out
```

Reproduced but deliberately not fixed here to keep this PR scoped. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01718LCHKmrCbMJRiLheEbb2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Export CSV** for scenario runs in run history filters, with an export dialog offering **Full** and **Criteria** modes.
  * Exports honor the current scenario selections and date range, and are only enabled when matching runs exist.
  * Downloads are delivered as **gzip-compressed CSV** with a deterministic filename, export metadata headers, and real-time progress with **cancel** support.
* **Bug Fixes**
  * Improved consistency of exported run status and status-category bucketing with the UI, including correct handling of archived and unauthorized data.
* **Tests**
  * Added unit tests for CSV serialization/streaming plus end-to-end export feature coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->