### PR TITLE
feat(charts): pass strict admission control (read-only root, automount, seccomp, limits)

### DIFF
--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -70,7 +70,7 @@ See the [Docker image README](../../clickhouse-serverless/README.md) for the ful
 | Name | Description | Default |
 |------|-------------|---------|
 | `image.repository` | Image repository | `langwatch/clickhouse-serverless` |
-| `image.tag` | Image tag | `0.1.0` |
+| `image.tag` | Image tag | `0.2.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 ### Storage
@@ -106,6 +106,8 @@ Shared by cold storage and backups. Required when either `cold.enabled` or `back
 |------|-------------|---------|
 | `backup.enabled` | Enable native ClickHouse BACKUP/RESTORE to S3 (requires `objectStorage`) | `false` |
 | `backup.database` | Database to back up | `langwatch` |
+| `backup.user` | ClickHouse user for backup/restore operations | `default` |
+| `backup.resources` | CPU/memory requests + limits for the backup/restore Job containers | requests `100m`/`128Mi`, limits `500m`/`512Mi` |
 | `backup.full.schedule` | Cron schedule for full backups | `0 */12 * * *` |
 | `backup.incremental.schedule` | Cron schedule for incremental backups | `0 * * * *` |
 
@@ -160,6 +162,25 @@ This creates two users: `analyst` with read-only access to all databases, and `e
 | `scheduling.nodeSelector` | Node selector labels | `{}` |
 | `scheduling.affinity` | Affinity rules | `{}` |
 | `scheduling.tolerations` | Tolerations | `[]` |
+
+### ServiceAccount
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `serviceAccount.create` | Create a dedicated ServiceAccount | `true` |
+| `serviceAccount.name` | ServiceAccount name (defaults to the chart fullname) | `""` |
+| `serviceAccount.automountServiceAccountToken` | Mount the SA token; ClickHouse/Keeper need no Kubernetes API access. Also set on the pod specs so policies that inspect the pod (not the SA) accept it. | `false` |
+| `serviceAccount.annotations` | ServiceAccount annotations (e.g. IRSA role ARN) | `{}` |
+
+## Pod Security
+
+ClickHouse, Keeper, and the backup/restore Jobs run non-root (uid 101) with a
+read-only root filesystem, `RuntimeDefault` seccomp, dropped capabilities, no
+privilege escalation, and no mounted ServiceAccount token. The paths ClickHouse
+writes at runtime (server logs, the pid directory, `/tmp`, and the rendered
+`config.d`/`users.d`) are `emptyDir` volumes; data stays on the PVC, so the
+image layer is never writable. This clears Pod Security Admission `restricted`
+and Gatekeeper / Kyverno policies, including "read-only root on every container".
 
 ## Deployment Modes
 

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -65,6 +65,13 @@ See the [Docker image README](../../clickhouse-serverless/README.md) for the ful
 | `replicas` | Number of ClickHouse nodes. 1 = standalone MergeTree, 3+ = ReplicatedMergeTree + Keeper (must be odd) | `1` |
 | `clusterName` | ClickHouse cluster name used in macros and remote_servers config | `langwatch` |
 
+> **`memory` scales with ingest, not just stored size.** The image auto-tunes
+> `max_server_memory_usage` (~85% of the limit) and per-query limits from
+> `memory`, and large/concurrent inserts plus background merges spike well above
+> idle. Sub-2Gi values are fine for smoke or light local use, but raise `memory`
+> (and `cpu`) before pushing real trace throughput or a big ingest burst will
+> OOM the pod.
+
 ### Image
 
 | Name | Description | Default |

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -192,9 +192,11 @@ own quota instead of filling the node.
 
 ## Pod Security
 
-ClickHouse, Keeper, and the backup/restore Jobs run non-root (uid 101) with a
-read-only root filesystem, `RuntimeDefault` seccomp, dropped capabilities, no
-privilege escalation, and no mounted ServiceAccount token. The paths written at
+ClickHouse, Keeper, and the backup/restore Jobs run non-root (uid 101; Keeper's
+init container runs 65534) with a read-only root filesystem, `RuntimeDefault`
+seccomp, dropped capabilities, no privilege escalation, and no mounted
+ServiceAccount token. A `MustRunAs` constraint has to allow both uids, or it
+denies the Keeper pod on its init container. The paths written at
 runtime outside the data volume — server logs, `/tmp`, and the rendered
 `config.d`/`users.d` — are `emptyDir` volumes; everything else ClickHouse
 writes (`preprocessed_configs`, `status`, `uuid`, `format_schemas`,

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -179,15 +179,42 @@ This creates two users: `analyst` with read-only access to all databases, and `e
 | `serviceAccount.automountServiceAccountToken` | Mount the SA token; ClickHouse/Keeper need no Kubernetes API access. Also set on the pod specs so policies that inspect the pod (not the SA) accept it. | `false` |
 | `serviceAccount.annotations` | ServiceAccount annotations (e.g. IRSA role ARN) | `{}` |
 
+### Scratch volumes
+
+Writable `emptyDir`s for the paths touched outside the data PVC, so the pods can
+run with a read-only root filesystem. Bounded so a runaway pod is evicted on its
+own quota instead of filling the node.
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `scratch.logsSizeLimit` | Size cap for `/var/log/clickhouse-server` and `/var/log/clickhouse-keeper` | `2Gi` |
+| `scratch.tmpSizeLimit` | Size cap for `/tmp` on the server, Keeper, and the backup/restore Jobs | `1Gi` |
+
 ## Pod Security
 
 ClickHouse, Keeper, and the backup/restore Jobs run non-root (uid 101) with a
 read-only root filesystem, `RuntimeDefault` seccomp, dropped capabilities, no
-privilege escalation, and no mounted ServiceAccount token. The paths ClickHouse
-writes at runtime (server logs, the pid directory, `/tmp`, and the rendered
-`config.d`/`users.d`) are `emptyDir` volumes; data stays on the PVC, so the
-image layer is never writable. This clears Pod Security Admission `restricted`
-and Gatekeeper / Kyverno policies, including "read-only root on every container".
+privilege escalation, and no mounted ServiceAccount token. The paths written at
+runtime outside the data volume — server logs, `/tmp`, and the rendered
+`config.d`/`users.d` — are `emptyDir` volumes; everything else ClickHouse
+writes (`preprocessed_configs`, `status`, `uuid`, `format_schemas`,
+`user_files`, `tmp`, `access`) lives under `/var/lib/clickhouse` on the PVC, so
+the image layer is never writable. Keeper is the same: its state, raft log and
+preprocessed configs derive from `log_storage_path` and land on its PVC.
+
+The log and `/tmp` scratch volumes are size-bounded (`scratch.logsSizeLimit`,
+`scratch.tmpSizeLimit`) so a pod in an error loop is evicted on its own quota
+rather than filling the node's ephemeral storage.
+
+Under the LangWatch umbrella chart this clears Pod Security Admission
+`restricted` and the equivalent Gatekeeper / Kyverno policies, including
+"read-only root on every container".
+
+**Installing this chart standalone:** the preflight Secret-check Job is enabled
+by default and deliberately runs without `readOnlyRootFilesystem`, because
+`kubectl` writes a discovery cache. A cluster with a no-exceptions read-only-root
+constraint will deny it — set `preflight.enabled: false`. The umbrella chart
+already disables it (`clickhouse.preflight.enabled: false`).
 
 ## Deployment Modes
 

--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -25,11 +25,16 @@ spec:
             app.kubernetes.io/component: backup-full
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: full-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -38,10 +43,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -81,11 +90,16 @@ spec:
             app.kubernetes.io/component: backup-incremental
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: incremental-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -94,10 +108,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -135,11 +153,16 @@ spec:
             app.kubernetes.io/component: restore-data
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: restore-data
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -148,10 +171,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"

--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -42,6 +42,7 @@ spec:
               command: ["/scripts/backup-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:
@@ -107,6 +108,7 @@ spec:
               command: ["/scripts/backup-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:
@@ -170,6 +172,7 @@ spec:
               command: ["/scripts/restore-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:

--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -25,6 +25,11 @@ spec:
             app.kubernetes.io/component: backup-full
         spec:
           restartPolicy: Never
+          # Same ServiceAccount as the StatefulSets: these Jobs are configured
+          # by the chart's serviceAccount.* block, so they must not silently
+          # fall through to the namespace default SA (which would miss an IRSA
+          # annotation the backup path needs to reach S3).
+          serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
           # Backup jobs never call the Kubernetes API.
           automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
@@ -34,7 +39,8 @@ spec:
               type: RuntimeDefault
           volumes:
             - name: tmp
-              emptyDir: {}
+              emptyDir:
+                sizeLimit: {{ .Values.scratch.tmpSizeLimit }}
           containers:
             - name: full-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -91,6 +97,11 @@ spec:
             app.kubernetes.io/component: backup-incremental
         spec:
           restartPolicy: Never
+          # Same ServiceAccount as the StatefulSets: these Jobs are configured
+          # by the chart's serviceAccount.* block, so they must not silently
+          # fall through to the namespace default SA (which would miss an IRSA
+          # annotation the backup path needs to reach S3).
+          serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
           # Backup jobs never call the Kubernetes API.
           automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
@@ -100,7 +111,8 @@ spec:
               type: RuntimeDefault
           volumes:
             - name: tmp
-              emptyDir: {}
+              emptyDir:
+                sizeLimit: {{ .Values.scratch.tmpSizeLimit }}
           containers:
             - name: incremental-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -155,6 +167,11 @@ spec:
             app.kubernetes.io/component: restore-data
         spec:
           restartPolicy: Never
+          # Same ServiceAccount as the StatefulSets: these Jobs are configured
+          # by the chart's serviceAccount.* block, so they must not silently
+          # fall through to the namespace default SA (which would miss an IRSA
+          # annotation the backup path needs to reach S3).
+          serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
           # Backup jobs never call the Kubernetes API.
           automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
@@ -164,7 +181,8 @@ spec:
               type: RuntimeDefault
           volumes:
             - name: tmp
-              emptyDir: {}
+              emptyDir:
+                sizeLimit: {{ .Values.scratch.tmpSizeLimit }}
           containers:
             - name: restore-data
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
@@ -25,6 +25,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
+      # Set on the pod too (not just the SA) for policies that check the pod
+      # spec field. Keeper never calls the Kubernetes API.
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -125,8 +128,9 @@ spec:
           securityContext:
             runAsUser: 101  # clickhouse user
             runAsNonRoot: true
-            # Keeper needs a writable /var/lib/clickhouse-keeper outside the PVC.
-            readOnlyRootFilesystem: false
+            # Read-only root: keeper data is on the PVC and config is the
+            # keeper-config emptyDir; logs/pid/tmp are emptyDir-mounted below.
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
@@ -157,9 +161,22 @@ spec:
               mountPath: /var/lib/clickhouse-keeper
             - name: keeper-config
               mountPath: /etc/clickhouse-keeper
+            # Writable scratch so keeper runs read-only root: logs, pid, /tmp.
+            - name: keeper-logs
+              mountPath: /var/log/clickhouse-keeper
+            - name: keeper-run
+              mountPath: /var/run/clickhouse-keeper
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
         - name: keeper-config
+          emptyDir: {}
+        - name: keeper-logs
+          emptyDir: {}
+        - name: keeper-run
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: keeper-raft-template
           configMap:

--- a/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
@@ -128,8 +128,10 @@ spec:
           securityContext:
             runAsUser: 101  # clickhouse user
             runAsNonRoot: true
-            # Read-only root: keeper data is on the PVC and config is the
-            # keeper-config emptyDir; logs/pid/tmp are emptyDir-mounted below.
+            # Read-only root: keeper state, raft log and preprocessed configs
+            # all land on the PVC (they derive from log_storage_path), config
+            # is the keeper-config emptyDir, and logs/tmp are emptyDir-mounted
+            # below.
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
@@ -161,11 +163,14 @@ spec:
               mountPath: /var/lib/clickhouse-keeper
             - name: keeper-config
               mountPath: /etc/clickhouse-keeper
-            # Writable scratch so keeper runs read-only root: logs, pid, /tmp.
+            # Writable scratch so keeper runs read-only root. Keeper's state,
+            # raft log and preprocessed configs all derive from
+            # log_storage_path and land on the PVC, so only these two are
+            # needed. /var/log is mounted because the shipped config logs to
+            # console only — an operator who turns file logging back on via
+            # extraConfig must not crashloop against a read-only root.
             - name: keeper-logs
               mountPath: /var/log/clickhouse-keeper
-            - name: keeper-run
-              mountPath: /var/run/clickhouse-keeper
             - name: tmp
               mountPath: /tmp
 
@@ -173,11 +178,11 @@ spec:
         - name: keeper-config
           emptyDir: {}
         - name: keeper-logs
-          emptyDir: {}
-        - name: keeper-run
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.scratch.logsSizeLimit }}
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.scratch.tmpSizeLimit }}
         - name: keeper-raft-template
           configMap:
             name: {{ $fullname }}-keeper-raft

--- a/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
@@ -176,7 +176,10 @@ spec:
 
       volumes:
         - name: keeper-config
-          emptyDir: {}
+          # Holds rendered config only (ch-config writes here); bounded like
+          # every other scratch volume, so nothing is node-backed without a limit.
+          emptyDir:
+            sizeLimit: 64Mi
         - name: keeper-logs
           emptyDir:
             sizeLimit: {{ .Values.scratch.logsSizeLimit }}

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
+      # Set on the pod too (not just the SA) for policies that check the pod
+      # spec field rather than the ServiceAccount. ClickHouse never calls the
+      # Kubernetes API.
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -79,11 +83,13 @@ spec:
         - name: clickhouse
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # readOnlyRootFilesystem is intentionally omitted — ClickHouse writes
-          # to paths outside the data PVC (e.g. /tmp, format schemas) and would
-          # crashloop under a read-only root.
+          # Read-only root: ch-config only writes into config.d/users.d (both
+          # emptyDir mounts) and ClickHouse data lives on the PVC. The few
+          # remaining writable paths (logs, pid, /tmp) are emptyDir-mounted
+          # below, so the image layer itself never needs to be writable.
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:
@@ -230,6 +236,15 @@ spec:
               mountPath: /etc/clickhouse-server/config.d
             - name: users-d
               mountPath: /etc/clickhouse-server/users.d
+            # Writable scratch so the container runs read-only root: server
+            # logs, the pid dir, and /tmp. (config.d/users.d above are also
+            # writable emptyDirs, which is where ch-config renders config.)
+            - name: ch-logs
+              mountPath: /var/log/clickhouse-server
+            - name: ch-run
+              mountPath: /var/run/clickhouse-server
+            - name: tmp
+              mountPath: /tmp
             - name: secrets
               mountPath: /mnt/secrets
               readOnly: true
@@ -238,6 +253,12 @@ spec:
         - name: config-d
           emptyDir: {}
         - name: users-d
+          emptyDir: {}
+        - name: ch-logs
+          emptyDir: {}
+        - name: ch-run
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: secrets
           secret:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -88,6 +88,10 @@ spec:
           # remaining writable paths (logs, pid, /tmp) are emptyDir-mounted
           # below, so the image layer itself never needs to be writable.
           securityContext:
+            # The image already runs as uid 101 via its USER directive; pin it
+            # explicitly so it matches Keeper/backup and satisfies runAsUser /
+            # MustRunAs policies that read the pod spec.
+            runAsUser: 101
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
             # explicitly so it matches Keeper/backup and satisfies runAsUser /
             # MustRunAs policies that read the pod spec.
             runAsUser: 101
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # Read-only root: ch-config only writes into config.d/users.d (both
           # emptyDir mounts) and ClickHouse data lives on the PVC. The few
-          # remaining writable paths (logs, pid, /tmp) are emptyDir-mounted
+          # remaining writable paths (server logs and /tmp) are emptyDir-mounted
           # below, so the image layer itself never needs to be writable.
           securityContext:
             # The image already runs as uid 101 via its USER directive; pin it
@@ -257,9 +257,15 @@ spec:
 
       volumes:
         - name: config-d
-          emptyDir: {}
+          # Holds rendered config only (ch-config writes here); bounded like
+          # every other scratch volume, so nothing is node-backed without a limit.
+          emptyDir:
+            sizeLimit: 64Mi
         - name: users-d
-          emptyDir: {}
+          # Holds rendered config only (ch-config writes here); bounded like
+          # every other scratch volume, so nothing is node-backed without a limit.
+          emptyDir:
+            sizeLimit: 64Mi
         - name: ch-logs
           emptyDir:
             sizeLimit: {{ .Values.scratch.logsSizeLimit }}

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -242,12 +242,13 @@ spec:
             - name: users-d
               mountPath: /etc/clickhouse-server/users.d
             # Writable scratch so the container runs read-only root: server
-            # logs, the pid dir, and /tmp. (config.d/users.d above are also
-            # writable emptyDirs, which is where ch-config renders config.)
+            # logs and /tmp. (config.d/users.d above are also writable
+            # emptyDirs, which is where ch-config renders config; everything
+            # else ClickHouse writes — preprocessed_configs, status, uuid,
+            # format_schemas, user_files, tmp, access — is under
+            # /var/lib/clickhouse on the PVC.)
             - name: ch-logs
               mountPath: /var/log/clickhouse-server
-            - name: ch-run
-              mountPath: /var/run/clickhouse-server
             - name: tmp
               mountPath: /tmp
             - name: secrets
@@ -260,11 +261,11 @@ spec:
         - name: users-d
           emptyDir: {}
         - name: ch-logs
-          emptyDir: {}
-        - name: ch-run
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.scratch.logsSizeLimit }}
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.scratch.tmpSizeLimit }}
         - name: secrets
           secret:
             secretName: {{ include "clickhouse-serverless.secretName" . }}

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -112,6 +112,19 @@ keeper:
     size: 10Gi
     storageClass: ""  # defaults to parent storage.storageClass
 
+# Writable scratch (emptyDir) for the paths ClickHouse and Keeper touch outside
+# their data PVC, so both can run with a read-only root filesystem.
+#
+# These are bounded on purpose. An unbounded emptyDir is backed by the node's
+# ephemeral storage, so a pod stuck in a merge/replication error loop can fill
+# the node and trigger DiskPressure evictions for unrelated workloads. With a
+# sizeLimit the kubelet evicts only the offending pod. The shipped ClickHouse
+# config rotates server logs at 1000M x 10, so raise logsSizeLimit if you also
+# raise that.
+scratch:
+  logsSizeLimit: 2Gi
+  tmpSizeLimit: 1Gi
+
 # ServiceAccount
 serviceAccount:
   create: true

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -118,9 +118,18 @@ keeper:
 # These are bounded on purpose. An unbounded emptyDir is backed by the node's
 # ephemeral storage, so a pod stuck in a merge/replication error loop can fill
 # the node and trigger DiskPressure evictions for unrelated workloads. With a
-# sizeLimit the kubelet evicts only the offending pod. The shipped ClickHouse
-# config rotates server logs at 1000M x 10, so raise logsSizeLimit if you also
-# raise that.
+# sizeLimit the kubelet evicts only the offending pod.
+#
+# logsSizeLimit is deliberately BELOW the image's own retention ceiling. The
+# chart renders `console: true` into config.d, but it does not disable the base
+# image's file logging, which rotates at 1000M x 10 for each of
+# clickhouse-server.log and clickhouse-server.err.log — roughly 20Gi if both
+# ever fill. Sizing the volume for that would defeat the point: the cap exists
+# so a pathological logger is evicted on its own quota long before it reaches
+# it. Normal operation stays far below 2Gi, and the pod's logs are on stdout
+# regardless, so cluster log collection is unaffected either way.
+#
+# Raise it if you deliberately want the full on-disk retention.
 scratch:
   logsSizeLimit: 2Gi
   tmpSizeLimit: 1Gi

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -76,6 +76,12 @@ self-hosting. The values you most often override:
 | `autoscaling.minReplicas` / `maxReplicas` | HPA bounds                                              |
 | `resources`                   | Pod CPU/memory requests + limits                                     |
 | `otel.endpoint`               | Optional OTLP HTTP exporter URL (gateway emits its own spans)        |
+| `automountServiceAccountToken`| Mount the SA token into the pod (default `false`; the gateway needs no Kubernetes API access) |
+
+The pod ships hardened (`podSecurityContext` / `containerSecurityContext` in
+`values.yaml`): non-root, read-only root, dropped capabilities, `RuntimeDefault`
+seccomp, no mounted SA token. It clears Pod Security Admission `restricted` and
+Gatekeeper / Kyverno policies as-is.
 
 Many `values.yaml` knobs are exposed as forward-compat for v1.1 and
 have no effect in v1 (e.g. `cache.lruSize`, `redis.url`,

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -76,12 +76,17 @@ self-hosting. The values you most often override:
 | `autoscaling.minReplicas` / `maxReplicas` | HPA bounds                                              |
 | `resources`                   | Pod CPU/memory requests + limits                                     |
 | `otel.endpoint`               | Optional OTLP HTTP exporter URL (gateway emits its own spans)        |
-| `automountServiceAccountToken`| Mount the SA token into the pod (default `false`; the gateway needs no Kubernetes API access) |
 
 The pod ships hardened (`podSecurityContext` / `containerSecurityContext` in
-`values.yaml`): non-root, read-only root, dropped capabilities, `RuntimeDefault`
-seccomp, no mounted SA token. It clears Pod Security Admission `restricted` and
-Gatekeeper / Kyverno policies as-is.
+`values.yaml`): non-root at both pod and container level, read-only root,
+dropped capabilities, `RuntimeDefault` seccomp, and resource requests+limits.
+It clears Pod Security Admission `restricted` and Gatekeeper / Kyverno
+policies as-is.
+
+The ServiceAccount token is never mounted. That is hardcoded in the pod spec
+rather than exposed as a value: the gateway makes no Kubernetes API calls, and
+it is a public-facing, tenant-controlled egress workload, so there is no
+configuration under which projecting a cluster credential into it is correct.
 
 Many `values.yaml` knobs are exposed as forward-compat for v1.1 and
 have no effect in v1 (e.g. `cache.lruSize`, `redis.url`,

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -190,11 +190,6 @@ guardrails:
   postTimeout: 2s
   streamChunkWindow: 50ms
 
-# The gateway does not call the Kubernetes API. Default to not mounting the
-# SA token; many clusters deny pods that automount it. Set true only if a
-# sidecar needs in-cluster API access.
-automountServiceAccountToken: false
-
 # Pod-level security.
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -190,6 +190,11 @@ guardrails:
   postTimeout: 2s
   streamChunkWindow: 50ms
 
+# The gateway does not call the Kubernetes API. Default to not mounting the
+# SA token; many clusters deny pods that automount it. Set true only if a
+# sidecar needs in-cluster API access.
+automountServiceAccountToken: false
+
 # Pod-level security.
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -205,6 +205,9 @@ podSecurityContext:
     type: RuntimeDefault
 
 containerSecurityContext:
+  # runAsNonRoot is also set on the pod above; some Gatekeeper constraints
+  # inspect the container-level field directly, so set it here too.
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -68,6 +68,7 @@ All overlays live in `examples/overlays/`:
 | `postgres-external` | External PostgreSQL (RDS, Cloud SQL) |
 | `redis-external` | External Redis (ElastiCache, Memorystore) |
 | `cold-storage-s3` | S3 cold storage tiering + backups |
+| `strict-admission` | Toggles for Pod Security Admission `restricted` / Gatekeeper / Kyverno clusters |
 
 ### All-in-one profiles
 
@@ -122,6 +123,17 @@ For development, set `autogen.enabled: true` to auto-generate all secrets.
 | **Prometheus** | `prometheus.chartManaged: true` | Optional — for metrics collection |
 
 For a complete installation guide, visit the [documentation](https://docs.langwatch.ai/self-hosting/kubernetes-helm).
+
+### Pod security
+
+Every pod (PostgreSQL, Redis, and ClickHouse included) runs read-only-root,
+non-root, with dropped capabilities, `RuntimeDefault` seccomp, no mounted SA
+token, and resource requests/limits on every container. That clears Pod
+Security Admission `restricted` and Gatekeeper / Kyverno policies as shipped.
+On clusters that enforce them, add `examples/overlays/strict-admission.yaml`,
+which turns off the three features that can't comply: the token-using preflight
+hook, the upstream Prometheus subchart, and the custom-metrics gateway HPA. Full
+details in [Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
 
 ### Regenerate this table
 

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -70,6 +70,8 @@ All overlays live in `examples/overlays/`:
 | `cold-storage-s3` | S3 cold storage tiering + backups |
 | `strict-admission` | Toggles for Pod Security Admission `restricted` / Gatekeeper / Kyverno clusters |
 
+> **Sizing notes.** The Node app and workers need roughly **2Gi to boot** (they cold-load the TS server through tsx); the `size-minimal` and `size-dev` overlays account for this, so don't trim app/worker memory below ~2Gi or they OOM at startup. **ClickHouse memory scales with ingest volume** - the chart-managed defaults in `size-minimal`/`size-dev` (1-2Gi) are for light/local use; raise `clickhouse.memory` (and `cpu`) before pushing real trace throughput, or a large ingest burst will OOM it.
+
 ### All-in-one profiles
 
 For common scenarios, use the bundled profiles in `examples/`:

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -128,14 +128,18 @@ For a complete installation guide, visit the [documentation](https://docs.langwa
 
 ### Pod security
 
-Every pod (PostgreSQL, Redis, and ClickHouse included) runs read-only-root,
-non-root, with dropped capabilities, `RuntimeDefault` seccomp, no mounted SA
-token, and resource requests/limits on every container. That clears Pod
-Security Admission `restricted` and Gatekeeper / Kyverno policies as shipped.
-On clusters that enforce them, add `examples/overlays/strict-admission.yaml`,
-which turns off the three features that can't comply: the token-using preflight
-hook, the upstream Prometheus subchart, and the custom-metrics gateway HPA. Full
-details in [Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
+Every LangWatch pod and every bundled datastore (PostgreSQL, Redis, ClickHouse,
+Keeper) runs read-only-root, non-root at both pod and container level, with
+dropped capabilities, `RuntimeDefault` seccomp, no mounted SA token, and
+resource requests/limits on every container.
+
+A default install does **not** clear Pod Security Admission `restricted` on its
+own: two bundled components can't comply. On clusters that enforce it, add
+`examples/overlays/strict-admission.yaml`, which turns off the upstream
+Prometheus subchart and the Langy assistant (whose manager must run as root to
+give each worker its own UID — never force it non-root), plus the
+custom-metrics gateway HPA. Full details in
+[Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
 
 ### Regenerate this table
 

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -128,17 +128,18 @@ For a complete installation guide, visit the [documentation](https://docs.langwa
 
 ### Pod security
 
-Every LangWatch pod and every bundled datastore (PostgreSQL, Redis, ClickHouse,
-Keeper) runs read-only-root, non-root at both pod and container level, with
+Every LangWatch pod (including the cron pods) and every bundled datastore
+(PostgreSQL, Redis, ClickHouse, Keeper) runs read-only-root, non-root at both pod and container level, with
 dropped capabilities, `RuntimeDefault` seccomp, no mounted SA token, and
 resource requests/limits on every container.
 
 A default install does **not** clear Pod Security Admission `restricted` on its
-own: two bundled components can't comply. On clusters that enforce it, add
+own: three bundled components can't comply. On clusters that enforce it, add
 `examples/overlays/strict-admission.yaml`, which turns off the upstream
-Prometheus subchart and the Langy assistant (whose manager must run as root to
-give each worker its own UID — never force it non-root), plus the
-custom-metrics gateway HPA. Full details in
+Prometheus subchart, the Langy assistant (whose manager must run as root to
+give each worker its own UID — never force it non-root), and the ClickHouse
+preflight Job (it runs kubectl, so it needs a token and a writable root), plus
+the custom-metrics gateway HPA. Full details in
 [Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
 
 ### Regenerate this table

--- a/charts/langwatch/examples/overlays/size-dev.yaml
+++ b/charts/langwatch/examples/overlays/size-dev.yaml
@@ -17,9 +17,10 @@ app:
 workers:
   enabled: true
   replicaCount: 1
+  # Same image as the app: needs ~2Gi to cold-load via tsx without OOM-restarts.
   resources:
-    requests: { cpu: 100m, memory: 512Mi }
-    limits:   { cpu: 500m, memory: 1Gi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -39,7 +40,9 @@ langevals:
 clickhouse:
   chartManaged: true
   replicas: 1
-  memory: 1Gi
+  # 2Gi handles light dev ingest. Memory scales with ingest burst size and
+  # background merges, so raise clickhouse.memory if you replay real volume.
+  memory: 2Gi
   cpu: 1
   storage:
     size: 5Gi

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -1,6 +1,9 @@
-# size-minimal.yaml — Absolute minimum resources for CI smoke tests.
+# size-minimal.yaml - smallest footprint that still boots and serves.
+# For CI smoke tests and tiny demos, not real workloads.
 #
-# Everything runs but with tiny limits. Not suitable for real workloads.
+# The Node app and workers need ~2Gi to start: they cold-load the TS server
+# via tsx, and below that V8 can't size its heap and the pod OOMs at boot.
+# ClickHouse auto-tunes to its limit, so give it >=1Gi.
 #
 # Usage:
 #   helm install lw . \
@@ -13,14 +16,14 @@ app:
   features:
     skipEnvValidation: true
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 workers:
   replicaCount: 1
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -31,8 +34,8 @@ langwatch_nlp:
 langevals:
   replicaCount: 1
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 100m, memory: 512Mi }
+    limits:   { cpu: 500m, memory: 1Gi }
   extraEnvs:
     - { name: DISABLE_EVALUATORS_PRELOAD, value: "true" }
     - { name: WEB_CONCURRENCY, value: "1" }
@@ -40,7 +43,10 @@ langevals:
 clickhouse:
   chartManaged: true
   replicas: 1
-  memory: 512Mi
+  # 1Gi covers smoke/light use only. ClickHouse memory scales with ingest
+  # burst size and background merges, so a real trace flood will OOM this -
+  # raise clickhouse.memory (and cpu) before pushing meaningful volume.
+  memory: 1Gi
   cpu: 1
   storage:
     size: 1Gi

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -17,7 +17,10 @@ app:
     limits:   { cpu: 250m, memory: 512Mi }
 
 workers:
-  enabled: false
+  replicaCount: 1
+  resources:
+    requests: { cpu: 50m, memory: 256Mi }
+    limits:   { cpu: 250m, memory: 512Mi }
 
 langwatch_nlp:
   replicaCount: 1

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -5,6 +5,11 @@
 # via tsx, and below that V8 can't size its heap and the pod OOMs at boot.
 # ClickHouse auto-tunes to its limit, so give it >=1Gi.
 #
+# Budget accordingly: this totals roughly 3.7Gi of memory requests and ~2 CPU
+# across the release, which is more than a single 2-vCPU node can schedule once
+# control-plane reservations are counted. "Minimal" here means the smallest
+# that actually boots, not something that fits anywhere.
+#
 # Usage:
 #   helm install lw . \
 #     -f examples/overlays/size-minimal.yaml \
@@ -20,6 +25,10 @@ app:
     limits:   { cpu: 1, memory: 2Gi }
 
 workers:
+  # Pinned true rather than inherited: an overlay has to be self-contained, or
+  # stacking it after a base values file that disables workers silently drops
+  # them (tests/values-e2e.yaml does exactly that).
+  enabled: true
   replicaCount: 1
   resources:
     requests: { cpu: 250m, memory: 768Mi }

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -5,10 +5,14 @@
 # via tsx, and below that V8 can't size its heap and the pod OOMs at boot.
 # ClickHouse auto-tunes to its limit, so give it >=1Gi.
 #
-# Budget accordingly: this totals roughly 3.7Gi of memory requests and ~2 CPU
-# across the release, which is more than a single 2-vCPU node can schedule once
+# Budget accordingly: this totals ~4.7Gi of memory requests and ~2.4 CPU across
+# the release, which is more than a single 2-vCPU node can schedule once
 # control-plane reservations are counted. "Minimal" here means the smallest
 # that actually boots, not something that fits anywhere.
+#
+# ~1Gi / 500m of that is the Langy assistant, which ships enabled and which this
+# overlay does not disable. Stack examples/overlays/langy-disabled.yaml to drop
+# it if you are trying to fit a small node.
 #
 # Usage:
 #   helm install lw . \

--- a/charts/langwatch/examples/overlays/strict-admission.yaml
+++ b/charts/langwatch/examples/overlays/strict-admission.yaml
@@ -1,0 +1,48 @@
+# strict-admission.yaml - for clusters that enforce Pod Security Admission
+# "restricted" or an equivalent OPA Gatekeeper / Kyverno bundle.
+#
+# The hardened pod defaults (read-only root, non-root, dropped capabilities,
+# RuntimeDefault seccomp, no automounted token, resource requests+limits) are
+# already on by default, so this overlay only flips the three features that
+# need a token or an external API and would otherwise be rejected.
+#
+# Usage (stack on a size + access overlay):
+#   helm install lw . \
+#     -f examples/overlays/size-prod.yaml \
+#     -f examples/overlays/access-ingress.yaml \
+#     -f examples/overlays/strict-admission.yaml
+#
+# For production, also stack the external-datastore overlays. Managed databases
+# give you backups and HA and deploy no datastore pods at all. (In-cluster
+# datastores do comply with read-only-root, but external is the better choice.)
+#   -f examples/overlays/postgres-external.yaml
+#   -f examples/overlays/redis-external.yaml
+#   -f examples/overlays/clickhouse-external.yaml
+
+# Preflight runs kubectl to check Secret keys, so it needs an SA token.
+# Disable it where token automounting is denied.
+preflight:
+  enabled: false
+
+# Bundled Prometheus is an upstream subchart we don't harden; bring your own.
+prometheus:
+  chartManaged: false
+
+# The gateway's default HPA needs prometheus-adapter for its custom metric.
+# Run a fixed replica count instead unless you have a custom metrics API.
+gateway:
+  autoscaling:
+    enabled: false
+  replicaCount: 2
+
+app:
+  telemetry:
+    # Prometheus is off above, so don't expose app metrics either - nothing
+    # would scrape them. This is already the default; pinned here so the two
+    # stay coupled if a base values file turned metrics on.
+    metrics:
+      enabled: false
+    # Anonymous usage analytics phone home to LangWatch. Not an admission
+    # concern, but uncomment for an air-gapped / no-egress install.
+    # usage:
+    #   enabled: false

--- a/charts/langwatch/examples/overlays/strict-admission.yaml
+++ b/charts/langwatch/examples/overlays/strict-admission.yaml
@@ -31,6 +31,17 @@
 prometheus:
   chartManaged: false
 
+# The ClickHouse subchart's preflight Job shells out to kubectl to check the
+# Secret's keys, so it needs both an automounted token and a writable root (for
+# kubectl's discovery cache). It only renders when you supply the Secret
+# yourself (clickhouse.auth.existingSecret) rather than using autogen, which is
+# the recommended production path — so pin it off here rather than leaving it to
+# chance. The umbrella already defaults it off; this keeps that true if a base
+# values file turns it on.
+clickhouse:
+  preflight:
+    enabled: false
+
 # The Langy assistant's manager process runs as UID 0 with CHOWN, DAC_OVERRIDE,
 # FOWNER, SETUID and SETGID, and carries no seccomp profile. That is deliberate
 # and load-bearing, NOT an oversight: the manager hands every opencode worker a

--- a/charts/langwatch/examples/overlays/strict-admission.yaml
+++ b/charts/langwatch/examples/overlays/strict-admission.yaml
@@ -1,10 +1,18 @@
 # strict-admission.yaml - for clusters that enforce Pod Security Admission
 # "restricted" or an equivalent OPA Gatekeeper / Kyverno bundle.
 #
-# The hardened pod defaults (read-only root, non-root, dropped capabilities,
-# RuntimeDefault seccomp, no automounted token, resource requests+limits) are
-# already on by default, so this overlay only flips the three features that
-# need a token or an external API and would otherwise be rejected.
+# LangWatch's own pods (app, workers, nlp, langevals, gateway) and the bundled
+# datastores (PostgreSQL, Redis, ClickHouse, Keeper) already ship hardened:
+# read-only root, non-root, dropped capabilities, RuntimeDefault seccomp, no
+# automounted token, resource requests+limits. This overlay turns off the two
+# components that CANNOT comply, because their compliance is not a matter of
+# configuration:
+#
+#   - the bundled Prometheus, an upstream subchart we do not control;
+#   - the Langy agent, which must run as root by design (see below).
+#
+# It also drops the gateway HPA, which needs a custom metrics API rather than
+# an admission exemption.
 #
 # Usage (stack on a size + access overlay):
 #   helm install lw . \
@@ -19,13 +27,29 @@
 #   -f examples/overlays/redis-external.yaml
 #   -f examples/overlays/clickhouse-external.yaml
 
-# Preflight runs kubectl to check Secret keys, so it needs an SA token.
-# Disable it where token automounting is denied.
-preflight:
-  enabled: false
-
 # Bundled Prometheus is an upstream subchart we don't harden; bring your own.
 prometheus:
+  chartManaged: false
+
+# The Langy assistant's manager process runs as UID 0 with CHOWN, DAC_OVERRIDE,
+# FOWNER, SETUID and SETGID, and carries no seccomp profile. That is deliberate
+# and load-bearing, NOT an oversight: the manager hands every opencode worker a
+# distinct UID via child_process.spawn({uid,gid}), which needs those exact
+# capabilities from a root-effective-uid process. Without them, sibling workers
+# share a UID and can read each other's project API keys and GitHub tokens off
+# disk (ADR-033; specs/langy/langy-deploy-hardening.feature).
+#
+# So on a restricted cluster the answer is to NOT deploy the agent, never to
+# "fix" it by forcing runAsNonRoot — that silently re-opens cross-worker
+# credential theft. Opting the whole pod out needs no acceptance value: with
+# nothing deployed there is no workload to sandbox.
+#
+# LangWatch runs fine without it; you lose the in-product assistant only.
+# Pinned here rather than deferred to examples/overlays/langy-disabled.yaml
+# (which sets the same key) so this overlay is self-contained: an operator who
+# applies only strict-admission.yaml must not silently keep a pod their cluster
+# will reject.
+langyagent:
   chartManaged: false
 
 # The gateway's default HPA needs prometheus-adapter for its custom metric.

--- a/charts/langwatch/examples/values-local.yaml
+++ b/charts/langwatch/examples/values-local.yaml
@@ -30,9 +30,10 @@ app:
 workers:
   enabled: true
   replicaCount: 1
+  # Same image as the app: needs ~2Gi to cold-load via tsx without OOM-restarts.
   resources:
-    requests: { cpu: 100m, memory: 512Mi }
-    limits:   { cpu: 500m, memory: 1Gi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -53,7 +54,9 @@ clickhouse:
   chartManaged: true
   image: { pullPolicy: Never }
   replicas: 1
-  memory: 1Gi
+  # Memory scales with ingest burst size; 2Gi suits local use, raise it before
+  # replaying real trace volume.
+  memory: 2Gi
   cpu: 1
   storage: { size: 5Gi }
 

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -945,3 +945,28 @@ podAffinity:
     {{- .Values.clickhouse.external.cluster -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+  Security contexts: a per-component override LAYERS onto the hardened global
+  default. The operator's key wins; every key they do not mention keeps its
+  default. Overriding one field is therefore never a way to drop the others.
+
+  Use mustMergeOverwrite, not coalesce: coalesce is all-or-nothing, taking the
+  component map whole as soon as it is non-empty, which makes a partial
+  override behave as a full replacement. deepCopy because mustMergeOverwrite
+  mutates its first argument and .Values.global is shared across every
+  component in the release.
+
+  Usage: {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.app) }}
+*/}}
+{{- define "langwatch.podSecurityContext" -}}
+{{- $global := .ctx.Values.global.podSecurityContext | default dict -}}
+{{- $override := .component.podSecurityContext | default dict -}}
+{{- toYaml (mustMergeOverwrite (deepCopy $global) $override) -}}
+{{- end -}}
+
+{{- define "langwatch.containerSecurityContext" -}}
+{{- $global := .ctx.Values.global.containerSecurityContext | default dict -}}
+{{- $override := .component.containerSecurityContext | default dict -}}
+{{- toYaml (mustMergeOverwrite (deepCopy $global) $override) -}}
+{{- end -}}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -961,8 +961,13 @@ podAffinity:
 */}}
 {{- define "langwatch.podSecurityContext" -}}
 {{- $global := .ctx.Values.global.podSecurityContext | default dict -}}
+{{- /* Components whose image pins its own uid pass "base" instead of the
+       global default — the bundled datastores cannot run as uid 1000. The
+       override still layers on top, so a partial override cannot strip the
+       uid, runAsNonRoot or the seccomp profile. */ -}}
+{{- $defaults := .base | default $global -}}
 {{- $override := .component.podSecurityContext | default dict -}}
-{{- toYaml (mustMergeOverwrite (deepCopy $global) $override) -}}
+{{- toYaml (mustMergeOverwrite (deepCopy $defaults) $override) -}}
 {{- end -}}
 
 {{- define "langwatch.containerSecurityContext" -}}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -117,12 +117,20 @@ spec:
           volumeMounts:
             - name: next-dir
               mountPath: /next-tmp
+          # Mirrors the main container's hardening so strict admission policies
+          # (require-resource-limits, read-only-root-filesystem) accept the
+          # init container too. It only writes to the next-dir emptyDir, so a
+          # read-only root filesystem is safe here.
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 200m, memory: 256Mi }
       containers:
         {{- with .Values.app.extraContainers}}
         {{- toYaml . | nindent 8 }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -102,35 +102,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.app.extraInitContainers}}
       initContainers:
-        {{- with .Values.app.extraInitContainers}}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        # Fix permissions for Next.js cache/static directories when running as non-root
-        - name: fix-nextjs-permissions
-          image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
-          command: ['sh', '-c']
-          args:
-            - |
-              cp -r /app/langwatch/.next/* /next-tmp/ 2>/dev/null || true
-              echo "Copied .next contents to writable volume"
-          volumeMounts:
-            - name: next-dir
-              mountPath: /next-tmp
-          # Mirrors the main container's hardening so strict admission policies
-          # (require-resource-limits, read-only-root-filesystem) accept the
-          # init container too. It only writes to the next-dir emptyDir, so a
-          # read-only root filesystem is safe here.
-          securityContext:
-            runAsUser: 1000
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-          resources:
-            requests: { cpu: 50m, memory: 64Mi }
-            limits: { cpu: 200m, memory: 256Mi }
+      {{- end }}
       containers:
         {{- with .Values.app.extraContainers}}
         {{- toYaml . | nindent 8 }}
@@ -372,8 +347,6 @@ spec:
             {{- end }}
             - name: tmp-dir
               mountPath: /tmp
-            - name: next-dir
-              mountPath: /app/langwatch/.next
             {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
             # Stored-objects local-FS mount — renders ONLY when local-FS is
             # the active backend (dataplane disabled). Single-replica only
@@ -390,8 +363,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: tmp-dir
-          emptyDir: {}
-        - name: next-dir
           emptyDir: {}
         {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
         - name: stored-objects-data

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -73,10 +73,8 @@ spec:
       # The app does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
-      {{- with (coalesce .Values.app.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.app) | nindent 8 }}
 
       # Node selection - https://kubespec.dev/v1/Pod#spec.nodeSelector
       {{- with (coalesce .Values.app.nodeSelector .Values.global.scheduling.nodeSelector)}}
@@ -112,7 +110,7 @@ spec:
         {{- end }}
         - name: {{ .Release.Name }}-app
           securityContext:
-            {{- toYaml (coalesce .Values.app.containerSecurityContext .Values.global.containerSecurityContext) | nindent 12 }}
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.app) | nindent 12 }}
           image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
           imagePullPolicy: "{{ .Values.images.app.pullPolicy }}"
           ports:

--- a/charts/langwatch/templates/cronjobs/cronjobs.yaml
+++ b/charts/langwatch/templates/cronjobs/cronjobs.yaml
@@ -54,10 +54,8 @@ spec:
           # Kubernetes API, so don't mount the SA token.
           automountServiceAccountToken: {{ $root.Values.global.automountServiceAccountToken }}
           # Pod security context
-          {{- with (coalesce $root.Values.cronjobs.podSecurityContext $root.Values.global.podSecurityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+                    securityContext:
+            {{- include "langwatch.podSecurityContext" (dict "ctx" $root "component" $root.Values.cronjobs) | nindent 12 }}
           # Node selection
           {{- with (coalesce $root.Values.cronjobs.nodeSelector $root.Values.global.scheduling.nodeSelector) }}
           nodeSelector:
@@ -78,7 +76,7 @@ spec:
           containers:
             - name: {{ $root.Release.Name }}-{{ $jobName | kebabcase }}
               securityContext:
-                {{- toYaml (coalesce $root.Values.cronjobs.containerSecurityContext $root.Values.global.containerSecurityContext) | nindent 16 }}
+                {{- include "langwatch.containerSecurityContext" (dict "ctx" $root "component" $root.Values.cronjobs) | nindent 16 }}
               image: "{{ $root.Values.cronjobs.image.repository }}:{{ $root.Values.cronjobs.image.tag }}"
               imagePullPolicy: {{ $root.Values.cronjobs.image.pullPolicy }}
               env:

--- a/charts/langwatch/templates/cronjobs/cronjobs.yaml
+++ b/charts/langwatch/templates/cronjobs/cronjobs.yaml
@@ -54,7 +54,7 @@ spec:
           # Kubernetes API, so don't mount the SA token.
           automountServiceAccountToken: {{ $root.Values.global.automountServiceAccountToken }}
           # Pod security context
-                    securityContext:
+          securityContext:
             {{- include "langwatch.podSecurityContext" (dict "ctx" $root "component" $root.Values.cronjobs) | nindent 12 }}
           # Node selection
           {{- with (coalesce $root.Values.cronjobs.nodeSelector $root.Values.global.scheduling.nodeSelector) }}

--- a/charts/langwatch/templates/langevals/deployment.yaml
+++ b/charts/langwatch/templates/langevals/deployment.yaml
@@ -43,10 +43,8 @@ spec:
       # Langevals does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
-      {{- with (coalesce .Values.langevals.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.langevals) | nindent 8 }}
 
       # Node selection - https://kubespec.dev/v1/Pod#spec.nodeSelector
       {{- with (coalesce .Values.langevals.nodeSelector .Values.global.scheduling.nodeSelector)}}
@@ -72,10 +70,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.langevals.extraInitContainers}}
       initContainers:
-        {{- with .Values.langevals.extraInitContainers}}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
 
       containers:
         {{- with .Values.langevals.extraContainers}}
@@ -83,7 +81,7 @@ spec:
         {{- end }}
         - name: {{ .Release.Name }}-langevals
           securityContext:
-            {{- toYaml (coalesce .Values.langevals.containerSecurityContext .Values.global.containerSecurityContext) | nindent 12 }}
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.langevals) | nindent 12 }}
           image: "{{ .Values.images.langevals.repository }}:{{ .Values.images.langevals.tag }}"
           imagePullPolicy: {{ .Values.images.langevals.pullPolicy }}
           ports:

--- a/charts/langwatch/templates/langwatch_nlp/deployment.yaml
+++ b/charts/langwatch/templates/langwatch_nlp/deployment.yaml
@@ -43,10 +43,8 @@ spec:
       # The NLP service does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
-      {{- with (coalesce .Values.langwatch_nlp.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.langwatch_nlp) | nindent 8 }}
 
       # Node selection - https://kubespec.dev/v1/Pod#spec.nodeSelector
       {{- with (coalesce .Values.langwatch_nlp.nodeSelector .Values.global.scheduling.nodeSelector)}}
@@ -72,10 +70,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.langwatch_nlp.extraInitContainers}}
       initContainers:
-        {{- with .Values.langwatch_nlp.extraInitContainers}}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
 
       containers:
         {{- with .Values.langwatch_nlp.extraContainers}}
@@ -83,7 +81,7 @@ spec:
         {{- end }}
         - name: {{ .Release.Name }}-langwatch-nlp
           securityContext:
-            {{- toYaml (coalesce .Values.langwatch_nlp.containerSecurityContext .Values.global.containerSecurityContext) | nindent 12 }}
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.langwatch_nlp) | nindent 12 }}
           image: "{{ .Values.images.langwatch_nlp.repository }}:{{ .Values.images.langwatch_nlp.tag }}"
           imagePullPolicy: "{{ .Values.images.langwatch_nlp.pullPolicy }}"
           ports:

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -35,6 +35,7 @@ spec:
         - name: postgresql
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -82,6 +83,17 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+            # Writable scratch so the container can run read-only root:
+            # postgres needs its unix socket dir and /tmp writable.
+            - name: run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -23,6 +23,18 @@ spec:
     spec:
       # PostgreSQL does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: postgresql
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -40,8 +40,7 @@ spec:
       # layers on top rather than replacing, so a partial override cannot
       # strip runAsNonRoot or the seccomp profile.
       securityContext:
-        {{- $base := dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") }}
-        {{- toYaml (mustMergeOverwrite $base (.Values.postgresql.podSecurityContext | default dict)) | nindent 8 }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.postgresql "base" (dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault"))) | nindent 8 }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: postgresql
@@ -99,10 +98,15 @@ spec:
             - name: tmp
               mountPath: /tmp
       volumes:
+        # Bounded like every other scratch volume: an unbounded emptyDir is
+        # backed by node ephemeral storage, so a looping pod evicts neighbours
+        # instead of itself.
         - name: run
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.postgresql.scratchSizeLimit }}
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.postgresql.scratchSizeLimit }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -23,34 +23,30 @@ spec:
     spec:
       # PostgreSQL does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
-      {{- with .Values.global.scheduling.nodeSelector }}
+      {{- with (coalesce .Values.postgresql.nodeSelector .Values.global.scheduling.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.scheduling.tolerations }}
+      {{- with (coalesce .Values.postgresql.tolerations .Values.global.scheduling.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.scheduling.affinity }}
+      {{- with (coalesce .Values.postgresql.affinity .Values.global.scheduling.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # uid 999 is the postgresql image's own user, so this cannot inherit
+      # global.podSecurityContext (uid 1000). A per-component override
+      # layers on top rather than replacing, so a partial override cannot
+      # strip runAsNonRoot or the seccomp profile.
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        {{- $base := dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") }}
+        {{- toYaml (mustMergeOverwrite $base (.Values.postgresql.podSecurityContext | default dict)) | nindent 8 }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: postgresql
           securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.postgresql) | nindent 12 }}
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
           ports:

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - name: redis
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
@@ -86,6 +87,12 @@ spec:
           volumeMounts:
             - name: redis-data
               mountPath: /data
+            # Writable /tmp so the container can run read-only root.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -24,6 +24,18 @@ spec:
     spec:
       # Redis does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
         - name: redis
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -41,8 +41,7 @@ spec:
       # layers on top rather than replacing, so a partial override cannot
       # strip runAsNonRoot or the seccomp profile.
       securityContext:
-        {{- $base := dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") }}
-        {{- toYaml (mustMergeOverwrite $base (.Values.redis.podSecurityContext | default dict)) | nindent 8 }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.redis "base" (dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault"))) | nindent 8 }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
@@ -100,8 +99,12 @@ spec:
             - name: tmp
               mountPath: /tmp
       volumes:
+        # Bounded like every other scratch volume: an unbounded emptyDir is
+        # backed by node ephemeral storage, so a looping pod evicts neighbours
+        # instead of itself.
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.redis.scratchSizeLimit }}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -24,34 +24,30 @@ spec:
     spec:
       # Redis does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
-      {{- with .Values.global.scheduling.nodeSelector }}
+      {{- with (coalesce .Values.redis.nodeSelector .Values.global.scheduling.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.scheduling.tolerations }}
+      {{- with (coalesce .Values.redis.tolerations .Values.global.scheduling.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.scheduling.affinity }}
+      {{- with (coalesce .Values.redis.affinity .Values.global.scheduling.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # uid 999 is the redis image's own user, so this cannot inherit
+      # global.podSecurityContext (uid 1000). A per-component override
+      # layers on top rather than replacing, so a partial override cannot
+      # strip runAsNonRoot or the seccomp profile.
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        {{- $base := dict "runAsUser" 999 "runAsGroup" 999 "fsGroup" 999 "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") }}
+        {{- toYaml (mustMergeOverwrite $base (.Values.redis.podSecurityContext | default dict)) | nindent 8 }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
           securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.redis) | nindent 12 }}
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy | default "IfNotPresent" }}
           {{- if $authEnabled }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -70,10 +70,8 @@ spec:
     spec:
       # Workers do not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
-      {{- with (coalesce .Values.workers.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.workers) | nindent 8 }}
 
       {{- with (coalesce .Values.workers.nodeSelector .Values.global.scheduling.nodeSelector)}}
       nodeSelector:
@@ -102,17 +100,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.workers.extraInitContainers}}
       initContainers:
-        {{- with .Values.workers.extraInitContainers}}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       containers:
         {{- with .Values.workers.extraContainers}}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: {{ .Release.Name }}-workers
           securityContext:
-            {{- toYaml (coalesce .Values.workers.containerSecurityContext .Values.global.containerSecurityContext) | nindent 12 }}
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.workers) | nindent 12 }}
           image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
           imagePullPolicy: "{{ .Values.images.app.pullPolicy }}"
           workingDir: /app/langwatch

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -43,7 +43,7 @@ tmpl_only() {
 # Check rendered YAML contains a string (uses <<< to avoid broken pipe with large output)
 assert_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if grep -qF "$needle" <<< "$haystack"; then
+  if grep -qF -- "$needle" <<< "$haystack"; then
     pass "$label"
   else
     fail "$label: expected to find '$needle'"
@@ -53,7 +53,7 @@ assert_contains() {
 # Check rendered YAML does NOT contain a string
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if grep -qF "$needle" <<< "$haystack"; then
+  if grep -qF -- "$needle" <<< "$haystack"; then
     fail "$label: expected NOT to find '$needle'"
   else
     pass "$label"
@@ -63,7 +63,10 @@ assert_not_contains() {
 # Count occurrences of a pattern in rendered YAML
 count_matches() {
   local haystack="$1" pattern="$2"
-  grep -c "$pattern" <<< "$haystack" || echo "0"
+  # grep -c already prints 0 when there are no matches; it just exits 1. The
+  # `|| echo 0` form would append a SECOND line, and the caller's (( n >= 10 ))
+  # then dies with an arithmetic syntax error instead of reporting the count.
+  grep -c -- "$pattern" <<< "$haystack" || true
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -257,7 +260,14 @@ test_size_overlays() {
     -f "${OVERLAYS}/size-minimal.yaml" \
     -f "${OVERLAYS}/access-nodeport.yaml")
   assert_contains "minimal: workers deployed" "$min_out" "# Source: langwatch/templates/workers/deployment.yaml"
-  assert_contains "minimal: app replicas 1" "$min_out" "replicas: 1"
+  # Scoped to the app Deployment: the full render carries six other `replicas: 1`
+  # lines (redis, postgres, clickhouse, nlp, langevals), so a whole-document
+  # grep passes even for size-prod, where the app has two.
+  local min_app
+  min_app=$(tmpl_only "templates/app/deployment.yaml" --set autogen.enabled=true \
+    -f "${OVERLAYS}/size-minimal.yaml" \
+    -f "${OVERLAYS}/access-nodeport.yaml")
+  assert_contains "minimal: app replicas 1" "$min_app" "replicas: 1"
 
   # size-prod: 2 app replicas, PDB
   local prod_out
@@ -278,63 +288,165 @@ test_size_overlays() {
 
 # ─────────────────────────────────────────────────────────────────────────────
 # SUITE: pod security hardening — guard the strict-admission posture
-# (every container read-only-root + non-escalating + RuntimeDefault seccomp,
-# no automounted SA token, no privileged/writable-root opt-outs). These render-
-# level checks catch regressions of the hardening without needing Gatekeeper.
+#
+# Assertions here are scoped PER WORKLOAD via --show-only, never grepped over
+# the whole render. A whole-render grep ("is readOnlyRootFilesystem present?")
+# passes when one container out of ten has it, and a whole-render count
+# ("at least 10 sites") passes when a workload regresses as long as some other
+# workload gains a field. Both let the exact regression they name through.
+#
+# Two workloads deliberately do NOT comply and are listed as exemptions below.
+# An exemption is only legitimate if strict-admission.yaml turns that workload
+# off, which the last block asserts.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# Workloads LangWatch authors and hardens. Every container must carry the full
+# posture. Adding a workload to the chart without adding it here fails the
+# "no untriaged workloads" check below — that is deliberate.
+HARDENED_WORKLOADS=(
+  "templates/app/deployment.yaml"
+  "templates/workers/deployment.yaml"
+  "templates/langwatch_nlp/deployment.yaml"
+  "templates/langevals/deployment.yaml"
+  "templates/postgresql/statefulset.yaml"
+  "templates/redis/statefulset.yaml"
+  "charts/gateway/templates/deployment.yaml"
+  "charts/clickhouse/templates/statefulset.yaml"
+)
+
+# Workloads that cannot comply, each with the reason and the values key that
+# removes it. strict-admission.yaml must set every one of these to false.
+EXEMPT_WORKLOADS=(
+  # Upstream subchart we do not control: no readOnlyRootFilesystem, no seccomp,
+  # no limits on the config-reload sidecar.
+  "charts/prometheus/templates/deploy.yaml:prometheus.chartManaged"
+  # Root by design: the manager needs CHOWN/DAC_OVERRIDE/FOWNER/SETUID/SETGID
+  # to hand each worker a distinct UID. Forcing it non-root re-opens
+  # cross-worker credential theft (ADR-033).
+  "charts/langyagent/templates/deployment.yaml:langyagent.chartManaged"
+)
+
+# Assert one workload template carries the full hardened posture.
+assert_workload_hardened() {
+  local tpl="$1" out
+  out=$(tmpl_only "$tpl" --set autogen.enabled=true) || {
+    fail "hardening: could not render $tpl"; return
+  }
+
+  assert_contains "hardening[$tpl]: read-only root"        "$out" "readOnlyRootFilesystem: true"
+  assert_contains "hardening[$tpl]: privilege esc off"     "$out" "allowPrivilegeEscalation: false"
+  assert_contains "hardening[$tpl]: RuntimeDefault seccomp" "$out" "type: RuntimeDefault"
+  assert_contains "hardening[$tpl]: SA token not mounted"  "$out" "automountServiceAccountToken: false"
+  assert_not_contains "hardening[$tpl]: not writable-root" "$out" "readOnlyRootFilesystem: false"
+  assert_not_contains "hardening[$tpl]: not privileged"    "$out" "privileged: true"
+
+  # Capabilities are dropped in two rendered forms: `drop: ["ALL"]` inline
+  # (datastores) and a `- ALL` list item (global containerSecurityContext).
+  if grep -qE 'drop: \["ALL"\]|^[[:space:]]+- ALL' <<< "$out"; then
+    pass "hardening[$tpl]: capabilities dropped"
+  else
+    fail "hardening[$tpl]: expected capabilities.drop ALL"
+  fi
+
+  # runAsNonRoot must appear at BOTH pod and container level: Kubernetes
+  # inherits the pod-level value, but some Gatekeeper flavours of
+  # k8sreadonlyrootfilesystem read the container-level field directly and deny
+  # pods that only carry it on the pod. Regression guard for the customer
+  # report where pod-level alone tripped their constraint — so this asserts
+  # TWO occurrences, which a pod-level-only regression cannot satisfy.
+  local nr
+  nr=$(count_matches "$out" "runAsNonRoot: true")
+  if (( nr >= 2 )); then
+    pass "hardening[$tpl]: runAsNonRoot at pod + container level"
+  else
+    fail "hardening[$tpl]: expected runAsNonRoot at pod AND container level, found $nr occurrence(s)"
+  fi
+}
+
 test_pod_security() {
   sep; info "Suite: pod security hardening"
 
-  # Default render: chart-managed everything (app, workers, nlp, langevals,
-  # cronjobs, postgres, redis, clickhouse, gateway).
+  local tpl
+  for tpl in "${HARDENED_WORKLOADS[@]}"; do
+    assert_workload_hardened "$tpl"
+  done
+
   local def
   def=$(tmpl --set autogen.enabled=true)
 
-  assert_contains "hardening: read-only root filesystem set" "$def" "readOnlyRootFilesystem: true"
-  # After hardening, nothing opts back into a writable root.
-  assert_not_contains "hardening: no writable-root containers" "$def" "readOnlyRootFilesystem: false"
-  assert_contains "hardening: RuntimeDefault seccomp" "$def" "type: RuntimeDefault"
-  assert_contains "hardening: privilege escalation disabled" "$def" "allowPrivilegeEscalation: false"
-  assert_not_contains "hardening: no privileged containers" "$def" "privileged: true"
-  assert_contains "hardening: SA token not automounted" "$def" "automountServiceAccountToken: false"
-  assert_contains "hardening: clickhouse pins uid 101" "$def" "runAsUser: 101"
+  # ClickHouse pins its image uid explicitly rather than relying on the USER
+  # directive, so MustRunAs policies that read the pod spec accept it.
+  local ch
+  ch=$(tmpl_only "charts/clickhouse/templates/statefulset.yaml" --set autogen.enabled=true)
+  assert_contains "hardening: clickhouse pins uid 101" "$ch" "runAsUser: 101"
+
   # The app moved off Next.js; the dead permissions init container stays gone.
   assert_not_contains "hardening: no dead next.js init container" "$def" "fix-nextjs-permissions"
 
-  # read-only root should cover every workload container (app, workers, nlp,
-  # langevals, 2 cronjobs, postgres, redis, clickhouse, gateway = 10).
-  local ro_count
-  ro_count=$(count_matches "$def" "readOnlyRootFilesystem: true")
-  if (( ro_count >= 10 )); then
-    pass "hardening: read-only root on $ro_count containers (>=10)"
+  # A per-component securityContext override layers onto the hardened global
+  # default rather than replacing it: the overridden key takes the operator's
+  # value, every other key keeps its default. Checked at both pod and container
+  # level, since each has its own merge site.
+  local pod_override cont_override
+  pod_override=$(tmpl_only "templates/app/deployment.yaml" \
+    --set autogen.enabled=true --set app.podSecurityContext.fsGroup=2000)
+  assert_contains "override: fsGroup applied"            "$pod_override" "fsGroup: 2000"
+  assert_contains "override: keeps runAsNonRoot default" "$pod_override" "runAsNonRoot: true"
+  assert_contains "override: keeps seccomp default"      "$pod_override" "type: RuntimeDefault"
+
+  cont_override=$(tmpl_only "templates/app/deployment.yaml" \
+    --set autogen.enabled=true --set app.containerSecurityContext.readOnlyRootFilesystem=false)
+  assert_contains "override: readOnlyRootFilesystem applied"    "$cont_override" "readOnlyRootFilesystem: false"
+  assert_contains "override: keeps allowPrivilegeEscalation"    "$cont_override" "allowPrivilegeEscalation: false"
+  assert_contains "override: keeps dropped capabilities"        "$cont_override" "- ALL"
+
+  # No workload may exist that is neither hardened nor a recorded exemption.
+  # This is what stops a new subchart from silently shipping unhardened.
+  local rendered expected found
+  rendered=$(awk '/^# Source:/{src=$3} /^kind: (Deployment|StatefulSet|CronJob|Job)$/{print src}' <<< "$def" \
+    | sed 's|^langwatch/||' | sort -u)
+  expected=$(printf '%s\n' "${HARDENED_WORKLOADS[@]}" "${EXEMPT_WORKLOADS[@]%%:*}" | sort -u)
+  found=$(comm -23 <(printf '%s\n' "$rendered") <(printf '%s\n' "$expected") || true)
+  if [[ -z "$found" ]]; then
+    pass "hardening: no untriaged workloads in the default render"
   else
-    fail "hardening: expected >=10 read-only-root containers, found $ro_count"
+    fail "hardening: workload(s) neither hardened nor exempt: $(tr '\n' ' ' <<< "$found")"
   fi
 
-  # runAsNonRoot must be set at the *container* level too, not only the pod,
-  # because some Gatekeeper flavours of k8sreadonlyrootfilesystem inspect the
-  # container-level field directly. Regression guard for the customer report
-  # where pod-level alone tripped their constraint.
-  local nr_count
-  nr_count=$(count_matches "$def" "runAsNonRoot: true")
-  if (( nr_count >= 10 )); then
-    pass "hardening: container-level runAsNonRoot on $nr_count sites (>=10)"
-  else
-    fail "hardening: expected >=10 container-level runAsNonRoot, found $nr_count"
-  fi
-
-  # Gateway pod must set automount on the POD spec, not just its ServiceAccount
-  # (regression guard for the gap this work closed).
-  local gw_block
-  gw_block=$(awk -v RS='---' '/kind: Deployment/ && /name: '"${RELEASE}"'-gateway/{print}' <<< "$def")
-  assert_contains "hardening: gateway pod automount disabled" "$gw_block" "automountServiceAccountToken: false"
-
-  # strict-admission overlay drops the components that can't comply.
-  local strict
+  # strict-admission overlay must remove every exempt workload, and the
+  # gateway HPA. Asserted against the workload's own template source, so an
+  # unrelated resource keeping the same string cannot mask a failure.
+  local strict entry
   strict=$(tmpl --set autogen.enabled=true -f "${OVERLAYS}/strict-admission.yaml")
-  assert_not_contains "strict-admission: prometheus subchart off" "$strict" "prometheus-config"
-  assert_not_contains "strict-admission: gateway HPA off" "$strict" "kind: HorizontalPodAutoscaler"
-  assert_not_contains "strict-admission: app metrics scrape off" "$strict" "prometheus.io/scrape"
+  for entry in "${EXEMPT_WORKLOADS[@]}"; do
+    assert_not_contains "strict-admission: ${entry##*:} off" "$strict" "# Source: langwatch/${entry%%:*}"
+  done
+  assert_not_contains "strict-admission: gateway HPA off" "$strict" "# Source: langwatch/charts/gateway/templates/hpa.yaml"
+
+  # app metrics: prove the overlay actually suppresses the scrape annotation.
+  # Asserting its absence against a default render is vacuous — the annotation
+  # is off by chart default, so it is absent whether or not the overlay works.
+  #
+  # The overlay's job is to win over a BASE VALUES FILE that turned metrics on,
+  # so the baseline has to come from `-f` too: `--set` outranks every `-f`
+  # regardless of order, so a --set baseline could never be overridden and the
+  # test would fail against a perfectly good overlay.
+  local metrics_base
+  metrics_base=$(mktemp)
+  cat > "$metrics_base" <<'YAML'
+app:
+  telemetry:
+    metrics:
+      enabled: true
+      apiKey:
+        value: test-key
+YAML
+  local metrics_on metrics_off
+  metrics_on=$(tmpl --set autogen.enabled=true -f "$metrics_base")
+  assert_contains "baseline: app metrics scrape present when enabled" "$metrics_on" "prometheus.io/scrape"
+  metrics_off=$(tmpl --set autogen.enabled=true -f "$metrics_base" -f "${OVERLAYS}/strict-admission.yaml")
+  assert_not_contains "strict-admission: app metrics scrape off" "$metrics_off" "prometheus.io/scrape"
+  rm -f "$metrics_base"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -548,11 +660,14 @@ test_install_minimal() {
     -f "${CHART_DIR}/tests/values-e2e.yaml"
   pass "helm install (minimal + nodeport)"
 
-  # Workers should NOT exist
+  # values-e2e.yaml is passed last and sets workers.enabled=false, so this
+  # asserts the ENABLE GATE still removes the Deployment. It is not a statement
+  # about size-minimal, which enables workers — the label used to say otherwise
+  # and only stayed green by accident of the -f ordering.
   if kc get deployment "${RELEASE}-workers" &>/dev/null; then
-    fail "Workers Deployment should not exist in size-minimal"
+    fail "workers.enabled=false should remove the Workers Deployment"
   else
-    pass "Workers Deployment absent (size-minimal)"
+    pass "Workers Deployment absent (workers.enabled=false via values-e2e)"
   fi
 
   # ClickHouse should be a single pod

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -311,6 +311,18 @@ test_pod_security() {
     fail "hardening: expected >=10 read-only-root containers, found $ro_count"
   fi
 
+  # runAsNonRoot must be set at the *container* level too, not only the pod,
+  # because some Gatekeeper flavours of k8sreadonlyrootfilesystem inspect the
+  # container-level field directly. Regression guard for the customer report
+  # where pod-level alone tripped their constraint.
+  local nr_count
+  nr_count=$(count_matches "$def" "runAsNonRoot: true")
+  if (( nr_count >= 10 )); then
+    pass "hardening: container-level runAsNonRoot on $nr_count sites (>=10)"
+  else
+    fail "hardening: expected >=10 container-level runAsNonRoot, found $nr_count"
+  fi
+
   # Gateway pod must set automount on the POD spec, not just its ServiceAccount
   # (regression guard for the gap this work closed).
   local gw_block

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -314,6 +314,28 @@ HARDENED_WORKLOADS=(
   "charts/clickhouse/templates/statefulset.yaml"
 )
 
+# Workloads that render only behind a non-default value. They are as
+# operator-facing as the default ones, and the default render cannot see them,
+# so each needs its own flag set.
+HARDENED_WORKLOADS_GATED=(
+  "charts/clickhouse/templates/keeper-statefulset.yaml"
+  "charts/clickhouse/templates/backup-cronjobs.yaml"
+  "templates/cronjobs/cronjobs.yaml"
+)
+
+CH_FULL_FLAGS=(--set autogen.enabled=true
+               --set clickhouse.replicas=3
+               --set clickhouse.backup.enabled=true
+               --set clickhouse.objectStorage.bucket=test
+               --set clickhouse.objectStorage.region=us-east-1)
+
+# values.yaml ships `cronjobs.jobs: {}` as an operator extension point, so the
+# template renders nothing by default. Populate one so it is actually exercised.
+CRONJOB_FLAGS=(--set autogen.enabled=true
+               --set cronjobs.jobs.probe.enabled=true
+               --set "cronjobs.jobs.probe.schedule=0 0 * * *"
+               --set cronjobs.jobs.probe.endpoint=/api/cron/probe)
+
 # Workloads that cannot comply, each with the reason and the values key that
 # removes it. strict-admission.yaml must set every one of these to false.
 EXEMPT_WORKLOADS=(
@@ -324,65 +346,77 @@ EXEMPT_WORKLOADS=(
   # to hand each worker a distinct UID. Forcing it non-root re-opens
   # cross-worker credential theft (ADR-033).
   "charts/langyagent/templates/deployment.yaml:langyagent.chartManaged"
+  # Runs kubectl against Secrets, so it needs its token and a writable root for
+  # kubectl's discovery cache. Only renders on the operator-owned-Secret path.
+  "charts/clickhouse/templates/preflight-secrets-job.yaml:clickhouse.preflight.enabled"
 )
 
+# Every emptyDir in the rendered manifest must declare a sizeLimit: they are
+# backed by node ephemeral storage, so an unbounded one lets a single looping
+# pod evict its neighbours. Counts, not presence — these templates carry
+# several, and a presence check passes while any one of them loses its bound.
+assert_every_emptydir_bounded() {
+  local label="$1" manifest="$2" dirs bounded
+  dirs=$(count_matches "$manifest" "^[[:space:]]*emptyDir:")
+  bounded=$(count_matches "$manifest" "^[[:space:]]*sizeLimit:")
+  if (( dirs == bounded )); then
+    pass "hardening: $label — all $dirs emptyDir(s) size-bounded"
+  else
+    fail "hardening: $label — $bounded of $dirs emptyDir(s) size-bounded"
+  fi
+}
+
 # Assert one workload template carries the full hardened posture on EVERY
-# container it renders, not merely somewhere in the document. Extra helm flags
-# may follow the template path (some workloads only render when a feature is on).
+# container of EVERY pod spec it renders. Extra helm flags may follow the
+# template path (some workloads only render when a feature is on).
+#
+# This reads fields off each container OBJECT via charts/lib/pod-security-report.rb.
+# Counting matches across the rendered text does not work: a template with three
+# pod specs keeps its totals unchanged when a field moves from a container up to
+# the pod level (where Kubernetes ignores it), so a counting assertion reports
+# full coverage while containers run unhardened. Presence greps are worse again —
+# one hit anywhere satisfies them for the whole document.
 assert_workload_hardened() {
   local tpl="$1"; shift
-  local out
+  local out report
   out=$(tmpl_only "$tpl" "$@") || {
     fail "hardening: could not render $tpl"; return
   }
-
-  # One `image:` line per container, so this is the container count and the
-  # per-field counts below scale with it automatically as containers are added.
-  local containers ro ape
-  containers=$(count_matches "$out" "^[[:space:]]*image:")
-  if (( containers == 0 )); then
+  report=$(ruby "${CHART_DIR}/../lib/pod-security-report.rb" <<< "$out") || {
+    fail "hardening[$tpl]: could not parse the rendered manifest"; return
+  }
+  if [[ -z "$report" ]]; then
     fail "hardening[$tpl]: rendered no containers"; return
   fi
 
-  ro=$(count_matches "$out" "readOnlyRootFilesystem: true")
-  if (( ro == containers )); then
-    pass "hardening[$tpl]: read-only root on all $containers container(s)"
-  else
-    fail "hardening[$tpl]: read-only root on $ro of $containers container(s)"
+  local id cname ro ape nonroot podnonroot caps seccomp automount res
+  local missing failures=0 containers=0
+  while IFS='|' read -r id cname ro ape nonroot podnonroot caps seccomp automount res; do
+    [[ -z "$id" ]] && continue
+    containers=$((containers + 1))
+    missing=""
+    (( ro == 1 ))         || missing+=" readOnlyRootFilesystem:true"
+    (( ape == 1 ))        || missing+=" allowPrivilegeEscalation:false"
+    (( caps == 1 ))       || missing+=" capabilities.drop:[ALL]"
+    (( res == 1 ))        || missing+=" resources.requests+limits(cpu,memory)"
+    # runAsNonRoot is required at BOTH levels. Kubernetes inherits the pod-level
+    # value, but some Gatekeeper constraints read the container field directly
+    # and deny a pod that carries it only on the pod.
+    (( nonroot == 1 ))    || missing+=" container.runAsNonRoot:true"
+    (( podnonroot == 1 )) || missing+=" pod.runAsNonRoot:true"
+    (( seccomp == 1 ))    || missing+=" pod.seccompProfile:RuntimeDefault"
+    (( automount == 1 ))  || missing+=" pod.automountServiceAccountToken:false"
+    if [[ -n "$missing" ]]; then
+      fail "hardening[$tpl]: ${id} container '${cname}' missing:${missing}"
+      failures=$((failures + 1))
+    fi
+  done <<< "$report"
+
+  if (( failures == 0 )); then
+    pass "hardening[$tpl]: all $containers container(s) fully hardened"
   fi
 
-  ape=$(count_matches "$out" "allowPrivilegeEscalation: false")
-  if (( ape == containers )); then
-    pass "hardening[$tpl]: privilege escalation off on all $containers container(s)"
-  else
-    fail "hardening[$tpl]: privilege escalation off on $ape of $containers container(s)"
-  fi
-
-  assert_contains "hardening[$tpl]: RuntimeDefault seccomp" "$out" "type: RuntimeDefault"
-  assert_contains "hardening[$tpl]: SA token not mounted"  "$out" "automountServiceAccountToken: false"
-  assert_not_contains "hardening[$tpl]: not writable-root" "$out" "readOnlyRootFilesystem: false"
-  assert_not_contains "hardening[$tpl]: not privileged"    "$out" "privileged: true"
-
-  # Capabilities are dropped in two rendered forms: `drop: ["ALL"]` inline
-  # (datastores) and a `- ALL` list item (global containerSecurityContext).
-  if grep -qE 'drop: \["ALL"\]|^[[:space:]]+- ALL' <<< "$out"; then
-    pass "hardening[$tpl]: capabilities dropped"
-  else
-    fail "hardening[$tpl]: expected capabilities.drop ALL"
-  fi
-
-  # runAsNonRoot must appear at BOTH pod and container level: Kubernetes
-  # inherits the pod-level value, but some Gatekeeper constraints read the
-  # container-level field directly and deny pods that only carry it on the pod.
-  # Expect one per container plus at least one pod-level declaration, so a
-  # pod-level-only regression cannot satisfy it.
-  local nr
-  nr=$(count_matches "$out" "runAsNonRoot: true")
-  if (( nr >= containers + 1 )); then
-    pass "hardening[$tpl]: runAsNonRoot at pod + all $containers container(s)"
-  else
-    fail "hardening[$tpl]: expected >= $((containers + 1)) runAsNonRoot (pod + each container), found $nr"
-  fi
+  assert_not_contains "hardening[$tpl]: not privileged" "$out" "privileged: true"
 }
 
 test_pod_security() {
@@ -393,33 +427,50 @@ test_pod_security() {
     assert_workload_hardened "$tpl" --set autogen.enabled=true
   done
 
-  # Keeper and the backup/restore Jobs render only when replication and backup
-  # are switched on, so the default pass above never sees them — they were
-  # hardened with nothing asserting it, and the ClickHouse live e2e only checks
-  # that the CronJob objects exist, never that a Job runs. Cover them here.
-  local ch_full_flags=(--set autogen.enabled=true
-                       --set clickhouse.replicas=3
-                       --set clickhouse.backup.enabled=true
-                       --set clickhouse.objectStorage.bucket=test
-                       --set clickhouse.objectStorage.region=us-east-1)
-  for tpl in "charts/clickhouse/templates/keeper-statefulset.yaml" \
-             "charts/clickhouse/templates/backup-cronjobs.yaml"; do
-    assert_workload_hardened "$tpl" "${ch_full_flags[@]}"
+  # Keeper, the backup/restore Jobs and the cron pods render only when a
+  # non-default value switches them on, so the default pass above never sees
+  # them. That blind spot is not theoretical: the cronjobs template shipped
+  # unrenderable because nothing in the repo ever rendered it.
+  for tpl in "${HARDENED_WORKLOADS_GATED[@]}"; do
+    case "$tpl" in
+      templates/cronjobs/*) assert_workload_hardened "$tpl" "${CRONJOB_FLAGS[@]}" ;;
+      *)                    assert_workload_hardened "$tpl" "${CH_FULL_FLAGS[@]}" ;;
+    esac
+  done
+
+  # The hardened posture must also survive the overlays operators actually
+  # install — strict-admission most of all, since it is what the docs tell a
+  # locked-down cluster to apply. A per-component securityContext override in an
+  # overlay now MERGES over the defaults, so an overlay could relax a control
+  # without the default render noticing.
+  for tpl in "${HARDENED_WORKLOADS[@]}"; do
+    assert_workload_hardened "$tpl" --set autogen.enabled=true \
+      -f "${OVERLAYS}/strict-admission.yaml"
   done
 
   # The backup Jobs talk to S3, so they must carry the chart's ServiceAccount
   # rather than falling through to the namespace default, which would miss an
-  # IRSA annotation set on the chart SA.
+  # IRSA annotation set on the chart SA. Assert the VALUE: the key alone is
+  # satisfied by `serviceAccountName: default`, which is the bug.
   local backup_out
-  backup_out=$(tmpl_only "charts/clickhouse/templates/backup-cronjobs.yaml" "${ch_full_flags[@]}")
-  assert_contains "hardening: backup Jobs use the chart ServiceAccount" "$backup_out" "serviceAccountName:"
+  backup_out=$(tmpl_only "charts/clickhouse/templates/backup-cronjobs.yaml" "${CH_FULL_FLAGS[@]}")
+  assert_contains "hardening: backup Jobs use the chart ServiceAccount" "$backup_out" \
+    "serviceAccountName: ${RELEASE}-clickhouse"
 
   # Scratch volumes are bounded so a pod in an error loop is evicted on its own
-  # quota instead of filling the node's ephemeral storage.
+  # quota instead of filling the node's ephemeral storage. Compare counts, not
+  # presence: these templates carry several emptyDirs and a presence check is
+  # satisfied while any one of them silently loses its bound.
   local ch_sts
-  ch_sts=$(tmpl_only "charts/clickhouse/templates/statefulset.yaml" "${ch_full_flags[@]}")
-  assert_contains "hardening: clickhouse scratch volumes are bounded" "$ch_sts" "sizeLimit:"
-  assert_contains "hardening: backup Job scratch is bounded" "$backup_out" "sizeLimit:"
+  ch_sts=$(tmpl_only "charts/clickhouse/templates/statefulset.yaml" "${CH_FULL_FLAGS[@]}")
+  assert_every_emptydir_bounded "clickhouse statefulset" "$ch_sts"
+  assert_every_emptydir_bounded "backup Jobs" "$backup_out"
+  assert_every_emptydir_bounded "keeper" \
+    "$(tmpl_only "charts/clickhouse/templates/keeper-statefulset.yaml" "${CH_FULL_FLAGS[@]}")"
+  assert_every_emptydir_bounded "postgresql" \
+    "$(tmpl_only "templates/postgresql/statefulset.yaml" --set autogen.enabled=true)"
+  assert_every_emptydir_bounded "redis" \
+    "$(tmpl_only "templates/redis/statefulset.yaml" --set autogen.enabled=true)"
 
   local def
   def=$(tmpl --set autogen.enabled=true)
@@ -451,14 +502,28 @@ test_pod_security() {
   assert_contains "override: keeps dropped capabilities"        "$cont_override" "- ALL"
 
   # No workload may exist that is neither hardened nor a recorded exemption.
-  # This is what stops a new subchart from silently shipping unhardened.
-  local rendered expected found
-  rendered=$(awk '/^# Source:/{src=$3} /^kind: (Deployment|StatefulSet|CronJob|Job)$/{print src}' <<< "$def" \
-    | sed 's|^langwatch/||' | sort -u)
-  expected=$(printf '%s\n' "${HARDENED_WORKLOADS[@]}" "${EXEMPT_WORKLOADS[@]%%:*}" | sort -u)
-  found=$(comm -23 <(printf '%s\n' "$rendered") <(printf '%s\n' "$expected") || true)
+  #
+  # The triage set is the UNION of the default render and every feature-gated
+  # render, because a workload that is off by default is exactly where an
+  # unhardened one hides — reading the default render alone is how the cronjobs
+  # template stayed untriaged and unrenderable. LC_ALL=C pins byte ordering so
+  # `comm`'s sorted-input contract holds regardless of runner locale; comm does
+  # not warn when it is violated, it just returns the wrong answer.
+  local rendered expected found all_renders
+  all_renders=$(
+    printf '%s\n' "$def"
+    tmpl "${CH_FULL_FLAGS[@]}"
+    tmpl "${CRONJOB_FLAGS[@]}"
+    tmpl --set autogen.enabled=true --set clickhouse.preflight.enabled=true \
+      --set clickhouse.autogen.enabled=false --set clickhouse.auth.existingSecret=ch-secret 2>/dev/null || true
+  )
+  rendered=$(awk '/^# Source:/{src=$3} /^kind: (Deployment|StatefulSet|CronJob|Job)$/{print src}' <<< "$all_renders" \
+    | sed 's|^langwatch/||' | LC_ALL=C sort -u)
+  expected=$(printf '%s\n' "${HARDENED_WORKLOADS[@]}" "${HARDENED_WORKLOADS_GATED[@]}" \
+    "${EXEMPT_WORKLOADS[@]%%:*}" | LC_ALL=C sort -u)
+  found=$(LC_ALL=C comm -23 <(printf '%s\n' "$rendered") <(printf '%s\n' "$expected") || true)
   if [[ -z "$found" ]]; then
-    pass "hardening: no untriaged workloads in the default render"
+    pass "hardening: no untriaged workloads across default + feature-gated renders"
   else
     fail "hardening: workload(s) neither hardened nor exempt: $(tr '\n' ' ' <<< "$found")"
   fi
@@ -488,6 +553,9 @@ test_pod_security() {
   # test would fail against a perfectly good overlay.
   local metrics_base
   metrics_base=$(mktemp)
+  # fail() exits, so a trailing rm never runs on the failure path; RETURN fires
+  # either way and keeps failing CI runs from leaking a temp file each time.
+  trap 'rm -f "$metrics_base"' RETURN
   cat > "$metrics_base" <<'YAML'
 app:
   telemetry:
@@ -502,7 +570,6 @@ YAML
   metrics_off=$(tmpl --set autogen.enabled=true -f "$metrics_base" -f "${OVERLAYS}/strict-admission.yaml")
   assert_contains "strict-admission: metrics render produced a manifest" "$metrics_off" "kind: Deployment"
   assert_not_contains "strict-admission: app metrics scrape off" "$metrics_off" "prometheus.io/scrape"
-  rm -f "$metrics_base"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -23,7 +23,13 @@ OVERLAYS="${CHART_DIR}/examples/overlays"
 # shellcheck source=../../lib/test-helpers.sh
 source "$(cd "$(dirname "$0")/../../lib" && pwd)/test-helpers.sh"
 
-trap cleanup_cluster EXIT
+# Temp files registered here are removed on exit, however the script leaves.
+TMP_FILES=()
+cleanup_all() {
+  rm -f "${TMP_FILES[@]:-}"
+  cleanup_cluster
+}
+trap cleanup_all EXIT
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -551,11 +557,14 @@ test_pod_security() {
   # so the baseline has to come from `-f` too: `--set` outranks every `-f`
   # regardless of order, so a --set baseline could never be overridden and the
   # test would fail against a perfectly good overlay.
+  # Registered for cleanup rather than removed inline: fail() exits, so a
+  # trailing rm never runs on the failure path and each red CI run would leak
+  # a temp file. (A `trap ... RETURN` here would be worse — it is global, so it
+  # fires on every later function return, where this local is gone and `set -u`
+  # makes that fatal.)
   local metrics_base
   metrics_base=$(mktemp)
-  # fail() exits, so a trailing rm never runs on the failure path; RETURN fires
-  # either way and keeps failing CI runs from leaking a temp file each time.
-  trap 'rm -f "$metrics_base"' RETURN
+  TMP_FILES+=("$metrics_base")
   cat > "$metrics_base" <<'YAML'
 app:
   telemetry:

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -277,6 +277,55 @@ test_size_overlays() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: pod security hardening — guard the strict-admission posture
+# (every container read-only-root + non-escalating + RuntimeDefault seccomp,
+# no automounted SA token, no privileged/writable-root opt-outs). These render-
+# level checks catch regressions of the hardening without needing Gatekeeper.
+# ─────────────────────────────────────────────────────────────────────────────
+test_pod_security() {
+  sep; info "Suite: pod security hardening"
+
+  # Default render: chart-managed everything (app, workers, nlp, langevals,
+  # cronjobs, postgres, redis, clickhouse, gateway).
+  local def
+  def=$(tmpl --set autogen.enabled=true)
+
+  assert_contains "hardening: read-only root filesystem set" "$def" "readOnlyRootFilesystem: true"
+  # After hardening, nothing opts back into a writable root.
+  assert_not_contains "hardening: no writable-root containers" "$def" "readOnlyRootFilesystem: false"
+  assert_contains "hardening: RuntimeDefault seccomp" "$def" "type: RuntimeDefault"
+  assert_contains "hardening: privilege escalation disabled" "$def" "allowPrivilegeEscalation: false"
+  assert_not_contains "hardening: no privileged containers" "$def" "privileged: true"
+  assert_contains "hardening: SA token not automounted" "$def" "automountServiceAccountToken: false"
+  assert_contains "hardening: clickhouse pins uid 101" "$def" "runAsUser: 101"
+  # The app moved off Next.js; the dead permissions init container stays gone.
+  assert_not_contains "hardening: no dead next.js init container" "$def" "fix-nextjs-permissions"
+
+  # read-only root should cover every workload container (app, workers, nlp,
+  # langevals, 2 cronjobs, postgres, redis, clickhouse, gateway = 10).
+  local ro_count
+  ro_count=$(count_matches "$def" "readOnlyRootFilesystem: true")
+  if (( ro_count >= 10 )); then
+    pass "hardening: read-only root on $ro_count containers (>=10)"
+  else
+    fail "hardening: expected >=10 read-only-root containers, found $ro_count"
+  fi
+
+  # Gateway pod must set automount on the POD spec, not just its ServiceAccount
+  # (regression guard for the gap this work closed).
+  local gw_block
+  gw_block=$(awk -v RS='---' '/kind: Deployment/ && /name: '"${RELEASE}"'-gateway/{print}' <<< "$def")
+  assert_contains "hardening: gateway pod automount disabled" "$gw_block" "automountServiceAccountToken: false"
+
+  # strict-admission overlay drops the components that can't comply.
+  local strict
+  strict=$(tmpl --set autogen.enabled=true -f "${OVERLAYS}/strict-admission.yaml")
+  assert_not_contains "strict-admission: prometheus subchart off" "$strict" "prometheus-config"
+  assert_not_contains "strict-admission: gateway HPA off" "$strict" "kind: HorizontalPodAutoscaler"
+  assert_not_contains "strict-admission: app metrics scrape off" "$strict" "prometheus.io/scrape"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: infrastructure overlays — verify external DB wiring
 # ─────────────────────────────────────────────────────────────────────────────
 test_infra_overlays() {
@@ -652,6 +701,7 @@ main() {
   test_langwatch_endpoint
   test_backup_metrics_gate
   test_size_overlays
+  test_pod_security
   test_infra_overlays
   test_overlay_stacking
   test_workers_probes

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -326,15 +326,38 @@ EXEMPT_WORKLOADS=(
   "charts/langyagent/templates/deployment.yaml:langyagent.chartManaged"
 )
 
-# Assert one workload template carries the full hardened posture.
+# Assert one workload template carries the full hardened posture on EVERY
+# container it renders, not merely somewhere in the document. Extra helm flags
+# may follow the template path (some workloads only render when a feature is on).
 assert_workload_hardened() {
-  local tpl="$1" out
-  out=$(tmpl_only "$tpl" --set autogen.enabled=true) || {
+  local tpl="$1"; shift
+  local out
+  out=$(tmpl_only "$tpl" "$@") || {
     fail "hardening: could not render $tpl"; return
   }
 
-  assert_contains "hardening[$tpl]: read-only root"        "$out" "readOnlyRootFilesystem: true"
-  assert_contains "hardening[$tpl]: privilege esc off"     "$out" "allowPrivilegeEscalation: false"
+  # One `image:` line per container, so this is the container count and the
+  # per-field counts below scale with it automatically as containers are added.
+  local containers ro ape
+  containers=$(count_matches "$out" "^[[:space:]]*image:")
+  if (( containers == 0 )); then
+    fail "hardening[$tpl]: rendered no containers"; return
+  fi
+
+  ro=$(count_matches "$out" "readOnlyRootFilesystem: true")
+  if (( ro == containers )); then
+    pass "hardening[$tpl]: read-only root on all $containers container(s)"
+  else
+    fail "hardening[$tpl]: read-only root on $ro of $containers container(s)"
+  fi
+
+  ape=$(count_matches "$out" "allowPrivilegeEscalation: false")
+  if (( ape == containers )); then
+    pass "hardening[$tpl]: privilege escalation off on all $containers container(s)"
+  else
+    fail "hardening[$tpl]: privilege escalation off on $ape of $containers container(s)"
+  fi
+
   assert_contains "hardening[$tpl]: RuntimeDefault seccomp" "$out" "type: RuntimeDefault"
   assert_contains "hardening[$tpl]: SA token not mounted"  "$out" "automountServiceAccountToken: false"
   assert_not_contains "hardening[$tpl]: not writable-root" "$out" "readOnlyRootFilesystem: false"
@@ -349,17 +372,16 @@ assert_workload_hardened() {
   fi
 
   # runAsNonRoot must appear at BOTH pod and container level: Kubernetes
-  # inherits the pod-level value, but some Gatekeeper flavours of
-  # k8sreadonlyrootfilesystem read the container-level field directly and deny
-  # pods that only carry it on the pod. Regression guard for the customer
-  # report where pod-level alone tripped their constraint — so this asserts
-  # TWO occurrences, which a pod-level-only regression cannot satisfy.
+  # inherits the pod-level value, but some Gatekeeper constraints read the
+  # container-level field directly and deny pods that only carry it on the pod.
+  # Expect one per container plus at least one pod-level declaration, so a
+  # pod-level-only regression cannot satisfy it.
   local nr
   nr=$(count_matches "$out" "runAsNonRoot: true")
-  if (( nr >= 2 )); then
-    pass "hardening[$tpl]: runAsNonRoot at pod + container level"
+  if (( nr >= containers + 1 )); then
+    pass "hardening[$tpl]: runAsNonRoot at pod + all $containers container(s)"
   else
-    fail "hardening[$tpl]: expected runAsNonRoot at pod AND container level, found $nr occurrence(s)"
+    fail "hardening[$tpl]: expected >= $((containers + 1)) runAsNonRoot (pod + each container), found $nr"
   fi
 }
 
@@ -368,8 +390,36 @@ test_pod_security() {
 
   local tpl
   for tpl in "${HARDENED_WORKLOADS[@]}"; do
-    assert_workload_hardened "$tpl"
+    assert_workload_hardened "$tpl" --set autogen.enabled=true
   done
+
+  # Keeper and the backup/restore Jobs render only when replication and backup
+  # are switched on, so the default pass above never sees them — they were
+  # hardened with nothing asserting it, and the ClickHouse live e2e only checks
+  # that the CronJob objects exist, never that a Job runs. Cover them here.
+  local ch_full_flags=(--set autogen.enabled=true
+                       --set clickhouse.replicas=3
+                       --set clickhouse.backup.enabled=true
+                       --set clickhouse.objectStorage.bucket=test
+                       --set clickhouse.objectStorage.region=us-east-1)
+  for tpl in "charts/clickhouse/templates/keeper-statefulset.yaml" \
+             "charts/clickhouse/templates/backup-cronjobs.yaml"; do
+    assert_workload_hardened "$tpl" "${ch_full_flags[@]}"
+  done
+
+  # The backup Jobs talk to S3, so they must carry the chart's ServiceAccount
+  # rather than falling through to the namespace default, which would miss an
+  # IRSA annotation set on the chart SA.
+  local backup_out
+  backup_out=$(tmpl_only "charts/clickhouse/templates/backup-cronjobs.yaml" "${ch_full_flags[@]}")
+  assert_contains "hardening: backup Jobs use the chart ServiceAccount" "$backup_out" "serviceAccountName:"
+
+  # Scratch volumes are bounded so a pod in an error loop is evicted on its own
+  # quota instead of filling the node's ephemeral storage.
+  local ch_sts
+  ch_sts=$(tmpl_only "charts/clickhouse/templates/statefulset.yaml" "${ch_full_flags[@]}")
+  assert_contains "hardening: clickhouse scratch volumes are bounded" "$ch_sts" "sizeLimit:"
+  assert_contains "hardening: backup Job scratch is bounded" "$backup_out" "sizeLimit:"
 
   local def
   def=$(tmpl --set autogen.enabled=true)

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -251,12 +251,12 @@ test_backup_metrics_gate() {
 test_size_overlays() {
   sep; info "Suite: size overlays"
 
-  # size-minimal: workers disabled, 1 replica each
+  # size-minimal: workers enabled (the smoke test exercises them), 1 replica each
   local min_out
   min_out=$(tmpl --set autogen.enabled=true \
     -f "${OVERLAYS}/size-minimal.yaml" \
     -f "${OVERLAYS}/access-nodeport.yaml")
-  assert_not_contains "minimal: workers disabled" "$min_out" "# Source: langwatch/templates/workers/deployment.yaml"
+  assert_contains "minimal: workers deployed" "$min_out" "# Source: langwatch/templates/workers/deployment.yaml"
   assert_contains "minimal: app replicas 1" "$min_out" "replicas: 1"
 
   # size-prod: 2 app replicas, PDB

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -468,6 +468,11 @@ test_pod_security() {
   # unrelated resource keeping the same string cannot mask a failure.
   local strict entry
   strict=$(tmpl --set autogen.enabled=true -f "${OVERLAYS}/strict-admission.yaml")
+  # tmpl folds stderr into its output, so a failed render is a string that
+  # happens to contain none of the needles below — every assert_not_contains
+  # would pass on a broken overlay. Confirm we are looking at a real manifest
+  # before drawing conclusions from what is missing from it.
+  assert_contains "strict-admission: overlay renders a manifest" "$strict" "kind: Deployment"
   for entry in "${EXEMPT_WORKLOADS[@]}"; do
     assert_not_contains "strict-admission: ${entry##*:} off" "$strict" "# Source: langwatch/${entry%%:*}"
   done
@@ -495,6 +500,7 @@ YAML
   metrics_on=$(tmpl --set autogen.enabled=true -f "$metrics_base")
   assert_contains "baseline: app metrics scrape present when enabled" "$metrics_on" "prometheus.io/scrape"
   metrics_off=$(tmpl --set autogen.enabled=true -f "$metrics_base" -f "${OVERLAYS}/strict-admission.yaml")
+  assert_contains "strict-admission: metrics render produced a manifest" "$metrics_off" "kind: Deployment"
   assert_not_contains "strict-admission: app metrics scrape off" "$metrics_off" "prometheus.io/scrape"
   rm -f "$metrics_base"
 }

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -27,7 +27,13 @@ global:
     seccompProfile:
       type: RuntimeDefault
   ## @param global.containerSecurityContext [object] Default container security context (applied cluster-wide unless overridden).
+  # runAsNonRoot is also set at the pod level above; Kubernetes inherits it,
+  # but some Gatekeeper constraints (e.g. certain flavours of
+  # k8sreadonlyrootfilesystem) inspect the *container-level* field directly and
+  # deny pods that only carry it at pod level. Setting it on both keeps every
+  # policy variant happy without changing runtime behaviour.
   containerSecurityContext:
+    runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1358,6 +1358,8 @@ postgresql:
   tolerations: []
   ## @param postgresql.affinity [object] Affinity rules. Falls back to global.scheduling.affinity.
   affinity: {}
+  ## @param postgresql.scratchSizeLimit [string, default: 1Gi] Size cap for the writable scratch emptyDirs (socket dir, /tmp) the container needs under a read-only root filesystem. Bounded so a looping pod is evicted on its own quota rather than filling the node.
+  scratchSizeLimit: 1Gi
   # Whether to manage PostgreSQL via this chart or use external instance
   ## @param postgresql.chartManaged [default: true] Manage PostgreSQL via this chart.
   chartManaged: true
@@ -1571,6 +1573,8 @@ redis:
   tolerations: []
   ## @param redis.affinity [object] Affinity rules. Falls back to global.scheduling.affinity.
   affinity: {}
+  ## @param redis.scratchSizeLimit [string, default: 1Gi] Size cap for the writable scratch emptyDirs (socket dir, /tmp) the container needs under a read-only root filesystem. Bounded so a looping pod is evicted on its own quota rather than filling the node.
+  scratchSizeLimit: 1Gi
   # Whether to manage Redis via this chart or use external instance
   ## @param redis.chartManaged [default: true] Manage Redis via this chart.
   chartManaged: true

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1347,6 +1347,17 @@ prometheus:
 # Primary database for LangWatch application data
 ## @section PostgreSQL
 postgresql:
+  ## @extra postgresql.podSecurityContext Pod security context overrides.
+  ## @param postgresql.podSecurityContext [object] Layered over the image's own uid 999 base (runAsUser/runAsGroup/fsGroup, runAsNonRoot, RuntimeDefault seccomp). Keys you omit keep their hardened default.
+  podSecurityContext: {}
+  ## @param postgresql.containerSecurityContext [object] Container security context overrides. Layered over global.containerSecurityContext; keys you omit keep their hardened default.
+  containerSecurityContext: {}
+  ## @param postgresql.nodeSelector [object] Node selector. Falls back to global.scheduling.nodeSelector.
+  nodeSelector: {}
+  ## @param postgresql.tolerations [array] Tolerations. Falls back to global.scheduling.tolerations.
+  tolerations: []
+  ## @param postgresql.affinity [object] Affinity rules. Falls back to global.scheduling.affinity.
+  affinity: {}
   # Whether to manage PostgreSQL via this chart or use external instance
   ## @param postgresql.chartManaged [default: true] Manage PostgreSQL via this chart.
   chartManaged: true
@@ -1549,6 +1560,17 @@ clickhouse:
 # In-memory data store for caching and session management
 ## @section Redis
 redis:
+  ## @extra redis.podSecurityContext Pod security context overrides.
+  ## @param redis.podSecurityContext [object] Layered over the image's own uid 999 base (runAsUser/runAsGroup/fsGroup, runAsNonRoot, RuntimeDefault seccomp). Keys you omit keep their hardened default.
+  podSecurityContext: {}
+  ## @param redis.containerSecurityContext [object] Container security context overrides. Layered over global.containerSecurityContext; keys you omit keep their hardened default.
+  containerSecurityContext: {}
+  ## @param redis.nodeSelector [object] Node selector. Falls back to global.scheduling.nodeSelector.
+  nodeSelector: {}
+  ## @param redis.tolerations [array] Tolerations. Falls back to global.scheduling.tolerations.
+  tolerations: []
+  ## @param redis.affinity [object] Affinity rules. Falls back to global.scheduling.affinity.
+  affinity: {}
   # Whether to manage Redis via this chart or use external instance
   ## @param redis.chartManaged [default: true] Manage Redis via this chart.
   chartManaged: true

--- a/charts/lib/pod-security-report.rb
+++ b/charts/lib/pod-security-report.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# Reads a rendered Helm manifest on stdin and emits ONE LINE PER CONTAINER:
+#
+#   <kind>/<name>|<container>|ro|ape|nonroot|podnonroot|caps|seccomp|automount|resources
+#
+# where each flag is 1 or 0.
+#
+# Why this exists. The pod-security assertions used to grep and count strings
+# across the whole rendered document. That is unsound for any template with
+# more than one pod spec or more than one container: moving a container-level
+# field up to the pod level (where Kubernetes ignores it) keeps the totals
+# identical, so a suite counting lines reports "read-only root on all 3
+# containers" while two of the three actually run writable-root. Fields have to
+# be read off the container object they belong to, which needs a parser.
+#
+# Ruby's YAML (Psych) is stdlib and ships on macOS and the ubuntu-latest
+# runners, so this adds no dependency. Init containers are included: admission
+# policies evaluate them too.
+
+require "yaml"
+
+# The pod template lives at a different path per workload kind.
+def pod_spec(doc)
+  return nil unless doc.is_a?(Hash)
+  case doc["kind"]
+  when "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"
+    doc.dig("spec", "template", "spec")
+  when "CronJob"
+    doc.dig("spec", "jobTemplate", "spec", "template", "spec")
+  end
+end
+
+# Classic method body, not an endless def: the macOS system Ruby is 2.6.
+def flag(value)
+  value ? 1 : 0
+end
+
+def resources_complete?(container)
+  res = container["resources"] || {}
+  %w[requests limits].all? do |section|
+    %w[cpu memory].all? { |key| !res.dig(section, key).nil? }
+  end
+end
+
+YAML.load_stream(ARGF.read) do |doc|
+  spec = pod_spec(doc)
+  next if spec.nil?
+
+  pod_sc = spec["securityContext"] || {}
+  seccomp = pod_sc.dig("seccompProfile", "type") == "RuntimeDefault"
+  automount = spec["automountServiceAccountToken"] == false
+  pod_non_root = pod_sc["runAsNonRoot"] == true
+  workload = "#{doc["kind"]}/#{doc.dig("metadata", "name")}"
+
+  (Array(spec["initContainers"]) + Array(spec["containers"])).each do |container|
+    sc = container["securityContext"] || {}
+    caps = Array(sc.dig("capabilities", "drop")).map(&:to_s).include?("ALL")
+
+    puts [
+      workload,
+      container["name"],
+      flag(sc["readOnlyRootFilesystem"] == true),
+      flag(sc["allowPrivilegeEscalation"] == false),
+      flag(sc["runAsNonRoot"] == true),
+      flag(pod_non_root),
+      flag(caps),
+      flag(seccomp),
+      flag(automount),
+      flag(resources_complete?(container)),
+    ].join("|")
+  end
+end

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -55778,7 +55778,7 @@ spec:
 
 ## Pod Security
 
-Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
+Every LangWatch pod — app, workers, NLP, LangEvals, gateway — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
 
 ```yaml
 # Pod-level (global.podSecurityContext)
@@ -55789,30 +55789,44 @@ seccompProfile:
   type: RuntimeDefault
 
 # Container-level (global.containerSecurityContext)
+runAsNonRoot: true
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: true
 capabilities:
   drop: [ALL]
 ```
 
-The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532. If you write a Gatekeeper `MustRunAs` constraint, allow those, not just 1000.
 
-The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+`runAsNonRoot` is deliberately set at both pod and container level. Kubernetes inherits the pod-level value, but some Gatekeeper constraints read the container-level field directly and deny pods that only carry it on the pod.
+
+The ServiceAccount token isn't mounted (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every one of those pods. Anything a process writes at runtime (the app's `/tmp`, ClickHouse's server logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
 
 ### Strict admission control
 
-These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+On a cluster enforcing Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) or an equivalent Gatekeeper / Kyverno bundle, apply the [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml):
 
-Two features need a token or an external API, so turn them off where those policies are enforced:
+```bash
+helm install lw . \
+  -f examples/overlays/size-prod.yaml \
+  -f examples/overlays/access-ingress.yaml \
+  -f examples/overlays/strict-admission.yaml
+```
 
-- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
-- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but two bundled components cannot, and the overlay turns both off:
 
-The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+- **Prometheus** (`prometheus.chartManaged`) is an upstream subchart LangWatch doesn't control. Its pods carry no `readOnlyRootFilesystem`, no seccomp profile, and no resource limits on the config-reload sidecar. Bring your own, or disable metrics.
+- **The Langy assistant** (`langyagent.chartManaged`) runs its manager as root with `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID` and `SETGID`. That is by design: the manager gives every assistant worker a distinct UID, and without those capabilities sibling workers share a UID and can read each other's credentials. Don't force it non-root — deploy it on a cluster that allows it, or run without the assistant.
+
+One more toggle in the overlay isn't an admission failure but an unmet dependency:
+
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one; the overlay pins `gateway.replicaCount: 2` instead.
 
 With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
 
-In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
+In-cluster datastores satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -55876,7 +55890,7 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
 - [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
-- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
+- [ ] On strict admission clusters: apply `examples/overlays/strict-admission.yaml` (`prometheus.chartManaged: false`, `langyagent.chartManaged: false`, and — without a custom metrics API — `gateway.autoscaling.enabled: false`)
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -55778,7 +55778,7 @@ spec:
 
 ## Pod Security
 
-Every LangWatch pod — app, workers, NLP, LangEvals, gateway — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
+Every LangWatch pod — app, workers, NLP, LangEvals, gateway, and the cron pods — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
 
 ```yaml
 # Pod-level (global.podSecurityContext)
@@ -55796,11 +55796,11 @@ capabilities:
   drop: [ALL]
 ```
 
-The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532. If you write a Gatekeeper `MustRunAs` constraint, allow those, not just 1000.
+The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532, and Keeper's init container 65534. If you write a Gatekeeper `MustRunAs` constraint, allow all of those, not just 1000: a constraint that misses the init container's 65534 denies the whole Keeper pod. (The bundled Prometheus also runs 65534, though `strict-admission` removes it.)
 
 `runAsNonRoot` is deliberately set at both pod and container level. Kubernetes inherits the pod-level value, but some Gatekeeper constraints read the container-level field directly and deny pods that only carry it on the pod.
 
-The ServiceAccount token isn't mounted (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+No LangWatch pod mounts a ServiceAccount token (`global.automountServiceAccountToken: false`); none of these services talk to the Kubernetes API. The bundled Prometheus does mount one — it is an upstream subchart, and `strict-admission` removes it.
 
 The root filesystem is read-only on every one of those pods. Anything a process writes at runtime (the app's `/tmp`, ClickHouse's server logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
 
@@ -55815,10 +55815,11 @@ helm install lw . \
   -f examples/overlays/strict-admission.yaml
 ```
 
-A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but two bundled components cannot, and the overlay turns both off:
+A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but three bundled components cannot, and the overlay turns all three off:
 
 - **Prometheus** (`prometheus.chartManaged`) is an upstream subchart LangWatch doesn't control. Its pods carry no `readOnlyRootFilesystem`, no seccomp profile, and no resource limits on the config-reload sidecar. Bring your own, or disable metrics.
 - **The Langy assistant** (`langyagent.chartManaged`) runs its manager as root with `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID` and `SETGID`. That is by design: the manager gives every assistant worker a distinct UID, and without those capabilities sibling workers share a UID and can read each other's credentials. Don't force it non-root — deploy it on a cluster that allows it, or run without the assistant.
+- **The ClickHouse preflight Job** (`clickhouse.preflight.enabled`) shells out to `kubectl` to check your Secret's keys, so it needs both an automounted token and a writable root for kubectl's discovery cache. It only renders when you supply the ClickHouse Secret yourself rather than using autogen — which is the production path, so the overlay pins it off.
 
 One more toggle in the overlay isn't an admission failure but an unmet dependency:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -55778,27 +55778,41 @@ spec:
 
 ## Pod Security
 
-The Helm chart applies secure defaults to all pods:
+Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
 
 ```yaml
-# Pod-level (applied via global.podSecurityContext)
+# Pod-level (global.podSecurityContext)
 runAsNonRoot: true
 runAsUser: 1000
 fsGroup: 1000
+seccompProfile:
+  type: RuntimeDefault
 
-# Container-level (applied via global.containerSecurityContext)
+# Container-level (global.containerSecurityContext)
 allowPrivilegeEscalation: false
-capabilities:
-  drop:
-    - ALL
 readOnlyRootFilesystem: true
+capabilities:
+  drop: [ALL]
 ```
 
-These ensure:
-- No containers run as root
-- No privilege escalation is possible
-- Containers cannot modify their own filesystem
-- All Linux capabilities are dropped
+The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+
+### Strict admission control
+
+These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+
+Two features need a token or an external API, so turn them off where those policies are enforced:
+
+- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+
+The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+
+With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
+
+In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -55861,7 +55875,8 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] ClickHouse backups enabled and tested
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
-- [ ] Pod security contexts verified (non-root, read-only filesystem)
+- [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
+- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -134,27 +134,41 @@ spec:
 
 ## Pod Security
 
-The Helm chart applies secure defaults to all pods:
+Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
 
 ```yaml
-# Pod-level (applied via global.podSecurityContext)
+# Pod-level (global.podSecurityContext)
 runAsNonRoot: true
 runAsUser: 1000
 fsGroup: 1000
+seccompProfile:
+  type: RuntimeDefault
 
-# Container-level (applied via global.containerSecurityContext)
+# Container-level (global.containerSecurityContext)
 allowPrivilegeEscalation: false
-capabilities:
-  drop:
-    - ALL
 readOnlyRootFilesystem: true
+capabilities:
+  drop: [ALL]
 ```
 
-These ensure:
-- No containers run as root
-- No privilege escalation is possible
-- Containers cannot modify their own filesystem
-- All Linux capabilities are dropped
+The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+
+### Strict admission control
+
+These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+
+Two features need a token or an external API, so turn them off where those policies are enforced:
+
+- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+
+The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+
+With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
+
+In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -217,7 +231,8 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] ClickHouse backups enabled and tested
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
-- [ ] Pod security contexts verified (non-root, read-only filesystem)
+- [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
+- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -134,7 +134,7 @@ spec:
 
 ## Pod Security
 
-Every LangWatch pod — app, workers, NLP, LangEvals, gateway — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
+Every LangWatch pod — app, workers, NLP, LangEvals, gateway, and the cron pods — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
 
 ```yaml
 # Pod-level (global.podSecurityContext)
@@ -152,11 +152,11 @@ capabilities:
   drop: [ALL]
 ```
 
-The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532. If you write a Gatekeeper `MustRunAs` constraint, allow those, not just 1000.
+The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532, and Keeper's init container 65534. If you write a Gatekeeper `MustRunAs` constraint, allow all of those, not just 1000: a constraint that misses the init container's 65534 denies the whole Keeper pod. (The bundled Prometheus also runs 65534, though `strict-admission` removes it.)
 
 `runAsNonRoot` is deliberately set at both pod and container level. Kubernetes inherits the pod-level value, but some Gatekeeper constraints read the container-level field directly and deny pods that only carry it on the pod.
 
-The ServiceAccount token isn't mounted (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+No LangWatch pod mounts a ServiceAccount token (`global.automountServiceAccountToken: false`); none of these services talk to the Kubernetes API. The bundled Prometheus does mount one — it is an upstream subchart, and `strict-admission` removes it.
 
 The root filesystem is read-only on every one of those pods. Anything a process writes at runtime (the app's `/tmp`, ClickHouse's server logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
 
@@ -171,10 +171,11 @@ helm install lw . \
   -f examples/overlays/strict-admission.yaml
 ```
 
-A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but two bundled components cannot, and the overlay turns both off:
+A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but three bundled components cannot, and the overlay turns all three off:
 
 - **Prometheus** (`prometheus.chartManaged`) is an upstream subchart LangWatch doesn't control. Its pods carry no `readOnlyRootFilesystem`, no seccomp profile, and no resource limits on the config-reload sidecar. Bring your own, or disable metrics.
 - **The Langy assistant** (`langyagent.chartManaged`) runs its manager as root with `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID` and `SETGID`. That is by design: the manager gives every assistant worker a distinct UID, and without those capabilities sibling workers share a UID and can read each other's credentials. Don't force it non-root — deploy it on a cluster that allows it, or run without the assistant.
+- **The ClickHouse preflight Job** (`clickhouse.preflight.enabled`) shells out to `kubectl` to check your Secret's keys, so it needs both an automounted token and a writable root for kubectl's discovery cache. It only renders when you supply the ClickHouse Secret yourself rather than using autogen — which is the production path, so the overlay pins it off.
 
 One more toggle in the overlay isn't an admission failure but an unmet dependency:
 

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -134,7 +134,7 @@ spec:
 
 ## Pod Security
 
-Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
+Every LangWatch pod — app, workers, NLP, LangEvals, gateway — and every bundled datastore — PostgreSQL, Redis, ClickHouse, Keeper — runs hardened. The defaults the first-party services inherit:
 
 ```yaml
 # Pod-level (global.podSecurityContext)
@@ -145,30 +145,44 @@ seccompProfile:
   type: RuntimeDefault
 
 # Container-level (global.containerSecurityContext)
+runAsNonRoot: true
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: true
 capabilities:
   drop: [ALL]
 ```
 
-The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+The bundled datastores carry the same posture but keep their image's own uid — PostgreSQL and Redis run 999, ClickHouse and Keeper 101, the gateway 65532. If you write a Gatekeeper `MustRunAs` constraint, allow those, not just 1000.
 
-The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+`runAsNonRoot` is deliberately set at both pod and container level. Kubernetes inherits the pod-level value, but some Gatekeeper constraints read the container-level field directly and deny pods that only carry it on the pod.
+
+The ServiceAccount token isn't mounted (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every one of those pods. Anything a process writes at runtime (the app's `/tmp`, ClickHouse's server logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
 
 ### Strict admission control
 
-These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+On a cluster enforcing Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) or an equivalent Gatekeeper / Kyverno bundle, apply the [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml):
 
-Two features need a token or an external API, so turn them off where those policies are enforced:
+```bash
+helm install lw . \
+  -f examples/overlays/size-prod.yaml \
+  -f examples/overlays/access-ingress.yaml \
+  -f examples/overlays/strict-admission.yaml
+```
 
-- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
-- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+A **default** install does not pass on its own. Everything LangWatch authors already complies — read-only root, non-root at both levels, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, CPU + memory requests and limits — but two bundled components cannot, and the overlay turns both off:
 
-The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+- **Prometheus** (`prometheus.chartManaged`) is an upstream subchart LangWatch doesn't control. Its pods carry no `readOnlyRootFilesystem`, no seccomp profile, and no resource limits on the config-reload sidecar. Bring your own, or disable metrics.
+- **The Langy assistant** (`langyagent.chartManaged`) runs its manager as root with `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID` and `SETGID`. That is by design: the manager gives every assistant worker a distinct UID, and without those capabilities sibling workers share a UID and can read each other's credentials. Don't force it non-root — deploy it on a cluster that allows it, or run without the assistant.
+
+One more toggle in the overlay isn't an admission failure but an unmet dependency:
+
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one; the overlay pins `gateway.replicaCount: 2` instead.
 
 With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
 
-In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
+In-cluster datastores satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -232,7 +246,7 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
 - [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
-- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
+- [ ] On strict admission clusters: apply `examples/overlays/strict-admission.yaml` (`prometheus.chartManaged: false`, `langyagent.chartManaged: false`, and — without a custom metrics API — `gateway.autoscaling.enabled: false`)
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
@@ -12,13 +12,13 @@
  *
  * See specs/server/worker-liveness-probe.feature.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Counter, register } from "prom-client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  WORKER_LIVENESS_PATH,
   createWorkerMetricsHandler,
+  WORKER_LIVENESS_PATH,
 } from "../startWorkers";
 
 // Derive the fakes' types from the handler itself, so this test cannot drift

--- a/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
@@ -14,6 +14,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { Counter, register } from "prom-client";
+
 import {
   WORKER_LIVENESS_PATH,
   createWorkerMetricsHandler,
@@ -25,16 +27,33 @@ type Handler = ReturnType<typeof createWorkerMetricsHandler>;
 type HandlerRequest = Parameters<Handler>[0];
 type HandlerResponse = Parameters<Handler>[1];
 
-/** Captures what the handler wrote, without binding a port. */
+/**
+ * Captures what the handler wrote, without binding a port.
+ *
+ * Headers are captured from BOTH paths the handler uses — `writeHead(status,
+ * headers)` for the liveness reply and `setHeader(name, value)` for the metrics
+ * reply. A fake that drops them (a no-op `setHeader`, a `writeHead` that reads
+ * only its first argument) lets the Content-Type line be deleted from the
+ * handler with every test still green, while Prometheus silently stops parsing
+ * the worker registry.
+ */
 function fakeExchange(url: string) {
   const req = { url, headers: {} } as unknown as HandlerRequest;
-  const captured: { status?: number; body?: string } = {};
+  const captured: {
+    status?: number;
+    body?: string;
+    headers: Record<string, string>;
+  } = { headers: {} };
   const res = {
-    writeHead(status: number) {
+    writeHead(status: number, headers?: Record<string, string>) {
       captured.status = status;
+      for (const [name, value] of Object.entries(headers ?? {})) {
+        captured.headers[name.toLowerCase()] = value;
+      }
       return this;
     },
-    setHeader() {
+    setHeader(name: string, value: string) {
+      captured.headers[name.toLowerCase()] = value;
       return this;
     },
     end(body?: string) {
@@ -51,6 +70,7 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 describe("createWorkerMetricsHandler", () => {
   describe("given the liveness path", () => {
     describe("when the metrics gate would throw (production, no API key)", () => {
+      /** @scenario Default install — no metrics API key in production */
       it("answers 200 without consulting the gate", async () => {
         // The default-install case: this is exactly the configuration that
         // made a /metrics probe crash-loop every stock worker deployment.
@@ -68,6 +88,7 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the request carries no credentials", () => {
+      /** @scenario Key configured, probe still sends nothing */
       it("answers 200 even though the gate would reject", async () => {
         // The secretKeyRef case: the key exists in the container's env, but no
         // rendered httpGet header can ever carry it.
@@ -82,19 +103,23 @@ describe("createWorkerMetricsHandler", () => {
       });
     });
 
-    it("returns no metric samples", async () => {
-      const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
+    describe("when the probe reads the response body", () => {
+      /** @scenario The liveness endpoint leaks no telemetry */
+      it("returns no metric samples", async () => {
+        const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
 
-      createWorkerMetricsHandler(() => true)(req, res);
-      await flush();
+        createWorkerMetricsHandler(() => true)(req, res);
+        await flush();
 
-      expect(captured.body).toBe("ok");
-      expect(captured.body).not.toContain("#");
+        expect(captured.body).toBe("ok");
+        expect(captured.headers["content-type"]).toBe("text/plain");
+      });
     });
   });
 
   describe("given the metrics path", () => {
     describe("when the gate rejects the caller", () => {
+      /** @scenario Metrics still require the bearer when a key is set */
       it("answers 401", async () => {
         const { req, res, captured } = fakeExchange("/metrics");
 
@@ -106,6 +131,7 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the gate throws (production, no API key)", () => {
+      /** @scenario Metrics still fail closed in production without a key */
       it("fails closed with 500", async () => {
         const { req, res, captured } = fakeExchange("/metrics");
 
@@ -119,28 +145,47 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the gate accepts the caller", () => {
-      it("serves the registry rather than an auth failure", async () => {
+      /** @scenario Metrics are served to a correctly authenticated caller */
+      it("serves the registry with the Prometheus content type", async () => {
+        // Register a sample so the body is non-empty in this process. Without
+        // one the registry renders "" and any "did it serve?" assertion passes
+        // on the empty string.
+        const probe = new Counter({
+          name: "worker_metrics_handler_probe_total",
+          help: "Fixture counter proving the registry is rendered.",
+          registers: [register],
+        });
+        probe.inc();
+
         const { req, res, captured } = fakeExchange("/metrics");
 
         createWorkerMetricsHandler(() => true)(req, res);
         await flush();
 
-        // Success writes no explicit status (Node defaults to 200); what
-        // matters is that neither auth branch fired.
+        // Neither auth branch fired: success takes the implicit-200 path and
+        // writes no explicit status.
         expect(captured.status).toBeUndefined();
-        expect(typeof captured.body).toBe("string");
+        // Prometheus needs this exact content type to parse the response; the
+        // handler sets it via setHeader, so the fake must capture it.
+        expect(captured.headers["content-type"]).toBe(register.contentType);
+        expect(captured.body).toContain("worker_metrics_handler_probe_total");
+
+        register.removeSingleMetric("worker_metrics_handler_probe_total");
       });
     });
   });
 
   describe("given an unknown path", () => {
-    it("answers 404", async () => {
-      const { req, res, captured } = fakeExchange("/not-a-real-path");
+    describe("when any caller requests it", () => {
+      /** @scenario An unrelated path is not served */
+      it("answers 404", async () => {
+        const { req, res, captured } = fakeExchange("/not-a-real-path");
 
-      createWorkerMetricsHandler(() => true)(req, res);
-      await flush();
+        createWorkerMetricsHandler(() => true)(req, res);
+        await flush();
 
-      expect(captured.status).toBe(404);
+        expect(captured.status).toBe(404);
+      });
     });
   });
 });

--- a/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
@@ -12,7 +12,7 @@
  *
  * See specs/server/worker-liveness-probe.feature.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Counter, register } from "prom-client";
 
@@ -64,10 +64,21 @@ function fakeExchange(url: string) {
   return { req, res, captured };
 }
 
+/**
+ * Name of the fixture metric the "serves the registry" test registers. Removed
+ * in afterEach rather than at the end of the test body, so a failing assertion
+ * cannot leave it behind in the process-wide prom-client registry.
+ */
+const PROBE_METRIC = "worker_metrics_handler_probe_total";
+
 /** Drains the handler's floating `register.metrics()` promise chain. */
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 
 describe("createWorkerMetricsHandler", () => {
+  afterEach(() => {
+    register.removeSingleMetric(PROBE_METRIC);
+  });
+
   describe("given the liveness path", () => {
     describe("when the metrics gate would throw (production, no API key)", () => {
       /** @scenario Default install — no metrics API key in production */
@@ -105,7 +116,7 @@ describe("createWorkerMetricsHandler", () => {
 
     describe("when the probe reads the response body", () => {
       /** @scenario The liveness endpoint leaks no telemetry */
-      it("returns no metric samples", async () => {
+      it("answers ok as plain text, with no metric samples", async () => {
         const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
 
         createWorkerMetricsHandler(() => true)(req, res);
@@ -151,7 +162,7 @@ describe("createWorkerMetricsHandler", () => {
         // one the registry renders "" and any "did it serve?" assertion passes
         // on the empty string.
         const probe = new Counter({
-          name: "worker_metrics_handler_probe_total",
+          name: PROBE_METRIC,
           help: "Fixture counter proving the registry is rendered.",
           registers: [register],
         });
@@ -162,15 +173,15 @@ describe("createWorkerMetricsHandler", () => {
         createWorkerMetricsHandler(() => true)(req, res);
         await flush();
 
-        // Neither auth branch fired: success takes the implicit-200 path and
-        // writes no explicit status.
-        expect(captured.status).toBeUndefined();
+        // Neither auth branch fired. Assert the outcome a scraper observes, not
+        // which Node code path produced it: the success path currently writes no
+        // explicit status and relies on the implicit 200, but an explicit
+        // writeHead(200) is equally correct and must not turn this red.
+        expect(captured.status ?? 200).toBe(200);
         // Prometheus needs this exact content type to parse the response; the
         // handler sets it via setHeader, so the fake must capture it.
         expect(captured.headers["content-type"]).toBe(register.contentType);
-        expect(captured.body).toContain("worker_metrics_handler_probe_total");
-
-        register.removeSingleMetric("worker_metrics_handler_probe_total");
+        expect(captured.body).toContain(PROBE_METRIC);
       });
     });
   });

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -20,9 +20,9 @@ export interface WorkerHandle {
 export interface StartWorkersOptions {
   /**
    * Expose the worker prom-client registry over its own HTTP port. On for the
-   * standalone worker deployment (the web process scrapes it at
-   * `GET /workers/metrics`); off for the in-process dev mode, where the web
-   * server already serves the shared registry at `/metrics`.
+   * standalone worker deployment, where a scraper reaches the worker directly
+   * on the metrics port; off for the in-process dev mode, where the web server
+   * already serves the shared registry at `/metrics`.
    */
   shouldStartMetricsServer?: boolean;
 }
@@ -181,11 +181,18 @@ export function createWorkerMetricsHandler(
   };
 }
 
-// Expose the worker process's prom-client registry over HTTP so the web
-// process can scrape it at GET /workers/metrics (proxied in start.ts). In
-// the in-process dev mode this is skipped — the web server serves the same
-// (shared) registry at /metrics directly. The same listener serves the
-// unauthenticated liveness path the chart's probes call.
+// Expose the worker process's prom-client registry over HTTP on the worker
+// metrics port, behind the same bearer gate the web process uses. In a split
+// deployment this port is what a scraper talks to: the chart's Prometheus
+// scrape config targets the worker pod directly on it, NOT the web process's
+// `/workers/metrics` proxy — that proxy dials its own loopback, so it only
+// resolves when the workers share the web process (in-process dev mode).
+//
+// In that in-process mode this listener is skipped entirely; the web server
+// serves the same shared registry at /metrics.
+//
+// The same listener serves the unauthenticated liveness path the chart's
+// probes call.
 async function bootMetricsServer(
   shutdownHandles: ShutdownHandles,
 ): Promise<void> {

--- a/specs/security/helm-strict-admission.feature
+++ b/specs/security/helm-strict-admission.feature
@@ -1,0 +1,141 @@
+Feature: The Helm chart installs on a cluster that enforces strict admission control
+  As someone running LangWatch on a locked-down Kubernetes cluster,
+  I want the chart's pods to satisfy the admission policies my platform team
+  enforces,
+  so that installing LangWatch is a helm command rather than a negotiation with
+  the people who own the cluster.
+
+  # Cross-references:
+  #   ADR-033 — Langy worker isolation: why the assistant's manager runs as root.
+  #   specs/langy/langy-deploy-hardening.feature — the per-worker UID model that
+  #     root capability set exists to serve.
+  #   charts/langwatch/examples/overlays/strict-admission.yaml — the overlay
+  #     these scenarios describe.
+  #   docs/self-hosting/security.mdx — the operator-facing version of this.
+  #
+  # Context. A self-hosted customer on a managed cluster with an OPA Gatekeeper
+  # bundle could not install the chart: several enforced policies denied the
+  # pods. The enforced set was seccomp profile present, no automounted
+  # ServiceAccount token, resource requests and limits on every container, no
+  # privilege escalation, and — with no exceptions — a read-only root
+  # filesystem on every container.
+  #
+  # Two things make this hard to keep true. First, the policies VALIDATE rather
+  # than mutate, so a missing field is a denial, not a default. Second, some
+  # constraint implementations read the CONTAINER-level securityContext field
+  # directly, so setting a value only at pod level — which Kubernetes itself
+  # treats as inherited — is still a denial.
+  #
+  # The through-line: a workload is either hardened, or it is a recorded
+  # exception that the strict-admission overlay removes. There is no third
+  # category, and "we harden it by default and hope nobody overrides it" is a
+  # bug — see the override scenarios at the end.
+
+  # ===========================================================================
+  # The posture every LangWatch workload carries
+  # ===========================================================================
+
+  Scenario: Every LangWatch workload and bundled datastore ships hardened
+    Given the chart is rendered with its default values
+    When I inspect each workload LangWatch authors, including the bundled
+      PostgreSQL, Redis, ClickHouse and Keeper
+    Then every container runs with a read-only root filesystem
+    And every container drops all Linux capabilities
+    And every container disallows privilege escalation
+    And every pod carries a RuntimeDefault seccomp profile
+    And every pod declines to mount a ServiceAccount token
+    And every container declares CPU and memory requests and limits
+
+  Scenario: Non-root is asserted where a policy engine will actually look for it
+    Given the chart is rendered with its default values
+    When I inspect a workload's security context
+    Then it declares non-root at the pod level
+    And it declares non-root at the container level as well
+    # Kubernetes inherits the pod-level value, so the container-level copy
+    # changes no runtime behaviour. It exists because constraint
+    # implementations that read the container field deny pods that carry the
+    # value only on the pod, which is how the customer's install first failed.
+
+  Scenario: A bundled datastore keeps its own image user
+    Given the chart is rendered with its default values
+    When I inspect a bundled datastore's security context
+    Then it runs as the user its image ships with, not the shared default
+    And it still carries the rest of the hardened posture
+    # An operator writing a MustRunAs constraint needs to allow those uids, so
+    # the documentation names them rather than implying a single uid.
+
+  Scenario: Writable paths live on mounted volumes, never the image layer
+    Given a bundled datastore is running with a read-only root filesystem
+    When it writes the paths it needs at runtime
+    Then persistent data is written to its own volume
+    And any remaining runtime path is written to a mounted scratch volume
+    And no write is attempted against the image layer
+
+  Scenario: Scratch volumes cannot exhaust the node they run on
+    Given a datastore writes logs to a scratch volume
+    When that workload enters an error loop and writes without bound
+    Then the workload is capped by its own volume quota
+    And unrelated workloads on the same node keep their disk
+    # An unbounded scratch volume is backed by node ephemeral storage, so the
+    # failure lands on every neighbour rather than the pod that caused it.
+
+  # ===========================================================================
+  # What cannot comply, and what the operator does about it
+  # ===========================================================================
+
+  Scenario: A default install is honest that it does not pass on its own
+    Given a cluster that enforces the restricted pod security standard
+    When an operator installs the chart with default values
+    Then the workloads LangWatch authors are admitted
+    And the components that cannot comply are rejected
+    And the documentation told them to expect this and which overlay to apply
+    # The failure mode being designed out is a docs promise of "passes with no
+    # extra config" that sends an operator into a denial they were told not to
+    # expect.
+
+  Scenario: The strict-admission overlay removes every non-complying component
+    Given a cluster that enforces the restricted pod security standard
+    When an operator installs the chart with the strict-admission overlay
+    Then no workload in the release violates the enforced policies
+    And the assistant is not deployed
+    And the bundled metrics stack is not deployed
+
+  Scenario: The assistant is removed rather than de-privileged
+    Given the assistant's manager requires root and a narrow capability set so
+      it can give each of its workers a distinct user id
+    When an operator installs onto a cluster that forbids running as root
+    Then the overlay opts the assistant out of the install entirely
+    And the chart never quietly relaxes the assistant to run as non-root
+    # Running that manager as an unprivileged user does not make it safe; it
+    # makes sibling workers share a uid and read each other's credentials off
+    # disk. Removing the workload is the safe answer, weakening it is not.
+
+  Scenario: An exempt component must be one the overlay actually disables
+    Given a workload that does not carry the hardened posture
+    When the chart's own checks run
+    Then that workload must be recorded as a known exception
+    And the strict-admission overlay must remove it
+    And a workload that is neither hardened nor recorded fails the checks
+    # This is what stops a newly added subchart from shipping unhardened and
+    # being noticed by a customer's admission controller rather than by us.
+
+  # ===========================================================================
+  # Overrides layer onto the posture, they do not replace it
+  # ===========================================================================
+
+  Scenario: A partial security-context override keeps the defaults it did not mention
+    Given an operator overrides a single security-context field on one component
+    When the chart is rendered
+    Then the overridden field takes the operator's value
+    And every other hardened default for that component is still present
+    # Previously an override replaced the whole security context, so setting
+    # one field — a group id for a storage class, say — silently dropped
+    # non-root, the user id and the seccomp profile, and nothing in the
+    # rendered output said so.
+
+  Scenario: Deliberately relaxing one control does not relax the others
+    Given an operator turns off the read-only root filesystem for one component
+    When the chart is rendered
+    Then only that control is relaxed
+    And that component still drops all capabilities and disallows privilege
+      escalation

--- a/specs/security/helm-strict-admission.feature
+++ b/specs/security/helm-strict-admission.feature
@@ -31,10 +31,18 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
   # category, and "we harden it by default and hope nobody overrides it" is a
   # bug — see the override scenarios at the end.
 
+  # Tagging. These scenarios are verified by charts/langwatch/tests/e2e-overlays.sh
+  # (test_pod_security), but the parity checker's shell binding roots scan .bats
+  # only, so a chart-e2e scenario cannot bind to a .sh assertion as written.
+  # They carry @e2e @unimplemented so the gap is a tracked one rather than an
+  # untagged file, which the checker skips entirely — an untagged .feature
+  # reports "0/0 all bound" and enforces nothing.
+
   # ===========================================================================
   # The posture every LangWatch workload carries
   # ===========================================================================
 
+  @e2e @unimplemented
   Scenario: Every LangWatch workload and bundled datastore ships hardened
     Given the chart is rendered with its default values
     When I inspect each workload LangWatch authors, including the bundled
@@ -46,6 +54,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     And every pod declines to mount a ServiceAccount token
     And every container declares CPU and memory requests and limits
 
+  @e2e @unimplemented
   Scenario: Non-root is asserted where a policy engine will actually look for it
     Given the chart is rendered with its default values
     When I inspect a workload's security context
@@ -56,6 +65,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     # implementations that read the container field deny pods that carry the
     # value only on the pod, which is how the customer's install first failed.
 
+  @e2e @unimplemented
   Scenario: A bundled datastore keeps its own image user
     Given the chart is rendered with its default values
     When I inspect a bundled datastore's security context
@@ -64,6 +74,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     # An operator writing a MustRunAs constraint needs to allow those uids, so
     # the documentation names them rather than implying a single uid.
 
+  @e2e @unimplemented
   Scenario: Writable paths live on mounted volumes, never the image layer
     Given a bundled datastore is running with a read-only root filesystem
     When it writes the paths it needs at runtime
@@ -71,6 +82,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     And any remaining runtime path is written to a mounted scratch volume
     And no write is attempted against the image layer
 
+  @e2e @unimplemented
   Scenario: Scratch volumes cannot exhaust the node they run on
     Given a datastore writes logs to a scratch volume
     When that workload enters an error loop and writes without bound
@@ -83,6 +95,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
   # What cannot comply, and what the operator does about it
   # ===========================================================================
 
+  @e2e @unimplemented
   Scenario: A default install is honest that it does not pass on its own
     Given a cluster that enforces the restricted pod security standard
     When an operator installs the chart with default values
@@ -93,6 +106,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     # extra config" that sends an operator into a denial they were told not to
     # expect.
 
+  @e2e @unimplemented
   Scenario: The strict-admission overlay removes every non-complying component
     Given a cluster that enforces the restricted pod security standard
     When an operator installs the chart with the strict-admission overlay
@@ -100,6 +114,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     And the assistant is not deployed
     And the bundled metrics stack is not deployed
 
+  @e2e @unimplemented
   Scenario: The assistant is removed rather than de-privileged
     Given the assistant's manager requires root and a narrow capability set so
       it can give each of its workers a distinct user id
@@ -110,6 +125,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     # makes sibling workers share a uid and read each other's credentials off
     # disk. Removing the workload is the safe answer, weakening it is not.
 
+  @e2e @unimplemented
   Scenario: An exempt component must be one the overlay actually disables
     Given a workload that does not carry the hardened posture
     When the chart's own checks run
@@ -123,6 +139,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
   # Overrides layer onto the posture, they do not replace it
   # ===========================================================================
 
+  @e2e @unimplemented
   Scenario: A partial security-context override keeps the defaults it did not mention
     Given an operator overrides a single security-context field on one component
     When the chart is rendered
@@ -133,6 +150,7 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
     # non-root, the user id and the seccomp profile, and nothing in the
     # rendered output said so.
 
+  @e2e @unimplemented
   Scenario: Deliberately relaxing one control does not relax the others
     Given an operator turns off the read-only root filesystem for one component
     When the chart is rendered

--- a/specs/security/helm-strict-admission.feature
+++ b/specs/security/helm-strict-admission.feature
@@ -46,7 +46,8 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
   Scenario: Every LangWatch workload and bundled datastore ships hardened
     Given the chart is rendered with its default values
     When I inspect each workload LangWatch authors, including the bundled
-      PostgreSQL, Redis, ClickHouse and Keeper
+      PostgreSQL, Redis, ClickHouse and Keeper, but excluding the components
+      recorded below as unable to comply
     Then every container runs with a read-only root filesystem
     And every container drops all Linux capabilities
     And every container disallows privilege escalation
@@ -84,8 +85,8 @@ Feature: The Helm chart installs on a cluster that enforces strict admission con
 
   @e2e @unimplemented
   Scenario: Scratch volumes cannot exhaust the node they run on
-    Given a datastore writes logs to a scratch volume
-    When that workload enters an error loop and writes without bound
+    Given a workload writes to a scratch volume rather than its data volume
+    When it enters an error loop and writes without bound
     Then the workload is capped by its own volume quota
     And unrelated workloads on the same node keep their disk
     # An unbounded scratch volume is backed by node ephemeral storage, so the

--- a/specs/server/metrics-collection.feature
+++ b/specs/server/metrics-collection.feature
@@ -24,16 +24,19 @@ Feature: Metrics collection in a deployed chart
 
   Rule: Both tiers come up in every metrics configuration
 
+    @e2e @unimplemented
     Scenario: Default install, with no metrics key configured
       Given no metrics API key is configured
       Then the app pod becomes ready
       And the workers pod becomes ready
 
+    @e2e @unimplemented
     Scenario: Install with a metrics key configured
       Given a metrics API key is configured
       Then the app pod becomes ready
       And the workers pod becomes ready
 
+    @e2e @unimplemented
     Scenario: Install with the metrics key delivered from a secret store
       Given a metrics API key is delivered to the containers from a secret store
       Then the app pod becomes ready
@@ -41,6 +44,7 @@ Feature: Metrics collection in a deployed chart
 
   Rule: Without a key, metrics collection fails closed and liveness still answers
 
+    @e2e @unimplemented
     Scenario: The worker refuses to serve metrics to anyone
       Given no metrics API key is configured
       When a caller requests the worker metrics endpoint with any credentials
@@ -48,6 +52,7 @@ Feature: Metrics collection in a deployed chart
       And no metric samples are returned
       # Fail-closed: an unset key is a misconfiguration, not an invitation.
 
+    @e2e @unimplemented
     Scenario: Liveness is unaffected by the missing key
       Given no metrics API key is configured
       When the kubelet requests the worker liveness endpoint without credentials
@@ -56,18 +61,21 @@ Feature: Metrics collection in a deployed chart
 
   Rule: With a key, metrics are collectable only by an authenticated caller
 
+    @e2e @unimplemented
     Scenario: An unauthenticated scrape is rejected
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint without credentials
       Then the request is rejected as unauthorized
       And no metric samples are returned
 
+    @e2e @unimplemented
     Scenario: A scrape presenting the wrong credential is rejected
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint with an incorrect key
       Then the request is rejected as unauthorized
       And no metric samples are returned
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects worker metrics
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint with the configured key
@@ -75,12 +83,14 @@ Feature: Metrics collection in a deployed chart
       And metric samples are returned
       # The path Prometheus actually uses. Previously unproven in a cluster.
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects app metrics
       Given a metrics API key is configured
       When a caller requests the app metrics endpoint with the configured key
       Then the response is successful
       And metric samples are returned
 
+    @e2e @unimplemented
     Scenario: The liveness endpoint stays credential-free even once a key exists
       Given a metrics API key is configured
       When the kubelet requests the worker liveness endpoint without credentials
@@ -89,6 +99,7 @@ Feature: Metrics collection in a deployed chart
 
   Rule: A key delivered from a secret store reaches the process
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects metrics when the key came from a secret
       Given a metrics API key is delivered to the containers from a secret store
       When a caller requests the worker metrics endpoint with the configured key

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -37,6 +37,7 @@ Feature: Worker liveness probe endpoint
 
   Rule: /healthz answers unauthenticated, in every auth configuration
 
+    @unit
     Scenario: Default install — no metrics API key in production
       Given the worker is running in production mode
       And no metrics API key is configured
@@ -44,29 +45,34 @@ Feature: Worker liveness probe endpoint
       Then the response status is 200
       # The case that would otherwise crash-loop every default install.
 
+    @unit
     Scenario: Key configured, probe still sends nothing
       Given a metrics API key is configured
       When the kubelet requests "/healthz" without an Authorization header
       Then the response status is 200
       # Covers secretKeyRef delivery: the probe never needs the key at all.
 
+    @unit
     Scenario: The liveness endpoint leaks no telemetry
       When the kubelet requests "/healthz"
       Then the response body does not contain any metric samples
 
   Rule: /metrics keeps its bearer gate unchanged
 
+    @unit
     Scenario: Metrics still require the bearer when a key is set
       Given a metrics API key is configured
       When a caller requests "/metrics" without an Authorization header
       Then the response status is 401
 
+    @unit
     Scenario: Metrics still fail closed in production without a key
       Given the worker is running in production mode
       And no metrics API key is configured
       When a caller requests "/metrics" with any credentials
       Then the response status is 500
 
+    @unit
     Scenario: Metrics are served to a correctly authenticated caller
       Given a metrics API key is configured
       When a caller requests "/metrics" with the matching bearer token
@@ -75,12 +81,14 @@ Feature: Worker liveness probe endpoint
 
   Rule: Unknown paths stay 404
 
+    @unit
     Scenario: An unrelated path is not served
       When a caller requests "/not-a-real-path"
       Then the response status is 404
 
   Rule: The chart probes the liveness endpoint, not the metrics endpoint
 
+    @e2e @unimplemented
     Scenario: Worker probes target /healthz with no credentials
       Given the Helm chart renders the workers Deployment
       Then the startup probe performs an HTTP GET on "/healthz"


### PR DESCRIPTION
Supersedes #4967, which was 627 commits behind `main` and no longer mergeable. Same goal, rebased, with the review findings actioned.

Follow-up to #4927, and supersedes #4948 (folded in).

## Why

LangWatch's Helm charts didn't install on clusters that enforce strict admission control (Pod Security Admission `restricted`, or an equivalent Gatekeeper / Kyverno bundle). #4927 closed most of it. This closes the rest, including the bundled datastores, and corrects what the chart claims about itself.

## What changed

**Pods**
- postgresql / redis / clickhouse / keeper: `readOnlyRootFilesystem: true` with `emptyDir` scratch for the runtime paths outside the data volume (Postgres' socket dir, ClickHouse's server logs, `/tmp`).
- clickhouse / keeper: `automountServiceAccountToken` set on the pod spec, not just the ServiceAccount, for policies that inspect the pod.
- backup/restore Jobs: read-only root, `/tmp` scratch, pod-level automount, and the chart's own ServiceAccount — they previously ran under the namespace default SA, so an IRSA annotation on the chart SA never reached the one component that talks to S3.
- app: removed the dead `fix-nextjs-permissions` init container and its `next-dir` volume. The app is Vite now; nothing reads or writes `.next`.
- Scratch volumes are size-bounded (`scratch.logsSizeLimit` 2Gi, `scratch.tmpSizeLimit` 1Gi). They are backed by node ephemeral storage, so an unbounded one makes a single pod's error loop everyone else's problem.

**Security-context overrides now layer, not replace**

A per-component `podSecurityContext` / `containerSecurityContext` override merges over the global default: the key you set wins, everything you didn't mention keeps its hardened value. `coalesce` is all-or-nothing and cannot express "override this one field", so two shared helpers do the merge and all ten call sites use them.

PostgreSQL and Redis consumed neither global context, which is why cross-cutting flags had to be retyped into those two files by hand. They now take `global.containerSecurityContext` through the same helper, keep only their image's uid at pod level, and gain per-component `nodeSelector` / `tolerations` / `affinity` so the datastores can be pinned without moving every other pod.

**The strict-admission overlay**

- Drops `preflight.enabled` — the hook no longer exists on `main`.
- Adds `langyagent.chartManaged: false`. The assistant is chart-managed by default and its manager runs as root with `CHOWN`/`DAC_OVERRIDE`/`FOWNER`/`SETUID`/`SETGID` so it can hand each worker a distinct uid; on a restricted cluster that pod is rejected. It opts the pod out rather than de-privileging it — an unprivileged manager cannot do the per-uid handoff that keeps one worker out of another's credentials (ADR-033, `specs/langy/langy-deploy-hardening.feature`).

**Docs**

`security.mdx` claimed the defaults pass `restricted` "with no extra config" and then listed the required config seven lines later. It now says a default install does not pass on its own, names the two components that cannot comply, and leads with the overlay. Also removed the stale `.next` reference, corrected the uid example (the datastores run 999/101/65532, so a `MustRunAs` written from that block would have denied them), and dropped the ClickHouse README's claim that a standalone install clears read-only-root — its preflight Job deliberately doesn't.

**Tests**

`test_pod_security` grepped the whole render, so "is `readOnlyRootFilesystem` present?" passed on one container out of ten, and "at least 10 `runAsNonRoot` sites" passed when a workload regressed as long as another gained a field — removing the container-level `runAsNonRoot` the suite exists to guard left it green. Each workload is now rendered with `--show-only` and asserted individually. Prometheus and the assistant are explicit exemptions carrying their reason and the key that removes them, and a new check fails on any workload that is neither hardened nor exempt, so a future subchart can't ship unhardened unnoticed.

Adds `specs/security/helm-strict-admission.feature`, which didn't exist.

## Also carries a commit orphaned by #5524

#5524 was squash-merged as `4c182f0f5`, but its last commit — `docs(workers): describe how the worker registry is actually scraped` — was authored about two hours after the squash and never made it in. Four of that branch's five commits are in `main` byte-for-byte; that one is not. It is cherry-picked here.

It corrects two comments in `startWorkers.ts` that claimed the web process scrapes the worker registry at `GET /workers/metrics`. In a split deployment it cannot: that proxy dials its own loopback, so it only resolves when the workers share the web process. The chart's Prometheus scrape config targets the worker pod directly on the metrics port.

## Also: binds the worker-probe specs so the parity gate enforces them

Post-merge follow-up to #5524 (originally opened as #6314, folded in here).

`specs/server/worker-liveness-probe.feature` and `specs/server/metrics-collection.feature` shipped **untagged**. `check-feature-parity.ts` only counts a scenario carrying `@unit` / `@integration` / `@e2e` / `@regression`, so an untagged file contributes nothing in either direction — the run prints `0/0 ✓ all bound` and the check passes vacuously. 17 scenarios describing the probe contract were decorative. (The `specs/security/helm-strict-admission.feature` this PR adds had the same problem; it is tagged too.)

The seven handler scenarios are now `@unit` and bound via `/** @scenario … */`; enforced scenarios go from **3381 to 3388**. The chart-render and live-cluster scenarios are `@e2e @unimplemented` — genuinely covered by `e2e-overlays.sh` / `e2e.sh`, but the checker's shell binding roots scan `.bats` only, so a `.sh` assertion cannot bind as written. Tracked rather than invisible.

Two of the newly-enforced tests could not fail, which matters once they are load-bearing:

- The response fake discarded headers on both paths (`setHeader` was a no-op; `writeHead` read only its status argument), so deleting `res.setHeader("Content-Type", register.contentType)` kept all seven green while Prometheus would silently stop parsing the worker registry.
- `serves the registry rather than an auth failure` asserted the status was `undefined` and the body was a string — both true of the empty string, and the registry is empty in this test process.

Both are fixed and mutation-verified: deleting either `Content-Type` line now turns the suite red.

## Test plan

- [x] `helm lint` clean on all three charts
- [x] `helm template` renders and parses for defaults, all 15 overlays, size-prod + ingress + strict-admission stacked, `clickhouse.replicas=3`, and both subcharts standalone
- [x] 155 assertions across all eleven render-level e2e suites pass, including #5524's `test_workers_probes`
- [x] `pnpm test:unit run src/server/workers/__tests__/workerMetricsHandler.unit.test.ts` — 7 passed
- [x] `check-feature-parity` passes; enforced scenarios 3381 → 3388
- [x] Mutation-tested the strengthened header assertions — deleting either `Content-Type` line fails the suite, green again once reverted
- [x] Mutation-tested the new guard: reverting the container-level `runAsNonRoot` line now fails the suite (it passed before)
- [x] Verified overrides layer — `--set app.podSecurityContext.fsGroup=2000` keeps `runAsNonRoot`, `runAsUser` and the seccomp profile; `--set app.containerSecurityContext.readOnlyRootFilesystem=false` keeps `allowPrivilegeEscalation: false` and `capabilities.drop`
- [x] Datastores verified to boot read-only against this exact mount set (postgres first-boot initdb and restart-on-existing-PGDATA, redis, clickhouse incl. cold-storage + backup, keeper) — the previous "these need a writable root" comments did not hold

## Review pass

Audited with `/review-pr` after the work above, which found a **P0 in this branch**: the cronjobs pod `securityContext` was mis-indented, so `helm template` failed for any release defining a cron job. Nothing caught it — `cronjobs.jobs` ships `{}` and both e2e values files disable cronjobs, so no render in the repo produced that template and CI was green.

The audit also showed the rewritten pod-security assertions were still unsound: they counted matches across the whole document, so moving `readOnlyRootFilesystem` off two of three backup containers and up to the pod level (where Kubernetes ignores it) kept the totals equal and the suite green. They now parse the manifest and read fields off each container object, via `charts/lib/pod-security-report.rb`. All three of those regressions now fail with the workload and container named.

Docs corrections from the same pass: the `MustRunAs` uid list omitted 65534 (Keeper's init container), "two bundled components cannot comply" is three (the ClickHouse preflight Job), and the `size-minimal` footprint was understated by ~1Gi.

## Deployment Impact

Self-hosted Helm only; SaaS unaffected. On `helm upgrade` the datastore pod specs change, so the bundled single-replica PostgreSQL/Redis/ClickHouse restart in place — expect a short blip if you run them chart-managed. Postgres and Redis now honour `global.scheduling.*`, which they previously ignored: if you set a global node pin, those two will move.

New values are additive (`scratch.*` on the ClickHouse chart; `podSecurityContext` / `containerSecurityContext` / `nodeSelector` / `tolerations` / `affinity` on postgresql and redis). `size-minimal` now schedules a workers pod and totals ~4.7Gi requests / ~2.4 CPU (~1Gi of which is the Langy assistant), which no longer fits a single 2-vCPU node. `size-dev` and `examples/values-local.yaml` were re-sized on the same basis. No secret, CRD, RBAC or data-migration changes.

## Deliberately not done

- **No seccomp profile added to `charts/langyagent`.** It has none, so it is denied where seccomp presence is enforced. Adding `RuntimeDefault` to a workload that runs LLM-generated shell under a sandboxed runtime needs runtime verification I can't do from a chart render, and the overlay removes the pod on exactly the clusters that would reject it. Worth a follow-up.
- **`/tmp` on the app/workers/nlp/langevals pods is still unbounded.** Their usage is app-driven and I have no measured ceiling; guessing one trades a disk-exhaustion risk for an eviction risk. The ClickHouse volumes are bounded because their failure mode is concrete (1000M x 10 log rotation).
- **The ClickHouse backup CronJobs are kept.** They looked removable, but they're live backup machinery with in-flight work; removing them is a product decision, not cleanup.