### PR TITLE
fix(clickhouse): give every ALTER-added Array column an explicit DEFAULT

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00057_array_column_defaults.sql
+++ b/langwatch/src/server/clickhouse/migrations/00057_array_column_defaults.sql
@@ -27,12 +27,27 @@
 -- the default instead of decoding a header that was never written.
 --
 -- These MODIFYs are idempotent — replaying one that is already applied is a
--- no-op — which matters because the first seven were applied by hand during
--- the 2026-07-28 incident, ahead of this migration.
+-- no-op — which matters because all seven were applied by hand during the
+-- 2026-07-28 incident, ahead of this migration.
 --
 -- Cluster note: no ON CLUSTER. When CLICKHOUSE_CLUSTER is set the database
 -- uses the Replicated engine (00001), which propagates DDL to every node on
 -- its own; ON CLUSTER against a Replicated database is rejected.
+--
+-- Scope — these seven are every ALTER-added Array column that still exists:
+--
+--   trace_summaries.AnnotationIds (00013) was the first occurrence, and is
+--     already fixed by 00014.
+--   trace_summaries.`Events.*` (00019) is the same defect, but 00025 DROPped
+--     all four columns, so there is nothing left to modify. MODIFY COLUMN has
+--     no IF EXISTS escape, so naming a dropped column fails the whole
+--     migration. The surviving `Events.*` columns are on stored_spans, where
+--     they come from the original CREATE (00002) and so are materialised in
+--     every part — not this defect.
+--   simulation_runs.RoleCosts / RoleLatencies (00008) are Map, not Array. The
+--     same variable-size header applies, but the incident did not implicate
+--     them and a Map default needs its own type-checked literal; tracked
+--     separately rather than folded into an incident fix.
 --
 -- The corresponding rule for new code: an Array column added by ALTER MUST
 -- carry a DEFAULT. Prefer `DEFAULT []` at ADD time over a follow-up migration.
@@ -81,45 +96,14 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
     DEFAULT [] CODEC(ZSTD(1));
 -- +goose StatementEnd
 
--- --- trace_summaries Events.* (added by 00019) ------------------------------
---
--- Same defect, already surfacing on this table as
---   ATTEMPT_TO_READ_AFTER_EOF: (while reading column Events.Attributes)
--- rather than as an allocation failure — the header decodes to a length that
--- runs off the end of the stream instead of to an absurd one.
---
--- These are Nested subcolumns, so all four must stay the same length; an empty
--- default on each keeps that invariant on a part that carries none of them.
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
-  MODIFY COLUMN `Events.SpanId` Array(String) DEFAULT [] CODEC(ZSTD(1));
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
-  MODIFY COLUMN `Events.Timestamp` Array(DateTime64(3)) DEFAULT [] CODEC(ZSTD(1));
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
-  MODIFY COLUMN `Events.Name` Array(LowCardinality(String)) DEFAULT [] CODEC(ZSTD(1));
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
-  MODIFY COLUMN `Events.Attributes`
-    Array(Map(LowCardinality(String), String)) DEFAULT [] CODEC(ZSTD(1));
--- +goose StatementEnd
-
 -- +goose ENVSUB OFF
 
 -- +goose Down
--- Down migrations are commented out to prevent accidental data loss.
--- To roll back, uncomment and run manually.
---
--- Rolling back reinstates the defect: it drops the DEFAULT, so parts written
--- before the original ADD COLUMN decode an unwritten size header again.
+-- IRREVERSIBLE: rolling back reinstates the defect. Dropping the DEFAULT puts
+-- parts written before the original ADD COLUMN back to decoding a size header
+-- that was never written, which is the read-time OOM this migration exists to
+-- stop. The Down migration is therefore commented out to prevent accidental
+-- data loss. To roll back, uncomment and run manually.
 --
 -- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics       MODIFY COLUMN AnnotationIds Array(String) CODEC(ZSTD(1));
 -- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics       MODIFY COLUMN AppliedEventIds Array(String) CODEC(ZSTD(1));
@@ -128,7 +112,3 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
 -- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN SubAgentIds Array(String) CODEC(ZSTD(1));
 -- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN StepStartedAt Array(UInt64) CODEC(ZSTD(1));
 -- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN MetricSeries Array(Tuple(String, String, String, String, String, Float64)) CODEC(ZSTD(1));
--- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.SpanId` Array(String) CODEC(ZSTD(1));
--- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Timestamp` Array(DateTime64(3)) CODEC(ZSTD(1));
--- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Name` Array(LowCardinality(String)) CODEC(ZSTD(1));
--- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1));

--- a/langwatch/src/server/clickhouse/migrations/00057_array_column_defaults.sql
+++ b/langwatch/src/server/clickhouse/migrations/00057_array_column_defaults.sql
@@ -1,0 +1,134 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- Every Array column added by ALTER gets an explicit DEFAULT.
+--
+-- An `ADD COLUMN` without a DEFAULT leaves the column unmaterialised in every
+-- part written before the ALTER. For an Array the absent column's size header
+-- is read as garbage, and ClickHouse tries to allocate whatever that garbage
+-- says — surfacing as, at read time:
+--
+--   Code: 173. DB::Exception: Amount of memory requested to allocate is more
+--   than allowed: (while reading column <name>) ... max_rows_to_read = 1
+--
+-- and at merge time as Code 241 with a multi-GiB chunk request. The read
+-- failure throws out of the fold's read-back, fails the job, and GroupQueue
+-- retries it until the aggregate's group wedges.
+--
+-- This is the second occurrence. 00014 already diagnosed and fixed it for
+-- trace_summaries.AnnotationIds, with the same error string in its comment;
+-- 00053/00054/00056 then reintroduced it on three more tables. Every scalar
+-- column those migrations added carries a DEFAULT — only the Array ones do
+-- not, which is why it went unnoticed.
+--
+-- Changing only the DEFAULT is a metadata operation: no part is rewritten and
+-- no mutation is scheduled. Reads of a part that lacks the column synthesise
+-- the default instead of decoding a header that was never written.
+--
+-- These MODIFYs are idempotent — replaying one that is already applied is a
+-- no-op — which matters because the first seven were applied by hand during
+-- the 2026-07-28 incident, ahead of this migration.
+--
+-- Cluster note: no ON CLUSTER. When CLICKHOUSE_CLUSTER is set the database
+-- uses the Replicated engine (00001), which propagates DDL to every node on
+-- its own; ON CLUSTER against a Replicated database is rejected.
+--
+-- The corresponding rule for new code: an Array column added by ALTER MUST
+-- carry a DEFAULT. Prefer `DEFAULT []` at ADD time over a follow-up migration.
+-- ============================================================================
+
+-- --- trace_analytics (added by 00056) ---------------------------------------
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics
+  MODIFY COLUMN AnnotationIds Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics
+  MODIFY COLUMN AppliedEventIds Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- --- evaluation_analytics (added by 00056) ----------------------------------
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_analytics
+  MODIFY COLUMN AppliedEventIds Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- --- coding_agent_sessions (added by 00053 and 00054) -----------------------
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  MODIFY COLUMN AppliedEventIds Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  MODIFY COLUMN SubAgentIds Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  MODIFY COLUMN StepStartedAt Array(UInt64) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  MODIFY COLUMN MetricSeries
+    Array(Tuple(String, String, String, String, String, Float64))
+    DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- --- trace_summaries Events.* (added by 00019) ------------------------------
+--
+-- Same defect, already surfacing on this table as
+--   ATTEMPT_TO_READ_AFTER_EOF: (while reading column Events.Attributes)
+-- rather than as an allocation failure — the header decodes to a length that
+-- runs off the end of the stream instead of to an absurd one.
+--
+-- These are Nested subcolumns, so all four must stay the same length; an empty
+-- default on each keeps that invariant on a part that carries none of them.
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MODIFY COLUMN `Events.SpanId` Array(String) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MODIFY COLUMN `Events.Timestamp` Array(DateTime64(3)) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MODIFY COLUMN `Events.Name` Array(LowCardinality(String)) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MODIFY COLUMN `Events.Attributes`
+    Array(Map(LowCardinality(String), String)) DEFAULT [] CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- Down migrations are commented out to prevent accidental data loss.
+-- To roll back, uncomment and run manually.
+--
+-- Rolling back reinstates the defect: it drops the DEFAULT, so parts written
+-- before the original ADD COLUMN decode an unwritten size header again.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics       MODIFY COLUMN AnnotationIds Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_analytics       MODIFY COLUMN AppliedEventIds Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_analytics  MODIFY COLUMN AppliedEventIds Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN AppliedEventIds Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN SubAgentIds Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN StepStartedAt Array(UInt64) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions MODIFY COLUMN MetricSeries Array(Tuple(String, String, String, String, String, Float64)) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.SpanId` Array(String) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Timestamp` Array(DateTime64(3)) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Name` Array(LowCardinality(String)) CODEC(ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries       MODIFY COLUMN `Events.Attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1));


### PR DESCRIPTION
Fixes the root cause of the 2026-07-28 `trace_processing` fold outage.

## What broke

An `ADD COLUMN` without a `DEFAULT` leaves the column **unmaterialised in every part written before the ALTER**. For an `Array`, the absent column's size header decodes as garbage and ClickHouse allocates whatever it claims:

```
Code: 173. DB::Exception: Amount of memory requested to allocate is more than allowed:
(while reading column AnnotationIds): (while reading from part .../202630_0_412188_18749/
in table langwatch.trace_analytics ... from mark 24 with max_rows_to_read = 1, offset = 4380)
```

`max_rows_to_read = 1` — a single row blew the allocation, while the whole `AnnotationIds` column is **6,286 bytes across 267,195 rows**. The size was never the problem; the header was.

That read is `queryLatestVersion`, the ADR-066 fold read-back. It throws, the fold job fails, GroupQueue retries it, and the per-trace group wedges. At peak: **9,374 OOMs in 15 minutes**, 3,267 failed folds/hour, and `gq_parked_groups` climbing 0 → 9,396 as retrying jobs held their tenants' in-flight slots and head-of-line-blocked unrelated work.

`traceAnalytics` was the only failing projection; every other one was at zero.

## Why it went unnoticed

**This is the second occurrence.** `00014_add_annotation_ids_default.sql` already diagnosed and fixed it for `trace_summaries.AnnotationIds`, quoting the same error string in its own comment:

> `-- Fix: AnnotationIds was added without DEFAULT, causing unmaterialized column data in old parts. During merges the corrupted size header can trigger "Amount of memory requested to allocate is more than allowed" OOM errors.`

`00053`, `00054` and `00056` then reintroduced it on three more tables. The tell is that **every scalar column those migrations added carries a `DEFAULT`** — `SpanCount UInt32 DEFAULT 0`, `LastEventOccurredAt UInt64 DEFAULT 0`, four `Bool DEFAULT 0` — and **only the `Array` ones do not**. A scalar with no `DEFAULT` reads back as the type's zero and nobody notices; an `Array` decodes a header that was never written.

The physical evidence, from `system.parts_columns`:

| column | bytes | rows | parts |
|---|---|---|---|
| `Models` | 1,643,912 | 2,484,534 | **89** |
| `Labels` | 1,281,669 | 2,484,534 | **89** |
| `AppliedEventIds` | 453,888 | 267,195 | **27** |
| `AnnotationIds` | 6,286 | 267,195 | **27** |

Columns from the original `CREATE` live in 89 parts; the ALTER-added ones in 27. The other 62 parts never materialised them.

## The trigger

The app deployed **ahead of the migration**. `system.errors` at 15:08:24, seventeen minutes before the first OOM:

```
UNKNOWN_IDENTIFIER  41  "Unknown expression identifier `LastEventOccurredAt` in scope
                         SELECT * FROM trace_analytics WHERE (TenantId = …)"
INCORRECT_DATA       8  "Unknown field found while parsing JSONEachRow format:
                         TraceNameFromFallback"
```

New code queried and wrote columns that did not exist yet. This is exactly the ordering hazard ADR-066 records as a release procedure — the workers Deployment runs `start:workers` and never `start:prepare:db`, so an adopter's migration must land out of band first. It didn't. That is a strong argument for promoting it to a `pre-upgrade` Helm hook rather than leaving it as prose; raised separately.

## What this changes

`MODIFY COLUMN … DEFAULT []` on all **7** ALTER-added Array columns that still exist:

- `trace_analytics` — `AnnotationIds`, `AppliedEventIds` (00056)
- `evaluation_analytics` — `AppliedEventIds` (00056)
- `coding_agent_sessions` — `AppliedEventIds` (00054), `SubAgentIds`, `StepStartedAt`, `MetricSeries` (00053)

Deliberately **not** included, each for a reason:

- `trace_summaries.AnnotationIds` (00013) — the first occurrence, already fixed by `00014`.
- `trace_summaries.Events.*` (00019) — the same defect, but `00025` **dropped** all four columns, so there is nothing left to modify. `MODIFY COLUMN` has no `IF EXISTS` escape, so naming a dropped column would fail the entire migration. (The surviving `Events.*` columns live on `stored_spans`, where they come from the original `CREATE` in `00002` and are therefore materialised in every part — not this defect, despite an `ATTEMPT_TO_READ_AFTER_EOF: (while reading column Events.Attributes)` in `system.errors` that points at a different table UUID.)
- `simulation_runs.RoleCosts` / `RoleLatencies` (00008) — `Map`, not `Array`. The same variable-size header reasoning applies, but the incident did not implicate them and a `Map` default needs its own type-checked literal, so it is tracked separately rather than folded into an incident fix.

Properties worth stating explicitly:

- **Metadata-only.** Changing only a `DEFAULT` rewrites no part and schedules no mutation.
- **Idempotent.** Seven of these were applied by hand during the incident, ahead of this migration; replaying them is a no-op.
- **No `ON CLUSTER`.** With `CLICKHOUSE_CLUSTER` set the database uses the Replicated engine (`00001`), which propagates DDL to every node itself — `ON CLUSTER` against a Replicated database is rejected.

## What it does not fix

A part whose column stream is **partially written** rather than absent. After the ALTERs landed, errors collapsed from two parts to one — `202630_0_412188_18749`, week 30's base part — which still gets read at real mark offsets. Repairing that needs `ALTER TABLE … MATERIALIZE COLUMN AnnotationIds IN PARTITION '202630'`, which is a **mutation**: it would block a deploy behind a long-running rewrite, so it belongs in the incident runbook, not here.

Three follow-ups, tracked separately:

1. **Drop `SELECT *` from `queryLatestVersion`.** The fold read-back pulls every column including unbounded arrays it does not need. Naming columns sidesteps corrupt streams entirely and is the durable fix independent of this one.
2. **The two `simulation_runs` Map columns**, which need a type-checked default literal.
3. **A guard so there is no third occurrence** — reject an `ADD COLUMN` of an `Array` type without a `DEFAULT` at CI time.

## Verification

Confirms the fix landed and shows the remaining part:

```sql
SELECT table, name, default_kind, default_expression
FROM system.columns
WHERE database='langwatch' AND name IN ('AnnotationIds','AppliedEventIds')
ORDER BY table, name;
```

`trace_summaries.AnnotationIds` already read `DEFAULT []` before this change — that is `00014`'s fix, and it is why that column never failed.


Locally, against `clickhouse-server 25.10.2.65` — the version CI runs — on a throwaway database:

- `00001`…`00057` apply clean. The earlier red was `00057` itself: `Code: 10 … Cannot find column `Events.SpanId` to modify (NOT_FOUND_COLUMN_IN_BLOCK)` aborted the shared `Run ClickHouse migrations` setup step, which is why all six `test-integration` shards and `e2e` failed together without reaching a single test.
- All seven columns report `default_kind = DEFAULT`, `default_expression = []` in `system.columns`. `trace_summaries.AnnotationIds` already did, from `00014`.
- `system.mutations` holds the same 15 rows before and after `00057` — **metadata-only** confirmed. Four of those 15 are `00025`'s `DROP COLUMN IF EXISTS Events.*`, which is the direct evidence that the `Events.*` group had nothing left to modify.
- Replaying all seven `ALTER`s by hand succeeds and schedules no mutation — **idempotent** confirmed.
- The only surviving `Events.*` columns are on `stored_spans`, with no `default_kind` — original-`CREATE` columns, materialised in every part.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading analytics and coding session data containing array fields.
  * Prevented failures caused by missing array metadata during data reads and merges.
  * Existing data formats and compression behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->