### PR TITLE
test(server): bind the worker probe specs so the parity gate enforces them

### DIFF
--- a/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
@@ -14,6 +14,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { Counter, register } from "prom-client";
+
 import {
   WORKER_LIVENESS_PATH,
   createWorkerMetricsHandler,
@@ -25,16 +27,33 @@ type Handler = ReturnType<typeof createWorkerMetricsHandler>;
 type HandlerRequest = Parameters<Handler>[0];
 type HandlerResponse = Parameters<Handler>[1];
 
-/** Captures what the handler wrote, without binding a port. */
+/**
+ * Captures what the handler wrote, without binding a port.
+ *
+ * Headers are captured from BOTH paths the handler uses — `writeHead(status,
+ * headers)` for the liveness reply and `setHeader(name, value)` for the metrics
+ * reply. A fake that drops them (a no-op `setHeader`, a `writeHead` that reads
+ * only its first argument) lets the Content-Type line be deleted from the
+ * handler with every test still green, while Prometheus silently stops parsing
+ * the worker registry.
+ */
 function fakeExchange(url: string) {
   const req = { url, headers: {} } as unknown as HandlerRequest;
-  const captured: { status?: number; body?: string } = {};
+  const captured: {
+    status?: number;
+    body?: string;
+    headers: Record<string, string>;
+  } = { headers: {} };
   const res = {
-    writeHead(status: number) {
+    writeHead(status: number, headers?: Record<string, string>) {
       captured.status = status;
+      for (const [name, value] of Object.entries(headers ?? {})) {
+        captured.headers[name.toLowerCase()] = value;
+      }
       return this;
     },
-    setHeader() {
+    setHeader(name: string, value: string) {
+      captured.headers[name.toLowerCase()] = value;
       return this;
     },
     end(body?: string) {
@@ -51,6 +70,7 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 describe("createWorkerMetricsHandler", () => {
   describe("given the liveness path", () => {
     describe("when the metrics gate would throw (production, no API key)", () => {
+      /** @scenario Default install — no metrics API key in production */
       it("answers 200 without consulting the gate", async () => {
         // The default-install case: this is exactly the configuration that
         // made a /metrics probe crash-loop every stock worker deployment.
@@ -68,6 +88,7 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the request carries no credentials", () => {
+      /** @scenario Key configured, probe still sends nothing */
       it("answers 200 even though the gate would reject", async () => {
         // The secretKeyRef case: the key exists in the container's env, but no
         // rendered httpGet header can ever carry it.
@@ -82,19 +103,23 @@ describe("createWorkerMetricsHandler", () => {
       });
     });
 
-    it("returns no metric samples", async () => {
-      const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
+    describe("when the probe reads the response body", () => {
+      /** @scenario The liveness endpoint leaks no telemetry */
+      it("returns no metric samples", async () => {
+        const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
 
-      createWorkerMetricsHandler(() => true)(req, res);
-      await flush();
+        createWorkerMetricsHandler(() => true)(req, res);
+        await flush();
 
-      expect(captured.body).toBe("ok");
-      expect(captured.body).not.toContain("#");
+        expect(captured.body).toBe("ok");
+        expect(captured.headers["content-type"]).toBe("text/plain");
+      });
     });
   });
 
   describe("given the metrics path", () => {
     describe("when the gate rejects the caller", () => {
+      /** @scenario Metrics still require the bearer when a key is set */
       it("answers 401", async () => {
         const { req, res, captured } = fakeExchange("/metrics");
 
@@ -106,6 +131,7 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the gate throws (production, no API key)", () => {
+      /** @scenario Metrics still fail closed in production without a key */
       it("fails closed with 500", async () => {
         const { req, res, captured } = fakeExchange("/metrics");
 
@@ -119,28 +145,47 @@ describe("createWorkerMetricsHandler", () => {
     });
 
     describe("when the gate accepts the caller", () => {
-      it("serves the registry rather than an auth failure", async () => {
+      /** @scenario Metrics are served to a correctly authenticated caller */
+      it("serves the registry with the Prometheus content type", async () => {
+        // Register a sample so the body is non-empty in this process. Without
+        // one the registry renders "" and any "did it serve?" assertion passes
+        // on the empty string.
+        const probe = new Counter({
+          name: "worker_metrics_handler_probe_total",
+          help: "Fixture counter proving the registry is rendered.",
+          registers: [register],
+        });
+        probe.inc();
+
         const { req, res, captured } = fakeExchange("/metrics");
 
         createWorkerMetricsHandler(() => true)(req, res);
         await flush();
 
-        // Success writes no explicit status (Node defaults to 200); what
-        // matters is that neither auth branch fired.
+        // Neither auth branch fired: success takes the implicit-200 path and
+        // writes no explicit status.
         expect(captured.status).toBeUndefined();
-        expect(typeof captured.body).toBe("string");
+        // Prometheus needs this exact content type to parse the response; the
+        // handler sets it via setHeader, so the fake must capture it.
+        expect(captured.headers["content-type"]).toBe(register.contentType);
+        expect(captured.body).toContain("worker_metrics_handler_probe_total");
+
+        register.removeSingleMetric("worker_metrics_handler_probe_total");
       });
     });
   });
 
   describe("given an unknown path", () => {
-    it("answers 404", async () => {
-      const { req, res, captured } = fakeExchange("/not-a-real-path");
+    describe("when any caller requests it", () => {
+      /** @scenario An unrelated path is not served */
+      it("answers 404", async () => {
+        const { req, res, captured } = fakeExchange("/not-a-real-path");
 
-      createWorkerMetricsHandler(() => true)(req, res);
-      await flush();
+        createWorkerMetricsHandler(() => true)(req, res);
+        await flush();
 
-      expect(captured.status).toBe(404);
+        expect(captured.status).toBe(404);
+      });
     });
   });
 });

--- a/specs/server/metrics-collection.feature
+++ b/specs/server/metrics-collection.feature
@@ -24,16 +24,19 @@ Feature: Metrics collection in a deployed chart
 
   Rule: Both tiers come up in every metrics configuration
 
+    @e2e @unimplemented
     Scenario: Default install, with no metrics key configured
       Given no metrics API key is configured
       Then the app pod becomes ready
       And the workers pod becomes ready
 
+    @e2e @unimplemented
     Scenario: Install with a metrics key configured
       Given a metrics API key is configured
       Then the app pod becomes ready
       And the workers pod becomes ready
 
+    @e2e @unimplemented
     Scenario: Install with the metrics key delivered from a secret store
       Given a metrics API key is delivered to the containers from a secret store
       Then the app pod becomes ready
@@ -41,6 +44,7 @@ Feature: Metrics collection in a deployed chart
 
   Rule: Without a key, metrics collection fails closed and liveness still answers
 
+    @e2e @unimplemented
     Scenario: The worker refuses to serve metrics to anyone
       Given no metrics API key is configured
       When a caller requests the worker metrics endpoint with any credentials
@@ -48,6 +52,7 @@ Feature: Metrics collection in a deployed chart
       And no metric samples are returned
       # Fail-closed: an unset key is a misconfiguration, not an invitation.
 
+    @e2e @unimplemented
     Scenario: Liveness is unaffected by the missing key
       Given no metrics API key is configured
       When the kubelet requests the worker liveness endpoint without credentials
@@ -56,18 +61,21 @@ Feature: Metrics collection in a deployed chart
 
   Rule: With a key, metrics are collectable only by an authenticated caller
 
+    @e2e @unimplemented
     Scenario: An unauthenticated scrape is rejected
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint without credentials
       Then the request is rejected as unauthorized
       And no metric samples are returned
 
+    @e2e @unimplemented
     Scenario: A scrape presenting the wrong credential is rejected
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint with an incorrect key
       Then the request is rejected as unauthorized
       And no metric samples are returned
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects worker metrics
       Given a metrics API key is configured
       When a caller requests the worker metrics endpoint with the configured key
@@ -75,12 +83,14 @@ Feature: Metrics collection in a deployed chart
       And metric samples are returned
       # The path Prometheus actually uses. Previously unproven in a cluster.
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects app metrics
       Given a metrics API key is configured
       When a caller requests the app metrics endpoint with the configured key
       Then the response is successful
       And metric samples are returned
 
+    @e2e @unimplemented
     Scenario: The liveness endpoint stays credential-free even once a key exists
       Given a metrics API key is configured
       When the kubelet requests the worker liveness endpoint without credentials
@@ -89,6 +99,7 @@ Feature: Metrics collection in a deployed chart
 
   Rule: A key delivered from a secret store reaches the process
 
+    @e2e @unimplemented
     Scenario: An authenticated scrape collects metrics when the key came from a secret
       Given a metrics API key is delivered to the containers from a secret store
       When a caller requests the worker metrics endpoint with the configured key

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -37,6 +37,7 @@ Feature: Worker liveness probe endpoint
 
   Rule: /healthz answers unauthenticated, in every auth configuration
 
+    @unit
     Scenario: Default install — no metrics API key in production
       Given the worker is running in production mode
       And no metrics API key is configured
@@ -44,29 +45,34 @@ Feature: Worker liveness probe endpoint
       Then the response status is 200
       # The case that would otherwise crash-loop every default install.
 
+    @unit
     Scenario: Key configured, probe still sends nothing
       Given a metrics API key is configured
       When the kubelet requests "/healthz" without an Authorization header
       Then the response status is 200
       # Covers secretKeyRef delivery: the probe never needs the key at all.
 
+    @unit
     Scenario: The liveness endpoint leaks no telemetry
       When the kubelet requests "/healthz"
       Then the response body does not contain any metric samples
 
   Rule: /metrics keeps its bearer gate unchanged
 
+    @unit
     Scenario: Metrics still require the bearer when a key is set
       Given a metrics API key is configured
       When a caller requests "/metrics" without an Authorization header
       Then the response status is 401
 
+    @unit
     Scenario: Metrics still fail closed in production without a key
       Given the worker is running in production mode
       And no metrics API key is configured
       When a caller requests "/metrics" with any credentials
       Then the response status is 500
 
+    @unit
     Scenario: Metrics are served to a correctly authenticated caller
       Given a metrics API key is configured
       When a caller requests "/metrics" with the matching bearer token
@@ -75,12 +81,14 @@ Feature: Worker liveness probe endpoint
 
   Rule: Unknown paths stay 404
 
+    @unit
     Scenario: An unrelated path is not served
       When a caller requests "/not-a-real-path"
       Then the response status is 404
 
   Rule: The chart probes the liveness endpoint, not the metrics endpoint
 
+    @e2e @unimplemented
     Scenario: Worker probes target /healthz with no credentials
       Given the Helm chart renders the workers Deployment
       Then the startup probe performs an HTTP GET on "/healthz"


### PR DESCRIPTION
Post-merge follow-up to #5524. Closes finding #1 from the handoff brief — the highest-leverage one, because it is what makes every other finding on those files regression-proof.

## Why

`specs/server/worker-liveness-probe.feature` and `specs/server/metrics-collection.feature` shipped with **no tags at all**.

`check-feature-parity.ts` only counts a scenario if it carries one of `@unit` / `@integration` / `@e2e` / `@regression` (`BOUND_TAGS`, line 141; the filter is line 576). An untagged file therefore contributes zero scenarios in either direction — the run prints `0/0 ✓ all bound` and the `feature-parity` check passes vacuously. In CI output that is indistinguishable from a fully-bound file. 17 scenarios describing the probe contract were decorative.

## What changed

**Tagging and binding.** The seven handler-level scenarios are tagged `@unit` and bound to the tests that already covered them, via `/** @scenario <title> */` above each `it(...)`. Enforced scenarios go from **3381 to 3388**.

The chart-rendering scenario and the eleven live-cluster scenarios are tagged `@e2e @unimplemented`. They *are* covered — by `test_workers_probes` in `e2e-overlays.sh` and `test_metrics_collection` in `e2e.sh` — but the checker's shell binding roots scan `.bats` only, so a `.sh` assertion cannot bind as written. `@unimplemented` records that as a tracked gap instead of hiding it behind an untagged file.

**Two of the newly-enforced tests could not fail.** That mattered less while they were decorative; it matters now.

- The response fake discarded headers on both paths the handler uses — `setHeader` was a no-op, and `writeHead` read only its status argument. Deleting `res.setHeader("Content-Type", register.contentType)` from the handler left all seven tests green while Prometheus would silently stop parsing the worker registry. The fake now captures headers from both, and the metrics and liveness tests assert the content type.
- `serves the registry rather than an auth failure` asserted `captured.status` was `undefined` and `typeof body === "string"`. Both hold for the empty string, and the registry *is* empty in this test process. It now registers a fixture counter and asserts the sample appears in the body.

Also drops a dead assertion (`not.toContain("#")` after an exact `toBe("ok")`) and wraps the two bare `it()` blocks in the `describe("when …")` the repo convention requires.

## Test plan

- [x] `pnpm test:unit run src/server/workers/__tests__/workerMetricsHandler.unit.test.ts` — 7 passed
- [x] `check-feature-parity` passes; enforced count 3381 → 3388
- [x] Mutation-tested both strengthened assertions, since the point is that they *can* fail:
  - deleting `res.setHeader("Content-Type", register.contentType)` → `serves the registry with the Prometheus content type` fails
  - dropping the `Content-Type` from the `/healthz` `writeHead` → `returns no metric samples` fails
  - both green again once reverted

## Not in scope

The remaining handoff findings are untouched here, notably the probe port being hardcoded to `2999` while the listener's port is env-derived (`workers.extraEnvs` can move the listener and leave the probes pinned), and the `startupProbe` budget being 120s against the app's 300s. Those are chart changes and want their own PR.
