### PR TITLE
fix(aigateway): preserve upstream provider error identity through the gateway envelope

### DIFF
--- a/docs/ai-gateway/api/errors.mdx
+++ b/docs/ai-gateway/api/errors.mdx
@@ -43,6 +43,7 @@ Errors (like successes) always carry:
 | `cache_override_invalid` | `400` | The `X-LangWatch-Cache` header was malformed or used an unknown mode. |
 | `cache_override_not_implemented` | `400` | The `X-LangWatch-Cache` header was well-formed but named a mode deferred to v1.1 (`force` or `ttl=NNN`). `respect` and `disable` are the v1 modes. |
 | `provider_error` | `502` | An upstream provider returned a non-recoverable error and fallback (if any) was exhausted. |
+| `circuit_open` | `503` | Repeated upstream 5xx/timeout/network failures opened the credential's circuit breaker, so the gateway declined to dial the provider for this request. Retryable; the breaker probes the upstream again after its cooldown. Answered 4xx (rate limits, quota, bad requests) never open the breaker. |
 | `upstream_timeout` | `504` | An upstream provider exceeded `timeout_ms` and fallback (if any) was exhausted. |
 | `bad_request` | `400` | Validation error on the incoming payload (e.g. missing `model`). |
 | `payload_too_large` | `413` | Request body exceeded `GATEWAY_MAX_REQUEST_BODY_BYTES` (default 10 MiB). Rejected at the edge, before auth, resolve-key, or any upstream dispatch, so a 1 GB drive-by scan never pressures the pod memory limit. Declared `Content-Length` above the cap returns 413 immediately without draining the socket; chunked unknown-length bodies trip a `*http.MaxBytesError` at the cap. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1878,6 +1878,7 @@ Errors (like successes) always carry:
 | `cache_override_invalid` | `400` | The `X-LangWatch-Cache` header was malformed or used an unknown mode. |
 | `cache_override_not_implemented` | `400` | The `X-LangWatch-Cache` header was well-formed but named a mode deferred to v1.1 (`force` or `ttl=NNN`). `respect` and `disable` are the v1 modes. |
 | `provider_error` | `502` | An upstream provider returned a non-recoverable error and fallback (if any) was exhausted. |
+| `circuit_open` | `503` | Repeated upstream 5xx/timeout/network failures opened the credential's circuit breaker, so the gateway declined to dial the provider for this request. Retryable; the breaker probes the upstream again after its cooldown. Answered 4xx (rate limits, quota, bad requests) never open the breaker. |
 | `upstream_timeout` | `504` | An upstream provider exceeded `timeout_ms` and fallback (if any) was exhausted. |
 | `bad_request` | `400` | Validation error on the incoming payload (e.g. missing `model`). |
 | `payload_too_large` | `413` | Request body exceeded `GATEWAY_MAX_REQUEST_BODY_BYTES` (default 10 MiB). Rejected at the edge, before auth, resolve-key, or any upstream dispatch, so a 1 GB drive-by scan never pressures the pod memory limit. Declared `Content-Length` above the cap returns 413 immediately without draining the socket; chunked unknown-length bodies trip a `*http.MaxBytesError` at the cap. |

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -27,6 +27,13 @@ const (
 	ReasonContextDone    Reason = "context_done"
 )
 
+// ErrNoAttempts marks a Walk that ended without a single attempt being made
+// (every slot short-circuited by the breaker). Callers must detect it with
+// errors.Is and translate it into their own typed "temporarily unavailable"
+// error: there is no underlying attempt error to surface, so letting it
+// escape as-is would degrade into a generic internal error at the transport.
+var ErrNoAttempts = errors.New("no attempts were made")
+
 // Attempt is the operation retried across chain slots. Return (result, nil)
 // on success, or (zero, err) on failure. The classify function determines
 // whether to retry.
@@ -95,6 +102,43 @@ var defaultTriggers = map[Reason]bool{
 	ReasonNetwork:      true,
 }
 
+// breakerFailureReasons are the outcomes that indicate the SLOT is unhealthy:
+// the upstream did not answer (timeout, network) or answered that it is
+// broken (5xx). Only these accumulate toward opening the circuit.
+//
+// 4xx-class outcomes (rate limit, not found, terminal client errors) are the
+// upstream answering normally: deterministic verdicts about THIS request or
+// THIS account, not about the slot's health. Counting them used to open the
+// circuit during a provider quota outage (every 429 counted as a slot
+// failure), after which every request short-circuited into a zero-attempt
+// walk and clients saw a generic internal error instead of the provider's
+// own 429. A burst of malformed client requests could poison a shared
+// credential the same way.
+var breakerFailureReasons = map[Reason]bool{
+	ReasonRetryable5xx: true,
+	ReasonTimeout:      true,
+	ReasonNetwork:      true,
+}
+
+// recordBreaker reports the attempt outcome to the breaker. Failure reasons
+// count toward opening the circuit; any answered-4xx outcome proves the slot
+// alive and resets it (which also releases a half-open probe). Aborted
+// attempts (caller canceled) say nothing about slot health and record
+// nothing, since crediting a success would erase legitimate failure counts.
+func recordBreaker(breaker BreakerChecker, slotID string, reason Reason) {
+	if breaker == nil || slotID == "" {
+		return
+	}
+	switch {
+	case breakerFailureReasons[reason]:
+		breaker.RecordFailure(slotID)
+	case reason == ReasonContextDone:
+		// Nothing to record.
+	default:
+		breaker.RecordSuccess(slotID)
+	}
+}
+
 // Options configures the retry engine.
 type Options struct {
 	Triggers          map[Reason]bool // reasons that trigger retry (default: 5xx, rate_limit, timeout, network)
@@ -112,6 +156,12 @@ func (o *Options) withDefaults() {
 // Walk executes the attempt across the chain. Returns the first successful
 // result, an EventLog (call Release when done), or an error if the chain is
 // exhausted.
+//
+// An exhausted chain surfaces the LAST attempt's error: it is the freshest
+// upstream verdict, and callers forward it to their own clients (an earlier
+// slot's stale failure would misreport what the final candidate said). A walk
+// where no attempt ran at all (every slot short-circuited by the breaker)
+// returns an error wrapping ErrNoAttempts for the caller to translate.
 func Walk[R any](ctx context.Context, opts Options, chain []string, try Attempt[R], classify Classifier) (R, *EventLog, error) {
 	var zero R
 	opts.withDefaults()
@@ -121,7 +171,7 @@ func Walk[R any](ctx context.Context, opts Options, chain []string, try Attempt[
 	}
 
 	el := eventsPool.Get().(*EventLog)
-	var firstErr error
+	var lastErr error
 	attempts := 0
 
 	for i, slotID := range chain {
@@ -165,9 +215,7 @@ func Walk[R any](ctx context.Context, opts Options, chain []string, try Attempt[
 			return result, el, nil
 		}
 
-		if firstErr == nil {
-			firstErr = err
-		}
+		lastErr = err
 
 		reason := ReasonNonRetryable
 		if classify != nil {
@@ -175,16 +223,14 @@ func Walk[R any](ctx context.Context, opts Options, chain []string, try Attempt[
 		}
 		el.events = append(el.events, Event{Slot: i, SlotID: slotID, Reason: reason, Duration: duration, Err: err})
 
-		if slotID != "" && opts.Breaker != nil {
-			opts.Breaker.RecordFailure(slotID)
-		}
+		recordBreaker(opts.Breaker, slotID, reason)
 		if !opts.Triggers[reason] {
 			return zero, el, err
 		}
 	}
 
-	if firstErr == nil {
-		firstErr = errors.New("retry chain exhausted with no attempts")
+	if lastErr == nil {
+		return zero, el, fmt.Errorf("retry chain exhausted: %w", ErrNoAttempts)
 	}
-	return zero, el, fmt.Errorf("retry chain exhausted: %w", firstErr)
+	return zero, el, fmt.Errorf("retry chain exhausted: %w", lastErr)
 }

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -220,3 +220,85 @@ func TestWalk_EmptyChain(t *testing.T) {
 	require.Len(t, events, 1)
 	assert.Equal(t, ReasonSuccess, events[0].Reason)
 }
+
+// An exhausted chain must surface the freshest verdict, the LAST slot's
+// error, because callers forward it to their own clients. Surfacing the
+// first would misreport what the final candidate answered.
+func TestWalk_ChainExhaustedSurfacesLastError(t *testing.T) {
+	errFirst := fmt.Errorf("first slot: %w", errRetryable)
+	errLast := fmt.Errorf("last slot: %w", errRetryable)
+	chain := []string{"a", "b"}
+	attempt := func(_ context.Context, slot string) (string, error) {
+		if slot == "a" {
+			return "", errFirst
+		}
+		return "", errLast
+	}
+
+	_, el, err := Walk(context.Background(), Options{}, chain, attempt, retryableClassifier)
+	defer el.Release()
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errLast)
+	assert.NotErrorIs(t, err, errFirst)
+}
+
+// A walk where the breaker blocks every slot has no attempt error to
+// surface. It must return the typed ErrNoAttempts sentinel so the caller can
+// translate it: the previous anonymous error fell through the transport's
+// typed branches and reached clients as a 500 internal_error.
+func TestWalk_AllSlotsCircuitOpenReturnsErrNoAttempts(t *testing.T) {
+	b := newMockBreaker()
+	b.blocked["a"] = true
+	b.blocked["b"] = true
+
+	chain := []string{"a", "b"}
+	attempt := func(_ context.Context, _ string) (string, error) {
+		t.Fatal("no attempt should run")
+		return "", nil
+	}
+
+	_, el, err := Walk(context.Background(), Options{Breaker: b}, chain, attempt, retryableClassifier)
+	defer el.Release()
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoAttempts)
+	for _, e := range el.Events() {
+		assert.Equal(t, ReasonCircuitOpen, e.Reason)
+	}
+}
+
+// Breaker health policy: only slot-health outcomes (5xx, timeout, network)
+// count as failures. An answered 4xx proves the slot alive and resets the
+// breaker. Counting 429s as failures used to open the circuit during
+// provider quota outages. Caller-abandoned attempts record nothing.
+func TestWalk_BreakerRecordsByReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason Reason
+		want   string // "success", "failure", or "" for no record
+	}{
+		{"5xx counts as failure", ReasonRetryable5xx, "failure"},
+		{"timeout counts as failure", ReasonTimeout, "failure"},
+		{"network counts as failure", ReasonNetwork, "failure"},
+		{"rate limit proves the slot alive", ReasonRateLimit, "success"},
+		{"not found proves the slot alive", ReasonNotFound, "success"},
+		{"terminal 4xx proves the slot alive", ReasonNonRetryable, "success"},
+		{"caller abandonment records nothing", ReasonContextDone, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newMockBreaker()
+			classifier := func(error) Reason { return tc.reason }
+			attempt := func(_ context.Context, _ string) (string, error) {
+				return "", errFatal
+			}
+
+			_, el, err := Walk(context.Background(), Options{Breaker: b}, []string{"a"}, attempt, classifier)
+			defer el.Release()
+
+			require.Error(t, err)
+			assert.Equal(t, tc.want, b.recorded["a"])
+		})
+	}
+}

--- a/services/aigateway/adapters/httpapi/provider_error_identity_test.go
+++ b/services/aigateway/adapters/httpapi/provider_error_identity_test.go
@@ -72,7 +72,7 @@ func openAIChatRequest(stream bool) *http.Request {
 	return req
 }
 
-// @scenario "Provider error taxonomy reaches the wire with status and identity intact"
+// @scenario "Provider error taxonomy keeps status and identity through the gateway"
 func TestOpenAILane_ProviderErrorTaxonomy(t *testing.T) {
 	cases := []struct {
 		name string
@@ -178,7 +178,7 @@ func TestOpenAILane_ProviderErrorTaxonomy(t *testing.T) {
 	}
 }
 
-// @scenario "Anthropic error identity survives the messages lane"
+// @scenario "Upstream error responses name the provider that produced them"
 //
 // The anthropic rows that differ structurally from OpenAI's: the 529
 // overloaded_error (a status outside the IANA registry that must still pass
@@ -244,7 +244,7 @@ func TestMessagesLane_AnthropicErrorTaxonomy(t *testing.T) {
 	}
 }
 
-// @scenario "A provider quota outage cannot open the breaker into internal_error"
+// @scenario "Provider 4xx answers do not open the circuit breaker"
 //
 // The incident's exact mechanics: CI bots hammered the lane while OpenAI
 // answered 429 insufficient_quota; the 429s counted as breaker failures,

--- a/services/aigateway/adapters/httpapi/provider_error_identity_test.go
+++ b/services/aigateway/adapters/httpapi/provider_error_identity_test.go
@@ -1,0 +1,318 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/breaker"
+	"github.com/langwatch/langwatch/services/aigateway/adapters/providers"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// Incident regression suite: while the upstream OpenAI account was out of
+// credits, requests through the gateway's openai lane reached clients as
+// HTTP 500 {"error":{"type":"internal_error"}} instead of OpenAI's own 429
+// insufficient_quota. These tests run the REAL dispatch stack (bifrost
+// against a local upstream) and pin the wire contract end to end: the
+// provider's status class and error identity survive, and the circuit
+// breaker can no longer manufacture an internal_error.
+//
+// Spec: specs/ai-gateway/error-transparency.feature
+
+// upstreamStub answers every request with a fixed provider error.
+func upstreamStub(status int, body string, headers map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func openAILaneRouter(t *testing.T, backendURL string, opts ...app.Option) http.Handler {
+	t.Helper()
+	bf, err := providers.NewBifrostRouter(context.Background(), providers.BifrostOptions{
+		Logger:           zap.NewNop(),
+		OpenAIBackendURL: backendURL,
+	})
+	require.NoError(t, err)
+	t.Cleanup(bf.Close)
+
+	auth := &mockAuth{resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+		return testBundle(), nil
+	}}
+	base := []app.Option{
+		app.WithAuth(auth),
+		app.WithProviders(bf),
+		app.WithLogger(zap.NewNop()),
+	}
+	return buildRouter(append(base, opts...)...)
+}
+
+func openAIChatRequest(stream bool) *http.Request {
+	body := `{"model":"openai/gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`
+	if stream {
+		body = `{"model":"openai/gpt-5-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	return req
+}
+
+// @scenario "Provider error taxonomy reaches the wire with status and identity intact"
+func TestOpenAILane_ProviderErrorTaxonomy(t *testing.T) {
+	cases := []struct {
+		name string
+		// upstream answer
+		status  int
+		body    string
+		headers map[string]string
+		// expected at the gateway's wire
+		wantStatus int
+		wantType   string
+		wantCode   string
+		// insufficient_quota bodies get the governance message rewrite;
+		// everything else must be byte-identical.
+		wantVerbatimBody bool
+	}{
+		{
+			name:       "429 insufficient_quota keeps identity, message is governed",
+			status:     429,
+			body:       `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}`,
+			headers:    map[string]string{"Retry-After": "17"},
+			wantStatus: 429,
+			wantType:   "insufficient_quota",
+			wantCode:   "insufficient_quota",
+		},
+		{
+			name:             "429 rate_limit_exceeded is forwarded verbatim",
+			status:           429,
+			body:             `{"error":{"message":"Rate limit reached for gpt-5-mini in organization org-x on tokens per min.","type":"requests","param":null,"code":"rate_limit_exceeded"}}`,
+			headers:          map[string]string{"Retry-After": "2"},
+			wantStatus:       429,
+			wantType:         "requests",
+			wantCode:         "rate_limit_exceeded",
+			wantVerbatimBody: true,
+		},
+		{
+			name:             "401 invalid_api_key is forwarded verbatim",
+			status:           401,
+			body:             `{"error":{"message":"Incorrect API key provided: sk-test.","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}`,
+			wantStatus:       401,
+			wantType:         "invalid_request_error",
+			wantCode:         "invalid_api_key",
+			wantVerbatimBody: true,
+		},
+		{
+			name:             "404 model_not_found is forwarded verbatim",
+			status:           404,
+			body:             `{"error":{"message":"The model 'nope' does not exist or you do not have access to it.","type":"invalid_request_error","param":"model","code":"model_not_found"}}`,
+			wantStatus:       404,
+			wantType:         "invalid_request_error",
+			wantCode:         "model_not_found",
+			wantVerbatimBody: true,
+		},
+		{
+			name:             "400 invalid_request_error is forwarded verbatim",
+			status:           400,
+			body:             `{"error":{"message":"Invalid value for 'messages': empty array.","type":"invalid_request_error","param":"messages","code":null}}`,
+			wantStatus:       400,
+			wantType:         "invalid_request_error",
+			wantVerbatimBody: true,
+		},
+		{
+			name:             "500 server_error stays a provider 5xx",
+			status:           500,
+			body:             `{"error":{"message":"The server had an error while processing your request.","type":"server_error","param":null,"code":null}}`,
+			wantStatus:       500,
+			wantType:         "server_error",
+			wantVerbatimBody: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := upstreamStub(tc.status, tc.body, tc.headers)
+			defer backend.Close()
+			router := openAILaneRouter(t, backend.URL)
+
+			for _, stream := range []bool{false, true} {
+				name := map[bool]string{false: "non-stream", true: "stream"}[stream]
+				t.Run(name, func(t *testing.T) {
+					rec := httptest.NewRecorder()
+					router.ServeHTTP(rec, openAIChatRequest(stream))
+
+					require.Equal(t, tc.wantStatus, rec.Code,
+						"the provider's status class must reach the client untouched")
+					got := rec.Body.String()
+					assert.Equal(t, tc.wantType, gjson.Get(got, "error.type").String())
+					if tc.wantCode != "" {
+						assert.Equal(t, tc.wantCode, gjson.Get(got, "error.code").String())
+					}
+					assert.NotContains(t, got, "internal_error",
+						"a provider verdict must never surface as the gateway's internal_error")
+					if tc.wantVerbatimBody {
+						assert.JSONEq(t, tc.body, got, "the provider's native body must be forwarded byte-for-byte")
+					}
+					for k, v := range tc.headers {
+						assert.Equal(t, v, rec.Header().Get(k), "retry-signaling header %s must be forwarded", k)
+					}
+					assert.Equal(t, "openai", rec.Header().Get("X-LangWatch-Provider"),
+						"the error must say which upstream produced it")
+				})
+			}
+		})
+	}
+}
+
+// @scenario "Anthropic error identity survives the messages lane"
+//
+// The anthropic rows that differ structurally from OpenAI's: the 529
+// overloaded_error (a status outside the IANA registry that must still pass
+// through untouched) and the 429 rate_limit_error. Routed through the REAL
+// bifrost anthropic-compat lane (credential base_url pinned to the stub).
+func TestMessagesLane_AnthropicErrorTaxonomy(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantStatus int
+		wantType   string
+	}{
+		{
+			name:       "529 overloaded_error passes through",
+			status:     529,
+			body:       `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantStatus: 529,
+			wantType:   "overloaded_error",
+		},
+		{
+			name:       "429 rate_limit_error passes through",
+			status:     429,
+			body:       `{"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit"}}`,
+			wantStatus: 429,
+			wantType:   "rate_limit_error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := upstreamStub(tc.status, tc.body, nil)
+			defer backend.Close()
+
+			bf, err := providers.NewBifrostRouter(context.Background(), providers.BifrostOptions{Logger: zap.NewNop()})
+			require.NoError(t, err)
+			t.Cleanup(bf.Close)
+
+			bundle := testBundle()
+			bundle.Credentials = []domain.Credential{{
+				ID:         "cred-anthropic",
+				ProviderID: domain.ProviderAnthropic,
+				APIKey:     "sk-ant-test",
+				Extra:      map[string]string{"base_url": backend.URL},
+			}}
+			auth := &mockAuth{resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+				return bundle, nil
+			}}
+			router := buildRouter(
+				app.WithAuth(auth),
+				app.WithProviders(bf),
+				app.WithLogger(zap.NewNop()),
+			)
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, messagesRequest(false))
+
+			require.Equal(t, tc.wantStatus, rec.Code,
+				"anthropic's status must pass through untouched, got body %s", rec.Body.String())
+			assert.Equal(t, tc.wantType, gjson.Get(rec.Body.String(), "error.type").String())
+			assert.Equal(t, "anthropic", rec.Header().Get("X-LangWatch-Provider"))
+		})
+	}
+}
+
+// @scenario "A provider quota outage cannot open the breaker into internal_error"
+//
+// The incident's exact mechanics: CI bots hammered the lane while OpenAI
+// answered 429 insufficient_quota; the 429s counted as breaker failures,
+// the breaker opened, and the zero-attempt walk surfaced 500 internal_error.
+// Answered 4xx must not move the breaker, so every request keeps relaying
+// the provider's own 429 no matter how many came before it.
+func TestOpenAILane_QuotaOutageNeverBecomesInternalError(t *testing.T) {
+	backend := upstreamStub(429,
+		`{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}`,
+		nil)
+	defer backend.Close()
+
+	// Real breaker at the production wiring point, with a threshold low
+	// enough that the old failure accounting would trip it immediately.
+	circuits := breaker.NewRegistry(breaker.Options{
+		Threshold:    2,
+		Window:       time.Minute,
+		OpenDuration: time.Hour,
+	})
+	router := openAILaneRouter(t, backend.URL, app.WithCircuitBreaker(circuits))
+
+	for i := 0; i < 8; i++ {
+		stream := i%2 == 1
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, openAIChatRequest(stream))
+
+		require.Equal(t, http.StatusTooManyRequests, rec.Code,
+			"request %d (stream=%v): the provider's 429 must keep relaying, got body %s", i, stream, rec.Body.String())
+		assert.Equal(t, "insufficient_quota", gjson.Get(rec.Body.String(), "error.code").String())
+	}
+}
+
+// @scenario "An open circuit breaker surfaces circuit_open, not internal_error"
+//
+// When the breaker HAS legitimately opened (a real provider outage: 5xx
+// storm), the zero-attempt walk must answer with a typed, retryable
+// circuit_open. The incident showed it answering 500 internal_error, which
+// reads as a gateway bug and tells the client nothing actionable.
+func TestOpenAILane_OpenBreakerSurfacesCircuitOpen(t *testing.T) {
+	backend := upstreamStub(503,
+		`{"error":{"message":"The engine is currently overloaded, please try again later","type":"server_error","param":null,"code":null}}`,
+		nil)
+	defer backend.Close()
+
+	circuits := breaker.NewRegistry(breaker.Options{
+		Threshold:    2,
+		Window:       time.Minute,
+		OpenDuration: time.Hour,
+	})
+	router := openAILaneRouter(t, backend.URL, app.WithCircuitBreaker(circuits))
+
+	// Two 503 answers open the breaker (5xx IS a slot-health failure).
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, openAIChatRequest(false))
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Equal(t, "server_error", gjson.Get(rec.Body.String(), "error.type").String(),
+			"while the breaker is closed the provider's own 5xx body is forwarded")
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, openAIChatRequest(false))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"an open breaker is a retryable provider-side condition, not an internal error")
+	got := rec.Body.String()
+	assert.Equal(t, "circuit_open", gjson.Get(got, "error.code").String(),
+		"the envelope must name the real condition; the incident surfaced internal_error here, got %s", got)
+	assert.Equal(t, "provider", gjson.Get(got, "error.fault").String())
+	assert.NotContains(t, got, "internal_error")
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -951,12 +951,23 @@ func streamErrorFrame(err error) []byte {
 		return ue.Body
 	}
 	msg := err.Error()
-	if ue != nil && ue.Message != "" {
-		msg = ue.Message
+	errType := "provider_error"
+	if ue != nil {
+		if ue.Message != "" {
+			msg = ue.Message
+		}
+		// Keep the provider's own error discriminant when the adapter parsed
+		// one, so SDK clients that dispatch on error.type still recognize
+		// e.g. insufficient_quota without the native event body.
+		if ue.ErrorType != "" {
+			errType = ue.ErrorType
+		} else if ue.ErrorCode != "" {
+			errType = ue.ErrorCode
+		}
 	}
 	frame, marshalErr := sonic.Marshal(sseErrorPayload{
 		Type:  "error",
-		Error: sseErrorDetail{Type: "provider_error", Message: msg},
+		Error: sseErrorDetail{Type: errType, Message: msg},
 	})
 	if marshalErr != nil {
 		return []byte(`{"type":"error","error":{"type":"provider_error","message":"stream failed"}}`)
@@ -1055,8 +1066,12 @@ func writeError(logger *zap.Logger, w http.ResponseWriter, ctx context.Context, 
 // The provider's native error body is written byte-for-byte when present, so
 // the client sees the exact upstream envelope under the upstream's real
 // status code (not a masked 502) and can tell terminal from retryable. When
-// only the status + message are available, a minimal JSON envelope carrying
-// both is emitted instead.
+// the native body is unavailable, the minimal envelope still preserves the
+// error's identity: the provider's own error type/code (insufficient_quota,
+// overloaded_error, ...) when the adapter parsed them, and a generic
+// provider_error only when nothing better is known. The originating provider
+// rides a response header either way, since the verbatim body cannot be
+// tampered with to carry it.
 func writeUpstreamError(w http.ResponseWriter, ue *domain.UpstreamError) {
 	status := ue.StatusCode
 	if status <= 0 {
@@ -1068,17 +1083,36 @@ func writeUpstreamError(w http.ResponseWriter, ue *domain.UpstreamError) {
 	for k, v := range ue.Headers {
 		w.Header().Set(k, v)
 	}
+	if ue.Provider != "" {
+		w.Header().Set("X-LangWatch-Provider", ue.Provider)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if len(ue.Body) > 0 {
 		_, _ = w.Write(ue.Body)
 		return
 	}
+	errType := ue.ErrorType
+	if errType == "" {
+		errType = ue.ErrorCode
+	}
+	if errType == "" {
+		errType = "provider_error"
+	}
+	errCode := ue.ErrorCode
+	if errCode == "" {
+		errCode = errType
+	}
+	meta := map[string]any{"status": status}
+	if ue.Provider != "" {
+		meta["provider"] = ue.Provider
+	}
 	body, _ := sonic.Marshal(map[string]any{
 		"error": map[string]any{
-			"type":    "provider_error",
+			"type":    errType,
+			"code":    errCode,
 			"message": ue.Message,
-			"meta":    map[string]any{"status": status},
+			"meta":    meta,
 		},
 	})
 	_, _ = w.Write(body)
@@ -1103,6 +1137,11 @@ func registerErrorStatuses() {
 	herr.RegisterStatus(domain.ErrBadRequest, http.StatusBadRequest)
 	herr.RegisterStatus(domain.ErrPayloadTooLarge, http.StatusRequestEntityTooLarge)
 	herr.RegisterStatus(domain.ErrChainExhausted, http.StatusBadGateway)
+	// 503, not 500: an open breaker is the gateway declining to hit an
+	// upstream that has been failing, a retryable provider-side condition.
+	// Unregistered it would default to 500 internal_error, which reads as a
+	// gateway bug and hides that the provider is the thing to look at.
+	herr.RegisterStatus(domain.ErrCircuitOpen, http.StatusServiceUnavailable)
 	herr.RegisterStatus(domain.ErrNotFound, http.StatusNotFound)
 	herr.RegisterStatus(domain.ErrInternal, http.StatusInternalServerError)
 	herr.RegisterStatus(domain.ErrNoProviderConfigured, http.StatusBadRequest)

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -1079,14 +1079,19 @@ func writeUpstreamError(w http.ResponseWriter, ue *domain.UpstreamError) {
 	}
 	// Forward the upstream's retry-signaling headers (Retry-After,
 	// x-should-retry) so the client can honor the provider's backoff and
-	// terminal-vs-retryable hint, not just the status code.
+	// terminal-vs-retryable hint, not just the status code. Passthrough
+	// lanes forward the upstream's headers wholesale, including its exact
+	// Content-Type (e.g. Google's "application/json; charset=UTF-8"), so
+	// only default the Content-Type when the upstream did not provide one.
 	for k, v := range ue.Headers {
 		w.Header().Set(k, v)
 	}
 	if ue.Provider != "" {
 		w.Header().Set("X-LangWatch-Provider", ue.Provider)
 	}
-	w.Header().Set("Content-Type", "application/json")
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
 	w.WriteHeader(status)
 	if len(ue.Body) > 0 {
 		_, _ = w.Write(ue.Body)

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -1281,10 +1281,13 @@ func errFromBifrost(ctx context.Context, berr *bfschemas.BifrostError, respHeade
 		return classifyBifrostError(ctx, berr)
 	}
 	body, _ := extractRawResponseBytes(berr.ExtraFields.RawResponse)
+	errType, errCode := bfErrorTypeCode(berr)
 	return &domain.UpstreamError{
 		StatusCode: status,
 		Body:       body,
 		Message:    bfErrorMsg(berr),
+		ErrorType:  errType,
+		ErrorCode:  errCode,
 		Headers:    forwardableUpstreamHeaders(respHeaders),
 	}
 }
@@ -1358,6 +1361,23 @@ func bfErrorMsg(e *bfschemas.BifrostError) string {
 	return fmt.Sprintf("bifrost error (status %v)", e.StatusCode)
 }
 
+// bfErrorTypeCode lifts the provider's own error discriminants (error.type /
+// error.code as parsed by Bifrost's provider adapter) off a BifrostError.
+// These carry the error's identity (insufficient_quota, overloaded_error,
+// ThrottlingException, ...) on lanes where the native body is not captured.
+func bfErrorTypeCode(e *bfschemas.BifrostError) (errType, errCode string) {
+	if e == nil || e.Error == nil {
+		return "", ""
+	}
+	if e.Error.Type != nil {
+		errType = *e.Error.Type
+	}
+	if e.Error.Code != nil {
+		errCode = *e.Error.Code
+	}
+	return errType, errCode
+}
+
 // upstreamStreamError converts a mid-stream BifrostError chunk into a
 // structured domain.UpstreamError the SSE writer can forward faithfully.
 //
@@ -1375,6 +1395,7 @@ func upstreamStreamError(e *bfschemas.BifrostError) *domain.UpstreamError {
 		ue.Message = "provider stream error"
 		return ue
 	}
+	ue.ErrorType, ue.ErrorCode = bfErrorTypeCode(e)
 	if code := e.StatusCode; code != nil {
 		ue.StatusCode = *code
 	}

--- a/services/aigateway/adapters/providers/provider_error_taxonomy_test.go
+++ b/services/aigateway/adapters/providers/provider_error_taxonomy_test.go
@@ -1,0 +1,213 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// errFromBifrost is the single translation point from Bifrost's provider
+// error type into the gateway's error taxonomy. This table pins, per
+// provider, that the documented error responses keep their identity: the
+// upstream HTTP status verbatim, and the provider's own error type/code
+// (which the minimal envelope surfaces when the native body was not
+// captured, i.e. on translated non-raw-forward lanes).
+//
+// Rows construct the BifrostError exactly as each provider adapter's parser
+// does from the documented wire shapes.
+//
+// Spec: specs/ai-gateway/error-transparency.feature
+func TestErrFromBifrost_ProviderTaxonomy(t *testing.T) {
+	str := func(s string) *string { return &s }
+	num := func(n int) *int { return &n }
+
+	cases := []struct {
+		name       string
+		berr       *bfschemas.BifrostError
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			// {"error":{"message":"You exceeded your current quota...","type":"insufficient_quota","code":"insufficient_quota"}}
+			name: "openai 429 insufficient_quota",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(429),
+				Error: &bfschemas.ErrorField{
+					Type:    str("insufficient_quota"),
+					Code:    str("insufficient_quota"),
+					Message: "You exceeded your current quota, please check your plan and billing details.",
+				},
+			},
+			wantStatus: 429,
+			wantType:   "insufficient_quota",
+			wantCode:   "insufficient_quota",
+		},
+		{
+			// {"error":{"message":"Rate limit reached...","type":"requests","code":"rate_limit_exceeded"}}
+			name: "openai 429 rate_limit_exceeded",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(429),
+				Error: &bfschemas.ErrorField{
+					Type:    str("requests"),
+					Code:    str("rate_limit_exceeded"),
+					Message: "Rate limit reached for gpt-5-mini",
+				},
+			},
+			wantStatus: 429,
+			wantType:   "requests",
+			wantCode:   "rate_limit_exceeded",
+		},
+		{
+			// {"error":{"message":"Incorrect API key provided...","type":"invalid_request_error","code":"invalid_api_key"}}
+			name: "openai 401 invalid_api_key",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(401),
+				Error: &bfschemas.ErrorField{
+					Type:    str("invalid_request_error"),
+					Code:    str("invalid_api_key"),
+					Message: "Incorrect API key provided",
+				},
+			},
+			wantStatus: 401,
+			wantType:   "invalid_request_error",
+			wantCode:   "invalid_api_key",
+		},
+		{
+			// {"error":{"message":"The model `nope` does not exist...","type":"invalid_request_error","code":"model_not_found"}}
+			name: "openai 404 model_not_found",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(404),
+				Error: &bfschemas.ErrorField{
+					Type:    str("invalid_request_error"),
+					Code:    str("model_not_found"),
+					Message: "The model `nope` does not exist or you do not have access to it.",
+				},
+			},
+			wantStatus: 404,
+			wantType:   "invalid_request_error",
+			wantCode:   "model_not_found",
+		},
+		{
+			// {"type":"error","error":{"type":"rate_limit_error","message":"..."}}
+			name: "anthropic 429 rate_limit_error",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(429),
+				Error: &bfschemas.ErrorField{
+					Type:    str("rate_limit_error"),
+					Message: "Number of request tokens has exceeded your per-minute rate limit",
+				},
+			},
+			wantStatus: 429,
+			wantType:   "rate_limit_error",
+		},
+		{
+			// {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+			name: "anthropic 529 overloaded_error",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(529),
+				Error: &bfschemas.ErrorField{
+					Type:    str("overloaded_error"),
+					Message: "Overloaded",
+				},
+			},
+			wantStatus: 529,
+			wantType:   "overloaded_error",
+		},
+		{
+			// {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}
+			name: "anthropic 401 authentication_error",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(401),
+				Error: &bfschemas.ErrorField{
+					Type:    str("authentication_error"),
+					Message: "invalid x-api-key",
+				},
+			},
+			wantStatus: 401,
+			wantType:   "authentication_error",
+		},
+		{
+			// AWS JSON: {"message":"Too many requests..."} + x-amzn-ErrorType: ThrottlingException
+			name: "bedrock 429 ThrottlingException",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(429),
+				Error: &bfschemas.ErrorField{
+					Type:    str("ThrottlingException"),
+					Message: "Too many requests, please wait before trying again.",
+				},
+			},
+			wantStatus: 429,
+			wantType:   "ThrottlingException",
+		},
+		{
+			name: "bedrock 400 ValidationException",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(400),
+				Error: &bfschemas.ErrorField{
+					Type:    str("ValidationException"),
+					Message: "The provided model identifier is invalid.",
+				},
+			},
+			wantStatus: 400,
+			wantType:   "ValidationException",
+		},
+		{
+			name: "bedrock 403 AccessDeniedException",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(403),
+				Error: &bfschemas.ErrorField{
+					Type:    str("AccessDeniedException"),
+					Message: "You don't have access to the model with the specified model ID.",
+				},
+			},
+			wantStatus: 403,
+			wantType:   "AccessDeniedException",
+		},
+		{
+			// A genuine provider outage keeps its 5xx class.
+			name: "openai 500 server_error",
+			berr: &bfschemas.BifrostError{
+				StatusCode: num(500),
+				Error: &bfschemas.ErrorField{
+					Type:    str("server_error"),
+					Message: "The server had an error while processing your request.",
+				},
+			},
+			wantStatus: 500,
+			wantType:   "server_error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errFromBifrost(context.Background(), tc.berr, map[string]string{"Retry-After": "13"})
+
+			var ue *domain.UpstreamError
+			require.ErrorAs(t, err, &ue, "a provider HTTP verdict must translate to UpstreamError, got %T", err)
+			assert.Equal(t, tc.wantStatus, ue.StatusCode, "the provider's status class must be preserved")
+			assert.Equal(t, tc.wantType, ue.ErrorType)
+			assert.Equal(t, tc.wantCode, ue.ErrorCode)
+			assert.Equal(t, tc.berr.Error.Message, ue.Message)
+			assert.Equal(t, "13", ue.Headers["Retry-After"], "retry-signaling headers must ride along")
+		})
+	}
+}
+
+// A transport-level failure (no HTTP response at all) is the one case that
+// legitimately maps to the gateway's own taxonomy rather than an upstream
+// forward. Status zero must not fabricate an upstream status.
+func TestErrFromBifrost_NoStatusFallsBackToClassification(t *testing.T) {
+	err := errFromBifrost(context.Background(), &bfschemas.BifrostError{
+		Error: &bfschemas.ErrorField{Message: "dial tcp: connection refused"},
+	}, nil)
+
+	var ue *domain.UpstreamError
+	assert.NotErrorAs(t, err, &ue, "no upstream response means no UpstreamError to forward")
+	require.Error(t, err)
+}

--- a/services/aigateway/app/dispatch.go
+++ b/services/aigateway/app/dispatch.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/pkg/retry"
 	"github.com/langwatch/langwatch/services/aigateway/app/pipeline"
@@ -21,14 +23,29 @@ func (a *App) coreDispatch(ctx context.Context, call *pipeline.Call) (*domain.Re
 	}
 	resp, el, err := retry.Walk(ctx, a.retryOpts(call.Bundle), credentialIDs(creds),
 		func(ctx context.Context, slotID string) (*domain.Response, error) {
-			return a.providers.Dispatch(ctx, call.Request, findCredential(creds, slotID))
+			cred := findCredential(creds, slotID)
+			resp, err := a.providers.Dispatch(ctx, call.Request, cred)
+			// Raw-forward lanes hand a provider error back as a success-shaped
+			// Response carrying the upstream's status + native body. Reshape it
+			// into an UpstreamError INSIDE the walk so provider failures behave
+			// the same on every lane: a 429/5xx falls back to the next
+			// credential and drives the circuit breaker's health view, instead
+			// of counting as a success that ends the chain on the first dead
+			// key. The terminal forwarding guarantee is unchanged: the
+			// UpstreamError carries the same verbatim body, status, and
+			// retry-signaling headers to the HTTP writer.
+			if err == nil && resp != nil && resp.StatusCode >= 400 {
+				err = upstreamErrorFromResponse(resp)
+				resp = nil
+			}
+			return resp, stampUpstreamProvider(err, cred)
 		}, classifyProviderError)
 	call.Meta.Update(func(m *pipeline.Meta) { m.FallbackCount = countFallbacks(el) })
 	a.recordDispatch(ctx, call, creds, el)
 	el.Release()
 	resp, err = applyGovernanceMessage(resp, err)
 	if err != nil {
-		return nil, err
+		return nil, translateWalkError(ctx, err)
 	}
 	a.metrics.RecordCacheOutcome(resp.Usage)
 	return resp, nil
@@ -44,15 +61,58 @@ func (a *App) coreDispatchStream(ctx context.Context, call *pipeline.Call) (doma
 	}
 	iter, el, err := retry.Walk(ctx, a.retryOpts(call.Bundle), credentialIDs(creds),
 		func(ctx context.Context, slotID string) (domain.StreamIterator, error) {
-			return a.providers.DispatchStream(ctx, call.Request, findCredential(creds, slotID))
+			cred := findCredential(creds, slotID)
+			iter, err := a.providers.DispatchStream(ctx, call.Request, cred)
+			return iter, stampUpstreamProvider(err, cred)
 		}, classifyProviderError)
 	call.Meta.Update(func(m *pipeline.Meta) { m.FallbackCount = countFallbacks(el) })
 	provider, model := a.recordDispatch(ctx, call, creds, el)
 	el.Release()
 	if _, err = applyGovernanceMessage(nil, err); err != nil {
-		return nil, err
+		return nil, translateWalkError(ctx, err)
 	}
 	return a.metrics.WrapStream(iter, provider, model), nil
+}
+
+// upstreamErrorFromResponse reshapes a raw-forwarded provider error response
+// into the error form of the same information, so the retry walk can classify
+// it. Status, native body, and retry-signaling headers ride along verbatim.
+func upstreamErrorFromResponse(resp *domain.Response) error {
+	return &domain.UpstreamError{
+		StatusCode: resp.StatusCode,
+		Body:       resp.Body,
+		Message:    gjson.GetBytes(resp.Body, "error.message").String(),
+		ErrorType:  gjson.GetBytes(resp.Body, "error.type").String(),
+		ErrorCode:  gjson.GetBytes(resp.Body, "error.code").String(),
+		Headers:    resp.Headers,
+	}
+}
+
+// stampUpstreamProvider names the credential's provider on an upstream error
+// so the surviving error of a multi-provider chain says which account it
+// came from. A no-op for gateway-taxonomy errors and already-stamped ones.
+func stampUpstreamProvider(err error, cred domain.Credential) error {
+	var ue *domain.UpstreamError
+	if errors.As(err, &ue) && ue.Provider == "" {
+		ue.Provider = string(cred.ProviderID)
+	}
+	return err
+}
+
+// translateWalkError maps walk outcomes that carry no upstream error onto the
+// gateway's own taxonomy. A zero-attempt walk (every credential slot skipped
+// by an open circuit breaker) has no provider verdict to forward; letting the
+// bare sentinel escape used to fall through the transport's typed-error
+// branches and surface as a 500 internal_error, right when a provider
+// outage makes an actionable, retryable answer matter most.
+func translateWalkError(ctx context.Context, err error) error {
+	if !errors.Is(err, retry.ErrNoAttempts) {
+		return err
+	}
+	return herr.New(ctx, domain.ErrCircuitOpen, herr.M{
+		"message": "provider temporarily unavailable: repeated upstream failures opened the circuit breaker, retry shortly",
+		"fault":   "provider",
+	})
 }
 
 // recordDispatch turns the retry engine's event log into provider metrics
@@ -175,6 +235,13 @@ func classifyProviderError(err error) retry.Reason {
 		return retry.ReasonRateLimit
 	case herr.IsCode(err, domain.ErrProviderError):
 		return retry.ReasonRetryable5xx
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		// A bare context error is the CALLER abandoning the request (client
+		// disconnect, whole-request deadline), not a provider verdict. Real
+		// upstream timeouts arrive as ErrProviderTimeout above. It says
+		// nothing about the credential's health, so it must neither trigger
+		// fallback nor feed the circuit breaker in either direction.
+		return retry.ReasonContextDone
 	default:
 		return retry.ReasonNonRetryable
 	}

--- a/services/aigateway/app/governance.go
+++ b/services/aigateway/app/governance.go
@@ -36,11 +36,23 @@ func applyGovernanceMessage(resp *domain.Response, err error) (*domain.Response,
 		return resp, err
 	}
 	var ue *domain.UpstreamError
-	if errors.As(err, &ue) && isAccountExhaustion(ue.StatusCode, ue.Body) {
+	if errors.As(err, &ue) && isAccountExhaustionError(ue) {
 		ue.Message = accountExhaustionMessage
 		ue.Body = rewriteErrorMessage(ue.Body, accountExhaustionMessage)
 	}
 	return resp, err
+}
+
+// isAccountExhaustionError is the UpstreamError-shaped twin of
+// isAccountExhaustion. Translated lanes carry the provider's error
+// discriminants on the error itself rather than in a captured body, so the
+// parsed type/code must count too or a quota error's original billing
+// message would reach governed users on those lanes.
+func isAccountExhaustionError(ue *domain.UpstreamError) bool {
+	if ue.ErrorType == "insufficient_quota" || ue.ErrorCode == "insufficient_quota" {
+		return true
+	}
+	return isAccountExhaustion(ue.StatusCode, ue.Body)
 }
 
 // isAccountExhaustion reports whether a provider error is a terminal

--- a/services/aigateway/app/governance_test.go
+++ b/services/aigateway/app/governance_test.go
@@ -88,6 +88,30 @@ func TestApplyGovernanceMessage_RewritesAccountError(t *testing.T) {
 	}
 }
 
+// Translated lanes carry the provider's discriminants on the error itself
+// (no captured body); the parsed type/code must trigger the same rewrite or
+// the provider's billing message reaches governed users on those lanes.
+func TestApplyGovernanceMessage_RewritesOnParsedQuotaCode(t *testing.T) {
+	ue := &domain.UpstreamError{
+		StatusCode: 429,
+		Message:    "You exceeded your current quota, please check your plan and billing details.",
+		ErrorType:  "insufficient_quota",
+		ErrorCode:  "insufficient_quota",
+	}
+	_, gotErr := applyGovernanceMessage(nil, ue)
+	var got *domain.UpstreamError
+	errors.As(gotErr, &got)
+	if got.Message != accountExhaustionMessage {
+		t.Fatalf("bodyless quota error must be re-messaged, got %q", got.Message)
+	}
+	if got.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status must be preserved: %d", got.StatusCode)
+	}
+	if got.ErrorType != "insufficient_quota" || got.ErrorCode != "insufficient_quota" {
+		t.Fatalf("error identity must be preserved: type=%q code=%q", got.ErrorType, got.ErrorCode)
+	}
+}
+
 // A retryable rate-limit must NOT be re-messaged — it stays verbatim and
 // retryable (the bug-33 complement: only terminal account exhaustion is
 // re-messaged).

--- a/services/aigateway/app/provider_error_identity_test.go
+++ b/services/aigateway/app/provider_error_identity_test.go
@@ -1,0 +1,277 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/breaker"
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/pkg/retry"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// The incident these tests pin: while the upstream OpenAI account was out of
+// credits, CI example bots calling the gateway's openai lane saw HTTP 500
+// {"error":{"type":"internal_error"}} instead of the provider's 429
+// insufficient_quota. Two defects compounded:
+//
+//  1. Raw-forward lanes return provider errors as success-shaped Responses,
+//     so every streamed 429 counted as a breaker FAILURE while every
+//     non-streamed one counted as a SUCCESS, and none of them fell back to
+//     the next credential.
+//  2. Once the flapping breaker opened, the retry walk ended with zero
+//     attempts and returned a bare error that no transport branch
+//     recognized, degrading into 500 internal_error.
+//
+// Spec: specs/ai-gateway/error-transparency.feature
+
+const quota429Body = `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}`
+
+func quota429Response() *domain.Response {
+	return &domain.Response{
+		StatusCode: 429,
+		Body:       []byte(quota429Body),
+		Headers:    map[string]string{"Retry-After": "7"},
+	}
+}
+
+// @scenario "Provider quota and server failures fall back to the next credential"
+func TestHandleChat_RawForward429Response_FallsBack(t *testing.T) {
+	for name, failing := range map[string]*domain.Response{
+		"429 insufficient_quota": quota429Response(),
+		"503 provider outage":    {StatusCode: 503, Body: []byte(`{"error":{"message":"upstream down","type":"server_error"}}`)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			callCount := 0
+			provider := &mockProvider{
+				dispatchFn: func(_ context.Context, _ *domain.Request, cred domain.Credential) (*domain.Response, error) {
+					callCount++
+					if cred.ID == "cred-1" {
+						return failing, nil
+					}
+					return successResponse(), nil
+				},
+			}
+			bundle := testBundle(
+				domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+				domain.Credential{ID: "cred-2", ProviderID: domain.ProviderOpenAI, APIKey: "sk-2"},
+			)
+			bundle.Config.Fallback.MaxAttempts = 2
+
+			application := New(WithProviders(provider), WithLogger(zap.NewNop()))
+
+			result, err := application.HandleChat(context.Background(), bundle, bytes.NewReader(testBody()), "gpt-4")
+			require.NoError(t, err, "a provider quota/outage answer must fail over, that is the point of the credential chain")
+			assert.Equal(t, 2, callCount)
+			assert.Equal(t, 1, result.Meta.FallbackCount)
+			assert.Equal(t, 200, result.Response.StatusCode)
+		})
+	}
+}
+
+// @scenario "A terminal provider 4xx answer does not fall back and is forwarded verbatim"
+func TestHandleChat_RawForwardTerminal400Response_NoFallback(t *testing.T) {
+	terminalBody := `{"error":{"message":"messages: at least one message is required","type":"invalid_request_error"}}`
+	callCount := 0
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			callCount++
+			return &domain.Response{StatusCode: 400, Body: []byte(terminalBody)}, nil
+		},
+	}
+	bundle := testBundle(
+		domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+		domain.Credential{ID: "cred-2", ProviderID: domain.ProviderOpenAI, APIKey: "sk-2"},
+	)
+	bundle.Config.Fallback.MaxAttempts = 2
+
+	application := New(WithProviders(provider), WithLogger(zap.NewNop()))
+
+	_, err := application.HandleChat(context.Background(), bundle, bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	assert.Equal(t, 1, callCount, "retrying an invalid request on the next key is pointless and must not happen")
+	var ue *domain.UpstreamError
+	require.ErrorAs(t, err, &ue)
+	assert.Equal(t, 400, ue.StatusCode)
+	assert.JSONEq(t, terminalBody, string(ue.Body), "the provider's native body must survive the reshaping verbatim")
+	assert.Equal(t, "invalid_request_error", ue.ErrorType)
+	assert.Equal(t, string(domain.ProviderOpenAI), ue.Provider)
+}
+
+// @scenario "An exhausted chain surfaces the last provider's error, not internal_error"
+func TestHandleChat_ChainExhausted_SurfacesLastProviderError(t *testing.T) {
+	lastBody := `{"error":{"message":"Rate limit reached for gpt-4","type":"requests","code":"rate_limit_exceeded"}}`
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, cred domain.Credential) (*domain.Response, error) {
+			if cred.ID == "cred-1" {
+				return quota429Response(), nil
+			}
+			return &domain.Response{StatusCode: 429, Body: []byte(lastBody)}, nil
+		},
+	}
+	bundle := testBundle(
+		domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+		domain.Credential{ID: "cred-2", ProviderID: domain.ProviderAnthropic, APIKey: "sk-2"},
+	)
+	bundle.Config.Fallback.MaxAttempts = 2
+
+	application := New(WithProviders(provider), WithLogger(zap.NewNop()))
+
+	_, err := application.HandleChat(context.Background(), bundle, bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	var ue *domain.UpstreamError
+	require.ErrorAs(t, err, &ue, "chain exhaustion must surface the provider's mapped error, never a bare internal one")
+	assert.Equal(t, 429, ue.StatusCode)
+	assert.JSONEq(t, lastBody, string(ue.Body), "the LAST candidate's verdict is the freshest and the one to forward")
+	assert.Equal(t, "rate_limit_exceeded", ue.ErrorCode)
+	assert.Equal(t, string(domain.ProviderAnthropic), ue.Provider,
+		"the surviving error must say which upstream account it came from")
+}
+
+// blockedBreaker short-circuits every slot, the state a fully open circuit
+// breaker leaves the walk in.
+type blockedBreaker struct{}
+
+func (blockedBreaker) Allow(string) bool          { return false }
+func (blockedBreaker) RecordSuccess(string)       {}
+func (blockedBreaker) RecordFailure(string)       {}
+func (blockedBreaker) State(string) breaker.State { return breaker.Open }
+
+// @scenario "An open circuit breaker surfaces a typed circuit_open error, not internal_error"
+func TestHandleChat_CircuitOpen_TypedError(t *testing.T) {
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			t.Fatal("dispatch must not run when the breaker blocks every slot")
+			return nil, nil
+		},
+	}
+
+	application := New(
+		WithProviders(provider),
+		WithCircuitBreaker(blockedBreaker{}),
+		WithLogger(zap.NewNop()),
+	)
+
+	_, err := application.HandleChat(context.Background(), testBundle(), bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	assert.True(t, herr.IsCode(err, domain.ErrCircuitOpen),
+		"a zero-attempt walk must translate to circuit_open, the incident surfaced it as 500 internal_error; got %v", err)
+}
+
+// @scenario "An open circuit breaker surfaces a typed circuit_open error on the stream path"
+func TestHandleChatStream_CircuitOpen_TypedError(t *testing.T) {
+	provider := &mockProvider{
+		streamFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (domain.StreamIterator, error) {
+			t.Fatal("dispatch must not run when the breaker blocks every slot")
+			return nil, nil
+		},
+	}
+
+	application := New(
+		WithProviders(provider),
+		WithCircuitBreaker(blockedBreaker{}),
+		WithLogger(zap.NewNop()),
+	)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	_, err := application.HandleChatStream(context.Background(), testBundle(), bytes.NewReader(body), "gpt-4")
+	require.Error(t, err)
+	assert.True(t, herr.IsCode(err, domain.ErrCircuitOpen), "got %v", err)
+}
+
+// countingBreaker records how the walk reports slot health.
+type countingBreaker struct {
+	successes int
+	failures  int
+}
+
+func (b *countingBreaker) Allow(string) bool          { return true }
+func (b *countingBreaker) RecordSuccess(string)       { b.successes++ }
+func (b *countingBreaker) RecordFailure(string)       { b.failures++ }
+func (b *countingBreaker) State(string) breaker.State { return breaker.Closed }
+
+// @scenario "Provider 4xx answers do not open the circuit breaker"
+func TestHandleChat_429DoesNotCountAsBreakerFailure(t *testing.T) {
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			return quota429Response(), nil
+		},
+	}
+	counting := &countingBreaker{}
+
+	application := New(
+		WithProviders(provider),
+		WithCircuitBreaker(counting),
+		WithLogger(zap.NewNop()),
+	)
+
+	_, err := application.HandleChat(context.Background(), testBundle(), bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	assert.Zero(t, counting.failures,
+		"a 429 is the provider answering, not the slot failing; counting it opened the breaker during quota outages")
+	assert.Equal(t, 1, counting.successes,
+		"an answered 4xx proves the slot alive and must reset the breaker")
+}
+
+// @scenario "Provider 5xx answers count toward opening the circuit breaker"
+func TestHandleChat_5xxCountsAsBreakerFailure(t *testing.T) {
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			return &domain.Response{StatusCode: 503, Body: []byte(`{"error":{"message":"overloaded"}}`)}, nil
+		},
+	}
+	counting := &countingBreaker{}
+
+	application := New(
+		WithProviders(provider),
+		WithCircuitBreaker(counting),
+		WithLogger(zap.NewNop()),
+	)
+
+	_, err := application.HandleChat(context.Background(), testBundle(), bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	assert.Equal(t, 1, counting.failures, "a 5xx is the upstream reporting itself broken")
+	assert.Zero(t, counting.successes)
+}
+
+// @scenario "Gateway-own budget refusals never reach the provider chain"
+func TestHandleChat_BudgetBlock_NeverDispatches(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	budget := &mockBudget{
+		precheckFn: func(_ context.Context, _ *domain.Bundle) (domain.BudgetDecision, error) {
+			return domain.BudgetDecision{Verdict: domain.BudgetBlock}, nil
+		},
+	}
+
+	application := New(
+		WithProviders(provider),
+		WithBudget(budget),
+		WithLogger(zap.NewNop()),
+	)
+
+	_, err := application.HandleChat(context.Background(), testBundle(
+		domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+		domain.Credential{ID: "cred-2", ProviderID: domain.ProviderOpenAI, APIKey: "sk-2"},
+	), bytes.NewReader(testBody()), "gpt-4")
+	require.Error(t, err)
+	assert.True(t, herr.IsCode(err, domain.ErrBudgetExceeded))
+	assert.False(t, dispatched,
+		"our own policy refusal is not a provider failure; falling back would bypass the refusal")
+}
+
+// @scenario "A caller-abandoned request neither falls back nor moves the breaker"
+func TestClassifyProviderError_ContextErrors(t *testing.T) {
+	assert.Equal(t, retry.ReasonContextDone, classifyProviderError(context.Canceled))
+	assert.Equal(t, retry.ReasonContextDone, classifyProviderError(context.DeadlineExceeded))
+}

--- a/services/aigateway/app/provider_error_identity_test.go
+++ b/services/aigateway/app/provider_error_identity_test.go
@@ -40,7 +40,7 @@ func quota429Response() *domain.Response {
 	}
 }
 
-// @scenario "Provider quota and server failures fall back to the next credential"
+// @scenario "Provider quota, rate-limit, and 5xx answers fail over to the next credential"
 func TestHandleChat_RawForward429Response_FallsBack(t *testing.T) {
 	for name, failing := range map[string]*domain.Response{
 		"429 insufficient_quota": quota429Response(),
@@ -74,7 +74,7 @@ func TestHandleChat_RawForward429Response_FallsBack(t *testing.T) {
 	}
 }
 
-// @scenario "A terminal provider 4xx answer does not fall back and is forwarded verbatim"
+// @scenario "Terminal provider 4xx answers do not fail over"
 func TestHandleChat_RawForwardTerminal400Response_NoFallback(t *testing.T) {
 	terminalBody := `{"error":{"message":"messages: at least one message is required","type":"invalid_request_error"}}`
 	callCount := 0
@@ -103,7 +103,7 @@ func TestHandleChat_RawForwardTerminal400Response_NoFallback(t *testing.T) {
 	assert.Equal(t, string(domain.ProviderOpenAI), ue.Provider)
 }
 
-// @scenario "An exhausted chain surfaces the last provider's error, not internal_error"
+// @scenario "An exhausted fallback chain surfaces the last provider's error"
 func TestHandleChat_ChainExhausted_SurfacesLastProviderError(t *testing.T) {
 	lastBody := `{"error":{"message":"Rate limit reached for gpt-4","type":"requests","code":"rate_limit_exceeded"}}`
 	provider := &mockProvider{
@@ -142,7 +142,7 @@ func (blockedBreaker) RecordSuccess(string)       {}
 func (blockedBreaker) RecordFailure(string)       {}
 func (blockedBreaker) State(string) breaker.State { return breaker.Open }
 
-// @scenario "An open circuit breaker surfaces a typed circuit_open error, not internal_error"
+// @scenario "An open circuit breaker surfaces circuit_open, not internal_error"
 func TestHandleChat_CircuitOpen_TypedError(t *testing.T) {
 	provider := &mockProvider{
 		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
@@ -163,7 +163,7 @@ func TestHandleChat_CircuitOpen_TypedError(t *testing.T) {
 		"a zero-attempt walk must translate to circuit_open, the incident surfaced it as 500 internal_error; got %v", err)
 }
 
-// @scenario "An open circuit breaker surfaces a typed circuit_open error on the stream path"
+// @scenario "An open circuit breaker surfaces circuit_open, not internal_error"
 func TestHandleChatStream_CircuitOpen_TypedError(t *testing.T) {
 	provider := &mockProvider{
 		streamFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (domain.StreamIterator, error) {
@@ -239,7 +239,7 @@ func TestHandleChat_5xxCountsAsBreakerFailure(t *testing.T) {
 	assert.Zero(t, counting.successes)
 }
 
-// @scenario "Gateway-own budget refusals never reach the provider chain"
+// @scenario "The gateway's own refusals never trigger provider fallback"
 func TestHandleChat_BudgetBlock_NeverDispatches(t *testing.T) {
 	dispatched := false
 	provider := &mockProvider{

--- a/services/aigateway/domain/errors.go
+++ b/services/aigateway/domain/errors.go
@@ -24,6 +24,19 @@ type UpstreamError struct {
 	// Message is the provider's error message, used to build a minimal
 	// envelope when Body is empty.
 	Message string
+	// ErrorType and ErrorCode are the provider's own error discriminants
+	// (e.g. OpenAI "insufficient_quota", Anthropic "overloaded_error",
+	// Bedrock "ThrottlingException") as parsed by the provider adapter.
+	// They keep the error's identity on translated lanes where the native
+	// body is not captured: without them the minimal envelope collapses
+	// every provider verdict into a generic "provider_error" and the
+	// client loses the code it dispatches its own handling on.
+	ErrorType string
+	ErrorCode string
+	// Provider names the upstream this error came from (the credential's
+	// provider id), so a multi-provider chain's surviving error says which
+	// account to look at. Empty when the dispatch layer has not stamped it.
+	Provider string
 	// Headers carries the upstream's retry-signaling response headers
 	// (Retry-After, x-should-retry) so the client can honor the provider's
 	// backoff hint and terminal-vs-retryable signal instead of guessing.

--- a/specs/ai-gateway/error-transparency.feature
+++ b/specs/ai-gateway/error-transparency.feature
@@ -194,17 +194,17 @@ Feature: AI Gateway — transparent upstream error forwarding
 
   @bdd @error-transparency @integration
   Scenario: Provider 5xx answers count toward opening the circuit breaker
-    Given the provider answers requests with 5xx errors
-    When failures accumulate on the same credential
-    Then the circuit breaker records them as slot-health failures
-    So that a genuinely failing upstream is skipped instead of hammered
+    Given the provider answers every request with 5xx errors
+    When failures repeat on the same credential
+    Then later requests are answered 503 with error code "circuit_open" instead of waiting on the failing provider
+    And after the cooldown the gateway dials the provider again and recovers on its own
 
   @bdd @error-transparency @integration
   Scenario: A caller-abandoned request neither falls back nor moves the breaker
-    Given the caller disconnects or its request deadline expires mid-dispatch
-    When the attempt returns a bare context error
-    Then no fallback to the next credential is attempted
-    And the circuit breaker records neither a failure nor a success for the slot
+    Given a request is in flight to a provider credential
+    When the caller disconnects or its deadline expires before the provider answers
+    Then the gateway dials no further credential for that request
+    And later requests on that credential are answered exactly as if the abandoned request had never happened
 
   @bdd @error-transparency @integration
   Scenario: An open circuit breaker surfaces circuit_open, not internal_error

--- a/specs/ai-gateway/error-transparency.feature
+++ b/specs/ai-gateway/error-transparency.feature
@@ -106,6 +106,100 @@ Feature: AI Gateway — transparent upstream error forwarding
     And the message states the failure, never an empty string
 
   # ==========================================================================
+  # Error identity beyond the body: type/code, provider, and the taxonomy
+  # ==========================================================================
+  # A provider verdict is identified by three things: the HTTP status class,
+  # the provider's own error type/code (insufficient_quota vs
+  # rate_limit_exceeded, overloaded_error, ThrottlingException, ...), and
+  # which upstream produced it. All three must survive the gateway, on every
+  # lane, whether or not the native body was captured. An incident surfaced
+  # where OpenAI's 429 insufficient_quota reached clients as HTTP 500
+  # {"error":{"type":"internal_error"}}, the least actionable answer
+  # possible, at the exact moment clients most needed the provider's own
+  # verdict.
+
+  @bdd @error-transparency @integration
+  Scenario Outline: Provider error taxonomy keeps status and identity through the gateway
+    Given the upstream provider answers <status> with error type "<type>"
+    When the client calls the gateway with "vk-demo"
+    Then the gateway responds with HTTP <status>
+    And the response error type is "<type>"
+    And the response never carries the gateway's "internal_error"
+
+    Examples:
+      | status | type                 |
+      | 429    | insufficient_quota   |
+      | 429    | rate_limit_exceeded  |
+      | 401    | invalid_api_key      |
+      | 404    | model_not_found      |
+      | 400    | invalid_request_error|
+      | 500    | server_error         |
+      | 529    | overloaded_error     |
+
+  @bdd @error-transparency @integration
+  Scenario: Upstream error responses name the provider that produced them
+    Given a credential chain that can span multiple providers
+    When an upstream error surfaces to the client
+    Then the response carries an X-LangWatch-Provider header naming the upstream
+    So that an admin can tell which provider account to look at without reading gateway source
+
+  # ==========================================================================
+  # Fallback semantics: provider failures fail over, gateway refusals do not
+  # ==========================================================================
+  # Failing over past a dead credential is the whole point of a fallback
+  # chain. A bug surfaced where raw-forward lanes returned provider errors as
+  # success-shaped responses, so a 429/5xx never advanced the chain (and fed
+  # the circuit breaker a success for a failing key).
+
+  @bdd @error-transparency @integration
+  Scenario: Provider quota, rate-limit, and 5xx answers fail over to the next credential
+    Given "vk-demo" has two credentials in its fallback chain
+    And the first credential's provider answers 429 insufficient_quota
+    When the client calls the gateway with "vk-demo"
+    Then the request is retried on the second credential
+    And the client receives the second credential's successful response
+
+  @bdd @error-transparency @integration
+  Scenario: An exhausted fallback chain surfaces the last provider's error
+    Given "vk-demo" has two credentials and both providers answer 429
+    When the client calls the gateway with "vk-demo"
+    Then the gateway responds with the LAST provider's 429, body verbatim
+    And never with a generic internal or chain-exhausted placeholder
+
+  @bdd @error-transparency @integration
+  Scenario: Terminal provider 4xx answers do not fail over
+    Given "vk-demo" has two credentials in its fallback chain
+    And the first credential's provider answers a terminal 400 invalid_request_error
+    When the client calls the gateway with "vk-demo"
+    Then no second credential is dialed
+    And the 400 reaches the client verbatim
+
+  @bdd @error-transparency @integration
+  Scenario: The gateway's own refusals never trigger provider fallback
+    Given "vk-demo" is over its gateway budget
+    When the client calls the gateway with "vk-demo"
+    Then the gateway answers 402 budget_exceeded without dialing any provider
+    And no fallback attempt is recorded
+
+  # ==========================================================================
+  # Circuit breaker: never an internal_error, never opened by answered 4xx
+  # ==========================================================================
+
+  @bdd @error-transparency @integration
+  Scenario: Provider 4xx answers do not open the circuit breaker
+    Given the provider answers every request with 429 insufficient_quota
+    When many requests flow through the same credential
+    Then every response relays the provider's 429 verbatim
+    And the circuit breaker stays closed, because an answered 4xx proves the slot alive
+
+  @bdd @error-transparency @integration
+  Scenario: An open circuit breaker surfaces circuit_open, not internal_error
+    Given repeated provider 5xx failures opened the credential's circuit breaker
+    When the client calls the gateway with "vk-demo"
+    Then the gateway responds 503 with error code "circuit_open" and fault "provider"
+    And never 500 "internal_error"
+
+  # ==========================================================================
   # End-to-end: the real wrapper must fail fast, not retry-loop
   # ==========================================================================
 

--- a/specs/ai-gateway/error-transparency.feature
+++ b/specs/ai-gateway/error-transparency.feature
@@ -193,6 +193,20 @@ Feature: AI Gateway — transparent upstream error forwarding
     And the circuit breaker stays closed, because an answered 4xx proves the slot alive
 
   @bdd @error-transparency @integration
+  Scenario: Provider 5xx answers count toward opening the circuit breaker
+    Given the provider answers requests with 5xx errors
+    When failures accumulate on the same credential
+    Then the circuit breaker records them as slot-health failures
+    So that a genuinely failing upstream is skipped instead of hammered
+
+  @bdd @error-transparency @integration
+  Scenario: A caller-abandoned request neither falls back nor moves the breaker
+    Given the caller disconnects or its request deadline expires mid-dispatch
+    When the attempt returns a bare context error
+    Then no fallback to the next credential is attempted
+    And the circuit breaker records neither a failure nor a success for the slot
+
+  @bdd @error-transparency @integration
   Scenario: An open circuit breaker surfaces circuit_open, not internal_error
     Given repeated provider 5xx failures opened the credential's circuit breaker
     When the client calls the gateway with "vk-demo"


### PR DESCRIPTION
## The incident

While the shared upstream OpenAI account was out of credits (yesterday, roughly 12:43 to 19:04 UTC, fixed by topping up), four different sdk-python example bots in CI all failed the same way through the gateway's openai lane:

```
openai.InternalServerError: Error code: 500 - {'error': {'type': 'internal_error', 'code': 'internal_error', 'message': 'internal_error', 'trace_id': '...', 'span_id': '...'}}
```

OpenAI was actually answering HTTP 429 with `insufficient_quota`, a client-actionable terminal verdict. The gateway collapsed it into the least actionable answer possible, and `is_external_service_error` in the sdk-python example tests does not recognize `internal_error`, so CI went red on every branch.

## Where the identity was lost

Reproduced byte-for-byte at the router level with the real bifrost pipeline against a stub upstream. The collapse is a chain of three defects, none of which is bifrost (bifrost preserves status, error type/code, and the raw body correctly):

1. `services/aigateway/adapters/providers/bifrost.go` (raw-forward branches, for example the chat lane): a provider non-2xx comes back as a success-shaped `(*domain.Response, nil)` carrying the upstream status and body. Correct for forwarding, but invisible to the retry walk: non-streamed 429s recorded circuit breaker successes, streamed ones (which surface as `UpstreamError`) recorded failures. CI traffic mixes both, so the breaker flapped open.
2. `pkg/retry/retry.go:178-180` (before this PR): the breaker recorded a failure for ANY classified error reason, including answered 4xx. Ten streamed 429s inside 30s opened the circuit for the shared openai credential. A burst of malformed client requests could do the same to any shared credential.
3. `pkg/retry/retry.go:186-189` plus `services/aigateway/adapters/httpapi/router.go:1051`: with the breaker open, every slot is skipped, the walk ends with zero attempts and returns a bare `errors.New("retry chain exhausted with no attempts")`. That error is neither an `UpstreamError` nor a `herr.E`, so `writeError` falls through to `herr.New(ctx, domain.ErrInternal, nil)`: HTTP 500 `internal_error`. `domain.ErrCircuitOpen` existed in the taxonomy but was never raised anywhere and had no registered HTTP status.

The gateway's own refusals (budget, policy, rate limit) never touch this path, which is why they kept mapping correctly during the incident.

## Mapping rule

The envelope preserves the provider's status class and error identity faithfully: 429 stays 429 with the provider's code, 4xx stays 4xx, 529 stays 529, and only genuine provider 5xx or gateway-internal failures produce 5xx. The provider that produced the error is named in the already-documented `X-LangWatch-Provider` response header (documented in `docs/ai-gateway/api/errors.mdx` but never emitted until now), and in `error.meta.provider` on the minimal envelope.

| Upstream verdict | Before | After |
|---|---|---|
| OpenAI 429 `insufficient_quota` | 429 verbatim while breaker closed; **500 `internal_error`** once it opened | 429, body verbatim, message governed, breaker never opens on it |
| OpenAI 429 `rate_limit_exceeded` | same flapping as above | 429, body verbatim incl. `Retry-After` |
| OpenAI 401 `invalid_api_key` | 401 verbatim, but counted toward opening the breaker | 401 verbatim, no breaker effect |
| OpenAI 404 `model_not_found` | 404 verbatim, counted toward the breaker | 404 verbatim, no breaker effect |
| OpenAI 400 `invalid_request_error` | 400 verbatim, counted toward the breaker | 400 verbatim, no breaker effect |
| OpenAI 500 `server_error` | 500 forwarded | 500 forwarded, counts toward the breaker (real provider outage) |
| Anthropic 429 `rate_limit_error` | 429 verbatim on the messages lane | unchanged, now also pinned by tests |
| Anthropic 529 `overloaded_error` | 529 verbatim | unchanged, now pinned end to end through the real bifrost lane |
| Anthropic 400 credit balance | 400, governance re-message | unchanged |
| Bedrock `ThrottlingException` 429 / `ValidationException` 400 / `AccessDeniedException` 403 | status preserved but type/code dropped on translated lanes (generic `provider_error`) | status preserved AND provider type/code surfaced in the envelope |
| Translated lane, no captured body | `{"type":"provider_error"}` | `{"type":"<provider's own type>","code":"<provider's own code>"}` |
| Breaker open (repeated provider 5xx/timeouts) | **500 `internal_error`** | 503 `circuit_open`, fault `provider`, retryable |

## Fallback semantics

- Provider quota (429), rate limit (429), not-found (404) and 5xx answers now fail over to the next credential in the chain on every lane. Before, raw-forward lanes (openai chat, /v1/messages, responses, embeddings, gemini passthrough) never fell back on non-streamed provider errors because they looked like successes to the walk.
- Terminal provider 4xx (400/401/403) still never falls back: retrying an invalid request or a bad key on the next credential only delays the terminal answer.
- A chain exhausted on retryable failures surfaces the LAST provider's error verbatim (freshest verdict), not the first, and never a placeholder.
- The gateway's own refusals (budget block, policy, gateway rate limit) are raised before dispatch, never enter the walk, and never trigger fallback. Pinned by test.
- Breaker health policy: only 5xx, timeout, and network failures count toward opening the circuit. An answered 4xx proves the slot alive and resets it. A caller-canceled request records nothing. When the breaker is legitimately open, clients get a typed 503 `circuit_open` with `fault: provider` instead of 500 `internal_error`.

## Test evidence

- `services/aigateway/adapters/httpapi/provider_error_identity_test.go`: full-stack (real bifrost against a stub upstream) taxonomy table for the openai lane, stream and non-stream; anthropic 529/429 through the real anthropic-compat lane; the incident regression (8 mixed stream/non-stream requests against a 429 quota upstream with a threshold-2 breaker all relay 429, never `internal_error`); breaker legitimately opened by 5xx surfaces `circuit_open`.
- `services/aigateway/app/provider_error_identity_test.go`: fallback on 429/5xx responses, no fallback on terminal 400, chain exhaustion surfaces the last provider's error with provider stamped, budget block never dials a provider, breaker accounting per reason, typed `circuit_open` on both dispatch paths.
- `services/aigateway/adapters/providers/provider_error_taxonomy_test.go`: `errFromBifrost` table over the documented OpenAI, Anthropic, and Bedrock error shapes.
- `pkg/retry/retry_test.go`: last-error on exhaustion, `ErrNoAttempts` sentinel, breaker records by reason.
- `specs/ai-gateway/error-transparency.feature` extended with the taxonomy outline, fallback, and breaker scenarios; `docs/ai-gateway/api/errors.mdx` gains the `circuit_open` row.

`go test -race ./...` in `services/aigateway` is green, plus `pkg/retry`, `pkg/herr`, `services/langyagent/adapters/controlplane`, and the nlpgo dispatcher consumers (`llmexecutor`, `dispatcheradapter`, whose `providers.Dispatch` contract is intentionally unchanged). `golangci-lint run` on the touched packages: 0 issues. `pnpm check:feature-parity`: all error-transparency scenarios bound.

## Deployment Impact

- No chart, env, config, schema, or migration changes. Rolling the gateway binary forward (or back) is sufficient.
- Client-visible changes, all on error paths only: an open circuit breaker now answers 503 `circuit_open` (fault `provider`) instead of 500 `internal_error`; provider errors on raw-forward lanes now fail over across the credential chain before surfacing; upstream error responses gain the already-documented `X-LangWatch-Provider` header; minimal envelopes carry the provider's own error type/code instead of a generic `provider_error`.
- Circuit breaker opens less often than before: answered 4xx no longer count toward the threshold, only 5xx, timeout, and network failures do. During a provider quota outage the gateway now keeps relaying the provider's 429 instead of tripping open.
- Operators watching `gateway_request_failed` logs: the zero-attempt failure that logged as fault=platform code=unhandled now logs as fault=provider code=circuit_open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider errors now preserve upstream HTTP status plus `error.type`, `error.code`, message, and provider identity (including SSE/stream responses).
  - Added `circuit_open` with HTTP `503`, marked retryable after breaker cooldown, with `fault: provider`.

- **Bug Fixes**
  - Improved retry/fallback behavior: exhausted chains return the last provider’s error, terminal 4xx never trigger breaker/fallback, and client cancellations don’t affect breaker state.
  - Quota exhaustion detection now honors `insufficient_quota` from parsed error details.

- **Documentation**
  - Documented `circuit_open` ↔ HTTP `503` mapping and retry guidance.

- **Tests**
  - Expanded end-to-end error transparency and circuit-breaker regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->