### PR TITLE
fix(tests): un-skip 14 integration suites that had never run anywhere

### DIFF
--- a/.ast-grep/rule-tests/__snapshots__/no-clickhouse-env-skip-guard-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/no-clickhouse-env-skip-guard-snapshot.yml
@@ -1,12 +1,31 @@
 id: no-clickhouse-env-skip-guard
 snapshots:
   ? |
+    const isTestcontainersOnly = !!(
+      process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+    );
+  : labels:
+    - source: |-
+        const isTestcontainersOnly = !!(
+          process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+        );
+      style: primary
+      start: 0
+      end: 102
+  ? |
     const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
   : labels:
     - source: const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
       style: primary
       start: 0
       end: 63
+  ? |
+    describe.skipIf(!!process.env.CI_CLICKHOUSE_URL)("suite", () => {});
+  : labels:
+    - source: describe.skipIf(!!process.env.CI_CLICKHOUSE_URL)("suite", () => {})
+      style: primary
+      start: 0
+      end: 67
   ? |
     describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
   : labels:
@@ -21,6 +40,13 @@ snapshots:
       style: primary
       start: 0
       end: 56
+  ? |
+    describe.skipIf(process.env.CI_CLICKHOUSE_URL)("suite", () => {});
+  : labels:
+    - source: describe.skipIf(process.env.CI_CLICKHOUSE_URL)("suite", () => {})
+      style: primary
+      start: 0
+      end: 65
   ? |
     describe.skipIf(process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
   : labels:

--- a/.ast-grep/rule-tests/__snapshots__/no-clickhouse-env-skip-guard-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/no-clickhouse-env-skip-guard-snapshot.yml
@@ -1,0 +1,30 @@
+id: no-clickhouse-env-skip-guard
+snapshots:
+  ? |
+    const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+  : labels:
+    - source: const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+      style: primary
+      start: 0
+      end: 63
+  ? |
+    describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
+  : labels:
+    - source: describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)("suite", () => {})
+      style: primary
+      start: 0
+      end: 69
+  ? |
+    describe.skipIf(isTestcontainersOnly)("suite", () => {});
+  : labels:
+    - source: describe.skipIf(isTestcontainersOnly)("suite", () => {})
+      style: primary
+      start: 0
+      end: 56
+  ? |
+    describe.skipIf(process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
+  : labels:
+    - source: describe.skipIf(process.env.TEST_CLICKHOUSE_URL)("suite", () => {})
+      style: primary
+      start: 0
+      end: 67

--- a/.ast-grep/rule-tests/no-clickhouse-env-skip-guard-test.yml
+++ b/.ast-grep/rule-tests/no-clickhouse-env-skip-guard-test.yml
@@ -1,0 +1,25 @@
+id: no-clickhouse-env-skip-guard
+valid:
+  # The correct polarity: skip when the services are ABSENT. This is what the
+  # ClickHouse-dependent suites already do, and it must keep passing.
+  - |
+    const hasTestcontainers = !!(
+      process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+    );
+    describe.skipIf(!hasTestcontainers)("needs clickhouse", () => {});
+  # An unrelated, honestly-named guard.
+  - |
+    const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
+    describe.skipIf(!hasCredentialsSecret)("model providers", () => {});
+  # No guard at all — the outcome #6327 wanted.
+  - |
+    describe("plan.getActivePlan integration", () => {});
+invalid:
+  - |
+    const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+  - |
+    describe.skipIf(isTestcontainersOnly)("suite", () => {});
+  - |
+    describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
+  - |
+    describe.skipIf(process.env.TEST_CLICKHOUSE_URL)("suite", () => {});

--- a/.ast-grep/rule-tests/no-clickhouse-env-skip-guard-test.yml
+++ b/.ast-grep/rule-tests/no-clickhouse-env-skip-guard-test.yml
@@ -18,8 +18,16 @@ invalid:
   - |
     const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
   - |
+    const isTestcontainersOnly = !!(
+      process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+    );
+  - |
     describe.skipIf(isTestcontainersOnly)("suite", () => {});
   - |
     describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
   - |
     describe.skipIf(process.env.TEST_CLICKHOUSE_URL)("suite", () => {});
+  - |
+    describe.skipIf(!!process.env.CI_CLICKHOUSE_URL)("suite", () => {});
+  - |
+    describe.skipIf(process.env.CI_CLICKHOUSE_URL)("suite", () => {});

--- a/.ast-grep/rules/no-clickhouse-env-skip-guard.yml
+++ b/.ast-grep/rules/no-clickhouse-env-skip-guard.yml
@@ -26,6 +26,10 @@ rule:
     # The same inversion written inline, without the misleading name.
     - pattern: describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)($$$)
     - pattern: describe.skipIf(process.env.TEST_CLICKHOUSE_URL)($$$)
+    - pattern: describe.skipIf(!!process.env.CI_CLICKHOUSE_URL)($$$)
+    - pattern: describe.skipIf(process.env.CI_CLICKHOUSE_URL)($$$)
 files:
   - "langwatch/**/*.test.ts"
+  - "langwatch/**/*.test.tsx"
   - "langwatch/**/*.spec.ts"
+  - "langwatch/**/*.spec.tsx"

--- a/.ast-grep/rules/no-clickhouse-env-skip-guard.yml
+++ b/.ast-grep/rules/no-clickhouse-env-skip-guard.yml
@@ -1,0 +1,31 @@
+id: no-clickhouse-env-skip-guard
+message: >
+  This skip guard is inverted, and inverted it means "always skip".
+  `TEST_CLICKHOUSE_URL` does not mean "we are in the testcontainers-only lane";
+  it means "globalSetup provisioned services". `setup.ts` is a setupFiles entry
+  for the WHOLE integration lane and sets it in both the testcontainers and
+  native-local modes, and `setupEnv.ts` sets it again from `CI_CLICKHOUSE_URL`
+  in CI — so it is always truthy there, and skipping WHEN it is present skips
+  the suite in every mode, forever. A skipped suite reports green, so nothing
+  ever says so: 15 suites sat like this until #6327, and the 78 tests inside
+  them had never run in any environment, had rotted into assertions the code no
+  longer satisfied, and were hiding a real bug in the model-provider read path.
+  The correct polarity is the one `export-summary-blob-resolution` and
+  `eventLogDurability` use — `const hasTestcontainers = !!(...); ` then
+  `describe.skipIf(!hasTestcontainers)`, i.e. skip when services are ABSENT.
+  Better still, drop the guard: the integration lane always provisions them.
+  See #6327 and PR #5988.
+severity: error
+language: TypeScript
+rule:
+  any:
+    # The exact idiom that spread to 15 files by copy-paste. The name asserts
+    # the opposite of what the value holds, which is why it kept being reused.
+    - pattern: const isTestcontainersOnly = $$$REST
+    - pattern: describe.skipIf(isTestcontainersOnly)($$$)
+    # The same inversion written inline, without the misleading name.
+    - pattern: describe.skipIf(!!process.env.TEST_CLICKHOUSE_URL)($$$)
+    - pattern: describe.skipIf(process.env.TEST_CLICKHOUSE_URL)($$$)
+files:
+  - "langwatch/**/*.test.ts"
+  - "langwatch/**/*.spec.ts"

--- a/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.gracefulFallback.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.gracefulFallback.integration.test.ts
@@ -29,10 +29,9 @@ import {
   PersonalVirtualKeyService,
 } from "../personalVirtualKey.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
 const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
 
-describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+describe.skipIf(!hasCredentialsSecret)(
   "PersonalVirtualKeyService.issue — graceful fallback when no default policy (real DB)",
   () => {
     const service = PersonalVirtualKeyService.create(prisma, {

--- a/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
@@ -6,11 +6,7 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import {
-  OrganizationUserRole,
-  RoleBindingScopeType,
-  TeamUserRole,
-} from "@prisma/client";
+import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -34,6 +30,7 @@ import { prisma } from "../../../db";
 import { ENTERPRISE_FEATURE_ERRORS } from "../../enterprise";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
+import { grantOrganizationAdmin } from "./helpers/roleBindings";
 
 describe("enterprise feature guards", () => {
   const testNamespace = `ent-guard-${nanoid(8)}`;
@@ -105,33 +102,13 @@ describe("enterprise feature guards", () => {
       },
     });
 
-    // RoleBindings, not just the OrganizationUser/TeamUser rows above.
-    //
-    // `OrganizationUser.role = ADMIN` does NOT confer admin permissions on its
-    // own — `hasOrganizationPermission` gives every member only MEMBER's base
-    // bag as a floor, then resolves the rest through ORGANIZATION-scoped
-    // bindings, and the legacy TeamUser union deliberately cannot grant
-    // `organization:*` (ADR-021). Without these rows the caller is rejected at
-    // the permission gate with UNAUTHORIZED and never reaches the enterprise
-    // guard each test here is about, which is exactly what happened while this
-    // suite was skipped.
-    await prisma.roleBinding.create({
-      data: {
-        organizationId: organization.id,
-        userId: user.id,
-        role: TeamUserRole.ADMIN,
-        scopeType: RoleBindingScopeType.ORGANIZATION,
-        scopeId: organization.id,
-      },
-    });
-    await prisma.roleBinding.create({
-      data: {
-        organizationId: organization.id,
-        userId: user.id,
-        role: TeamUserRole.ADMIN,
-        scopeType: RoleBindingScopeType.TEAM,
-        scopeId: team.id,
-      },
+    // Without these the caller is refused at the permission gate and never
+    // reaches the enterprise guard each test here is about — see the helper.
+    await grantOrganizationAdmin({
+      prisma,
+      organizationId: organization.id,
+      userId: user.id,
+      teamId: team.id,
     });
 
     // Create a custom role for tests that need one
@@ -161,6 +138,10 @@ describe("enterprise feature guards", () => {
   });
 
   afterAll(async () => {
+    // First, and without a `.catch`: the bindings hold an FK to CustomRole, so
+    // a failure here would otherwise resurface as a confusing error on the
+    // customRole cleanup below, or vanish into a swallowed one.
+    await prisma.roleBinding.deleteMany({ where: { organizationId } });
     await prisma.teamUser
       .deleteMany({
         where: {

--- a/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
@@ -138,6 +138,12 @@ describe("enterprise feature guards", () => {
   });
 
   afterAll(async () => {
+    // beforeAll assigns organizationId as its first statement; if it threw
+    // before that, Vitest still runs this afterAll, and Prisma treats an
+    // undefined filter value as "no filter" — every deleteMany below would
+    // match the whole table instead of just this run's rows.
+    if (!organizationId) return;
+
     // First, and without a `.catch`: the bindings hold an FK to CustomRole, so
     // a failure here would otherwise resurface as a confusing error on the
     // customRole cleanup below, or vanish into a swallowed one.

--- a/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
@@ -6,7 +6,11 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -31,9 +35,7 @@ import { ENTERPRISE_FEATURE_ERRORS } from "../../enterprise";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)("enterprise feature guards", () => {
+describe("enterprise feature guards", () => {
   const testNamespace = `ent-guard-${nanoid(8)}`;
   let organizationId: string;
   let userId: string;
@@ -100,6 +102,35 @@ describe.skipIf(isTestcontainersOnly)("enterprise feature guards", () => {
         userId: user.id,
         teamId: team.id,
         role: TeamUserRole.ADMIN,
+      },
+    });
+
+    // RoleBindings, not just the OrganizationUser/TeamUser rows above.
+    //
+    // `OrganizationUser.role = ADMIN` does NOT confer admin permissions on its
+    // own — `hasOrganizationPermission` gives every member only MEMBER's base
+    // bag as a floor, then resolves the rest through ORGANIZATION-scoped
+    // bindings, and the legacy TeamUser union deliberately cannot grant
+    // `organization:*` (ADR-021). Without these rows the caller is rejected at
+    // the permission gate with UNAUTHORIZED and never reaches the enterprise
+    // guard each test here is about, which is exactly what happened while this
+    // suite was skipped.
+    await prisma.roleBinding.create({
+      data: {
+        organizationId: organization.id,
+        userId: user.id,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organization.id,
+      },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        organizationId: organization.id,
+        userId: user.id,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: team.id,
       },
     });
 

--- a/langwatch/src/server/api/routers/__tests__/helpers/roleBindings.ts
+++ b/langwatch/src/server/api/routers/__tests__/helpers/roleBindings.ts
@@ -1,0 +1,99 @@
+/**
+ * RoleBinding fixtures for router integration suites.
+ *
+ * Not a `*.test.ts` file on purpose — it holds no assertions, only the setup.
+ *
+ * WHY THIS EXISTS. Creating an `OrganizationUser` with `role: ADMIN` does not
+ * make the caller an admin. `hasOrganizationPermission` gives every org member
+ * only MEMBER's base bag as a floor and resolves everything above it through
+ * ORGANIZATION-scoped `RoleBinding` rows; the legacy `TeamUser` union
+ * deliberately cannot confer `organization:*` (ADR-021). A suite that creates
+ * only the membership rows is therefore refused at the permission gate, before
+ * reaching whatever guard it was written to exercise — which is exactly how
+ * several suites came to assert nothing while still reporting green (#6327).
+ */
+import type { PrismaClient } from "@prisma/client";
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+
+/**
+ * Grants a user real admin rights in an organization, and optionally in one
+ * team within it, by creating the bindings the RBAC resolver actually reads.
+ *
+ * Pass `teamId` when the suite calls a team-scoped procedure
+ * (`checkTeamPermission`); omit it for org-only surfaces.
+ */
+export async function grantOrganizationAdmin({
+  prisma,
+  organizationId,
+  userId,
+  teamId,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+  userId: string;
+  teamId?: string;
+}): Promise<void> {
+  await prisma.roleBinding.create({
+    data: {
+      organizationId,
+      userId,
+      role: TeamUserRole.ADMIN,
+      scopeType: RoleBindingScopeType.ORGANIZATION,
+      scopeId: organizationId,
+    },
+  });
+
+  if (teamId) {
+    await prisma.roleBinding.create({
+      data: {
+        organizationId,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: teamId,
+      },
+    });
+  }
+}
+
+/**
+ * Binds a custom role to a user at TEAM scope.
+ *
+ * The legacy `TeamUser.assignedRoleId` column is NOT enough: the guards read
+ * the assignment through `getUserCustomRoleBinding`, a RoleBinding lookup. With
+ * only the legacy column set, a caller's old permissions read as undefined and
+ * `getRoleChangeType` sees no role change at all — so the limit under test is
+ * never asserted and the procedure returns success.
+ */
+export async function bindCustomRoleToTeam({
+  prisma,
+  organizationId,
+  userId,
+  teamId,
+  customRoleId,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+  userId: string;
+  teamId: string;
+  customRoleId: string;
+}): Promise<void> {
+  await prisma.roleBinding.deleteMany({
+    where: {
+      organizationId,
+      userId,
+      scopeType: RoleBindingScopeType.TEAM,
+      scopeId: teamId,
+    },
+  });
+  await prisma.roleBinding.create({
+    data: {
+      organizationId,
+      userId,
+      role: TeamUserRole.CUSTOM,
+      customRoleId,
+      scopeType: RoleBindingScopeType.TEAM,
+      scopeId: teamId,
+    },
+  });
+}

--- a/langwatch/src/server/api/routers/__tests__/monitors-evaluator.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/monitors-evaluator.integration.test.ts
@@ -7,22 +7,38 @@
  * Requires: PostgreSQL database (Prisma)
  */
 import { EvaluationExecutionMode } from "@prisma/client";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import { PlanProviderService } from "~/server/app-layer/subscription/plan-provider";
+import { UNLIMITED_PLAN } from "../../../../../ee/licensing/constants";
 import { getTestUser } from "../../../../utils/testUtils";
 import { prisma } from "../../../db";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-// TEST_CLICKHOUSE_URL indicates testcontainers mode without full infrastructure
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)("Monitor-Evaluator Integration", () => {
+describe("Monitor-Evaluator Integration", () => {
   const projectId = "test-project-id";
   let caller: ReturnType<typeof appRouter.createCaller>;
   let testEvaluatorId: string;
 
   beforeAll(async () => {
+    // `evaluators.create` and `monitors.create` both run the
+    // license-enforcement middleware, which reads `getApp().planProvider`.
+    // Without an app in place the first call in this hook throws "App not
+    // initialized" and the whole file fails during setup.
+    //
+    // UNLIMITED_PLAN because this suite is about the monitor↔evaluator
+    // relation, not about quotas: the fixed `test-project-id` accumulates
+    // monitors across runs, so any finite `maxOnlineEvaluations` makes the
+    // suite fail based on how often it has been run before.
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: async () => UNLIMITED_PLAN,
+      }),
+    });
+
     // Clean up any existing test monitors before running tests
     await prisma.monitor.deleteMany({
       where: { projectId },
@@ -231,5 +247,9 @@ describe.skipIf(isTestcontainersOnly)("Monitor-Evaluator Integration", () => {
         monitorWithEvaluator?.evaluatorId,
       );
     });
+  });
+
+  afterAll(async () => {
+    await resetApp();
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -191,6 +191,12 @@ describe("organization member role plan limit enforcement", () => {
   });
 
   afterAll(async () => {
+    // beforeAll assigns organizationId as its first statement; if it threw
+    // before that, Vitest still runs this afterAll, and Prisma treats an
+    // undefined filter value as "no filter" — every deleteMany below would
+    // match the whole table instead of just this run's rows.
+    if (!organizationId) return;
+
     // Clean up in reverse creation order.
     //
     // RoleBindings go first and WITHOUT a `.catch`: they hold an FK to

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -7,7 +7,11 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -30,308 +34,340 @@ import { LICENSE_LIMIT_ERRORS } from "../../../license-enforcement/license-limit
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("organization member role plan limit enforcement", () => {
+  const testNamespace = `member-role-limit-${nanoid(8)}`;
+  let organizationId: string;
+  let adminUserId: string;
+  let targetUserId: string;
+  let teamId: string;
+  let customRoleId: string;
+  let mockGetActivePlan: ReturnType<typeof vi.fn>;
 
-describe.skipIf(isTestcontainersOnly)(
-  "organization member role plan limit enforcement",
-  () => {
-    const testNamespace = `member-role-limit-${nanoid(8)}`;
-    let organizationId: string;
-    let adminUserId: string;
-    let targetUserId: string;
-    let teamId: string;
-    let customRoleId: string;
-    let mockGetActivePlan: ReturnType<typeof vi.fn>;
+  beforeAll(async () => {
+    // Create organization
+    const organization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `--test-org-${testNamespace}`,
+      },
+    });
+    organizationId = organization.id;
 
-    beforeAll(async () => {
-      // Create organization
-      const organization = await prisma.organization.create({
-        data: {
-          name: "Test Organization",
-          slug: `--test-org-${testNamespace}`,
-        },
-      });
-      organizationId = organization.id;
+    // Create admin user (the caller)
+    const adminUser = await prisma.user.create({
+      data: {
+        name: "Admin User",
+        email: `admin-${testNamespace}@example.com`,
+      },
+    });
+    adminUserId = adminUser.id;
 
-      // Create admin user (the caller)
-      const adminUser = await prisma.user.create({
-        data: {
-          name: "Admin User",
-          email: `admin-${testNamespace}@example.com`,
-        },
-      });
-      adminUserId = adminUser.id;
-
-      await prisma.organizationUser.create({
-        data: {
-          userId: adminUser.id,
-          organizationId: organization.id,
-          role: OrganizationUserRole.ADMIN,
-        },
-      });
-
-      // Create a team + admin membership so RBAC passes
-      const team = await prisma.team.create({
-        data: {
-          name: "Test Team",
-          slug: `--test-team-${testNamespace}`,
-          organizationId: organization.id,
-        },
-      });
-      teamId = team.id;
-
-      await prisma.teamUser.create({
-        data: {
-          userId: adminUser.id,
-          teamId: team.id,
-          role: TeamUserRole.ADMIN,
-        },
-      });
-
-      // Create a custom role with non-view permissions (makes EXTERNAL user a FullMember)
-      const customRole = await prisma.customRole.create({
-        data: {
-          organizationId: organization.id,
-          name: `test-editor-${testNamespace}`,
-          permissions: ["project:create", "project:update"],
-        },
-      });
-      customRoleId = customRole.id;
-
-      // Create target user as MEMBER (full member)
-      const targetUser = await prisma.user.create({
-        data: {
-          name: "Target User",
-          email: `target-${testNamespace}@example.com`,
-        },
-      });
-      targetUserId = targetUser.id;
-
-      await prisma.organizationUser.create({
-        data: {
-          userId: targetUser.id,
-          organizationId: organization.id,
-          role: OrganizationUserRole.MEMBER,
-        },
-      });
-
-      await prisma.teamUser.create({
-        data: {
-          userId: targetUser.id,
-          teamId: team.id,
-          role: TeamUserRole.MEMBER,
-        },
-      });
+    await prisma.organizationUser.create({
+      data: {
+        userId: adminUser.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
     });
 
-    beforeEach(async () => {
-      await resetApp();
-      mockGetActivePlan = vi.fn();
-      globalForApp.__langwatch_app = createTestApp({
-        planProvider: PlanProviderService.create({
-          getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-        }),
-      });
+    // Create a team + admin membership so RBAC passes
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId: organization.id,
+      },
+    });
+    teamId = team.id;
 
-      // Guarantee target user starts as MEMBER with built-in MEMBER team role
-      await prisma.organizationUser.update({
+    await prisma.teamUser.create({
+      data: {
+        userId: adminUser.id,
+        teamId: team.id,
+        role: TeamUserRole.ADMIN,
+      },
+    });
+
+    // The ORGANIZATION-scoped binding is what actually confers
+    // `organization:manage`. `OrganizationUser.role = ADMIN` alone does not:
+    // `hasOrganizationPermission` grants every member only MEMBER's base bag
+    // as a floor and resolves everything above it through bindings, and the
+    // legacy TeamUser union deliberately cannot confer `organization:*`
+    // (ADR-021). Without this the caller is refused before any plan-limit
+    // logic runs, so the suite would assert nothing about plan limits.
+    await prisma.roleBinding.create({
+      data: {
+        organizationId: organization.id,
+        userId: adminUser.id,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organization.id,
+      },
+    });
+
+    // Create a custom role with non-view permissions (makes EXTERNAL user a FullMember)
+    const customRole = await prisma.customRole.create({
+      data: {
+        organizationId: organization.id,
+        name: `test-editor-${testNamespace}`,
+        permissions: ["project:create", "project:update"],
+      },
+    });
+    customRoleId = customRole.id;
+
+    // Create target user as MEMBER (full member)
+    const targetUser = await prisma.user.create({
+      data: {
+        name: "Target User",
+        email: `target-${testNamespace}@example.com`,
+      },
+    });
+    targetUserId = targetUser.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: targetUser.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+
+    await prisma.teamUser.create({
+      data: {
+        userId: targetUser.id,
+        teamId: team.id,
+        role: TeamUserRole.MEMBER,
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await resetApp();
+    mockGetActivePlan = vi.fn();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
+      }),
+    });
+
+    // Guarantee target user starts as MEMBER with built-in MEMBER team role
+    await prisma.organizationUser.update({
+      where: {
+        userId_organizationId: {
+          userId: targetUserId,
+          organizationId,
+        },
+      },
+      data: { role: OrganizationUserRole.MEMBER },
+    });
+    await prisma.teamUser.update({
+      where: {
+        userId_teamId: {
+          userId: targetUserId,
+          teamId,
+        },
+      },
+      data: { role: TeamUserRole.MEMBER, assignedRoleId: null },
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+  });
+
+  afterAll(async () => {
+    // Clean up in reverse creation order
+    await prisma.teamUser
+      .deleteMany({
         where: {
-          userId_organizationId: {
-            userId: targetUserId,
-            organizationId,
-          },
+          team: { slug: `--test-team-${testNamespace}` },
         },
-        data: { role: OrganizationUserRole.MEMBER },
-      });
-      await prisma.teamUser.update({
+      })
+      .catch(() => {});
+    await prisma.customRole
+      .deleteMany({
+        where: { organizationId },
+      })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({
+        where: { slug: `--test-team-${testNamespace}` },
+      })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({
+        where: { organizationId },
+      })
+      .catch(() => {});
+    await prisma.organization
+      .delete({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
         where: {
-          userId_teamId: {
-            userId: targetUserId,
-            teamId,
-          },
+          email: { endsWith: `${testNamespace}@example.com` },
         },
-        data: { role: TeamUserRole.MEMBER, assignedRoleId: null },
-      });
+      })
+      .catch(() => {});
+
+    await resetApp();
+  });
+
+  function createCaller() {
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: adminUserId },
+        expires: "2099-01-01",
+      },
+      permissionChecked: true,
+      publiclyShared: false,
     });
+    return appRouter.createCaller(ctx);
+  }
 
-    afterEach(async () => {
-      await resetApp();
-    });
-
-    afterAll(async () => {
-      // Clean up in reverse creation order
-      await prisma.teamUser
-        .deleteMany({
-          where: {
-            team: { slug: `--test-team-${testNamespace}` },
-          },
-        })
-        .catch(() => {});
-      await prisma.customRole
-        .deleteMany({
-          where: { organizationId },
-        })
-        .catch(() => {});
-      await prisma.team
-        .deleteMany({
-          where: { slug: `--test-team-${testNamespace}` },
-        })
-        .catch(() => {});
-      await prisma.organizationUser
-        .deleteMany({
-          where: { organizationId },
-        })
-        .catch(() => {});
-      await prisma.organization
-        .delete({ where: { id: organizationId } })
-        .catch(() => {});
-      await prisma.user
-        .deleteMany({
-          where: {
-            email: { endsWith: `${testNamespace}@example.com` },
-          },
-        })
-        .catch(() => {});
-
-      await resetApp();
-    });
-
-    function createCaller() {
-      const ctx = createInnerTRPCContext({
-        session: {
-          user: { id: adminUserId },
-          expires: "2099-01-01",
-        },
-        permissionChecked: true,
-        publiclyShared: false,
-      });
-      return appRouter.createCaller(ctx);
-    }
-
-    describe("updateMemberRole", () => {
-      describe("when demoting MEMBER to EXTERNAL (full-to-lite change)", () => {
-        it("rejects when lite member limit reached", async () => {
-          mockGetActivePlan.mockResolvedValue({
-            maxMembers: 100,
-            maxMembersLite: 0, // No lite members allowed
-            overrideAddingLimitations: false,
-          });
-
-          const caller = createCaller();
-
-          await expect(
-            caller.organization.updateMemberRole({
-              userId: targetUserId,
-              organizationId,
-              role: OrganizationUserRole.EXTERNAL,
-            }),
-          ).rejects.toMatchObject({
-            code: "FORBIDDEN",
-            message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
-          });
+  describe("updateMemberRole", () => {
+    describe("when demoting MEMBER to EXTERNAL (full-to-lite change)", () => {
+      it("rejects when lite member limit reached", async () => {
+        mockGetActivePlan.mockResolvedValue({
+          maxMembers: 100,
+          maxMembersLite: 0, // No lite members allowed
+          overrideAddingLimitations: false,
         });
 
-        it("allows when overrideAddingLimitations is true", async () => {
-          mockGetActivePlan.mockResolvedValue({
-            maxMembers: 100,
-            maxMembersLite: 0, // No lite members allowed, but override active
-            overrideAddingLimitations: true,
-          });
+        const caller = createCaller();
 
-          const caller = createCaller();
-
-          await caller.organization.updateMemberRole({
+        await expect(
+          caller.organization.updateMemberRole({
             userId: targetUserId,
             organizationId,
             role: OrganizationUserRole.EXTERNAL,
-          });
-
-          const updated = await prisma.organizationUser.findUnique({
-            where: {
-              userId_organizationId: {
-                userId: targetUserId,
-                organizationId,
-              },
-            },
-          });
-          expect(updated?.role).toBe(OrganizationUserRole.EXTERNAL);
+          }),
+        ).rejects.toMatchObject({
+          code: "FORBIDDEN",
+          message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
         });
       });
+
+      it("allows when overrideAddingLimitations is true", async () => {
+        mockGetActivePlan.mockResolvedValue({
+          maxMembers: 100,
+          maxMembersLite: 0, // No lite members allowed, but override active
+          overrideAddingLimitations: true,
+        });
+
+        const caller = createCaller();
+
+        // Resolving IS the assertion: the sibling test above proves the same
+        // call is rejected with MEMBER_LITE_LIMIT when the override is off,
+        // so the pair isolates the override as the only difference.
+        //
+        // Deliberately not asserting the persisted row. `createTestApp` wires
+        // `organizations` to a NullOrganizationRepository, so the write this
+        // procedure delegates is a no-op here by design — the row would still
+        // read MEMBER however well the limit gate behaved. Persistence is the
+        // repository's own contract and is tested there.
+        await expect(
+          caller.organization.updateMemberRole({
+            userId: targetUserId,
+            organizationId,
+            role: OrganizationUserRole.EXTERNAL,
+          }),
+        ).resolves.toEqual({ success: true });
+      });
     });
+  });
 
-    describe("updateTeamMemberRole", () => {
-      describe("when changing EXTERNAL user from custom role to built-in VIEWER (full-to-lite change)", () => {
-        beforeEach(async () => {
-          // Set target user as EXTERNAL with custom role (non-view permissions → FullMember)
-          await prisma.organizationUser.update({
-            where: {
-              userId_organizationId: {
-                userId: targetUserId,
-                organizationId,
-              },
-            },
-            data: { role: OrganizationUserRole.EXTERNAL },
-          });
-          await prisma.teamUser.update({
-            where: {
-              userId_teamId: {
-                userId: targetUserId,
-                teamId,
-              },
-            },
-            data: { role: TeamUserRole.CUSTOM, assignedRoleId: customRoleId },
-          });
-        });
-
-        it("rejects when lite member limit reached", async () => {
-          mockGetActivePlan.mockResolvedValue({
-            maxMembers: 100,
-            maxMembersLite: 0, // No lite members allowed
-            overrideAddingLimitations: false,
-          });
-
-          const caller = createCaller();
-
-          await expect(
-            caller.organization.updateTeamMemberRole({
-              teamId,
+  describe("updateTeamMemberRole", () => {
+    describe("when changing EXTERNAL user from custom role to built-in VIEWER (full-to-lite change)", () => {
+      beforeEach(async () => {
+        // Set target user as EXTERNAL with custom role (non-view permissions → FullMember)
+        await prisma.organizationUser.update({
+          where: {
+            userId_organizationId: {
               userId: targetUserId,
-              role: TeamUserRole.VIEWER,
-            }),
-          ).rejects.toMatchObject({
-            code: "FORBIDDEN",
-            message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
-          });
+              organizationId,
+            },
+          },
+          data: { role: OrganizationUserRole.EXTERNAL },
+        });
+        await prisma.teamUser.update({
+          where: {
+            userId_teamId: {
+              userId: targetUserId,
+              teamId,
+            },
+          },
+          data: { role: TeamUserRole.CUSTOM, assignedRoleId: customRoleId },
         });
 
-        it("allows when overrideAddingLimitations is true", async () => {
-          mockGetActivePlan.mockResolvedValue({
-            maxMembers: 100,
-            maxMembersLite: 0, // No lite members allowed, but override active
-            overrideAddingLimitations: true,
-          });
+        // The guard reads the custom role through `getUserCustomRoleBinding`
+        // — a RoleBinding lookup — not through the legacy
+        // `TeamUser.assignedRoleId` set above. Without this binding the
+        // caller's old permissions read as undefined, `getRoleChangeType`
+        // sees no full-to-lite transition, and the limit is never asserted:
+        // the mutation returns `{ success: true }` and the rejection this
+        // block is about silently stops being tested.
+        await prisma.roleBinding.deleteMany({
+          where: {
+            organizationId,
+            userId: targetUserId,
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: teamId,
+          },
+        });
+        await prisma.roleBinding.create({
+          data: {
+            organizationId,
+            userId: targetUserId,
+            role: TeamUserRole.CUSTOM,
+            customRoleId,
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: teamId,
+          },
+        });
+      });
 
-          const caller = createCaller();
+      it("rejects when lite member limit reached", async () => {
+        mockGetActivePlan.mockResolvedValue({
+          maxMembers: 100,
+          maxMembersLite: 0, // No lite members allowed
+          overrideAddingLimitations: false,
+        });
 
-          await caller.organization.updateTeamMemberRole({
+        const caller = createCaller();
+
+        await expect(
+          caller.organization.updateTeamMemberRole({
             teamId,
             userId: targetUserId,
             role: TeamUserRole.VIEWER,
-          });
-
-          const updated = await prisma.teamUser.findUnique({
-            where: {
-              userId_teamId: {
-                userId: targetUserId,
-                teamId,
-              },
-            },
-          });
-          expect(updated?.role).toBe(TeamUserRole.VIEWER);
-          expect(updated?.assignedRoleId).toBeNull();
+          }),
+        ).rejects.toMatchObject({
+          code: "FORBIDDEN",
+          message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
         });
       });
+
+      it("allows when overrideAddingLimitations is true", async () => {
+        mockGetActivePlan.mockResolvedValue({
+          maxMembers: 100,
+          maxMembersLite: 0, // No lite members allowed, but override active
+          overrideAddingLimitations: true,
+        });
+
+        const caller = createCaller();
+
+        // As above: resolving is the assertion, paired against the sibling
+        // rejection. The persisted row is not checked because this app's
+        // organization repository is a deliberate no-op.
+        await expect(
+          caller.organization.updateTeamMemberRole({
+            teamId,
+            userId: targetUserId,
+            role: TeamUserRole.VIEWER,
+          }),
+        ).resolves.toEqual({ success: true });
+      });
     });
-  },
-);
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -7,7 +7,11 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -20,11 +24,14 @@ import {
   vi,
 } from "vitest";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { OrganizationService } from "~/server/app-layer/organizations/organization.service";
+import { PrismaOrganizationRepository } from "~/server/app-layer/organizations/repositories/organization.prisma.repository";
 import { createTestApp } from "~/server/app-layer/presets";
 import {
   type PlanProvider,
   PlanProviderService,
 } from "~/server/app-layer/subscription/plan-provider";
+import { PromptTagRepository } from "~/server/prompt-config/repositories/prompt-tag.repository";
 import { prisma } from "../../../db";
 import { LICENSE_LIMIT_ERRORS } from "../../../license-enforcement/license-limit-guard";
 import { appRouter } from "../../root";
@@ -88,12 +95,19 @@ describe("organization member role plan limit enforcement", () => {
       },
     });
 
-    // Without this the caller is refused before any plan-limit logic runs, so
+    // Without these the caller is refused before any plan-limit logic runs, so
     // the suite would assert nothing about plan limits — see the helper.
+    //
+    // The TEAM-scoped binding matters for a second reason: the repository's
+    // "don't strand a team without an admin" guard counts TEAM-scoped ADMIN
+    // *bindings*, not the `TeamUser` row above. With none, demoting anyone on
+    // the team is refused with "No admin found for this team" before the plan
+    // logic is reached.
     await grantOrganizationAdmin({
       prisma,
       organizationId: organization.id,
       userId: adminUser.id,
+      teamId: team.id,
     });
 
     // Create a custom role with non-view permissions (makes EXTERNAL user a FullMember)
@@ -139,6 +153,16 @@ describe("organization member role plan limit enforcement", () => {
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
       }),
+      // A REAL organization service, against the test database. `createTestApp`
+      // defaults to a NullOrganizationRepository, which resolves without
+      // writing — so an allow-path test could only assert "the call didn't
+      // throw", and a mutation that silently no-ops the override would pass.
+      // The plan gate is what these tests are about, but proving the write
+      // landed is what distinguishes "allowed" from "quietly dropped".
+      organizations: new OrganizationService(
+        new PrismaOrganizationRepository(prisma),
+        new PromptTagRepository(prisma),
+      ),
     });
 
     // Guarantee target user starts as MEMBER with built-in MEMBER team role
@@ -255,15 +279,11 @@ describe("organization member role plan limit enforcement", () => {
 
         const caller = createCaller();
 
-        // Resolving IS the assertion: the sibling test above proves the same
-        // call is rejected with MEMBER_LITE_LIMIT when the override is off,
-        // so the pair isolates the override as the only difference.
-        //
-        // Deliberately not asserting the persisted row. `createTestApp` wires
-        // `organizations` to a NullOrganizationRepository, so the write this
-        // procedure delegates is a no-op here by design — the row would still
-        // read MEMBER however well the limit gate behaved. Persistence is the
-        // repository's own contract and is tested there.
+        // Two assertions, and the second is the one that matters. The sibling
+        // above proves this call is rejected when the override is off, so
+        // resolving isolates the override — but resolving alone cannot tell
+        // "the override let the write through" apart from "the write silently
+        // did nothing". Reading the row back distinguishes them.
         await expect(
           caller.organization.updateMemberRole({
             userId: targetUserId,
@@ -271,6 +291,13 @@ describe("organization member role plan limit enforcement", () => {
             role: OrganizationUserRole.EXTERNAL,
           }),
         ).resolves.toEqual({ success: true });
+
+        const updated = await prisma.organizationUser.findUnique({
+          where: {
+            userId_organizationId: { userId: targetUserId, organizationId },
+          },
+        });
+        expect(updated?.role).toBe(OrganizationUserRole.EXTERNAL);
       });
     });
   });
@@ -339,9 +366,8 @@ describe("organization member role plan limit enforcement", () => {
 
         const caller = createCaller();
 
-        // As above: resolving is the assertion, paired against the sibling
-        // rejection. The persisted row is not checked because this app's
-        // organization repository is a deliberate no-op.
+        // As above: resolving isolates the override, the read-back proves the
+        // write actually landed rather than being quietly dropped.
         await expect(
           caller.organization.updateTeamMemberRole({
             teamId,
@@ -349,6 +375,23 @@ describe("organization member role plan limit enforcement", () => {
             role: TeamUserRole.VIEWER,
           }),
         ).resolves.toEqual({ success: true });
+
+        // Read the BINDING, not the `TeamUser` row. `updateTeamMemberRole`
+        // replaces the TEAM-scoped RoleBinding and leaves the legacy row
+        // untouched — asserting on `TeamUser.role` here would fail against
+        // correct behaviour, which is what the original assertion did.
+        const binding = await prisma.roleBinding.findFirst({
+          where: {
+            organizationId,
+            userId: targetUserId,
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: teamId,
+          },
+        });
+        expect(binding?.role).toBe(TeamUserRole.VIEWER);
+        // The custom role is cleared, not carried over — the point of the
+        // full-to-lite change under test.
+        expect(binding?.customRoleId).toBeNull();
       });
     });
   });

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -7,11 +7,7 @@
  *
  * Requires: PostgreSQL database (Prisma)
  */
-import {
-  OrganizationUserRole,
-  RoleBindingScopeType,
-  TeamUserRole,
-} from "@prisma/client";
+import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -33,6 +29,10 @@ import { prisma } from "../../../db";
 import { LICENSE_LIMIT_ERRORS } from "../../../license-enforcement/license-limit-guard";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
+import {
+  bindCustomRoleToTeam,
+  grantOrganizationAdmin,
+} from "./helpers/roleBindings";
 
 describe("organization member role plan limit enforcement", () => {
   const testNamespace = `member-role-limit-${nanoid(8)}`;
@@ -88,21 +88,12 @@ describe("organization member role plan limit enforcement", () => {
       },
     });
 
-    // The ORGANIZATION-scoped binding is what actually confers
-    // `organization:manage`. `OrganizationUser.role = ADMIN` alone does not:
-    // `hasOrganizationPermission` grants every member only MEMBER's base bag
-    // as a floor and resolves everything above it through bindings, and the
-    // legacy TeamUser union deliberately cannot confer `organization:*`
-    // (ADR-021). Without this the caller is refused before any plan-limit
-    // logic runs, so the suite would assert nothing about plan limits.
-    await prisma.roleBinding.create({
-      data: {
-        organizationId: organization.id,
-        userId: adminUser.id,
-        role: TeamUserRole.ADMIN,
-        scopeType: RoleBindingScopeType.ORGANIZATION,
-        scopeId: organization.id,
-      },
+    // Without this the caller is refused before any plan-limit logic runs, so
+    // the suite would assert nothing about plan limits — see the helper.
+    await grantOrganizationAdmin({
+      prisma,
+      organizationId: organization.id,
+      userId: adminUser.id,
     });
 
     // Create a custom role with non-view permissions (makes EXTERNAL user a FullMember)
@@ -176,7 +167,14 @@ describe("organization member role plan limit enforcement", () => {
   });
 
   afterAll(async () => {
-    // Clean up in reverse creation order
+    // Clean up in reverse creation order.
+    //
+    // RoleBindings go first and WITHOUT a `.catch`: they hold an FK to
+    // CustomRole, so a failure here would surface as a confusing error on the
+    // `customRole.deleteMany` below — or, swallowed, as rows that outlive the
+    // run. Deleting the organization would cascade them anyway; doing it
+    // explicitly means a broken teardown says so instead of passing quietly.
+    await prisma.roleBinding.deleteMany({ where: { organizationId } });
     await prisma.teamUser
       .deleteMany({
         where: {
@@ -225,7 +223,7 @@ describe("organization member role plan limit enforcement", () => {
     return appRouter.createCaller(ctx);
   }
 
-  describe("updateMemberRole", () => {
+  describe("when calling updateMemberRole", () => {
     describe("when demoting MEMBER to EXTERNAL (full-to-lite change)", () => {
       it("rejects when lite member limit reached", async () => {
         mockGetActivePlan.mockResolvedValue({
@@ -277,7 +275,7 @@ describe("organization member role plan limit enforcement", () => {
     });
   });
 
-  describe("updateTeamMemberRole", () => {
+  describe("when calling updateTeamMemberRole", () => {
     describe("when changing EXTERNAL user from custom role to built-in VIEWER (full-to-lite change)", () => {
       beforeEach(async () => {
         // Set target user as EXTERNAL with custom role (non-view permissions → FullMember)
@@ -300,30 +298,14 @@ describe("organization member role plan limit enforcement", () => {
           data: { role: TeamUserRole.CUSTOM, assignedRoleId: customRoleId },
         });
 
-        // The guard reads the custom role through `getUserCustomRoleBinding`
-        // — a RoleBinding lookup — not through the legacy
-        // `TeamUser.assignedRoleId` set above. Without this binding the
-        // caller's old permissions read as undefined, `getRoleChangeType`
-        // sees no full-to-lite transition, and the limit is never asserted:
-        // the mutation returns `{ success: true }` and the rejection this
-        // block is about silently stops being tested.
-        await prisma.roleBinding.deleteMany({
-          where: {
-            organizationId,
-            userId: targetUserId,
-            scopeType: RoleBindingScopeType.TEAM,
-            scopeId: teamId,
-          },
-        });
-        await prisma.roleBinding.create({
-          data: {
-            organizationId,
-            userId: targetUserId,
-            role: TeamUserRole.CUSTOM,
-            customRoleId,
-            scopeType: RoleBindingScopeType.TEAM,
-            scopeId: teamId,
-          },
+        // The binding, not the legacy `assignedRoleId` set above, is what the
+        // guard reads — see the helper.
+        await bindCustomRoleToTeam({
+          prisma,
+          organizationId,
+          userId: targetUserId,
+          teamId,
+          customRoleId,
         });
       });
 

--- a/langwatch/src/server/api/routers/__tests__/plan.getActivePlan.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/plan.getActivePlan.integration.test.ts
@@ -31,11 +31,7 @@ import { prisma } from "../../../db";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-// TEST_CLICKHOUSE_URL indicates testcontainers mode without full infrastructure
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)("plan.getActivePlan integration", () => {
+describe("plan.getActivePlan integration", () => {
   const testNamespace = `plan-active-${nanoid(8)}`;
   let organizationId: string;
   let userId: string;

--- a/langwatch/src/server/api/routers/__tests__/project.regenerateApiKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.regenerateApiKey.integration.test.ts
@@ -14,270 +14,269 @@ import { prisma } from "../../../db";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-// Skip when running with testcontainers only (no PostgreSQL)
-// TEST_CLICKHOUSE_URL indicates testcontainers mode without full infrastructure
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("project.regenerateApiKey integration", () => {
+  const testNamespace = `regen-api-key-${nanoid(8)}`;
+  let projectId: string;
+  let caller: ReturnType<typeof appRouter.createCaller>;
+  // A caller for a user who can view but NOT manage the project, used to prove
+  // rotation is gated on `project:manage`.
+  let viewerCaller: ReturnType<typeof appRouter.createCaller>;
 
-describe.skipIf(isTestcontainersOnly)(
-  "project.regenerateApiKey integration",
-  () => {
-    const testNamespace = `regen-api-key-${nanoid(8)}`;
-    let projectId: string;
-    let caller: ReturnType<typeof appRouter.createCaller>;
-    // A caller for a user who can view but NOT manage the project, used to prove
-    // rotation is gated on `project:manage`.
-    let viewerCaller: ReturnType<typeof appRouter.createCaller>;
-
-    beforeAll(async () => {
-      // Create isolated test data for this test suite
-      const organization = await prisma.organization.create({
-        data: {
-          name: "Test Organization",
-          slug: `--test-org-${testNamespace}`,
-        },
-      });
-
-      const team = await prisma.team.create({
-        data: {
-          name: "Test Team",
-          slug: `--test-team-${testNamespace}`,
-          organizationId: organization.id,
-        },
-      });
-
-      const project = await prisma.project.create({
-        data: {
-          name: "Test Project",
-          slug: `--test-project-${testNamespace}`,
-          apiKey: `sk-lw-test-${nanoid()}`,
-          teamId: team.id,
-          language: "en",
-          framework: "test",
-        },
-      });
-      projectId = project.id;
-
-      const user = await prisma.user.create({
-        data: {
-          name: "Test User",
-          email: `test-${testNamespace}@example.com`,
-        },
-      });
-
-      // Add user to organization and team
-      await prisma.organizationUser.create({
-        data: {
-          userId: user.id,
-          organizationId: organization.id,
-          role: OrganizationUserRole.ADMIN,
-        },
-      });
-
-      await prisma.teamUser.create({
-        data: {
-          userId: user.id,
-          teamId: team.id,
-          role: TeamUserRole.ADMIN,
-        },
-      });
-
-      const ctx = createInnerTRPCContext({
-        session: {
-          user: { id: user.id },
-          expires: "1",
-        },
-      });
-      caller = appRouter.createCaller(ctx);
-
-      // A second user on the SAME org/team/project with view-only roles
-      // (org MEMBER + team VIEWER). Neither role grants `project:manage`, so
-      // this caller must be rejected when it tries to rotate the base key.
-      const viewer = await prisma.user.create({
-        data: {
-          name: "Viewer User",
-          email: `viewer-${testNamespace}@example.com`,
-        },
-      });
-      await prisma.organizationUser.create({
-        data: {
-          userId: viewer.id,
-          organizationId: organization.id,
-          role: OrganizationUserRole.MEMBER,
-        },
-      });
-      await prisma.teamUser.create({
-        data: {
-          userId: viewer.id,
-          teamId: team.id,
-          role: TeamUserRole.VIEWER,
-        },
-      });
-      const viewerCtx = createInnerTRPCContext({
-        session: {
-          user: { id: viewer.id },
-          expires: "1",
-        },
-      });
-      viewerCaller = appRouter.createCaller(viewerCtx);
+  beforeAll(async () => {
+    // Create isolated test data for this test suite
+    const organization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `--test-org-${testNamespace}`,
+      },
     });
 
-    afterAll(async () => {
-      // Cleanup test data
-      await prisma.project
-        .deleteMany({
-          where: { slug: { startsWith: `--test-project-${testNamespace}` } },
-        })
-        .catch(() => {});
-      await prisma.teamUser
-        .deleteMany({
-          where: { team: { slug: `--test-team-${testNamespace}` } },
-        })
-        .catch(() => {});
-      await prisma.team
-        .deleteMany({
-          where: { slug: `--test-team-${testNamespace}` },
-        })
-        .catch(() => {});
-      await prisma.organizationUser
-        .deleteMany({
-          where: { organization: { slug: `--test-org-${testNamespace}` } },
-        })
-        .catch(() => {});
-      await prisma.organization
-        .deleteMany({
-          where: { slug: `--test-org-${testNamespace}` },
-        })
-        .catch(() => {});
-      await prisma.user
-        .deleteMany({
-          where: { email: `test-${testNamespace}@example.com` },
-        })
-        .catch(() => {});
-      await prisma.user
-        .deleteMany({
-          where: { email: `viewer-${testNamespace}@example.com` },
-        })
-        .catch(() => {});
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId: organization.id,
+      },
     });
 
-    describe("given an existing project", () => {
-      describe("when regenerating the API key", () => {
-        it("regenerates API key for existing project", async () => {
-          // Get the original API key
-          const project = await prisma.project.findUnique({
-            where: { id: projectId },
-            select: { apiKey: true },
-          });
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        slug: `--test-project-${testNamespace}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId: team.id,
+        language: "en",
+        framework: "test",
+      },
+    });
+    projectId = project.id;
 
-          if (!project) {
-            throw new Error("Test project not found");
-          }
-
-          const originalApiKey = project.apiKey;
-
-          // Regenerate the API key
-          const result = await caller.project.regenerateApiKey({ projectId });
-
-          // Verify the new key is different
-          expect(result.apiKey).not.toBe(originalApiKey);
-          expect(result.apiKey).toMatch(/^sk-lw-/);
-
-          // Verify the key was actually updated in the database
-          const updatedProject = await prisma.project.findUnique({
-            where: { id: projectId },
-            select: { apiKey: true },
-          });
-          expect(updatedProject?.apiKey).toBe(result.apiKey);
-          expect(updatedProject?.apiKey).not.toBe(originalApiKey);
-        });
-      });
+    const user = await prisma.user.create({
+      data: {
+        name: "Test User",
+        email: `test-${testNamespace}@example.com`,
+      },
     });
 
-    describe("given a nonexistent project", () => {
-      describe("when regenerating the API key", () => {
-        it("returns UNAUTHORIZED for nonexistent project (secure behavior - does not reveal project existence)", async () => {
-          await expect(
-            caller.project.regenerateApiKey({
-              projectId: "nonexistent-project-id",
-            }),
-          ).rejects.toMatchObject({
-            code: "UNAUTHORIZED",
-          });
-        });
-      });
+    // Add user to organization and team
+    await prisma.organizationUser.create({
+      data: {
+        userId: user.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
     });
 
-    describe("given rotation invalidates the previous base key", () => {
-      /** @scenario "Rotation invalidates the previous base key" */
-      it("makes the old base key stop authenticating and the new one authenticate scoped to the project", async () => {
-        const before = await prisma.project.findUnique({
+    await prisma.teamUser.create({
+      data: {
+        userId: user.id,
+        teamId: team.id,
+        role: TeamUserRole.ADMIN,
+      },
+    });
+
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: user.id },
+        expires: "1",
+      },
+    });
+    caller = appRouter.createCaller(ctx);
+
+    // A second user on the SAME org/team/project with view-only roles
+    // (org MEMBER + team VIEWER). Neither role grants `project:manage`, so
+    // this caller must be rejected when it tries to rotate the base key.
+    const viewer = await prisma.user.create({
+      data: {
+        name: "Viewer User",
+        email: `viewer-${testNamespace}@example.com`,
+      },
+    });
+    await prisma.organizationUser.create({
+      data: {
+        userId: viewer.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    await prisma.teamUser.create({
+      data: {
+        userId: viewer.id,
+        teamId: team.id,
+        role: TeamUserRole.VIEWER,
+      },
+    });
+    const viewerCtx = createInnerTRPCContext({
+      session: {
+        user: { id: viewer.id },
+        expires: "1",
+      },
+    });
+    viewerCaller = appRouter.createCaller(viewerCtx);
+  });
+
+  afterAll(async () => {
+    // Cleanup test data
+    await prisma.project
+      .deleteMany({
+        where: { slug: { startsWith: `--test-project-${testNamespace}` } },
+      })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({
+        where: { team: { slug: `--test-team-${testNamespace}` } },
+      })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({
+        where: { slug: `--test-team-${testNamespace}` },
+      })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({
+        where: { organization: { slug: `--test-org-${testNamespace}` } },
+      })
+      .catch(() => {});
+    await prisma.organization
+      .deleteMany({
+        where: { slug: `--test-org-${testNamespace}` },
+      })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { email: `test-${testNamespace}@example.com` },
+      })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { email: `viewer-${testNamespace}@example.com` },
+      })
+      .catch(() => {});
+  });
+
+  describe("given an existing project", () => {
+    describe("when regenerating the API key", () => {
+      it("regenerates API key for existing project", async () => {
+        // Get the original API key
+        const project = await prisma.project.findUnique({
           where: { id: projectId },
           select: { apiKey: true },
         });
-        const originalApiKey = before!.apiKey;
 
-        const resolver = TokenResolver.create(prisma);
+        if (!project) {
+          throw new Error("Test project not found");
+        }
 
-        // Sanity: the original base key authenticates to this project via the
-        // real legacy-key resolution path before rotation.
-        const resolvedBefore = await resolver.resolve({
-          token: originalApiKey,
-        });
-        expect(resolvedBefore?.type).toBe("legacyProjectKey");
-        expect(resolvedBefore?.project.id).toBe(projectId);
+        const originalApiKey = project.apiKey;
 
-        const { apiKey: newApiKey } = await caller.project.regenerateApiKey({
-          projectId,
-        });
+        // Regenerate the API key
+        const result = await caller.project.regenerateApiKey({ projectId });
 
-        // The previous raw key no longer resolves to anything.
-        const resolvedOld = await resolver.resolve({ token: originalApiKey });
-        expect(resolvedOld).toBeNull();
+        // Verify the new key is different
+        expect(result.apiKey).not.toBe(originalApiKey);
+        expect(result.apiKey).toMatch(/^sk-lw-/);
 
-        // The new key resolves, scoped to the same project.
-        const resolvedNew = await resolver.resolve({ token: newApiKey });
-        expect(resolvedNew?.type).toBe("legacyProjectKey");
-        expect(resolvedNew?.project.id).toBe(projectId);
-      });
-    });
-
-    describe("given a user without project:manage permission", () => {
-      it("rejects the rotation and leaves the base key unchanged", async () => {
-        const before = await prisma.project.findUnique({
+        // Verify the key was actually updated in the database
+        const updatedProject = await prisma.project.findUnique({
           where: { id: projectId },
           select: { apiKey: true },
         });
-        const keyBefore = before!.apiKey;
+        expect(updatedProject?.apiKey).toBe(result.apiKey);
+        expect(updatedProject?.apiKey).not.toBe(originalApiKey);
+      });
+    });
+  });
 
+  describe("given a nonexistent project", () => {
+    describe("when regenerating the API key", () => {
+      it("refuses without revealing whether the project exists", async () => {
         await expect(
-          viewerCaller.project.regenerateApiKey({ projectId }),
+          caller.project.regenerateApiKey({
+            projectId: "nonexistent-project-id",
+          }),
         ).rejects.toMatchObject({
-          // checkProjectPermission("project:manage") throws UNAUTHORIZED when the
-          // caller lacks the permission (see server/api/rbac.ts checkProjectPermission).
-          code: "UNAUTHORIZED",
+          // Same refusal a real-but-forbidden project gets, which is the
+          // property under test: the answer must not distinguish "no such
+          // project" from "not yours".
+          code: "FORBIDDEN",
         });
-
-        const after = await prisma.project.findUnique({
-          where: { id: projectId },
-          select: { apiKey: true },
-        });
-        expect(after!.apiKey).toBe(keyBefore);
       });
     });
+  });
 
-    describe("given a successful rotation", () => {
-      /** @scenario "Rotation is recorded for audit" */
-      it("records an audit-log entry for the rotation", async () => {
-        await caller.project.regenerateApiKey({ projectId });
-
-        const entry = await prisma.auditLog.findFirst({
-          where: {
-            action: "project.apiKey.regenerated",
-            projectId,
-          },
-        });
-        expect(entry).not.toBeNull();
+  describe("given rotation invalidates the previous base key", () => {
+    /** @scenario "Rotation invalidates the previous base key" */
+    it("makes the old base key stop authenticating and the new one authenticate scoped to the project", async () => {
+      const before = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true },
       });
+      const originalApiKey = before!.apiKey;
+
+      const resolver = TokenResolver.create(prisma);
+
+      // Sanity: the original base key authenticates to this project via the
+      // real legacy-key resolution path before rotation.
+      const resolvedBefore = await resolver.resolve({
+        token: originalApiKey,
+      });
+      expect(resolvedBefore?.type).toBe("legacyProjectKey");
+      expect(resolvedBefore?.project.id).toBe(projectId);
+
+      const { apiKey: newApiKey } = await caller.project.regenerateApiKey({
+        projectId,
+      });
+
+      // The previous raw key no longer resolves to anything.
+      const resolvedOld = await resolver.resolve({ token: originalApiKey });
+      expect(resolvedOld).toBeNull();
+
+      // The new key resolves, scoped to the same project.
+      const resolvedNew = await resolver.resolve({ token: newApiKey });
+      expect(resolvedNew?.type).toBe("legacyProjectKey");
+      expect(resolvedNew?.project.id).toBe(projectId);
     });
-  },
-);
+  });
+
+  describe("given a user without project:manage permission", () => {
+    it("rejects the rotation and leaves the base key unchanged", async () => {
+      const before = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true },
+      });
+      const keyBefore = before!.apiKey;
+
+      await expect(
+        viewerCaller.project.regenerateApiKey({ projectId }),
+      ).rejects.toMatchObject({
+        // `checkProjectPermission` spells UNAUTHORIZED, but attaches a
+        // `ProjectPermissionDeniedError` cause and `handledErrorMiddleware`
+        // re-derives the wire code from its 403 — so FORBIDDEN is what a
+        // caller sees, and what this asserts. The caller is authenticated;
+        // they just lack `project:manage`.
+        code: "FORBIDDEN",
+      });
+
+      const after = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true },
+      });
+      expect(after!.apiKey).toBe(keyBefore);
+    });
+  });
+
+  describe("given a successful rotation", () => {
+    /** @scenario "Rotation is recorded for audit" */
+    it("records an audit-log entry for the rotation", async () => {
+      await caller.project.regenerateApiKey({ projectId });
+
+      const entry = await prisma.auditLog.findFirst({
+        where: {
+          action: "project.apiKey.regenerated",
+          projectId,
+        },
+      });
+      expect(entry).not.toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
@@ -36,185 +36,178 @@ import { prisma } from "../../../db";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("workflow.create node LLM materialization", () => {
+  const testNamespace = `wf-node-llm-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+  let userId: string;
+  let caller: ReturnType<typeof appRouter.createCaller>;
 
-describe.skipIf(isTestcontainersOnly)(
-  "workflow.create node LLM materialization",
-  () => {
-    const testNamespace = `wf-node-llm-${nanoid(8)}`;
-    let organizationId: string;
-    let teamId: string;
-    let projectId: string;
-    let userId: string;
-    let caller: ReturnType<typeof appRouter.createCaller>;
+  const createdWorkflowIds: string[] = [];
 
-    const createdWorkflowIds: string[] = [];
+  const persistedLlmValue = async (
+    workflowId: string,
+  ): Promise<LLMConfig | undefined> => {
+    const workflow = await prisma.workflow.findUniqueOrThrow({
+      where: { id: workflowId, projectId },
+      include: { latestVersion: true },
+    });
+    const dsl = workflow.latestVersion?.dsl as unknown as Workflow;
+    const signature = dsl.nodes.find((n) => n.type === "signature");
+    return signature?.data.parameters?.find((p) => p.type === "llm")?.value as
+      | LLMConfig
+      | undefined;
+  };
 
-    const persistedLlmValue = async (
-      workflowId: string,
-    ): Promise<LLMConfig | undefined> => {
-      const workflow = await prisma.workflow.findUniqueOrThrow({
-        where: { id: workflowId, projectId },
-        include: { latestVersion: true },
-      });
-      const dsl = workflow.latestVersion?.dsl as unknown as Workflow;
-      const signature = dsl.nodes.find((n) => n.type === "signature");
-      return signature?.data.parameters?.find((p) => p.type === "llm")?.value as
-        | LLMConfig
-        | undefined;
-    };
+  const createFromBlankTemplate = async (dslOverrides?: object) => {
+    const result = await caller.workflow.create({
+      projectId,
+      dsl: {
+        ...JSON.parse(JSON.stringify(blankTemplate)),
+        name: `Test ${nanoid(6)}`,
+        version: "1",
+        ...dslOverrides,
+      },
+      commitMessage: "Workflow creation",
+    });
+    createdWorkflowIds.push(result.workflow.id);
+    return result;
+  };
 
-    const createFromBlankTemplate = async (dslOverrides?: object) => {
-      const result = await caller.workflow.create({
-        projectId,
-        dsl: {
-          ...JSON.parse(JSON.stringify(blankTemplate)),
-          name: `Test ${nanoid(6)}`,
-          version: "1",
-          ...dslOverrides,
-        },
-        commitMessage: "Workflow creation",
-      });
-      createdWorkflowIds.push(result.workflow.id);
-      return result;
-    };
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `--test-org-${testNamespace}`,
+      },
+    });
+    organizationId = organization.id;
 
-    beforeAll(async () => {
-      const organization = await prisma.organization.create({
-        data: {
-          name: "Test Organization",
-          slug: `--test-org-${testNamespace}`,
-        },
-      });
-      organizationId = organization.id;
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
 
-      const team = await prisma.team.create({
-        data: {
-          name: "Test Team",
-          slug: `--test-team-${testNamespace}`,
-          organizationId,
-        },
-      });
-      teamId = team.id;
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        slug: `--test-project-${testNamespace}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+    projectId = project.id;
 
-      const project = await prisma.project.create({
-        data: {
-          name: "Test Project",
-          slug: `--test-project-${testNamespace}`,
-          apiKey: `sk-lw-test-${nanoid()}`,
-          teamId,
-          language: "en",
-          framework: "test",
-        },
-      });
-      projectId = project.id;
+    const user = await prisma.user.create({
+      data: {
+        name: "Test User",
+        email: `test-${testNamespace}@example.com`,
+      },
+    });
+    userId = user.id;
 
-      const user = await prisma.user.create({
-        data: {
-          name: "Test User",
-          email: `test-${testNamespace}@example.com`,
-        },
-      });
-      userId = user.id;
-
-      await prisma.organizationUser.create({
-        data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
-      });
-      await prisma.teamUser.create({
-        data: { userId, teamId, role: TeamUserRole.ADMIN },
-      });
-
-      caller = appRouter.createCaller(
-        createInnerTRPCContext({
-          session: { user: { id: userId }, expires: "1" },
-        }),
-      );
+    await prisma.organizationUser.create({
+      data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
+    });
+    await prisma.teamUser.create({
+      data: { userId, teamId, role: TeamUserRole.ADMIN },
     });
 
-    afterAll(async () => {
-      // Detach the required CurrentVersion/LatestVersion relations before
-      // deleting versions, or the deleteMany violates the FK.
-      await prisma.workflow.updateMany({
-        where: { projectId },
-        data: { currentVersionId: null, latestVersionId: null },
-      });
-      await prisma.workflowVersion.deleteMany({ where: { projectId } });
-      await prisma.workflow.deleteMany({ where: { projectId } });
-      await prisma.modelDefaultConfig.deleteMany({
-        where: { organizationId },
-      });
-      await prisma.teamUser.deleteMany({ where: { teamId } });
-      await prisma.organizationUser.deleteMany({ where: { organizationId } });
-      await prisma.project.delete({ where: { id: projectId } });
-      await prisma.team.delete({ where: { id: teamId } });
-      await prisma.organization.delete({ where: { id: organizationId } });
-      await prisma.user.delete({ where: { id: userId } });
+    caller = appRouter.createCaller(
+      createInnerTRPCContext({
+        session: { user: { id: userId }, expires: "1" },
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    // Detach the required CurrentVersion/LatestVersion relations before
+    // deleting versions, or the deleteMany violates the FK.
+    await prisma.workflow.updateMany({
+      where: { projectId },
+      data: { currentVersionId: null, latestVersionId: null },
+    });
+    await prisma.workflowVersion.deleteMany({ where: { projectId } });
+    await prisma.workflow.deleteMany({ where: { projectId } });
+    await prisma.modelDefaultConfig.deleteMany({
+      where: { organizationId },
+    });
+    await prisma.teamUser.deleteMany({ where: { teamId } });
+    await prisma.organizationUser.deleteMany({ where: { organizationId } });
+    await prisma.project.delete({ where: { id: projectId } });
+    await prisma.team.delete({ where: { id: teamId } });
+    await prisma.organization.delete({ where: { id: organizationId } });
+    await prisma.user.delete({ where: { id: userId } });
+  });
+
+  /** @scenario Creating a workflow on a fresh install starts it with a ready-to-use model */
+  it("persists the registry flagship on LLM nodes when nothing is configured anywhere", async () => {
+    const { workflow } = await createFromBlankTemplate();
+
+    const llm = await persistedLlmValue(workflow.id);
+    expect(llm?.model).toBe(DEFAULT_MODEL);
+    expect(llm?.model).not.toBe("");
+  });
+
+  /** @scenario Creating a workflow uses the configured default model when one is set */
+  it("persists the cascade-resolved model when a project default is configured", async () => {
+    const config = await prisma.modelDefaultConfig.create({
+      data: {
+        config: { DEFAULT: "anthropic/claude-haiku-4-5-20251001" },
+        organizationId,
+        scopes: {
+          create: [{ scopeType: "PROJECT", scopeId: projectId }],
+        },
+      },
     });
 
-    /** @scenario Creating a workflow on a fresh install starts it with a ready-to-use model */
-    it("persists the registry flagship on LLM nodes when nothing is configured anywhere", async () => {
+    try {
       const { workflow } = await createFromBlankTemplate();
-
       const llm = await persistedLlmValue(workflow.id);
-      expect(llm?.model).toBe(DEFAULT_MODEL);
-      expect(llm?.model).not.toBe("");
+      expect(llm?.model).toBe("anthropic/claude-haiku-4-5-20251001");
+    } finally {
+      await prisma.modelDefaultConfig.delete({ where: { id: config.id } });
+    }
+  });
+
+  /** @scenario A workflow created by an older client keeps its old workflow-wide model */
+  it("folds a legacy client's default_llm into the node and drops the field", async () => {
+    const { workflow } = await createFromBlankTemplate({
+      default_llm: { model: "openai/gpt-5-mini", max_tokens: 256 },
     });
 
-    /** @scenario Creating a workflow uses the configured default model when one is set */
-    it("persists the cascade-resolved model when a project default is configured", async () => {
-      const config = await prisma.modelDefaultConfig.create({
-        data: {
-          config: { DEFAULT: "anthropic/claude-haiku-4-5-20251001" },
-          organizationId,
-          scopes: {
-            create: [{ scopeType: "PROJECT", scopeId: projectId }],
-          },
-        },
-      });
+    const llm = await persistedLlmValue(workflow.id);
+    expect(llm).toEqual({ model: "openai/gpt-5-mini", max_tokens: 256 });
 
-      try {
-        const { workflow } = await createFromBlankTemplate();
-        const llm = await persistedLlmValue(workflow.id);
-        expect(llm?.model).toBe("anthropic/claude-haiku-4-5-20251001");
-      } finally {
-        await prisma.modelDefaultConfig.delete({ where: { id: config.id } });
-      }
+    const stored = await prisma.workflow.findUniqueOrThrow({
+      where: { id: workflow.id, projectId },
+      include: { latestVersion: true },
+    });
+    expect("default_llm" in (stored.latestVersion?.dsl as object)).toBe(false);
+  });
+
+  /** @scenario An explicit node-owned model is never rewritten */
+  it("keeps an explicit node-owned model untouched", async () => {
+    const template = JSON.parse(
+      JSON.stringify(blankTemplate),
+    ) as typeof blankTemplate;
+    const llmParam = template.nodes
+      .find((n) => n.type === "signature")!
+      .data.parameters!.find((p) => p.type === "llm")!;
+    llmParam.value = { model: "gemini/gemini-2.5-flash" };
+
+    const { workflow } = await createFromBlankTemplate({
+      nodes: template.nodes,
     });
 
-    /** @scenario A workflow created by an older client keeps its old workflow-wide model */
-    it("folds a legacy client's default_llm into the node and drops the field", async () => {
-      const { workflow } = await createFromBlankTemplate({
-        default_llm: { model: "openai/gpt-5-mini", max_tokens: 256 },
-      });
-
-      const llm = await persistedLlmValue(workflow.id);
-      expect(llm).toEqual({ model: "openai/gpt-5-mini", max_tokens: 256 });
-
-      const stored = await prisma.workflow.findUniqueOrThrow({
-        where: { id: workflow.id, projectId },
-        include: { latestVersion: true },
-      });
-      expect("default_llm" in (stored.latestVersion?.dsl as object)).toBe(
-        false,
-      );
-    });
-
-    /** @scenario An explicit node-owned model is never rewritten */
-    it("keeps an explicit node-owned model untouched", async () => {
-      const template = JSON.parse(
-        JSON.stringify(blankTemplate),
-      ) as typeof blankTemplate;
-      const llmParam = template.nodes
-        .find((n) => n.type === "signature")!
-        .data.parameters!.find((p) => p.type === "llm")!;
-      llmParam.value = { model: "gemini/gemini-2.5-flash" };
-
-      const { workflow } = await createFromBlankTemplate({
-        nodes: template.nodes,
-      });
-
-      const llm = await persistedLlmValue(workflow.id);
-      expect(llm?.model).toBe("gemini/gemini-2.5-flash");
-    });
-  },
-);
+    const llm = await persistedLlmValue(workflow.id);
+    expect(llm?.model).toBe("gemini/gemini-2.5-flash");
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
@@ -128,41 +128,31 @@ describe("workflow.create node LLM materialization", () => {
   });
 
   afterAll(async () => {
-    // beforeAll assigns these in sequence; a failure partway through leaves
-    // later ones undefined, and Prisma treats an undefined filter as "no
-    // filter" — updateMany/deleteMany below would touch the whole table
-    // instead of just this run's rows.
-    if (projectId) {
-      // Detach the required CurrentVersion/LatestVersion relations before
-      // deleting versions, or the deleteMany violates the FK.
-      await prisma.workflow.updateMany({
-        where: { projectId },
-        data: { currentVersionId: null, latestVersionId: null },
-      });
-      await prisma.workflowVersion.deleteMany({ where: { projectId } });
-      await prisma.workflow.deleteMany({ where: { projectId } });
-      await prisma.project.delete({ where: { id: projectId } });
-    }
-    if (organizationId) {
-      await prisma.modelDefaultConfig.deleteMany({
-        where: { organizationId },
-      });
-    }
-    if (teamId) {
-      await prisma.teamUser.deleteMany({ where: { teamId } });
-    }
-    if (organizationId) {
-      await prisma.organizationUser.deleteMany({ where: { organizationId } });
-    }
-    if (teamId) {
-      await prisma.team.delete({ where: { id: teamId } });
-    }
-    if (organizationId) {
-      await prisma.organization.delete({ where: { id: organizationId } });
-    }
-    if (userId) {
-      await prisma.user.delete({ where: { id: userId } });
-    }
+    // beforeAll assigns these four ids in sequence and Vitest runs afterAll
+    // even when beforeAll throws, so a failure partway through leaves the
+    // later ones undefined. Prisma drops an undefined `where` key rather than
+    // matching nothing, which would turn each deleteMany below into "delete
+    // every row in the table". Setup is all-or-nothing, so teardown is too:
+    // bail before a single filter is built.
+    if (!organizationId || !teamId || !projectId || !userId) return;
+
+    // Detach the required CurrentVersion/LatestVersion relations before
+    // deleting versions, or the deleteMany violates the FK.
+    await prisma.workflow.updateMany({
+      where: { projectId },
+      data: { currentVersionId: null, latestVersionId: null },
+    });
+    await prisma.workflowVersion.deleteMany({ where: { projectId } });
+    await prisma.workflow.deleteMany({ where: { projectId } });
+    await prisma.modelDefaultConfig.deleteMany({
+      where: { organizationId },
+    });
+    await prisma.teamUser.deleteMany({ where: { teamId } });
+    await prisma.organizationUser.deleteMany({ where: { organizationId } });
+    await prisma.project.delete({ where: { id: projectId } });
+    await prisma.team.delete({ where: { id: teamId } });
+    await prisma.organization.delete({ where: { id: organizationId } });
+    await prisma.user.delete({ where: { id: userId } });
   });
 
   /** @scenario Creating a workflow on a fresh install starts it with a ready-to-use model */

--- a/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.node-llm-materialization.integration.test.ts
@@ -128,23 +128,41 @@ describe("workflow.create node LLM materialization", () => {
   });
 
   afterAll(async () => {
-    // Detach the required CurrentVersion/LatestVersion relations before
-    // deleting versions, or the deleteMany violates the FK.
-    await prisma.workflow.updateMany({
-      where: { projectId },
-      data: { currentVersionId: null, latestVersionId: null },
-    });
-    await prisma.workflowVersion.deleteMany({ where: { projectId } });
-    await prisma.workflow.deleteMany({ where: { projectId } });
-    await prisma.modelDefaultConfig.deleteMany({
-      where: { organizationId },
-    });
-    await prisma.teamUser.deleteMany({ where: { teamId } });
-    await prisma.organizationUser.deleteMany({ where: { organizationId } });
-    await prisma.project.delete({ where: { id: projectId } });
-    await prisma.team.delete({ where: { id: teamId } });
-    await prisma.organization.delete({ where: { id: organizationId } });
-    await prisma.user.delete({ where: { id: userId } });
+    // beforeAll assigns these in sequence; a failure partway through leaves
+    // later ones undefined, and Prisma treats an undefined filter as "no
+    // filter" — updateMany/deleteMany below would touch the whole table
+    // instead of just this run's rows.
+    if (projectId) {
+      // Detach the required CurrentVersion/LatestVersion relations before
+      // deleting versions, or the deleteMany violates the FK.
+      await prisma.workflow.updateMany({
+        where: { projectId },
+        data: { currentVersionId: null, latestVersionId: null },
+      });
+      await prisma.workflowVersion.deleteMany({ where: { projectId } });
+      await prisma.workflow.deleteMany({ where: { projectId } });
+      await prisma.project.delete({ where: { id: projectId } });
+    }
+    if (organizationId) {
+      await prisma.modelDefaultConfig.deleteMany({
+        where: { organizationId },
+      });
+    }
+    if (teamId) {
+      await prisma.teamUser.deleteMany({ where: { teamId } });
+    }
+    if (organizationId) {
+      await prisma.organizationUser.deleteMany({ where: { organizationId } });
+    }
+    if (teamId) {
+      await prisma.team.delete({ where: { id: teamId } });
+    }
+    if (organizationId) {
+      await prisma.organization.delete({ where: { id: organizationId } });
+    }
+    if (userId) {
+      await prisma.user.delete({ where: { id: userId } });
+    }
   });
 
   /** @scenario Creating a workflow on a fresh install starts it with a ready-to-use model */

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.authz.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.authz.integration.test.ts
@@ -25,10 +25,9 @@ import { prisma } from "../../db";
 import { ModelProviderScopeForbiddenError } from "../errors";
 import { ModelProviderService } from "../modelProvider.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
 const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
 
-describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+describe.skipIf(!hasCredentialsSecret)(
   "ModelProviderService scope authz (real DB)",
   () => {
     const ns = `mp-authz-${nanoid(8)}`;
@@ -268,7 +267,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           expect(result).toBeDefined();
           // Read back directly via prisma to check the scope row landed.
           const stored = await prisma.modelProvider.findFirst({
-            where: { id: result.id, projectId: projectAId },
+            where: { id: result.id },
             include: { scopes: true },
           });
           const scopes = stored?.scopes ?? [];
@@ -284,7 +283,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         /** @scenario Assigning a provider to an org without manage permission is denied */
         it("rejects with FORBIDDEN and does not persist", async () => {
           const before = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "anthropic" },
+            where: { organizationId, provider: "anthropic" },
           });
           await expect(
             service().updateModelProvider(
@@ -304,7 +303,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
             meta: { requiredPermission: "organization:manage" },
           });
           const after = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "anthropic" },
+            where: { organizationId, provider: "anthropic" },
           });
           expect(after).toBe(before);
         });
@@ -345,7 +344,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           );
           expect(result).toBeDefined();
           const stored = await prisma.modelProvider.findFirst({
-            where: { id: result.id, projectId: projectAId },
+            where: { id: result.id },
             include: { scopes: true },
           });
           const scopes = stored?.scopes ?? [];
@@ -385,7 +384,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         /** @scenario Adding an unauthorized team scope to an existing provider is rejected */
         it("rejects the entire mutation with no partial persistence", async () => {
           const before = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "deepseek" },
+            where: { organizationId, provider: "deepseek" },
           });
           await expect(
             service().updateModelProvider(
@@ -404,7 +403,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           ).rejects.toMatchObject({ code: "model_provider_scope_forbidden" });
 
           const after = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "deepseek" },
+            where: { organizationId, provider: "deepseek" },
           });
           expect(after).toBe(before);
         });
@@ -427,7 +426,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
             ctxFor(orgAdminUserId),
           );
           const stored = await prisma.modelProvider.findFirst({
-            where: { id: result.id, projectId: projectAId },
+            where: { id: result.id },
             include: { scopes: true },
           });
           const scopes = stored?.scopes ?? [];
@@ -463,7 +462,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           // Sanity check: both scopes persisted.
           {
             const stored = await prisma.modelProvider.findFirst({
-              where: { id: created.id, projectId: projectAId },
+              where: { id: created.id },
               include: { scopes: true },
             });
             expect(stored?.scopes).toHaveLength(2);
@@ -481,7 +480,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           );
 
           const after = await prisma.modelProvider.findFirst({
-            where: { id: created.id, projectId: projectAId },
+            where: { id: created.id },
             include: { scopes: true },
           });
           expect(after?.scopes).toHaveLength(1);
@@ -581,7 +580,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         /** @scenario Update of a vanished id surfaces NOT_FOUND instead of silently creating */
         it("throws NOT_FOUND instead of falling through to create a new row", async () => {
           const beforeCount = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "groq" },
+            where: { organizationId, provider: "groq" },
           });
           await expect(
             service().updateModelProvider(
@@ -599,7 +598,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
             // class) is what keeps this honest across the tRPC boundary.
           ).rejects.toMatchObject({ code: "model_provider_not_found" });
           const afterCount = await prisma.modelProvider.count({
-            where: { projectId: projectAId, provider: "groq" },
+            where: { organizationId, provider: "groq" },
           });
           expect(afterCount).toBe(beforeCount);
         });
@@ -681,7 +680,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
           );
 
           const remaining = await prisma.modelProvider.findFirst({
-            where: { id: mp.id, projectId: projectAId },
+            where: { id: mp.id },
             include: { scopes: true },
           });
           expect(remaining).toBeNull();
@@ -737,7 +736,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
 
             // Row still present
             const stillThere = await prisma.modelProvider.findFirst({
-              where: { id: mp.id, projectId: projectAId },
+              where: { id: mp.id },
             });
             expect(stillThere).not.toBeNull();
           } finally {

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.deleteScope.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.deleteScope.integration.test.ts
@@ -26,10 +26,9 @@ import { prisma } from "../../db";
 import { ModelProviderRepository } from "../modelProvider.repository";
 import { ModelProviderService } from "../modelProvider.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
 const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
 
-describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+describe.skipIf(!hasCredentialsSecret)(
   "ModelProviderService scope-aware deletion (real DB)",
   () => {
     const ns = `mp-del-${nanoid(8)}`;
@@ -241,7 +240,12 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
               { id: created.id, projectId: projectAId, provider: "openai" },
               ctxFor(orgAdminUserId),
             ),
-          ).rejects.toMatchObject({ code: "NOT_FOUND" });
+            // `model_provider_not_found`, not the tRPC `NOT_FOUND` this once
+            // asserted: the service throws a HandledError now. The property
+            // under test is unchanged — a cross-tenant id is refused, and
+            // refused as "not found" so it can't be used to probe for
+            // existence.
+          ).rejects.toMatchObject({ code: "model_provider_not_found" });
 
           const row = await prisma.modelProvider.findUnique({
             where: { id: created.id },

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.enabledCollapse.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.enabledCollapse.integration.test.ts
@@ -19,10 +19,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { prisma } from "../../db";
 import { ModelProviderService } from "../modelProvider.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
 const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
 
-describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+describe.skipIf(!hasCredentialsSecret)(
   "ModelProviderService enabled-vs-scope collapse (real DB)",
   () => {
     const ns = `mp-enabled-${nanoid(8)}`;

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
@@ -18,10 +18,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { prisma } from "../../db";
 import { ModelProviderService } from "../modelProvider.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
 const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
 
-describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+describe.skipIf(!hasCredentialsSecret)(
   "ModelProviderService multi-instance create (real DB)",
   () => {
     const ns = `mp-multi-${nanoid(8)}`;
@@ -139,7 +138,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
       expect(second.id).not.toBe(first.id);
 
       const rows = await prisma.modelProvider.findMany({
-        where: { projectId, provider: "openai" },
+        where: { organizationId, provider: "openai" },
         include: { scopes: true },
       });
 
@@ -199,7 +198,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         ctx(),
       );
       const createdRow = await prisma.modelProvider.findFirst({
-        where: { id: created.id, projectId },
+        where: { id: created.id },
       });
 
       // The drawer's masked-only save: id + scopes, no customKeys. The row is
@@ -219,7 +218,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
 
       expect(updated.id).toBe(created.id);
       const rows = await prisma.modelProvider.findMany({
-        where: { name: `OpenAI Org Edit ${ns}`, projectId },
+        where: { name: `OpenAI Org Edit ${ns}`, organizationId },
         include: { scopes: true },
       });
       expect(rows).toHaveLength(1);

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -771,8 +771,15 @@ export class ModelProviderService {
     // which the settings list surfaces here by inheritance — resolved to null
     // and 404'd. Worse, it made the read gate below unreachable for exactly
     // the scopes it exists to judge: a row that never loads is never asked
-    // about. The gate, not the lookup, is the security boundary — the anchor
-    // keeps the query inside one tenant and `canReadAnyScope` then decides.
+    // about.
+    //
+    // Two boundaries, both load-bearing, and neither substitutes for the
+    // other: `findByIdForOrganization` is the TENANT boundary — it cannot
+    // return a row belonging to another organization — and `canReadAnyScope`
+    // below is the SCOPE-VISIBILITY boundary, deciding whether this caller may
+    // see this row within that tenant. Widening the lookup is only safe
+    // because the second one exists; do not drop either.
+    //
     // Falls back to the project lookup when the tenant can't be resolved, so
     // a missing project can't widen the blast radius.
     const anchor = await this.resolveOrganizationAnchor({ projectId });

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -765,7 +765,20 @@ export class ModelProviderService {
     projectId: string,
     ctx: AuthzContext,
   ): Promise<ModelProviderWithScopes> {
-    const existing = await this.repository.findById(id, projectId);
+    // Org-anchored, for the same reason the edit path is (see
+    // `findEditableById`): `findById` matches only rows carrying a PROJECT
+    // scope for this project, so an ORGANIZATION- or TEAM-scoped provider —
+    // which the settings list surfaces here by inheritance — resolved to null
+    // and 404'd. Worse, it made the read gate below unreachable for exactly
+    // the scopes it exists to judge: a row that never loads is never asked
+    // about. The gate, not the lookup, is the security boundary — the anchor
+    // keeps the query inside one tenant and `canReadAnyScope` then decides.
+    // Falls back to the project lookup when the tenant can't be resolved, so
+    // a missing project can't widen the blast radius.
+    const anchor = await this.resolveOrganizationAnchor({ projectId });
+    const existing = anchor
+      ? await this.repository.findByIdForOrganization(id, anchor)
+      : await this.repository.findById(id, projectId);
     if (!existing) {
       throw new ModelProviderNotFoundError();
     }

--- a/langwatch/src/server/routes/__tests__/workflows-post-event-model-not-set.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/workflows-post-event-model-not-set.integration.test.ts
@@ -25,97 +25,92 @@ vi.mock("~/server/api/rbac", async (importActual) => {
 
 import { prisma } from "~/server/db";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("POST /api/workflows/post_event with a modelless LLM node", () => {
+  const testNamespace = `post-event-llm-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
 
-describe.skipIf(isTestcontainersOnly)(
-  "POST /api/workflows/post_event with a modelless LLM node",
-  () => {
-    const testNamespace = `post-event-llm-${nanoid(8)}`;
-    let organizationId: string;
-    let teamId: string;
-    let projectId: string;
-
-    beforeAll(async () => {
-      const organization = await prisma.organization.create({
-        data: { name: "Test Org", slug: `--test-org-${testNamespace}` },
-      });
-      organizationId = organization.id;
-      const team = await prisma.team.create({
-        data: {
-          name: "Test Team",
-          slug: `--test-team-${testNamespace}`,
-          organizationId,
-        },
-      });
-      teamId = team.id;
-      const project = await prisma.project.create({
-        data: {
-          name: "Test Project",
-          slug: `--test-project-${testNamespace}`,
-          apiKey: `sk-lw-test-${nanoid()}`,
-          teamId,
-          language: "en",
-          framework: "test",
-        },
-      });
-      projectId = project.id;
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Test Org", slug: `--test-org-${testNamespace}` },
     });
-
-    afterAll(async () => {
-      await prisma.project.delete({ where: { id: projectId } });
-      await prisma.team.delete({ where: { id: teamId } });
-      await prisma.organization.delete({ where: { id: organizationId } });
+    organizationId = organization.id;
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
     });
+    teamId = team.id;
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        slug: `--test-project-${testNamespace}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+    projectId = project.id;
+  });
 
-    /** @scenario Running a workflow with a modelless LLM node is rejected as a fixable problem */
-    it("returns 422 with the typed cause and the node name, not an opaque 500", async () => {
-      const { app } = await import("../workflows");
+  afterAll(async () => {
+    await prisma.project.delete({ where: { id: projectId } });
+    await prisma.team.delete({ where: { id: teamId } });
+    await prisma.organization.delete({ where: { id: organizationId } });
+  });
 
-      const res = await app.request("/api/workflows/post_event", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          projectId,
-          event: {
-            type: "execute_component",
-            payload: {
-              trace_id: "trace-1",
-              workflow: {
-                spec_version: "1.5",
-                workflow_id: "wf-1",
-                name: "Test Workflow",
-                icon: "🧩",
-                description: "",
-                version: "1.0",
-                template_adapter: "default",
-                enable_tracing: true,
-                state: {},
-                nodes: [
-                  {
-                    id: "llm_call",
-                    type: "signature",
-                    data: {
-                      name: "LLM Call",
-                      parameters: [
-                        { identifier: "llm", type: "llm", value: undefined },
-                      ],
-                    },
+  /** @scenario Running a workflow with a modelless LLM node is rejected as a fixable problem */
+  it("returns 422 with the typed cause and the node name, not an opaque 500", async () => {
+    const { app } = await import("../workflows");
+
+    const res = await app.request("/api/workflows/post_event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId,
+        event: {
+          type: "execute_component",
+          payload: {
+            trace_id: "trace-1",
+            workflow: {
+              spec_version: "1.5",
+              workflow_id: "wf-1",
+              name: "Test Workflow",
+              icon: "🧩",
+              description: "",
+              version: "1.0",
+              template_adapter: "default",
+              enable_tracing: true,
+              state: {},
+              nodes: [
+                {
+                  id: "llm_call",
+                  type: "signature",
+                  data: {
+                    name: "LLM Call",
+                    parameters: [
+                      { identifier: "llm", type: "llm", value: undefined },
+                    ],
                   },
-                ],
-                edges: [],
-              },
-              node_id: "llm_call",
-              inputs: {},
+                },
+              ],
+              edges: [],
             },
+            node_id: "llm_call",
+            inputs: {},
           },
-        }),
-      });
-
-      expect(res.status).toBe(422);
-      const body = (await res.json()) as { error: string; cause: string };
-      expect(body.cause).toBe("LLM_MODEL_NOT_SET");
-      expect(body.error).toContain('LLM node "LLM Call"');
-      expect(body.error).not.toContain("Model provider not configured");
+        },
+      }),
     });
-  },
-);
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; cause: string };
+    expect(body.cause).toBe("LLM_MODEL_NOT_SET");
+    expect(body.error).toContain('LLM node "LLM Call"');
+    expect(body.error).not.toContain("Model provider not configured");
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
@@ -50,29 +50,25 @@ describe("Scenario / run-plan model persistence (real DB)", () => {
   });
 
   afterAll(async () => {
-    // Each guarded by its own id: beforeAll assigns organizationId, teamId and
-    // projectId in sequence, so a failure partway through leaves later ones
-    // undefined — and Prisma treats an undefined filter as "no filter", which
-    // would delete every row in the table instead of just this run's.
-    if (projectId) {
-      await prisma.scenario
-        .deleteMany({ where: { projectId } })
-        .catch(() => {});
-      await prisma.simulationSuite
-        .deleteMany({ where: { projectId } })
-        .catch(() => {});
-      await prisma.project
-        .deleteMany({ where: { id: projectId } })
-        .catch(() => {});
-    }
-    if (teamId) {
-      await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
-    }
-    if (organizationId) {
-      await prisma.organization
-        .deleteMany({ where: { id: organizationId } })
-        .catch(() => {});
-    }
+    // beforeAll assigns these three ids in sequence and Vitest runs afterAll
+    // even when beforeAll throws, so a failure partway through leaves the
+    // later ones undefined. Prisma drops an undefined `where` key rather than
+    // matching nothing, which would turn each deleteMany below into "delete
+    // every row in the table". Setup is all-or-nothing, so teardown is too:
+    // bail before a single filter is built.
+    if (!organizationId || !teamId || !projectId) return;
+
+    await prisma.scenario.deleteMany({ where: { projectId } }).catch(() => {});
+    await prisma.simulationSuite
+      .deleteMany({ where: { projectId } })
+      .catch(() => {});
+    await prisma.project
+      .deleteMany({ where: { id: projectId } })
+      .catch(() => {});
+    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { id: organizationId } })
+      .catch(() => {});
   });
 
   describe("given a scenario", () => {

--- a/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
@@ -17,116 +17,109 @@ import { prisma } from "../../db";
 import { SuiteRepository } from "../../suites/suite.repository";
 import { ScenarioService } from "../scenario.service";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("Scenario / run-plan model persistence (real DB)", () => {
+  const ns = `sim-models-${nanoid(8)}`;
+  let projectId: string;
+  let teamId: string;
+  let organizationId: string;
 
-describe.skipIf(isTestcontainersOnly)(
-  "Scenario / run-plan model persistence (real DB)",
-  () => {
-    const ns = `sim-models-${nanoid(8)}`;
-    let projectId: string;
-    let teamId: string;
-    let organizationId: string;
-
-    beforeAll(async () => {
-      const org = await prisma.organization.create({
-        data: { name: `Models Org ${ns}`, slug: `--models-${ns}` },
-      });
-      organizationId = org.id;
-      const team = await prisma.team.create({
-        data: {
-          name: `Models Team ${ns}`,
-          slug: `--models-team-${ns}`,
-          organizationId,
-        },
-      });
-      teamId = team.id;
-      const project = await prisma.project.create({
-        data: {
-          name: `Models Proj ${ns}`,
-          slug: `--models-proj-${ns}`,
-          teamId,
-          language: "typescript",
-          framework: "other",
-          apiKey: `models-key-${ns}`,
-        },
-      });
-      projectId = project.id;
+  beforeAll(async () => {
+    const org = await prisma.organization.create({
+      data: { name: `Models Org ${ns}`, slug: `--models-${ns}` },
     });
-
-    afterAll(async () => {
-      await prisma.scenario
-        .deleteMany({ where: { projectId } })
-        .catch(() => {});
-      await prisma.simulationSuite
-        .deleteMany({ where: { projectId } })
-        .catch(() => {});
-      await prisma.project
-        .deleteMany({ where: { id: projectId } })
-        .catch(() => {});
-      await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
-      await prisma.organization
-        .deleteMany({ where: { id: organizationId } })
-        .catch(() => {});
+    organizationId = org.id;
+    const team = await prisma.team.create({
+      data: {
+        name: `Models Team ${ns}`,
+        slug: `--models-team-${ns}`,
+        organizationId,
+      },
     });
+    teamId = team.id;
+    const project = await prisma.project.create({
+      data: {
+        name: `Models Proj ${ns}`,
+        slug: `--models-proj-${ns}`,
+        teamId,
+        language: "typescript",
+        framework: "other",
+        apiKey: `models-key-${ns}`,
+      },
+    });
+    projectId = project.id;
+  });
 
-    describe("given a scenario", () => {
-      describe("when it is updated with a simulator and judge model", () => {
-        /** @scenario "Simulator and judge models are persisted on the scenario" */
-        it("stores both model selections", async () => {
-          const service = ScenarioService.create(prisma);
-          const created = await service.create({
-            projectId,
-            name: `Scenario ${ns}`,
-            situation: "User asks for a refund",
-            criteria: ["Agent is polite"],
-            labels: [],
-          });
-          // Defaults to null until explicitly chosen.
-          expect(created.simulatorModel).toBeNull();
-          expect(created.judgeModel).toBeNull();
+  afterAll(async () => {
+    await prisma.scenario.deleteMany({ where: { projectId } }).catch(() => {});
+    await prisma.simulationSuite
+      .deleteMany({ where: { projectId } })
+      .catch(() => {});
+    await prisma.project
+      .deleteMany({ where: { id: projectId } })
+      .catch(() => {});
+    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { id: organizationId } })
+      .catch(() => {});
+  });
 
-          const updated = await service.update(created.id, projectId, {
-            simulatorModel: "openai/gpt-5-mini",
-            judgeModel: "openai/gpt-5-nano",
-          });
-          expect(updated.simulatorModel).toBe("openai/gpt-5-mini");
-          expect(updated.judgeModel).toBe("openai/gpt-5-nano");
-
-          const reread = await prisma.scenario.findFirst({
-            where: { id: created.id, projectId },
-          });
-          expect(reread?.simulatorModel).toBe("openai/gpt-5-mini");
-          expect(reread?.judgeModel).toBe("openai/gpt-5-nano");
+  describe("given a scenario", () => {
+    describe("when it is updated with a simulator and judge model", () => {
+      /** @scenario "Simulator and judge models are persisted on the scenario" */
+      it("stores both model selections", async () => {
+        const service = ScenarioService.create(prisma);
+        const created = await service.create({
+          projectId,
+          name: `Scenario ${ns}`,
+          situation: "User asks for a refund",
+          criteria: ["Agent is polite"],
+          labels: [],
         });
-      });
-    });
+        // Defaults to null until explicitly chosen.
+        expect(created.simulatorModel).toBeNull();
+        expect(created.judgeModel).toBeNull();
 
-    describe("given a run plan", () => {
-      describe("when it is saved with a simulator and judge model", () => {
-        /** @scenario "Simulator and judge models are persisted on the run plan" */
-        it("stores both model selections", async () => {
-          const repo = new SuiteRepository(prisma);
-          const created = await repo.create({
-            projectId,
-            name: `Run plan ${ns}`,
-            slug: `run-plan-${ns}`,
-            scenarioIds: [],
-            targets: [],
-            repeatCount: 1,
-            labels: [],
-            simulatorModel: "openai/gpt-5-mini",
-            judgeModel: "openai/gpt-5-nano",
-          });
-          expect(created.simulatorModel).toBe("openai/gpt-5-mini");
-          expect(created.judgeModel).toBe("openai/gpt-5-nano");
-
-          const reread = await prisma.simulationSuite.findFirst({
-            where: { id: created.id, projectId },
-          });
-          expect(reread?.simulatorModel).toBe("openai/gpt-5-mini");
-          expect(reread?.judgeModel).toBe("openai/gpt-5-nano");
+        const updated = await service.update(created.id, projectId, {
+          simulatorModel: "openai/gpt-5-mini",
+          judgeModel: "openai/gpt-5-nano",
         });
+        expect(updated.simulatorModel).toBe("openai/gpt-5-mini");
+        expect(updated.judgeModel).toBe("openai/gpt-5-nano");
+
+        const reread = await prisma.scenario.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(reread?.simulatorModel).toBe("openai/gpt-5-mini");
+        expect(reread?.judgeModel).toBe("openai/gpt-5-nano");
       });
     });
-  },
-);
+  });
+
+  describe("given a run plan", () => {
+    describe("when it is saved with a simulator and judge model", () => {
+      /** @scenario "Simulator and judge models are persisted on the run plan" */
+      it("stores both model selections", async () => {
+        const repo = new SuiteRepository(prisma);
+        const created = await repo.create({
+          projectId,
+          name: `Run plan ${ns}`,
+          slug: `run-plan-${ns}`,
+          scenarioIds: [],
+          targets: [],
+          repeatCount: 1,
+          labels: [],
+          simulatorModel: "openai/gpt-5-mini",
+          judgeModel: "openai/gpt-5-nano",
+        });
+        expect(created.simulatorModel).toBe("openai/gpt-5-mini");
+        expect(created.judgeModel).toBe("openai/gpt-5-nano");
+
+        const reread = await prisma.simulationSuite.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(reread?.simulatorModel).toBe("openai/gpt-5-mini");
+        expect(reread?.judgeModel).toBe("openai/gpt-5-nano");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenarioSuiteModelPersistence.integration.test.ts
@@ -4,8 +4,8 @@
  * Real-Postgres integration coverage for persisting the user-simulator and
  * judge model overrides on a Scenario and a run plan (SimulationSuite).
  *
- * Requires: PostgreSQL (Prisma). Skipped in the Testcontainers-only
- * ClickHouse suite.
+ * Requires: PostgreSQL (Prisma). Runs unconditionally — every harness
+ * provides Postgres.
  *
  * @see specs/scenarios/scenario-model-selection.feature
  * @see specs/suites/suite-model-selection.feature
@@ -50,17 +50,29 @@ describe("Scenario / run-plan model persistence (real DB)", () => {
   });
 
   afterAll(async () => {
-    await prisma.scenario.deleteMany({ where: { projectId } }).catch(() => {});
-    await prisma.simulationSuite
-      .deleteMany({ where: { projectId } })
-      .catch(() => {});
-    await prisma.project
-      .deleteMany({ where: { id: projectId } })
-      .catch(() => {});
-    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
-    await prisma.organization
-      .deleteMany({ where: { id: organizationId } })
-      .catch(() => {});
+    // Each guarded by its own id: beforeAll assigns organizationId, teamId and
+    // projectId in sequence, so a failure partway through leaves later ones
+    // undefined — and Prisma treats an undefined filter as "no filter", which
+    // would delete every row in the table instead of just this run's.
+    if (projectId) {
+      await prisma.scenario
+        .deleteMany({ where: { projectId } })
+        .catch(() => {});
+      await prisma.simulationSuite
+        .deleteMany({ where: { projectId } })
+        .catch(() => {});
+      await prisma.project
+        .deleteMany({ where: { id: projectId } })
+        .catch(() => {});
+    }
+    if (teamId) {
+      await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    }
+    if (organizationId) {
+      await prisma.organization
+        .deleteMany({ where: { id: organizationId } })
+        .catch(() => {});
+    }
   });
 
   describe("given a scenario", () => {

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
@@ -188,21 +188,37 @@ describe("runWorkflow with a pre-1.5 published version", () => {
   });
 
   afterAll(async () => {
-    await prisma.workflow.updateMany({
-      where: { projectId },
-      data: {
-        currentVersionId: null,
-        latestVersionId: null,
-        publishedId: null,
-      },
-    });
-    await prisma.workflowVersion.deleteMany({ where: { projectId } });
-    await prisma.workflow.deleteMany({ where: { projectId } });
-    await prisma.modelProvider.deleteMany({ where: { organizationId } });
-    await prisma.project.delete({ where: { id: projectId } });
-    await prisma.team.delete({ where: { id: teamId } });
-    await prisma.organization.delete({ where: { id: organizationId } });
-    await prisma.user.delete({ where: { id: userId } });
+    // beforeAll assigns these in sequence; a failure partway through leaves
+    // later ones undefined, and Prisma treats an undefined filter as "no
+    // filter" — updateMany/deleteMany below would touch the whole table
+    // instead of just this run's rows. The singular `.delete()` calls are
+    // safe either way (an undefined id just throws), but skip them too once
+    // there is nothing they'd successfully find.
+    if (projectId) {
+      await prisma.workflow.updateMany({
+        where: { projectId },
+        data: {
+          currentVersionId: null,
+          latestVersionId: null,
+          publishedId: null,
+        },
+      });
+      await prisma.workflowVersion.deleteMany({ where: { projectId } });
+      await prisma.workflow.deleteMany({ where: { projectId } });
+      await prisma.project.delete({ where: { id: projectId } });
+    }
+    if (organizationId) {
+      await prisma.modelProvider.deleteMany({ where: { organizationId } });
+    }
+    if (teamId) {
+      await prisma.team.delete({ where: { id: teamId } });
+    }
+    if (organizationId) {
+      await prisma.organization.delete({ where: { id: organizationId } });
+    }
+    if (userId) {
+      await prisma.user.delete({ where: { id: userId } });
+    }
   });
 
   /** @scenario Published workflows saved before the change still run with their old model */

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
@@ -28,208 +28,203 @@ import type {
 import { prisma } from "../../db";
 import { runWorkflow } from "../runWorkflow";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+describe("runWorkflow with a pre-1.5 published version", () => {
+  const testNamespace = `run-wf-legacy-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+  let workflowId: string;
+  let userId: string;
 
-describe.skipIf(isTestcontainersOnly)(
-  "runWorkflow with a pre-1.5 published version",
-  () => {
-    const testNamespace = `run-wf-legacy-${nanoid(8)}`;
-    let organizationId: string;
-    let teamId: string;
-    let projectId: string;
-    let workflowId: string;
-    let userId: string;
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Test Org", slug: `--test-org-${testNamespace}` },
+    });
+    organizationId = organization.id;
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        slug: `--test-project-${testNamespace}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+    projectId = project.id;
 
-    beforeAll(async () => {
-      const organization = await prisma.organization.create({
-        data: { name: "Test Org", slug: `--test-org-${testNamespace}` },
-      });
-      organizationId = organization.id;
-      const team = await prisma.team.create({
-        data: {
-          name: "Test Team",
-          slug: `--test-team-${testNamespace}`,
-          organizationId,
-        },
-      });
-      teamId = team.id;
-      const project = await prisma.project.create({
-        data: {
-          name: "Test Project",
-          slug: `--test-project-${testNamespace}`,
-          apiKey: `sk-lw-test-${nanoid()}`,
-          teamId,
-          language: "en",
-          framework: "test",
-        },
-      });
-      projectId = project.id;
+    const user = await prisma.user.create({
+      data: {
+        name: "Test User",
+        email: `test-${testNamespace}@example.com`,
+      },
+    });
+    userId = user.id;
 
-      const user = await prisma.user.create({
-        data: {
-          name: "Test User",
-          email: `test-${testNamespace}@example.com`,
-        },
-      });
-      userId = user.id;
+    // addEnvs enriches the folded model with provider params, so the
+    // project needs an enabled provider for it (keys come from env).
+    await prisma.modelProvider.create({
+      data: {
+        name: "OpenAI",
+        provider: "openai",
+        enabled: true,
+        organizationId,
+        scopes: { create: [{ scopeType: "PROJECT", scopeId: projectId }] },
+      },
+    });
 
-      // addEnvs enriches the folded model with provider params, so the
-      // project needs an enabled provider for it (keys come from env).
-      await prisma.modelProvider.create({
-        data: {
-          name: "OpenAI",
-          provider: "openai",
-          enabled: true,
-          organizationId,
-          scopes: { create: [{ scopeType: "PROJECT", scopeId: projectId }] },
-        },
-      });
-
-      // Persist the exact legacy shape: spec_version 1.4, workflow-level
-      // default_llm, signature node whose llm parameter has no value.
-      const workflow = await prisma.workflow.create({
-        data: {
-          id: `workflow_${nanoid()}`,
-          projectId,
-          name: "Legacy published workflow",
-          icon: "🧩",
-          description: "",
-        },
-      });
-      workflowId = workflow.id;
-      const legacyDsl = {
-        spec_version: "1.4",
-        workflow_id: workflowId,
+    // Persist the exact legacy shape: spec_version 1.4, workflow-level
+    // default_llm, signature node whose llm parameter has no value.
+    const workflow = await prisma.workflow.create({
+      data: {
+        id: `workflow_${nanoid()}`,
+        projectId,
         name: "Legacy published workflow",
         icon: "🧩",
         description: "",
+      },
+    });
+    workflowId = workflow.id;
+    const legacyDsl = {
+      spec_version: "1.4",
+      workflow_id: workflowId,
+      name: "Legacy published workflow",
+      icon: "🧩",
+      description: "",
+      version: "1",
+      template_adapter: "default",
+      enable_tracing: true,
+      default_llm: { model: "openai/gpt-5-mini", max_tokens: 256 },
+      state: {},
+      nodes: [
+        {
+          id: "entry",
+          type: "entry",
+          position: { x: 0, y: 0 },
+          data: {
+            name: "Entry point",
+            outputs: [{ identifier: "input", type: "str" }],
+            entry_selection: "random",
+            train_size: 0.8,
+            test_size: 0.2,
+            seed: 42,
+          },
+        },
+        {
+          id: "llm_call",
+          type: "signature",
+          position: { x: 300, y: 0 },
+          data: {
+            name: "LLM Call",
+            parameters: [
+              { identifier: "llm", type: "llm", value: null },
+              {
+                identifier: "instructions",
+                type: "str",
+                value: "You are a helpful assistant.",
+              },
+            ],
+            inputs: [{ identifier: "input", type: "str" }],
+            outputs: [{ identifier: "output", type: "str" }],
+          },
+        },
+        {
+          id: "end",
+          type: "end",
+          position: { x: 600, y: 0 },
+          data: {
+            name: "End",
+            inputs: [{ identifier: "output", type: "str" }],
+          },
+        },
+      ],
+      edges: [
+        {
+          id: "e0",
+          source: "entry",
+          sourceHandle: "outputs.input",
+          target: "llm_call",
+          targetHandle: "inputs.input",
+          type: "default",
+        },
+        {
+          id: "e1",
+          source: "llm_call",
+          sourceHandle: "outputs.output",
+          target: "end",
+          targetHandle: "inputs.output",
+          type: "default",
+        },
+      ],
+    };
+    const version = await prisma.workflowVersion.create({
+      data: {
+        id: nanoid(),
+        projectId,
+        workflowId,
         version: "1",
-        template_adapter: "default",
-        enable_tracing: true,
-        default_llm: { model: "openai/gpt-5-mini", max_tokens: 256 },
-        state: {},
-        nodes: [
-          {
-            id: "entry",
-            type: "entry",
-            position: { x: 0, y: 0 },
-            data: {
-              name: "Entry point",
-              outputs: [{ identifier: "input", type: "str" }],
-              entry_selection: "random",
-              train_size: 0.8,
-              test_size: 0.2,
-              seed: 42,
-            },
-          },
-          {
-            id: "llm_call",
-            type: "signature",
-            position: { x: 300, y: 0 },
-            data: {
-              name: "LLM Call",
-              parameters: [
-                { identifier: "llm", type: "llm", value: null },
-                {
-                  identifier: "instructions",
-                  type: "str",
-                  value: "You are a helpful assistant.",
-                },
-              ],
-              inputs: [{ identifier: "input", type: "str" }],
-              outputs: [{ identifier: "output", type: "str" }],
-            },
-          },
-          {
-            id: "end",
-            type: "end",
-            position: { x: 600, y: 0 },
-            data: {
-              name: "End",
-              inputs: [{ identifier: "output", type: "str" }],
-            },
-          },
-        ],
-        edges: [
-          {
-            id: "e0",
-            source: "entry",
-            sourceHandle: "outputs.input",
-            target: "llm_call",
-            targetHandle: "inputs.input",
-            type: "default",
-          },
-          {
-            id: "e1",
-            source: "llm_call",
-            sourceHandle: "outputs.output",
-            target: "end",
-            targetHandle: "inputs.output",
-            type: "default",
-          },
-        ],
-      };
-      const version = await prisma.workflowVersion.create({
-        data: {
-          id: nanoid(),
-          projectId,
-          workflowId,
-          version: "1",
-          commitMessage: "legacy publish",
-          authorId: userId,
-          autoSaved: false,
-          dsl: legacyDsl,
-        },
-      });
-      await prisma.workflow.update({
-        where: { id: workflowId, projectId },
-        data: {
-          currentVersionId: version.id,
-          latestVersionId: version.id,
-          publishedId: version.id,
-        },
-      });
+        commitMessage: "legacy publish",
+        authorId: userId,
+        autoSaved: false,
+        dsl: legacyDsl,
+      },
+    });
+    await prisma.workflow.update({
+      where: { id: workflowId, projectId },
+      data: {
+        currentVersionId: version.id,
+        latestVersionId: version.id,
+        publishedId: version.id,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.workflow.updateMany({
+      where: { projectId },
+      data: {
+        currentVersionId: null,
+        latestVersionId: null,
+        publishedId: null,
+      },
+    });
+    await prisma.workflowVersion.deleteMany({ where: { projectId } });
+    await prisma.workflow.deleteMany({ where: { projectId } });
+    await prisma.modelProvider.deleteMany({ where: { organizationId } });
+    await prisma.project.delete({ where: { id: projectId } });
+    await prisma.team.delete({ where: { id: teamId } });
+    await prisma.organization.delete({ where: { id: organizationId } });
+    await prisma.user.delete({ where: { id: userId } });
+  });
+
+  /** @scenario Published workflows saved before the change still run with their old model */
+  it("dispatches the folded model on the node and no workflow-level default", async () => {
+    nlpgoFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: {}, status: "success" }),
     });
 
-    afterAll(async () => {
-      await prisma.workflow.updateMany({
-        where: { projectId },
-        data: {
-          currentVersionId: null,
-          latestVersionId: null,
-          publishedId: null,
-        },
-      });
-      await prisma.workflowVersion.deleteMany({ where: { projectId } });
-      await prisma.workflow.deleteMany({ where: { projectId } });
-      await prisma.modelProvider.deleteMany({ where: { organizationId } });
-      await prisma.project.delete({ where: { id: projectId } });
-      await prisma.team.delete({ where: { id: teamId } });
-      await prisma.organization.delete({ where: { id: organizationId } });
-      await prisma.user.delete({ where: { id: userId } });
-    });
+    await runWorkflow(workflowId, projectId, { input: "hello" });
 
-    /** @scenario Published workflows saved before the change still run with their old model */
-    it("dispatches the folded model on the node and no workflow-level default", async () => {
-      nlpgoFetchMock.mockResolvedValue({
-        ok: true,
-        json: async () => ({ result: {}, status: "success" }),
-      });
+    expect(nlpgoFetchMock).toHaveBeenCalledTimes(1);
+    const dispatched = nlpgoFetchMock.mock.calls[0]![0] as {
+      body: { payload: { workflow: Workflow } };
+    };
+    const workflow = dispatched.body.payload.workflow;
 
-      await runWorkflow(workflowId, projectId, { input: "hello" });
-
-      expect(nlpgoFetchMock).toHaveBeenCalledTimes(1);
-      const dispatched = nlpgoFetchMock.mock.calls[0]![0] as {
-        body: { payload: { workflow: Workflow } };
-      };
-      const workflow = dispatched.body.payload.workflow;
-
-      const signature = workflow.nodes.find((n) => n.type === "signature");
-      const llmValue = signature?.data.parameters?.find((p) => p.type === "llm")
-        ?.value as LLMConfig;
-      expect(llmValue.model).toBe("openai/gpt-5-mini");
-      expect(llmValue.max_tokens).toBe(256);
-      expect("default_llm" in workflow).toBe(false);
-    });
-  },
-);
+    const signature = workflow.nodes.find((n) => n.type === "signature");
+    const llmValue = signature?.data.parameters?.find((p) => p.type === "llm")
+      ?.value as LLMConfig;
+    expect(llmValue.model).toBe("openai/gpt-5-mini");
+    expect(llmValue.max_tokens).toBe(256);
+    expect("default_llm" in workflow).toBe(false);
+  });
+});

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
@@ -188,37 +188,29 @@ describe("runWorkflow with a pre-1.5 published version", () => {
   });
 
   afterAll(async () => {
-    // beforeAll assigns these in sequence; a failure partway through leaves
-    // later ones undefined, and Prisma treats an undefined filter as "no
-    // filter" — updateMany/deleteMany below would touch the whole table
-    // instead of just this run's rows. The singular `.delete()` calls are
-    // safe either way (an undefined id just throws), but skip them too once
-    // there is nothing they'd successfully find.
-    if (projectId) {
-      await prisma.workflow.updateMany({
-        where: { projectId },
-        data: {
-          currentVersionId: null,
-          latestVersionId: null,
-          publishedId: null,
-        },
-      });
-      await prisma.workflowVersion.deleteMany({ where: { projectId } });
-      await prisma.workflow.deleteMany({ where: { projectId } });
-      await prisma.project.delete({ where: { id: projectId } });
-    }
-    if (organizationId) {
-      await prisma.modelProvider.deleteMany({ where: { organizationId } });
-    }
-    if (teamId) {
-      await prisma.team.delete({ where: { id: teamId } });
-    }
-    if (organizationId) {
-      await prisma.organization.delete({ where: { id: organizationId } });
-    }
-    if (userId) {
-      await prisma.user.delete({ where: { id: userId } });
-    }
+    // beforeAll assigns these four ids in sequence and Vitest runs afterAll
+    // even when beforeAll throws, so a failure partway through leaves the
+    // later ones undefined. Prisma drops an undefined `where` key rather than
+    // matching nothing, which would turn each deleteMany below into "delete
+    // every row in the table". Setup is all-or-nothing, so teardown is too:
+    // bail before a single filter is built.
+    if (!organizationId || !teamId || !projectId || !userId) return;
+
+    await prisma.workflow.updateMany({
+      where: { projectId },
+      data: {
+        currentVersionId: null,
+        latestVersionId: null,
+        publishedId: null,
+      },
+    });
+    await prisma.workflowVersion.deleteMany({ where: { projectId } });
+    await prisma.workflow.deleteMany({ where: { projectId } });
+    await prisma.modelProvider.deleteMany({ where: { organizationId } });
+    await prisma.project.delete({ where: { id: projectId } });
+    await prisma.team.delete({ where: { id: teamId } });
+    await prisma.organization.delete({ where: { id: organizationId } });
+    await prisma.user.delete({ where: { id: userId } });
   });
 
   /** @scenario Published workflows saved before the change still run with their old model */


### PR DESCRIPTION
# Related Issue

- Resolves #6327

Closes #6327.

14 integration suites carried `describe.skipIf(isTestcontainersOnly)`, which is `skipIf(true)` in every environment. The 78 tests inside them had never executed — not in CI, not locally, not once since the guard was added.

## Why the guard always fired

`TEST_CLICKHOUSE_URL` does not mean "we are in the testcontainers-only lane". It means **"globalSetup provisioned services"** — which is what `isUsingGlobalSetupContainers()` reads it for, and which is always true in the integration lane:

```
setup.ts        (setupFiles, WHOLE lane)  → TEST_CLICKHOUSE_URL = info.clickHouseUrl   # both modes
setupEnv.ts     (setupFiles, WHOLE lane)  → TEST_CLICKHOUSE_URL = CI_CLICKHOUSE_URL    # in CI
                                                    ↓
const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL    // always true
describe.skipIf(isTestcontainersOnly)(...)                        // skipIf(true)
```

The name asserts the opposite of what the value holds, which is why it kept being copy-pasted. A skipped suite reports green, so nothing ever said so. Second sighting — #5988 caught the first.

## What un-skipping found

36 failures across 7 files, from four causes. **Three were stale tests. One was a real bug.**

### 🐛 Real bug: `getById` 404s on org- and team-scoped model providers

`ModelProviderService.getById` looked the row up with `findById`, which matches only rows carrying a **PROJECT** scope for that project. A provider granted at ORGANIZATION or TEAM scope — which the settings list surfaces here by inheritance — resolved to null and 404'd.

The **edit** path had already been fixed for this exact problem and carries a comment saying so:

> *"a PROJECT-only lookup is why editing an org-scoped provider used to 404"*

The **read** path never was, because the test that would have caught it was skipped.

It also made the read gate unreachable for the scopes it exists to judge. `getById`'s own docstring promises *"returns the row when the caller can see any of its scope entries"*, but a row that never loads is never asked about — `canReadAnyScope` was dead code for ORGANIZATION and TEAM scopes.

Now org-anchored like the edit path. The security posture is unchanged and identical to what the edit path already ships: the anchor keeps the query inside one tenant, and `canReadAnyScope` — the actual boundary — still decides. Cross-tenant probing stays refused as `not found`, pinned by `deleteScope`'s cross-org test.

### Stale tests

| What | Why it drifted |
|---|---|
| Fixtures made `OrganizationUser`/`TeamUser` rows but no `RoleBinding` | A bare `OrganizationUser.role = ADMIN` confers only MEMBER's base bag, and the legacy TeamUser union deliberately cannot grant `organization:*` (ADR-021). Callers were refused *before* reaching the guard each suite was about. |
| Plan-limit suite set `TeamUser.assignedRoleId` for the custom role | The guard reads a `RoleBinding`. With none, `getRoleChangeType` saw no full→lite transition and the limit was never asserted — the suite returned `{ success: true }` and tested **nothing**. |
| `regenerateApiKey` expected `UNAUTHORIZED` | The wire code is `FORBIDDEN`, re-derived by `handledErrorMiddleware` from the handled cause's 403, and deliberately so — the caller is authenticated, they just lack the permission. |
| `deleteScope` expected tRPC `NOT_FOUND` | The service throws `model_provider_not_found` since the handled-errors migration. |
| modelProvider read-backs queried `ModelProvider.projectId` | That column is gone; the model moved to `organizationId` + N `ModelProviderScope` rows. |
| Two plan-limit tests asserted a persisted row | `createTestApp` wires `organizations` to a `NullOrganizationRepository`, which by design persists nothing — the row would read stale however well the gate behaved. They now assert the call *resolves*, paired against a sibling proving it *rejects* without the override, which is the behaviour those tests are actually about. |
| `monitors-evaluator` never initialised the app layer | The evaluators router now needs it for license enforcement. Given `UNLIMITED_PLAN`, since the suite is about the monitor↔evaluator relation and its fixed project id accumulates rows across runs. |

## Prevention

An ast-grep rule (`no-clickhouse-env-skip-guard`) bans the **inverted** guard specifically — not the env var.

This distinction is the point: `describe.skipIf(!hasTestcontainers)` is *correct* and stays legal, and several ClickHouse-dependent suites rely on it. My first draft banned the variable outright and lit up five files that were using it properly; a rule that flags correct code gets switched off, which is the failure mode the repo's own config comments warn about. It now targets the `isTestcontainersOnly` idiom that spread by copy-paste, plus the same inversion written inline.

It flags exactly one remaining file — `langySessionKey.integration.test.ts` — which **#6288** fixes and this branch deliberately leaves alone to avoid a conflict. The CI job scans changed files only, so the order the two merge in doesn't matter.

## Not fixed here

`modelIdBoundary.integration.test.ts` fails against the **live Anthropic API** with a 404 for a retired model id (`claude-sonnet-4-20250514`). Untouched by this branch, never guarded, fails on `main` the same way. Worth its own issue — an integration test making real third-party calls will keep breaking on someone else's schedule.

## Verification

14 files / 78 tests pass · `typecheck`, `typecheck:tests`, `lint` clean · ast-grep 24/24 rule fixtures pass · Biome new-violations gate reproduced against the merge base: **0 new**.

Most of the line count is Biome reindentation from removing one wrapper level of `describe`; `?w=1` shows ~280 substantive lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated static check that detects incorrect ClickHouse-related `describe.skipIf(...)` guard patterns in TypeScript test code.
* **Bug Fixes**
  * Improved model provider lookup to prefer organization-scoped resolution when possible, while keeping existing authorization behavior unchanged.
* **Tests**
  * Expanded integration test coverage by removing ClickHouse-based conditional skips and standardizing gating on credential availability.
  * Updated test setup/teardown, authorization reachability via new role-binding helpers, and adjusted expected error codes/queries to reflect real behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->