### PR TITLE
feat(aigateway): three-tier parameter policy for translated lanes with drop_tuning_params

### DIFF
--- a/docs/ai-gateway/api/errors.mdx
+++ b/docs/ai-gateway/api/errors.mdx
@@ -45,6 +45,7 @@ Errors (like successes) always carry:
 | `provider_error` | `502` | An upstream provider returned a non-recoverable error and fallback (if any) was exhausted. |
 | `upstream_timeout` | `504` | An upstream provider exceeded `timeout_ms` and fallback (if any) was exhausted. |
 | `bad_request` | `400` | Validation error on the incoming payload (e.g. missing `model`). |
+| `unsupported_parameter` | `400` | The parameter policy refused a request parameter for the target lane: either the request depends on it functionally and the lane cannot honor it, or `drop_tuning_params` is `false` and the lane has no mapping for it. The message names the parameter, the lane, and why. See [Parameter mapping](/ai-gateway/parameter-mapping). |
 | `payload_too_large` | `413` | Request body exceeded `GATEWAY_MAX_REQUEST_BODY_BYTES` (default 10 MiB). Rejected at the edge, before auth, resolve-key, or any upstream dispatch, so a 1 GB drive-by scan never pressures the pod memory limit. Declared `Content-Length` above the cap returns 413 immediately without draining the socket; chunked unknown-length bodies trip a `*http.MaxBytesError` at the cap. |
 | `internal_error` | `500` | Unclassified gateway error. `X-LangWatch-Request-Id` is how we trace it. |
 

--- a/docs/ai-gateway/parameter-mapping.mdx
+++ b/docs/ai-gateway/parameter-mapping.mdx
@@ -1,0 +1,84 @@
+---
+title: "Parameter mapping"
+description: "How every OpenAI chat-completions parameter behaves on each provider lane, and how to control dropping with drop_tuning_params."
+sidebarTitle: "Parameter mapping"
+---
+
+The gateway speaks the OpenAI chat-completions wire format to every provider. For OpenAI-compatible targets (OpenAI, Azure OpenAI, self-hosted vLLM and other custom OpenAI-compatible endpoints) the request body is forwarded byte-for-byte, so whatever the provider accepts, you get. For the translated lanes (Anthropic, Bedrock, Gemini, Vertex) the gateway builds the provider-native request itself, and every parameter follows an explicit policy:
+
+- **mapped**: translated faithfully to the provider's native field.
+- **dropped**: a tuning parameter with no equivalent on the lane. By default it is removed, the request proceeds, and the drop is signaled (see below). It is never silently ignored.
+- **refused**: the request depends on the parameter functionally; honoring the request without it would change what you observably get. These always fail with a clear `400 unsupported_parameter` error naming the parameter, the lane, and why.
+
+## drop_tuning_params
+
+Send `"drop_tuning_params": false` in the request body to opt into strict mode: any parameter the lane cannot map then refuses instead of dropping. The default is `true`. The field itself is consumed by the gateway and never reaches a provider.
+
+```json
+{
+  "model": "anthropic/claude-haiku-4-5",
+  "messages": [{"role": "user", "content": "hi"}],
+  "seed": 42,
+  "drop_tuning_params": false
+}
+```
+
+```json
+{
+  "error": {
+    "type": "unsupported_parameter",
+    "code": "unsupported_parameter",
+    "message": "refusing to drop 'seed' for anthropic/claude-haiku-4-5: drop_tuning_params is false and Anthropic has no sampling seed. Remove it, set drop_tuning_params to true, or use a model that supports it"
+  }
+}
+```
+
+## Drop signals
+
+When a parameter is dropped, the drop is visible in three places:
+
+- Response body: `extra_fields.params_dropped` lists the dropped parameter names (on streams, on the final usage-bearing chunk).
+- Response header: `X-LangWatch-Params-Dropped` carries the same list, comma separated.
+- Trace: the gateway span records `langwatch.gateway.params_dropped`.
+
+## The table
+
+{/* param-table:begin generated from paramPolicyTable, kept in sync by TestParamPolicyDocsInSync */}
+| Parameter | anthropic | bedrock | gemini / vertex | Notes |
+|---|---|---|---|---|
+| `audio` | dropped | dropped | dropped |  |
+| `frequency_penalty` | dropped | dropped | mapped |  |
+| `function_call` | refused | refused | refused |  |
+| `functions` | refused | refused | refused |  |
+| `logit_bias` | dropped | dropped | dropped |  |
+| `logprobs` | refused | refused | mapped |  |
+| `metadata` | dropped | dropped | dropped |  |
+| `modalities` | dropped | dropped | dropped |  |
+| `n` | dropped | dropped | dropped | n: 1 passes; n > 1 is reduced to one completion and signaled |
+| `parallel_tool_calls` | dropped | dropped | dropped |  |
+| `prediction` | dropped | dropped | dropped |  |
+| `presence_penalty` | dropped | dropped | mapped |  |
+| `prompt_cache_key` | dropped | dropped | dropped |  |
+| `prompt_cache_retention` | dropped | dropped | dropped |  |
+| `reasoning_effort` | mapped | mapped | mapped | bedrock: mapped for Anthropic (thinking) and Nova; refused for other families |
+| `response_format` | mapped | mapped | mapped | anthropic: json_schema enforced; json_object refused (no parseable-JSON guarantee); bedrock: json_schema enforced; json_object refused (no parseable-JSON guarantee); gemini: json_object and json_schema both enforced |
+| `safety_identifier` | dropped | dropped | dropped |  |
+| `seed` | dropped | dropped | dropped |  |
+| `service_tier` | dropped | dropped | dropped | anthropic: "auto" passes natively; other values dropped; bedrock: dropped (AWS validates a different enum); gemini: dropped |
+| `stop` | mapped | mapped | mapped |  |
+| `store` | dropped | dropped | dropped |  |
+| `stream_options` | mapped | mapped | mapped |  |
+| `temperature` | mapped | mapped | mapped |  |
+| `tool_choice` | mapped | mapped | mapped | anthropic: none/auto/required/named mapped; named must exist in tools; allowed_tools refused; bedrock: none maps by removing tools (Converse has no none mode); named must exist in tools; allowed_tools refused; gemini: none/auto/required/named mapped; named must exist in tools; allowed_tools refused |
+| `tools` | mapped | mapped | mapped |  |
+| `top_logprobs` | refused | refused | mapped |  |
+| `top_p` | mapped | mapped | mapped | anthropic: dropped with a signal when temperature is also set (Anthropic models reject the pair); bedrock: dropped with a signal when temperature is also set on Anthropic models (they reject the pair); other families take both |
+| `user` | dropped | dropped | dropped |  |
+| `verbosity` | dropped | dropped | dropped |  |
+| `web_search_options` | dropped | dropped | dropped |  |
+| any other key | dropped | dropped | dropped | vendor params with no mapping on translated lanes |
+{/* param-table:end */}
+
+## reasoning_effort budgets
+
+On lanes that map `reasoning_effort` to a thinking budget (Anthropic models without adaptive thinking, on both the anthropic and bedrock lanes), the budget is derived from your output cap: `budget = 1024 + ratio x (max_tokens - 1024)` with ratios `minimal 0.025`, `low 0.15`, `medium 0.425`, `high 0.80`, `xhigh 0.92`, `max 1.0`. Claude Opus and Sonnet 4.6+ use the provider's adaptive thinking with your effort passed through (`minimal` maps to `low`). Gemini thinking models receive the effort natively. Thinking tokens count inside `usage.completion_tokens`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -606,6 +606,7 @@
                 ]
               },
               "ai-gateway/model-naming",
+              "ai-gateway/parameter-mapping",
               "ai-gateway/model-aliases",
               {
                 "group": "Operations",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1880,6 +1880,7 @@ Errors (like successes) always carry:
 | `provider_error` | `502` | An upstream provider returned a non-recoverable error and fallback (if any) was exhausted. |
 | `upstream_timeout` | `504` | An upstream provider exceeded `timeout_ms` and fallback (if any) was exhausted. |
 | `bad_request` | `400` | Validation error on the incoming payload (e.g. missing `model`). |
+| `unsupported_parameter` | `400` | The parameter policy refused a request parameter for the target lane: either the request depends on it functionally and the lane cannot honor it, or `drop_tuning_params` is `false` and the lane has no mapping for it. The message names the parameter, the lane, and why. See [Parameter mapping](/ai-gateway/parameter-mapping). |
 | `payload_too_large` | `413` | Request body exceeded `GATEWAY_MAX_REQUEST_BODY_BYTES` (default 10 MiB). Rejected at the edge, before auth, resolve-key, or any upstream dispatch, so a 1 GB drive-by scan never pressures the pod memory limit. Declared `Content-Length` above the cap returns 413 immediately without draining the socket; chunked unknown-length bodies trip a `*http.MaxBytesError` at the cap. |
 | `internal_error` | `500` | Unclassified gateway error. `X-LangWatch-Request-Id` is how we trace it. |
 
@@ -8253,6 +8254,95 @@ The gateway and the existing LangWatch SDK live in the same project: the VK you 
 3. **[CLI Integrations](/ai-gateway/cli/overview)**: Claude Code, Codex, opencode, Cursor, Aider.
 4. **[Self-Hosting](/ai-gateway/self-hosting/helm)**: ship the gateway with your LangWatch Helm chart.
 5. **[AI Governance](/ai-governance/overview)**: once the gateway is in place, layer on org-wide controls: anomaly detection, OCSF/SIEM export, per-user workspaces, IngestionSources for non-gateway telemetry.
+
+---
+
+# FILE: ./ai-gateway/parameter-mapping.mdx
+
+---
+title: "Parameter mapping"
+description: "How every OpenAI chat-completions parameter behaves on each provider lane, and how to control dropping with drop_tuning_params."
+sidebarTitle: "Parameter mapping"
+---
+
+The gateway speaks the OpenAI chat-completions wire format to every provider. For OpenAI-compatible targets (OpenAI, Azure OpenAI, self-hosted vLLM and other custom OpenAI-compatible endpoints) the request body is forwarded byte-for-byte, so whatever the provider accepts, you get. For the translated lanes (Anthropic, Bedrock, Gemini, Vertex) the gateway builds the provider-native request itself, and every parameter follows an explicit policy:
+
+- **mapped**: translated faithfully to the provider's native field.
+- **dropped**: a tuning parameter with no equivalent on the lane. By default it is removed, the request proceeds, and the drop is signaled (see below). It is never silently ignored.
+- **refused**: the request depends on the parameter functionally; honoring the request without it would change what you observably get. These always fail with a clear `400 unsupported_parameter` error naming the parameter, the lane, and why.
+
+## drop_tuning_params
+
+Send `"drop_tuning_params": false` in the request body to opt into strict mode: any parameter the lane cannot map then refuses instead of dropping. The default is `true`. The field itself is consumed by the gateway and never reaches a provider.
+
+```json
+{
+  "model": "anthropic/claude-haiku-4-5",
+  "messages": [{"role": "user", "content": "hi"}],
+  "seed": 42,
+  "drop_tuning_params": false
+}
+```
+
+```json
+{
+  "error": {
+    "type": "unsupported_parameter",
+    "code": "unsupported_parameter",
+    "message": "refusing to drop 'seed' for anthropic/claude-haiku-4-5: drop_tuning_params is false and Anthropic has no sampling seed. Remove it, set drop_tuning_params to true, or use a model that supports it"
+  }
+}
+```
+
+## Drop signals
+
+When a parameter is dropped, the drop is visible in three places:
+
+- Response body: `extra_fields.params_dropped` lists the dropped parameter names (on streams, on the final usage-bearing chunk).
+- Response header: `X-LangWatch-Params-Dropped` carries the same list, comma separated.
+- Trace: the gateway span records `langwatch.gateway.params_dropped`.
+
+## The table
+
+{/* param-table:begin generated from paramPolicyTable, kept in sync by TestParamPolicyDocsInSync */}
+| Parameter | anthropic | bedrock | gemini / vertex | Notes |
+|---|---|---|---|---|
+| `audio` | dropped | dropped | dropped |  |
+| `frequency_penalty` | dropped | dropped | mapped |  |
+| `function_call` | refused | refused | refused |  |
+| `functions` | refused | refused | refused |  |
+| `logit_bias` | dropped | dropped | dropped |  |
+| `logprobs` | refused | refused | mapped |  |
+| `metadata` | dropped | dropped | dropped |  |
+| `modalities` | dropped | dropped | dropped |  |
+| `n` | dropped | dropped | dropped | n: 1 passes; n > 1 is reduced to one completion and signaled |
+| `parallel_tool_calls` | dropped | dropped | dropped |  |
+| `prediction` | dropped | dropped | dropped |  |
+| `presence_penalty` | dropped | dropped | mapped |  |
+| `prompt_cache_key` | dropped | dropped | dropped |  |
+| `prompt_cache_retention` | dropped | dropped | dropped |  |
+| `reasoning_effort` | mapped | mapped | mapped | bedrock: mapped for Anthropic (thinking) and Nova; refused for other families |
+| `response_format` | mapped | mapped | mapped | anthropic: json_schema enforced; json_object refused (no parseable-JSON guarantee); bedrock: json_schema enforced; json_object refused (no parseable-JSON guarantee); gemini: json_object and json_schema both enforced |
+| `safety_identifier` | dropped | dropped | dropped |  |
+| `seed` | dropped | dropped | dropped |  |
+| `service_tier` | dropped | dropped | dropped | anthropic: "auto" passes natively; other values dropped; bedrock: dropped (AWS validates a different enum); gemini: dropped |
+| `stop` | mapped | mapped | mapped |  |
+| `store` | dropped | dropped | dropped |  |
+| `stream_options` | mapped | mapped | mapped |  |
+| `temperature` | mapped | mapped | mapped |  |
+| `tool_choice` | mapped | mapped | mapped | anthropic: none/auto/required/named mapped; named must exist in tools; allowed_tools refused; bedrock: none maps by removing tools (Converse has no none mode); named must exist in tools; allowed_tools refused; gemini: none/auto/required/named mapped; named must exist in tools; allowed_tools refused |
+| `tools` | mapped | mapped | mapped |  |
+| `top_logprobs` | refused | refused | mapped |  |
+| `top_p` | mapped | mapped | mapped | anthropic: dropped with a signal when temperature is also set (Anthropic models reject the pair); bedrock: dropped with a signal when temperature is also set on Anthropic models (they reject the pair); other families take both |
+| `user` | dropped | dropped | dropped |  |
+| `verbosity` | dropped | dropped | dropped |  |
+| `web_search_options` | dropped | dropped | dropped |  |
+| any other key | dropped | dropped | dropped | vendor params with no mapping on translated lanes |
+{/* param-table:end */}
+
+## reasoning_effort budgets
+
+On lanes that map `reasoning_effort` to a thinking budget (Anthropic models without adaptive thinking, on both the anthropic and bedrock lanes), the budget is derived from your output cap: `budget = 1024 + ratio x (max_tokens - 1024)` with ratios `minimal 0.025`, `low 0.15`, `medium 0.425`, `high 0.80`, `xhigh 0.92`, `max 1.0`. Claude Opus and Sonnet 4.6+ use the provider's adaptive thinking with your effort passed through (`minimal` maps to `low`). Gemini thinking models receive the effort natively. Thinking tokens count inside `usage.completion_tokens`.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -413,6 +413,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Audit log](https://langwatch.ai/docs/ai-gateway/audit.md): Who did what, when, to which resource, gateway mutations land in the same audit log as the rest of the platform.
 
 - [Model Naming](https://langwatch.ai/docs/ai-gateway/model-naming.md): How to name models in requests, bare, prefixed, or aliased, and how the gateway resolves each.
+- [Parameter mapping](https://langwatch.ai/docs/ai-gateway/parameter-mapping.md): How every OpenAI chat-completions parameter behaves on each provider lane, and how to control dropping with drop_tuning_params.
 - [Model Aliases](https://langwatch.ai/docs/ai-gateway/model-aliases.md): Per-VK redirects from client-facing model names to specific provider/model/deployment combinations.
 
 ### Operations

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -918,6 +918,9 @@ func setMetaHeaders(w http.ResponseWriter, meta app.DispatchMeta) {
 	if meta.CacheMode != "" {
 		h.Set("X-LangWatch-Cache-Mode", meta.CacheMode)
 	}
+	if len(meta.ParamsDropped) > 0 {
+		h.Set("X-LangWatch-Params-Dropped", strings.Join(meta.ParamsDropped, ","))
+	}
 	if meta.CustomerTraceparent != "" {
 		h.Set("Traceparent", meta.CustomerTraceparent)
 	}
@@ -1101,6 +1104,7 @@ func registerErrorStatuses() {
 	herr.RegisterStatus(domain.ErrProviderError, http.StatusBadGateway)
 	herr.RegisterStatus(domain.ErrProviderTimeout, http.StatusGatewayTimeout)
 	herr.RegisterStatus(domain.ErrBadRequest, http.StatusBadRequest)
+	herr.RegisterStatus(domain.ErrUnsupportedParameter, http.StatusBadRequest)
 	herr.RegisterStatus(domain.ErrPayloadTooLarge, http.StatusRequestEntityTooLarge)
 	herr.RegisterStatus(domain.ErrChainExhausted, http.StatusBadGateway)
 	herr.RegisterStatus(domain.ErrNotFound, http.StatusNotFound)

--- a/services/aigateway/adapters/providers/bedrock_vpce.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce.go
@@ -27,6 +27,8 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/bytedance/sonic"
+	bfanthropic "github.com/maximhq/bifrost/core/providers/anthropic"
+	bfproviderutils "github.com/maximhq/bifrost/core/providers/utils"
 	bfschemas "github.com/maximhq/bifrost/core/schemas"
 
 	"github.com/langwatch/langwatch/pkg/herr"
@@ -148,7 +150,7 @@ func (r *BifrostRouter) dispatchBedrockVPCE(
 	cred domain.Credential,
 	endpoint string,
 ) (*domain.Response, error) {
-	input, err := r.buildConverseInput(ctx, req, provider, model, cred)
+	input, dropped, err := r.buildConverseInput(ctx, req, provider, model, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -161,6 +163,7 @@ func (r *BifrostRouter) dispatchBedrockVPCE(
 
 	bfResp := converseOutputToBifrost(out, model)
 	body, _ := sonic.Marshal(bfResp)
+	body = injectParamsDropped(body, dropped)
 	return &domain.Response{
 		Body:       body,
 		StatusCode: 200,
@@ -180,7 +183,7 @@ func (r *BifrostRouter) dispatchBedrockVPCEStream(
 	cred domain.Credential,
 	endpoint string,
 ) (domain.StreamIterator, error) {
-	input, err := r.buildConverseInput(ctx, req, provider, model, cred)
+	input, dropped, err := r.buildConverseInput(ctx, req, provider, model, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +203,10 @@ func (r *BifrostRouter) dispatchBedrockVPCEStream(
 	}
 
 	return &bedrockStreamIterator{
-		ctx:    ctx,
-		stream: out.GetStream(),
-		model:  model,
+		ctx:           ctx,
+		stream:        out.GetStream(),
+		model:         model,
+		paramsDropped: dropped,
 	}, nil
 }
 
@@ -214,26 +218,159 @@ func (r *BifrostRouter) buildConverseInput(
 	provider bfschemas.ModelProvider,
 	model string,
 	cred domain.Credential,
-) (*bedrockruntime.ConverseInput, error) {
-	bfReq, _, err := buildChatRequest(ctx, req, provider, model)
+) (*bedrockruntime.ConverseInput, []string, error) {
+	bfReq, dispatchCtx, err := buildChatRequest(ctx, req, provider, model)
 	if err != nil {
-		// Client-body problem, same classification as the Bifrost chat lanes.
-		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": err.Error()})
+		return nil, nil, classifyChatBuildError(ctx, err)
 	}
+	dropped := paramsDroppedFrom(dispatchCtx)
+	stampParamsDropped(ctx, dropped)
 
 	system, messages, err := mapBedrockMessages(bfReq.Input)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	input := &bedrockruntime.ConverseInput{
-		ModelId:         aws.String(bedrockModelID(model, cred)),
-		Messages:        messages,
-		System:          system,
-		InferenceConfig: mapBedrockInferenceConfig(bfReq.Params),
-		ToolConfig:      mapBedrockToolConfig(bfReq.Params),
+	additional, err := mapBedrockAdditionalFields(ctx, bfReq.Params, model)
+	if err != nil {
+		return nil, nil, err
 	}
-	return input, nil
+	input := &bedrockruntime.ConverseInput{
+		ModelId:                      aws.String(bedrockModelID(model, cred)),
+		Messages:                     messages,
+		System:                       system,
+		InferenceConfig:              mapBedrockInferenceConfig(bfReq.Params),
+		ToolConfig:                   mapBedrockToolConfig(bfReq.Params),
+		AdditionalModelRequestFields: additional,
+	}
+	return input, dropped, nil
+}
+
+// mapBedrockAdditionalFields maps the neutral params the Converse API only
+// accepts through additionalModelRequestFields: extended thinking
+// (reasoning_effort / reasoning.max_tokens) and json_schema structured
+// output. Wire shapes mirror bifrost's own bedrock translator exactly
+// (providers/bedrock/utils.go), and the budget math reuses bifrost's
+// helpers so the two bedrock paths cannot drift apart. Returns nil when
+// neither feature is requested.
+//
+// One deliberate divergence from bifrost: when the caller sent no output
+// cap, the thinking budget is computed against the model's default
+// maximum WITHOUT writing that default into inferenceConfig.maxTokens.
+// Converse applies the same default on its own, so forcing the field adds
+// nothing except an output cap the caller never asked for.
+func mapBedrockAdditionalFields(ctx context.Context, params *bfschemas.ChatParameters, model string) (brdocument.Interface, error) {
+	if params == nil {
+		return nil, nil
+	}
+	fields := map[string]any{}
+
+	if params.Reasoning != nil && !bfschemas.IsAnthropicModel(model) {
+		// Non-Anthropic families reach here only if the parameter policy
+		// allowed them (Nova); the VPCE path serves Anthropic inference
+		// profiles, so keep the honest refusal rather than guessing a
+		// mapping bifrost implements differently per family.
+		return nil, herr.New(ctx, domain.ErrUnsupportedParameter, herr.M{
+			"message": fmt.Sprintf("refusing to drop 'reasoning_effort' for bedrock/%s: the managed Bedrock endpoint maps reasoning for Anthropic models only. Remove it, or use an Anthropic model", model),
+			"fault":   "customer",
+		})
+	}
+	if params.Reasoning != nil {
+		effort := ""
+		if params.Reasoning.Effort != nil {
+			effort = *params.Reasoning.Effort
+		}
+		switch {
+		case params.Reasoning.MaxTokens != nil:
+			budget := *params.Reasoning.MaxTokens
+			if budget == -1 {
+				budget = anthropicMinimumThinkingBudget
+			}
+			if budget < anthropicMinimumThinkingBudget {
+				return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{
+					"reason": fmt.Sprintf("reasoning.max_tokens must be >= %d for anthropic", anthropicMinimumThinkingBudget),
+				})
+			}
+			fields["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
+		case effort != "" && effort != "none":
+			if bfanthropic.SupportsAdaptiveThinking(model) {
+				fields["thinking"] = map[string]any{"type": "adaptive"}
+				setOutputConfig(fields, "effort", bfanthropic.MapBifrostEffortToAnthropic(effort))
+			} else {
+				maxTokens := bfproviderutils.GetMaxOutputTokensOrDefault(model, bedrockDefaultCompletionMaxTokens)
+				if params.MaxCompletionTokens != nil {
+					maxTokens = *params.MaxCompletionTokens
+				}
+				budget, err := bfproviderutils.GetBudgetTokensFromReasoningEffort(effort, anthropicMinimumThinkingBudget, maxTokens)
+				if err != nil {
+					return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": err.Error()})
+				}
+				fields["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
+			}
+		}
+	}
+
+	if schema, name, ok := jsonSchemaFromResponseFormat(params.ResponseFormat); ok {
+		if !bfschemas.IsAnthropicModel(model) {
+			return nil, herr.New(ctx, domain.ErrUnsupportedParameter, herr.M{
+				"message": fmt.Sprintf("refusing to drop 'response_format' for bedrock/%s: the managed Bedrock endpoint enforces json_schema for Anthropic models only. Remove it, or use an Anthropic model", model),
+				"fault":   "customer",
+			})
+		}
+		_ = name // Anthropic's output_config carries type + schema only, same as bifrost.
+		setOutputConfig(fields, "format", map[string]any{"type": "json_schema", "schema": schema})
+	}
+
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	return brdocument.NewLazyDocument(fields), nil
+}
+
+// anthropicMinimumThinkingBudget and bedrockDefaultCompletionMaxTokens
+// mirror bifrost's anthropic.MinimumReasoningMaxTokens (1024) and
+// bedrock.DefaultCompletionMaxTokens (4096); the constants are not
+// exported in a shared place, so they are pinned here and by the policy
+// tests.
+const (
+	anthropicMinimumThinkingBudget    = 1024
+	bedrockDefaultCompletionMaxTokens = 4096
+)
+
+// setOutputConfig upserts a key under additionalModelRequestFields'
+// output_config object, preserving siblings (effort and format coexist on
+// adaptive-thinking structured-output requests).
+func setOutputConfig(fields map[string]any, key string, value any) {
+	cfg, _ := fields["output_config"].(map[string]any)
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg[key] = value
+	fields["output_config"] = cfg
+}
+
+// jsonSchemaFromResponseFormat extracts the schema object (and name) from
+// an OpenAI response_format of type json_schema. Returns ok false for
+// absent response_format or other types (json_object never reaches this
+// mapper: the parameter policy refuses it on the bedrock lane).
+func jsonSchemaFromResponseFormat(rf *interface{}) (schema any, name string, ok bool) {
+	if rf == nil {
+		return nil, "", false
+	}
+	m, isMap := (*rf).(map[string]interface{})
+	if !isMap || m["type"] != "json_schema" {
+		return nil, "", false
+	}
+	js, isMap := m["json_schema"].(map[string]interface{})
+	if !isMap {
+		return nil, "", false
+	}
+	name, _ = js["name"].(string)
+	schema, hasSchema := js["schema"]
+	if !hasSchema {
+		return nil, "", false
+	}
+	return schema, name, true
 }
 
 // mapBedrockMessages splits the neutral Bifrost message list into Bedrock's
@@ -619,6 +756,9 @@ type bedrockStreamIterator struct {
 	usage   domain.Usage
 	err     error
 	done    bool
+	// paramsDropped is the parameter-policy drop list; injected into the
+	// usage-bearing final chunk, mirroring the bifrost stream iterator.
+	paramsDropped []string
 
 	// toolIndex maps a Bedrock content-block index to the OpenAI tool-call
 	// index so multi-tool streams keep stable per-call indices in the deltas.
@@ -746,7 +886,8 @@ func (it *bedrockStreamIterator) chunkWithFinish(finish string) []byte {
 }
 
 func (it *bedrockStreamIterator) usageChunk() []byte {
-	return it.marshalChunk(&bfschemas.ChatStreamResponseChoiceDelta{}, nil, bedrockLLMUsage(usagePtr(it.usage)))
+	chunk := it.marshalChunk(&bfschemas.ChatStreamResponseChoiceDelta{}, nil, bedrockLLMUsage(usagePtr(it.usage)))
+	return injectParamsDropped(chunk, it.paramsDropped)
 }
 
 // marshalChunk builds and serializes a chat.completion.chunk carrying the given

--- a/services/aigateway/adapters/providers/bedrock_vpce_params_test.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce_params_test.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// docJSON marshals an AWS document.Interface back to JSON for assertions.
+func docJSON(t *testing.T, d interface{ MarshalSmithyDocument() ([]byte, error) }) []byte {
+	t.Helper()
+	b, err := d.MarshalSmithyDocument()
+	if err != nil {
+		t.Fatalf("marshal document: %v", err)
+	}
+	return b
+}
+
+func vpceParams(t *testing.T, body string) *bfschemas.ChatParameters {
+	t.Helper()
+	_, params, err := parseOpenAIChatRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return params
+}
+
+// @scenario "the managed Bedrock endpoint maps reasoning and json_schema like public bedrock"
+// The VPCE mapper used to drop reasoning and response_format entirely
+// while bifrost's public bedrock lane mapped them: the exact divergence
+// the shared policy table exists to prevent. Wire shapes mirror bifrost's
+// bedrock translator.
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestVPCE_MapsReasoningEffortToThinking(t *testing.T) {
+	// Non-adaptive Claude: budget = 1024 + 0.15 x (2048 - 1024) = 1177.
+	params := vpceParams(t, `{"model":"m","messages":[],"reasoning_effort":"low","max_tokens":2048}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	j := docJSON(t, doc)
+	if gjson.GetBytes(j, "thinking.type").String() != "enabled" {
+		t.Fatalf("thinking = %s, want enabled", j)
+	}
+	if got := gjson.GetBytes(j, "thinking.budget_tokens").Int(); got != 1177 {
+		t.Fatalf("budget_tokens = %d, want 1177 (1024 + 0.15 x 1024)", got)
+	}
+}
+
+func TestVPCE_AdaptiveThinkingOnOpus47(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"reasoning_effort":"minimal"}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "eu.anthropic.claude-opus-4-7-v1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	j := docJSON(t, doc)
+	if gjson.GetBytes(j, "thinking.type").String() != "adaptive" {
+		t.Fatalf("thinking = %s, want adaptive on 4.7", j)
+	}
+	if gjson.GetBytes(j, "output_config.effort").String() != "low" {
+		t.Fatalf("effort = %s, want minimal mapped to low", j)
+	}
+}
+
+func TestVPCE_MapsJSONSchemaToOutputConfig(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"response_format":{"type":"json_schema","json_schema":{"name":"city","strict":true,"schema":{"type":"object","properties":{"city":{"type":"string"}}}}}}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	j := docJSON(t, doc)
+	if gjson.GetBytes(j, "output_config.format.type").String() != "json_schema" {
+		t.Fatalf("format = %s, want json_schema under output_config", j)
+	}
+	if !gjson.GetBytes(j, "output_config.format.schema.properties.city").Exists() {
+		t.Fatalf("schema not carried verbatim: %s", j)
+	}
+}
+
+func TestVPCE_EffortAndSchemaCoexistUnderOutputConfig(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"reasoning_effort":"high","response_format":{"type":"json_schema","json_schema":{"name":"s","schema":{"type":"object"}}}}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "anthropic.claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	j := docJSON(t, doc)
+	if gjson.GetBytes(j, "output_config.effort").String() != "high" || !gjson.GetBytes(j, "output_config.format").Exists() {
+		t.Fatalf("output_config must merge effort and format: %s", j)
+	}
+}
+
+func TestVPCE_ThinkingBudgetFloor(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"reasoning_max_tokens":512}`)
+	_, err := mapBedrockAdditionalFields(context.Background(), params, "anthropic.claude-haiku-4-5")
+	if err == nil || !strings.Contains(err.Error(), "1024") {
+		t.Fatalf("sub-floor budget accepted: %v", err)
+	}
+}
+
+func TestVPCE_NoFeaturesMeansNilDocument(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"temperature":0.2}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "anthropic.claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc != nil {
+		b, _ := sonic.Marshal(doc)
+		t.Fatalf("additional fields = %s, want nil when nothing is requested", b)
+	}
+}
+
+// The caller's absent output cap must NOT be force-set: the budget is
+// computed against the model default, but inferenceConfig stays as sent.
+func TestVPCE_NoForcedOutputCap(t *testing.T) {
+	params := vpceParams(t, `{"model":"m","messages":[],"reasoning_effort":"low"}`)
+	doc, err := mapBedrockAdditionalFields(context.Background(), params, "anthropic.claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("thinking not mapped")
+	}
+	if params.MaxCompletionTokens != nil {
+		t.Fatal("mapping must not write an output cap the caller never sent")
+	}
+	cfg := mapBedrockInferenceConfig(params)
+	if cfg != nil && cfg.MaxTokens != nil {
+		t.Fatal("inferenceConfig.maxTokens must stay absent")
+	}
+}

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,8 @@ import (
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/langwatch/langwatch/pkg/herr"
@@ -247,11 +250,9 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 
 	bfReq, dispatchCtx, err := buildChatRequest(ctx, req, provider, model)
 	if err != nil {
-		// Everything buildChatRequest can reject is a client-body problem
-		// (unparseable JSON, malformed params): classify it as a 400 the
-		// same way the embeddings lane does, not an internal error.
-		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": err.Error()})
+		return nil, classifyChatBuildError(ctx, err)
 	}
+	stampParamsDropped(ctx, paramsDroppedFrom(dispatchCtx))
 
 	bfCtx := bfschemas.NewBifrostContext(withCredential(dispatchCtx, cred), time.Time{})
 
@@ -291,11 +292,57 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 	}
 
 	body, _ := sonic.Marshal(resp)
+	// Translated-lane response contract: a 200 must carry at least one
+	// choice, and a policy drop must be visible on the envelope.
+	body = ensureChoicesPresent(body)
+	body = injectParamsDropped(body, paramsDroppedFrom(dispatchCtx))
 	return &domain.Response{
 		Body:       body,
 		StatusCode: http.StatusOK,
 		Usage:      extractUsage(resp),
 	}, nil
+}
+
+// ensureChoicesPresent repairs a 200 whose choices came back null or
+// empty. The gemini translator skips candidates whose content has no
+// parts (providers/gemini/chat.go, the thinking-exhausted-cap case), so
+// a model that spent the whole completion budget on thinking produced an
+// HTTP 200 with "choices": null, usage billed, and no signal anywhere: an
+// empty success that also breaks strict OpenAI parsers. Synthesizing a
+// finish_reason "length" choice with empty content makes the outcome what
+// an OpenAI client understands: the cap truncated the answer.
+func ensureChoicesPresent(body []byte) []byte {
+	choices := gjson.GetBytes(body, "choices")
+	if choices.IsArray() && len(choices.Array()) > 0 {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "choices", []map[string]any{{
+		"index": 0,
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": "",
+		},
+		"finish_reason": "length",
+	}})
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// injectParamsDropped records the parameter-policy drop list on the
+// response envelope (extra_fields.params_dropped), alongside the
+// X-LangWatch-Params-Dropped header and the span attribute, so a dropped
+// parameter is observable from the response body alone.
+func injectParamsDropped(body []byte, dropped []string) []byte {
+	if len(dropped) == 0 {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "extra_fields.params_dropped", dropped)
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 // dispatchResponses routes /v1/responses traffic through Bifrost's
@@ -541,9 +588,10 @@ func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request,
 
 	bfReq, dispatchCtx, err := buildChatRequest(ctx, req, provider, model)
 	if err != nil {
-		// Client-body problem, same classification as the sync lane.
-		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": err.Error()})
+		return nil, classifyChatBuildError(ctx, err)
 	}
+	dropped := paramsDroppedFrom(dispatchCtx)
+	stampParamsDropped(ctx, dropped)
 
 	bfCtx := bfschemas.NewBifrostContext(withCredential(dispatchCtx, cred), time.Time{})
 
@@ -552,7 +600,33 @@ func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request,
 		return nil, errFromBifrost(ctx, berr, bifrostResponseHeaders(bfCtx))
 	}
 
-	return &bifrostStreamIterator{ch: ch}, nil
+	return &bifrostStreamIterator{ch: ch, paramsDropped: dropped}, nil
+}
+
+// classifyChatBuildError turns a buildChatRequest failure into the right
+// client-facing 400: parameter-policy refusals carry the policy's full
+// sentence under unsupported_parameter (the code OpenAI itself uses for
+// parameter rejections), everything else is a malformed client body.
+func classifyChatBuildError(ctx context.Context, err error) error {
+	var refusal *paramRefusalError
+	if errors.As(err, &refusal) {
+		return herr.New(ctx, domain.ErrUnsupportedParameter, herr.M{"message": refusal.msg, "fault": "customer"})
+	}
+	// Everything else buildChatRequest can reject is a client-body problem
+	// (unparseable JSON, malformed params): classify it as a 400 the same
+	// way the embeddings lane does, not an internal error.
+	return herr.New(ctx, domain.ErrBadRequest, herr.M{"reason": err.Error()})
+}
+
+// stampParamsDropped records the policy drop list on the gateway's
+// request span so drops are visible on the trace, not only on the
+// response envelope. Parameter names are shape metadata, never content.
+func stampParamsDropped(ctx context.Context, dropped []string) {
+	if len(dropped) == 0 {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.StringSlice("langwatch.gateway.params_dropped", dropped))
 }
 
 // dispatchMessagesStream raw-forwards a streaming /v1/messages request
@@ -749,6 +823,25 @@ func rawForwardCtx(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, bfschemas.BifrostContextKeyUseRawRequestBody, true)
 	ctx = context.WithValue(ctx, bfschemas.BifrostContextKeySendBackRawResponse, true)
 	return ctx
+}
+
+// paramsDroppedCtxKey carries the parameter-policy drop list from the
+// parse layer to the response path, so the drop can be signaled on the
+// response envelope, header, and span.
+type paramsDroppedCtxKey struct{}
+
+func withParamsDropped(ctx context.Context, dropped []string) context.Context {
+	if len(dropped) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, paramsDroppedCtxKey{}, dropped)
+}
+
+// paramsDroppedFrom returns the drop list recorded by the parameter
+// policy, nil when nothing was dropped.
+func paramsDroppedFrom(ctx context.Context) []string {
+	dropped, _ := ctx.Value(paramsDroppedCtxKey{}).([]string)
+	return dropped
 }
 
 // rawResponseBytes extracts the provider's native chat-completion
@@ -1484,6 +1577,11 @@ type bifrostStreamIterator struct {
 	// first delta, driving the leading-role repair in ensureLeadingRoleDelta
 	// (see chat_stream_role.go). Lazily allocated on the first chat chunk.
 	roleSeenByChoice map[int]bool
+	// paramsDropped is the parameter-policy drop list for this request;
+	// injected into the final usage-bearing chunk so streamed responses
+	// carry the same extra_fields.params_dropped signal as sync ones.
+	// Never set on raw-framing passthrough streams.
+	paramsDropped []string
 }
 
 func (it *bifrostStreamIterator) Next(ctx context.Context) bool {
@@ -1508,10 +1606,14 @@ func (it *bifrostStreamIterator) Next(ctx context.Context) bool {
 		if chunk.BifrostChatResponse != nil {
 			it.ensureLeadingRoleDelta(chunk.BifrostChatResponse)
 			data, _ := sonic.Marshal(chunk.BifrostChatResponse)
-			it.current = data
 			if chunk.BifrostChatResponse.Usage != nil {
 				it.usage = extractUsage(chunk.BifrostChatResponse)
+				// The usage-bearing final chunk carries the policy drop
+				// signal, mirroring extra_fields.params_dropped on sync
+				// responses.
+				data = injectParamsDropped(data, it.paramsDropped)
 			}
+			it.current = data
 		} else if chunk.BifrostResponsesStreamResponse != nil {
 			// Responses API stream frames (response.created /
 			// response.output_text.delta / response.completed / ...).

--- a/services/aigateway/adapters/providers/bifrost_parser.go
+++ b/services/aigateway/adapters/providers/bifrost_parser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 
 	bfschemas "github.com/maximhq/bifrost/core/schemas"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/langwatch/langwatch/services/aigateway/app/pipeline"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
@@ -145,7 +147,7 @@ func buildChatRequest(
 		return &bfschemas.BifrostChatRequest{
 				Provider:       provider,
 				Model:          model,
-				RawRequestBody: req.Body,
+				RawRequestBody: stripDropTuningParams(req.Body),
 				Input:          []bfschemas.ChatMessage{},
 			},
 			rawForwardCtx(ctx),
@@ -160,11 +162,14 @@ func buildChatRequest(
 	// preserves byte-for-byte identity and keeps cache hits working.
 	// Translation earns its keep only when the target wire format
 	// differs from the inbound (Anthropic / Gemini / Bedrock / Vertex).
+	// The parameter policy never applies here: whatever the provider
+	// accepts, the client gets, and the body stays byte-identical except
+	// for stripping the gateway-only drop_tuning_params field when present.
 	if isOpenAICompatibleProvider(provider) {
 		return &bfschemas.BifrostChatRequest{
 				Provider:       provider,
 				Model:          model,
-				RawRequestBody: req.Body,
+				RawRequestBody: stripDropTuningParams(req.Body),
 				Input:          []bfschemas.ChatMessage{},
 			},
 			rawForwardCtx(ctx),
@@ -175,12 +180,41 @@ func buildChatRequest(
 	if err != nil {
 		return nil, ctx, err
 	}
+	policy, err := applyParamPolicy(req.Body, params, provider, model)
+	if err != nil {
+		return nil, ctx, err
+	}
+	if len(policy.dropped) > 0 {
+		// The response-header seam for both sync and stream lanes is the
+		// dispatch meta accumulator (setMetaHeaders writes it before the
+		// first byte on either lane).
+		if meta := pipeline.MetaFromContext(ctx); meta != nil {
+			droppedCopy := slices.Clone(policy.dropped)
+			meta.Update(func(m *pipeline.Meta) { m.ParamsDropped = droppedCopy })
+		}
+		ctx = withParamsDropped(ctx, policy.dropped)
+	}
 	return &bfschemas.BifrostChatRequest{
 		Provider: provider,
 		Model:    model,
 		Input:    messages,
 		Params:   params,
 	}, ctx, nil
+}
+
+// stripDropTuningParams removes the gateway-only drop_tuning_params field before a
+// body is forwarded to a provider. Only mutates when the field is present
+// so raw-forward bodies stay byte-identical for the overwhelmingly common
+// case (OpenAI's prompt-prefix auto-cache depends on that identity).
+func stripDropTuningParams(body []byte) []byte {
+	if !gjson.GetBytes(body, "drop_tuning_params").Exists() {
+		return body
+	}
+	out, err := sjson.DeleteBytes(body, "drop_tuning_params")
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 // isOpenAICompatibleProvider reports whether the destination provider
@@ -231,6 +265,7 @@ func parseOpenAIChatRequest(body []byte) ([]bfschemas.ChatMessage, *bfschemas.Ch
 	if len(body) == 0 {
 		return nil, nil, nil
 	}
+	body = normalizeStopString(body)
 
 	var messagesWrap struct {
 		Messages []bfschemas.ChatMessage `json:"messages"`
@@ -250,6 +285,23 @@ func parseOpenAIChatRequest(body []byte) ([]bfschemas.ChatMessage, *bfschemas.Ch
 	liftExtensionParams(body, &params)
 
 	return messagesWrap.Messages, &params, nil
+}
+
+// normalizeStopString accepts OpenAI's bare-string form of `stop`
+// ("stop": "END") by rewriting it to the one-element list form before the
+// structured parse. ChatParameters types Stop as []string, so without
+// this a valid OpenAI body that works on every raw-forward lane would
+// 400 on the translated lanes.
+func normalizeStopString(body []byte) []byte {
+	v := gjson.GetBytes(body, "stop")
+	if v.Type != gjson.String {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "stop", []string{v.String()})
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 // liftMaxTokensAlias maps the legacy OpenAI output cap `max_tokens` onto

--- a/services/aigateway/adapters/providers/param_policy.go
+++ b/services/aigateway/adapters/providers/param_policy.go
@@ -1,0 +1,576 @@
+package providers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// Parameter policy for the translated chat lanes.
+//
+// Raw-forward lanes (OpenAI, Azure, vLLM) pass the body through
+// byte-identical and are never consulted here: whatever the provider
+// accepts, the client gets. The translated lanes (Anthropic, Bedrock,
+// Gemini, Vertex, and the Bedrock VPCE path) are different: the gateway
+// builds the provider request itself, so every OpenAI chat-completions
+// parameter needs an explicit disposition or it silently disagrees with
+// the client (#6290). This table is the single source of truth:
+//
+//   - dispMapped: the parameter reaches the provider faithfully, either
+//     through the bifrost translator or through a mapping this layer
+//     performs itself.
+//   - dispDropped (tier 3): a tuning parameter with no equivalent on the
+//     lane. With drop_tuning_params true (the default) the parameter is removed
+//     and the request proceeds, and the drop is signaled on the response
+//     (params_dropped, response header, span attribute). With drop_tuning_params
+//     false the request is refused instead.
+//   - dispRefused (tier 2): the request depends on the parameter
+//     functionally; honoring the request without it would change what the
+//     client observably gets. Always refused, regardless of drop_tuning_params.
+//
+// The docs page docs/self-hosting/gateway-parameter-mapping.mdx renders
+// this table; TestParamPolicyDocsInSync keeps the two from drifting.
+
+// policyLane identifies a translated lane for parameter policy. Vertex
+// dispatches through the gemini translation and shares laneGemini; the
+// Bedrock VPCE path shares laneBedrock, which is what keeps it from
+// diverging from the public bedrock lane again.
+type policyLane string
+
+const (
+	laneAnthropic policyLane = "anthropic"
+	laneBedrock   policyLane = "bedrock"
+	laneGemini    policyLane = "gemini"
+)
+
+// policyLaneFor maps a dispatch target onto its policy lane. The second
+// return is false for raw-forward providers, which bypass the policy
+// entirely.
+func policyLaneFor(provider bfschemas.ModelProvider) (policyLane, bool) {
+	if isOpenAICompatibleProvider(provider) {
+		return "", false
+	}
+	switch bfschemas.ModelProvider(baseProviderType(provider)) {
+	case bfschemas.Anthropic:
+		return laneAnthropic, true
+	case bfschemas.Bedrock:
+		return laneBedrock, true
+	case bfschemas.Gemini, bfschemas.Vertex:
+		return laneGemini, true
+	default:
+		// Other structured lanes (xai, groq, cerebras, elevenlabs ...)
+		// speak the OpenAI parameter surface natively through bifrost's
+		// openai-shape converters; nothing to police at this layer.
+		return "", false
+	}
+}
+
+// baseProviderType collapses derived provider keys (the per-endpoint
+// anthropic-compat providers) onto their base type so the policy treats
+// a self-hosted Anthropic-compatible server like the anthropic lane.
+func baseProviderType(provider bfschemas.ModelProvider) string {
+	if len(provider) > len(anthropicCompatPrefix) && string(provider[:len(anthropicCompatPrefix)]) == anthropicCompatPrefix {
+		return string(bfschemas.Anthropic)
+	}
+	return string(provider)
+}
+
+type disposition int
+
+const (
+	dispMapped disposition = iota
+	dispDropped
+	dispRefused
+)
+
+// ruleCtx carries what value-dependent rules may inspect.
+type ruleCtx struct {
+	body   []byte
+	params *bfschemas.ChatParameters
+	lane   policyLane
+	model  string
+	value  gjson.Result
+}
+
+type paramRule struct {
+	disp disposition
+	// why completes the refusal sentence for dispRefused ("the request
+	// depends on it functionally (<why>)") and documents the drop for
+	// dispDropped.
+	why string
+	// note is the docs-table annotation for value-dependent rules; the
+	// rendered docs page carries it in the notes column.
+	note string
+	// refine adjusts the disposition based on the request value, model
+	// family, or parameter combination. Optional.
+	refine func(rc ruleCtx) (disposition, string)
+	// clear removes the parameter from the typed params so a translator
+	// that would forward it badly cannot see it. Only needed where the
+	// translator reads the field; parameters the translators already
+	// ignore need no clearing. Optional.
+	clear func(p *bfschemas.ChatParameters)
+}
+
+// mapped is the shorthand for parameters the lane translates faithfully.
+func mapped() paramRule { return paramRule{disp: dispMapped} }
+
+func dropped(why string) paramRule { return paramRule{disp: dispDropped, why: why} }
+
+func refused(why string) paramRule { return paramRule{disp: dispRefused, why: why} }
+
+// paramPolicyDefaultRule governs request keys the table does not name
+// (vendor params like min_p, repetition_penalty, chat_template_kwargs):
+// no translated lane can map them, so they are droppable tuning knobs.
+var paramPolicyDefaultRule = dropped("this lane has no mapping for it")
+
+// paramPolicyIgnoredKeys are body keys that are not provider parameters:
+// routing and transport fields the gateway consumes itself, plus the
+// extension keys the parser lifts explicitly.
+var paramPolicyIgnoredKeys = map[string]bool{
+	"model":              true,
+	"messages":           true,
+	"stream":             true,
+	"drop_tuning_params": true,
+	// Lifted extension keys (see chatExtensionKeys).
+	"cached_content":  true,
+	"safety_settings": true,
+	"labels":          true,
+	// The cap pair is normalized by liftMaxTokensAlias and mapped on
+	// every translated lane (#6285).
+	"max_tokens":            true,
+	"max_completion_tokens": true,
+	// Anthropic-native knobs promoted to the neutral layer; they pass
+	// through typed and are honored or ignored per provider feature set.
+	"top_k":                true,
+	"speed":                true,
+	"inference_geo":        true,
+	"mcp_servers":          true,
+	"container":            true,
+	"cache_control":        true,
+	"task_budget":          true,
+	"context_management":   true,
+	"thinking":             true,
+	"reasoning":            true,
+	"reasoning_max_tokens": true,
+	// fallbacks is bifrost transport config, stripped downstream.
+	"fallbacks": true,
+}
+
+// refineN keeps n: 1 mapped (it is the default) and classifies n > 1 as
+// droppable: the translators produce a single choice, so the drop is
+// "you get one completion", signaled, never silent.
+func refineN(rc ruleCtx) (disposition, string) {
+	if rc.value.Type == gjson.Number && rc.value.Int() <= 1 {
+		return dispMapped, ""
+	}
+	return dispDropped, "the lane returns a single completion; n was reduced to 1"
+}
+
+// refineResponseFormat: json_schema is enforced on every translated lane;
+// json_object has no sound mechanism on the Anthropic families (the model
+// answers fenced markdown, which breaks clients that json-parse the
+// guarantee), so it is contract-refused there and mapped on gemini.
+func refineResponseFormat(rc ruleCtx) (disposition, string) {
+	switch rc.value.Get("type").String() {
+	case "json_object":
+		if rc.lane == laneGemini {
+			return dispMapped, ""
+		}
+		return dispRefused, "the response would not be guaranteed parseable JSON on this lane"
+	case "json_schema", "":
+		return dispMapped, ""
+	default:
+		return dispMapped, ""
+	}
+}
+
+// refineServiceTier: OpenAI's values do not exist on these lanes.
+// Anthropic accepts "auto" natively so that single value is mapped;
+// everything else would either 400 upstream (Bedrock validates it against
+// a different enum) or mislead, so it is droppable, and clearing the
+// typed field keeps the translators from forwarding it verbatim.
+func refineServiceTier(rc ruleCtx) (disposition, string) {
+	if rc.lane == laneAnthropic && rc.value.String() == "auto" {
+		return dispMapped, ""
+	}
+	return dispDropped, "the lane has no OpenAI-compatible service tiers"
+}
+
+// refineTopP drops top_p (with a signal) when temperature is also set
+// and the target is an Anthropic model: the models reject the pair with a
+// hard 400 ("temperature and top_p cannot both be specified"), verified
+// live on both the anthropic and bedrock lanes. Temperature wins, which
+// matches what bifrost's translator silently did; the difference is the
+// drop is now visible. Alone, top_p maps faithfully everywhere.
+func refineTopP(rc ruleCtx) (disposition, string) {
+	if rc.params.Temperature == nil || rc.params.TopP == nil {
+		return dispMapped, ""
+	}
+	if rc.lane == laneBedrock && !bfschemas.IsAnthropicModel(rc.model) {
+		return dispMapped, ""
+	}
+	return dispDropped, "Anthropic models reject temperature and top_p together; temperature wins"
+}
+
+func clearTopP(p *bfschemas.ChatParameters) { p.TopP = nil }
+
+// refineBedrockReasoning refuses reasoning_effort for Bedrock model
+// families where bifrost would silently drop the reasoning AND force the
+// output cap to a model default the caller never sent. Anthropic and Nova
+// families map it faithfully.
+func refineBedrockReasoning(rc ruleCtx) (disposition, string) {
+	if bedrockModelSupportsReasoning(rc.model) {
+		return dispMapped, ""
+	}
+	return dispRefused, "this Bedrock model family has no reasoning mapping and the requested reasoning depth would be silently ignored"
+}
+
+// refineToolChoice polices the shapes the translators mistranslate:
+//   - "none" on Bedrock: Converse has no none mode and bifrost drops the
+//     field, which lets the model call tools it was told not to call. The
+//     policy maps it faithfully by removing the tools instead.
+//   - a named function that is not in tools: bifrost's bedrock translator
+//     silently nulls it and Converse rejects it downstream; refuse with a
+//     message that names the problem.
+//   - "allowed_tools": Anthropic's translator collapses it to "any" and
+//     discards the list; the other lanes drop it. Functional, refused.
+func refineToolChoice(rc ruleCtx) (disposition, string) {
+	if rc.value.Type == gjson.String {
+		return dispMapped, ""
+	}
+	choiceType := rc.value.Get("type").String()
+	switch choiceType {
+	case "allowed_tools":
+		return dispRefused, "the allowed tool list would be discarded in translation"
+	case "function":
+		name := rc.value.Get("function.name").String()
+		if name != "" && !toolListContains(rc.body, name) {
+			return dispRefused, fmt.Sprintf("tool_choice names %q but no tool with that name is in tools", name)
+		}
+	}
+	return dispMapped, ""
+}
+
+func toolListContains(body []byte, name string) bool {
+	found := false
+	gjson.GetBytes(body, "tools").ForEach(func(_, tool gjson.Result) bool {
+		if tool.Get("function.name").String() == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// paramPolicyTable is the per-parameter, per-lane disposition table. Keys
+// are the OpenAI wire names. A parameter absent here falls to
+// paramPolicyDefaultRule.
+var paramPolicyTable = map[string]map[policyLane]paramRule{
+	"temperature": {
+		laneAnthropic: mapped(), laneBedrock: mapped(), laneGemini: mapped(),
+	},
+	"top_p": {
+		laneAnthropic: {disp: dispMapped, refine: refineTopP, clear: clearTopP, note: "dropped with a signal when temperature is also set (Anthropic models reject the pair)"},
+		laneBedrock:   {disp: dispMapped, refine: refineTopP, clear: clearTopP, note: "dropped with a signal when temperature is also set on Anthropic models (they reject the pair); other families take both"},
+		laneGemini:    mapped(),
+	},
+	"stop": {
+		// The bare-string form is normalized to a list by the parser
+		// (liftStopString), so both OpenAI shapes map on every lane.
+		laneAnthropic: mapped(), laneBedrock: mapped(), laneGemini: mapped(),
+	},
+	"n": {
+		laneAnthropic: {disp: dispDropped, refine: refineN, note: "n: 1 passes; n > 1 is reduced to one completion and signaled"},
+		laneBedrock:   {disp: dispDropped, refine: refineN, note: "n: 1 passes; n > 1 is reduced to one completion and signaled"},
+		laneGemini:    {disp: dispDropped, refine: refineN, note: "n: 1 passes; n > 1 is reduced to one completion and signaled"},
+	},
+	"presence_penalty": {
+		laneAnthropic: dropped("Anthropic has no presence penalty"),
+		laneBedrock:   dropped("Bedrock Converse has no presence penalty"),
+		laneGemini:    mapped(),
+	},
+	"frequency_penalty": {
+		laneAnthropic: dropped("Anthropic has no frequency penalty"),
+		laneBedrock:   dropped("Bedrock Converse has no frequency penalty"),
+		laneGemini:    mapped(),
+	},
+	"logit_bias": {
+		laneAnthropic: dropped("Anthropic has no logit bias"),
+		laneBedrock:   dropped("Bedrock Converse has no logit bias"),
+		laneGemini:    dropped("Gemini has no logit bias"),
+	},
+	"logprobs": {
+		laneAnthropic: refused("the requested log probabilities would be silently absent from the response"),
+		laneBedrock:   refused("the requested log probabilities would be silently absent from the response"),
+		laneGemini:    mapped(),
+	},
+	"top_logprobs": {
+		laneAnthropic: refused("the requested log probabilities would be silently absent from the response"),
+		laneBedrock:   refused("the requested log probabilities would be silently absent from the response"),
+		laneGemini:    mapped(),
+	},
+	"seed": {
+		laneAnthropic: dropped("Anthropic has no sampling seed"),
+		laneBedrock:   dropped("Bedrock Converse has no sampling seed"),
+		laneGemini:    dropped("the Gemini translation does not map a sampling seed"),
+	},
+	"user": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"response_format": {
+		laneAnthropic: {disp: dispMapped, refine: refineResponseFormat, note: "json_schema enforced; json_object refused (no parseable-JSON guarantee)"},
+		laneBedrock:   {disp: dispMapped, refine: refineResponseFormat, note: "json_schema enforced; json_object refused (no parseable-JSON guarantee)"},
+		laneGemini:    {disp: dispMapped, refine: refineResponseFormat, note: "json_object and json_schema both enforced"},
+	},
+	"tools": {
+		laneAnthropic: mapped(), laneBedrock: mapped(), laneGemini: mapped(),
+	},
+	"tool_choice": {
+		laneAnthropic: {disp: dispMapped, refine: refineToolChoice, note: "none/auto/required/named mapped; named must exist in tools; allowed_tools refused"},
+		laneBedrock:   {disp: dispMapped, refine: refineToolChoice, note: "none maps by removing tools (Converse has no none mode); named must exist in tools; allowed_tools refused"},
+		laneGemini:    {disp: dispMapped, refine: refineToolChoice, note: "none/auto/required/named mapped; named must exist in tools; allowed_tools refused"},
+	},
+	"parallel_tool_calls": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"stream_options": {
+		// Translated lanes emit native usage on every stream; the flag has
+		// nothing to switch.
+		laneAnthropic: mapped(), laneBedrock: mapped(), laneGemini: mapped(),
+	},
+	"reasoning_effort": {
+		laneAnthropic: mapped(),
+		laneBedrock:   {disp: dispMapped, refine: refineBedrockReasoning, note: "mapped for Anthropic (thinking) and Nova; refused for other families"},
+		laneGemini:    mapped(),
+	},
+	"verbosity": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"prediction": {
+		laneAnthropic: dropped("predicted outputs are OpenAI-only"),
+		laneBedrock:   dropped("predicted outputs are OpenAI-only"),
+		laneGemini:    dropped("predicted outputs are OpenAI-only"),
+	},
+	"modalities": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"audio": {
+		laneAnthropic: dropped("audio output is not mapped on this lane"),
+		laneBedrock:   dropped("audio output is not mapped on this lane"),
+		laneGemini:    dropped("audio output is not mapped on this lane"),
+	},
+	"store": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"metadata": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"service_tier": {
+		laneAnthropic: {disp: dispDropped, refine: refineServiceTier, clear: clearServiceTier, note: "\"auto\" passes natively; other values dropped"},
+		laneBedrock:   {disp: dispDropped, refine: refineServiceTier, clear: clearServiceTier, note: "dropped (AWS validates a different enum)"},
+		laneGemini:    {disp: dispDropped, refine: refineServiceTier, clear: clearServiceTier, note: "dropped"},
+	},
+	"web_search_options": {
+		laneAnthropic: dropped("web search is not mapped on this lane"),
+		laneBedrock:   dropped("web search is not mapped on this lane"),
+		laneGemini:    dropped("web search is not mapped on this lane"),
+	},
+	"prompt_cache_key": {
+		laneAnthropic: dropped("OpenAI prompt-cache routing does not exist on this lane"),
+		laneBedrock:   dropped("OpenAI prompt-cache routing does not exist on this lane"),
+		laneGemini:    dropped("OpenAI prompt-cache routing does not exist on this lane"),
+	},
+	"prompt_cache_retention": {
+		laneAnthropic: dropped("OpenAI prompt-cache routing does not exist on this lane"),
+		laneBedrock:   dropped("OpenAI prompt-cache routing does not exist on this lane"),
+		laneGemini:    dropped("OpenAI prompt-cache routing does not exist on this lane"),
+	},
+	"safety_identifier": {
+		laneAnthropic: dropped("not mapped on this lane"),
+		laneBedrock:   dropped("not mapped on this lane"),
+		laneGemini:    dropped("not mapped on this lane"),
+	},
+	"functions": {
+		laneAnthropic: refused("the legacy function-calling tools would be silently discarded; use tools"),
+		laneBedrock:   refused("the legacy function-calling tools would be silently discarded; use tools"),
+		laneGemini:    refused("the legacy function-calling tools would be silently discarded; use tools"),
+	},
+	"function_call": {
+		laneAnthropic: refused("the legacy function-calling directive would be silently discarded; use tool_choice"),
+		laneBedrock:   refused("the legacy function-calling directive would be silently discarded; use tool_choice"),
+		laneGemini:    refused("the legacy function-calling directive would be silently discarded; use tool_choice"),
+	},
+}
+
+func clearServiceTier(p *bfschemas.ChatParameters) { p.ServiceTier = nil }
+
+// bedrockModelSupportsReasoning mirrors the families bifrost maps
+// reasoning for on Converse: Anthropic models (thinking) and Amazon Nova
+// (maxReasoningEffort). Everything else drops reasoning inside bifrost
+// while force-setting an output cap, which is what the policy refuses.
+// Uses bifrost's own family matchers so the policy and the translator
+// can never disagree about a model's family.
+func bedrockModelSupportsReasoning(model string) bool {
+	return bfschemas.IsAnthropicModel(model) || bfschemas.IsNovaModel(model)
+}
+
+// paramPolicyResult is what applyParamPolicy reports back for the
+// response-side signals.
+type paramPolicyResult struct {
+	dropped []string
+}
+
+// dropParamsDefault: tier-3 parameters are dropped (with a signal) unless
+// the client opts into strict mode with "drop_tuning_params": false.
+func dropTuningParamsEnabled(body []byte) bool {
+	return gjson.GetBytes(body, "drop_tuning_params").Type != gjson.False
+}
+
+// applyParamPolicy walks the request's top-level keys and applies the
+// table: mapped keys pass, droppable keys are dropped (signaled) or
+// refused in strict mode, contract keys always refuse. It also performs
+// the mapping-side fixes the table promises (anthropic top_p coexistence,
+// bedrock tool_choice none).
+func applyParamPolicy(body []byte, params *bfschemas.ChatParameters, provider bfschemas.ModelProvider, model string) (paramPolicyResult, error) {
+	var result paramPolicyResult
+	lane, ok := policyLaneFor(provider)
+	if !ok {
+		return result, nil
+	}
+	strict := !dropTuningParamsEnabled(body)
+	laneLabel := fmt.Sprintf("%s/%s", lane, model)
+
+	var refusal *paramRefusalError
+	gjson.ParseBytes(body).ForEach(func(key, value gjson.Result) bool {
+		name := key.String()
+		if paramPolicyIgnoredKeys[name] {
+			return true
+		}
+		laneRules, known := paramPolicyTable[name]
+		rule := paramPolicyDefaultRule
+		if known {
+			rule = laneRules[lane]
+		}
+		disp, why := rule.disp, rule.why
+		if rule.refine != nil {
+			disp, why = rule.refine(ruleCtx{body: body, params: params, lane: lane, model: model, value: value})
+			if why == "" {
+				why = rule.why
+			}
+		}
+		switch disp {
+		case dispMapped:
+			return true
+		case dispRefused:
+			refusal = &paramRefusalError{msg: fmt.Sprintf(
+				"refusing to drop '%s' for %s: the request depends on it functionally (%s). Remove it, or use a model that supports it",
+				name, laneLabel, why)}
+			return false
+		case dispDropped:
+			if strict {
+				refusal = &paramRefusalError{msg: fmt.Sprintf(
+					"refusing to drop '%s' for %s: drop_tuning_params is false and %s. Remove it, set drop_tuning_params to true, or use a model that supports it",
+					name, laneLabel, why)}
+				return false
+			}
+			if rule.clear != nil {
+				rule.clear(params)
+			}
+			result.dropped = append(result.dropped, name)
+			return true
+		}
+		return true
+	})
+	if refusal != nil {
+		return paramPolicyResult{}, refusal
+	}
+	sort.Strings(result.dropped)
+
+	applyPolicyMappings(body, params, lane)
+	return result, nil
+}
+
+// applyPolicyMappings performs the gateway-side mappings the table
+// classifies as mapped but the vendored translators get wrong.
+func applyPolicyMappings(body []byte, params *bfschemas.ChatParameters, lane policyLane) {
+	// Bedrock: Converse has no tool_choice "none"; bifrost drops the field
+	// and the model may call tools it was told not to call. Removing the
+	// tools is the faithful translation of "never call a tool".
+	if lane == laneBedrock && params.ToolChoice != nil && toolChoiceIsNone(body) {
+		params.Tools = nil
+		params.ToolChoice = nil
+	}
+}
+
+func toolChoiceIsNone(body []byte) bool {
+	v := gjson.GetBytes(body, "tool_choice")
+	return v.Type == gjson.String && v.String() == "none"
+}
+
+// renderParamPolicyTable renders the policy table as the markdown the
+// docs page carries; TestParamPolicyDocsInSync diffs the two so the table
+// in the code and the table customers read cannot drift apart.
+func renderParamPolicyTable() string {
+	names := make([]string, 0, len(paramPolicyTable))
+	for name := range paramPolicyTable {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	label := func(r paramRule) string {
+		switch r.disp {
+		case dispMapped:
+			return "mapped"
+		case dispDropped:
+			return "dropped"
+		default:
+			return "refused"
+		}
+	}
+	var b strings.Builder
+	b.WriteString("| Parameter | anthropic | bedrock | gemini / vertex | Notes |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, name := range names {
+		rules := paramPolicyTable[name]
+		note := ""
+		if a, bd, g := rules[laneAnthropic].note, rules[laneBedrock].note, rules[laneGemini].note; a == bd && bd == g {
+			note = a
+		} else {
+			for _, lane := range []policyLane{laneAnthropic, laneBedrock, laneGemini} {
+				if n := rules[lane].note; n != "" {
+					if note != "" {
+						note += "; "
+					}
+					note += string(lane) + ": " + n
+				}
+			}
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n",
+			name, label(rules[laneAnthropic]), label(rules[laneBedrock]), label(rules[laneGemini]), note)
+	}
+	b.WriteString("| any other key | dropped | dropped | dropped | vendor params with no mapping on translated lanes |\n")
+	return b.String()
+}
+
+// paramRefusalError marks a policy refusal so the dispatch call sites can
+// classify it as unsupported_parameter (400) instead of a generic parse
+// failure. The message is the full client-facing sentence.
+type paramRefusalError struct{ msg string }
+
+func (e *paramRefusalError) Error() string { return e.msg }

--- a/services/aigateway/adapters/providers/param_policy_render_test.go
+++ b/services/aigateway/adapters/providers/param_policy_render_test.go
@@ -1,0 +1,40 @@
+package providers
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The docs page carries the policy table between generated-block markers;
+// this test regenerates it from paramPolicyTable and diffs, so the table
+// in the code and the table customers read cannot drift apart. To update
+// the docs after a table change, paste the output of
+// go test -run TestPrintParamTable -v between the markers.
+func TestParamPolicyDocsInSync(t *testing.T) {
+	raw, err := os.ReadFile("../../../../docs/ai-gateway/parameter-mapping.mdx")
+	if err != nil {
+		t.Fatalf("docs page missing: %v", err)
+	}
+	page := string(raw)
+	begin := "{/* param-table:begin generated from paramPolicyTable, kept in sync by TestParamPolicyDocsInSync */}"
+	end := "{/* param-table:end */}"
+	i := strings.Index(page, begin)
+	j := strings.Index(page, end)
+	if i < 0 || j < 0 || j < i {
+		t.Fatal("param-table markers missing from docs/ai-gateway/parameter-mapping.mdx")
+	}
+	docTable := strings.TrimSpace(page[i+len(begin) : j])
+	want := strings.TrimSpace(renderParamPolicyTable())
+	if docTable != want {
+		t.Fatalf("docs table drifted from paramPolicyTable.\nRegenerate with: go test ./services/aigateway/adapters/providers -run TestPrintParamTable -v\n\nwant:\n%s\n\ngot:\n%s", want, docTable)
+	}
+}
+
+// TestPrintParamTable is the generator: go test -run TestPrintParamTable -v
+// prints the canonical table for pasting into the docs page.
+func TestPrintParamTable(t *testing.T) {
+	if testing.Verbose() {
+		t.Log("\n" + renderParamPolicyTable())
+	}
+}

--- a/services/aigateway/adapters/providers/param_policy_test.go
+++ b/services/aigateway/adapters/providers/param_policy_test.go
@@ -1,0 +1,392 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func chatReq(body string) *domain.Request {
+	return &domain.Request{Type: domain.RequestTypeChat, Body: []byte(body)}
+}
+
+// build runs buildChatRequest and returns the request, the dropped list
+// recorded on the returned context, and the error.
+func build(t *testing.T, provider bfschemas.ModelProvider, model, body string) (*bfschemas.BifrostChatRequest, []string, error) {
+	t.Helper()
+	bfReq, ctx, err := buildChatRequest(context.Background(), chatReq(body), provider, model)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bfReq, paramsDroppedFrom(ctx), nil
+}
+
+// @scenario "tier-3 params are dropped with a signal by default"
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestParamPolicy_DroppableParamsPerLane(t *testing.T) {
+	cases := []struct {
+		lane     string
+		provider bfschemas.ModelProvider
+		param    string
+		body     string
+	}{
+		{"anthropic", bfschemas.Anthropic, "seed", `{"model":"m","messages":[],"seed":42}`},
+		{"anthropic", bfschemas.Anthropic, "logit_bias", `{"model":"m","messages":[],"logit_bias":{"1":-100}}`},
+		{"anthropic", bfschemas.Anthropic, "presence_penalty", `{"model":"m","messages":[],"presence_penalty":0.5}`},
+		{"anthropic", bfschemas.Anthropic, "user", `{"model":"m","messages":[],"user":"u1"}`},
+		{"anthropic", bfschemas.Anthropic, "metadata", `{"model":"m","messages":[],"metadata":{"a":"b"}}`},
+		{"anthropic", bfschemas.Anthropic, "store", `{"model":"m","messages":[],"store":true}`},
+		{"anthropic", bfschemas.Anthropic, "prediction", `{"model":"m","messages":[],"prediction":{"type":"content","content":"x"}}`},
+		{"anthropic", bfschemas.Anthropic, "verbosity", `{"model":"m","messages":[],"verbosity":"low"}`},
+		{"anthropic", bfschemas.Anthropic, "web_search_options", `{"model":"m","messages":[],"web_search_options":{}}`},
+		{"anthropic", bfschemas.Anthropic, "n", `{"model":"m","messages":[],"n":2}`},
+		{"anthropic", bfschemas.Anthropic, "min_p", `{"model":"m","messages":[],"min_p":0.1}`},
+		{"bedrock", bfschemas.Bedrock, "frequency_penalty", `{"model":"m","messages":[],"frequency_penalty":0.5}`},
+		{"bedrock", bfschemas.Bedrock, "seed", `{"model":"m","messages":[],"seed":42}`},
+		{"bedrock", bfschemas.Bedrock, "service_tier", `{"model":"m","messages":[],"service_tier":"auto"}`},
+		{"gemini", bfschemas.Gemini, "logit_bias", `{"model":"m","messages":[],"logit_bias":{"1":-100}}`},
+		{"gemini", bfschemas.Gemini, "seed", `{"model":"m","messages":[],"seed":42}`},
+		{"vertex", bfschemas.Vertex, "seed", `{"model":"m","messages":[],"seed":42}`},
+	}
+	for _, tc := range cases {
+		_, dropped, err := build(t, tc.provider, "m", tc.body)
+		if err != nil {
+			t.Fatalf("%s/%s: unexpected error: %v", tc.lane, tc.param, err)
+		}
+		found := false
+		for _, d := range dropped {
+			if d == tc.param {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s/%s: dropped = %v, want the param recorded (never silent)", tc.lane, tc.param, dropped)
+		}
+	}
+}
+
+// @scenario "drop_tuning_params false refuses any unmappable param"
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestParamPolicy_StrictModeRefusesDroppable(t *testing.T) {
+	_, _, err := build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"seed":42,"drop_tuning_params":false}`)
+	if err == nil {
+		t.Fatal("strict mode accepted an unmappable param")
+	}
+	for _, want := range []string{"refusing to drop 'seed'", "anthropic/claude-haiku-4-5", "drop_tuning_params is false", "set drop_tuning_params to true"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("refusal %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// @scenario "contract params always refuse, drop_tuning_params cannot drop them"
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestParamPolicy_ContractParamsAlwaysRefuse(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider bfschemas.ModelProvider
+		model    string
+		body     string
+		wantIn   string
+	}{
+		{"json_object anthropic", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"response_format":{"type":"json_object"},"drop_tuning_params":true}`,
+			"parseable JSON"},
+		{"json_object bedrock", bfschemas.Bedrock, "anthropic.claude-haiku",
+			`{"model":"m","messages":[],"response_format":{"type":"json_object"}}`,
+			"parseable JSON"},
+		{"logprobs anthropic", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"logprobs":true}`,
+			"log probabilities"},
+		{"top_logprobs bedrock", bfschemas.Bedrock, "anthropic.claude-haiku",
+			`{"model":"m","messages":[],"top_logprobs":3}`,
+			"log probabilities"},
+		{"legacy functions", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"functions":[{"name":"f"}]}`,
+			"use tools"},
+		{"legacy function_call", bfschemas.Gemini, "gemini-2.5-flash",
+			`{"model":"m","messages":[],"function_call":"auto"}`,
+			"use tool_choice"},
+		{"allowed_tools", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"tool_choice":{"type":"allowed_tools","allowed_tools":{"mode":"auto","tools":[]}}}`,
+			"allowed tool list"},
+		{"bedrock reasoning non-anthropic", bfschemas.Bedrock, "amazon.titan-text-express-v1",
+			`{"model":"m","messages":[],"reasoning_effort":"low"}`,
+			"reasoning"},
+	}
+	for _, tc := range cases {
+		_, _, err := build(t, tc.provider, tc.model, tc.body)
+		if err == nil {
+			t.Fatalf("%s: contract param accepted", tc.name)
+		}
+		if !strings.Contains(err.Error(), "refusing to drop") || !strings.Contains(err.Error(), "depends on it functionally") {
+			t.Fatalf("%s: refusal copy off: %q", tc.name, err.Error())
+		}
+		if !strings.Contains(err.Error(), tc.wantIn) {
+			t.Fatalf("%s: refusal %q missing %q", tc.name, err.Error(), tc.wantIn)
+		}
+	}
+}
+
+// Mapped params pass the policy untouched and record nothing.
+func TestParamPolicy_MappedParamsPass(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider bfschemas.ModelProvider
+		model    string
+		body     string
+	}{
+		{"temperature+stop anthropic", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"temperature":0.2,"stop":["x"],"max_tokens":16}`},
+		{"json_schema anthropic", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"response_format":{"type":"json_schema","json_schema":{"name":"s","schema":{"type":"object"}}}}`},
+		{"json_object gemini", bfschemas.Gemini, "gemini-2.5-flash",
+			`{"model":"m","messages":[],"response_format":{"type":"json_object"}}`},
+		{"logprobs gemini", bfschemas.Gemini, "gemini-2.5-flash",
+			`{"model":"m","messages":[],"logprobs":true,"top_logprobs":2}`},
+		{"penalties gemini", bfschemas.Gemini, "gemini-2.5-flash",
+			`{"model":"m","messages":[],"presence_penalty":0.1,"frequency_penalty":0.1}`},
+		{"reasoning bedrock claude", bfschemas.Bedrock, "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+			`{"model":"m","messages":[],"reasoning_effort":"low","max_tokens":2048}`},
+		{"reasoning bedrock nova", bfschemas.Bedrock, "amazon.nova-pro-v1:0",
+			`{"model":"m","messages":[],"reasoning_effort":"low"}`},
+		{"n=1", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"n":1}`},
+		{"service_tier auto anthropic", bfschemas.Anthropic, "claude-haiku-4-5",
+			`{"model":"m","messages":[],"service_tier":"auto"}`},
+		{"named tool present", bfschemas.Bedrock, "anthropic.claude-haiku",
+			`{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}],"tool_choice":{"type":"function","function":{"name":"f"}}}`},
+	}
+	for _, tc := range cases {
+		_, dropped, err := build(t, tc.provider, tc.model, tc.body)
+		if err != nil {
+			t.Fatalf("%s: unexpected refusal: %v", tc.name, err)
+		}
+		if len(dropped) != 0 {
+			t.Fatalf("%s: dropped = %v, want none", tc.name, dropped)
+		}
+	}
+}
+
+// @scenario "a named tool_choice must reference a tool in the request"
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestParamPolicy_NamedToolChoiceMustExist(t *testing.T) {
+	_, _, err := build(t, bfschemas.Bedrock, "anthropic.claude-haiku",
+		`{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}],"tool_choice":{"type":"function","function":{"name":"ghost"}}}`)
+	if err == nil {
+		t.Fatal("named tool_choice for a missing tool accepted; Bedrock would silently null it and 400 downstream")
+	}
+	if !strings.Contains(err.Error(), `"ghost"`) {
+		t.Fatalf("refusal %q does not name the missing tool", err.Error())
+	}
+}
+
+// Bedrock tool_choice "none": Converse has no none mode, so the faithful
+// mapping removes the tools entirely. A model with no tools can call none.
+func TestParamPolicy_BedrockToolChoiceNoneRemovesTools(t *testing.T) {
+	bfReq, dropped, err := build(t, bfschemas.Bedrock, "anthropic.claude-haiku",
+		`{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}],"tool_choice":"none"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Fatalf("dropped = %v, want none: this is a mapping, not a drop", dropped)
+	}
+	if bfReq.Params.Tools != nil || bfReq.Params.ToolChoice != nil {
+		t.Fatal("tool_choice none on bedrock must remove tools and tool_choice; bifrost would otherwise default to auto")
+	}
+}
+
+// Anthropic keeps its native none mode; tools stay.
+func TestParamPolicy_AnthropicToolChoiceNoneKeepsTools(t *testing.T) {
+	bfReq, _, err := build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}],"tool_choice":"none"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bfReq.Params.Tools == nil {
+		t.Fatal("anthropic maps none natively; tools must not be removed")
+	}
+}
+
+// @scenario "top_p with temperature is dropped visibly on Anthropic models"
+// Anthropic models reject the pair with a hard 400 (verified live on the
+// anthropic and bedrock lanes), so the faithful options are refuse or
+// drop; top_p is a tuning knob, so it drops with a signal and temperature
+// wins. Alone, top_p maps everywhere. Non-Anthropic bedrock families take
+// both.
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestParamPolicy_TopPWithTemperature(t *testing.T) {
+	bfReq, dropped, err := build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"temperature":0.3,"top_p":0.9}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "top_p" {
+		t.Fatalf("dropped = %v, want [top_p]", dropped)
+	}
+	if bfReq.Params.TopP != nil {
+		t.Fatal("TopP not cleared; the provider rejects the pair")
+	}
+	if bfReq.Params.Temperature == nil {
+		t.Fatal("temperature must survive")
+	}
+
+	// Alone, top_p maps: no drop, field kept.
+	bfReq2, dropped2, err := build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"top_p":0.9}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped2) != 0 || bfReq2.Params.TopP == nil {
+		t.Fatalf("top_p alone must map (dropped=%v)", dropped2)
+	}
+
+	// Bedrock keeps both for non-Anthropic families.
+	bfReq3, dropped3, err := build(t, bfschemas.Bedrock, "amazon.nova-pro-v1:0",
+		`{"model":"m","messages":[],"temperature":0.3,"top_p":0.9}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped3) != 0 || bfReq3.Params.TopP == nil {
+		t.Fatalf("nova takes both (dropped=%v)", dropped3)
+	}
+
+	// Strict mode refuses the combination instead of dropping.
+	_, _, err = build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"temperature":0.3,"top_p":0.9,"drop_tuning_params":false}`)
+	if err == nil {
+		t.Fatal("strict mode must refuse the unmappable combination")
+	}
+}
+
+// service_tier is cleared from the typed params when dropped, so the
+// bedrock translator cannot forward it into AWS's different enum (which
+// answers a hard 400 for OpenAI's values).
+func TestParamPolicy_ServiceTierClearedOnDrop(t *testing.T) {
+	bfReq, dropped, err := build(t, bfschemas.Bedrock, "anthropic.claude-haiku",
+		`{"model":"m","messages":[],"service_tier":"auto"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "service_tier" {
+		t.Fatalf("dropped = %v, want [service_tier]", dropped)
+	}
+	if bfReq.Params.ServiceTier != nil {
+		t.Fatal("ServiceTier not cleared; the translator would forward it and AWS 400s")
+	}
+}
+
+// stop as a bare string (valid OpenAI) is normalized, not rejected.
+func TestParamPolicy_StopStringNormalized(t *testing.T) {
+	bfReq, dropped, err := build(t, bfschemas.Anthropic, "claude-haiku-4-5",
+		`{"model":"m","messages":[],"stop":"END"}`)
+	if err != nil {
+		t.Fatalf("bare-string stop rejected: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Fatalf("dropped = %v, want none", dropped)
+	}
+	if len(bfReq.Params.Stop) != 1 || bfReq.Params.Stop[0] != "END" {
+		t.Fatalf("Stop = %v, want [END]", bfReq.Params.Stop)
+	}
+}
+
+// Raw-forward lanes bypass the policy entirely: strict mode plus an
+// unmappable param must not refuse, and the body stays byte-identical
+// except for stripping the gateway-only drop_tuning_params field.
+func TestParamPolicy_RawForwardBypassesPolicy(t *testing.T) {
+	withFlag := `{"model":"gpt-5-mini","messages":[],"seed":42,"drop_tuning_params":false}`
+	bfReq, _, err := buildChatRequest(context.Background(), chatReq(withFlag), bfschemas.OpenAI, "gpt-5-mini")
+	if err != nil {
+		t.Fatalf("raw lane consulted the policy: %v", err)
+	}
+	if gjson.GetBytes(bfReq.RawRequestBody, "drop_tuning_params").Exists() {
+		t.Fatal("drop_tuning_params must be stripped before the provider sees the body")
+	}
+	if !gjson.GetBytes(bfReq.RawRequestBody, "seed").Exists() {
+		t.Fatal("raw-forward must keep every provider param")
+	}
+
+	plain := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}],"seed":42}`
+	bfReq2, _, err := buildChatRequest(context.Background(), chatReq(plain), bfschemas.OpenAI, "gpt-5-mini")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(bfReq2.RawRequestBody) != plain {
+		t.Fatal("raw-forward body must stay byte-identical when drop_tuning_params is absent")
+	}
+}
+
+// drop_tuning_params itself never reaches a translated provider either: the
+// translated lanes rebuild the request from typed params, and drop_tuning_params
+// is not one of them, so nothing to assert beyond the policy reading it.
+func TestParamPolicy_DropTuningParamsDefaultTrue(t *testing.T) {
+	if !dropTuningParamsEnabled([]byte(`{"model":"m"}`)) {
+		t.Fatal("drop_tuning_params must default to true")
+	}
+	if dropTuningParamsEnabled([]byte(`{"model":"m","drop_tuning_params":false}`)) {
+		t.Fatal("explicit false must disable dropping")
+	}
+	if !dropTuningParamsEnabled([]byte(`{"model":"m","drop_tuning_params":true}`)) {
+		t.Fatal("explicit true keeps dropping enabled")
+	}
+}
+
+// classifyChatBuildError: policy refusals carry unsupported_parameter,
+// everything else stays bad_request.
+func TestClassifyChatBuildError(t *testing.T) {
+	refusal := classifyChatBuildError(context.Background(), &paramRefusalError{msg: "refusing to drop 'x'"})
+	if !strings.Contains(refusal.Error(), "unsupported_parameter") {
+		t.Fatalf("refusal classified as %v, want unsupported_parameter", refusal)
+	}
+	other := classifyChatBuildError(context.Background(), context.DeadlineExceeded)
+	if !strings.Contains(other.Error(), "bad_request") {
+		t.Fatalf("non-refusal classified as %v, want bad_request", other)
+	}
+}
+
+// @scenario "a thinking-exhausted cap yields finish_reason length, not an empty 200"
+// Spec: specs/ai-gateway/openai-param-compat.feature
+func TestEnsureChoicesPresent(t *testing.T) {
+	repaired := ensureChoicesPresent([]byte(`{"id":"x","choices":null,"usage":{"completion_tokens":12}}`))
+	if gjson.GetBytes(repaired, "choices.0.finish_reason").String() != "length" {
+		t.Fatalf("null choices not repaired: %s", repaired)
+	}
+	if gjson.GetBytes(repaired, "choices.0.message.role").String() != "assistant" {
+		t.Fatalf("synthesized choice malformed: %s", repaired)
+	}
+	if gjson.GetBytes(repaired, "usage.completion_tokens").Int() != 12 {
+		t.Fatalf("usage must stay intact: %s", repaired)
+	}
+
+	empty := ensureChoicesPresent([]byte(`{"id":"x","choices":[]}`))
+	if gjson.GetBytes(empty, "choices.#").Int() != 1 {
+		t.Fatalf("empty choices not repaired: %s", empty)
+	}
+
+	untouched := `{"id":"x","choices":[{"index":0,"finish_reason":"stop"}]}`
+	if string(ensureChoicesPresent([]byte(untouched))) != untouched {
+		t.Fatal("populated choices must pass through untouched")
+	}
+}
+
+func TestInjectParamsDropped(t *testing.T) {
+	out := injectParamsDropped([]byte(`{"id":"x","extra_fields":{"provider":"anthropic"}}`), []string{"seed", "user"})
+	if got := gjson.GetBytes(out, "extra_fields.params_dropped").Raw; got != `["seed","user"]` {
+		t.Fatalf("params_dropped = %s", got)
+	}
+	if gjson.GetBytes(out, "extra_fields.provider").String() != "anthropic" {
+		t.Fatal("sibling extra_fields keys must survive")
+	}
+	plain := `{"id":"x"}`
+	if string(injectParamsDropped([]byte(plain), nil)) != plain {
+		t.Fatal("no drops must mean no mutation")
+	}
+}

--- a/services/aigateway/app/pipeline/pipeline.go
+++ b/services/aigateway/app/pipeline/pipeline.go
@@ -36,6 +36,11 @@ type Meta struct {
 	BudgetWarnings      []string
 	CacheMode           string
 	CustomerTraceparent string
+	// ParamsDropped lists request parameters the parameter policy removed
+	// on a translated lane (drop_tuning_params semantics). Surfaced as the
+	// X-LangWatch-Params-Dropped response header on both sync and stream
+	// lanes so a drop is never silent.
+	ParamsDropped []string
 }
 
 // MetaAccumulator is what interceptors write response metadata into. Dispatch
@@ -69,6 +74,7 @@ func (a *MetaAccumulator) Snapshot() Meta {
 	defer a.mu.Unlock()
 	out := a.meta
 	out.BudgetWarnings = slices.Clone(a.meta.BudgetWarnings)
+	out.ParamsDropped = slices.Clone(a.meta.ParamsDropped)
 	return out
 }
 

--- a/services/aigateway/domain/errors.go
+++ b/services/aigateway/domain/errors.go
@@ -66,4 +66,10 @@ const (
 	// Clients receive it as a 401 with this code so Langy can render the
 	// re-authenticate card instead of a generic provider error.
 	ErrCodexSessionExpired = herr.Code("codex_session_expired")
+	// ErrUnsupportedParameter means the parameter policy refused a request
+	// parameter for the target lane: either the request depends on it
+	// functionally and the lane cannot honor it, or drop_tuning_params is false
+	// and the lane has no mapping for it. The code matches OpenAI's own
+	// parameter rejections so SDK error handling stays familiar.
+	ErrUnsupportedParameter = herr.Code("unsupported_parameter")
 )

--- a/specs/ai-gateway/openai-param-compat.feature
+++ b/specs/ai-gateway/openai-param-compat.feature
@@ -172,6 +172,63 @@ Feature: AI Gateway — OpenAI client-param compatibility translation
       # Mirrors the strictness of max_completion_tokens, which is typed as
       # an integer and already rejects malformed values at parse time.
 
+  Rule: Every parameter has an explicit disposition per translated lane
+
+    # The parameter policy table (adapters/providers/param_policy.go) is
+    # the single source of truth: every OpenAI chat-completions parameter
+    # is mapped, dropped with a signal, or refused, per lane. Raw-forward
+    # lanes bypass it entirely. The docs page
+    # docs/ai-gateway/parameter-mapping.mdx renders the table and a parity
+    # test keeps the two in sync.
+
+    @unit
+    Scenario: tier-3 params are dropped with a signal by default
+      When a client sends a tuning param the lane cannot map (seed, logit_bias, user, ...) with drop_tuning_params unset
+      Then the request proceeds without the param
+      And the response carries extra_fields.params_dropped naming it
+      And the X-LangWatch-Params-Dropped response header carries the same list
+      And the gateway span records langwatch.gateway.params_dropped
+
+    @unit
+    Scenario: drop_tuning_params false refuses any unmappable param
+      When a client sends seed toward anthropic with drop_tuning_params false
+      Then the gateway responds 400 unsupported_parameter
+      And the message names the param, the lane, and how to proceed
+
+    @unit
+    Scenario: contract params always refuse, drop_tuning_params cannot drop them
+      When a client sends response_format json_object toward anthropic or bedrock, or logprobs toward anthropic or bedrock, or legacy functions, or tool_choice allowed_tools, or reasoning_effort toward a Bedrock family with no reasoning mapping
+      Then the gateway responds 400 unsupported_parameter regardless of drop_tuning_params
+      And the message explains the functional dependency
+
+    @unit
+    Scenario: a named tool_choice must reference a tool in the request
+      When tool_choice names a function absent from tools on a translated lane
+      Then the gateway refuses with the missing name instead of letting the provider fail downstream
+
+    @unit
+    Scenario: top_p with temperature is dropped visibly on Anthropic models
+      When a client sends both temperature and top_p toward an Anthropic model on the anthropic or bedrock lane
+      Then top_p is dropped with a signal and temperature wins
+      And strict mode refuses the combination instead
+      # Verified live: Anthropic models hard-400 the pair ("temperature and
+      # top_p cannot both be specified"), so a faithful both-params mapping
+      # does not exist; the previous behavior was the same drop, silent.
+
+    @unit
+    Scenario: a thinking-exhausted cap yields finish_reason length, not an empty 200
+      Given a gemini request whose thinking consumes the whole completion cap
+      When the provider answers with no content parts
+      Then the response carries one choice with finish_reason "length" and empty content
+      And usage stays intact
+      # Previously: HTTP 200 with choices null, usage billed, no signal.
+
+    @unit
+    Scenario: the managed Bedrock endpoint maps reasoning and json_schema like public bedrock
+      When a request with reasoning_effort or response_format json_schema dispatches over the Bedrock VPCE path
+      Then additionalModelRequestFields carries the same thinking and output_config shapes bifrost's bedrock translator emits
+      And no output cap the caller never sent is force-set
+
     @live
     Scenario Outline: client cap verifiably bounds output on every translated lane
       When a client POSTs /v1/chat/completions toward <provider> with <cap_field> 16 asking for a long answer, <mode>


### PR DESCRIPTION
Implements the three-tier parameter policy approved from the [full parameter fidelity audit](https://github.com/langwatch/langwatch/issues/6290#issuecomment-5109323199). Closes most of #6290 (what remains is scoped there).

STACKED on #6285 (`fix/max-tokens-anthropic-bedrock`), which owns the parser this PR builds on. Base is set to that branch; retarget to `main` and rebase when #6285 merges.

## What

Raw-forward lanes (openai, azure, vllm) pass every parameter through byte-identical; nothing changes there. On the translated lanes (anthropic, bedrock, gemini, vertex, bedrock VPCE), where the gateway builds the provider request itself, every OpenAI chat-completions parameter now has an explicit disposition in ONE table (`services/aigateway/adapters/providers/param_policy.go`):

- **mapped**: translated faithfully (by the bifrost translator, or by this layer where the translator gets it wrong).
- **dropped** (tier 3, tuning): removed, request proceeds, and the drop is signaled in three places: `extra_fields.params_dropped` on the response body (on streams: the final usage-bearing chunk), the `X-LangWatch-Params-Dropped` response header, and the `langwatch.gateway.params_dropped` span attribute. Never silent.
- **refused** (tier 2, contract): the request depends on the parameter functionally; always fails with `400 unsupported_parameter` and copy that names the parameter, the lane, and why:

```
refusing to drop 'response_format' for anthropic/claude-haiku-4-5: the request depends on it
functionally (the response would not be guaranteed parseable JSON on this lane). Remove it, or
use a model that supports it
```

**The option: `drop_tuning_params` (body field, default `true`).** `false` = strict mode: any unmappable parameter refuses instead of dropping. Contract parameters always refuse regardless. The name is deliberate: the flag only governs tuning parameters, and the semantics differ from LiteLLM's `drop_params` (which drops everything), so reusing that name would be a false compatibility promise. The field is consumed by the gateway and stripped before any provider dispatch (on raw lanes only when present, preserving byte-identity otherwise).

Unknown vendor keys (`min_p`, `repetition_penalty`, ...) fall to the droppable default on translated lanes, so they are signaled too.

## Fixed outright (from the audit's S1 list)

| Defect | Fix |
|---|---|
| anthropic discarded `top_p` whenever `temperature` was present (translator else-if), silently | the pair is genuinely unmappable: Anthropic models hard-400 both together (verified live on the anthropic AND bedrock lanes). The drop is now visible (signal) and strict mode refuses; non-Anthropic bedrock families keep both |
| bedrock `tool_choice: "none"` became auto (model could call tools it was told not to) | mapped faithfully by removing the tools from the Converse request |
| `service_tier` forwarded verbatim into AWS's different enum, hard 400 | validated per lane: anthropic `"auto"` passes natively, everything else drops with a signal and the typed field is cleared |
| `n > 1` silently returned one choice | dropped-to-1 WITH signal by default; refuses under strict mode; `n: 1` passes |
| bedrock `reasoning_effort` on non-Anthropic/non-Nova families: reasoning silently dropped AND an output cap force-set | refused pre-dispatch (policy-visible), so bifrost's force-set never runs |
| `response_format json_object` silently dropped on anthropic/bedrock (fenced markdown for a parseable-JSON guarantee) | tier-2 refused: bifrost offers no sound mechanism, and a silent quality degrade is exactly what the policy exists to prevent; `json_schema` stays enforced on all lanes |
| gemini answered HTTP 200 with `choices: null` (usage billed, no error) when thinking consumed the completion cap | response-contract repair: one synthesized choice with `finish_reason "length"`, empty content, usage intact |
| named `tool_choice` for a function absent from `tools` silently nulled (bedrock) or failed downstream | refused with the missing name, on every translated lane |
| `stop` as a bare string 400ed on translated lanes (valid OpenAI shape) | normalized to the list form in the parse; mapped everywhere |
| legacy `functions` / `function_call` silently dropped | tier-2 refused with pointer to `tools` / `tool_choice` (full legacy mapping incl. response-side stays in #6290) |

## Bedrock VPCE under the same table

The VPCE mapper consults the same policy (it is the bedrock lane) and now maps what the table says bedrock maps, mirroring bifrost's wire shapes exactly: `reasoning_effort` to `additionalModelRequestFields.thinking` (adaptive + `output_config.effort` on 4.6+/4.7, else `budget_tokens = 1024 + ratio x (max_tokens - 1024)` using bifrost's own helpers), and `response_format json_schema` to `output_config.format`. One deliberate divergence, per the audit: when the caller sent no output cap, the thinking budget is computed against the model default WITHOUT force-setting `inferenceConfig.maxTokens`. The VPCE content-part gaps (vision/file/audio parts, cachePoint, tool-result grouping) are follow-up scoped in #6290.

## Docs

`docs/ai-gateway/parameter-mapping.mdx`: the full param x lane table (generated from the code table; `TestParamPolicyDocsInSync` fails the build if they drift), `drop_tuning_params` semantics, the drop signals, and the `reasoning_effort` budget ratios. `unsupported_parameter` added to the errors reference.

## Evidence (local stack, real provider keys)

BEFORE (documented in the audit): seed/n/logit_bias silently ignored, `service_tier` a hard AWS 400, `tool_choice "none"` calling tools, `json_object` answering fenced markdown, gemini empty 200s.

AFTER:

```
# tier-3 drop with the three signals
drop+signal seed:        200 hdr=X-LangWatch-Params-Dropped: seed  body extra_fields.params_dropped=["seed"]
n=2 drop-to-1 + signal:  200 one choice, hdr/body dropped=["n"]
service_tier (bedrock):  200 dropped+signaled  (before: hard AWS 400 enum validation error)
top_p+temperature:       200 dropped+signaled on anthropic AND bedrock Claude (the models hard-400 the pair; verified live)
streamed:                SSE response carries the header AND the final usage chunk carries extra_fields.params_dropped=["seed","user"]

# strict mode
seed + drop_tuning_params:false -> 400 unsupported_parameter
  "refusing to drop 'seed' for anthropic/claude-haiku-4-5: drop_tuning_params is false and Anthropic
   has no sampling seed. Remove it, set drop_tuning_params to true, or use a model that supports it"

# tier-2 contract refusals (drop_tuning_params cannot drop these)
json_object (anthropic): 400 "the response would not be guaranteed parseable JSON on this lane"
ghost named tool:        400 'tool_choice names "ghost" but no tool with that name is in tools'
titan reasoning_effort:  400 "this Bedrock model family has no reasoning mapping ..."

# mapped cells keep working
json_schema (anthropic):     200 {"city": "Paris"}
bedrock claude reasoning:    200 thinking observed (ct=72 for "391")
bedrock tool_choice "none":  200 and the model calls no tools
stop as bare string:         200 stops before "7"
gemini max_tokens 12:        200 finish_reason "length", empty content, usage intact  (before: choices: null)
```

## Tests

- Table-driven policy unit tests per cell: droppable per lane (incl. unknown vendor keys), strict-mode refusals with the exact copy, contract refusals immune to `drop_tuning_params`, named-tool validation, bedrock none-removes-tools vs anthropic native none, top_p injection with merge-flag context (and the Opus 4.7 guard), service_tier clearing, stop-string normalization, raw-lane bypass with byte-identity, default-true semantics.
- Response-contract tests: `ensureChoicesPresent` (null and empty choices repaired, populated untouched, usage intact), `extra_fields.params_dropped` injection preserving siblings.
- VPCE: thinking budget math against bifrost's helpers (1177 for low at 2048), adaptive on 4.7 with `minimal` mapped to `low`, json_schema under `output_config.format`, effort+format coexistence, the 1024 floor, nil document when nothing is requested, and no forced output cap.
- Spec: 7 new scenarios under a new rule in `specs/ai-gateway/openai-param-compat.feature`, all bound.
- Full battery: gofmt, go build, go vet, go test -race (whole service), pinned golangci-lint 0 issues, docs parity test green.

## Deployment Impact

- No schema, chart, or environment changes; control plane untouched.
- Previously-silent behavior becomes visible: requests carrying tier-2 params on translated lanes (json_object on anthropic/bedrock, logprobs on anthropic/bedrock, legacy functions, allowed_tools, reasoning_effort on unsupported bedrock families, named ghost tools) now 400 with actionable copy instead of silently misbehaving. Requests carrying tuning params keep working and gain the drop signals.
- New body field `drop_tuning_params` (default true, backward compatible); stripped before providers see it.
- Response envelopes on translated lanes may carry `extra_fields.params_dropped` and the `X-LangWatch-Params-Dropped` header.
