### PR TITLE
fix(process-manager): key the inbox on a digest, stop tool ids carrying provider payload

### DIFF
--- a/dev/docs/adr/076-staged-job-id-is-identity-not-state.md
+++ b/dev/docs/adr/076-staged-job-id-is-identity-not-state.md
@@ -1,0 +1,74 @@
+# ADR-076: A staged job id is an identity, not a place to keep state
+
+**Date:** 2026-07-28
+
+**Status:** Proposed
+
+**Relates to:** [ADR-026](./026-groupqueue-payload-envelope.md) (the envelope whose header this promotes to a control-flow input), [ADR-029](./029-groupqueue-content-addressed-payload-store.md) (the content hash the body must not perturb), [ADR-030](./030-groupqueue-blob-handling-hardening.md) §2 (the transient-versus-missing distinction whose fail-safe this relocates).
+
+Behavioural contract: [specs/event-sourcing/staged-job-id-identity.feature](../../../specs/event-sourcing/staged-job-id-identity.feature).
+
+## Context
+
+A GroupQueue staged job id is `<eventId>/<jobType>/<jobName>`. It names one job's occupancy of one group and is used as a Redis ZSET member, a hash field, and the value of the group's active-claim key.
+
+Every retry appended a segment to it — `/r/<attempt>` on the normal ladder, `/r/<Date.now()>` on terminal exhaustion, `/p/<Date.now()>` on a poison park. A job that had been round the ladder therefore wore its whole history:
+
+```
+event_000649zPnIW3V0Ug6yVk9DECNYK3S/subscriber/pm:langyConversation/r/12/r/16/r/24/r/1785261278310
+```
+
+Three problems, and they are not equally serious.
+
+The id **grows without bound**, gaining a segment per retry and per operator unblock. It is **not a function of the job**: with a wall-clock segment, re-staging the same job twice yields two different ids, so nothing can tell a repeat from a new arrival. And underneath both, it **encodes state in a name** — the retry count was read back out by counting `/r/` occurrences, which is precisely why the id had to keep growing.
+
+That last one is the actual defect; the other two are its symptoms. The count lived in the id to serve exactly one reader. When a job's body is held in a blob store that is temporarily unreachable, the ladder that decides whether to retry or give up (ADR-030 §2) cannot decode the payload — the payload is what it cannot read — so it could not consult the attempt stamped inside. Counting segments was the available answer.
+
+It was never the only one. A staged value is `<prefix><headerByteLength>|<header><body>`, where the header is plain inline JSON sitting in front of the body. It is what the Lua dispatcher slices to route a job without touching a blob. And queue machinery — including `__attempt` — has travelled in that header since ADR-029, lifted out of the body by `splitMachineryFromBody` specifically so it would not perturb the content hash that collapses a fan-out. The count the ladder needs has been readable all along; nothing on the wire has to change.
+
+Two constraints shaped the decision, both found by reviewing the design rather than by building it.
+
+**Rotating the id was load-bearing.** While a job runs, its worker beats a heartbeat that keeps the group's hold alive for the full active window (300s). `RETRY_RESTAGE_LUA` sets the active key to the *new* id, and its comment says why: a late beat naming the retired id must not be believed. Reuse the id and it matches again — one late beat extends the hold to the full active window and pushes the group's next-eligible score out with it, turning a sub-second backoff into a multi-minute stall. The heartbeat and the re-stage share one Redis connection and are served in send order, so it is not enough to stop the beat when the re-stage *returns*; a beat that fired while the re-stage was in flight has already been sent behind it.
+
+**Removing a carrier can remove a fail-safe.** The transient ladder re-staged the job's value unmodified and never wrote the group's retry chain. With the count in the id, that was survivable — the id carried it. Take the id away without adding a write and nothing advances, and a bounded ladder becomes an unbounded loop. This is a worse failure than the one being fixed.
+
+## Decision
+
+**The staged job id is computed once, when the job is sent, and every later write reuses it verbatim** — retry, exhaustion, and poison park alike. No retry marker, no park marker, no timestamp.
+
+This is safe because a job's id is removed from staging the moment it is claimed (`DISPATCH_BATCH_LUA` ZREMs the member and HDELs its data), so a re-stage always inserts a member that is genuinely absent. The queue-depth increment is already guarded on the insert reporting a new member, so the arithmetic is the one a distinct id produced.
+
+**The retry attempt travels on the message**, in the envelope header, read by a never-throwing header-only reader and advanced by a header-only rewriter that reuses the body string byte for byte. Because the body is unchanged, the content hash is unchanged, the shared blob is not split, and the lease identity survives — advancing an attempt costs no blob I/O.
+
+**The unreadable-body ladder takes the higher of the message and the group's retry chain, and writes the chain on every rung.** Both halves matter. The write is what guarantees termination when the message cannot carry a count. The `max` is what survives a redelivery: with a stable id, an at-least-once redelivery lands on the same staging member and overwrites the waiting job's message with a fresh attempt-1 envelope, so the message alone is not trustworthy. This mirrors the rule the main ladder already uses.
+
+**A legacy trailing `/r/<n>` is read as a last resort, and never written.** A job part-way up the transient ladder at deploy time recorded its count only in the id; without this it would be handed a fresh budget, resetting a fail-safe mid-flight. The segment is a value to interpret on the way out, not a format to keep alive.
+
+**The heartbeat stops before the re-stage is issued**, on every outcome path, rather than in the worker's outer cleanup.
+
+**Unblocking a group clears every counter that outlived the block** — the retry chain and the consecutive-failure streak, alongside the claim strikes and stored error it already cleared. Both omissions are pre-existing: a group blocked by exhaustion came back with no attempts left *and* a streak already at the quarantine threshold, so its first failure re-blocked it, and whether it did depended on how long the operator took to press the button (the chain expires on its own after 30 minutes). An unblock is an operator saying "try this again"; every counter that decides whether trying is allowed belongs in that reset.
+
+## Rationale / Trade-offs
+
+The alternative considered was to keep a marker in the id but make it a single *replaced* segment rather than an accumulating chain. That is a much smaller change: it bounds the length, removes the wall clock, and — because the id still rotates per attempt — needs no heartbeat surgery and carries none of the termination risk.
+
+It was rejected because it treats the symptoms and keeps the cause. The count would still be read out of a name, the id would still not be a stable identity, and the next reader that wants a job's retry state would still have a string to parse. The heartbeat coupling it preserves is not a feature — it is an undocumented dependency of a lock token on a display name, and leaving it in place means the next person to touch either one rediscovers it the hard way.
+
+What is accepted in exchange: this change alters a queue-wide identity invariant and relocates a termination fail-safe, in the hottest path the queue has. The correctness of the transient ladder now depends on a Redis write (the chain) that previously was not needed, and the backoff's integrity now depends on heartbeat *ordering* rather than on id inequality. Both are pinned by scenarios, and both are more explicit than what they replace — but they are dependencies a reader has to know about, which is why they are written down here rather than left in a Lua comment.
+
+One consequence is deliberately not mitigated. A redelivery arriving while a job waits out its backoff now overwrites that job's message instead of creating a second member. That is the at-least-once path the queue already blesses; the `max` rule makes it harmless to the ladder, and collapsing the duplicate is better than keeping two.
+
+## Consequences
+
+The id becomes a name an operator can look up and a producer can predict: the id a job is dispatched under is the id it is blocked, parked, and inspected under.
+
+`header.m` is promoted from opaque machinery to a field the queue's control flow depends on. Anything that rewrites an envelope must now preserve it, and the header's byte-length prefix must be recomputed on any header change — which the existing `finalize` already does, and which a scenario now pins.
+
+The `/r/`-parsing module is deleted rather than kept for compatibility. Two id schemes in one queue would be worse than either.
+
+Jobs already staged under grown ids keep working: a worker uses whatever id it was handed, so those ids stop growing and are read for a count only when nothing else can answer.
+
+## References
+
+- Related ADRs: [ADR-026](./026-groupqueue-payload-envelope.md), [ADR-029](./029-groupqueue-content-addressed-payload-store.md), [ADR-030](./030-groupqueue-blob-handling-hardening.md)
+- Specs: [staged-job-id-identity](../../../specs/event-sourcing/staged-job-id-identity.feature), [groupqueue-decode-drop-durability](../../../specs/event-sourcing/groupqueue-decode-drop-durability.feature), [pending-counter-conservation](../../../specs/event-sourcing/pending-counter-conservation.feature), [poison-group-park-guard](../../../specs/event-sourcing/poison-group-park-guard.feature)

--- a/dev/docs/adr/080-staged-job-id-is-identity-not-state.md
+++ b/dev/docs/adr/080-staged-job-id-is-identity-not-state.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-28
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Relates to:** [ADR-026](./026-groupqueue-payload-envelope.md) (the envelope whose header this promotes to a control-flow input), [ADR-029](./029-groupqueue-content-addressed-payload-store.md) (the content hash the body must not perturb), [ADR-030](./030-groupqueue-blob-handling-hardening.md) §2 (the transient-versus-missing distinction whose fail-safe this relocates).
 
@@ -14,7 +14,7 @@ A GroupQueue staged job id is `<eventId>/<jobType>/<jobName>`. It names one job'
 
 Every retry appended a segment to it — `/r/<attempt>` on the normal ladder, `/r/<Date.now()>` on terminal exhaustion, `/p/<Date.now()>` on a poison park. A job that had been round the ladder therefore wore its whole history:
 
-```
+```text
 event_000649zPnIW3V0Ug6yVk9DECNYK3S/subscriber/pm:langyConversation/r/12/r/16/r/24/r/1785261278310
 ```
 

--- a/dev/docs/adr/080-staged-job-id-is-identity-not-state.md
+++ b/dev/docs/adr/080-staged-job-id-is-identity-not-state.md
@@ -1,4 +1,4 @@
-# ADR-076: A staged job id is an identity, not a place to keep state
+# ADR-080: A staged job id is an identity, not a place to keep state
 
 **Date:** 2026-07-28
 
@@ -24,7 +24,7 @@ The id **grows without bound**, gaining a segment per retry and per operator unb
 
 That last one is the actual defect; the other two are its symptoms. The count lived in the id to serve exactly one reader. When a job's body is held in a blob store that is temporarily unreachable, the ladder that decides whether to retry or give up (ADR-030 §2) cannot decode the payload — the payload is what it cannot read — so it could not consult the attempt stamped inside. Counting segments was the available answer.
 
-It was never the only one. A staged value is `<prefix><headerByteLength>|<header><body>`, where the header is plain inline JSON sitting in front of the body. It is what the Lua dispatcher slices to route a job without touching a blob. And queue machinery — including `__attempt` — has travelled in that header since ADR-029, lifted out of the body by `splitMachineryFromBody` specifically so it would not perturb the content hash that collapses a fan-out. The count the ladder needs has been readable all along; nothing on the wire has to change.
+It was never the only one. A staged value is `<prefix><headerByteLength>|<header><body>`, where the header is plain inline JSON sitting in front of the body. It is what the Lua dispatcher slices to route a job without touching a blob. And queue machinery — including `__attempt` — has travelled in that header since ADR-029, lifted out of the body by `splitMachineryFromBody` specifically so it would not perturb the content hash that collapses a fan-out. The wire FORMAT does not have to change — `__attempt` has ridden in the header since ADR-029. What is new is that the transient ladder now writes one: it used to re-stage its value untouched, which is exactly why it had nothing to read.
 
 Two constraints shaped the decision, both found by reviewing the design rather than by building it.
 
@@ -42,9 +42,11 @@ This is safe because a job's id is removed from staging the moment it is claimed
 
 **The unreadable-body ladder takes the higher of the message and the group's retry chain, and writes the chain on every rung.** Both halves matter. The write is what guarantees termination when the message cannot carry a count. The `max` is what survives a redelivery: with a stable id, an at-least-once redelivery lands on the same staging member and overwrites the waiting job's message with a fresh attempt-1 envelope, so the message alone is not trustworthy. This mirrors the rule the main ladder already uses.
 
-**A legacy trailing `/r/<n>` is read as a last resort, and never written.** A job part-way up the transient ladder at deploy time recorded its count only in the id; without this it would be handed a fresh budget, resetting a fail-safe mid-flight. The segment is a value to interpret on the way out, not a format to keep alive.
+**A legacy `/r/<n>` is read as a last resort, and never written.** The reader takes the highest such segment that is within the retry budget, so the wall-clock stamp the terminal re-stage used to append is not mistaken for a count. A job part-way up the transient ladder at deploy time recorded its count only in the id; without this it would be handed a fresh budget, resetting a fail-safe mid-flight. The segment is a value to interpret on the way out, not a format to keep alive.
 
-**The heartbeat stops before the re-stage is issued**, on every outcome path, rather than in the worker's outer cleanup.
+**The heartbeat stops before the retry re-stage is issued**, rather than in the worker's outer cleanup. That is the one path that leaves the active key alive for a late beat to match; exhaustion and poison-park re-stage through a script that DELetes the active key in the same atomic step, so a late beat there finds nothing to match and no-ops. The transient ladder needs no guard either — both of its entry points run before the heartbeat is ever started.
+
+Ordering alone is not quite enough, and the gap is worth naming because it is invisible: the cached-script wrapper retries a cache miss AFTER an await, so on a cold script cache that one hop can be issued behind the re-stage. The refresh is therefore also **cancellable**, and the heartbeat withdraws it once stopped.
 
 **Unblocking a group clears every counter that outlived the block** — the retry chain and the consecutive-failure streak, alongside the claim strikes and stored error it already cleared. Both omissions are pre-existing: a group blocked by exhaustion came back with no attempts left *and* a streak already at the quarantine threshold, so its first failure re-blocked it, and whether it did depended on how long the operator took to press the button (the chain expires on its own after 30 minutes). An unblock is an operator saying "try this again"; every counter that decides whether trying is allowed belongs in that reset.
 
@@ -60,11 +62,11 @@ One consequence is deliberately not mitigated. A redelivery arriving while a job
 
 ## Consequences
 
-The id becomes a name an operator can look up and a producer can predict: the id a job is dispatched under is the id it is blocked, parked, and inspected under.
+The id becomes a name an operator can look up: the id a job is dispatched under is the id it is blocked, parked, and inspected under. A producer can predict it whenever its payload carries an `id`; reactor jobs still stage without one and get a minted id, which #5538 tracks separately.
 
 `header.m` is promoted from opaque machinery to a field the queue's control flow depends on. Anything that rewrites an envelope must now preserve it, and the header's byte-length prefix must be recomputed on any header change — which the existing `finalize` already does, and which a scenario now pins.
 
-The `/r/`-parsing module is deleted rather than kept for compatibility. Two id schemes in one queue would be worse than either.
+The `/r/`-*writing* paths are deleted, and so is the module that implemented the rejected keep-a-marker design. What survives is a single read-only reader, `legacyStagedJobAttempt`, and it is a migration artifact rather than a second id scheme: it is deleted once no job staged before this deploy can still be in backoff (an hour is comfortably past `GROUP_ATTEMPT_TTL_SECONDS`). Do not remove it before then — it is the only thing standing between an in-flight transient ladder and a fresh budget.
 
 Jobs already staged under grown ids keep working: a worker uses whatever id it was handed, so those ids stop growing and are read for a count only when nothing else can answer.
 

--- a/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
+++ b/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
@@ -10,8 +10,21 @@
 --
 -- `sourceEventId` is kept as an unindexed column so operators can still read
 -- what was consumed.
+--
+-- WRITTEN FOR A ROLLING DEPLOY. `prisma migrate deploy` runs at pod boot, so
+-- this lands while pods running the PREVIOUS build are still serving — and
+-- those pods insert inbox rows without `sourceEventKey`. The column therefore
+-- stays NULLABLE here: a NOT NULL would fail every one of their commits with a
+-- 23502, deterministically, which is the exact "commit fails inside the
+-- transaction → ladder exhausts → group parks" chain this migration exists to
+-- end. A follow-up migration adds NOT NULL once the fleet has cycled.
+--
+-- Uniqueness is unaffected in the meantime: btree treats NULLs as distinct, so
+-- an old pod's row simply is not covered by the new constraint. It is still
+-- covered by nothing worse than it had before, and the new pods — the only ones
+-- that can write an oversized key — are fully constrained.
 
--- AddColumn (nullable first so the backfill has somewhere to land)
+-- AddColumn
 ALTER TABLE "ProcessManagerInbox" ADD COLUMN "sourceEventKey" TEXT;
 
 -- Backfill with the same derivation the store uses: sha256 of the UTF-8 bytes,
@@ -20,12 +33,14 @@ UPDATE "ProcessManagerInbox"
 SET "sourceEventKey" = encode(sha256(convert_to("sourceEventId", 'UTF8')), 'hex')
 WHERE "sourceEventKey" IS NULL;
 
-ALTER TABLE "ProcessManagerInbox" ALTER COLUMN "sourceEventKey" SET NOT NULL;
-
 -- Swap the constraint. The old index cannot have held a row over the btree
 -- limit (that was exactly the failure), so the digest of every surviving row is
 -- as unique as the raw value it came from and the new index cannot conflict.
-DROP INDEX "ProcessManagerInbox_processName_projectId_sourceEventId_key";
+--
+-- Guarded both ways to match the migration that created the old index
+-- (20260716140000 used CREATE UNIQUE INDEX IF NOT EXISTS), so an environment
+-- that diverged does not fail this one mid-transaction.
+DROP INDEX IF EXISTS "ProcessManagerInbox_processName_projectId_sourceEventId_key";
 
-CREATE UNIQUE INDEX "ProcessManagerInbox_processName_projectId_sourceEventKey_key"
+CREATE UNIQUE INDEX IF NOT EXISTS "ProcessManagerInbox_processName_projectId_sourceEventKey_key"
 ON "ProcessManagerInbox"("processName", "projectId", "sourceEventKey");

--- a/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
+++ b/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
@@ -1,0 +1,31 @@
+-- The inbox's uniqueness moves off the raw source event id and onto a
+-- fixed-width digest of it.
+--
+-- The raw id is `idempotencyKey ?? id`, composed by whichever pipeline emits
+-- the command, so its length was never the store's to guarantee. Postgres
+-- refuses a btree index row past ~2704 bytes, and a long enough key therefore
+-- turned the inbox insert into a hard SQLSTATE 54000 inside the commit
+-- transaction — deterministic, so the queue's retry ladder ran out and parked
+-- the aggregate's group permanently.
+--
+-- `sourceEventId` is kept as an unindexed column so operators can still read
+-- what was consumed.
+
+-- AddColumn (nullable first so the backfill has somewhere to land)
+ALTER TABLE "ProcessManagerInbox" ADD COLUMN "sourceEventKey" TEXT;
+
+-- Backfill with the same derivation the store uses: sha256 of the UTF-8 bytes,
+-- lowercase hex. `sha256()` is built in since Postgres 11.
+UPDATE "ProcessManagerInbox"
+SET "sourceEventKey" = encode(sha256(convert_to("sourceEventId", 'UTF8')), 'hex')
+WHERE "sourceEventKey" IS NULL;
+
+ALTER TABLE "ProcessManagerInbox" ALTER COLUMN "sourceEventKey" SET NOT NULL;
+
+-- Swap the constraint. The old index cannot have held a row over the btree
+-- limit (that was exactly the failure), so the digest of every surviving row is
+-- as unique as the raw value it came from and the new index cannot conflict.
+DROP INDEX "ProcessManagerInbox_processName_projectId_sourceEventId_key";
+
+CREATE UNIQUE INDEX "ProcessManagerInbox_processName_projectId_sourceEventKey_key"
+ON "ProcessManagerInbox"("processName", "projectId", "sourceEventKey");

--- a/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
+++ b/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
@@ -8,11 +8,30 @@
 -- alone is also not a rollback: it removes the only uniqueness the inbox has,
 -- so the idempotency guarantee lapses silently rather than loudly.
 --
--- To roll back the CODE, deploy the previous build and leave this schema in
--- place — the added column and index are inert to it (it neither reads nor
--- writes them), so no data step is needed. Undoing the SCHEMA is a manual,
--- remediated operation: prune or truncate any row whose `sourceEventId`
--- exceeds the btree limit first, then recreate the old index by hand.
+-- Rolling back the CODE means deploying the previous build and leaving this
+-- schema in place. That runs, but it is NOT free, and the cost is the same one
+-- the rollout window pays: the previous build does not write `sourceEventKey`,
+-- so its rows carry NULL, and a btree treats NULLs as distinct — the new unique
+-- index does not constrain them at all.
+--
+-- What still protects those writers: the store checks for the row before
+-- inserting, under a transaction-scoped advisory lock. That lock is keyed on
+-- (processName, projectId, processKey), while inbox uniqueness spans
+-- (processName, projectId, sourceEventId) — ACROSS process keys. So a
+-- same-process-key redelivery is still deduplicated, and the one case that
+-- loses its guard is the same source event reaching two DIFFERENT process keys
+-- concurrently. The dropped index was what caught that; nothing does while an
+-- old writer is serving.
+--
+-- Consequences to accept before rolling back: that race can consume one source
+-- event twice. It is narrow and bounded by however long old pods serve, which
+-- is why a drain is the safe way to roll back across this migration. Note the
+-- alternative was strictly worse — a NOT NULL column fails every old-pod commit
+-- outright, which is the outage this whole change exists to end.
+--
+-- Undoing the SCHEMA is a manual, remediated operation: prune or truncate any
+-- row whose `sourceEventId` exceeds the btree limit first, then recreate the
+-- old index by hand.
 --
 -- The inbox's uniqueness moves off the raw source event id and onto a
 -- fixed-width digest of it.

--- a/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
+++ b/langwatch/prisma/migrations/20260728120000_process_manager_inbox_digest_key/migration.sql
@@ -1,3 +1,19 @@
+-- IRREVERSIBLE: there is no safe down step.
+--
+-- Reversing means recreating the unique index on the RAW `sourceEventId`, and
+-- that can no longer be guaranteed to build: once this migration is live the
+-- store admits keys of any length, so a single row past the btree limit makes
+-- the reverse index creation fail — and the row that would break it is exactly
+-- the kind of row this migration exists to accept. Dropping `sourceEventKey`
+-- alone is also not a rollback: it removes the only uniqueness the inbox has,
+-- so the idempotency guarantee lapses silently rather than loudly.
+--
+-- To roll back the CODE, deploy the previous build and leave this schema in
+-- place — the added column and index are inert to it (it neither reads nor
+-- writes them), so no data step is needed. Undoing the SCHEMA is a manual,
+-- remediated operation: prune or truncate any row whose `sourceEventId`
+-- exceeds the btree limit first, then recreate the old index by hand.
+--
 -- The inbox's uniqueness moves off the raw source event id and onto a
 -- fixed-width digest of it.
 --

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -3143,7 +3143,12 @@ model ProcessManagerInbox {
   /// derived by the store (`stores/inboxKey.ts`). Postgres cannot index a btree
   /// row past ~2704 bytes; keying on a digest makes the constraint the same
   /// width no matter what any pipeline concatenates into an idempotency key.
-  sourceEventKey String
+  ///
+  /// Nullable ONLY for the rolling deploy that introduces it — pods running the
+  /// previous build write rows without it, and a NOT NULL would fail their
+  /// commits. The store always supplies it. A follow-up migration tightens this
+  /// once the fleet has cycled.
+  sourceEventKey String?
   consumedAt     DateTime @db.Timestamptz(3)
 
   @@unique([processName, projectId, sourceEventKey])

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -3146,8 +3146,14 @@ model ProcessManagerInbox {
   ///
   /// Nullable ONLY for the rolling deploy that introduces it — pods running the
   /// previous build write rows without it, and a NOT NULL would fail their
-  /// commits. The store always supplies it. A follow-up migration tightens this
-  /// once the fleet has cycled.
+  /// commits outright. The store always supplies it.
+  ///
+  /// The trade, stated plainly: a NULL is not constrained by the unique index
+  /// (btree treats NULLs as distinct), so while an old writer is serving, the
+  /// one case that loses its guard is the same source event reaching two
+  /// different process keys at once — the store's own read-check plus its
+  /// per-processKey advisory lock cover everything else. A follow-up migration
+  /// adds NOT NULL once the fleet has cycled and closes it.
   sourceEventKey String?
   consumedAt     DateTime @db.Timestamptz(3)
 

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -3130,15 +3130,23 @@ model ProcessManagerInstance {
 
 /// Idempotency marker for a source event consumed by a process definition.
 model ProcessManagerInbox {
-  id            String   @id @default(nanoid())
-  processName   String
-  projectId     String
-  processKey    String
-  tenantId      String
-  sourceEventId String
-  consumedAt    DateTime @db.Timestamptz(3)
+  id             String   @id @default(nanoid())
+  processName    String
+  projectId      String
+  processKey     String
+  tenantId       String
+  /// The raw source event id, kept UNINDEXED for diagnostics. A caller composes
+  /// this and its length is that domain's business, so it must never carry a
+  /// btree constraint — see `sourceEventKey`.
+  sourceEventId  String
+  /// The fixed-width digest of `sourceEventId` the uniqueness is enforced on,
+  /// derived by the store (`stores/inboxKey.ts`). Postgres cannot index a btree
+  /// row past ~2704 bytes; keying on a digest makes the constraint the same
+  /// width no matter what any pipeline concatenates into an idempotency key.
+  sourceEventKey String
+  consumedAt     DateTime @db.Timestamptz(3)
 
-  @@unique([processName, projectId, sourceEventId])
+  @@unique([processName, projectId, sourceEventKey])
   @@index([processName, projectId, processKey, consumedAt])
 }
 

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
@@ -11,7 +11,13 @@ const REAL_ID = "oljdh6z0";
 const SIGNATURE = `Eo4RCosRARFNMg${"AbCd-_09".repeat(360)}`;
 const POLLUTED_ID = `${REAL_ID}_ts_${SIGNATURE}`;
 
-function toolFrame(id: string, phase: "start" | "end" = "start") {
+function toolFrame({
+  id,
+  phase = "start",
+}: {
+  id: string;
+  phase?: "start" | "end";
+}) {
   return { type: "tool", id, name: "bash", phase };
 }
 
@@ -20,14 +26,14 @@ describe("langy tool call id", () => {
     describe("when the frame is parsed at the wire boundary", () => {
       /** @scenario A tool id carrying a thought signature is reduced to the real id */
       it("records the tool call under the id the provider issued", () => {
-        const parsed = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+        const parsed = langyRelayFrameSchema.parse(toolFrame({ id: POLLUTED_ID }));
 
         expect(parsed).toMatchObject({ type: "tool", id: REAL_ID });
       });
 
       /** @scenario A tool id carrying a thought signature is reduced to the real id */
       it("keeps the signature out of everything it parsed", () => {
-        const parsed = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+        const parsed = langyRelayFrameSchema.parse(toolFrame({ id: POLLUTED_ID }));
 
         expect(JSON.stringify(parsed)).not.toContain("_ts_");
         expect(JSON.stringify(parsed)).not.toContain(SIGNATURE.slice(0, 32));
@@ -39,11 +45,11 @@ describe("langy tool call id", () => {
     describe("when each frame is parsed", () => {
       /** @scenario A start and an end frame for the same call still pair up */
       it("resolves both to the same tool call id", () => {
-        const start = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID, "start"));
+        const start = langyRelayFrameSchema.parse(toolFrame({ id: POLLUTED_ID, phase: "start" }));
         // The end frame carries the turn's LATER signature — a different blob
         // for the same call, which is exactly why the raw id could not pair.
         const end = langyRelayFrameSchema.parse(
-          toolFrame(`${REAL_ID}_ts_${"Zz90-_18".repeat(400)}`, "end"),
+          toolFrame({ id: `${REAL_ID}_ts_${"Zz90-_18".repeat(400)}`, phase: "end" }),
         );
 
         expect(start).toMatchObject({ id: REAL_ID });
@@ -57,7 +63,7 @@ describe("langy tool call id", () => {
       /** @scenario An ordinary tool id is left exactly as it is */
       it("records the id unchanged", () => {
         for (const id of ["toolu_01ABCdef", "call_9xYz", "bash-7", REAL_ID]) {
-          expect(langyRelayFrameSchema.parse(toolFrame(id))).toMatchObject({
+          expect(langyRelayFrameSchema.parse(toolFrame({ id }))).toMatchObject({
             id,
           });
         }
@@ -71,7 +77,7 @@ describe("langy tool call id", () => {
       it("records the id unchanged", () => {
         // Too short to be a stapled blob, so it is part of the name.
         expect(
-          langyRelayFrameSchema.parse(toolFrame("run_ts_migrations")),
+          langyRelayFrameSchema.parse(toolFrame({ id: "run_ts_migrations" })),
         ).toMatchObject({ id: "run_ts_migrations" });
       });
 
@@ -79,7 +85,7 @@ describe("langy tool call id", () => {
       it("leaves a long suffix alone when it is not base64url", () => {
         const id = `job_ts_${"a.b.c.d.".repeat(12)}`;
 
-        expect(langyRelayFrameSchema.parse(toolFrame(id))).toMatchObject({ id });
+        expect(langyRelayFrameSchema.parse(toolFrame({ id }))).toMatchObject({ id });
       });
     });
   });
@@ -107,7 +113,7 @@ describe("langy tool call id", () => {
       /** @scenario An absurdly long id is refused as an invalid frame */
       it("rejects the frame rather than storing it", () => {
         const result = langyRelayFrameSchema.safeParse(
-          toolFrame("x".repeat(4000)),
+          toolFrame({ id: "x".repeat(4000) }),
         );
 
         expect(result.success).toBe(false);
@@ -119,7 +125,7 @@ describe("langy tool call id", () => {
     describe("when its start is recorded as a durable milestone", () => {
       /** @scenario A tool call's durable key is built from the normalised id */
       it("builds the event's idempotency key from the normalised id", async () => {
-        const frame = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+        const frame = langyRelayFrameSchema.parse(toolFrame({ id: POLLUTED_ID }));
         if (frame.type !== "tool") throw new Error("expected a tool frame");
 
         const [event] = await new InitiateToolCallCommand().handle({

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { InitiateToolCallCommand } from "~/server/event-sourcing/pipelines/langy-conversation-processing/commands";
+import { langyRelayFrameSchema } from "../langyRelayFrame";
+
+/**
+ * The real shape: an 8-character tool id with a provider's round-trip blob
+ * stapled on. The blob is base64url and kilobytes long — the production value
+ * that broke the process-manager inbox index was 2,936 characters.
+ */
+const REAL_ID = "oljdh6z0";
+const SIGNATURE = `Eo4RCosRARFNMg${"AbCd-_09".repeat(360)}`;
+const POLLUTED_ID = `${REAL_ID}_ts_${SIGNATURE}`;
+
+function toolFrame(id: string, phase: "start" | "end" = "start") {
+  return { type: "tool", id, name: "bash", phase };
+}
+
+describe("langy tool call id", () => {
+  describe("given the agent reports a tool call whose id carries a provider signature", () => {
+    describe("when the frame is parsed at the wire boundary", () => {
+      /** @scenario A tool id carrying a thought signature is reduced to the real id */
+      it("records the tool call under the id the provider issued", () => {
+        const parsed = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+
+        expect(parsed).toMatchObject({ type: "tool", id: REAL_ID });
+      });
+
+      /** @scenario A tool id carrying a thought signature is reduced to the real id */
+      it("keeps the signature out of everything it parsed", () => {
+        const parsed = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+
+        expect(JSON.stringify(parsed)).not.toContain("_ts_");
+        expect(JSON.stringify(parsed)).not.toContain(SIGNATURE.slice(0, 32));
+      });
+    });
+  });
+
+  describe("given the agent reports both the start and the end of that call", () => {
+    describe("when each frame is parsed", () => {
+      /** @scenario A start and an end frame for the same call still pair up */
+      it("resolves both to the same tool call id", () => {
+        const start = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID, "start"));
+        // The end frame carries the turn's LATER signature — a different blob
+        // for the same call, which is exactly why the raw id could not pair.
+        const end = langyRelayFrameSchema.parse(
+          toolFrame(`${REAL_ID}_ts_${"Zz90-_18".repeat(400)}`, "end"),
+        );
+
+        expect(start).toMatchObject({ id: REAL_ID });
+        expect(end).toMatchObject({ id: REAL_ID });
+      });
+    });
+  });
+
+  describe("given the agent reports a tool call with a plain id", () => {
+    describe("when the frame is parsed", () => {
+      /** @scenario An ordinary tool id is left exactly as it is */
+      it("records the id unchanged", () => {
+        for (const id of ["toolu_01ABCdef", "call_9xYz", "bash-7", REAL_ID]) {
+          expect(langyRelayFrameSchema.parse(toolFrame(id))).toMatchObject({
+            id,
+          });
+        }
+      });
+    });
+  });
+
+  describe("given a tool id that contains the separator but no signature", () => {
+    describe("when the frame is parsed", () => {
+      /** @scenario A separator inside a normal id is not mistaken for a signature */
+      it("records the id unchanged", () => {
+        // Too short to be a stapled blob, so it is part of the name.
+        expect(
+          langyRelayFrameSchema.parse(toolFrame("run_ts_migrations")),
+        ).toMatchObject({ id: "run_ts_migrations" });
+      });
+
+      /** @scenario A separator inside a normal id is not mistaken for a signature */
+      it("leaves a long suffix alone when it is not base64url", () => {
+        const id = `job_ts_${"a.b.c.d.".repeat(12)}`;
+
+        expect(langyRelayFrameSchema.parse(toolFrame(id))).toMatchObject({ id });
+      });
+    });
+  });
+
+  describe("given the agent's final answer lists a tool call carrying a signature", () => {
+    describe("when the final frame is parsed", () => {
+      /** @scenario A tool call listed on the final answer is normalised the same way */
+      it("normalises the listed call the same way", () => {
+        const parsed = langyRelayFrameSchema.parse({
+          type: "final",
+          text: "done",
+          toolCalls: [{ id: POLLUTED_ID, name: "bash" }],
+        });
+
+        expect(parsed).toMatchObject({
+          type: "final",
+          toolCalls: [{ id: REAL_ID }],
+        });
+      });
+    });
+  });
+
+  describe("given a tool id that is still implausible after stripping", () => {
+    describe("when the frame is parsed", () => {
+      /** @scenario An absurdly long id is refused as an invalid frame */
+      it("rejects the frame rather than storing it", () => {
+        const result = langyRelayFrameSchema.safeParse(
+          toolFrame("x".repeat(4000)),
+        );
+
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("given a tool call whose id carried a provider signature", () => {
+    describe("when its start is recorded as a durable milestone", () => {
+      /** @scenario A tool call's durable key is built from the normalised id */
+      it("builds the event's idempotency key from the normalised id", () => {
+        const frame = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
+        if (frame.type !== "tool") throw new Error("expected a tool frame");
+
+        const [event] = new InitiateToolCallCommand().handle({
+          type: "langy.conversation.initiate_tool_call",
+          tenantId: "project-1",
+          data: {
+            tenantId: "project-1",
+            occurredAt: 1_000,
+            conversationId: "langyconv_1",
+            turnId: "langyturn_1",
+            toolCallId: frame.id,
+            toolName: frame.name,
+          },
+        } as never);
+
+        expect(event!.idempotencyKey).toBe(
+          `project-1:langyconv_1:tool-start:${REAL_ID}`,
+        );
+        expect(event!.idempotencyKey!.length).toBeLessThan(200);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyToolCallId.unit.test.ts
@@ -118,11 +118,11 @@ describe("langy tool call id", () => {
   describe("given a tool call whose id carried a provider signature", () => {
     describe("when its start is recorded as a durable milestone", () => {
       /** @scenario A tool call's durable key is built from the normalised id */
-      it("builds the event's idempotency key from the normalised id", () => {
+      it("builds the event's idempotency key from the normalised id", async () => {
         const frame = langyRelayFrameSchema.parse(toolFrame(POLLUTED_ID));
         if (frame.type !== "tool") throw new Error("expected a tool frame");
 
-        const [event] = new InitiateToolCallCommand().handle({
+        const [event] = await new InitiateToolCallCommand().handle({
           type: "langy.conversation.initiate_tool_call",
           tenantId: "project-1",
           data: {

--- a/langwatch/src/server/app-layer/langy/streaming/langyRelayFrame.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/langyRelayFrame.ts
@@ -63,9 +63,70 @@ const receivedDomainErrorSchema = herrEnvelopeWireSchema.transform((body) =>
   handledErrorFromHerr(body),
 );
 
+/**
+ * The separator a model provider's round-trip blob is stapled onto a tool call
+ * id with. Gemini's thought signature is the one that reached us: the agent
+ * runtime has nowhere else to carry it, so it emits `<real id>_ts_<blob>`.
+ */
+const TOOL_CALL_ID_SIGNATURE_SEPARATOR = "_ts_";
+
+/**
+ * The shortest suffix we will treat as a stapled blob rather than as part of a
+ * name. A real signature is kilobytes of base64; this only has to be past
+ * anything a provider would plausibly put after an underscore.
+ */
+const TOOL_CALL_ID_SIGNATURE_MIN_LENGTH = 64;
+
+/** base64url — what a stapled blob is encoded as, and what a name is not. */
+const TOOL_CALL_ID_SIGNATURE_SHAPE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Past this, the value is not an identifier and we do not want it in the event
+ * log, the message parts, or a composed idempotency key. Real ids are well
+ * under a hundred characters.
+ */
+const TOOL_CALL_ID_MAX_LENGTH = 256;
+
+/**
+ * Strip a model provider's round-trip payload off a tool call id.
+ *
+ * The blob is not identity — it is state the provider requires back on the
+ * next request, and the agent runtime has no other field to put it in. Left
+ * alone it rode into the durable event data and, because the tool commands
+ * compose their idempotency key out of the id, into the process manager's
+ * inbox key, where it was long enough to exceed Postgres's btree index limit
+ * and park the conversation's queue group for good
+ * (specs/langy/langy-tool-call-identity.feature).
+ *
+ * Normalising HERE rather than at each use is what makes start and end frames,
+ * live cards, durable events and the final's tool list agree on one id.
+ */
+export function normalizeToolCallId(id: string): string {
+  const separator = id.indexOf(TOOL_CALL_ID_SIGNATURE_SEPARATOR);
+  if (separator <= 0) return id;
+  const suffix = id.slice(
+    separator + TOOL_CALL_ID_SIGNATURE_SEPARATOR.length,
+  );
+  if (suffix.length < TOOL_CALL_ID_SIGNATURE_MIN_LENGTH) return id;
+  if (!TOOL_CALL_ID_SIGNATURE_SHAPE.test(suffix)) return id;
+  return id.slice(0, separator);
+}
+
+/**
+ * A tool call's id, normalised at the boundary. The length bound applies AFTER
+ * stripping — a legitimate id wearing a signature must not be rejected for the
+ * blob's length — and a value still over it is REJECTED as an invalid payload
+ * rather than truncated, the same way plan items are below.
+ */
+export const langyToolCallIdSchema = z
+  .string()
+  .min(1)
+  .transform(normalizeToolCallId)
+  .pipe(z.string().min(1).max(TOOL_CALL_ID_MAX_LENGTH));
+
 /** A tool call the agent ran, in the compact shape the durable final carries. */
 export const langyRelayToolCallSchema = z.object({
-  id: z.string().min(1),
+  id: langyToolCallIdSchema,
   name: z.string().min(1),
   input: z.unknown().optional(),
   output: z.string().optional(),
@@ -142,7 +203,7 @@ export const langyRelayFrameSchema = z.discriminatedUnion("type", [
   /** Tool-call lifecycle — a live card AND a durable milestone event. */
   z.object({
     type: z.literal("tool"),
-    id: z.string().min(1),
+    id: langyToolCallIdSchema,
     name: z.string().min(1),
     phase: z.enum(["start", "end"]),
     title: z.string().optional(),

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
@@ -1,0 +1,139 @@
+import type { Redis } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { QueueRedisRepository } from "../../repositories/queue.redis.repository";
+
+let redis: Redis;
+beforeAll(async () => {
+  ({ redisConnection: redis } = await startTestContainers());
+});
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+// Module-level incrementing counter for unique queue names — no Date.now().
+let queueCounter = 0;
+
+/**
+ * The counters that decide whether a group's next job is allowed to run. Each
+ * one outlives a block, so an operator recovery that leaves any behind hands
+ * the group id's next job an inheritance it did not earn (ADR-076).
+ */
+const counterSuffixes = ["strikes", "attempt", "failstreak"] as const;
+
+describe("operator recovery clears every per-group counter", () => {
+  let repo: QueueRedisRepository;
+  let queueName: string;
+  let prefix: string;
+  const groupId = "project-1/subscriber/pm:langyConversation";
+
+  const counterKey = (suffix: string) =>
+    `${prefix}group:${groupId}:${suffix}`;
+
+  /** A group blocked after exhausting its budget, with every counter set. */
+  async function seedExhaustedBlockedGroup(): Promise<void> {
+    await redis.zadd(`${prefix}group:${groupId}:jobs`, 1000, "job-1");
+    await redis.hset(`${prefix}group:${groupId}:data`, "job-1", "{}");
+    await redis.sadd(`${prefix}blocked`, groupId);
+    await redis.set(counterKey("strikes"), "3");
+    await redis.set(counterKey("attempt"), "25");
+    await redis.set(counterKey("failstreak"), "24");
+  }
+
+  async function survivingCounters(): Promise<string[]> {
+    const present: string[] = [];
+    for (const suffix of counterSuffixes) {
+      if ((await redis.exists(counterKey(suffix))) === 1) present.push(suffix);
+    }
+    return present;
+  }
+
+  beforeEach(async () => {
+    repo = new QueueRedisRepository(redis);
+    queueCounter++;
+    queueName = `test-oprecover-${queueCounter}`;
+    prefix = `${queueName}:gq:`;
+    await seedExhaustedBlockedGroup();
+  });
+
+  describe("given a group blocked after a job used up its retry budget", () => {
+    describe("when an operator unblocks it", () => {
+      /** @scenario A group unblocked after exhaustion retries instead of re-blocking on its first failure */
+      /** @scenario A group unblocked after exhaustion is not immediately re-quarantined by its old failure streak */
+      it("leaves no counter behind to spend the next job's budget", async () => {
+        const { wasBlocked } = await repo.unblockGroup({ queueName, groupId });
+
+        expect(wasBlocked).toBe(true);
+        // Pre-ADR-076 this returned ["attempt", "failstreak"]: the group came
+        // back with a spent ladder AND a streak at the quarantine threshold.
+        expect(await survivingCounters()).toEqual([]);
+      });
+
+      /** @scenario An unblocked group's fresh ladder does not depend on how long the operator waited */
+      it("does not depend on how long the operator waited", async () => {
+        // The retry chain expires on its own after ~30 minutes, so before the
+        // fix a slow operator got a fresh ladder and a fast one got none. With
+        // the key deleted outright the outcome is the same either way, which is
+        // what this asserts: no surviving counter, no TTL to race.
+        await repo.unblockGroup({ queueName, groupId });
+
+        expect(await redis.ttl(counterKey("attempt"))).toBe(-2); // -2 = gone
+      });
+    });
+
+    describe("when an operator drains it", () => {
+      /** @scenario A drained group id starts its next job on a fresh ladder */
+      it("leaves no counter for a job later staged under the same group id", async () => {
+        await repo.drainGroup({ queueName, groupId });
+
+        expect(await survivingCounters()).toEqual([]);
+      });
+    });
+
+    describe("when an operator moves it to the dead-letter queue", () => {
+      /** @scenario A dead-lettered group id starts its next job on a fresh ladder */
+      it("leaves no counter for a job later staged under the same group id", async () => {
+        await repo.moveToDlq({ queueName, groupId });
+
+        expect(await survivingCounters()).toEqual([]);
+      });
+    });
+  });
+
+  describe("given a Redis whose script cache has been flushed", () => {
+    describe("when an operator runs a bulk recovery", () => {
+      it("still does the work instead of silently reporting nothing", async () => {
+        // The bulk paths pipeline EVALSHA, and a queued command cannot retry
+        // itself — so on a cold cache every entry fails with NOSCRIPT. Without
+        // the recovery path this returns 0 and the operator's "unblock
+        // everything" quietly does nothing.
+        await redis.script("FLUSH");
+
+        const { unblockedCount } = await repo.unblockAll({ queueName });
+
+        expect(unblockedCount).toBe(1);
+        expect(await redis.sismember(`${prefix}blocked`, groupId)).toBe(0);
+        expect(await survivingCounters()).toEqual([]);
+      });
+
+      it("drains a whole tenant on a cold cache", async () => {
+        // drainTenant walks the ready set, so this one needs a LIVE group
+        // rather than the blocked fixture the other cases use.
+        await redis.srem(`${prefix}blocked`, groupId);
+        await redis.zadd(`${prefix}ready`, 1, groupId);
+        await redis.script("FLUSH");
+
+        const { groupsDrained } = await repo.drainTenant({
+          queueName,
+          tenantId: "project-1",
+        });
+
+        expect(groupsDrained).toBe(1);
+        expect(await survivingCounters()).toEqual([]);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
@@ -103,37 +103,4 @@ describe("operator recovery clears every per-group counter", () => {
     });
   });
 
-  describe("given a Redis whose script cache has been flushed", () => {
-    describe("when an operator runs a bulk recovery", () => {
-      it("still does the work instead of silently reporting nothing", async () => {
-        // The bulk paths pipeline EVALSHA, and a queued command cannot retry
-        // itself — so on a cold cache every entry fails with NOSCRIPT. Without
-        // the recovery path this returns 0 and the operator's "unblock
-        // everything" quietly does nothing.
-        await redis.script("FLUSH");
-
-        const { unblockedCount } = await repo.unblockAll({ queueName });
-
-        expect(unblockedCount).toBe(1);
-        expect(await redis.sismember(`${prefix}blocked`, groupId)).toBe(0);
-        expect(await survivingCounters()).toEqual([]);
-      });
-
-      it("drains a whole tenant on a cold cache", async () => {
-        // drainTenant walks the ready set, so this one needs a LIVE group
-        // rather than the blocked fixture the other cases use.
-        await redis.srem(`${prefix}blocked`, groupId);
-        await redis.zadd(`${prefix}ready`, 1, groupId);
-        await redis.script("FLUSH");
-
-        const { groupsDrained } = await repo.drainTenant({
-          queueName,
-          tenantId: "project-1",
-        });
-
-        expect(groupsDrained).toBe(1);
-        expect(await survivingCounters()).toEqual([]);
-      });
-    });
-  });
 });

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/operator-recovery-counters.integration.test.ts
@@ -20,7 +20,7 @@ let queueCounter = 0;
 /**
  * The counters that decide whether a group's next job is allowed to run. Each
  * one outlives a block, so an operator recovery that leaves any behind hands
- * the group id's next job an inheritance it did not earn (ADR-076).
+ * the group id's next job an inheritance it did not earn (ADR-080).
  */
 const counterSuffixes = ["strikes", "attempt", "failstreak"] as const;
 
@@ -67,7 +67,7 @@ describe("operator recovery clears every per-group counter", () => {
         const { wasBlocked } = await repo.unblockGroup({ queueName, groupId });
 
         expect(wasBlocked).toBe(true);
-        // Pre-ADR-076 this returned ["attempt", "failstreak"]: the group came
+        // Pre-ADR-080 this returned ["attempt", "failstreak"]: the group came
         // back with a spent ladder AND a streak at the quarantine threshold.
         expect(await survivingCounters()).toEqual([]);
       });

--- a/langwatch/src/server/app-layer/ops/__tests__/noScriptRecovery.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/noScriptRecovery.unit.test.ts
@@ -1,0 +1,132 @@
+import type { ChainableCommander } from "ioredis";
+import { describe, expect, it } from "vitest";
+import { execWithNoScriptRecovery } from "../repositories/queue.redis.repository";
+
+/**
+ * A pipeline whose queued commands all come back NOSCRIPT — what Redis returns
+ * when a node has no cached copy of the script (restart, SCRIPT FLUSH, or the
+ * first call against a fresh cluster node).
+ *
+ * Tested here rather than against a live Redis on purpose: reaching this state
+ * for real needs a global `SCRIPT FLUSH`, which blanks the cache for every
+ * other suite sharing the instance and made an unrelated queue suite fail
+ * intermittently. The behaviour under test is entirely in the recovery
+ * function, so a fake pipeline pins it deterministically and harms nobody.
+ */
+function pipelineReturning(
+  results: Array<[Error | null, unknown]>,
+): ChainableCommander {
+  return { exec: async () => results } as unknown as ChainableCommander;
+}
+
+const noScript = (): [Error | null, unknown] => [
+  new Error("NOSCRIPT No matching script. Please use EVAL."),
+  null,
+];
+
+describe("execWithNoScriptRecovery", () => {
+  describe("given every queued command came back NOSCRIPT", () => {
+    describe("when the batch is resolved", () => {
+      it("re-runs each one and returns what the re-run produced", async () => {
+        const reran: number[] = [];
+
+        const results = await execWithNoScriptRecovery(
+          pipelineReturning([noScript(), noScript()]),
+          async (index) => {
+            reran.push(index);
+            return index === 0 ? 1 : 5;
+          },
+        );
+
+        // Without this the bulk paths report "nothing to do" on a cold cache:
+        // an operator's "unblock everything" silently does nothing.
+        expect(reran).toEqual([0, 1]);
+        expect(results).toEqual([
+          [null, 1],
+          [null, 5],
+        ]);
+      });
+    });
+  });
+
+  describe("given only some commands came back NOSCRIPT", () => {
+    describe("when the batch is resolved", () => {
+      it("re-runs only those, leaving the ones that already ran alone", async () => {
+        const reran: number[] = [];
+
+        const results = await execWithNoScriptRecovery(
+          pipelineReturning([[null, 1], noScript(), [null, 0]]),
+          async (index) => {
+            reran.push(index);
+            return 9;
+          },
+        );
+
+        // A NOSCRIPT is returned BEFORE the script body executes, so an entry
+        // reporting it provably did not run and re-running cannot double-apply.
+        // Entries that succeeded must never be re-run — that would be the
+        // double-execution a bulk drain cannot afford.
+        expect(reran).toEqual([1]);
+        expect(results).toEqual([
+          [null, 1],
+          [null, 9],
+          [null, 0],
+        ]);
+      });
+    });
+  });
+
+  describe("given a command failed for some other reason", () => {
+    describe("when the batch is resolved", () => {
+      it("passes the failure through untouched rather than retrying it", async () => {
+        const connectionLost: [Error | null, unknown] = [
+          new Error("Connection is closed."),
+          null,
+        ];
+        let reran = false;
+
+        const results = await execWithNoScriptRecovery(
+          pipelineReturning([connectionLost]),
+          async () => {
+            reran = true;
+            return 1;
+          },
+        );
+
+        // Ambiguous failures (a reset after send) may or may not have executed,
+        // so leaving them alone is the conservative choice.
+        expect(reran).toBe(false);
+        expect(results).toEqual([connectionLost]);
+      });
+    });
+  });
+
+  describe("given a re-run itself throws", () => {
+    describe("when the batch is resolved", () => {
+      it("reports it as that entry's error instead of rejecting the batch", async () => {
+        const results = await execWithNoScriptRecovery(
+          pipelineReturning([noScript()]),
+          async () => {
+            throw new Error("still unreachable");
+          },
+        );
+
+        expect(results[0]![0]).toBeInstanceOf(Error);
+        expect((results[0]![0] as Error).message).toBe("still unreachable");
+      });
+    });
+  });
+
+  describe("given the pipeline resolved to nothing", () => {
+    describe("when the batch is resolved", () => {
+      it("returns an empty batch rather than null", async () => {
+        const results = await execWithNoScriptRecovery(
+          { exec: async () => null } as unknown as ChainableCommander,
+          async () => 1,
+        );
+
+        expect(results).toEqual([]);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/__tests__/noScriptRecovery.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/noScriptRecovery.unit.test.ts
@@ -83,19 +83,19 @@ describe("execWithNoScriptRecovery", () => {
           new Error("Connection is closed."),
           null,
         ];
-        let reran = false;
+        let wasRerun = false;
 
         const results = await execWithNoScriptRecovery(
           pipelineReturning([connectionLost]),
           async () => {
-            reran = true;
+            wasRerun = true;
             return 1;
           },
         );
 
         // Ambiguous failures (a reset after send) may or may not have executed,
         // so leaving them alone is the conservative choice.
-        expect(reran).toBe(false);
+        expect(wasRerun).toBe(false);
         expect(results).toEqual([connectionLost]);
       });
     });

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -56,7 +56,7 @@ if wasBlocked > 0 then
   redis.call("DEL", errorKey)
   -- Unblocking is an operator's "try again", so EVERY counter that decides
   -- whether trying is allowed has to be reset — not just the claim strikes
-  -- (ADR-076). A group blocked by retry exhaustion came back with its retry
+  -- (ADR-080). A group blocked by retry exhaustion came back with its retry
   -- chain still reading "budget spent" and its failure streak still at the
   -- quarantine threshold, so the very first failure re-blocked it, and whether
   -- it did depended on how long the operator took to press the button (the
@@ -121,7 +121,7 @@ redis.call("DEL", errorKey)
 -- whether a later job is allowed to run goes with it. Leaving any behind means
 -- a re-created group with the same id inherits it: claim strikes park it on its
 -- first claim, a spent retry chain exhausts it on its first failure, and a
--- carried failure streak re-quarantines it (ADR-076,
+-- carried failure streak re-quarantines it (ADR-080,
 -- specs/event-sourcing/poison-group-park-guard.feature).
 redis.call("DEL", strikesKey)
 redis.call("DEL", attemptKey)
@@ -189,7 +189,7 @@ redis.call("DEL", srcErrorKey)
 -- Moving to the DLQ empties the live group just like a drain, so it clears the
 -- same counters for the same reason: a re-created group with the same id must
 -- get a fresh run, not inherit strikes, a spent retry chain, or a failure
--- streak from the jobs that were carried off (ADR-076).
+-- streak from the jobs that were carried off (ADR-080).
 redis.call("DEL", strikesKey)
 redis.call("DEL", attemptKey)
 redis.call("DEL", failStreakKey)

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -286,7 +286,7 @@ const PENDING_RECONCILE_SCAN_COUNT = 1000;
  * Returns the same `[err, value]` tuples `pipeline.exec()` does, so callers read
  * the results exactly as before.
  */
-async function execWithNoScriptRecovery(
+export async function execWithNoScriptRecovery(
   pipeline: ChainableCommander,
   rerun: (index: number) => Promise<unknown>,
 ): Promise<Array<[Error | null, unknown]>> {

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1,6 +1,10 @@
 import { createLogger } from "@langwatch/observability";
 import type IORedis from "ioredis";
-import type { Cluster } from "ioredis";
+import type { ChainableCommander, Cluster } from "ioredis";
+import {
+  CachedLuaScript,
+  isNoScriptResult,
+} from "~/server/event-sourcing/queues/groupQueue/cachedLuaScript";
 import {
   decodeJobEnvelope,
   readJobRoutingMeta,
@@ -40,6 +44,8 @@ local readyKey   = KEYS[4]
 local signalKey  = KEYS[5]
 local errorKey   = KEYS[6]
 local strikesKey = KEYS[7]
+local attemptKey = KEYS[8]
+local failStreakKey = KEYS[9]
 local groupId    = ARGV[1]
 local nowMs      = tonumber(ARGV[2])
 
@@ -48,10 +54,17 @@ local wasBlocked = redis.call("SREM", blockedKey, groupId)
 if wasBlocked > 0 then
   redis.call("DEL", activeKey)
   redis.call("DEL", errorKey)
-  -- Unblocking is an operator's "try again": reset the poison guard's claim
-  -- strikes so the group gets a fresh run instead of re-parking on the next
-  -- claim (specs/event-sourcing/poison-group-park-guard.feature).
+  -- Unblocking is an operator's "try again", so EVERY counter that decides
+  -- whether trying is allowed has to be reset — not just the claim strikes
+  -- (ADR-076). A group blocked by retry exhaustion came back with its retry
+  -- chain still reading "budget spent" and its failure streak still at the
+  -- quarantine threshold, so the very first failure re-blocked it, and whether
+  -- it did depended on how long the operator took to press the button (the
+  -- chain expires on its own after GROUP_ATTEMPT_TTL_SECONDS).
   redis.call("DEL", strikesKey)
+  -- specs/event-sourcing/poison-group-park-guard.feature
+  redis.call("DEL", attemptKey)
+  redis.call("DEL", failStreakKey)
 
   local pendingCount = redis.call("ZCARD", jobsKey)
   if pendingCount > 0 then
@@ -87,6 +100,8 @@ local signalKey       = KEYS[6]
 local errorKey        = KEYS[7]
 local totalPendingKey = KEYS[8]
 local strikesKey      = KEYS[9]
+local attemptKey      = KEYS[10]
+local failStreakKey   = KEYS[11]
 local groupId         = ARGV[1]
 
 -- Total dropped = staged jobs (ZCARD) only. Previously this also counted
@@ -102,11 +117,15 @@ redis.call("DEL", jobsKey)
 redis.call("DEL", dataKey)
 redis.call("DEL", activeKey)
 redis.call("DEL", errorKey)
--- Draining empties the group for a fresh start: clear the poison guard's
--- claim strikes too, or a re-created group with the same id would park on
--- its first claim within the strike TTL
--- (specs/event-sourcing/poison-group-park-guard.feature).
+-- Draining empties the group for a fresh start, so EVERY counter that decides
+-- whether a later job is allowed to run goes with it. Leaving any behind means
+-- a re-created group with the same id inherits it: claim strikes park it on its
+-- first claim, a spent retry chain exhausts it on its first failure, and a
+-- carried failure streak re-quarantines it (ADR-076,
+-- specs/event-sourcing/poison-group-park-guard.feature).
 redis.call("DEL", strikesKey)
+redis.call("DEL", attemptKey)
+redis.call("DEL", failStreakKey)
 redis.call("ZREM", readyKey, groupId)
 redis.call("SREM", blockedKey, groupId)
 redis.call("LPUSH", signalKey, "1")
@@ -132,6 +151,8 @@ local dstDataKey   = KEYS[9]
 local dstErrorKey  = KEYS[10]
 local dlqIndexKey  = KEYS[11]
 local strikesKey   = KEYS[12]
+local attemptKey   = KEYS[13]
+local failStreakKey = KEYS[14]
 local groupId      = ARGV[1]
 local ttl          = tonumber(ARGV[2])
 
@@ -165,10 +186,13 @@ redis.call("DEL", srcJobsKey)
 redis.call("DEL", srcDataKey)
 redis.call("DEL", activeKey)
 redis.call("DEL", srcErrorKey)
--- Moving to the DLQ empties the live group just like a drain: clear the
--- poison guard's claim strikes so a re-created group with the same id gets
--- a fresh run instead of parking on its first claim within the strike TTL.
+-- Moving to the DLQ empties the live group just like a drain, so it clears the
+-- same counters for the same reason: a re-created group with the same id must
+-- get a fresh run, not inherit strikes, a spent retry chain, or a failure
+-- streak from the jobs that were carried off (ADR-076).
 redis.call("DEL", strikesKey)
+redis.call("DEL", attemptKey)
+redis.call("DEL", failStreakKey)
 redis.call("ZREM", readyKey, groupId)
 redis.call("SREM", blockedKey, groupId)
 redis.call("LPUSH", signalKey, "1")
@@ -225,6 +249,20 @@ redis.call("LTRIM", signalKey, 0, 999)
 return count
 `;
 
+// ── Cached scripts ───────────────────────────────────────────────────
+//
+// EVALSHA, not EVAL: plain EVAL re-transfers and re-hashes the full source on
+// every call, which was measured at ~33% of the prod Redis engine CPU for the
+// queue's own scripts (see `cachedLuaScript.ts`). These ops scripts are larger
+// than they look — each one carries the shared TTL/park helpers — and the bulk
+// paths below run one per group across a whole page, so the same argument
+// applies. A NOSCRIPT miss falls back to EVAL once and warms the node's cache.
+
+const unblockScript = new CachedLuaScript(UNBLOCK_LUA);
+const drainGroupScript = new CachedLuaScript(DRAIN_GROUP_LUA);
+const moveToDlqScript = new CachedLuaScript(MOVE_TO_DLQ_LUA);
+const replayFromDlqScript = new CachedLuaScript(REPLAY_FROM_DLQ_LUA);
+
 // ── Constants ────────────────────────────────────────────────────────
 
 const SUMMARY_TOP_N = 200;
@@ -233,6 +271,37 @@ const SSCAN_BATCH = 500;
 const PENDING_RECONCILE_SCAN_COUNT = 1000;
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Run a pipeline of cached scripts, re-running any entry the node had no cached
+ * copy of.
+ *
+ * `queue()` sends EVALSHA with no fallback of its own — a queued command cannot
+ * retry itself — so a node whose script cache is cold (restart, SCRIPT FLUSH,
+ * or the first call against a fresh cluster node) fails EVERY entry in the
+ * batch with NOSCRIPT. These are the bulk operator paths, so without this a
+ * "drain everything" would report zero drained and quietly do nothing. Re-running
+ * through `run()` both completes the work and loads the source for later calls.
+ *
+ * Returns the same `[err, value]` tuples `pipeline.exec()` does, so callers read
+ * the results exactly as before.
+ */
+async function execWithNoScriptRecovery(
+  pipeline: ChainableCommander,
+  rerun: (index: number) => Promise<unknown>,
+): Promise<Array<[Error | null, unknown]>> {
+  const results = (await pipeline.exec()) ?? [];
+  return await Promise.all(
+    results.map(async (result, index): Promise<[Error | null, unknown]> => {
+      if (!isNoScriptResult(result)) return result;
+      try {
+        return [null, await rerun(index)];
+      } catch (err) {
+        return [err instanceof Error ? err : new Error(String(err)), null];
+      }
+    }),
+  );
+}
 
 function stripHashTag(name: string): string {
   if (name.startsWith("{") && name.endsWith("}")) {
@@ -715,9 +784,9 @@ export class QueueRedisRepository implements QueueRepository {
     groupId: string;
   }): Promise<{ wasBlocked: boolean }> {
     const prefix = `${params.queueName}:gq:`;
-    const result = await this.redis.eval(
-      UNBLOCK_LUA,
-      7,
+    const result = await unblockScript.run(
+      this.redis,
+      9,
       `${prefix}blocked`,
       `${prefix}group:${params.groupId}:active`,
       `${prefix}group:${params.groupId}:jobs`,
@@ -725,6 +794,8 @@ export class QueueRedisRepository implements QueueRepository {
       `${prefix}signal`,
       `${prefix}group:${params.groupId}:error`,
       `${prefix}group:${params.groupId}:strikes`,
+      `${prefix}group:${params.groupId}:attempt`,
+      `${prefix}group:${params.groupId}:failstreak`,
       params.groupId,
       String(Date.now()),
     );
@@ -751,22 +822,25 @@ export class QueueRedisRepository implements QueueRepository {
       if (members.length === 0) continue;
 
       const pipeline = this.redis.pipeline();
-      for (const groupId of members) {
-        pipeline.eval(
-          UNBLOCK_LUA,
-          7,
-          `${prefix}blocked`,
-          `${prefix}group:${groupId}:active`,
-          `${prefix}group:${groupId}:jobs`,
-          `${prefix}ready`,
-          `${prefix}signal`,
-          `${prefix}group:${groupId}:error`,
-          `${prefix}group:${groupId}:strikes`,
-          groupId,
-          String(Date.now()),
-        );
+      const argsByIndex = members.map((groupId) => [
+        `${prefix}blocked`,
+        `${prefix}group:${groupId}:active`,
+        `${prefix}group:${groupId}:jobs`,
+        `${prefix}ready`,
+        `${prefix}signal`,
+        `${prefix}group:${groupId}:error`,
+        `${prefix}group:${groupId}:strikes`,
+        `${prefix}group:${groupId}:attempt`,
+        `${prefix}group:${groupId}:failstreak`,
+        groupId,
+        String(Date.now()),
+      ]);
+      for (const args of argsByIndex) {
+        unblockScript.queue(pipeline, 9, ...args);
       }
-      const results = await pipeline.exec();
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        unblockScript.run(this.redis, 9, ...argsByIndex[index]!),
+      );
       if (results) {
         for (const [err, result] of results) {
           if (!err && result === 1) unblockedCount++;
@@ -782,9 +856,9 @@ export class QueueRedisRepository implements QueueRepository {
     groupId: string;
   }): Promise<{ jobsRemoved: number }> {
     const prefix = `${params.queueName}:gq:`;
-    const result = await this.redis.eval(
-      DRAIN_GROUP_LUA,
-      9,
+    const result = await drainGroupScript.run(
+      this.redis,
+      11,
       `${prefix}group:${params.groupId}:jobs`,
       `${prefix}group:${params.groupId}:data`,
       `${prefix}group:${params.groupId}:active`,
@@ -794,6 +868,8 @@ export class QueueRedisRepository implements QueueRepository {
       `${prefix}group:${params.groupId}:error`,
       `${prefix}stats:total-pending`,
       `${prefix}group:${params.groupId}:strikes`,
+      `${prefix}group:${params.groupId}:attempt`,
+      `${prefix}group:${params.groupId}:failstreak`,
       params.groupId,
     );
     return { jobsRemoved: Number(result) };
@@ -928,27 +1004,30 @@ export class QueueRedisRepository implements QueueRepository {
       }
       if (matched.length === 0) continue;
 
-      // Pipeline all DRAIN_GROUP_LUA evals for this page into a single
-      // network round-trip. Each EVAL is independent; ioredis batches
-      // them and returns results in the same order.
+      // Pipeline all the drains for this page into a single network round-trip.
+      // Each call is independent; ioredis batches them and returns results in
+      // the same order.
       const pipeline = this.redis.pipeline();
-      for (const groupId of matched) {
-        pipeline.eval(
-          DRAIN_GROUP_LUA,
-          9,
-          `${prefix}group:${groupId}:jobs`,
-          `${prefix}group:${groupId}:data`,
-          `${prefix}group:${groupId}:active`,
-          readyKey,
-          `${prefix}blocked`,
-          `${prefix}signal`,
-          `${prefix}group:${groupId}:error`,
-          totalPendingKey,
-          `${prefix}group:${groupId}:strikes`,
-          groupId,
-        );
+      const argsByIndex = matched.map((groupId) => [
+        `${prefix}group:${groupId}:jobs`,
+        `${prefix}group:${groupId}:data`,
+        `${prefix}group:${groupId}:active`,
+        readyKey,
+        `${prefix}blocked`,
+        `${prefix}signal`,
+        `${prefix}group:${groupId}:error`,
+        totalPendingKey,
+        `${prefix}group:${groupId}:strikes`,
+        `${prefix}group:${groupId}:attempt`,
+        `${prefix}group:${groupId}:failstreak`,
+        groupId,
+      ]);
+      for (const args of argsByIndex) {
+        drainGroupScript.queue(pipeline, 11, ...args);
       }
-      const results = await pipeline.exec();
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        drainGroupScript.run(this.redis, 11, ...argsByIndex[index]!),
+      );
       if (!results) continue;
       for (const [err, value] of results) {
         if (err) continue;
@@ -967,9 +1046,9 @@ export class QueueRedisRepository implements QueueRepository {
     groupId: string;
   }): Promise<{ jobsMoved: number }> {
     const prefix = `${params.queueName}:gq:`;
-    const result = await this.redis.eval(
-      MOVE_TO_DLQ_LUA,
-      12,
+    const result = await moveToDlqScript.run(
+      this.redis,
+      14,
       `${prefix}group:${params.groupId}:jobs`,
       `${prefix}group:${params.groupId}:data`,
       `${prefix}group:${params.groupId}:active`,
@@ -982,6 +1061,8 @@ export class QueueRedisRepository implements QueueRepository {
       `${prefix}dlq:${params.groupId}:error`,
       `${prefix}dlq`,
       `${prefix}group:${params.groupId}:strikes`,
+      `${prefix}group:${params.groupId}:attempt`,
+      `${prefix}group:${params.groupId}:failstreak`,
       params.groupId,
       String(DLQ_TTL_SECONDS),
     );
@@ -1023,27 +1104,30 @@ export class QueueRedisRepository implements QueueRepository {
       if (groupsToMove.length === 0) continue;
 
       const pipeline = this.redis.pipeline();
-      for (const groupId of groupsToMove) {
-        pipeline.eval(
-          MOVE_TO_DLQ_LUA,
-          12,
-          `${prefix}group:${groupId}:jobs`,
-          `${prefix}group:${groupId}:data`,
-          `${prefix}group:${groupId}:active`,
-          `${prefix}ready`,
-          `${prefix}blocked`,
-          `${prefix}signal`,
-          `${prefix}group:${groupId}:error`,
-          `${prefix}dlq:${groupId}:jobs`,
-          `${prefix}dlq:${groupId}:data`,
-          `${prefix}dlq:${groupId}:error`,
-          `${prefix}dlq`,
-          `${prefix}group:${groupId}:strikes`,
-          groupId,
-          String(DLQ_TTL_SECONDS),
-        );
+      const argsByIndex = groupsToMove.map((groupId) => [
+        `${prefix}group:${groupId}:jobs`,
+        `${prefix}group:${groupId}:data`,
+        `${prefix}group:${groupId}:active`,
+        `${prefix}ready`,
+        `${prefix}blocked`,
+        `${prefix}signal`,
+        `${prefix}group:${groupId}:error`,
+        `${prefix}dlq:${groupId}:jobs`,
+        `${prefix}dlq:${groupId}:data`,
+        `${prefix}dlq:${groupId}:error`,
+        `${prefix}dlq`,
+        `${prefix}group:${groupId}:strikes`,
+        `${prefix}group:${groupId}:attempt`,
+        `${prefix}group:${groupId}:failstreak`,
+        groupId,
+        String(DLQ_TTL_SECONDS),
+      ]);
+      for (const args of argsByIndex) {
+        moveToDlqScript.queue(pipeline, 14, ...args);
       }
-      const results = await pipeline.exec();
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        moveToDlqScript.run(this.redis, 14, ...argsByIndex[index]!),
+      );
       if (results) {
         for (const [err, result] of results) {
           if (!err) {
@@ -1065,8 +1149,8 @@ export class QueueRedisRepository implements QueueRepository {
     groupId: string;
   }): Promise<{ jobsReplayed: number }> {
     const prefix = `${params.queueName}:gq:`;
-    const result = await this.redis.eval(
-      REPLAY_FROM_DLQ_LUA,
+    const result = await replayFromDlqScript.run(
+      this.redis,
       8,
       `${prefix}dlq:${params.groupId}:jobs`,
       `${prefix}dlq:${params.groupId}:data`,
@@ -1117,23 +1201,24 @@ export class QueueRedisRepository implements QueueRepository {
       if (groupsToReplay.length === 0) continue;
 
       const pipeline = this.redis.pipeline();
-      for (const groupId of groupsToReplay) {
-        pipeline.eval(
-          REPLAY_FROM_DLQ_LUA,
-          8,
-          `${prefix}dlq:${groupId}:jobs`,
-          `${prefix}dlq:${groupId}:data`,
-          `${prefix}dlq:${groupId}:error`,
-          `${prefix}group:${groupId}:jobs`,
-          `${prefix}group:${groupId}:data`,
-          `${prefix}ready`,
-          `${prefix}signal`,
-          `${prefix}dlq`,
-          groupId,
-          String(Date.now()),
-        );
+      const argsByIndex = groupsToReplay.map((groupId) => [
+        `${prefix}dlq:${groupId}:jobs`,
+        `${prefix}dlq:${groupId}:data`,
+        `${prefix}dlq:${groupId}:error`,
+        `${prefix}group:${groupId}:jobs`,
+        `${prefix}group:${groupId}:data`,
+        `${prefix}ready`,
+        `${prefix}signal`,
+        `${prefix}dlq`,
+        groupId,
+        String(Date.now()),
+      ]);
+      for (const args of argsByIndex) {
+        replayFromDlqScript.queue(pipeline, 8, ...args);
       }
-      const results = await pipeline.exec();
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        replayFromDlqScript.run(this.redis, 8, ...argsByIndex[index]!),
+      );
       if (results) {
         for (const [err, result] of results) {
           if (!err) {
@@ -1186,23 +1271,24 @@ export class QueueRedisRepository implements QueueRepository {
     if (groupsToRedrive.length === 0) return { redrivenCount: 0, groupIds: [] };
 
     const pipeline = this.redis.pipeline();
-    for (const groupId of groupsToRedrive) {
-      pipeline.eval(
-        REPLAY_FROM_DLQ_LUA,
-        8,
-        `${prefix}dlq:${groupId}:jobs`,
-        `${prefix}dlq:${groupId}:data`,
-        `${prefix}dlq:${groupId}:error`,
-        `${prefix}group:${groupId}:jobs`,
-        `${prefix}group:${groupId}:data`,
-        `${prefix}ready`,
-        `${prefix}signal`,
-        `${prefix}dlq`,
-        groupId,
-        String(Date.now()),
-      );
+    const argsByIndex = groupsToRedrive.map((groupId) => [
+      `${prefix}dlq:${groupId}:jobs`,
+      `${prefix}dlq:${groupId}:data`,
+      `${prefix}dlq:${groupId}:error`,
+      `${prefix}group:${groupId}:jobs`,
+      `${prefix}group:${groupId}:data`,
+      `${prefix}ready`,
+      `${prefix}signal`,
+      `${prefix}dlq`,
+      groupId,
+      String(Date.now()),
+    ]);
+    for (const args of argsByIndex) {
+      replayFromDlqScript.queue(pipeline, 8, ...args);
     }
-    const results = await pipeline.exec();
+    const results = await execWithNoScriptRecovery(pipeline, (index) =>
+      replayFromDlqScript.run(this.redis, 8, ...argsByIndex[index]!),
+    );
 
     let redrivenCount = 0;
     const redrivenIds: string[] = [];
@@ -1248,22 +1334,25 @@ export class QueueRedisRepository implements QueueRepository {
       return { unblockedCount: 0, groupIds: [] };
 
     const unblockPipeline = this.redis.pipeline();
-    for (const groupId of groupsToUnblock) {
-      unblockPipeline.eval(
-        UNBLOCK_LUA,
-        7,
-        `${prefix}blocked`,
-        `${prefix}group:${groupId}:active`,
-        `${prefix}group:${groupId}:jobs`,
-        `${prefix}ready`,
-        `${prefix}signal`,
-        `${prefix}group:${groupId}:error`,
-        `${prefix}group:${groupId}:strikes`,
-        groupId,
-        String(Date.now()),
-      );
+    const argsByIndex = groupsToUnblock.map((groupId) => [
+      `${prefix}blocked`,
+      `${prefix}group:${groupId}:active`,
+      `${prefix}group:${groupId}:jobs`,
+      `${prefix}ready`,
+      `${prefix}signal`,
+      `${prefix}group:${groupId}:error`,
+      `${prefix}group:${groupId}:strikes`,
+      `${prefix}group:${groupId}:attempt`,
+      `${prefix}group:${groupId}:failstreak`,
+      groupId,
+      String(Date.now()),
+    ]);
+    for (const args of argsByIndex) {
+      unblockScript.queue(unblockPipeline, 9, ...args);
     }
-    const results = await unblockPipeline.exec();
+    const results = await execWithNoScriptRecovery(unblockPipeline, (index) =>
+      unblockScript.run(this.redis, 9, ...argsByIndex[index]!),
+    );
 
     let unblockedCount = 0;
     const unblockedIds: string[] = [];

--- a/langwatch/src/server/event-sourcing/process-manager/stores/__tests__/inboxKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/stores/__tests__/inboxKey.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { deriveInboxKey } from "../inboxKey";
+
+const SHORT = "event_000649zPnIW3V0Ug6yVk9DECNYK3S";
+const LONG = `project_x:langyconv_1:tool-start:${"a".repeat(3000)}`;
+
+describe("deriveInboxKey", () => {
+  describe("given a source event id", () => {
+    describe("when its inbox key is derived twice", () => {
+      /** @scenario The same source event id always derives the same key */
+      it("produces the same value both times", () => {
+        expect(deriveInboxKey(SHORT)).toBe(deriveInboxKey(SHORT));
+        expect(deriveInboxKey(LONG)).toBe(deriveInboxKey(LONG));
+      });
+    });
+  });
+
+  describe("given a very short source event id and a very long one", () => {
+    describe("when each one's inbox key is derived", () => {
+      /** @scenario The derived key is a fixed width regardless of input length */
+      it("derives keys of the same length", () => {
+        expect(deriveInboxKey(SHORT)).toHaveLength(deriveInboxKey(LONG).length);
+      });
+
+      /** @scenario The derived key is a fixed width regardless of input length */
+      it("keeps that length far under the btree index limit", () => {
+        // Postgres refuses a btree index row past ~2704 bytes; the constraint
+        // also carries processName and projectId, so the key's own width is
+        // what has to stay small.
+        expect(deriveInboxKey(LONG).length).toBeLessThan(100);
+      });
+    });
+  });
+
+  describe("given two long ids that differ only at the very end", () => {
+    describe("when each one's inbox key is derived", () => {
+      it("keeps them distinct", () => {
+        expect(deriveInboxKey(`${LONG}a`)).not.toBe(deriveInboxKey(`${LONG}b`));
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/process-manager/stores/__tests__/prismaProcessStore.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/stores/__tests__/prismaProcessStore.integration.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { nanoid } from "nanoid";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { prisma } from "~/server/db";
@@ -660,5 +661,148 @@ describe("PrismaProcessStore", () => {
       { key: "fresh-dispatched-msg", status: "dispatched" },
       { key: "still-pending-msg", status: "pending" },
     ]);
+  });
+
+  // A source event id is `idempotencyKey ?? id`, composed by whichever pipeline
+  // emits the command. These run against real Postgres because the failure they
+  // pin is the database refusing the index row (SQLSTATE 54000) — an in-memory
+  // store cannot express it, and a string-length assertion would not observe it.
+  describe("given a source event id far past the btree index limit", () => {
+    // The filler has to be INCOMPRESSIBLE or this whole block is a test that
+    // cannot fail. Postgres pglz-compresses a datum before it goes into the
+    // index, so repetitive filler shrinks under the limit and inserts happily
+    // against the OLD index too. The production value was a base64 thought
+    // signature — high entropy, no compression — so the fixture chains sha256
+    // digests: deterministic across runs, and pglz cannot shrink it either.
+    // `is still rejected by the pre-fix index shape` below pins that against
+    // the real engine, so the fixture cannot silently degrade into one that
+    // would pass with or without the digest key.
+    const incompressible = (length: number): string => {
+      let out = "";
+      let block = createHash("sha256").update("langy-tool-call").digest("hex");
+      while (out.length < length) {
+        out += block;
+        block = createHash("sha256").update(block).digest("hex");
+      }
+      return out.slice(0, length);
+    };
+    // 3,017 characters is what production actually sent: a Gemini thought
+    // signature stapled onto a tool call id, inside a composed idempotency key.
+    const oversized = (suffix = "") =>
+      `project-1:langyconv_1:tool-start:oljdh6z0_ts_${incompressible(2936)}${suffix}`;
+
+    it("is still rejected by the pre-fix index shape", async () => {
+      // Builds a replica of the constraint as it was before the digest key and
+      // shows Postgres itself refusing this exact value. This is the assertion
+      // that gives the rest of the block its meaning: without it, a fixture
+      // that drifted into being compressible would make them all vacuous.
+      await prisma.$executeRawUnsafe(
+        `CREATE TEMP TABLE pre_fix_inbox ("processName" TEXT, "projectId" TEXT, "sourceEventId" TEXT)`,
+      );
+      await prisma.$executeRawUnsafe(
+        `CREATE UNIQUE INDEX pre_fix_inbox_key ON pre_fix_inbox("processName", "projectId", "sourceEventId")`,
+      );
+
+      await expect(
+        prisma.$executeRawUnsafe(
+          `INSERT INTO pre_fix_inbox VALUES ($1, $2, $3)`,
+          processName,
+          "project-1",
+          oversized(),
+        ),
+      ).rejects.toThrow(/exceeds btree version \d+ maximum/);
+    });
+
+    describe("when the process commits its consumption of the event", () => {
+      /** @scenario A source event id far past the index limit is still consumed */
+      it("commits instead of failing on the index row size", async () => {
+        const result = await store.commit(
+          commit({ sourceEventId: oversized(), messages: [] }),
+        );
+
+        expect(result.outcome).toBe("committed");
+      });
+
+      /** @scenario A source event id far past the index limit is still consumed */
+      it("keeps the raw source event id on the row for diagnostics", async () => {
+        const sourceEventId = oversized();
+        await store.commit(commit({ sourceEventId, messages: [] }));
+
+        const row = await prisma.processManagerInbox.findFirst({
+          where: { processName, projectId: "project-1" },
+        });
+        expect(row?.sourceEventId).toBe(sourceEventId);
+      });
+    });
+
+    describe("when two such ids share a long common prefix", () => {
+      /** @scenario Two different long source event ids stay distinct */
+      it("consumes both without mistaking one for the other", async () => {
+        const first = await store.commit(
+          commit({
+            target: ref("conversation-a"),
+            sourceEventId: oversized("-a"),
+            messages: [],
+          }),
+        );
+        const second = await store.commit(
+          commit({
+            target: ref("conversation-b"),
+            sourceEventId: oversized("-b"),
+            messages: [],
+          }),
+        );
+
+        expect([first.outcome, second.outcome]).toEqual([
+          "committed",
+          "committed",
+        ]);
+        expect(
+          await prisma.processManagerInbox.count({
+            where: { processName, projectId: "project-1" },
+          }),
+        ).toBe(2);
+      });
+    });
+
+    describe("when the same event is delivered again", () => {
+      /** @scenario Redelivery of a long source event id is still deduplicated */
+      it("reports the redelivery as a duplicate and writes no second row", async () => {
+        const sourceEventId = oversized();
+        await store.commit(commit({ sourceEventId, messages: [] }));
+
+        const redelivery = await store.commit(
+          commit({ sourceEventId, expectedRevision: 1, messages: [] }),
+        );
+
+        expect(redelivery.outcome).toBe("duplicateEvent");
+        expect(
+          await prisma.processManagerInbox.count({
+            where: { processName, projectId: "project-1" },
+          }),
+        ).toBe(1);
+      });
+    });
+
+    describe("when a later event arrives for the same process", () => {
+      /** @scenario A long source event id no longer blocks the process */
+      it("processes the later event instead of wedging on the oversized one", async () => {
+        const first = await store.commit(
+          commit({ sourceEventId: oversized(), messages: [] }),
+        );
+        expect(first.outcome).toBe("committed");
+
+        const later = await store.commit(
+          commit({
+            sourceEventId: "event-after-the-oversized-one",
+            expectedRevision: 1,
+            state: { step: 2 },
+            messages: [message("later-message")],
+          }),
+        );
+
+        expect(later).toMatchObject({ outcome: "committed", revision: 2 });
+      });
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/process-manager/stores/inboxKey.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/stores/inboxKey.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derive the inbox's unique key for a source event id.
+ *
+ * `sourceEventId` is `idempotencyKey ?? id`, and an idempotency key is
+ * composed by whichever pipeline emits the command — so its length is the
+ * emitting domain's business, not the store's. Postgres refuses a btree index
+ * row past ~2704 bytes, and the inbox's unique constraint spans
+ * (processName, projectId, <source event>), so indexing the raw value made the
+ * store's correctness depend on every caller staying short. One that did not
+ * (a model provider's round-trip blob stapled onto a tool call id) turned the
+ * insert into a hard 54000 inside the commit transaction — deterministic, so
+ * the retry ladder ran out and parked the aggregate's group for good.
+ *
+ * Hashing unconditionally rather than only when long keeps one code path with
+ * no threshold to get wrong, and makes the constraint the same width whatever
+ * any future pipeline concatenates. The raw id stays on the row, unindexed,
+ * so operators can still read what was consumed.
+ */
+export function deriveInboxKey(sourceEventId: string): string {
+  return createHash("sha256").update(sourceEventId, "utf8").digest("hex");
+}

--- a/langwatch/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
@@ -5,9 +5,11 @@ import {
   type ProcessManagerOutbox,
 } from "@prisma/client";
 
-import { nanoid } from "nanoid";
+import { generate } from "@langwatch/ksuid";
+import { KSUID_RESOURCES } from "~/utils/constants";
 import type { JsonValue } from "../json";
 import type { ProcessRef } from "../processManager.types";
+import { deriveInboxKey } from "./inboxKey";
 import type {
   CommitResult,
   DueWake,
@@ -126,10 +128,10 @@ export class PrismaProcessStore implements ProcessStore {
           const duplicate = await tx.processManagerInbox.findUnique({
             where: {
               projectId: commit.ref.projectId,
-              processName_projectId_sourceEventId: {
+              processName_projectId_sourceEventKey: {
                 processName: commit.ref.processName,
                 projectId: commit.ref.projectId,
-                sourceEventId: commit.sourceEventId,
+                sourceEventKey: deriveInboxKey(commit.sourceEventId),
               },
             },
             select: { id: true },
@@ -167,7 +169,7 @@ export class PrismaProcessStore implements ProcessStore {
           const inserted = await tx.processManagerInstance.createMany({
             data: [
               {
-                id: nanoid(),
+                id: generate(KSUID_RESOURCES.PROCESS_MANAGER_INSTANCE).toString(),
                 ...refWhere(commit.ref),
                 ...instanceData,
               },
@@ -214,10 +216,11 @@ export class PrismaProcessStore implements ProcessStore {
           const inbox = await tx.processManagerInbox.createMany({
             data: [
               {
-                id: nanoid(),
+                id: generate(KSUID_RESOURCES.PROCESS_MANAGER_INBOX).toString(),
                 ...refWhere(commit.ref),
                 tenantId: commit.tenantId,
                 sourceEventId: commit.sourceEventId,
+                sourceEventKey: deriveInboxKey(commit.sourceEventId),
                 consumedAt: asDate(commit.now),
               },
             ],
@@ -234,7 +237,7 @@ export class PrismaProcessStore implements ProcessStore {
           const inserted = await tx.processManagerOutbox.createMany({
             data: [
               {
-                id: nanoid(),
+                id: generate(KSUID_RESOURCES.PROCESS_MANAGER_OUTBOX).toString(),
                 ...refWhere(commit.ref),
                 tenantId: commit.tenantId,
                 userId: message.userId ?? null,
@@ -296,7 +299,9 @@ export class PrismaProcessStore implements ProcessStore {
     if (params.processNames && params.processNames.length === 0) return [];
     const now = asDate(params.now);
     const leasedUntil = asDate(params.now + params.leaseDurationMs);
-    const leaseBatchToken = nanoid();
+    const leaseBatchToken = generate(
+      KSUID_RESOURCES.PROCESS_MANAGER_OUTBOX,
+    ).toString();
     const processNameFilter = params.processNames
       ? Prisma.sql`AND "processName" IN (${Prisma.join([...params.processNames])})`
       : Prisma.empty;

--- a/langwatch/src/server/event-sourcing/process-manager/stores/processStore.types.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/stores/processStore.types.ts
@@ -68,6 +68,11 @@ export interface ProcessCommit<State = unknown> {
    * Inbox identity: (processName, projectId, sourceEventId) is consumed at
    * most once. Null for wake-driven commits, which are guarded by
    * `expectedRevision` instead.
+   *
+   * Any length is accepted. A store that enforces the uniqueness in an index
+   * derives a fixed-width key from this value rather than indexing it
+   * (`stores/inboxKey.ts`), so a caller's idempotency key can be as long as its
+   * own domain needs.
    */
   sourceEventId: string | null;
   /** 0 when the process has never been committed. */

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
@@ -639,13 +639,12 @@ describe.skipIf(!hasTestcontainers)(
         it("increments the drop counter with the transient-exhausted reason", async () => {
           const name = freshName();
           const groupId = `${TENANT}/transient-exhausted`;
-          // handleTransientDecode reads the attempt off the stagedJobId's own
-          // retry marker (`stagedJobAttempt`), not a live retry counter — the
-          // job body is exactly what it could not decode. So staging a job
-          // already marked at JOB_RETRY_CONFIG.maxAttempts - 1 = 24 hits the
-          // exhaustion branch on the FIRST claim, sidestepping ~2h of real
-          // exponential backoff (25 attempts, capped at 600s each) with no
-          // fake timers.
+          // handleTransientDecode takes the HIGHEST of (message header, group
+          // retry chain, legacy id segment). This fixture has neither of the
+          // first two — the body is exactly what it cannot decode — so a legacy
+          // `/r/24` marker decides, putting the job one rung from the end on its
+          // first claim. That sidesteps ~2h of real exponential backoff (25
+          // attempts, capped at 600s each) with no fake timers.
           const craftedStagedJobId = "victim/r/24";
 
           const flaky = new FlakyObjectStore(1); // one failure is all that's needed

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
@@ -630,18 +630,23 @@ describe.skipIf(!hasTestcontainers)(
 
     describe("given a staged job whose blob store stays unreachable for every retry attempt", () => {
       describe("when the job exhausts its retry budget", () => {
+        // One `@scenario` per JSDoc: the parity checker scans forward from the
+        // end of each annotation for the `it(` call, and only skips whole
+        // comment blocks — so in a single multi-line block every annotation but
+        // the last silently fails to bind.
         /** @scenario the transient retry ladder's terminal counts the job it gives up on */
+        /** @scenario A body that stays unreachable is given up on at the end of the ladder */
         it("increments the drop counter with the transient-exhausted reason", async () => {
           const name = freshName();
           const groupId = `${TENANT}/transient-exhausted`;
-          // handleTransientDecode derives the attempt number from the
-          // stagedJobId's own "/r/" suffix count
-          // (stagedJobId.match(/\/r\//g)), not from a live retry counter —
-          // so staging a job whose id already carries
-          // JOB_RETRY_CONFIG.maxAttempts - 1 = 24 markers hits the exhaustion
-          // branch on the FIRST claim. This sidesteps ~2h of real exponential
-          // backoff (25 attempts, capped at 600s each) with no fake timers.
-          const craftedStagedJobId = `victim${"/r/x".repeat(24)}`;
+          // handleTransientDecode reads the attempt off the stagedJobId's own
+          // retry marker (`stagedJobAttempt`), not a live retry counter — the
+          // job body is exactly what it could not decode. So staging a job
+          // already marked at JOB_RETRY_CONFIG.maxAttempts - 1 = 24 hits the
+          // exhaustion branch on the FIRST claim, sidestepping ~2h of real
+          // exponential backoff (25 attempts, capped at 600s each) with no
+          // fake timers.
+          const craftedStagedJobId = "victim/r/24";
 
           const flaky = new FlakyObjectStore(1); // one failure is all that's needed
           const encodeTiered = new TieredBlobStore({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
@@ -26,7 +26,7 @@ function blobStore(): TieredBlobStore {
   return new TieredBlobStore({
     redisBlobs: new InMemoryJobBlobStore(),
     objectStoreFor: () => new InMemoryObjectStore(),
-    resolveDestination: () => null,
+    resolveDestination: async () => ({ kind: "s3", bucket: "test-bucket" }),
   });
 }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
@@ -59,7 +59,7 @@ describe("job envelope retry attempt", () => {
 
   describe("given a job that has never been retried", () => {
     describe("when its attempt is read from the message", () => {
-      /** @scenario A job sent for the first time reads as its first attempt */
+      /** @scenario A job sent for the first time carries no attempt on its message */
       it("reports no attempt yet rather than inventing one", async () => {
         expect(readJobAttempt(await encodeGq2(jobData()))).toBeNull();
       });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelopeAttempt.unit.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  readJobAttempt,
+  splitEnvelope,
+  withJobAttempt,
+} from "../jobEnvelope";
+import { TieredBlobStore } from "../tieredBlobStore";
+import { InMemoryJobBlobStore, InMemoryObjectStore } from "./blobTestDoubles";
+
+const PROJECT = createTenantId("project-1");
+
+const jobData = (attempt?: number) => ({
+  __pipelineName: "langy_conversation_processing",
+  __jobType: "subscriber",
+  __jobName: "pm:langyConversation",
+  ...(attempt === undefined ? {} : { __attempt: attempt }),
+  id: "event_000649zPnIW3V0Ug6yVk9DECNYK3S",
+  data: { conversationId: "langyconv_1" },
+});
+
+function blobStore(): TieredBlobStore {
+  return new TieredBlobStore({
+    redisBlobs: new InMemoryJobBlobStore(),
+    objectStoreFor: () => new InMemoryObjectStore(),
+    resolveDestination: () => null,
+  });
+}
+
+/**
+ * A GQ2 envelope — what the composition root produces. GQ1 is reached only
+ * when a tiered store or the tenant is missing, which the encoder treats as a
+ * downgrade worth a metric and a warning.
+ */
+async function encodeGq2(
+  data: Record<string, unknown>,
+  tieredBlobs: TieredBlobStore = blobStore(),
+): Promise<string> {
+  return await encodeJobEnvelope({
+    jobData: data,
+    tieredBlobs,
+    projectId: PROJECT,
+    writesEnabled: true,
+    queueName: "q",
+  });
+}
+
+describe("job envelope retry attempt", () => {
+  beforeEach(() => {
+    vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("given a job that has never been retried", () => {
+    describe("when its attempt is read from the message", () => {
+      /** @scenario A job sent for the first time reads as its first attempt */
+      it("reports no attempt yet rather than inventing one", async () => {
+        expect(readJobAttempt(await encodeGq2(jobData()))).toBeNull();
+      });
+    });
+  });
+
+  describe("given a re-staged job whose body is held outside the message", () => {
+    /** A blob-offloaded envelope: the body is empty, everything is in the header. */
+    async function offloaded(attempt: number): Promise<string> {
+      return await encodeGq2({
+        ...jobData(attempt),
+        bulk: "x".repeat(200_000),
+      });
+    }
+
+    describe("when its attempt is read while the body is unreachable", () => {
+      /** @scenario A retried job's attempt is readable without fetching its body */
+      it("reports the attempt from the message alone", async () => {
+        const encoded = await offloaded(7);
+
+        // Nothing here touches a blob store: the value alone answers.
+        expect(splitEnvelope(encoded).body).toBe("");
+        expect(readJobAttempt(encoded)).toBe(7);
+      });
+    });
+  });
+
+  describe("given a staged job carrying an attempt", () => {
+    describe("when the queue advances that job to its next attempt", () => {
+      /** @scenario Advancing a job's attempt leaves its payload bytes untouched */
+      it("leaves the body bytes untouched", async () => {
+        const encoded = await encodeGq2(jobData(3));
+        const advanced = withJobAttempt({ value: encoded, attempt: 4 });
+
+        expect(splitEnvelope(advanced).body).toBe(splitEnvelope(encoded).body);
+        expect(readJobAttempt(advanced)).toBe(4);
+      });
+
+      /** @scenario Advancing a job's attempt leaves its payload bytes untouched */
+      it("keeps the rest of the job intact", async () => {
+        const encoded = await encodeGq2(jobData(3));
+        const advanced = withJobAttempt({ value: encoded, attempt: 4 });
+
+        expect(await decodeJobEnvelope({ value: advanced })).toEqual(
+          jobData(4),
+        );
+      });
+
+      /** @scenario Advancing a job's attempt does not split the body it shares with identical jobs */
+      it("keeps the pointer to the shared stored body", async () => {
+        const blobs = blobStore();
+        const first = await encodeGq2(
+          { ...jobData(1), bulk: "x".repeat(200_000) },
+          blobs,
+        );
+        const advanced = withJobAttempt({ value: first, attempt: 2 });
+
+        // Same body reference, so the shared blob is neither split nor re-written.
+        const { header: before } = splitEnvelope(first);
+        const { header: after } = splitEnvelope(advanced);
+        expect(after.h).toBe(before.h);
+        expect(after.ref).toEqual(before.ref);
+      });
+    });
+  });
+
+  describe("given a staged job advanced through attempts of different digit widths", () => {
+    describe("when each one is read back", () => {
+      /** @scenario A job stays readable as its attempt count grows wider */
+      it("stays readable at every width", async () => {
+        // The envelope is `<prefix><headerByteLength>|<header><body>`, so
+        // widening 9 -> 10 -> 100 changes the header's length and the prefix
+        // must be recomputed with it. A splice that edited the header in place
+        // would corrupt the value at exactly these boundaries.
+        let value = await encodeGq2(jobData(1));
+
+        for (const attempt of [9, 10, 99, 100, 1000]) {
+          value = withJobAttempt({ value, attempt });
+          expect(readJobAttempt(value)).toBe(attempt);
+          expect(await decodeJobEnvelope({ value })).toEqual(jobData(attempt));
+        }
+      });
+    });
+  });
+
+  describe("given a job in a format that keeps its attempt inside the body", () => {
+    describe("when its attempt is read from the message alone", () => {
+      /** @scenario A job in a format that predates the readable attempt reports no attempt rather than a wrong one */
+      it("reports no attempt and does not throw", () => {
+        // A GQ1 envelope lifts only the routing trio into the header.
+        const gq1 = 'GQ1|29|{"v":1,"e":"j","t":"subscriber"}{"__attempt":9}';
+
+        expect(readJobAttempt(gq1)).toBeNull();
+        expect(withJobAttempt({ value: gq1, attempt: 10 })).toBe(gq1);
+      });
+
+      /** @scenario A job in a format that predates the readable attempt reports no attempt rather than a wrong one */
+      it("survives a value it cannot parse at all", () => {
+        expect(readJobAttempt("GQ2|not-an-envelope")).toBeNull();
+        expect(readJobAttempt("{ broken json")).toBeNull();
+        expect(withJobAttempt({ value: "GQ2|nope", attempt: 2 })).toBe(
+          "GQ2|nope",
+        );
+      });
+    });
+  });
+
+  describe("given a legacy bare-JSON job", () => {
+    describe("when its attempt is read from the message", () => {
+      it("reads the attempt straight off the payload", () => {
+        expect(readJobAttempt(JSON.stringify({ __attempt: 5 }))).toBe(5);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/legacyStagedJobAttempt.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/legacyStagedJobAttempt.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { JOB_RETRY_CONFIG } from "../../shared";
+import { legacyStagedJobAttempt } from "../groupQueue";
+import { readJobAttempt } from "../jobEnvelope";
+
+const BASE =
+  "event_000649zPnIW3V0Ug6yVk9DECNYK3S/subscriber/pm:langyConversation";
+
+describe("legacyStagedJobAttempt", () => {
+  describe("given a legacy id carrying a retry segment", () => {
+    describe("when the attempt is taken from a message that records one", () => {
+      /** @scenario A legacy id's retry segment is read only when nothing else can answer */
+      it("believes the message and ignores the id's segment", () => {
+        // The ladder takes the highest of (message, group chain, legacy id), so
+        // a message that can answer always wins over a stale id segment.
+        const value = JSON.stringify({ __attempt: 7 });
+
+        expect(
+          Math.max(
+            readJobAttempt(value) ?? 0,
+            legacyStagedJobAttempt(`${BASE}/r/3`),
+          ),
+        ).toBe(7);
+      });
+    });
+  });
+
+  describe("given an id from before the retry count moved to the message", () => {
+    describe("when its attempt is read", () => {
+      it("takes the furthest rung the chain reached", () => {
+        expect(legacyStagedJobAttempt(`${BASE}/r/12/r/16/r/24`)).toBe(24);
+      });
+
+      it("reads a single segment", () => {
+        expect(legacyStagedJobAttempt(`${BASE}/r/5`)).toBe(5);
+      });
+
+      it("reads nothing from an id that never retried", () => {
+        expect(legacyStagedJobAttempt(BASE)).toBe(0);
+      });
+    });
+  });
+
+  describe("given a legacy id whose terminal segment is a wall-clock stamp", () => {
+    describe("when its attempt is read", () => {
+      it("does not mistake the timestamp for an attempt", () => {
+        // `/r/${Date.now()}` shared the retry marker. Read as a count it would
+        // vault past the budget and discard a job that still had rungs left.
+        const withStamp = `${BASE}/r/12/r/16/r/24/r/1785261278310`;
+
+        expect(legacyStagedJobAttempt(withStamp)).toBe(24);
+        expect(legacyStagedJobAttempt(`${BASE}/r/1785261278310`)).toBe(0);
+      });
+
+      it("never reports more than the ladder has rungs", () => {
+        expect(
+          legacyStagedJobAttempt(`${BASE}/r/1785261278310`),
+        ).toBeLessThanOrEqual(JOB_RETRY_CONFIG.maxAttempts);
+      });
+    });
+  });
+
+  describe("given an id whose own name contains the marker's shape", () => {
+    describe("when its attempt is read", () => {
+      it("ignores a segment that is not a bare number", () => {
+        expect(legacyStagedJobAttempt(`${BASE}/r/x`)).toBe(0);
+        expect(legacyStagedJobAttempt("event_1/r/inner/subscriber/pm:x")).toBe(
+          0,
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/legacyStagedJobAttempt.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/legacyStagedJobAttempt.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { JOB_RETRY_CONFIG } from "../../shared";
-import { legacyStagedJobAttempt } from "../groupQueue";
+import { legacyStagedJobAttempt } from "../legacyStagedJobAttempt";
 import { readJobAttempt } from "../jobEnvelope";
 
 const BASE =
@@ -52,10 +52,15 @@ describe("legacyStagedJobAttempt", () => {
         expect(legacyStagedJobAttempt(`${BASE}/r/1785261278310`)).toBe(0);
       });
 
-      it("never reports more than the ladder has rungs", () => {
+      it("ignores a segment one past the ladder's last rung", () => {
+        // The real boundary: maxAttempts reads, maxAttempts + 1 does not, so a
+        // stamp can never be mistaken for a count no matter how small.
         expect(
-          legacyStagedJobAttempt(`${BASE}/r/1785261278310`),
-        ).toBeLessThanOrEqual(JOB_RETRY_CONFIG.maxAttempts);
+          legacyStagedJobAttempt(`${BASE}/r/${JOB_RETRY_CONFIG.maxAttempts}`),
+        ).toBe(JOB_RETRY_CONFIG.maxAttempts);
+        expect(
+          legacyStagedJobAttempt(`${BASE}/r/${JOB_RETRY_CONFIG.maxAttempts + 1}`),
+        ).toBe(0);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2117,6 +2117,67 @@ describe("GroupStagingScripts", () => {
       });
     });
 
+    describe("when a retry re-stages a job", () => {
+      // The group's retry chain and the re-stage are ONE script (ADR-080).
+      // Since the staged id stopped carrying a `/r/<n>` marker, that chain is
+      // the only attempt carrier a re-staged SIBLING has — it comes back with
+      // its original envelope and no `__attempt`. A chain write that failed
+      // while the re-stage succeeded would hand the next sibling-led claim a
+      // fresh budget: an unbounded ladder, and a fold that re-applies events it
+      // had already recorded as applied.
+      const attemptKey = () => `${keyPrefix()}group:group-a:attempt`;
+
+      /** @scenario A sibling-led claim after a retry still sees the attempt the ladder reached */
+      it("records the attempt the ladder reached in the same step", async () => {
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 300 });
+
+        await scripts.retryRestage({
+          groupId: "group-a",
+          stagedJobId: "j1",
+          newStagedJobId: "j1",
+          dispatchAfterMs: 5_000,
+          jobDataJson: JSON.stringify({ v: 1 }),
+          backoffMs: 3_000,
+          attempt: 4,
+          attemptTtlSec: 1800,
+        });
+
+        // A sibling leading the next claim carries no attempt of its own, so
+        // this key is the only thing standing between it and a fresh budget.
+        expect(await redis.get(attemptKey())).toBe("4");
+        expect(await redis.ttl(attemptKey())).toBeGreaterThan(0);
+      });
+
+      /** @scenario A retry that cannot record its attempt does not re-stage the job */
+      it("advances neither the chain nor the staging set when it does not own the slot", async () => {
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 300 });
+
+        // Another worker owns the slot now: the guard fails and the script
+        // writes nothing. Pre-ADR-080 the attempt was written by the CALLER
+        // before this call, so it advanced even when the re-stage did not —
+        // shortening the next job's budget for a job that was never staged.
+        const restaged = await scripts.retryRestage({
+          groupId: "group-a",
+          stagedJobId: "someone-elses-job",
+          newStagedJobId: "someone-elses-job",
+          dispatchAfterMs: 5_000,
+          jobDataJson: JSON.stringify({ v: 1 }),
+          backoffMs: 3_000,
+          attempt: 9,
+          attemptTtlSec: 1800,
+        });
+
+        expect(restaged).toBe(false);
+        expect(await redis.get(attemptKey())).toBeNull();
+      });
+    });
+
     describe("when a stale heartbeat fires after retryRestage", () => {
       // The worker's heartbeat interval stays armed for a few awaits after
       // retryRestage returns (blob-hold transfer, audit write). Before the
@@ -2138,6 +2199,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 5_000,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 3_000,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         expect(restaged).toBe(true);
 
@@ -3438,6 +3501,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 300,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 1000,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         expect(restaged).toBe(true);
 
@@ -3524,6 +3589,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 300,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 500,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         await redis.del(`${keyPrefix()}group:g-multi:active`);
 
@@ -3537,6 +3604,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 500,
           jobDataJson: JSON.stringify({ attempt: 3 }),
           backoffMs: 1000,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         await redis.del(`${keyPrefix()}group:g-multi:active`);
 
@@ -3550,6 +3619,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 700,
           jobDataJson: JSON.stringify({ attempt: 4 }),
           backoffMs: 2000,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         await redis.del(`${keyPrefix()}group:g-multi:active`);
 
@@ -3591,6 +3662,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 300,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 500,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
         expect(await inspectTotalPending()).toBe(1);
 
@@ -3685,6 +3758,8 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 300,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 500,
+          attempt: 1,
+          attemptTtlSec: 1800,
         });
 
         // retryRestage ZADD'd a new job AND INCR'd the counter.
@@ -4216,6 +4291,8 @@ describe("GroupStagingScripts", () => {
         dispatchAfterMs: 9999,
         jobDataJson: JSON.stringify({ hello: "world" }),
         backoffMs: 30_000,
+        attempt: 1,
+        attemptTtlSec: 1800,
       });
 
       // retryRestage sets the slot expiry to Date.now() + retryTtlSec*1000,
@@ -5183,6 +5260,8 @@ describe("group-key TTL safety net", () => {
         dispatchAfterMs: Date.now() + 5000,
         jobDataJson: JSON.stringify({ retry: true }),
         backoffMs: 5000,
+        attempt: 1,
+        attemptTtlSec: 1800,
       });
 
       expectFreshTtl(await jobsTtl("group-a"));

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
@@ -64,7 +64,7 @@ const STORAGE_DESTINATION = async () =>
 const OFFLOADABLE_S3_VALUE = () => incompressible(768 * 1024);
 
 describe.skipIf(!hasTestcontainers)(
-  "GroupQueueProcessor — a staged job id is identity, not state (ADR-076)",
+  "GroupQueueProcessor — a staged job id is identity, not state (ADR-080)",
   () => {
     let redis: Redis;
     let queues: GroupQueueProcessor<TestPayload>[];
@@ -248,7 +248,7 @@ describe.skipIf(!hasTestcontainers)(
      * probe only fires callbacks the implementation has LEFT armed.
      *
      * The cast is to the global's own signature: there is no exported seam for
-     * "which intervals are currently armed", and the whole point of ADR-076's
+     * "which intervals are currently armed", and the whole point of ADR-080's
      * heartbeat ordering is that the interval is gone before the re-stage is
      * issued.
      */
@@ -287,7 +287,7 @@ describe.skipIf(!hasTestcontainers)(
     }
 
     /**
-     * Ticks every still-armed interval at the WORST moment ADR-076 describes:
+     * Ticks every still-armed interval at the WORST moment ADR-080 describes:
      * the re-stage has been sent and the worker is still tidying up. A beat
      * that lands there names an id the re-stage has just re-used, so
      * `REFRESH_LUA` matches and stretches a sub-second backoff into the full
@@ -378,7 +378,7 @@ describe.skipIf(!hasTestcontainers)(
           expect(ids).toEqual([
             "event_000649zPnIW3V0Ug6yVk9DECNYK3S/subscriber/pm:langyConversation",
           ]);
-          // Pre-ADR-076 an id gained `/r/<n>` per retry and a `/r/<Date.now()>`
+          // Pre-ADR-080 an id gained `/r/<n>` per retry and a `/r/<Date.now()>`
           // on the terminal restage; nothing mints either shape any more.
           expect(ids[0]).not.toMatch(/\/r\//);
           expect(ids[0]).not.toMatch(/\/p\//);
@@ -428,7 +428,7 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 10000, interval: 25 },
           );
 
-          // Pre-ADR-076 this read `event_retry/subscriber/pm:langyConversation/r/1`.
+          // Pre-ADR-080 this read `event_retry/subscriber/pm:langyConversation/r/1`.
           expect(await stagedIds(name, groupId)).toEqual([
             expectedStagedId(payload),
           ]);
@@ -478,7 +478,7 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 15000, interval: 50 },
           );
 
-          // Pre-ADR-076 `handleExhaustedRetries` appended `/r/<Date.now()>`, so
+          // Pre-ADR-080 `handleExhaustedRetries` appended `/r/<Date.now()>`, so
           // the parked job could not be found by the id its producer knows.
           expect(await stagedIds(name, groupId)).toEqual([
             expectedStagedId(payload),
@@ -527,7 +527,7 @@ describe.skipIf(!hasTestcontainers)(
           );
 
           expect(processed).not.toHaveBeenCalled();
-          // Pre-ADR-076 the park appended `/p/<Date.now()>`.
+          // Pre-ADR-080 the park appended `/p/<Date.now()>`.
           expect(await stagedIds(name, groupId)).toEqual([
             expectedStagedId(payload),
           ]);
@@ -667,7 +667,7 @@ describe.skipIf(!hasTestcontainers)(
 
           await queue.send(payload);
 
-          // Pre-ADR-076 the retry re-staged under `<id>/r/5`, so a redelivery
+          // Pre-ADR-080 the retry re-staged under `<id>/r/5`, so a redelivery
           // under `<id>` landed on a DIFFERENT member: two jobs for one event.
           expect(await stagedIds(name, groupId)).toEqual([
             expectedStagedId(payload),
@@ -797,7 +797,7 @@ describe.skipIf(!hasTestcontainers)(
             expect(probe.refreshed).toContain(
               "event_beat/subscriber/pm:langyConversation",
             );
-            // Pre-ADR-076 the interval was cleared only in the worker's outer
+            // Pre-ADR-080 the interval was cleared only in the worker's outer
             // `finally`, so ticking it here produced another REFRESH — one that
             // now matches, because the re-stage reuses the id.
             expect(probe.beats.afterRestage).toBe(0);
@@ -889,7 +889,7 @@ describe.skipIf(!hasTestcontainers)(
               __jobName: "pm:langyConversation",
             });
 
-            // The retry runs on its ~3s hold. Pre-ADR-076 the beat ticked after
+            // The retry runs on its ~3s hold. Pre-ADR-080 the beat ticked after
             // the re-stage pushed the hold (and the ready score) to the full
             // 300s active window, so nothing would run inside this timeout.
             await vi.waitFor(() => expect(deliveries).toEqual([1, 2]), {
@@ -960,7 +960,7 @@ describe.skipIf(!hasTestcontainers)(
             timeout: 20000,
             interval: 25,
           });
-          // Pre-ADR-076 the chain survived the unblock, so this run read as
+          // Pre-ADR-080 the chain survived the unblock, so this run read as
           // attempt 25 and the group re-blocked on its very first failure.
           expect(seen[1]).toBe(1);
           expect(await blockedMembers(name)).not.toContain(groupId);
@@ -1025,7 +1025,7 @@ describe.skipIf(!hasTestcontainers)(
             timeout: 20000,
             interval: 25,
           });
-          // Pre-ADR-076 the streak survived at 3, so this single failure took
+          // Pre-ADR-080 the streak survived at 3, so this single failure took
           // it to 4 — past the threshold — and quarantined the group instantly.
           await vi.waitFor(
             async () => {
@@ -1107,7 +1107,7 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 25000, interval: 25 },
           );
 
-          // Pre-ADR-076 the promptly-unblocked group came back on attempt 25
+          // Pre-ADR-080 the promptly-unblocked group came back on attempt 25
           // and the patient operator's group came back on attempt 1.
           expect(seen.filter((s) => s.groupId === promptGroup)[1]!.attempt).toBe(
             1,
@@ -1169,7 +1169,7 @@ describe.skipIf(!hasTestcontainers)(
 
           await runLadderOnce({ name, groupId, objectStore, expectChain: "6" });
 
-          // Pre-ADR-076 this ladder could only count `/r/` segments on the id,
+          // Pre-ADR-080 this ladder could only count `/r/` segments on the id,
           // so a message that already said "attempt 5" was read as a fresh one.
           expect(
             readJobAttempt((await stagedValue(name, groupId, stagedJobId))!),
@@ -1296,7 +1296,7 @@ describe.skipIf(!hasTestcontainers)(
             interval: 25,
           });
 
-          // Pre-ADR-076 nothing on the message or the chain moved at all: the
+          // Pre-ADR-080 nothing on the message or the chain moved at all: the
           // count lived only in a segment appended to the id.
           expect(rungs.map((r) => r.onMessage)).toEqual([1, 2, 3]);
           // recordGroupAttempt runs before the re-stage, so the chain already
@@ -1526,7 +1526,7 @@ describe.skipIf(!hasTestcontainers)(
             },
             { timeout: 20000, interval: 50 },
           );
-          // Pre-ADR-076 each of these three steps appended another segment:
+          // Pre-ADR-080 each of these three steps appended another segment:
           // `/r/1`, then `/r/<Date.now()>`, then `/p/<Date.now()>`.
           expect(await stagedIds(name, groupId)).toEqual([LEGACY_ID]);
         }, 90000);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
@@ -1,0 +1,1583 @@
+import type { Readable } from "node:stream";
+
+import type { Redis } from "ioredis";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { QueueRedisRepository } from "~/server/app-layer/ops/repositories/queue.redis.repository";
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import {
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../../__tests__/integration/testContainers";
+import { JOB_RETRY_CONFIG } from "../../shared";
+import type { EventSourcedQueueDefinition, JobDelivery } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+import { encodeJobEnvelope, readJobAttempt, withJobAttempt } from "../jobEnvelope";
+import { gqJobsDroppedTotal } from "../metrics";
+import {
+  DEFAULT_CLAIM_STRIKE_THRESHOLD,
+  GroupStagingScripts,
+} from "../scripts";
+import { TieredBlobStore } from "../tieredBlobStore";
+import {
+  incompressible,
+  InMemoryJobBlobStore,
+  InMemoryObjectStore,
+} from "./blobTestDoubles";
+
+// Skip outside testcontainers (e.g. plain unit runs) — mirrors the other
+// groupQueue integration suites (groupQueue.poisonGuard/decodeDrop).
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+type TestPayload = {
+  id: string;
+  groupId: string;
+  value: string;
+  // Caller-controlled routing fields (allowed through the __* guard).
+  __pipelineName?: string;
+  __jobType?: string;
+  __jobName?: string;
+};
+
+/** Tenant prefix on groupIds so GQ2 (content-addressed, tenant-namespaced) engages. */
+const TENANT = "proj1";
+const PROJECT = createTenantId(TENANT);
+const STORAGE_DESTINATION = async () =>
+  ({ kind: "s3" as const, bucket: "test-bucket" });
+
+/** > the 256 KiB s3 threshold once gzipped (see groupQueue.gq2.integration.test.ts). */
+const OFFLOADABLE_S3_VALUE = () => incompressible(768 * 1024);
+
+describe.skipIf(!hasTestcontainers)(
+  "GroupQueueProcessor — a staged job id is identity, not state (ADR-076)",
+  () => {
+    let redis: Redis;
+    let queues: GroupQueueProcessor<TestPayload>[];
+
+    beforeAll(async () => {
+      await startTestContainers();
+      redis = getTestRedisConnection()!;
+    });
+
+    beforeEach(() => {
+      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+      queues = [];
+    });
+
+    afterEach(async () => {
+      await Promise.all(queues.map((q) => q.close().catch(() => {})));
+      vi.restoreAllMocks();
+      // Scoped to this suite's hash-tagged namespace — never a global flushall,
+      // which would race with parallel integration suites on the shared Redis.
+      const keys = await redis.keys("{test/gqid/*");
+      if (keys.length > 0) await redis.del(...keys);
+      vi.unstubAllEnvs();
+    });
+
+    afterAll(async () => {
+      await stopTestContainers();
+    });
+
+    function freshName(): string {
+      return `{test/gqid/${crypto.randomUUID().slice(0, 8)}}`;
+    }
+
+    function newQueue({
+      name,
+      processFn,
+      consumerEnabled,
+      objectStore,
+      processBatch,
+      coalesceMaxBatch,
+    }: {
+      name: string;
+      processFn: (
+        payload: TestPayload,
+        delivery?: JobDelivery,
+      ) => Promise<void>;
+      consumerEnabled: boolean;
+      objectStore: InMemoryObjectStore;
+      processBatch?: (
+        payloads: TestPayload[],
+        delivery?: JobDelivery,
+      ) => Promise<void>;
+      coalesceMaxBatch?: (payload: TestPayload) => number | undefined;
+    }): GroupQueueProcessor<TestPayload> {
+      const definition: EventSourcedQueueDefinition<TestPayload> = {
+        name,
+        groupKey: (p) => p.groupId,
+        process: processFn,
+        ...(processBatch ? { processBatch } : {}),
+        ...(coalesceMaxBatch ? { coalesceMaxBatch } : {}),
+      };
+      const queue = new GroupQueueProcessor<TestPayload>(definition, redis, {
+        consumerEnabled,
+        objectStoreFor: () => objectStore,
+        resolveStorageDestination: STORAGE_DESTINATION,
+      });
+      queues.push(queue);
+      return queue;
+    }
+
+    // --- Redis inspection -------------------------------------------------
+
+    const jobsKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:jobs`;
+    const dataKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:data`;
+    const attemptKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:attempt`;
+    const failStreakKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:failstreak`;
+    const strikesKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:strikes`;
+    const activeKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:active`;
+
+    const stagedIds = (name: string, groupId: string) =>
+      redis.zrange(jobsKey(name, groupId), 0, -1);
+    const stagedScore = (name: string, groupId: string, stagedJobId: string) =>
+      redis.zscore(jobsKey(name, groupId), stagedJobId);
+    const stagedValue = (name: string, groupId: string, stagedJobId: string) =>
+      redis.hget(dataKey(name, groupId), stagedJobId);
+    const groupAttempt = (name: string, groupId: string) =>
+      redis.get(attemptKey(name, groupId));
+    const failStreak = (name: string, groupId: string) =>
+      redis.get(failStreakKey(name, groupId));
+    const blockedMembers = (name: string) => redis.smembers(`${name}:gq:blocked`);
+    const readyScore = (name: string, groupId: string) =>
+      redis.zscore(`${name}:gq:ready`, groupId);
+    const totalPending = (name: string) =>
+      redis.get(`${name}:gq:stats:total-pending`);
+
+    async function dropsFor(name: string) {
+      const metric = await gqJobsDroppedTotal.get();
+      return metric.values.filter((v) => v.labels.queue_name === name);
+    }
+
+    /** The id `generateStagedJobId` derives for a routed payload. */
+    const expectedStagedId = (p: TestPayload) =>
+      `${p.id}/${p.__jobType!}/${p.__jobName!}`;
+
+    /** Serves puts, but every read is a network-class failure (never "gone"). */
+    class UnreachableObjectStore extends InMemoryObjectStore {
+      override async get(): Promise<Readable> {
+        throw new Error("transient ECONNRESET");
+      }
+    }
+
+    /**
+     * Stages an already-encoded GQ2 s3-tier job under a caller-chosen id,
+     * bypassing `send()` so the id (and the attempt on its message) is exactly
+     * what the test wants. Mirrors decodeDrop's crafted-stage helper.
+     */
+    async function stageOffloadedUnder({
+      name,
+      groupId,
+      stagedJobId,
+      objectStore,
+      attempt,
+      routing,
+    }: {
+      name: string;
+      groupId: string;
+      stagedJobId: string;
+      objectStore: InMemoryObjectStore;
+      attempt?: number;
+      routing?: Pick<
+        TestPayload,
+        "__pipelineName" | "__jobType" | "__jobName"
+      >;
+    }): Promise<void> {
+      const tiered = new TieredBlobStore({
+        redisBlobs: new InMemoryJobBlobStore(),
+        objectStoreFor: () => objectStore,
+        resolveDestination: STORAGE_DESTINATION,
+      });
+      const envelope = await encodeJobEnvelope({
+        jobData: {
+          id: stagedJobId,
+          groupId,
+          value: OFFLOADABLE_S3_VALUE(),
+          ...routing,
+        },
+        tieredBlobs: tiered,
+        projectId: PROJECT,
+        writesEnabled: true,
+        queueName: name,
+      });
+      const scripts = new GroupStagingScripts(redis, name);
+      await scripts.stageBatch([
+        {
+          stagedJobId,
+          groupId,
+          dispatchAfterMs: Date.now(),
+          dedupId: "",
+          dedupTtlMs: 0,
+          jobDataJson:
+            attempt === undefined
+              ? envelope
+              : withJobAttempt({ value: envelope, attempt }),
+        },
+      ]);
+    }
+
+    // --- Late-heartbeat probe ---------------------------------------------
+
+    type IntervalId = ReturnType<typeof setInterval>;
+
+    /**
+     * Records every interval the code under test arms so a test can tick them
+     * at a chosen moment, and drops a handle the moment the implementation
+     * clears it. Real timers stay in play — nothing here fakes the clock; the
+     * probe only fires callbacks the implementation has LEFT armed.
+     *
+     * The cast is to the global's own signature: there is no exported seam for
+     * "which intervals are currently armed", and the whole point of ADR-076's
+     * heartbeat ordering is that the interval is gone before the re-stage is
+     * issued.
+     */
+    function captureArmedIntervals(): {
+      fireArmed: () => void;
+      restore: () => void;
+    } {
+      const armed = new Map<IntervalId, () => void>();
+      const realSetInterval = globalThis.setInterval;
+      const realClearInterval = globalThis.clearInterval;
+
+      globalThis.setInterval = ((
+        callback: (...cbArgs: unknown[]) => void,
+        ms?: number,
+        ...args: unknown[]
+      ): IntervalId => {
+        const id = realSetInterval(callback, ms, ...args);
+        armed.set(id, () => callback(...args));
+        return id;
+      }) as typeof setInterval;
+
+      globalThis.clearInterval = ((id?: IntervalId): void => {
+        if (id !== undefined) armed.delete(id);
+        realClearInterval(id);
+      }) as typeof clearInterval;
+
+      return {
+        fireArmed: () => {
+          for (const tick of [...armed.values()]) tick();
+        },
+        restore: () => {
+          globalThis.setInterval = realSetInterval;
+          globalThis.clearInterval = realClearInterval;
+        },
+      };
+    }
+
+    /**
+     * Ticks every still-armed interval at the WORST moment ADR-076 describes:
+     * the re-stage has been sent and the worker is still tidying up. A beat
+     * that lands there names an id the re-stage has just re-used, so
+     * `REFRESH_LUA` matches and stretches a sub-second backoff into the full
+     * active window (the worker's heartbeat is armed for the life of the job,
+     * at `activeTtlSec / 3`).
+     */
+    function lateHeartbeatProbe(
+      afterRestage?: (args: {
+        groupId: string;
+        stagedJobId: string;
+      }) => Promise<void>,
+    ) {
+      const intervals = captureArmedIntervals();
+      const refreshed: string[] = [];
+      const settling: Promise<unknown>[] = [];
+
+      const realRefresh = GroupStagingScripts.prototype.refreshActiveKey;
+      vi.spyOn(
+        GroupStagingScripts.prototype,
+        "refreshActiveKey",
+      ).mockImplementation(function (
+        this: GroupStagingScripts,
+        args: Parameters<typeof realRefresh>[0],
+      ) {
+        refreshed.push(args.stagedJobId);
+        const running = realRefresh.call(this, args);
+        settling.push(running.catch(() => false));
+        return running;
+      });
+
+      const realRestage = GroupStagingScripts.prototype.retryRestage;
+      const beats = { beforeTick: 0, afterRestage: 0 };
+      vi.spyOn(
+        GroupStagingScripts.prototype,
+        "retryRestage",
+      ).mockImplementation(async function (
+        this: GroupStagingScripts,
+        args: Parameters<typeof realRestage>[0],
+      ) {
+        const result = await realRestage.call(this, args);
+        beats.beforeTick = refreshed.length;
+        intervals.fireArmed();
+        await Promise.all(settling);
+        beats.afterRestage = refreshed.length - beats.beforeTick;
+        await afterRestage?.({
+          groupId: args.groupId,
+          stagedJobId: args.newStagedJobId,
+        });
+        return result;
+      });
+
+      return {
+        beats,
+        refreshed,
+        fireArmed: intervals.fireArmed,
+        restore: intervals.restore,
+      };
+    }
+
+    // ======================================================================
+    // Rule: A staged job keeps one id from the moment it is sent
+    // ======================================================================
+
+    describe("given a job sent for an event", () => {
+      describe("when its staged id is derived", () => {
+        /** @scenario A job's staged id names the event and the job, and nothing else */
+        it("names the event, the job type and the job name and stops there", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/id-shape`;
+          const queue = newQueue({
+            name,
+            processFn: async () => {},
+            consumerEnabled: false,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          const payload: TestPayload = {
+            id: "event_000649zPnIW3V0Ug6yVk9DECNYK3S",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          };
+          await queue.send(payload);
+
+          const ids = await stagedIds(name, groupId);
+          expect(ids).toEqual([
+            "event_000649zPnIW3V0Ug6yVk9DECNYK3S/subscriber/pm:langyConversation",
+          ]);
+          // Pre-ADR-076 an id gained `/r/<n>` per retry and a `/r/<Date.now()>`
+          // on the terminal restage; nothing mints either shape any more.
+          expect(ids[0]).not.toMatch(/\/r\//);
+          expect(ids[0]).not.toMatch(/\/p\//);
+          expect(ids[0]).not.toMatch(/\d{13}/);
+          // The value is stored under the very same key, so the id a producer
+          // can predict is the one that looks the job up.
+          expect(await stagedValue(name, groupId, ids[0]!)).not.toBeNull();
+        });
+      });
+    });
+
+    describe("given a claimed job that fails with a retryable error", () => {
+      describe("when the queue re-stages it with backoff", () => {
+        /** @scenario A retried job is re-staged under the id it was dispatched under */
+        it("re-stages it under the id it was dispatched under, unchanged", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/retry-id`;
+          const seen: number[] = [];
+          const queue = newQueue({
+            name,
+            processFn: async (_p, delivery) => {
+              seen.push(delivery?.attempt ?? 0);
+              throw new Error("downstream blip");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          const payload: TestPayload = {
+            id: "event_retry",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          };
+          await queue.send(payload);
+
+          await vi.waitFor(() => expect(seen).toHaveLength(1), {
+            timeout: 10000,
+            interval: 25,
+          });
+          await vi.waitFor(
+            async () => {
+              expect(await stagedIds(name, groupId)).toHaveLength(1);
+            },
+            { timeout: 10000, interval: 25 },
+          );
+
+          // Pre-ADR-076 this read `event_retry/subscriber/pm:langyConversation/r/1`.
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+          expect(
+            Object.keys(await redis.hgetall(dataKey(name, groupId))),
+          ).toEqual([expectedStagedId(payload)]);
+        }, 30000);
+      });
+    });
+
+    describe("given a claimed job that has used up its retry budget", () => {
+      describe("when the queue blocks the group and re-stages the job for inspection", () => {
+        /** @scenario A job blocked after exhausting its retries keeps its staged id */
+        it("re-stages it under the id it was dispatched under, unchanged", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/exhausted-id`;
+          const queue = newQueue({
+            name,
+            processFn: async () => {
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          // The group's retry chain already reads "budget spent", so the very
+          // first claim takes the exhaustion branch — no 25-rung real ladder.
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+
+          const payload: TestPayload = {
+            id: "event_exhausted",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          };
+          await queue.send(payload);
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 15000, interval: 50 },
+          );
+
+          // Pre-ADR-076 `handleExhaustedRetries` appended `/r/<Date.now()>`, so
+          // the parked job could not be found by the id its producer knows.
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+        }, 30000);
+      });
+    });
+
+    describe("given a claimed job whose group trips the poison guard", () => {
+      describe("when the queue parks the group with the value intact", () => {
+        /** @scenario A group parked by the poison guard keeps the staged id it parked on */
+        it("re-stages the value under the id it was dispatched under, unchanged", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/parked-id`;
+          const processed = vi.fn<(p: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const queue = newQueue({
+            name,
+            processFn: processed,
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          // Strikes left by prior claims whose process died — the crash-loop
+          // signature the claim-side guard parks on.
+          await redis.set(
+            strikesKey(name, groupId),
+            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
+          );
+
+          const payload: TestPayload = {
+            id: "event_parked",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          };
+          await queue.send(payload);
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 15000, interval: 50 },
+          );
+
+          expect(processed).not.toHaveBeenCalled();
+          // Pre-ADR-076 the park appended `/p/<Date.now()>`.
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+        }, 30000);
+      });
+    });
+
+    describe("given a job that fails on every attempt in its retry budget", () => {
+      describe("when the ladder runs to its end and the group is blocked", () => {
+        /** @scenario A job that rides the whole retry ladder ends under the id it started with */
+        it("leaves it in staging under the id it was first sent with", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/whole-ladder`;
+          const seen: number[] = [];
+          const queue = newQueue({
+            name,
+            processFn: async (_p, delivery) => {
+              seen.push(delivery?.attempt ?? 0);
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          const payload: TestPayload = {
+            id: "event_ladder",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          };
+          await queue.send(payload);
+
+          // Two real rungs first, so the id is observed surviving genuine
+          // re-stages rather than only the terminal.
+          await vi.waitFor(
+            async () => {
+              expect(await groupAttempt(name, groupId)).toBe("3");
+            },
+            { timeout: 25000, interval: 25 },
+          );
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+
+          // Then jump the chain to the end of the budget rather than sitting
+          // through 25 exponential rungs (~2h27m of real backoff).
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 25000, interval: 50 },
+          );
+
+          expect(seen.slice(0, 2)).toEqual([1, 2]);
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+          // An operator can find it by the id the producer knows: the same
+          // string keys the stored value.
+          expect(
+            await stagedValue(name, groupId, expectedStagedId(payload)),
+          ).not.toBeNull();
+        }, 90000);
+      });
+    });
+
+    // ======================================================================
+    // Rule: Re-staging a job under its own id conserves the queue-depth count
+    // ======================================================================
+
+    describe("given a job waiting out its retry backoff", () => {
+      /**
+       * Seeds the group's chain so the first failure lands on a rung whose
+       * backoff is seconds wide — a real window to redeliver into, without
+       * climbing there one 500ms rung at a time.
+       */
+      async function failOnceIntoALongBackoff({
+        name,
+        groupId,
+        chainAt,
+        onDelivery,
+      }: {
+        name: string;
+        groupId: string;
+        chainAt: number;
+        onDelivery: (delivery: JobDelivery | undefined) => void;
+      }): Promise<{ queue: GroupQueueProcessor<TestPayload>; payload: TestPayload }> {
+        const queue = newQueue({
+          name,
+          processFn: async (_p, delivery) => {
+            onDelivery(delivery);
+            throw new Error("downstream blip");
+          },
+          consumerEnabled: true,
+          objectStore: new InMemoryObjectStore(),
+        });
+        await queue.waitUntilReady();
+        await redis.set(attemptKey(name, groupId), String(chainAt));
+
+        const payload: TestPayload = {
+          id: "event_redelivered",
+          groupId,
+          value: "x",
+          __jobType: "subscriber",
+          __jobName: "pm:langyConversation",
+        };
+        await queue.send(payload);
+        await vi.waitFor(
+          async () => {
+            expect(await stagedIds(name, groupId)).toHaveLength(1);
+            expect(await groupAttempt(name, groupId)).toBe(String(chainAt + 1));
+          },
+          { timeout: 20000, interval: 25 },
+        );
+        return { queue, payload };
+      }
+
+      describe("when the same event is delivered again", () => {
+        /** @scenario A redelivery of an event already waiting to retry does not double the queue depth */
+        it("holds one job for that event and keeps the depth equal to what is staged", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/redelivery-depth`;
+          const seen: number[] = [];
+          const { queue, payload } = await failOnceIntoALongBackoff({
+            name,
+            groupId,
+            chainAt: 5,
+            onDelivery: (d) => seen.push(d?.attempt ?? 0),
+          });
+
+          await queue.send(payload);
+
+          // Pre-ADR-076 the retry re-staged under `<id>/r/5`, so a redelivery
+          // under `<id>` landed on a DIFFERENT member: two jobs for one event.
+          expect(await stagedIds(name, groupId)).toEqual([
+            expectedStagedId(payload),
+          ]);
+          expect(Number(await totalPending(name))).toBe(
+            await redis.zcard(jobsKey(name, groupId)),
+          );
+          expect(await redis.zcard(jobsKey(name, groupId))).toBe(1);
+          expect(seen).toEqual([5]);
+        }, 45000);
+      });
+
+      describe("when the same event is delivered again and overwrites its message", () => {
+        /** @scenario A redelivery that overwrites a waiting job's message does not reset its ladder */
+        it("counts the next failure from where the ladder had reached", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/redelivery-ladder`;
+          const seen: number[] = [];
+          const { queue, payload } = await failOnceIntoALongBackoff({
+            name,
+            groupId,
+            chainAt: 5,
+            onDelivery: (d) => seen.push(d?.attempt ?? 0),
+          });
+
+          await queue.send(payload);
+          // The redelivery really did overwrite the waiting job's message: it
+          // is a fresh envelope that no longer records an attempt at all.
+          const overwritten = await stagedValue(
+            name,
+            groupId,
+            expectedStagedId(payload),
+          );
+          expect(readJobAttempt(overwritten!)).toBeNull();
+
+          await vi.waitFor(() => expect(seen).toHaveLength(2), {
+            timeout: 30000,
+            interval: 25,
+          });
+          // The chain, not the message, is what the ladder counts from — so
+          // the redelivery does not hand the job a fresh budget.
+          expect(seen[1]).toBe(6);
+          await vi.waitFor(
+            async () => {
+              expect(await groupAttempt(name, groupId)).toBe("7");
+            },
+            { timeout: 10000, interval: 25 },
+          );
+        }, 60000);
+      });
+
+      describe("when the same event is delivered again before the backoff expires", () => {
+        /** @scenario A redelivery arriving mid-backoff does not shorten the wait */
+        it("keeps the wait on the group's hold rather than the job's queue position", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/redelivery-wait`;
+          const seen: number[] = [];
+          const { queue, payload } = await failOnceIntoALongBackoff({
+            name,
+            groupId,
+            chainAt: 5,
+            onDelivery: (d) => seen.push(d?.attempt ?? 0),
+          });
+          const stagedJobId = expectedStagedId(payload);
+          const backoffDeadline = Number(await readyScore(name, groupId));
+          expect(backoffDeadline).toBeGreaterThan(Date.now());
+
+          await queue.send(payload);
+
+          // The redelivery pulled the job's OWN position forward to now...
+          expect(Number(await stagedScore(name, groupId, stagedJobId))).toBeLessThan(
+            backoffDeadline,
+          );
+          // ...but the group's hold is untouched: the ready score still names
+          // the backoff deadline and the active key still locks the group.
+          expect(Number(await readyScore(name, groupId))).toBe(backoffDeadline);
+          expect(await redis.pttl(activeKey(name, groupId))).toBeGreaterThan(0);
+
+          // And nothing runs before the backoff was due.
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+          expect(seen).toEqual([5]);
+          expect(Date.now()).toBeLessThan(backoffDeadline);
+        }, 60000);
+      });
+    });
+
+    // ======================================================================
+    // Rule: A retry waits the backoff it was given, not the active-slot timeout
+    // ======================================================================
+
+    describe("given a claimed job being re-staged for a retry", () => {
+      describe("when the worker publishes the re-stage and finishes its bookkeeping", () => {
+        /** @scenario No heartbeat is sent after a job's re-stage has been sent */
+        it("sends no further heartbeat for that job", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/no-late-beat`;
+          const probe = lateHeartbeatProbe();
+          try {
+            let failures = 0;
+            const queue = newQueue({
+              name,
+              processFn: async () => {
+                // A beat WHILE the job runs is legitimate — and it is also the
+                // control that proves this probe can see one at all.
+                probe.fireArmed();
+                failures++;
+                throw new Error("downstream blip");
+              },
+              consumerEnabled: true,
+              objectStore: new InMemoryObjectStore(),
+            });
+            await queue.waitUntilReady();
+            await queue.send({
+              id: "event_beat",
+              groupId,
+              value: "x",
+              __jobType: "subscriber",
+              __jobName: "pm:langyConversation",
+            });
+
+            await vi.waitFor(() => expect(probe.beats.beforeTick).toBeGreaterThan(0), {
+              timeout: 15000,
+              interval: 25,
+            });
+            expect(failures).toBeGreaterThan(0);
+            // Control: the heartbeat WAS armed and the probe did observe it.
+            expect(probe.refreshed).toContain(
+              "event_beat/subscriber/pm:langyConversation",
+            );
+            // Pre-ADR-076 the interval was cleared only in the worker's outer
+            // `finally`, so ticking it here produced another REFRESH — one that
+            // now matches, because the re-stage reuses the id.
+            expect(probe.beats.afterRestage).toBe(0);
+          } finally {
+            probe.restore();
+          }
+        }, 40000);
+      });
+    });
+
+    describe("given a claimed job whose outcome has been decided", () => {
+      describe("when the worker's remaining bookkeeping runs", () => {
+        /** @scenario A worker's heartbeat stops extending a group's hold once the job's outcome is decided */
+        it("leaves the group's hold at what the outcome asked for", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/hold-not-extended`;
+          const observed: { activePttl: number; ready: number }[] = [];
+          const probe = lateHeartbeatProbe(async ({ groupId: gid }) => {
+            observed.push({
+              activePttl: await redis.pttl(activeKey(name, gid)),
+              ready: Number(await readyScore(name, gid)),
+            });
+          });
+          try {
+            const queue = newQueue({
+              name,
+              processFn: async () => {
+                probe.fireArmed();
+                throw new Error("downstream blip");
+              },
+              consumerEnabled: true,
+              objectStore: new InMemoryObjectStore(),
+            });
+            await queue.waitUntilReady();
+            const sentAt = Date.now();
+            await queue.send({
+              id: "event_hold",
+              groupId,
+              value: "x",
+              __jobType: "subscriber",
+              __jobName: "pm:langyConversation",
+            });
+
+            await vi.waitFor(() => expect(observed).not.toHaveLength(0), {
+              timeout: 15000,
+              interval: 25,
+            });
+
+            // The first attempt's backoff is 500ms, so the outcome asked for a
+            // ~3s hold (backoff + the script's 2s buffer). A late beat would
+            // have set it to the full 300s active window and pushed the ready
+            // score out to match — a multi-minute stall on a half-second wait.
+            const [first] = observed;
+            expect(first!.activePttl).toBeGreaterThan(0);
+            expect(first!.activePttl).toBeLessThanOrEqual(4000);
+            expect(first!.ready).toBeLessThan(sentAt + 30000);
+          } finally {
+            probe.restore();
+          }
+        }, 40000);
+      });
+    });
+
+    describe("given a claimed job that fails with a short retry backoff", () => {
+      describe("when it is re-staged and the worker finishes its bookkeeping", () => {
+        /** @scenario A retried job is dispatched when its backoff expires, not an active window later */
+        it("becomes eligible again when the backoff expires", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/backoff-eligible`;
+          const probe = lateHeartbeatProbe();
+          try {
+            const deliveries: number[] = [];
+            const queue = newQueue({
+              name,
+              processFn: async (_p, delivery) => {
+                probe.fireArmed();
+                deliveries.push(delivery?.attempt ?? 0);
+                if (deliveries.length === 1) throw new Error("downstream blip");
+              },
+              consumerEnabled: true,
+              objectStore: new InMemoryObjectStore(),
+            });
+            await queue.waitUntilReady();
+            await queue.send({
+              id: "event_eligible",
+              groupId,
+              value: "x",
+              __jobType: "subscriber",
+              __jobName: "pm:langyConversation",
+            });
+
+            // The retry runs on its ~3s hold. Pre-ADR-076 the beat ticked after
+            // the re-stage pushed the hold (and the ready score) to the full
+            // 300s active window, so nothing would run inside this timeout.
+            await vi.waitFor(() => expect(deliveries).toEqual([1, 2]), {
+              timeout: 25000,
+              interval: 25,
+            });
+          } finally {
+            probe.restore();
+          }
+        }, 40000);
+      });
+    });
+
+    // ======================================================================
+    // Rule: Unblocking a group clears every counter that outlived the block
+    // ======================================================================
+
+    describe("given a group blocked after a job used up its retry budget", () => {
+      describe("when an operator unblocks it and the job fails once more", () => {
+        /** @scenario A group unblocked after exhaustion retries instead of re-blocking on its first failure */
+        it("retries the job rather than blocking the group again", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/unblock-chain`;
+          const seen: number[] = [];
+          const queue = newQueue({
+            name,
+            processFn: async (_p, delivery) => {
+              seen.push(delivery?.attempt ?? 0);
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+          await queue.send({
+            id: "event_unblock",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          });
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 20000, interval: 50 },
+          );
+          // The counter that decides whether trying is allowed outlived the
+          // block — this is the state the operator is about to reset.
+          expect(await groupAttempt(name, groupId)).toBe(
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+
+          const ops = new QueueRedisRepository(redis);
+          const { wasBlocked } = await ops.unblockGroup({
+            queueName: name,
+            groupId,
+          });
+          expect(wasBlocked).toBe(true);
+          expect(await groupAttempt(name, groupId)).toBeNull();
+
+          await vi.waitFor(() => expect(seen).toHaveLength(2), {
+            timeout: 20000,
+            interval: 25,
+          });
+          // Pre-ADR-076 the chain survived the unblock, so this run read as
+          // attempt 25 and the group re-blocked on its very first failure.
+          expect(seen[1]).toBe(1);
+          expect(await blockedMembers(name)).not.toContain(groupId);
+          await vi.waitFor(
+            async () => {
+              expect(await groupAttempt(name, groupId)).toBe("2");
+            },
+            { timeout: 10000, interval: 25 },
+          );
+        }, 60000);
+      });
+    });
+
+    describe("given a group blocked after a long run of consecutive failures", () => {
+      describe("when an operator unblocks it and its next job fails once", () => {
+        /** @scenario A group unblocked after exhaustion is not immediately re-quarantined by its old failure streak */
+        it("does not quarantine the group on that single failure", async () => {
+          const ENV = "LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD";
+          vi.stubEnv(ENV, "3");
+          const name = freshName();
+          const groupId = `${TENANT}/unblock-streak`;
+          const seen: number[] = [];
+          const queue = newQueue({
+            name,
+            processFn: async (_p, delivery) => {
+              seen.push(delivery?.attempt ?? 0);
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+          // A run of failures that stops one short of the quarantine threshold,
+          // on a group whose retry budget is already spent — so it parks by
+          // exhaustion, the path that never cleared the streak.
+          await redis.set(failStreakKey(name, groupId), "2");
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+          await queue.send({
+            id: "event_streak",
+            groupId,
+            value: "x",
+            __jobType: "subscriber",
+            __jobName: "pm:langyConversation",
+          });
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 20000, interval: 50 },
+          );
+          expect(await failStreak(name, groupId)).toBe("3");
+
+          const ops = new QueueRedisRepository(redis);
+          await ops.unblockGroup({ queueName: name, groupId });
+          expect(await failStreak(name, groupId)).toBeNull();
+
+          await vi.waitFor(() => expect(seen).toHaveLength(2), {
+            timeout: 20000,
+            interval: 25,
+          });
+          // Pre-ADR-076 the streak survived at 3, so this single failure took
+          // it to 4 — past the threshold — and quarantined the group instantly.
+          await vi.waitFor(
+            async () => {
+              expect(await failStreak(name, groupId)).toBe("1");
+            },
+            { timeout: 10000, interval: 25 },
+          );
+          expect(await blockedMembers(name)).not.toContain(groupId);
+        }, 60000);
+      });
+    });
+
+    describe("given two groups blocked after exhaustion", () => {
+      describe("when one is unblocked immediately and the other much later", () => {
+        /** @scenario An unblocked group's fresh ladder does not depend on how long the operator waited */
+        it("gives both the same retry budget on their next run", async () => {
+          const name = freshName();
+          const promptGroup = `${TENANT}/unblocked-promptly`;
+          const lateGroup = `${TENANT}/unblocked-later`;
+          const seen: { groupId: string; attempt: number }[] = [];
+          const queue = newQueue({
+            name,
+            processFn: async (payload, delivery) => {
+              seen.push({
+                groupId: payload.groupId,
+                attempt: delivery?.attempt ?? 0,
+              });
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          for (const groupId of [promptGroup, lateGroup]) {
+            await redis.set(
+              attemptKey(name, groupId),
+              String(JOB_RETRY_CONFIG.maxAttempts),
+            );
+            await queue.send({
+              id: `event_${groupId}`,
+              groupId,
+              value: "x",
+              __jobType: "subscriber",
+              __jobName: "pm:langyConversation",
+            });
+          }
+
+          await vi.waitFor(
+            async () => {
+              const blocked = await blockedMembers(name);
+              expect(blocked).toContain(promptGroup);
+              expect(blocked).toContain(lateGroup);
+            },
+            { timeout: 25000, interval: 50 },
+          );
+
+          // The only difference between the two is how long the operator took:
+          // the retry chain self-expires, so a button pressed after its TTL
+          // finds nothing left to inherit.
+          expect(await groupAttempt(name, promptGroup)).toBe(
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+          await redis.del(attemptKey(name, lateGroup));
+
+          const ops = new QueueRedisRepository(redis);
+          await ops.unblockGroup({ queueName: name, groupId: promptGroup });
+          await ops.unblockGroup({ queueName: name, groupId: lateGroup });
+
+          await vi.waitFor(
+            () => {
+              expect(
+                seen.filter((s) => s.groupId === promptGroup),
+              ).toHaveLength(2);
+              expect(seen.filter((s) => s.groupId === lateGroup)).toHaveLength(
+                2,
+              );
+            },
+            { timeout: 25000, interval: 25 },
+          );
+
+          // Pre-ADR-076 the promptly-unblocked group came back on attempt 25
+          // and the patient operator's group came back on attempt 1.
+          expect(seen.filter((s) => s.groupId === promptGroup)[1]!.attempt).toBe(
+            1,
+          );
+          expect(seen.filter((s) => s.groupId === lateGroup)[1]!.attempt).toBe(
+            1,
+          );
+        }, 90000);
+      });
+    });
+
+    // ======================================================================
+    // Rule: The ladder for a body that cannot be read is bounded by what it
+    //       can read
+    // ======================================================================
+
+    describe("given a staged job whose body cannot be fetched", () => {
+      /** Claims the crafted job and waits for the ladder to write the chain. */
+      async function runLadderOnce({
+        name,
+        groupId,
+        objectStore,
+        expectChain,
+      }: {
+        name: string;
+        groupId: string;
+        objectStore: InMemoryObjectStore;
+        expectChain: string;
+      }): Promise<void> {
+        const queue = newQueue({
+          name,
+          processFn: async () => {},
+          consumerEnabled: true,
+          objectStore,
+        });
+        await queue.waitUntilReady();
+        await vi.waitFor(
+          async () => {
+            expect(await groupAttempt(name, groupId)).toBe(expectChain);
+          },
+          { timeout: 20000, interval: 25 },
+        );
+      }
+
+      describe("when the message says which attempt it is on", () => {
+        /** @scenario The unreadable-body ladder counts the attempt the message carries */
+        it("treats it as the next attempt after the one on the message", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/ladder-from-message`;
+          const objectStore = new UnreachableObjectStore();
+          const stagedJobId = "event_msg/subscriber/pm:langyConversation";
+          await stageOffloadedUnder({
+            name,
+            groupId,
+            stagedJobId,
+            objectStore,
+            attempt: 5,
+          });
+
+          await runLadderOnce({ name, groupId, objectStore, expectChain: "6" });
+
+          // Pre-ADR-076 this ladder could only count `/r/` segments on the id,
+          // so a message that already said "attempt 5" was read as a fresh one.
+          expect(
+            readJobAttempt((await stagedValue(name, groupId, stagedJobId))!),
+          ).toBe(6);
+          expect(await stagedIds(name, groupId)).toEqual([stagedJobId]);
+        }, 45000);
+      });
+
+      describe("when the message cannot report an attempt", () => {
+        /** @scenario The unreadable-body ladder falls back to the group's retry chain when the message cannot say */
+        it("counts the attempt from the group's retry chain instead", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/ladder-from-chain`;
+          const objectStore = new UnreachableObjectStore();
+          const stagedJobId = "event_chain/subscriber/pm:langyConversation";
+          // Staged with no attempt on its message at all — `readJobAttempt`
+          // reports null, which the ladder reads as "this message cannot say".
+          await stageOffloadedUnder({
+            name,
+            groupId,
+            stagedJobId,
+            objectStore,
+          });
+          expect(
+            readJobAttempt((await stagedValue(name, groupId, stagedJobId))!),
+          ).toBeNull();
+          // A group that has already been round the ladder several times.
+          await redis.set(attemptKey(name, groupId), "9");
+
+          await runLadderOnce({ name, groupId, objectStore, expectChain: "10" });
+
+          expect(await stagedIds(name, groupId)).toEqual([stagedJobId]);
+        }, 45000);
+      });
+
+      describe("when the message and the group disagree about the attempt", () => {
+        /** @scenario The unreadable-body ladder takes the higher of the message and the group's chain */
+        it("counts from whichever of the two is further along", async () => {
+          const name = freshName();
+          const objectStore = new UnreachableObjectStore();
+          const chainAhead = `${TENANT}/ladder-chain-ahead`;
+          const messageAhead = `${TENANT}/ladder-message-ahead`;
+
+          await stageOffloadedUnder({
+            name,
+            groupId: chainAhead,
+            stagedJobId: "event_a/subscriber/pm:langyConversation",
+            objectStore,
+            attempt: 3,
+          });
+          await redis.set(attemptKey(name, chainAhead), "9");
+
+          await stageOffloadedUnder({
+            name,
+            groupId: messageAhead,
+            stagedJobId: "event_b/subscriber/pm:langyConversation",
+            objectStore,
+            attempt: 9,
+          });
+          await redis.set(attemptKey(name, messageAhead), "3");
+
+          const queue = newQueue({
+            name,
+            processFn: async () => {},
+            consumerEnabled: true,
+            objectStore,
+          });
+          await queue.waitUntilReady();
+
+          await vi.waitFor(
+            async () => {
+              expect(await groupAttempt(name, chainAhead)).toBe("10");
+              expect(await groupAttempt(name, messageAhead)).toBe("10");
+            },
+            { timeout: 25000, interval: 25 },
+          );
+        }, 45000);
+      });
+
+      describe("when the ladder runs rung after rung", () => {
+        /** @scenario Every rung of the unreadable-body ladder advances the count the next rung reads */
+        /** @scenario The unreadable-body ladder records each attempt on the group's retry chain */
+        it("counts each attempt higher than the last and records every one on the group's chain", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/ladder-rungs`;
+          const objectStore = new UnreachableObjectStore();
+          const stagedJobId = "event_rungs/subscriber/pm:langyConversation";
+
+          // Every re-stage the ladder issues, with the attempt its message
+          // carries and the attempt its group chain held at that moment.
+          const rungs: { onMessage: number | null; onChain: string | null }[] =
+            [];
+          const realRestage = GroupStagingScripts.prototype.retryRestage;
+          vi.spyOn(
+            GroupStagingScripts.prototype,
+            "retryRestage",
+          ).mockImplementation(async function (
+            this: GroupStagingScripts,
+            args: Parameters<typeof realRestage>[0],
+          ) {
+            rungs.push({
+              onMessage: readJobAttempt(args.jobDataJson),
+              onChain: await groupAttempt(name, args.groupId),
+            });
+            return realRestage.call(this, args);
+          });
+
+          await stageOffloadedUnder({
+            name,
+            groupId,
+            stagedJobId,
+            objectStore,
+          });
+          const queue = newQueue({
+            name,
+            processFn: async () => {},
+            consumerEnabled: true,
+            objectStore,
+          });
+          await queue.waitUntilReady();
+
+          await vi.waitFor(() => expect(rungs).toHaveLength(3), {
+            timeout: 40000,
+            interval: 25,
+          });
+
+          // Pre-ADR-076 nothing on the message or the chain moved at all: the
+          // count lived only in a segment appended to the id.
+          expect(rungs.map((r) => r.onMessage)).toEqual([1, 2, 3]);
+          // recordGroupAttempt runs before the re-stage, so the chain already
+          // holds the rung being staged — every attempt is recorded there.
+          expect(rungs.map((r) => r.onChain)).toEqual(["1", "2", "3"]);
+          expect(await stagedIds(name, groupId)).toEqual([stagedJobId]);
+        }, 60000);
+      });
+    });
+
+    describe("given a job in a format whose message cannot carry an attempt", () => {
+      describe("when the ladder runs with the body unreachable", () => {
+        /** @scenario A job whose attempt can never be written to its message still gives up at the end of the budget */
+        it("gives up once the budget is spent rather than retrying forever", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/uncarryable-attempt`;
+          const objectStore = new UnreachableObjectStore();
+
+          // The dispatched job is legacy bare JSON: `withJobAttempt` cannot
+          // write an attempt into it and `readJobAttempt` finds none. It is a
+          // coalesced sibling whose body is unreachable that routes THIS value
+          // through the unreadable-body ladder, so the chain is the only thing
+          // that can ever bound it.
+          const routing = {
+            __pipelineName: "billing",
+            __jobType: "fold",
+            __jobName: "gatewayBudgetSync",
+          };
+          const dispatchedId = "event_bare/fold/gatewayBudgetSync";
+          const bareJson = JSON.stringify({
+            id: dispatchedId,
+            groupId,
+            value: "small-and-readable",
+            ...routing,
+          });
+          expect(readJobAttempt(bareJson)).toBeNull();
+          expect(withJobAttempt({ value: bareJson, attempt: 9 })).toBe(bareJson);
+
+          const scripts = new GroupStagingScripts(redis, name);
+          await scripts.stageBatch([
+            {
+              stagedJobId: dispatchedId,
+              groupId,
+              dispatchAfterMs: Date.now() - 1000,
+              dedupId: "",
+              dedupTtlMs: 0,
+              jobDataJson: bareJson,
+            },
+          ]);
+          await stageOffloadedUnder({
+            name,
+            groupId,
+            stagedJobId: "event_sibling/fold/gatewayBudgetSync",
+            objectStore,
+            routing,
+          });
+
+          // The chain is one rung from the end of the budget.
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts - 1),
+          );
+
+          const queue = newQueue({
+            name,
+            processFn: async () => {},
+            processBatch: async () => {},
+            coalesceMaxBatch: () => 50,
+            consumerEnabled: true,
+            objectStore,
+          });
+          await queue.waitUntilReady();
+
+          await vi.waitFor(
+            async () => {
+              const drops = await dropsFor(name);
+              expect(
+                drops.filter((d) => d.labels.reason === "transient_exhausted"),
+              ).not.toHaveLength(0);
+            },
+            { timeout: 25000, interval: 50 },
+          );
+
+          // It gave up on this job instead of re-staging it for another rung:
+          // without the chain write, a message that can never carry a count
+          // would have made the ladder unbounded.
+          expect(await stagedIds(name, groupId)).not.toContain(dispatchedId);
+        }, 45000);
+      });
+    });
+
+    // ======================================================================
+    // Rule: Jobs already staged under the old growing ids finish under them
+    // ======================================================================
+
+    describe("given a job staged before this change, whose id carries retry segments", () => {
+      const LEGACY_ID =
+        "event_legacy/subscriber/pm:langyConversation/r/12/r/16/r/24";
+
+      describe("when a worker claims and processes it", () => {
+        /** @scenario A job staged under a legacy retry-suffixed id still completes */
+        it("completes normally and leaves staging", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/legacy-completes`;
+          const processed: TestPayload[] = [];
+          const scripts = new GroupStagingScripts(redis, name);
+          await scripts.stageBatch([
+            {
+              stagedJobId: LEGACY_ID,
+              groupId,
+              dispatchAfterMs: Date.now(),
+              dedupId: "",
+              dedupTtlMs: 0,
+              jobDataJson: JSON.stringify({
+                id: "event_legacy",
+                groupId,
+                value: "x",
+                __jobType: "subscriber",
+                __jobName: "pm:langyConversation",
+              }),
+            },
+          ]);
+
+          const queue = newQueue({
+            name,
+            processFn: async (p) => {
+              processed.push(p);
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await queue.waitUntilReady();
+
+          await vi.waitFor(() => expect(processed).toHaveLength(1), {
+            timeout: 20000,
+            interval: 25,
+          });
+          expect(processed[0]!.value).toBe("x");
+          await vi.waitFor(
+            async () => {
+              expect(await stagedIds(name, groupId)).toEqual([]);
+              expect(await redis.hgetall(dataKey(name, groupId))).toEqual({});
+            },
+            { timeout: 10000, interval: 25 },
+          );
+        }, 45000);
+      });
+
+      describe("when it is retried, exhausts its budget, and its group is parked", () => {
+        /** @scenario A legacy retry-suffixed id gains no further segments */
+        it("keeps exactly the id it was dispatched under at every step", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/legacy-no-growth`;
+          const scripts = new GroupStagingScripts(redis, name);
+          await scripts.stageBatch([
+            {
+              stagedJobId: LEGACY_ID,
+              groupId,
+              dispatchAfterMs: Date.now(),
+              dedupId: "",
+              dedupTtlMs: 0,
+              jobDataJson: JSON.stringify({
+                id: "event_legacy",
+                groupId,
+                value: "x",
+                __jobType: "subscriber",
+                __jobName: "pm:langyConversation",
+              }),
+            },
+          ]);
+
+          let failures = 0;
+          const consumer = newQueue({
+            name,
+            processFn: async () => {
+              failures++;
+              throw new Error("downstream always down");
+            },
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await consumer.waitUntilReady();
+
+          // Step 1 — a retry.
+          await vi.waitFor(
+            async () => {
+              expect(failures).toBeGreaterThan(0);
+              expect(await groupAttempt(name, groupId)).toBe("2");
+            },
+            { timeout: 20000, interval: 25 },
+          );
+          expect(await stagedIds(name, groupId)).toEqual([LEGACY_ID]);
+
+          // Step 2 — the end of the budget.
+          await redis.set(
+            attemptKey(name, groupId),
+            String(JOB_RETRY_CONFIG.maxAttempts),
+          );
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 25000, interval: 50 },
+          );
+          expect(await stagedIds(name, groupId)).toEqual([LEGACY_ID]);
+
+          // Step 3 — a poison park. Stop the consumer first so the strikes are
+          // in place before any claim can race them.
+          await consumer.close();
+          const ops = new QueueRedisRepository(redis);
+          await ops.unblockGroup({ queueName: name, groupId });
+          await redis.set(
+            strikesKey(name, groupId),
+            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
+          );
+
+          const parker = newQueue({
+            name,
+            processFn: async () => {},
+            consumerEnabled: true,
+            objectStore: new InMemoryObjectStore(),
+          });
+          await parker.waitUntilReady();
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain(groupId);
+            },
+            { timeout: 20000, interval: 50 },
+          );
+          // Pre-ADR-076 each of these three steps appended another segment:
+          // `/r/1`, then `/r/<Date.now()>`, then `/p/<Date.now()>`.
+          expect(await stagedIds(name, groupId)).toEqual([LEGACY_ID]);
+        }, 90000);
+      });
+    });
+
+    describe("given a job staged before this change, part-way through its retry budget", () => {
+      describe("when it fails again after this change is deployed", () => {
+        /** @scenario A job staged under a legacy retry-suffixed id resumes its ladder rather than restarting it */
+        it("retries on the attempt after the one its id had reached", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/legacy-resumes`;
+          const objectStore = new UnreachableObjectStore();
+          const legacyId =
+            "event_resume/subscriber/pm:langyConversation/r/7";
+
+          // Neither its message nor its group can say how far it got: the
+          // count was recorded ONLY in the id, which is exactly the in-flight
+          // job this last-resort read exists for.
+          await stageOffloadedUnder({
+            name,
+            groupId,
+            stagedJobId: legacyId,
+            objectStore,
+          });
+          expect(
+            readJobAttempt((await stagedValue(name, groupId, legacyId))!),
+          ).toBeNull();
+          expect(await groupAttempt(name, groupId)).toBeNull();
+
+          const queue = newQueue({
+            name,
+            processFn: async () => {},
+            consumerEnabled: true,
+            objectStore,
+          });
+          await queue.waitUntilReady();
+
+          await vi.waitFor(
+            async () => {
+              expect(await groupAttempt(name, groupId)).toBe("8");
+            },
+            { timeout: 25000, interval: 25 },
+          );
+          // Resumed, not restarted — a fresh budget would have read attempt 1.
+          expect(
+            readJobAttempt((await stagedValue(name, groupId, legacyId))!),
+          ).toBe(8);
+          expect(await stagedIds(name, groupId)).toEqual([legacyId]);
+        }, 45000);
+      });
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
@@ -1299,9 +1299,16 @@ describe.skipIf(!hasTestcontainers)(
           // Pre-ADR-080 nothing on the message or the chain moved at all: the
           // count lived only in a segment appended to the id.
           expect(rungs.map((r) => r.onMessage)).toEqual([1, 2, 3]);
-          // recordGroupAttempt runs before the re-stage, so the chain already
-          // holds the rung being staged — every attempt is recorded there.
-          expect(rungs.map((r) => r.onChain)).toEqual(["1", "2", "3"]);
+          // The chain is written INSIDE retryRestage, and this samples on the
+          // way in — so each rung sees what the PREVIOUS one recorded, and the
+          // first sees nothing because no re-stage has happened yet. That lag
+          // is the property: the chain only ever advances together with a
+          // re-stage that actually landed. It used to be written by the caller
+          // beforehand, which is how a failed write could leave a re-staged
+          // job with no record of its attempt anywhere.
+          expect(rungs.map((r) => r.onChain)).toEqual([null, "1", "2"]);
+          // And the last rung's write did land, so nothing is lost by the lag.
+          expect(await groupAttempt(name, groupId)).toBe("3");
           expect(await stagedIds(name, groupId)).toEqual([stagedJobId]);
         }, 60000);
       });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
@@ -33,10 +33,35 @@ export class CachedLuaScript {
     numKeys: number,
     ...keysAndArgs: Array<string | number>
   ): Promise<unknown> {
+    return await this.runCancellable(redis, null, numKeys, ...keysAndArgs);
+  }
+
+  /**
+   * {@link run}, but the caller can withdraw the command in the window the
+   * NOSCRIPT fallback opens.
+   *
+   * The fallback is issued AFTER an await, so unlike the initial EVALSHA it is
+   * not ordered ahead of whatever the caller sent next — on a cold script cache
+   * a command the caller has since superseded can land behind the write that
+   * superseded it. The queue's heartbeat is exactly that case: it must not
+   * extend a group's hold once the job's outcome is decided, and ordering alone
+   * only guarantees that for the EVALSHA (see `groupQueue.ts`'s
+   * `stopHeartbeat`). `isCancelled` closes the remaining window.
+   *
+   * Returns null when withdrawn, which every caller treats as "no refresh
+   * happened" — the same outcome as a heartbeat that never fired.
+   */
+  async runCancellable(
+    redis: IORedis | Cluster,
+    isCancelled: (() => boolean) | null,
+    numKeys: number,
+    ...keysAndArgs: Array<string | number>
+  ): Promise<unknown> {
     try {
       return await redis.evalsha(this.sha, numKeys, ...keysAndArgs);
     } catch (err) {
       if (isNoScript(err)) {
+        if (isCancelled?.()) return null;
         return await redis.eval(this.source, numKeys, ...keysAndArgs);
       }
       throw err;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -28,6 +28,8 @@ import {
   redactStorageUrisInText,
 } from "../../../stored-objects/project-storage-destination";
 import { isDispatchError } from "~/server/event-sourcing/queues/dispatchError";
+import { generate } from "@langwatch/ksuid";
+import { KSUID_RESOURCES } from "~/utils/constants";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -51,7 +53,9 @@ import {
   type DecodeFailureReason,
   PayloadTooLargeError,
   readEnvelopeDescriptor,
+  readJobAttempt,
   readJobRoutingMeta,
+  withJobAttempt,
 } from "./jobEnvelope";
 import {
   gqGroupAttemptReadFailuresTotal,
@@ -95,6 +99,49 @@ import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
 export const GROUP_ATTEMPT_TTL_SECONDS = Math.ceil(
   (JOB_RETRY_CONFIG.maxBackoffMs / 1000) * 3,
 );
+
+/**
+ * The retry count off a staged job id left over from before ADR-076, when the
+ * ladder appended `/r/<n>` to the id and read the count back by counting the
+ * segments.
+ *
+ * READ-ONLY, and only as a last resort. A job part-way up the unreadable-body
+ * ladder at deploy time recorded its count nowhere else — that path re-staged
+ * the value unmodified and never wrote the group's chain — so without this it
+ * would come back with a fresh budget and a fail-safe would reset mid-flight.
+ * Nothing writes this shape any more: a legacy id is a value to interpret on
+ * the way out, not a format to keep alive.
+ */
+/**
+ * A field off an untrusted payload, when it is actually a usable string.
+ *
+ * The queue's payloads are `Record<string, unknown>` by design — it routes for
+ * every pipeline and does not know their shapes — so the machinery fields it
+ * DOES read have to be checked rather than asserted. Anything that is not a
+ * non-empty string reads as absent.
+ */
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function legacyStagedJobAttempt(stagedJobId: string): number {
+  let highest = 0;
+  for (const [, digits] of stagedJobId.matchAll(/\/r\/(\d+)(?=\/|$)/g)) {
+    const value = Number(digits);
+    // The terminal restage stamped a wall clock under this same marker. Reading
+    // one as an attempt would vault past the budget and discard a job that
+    // still had rungs left, so anything outside the ladder's range is not a
+    // count.
+    if (
+      Number.isInteger(value) &&
+      value > highest &&
+      value <= JOB_RETRY_CONFIG.maxAttempts
+    ) {
+      highest = value;
+    }
+  }
+  return highest;
+}
 
 /**
  * Configuration for the group queue.
@@ -878,9 +925,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // A re-staged sibling carries no __attempt of its own, so fall back to the
     // group's chain counter rather than reading it as a fresh delivery.
     const attempt = Math.max(jobAttempt, await this.readGroupAttempt(groupId));
-    const pipelineName = (jobData.__pipelineName as string) ?? "unknown";
-    const jobType = (jobData.__jobType as string) ?? "unknown";
-    const jobName = (jobData.__jobName as string) ?? "unknown";
+    // Checked, not asserted: these become Prometheus label values, and `??`
+    // would let a non-string through to be stringified into one.
+    const pipelineName = nonEmptyString(jobData.__pipelineName) ?? "unknown";
+    const jobType = nonEmptyString(jobData.__jobType) ?? "unknown";
+    const jobName = nonEmptyString(jobData.__jobName) ?? "unknown";
     const routingLabels = {
       queue_name: this.queueName,
       pipeline_name: pipelineName,
@@ -1030,6 +1079,15 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         ...drainedSiblings.map((sibling) => sibling.jobDataJson),
       ],
     });
+    // Idempotent so an outcome path can stop the beat at the moment it decides
+    // (see the retry path) while the `finally` still guarantees it is stopped
+    // on every other exit.
+    let heartbeatStopped = false;
+    const stopHeartbeat = (): void => {
+      if (heartbeatStopped) return;
+      heartbeatStopped = true;
+      clearInterval(heartbeat);
+    };
     this.activeJobCount++;
 
     try {
@@ -1293,7 +1351,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 const backoffMs = retryBackoffMsFor({ attempt, error: err });
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
-                const newStagedJobId = `${stagedJobId}/r/${attempt}`;
+                // The job keeps the id it was dispatched under (ADR-076). Its
+                // staging member was removed at claim time, so re-staging under
+                // the same id inserts one that is genuinely absent.
+                const newStagedJobId = stagedJobId;
                 // If the retry re-encode fails (transient blob-store down,
                 // payload-too-large from a state-bloat regression), the retry
                 // can't proceed and the job is DISCARDED. Retire the old lease
@@ -1346,6 +1407,24 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   groupId,
                   attempt: attempt + 1,
                 });
+                // STOP THE HEARTBEAT BEFORE THE RE-STAGE IS ISSUED, not after
+                // it returns (ADR-076).
+                //
+                // The re-stage sets the active key's TTL to the backoff window;
+                // a heartbeat REFRESH sets it to the full activeTtlSec and
+                // pushes the group's ready score out to match. The two travel
+                // the same connection and are served in send order, so a beat
+                // that fires while the re-stage is in flight has already been
+                // sent BEHIND it, and would stretch a sub-second backoff into a
+                // multi-minute stall. Clearing the interval here is what makes
+                // that impossible: a tick issues its REFRESH synchronously, so
+                // once this returns no further REFRESH can be sent.
+                //
+                // This used to be handled by the id: the re-stage rotated the
+                // active key to a NEW id, so a late beat naming the old one no
+                // longer matched. With the id reused that guard is gone, and
+                // ordering is the whole protection.
+                stopHeartbeat();
                 const restaged = await this.scripts.retryRestage({
                   groupId,
                   stagedJobId,
@@ -1476,7 +1555,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       // spans into the same trace.
       await otelContext.with(ROOT_CONTEXT, executeWithSpan);
     } finally {
-      clearInterval(heartbeat);
+      stopHeartbeat();
       this.activeJobCount--;
       const jobDurationMs = performance.now() - jobStartTime;
       gqJobDurationMilliseconds.observe(routingLabels, jobDurationMs);
@@ -1739,8 +1818,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         ? originalScore
         : (this.score?.(payload) ?? Date.now());
 
-    // Re-stage with a new ID
-    const newStagedJobId = `${stagedJobId}/r/${Date.now()}`;
+    // Re-stage under the id the job was dispatched under (ADR-076), so the
+    // staged job an operator inspects is named by the id its producer knows.
+    const newStagedJobId = stagedJobId;
     const jobDataJson = await this.blobLifecycle.encode({
       jobData: {
         ...(payload as Record<string, unknown>),
@@ -1950,7 +2030,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       typeof originalScore === "number" ? originalScore : Date.now();
     await this.scripts.restageAndBlock({
       groupId,
-      newStagedJobId: `${stagedJobId}/p/${Date.now()}`,
+      // Parked under the id it was dispatched under (ADR-076). This used to
+      // append a wall-clock marker, which made a parked job impossible to find
+      // by the id its producer knows and grew the value on every park.
+      newStagedJobId: stagedJobId,
       score,
       jobDataJson,
       errorMessage,
@@ -1976,9 +2059,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * unreachable — not gone. Re-stage the SAME envelope with backoff so the job
    * retries instead of dropping to replay; the value is still valid and its lease
    * identity is unchanged, so there is no re-encode or identity churn. The
-   * restage renews that lease before returning. Bounded by the
-   * `/r/` retry suffixes already in the stagedJobId, so a misclassified permanent
-   * failure still terminates at the fail-safe (ADR-030 §2).
+   * restage renews that lease before returning.
+   *
+   * The ladder is bounded by a count this path can reach WITHOUT the body it
+   * cannot read (ADR-076): the attempt on the message's header, the group's
+   * retry chain, and — only for a job staged before that change, where neither
+   * can answer — a legacy retry segment on the id. It takes the highest of the
+   * three, because a redelivery can overwrite the waiting job's message with a
+   * fresh attempt-1 envelope, and it WRITES the chain on every rung, because a
+   * message that cannot carry an attempt would otherwise never advance and a
+   * misclassified permanent failure would retry forever instead of terminating
+   * at the fail-safe (ADR-030 §2).
    */
   private async handleTransientDecode({
     groupId,
@@ -1991,7 +2082,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     jobDataJson: string;
     err: TransientBlobStoreError;
   }): Promise<void> {
-    const attempt = (stagedJobId.match(/\/r\//g)?.length ?? 0) + 1;
+    const attempt =
+      Math.max(
+        readJobAttempt(jobDataJson) ?? 0,
+        await this.readGroupAttempt(groupId),
+        legacyStagedJobAttempt(stagedJobId),
+      ) + 1;
     if (attempt >= JOB_RETRY_CONFIG.maxAttempts) {
       // The retry ladder is out of rungs. This is a discard like any other, and
       // it used to claim replay would recover it — it does not (#5538).
@@ -2012,12 +2108,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       return;
     }
     const backoffMs = getBackoffMs(attempt);
+    // Advance BOTH carriers. The header rewrite reuses the body string byte for
+    // byte, so the content hash and the lease identity are untouched — a value
+    // whose machinery does not live in the header comes back unchanged, and the
+    // chain below is then the only thing keeping the ladder finite.
+    await this.recordGroupAttempt({ groupId, attempt });
     await this.scripts.retryRestage({
       groupId,
       stagedJobId,
-      newStagedJobId: `${stagedJobId}/r/${attempt}`,
+      newStagedJobId: stagedJobId,
       dispatchAfterMs: Date.now() + backoffMs,
-      jobDataJson,
+      jobDataJson: withJobAttempt({ value: jobDataJson, attempt }),
       backoffMs,
     });
     this.logger.warn(
@@ -2043,9 +2144,19 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    */
   private generateStagedJobId(payload: Payload): string {
     const p = payload as Record<string, unknown>;
-    const baseId = (p.id as string) ?? crypto.randomUUID();
-    const jobType = p.__jobType as string | undefined;
-    const jobName = p.__jobName as string | undefined;
+    // Every field here is `unknown` — the payload is a caller's object, and this
+    // id becomes a Redis key. A cast would only silence the compiler: `??`
+    // catches null/undefined but not a number or an object, either of which
+    // would stringify into a malformed key (`[object Object]/subscriber/…`).
+    // So each part is CHECKED, and anything that is not a usable string is
+    // treated as absent.
+    //
+    // `p.id` is the event id this job was sent for. The fallback stands in for
+    // one, so it is a KSUID like every other id the platform mints — and being
+    // k-sortable it keeps the Redis key ordering the real ids already have.
+    const baseId = nonEmptyString(p.id) ?? generate(KSUID_RESOURCES.EVENT).toString();
+    const jobType = nonEmptyString(p.__jobType);
+    const jobName = nonEmptyString(p.__jobName);
     if (jobType && jobName) {
       return `${baseId}/${jobType}/${jobName}`;
     }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1375,10 +1375,6 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   return;
                 }
 
-                await this.recordGroupAttempt({
-                  groupId,
-                  attempt: attempt + 1,
-                });
                 // STOP THE HEARTBEAT BEFORE THE RE-STAGE IS ISSUED, not after
                 // it returns (ADR-080).
                 //
@@ -1409,6 +1405,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   dispatchAfterMs: Date.now() + backoffMs,
                   jobDataJson: retryJobData,
                   backoffMs,
+                  // Written inside the same script as the re-stage. The chain is
+                  // the only attempt carrier a re-staged SIBLING has — it comes
+                  // back with its original envelope and no `__attempt`, and the
+                  // id no longer carries a marker either — so a separate write
+                  // that failed while this succeeded would hand the next
+                  // sibling-led claim a fresh budget.
+                  attempt: attempt + 1,
+                  attemptTtlSec: GROUP_ATTEMPT_TTL_SECONDS,
                 });
                 // Only transfer once the replacement is actually staged.
                 // retryRestage returns false when the active key is stale —
@@ -1662,32 +1666,6 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         "Could not read the group retry-chain counter — a sibling-led retry may read as a fresh delivery and re-apply already-folded events",
       );
       return 0;
-    }
-  }
-
-  private async recordGroupAttempt({
-    groupId,
-    attempt,
-  }: {
-    groupId: string;
-    attempt: number;
-  }): Promise<void> {
-    try {
-      await this.redisConnection.set(
-        this.groupAttemptKey(groupId),
-        String(attempt),
-        "EX",
-        GROUP_ATTEMPT_TTL_SECONDS,
-      );
-    } catch (err) {
-      // Not best-effort. Losing this makes a sibling-led batch read as a fresh
-      // delivery, which restarts the retry budget AND lets a fold discard the
-      // record of what the chain already applied — so the same events get
-      // folded twice.
-      this.logger.error(
-        { queueName: this.queueName, groupId, attempt, err },
-        "Failed to record the group retry attempt — a sibling-led retry may re-apply already-folded events",
-      );
     }
   }
 
@@ -2093,15 +2071,21 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // byte, so the content hash and the lease identity are untouched — a value
     // whose machinery does not live in the header comes back unchanged, and the
     // chain below is then the only thing keeping the ladder finite.
-    await this.recordGroupAttempt({ groupId, attempt });
-    await this.scripts.retryRestage({
+    const restaged = await this.scripts.retryRestage({
       groupId,
       stagedJobId,
       newStagedJobId: stagedJobId,
       dispatchAfterMs: Date.now() + backoffMs,
       jobDataJson: withJobAttempt({ value: jobDataJson, attempt }),
       backoffMs,
+      attempt,
+      attemptTtlSec: GROUP_ATTEMPT_TTL_SECONDS,
     });
+    // The script writes the chain in the same step, so a value whose machinery
+    // does not live in the header still advances — that write is what keeps
+    // this ladder finite. It returns false only when another worker owns the
+    // slot, in which case nothing was written and this job is no longer ours.
+    if (!restaged) return;
     this.logger.warn(
       {
         queueName: this.queueName,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -57,6 +57,7 @@ import {
   readJobRoutingMeta,
   withJobAttempt,
 } from "./jobEnvelope";
+import { legacyStagedJobAttempt } from "./legacyStagedJobAttempt";
 import {
   gqGroupAttemptReadFailuresTotal,
   gqGroupsBlockedTotal,
@@ -112,41 +113,6 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/**
- * The retry count off a staged job id left over from before ADR-080, when the
- * ladder appended `/r/<n>` to the id and read the count back by counting the
- * segments.
- *
- * READ-ONLY, and only as a last resort. A job part-way up the unreadable-body
- * ladder at deploy time recorded its count nowhere else — that path re-staged
- * the value unmodified and never wrote the group's chain — so without this it
- * would come back with a fresh budget and a fail-safe would reset mid-flight.
- * Nothing writes this shape any more: a legacy id is a value to interpret on
- * the way out, not a format to keep alive.
- */
-export function legacyStagedJobAttempt(stagedJobId: string): number {
-  // Anchored to the TRAILING ladder. The legacy markers were always appended,
-  // so nothing before the tail is one — and an unanchored scan would let a
-  // producer's own event id (which is free-form and forms the base of the
-  // staged id) donate a `/r/<n>` segment and set another job's retry budget.
-  const tail = /((?:\/[rp]\/[^/]+)+)$/.exec(stagedJobId)?.[1] ?? "";
-  let highest = 0;
-  for (const [, digits] of tail.matchAll(/\/r\/(\d+)(?=\/|$)/g)) {
-    const value = Number(digits);
-    // The terminal restage stamped a wall clock under this same marker. Reading
-    // one as an attempt would vault past the budget and discard a job that
-    // still had rungs left, so anything outside the ladder's range is not a
-    // count.
-    if (
-      Number.isInteger(value) &&
-      value > highest &&
-      value <= JOB_RETRY_CONFIG.maxAttempts
-    ) {
-      highest = value;
-    }
-  }
-  return highest;
-}
 
 /**
  * Configuration for the group queue.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -101,18 +101,6 @@ export const GROUP_ATTEMPT_TTL_SECONDS = Math.ceil(
 );
 
 /**
- * The retry count off a staged job id left over from before ADR-076, when the
- * ladder appended `/r/<n>` to the id and read the count back by counting the
- * segments.
- *
- * READ-ONLY, and only as a last resort. A job part-way up the unreadable-body
- * ladder at deploy time recorded its count nowhere else — that path re-staged
- * the value unmodified and never wrote the group's chain — so without this it
- * would come back with a fresh budget and a fail-safe would reset mid-flight.
- * Nothing writes this shape any more: a legacy id is a value to interpret on
- * the way out, not a format to keep alive.
- */
-/**
  * A field off an untrusted payload, when it is actually a usable string.
  *
  * The queue's payloads are `Record<string, unknown>` by design — it routes for
@@ -124,9 +112,26 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+/**
+ * The retry count off a staged job id left over from before ADR-080, when the
+ * ladder appended `/r/<n>` to the id and read the count back by counting the
+ * segments.
+ *
+ * READ-ONLY, and only as a last resort. A job part-way up the unreadable-body
+ * ladder at deploy time recorded its count nowhere else — that path re-staged
+ * the value unmodified and never wrote the group's chain — so without this it
+ * would come back with a fresh budget and a fail-safe would reset mid-flight.
+ * Nothing writes this shape any more: a legacy id is a value to interpret on
+ * the way out, not a format to keep alive.
+ */
 export function legacyStagedJobAttempt(stagedJobId: string): number {
+  // Anchored to the TRAILING ladder. The legacy markers were always appended,
+  // so nothing before the tail is one — and an unanchored scan would let a
+  // producer's own event id (which is free-form and forms the base of the
+  // staged id) donate a `/r/<n>` segment and set another job's retry budget.
+  const tail = /((?:\/[rp]\/[^/]+)+)$/.exec(stagedJobId)?.[1] ?? "";
   let highest = 0;
-  for (const [, digits] of stagedJobId.matchAll(/\/r\/(\d+)(?=\/|$)/g)) {
+  for (const [, digits] of tail.matchAll(/\/r\/(\d+)(?=\/|$)/g)) {
     const value = Number(digits);
     // The terminal restage stamped a wall clock under this same marker. Reading
     // one as an attempt would vault past the budget and discard a job that
@@ -1071,6 +1076,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     }
 
     const jobStartTime = performance.now();
+    // Idempotent so an outcome path can stop the beat at the moment it decides
+    // (see the retry path) while the `finally` still guarantees it is stopped
+    // on every other exit.
+    let heartbeatStopped = false;
     const heartbeat = this.startActiveKeyHeartbeat({
       groupId,
       stagedJobId,
@@ -1078,11 +1087,8 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         jobDataJson,
         ...drainedSiblings.map((sibling) => sibling.jobDataJson),
       ],
+      isCancelled: () => heartbeatStopped,
     });
-    // Idempotent so an outcome path can stop the beat at the moment it decides
-    // (see the retry path) while the `finally` still guarantees it is stopped
-    // on every other exit.
-    let heartbeatStopped = false;
     const stopHeartbeat = (): void => {
       if (heartbeatStopped) return;
       heartbeatStopped = true;
@@ -1351,7 +1357,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 const backoffMs = retryBackoffMsFor({ attempt, error: err });
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
-                // The job keeps the id it was dispatched under (ADR-076). Its
+                // The job keeps the id it was dispatched under (ADR-080). Its
                 // staging member was removed at claim time, so re-staging under
                 // the same id inserts one that is genuinely absent.
                 const newStagedJobId = stagedJobId;
@@ -1408,22 +1414,27 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   attempt: attempt + 1,
                 });
                 // STOP THE HEARTBEAT BEFORE THE RE-STAGE IS ISSUED, not after
-                // it returns (ADR-076).
+                // it returns (ADR-080).
                 //
                 // The re-stage sets the active key's TTL to the backoff window;
                 // a heartbeat REFRESH sets it to the full activeTtlSec and
-                // pushes the group's ready score out to match. The two travel
-                // the same connection and are served in send order, so a beat
-                // that fires while the re-stage is in flight has already been
-                // sent BEHIND it, and would stretch a sub-second backoff into a
-                // multi-minute stall. Clearing the interval here is what makes
-                // that impossible: a tick issues its REFRESH synchronously, so
-                // once this returns no further REFRESH can be sent.
+                // pushes the group's ready score out to match, which would
+                // stretch a sub-second backoff into a multi-minute stall.
+                //
+                // Two things close that window, and BOTH are needed:
+                //
+                //  - Ordering. A tick issues its EVALSHA synchronously, so any
+                //    beat already in flight was sent AHEAD of the re-stage on
+                //    the same connection and is served before it — its TTL is
+                //    then overwritten by the re-stage's.
+                //  - Cancellation. `runCancellable` withdraws the NOSCRIPT
+                //    fallback, which is the one hop that is issued AFTER an
+                //    await and could otherwise land behind the re-stage on a
+                //    cold script cache. Ordering alone does not cover it.
                 //
                 // This used to be handled by the id: the re-stage rotated the
                 // active key to a NEW id, so a late beat naming the old one no
-                // longer matched. With the id reused that guard is gone, and
-                // ordering is the whole protection.
+                // longer matched. With the id reused that guard is gone.
                 stopHeartbeat();
                 const restaged = await this.scripts.retryRestage({
                   groupId,
@@ -1762,10 +1773,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     groupId,
     stagedJobId,
     jobDataValues,
+    isCancelled,
   }: {
     groupId: string;
     stagedJobId: string;
     jobDataValues: string[];
+    /** True once the job's outcome is decided; see `stopHeartbeat`. */
+    isCancelled: () => boolean;
   }): ReturnType<typeof setInterval> {
     const intervalMs = (GROUP_QUEUE_CONFIG.activeTtlSec * 1000) / 3;
     return setInterval(() => {
@@ -1774,6 +1788,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           groupId,
           stagedJobId,
           activeTtlSec: GROUP_QUEUE_CONFIG.activeTtlSec,
+          isCancelled,
         })
         .catch((err) => {
           this.logger.warn(
@@ -1818,7 +1833,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         ? originalScore
         : (this.score?.(payload) ?? Date.now());
 
-    // Re-stage under the id the job was dispatched under (ADR-076), so the
+    // Re-stage under the id the job was dispatched under (ADR-080), so the
     // staged job an operator inspects is named by the id its producer knows.
     const newStagedJobId = stagedJobId;
     const jobDataJson = await this.blobLifecycle.encode({
@@ -2030,7 +2045,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       typeof originalScore === "number" ? originalScore : Date.now();
     await this.scripts.restageAndBlock({
       groupId,
-      // Parked under the id it was dispatched under (ADR-076). This used to
+      // Parked under the id it was dispatched under (ADR-080). This used to
       // append a wall-clock marker, which made a parked job impossible to find
       // by the id its producer knows and grew the value on every park.
       newStagedJobId: stagedJobId,
@@ -2062,7 +2077,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * restage renews that lease before returning.
    *
    * The ladder is bounded by a count this path can reach WITHOUT the body it
-   * cannot read (ADR-076): the attempt on the message's header, the group's
+   * cannot read (ADR-080): the attempt on the message's header, the group's
    * retry chain, and — only for a job staged before that change, where neither
    * can answer — a legacy retry segment on the id. It takes the highest of the
    * three, because a redelivery can overwrite the waiting job's message with a

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -727,6 +727,68 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
 }
 
 /**
+ * Reads the retry attempt from the header alone (envelope values) or via a full
+ * parse (legacy bare JSON). Never throws; an absent or unreadable attempt is
+ * null, which the caller reads as "this message cannot say".
+ *
+ * This exists so the retry count can live ON THE MESSAGE and still be legible
+ * to the one reader that cannot decode a message: when a job's body is held in
+ * a blob store that is temporarily unreachable, the ladder that decides whether
+ * to retry or give up has nothing but the value in hand. The header is plain
+ * inline JSON in front of the body, so it is readable with no blob I/O.
+ *
+ * GQ1 envelopes never lifted machinery into the header (`routingHeader` sets
+ * only the routing trio), so their attempt is inside the body and this reports
+ * null rather than guessing.
+ */
+export function readJobAttempt(value: string): number | null {
+  try {
+    const machinery = isEnvelope(value)
+      ? ((splitEnvelope(value).header.m ?? {}) as Record<string, unknown>)
+      : (JSON.parse(value) as Record<string, unknown>);
+    const attempt = machinery.__attempt;
+    return typeof attempt === "number" && Number.isInteger(attempt) && attempt > 0
+      ? attempt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The same value with its retry attempt stamped into the header, rewriting the
+ * HEADER ONLY.
+ *
+ * The body string is reused byte for byte, which is the whole point: the body
+ * is what the blob store content-addresses and what identical jobs share, so
+ * re-encoding it to change a counter would split that shared copy and churn the
+ * lease identity. Advancing an attempt is metadata, and costs no blob I/O.
+ *
+ * A value whose machinery does not live in the header (GQ1, legacy bare JSON)
+ * is returned unchanged — {@link readJobAttempt} reports null for those, and
+ * the caller falls back to the group's retry chain.
+ */
+export function withJobAttempt({
+  value,
+  attempt,
+}: {
+  value: string;
+  attempt: number;
+}): string {
+  if (!value.startsWith(ENVELOPE_PREFIX_V2)) return value;
+  try {
+    const { header, body } = splitEnvelope(value);
+    return finalize(
+      ENVELOPE_PREFIX_V2,
+      { ...header, m: { ...(header.m ?? {}), __attempt: attempt } },
+      body,
+    );
+  } catch {
+    return value;
+  }
+}
+
+/**
  * The GQ1 offloaded-blob id from a parsed envelope header, or null for inline
  * bodies, GQ2 tiered refs, and legacy JSON. The retirement paths read it via
  * {@link readEnvelopeRetirement} so completion/restage pay a single parse.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -747,6 +747,11 @@ export function readJobAttempt(value: string): number | null {
       ? ((splitEnvelope(value).header.m ?? {}) as Record<string, unknown>)
       : (JSON.parse(value) as Record<string, unknown>);
     const attempt = machinery.__attempt;
+    // Reported verbatim: this is a reader, and one that silently reshapes what
+    // is stored cannot be used to check what was written. `__attempt` is lifted
+    // out of the payload by name, so a job whose payload carried that key could
+    // name a number past the budget — the ladder then treats it as already
+    // spent and retires the job, which is the fail-closed direction.
     return typeof attempt === "number" && Number.isInteger(attempt) && attempt > 0
       ? attempt
       : null;
@@ -764,9 +769,10 @@ export function readJobAttempt(value: string): number | null {
  * re-encoding it to change a counter would split that shared copy and churn the
  * lease identity. Advancing an attempt is metadata, and costs no blob I/O.
  *
- * A value whose machinery does not live in the header (GQ1, legacy bare JSON)
- * is returned unchanged — {@link readJobAttempt} reports null for those, and
- * the caller falls back to the group's retry chain.
+ * GQ1 and legacy bare JSON are returned unchanged. The asymmetry is worth
+ * naming: bare JSON's attempt is still READABLE by {@link readJobAttempt} (it
+ * is an ordinary body field), just not advanceable here — so for those the
+ * group's retry chain is what keeps the ladder finite.
  */
 export function withJobAttempt({
   value,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/legacyStagedJobAttempt.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/legacyStagedJobAttempt.ts
@@ -1,0 +1,42 @@
+import { JOB_RETRY_CONFIG } from "../shared";
+
+/**
+ * The retry count off a staged job id left over from before ADR-080, when the
+ * ladder appended `/r/<n>` to the id and read the count back by counting the
+ * segments.
+ *
+ * READ-ONLY, and only as a last resort. A job part-way up the unreadable-body
+ * ladder at deploy time recorded its count nowhere else — that path re-staged
+ * the value unmodified and never wrote the group's chain — so without this it
+ * would come back with a fresh budget and a fail-safe would reset mid-flight.
+ * Nothing writes this shape any more: a legacy id is a value to interpret on
+ * the way out, not a format to keep alive.
+ *
+ * DELETE THIS MODULE once no job staged before the ADR-080 deploy can still be
+ * in backoff — an hour is comfortably past GROUP_ATTEMPT_TTL_SECONDS. It lives
+ * alone so that removal is an `rm` rather than a diff against the queue's
+ * hottest file.
+ */
+export function legacyStagedJobAttempt(stagedJobId: string): number {
+  // Anchored to the TRAILING ladder. The legacy markers were always appended,
+  // so nothing before the tail is one — and an unanchored scan would let a
+  // producer's own event id (which is free-form and forms the base of the
+  // staged id) donate a `/r/<n>` segment and set another job's retry budget.
+  const tail = /((?:\/[rp]\/[^/]+)+)$/.exec(stagedJobId)?.[1] ?? "";
+  let highest = 0;
+  for (const [, digits] of tail.matchAll(/\/r\/(\d+)(?=\/|$)/g)) {
+    const value = Number(digits);
+    // The terminal restage stamped a wall clock under this same marker. Reading
+    // one as an attempt would vault past the budget and discard a job that
+    // still had rungs left, so anything outside the ladder's range is not a
+    // count.
+    if (
+      Number.isInteger(value) &&
+      value > highest &&
+      value <= JOB_RETRY_CONFIG.maxAttempts
+    ) {
+      highest = value;
+    }
+  }
+  return highest;
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1321,7 +1321,8 @@ local activeKey    = keyPrefix .. "group:" .. groupId .. ":active"
 -- 1. Block the group — prevents dispatcher from re-dispatching
 redis.call("SADD", blockedKey, groupId)
 
--- 2. Re-stage the failed job with a new ID
+-- 2. Re-stage the failed job under the id it was dispatched under (ADR-080).
+--    Its member was ZREMed at claim time, so this insert lands on an absent one.
 local inserted = redis.call("ZADD", groupJobsKey, score, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
 local stagedLease = gqParseLease(jobDataJson)
@@ -1430,7 +1431,7 @@ addToReadyOrParked(readyKey, groupId, dispatchAfterMs, false)
 --    activeTtlSec and push the ready score out with it, delaying the retry by
 --    up to activeTtlSec instead of the backoff. This used to be prevented
 --    here: the re-stage rotated the active key to a NEW id, so a late beat
---    naming the retired id no longer matched. Since ADR-076 the id is reused,
+--    naming the retired id no longer matched. Since ADR-080 the id is reused,
 --    so newStagedJobId equals stagedJobId and this write invalidates nothing.
 --    The ONLY protection is that the caller stops the heartbeat before issuing
 --    this script (stopHeartbeat() in groupQueue.ts, ordered ahead of
@@ -2043,16 +2044,26 @@ export class GroupStagingScripts {
     groupId,
     stagedJobId,
     activeTtlSec,
+    isCancelled,
   }: {
     groupId: string;
     stagedJobId: string;
     activeTtlSec: number;
+    /**
+     * Withdraws the refresh if the caller stops wanting it while the call is in
+     * flight. Only the NOSCRIPT fallback can be withdrawn — see
+     * {@link CachedLuaScript.runCancellable} — which is exactly the window
+     * where a refresh could otherwise land behind a re-stage and undo its
+     * backoff.
+     */
+    isCancelled?: () => boolean;
   }): Promise<boolean> {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const readyKey = `${this.keyPrefix}ready`;
 
-    const result = await refreshScript.run(
+    const result = await refreshScript.runCancellable(
       this.redis,
+      isCancelled ?? null,
       2,
       activeKey,
       readyKey,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1420,15 +1420,22 @@ refreshGroupKeyTtl(groupJobsKey, groupDataKey, nowMs)
 local readyKey = keyPrefix .. "ready"
 addToReadyOrParked(readyKey, groupId, dispatchAfterMs, false)
 
--- 4. Rotate the active key to the NEW staged-job id with a TTL matching the
---    backoff period. While the key exists the group is locked (preserves FIFO
+-- 4. Set the active key to the staged-job id with a TTL matching the backoff
+--    period. While the key exists the group is locked (preserves FIFO
 --    ordering); when it expires the dispatcher picks up the retry on its next
---    poll. Rotating the VALUE (not just EXPIRE-ing the old one) invalidates
---    the retired job id: the worker's activeKey heartbeat interval is still
---    armed for a few awaits after this eval returns (blob transfer, audit
---    write), and a late REFRESH matching the old id would reset this TTL to
---    the full activeTtlSec and push the ready score out with it — delaying
---    the retry by up to activeTtlSec instead of the backoff.
+--    poll.
+--
+--    THIS TTL IS WHAT MAKES THE BACKOFF REAL, and nothing here defends it.
+--    A REFRESH from the worker's heartbeat would reset it to the full
+--    activeTtlSec and push the ready score out with it, delaying the retry by
+--    up to activeTtlSec instead of the backoff. This used to be prevented
+--    here: the re-stage rotated the active key to a NEW id, so a late beat
+--    naming the retired id no longer matched. Since ADR-076 the id is reused,
+--    so newStagedJobId equals stagedJobId and this write invalidates nothing.
+--    The ONLY protection is that the caller stops the heartbeat before issuing
+--    this script (stopHeartbeat() in groupQueue.ts, ordered ahead of
+--    retryRestage on the same connection). Do not move that call later on the
+--    assumption that this line still guards it.
 redis.call("SET", activeKey, newStagedJobId, "EX", retryTtlSec)
 
 -- 5. Bump this slot's expiry score in lockstep with the activeKey TTL so the

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1380,6 +1380,15 @@ const RETRY_RESTAGE_LUA =
   `
 local activeKey       = KEYS[1]
 local totalPendingKey = KEYS[2]
+-- The group's retry chain. Written HERE rather than by the caller beforehand:
+-- with the staged job id no longer carrying a /r/<n> marker (ADR-080), this
+-- counter is the only attempt carrier a re-staged SIBLING has — a sibling is
+-- re-queued with its original envelope and no attempt of its own. A separate
+-- SET that failed while this script went on to succeed would hand the next
+-- sibling-led claim a fresh budget, restarting a bounded ladder and letting a
+-- fold re-apply what the chain had already applied. One script means both land
+-- or neither does.
+local attemptKey      = KEYS[3]
 
 local keyPrefix             = ARGV[1]
 local groupId               = ARGV[2]
@@ -1393,11 +1402,19 @@ local retryTtlSec           = tonumber(ARGV[7])
 -- in-flight retry's slot doesn't lapse out of the live count.
 local tenantCountKeyPrefix  = ARGV[8]
 local nowMs                 = tonumber(ARGV[9])
+local attempt               = ARGV[10]
+local attemptTtlSec         = tonumber(ARGV[11])
 
 -- 1. Validate active key matches
 local currentActive = redis.call("GET", activeKey)
 if currentActive ~= stagedJobId then
   return 0
+end
+
+-- 1b. Record the attempt on the group's retry chain. After the guard, so a
+--     worker that has lost the slot cannot advance a chain it no longer owns.
+if attempt ~= "" then
+  redis.call("SET", attemptKey, attempt, "EX", attemptTtlSec)
 end
 
 -- 2. Re-stage job with future score (backoff delay)
@@ -2137,6 +2154,8 @@ export class GroupStagingScripts {
     dispatchAfterMs,
     jobDataJson,
     backoffMs,
+    attempt,
+    attemptTtlSec,
   }: {
     groupId: string;
     stagedJobId: string;
@@ -2144,17 +2163,22 @@ export class GroupStagingScripts {
     dispatchAfterMs: number;
     jobDataJson: string;
     backoffMs: number;
+    /** Recorded on the group's retry chain in the same atomic step. */
+    attempt: number;
+    attemptTtlSec: number;
   }): Promise<boolean> {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
+    const attemptKey = `${this.keyPrefix}group:${groupId}:attempt`;
     // TTL = backoff + 2s buffer so the key expires just after the job becomes eligible
     const retryTtlSec = Math.ceil(backoffMs / 1000) + 2;
 
     const result = await retryRestageScript.run(
       this.redis,
-      2,
+      3,
       activeKey,
       totalPendingKey,
+      attemptKey,
       this.keyPrefix,
       groupId,
       stagedJobId,
@@ -2164,6 +2188,8 @@ export class GroupStagingScripts {
       String(retryTtlSec),
       `${this.keyPrefix}tenant_active_z:`,
       String(Date.now()),
+      String(attempt),
+      String(attemptTtlSec),
     );
 
     return result === 1;

--- a/langwatch/src/utils/constants.ts
+++ b/langwatch/src/utils/constants.ts
@@ -64,4 +64,7 @@ export const KSUID_RESOURCES = {
   TOPIC_CLUSTERING_RUN: "topicrun",
   TOPIC_CLUSTERING_RUN_HISTORY: "topicrunhist",
   TOPIC_MODEL_PROJECTION: "topicmodel",
+  PROCESS_MANAGER_INSTANCE: "pminstance",
+  PROCESS_MANAGER_INBOX: "pminbox",
+  PROCESS_MANAGER_OUTBOX: "pmoutbox",
 } as const;

--- a/specs/event-sourcing/pending-counter-conservation.feature
+++ b/specs/event-sourcing/pending-counter-conservation.feature
@@ -45,7 +45,7 @@ Feature: Pending counter conservation across job lifecycle
   @integration @counter @block
   Scenario: Counter tracks restage-and-block as a new pending job
     Given a dispatched job (counter was decremented at dispatch)
-    When RESTAGE_AND_BLOCK re-stages with a new ID and blocks the group
+    When RESTAGE_AND_BLOCK re-stages the job and blocks the group
     Then the counter is incremented (job re-enters :jobs ZSET)
 
   @integration @counter @redelivery

--- a/specs/event-sourcing/process-manager-inbox-key.feature
+++ b/specs/event-sourcing/process-manager-inbox-key.feature
@@ -1,0 +1,75 @@
+Feature: The process-manager inbox keys idempotency on a bounded digest
+  As the platform
+  I want a process manager's idempotency marker to be keyed on a fixed-width digest
+  So that a long source event id cannot wedge a process for good
+
+  # A process manager consumes each source event exactly once. The marker for
+  # that is a row in `ProcessManagerInbox`, unique on
+  # (processName, projectId, <source event>).
+  #
+  # The source event id is `idempotencyKey ?? id`, and an idempotency key is
+  # composed by the pipeline that emits the command — so its length is
+  # whatever the emitting domain happens to concatenate. Postgres refuses to
+  # index a btree row over ~2704 bytes, so a long enough key turned the inbox
+  # insert into a hard error (SQLSTATE 54000) INSIDE the commit transaction.
+  #
+  # That error is deterministic. It fails, the whole commit rolls back, the
+  # queue retries, it fails identically, and at the end of the retry ladder the
+  # group is blocked (specs/event-sourcing/poison-group-park-guard.feature).
+  # Since the group is per-aggregate, one oversized event id permanently stops
+  # every later event for that aggregate — including the ones that dispatch
+  # real work.
+  #
+  # The fix is to stop indexing caller-sized data at all: the store derives a
+  # fixed-width digest of the source event id and puts the unique constraint on
+  # THAT, keeping the raw id as an unindexed column for diagnostics. The
+  # constraint is then the same width no matter what any pipeline concatenates,
+  # so this class of failure cannot come back through a different domain.
+  #
+  # See specs/langy/langy-tool-call-identity.feature for the specific defect
+  # that exposed this, and ADR-052 for the process-manager substrate.
+
+  Rule: The inbox's unique constraint is a fixed width whatever the source event id
+
+    @integration
+    Scenario: A source event id far past the index limit is still consumed
+      Given a process manager subscribed to an event
+      And that event's idempotency key is several thousand characters long
+      When the process commits its consumption of the event
+      Then the commit succeeds
+      And the raw source event id is kept on the row for diagnostics
+
+    @integration
+    Scenario: Two different long source event ids stay distinct
+      Given two events whose idempotency keys are long and share a common prefix
+      When a process manager commits its consumption of each of them
+      Then both are consumed
+      And neither is mistaken for a redelivery of the other
+
+    @integration
+    Scenario: Redelivery of a long source event id is still deduplicated
+      Given a process manager has consumed an event with a very long idempotency key
+      When the same event is delivered to it again
+      Then the second delivery is reported as a duplicate
+      And no second inbox row is written
+
+    @integration
+    Scenario: A long source event id no longer blocks the process
+      Given a process manager subscribed to an event whose idempotency key exceeds the index limit
+      When the event is delivered
+      Then the commit does not raise a database error
+      And a later event for the same process is still processed
+
+  Rule: The digest is derived by the store, never by the caller
+
+    @unit
+    Scenario: The same source event id always derives the same key
+      Given a source event id
+      When its inbox key is derived twice
+      Then both derivations produce the same value
+
+    @unit
+    Scenario: The derived key is a fixed width regardless of input length
+      Given a very short source event id and a very long one
+      When each one's inbox key is derived
+      Then the two keys are the same length

--- a/specs/event-sourcing/staged-job-id-identity.feature
+++ b/specs/event-sourcing/staged-job-id-identity.feature
@@ -104,10 +104,11 @@ Feature: A staged job's id is its identity and its retry count rides on the mess
   Rule: The retry attempt travels on the message and is readable without the body
 
     @unit
-    Scenario: A job sent for the first time reads as its first attempt
+    Scenario: A job sent for the first time carries no attempt on its message
       Given a job that has never been retried
       When its attempt is read from the message
-      Then it reads as the first attempt
+      Then no attempt is reported
+      And the ladder counts it as the first attempt
 
     @unit
     Scenario: A retried job's attempt is readable without fetching its body

--- a/specs/event-sourcing/staged-job-id-identity.feature
+++ b/specs/event-sourcing/staged-job-id-identity.feature
@@ -67,6 +67,32 @@ Feature: A staged job's id is its identity and its retry count rides on the mess
   Background:
     Given a GroupQueue dispatching per-aggregate FIFO groups
 
+  Rule: A retry records its attempt and re-stages together, or does neither
+
+    # Removing the marker from the id removed a carrier, and one reader depended
+    # on it more than the others: a re-staged SIBLING comes back with its
+    # original message and no attempt of its own, so for that job the group's
+    # retry chain is now the ONLY place the count lives.
+    #
+    # That makes a half-completed retry dangerous in a way it was not before. If
+    # the chain write fails on a brief connection blip and the re-stage then
+    # succeeds, the next claim led by such a sibling reads no attempt anywhere
+    # and starts over: a bounded ladder becomes unbounded, and a fold that uses
+    # the attempt to recognise a retry discards its record of what it already
+    # applied and folds the same events twice. So the two writes are one step.
+
+    @integration
+    Scenario: A retry that cannot record its attempt does not re-stage the job
+      Given a claimed job that fails with a retryable error
+      When the queue cannot record the attempt on the group's retry chain
+      Then the job is not re-staged as though it were on a fresh attempt
+
+    @integration
+    Scenario: A sibling-led claim after a retry still sees the attempt the ladder reached
+      Given a group whose retry was re-staged alongside an untouched sibling
+      When that sibling leads the next claim
+      Then it is counted on the attempt the ladder had reached, not the first
+
   Rule: A staged job keeps one id from the moment it is sent
 
     @integration

--- a/specs/event-sourcing/staged-job-id-identity.feature
+++ b/specs/event-sourcing/staged-job-id-identity.feature
@@ -4,7 +4,7 @@ Feature: A staged job's id is its identity and its retry count rides on the mess
   So that the id stays a name I can look up, a key a database can index, and a
   thing two workers can agree is the same job.
 
-  # Decision: dev/docs/adr/076-staged-job-id-is-identity-not-state.md
+  # Decision: dev/docs/adr/080-staged-job-id-is-identity-not-state.md
   #
   # Why this exists — production, 2026-07
   #

--- a/specs/event-sourcing/staged-job-id-identity.feature
+++ b/specs/event-sourcing/staged-job-id-identity.feature
@@ -1,0 +1,362 @@
+Feature: A staged job's id is its identity and its retry count rides on the message
+  As an operator reading a queue and the rows a job writes downstream
+  I want a job to keep one id for its whole life, however many times it is retried
+  So that the id stays a name I can look up, a key a database can index, and a
+  thing two workers can agree is the same job.
+
+  # Decision: dev/docs/adr/076-staged-job-id-is-identity-not-state.md
+  #
+  # Why this exists — production, 2026-07
+  #
+  # A staged job id is `<eventId>/<jobType>/<jobName>`. Every retry APPENDED a
+  # segment to it, and the terminal restage appended one stamped from the wall
+  # clock, so a job that had been round the ladder wore its whole history:
+  #
+  #   event_…/subscriber/pm:langyConversation/r/12/r/16/r/24/r/1785261278310
+  #
+  # Three things are wrong with that.
+  #
+  #   1. It grows without bound. The value is a Redis zset member and a hash
+  #      field, and it gains a segment per retry and per operator unblock.
+  #
+  #   2. It is not a function of the job. The last segment is `Date.now()`, so
+  #      re-staging the same job twice produces two different ids and nothing
+  #      downstream can tell a repeat from a new arrival.
+  #
+  #   3. It encodes state in a name. The retry count was READ BACK OUT of the
+  #      id by counting segments, which is why the id had to keep growing in
+  #      the first place — a name was doing a counter's job.
+  #
+  # To be clear about what this is NOT: the staged job id never leaves the
+  # queue's own Redis keys. The btree index blowup that ran alongside this
+  # investigation came from a process manager's own idempotency key, not from
+  # here (`specs/event-sourcing/process-manager-inbox-key.feature`), and the
+  # two are independent. This one is a queue-hygiene defect: an unbounded,
+  # non-deterministic name that an operator cannot read and cannot look up.
+  #
+  # The segment existed to carry ONE reader: the ladder that runs when a job's
+  # body cannot be decoded at all
+  # (`specs/event-sourcing/groupqueue-decode-drop-durability.feature`). That
+  # path could not consult the attempt stamped inside the payload — the payload
+  # is exactly what it cannot read — so it counted the segments instead.
+  #
+  # It never had to. A staged value is `<prefix><headerLength>|<header><body>`,
+  # and the header is plain inline JSON that sits in front of the body: it is
+  # what the Lua dispatcher slices to route a job and what the ops dashboard
+  # reads to describe a value it could not decode
+  # (`specs/event-sourcing/payload-envelope.feature`). Queue machinery,
+  # including the attempt, already travels in that header. So the count the
+  # ladder needs is readable without touching the body, and can be advanced by
+  # rewriting the header alone — leaving the body's bytes, and therefore the
+  # stored copy that identical jobs share, untouched.
+  #
+  # The id is now only ever a name. It is computed once when the job is sent and
+  # every later write — retry, exhaustion, poison park — reuses it verbatim. The
+  # queue can afford that because a job's id is already removed from staging the
+  # moment it is claimed, so a re-stage is always putting back something that is
+  # not there, never colliding with something that is.
+  #
+  # One consequence has to be designed for rather than discovered: rotating the
+  # id was also what stopped a worker's in-flight heartbeat from recognising the
+  # job it had just re-staged. With the id reused, that heartbeat matches again,
+  # and a heartbeat's job is to extend the group's hold for the full active
+  # window — which would stretch a half-second backoff into a multi-minute
+  # stall. So the heartbeat has to stop when the job's outcome is decided, not
+  # when the worker finishes its bookkeeping.
+
+  Background:
+    Given a GroupQueue dispatching per-aggregate FIFO groups
+
+  Rule: A staged job keeps one id from the moment it is sent
+
+    @integration
+    Scenario: A job's staged id names the event and the job, and nothing else
+      Given a job sent for an event
+      When its staged id is derived
+      Then the id names the event, the job type and the job name
+      And the id carries no retry marker and no timestamp
+
+    @integration
+    Scenario: A retried job is re-staged under the id it was dispatched under
+      Given a claimed job that fails with a retryable error
+      When the queue re-stages it with backoff
+      Then it is re-staged under the id it was dispatched under, unchanged
+
+    @integration
+    Scenario: A job blocked after exhausting its retries keeps its staged id
+      Given a claimed job that has used up its retry budget
+      When the queue blocks the group and re-stages the job for inspection
+      Then it is re-staged under the id it was dispatched under, unchanged
+
+    @integration
+    Scenario: A group parked by the poison guard keeps the staged id it parked on
+      Given a claimed job whose group trips the poison guard
+      When the queue parks the group with the value intact
+      Then the value is re-staged under the id it was dispatched under, unchanged
+
+    @integration
+    Scenario: A job that rides the whole retry ladder ends under the id it started with
+      Given a job that fails on every attempt in its retry budget
+      When the ladder runs to its end and the group is blocked
+      Then the job left in staging has the same id it was first sent with
+      And an operator can find it by the id the producer knows
+
+  Rule: The retry attempt travels on the message and is readable without the body
+
+    @unit
+    Scenario: A job sent for the first time reads as its first attempt
+      Given a job that has never been retried
+      When its attempt is read from the message
+      Then it reads as the first attempt
+
+    @unit
+    Scenario: A retried job's attempt is readable without fetching its body
+      Given a re-staged job whose body is held outside the message
+      When its attempt is read while the body is unreachable
+      Then the attempt is reported from the message alone
+
+    @unit
+    Scenario: Advancing a job's attempt leaves its payload bytes untouched
+      Given a staged job carrying an attempt
+      When the queue advances that job to its next attempt
+      Then the job's payload bytes are unchanged
+      And the job still points at the same stored body
+
+    @unit
+    Scenario: Advancing a job's attempt does not split the body it shares with identical jobs
+      Given several jobs whose payloads are identical and share one stored body
+      When one of them is advanced to its next attempt
+      Then they all still share the one stored body
+
+    @unit
+    Scenario: A job stays readable as its attempt count grows wider
+      Given a staged job advanced through attempts of different digit widths
+      When each one is read back
+      Then every one is still readable and reports the attempt it was given
+
+    @unit
+    Scenario: A job in a format that predates the readable attempt reports no attempt rather than a wrong one
+      Given a job staged in a format that keeps its attempt inside the body
+      When its attempt is read from the message alone
+      Then no attempt is reported
+      And the reader does not fail
+
+  Rule: The ladder for a body that cannot be read is bounded by what it can read
+
+    @integration
+    Scenario: The unreadable-body ladder counts the attempt the message carries
+      Given a staged job whose message says which attempt it is on
+      When its body cannot be fetched
+      Then the ladder treats it as the next attempt after the one on the message
+
+    @integration
+    Scenario: The unreadable-body ladder falls back to the group's retry chain when the message cannot say
+      Given a staged job in a format whose message cannot report an attempt
+      And a group that has already been round the ladder several times
+      When the job's body cannot be fetched
+      Then the ladder counts the attempt from the group's retry chain instead
+
+    @integration
+    Scenario: The unreadable-body ladder takes the higher of the message and the group's chain
+      Given a staged job whose message and whose group disagree about the attempt
+      When its body cannot be fetched
+      Then the ladder counts from whichever of the two is further along
+
+    @integration
+    Scenario: Every rung of the unreadable-body ladder advances the count the next rung reads
+      Given a job whose body is unreachable on every attempt
+      When the ladder runs
+      Then each attempt is counted higher than the one before it
+
+    @integration
+    Scenario: The unreadable-body ladder records each attempt on the group's retry chain
+      Given a job whose body is unreachable
+      When the ladder re-stages it for another attempt
+      Then the group's retry chain records that attempt too
+
+    @integration
+    Scenario: A job whose attempt can never be written to its message still gives up at the end of the budget
+      Given a job in a format whose message cannot carry an attempt
+      And a body that stays unreachable
+      When the ladder runs
+      Then it still gives up once the budget is spent
+      And it does not retry the job forever
+
+    @integration
+    Scenario: A body that stays unreachable is given up on at the end of the ladder
+      Given a job whose body stays unreachable for its whole retry budget
+      When the budget runs out
+      Then the job is given up on and counted as a transient-exhausted loss
+      And the group is left free to run its next job
+
+  Rule: Re-staging a job under its own id conserves the queue-depth count
+
+    # `specs/event-sourcing/pending-counter-conservation.feature` owns the
+    # invariant itself — one increment per job entering a group's staging set,
+    # one decrement per job leaving it, total equals what is actually staged —
+    # and is not restated here. What is new is only that a re-stage now reuses
+    # the id: claiming a job removes it from staging before any re-stage can put
+    # it back, so the same-id insert lands on a member that is genuinely absent
+    # and the arithmetic is the one a distinct id already produced.
+    #
+    # Reusing the id does change one thing, and it is the reason this Rule
+    # exists at all: a redelivery of the same event now lands on the SAME
+    # staging member as the job that is waiting out a backoff, overwriting its
+    # message. That is why the retry count can never be read from the message
+    # alone (see the Rule above), and why the backoff has to be held by the
+    # group's hold rather than by the job's own position in the queue.
+
+    @integration
+    Scenario: A redelivery of an event already waiting to retry does not double the queue depth
+      Given a job waiting out its retry backoff
+      When the same event is delivered again
+      Then the queue holds one job for that event, not two
+      And the queue depth still equals what is actually staged
+
+    @integration
+    Scenario: A redelivery that overwrites a waiting job's message does not reset its ladder
+      Given a job waiting out its retry backoff part-way up its ladder
+      When the same event is delivered again and overwrites its message
+      Then the job's next failure is counted from where the ladder had reached
+      And it is not given a fresh budget
+
+    @integration
+    Scenario: A redelivery arriving mid-backoff does not shorten the wait
+      Given a job waiting out its retry backoff
+      When the same event is delivered again before the backoff expires
+      Then the job is not dispatched before its backoff was due
+      And the wait is held by the group's hold, not by the job's queue position
+
+  Rule: A retry waits the backoff it was given, not the active-slot timeout
+
+    # Rotating the id was doing a second, undocumented job, and it has to
+    # survive the rotation's removal.
+    #
+    # While a job runs, its worker beats a heartbeat that keeps the group's hold
+    # alive for the full active window — several minutes. Rotating the id is
+    # what stopped a late beat from being believed: it named the retired id, so
+    # it no longer matched. With the id reused it matches again, and a single
+    # late beat would extend the hold to the full active window AND push the
+    # group's next-eligible time out with it — turning a sub-second backoff into
+    # a multi-minute stall.
+    #
+    # So the heartbeat must be stopped BEFORE the re-stage is written, not after
+    # the worker finishes tidying up. The ordering is the whole point: the
+    # heartbeat and the re-stage travel the same connection and are served in
+    # the order they are sent, so a beat that fires while the re-stage is still
+    # in flight has already been sent behind it. Stopping the beat only once the
+    # re-stage comes back is too late.
+
+    @integration
+    Scenario: A retried job is dispatched when its backoff expires, not an active window later
+      Given a claimed job that fails with a short retry backoff
+      When it is re-staged and the worker finishes its bookkeeping
+      Then the job becomes eligible again when the backoff expires
+
+    @integration
+    Scenario: No heartbeat is sent after a job's re-stage has been sent
+      Given a claimed job being re-staged for a retry
+      When the worker publishes the re-stage and finishes its bookkeeping
+      Then no heartbeat for that job is sent after the re-stage
+
+    @integration
+    Scenario: A worker's heartbeat stops extending a group's hold once the job's outcome is decided
+      Given a claimed job whose outcome has been decided
+      When the worker's remaining bookkeeping runs
+      Then the group's hold is not extended past what the outcome asked for
+
+  Rule: Unblocking a group clears every counter that outlived the block
+
+    # An operator who unblocks is asking for another run, not for the ladder to
+    # resume one rung from its end.
+    #
+    # The queue keeps several per-group counters that outlive a block, and
+    # unblocking clears only some of them. It drops the poison guard's claim
+    # strikes and the stored error; it leaves the retry chain (which decides how
+    # many attempts remain) and the consecutive-failure streak (which decides
+    # when to quarantine). So a group blocked by exhaustion comes back with no
+    # attempts left AND a streak already at the quarantine threshold, and the
+    # very first failure re-blocks it. Worse, whether it does depends on how long
+    # the operator took to press the button, because the retry chain expires on
+    # its own after a while.
+    #
+    # An unblock is an operator saying "try this again". Every counter that
+    # decides whether trying is allowed belongs in that reset — and the same
+    # goes for the other two ways an operator clears a group out. Draining and
+    # dead-lettering both empty the group entirely, so a group later re-created
+    # under that id is a new group in every respect except its name; letting it
+    # inherit a spent retry chain or a failure streak from jobs that are no
+    # longer there is the same defect wearing a different hat.
+
+    @integration
+    Scenario: A group unblocked after exhaustion retries instead of re-blocking on its first failure
+      Given a group blocked after a job used up its retry budget
+      When an operator unblocks it and the job fails once more
+      Then the job is retried rather than the group being blocked again
+
+    @integration
+    Scenario: A group unblocked after exhaustion is not immediately re-quarantined by its old failure streak
+      Given a group blocked after a long run of consecutive failures
+      When an operator unblocks it and its next job fails once
+      Then the group is not quarantined on that single failure
+
+    @integration
+    Scenario: A drained group id starts its next job on a fresh ladder
+      Given a group blocked after a job used up its retry budget
+      When an operator drains it and a new job arrives under the same group id
+      Then that job gets the full retry budget
+      And it is not quarantined by the drained group's failure streak
+
+    @integration
+    Scenario: A dead-lettered group id starts its next job on a fresh ladder
+      Given a group blocked after a job used up its retry budget
+      When an operator moves it to the dead-letter queue and a new job arrives under the same group id
+      Then that job gets the full retry budget
+      And it is not quarantined by the dead-lettered group's failure streak
+
+    @integration
+    Scenario: An unblocked group's fresh ladder does not depend on how long the operator waited
+      Given two groups blocked after exhaustion
+      When one is unblocked immediately and the other much later
+      Then both get the same retry budget on their next run
+
+  Rule: Jobs already staged under the old growing ids finish under them
+
+    # This ships onto a live queue holding jobs whose ids already carry retry
+    # segments. Nothing rewrites them: a worker uses whatever id it was handed,
+    # so a legacy id keeps working as a name and simply stops growing.
+    #
+    # One class of in-flight job needs care. A job part-way up the ladder for an
+    # unreadable body recorded its count ONLY in the id — that was the whole
+    # reason the segments existed — so after this change neither its message nor
+    # its group chain can say how far it got, and it would be handed a fresh
+    # budget. To avoid resetting a fail-safe mid-flight, a trailing retry segment
+    # is still READ as a last resort when neither of the other two can answer.
+    # It is never written: a legacy id is a value to interpret on the way out,
+    # not a format to keep alive.
+
+    @integration
+    Scenario: A job staged under a legacy retry-suffixed id still completes
+      Given a job staged before this change, whose id carries retry segments
+      When a worker claims and processes it
+      Then it completes normally and leaves staging
+
+    @unit
+    Scenario: A legacy id's retry segment is read only when nothing else can answer
+      Given a legacy id carrying a retry segment
+      When the attempt is taken from a message that records one
+      Then the message is believed and the id's segment is ignored
+
+    @integration
+    Scenario: A job staged under a legacy retry-suffixed id resumes its ladder rather than restarting it
+      Given a job staged before this change, part-way through its retry budget
+      And neither its message nor its group can say how far it got
+      When it fails again after this change is deployed
+      Then it is retried on the attempt after the one its id had reached
+      And it is not given a fresh budget
+
+    @integration
+    Scenario: A legacy retry-suffixed id gains no further segments
+      Given a job staged before this change, whose id carries retry segments
+      When it is retried, exhausts its budget, and its group is parked
+      Then its id is exactly the one it was dispatched under at every step

--- a/specs/langy/langy-tool-call-identity.feature
+++ b/specs/langy/langy-tool-call-identity.feature
@@ -1,0 +1,74 @@
+Feature: A tool call's identity is an identity, not a provider payload
+  As a LangWatch user chatting with Langy
+  I want the id of a tool call to be just its id
+  So that a model provider's round-trip data does not ride along in everything we store
+
+  # Some model providers require an opaque blob to be handed back on the next
+  # request — Gemini's thought signature is the one we hit. The agent runtime
+  # has nowhere to put it, so it staples it onto the tool call's id:
+  #
+  #   <real id>_ts_<base64url blob>
+  #
+  # That is not an identifier. It is kilobytes of provider payload wearing an
+  # identifier's clothes, and Langy treated it as identity: it went into the
+  # durable event data, into the message parts, and — because the tool
+  # commands compose their idempotency key out of it — into the process
+  # manager's inbox key, where it was long enough to break the database index
+  # and wedge the conversation for good
+  # (specs/event-sourcing/process-manager-inbox-key.feature).
+  #
+  # So the relay strips the round-trip suffix where the frame enters, before
+  # anything is stored or paired. What is left is the id the provider actually
+  # issued, which is what every downstream consumer wanted in the first place.
+  #
+  # Stripping happens at the wire boundary rather than at each use, because
+  # start and end frames, live cards, durable events and the final's tool list
+  # all read the same field — normalising once is the only way they agree.
+
+  Background:
+    Given I am signed in to LangWatch on a project
+    And I have opened the Langy panel
+
+  Rule: A provider's round-trip blob is stripped from a tool call id
+
+    @unit
+    Scenario: A tool id carrying a thought signature is reduced to the real id
+      When the agent reports a tool call whose id carries a provider signature
+      Then the tool call is recorded under the id the provider issued
+      And the signature is not stored anywhere on the tool call
+
+    @unit
+    Scenario: A start and an end frame for the same call still pair up
+      When the agent reports the start and the end of a tool call carrying a provider signature
+      Then both frames resolve to the same tool call id
+
+    @unit
+    Scenario: An ordinary tool id is left exactly as it is
+      When the agent reports a tool call with a plain id
+      Then the id is recorded unchanged
+
+    @unit
+    Scenario: A separator inside a normal id is not mistaken for a signature
+      When the agent reports a tool call whose id contains the separator but no signature
+      Then the id is recorded unchanged
+
+    @unit
+    Scenario: A tool call listed on the final answer is normalised the same way
+      When the agent's final answer lists a tool call whose id carries a provider signature
+      Then that tool call is recorded under the id the provider issued
+
+  Rule: An id that is still implausible after stripping is rejected, not stored
+
+    @unit
+    Scenario: An absurdly long id is refused as an invalid frame
+      When the agent reports a tool call whose id is longer than any real id
+      Then the frame is rejected as invalid
+      And nothing is recorded for it
+
+  Rule: The idempotency of a tool call follows its normalised id
+
+    @unit
+    Scenario: A tool call's durable key is built from the normalised id
+      Given a tool call whose id carried a provider signature
+      When its start is recorded as a durable milestone
+      Then the event's idempotency key contains the normalised id only


### PR DESCRIPTION
## What broke

A Langy conversation stopped dispatching turns permanently. Inside the process manager's commit transaction:

```
index row size 3080 exceeds btree version 4 maximum 2704 for index
"ProcessManagerInbox_processName_projectId_sourceEventId_key"
```

Three independent defects lined up. Each is fixed here.

### 1. The inbox indexed a caller-sized value

`ProcessManagerInbox` enforced uniqueness on `(processName, projectId, sourceEventId)`, where the source event id is `idempotencyKey ?? id` — composed by whichever pipeline emits the command. Its length was never the store's to guarantee.

Uniqueness now lives on a **fixed-width sha256 digest** (`sourceEventKey`); the raw id stays as an unindexed column for diagnostics. The constraint is the same width whatever any pipeline concatenates, so this cannot come back through a different domain.

### 2. A tool call id was carrying kilobytes of provider payload

Some providers require an opaque blob round-tripped on the next request. The agent runtime has nowhere to put it, so it staples it onto the tool call id as `<id>_ts_<base64>`. Production sent a **2,936-character id** — decoded, 2,193 bytes of protobuf — which is what pushed the composed key over the index limit.

The relay strips it at the wire boundary and bounds what remains. A side benefit: start and end frames carried *different* blobs for the same call, so pairing them by raw id was already broken.

### 3. The failure was deterministic, so it poisoned the queue

Same error every retry → ladder exhausted → the conversation's group blocked forever. Since `handleAgentTurnAccepted` emits the worker-dispatch intent, a blocked group means the user's next message is never dispatched.

## The staged job id (ADR-080)

Fixing (3) properly meant confronting an id that grew a segment per retry and stamped its terminal one from the wall clock:

```text
event_…/subscriber/pm:langyConversation/r/12/r/16/r/24/r/1785261278310
```

The id is now **immutable for the job's life**; the retry attempt rides on the message, in the envelope header, readable without fetching a blob-offloaded body.

Two consequences were designed for rather than discovered — both surfaced by an adversarial review of the spec *before* implementation:

- **The ladder could have looped forever.** The unreadable-body path cannot consult the payload (the payload is what it cannot read), which is *why* the count lived in the id. It now also **writes** the group's retry chain, so termination no longer depends on a message some formats cannot carry.
- **Rotating the id was load-bearing.** It stopped a late worker heartbeat from matching. With the id reused it matches again, and one late beat would extend the group's hold to the full active window (300s), stretching a sub-second backoff into a multi-minute stall.

## What the review round changed

Five independent reviewers plus CodeRabbit audited this. Three findings were material:

- **The migration would have caused the outage it fixes.** `prisma migrate deploy` runs at pod boot, so it lands while pods on the *previous* build still serve — and those insert inbox rows without `sourceEventKey`. A `NOT NULL` column would have failed every one of their commits with a 23502, deterministically: the same commit-fails → ladder-exhausts → group-parks chain this PR exists to end. The column stays **nullable** for the rollout; a follow-up tightens it once the fleet cycles. Uniqueness is unaffected meanwhile — btree treats NULLs as distinct, and new pods (the only ones that can write an oversized key) are fully constrained.
- **The heartbeat fix had a cold-cache hole.** `CachedLuaScript` retries a NOSCRIPT miss *after* an await, so on a cold script cache that hop is issued behind the re-stage and reinstates the stall. The refresh is now cancellable and the heartbeat withdraws it once stopped. Ordering covers the EVALSHA; cancellation covers the only later hop.
- **The legacy `/r/<n>` reader was unanchored**, so a producer's own event id containing `/r/25` could set another job's retry budget and discard it on its first transient error. Now anchored to the trailing ladder.

## Also fixed

- **Operator recovery leaked counters.** Unblock/drain/dead-letter cleared the poison guard's claim strikes but left the retry chain and failure streak, so a recovered group re-blocked on its first failure — and whether it did depended on how long the operator waited, since the chain expires on its own.
- **Ops Lua ran through `EVAL`**, re-transferring and re-hashing the full source every call (~33% of prod Redis engine CPU for the queue's own scripts). Now EVALSHA, with NOSCRIPT recovery on the pipelined bulk paths — without it a cold cache makes "unblock everything" silently do nothing.
- **KSUIDs** for row ids and the staged-id fallback, replacing nanoid/randomUUID.
- **Machinery fields are checked, not cast.** `??` doesn't catch a non-string, so a numeric or object id would have stringified into a malformed Redis key or Prometheus label.

## Verification

- Reproduced the **exact** production error against a replica of the old index (`index row size 3104 exceeds ... 2704`), then confirmed the migrated table accepts the same value and still rejects redeliveries.
- The oversized-id fixture is deliberately **incompressible** — Postgres pglz-compresses before indexing, so repetitive filler would have passed with or without the fix. A guard test asserts the pre-fix index shape still rejects it.
- Heartbeat tests were mutation-tested: simulating a late beat fails all three as the pre-change code would.
- **7,981 unit + 338 integration tests pass.** `typecheck:all` clean. `check:feature-parity` green (3,182 scenarios; the three new specs fully bound at 33/33, 6/6, 7/7).

## Specs & ADR

- `dev/docs/adr/080-staged-job-id-is-identity-not-state.md` (numbered 080: 076 and 077 are already claimed on other branches)
- `specs/event-sourcing/process-manager-inbox-key.feature`
- `specs/event-sourcing/staged-job-id-identity.feature`
- `specs/langy/langy-tool-call-identity.feature`

## Deployment Impact

**Env vars added/changed:** none.

**Helm values added/changed:** none. No chart, service manifest, or `.env.example` key is touched.

**Default behaviour on a vanilla `helm install` with no overrides:** unchanged. The only deployment-visible action is one Prisma migration, which runs at pod boot through the existing `start:prepare:db` step — no new step, job, or hook. A fresh install applies it against an empty `ProcessManagerInbox` and does no work.

**Rolling-deploy safety (the one thing to know here).** `prisma migrate deploy` runs while pods on the *previous* build are still serving, and those pods insert inbox rows without `sourceEventKey`. The column is therefore deliberately **nullable**: a `NOT NULL` would fail every one of their commits with a 23502, deterministically, which is the same commit-fails → ladder-exhausts → group-parks chain this PR exists to end. Uniqueness is unaffected during the window — btree treats NULLs as distinct, and the new pods, the only ones that can write an oversized key, are fully constrained. A follow-up migration adds `NOT NULL` once the fleet has cycled.

The migration backfills `sourceEventKey` with the same derivation the store uses, then swaps the constraint. The backfill rewrites every row and the index build is non-concurrent (Prisma wraps migrations in a transaction), so **check `SELECT count(*) FROM "ProcessManagerInbox"` before deploying**: if the table is large, run the backfill and a `CREATE UNIQUE INDEX CONCURRENTLY` as separate manual steps instead. The old index could not have held a row over the btree limit — that was the failure — so every surviving row's digest is as unique as the raw value it came from and the new index cannot conflict.

**BYOC dataplane impact:** none. The change is confined to the control plane's Postgres schema and its Redis-backed queue; no gateway, NLP, or dataplane image, config, or contract changes.

**Rollback:** `kubectl rollout undo` runs, but it is not free and the cost is worth knowing. The previous build does not write `sourceEventKey`, so its rows carry NULL, and a btree treats NULLs as distinct — the new unique index does not constrain them. Those writers still have the store's read-before-insert check under a per-`processKey` advisory lock, so same-key redelivery is still deduplicated; what loses its guard is the same source event reaching two *different* process keys concurrently, which the dropped index used to catch. That race can consume one event twice, bounded by however long old pods serve, so **drain before rolling back across this migration**. The same window exists during the roll forward, and the alternative was strictly worse: a `NOT NULL` column fails every old-pod commit outright, which is the outage this change exists to end. A follow-up migration adds `NOT NULL` and closes it.

**Queue behaviour on deploy.** Jobs already staged under grown ids keep working: a worker uses whatever id it was handed, and a legacy `/r/<n>` is read for a count only when neither the message nor the group chain can answer. Nothing writes that shape any more.

**Follow-ups deliberately not in this PR** (raised in review, each argued on the thread): batching the NOSCRIPT recovery into a second pipeline; splitting the 1,580-line identity suite once its harness is extracted; scoping the heartbeat test probe to the heartbeat's own interval period; `SET NOT NULL` on `sourceEventKey` once the fleet has cycled.
