### PR TITLE
fix(export): stop trace CSV losing a row at every batch boundary

### DIFF
--- a/langwatch/src/server/export/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/__tests__/csv-serializer.unit.test.ts
@@ -12,6 +12,7 @@ import {
   serializeTracesToSummaryCsv,
   serializeTracesToFullCsv,
 } from "../serializers/csv-serializer";
+import { stripCsvHeader } from "../export.service";
 
 // ---------------------------------------------------------------------------
 // Test data builders
@@ -539,16 +540,11 @@ describe("serializeTracesToFullCsv()", () => {
 // Streaming: chunks are concatenated straight into one file
 // ---------------------------------------------------------------------------
 
-/**
- * Mirrors ExportService.serializeCsvBatch: the first batch keeps its header,
- * later batches have it stripped, and the pieces are concatenated with no
- * separator. Kept in sync with export.service.ts by construction — if the
- * chunk contract changes, these tests fail.
- */
-function stripCsvHeader(csv: string): string {
-  const firstBreak = csv.indexOf("\r\n");
-  return firstBreak === -1 ? "" : csv.slice(firstBreak + 2);
-}
+// These tests reproduce ExportService.serializeCsvBatch: the first batch keeps
+// its header, later batches are stripped with the SAME function production
+// uses, and the pieces are concatenated with no separator. Importing rather
+// than re-implementing stripCsvHeader is the point — a local copy could keep
+// passing while the real one regressed.
 
 describe("when an export spans several batches", () => {
   it("keeps every row intact across a batch boundary", () => {

--- a/langwatch/src/server/export/__tests__/csv-serializer.unit.test.ts
+++ b/langwatch/src/server/export/__tests__/csv-serializer.unit.test.ts
@@ -534,3 +534,96 @@ describe("serializeTracesToFullCsv()", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Streaming: chunks are concatenated straight into one file
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors ExportService.serializeCsvBatch: the first batch keeps its header,
+ * later batches have it stripped, and the pieces are concatenated with no
+ * separator. Kept in sync with export.service.ts by construction — if the
+ * chunk contract changes, these tests fail.
+ */
+function stripCsvHeader(csv: string): string {
+  const firstBreak = csv.indexOf("\r\n");
+  return firstBreak === -1 ? "" : csv.slice(firstBreak + 2);
+}
+
+describe("when an export spans several batches", () => {
+  it("keeps every row intact across a batch boundary", () => {
+    const evaluatorNames: string[] = [];
+    const batch1 = serializeTracesToSummaryCsv({
+      traces: [
+        buildTrace({ trace_id: "trace-1" }),
+        buildTrace({ trace_id: "trace-2" }),
+      ],
+      evaluatorNames,
+    });
+    const batch2 = stripCsvHeader(
+      serializeTracesToSummaryCsv({
+        traces: [
+          buildTrace({ trace_id: "trace-3" }),
+          buildTrace({ trace_id: "trace-4" }),
+        ],
+        evaluatorNames,
+      }),
+    );
+
+    const rows = parseCsv(batch1 + batch2).data as Record<string, string>[];
+
+    // Before the fix this yielded 3 rows, with "trace-2" and "trace-3" fused
+    // into one — the last row of a chunk glued onto the first of the next.
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.trace_id)).toEqual([
+      "trace-1",
+      "trace-2",
+      "trace-3",
+      "trace-4",
+    ]);
+  });
+
+  it("writes exactly one header for the whole file", () => {
+    const evaluatorNames: string[] = [];
+    const batch1 = serializeTracesToSummaryCsv({
+      traces: [buildTrace({ trace_id: "a" })],
+      evaluatorNames,
+    });
+    const batch2 = stripCsvHeader(
+      serializeTracesToSummaryCsv({
+        traces: [buildTrace({ trace_id: "b" })],
+        evaluatorNames,
+      }),
+    );
+
+    const file = batch1 + batch2;
+    expect(file.split("trace_id")).toHaveLength(2);
+    expect((parseCsv(file).data as unknown[]).length).toBe(2);
+  });
+
+  it("keeps span rows intact across a batch boundary in full mode", () => {
+    const evaluatorNames: string[] = [];
+    // Full mode emits one row per span, so each trace needs at least one.
+    const batch1 = serializeTracesToFullCsv({
+      traces: [buildTrace({ trace_id: "trace-1", spans: [buildLLMSpan()] })],
+      evaluatorNames,
+    });
+    const batch2 = stripCsvHeader(
+      serializeTracesToFullCsv({
+        traces: [buildTrace({ trace_id: "trace-2", spans: [buildLLMSpan()] })],
+        evaluatorNames,
+      }),
+    );
+
+    const rows = parseCsv(batch1 + batch2).data as Record<string, string>[];
+    expect(rows.map((r) => r.trace_id)).toEqual(["trace-1", "trace-2"]);
+  });
+
+  it("terminates a chunk so nothing can fuse onto the next one", () => {
+    const csv = serializeTracesToSummaryCsv({
+      traces: [buildTrace()],
+      evaluatorNames: [],
+    });
+    expect(csv.endsWith("\r\n")).toBe(true);
+  });
+});

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -16,6 +16,7 @@ import type { Protections } from "~/server/traces/protections";
 import type { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import {
+  CSV_NEWLINE,
   serializeTracesToFullCsv,
   serializeTracesToSummaryCsv,
 } from "./serializers/csv-serializer";
@@ -344,9 +345,13 @@ function serializeJsonBatch({
 
 /**
  * Remove the first line (header) from a CSV string.
+ *
+ * Must search for the same sequence the serializer wrote. Splitting on "\n"
+ * while the rows are terminated with "\r\n" leaves a stray carriage return at
+ * the head of the chunk, which becomes a phantom leading field.
  */
 function stripCsvHeader(csv: string): string {
-  const firstNewline = csv.indexOf("\n");
-  if (firstNewline === -1) return "";
-  return csv.slice(firstNewline + 1);
+  const firstBreak = csv.indexOf(CSV_NEWLINE);
+  if (firstBreak === -1) return "";
+  return csv.slice(firstBreak + CSV_NEWLINE.length);
 }

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -349,8 +349,11 @@ function serializeJsonBatch({
  * Must search for the same sequence the serializer wrote. Splitting on "\n"
  * while the rows are terminated with "\r\n" leaves a stray carriage return at
  * the head of the chunk, which becomes a phantom leading field.
+ *
+ * Exported for the batch-boundary tests, which concatenate chunks exactly as
+ * this service does. A test-local copy could pass while this regressed.
  */
-function stripCsvHeader(csv: string): string {
+export function stripCsvHeader(csv: string): string {
   const firstBreak = csv.indexOf(CSV_NEWLINE);
   if (firstBreak === -1) return "";
   return csv.slice(firstBreak + CSV_NEWLINE.length);

--- a/langwatch/src/server/export/serializers/csv-serializer.ts
+++ b/langwatch/src/server/export/serializers/csv-serializer.ts
@@ -19,6 +19,22 @@ import type {
 } from "~/server/tracer/types";
 import { RESERVED_METADATA_KEYS } from "./constants";
 
+/**
+ * RFC 4180 line ending, stated explicitly rather than relying on PapaParse's
+ * default.
+ *
+ * Every chunk must both use this internally AND end with it. A streamed export
+ * concatenates chunks straight into one file, so a chunk with no trailing
+ * newline glues its last row onto the next chunk's first row — and a chunk
+ * that terminates rows with a different sequence than the one PapaParse wrote
+ * inside it makes the whole remainder of the file parse as a single row.
+ * Neither shows up until an export exceeds one batch.
+ *
+ * Exported so export.service.ts strips the header on the same sequence it was
+ * written with.
+ */
+export const CSV_NEWLINE = "\r\n";
+
 // ---------------------------------------------------------------------------
 // Summary CSV
 // ---------------------------------------------------------------------------
@@ -58,7 +74,10 @@ export function serializeTracesToSummaryCsv({
     buildSummaryRow({ trace, evaluatorNames }),
   );
 
-  return Parse.unparse({ fields: headers, data: rows });
+  return (
+    Parse.unparse({ fields: headers, data: rows }, { newline: CSV_NEWLINE }) +
+    CSV_NEWLINE
+  );
 }
 
 function buildSummaryHeaders({
@@ -173,7 +192,10 @@ export function serializeTracesToFullCsv({
     }
   }
 
-  return Parse.unparse({ fields: headers, data: rows });
+  return (
+    Parse.unparse({ fields: headers, data: rows }, { newline: CSV_NEWLINE }) +
+    CSV_NEWLINE
+  );
 }
 
 function buildFullHeaders({


### PR DESCRIPTION
Fixes #6281.

## The bug

Both trace CSV serializers returned `Parse.unparse(...)` with **no trailing newline**, and `ExportService` concatenates those chunks straight into the HTTP response. So the last row of each 100-trace batch fused onto the first row of the next:

```
batch 1 → "id,name\r\n1,alpha\r\n2,beta"        ← no terminator
batch 2 →                    "3,gamma\r\n4,delta"
                                  │
                    concatenated ▼
"id,name\r\n1,alpha\r\n2,beta3,gamma\r\n4,delta"
                          ^^^^^^^^^^^
```

Four rows in, **three out**, one of them corrupt (`{id: "2", name: "beta3"}`). Silent: the file parses without error, it just has fewer rows than the project has traces. A 5,000-trace export lost roughly 49 rows, and the corrupted ones shifted every column after the join.

A second bug sat behind it — PapaParse defaults to CRLF while `stripCsvHeader` searched for `"\n"`, so even a correctly-terminated chunk left a stray carriage return at the head of the next.

JSON/JSONL export was never affected; it already appends `"\n"` explicitly.

## The fix

`CSV_NEWLINE` is stated once and used in the three places that had to agree and didn't: the `unparse` call, the chunk terminator, and the header strip. Relying on a library default in one place while hard-coding a different literal in another is what made this reachable at all.

## Tests

Four regression tests, in both summary and full mode. They **execute the concatenation** rather than asserting the output string looks different — per the repo rule that a runtime bug needs a test that observes the runtime behaviour.

Confirmed they catch it. Reverting the serializer change:

```
× keeps every row intact across a batch boundary
× writes exactly one header for the whole file
× keeps span rows intact across a batch boundary in full mode
× terminates a chunk so nothing can fuse onto the next one
  Tests  4 failed | 18 passed
```

Restoring it: `Tests 22 passed`. Whole export suite: **66 passed**.

## Scope

Three files, all under `server/export/`. `export.service.ts` is the only consumer of these serializers.

Found while building the scenario run CSV export (#6273), which hit the identical bug in its own serializer and fixes it there. Kept separate so that PR stayed scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV exports so concatenating multiple batches no longer merges header/rows across batch boundaries.
  * Ensured only a single header row appears in summary exports.
  * Standardized line endings and added a trailing newline for both summary and full CSV exports.
* **Tests**
  * Added coverage for batch concatenation in both summary and full export modes, including verification of header counts and proper termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->