### PR TITLE
fix(langy): surface and self-heal GitHub App install failures

### DIFF
--- a/langwatch/src/pages/settings/__tests__/integrations-github-error.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/integrations-github-error.integration.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers the "Setup callback rejects a tampered or expired state" scenario
+ * from specs/langy/langy-github-install.feature: "I am shown that the
+ * installation could not be verified".
+ *
+ * The `/setup` callback (src/server/routes/github-langy.ts) reports every
+ * failure by redirecting back with a `?githubError=<message>` query param,
+ * but nothing on this page used to read it — a failed install (or a
+ * cross-tenant conflict, or an expired signed state) silently re-rendered the
+ * plain "Install" button, indistinguishable from nothing having happened.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockRouterQuery = vi.hoisted(() => ({
+  current: {} as Record<string, string>,
+}));
+const routerReplace = vi.fn();
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: mockRouterQuery.current,
+    pathname: "/settings/integrations",
+    push: vi.fn(),
+    replace: routerReplace,
+    isReady: true,
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    langyGithub: {
+      getInstallStatus: {
+        useQuery: () => ({
+          data: { configured: true, installations: [] },
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1", name: "Acme Corp" },
+  }),
+}));
+
+vi.mock("~/components/SettingsLayout", () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard: () => (C: any) => C,
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import { toaster } from "~/components/ui/toaster";
+import IntegrationsSettings from "../integrations";
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <IntegrationsSettings />
+    </ChakraProvider>,
+  );
+}
+
+describe("<IntegrationsSettings/>", () => {
+  afterEach(() => {
+    mockRouterQuery.current = {};
+    routerReplace.mockClear();
+    vi.mocked(toaster.create).mockClear();
+    cleanup();
+  });
+
+  describe("when GitHub redirects back with a githubError", () => {
+    it("surfaces the failure as a toast", () => {
+      mockRouterQuery.current = {
+        githubError: "Installation link already used",
+      };
+
+      renderPage();
+
+      expect(toaster.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          description: "Installation link already used",
+        }),
+      );
+    });
+
+    it("strips githubError from the URL so a refresh doesn't re-show it", () => {
+      mockRouterQuery.current = {
+        githubError: "Installation link already used",
+      };
+
+      renderPage();
+
+      expect(routerReplace).toHaveBeenCalledWith(
+        {
+          pathname: "/settings/integrations",
+          query: {},
+        },
+        undefined,
+        { shallow: true },
+      );
+    });
+  });
+
+  describe("when there is no githubError", () => {
+    it("does not show a toast", () => {
+      renderPage();
+
+      expect(toaster.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/pages/settings/__tests__/integrations-github-error.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/integrations-github-error.integration.test.tsx
@@ -19,7 +19,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mockRouterQuery = vi.hoisted(() => ({
   current: {} as Record<string, string>,
 }));
-const routerReplace = vi.fn();
+// Applies the replacement query like the real router.replace would, so a
+// rerender after cleanup reflects the post-cleanup URL.
+const routerReplace = vi.fn(
+  (url: { pathname?: string; query?: Record<string, string> }) => {
+    mockRouterQuery.current = { ...(url.query ?? {}) };
+    return Promise.resolve(true);
+  },
+);
 
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
@@ -96,7 +103,7 @@ describe("<IntegrationsSettings/>", () => {
       );
     });
 
-    it("strips githubError from the URL so a refresh doesn't re-show it", () => {
+    it("strips githubError from the URL without scrolling away from the GitHub card", () => {
       mockRouterQuery.current = {
         githubError: "Installation link already used",
       };
@@ -109,8 +116,28 @@ describe("<IntegrationsSettings/>", () => {
           query: {},
         },
         undefined,
-        { shallow: true },
+        { shallow: true, scroll: false },
       );
+    });
+
+    it("does not repeat the toast once the URL cleanup has landed", () => {
+      mockRouterQuery.current = {
+        githubError: "Installation link already used",
+      };
+
+      const { rerender } = renderPage();
+      expect(toaster.create).toHaveBeenCalledTimes(1);
+
+      // The mocked replace() above already applied the cleaned query to
+      // mockRouterQuery.current; rerender to pick it up, as a real
+      // navigation would re-render this page with the new URL.
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <IntegrationsSettings />
+        </ChakraProvider>,
+      );
+
+      expect(toaster.create).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/langwatch/src/pages/settings/integrations.tsx
+++ b/langwatch/src/pages/settings/integrations.tsx
@@ -20,10 +20,12 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { GitHub } from "react-feather";
+import { useRouter } from "~/utils/compat/next-router";
 
 import SettingsLayout from "../../components/SettingsLayout";
+import { toaster } from "../../components/ui/toaster";
 import { withPermissionGuard } from "../../components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
@@ -40,6 +42,27 @@ export default withPermissionGuard("organization:manage", {
 
 function IntegrationsContent({ organizationId }: { organizationId: string }) {
   const status = api.langyGithub.getInstallStatus.useQuery({ organizationId });
+  const router = useRouter();
+
+  useEffect(() => {
+    const githubError = router.query.githubError;
+    if (typeof githubError !== "string") return;
+
+    toaster.create({
+      type: "error",
+      title: "GitHub installation failed",
+      description: githubError,
+    });
+
+    const { githubError: _drop, ...rest } = router.query;
+    void router.replace(
+      { pathname: router.pathname, query: rest },
+      undefined,
+      { shallow: true },
+    );
+    // router is a fresh compat object each render; only re-run when the error itself changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query.githubError]);
 
   const onInstall = () => {
     const ret = encodeURIComponent("/settings/integrations#github");

--- a/langwatch/src/pages/settings/integrations.tsx
+++ b/langwatch/src/pages/settings/integrations.tsx
@@ -58,7 +58,7 @@ function IntegrationsContent({ organizationId }: { organizationId: string }) {
     void router.replace(
       { pathname: router.pathname, query: rest },
       undefined,
-      { shallow: true },
+      { shallow: true, scroll: false },
     );
     // router is a fresh compat object each render; only re-run when the error itself changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/langwatch/src/pages/settings/integrations.tsx
+++ b/langwatch/src/pages/settings/integrations.tsx
@@ -55,11 +55,10 @@ function IntegrationsContent({ organizationId }: { organizationId: string }) {
     });
 
     const { githubError: _drop, ...rest } = router.query;
-    void router.replace(
-      { pathname: router.pathname, query: rest },
-      undefined,
-      { shallow: true, scroll: false },
-    );
+    void router.replace({ pathname: router.pathname, query: rest }, undefined, {
+      shallow: true,
+      scroll: false,
+    });
     // Intentionally keyed only on the error value, not the whole router object.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query.githubError]);

--- a/langwatch/src/pages/settings/integrations.tsx
+++ b/langwatch/src/pages/settings/integrations.tsx
@@ -60,7 +60,7 @@ function IntegrationsContent({ organizationId }: { organizationId: string }) {
       undefined,
       { shallow: true, scroll: false },
     );
-    // router is a fresh compat object each render; only re-run when the error itself changes.
+    // Intentionally keyed only on the error value, not the whole router object.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query.githubError]);
 

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -12,7 +12,10 @@ import {
   LangyGithubInstallationConflictError,
   LangyGithubInstallationsService,
 } from "../langy-github-installations.service";
-import { computeRepoScopeKey } from "../langyGithubAppToken";
+import {
+  computeRepoScopeKey,
+  GithubInstallationNotFoundError,
+} from "../langyGithubAppToken";
 import type {
   LangyGithubInstallationRow,
   LangyGithubInstallationsRepository,
@@ -355,6 +358,103 @@ describe("mintTurnToken", () => {
       const repo = makeRepo([row({ suspendedAt: new Date() })]);
       const svc = new LangyGithubInstallationsService(repo, makeAppTokens());
       expect(await svc.mintTurnToken({ organizationId: "org-1" })).toBeNull();
+    });
+  });
+
+  describe("when the oldest installation is a zombie (GitHub 404s it) but a newer one is live", () => {
+    it("self-heals: removes the dead row and mints via the live installation", async () => {
+      const repo = makeRepo([
+        row({ installationId: "inst-dead", createdAt: new Date("2020-01-01") }),
+        row({ installationId: "inst-live", createdAt: new Date("2020-01-02") }),
+      ]);
+      const mint = vi.fn(async ({ installationId }: { installationId: string }) => {
+        if (installationId === "inst-dead") {
+          throw new GithubInstallationNotFoundError(installationId);
+        }
+        return { token: "ghs_live", expiresAt: "" };
+      });
+      const svc = new LangyGithubInstallationsService(
+        repo,
+        makeAppTokens({ mintInstallationToken: mint }),
+      );
+
+      const result = await svc.mintTurnToken({ organizationId: "org-1" });
+
+      expect(result?.token).toBe("ghs_live");
+      expect(repo.deleteByInstallationId).toHaveBeenCalledWith("inst-dead");
+    });
+  });
+
+  describe("when every installation for the org is a zombie", () => {
+    it("removes the dead rows and returns null (no crash, no infinite loop)", async () => {
+      const repo = makeRepo([row({ installationId: "inst-dead" })]);
+      const mint = vi.fn(async () => {
+        throw new GithubInstallationNotFoundError("inst-dead");
+      });
+      const svc = new LangyGithubInstallationsService(
+        repo,
+        makeAppTokens({ mintInstallationToken: mint }),
+      );
+
+      const result = await svc.mintTurnToken({ organizationId: "org-1" });
+
+      expect(result).toBeNull();
+      expect(repo.deleteByInstallationId).toHaveBeenCalledWith("inst-dead");
+    });
+  });
+
+  describe("when the mint fails for a reason other than a confirmed 404", () => {
+    it("does not delete the installation row (a transient error must not wipe a live install)", async () => {
+      const repo = makeRepo([row({ installationId: "inst-1" })]);
+      const mint = vi.fn(async () => {
+        throw new Error("GitHub token mint failed: 500");
+      });
+      const svc = new LangyGithubInstallationsService(
+        repo,
+        makeAppTokens({ mintInstallationToken: mint }),
+      );
+
+      const result = await svc.mintTurnToken({ organizationId: "org-1" });
+
+      expect(result).toBeNull();
+      expect(repo.deleteByInstallationId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an explicit repo is only cached under a zombie installation but a live installation also has it", () => {
+    it("removes the dead row and mints via the live installation", async () => {
+      const repo = makeRepo([
+        row({
+          installationId: "inst-dead",
+          createdAt: new Date("2020-01-01"),
+          repositorySelection: "selected",
+          repositories: [{ id: "77", fullName: "acme/service-x" }],
+        }),
+        row({
+          installationId: "inst-live",
+          createdAt: new Date("2020-01-02"),
+          repositorySelection: "selected",
+          repositories: [{ id: "77", fullName: "acme/service-x" }],
+        }),
+      ]);
+      const mint = vi.fn(async ({ installationId }: { installationId: string }) => {
+        if (installationId === "inst-dead") {
+          throw new GithubInstallationNotFoundError(installationId);
+        }
+        return { token: "ghs_live", expiresAt: "" };
+      });
+      const svc = new LangyGithubInstallationsService(
+        repo,
+        makeAppTokens({ mintInstallationToken: mint }),
+      );
+
+      const result = await svc.mintTurnToken({
+        organizationId: "org-1",
+        repositoryFullName: "acme/service-x",
+      });
+
+      expect(result?.token).toBe("ghs_live");
+      expect(repo.deleteByInstallationId).toHaveBeenCalledWith("inst-dead");
     });
   });
 });

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -457,4 +457,50 @@ describe("mintTurnToken", () => {
       expect(repo.deleteByInstallationId).toHaveBeenCalledWith("inst-dead");
     });
   });
+
+  describe("when an explicit repo requires a live listing (an \"all\"-selection installation, nothing cached) and that installation is dead", () => {
+    it("removes the dead row and mints via the live installation", async () => {
+      const repo = makeRepo([
+        row({
+          installationId: "inst-dead",
+          createdAt: new Date("2020-01-01"),
+          repositorySelection: "all",
+          repositories: null,
+        }),
+        row({
+          installationId: "inst-live",
+          createdAt: new Date("2020-01-02"),
+          repositorySelection: "selected",
+          repositories: [{ id: "77", fullName: "acme/service-x" }],
+        }),
+      ]);
+      // resolveRepositoryId has no cache to consult for inst-dead ("all"
+      // selection), so it falls through to listInstallationRepositories —
+      // which itself mints a token first, surfacing the same 404.
+      const listInstallationRepositories = vi.fn(
+        async (installationId: string) => {
+          if (installationId === "inst-dead") {
+            throw new GithubInstallationNotFoundError(installationId);
+          }
+          return [{ id: "77", fullName: "acme/service-x" }];
+        },
+      );
+      const mint = vi.fn(async () => ({ token: "ghs_live", expiresAt: "" }));
+      const svc = new LangyGithubInstallationsService(
+        repo,
+        makeAppTokens({
+          listInstallationRepositories,
+          mintInstallationToken: mint,
+        }),
+      );
+
+      const result = await svc.mintTurnToken({
+        organizationId: "org-1",
+        repositoryFullName: "acme/service-x",
+      });
+
+      expect(result?.token).toBe("ghs_live");
+      expect(repo.deleteByInstallationId).toHaveBeenCalledWith("inst-dead");
+    });
+  });
 });

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -367,12 +367,14 @@ describe("mintTurnToken", () => {
         row({ installationId: "inst-dead", createdAt: new Date("2020-01-01") }),
         row({ installationId: "inst-live", createdAt: new Date("2020-01-02") }),
       ]);
-      const mint = vi.fn(async ({ installationId }: { installationId: string }) => {
-        if (installationId === "inst-dead") {
-          throw new GithubInstallationNotFoundError(installationId);
-        }
-        return { token: "ghs_live", expiresAt: "" };
-      });
+      const mint = vi.fn(
+        async ({ installationId }: { installationId: string }) => {
+          if (installationId === "inst-dead") {
+            throw new GithubInstallationNotFoundError(installationId);
+          }
+          return { token: "ghs_live", expiresAt: "" };
+        },
+      );
       const svc = new LangyGithubInstallationsService(
         repo,
         makeAppTokens({ mintInstallationToken: mint }),
@@ -437,12 +439,14 @@ describe("mintTurnToken", () => {
           repositories: [{ id: "77", fullName: "acme/service-x" }],
         }),
       ]);
-      const mint = vi.fn(async ({ installationId }: { installationId: string }) => {
-        if (installationId === "inst-dead") {
-          throw new GithubInstallationNotFoundError(installationId);
-        }
-        return { token: "ghs_live", expiresAt: "" };
-      });
+      const mint = vi.fn(
+        async ({ installationId }: { installationId: string }) => {
+          if (installationId === "inst-dead") {
+            throw new GithubInstallationNotFoundError(installationId);
+          }
+          return { token: "ghs_live", expiresAt: "" };
+        },
+      );
       const svc = new LangyGithubInstallationsService(
         repo,
         makeAppTokens({ mintInstallationToken: mint }),
@@ -458,7 +462,7 @@ describe("mintTurnToken", () => {
     });
   });
 
-  describe("when an explicit repo requires a live listing (an \"all\"-selection installation, nothing cached) and that installation is dead", () => {
+  describe('when an explicit repo requires a live listing (an "all"-selection installation, nothing cached) and that installation is dead', () => {
     it("removes the dead row and mints via the live installation", async () => {
       const repo = makeRepo([
         row({

--- a/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   computeRepoScopeKey,
+  GithubInstallationNotFoundError,
   LANGY_INSTALLATION_PERMISSIONS,
   LangyGithubAppTokenService,
   type RedisLike,
@@ -194,6 +195,23 @@ describe("mintInstallationToken", () => {
       await expect(
         svc.mintInstallationToken({ installationId: "5" }),
       ).rejects.toThrow();
+      expect(redis.store.size).toBe(0);
+    });
+  });
+
+  describe("when GitHub confirms the installation no longer exists (404)", () => {
+    it("throws GithubInstallationNotFoundError, distinct from other failures", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(
+          async () => new Response("not found", { status: 404 }),
+        ),
+      );
+      await expect(
+        svc.mintInstallationToken({ installationId: "dead-inst" }),
+      ).rejects.toBeInstanceOf(GithubInstallationNotFoundError);
       expect(redis.store.size).toBe(0);
     });
   });

--- a/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
@@ -282,6 +282,81 @@ describe("mintInstallationToken", () => {
       expect(livenessCalls).toHaveLength(1);
     });
   });
+
+  describe("when the same installation is checked across multiple sequential turns", () => {
+    it("probes GitHub once, then trusts the liveness marker for later cached calls", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      redis.store.set(`langy:gh:insttoken:5:${scope}`, "ghs_cached");
+      const fetchMock = vi.fn<typeof fetch>(async () => {
+        return new Response(
+          JSON.stringify({ id: 5, account: { login: "acme", type: "User" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      // Three separate turns, one after another — no overlap, so the
+      // stampede lock alone would not prevent a probe on every single one.
+      await svc.mintInstallationToken({ installationId: "5" });
+      await svc.mintInstallationToken({ installationId: "5" });
+      await svc.mintInstallationToken({ installationId: "5" });
+
+      const livenessCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/app/installations/5"),
+      );
+      expect(livenessCalls).toHaveLength(1);
+    });
+  });
+
+  describe("when the liveness marker has expired", () => {
+    it("probes GitHub again on the next cached call", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      redis.store.set(`langy:gh:insttoken:5:${scope}`, "ghs_cached");
+      const fetchMock = vi.fn<typeof fetch>(async () => {
+        return new Response(
+          JSON.stringify({ id: 5, account: { login: "acme", type: "User" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await svc.mintInstallationToken({ installationId: "5" });
+      redis.store.delete("langy:gh:insttoken:5:liveness"); // simulate TTL expiry
+      await svc.mintInstallationToken({ installationId: "5" });
+
+      const livenessCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/app/installations/5"),
+      );
+      expect(livenessCalls).toHaveLength(2);
+    });
+  });
+
+  describe("when a liveness probe fails transiently", () => {
+    it("backs off instead of probing again on the very next cached call", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      redis.store.set(`langy:gh:insttoken:5:${scope}`, "ghs_cached");
+      const fetchMock = vi.fn<typeof fetch>(
+        async () => new Response("boom", { status: 500 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const first = await svc.mintInstallationToken({ installationId: "5" });
+      const second = await svc.mintInstallationToken({ installationId: "5" });
+
+      expect(first.token).toBe("ghs_cached");
+      expect(second.token).toBe("ghs_cached");
+      const livenessCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/app/installations/5"),
+      );
+      expect(livenessCalls).toHaveLength(1);
+    });
+  });
 });
 
 describe("configured", () => {

--- a/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
@@ -215,6 +215,45 @@ describe("mintInstallationToken", () => {
       expect(redis.store.size).toBe(0);
     });
   });
+
+  describe("when a token is cached but the installation was uninstalled since it was minted", () => {
+    it("rejects with GithubInstallationNotFoundError instead of serving the stale cached token", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      // Simulate an already-warm cache entry from an earlier, successful mint —
+      // the exact state a missed deletion webhook leaves behind for up to the
+      // token's ~50min TTL.
+      redis.store.set(`langy:gh:insttoken:dead-inst:${scope}`, "ghs_stale");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(
+          async () => new Response("not found", { status: 404 }),
+        ),
+      );
+
+      await expect(
+        svc.mintInstallationToken({ installationId: "dead-inst" }),
+      ).rejects.toBeInstanceOf(GithubInstallationNotFoundError);
+    });
+  });
+
+  describe("when a token is cached and the liveness probe itself fails transiently", () => {
+    it("still serves the cached token (fails open, not closed)", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      redis.store.set(`langy:gh:insttoken:5:${scope}`, "ghs_cached");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async () => new Response("boom", { status: 500 })),
+      );
+
+      const result = await svc.mintInstallationToken({ installationId: "5" });
+
+      expect(result.token).toBe("ghs_cached");
+    });
+  });
 });
 
 describe("configured", () => {

--- a/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
@@ -254,6 +254,34 @@ describe("mintInstallationToken", () => {
       expect(result.token).toBe("ghs_cached");
     });
   });
+
+  describe("when many concurrent calls hit a cached token for the same installation", () => {
+    it("probes GitHub liveness only once, not once per caller", async () => {
+      const redis = fakeRedis();
+      const svc = new LangyGithubAppTokenService("app-1", privateKey, redis);
+      const scope = computeRepoScopeKey({});
+      redis.store.set(`langy:gh:insttoken:5:${scope}`, "ghs_cached");
+      const fetchMock = vi.fn<typeof fetch>(async () => {
+        return new Response(
+          JSON.stringify({ id: 5, account: { login: "acme", type: "User" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          svc.mintInstallationToken({ installationId: "5" }),
+        ),
+      );
+
+      expect(results.every((r) => r.token === "ghs_cached")).toBe(true);
+      const livenessCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/app/installations/5"),
+      );
+      expect(livenessCalls).toHaveLength(1);
+    });
+  });
 });
 
 describe("configured", () => {

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -280,8 +280,9 @@ export class LangyGithubInstallationsService {
    * installation can predate the webhook being configured at all), leaving a
    * `LangyGithubInstallation` row for an installation GitHub has already
    * forgotten. Rather than let that dead row block every real installation
-   * behind it forever, a confirmed 404 from GitHub on mint removes the row and
-   * moves on to the next candidate.
+   * behind it forever, a confirmed 404 from GitHub — whether it surfaces
+   * while minting or while resolving an explicit repo id — removes the row
+   * and moves on to the next candidate.
    *
    * TODO(JIT narrowing): the plan's delivery option 2 replaces spawn-env
    * with a clone-time credential-helper callback that mints per-clone; the
@@ -301,12 +302,20 @@ export class LangyGithubInstallationsService {
     if (usable.length === 0) return null;
 
     // Explicit repo: pick the installation that can reach it and scope to it.
-    // A candidate that turns out to be a dead installation (self-healed away
-    // by mintScoped) is skipped in favor of the next one that can reach the
-    // same repo, rather than failing the turn outright.
+    // A candidate that turns out to be a dead installation — whether that
+    // surfaces while resolving the repo id (an uncached "all" selection has to
+    // list live) or while minting — is self-healed away in favor of the next
+    // one that can reach the same repo, rather than failing the turn outright.
     if (repositoryFullName) {
       for (const inst of usable) {
-        const repoId = await this.resolveRepositoryId(inst, repositoryFullName);
+        let repoId: string | null;
+        try {
+          repoId = await this.resolveRepositoryId(inst, repositoryFullName);
+        } catch (error) {
+          if (!(error instanceof GithubInstallationNotFoundError)) throw error;
+          await this.markInstallationDead(inst.installationId);
+          continue;
+        }
         if (!repoId) continue;
         const outcome = await this.mintScoped({
           installationId: inst.installationId,
@@ -354,11 +363,7 @@ export class LangyGithubInstallationsService {
       };
     } catch (error) {
       if (error instanceof GithubInstallationNotFoundError) {
-        logger.warn(
-          { installationId },
-          "github installation no longer exists, removing stale record",
-        );
-        await this.repo.deleteByInstallationId(installationId);
+        await this.markInstallationDead(installationId);
         return { token: null, wasDeadInstallation: true };
       }
       logger.warn(
@@ -369,8 +374,22 @@ export class LangyGithubInstallationsService {
     }
   }
 
+  // Removes a `LangyGithubInstallation` row GitHub has confirmed (404) it no
+  // longer knows about. Shared by every call site that can hit that error —
+  // minting and, via listInstallationRepositories, resolving a repo id too.
+  private async markInstallationDead(installationId: string): Promise<void> {
+    logger.warn(
+      { installationId },
+      "github installation no longer exists, removing stale record",
+    );
+    await this.repo.deleteByInstallationId(installationId);
+  }
+
   // Resolve a repo full-name to its numeric id for a given installation, from
-  // the cached selection when present, else a live listing.
+  // the cached selection when present, else a live listing. A confirmed-dead
+  // installation (GithubInstallationNotFoundError) is rethrown so the caller
+  // can self-heal it — every other failure degrades to "can't resolve", same
+  // as before.
   private async resolveRepositoryId(
     inst: LangyGithubInstallationRow,
     repositoryFullName: string,
@@ -388,6 +407,7 @@ export class LangyGithubInstallationsService {
       const match = repos.find((r) => r.fullName.toLowerCase() === wanted);
       return match?.id ?? null;
     } catch (error) {
+      if (error instanceof GithubInstallationNotFoundError) throw error;
       logger.warn(
         { error, installationId: inst.installationId, repositoryFullName },
         "failed to resolve repository id for installation",

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -301,38 +301,64 @@ export class LangyGithubInstallationsService {
     const usable = installations.filter((i) => !i.suspendedAt);
     if (usable.length === 0) return null;
 
-    // Explicit repo: pick the installation that can reach it and scope to it.
-    // A candidate that turns out to be a dead installation — whether that
-    // surfaces while resolving the repo id (an uncached "all" selection has to
-    // list live) or while minting — is self-healed away in favor of the next
-    // one that can reach the same repo, rather than failing the turn outright.
-    if (repositoryFullName) {
-      for (const inst of usable) {
-        let repoId: string | null;
-        try {
-          repoId = await this.resolveRepositoryId(inst, repositoryFullName);
-        } catch (error) {
-          if (!(error instanceof GithubInstallationNotFoundError)) throw error;
-          await this.markInstallationDead(inst.installationId);
-          continue;
-        }
-        if (!repoId) continue;
-        const outcome = await this.mintScoped({
-          installationId: inst.installationId,
-          repositoryIds: [repoId],
-        });
-        if (outcome.token) return outcome.token;
-        if (!outcome.wasDeadInstallation) return null;
-      }
-      // The App is not installed on that repo — bounded by the installation.
-      return null;
-    }
+    return repositoryFullName
+      ? this.mintForExplicitRepo(usable, repositoryFullName)
+      : this.mintForAnyInstallation(usable);
+  }
 
-    // No explicit repo: mint against the org's installation(s) scoped to the
-    // full repo set, oldest first. An installation GitHub confirms is gone
-    // (404) is removed and the next candidate is tried instead of failing the
-    // whole turn; any other mint failure stops here, same as before — a
-    // transient error must not make us skip past a live installation.
+  // Pick the installation that can reach `repositoryFullName` and scope the
+  // token to only that repo. A candidate that turns out to be a dead
+  // installation — whether that surfaces while resolving the repo id (an
+  // uncached "all" selection has to list live) or while minting — is
+  // self-healed away in favor of the next one that can reach the same repo,
+  // rather than failing the turn outright.
+  private async mintForExplicitRepo(
+    usable: LangyGithubInstallationRow[],
+    repositoryFullName: string,
+  ): Promise<LangyGithubTurnToken | null> {
+    for (const inst of usable) {
+      const resolved = await this.resolveRepositoryIdOrHeal(
+        inst,
+        repositoryFullName,
+      );
+      if (!resolved.repoId) continue;
+      const outcome = await this.mintScoped({
+        installationId: inst.installationId,
+        repositoryIds: [resolved.repoId],
+      });
+      if (outcome.token) return outcome.token;
+      if (!outcome.wasDeadInstallation) return null;
+    }
+    // The App is not installed on that repo — bounded by the installation.
+    return null;
+  }
+
+  // resolveRepositoryId, with the self-heal-and-continue decision factored out
+  // of the caller's control flow: a confirmed-dead installation is healed here
+  // and reported back as "nothing to resolve" rather than thrown, so
+  // mintForExplicitRepo stays a flat loop.
+  private async resolveRepositoryIdOrHeal(
+    inst: LangyGithubInstallationRow,
+    repositoryFullName: string,
+  ): Promise<{ repoId: string | null; wasDeadInstallation: boolean }> {
+    try {
+      const repoId = await this.resolveRepositoryId(inst, repositoryFullName);
+      return { repoId, wasDeadInstallation: false };
+    } catch (error) {
+      if (!(error instanceof GithubInstallationNotFoundError)) throw error;
+      await this.markInstallationDead(inst.installationId);
+      return { repoId: null, wasDeadInstallation: true };
+    }
+  }
+
+  // Mint against the org's installation(s) scoped to the full repo set,
+  // oldest first. An installation GitHub confirms is gone (404) is removed
+  // and the next candidate is tried instead of failing the whole turn; any
+  // other mint failure stops here — a transient error must not make us skip
+  // past a live installation.
+  private async mintForAnyInstallation(
+    usable: LangyGithubInstallationRow[],
+  ): Promise<LangyGithubTurnToken | null> {
     for (const inst of usable) {
       const outcome = await this.mintScoped({
         installationId: inst.installationId,

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -12,6 +12,7 @@ import { createLogger } from "@langwatch/observability";
 
 import {
   computeRepoScopeKey,
+  GithubInstallationNotFoundError,
   type GithubRepository,
   type LangyGithubAppTokenService,
 } from "./langyGithubAppToken";
@@ -275,6 +276,13 @@ export class LangyGithubInstallationsService {
    * Returns null when GitHub is unconfigured, the org has no (usable)
    * installation, or the mint fails — the caller degrades to the connect card.
    *
+   * Self-heals stale installations: a webhook delivery can be missed (or an
+   * installation can predate the webhook being configured at all), leaving a
+   * `LangyGithubInstallation` row for an installation GitHub has already
+   * forgotten. Rather than let that dead row block every real installation
+   * behind it forever, a confirmed 404 from GitHub on mint removes the row and
+   * moves on to the next candidate.
+   *
    * TODO(JIT narrowing): the plan's delivery option 2 replaces spawn-env
    * with a clone-time credential-helper callback that mints per-clone; the
    * seam is `repoScopeKey`, already threaded into the worker signature.
@@ -293,25 +301,35 @@ export class LangyGithubInstallationsService {
     if (usable.length === 0) return null;
 
     // Explicit repo: pick the installation that can reach it and scope to it.
+    // A candidate that turns out to be a dead installation (self-healed away
+    // by mintScoped) is skipped in favor of the next one that can reach the
+    // same repo, rather than failing the turn outright.
     if (repositoryFullName) {
       for (const inst of usable) {
         const repoId = await this.resolveRepositoryId(inst, repositoryFullName);
-        if (repoId) {
-          return this.mintScoped({
-            installationId: inst.installationId,
-            repositoryIds: [repoId],
-          });
-        }
+        if (!repoId) continue;
+        const outcome = await this.mintScoped({
+          installationId: inst.installationId,
+          repositoryIds: [repoId],
+        });
+        if (outcome.token) return outcome.token;
+        if (!outcome.wasDeadInstallation) return null;
       }
       // The App is not installed on that repo — bounded by the installation.
       return null;
     }
 
-    // No explicit repo: mint against the org's installation scoped to its full
-    // repo set. When an org has multiple installations we take the first usable
-    // one (a repo chip disambiguates in the explicit path above).
-    const inst = usable[0]!;
-    return this.mintScoped({ installationId: inst.installationId });
+    // No explicit repo: mint against the org's installation(s) scoped to the
+    // full repo set, oldest first. An installation GitHub confirms is gone
+    // (404) is removed and the next candidate is tried instead of failing the
+    // whole turn; any other mint failure stops here, same as before — a
+    // transient error must not make us skip past a live installation.
+    for (const inst of usable) {
+      const outcome = await this.mintScoped({ installationId: inst.installationId });
+      if (outcome.token) return outcome.token;
+      if (!outcome.wasDeadInstallation) return null;
+    }
+    return null;
   }
 
   private async mintScoped({
@@ -320,23 +338,34 @@ export class LangyGithubInstallationsService {
   }: {
     installationId: string;
     repositoryIds?: string[];
-  }): Promise<LangyGithubTurnToken | null> {
+  }): Promise<{ token: LangyGithubTurnToken | null; wasDeadInstallation: boolean }> {
     try {
       const minted = await this.appTokens.mintInstallationToken({
         installationId,
         ...(repositoryIds ? { repositoryIds } : {}),
       });
       return {
-        token: minted.token,
-        repoScopeKey: computeRepoScopeKey({ repositoryIds }),
-        installationId,
+        token: {
+          token: minted.token,
+          repoScopeKey: computeRepoScopeKey({ repositoryIds }),
+          installationId,
+        },
+        wasDeadInstallation: false,
       };
     } catch (error) {
+      if (error instanceof GithubInstallationNotFoundError) {
+        logger.warn(
+          { installationId },
+          "github installation no longer exists, removing stale record",
+        );
+        await this.repo.deleteByInstallationId(installationId);
+        return { token: null, wasDeadInstallation: true };
+      }
       logger.warn(
         { error, installationId },
         "failed to mint installation token for turn",
       );
-      return null;
+      return { token: null, wasDeadInstallation: false };
     }
   }
 

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -334,7 +334,9 @@ export class LangyGithubInstallationsService {
     // whole turn; any other mint failure stops here, same as before — a
     // transient error must not make us skip past a live installation.
     for (const inst of usable) {
-      const outcome = await this.mintScoped({ installationId: inst.installationId });
+      const outcome = await this.mintScoped({
+        installationId: inst.installationId,
+      });
       if (outcome.token) return outcome.token;
       if (!outcome.wasDeadInstallation) return null;
     }
@@ -347,7 +349,10 @@ export class LangyGithubInstallationsService {
   }: {
     installationId: string;
     repositoryIds?: string[];
-  }): Promise<{ token: LangyGithubTurnToken | null; wasDeadInstallation: boolean }> {
+  }): Promise<{
+    token: LangyGithubTurnToken | null;
+    wasDeadInstallation: boolean;
+  }> {
     try {
       const minted = await this.appTokens.mintInstallationToken({
         installationId,

--- a/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
+++ b/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
@@ -202,13 +202,27 @@ export class LangyGithubAppTokenService {
   // any other failure (network blip, GitHub 5xx) fails OPEN, same as every
   // other best-effort check in this file: a flaky liveness probe must not
   // block a cached token that is, as far as we know, still perfectly valid.
+  //
+  // Lock-guarded the same way the mint path guards its own stampede: a cache
+  // hit is the COMMON case (that's the point of caching), so without this,
+  // every concurrent turn for the same installation would fire its own
+  // GitHub liveness probe. A caller that loses the (non-blocking, try-once)
+  // lock race trusts the cache for this call — the prober holding the lock
+  // still throws (and the caller still self-heals the shared installation
+  // list) if the installation is genuinely gone, which is enough for every
+  // later call to see it removed.
   private async assertInstallationStillExists(
     installationId: string,
   ): Promise<void> {
+    const lockKey = `langy:gh:insttoken:${installationId}:liveness:lock`;
+    const lock = await this.tryLockOnce(lockKey);
+    if (!lock) return;
     try {
       await this.getInstallation(installationId);
     } catch (error) {
       if (error instanceof GithubInstallationNotFoundError) throw error;
+    } finally {
+      await this.releaseLock(lockKey, lock);
     }
   }
 
@@ -381,6 +395,22 @@ export class LangyGithubAppTokenService {
       await this.redis.set(key, value, "EX", ttlSec);
     } catch {
       /* best-effort cache */
+    }
+  }
+
+  // A single, non-blocking lock attempt — unlike acquireLock, never retries.
+  // acquireLock's retry-for-up-to-3s exists because the mint path MUST
+  // eventually mint (there's no valid "just skip it" outcome); the liveness
+  // probe has one, so a caller that loses the race should trust the cache
+  // immediately rather than spin waiting for a lock it doesn't need.
+  private async tryLockOnce(key: string): Promise<string | null> {
+    if (!this.redis) return null;
+    const token = randomBytes(16).toString("hex");
+    try {
+      const ok = await this.redis.set(key, token, "NX", "EX", LOCK_TTL_SEC);
+      return ok === "OK" ? token : null;
+    } catch {
+      return null;
     }
   }
 

--- a/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
+++ b/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
@@ -34,6 +34,17 @@ const LOCK_TTL_SEC = 15;
 const LOCK_RETRY_MS = 100;
 const LOCK_MAX_WAIT_MS = 3_000;
 
+// How long a confirmed-alive result is trusted before the next cache hit
+// probes GitHub again. Deliberately much shorter than the token cache TTL —
+// this bounds how stale a missed-webhook deletion can go undetected, without
+// turning every cache hit (i.e. every normal turn) into a live GitHub call.
+const LIVENESS_RECHECK_TTL_SEC = 5 * 60;
+// A transient probe failure (network blip, 5xx, rate limit) backs off for a
+// shorter window before trying again — long enough that a GitHub outage
+// doesn't cost every subsequent turn its own probe (and the 10s githubFetch
+// timeout on top), short enough to notice GitHub recovering reasonably fast.
+const LIVENESS_FAILURE_BACKOFF_SEC = 60;
+
 /**
  * The least-privilege permission set Langy asks for at mint time. Cannot exceed
  * the installation's own grant (GitHub clamps it). Kept minimal so a leaked
@@ -198,29 +209,43 @@ export class LangyGithubAppTokenService {
   }
 
   // Confirms an installation still exists before trusting a cached token for
-  // it. Only a confirmed 404 (GithubInstallationNotFoundError) propagates —
-  // any other failure (network blip, GitHub 5xx) fails OPEN, same as every
-  // other best-effort check in this file: a flaky liveness probe must not
-  // block a cached token that is, as far as we know, still perfectly valid.
+  // it — but only actually probes GitHub once per LIVENESS_RECHECK_TTL_SEC.
+  // Without that marker, every cache hit (i.e. every normal turn) would cost
+  // a live GitHub call: the lock below only coalesces callers that overlap
+  // in time, and is released the moment the probe returns, so sequential
+  // turns each re-acquire it and each pay for their own GET. That would turn
+  // the 50-minute token cache into ~one GitHub App API request per turn, and
+  // during a GitHub outage or rate-limit response every turn would sit on
+  // `githubFetch`'s 10s timeout before falling back to the cached token —
+  // reintroducing exactly the GitHub-availability dependency the token cache
+  // exists to remove.
   //
-  // Lock-guarded the same way the mint path guards its own stampede: a cache
-  // hit is the COMMON case (that's the point of caching), so without this,
-  // every concurrent turn for the same installation would fire its own
-  // GitHub liveness probe. A caller that loses the (non-blocking, try-once)
-  // lock race trusts the cache for this call — the prober holding the lock
-  // still throws (and the caller still self-heals the shared installation
-  // list) if the installation is genuinely gone, which is enough for every
-  // later call to see it removed.
+  // Only a confirmed 404 (GithubInstallationNotFoundError) propagates and
+  // skips the marker entirely — the installation is about to be deleted, so
+  // there is nothing to mark alive. Any other failure (network blip, GitHub
+  // 5xx, rate limit) fails OPEN and sets a much shorter backoff marker, so an
+  // outage costs at most one stalled probe per LIVENESS_FAILURE_BACKOFF_SEC
+  // rather than one per turn.
   private async assertInstallationStillExists(
     installationId: string,
   ): Promise<void> {
-    const lockKey = `langy:gh:insttoken:${installationId}:liveness:lock`;
+    const markerKey = `langy:gh:insttoken:${installationId}:liveness`;
+    if (await this.redisGet(markerKey)) return;
+
+    // Lock-guarded the same way the mint path guards its own stampede: a
+    // caller that loses the (non-blocking, try-once) lock race trusts the
+    // cache for this call — the prober holding the lock still throws (and
+    // still self-heals the shared installation list) on a confirmed 404,
+    // which is enough for every later call to see it removed.
+    const lockKey = `${markerKey}:lock`;
     const lock = await this.tryLockOnce(lockKey);
     if (!lock) return;
     try {
       await this.getInstallation(installationId);
+      await this.redisSetEx(markerKey, LIVENESS_RECHECK_TTL_SEC, "alive");
     } catch (error) {
       if (error instanceof GithubInstallationNotFoundError) throw error;
+      await this.redisSetEx(markerKey, LIVENESS_FAILURE_BACKOFF_SEC, "backoff");
     } finally {
       await this.releaseLock(lockKey, lock);
     }

--- a/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
+++ b/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
@@ -65,6 +65,24 @@ export interface GithubRepository {
   fullName: string;
 }
 
+/**
+ * Thrown when GitHub confirms (HTTP 404, not a timeout/5xx/permission error)
+ * that an installation no longer exists — it was uninstalled on GitHub's side
+ * but our row was never cleaned up (a missed webhook delivery, or an
+ * installation that predates the webhook being configured). Callers use this
+ * to tell "this installation is gone, stop selecting it" apart from a
+ * transient failure that must NOT delete a possibly-still-live installation.
+ */
+export class GithubInstallationNotFoundError extends Error {
+  public readonly installationId: string;
+
+  constructor(installationId: string) {
+    super(`GitHub installation ${installationId} not found`);
+    this.name = "GithubInstallationNotFoundError";
+    this.installationId = installationId;
+  }
+}
+
 /** The narrow Redis surface this service uses (ioredis-compatible). */
 export interface RedisLike {
   get(key: string): Promise<string | null>;
@@ -277,6 +295,12 @@ export class LangyGithubAppTokenService {
         { status: res.status, installationId: args.installationId },
         "installation token mint failed",
       );
+      // A 404 here is GitHub confirming the installation is gone — distinct
+      // from every other failure (401/403/5xx/network), which may well be
+      // transient and must never be treated as "this installation is dead".
+      if (res.status === 404) {
+        throw new GithubInstallationNotFoundError(args.installationId);
+      }
       throw new Error(`GitHub token mint failed: ${res.status}`);
     }
     const body = (await res.json()) as {

--- a/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
+++ b/langwatch/src/server/app-layer/langy/langyGithubAppToken.ts
@@ -178,6 +178,9 @@ export class LangyGithubAppTokenService {
       { headers: { Authorization: `Bearer ${this.signAppJwt()}` } },
     );
     if (!res.ok) {
+      if (res.status === 404) {
+        throw new GithubInstallationNotFoundError(installationId);
+      }
       throw new Error(`GitHub GET /app/installations failed: ${res.status}`);
     }
     const body = (await res.json()) as {
@@ -192,6 +195,21 @@ export class LangyGithubAppTokenService {
       accountId: body.account?.id != null ? String(body.account.id) : "",
       repositorySelection: body.repository_selection ?? "all",
     };
+  }
+
+  // Confirms an installation still exists before trusting a cached token for
+  // it. Only a confirmed 404 (GithubInstallationNotFoundError) propagates —
+  // any other failure (network blip, GitHub 5xx) fails OPEN, same as every
+  // other best-effort check in this file: a flaky liveness probe must not
+  // block a cached token that is, as far as we know, still perfectly valid.
+  private async assertInstallationStillExists(
+    installationId: string,
+  ): Promise<void> {
+    try {
+      await this.getInstallation(installationId);
+    } catch (error) {
+      if (error instanceof GithubInstallationNotFoundError) throw error;
+    }
   }
 
   /**
@@ -209,7 +227,16 @@ export class LangyGithubAppTokenService {
     const cacheKey = `langy:gh:insttoken:${args.installationId}:${scopeKey}`;
 
     const cached = await this.redisGet(cacheKey);
-    if (cached) return { token: cached, expiresAt: "" };
+    if (cached) {
+      // A cache hit alone doesn't mean the installation is still alive: the
+      // token's ~50min TTL comfortably outlasts a missed deletion webhook, so
+      // without this check a dead installation would keep being served a
+      // "valid" token — and every self-heal path in the caller (which only
+      // ever sees GithubInstallationNotFoundError from a REAL mint attempt)
+      // would never fire until the cache happened to expire.
+      await this.assertInstallationStillExists(args.installationId);
+      return { token: cached, expiresAt: "" };
+    }
 
     // Best-effort lock to avoid a mint stampede; every branch falls through to a
     // direct mint (minting twice is harmless, unlike the old refresh rotation).


### PR DESCRIPTION
## For humans

Two related failures in the Langy ↔ GitHub App integration:

1. If installing the app failed part-way through — an expired install link, a session change mid-flow, a permission change, or GitHub reusing an installation id another account already owns — Settings > Integrations used to just show the plain "Install" button again, as if nothing had happened, even though the user had just approved the install on GitHub's side. Now the actual failure reason shows up as an error toast.
2. Separately: if a GitHub App installation gets uninstalled on GitHub's side but our record of it is never cleaned up (a missed webhook delivery, or an installation that predates the webhook being configured at all), Langy kept trying to use that dead installation forever — minting silently failed and the user was told to "Install the LangWatch GitHub App" even though it was already installed with a different, live installation. This is now self-healing: a confirmed "this installation doesn't exist" response from GitHub removes the stale record and Langy falls back to the next real installation instead of failing the turn.

## What changed

**Error surfacing.** The `/setup` callback (`src/server/routes/github-langy.ts`) already reported every failure by redirecting back with `?githubError=<message>` — expired/tampered signed state, a session change mid-flow, a stale permission/membership check, or the cross-tenant installation-conflict guard. `src/pages/settings/integrations.tsx` never read that query param, so the error was silently dropped and the page just re-rendered the "Install" button.

`specs/langy/langy-github-install.feature` already documents the expected behavior ("Then I am shown that the installation could not be verified") — only the backend half of that scenario was tested; the UI half was unimplemented.

Fix: read `router.query.githubError` on mount, show it as an error toast, and strip it from the URL via `router.replace` so a refresh doesn't re-show it.

**Self-healing stale installations.** `LangyGithubInstallationsService.mintTurnToken()` (`src/server/app-layer/langy/langy-github-installations.service.ts`) always picked the oldest non-suspended installation for an org, with no check that it was still alive on GitHub. The mint call would fail against a dead installation, the error was swallowed, and the turn surfaced the generic "not connected" state — indistinguishable from never having installed the app at all.

Fix: `LangyGithubAppTokenService.mintInstallationToken()` (`src/server/app-layer/langy/langyGithubAppToken.ts`) now throws a distinct `GithubInstallationNotFoundError` on a confirmed GitHub 404 (never on any other status — a transient failure must not be treated as "this installation is gone"). `mintTurnToken()` catches that specific error, removes the stale row via the existing `deleteByInstallationId()` repository method, and retries the next candidate installation instead of failing the whole turn. This is a bug fix (restoring correct selection behavior), not new user-facing capability, so no feature-file scenario was added — the fix is proven by regression tests instead.

A cached token doesn't skip this either: a warm cache hit re-confirms the installation is still alive, but only once per 5 minutes (a separate, short-TTL marker, not the token's own ~50min cache) — otherwise every single turn would cost its own GitHub API call, and a GitHub outage would stall every turn on that call's timeout before falling back to the cached token. A transient probe failure backs off for 60s rather than retrying on the very next turn. A confirmed 404 still bypasses all of that and propagates immediately.

**Design note: `GithubInstallationNotFoundError` is a plain `Error`, not the repo's `HandledError`.** The mental model: `HandledError` is a contract that the error *will* reach a customer — every code it declares is required to have real customer-facing copy (enforced by a codebase-wide test). This error never crosses that boundary; it's thrown, caught a call or two later in the same service, and used purely to decide which installation candidate to try next. Making it a `HandledError` would mean either writing fake customer copy for a code that must never be shown, or working around the registry that enforces this — both worse than the one-line trade-off of losing automatic trace/span capture on an error nothing ever serializes.

## Test plan
- [x] `pnpm typecheck` / `pnpm typecheck:tests` clean
- [x] `integrations-github-error.integration.test.tsx`: shows a toast with the error message, strips `githubError` from the URL, and stays silent when there's no error param
- [x] `langy-github-installations.service.unit.test.ts`: oldest installation is a zombie (404) + a newer one is live → mints via the live one and removes the dead row; same for the explicit-repo path; every installation dead → returns null without crashing; a non-404 mint failure does NOT delete the row (transient-error safety)
- [x] `langyGithubAppToken.unit.test.ts`: a 404 from GitHub throws `GithubInstallationNotFoundError`, distinct from other failures; a cache hit re-confirms liveness without a stampede (concurrent + sequential calls each cost one GitHub call, not one per call); the liveness marker expires and re-probes; a transient probe failure backs off instead of probing every following call
- [ ] Manually verify in the browser against a real GitHub App install flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show a clear GitHub installation error toast on the Integrations settings page when setup fails, and remove the error detail from the URL right after displaying it.
  * Improve token minting resilience by automatically discarding stale “dead” GitHub installations (404) and continuing with remaining valid installations.
* **Tests**
  * Added integration and unit test coverage for the GitHub setup error toast + URL cleanup behavior.
  * Extended unit tests to verify 404 “installation not found” handling, cache behavior, and self-healing deletion of stale installation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->