### PR TITLE
feat(storage): add Azure parity and safe provider migration

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -111,6 +111,14 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'package.json'
               - '.npmrc'
+              # NOTE: 'charts/**' is deliberately NOT listed. Integration suites
+              # do render the chart and assert on the output, so a chart-only
+              # edit can break a test under platform/app/ without touching a file
+              # there — but this one flag gates nine jobs (typecheck, every unit
+              # and integration shard, e2e), so adding it would run the entire
+              # app suite for a comment change in values.yaml. That trade is a
+              # repo-wide cost decision, not part of this change; tracked
+              # separately.
               - '.github/workflows/langwatch-app-ci.yml'
               - '.github/.release-please-manifest.json'
               - '.github/scripts/**'
@@ -438,6 +446,18 @@ jobs:
           done
           exit 1
 
+      # The chart-rendering integration tests shell out to `helm template`, and
+      # skip themselves when helm or the chart dependencies are missing. That
+      # honesty is only honest if CI actually supplies both — otherwise the
+      # suite reports "skipped", the job exits 0, and every guard it contains
+      # is silently unenforced. REQUIRE_HELM_TESTS below turns a skip here into
+      # a failure, so this setup can never quietly rot.
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+      - name: Add chart dependency repositories
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add langwatch https://langwatch.github.io/langwatch
+
       - name: Run integration tests (shard ${{ matrix.shard }}/4)
         id: integration-tests
         working-directory: platform/app
@@ -450,6 +470,9 @@ jobs:
         # worker (execArgv is not), so it raises the heap where it's needed.
         env:
           NODE_OPTIONS: --max-old-space-size=8192
+          # Fail loudly if the helm-backed suites cannot run here, rather than
+          # skipping into a green job.
+          REQUIRE_HELM_TESTS: "1"
         run: |
           # shardFailureReporter feeds the globalSetup hard-floor so a wedged
           # shard that already printed failures exits 1, not a masked 0.

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -135,6 +135,39 @@ jobs:
       - name: "assert rendered email configuration"
         run: ./tests/email-gateway.sh
 
+  # The render matrix above proves the chart PARSES; these vitest suites
+  # assert on what it EMITS (env selection per provider, identity guards,
+  # migration postures, validation failures). They normally run inside the
+  # app CI's integration shards, but that workflow deliberately does not
+  # trigger on charts/** — so without this job a chart-only edit could break
+  # every behavioral guarantee while CI stays green.
+  behavioral:
+    name: "behavioral (rendered-output assertions)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: platform/app
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+        with:
+          version: v3.12.0
+      - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+      - run: helm repo add langwatch https://langwatch.github.io/langwatch
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          install: "@langwatch/web..."
+      - name: Generate required files
+        run: pnpm start:prepare:files
+      - name: Run helm behavioral suites
+        env:
+          # Turns a silent helm-unavailable skip into a hard failure — this
+          # job exists precisely so these suites cannot quietly not run.
+          REQUIRE_HELM_TESTS: "1"
+        run: |
+          pnpm test:unit run src/server/stored-objects/__tests__/helm-and-docs-shape.unit.test.ts
+          pnpm test:integration run src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+
   e2e:
     name: "e2e: ${{ matrix.name }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -159,6 +159,11 @@ jobs:
           install: "@langwatch/web..."
       - name: Generate required files
         run: pnpm start:prepare:files
+      # The integration config's globalSetup runs ClickHouse migrations via
+      # goose before any test file executes, helm-backed or not.
+      - name: Install Goose migration tool
+        working-directory: .
+        run: bash .github/scripts/install-goose.sh
       - name: Run helm behavioral suites
         env:
           # Turns a silent helm-unavailable skip into a hard failure — this

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -242,7 +242,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if not (has .Values.app.dataplane.provider (list "awsS3" "azureBlob")) }}
     {{- $errors = append $errors (printf "app.dataplane.provider is %q — must be one of awsS3, azureBlob" .Values.app.dataplane.provider) }}
   {{- end }}
+  {{/* Each legacy read flag belongs to exactly one migration direction. Set
+       alongside the provider it "migrates away from", it is a no-op the
+       operator almost certainly did not intend — reject rather than ignore. */}}
+  {{- if and (eq .Values.app.dataplane.provider "azureBlob") .Values.app.dataplane.legacyAzureRead }}
+    {{- $errors = append $errors "app.dataplane.legacyAzureRead is set but azureBlob is already the active provider — the flag is for keeping Azure reads alive AFTER moving writes to S3 (provider awsS3). Remove it." }}
+  {{- end }}
+  {{- if and (eq .Values.app.dataplane.provider "awsS3") .Values.app.dataplane.legacyS3ReadBucket }}
+    {{- $errors = append $errors "app.dataplane.legacyS3ReadBucket is set but awsS3 is already the active provider — the flag is for keeping S3 reads alive AFTER moving writes to Azure (provider azureBlob). Remove it." }}
+  {{- end }}
   {{- if eq .Values.app.dataplane.provider "awsS3" }}
+    {{- if empty .Values.app.dataplane.bucket }}
+      {{- $errors = append $errors "app.dataplane.provider is awsS3 but app.dataplane.bucket is empty — S3_BUCKET_NAME would render blank and every write would fall back to local storage" }}
+    {{- end }}
     {{- if .Values.app.dataplane.providers.awsS3.endpoint.secretKeyRef.name }}
       {{- if empty .Values.app.dataplane.providers.awsS3.endpoint.secretKeyRef.key }}
         {{- $errors = append $errors "app.dataplane.providers.awsS3.endpoint.secretKeyRef.name is set but key is empty" }}
@@ -875,8 +887,29 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 # why the connection settings below can outlive it (see legacyAzureRead).
 - name: STORED_OBJECTS_BACKEND
   value: "azure"
+{{- else }}
+- name: STORED_OBJECTS_BACKEND
+  value: "s3"
+- name: USE_S3_STORAGE
+  value: "true"
+# Emit S3_BUCKET_NAME — the app/server reads this name across all
+# storage code paths (storage.ts, stored-objects.service.ts,
+# env-create.mjs). The legacy `S3_BUCKET` env was a no-op for every
+# vanilla helm install because nothing read it; emitting it was a
+# silent bug that this fix resolves by aligning on S3_BUCKET_NAME.
+- name: S3_BUCKET_NAME
+  value: {{ .Values.app.dataplane.bucket | quote }}
+{{- include "langwatch.secretOrValue" (dict "envName" "S3_ENDPOINT" "fieldValues" .Values.app.dataplane.providers.awsS3.endpoint) }}
+{{- include "langwatch.secretOrValue" (dict "envName" "S3_ACCESS_KEY_ID" "fieldValues" .Values.app.dataplane.providers.awsS3.accessKeyId) }}
+{{- include "langwatch.secretOrValue" (dict "envName" "S3_SECRET_ACCESS_KEY" "fieldValues" .Values.app.dataplane.providers.awsS3.secretAccessKey) }}
+{{- include "langwatch.secretOrValue" (dict "envName" "S3_KEY_SALT" "fieldValues" .Values.app.dataplane.providers.awsS3.keySalt) }}
 {{- end }}
-{{/* Azure connection settings are emitted when Azure is the active write
+{{/* The active provider's WRITE configuration above never depends on the
+     legacy read flags below — an Azure->S3 migration must configure S3
+     writes exactly like a plain S3 install, or new writes silently fall
+     back to local storage while the operator believes S3 is live.
+
+     Azure connection settings are emitted when Azure is the active write
      backend OR when legacyAzureRead is set for an Azure->S3 migration. The
      app's driver registration resolves these for READS independently of the
      write toggle, so keeping them after the switch is what lets already
@@ -899,7 +932,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if or .Values.app.dataplane.providers.azureBlob.tokenAudience.value .Values.app.dataplane.providers.azureBlob.tokenAudience.secretKeyRef.name }}
 {{- include "langwatch.secretOrValue" (dict "envName" "AZURE_BLOB_TOKEN_AUDIENCE" "fieldValues" .Values.app.dataplane.providers.azureBlob.tokenAudience) }}
 {{- end }}
-{{- if .Values.app.dataplane.legacyS3ReadBucket }}
+{{- end }}
+{{/* Gated on azureBlob being ACTIVE, not just on the bucket being set: when
+     S3 is the active provider its write block above already emits
+     S3_BUCKET_NAME, and a second entry with a different value would be a
+     duplicate env var whose winner is undefined. */}}
+{{- if and (eq .Values.app.dataplane.provider "azureBlob") .Values.app.dataplane.legacyS3ReadBucket }}
 # Retains reads for persisted s3:// stored-object URIs and legacy consumers
 # that already carry an S3 bucket/key after writes switch to Azure. This does
 # not route provider-derived dataset chunks or GroupQueue durable payloads:
@@ -907,23 +945,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 # greenfield Azure install.
 - name: S3_BUCKET_NAME
   value: {{ .Values.app.dataplane.legacyS3ReadBucket | quote }}
-{{- include "langwatch.secretOrValue" (dict "envName" "S3_ENDPOINT" "fieldValues" .Values.app.dataplane.providers.awsS3.endpoint) }}
-{{- include "langwatch.secretOrValue" (dict "envName" "S3_ACCESS_KEY_ID" "fieldValues" .Values.app.dataplane.providers.awsS3.accessKeyId) }}
-{{- include "langwatch.secretOrValue" (dict "envName" "S3_SECRET_ACCESS_KEY" "fieldValues" .Values.app.dataplane.providers.awsS3.secretAccessKey) }}
-{{- include "langwatch.secretOrValue" (dict "envName" "S3_KEY_SALT" "fieldValues" .Values.app.dataplane.providers.awsS3.keySalt) }}
-{{- end }}
-{{- else }}
-- name: STORED_OBJECTS_BACKEND
-  value: "s3"
-- name: USE_S3_STORAGE
-  value: "true"
-# Emit S3_BUCKET_NAME — the app/server reads this name across all
-# storage code paths (storage.ts, stored-objects.service.ts,
-# env-create.mjs). The legacy `S3_BUCKET` env was a no-op for every
-# vanilla helm install because nothing read it; emitting it was a
-# silent bug that this fix resolves by aligning on S3_BUCKET_NAME.
-- name: S3_BUCKET_NAME
-  value: {{ .Values.app.dataplane.bucket | quote }}
 {{- include "langwatch.secretOrValue" (dict "envName" "S3_ENDPOINT" "fieldValues" .Values.app.dataplane.providers.awsS3.endpoint) }}
 {{- include "langwatch.secretOrValue" (dict "envName" "S3_ACCESS_KEY_ID" "fieldValues" .Values.app.dataplane.providers.awsS3.accessKeyId) }}
 {{- include "langwatch.secretOrValue" (dict "envName" "S3_SECRET_ACCESS_KEY" "fieldValues" .Values.app.dataplane.providers.awsS3.secretAccessKey) }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -900,11 +900,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- include "langwatch.secretOrValue" (dict "envName" "AZURE_BLOB_TOKEN_AUDIENCE" "fieldValues" .Values.app.dataplane.providers.azureBlob.tokenAudience) }}
 {{- end }}
 {{- if .Values.app.dataplane.legacyS3ReadBucket }}
-# S3->Azure migration: new writes go to Azure, but objects written before the
-# switch still carry s3:// URIs / bucket+key spool refs. createS3Client keeps
-# serving this bucket for those reads (it fails loud only when no S3 bucket is
-# configured at all), so pre-migration media, datasets, and staged payloads
-# stay readable. Omit on a greenfield Azure install.
+# Retains reads for persisted s3:// stored-object URIs and legacy consumers
+# that already carry an S3 bucket/key after writes switch to Azure. This does
+# not route provider-derived dataset chunks or GroupQueue durable payloads:
+# migrate every dataset and drain GroupQueue before cutover. Omit on a
+# greenfield Azure install.
 - name: S3_BUCKET_NAME
   value: {{ .Values.app.dataplane.legacyS3ReadBucket | quote }}
 {{- include "langwatch.secretOrValue" (dict "envName" "S3_ENDPOINT" "fieldValues" .Values.app.dataplane.providers.awsS3.endpoint) }}
@@ -913,6 +913,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- include "langwatch.secretOrValue" (dict "envName" "S3_KEY_SALT" "fieldValues" .Values.app.dataplane.providers.awsS3.keySalt) }}
 {{- end }}
 {{- else }}
+- name: STORED_OBJECTS_BACKEND
+  value: "s3"
 - name: USE_S3_STORAGE
   value: "true"
 # Emit S3_BUCKET_NAME — the app/server reads this name across all

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -325,7 +325,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{- $azureEndpoint := .Values.app.dataplane.providers.azureBlob.endpoint.value }}
       {{- $azureEndpointFromSecret := .Values.app.dataplane.providers.azureBlob.endpoint.secretKeyRef.name }}
       {{- $hasAuthority := or .Values.app.dataplane.providers.azureBlob.authorityHost.value .Values.app.dataplane.providers.azureBlob.authorityHost.secretKeyRef.name }}
-      {{- if and $azureEndpoint (not (contains ".blob.core.windows.net" $azureEndpoint)) }}
+      {{/* Hostnames are case-insensitive (the runtime check lowercases
+           before comparing), so classify on the lowered value or a valid
+           public endpoint written in uppercase gets rejected as sovereign. */}}
+      {{- if and $azureEndpoint (not (contains ".blob.core.windows.net" (lower $azureEndpoint))) }}
         {{- if not $hasAuthority }}
           {{- $errors = append $errors (printf "app.dataplane.providers.azureBlob.endpoint is %q, which is not the Azure public cloud — a token-based authMode also requires providers.azureBlob.authorityHost so tokens are requested from the matching identity authority" $azureEndpoint) }}
         {{- end }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -323,7 +323,8 @@ app:
     # Storage provider to use. Options: awsS3 (default), azureBlob.
     # When set to 'awsS3', enables AWS S3 native integration.
     # When set to 'azureBlob', enables Azure Blob Storage (STORED_OBJECTS_BACKEND=azure,
-    # AC37 / issue #4133) — SharedKey auth only, mirrors the awsS3 shape.
+    # AC37 / issue #4133) — shared key or a Microsoft Entra identity, selected
+    # by providers.azureBlob.authMode; mirrors the awsS3 shape.
     provider: awsS3
     bucket: "langwatch-dataset" # Bucket name for dataset storage
 
@@ -354,8 +355,8 @@ app:
           secretKeyRef: { name: "", key: "" }
 
       # Azure Blob Storage configuration for dataset + stored-objects storage
-      # (AC37, issue #4133). SharedKey auth only — workload identity is a later
-      # issue (#6087), per-project Azure BYOC is #6088.
+      # (AC37, issue #4133). Shared key or a Microsoft Entra identity, selected
+      # by authMode below (#6087). Per-project Azure BYOC is still #6088.
       ## @extra app.dataplane.providers.azureBlob Azure Blob provider configuration.
       ## @param app.dataplane.providers.azureBlob.accountName.value [string] Azure Storage account name (not recommended in production — use accountName.secretKeyRef).
       ## @param app.dataplane.providers.azureBlob.accountKey.value [string] Azure Storage account key (not recommended in production — use accountKey.secretKeyRef).

--- a/dev/docs/TESTING_PHILOSOPHY.md
+++ b/dev/docs/TESTING_PHILOSOPHY.md
@@ -174,7 +174,28 @@ The scenario title in the feature file should match the `it()` description in th
 | `@integration` | Component/boundary test | Testing rendering, API calls, DB queries |
 | `@regression` | Prevents a previously-fixed bug from recurring | Bug fix scenarios — must fail without the fix |
 | `@e2e` | Stable core flow (deprioritized) | Only for the 5-10 stable happy-path tests |
-| `@manual` | Verified by hand against real infrastructure, cannot run in CI | Needs a real cloud account/subscription. Still **requires a binding** to a test that self-skips without credentials, so the verification keeps an anchor in the codebase. Record the date and result in a comment above the scenario |
+| `@manual` | Verified by hand against real infrastructure that CI cannot reach | Last resort only — see the rules below the table |
+
+`@manual` is deliberately hard to qualify for, because it is also the easiest
+tag to abuse: anything marked manual is a test nobody runs automatically, and
+an agent (or a rushed human) reaching for it to dodge writing a real test
+defeats the whole pyramid. All of these must hold, or the scenario belongs in
+an automated tier:
+
+- The scenario **cannot** run in CI for a structural reason — it needs a real
+  cloud account/subscription or credentials CI cannot hold. "Hard to write",
+  "slow", or "needs Docker" never qualify.
+- Everything automatable about the behavior is already covered by `@unit` /
+  `@integration` scenarios (e.g. against an emulator); `@manual` covers only
+  the residue that specifically proves the real-infrastructure behavior.
+- It still **requires a binding** to a test that self-skips without
+  credentials, so the verification keeps an anchor in the codebase — the
+  parity checker enforces this like any automated tier.
+- The date and result of the last hand-run are recorded in a comment above the
+  scenario.
+
+Expect a reviewer to challenge every new `@manual`; the burden of proof is on
+the tag, not on the reviewer.
 
 Bug-fix feature specs should use `@regression` (alongside `@unit` or `@integration` for pyramid level):
 

--- a/dev/docs/TESTING_PHILOSOPHY.md
+++ b/dev/docs/TESTING_PHILOSOPHY.md
@@ -174,28 +174,6 @@ The scenario title in the feature file should match the `it()` description in th
 | `@integration` | Component/boundary test | Testing rendering, API calls, DB queries |
 | `@regression` | Prevents a previously-fixed bug from recurring | Bug fix scenarios — must fail without the fix |
 | `@e2e` | Stable core flow (deprioritized) | Only for the 5-10 stable happy-path tests |
-| `@manual` | Verified by hand against real infrastructure that CI cannot reach | Last resort only — see the rules below the table |
-
-`@manual` is deliberately hard to qualify for, because it is also the easiest
-tag to abuse: anything marked manual is a test nobody runs automatically, and
-an agent (or a rushed human) reaching for it to dodge writing a real test
-defeats the whole pyramid. All of these must hold, or the scenario belongs in
-an automated tier:
-
-- The scenario **cannot** run in CI for a structural reason — it needs a real
-  cloud account/subscription or credentials CI cannot hold. "Hard to write",
-  "slow", or "needs Docker" never qualify.
-- Everything automatable about the behavior is already covered by `@unit` /
-  `@integration` scenarios (e.g. against an emulator); `@manual` covers only
-  the residue that specifically proves the real-infrastructure behavior.
-- It still **requires a binding** to a test that self-skips without
-  credentials, so the verification keeps an anchor in the codebase — the
-  parity checker enforces this like any automated tier.
-- The date and result of the last hand-run are recorded in a comment above the
-  scenario.
-
-Expect a reviewer to challenge every new `@manual`; the burden of proof is on
-the tag, not on the reviewer.
 
 Bug-fix feature specs should use `@regression` (alongside `@unit` or `@integration` for pyramid level):
 

--- a/dev/docs/TESTING_PHILOSOPHY.md
+++ b/dev/docs/TESTING_PHILOSOPHY.md
@@ -174,6 +174,7 @@ The scenario title in the feature file should match the `it()` description in th
 | `@integration` | Component/boundary test | Testing rendering, API calls, DB queries |
 | `@regression` | Prevents a previously-fixed bug from recurring | Bug fix scenarios — must fail without the fix |
 | `@e2e` | Stable core flow (deprioritized) | Only for the 5-10 stable happy-path tests |
+| `@manual` | Verified by hand against real infrastructure, cannot run in CI | Needs a real cloud account/subscription. Still **requires a binding** to a test that self-skips without credentials, so the verification keeps an anchor in the codebase. Record the date and result in a comment above the scenario |
 
 Bug-fix feature specs should use `@regression` (alongside `@unit` or `@integration` for pyramid level):
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -53619,8 +53619,9 @@ Do not switch `STORED_OBJECTS_BACKEND` before copying existing data. The migrati
 pnpm run task migrateObjectStorage plan
 pnpm run task migrateObjectStorage copy
 
-# Stop app and worker writes, drain GroupQueue, then:
+# Stop all app and worker read/write traffic, drain GroupQueue, then:
 OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+OBJECT_STORAGE_MIGRATION_READS_PAUSED=1 \
   pnpm run task migrateObjectStorage finalize
 
 # Switch STORED_OBJECTS_BACKEND and active credentials, then deploy while
@@ -53628,7 +53629,7 @@ OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
 pnpm run task migrateObjectStorage verify
 ```
 
-`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
+`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless both reads and writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. Reads must remain paused because finalization publishes destination storage addresses before the target-provider deployment is active. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
 
 After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
 
@@ -53637,6 +53638,7 @@ After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provid
 | `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |
 | `OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER` | The other provider |
 | `OBJECT_STORAGE_MIGRATION_WRITES_PAUSED` | Must be `1` for `finalize` |
+| `OBJECT_STORAGE_MIGRATION_READS_PAUSED` | Must be `1` for `finalize` |
 | `OBJECT_STORAGE_MIGRATION_S3_BUCKET` | Global S3 source or destination bucket |
 | `OBJECT_STORAGE_MIGRATION_S3_ENDPOINT` | Optional custom S3 endpoint |
 | `OBJECT_STORAGE_MIGRATION_S3_REGION` | Optional S3 region. AWS uses its normal SDK region chain when omitted; custom endpoints default to `auto` |
@@ -53685,7 +53687,6 @@ The pod label and the ServiceAccount annotation are both emitted by the chart; t
 The ServiceAccount and the workload-identity label are applied to the app and the workers only. Cron pods call the app over HTTP and never touch storage themselves, so giving them a Blob-capable token would grant every cron image storage access it has no use for.
 
 The same identity must be available to any out-of-band job that writes bytes, such as the dataset backfill task; run it with the same ServiceAccount as the app and workers.
-</Warning>
 
 ## Email
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -53633,6 +53633,13 @@ pnpm run task migrateObjectStorage verify
 
 After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
 
+**Keep the source provider's read credentials configured through the rollback window.** Finalization rewrites stored-object addresses to the destination scheme, so a rollback that reverts `STORED_OBJECTS_BACKEND` *and* removes the destination provider's credentials leaves every rewritten address unreadable — the bytes still exist on both providers (no phase deletes them), but the deployment can no longer serve that scheme. Concretely:
+
+- **S3 → Azure**: after cutover, keep `S3_BUCKET_NAME` + S3 credentials configured (Helm: `app.dataplane.legacyS3ReadBucket`) so pre-migration `s3://` history stays readable. If you roll back to S3, keep the `AZURE_BLOB_*` settings configured (Helm: `app.dataplane.legacyAzureRead: true`) so the finalized `azure-blob://` addresses stay readable.
+- **Azure → S3**: the mirror image — keep `AZURE_BLOB_*` (Helm: `legacyAzureRead`) after cutover, and keep the S3 settings if you roll back.
+
+A rollback with the flag set is fully non-destructive: reads resolve per address scheme, and a reverse migration can later re-home the bytes. Also note: the plan reports rows addressed by a scheme outside both providers (for example `file://` from a local-storage era) — those rows are out of the migration's scope, stay on their current addresses, and remain readable as long as that scheme's backend stays configured.
+
 | Migration variable | Description |
 |---|---|
 | `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -53608,7 +53608,48 @@ Precedence, evaluated in this order: a per-project BYOC S3 bucket (if configured
 | `AZURE_BLOB_ENDPOINT` | Blob endpoint base URL. Optional on the Azure public cloud; required for sovereign clouds (`*.usgovcloudapi.net`, `*.chinacloudapi.cn`), private endpoints, and the Azurite emulator | `https://{accountName}.blob.core.windows.net` |
 
 <Warning>
-When `STORED_OBJECTS_BACKEND=azure` is set, `AZURE_BLOB_ACCOUNT_NAME` and `AZURE_BLOB_CONTAINER` are required, plus `AZURE_BLOB_ACCOUNT_KEY` when `AZURE_BLOB_AUTH_MODE` is `sharedKey` (the default). Under an identity mode the key must be absent — see below. An incomplete config fails loud when the destination is resolved, naming the missing variable — it never silently falls back to S3 or the local filesystem. During an S3→Azure migration, keep `S3_BUCKET_NAME` set: legacy S3 surfaces (persisted `s3://` objects, the trace spool, staged payloads) continue to read from and write to the S3 bucket, while new stored-objects and dataset writes target Azure. On an azure-only install (no `S3_BUCKET_NAME`), those legacy S3 surfaces are unavailable and fail with a clear error instead of writing to a bucket nobody reads. In the Helm chart, set `app.dataplane.legacyS3ReadBucket` to the pre-migration bucket (keeping the `awsS3` credential fields populated) to get exactly this state; leave it empty on a greenfield Azure install. Set `AZURE_BLOB_ENDPOINT` (chart: `app.dataplane.providers.azureBlob.endpoint`) for sovereign clouds or private endpoints; it defaults to `https://{accountName}.blob.core.windows.net`. Per-project Azure BYOC is tracked separately (issue #6088).
+When `STORED_OBJECTS_BACKEND=azure` is set, `AZURE_BLOB_ACCOUNT_NAME` and `AZURE_BLOB_CONTAINER` are required, plus `AZURE_BLOB_ACCOUNT_KEY` when `AZURE_BLOB_AUTH_MODE` is `sharedKey` (the default). Under an identity mode the key must be absent — see below. An incomplete active Azure configuration fails loudly and never falls back to S3 or the local filesystem. Inactive Azure settings are validated only when an `azure-blob://` address is used, so they cannot break global or private-bucket S3 traffic. Set `AZURE_BLOB_ENDPOINT` (chart: `app.dataplane.providers.azureBlob.endpoint`) for sovereign clouds or private endpoints; it defaults to `https://{accountName}.blob.core.windows.net`. Per-project Azure BYOC is tracked separately (issue #6088).
+</Warning>
+
+### Migrating an existing installation
+
+Do not switch `STORED_OBJECTS_BACKEND` before copying existing data. The migration task uses its own `OBJECT_STORAGE_MIGRATION_*` credentials, so source reads and destination writes do not depend on the app's active provider:
+
+```bash
+pnpm run task migrateObjectStorage plan
+pnpm run task migrateObjectStorage copy
+
+# Stop app and worker writes, drain GroupQueue, then:
+OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+  pnpm run task migrateObjectStorage finalize
+
+# Switch STORED_OBJECTS_BACKEND and active credentials, then deploy while
+# traffic remains paused.
+pnpm run task migrateObjectStorage verify
+```
+
+`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
+
+After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
+
+| Migration variable | Description |
+|---|---|
+| `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |
+| `OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER` | The other provider |
+| `OBJECT_STORAGE_MIGRATION_WRITES_PAUSED` | Must be `1` for `finalize` |
+| `OBJECT_STORAGE_MIGRATION_S3_BUCKET` | Global S3 source or destination bucket |
+| `OBJECT_STORAGE_MIGRATION_S3_ENDPOINT` | Optional custom S3 endpoint |
+| `OBJECT_STORAGE_MIGRATION_S3_REGION` | Optional S3 region. AWS uses its normal SDK region chain when omitted; custom endpoints default to `auto` |
+| `OBJECT_STORAGE_MIGRATION_S3_ACCESS_KEY_ID` | Optional explicit migration access key |
+| `OBJECT_STORAGE_MIGRATION_S3_SECRET_ACCESS_KEY` | Optional explicit migration secret key |
+| `OBJECT_STORAGE_MIGRATION_S3_SESSION_TOKEN` | Optional temporary-session token |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_NAME` | Azure source or destination account |
+| `OBJECT_STORAGE_MIGRATION_AZURE_CONTAINER` | Azure source or destination container |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT` | Optional sovereign/private endpoint |
+| `OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE` | `sharedKey`, `workloadIdentity`, `managedIdentity`, or `azureCli` |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY` | Required only for `sharedKey` |
+| `OBJECT_STORAGE_MIGRATION_AZURE_AUTHORITY_HOST` | Optional sovereign authority host |
+| `OBJECT_STORAGE_MIGRATION_AZURE_TOKEN_AUDIENCE` | Optional sovereign token audience |
 
 ### Authenticating without an account key
 
@@ -53767,7 +53808,7 @@ When using the Helm chart, configuration is set in `values.yaml` rather than env
 | `app.evaluators.google.enabled` | `GOOGLE_EVALUATOR_ENABLED` |
 | `app.evaluators.google.credentials.value` | `GOOGLE_CREDENTIALS_JSON` |
 | `app.telemetry.usage.enabled` | Inverse of `DISABLE_USAGE_STATS` |
-| `app.dataplane.enabled` | `USE_S3_STORAGE` (provider: `awsS3`) or `STORED_OBJECTS_BACKEND=azure` (provider: `azureBlob`) |
+| `app.dataplane.enabled` | `STORED_OBJECTS_BACKEND=s3` + `USE_S3_STORAGE` (provider: `awsS3`) or `STORED_OBJECTS_BACKEND=azure` (provider: `azureBlob`) |
 | `app.dataplane.bucket` | `S3_BUCKET_NAME` |
 | `app.dataplane.providers.azureBlob.accountName.value` | `AZURE_BLOB_ACCOUNT_NAME` |
 | `app.dataplane.providers.azureBlob.accountKey.value` | `AZURE_BLOB_ACCOUNT_KEY` (sharedKey mode only) |
@@ -53777,8 +53818,8 @@ When using the Helm chart, configuration is set in `values.yaml` rather than env
 | `app.dataplane.providers.azureBlob.endpoint.value` | `AZURE_BLOB_ENDPOINT` (sovereign clouds, private endpoints, emulator) |
 | `app.dataplane.providers.azureBlob.authorityHost.value` | `AZURE_BLOB_AUTHORITY_HOST` — required alongside a sovereign endpoint in a token-based mode |
 | `app.dataplane.providers.azureBlob.tokenAudience.value` | `AZURE_BLOB_TOKEN_AUDIENCE` — sovereign storage audience override |
-| `app.dataplane.legacyS3ReadBucket` | `S3_BUCKET_NAME` — set during an S3→Azure migration so pre-migration objects stay readable; leave empty on a greenfield Azure install |
-| `app.dataplane.legacyAzureRead` | Keeps the `AZURE_BLOB_*` settings emitted after moving writes back to S3, so **stored objects** already written to Azure stay readable (they carry an `azure-blob://` URI, so a read re-derives its own provider). The write toggle is not emitted, so new writes go to S3. **Does not cover dataset chunks** — those are addressed by index with no provider on the row, so they follow the current toggle and become unreachable after the switch. Do not set this on an install that already has datasets (see issue #6323) |
+| `app.dataplane.legacyS3ReadBucket` | Keeps persisted `s3://` stored-object URIs and true legacy bucket/key consumers readable after moving writes to Azure. It does not route provider-derived dataset chunks or GroupQueue durable payloads; run the migration and drain GroupQueue before switching |
+| `app.dataplane.legacyAzureRead` | Keeps `AZURE_BLOB_*` settings emitted after moving writes to S3 so persisted `azure-blob://` stored objects remain readable. It is not a dataset migration mechanism: dataset chunks require a verified copy before switching providers |
 | `postgresql.external.connectionString.value` | `DATABASE_URL` |
 | `redis.external.connectionString.value` | `REDIS_URL` |
 | `workers.enabled` | Inverse of `START_WORKERS` |

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -155,8 +155,9 @@ Do not switch `STORED_OBJECTS_BACKEND` before copying existing data. The migrati
 pnpm run task migrateObjectStorage plan
 pnpm run task migrateObjectStorage copy
 
-# Stop app and worker writes, drain GroupQueue, then:
+# Stop all app and worker read/write traffic, drain GroupQueue, then:
 OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+OBJECT_STORAGE_MIGRATION_READS_PAUSED=1 \
   pnpm run task migrateObjectStorage finalize
 
 # Switch STORED_OBJECTS_BACKEND and active credentials, then deploy while
@@ -164,7 +165,7 @@ OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
 pnpm run task migrateObjectStorage verify
 ```
 
-`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
+`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless both reads and writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. Reads must remain paused because finalization publishes destination storage addresses before the target-provider deployment is active. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
 
 After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
 
@@ -173,6 +174,7 @@ After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provid
 | `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |
 | `OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER` | The other provider |
 | `OBJECT_STORAGE_MIGRATION_WRITES_PAUSED` | Must be `1` for `finalize` |
+| `OBJECT_STORAGE_MIGRATION_READS_PAUSED` | Must be `1` for `finalize` |
 | `OBJECT_STORAGE_MIGRATION_S3_BUCKET` | Global S3 source or destination bucket |
 | `OBJECT_STORAGE_MIGRATION_S3_ENDPOINT` | Optional custom S3 endpoint |
 | `OBJECT_STORAGE_MIGRATION_S3_REGION` | Optional S3 region. AWS uses its normal SDK region chain when omitted; custom endpoints default to `auto` |
@@ -221,7 +223,6 @@ The pod label and the ServiceAccount annotation are both emitted by the chart; t
 The ServiceAccount and the workload-identity label are applied to the app and the workers only. Cron pods call the app over HTTP and never touch storage themselves, so giving them a Blob-capable token would grant every cron image storage access it has no use for.
 
 The same identity must be available to any out-of-band job that writes bytes, such as the dataset backfill task; run it with the same ServiceAccount as the app and workers.
-</Warning>
 
 ## Email
 

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -144,7 +144,48 @@ Precedence, evaluated in this order: a per-project BYOC S3 bucket (if configured
 | `AZURE_BLOB_ENDPOINT` | Blob endpoint base URL. Optional on the Azure public cloud; required for sovereign clouds (`*.usgovcloudapi.net`, `*.chinacloudapi.cn`), private endpoints, and the Azurite emulator | `https://{accountName}.blob.core.windows.net` |
 
 <Warning>
-When `STORED_OBJECTS_BACKEND=azure` is set, `AZURE_BLOB_ACCOUNT_NAME` and `AZURE_BLOB_CONTAINER` are required, plus `AZURE_BLOB_ACCOUNT_KEY` when `AZURE_BLOB_AUTH_MODE` is `sharedKey` (the default). Under an identity mode the key must be absent — see below. An incomplete config fails loud when the destination is resolved, naming the missing variable — it never silently falls back to S3 or the local filesystem. During an S3→Azure migration, keep `S3_BUCKET_NAME` set: legacy S3 surfaces (persisted `s3://` objects, the trace spool, staged payloads) continue to read from and write to the S3 bucket, while new stored-objects and dataset writes target Azure. On an azure-only install (no `S3_BUCKET_NAME`), those legacy S3 surfaces are unavailable and fail with a clear error instead of writing to a bucket nobody reads. In the Helm chart, set `app.dataplane.legacyS3ReadBucket` to the pre-migration bucket (keeping the `awsS3` credential fields populated) to get exactly this state; leave it empty on a greenfield Azure install. Set `AZURE_BLOB_ENDPOINT` (chart: `app.dataplane.providers.azureBlob.endpoint`) for sovereign clouds or private endpoints; it defaults to `https://{accountName}.blob.core.windows.net`. Per-project Azure BYOC is tracked separately (issue #6088).
+When `STORED_OBJECTS_BACKEND=azure` is set, `AZURE_BLOB_ACCOUNT_NAME` and `AZURE_BLOB_CONTAINER` are required, plus `AZURE_BLOB_ACCOUNT_KEY` when `AZURE_BLOB_AUTH_MODE` is `sharedKey` (the default). Under an identity mode the key must be absent — see below. An incomplete active Azure configuration fails loudly and never falls back to S3 or the local filesystem. Inactive Azure settings are validated only when an `azure-blob://` address is used, so they cannot break global or private-bucket S3 traffic. Set `AZURE_BLOB_ENDPOINT` (chart: `app.dataplane.providers.azureBlob.endpoint`) for sovereign clouds or private endpoints; it defaults to `https://{accountName}.blob.core.windows.net`. Per-project Azure BYOC is tracked separately (issue #6088).
+</Warning>
+
+### Migrating an existing installation
+
+Do not switch `STORED_OBJECTS_BACKEND` before copying existing data. The migration task uses its own `OBJECT_STORAGE_MIGRATION_*` credentials, so source reads and destination writes do not depend on the app's active provider:
+
+```bash
+pnpm run task migrateObjectStorage plan
+pnpm run task migrateObjectStorage copy
+
+# Stop app and worker writes, drain GroupQueue, then:
+OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+  pnpm run task migrateObjectStorage finalize
+
+# Switch STORED_OBJECTS_BACKEND and active credentials, then deploy while
+# traffic remains paused.
+pnpm run task migrateObjectStorage verify
+```
+
+`plan` is read-only. `copy` is resumable, verifies SHA-256 at the destination, and repairs a mismatched destination object. `finalize` refuses to run unless writes are explicitly paused, dataset uploads are idle, and GroupQueue has no pending, delayed, active, blocked, or staged durable references. It publishes newer ClickHouse stored-object rows only after the final verified copy; it does not rewrite or delete history. No phase deletes source bytes.
+
+After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
+
+| Migration variable | Description |
+|---|---|
+| `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |
+| `OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER` | The other provider |
+| `OBJECT_STORAGE_MIGRATION_WRITES_PAUSED` | Must be `1` for `finalize` |
+| `OBJECT_STORAGE_MIGRATION_S3_BUCKET` | Global S3 source or destination bucket |
+| `OBJECT_STORAGE_MIGRATION_S3_ENDPOINT` | Optional custom S3 endpoint |
+| `OBJECT_STORAGE_MIGRATION_S3_REGION` | Optional S3 region. AWS uses its normal SDK region chain when omitted; custom endpoints default to `auto` |
+| `OBJECT_STORAGE_MIGRATION_S3_ACCESS_KEY_ID` | Optional explicit migration access key |
+| `OBJECT_STORAGE_MIGRATION_S3_SECRET_ACCESS_KEY` | Optional explicit migration secret key |
+| `OBJECT_STORAGE_MIGRATION_S3_SESSION_TOKEN` | Optional temporary-session token |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_NAME` | Azure source or destination account |
+| `OBJECT_STORAGE_MIGRATION_AZURE_CONTAINER` | Azure source or destination container |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT` | Optional sovereign/private endpoint |
+| `OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE` | `sharedKey`, `workloadIdentity`, `managedIdentity`, or `azureCli` |
+| `OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY` | Required only for `sharedKey` |
+| `OBJECT_STORAGE_MIGRATION_AZURE_AUTHORITY_HOST` | Optional sovereign authority host |
+| `OBJECT_STORAGE_MIGRATION_AZURE_TOKEN_AUDIENCE` | Optional sovereign token audience |
 
 ### Authenticating without an account key
 
@@ -303,7 +344,7 @@ When using the Helm chart, configuration is set in `values.yaml` rather than env
 | `app.evaluators.google.enabled` | `GOOGLE_EVALUATOR_ENABLED` |
 | `app.evaluators.google.credentials.value` | `GOOGLE_CREDENTIALS_JSON` |
 | `app.telemetry.usage.enabled` | Inverse of `DISABLE_USAGE_STATS` |
-| `app.dataplane.enabled` | `USE_S3_STORAGE` (provider: `awsS3`) or `STORED_OBJECTS_BACKEND=azure` (provider: `azureBlob`) |
+| `app.dataplane.enabled` | `STORED_OBJECTS_BACKEND=s3` + `USE_S3_STORAGE` (provider: `awsS3`) or `STORED_OBJECTS_BACKEND=azure` (provider: `azureBlob`) |
 | `app.dataplane.bucket` | `S3_BUCKET_NAME` |
 | `app.dataplane.providers.azureBlob.accountName.value` | `AZURE_BLOB_ACCOUNT_NAME` |
 | `app.dataplane.providers.azureBlob.accountKey.value` | `AZURE_BLOB_ACCOUNT_KEY` (sharedKey mode only) |
@@ -313,8 +354,8 @@ When using the Helm chart, configuration is set in `values.yaml` rather than env
 | `app.dataplane.providers.azureBlob.endpoint.value` | `AZURE_BLOB_ENDPOINT` (sovereign clouds, private endpoints, emulator) |
 | `app.dataplane.providers.azureBlob.authorityHost.value` | `AZURE_BLOB_AUTHORITY_HOST` — required alongside a sovereign endpoint in a token-based mode |
 | `app.dataplane.providers.azureBlob.tokenAudience.value` | `AZURE_BLOB_TOKEN_AUDIENCE` — sovereign storage audience override |
-| `app.dataplane.legacyS3ReadBucket` | `S3_BUCKET_NAME` — set during an S3→Azure migration so pre-migration objects stay readable; leave empty on a greenfield Azure install |
-| `app.dataplane.legacyAzureRead` | Keeps the `AZURE_BLOB_*` settings emitted after moving writes back to S3, so **stored objects** already written to Azure stay readable (they carry an `azure-blob://` URI, so a read re-derives its own provider). The write toggle is not emitted, so new writes go to S3. **Does not cover dataset chunks** — those are addressed by index with no provider on the row, so they follow the current toggle and become unreachable after the switch. Do not set this on an install that already has datasets (see issue #6323) |
+| `app.dataplane.legacyS3ReadBucket` | Keeps persisted `s3://` stored-object URIs and true legacy bucket/key consumers readable after moving writes to Azure. It does not route provider-derived dataset chunks or GroupQueue durable payloads; run the migration and drain GroupQueue before switching |
+| `app.dataplane.legacyAzureRead` | Keeps `AZURE_BLOB_*` settings emitted after moving writes to S3 so persisted `azure-blob://` stored objects remain readable. It is not a dataset migration mechanism: dataset chunks require a verified copy before switching providers |
 | `postgresql.external.connectionString.value` | `DATABASE_URL` |
 | `redis.external.connectionString.value` | `REDIS_URL` |
 | `workers.enabled` | Inverse of `START_WORKERS` |

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -169,6 +169,13 @@ pnpm run task migrateObjectStorage verify
 
 After `finalize` succeeds, update `STORED_OBJECTS_BACKEND` and the active provider credentials while traffic remains paused, deploy that configuration, run `verify`, then resume traffic. A global migration excludes projects with private S3 buckets; they remain on their tenant-owned S3 destination.
 
+**Keep the source provider's read credentials configured through the rollback window.** Finalization rewrites stored-object addresses to the destination scheme, so a rollback that reverts `STORED_OBJECTS_BACKEND` *and* removes the destination provider's credentials leaves every rewritten address unreadable — the bytes still exist on both providers (no phase deletes them), but the deployment can no longer serve that scheme. Concretely:
+
+- **S3 → Azure**: after cutover, keep `S3_BUCKET_NAME` + S3 credentials configured (Helm: `app.dataplane.legacyS3ReadBucket`) so pre-migration `s3://` history stays readable. If you roll back to S3, keep the `AZURE_BLOB_*` settings configured (Helm: `app.dataplane.legacyAzureRead: true`) so the finalized `azure-blob://` addresses stay readable.
+- **Azure → S3**: the mirror image — keep `AZURE_BLOB_*` (Helm: `legacyAzureRead`) after cutover, and keep the S3 settings if you roll back.
+
+A rollback with the flag set is fully non-destructive: reads resolve per address scheme, and a reverse migration can later re-home the bytes. Also note: the plan reports rows addressed by a scheme outside both providers (for example `file://` from a local-storage era) — those rows are out of the migration's scope, stay on their current addresses, and remain readable as long as that scheme's backend stays configured.
+
 | Migration variable | Description |
 |---|---|
 | `OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER` | `s3` or `azure` |

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -400,7 +400,10 @@ FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_gateway_menu_enabled
 # an incomplete config with STORED_OBJECTS_BACKEND=azure fails loud when
 # the destination resolves (no silent fallback to S3 or local-FS). During an
 # S3->Azure migration keep S3_BUCKET_NAME set so legacy S3 surfaces (persisted
-# s3:// objects, trace spool, staged payloads) stay readable. SharedKey only.
+# s3:// objects, trace spool, staged payloads) stay readable.
+# "All four vars" above applies to the sharedKey default. Under an identity
+# mode the account key is NOT one of them — see AZURE_BLOB_AUTH_MODE below,
+# where setting a key alongside an identity mode is refused, not ignored.
 # STORED_OBJECTS_BACKEND=azure
 # AZURE_BLOB_AUTH_MODE selects how to authenticate: sharedKey (default),
 # workloadIdentity (AKS), managedIdentity (Azure VM/App Service), or azureCli

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -52,6 +52,7 @@
     "test:stripe-integration": "NODE_ENV=test PINO_LOG_LEVEL=warn vitest -c vitest.stripe-integration.config.ts",
     "task": "./scripts/run-task.sh",
     "task:backfill-datasets-s3": "pnpm run task backfillDatasetContentToS3",
+    "task:migrate-object-storage": "pnpm run task migrateObjectStorage",
     "prisma:generate:typescript": "pnpm prisma generate",
     "prisma:generate:migration": "pnpm prisma migrate dev --create-only",
     "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -52,7 +52,7 @@
     "test:stripe-integration": "NODE_ENV=test PINO_LOG_LEVEL=warn vitest -c vitest.stripe-integration.config.ts",
     "task": "./scripts/run-task.sh",
     "task:backfill-datasets-s3": "pnpm run task backfillDatasetContentToS3",
-    "task:migrate-object-storage": "pnpm run task migrateObjectStorage",
+    "task:migrate-object-storage": "NODE_OPTIONS=--max-old-space-size=4096 pnpm run task migrateObjectStorage",
     "prisma:generate:typescript": "pnpm prisma generate",
     "prisma:generate:migration": "pnpm prisma migrate dev --create-only",
     "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -656,7 +656,20 @@ const PYTHON_TEST_FILE_RE = /^test_.+\.py$/;
 const FEATURE_FILE_RE = /\.feature$/;
 const SKIP_DIR = new Set(["node_modules", ".next", "dist", "build"]);
 
-const BOUND_TAGS = new Set(["@unit", "@integration", "@e2e", "@regression"]);
+/**
+ * `@manual` is enforced like the automated tiers: the scenario cannot run in
+ * CI (it needs real cloud credentials), but it is still bound to a test that
+ * self-skips without them. Leaving it out of this set made it invisible to the
+ * scanner — neither bound nor reported unbound — so deleting its test failed
+ * nothing and the manual verification silently lost its anchor.
+ */
+const BOUND_TAGS = new Set([
+  "@unit",
+  "@integration",
+  "@e2e",
+  "@regression",
+  "@manual",
+]);
 
 /**
  * Scenarios tagged `@unimplemented` have no expected test and are filtered

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -656,20 +656,7 @@ const PYTHON_TEST_FILE_RE = /^test_.+\.py$/;
 const FEATURE_FILE_RE = /\.feature$/;
 const SKIP_DIR = new Set(["node_modules", ".next", "dist", "build"]);
 
-/**
- * `@manual` is enforced like the automated tiers: the scenario cannot run in
- * CI (it needs real cloud credentials), but it is still bound to a test that
- * self-skips without them. Leaving it out of this set made it invisible to the
- * scanner — neither bound nor reported unbound — so deleting its test failed
- * nothing and the manual verification silently lost its anchor.
- */
-const BOUND_TAGS = new Set([
-  "@unit",
-  "@integration",
-  "@e2e",
-  "@regression",
-  "@manual",
-]);
+const BOUND_TAGS = new Set(["@unit", "@integration", "@e2e", "@regression"]);
 
 /**
  * Scenarios tagged `@unimplemented` have no expected test and are filtered

--- a/platform/app/src/server/datasets/__tests__/azure-dataset-storage.integration.test.ts
+++ b/platform/app/src/server/datasets/__tests__/azure-dataset-storage.integration.test.ts
@@ -85,6 +85,7 @@ describe("AzureDatasetStorage against a real Azurite emulator", () => {
   describe("writeChunks() + readChunks()", () => {
     describe("given a dataset written to Azure Blob", () => {
       /** @scenario "Datasets round-trip through Azure Blob when azure is the configured backend" */
+      /** @scenario "An Azure-only installation supports every shared object-storage workload" */
       it("reads the same rows back in order", async () => {
         const projectId = `p-${nanoid(6)}`;
         const datasetId = `d-${nanoid(6)}`;

--- a/platform/app/src/server/datasets/dataset-storage.ts
+++ b/platform/app/src/server/datasets/dataset-storage.ts
@@ -160,6 +160,21 @@ export interface DatasetStorage {
  * truth for where a project's bytes live, so the azure backend (AC37, issue
  * #4133) covers datasets automatically once STORED_OBJECTS_BACKEND=azure is
  * configured: no separate dataset-specific toggle.
+ *
+ * MIGRATION LIMIT — datasets have no equivalent of `legacyAzureRead`. Stored
+ * objects survive a backend switch because they are addressed by a URI whose
+ * scheme picks the driver, so a read re-derives its provider. Dataset chunks
+ * are addressed by `{projectId, datasetId, index}` with no provider recorded
+ * anywhere (`contentLayout` records the FORMAT, postgres vs s3_jsonl, not the
+ * backend), so this selector can only consult the CURRENT toggle. Flip the
+ * backend after datasets exist and their chunks become unreachable — not
+ * deleted, just unaddressable until the toggle is flipped back.
+ *
+ * This is a pre-existing structural limit, not specific to Azure: the same
+ * holds for s3 -> local or local -> s3. Fixing it needs per-dataset storage
+ * provenance (a schema field plus a backfill), tracked in #6323. Documented
+ * here because `legacyAzureRead` otherwise implies a migration story that
+ * covers datasets, and it does not.
  */
 export const getDatasetStorage = async (
   projectId: string,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.codec.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.codec.unit.test.ts
@@ -2,20 +2,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
 import { detectCompression, MSGPACK_MIN_BYTES } from "../bodyCodec";
-import { decodeJobEnvelope, encodeJobEnvelope } from "../jobEnvelope";
+import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  splitEnvelope,
+} from "../jobEnvelope";
 import { TieredBlobStore } from "../tieredBlobStore";
 import { InMemoryJobBlobStore, InMemoryObjectStore } from "./blobTestDoubles";
 
 const PROJECT = createTenantId("project-codec");
 
-function makeTiered() {
+function makeTiered(s3ThresholdBytes = 256 * 1024) {
   const redisBlobs = new InMemoryJobBlobStore();
   const objectStore = new InMemoryObjectStore();
   const tieredBlobs = new TieredBlobStore({
     redisBlobs,
     objectStoreFor: () => objectStore,
     resolveDestination: async () => ({ kind: "s3", bucket: "test-bucket" }),
-    s3ThresholdBytes: 256 * 1024,
+    s3ThresholdBytes,
   });
   return { tieredBlobs, redisBlobs, objectStore };
 }
@@ -43,6 +47,35 @@ describe("jobEnvelope body codecs", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  /** @scenario Provider migration does not change the durable queue reference format */
+  it("Provider migration does not change the durable queue reference format", async () => {
+    const { tieredBlobs } = makeTiered(1);
+    const encoded = await encodeJobEnvelope({
+      jobData: {
+        projectId: PROJECT,
+        payload: "x".repeat(300 * 1024),
+      },
+      tieredBlobs,
+      projectId: PROJECT,
+    });
+
+    const { header } = splitEnvelope(encoded);
+
+    expect(header).toMatchObject({
+      v: 2,
+      e: "s3",
+      ref: {
+        tier: "s3",
+        projectId: PROJECT,
+      },
+    });
+    expect(Object.keys(header.ref ?? {}).sort()).toEqual([
+      "hash",
+      "projectId",
+      "tier",
+    ]);
   });
 
   describe("given a blob written before the codec change (gzip + JSON)", () => {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -608,6 +608,28 @@ describe("jobEnvelope", () => {
         ).toEqual(big);
       });
 
+      /** @scenario "Provider migration does not change the durable queue reference format" */
+      it("keeps the durable reference on the existing GQ2 wire shape", async () => {
+        const { tieredBlobs } = makeTiered(8);
+
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+        const lease = readEnvelopeLease(encoded);
+
+        expect(encoded.startsWith("GQ2|")).toBe(true);
+        expect(lease?.ref).toEqual({
+          tier: "s3",
+          projectId: PROJECT,
+          hash: expect.any(String),
+        });
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(big);
+      });
+
       it("exposes routing meta from the header without resolving the blob", async () => {
         const { tieredBlobs } = makeTiered();
         const encoded = await encodeJobEnvelope({

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.azure.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.azure.integration.test.ts
@@ -105,6 +105,7 @@ async function drain(stream: Readable | Buffer | null): Promise<string> {
 describe("groupQueue durable blob tier on an Azure-only install", () => {
   describe("given a job body over the durable threshold and no S3 configured", () => {
     /** @scenario "The groupQueue durable blob tier works on an Azure-only install" */
+    /** @scenario "An Azure-only installation supports every shared object-storage workload" */
     it("stores it in Azure Blob and reads the same bytes back", async () => {
       const store = azureOnlyStore();
       const body = Buffer.from("x".repeat(THRESHOLD * 4), "utf8");

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.azure.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.azure.integration.test.ts
@@ -104,7 +104,7 @@ async function drain(stream: Readable | Buffer | null): Promise<string> {
 
 describe("groupQueue durable blob tier on an Azure-only install", () => {
   describe("given a job body over the durable threshold and no S3 configured", () => {
-    /** @scenario "The groupQueue durable blob tier works in a token-based mode" */
+    /** @scenario "The groupQueue durable blob tier works on an Azure-only install" */
     it("stores it in Azure Blob and reads the same bytes back", async () => {
       const store = azureOnlyStore();
       const body = Buffer.from("x".repeat(THRESHOLD * 4), "utf8");

--- a/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
@@ -250,6 +250,7 @@ describe("AzureBlobDriver against a real Azurite emulator (path-style addressing
 
 describe("StoredObjectsService against a real Azurite emulator", () => {
   describe("given STORED_OBJECTS_BACKEND=azure is the resolved destination", () => {
+    /** @scenario "An Azure-only installation supports every shared object-storage workload" */
     it("persists an azure-blob storage_uri and streams the bytes back through the StorageRegistry on read", async () => {
       const registry = new StorageRegistry({
         // s3/file are mandatory on the registry but unused by this test —

--- a/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.unit.test.ts
@@ -632,7 +632,9 @@ describe("AzureBlobDriver", () => {
    * suite green. These pin the failure path itself.
    */
   describe("given a token-based auth mode where the token exchange fails", () => {
-    const tokenFailure = new Error("AADSTS70021: No matching federated identity record found");
+    const tokenFailure = new Error(
+      "AADSTS70021: No matching federated identity record found",
+    );
 
     beforeEach(() => {
       getAzureBlobTokenMock.mockRejectedValue(tokenFailure);
@@ -641,7 +643,15 @@ describe("AzureBlobDriver", () => {
     /** @scenario "A failed token exchange surfaces as a configuration error, not a storage error" */
     it.each([
       ["get" as const, () => newTokenModeDriver().get(URI)],
-      ["put" as const, () => newTokenModeDriver().put(URI, Buffer.from("x"), "application/octet-stream")],
+      [
+        "put" as const,
+        () =>
+          newTokenModeDriver().put(
+            URI,
+            Buffer.from("x"),
+            "application/octet-stream",
+          ),
+      ],
       ["delete" as const, () => newTokenModeDriver().delete(URI)],
       ["exists" as const, () => newTokenModeDriver().exists(URI)],
       ["head" as const, () => newTokenModeDriver().head(URI)],
@@ -656,10 +666,13 @@ describe("AzureBlobDriver", () => {
       await expect(newTokenModeDriver().get(URI)).rejects.toThrow();
 
       const sentAuthorizations = fetchSpy.mock.calls.map(
-        ([, init]) => (init?.headers as Record<string, string> | undefined)?.Authorization,
+        ([, init]) =>
+          (init?.headers as Record<string, string> | undefined)?.Authorization,
       );
       expect(sentAuthorizations).toHaveLength(0);
-      expect(sentAuthorizations.some((a) => a?.startsWith("SharedKey"))).toBe(false);
+      expect(sentAuthorizations.some((a) => a?.startsWith("SharedKey"))).toBe(
+        false,
+      );
     });
   });
 

--- a/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.unit.test.ts
@@ -623,6 +623,46 @@ describe("AzureBlobDriver", () => {
     }
   });
 
+  /**
+   * The headline contract of issue #6087 is that there is NO credential
+   * fallback: a token-mode driver that cannot get a token must fail, never
+   * quietly downgrade to shared-key or send the request unsigned. Every other
+   * token test here stubs a SUCCESSFUL acquisition, so adding a `catch` around
+   * the token call that fell back to shared-key signing would leave this whole
+   * suite green. These pin the failure path itself.
+   */
+  describe("given a token-based auth mode where the token exchange fails", () => {
+    const tokenFailure = new Error("AADSTS70021: No matching federated identity record found");
+
+    beforeEach(() => {
+      getAzureBlobTokenMock.mockRejectedValue(tokenFailure);
+    });
+
+    /** @scenario "A failed token exchange surfaces as a configuration error, not a storage error" */
+    it.each([
+      ["get" as const, () => newTokenModeDriver().get(URI)],
+      ["put" as const, () => newTokenModeDriver().put(URI, Buffer.from("x"), "application/octet-stream")],
+      ["delete" as const, () => newTokenModeDriver().delete(URI)],
+      ["exists" as const, () => newTokenModeDriver().exists(URI)],
+      ["head" as const, () => newTokenModeDriver().head(URI)],
+    ])("%s rejects without ever reaching the network or building a shared-key signature", async (_op, run) => {
+      await expect(run()).rejects.toThrow(tokenFailure);
+
+      // No fallback: nothing was sent at all, signed or unsigned.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("never constructs a SharedKey Authorization header as a fallback", async () => {
+      await expect(newTokenModeDriver().get(URI)).rejects.toThrow();
+
+      const sentAuthorizations = fetchSpy.mock.calls.map(
+        ([, init]) => (init?.headers as Record<string, string> | undefined)?.Authorization,
+      );
+      expect(sentAuthorizations).toHaveLength(0);
+      expect(sentAuthorizations.some((a) => a?.startsWith("SharedKey"))).toBe(false);
+    });
+  });
+
   describe("given a token-based auth mode signing the same operation against different endpoint addressing styles", () => {
     /** @scenario "Bearer authorization is identical regardless of endpoint addressing style" */
     it("produces the same Authorization header for a host-style and a path-style endpoint, neither carrying a SharedKey signature", async () => {

--- a/platform/app/src/server/stored-objects/__tests__/azure-credentials.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-credentials.unit.test.ts
@@ -177,7 +177,8 @@ describe("resolveAzureCredentials", () => {
       mockEnv.AZURE_BLOB_CONTAINER = "cont";
       process.env.AZURE_CLIENT_ID = "client-id";
       process.env.AZURE_TENANT_ID = "tenant-id";
-      process.env.AZURE_FEDERATED_TOKEN_FILE = "/var/run/secrets/azure/tokens/azure-identity-token";
+      process.env.AZURE_FEDERATED_TOKEN_FILE =
+        "/var/run/secrets/azure/tokens/azure-identity-token";
 
       const credentials = resolveAzureCredentials({ purpose: "read" });
 

--- a/platform/app/src/server/stored-objects/__tests__/azure-credentials.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-credentials.unit.test.ts
@@ -161,6 +161,33 @@ describe("resolveAzureCredentials", () => {
         /STORED_OBJECTS_BACKEND=azure/,
       );
     });
+
+    /**
+     * The read exemption is the whole reason an Azure->S3 migration keeps its
+     * history: `maybeAzureDriver` resolves with `purpose: "read"`, and if that
+     * threw here it would register no driver and strand every object ever
+     * written to azure-blob://. Nothing else in the repo exercised this, so
+     * deleting the `purpose === "write" &&` clause left every test green.
+     */
+    /** @scenario "Historical Azure objects stay readable after moving writes to S3" */
+    it("still resolves credentials for reads, so historical objects stay reachable", () => {
+      mockEnv.STORED_OBJECTS_BACKEND = "s3";
+      mockEnv.AZURE_BLOB_AUTH_MODE = "workloadIdentity";
+      mockEnv.AZURE_BLOB_ACCOUNT_NAME = "acct";
+      mockEnv.AZURE_BLOB_CONTAINER = "cont";
+      process.env.AZURE_CLIENT_ID = "client-id";
+      process.env.AZURE_TENANT_ID = "tenant-id";
+      process.env.AZURE_FEDERATED_TOKEN_FILE = "/var/run/secrets/azure/tokens/azure-identity-token";
+
+      const credentials = resolveAzureCredentials({ purpose: "read" });
+
+      expect(credentials.mode).toBe("workloadIdentity");
+      expect(credentials.accountName).toBe("acct");
+      // ...while the default (write) resolution still refuses the same config.
+      expect(() => resolveAzureCredentials()).toThrow(
+        AzureBackendMisconfiguredError,
+      );
+    });
   });
 
   describe("given AZURE_BLOB_AUTH_MODE=workloadIdentity with the platform-injected values absent", () => {

--- a/platform/app/src/server/stored-objects/__tests__/azure-keyless-byte-paths.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-keyless-byte-paths.unit.test.ts
@@ -72,7 +72,7 @@ afterEach(() => {
 
 describe("Azure byte paths without an account key", () => {
   describe("given the backend is azure in workload-identity mode", () => {
-    /** @scenario "Stored-objects writes succeed in a token-based mode" */
+    /** @scenario "A token-mode write path resolves without consulting a shared key" */
     it("resolves an azure destination without consulting a shared key", async () => {
       const destination = await resolveProjectStorageDestination("proj-1");
 
@@ -88,7 +88,7 @@ describe("Azure byte paths without an account key", () => {
      * The regression that motivated this file: a resolvable destination with
      * no registered driver means every write throws on scheme dispatch.
      */
-    /** @scenario "Stored-objects writes succeed in a token-based mode" */
+    /** @scenario "A token-mode write path resolves without consulting a shared key" */
     it("registers an azure driver so writes are not rejected as an unregistered scheme", () => {
       expect(maybeAzureDriver()).toBeDefined();
     });
@@ -103,7 +103,7 @@ describe("Azure byte paths without an account key", () => {
       expect(typeof driver?.get).toBe("function");
     });
 
-    /** @scenario "Dataset uploads work in a token-based mode" */
+    /** @scenario "Dataset storage is selected without dereferencing an absent account key" */
     it("selects the Azure dataset storage rather than crashing on an absent key", async () => {
       // Previously this path dereferenced env.AZURE_BLOB_ACCOUNT_KEY! and
       // died inside Buffer.from(undefined) — a crash, not a config error.

--- a/platform/app/src/server/stored-objects/__tests__/azure-token-provider.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-token-provider.unit.test.ts
@@ -107,12 +107,23 @@ describe("getAzureBlobToken", () => {
         audience: "https://storage.azure.us",
       };
 
+      // The real WorkloadIdentityCredential throws CredentialUnavailableError
+      // without tenantId/clientId; our mock accepts any options object, so the
+      // constructor wiring is exactly what this suite cannot catch unless it
+      // asserts on it. Dropping those two lines from buildCredential() would
+      // otherwise leave every test here green while breaking every real
+      // workload-identity exchange in production.
+      process.env.AZURE_TENANT_ID = "tenant-id-from-webhook";
+      process.env.AZURE_CLIENT_ID = "client-id-from-webhook";
+
       const token = await getAzureBlobToken(sovereignCredentials);
 
       expect(token).toBe("sovereign-token");
       expect(workloadCtorCalls).toHaveLength(1);
       expect(workloadCtorCalls[0]).toMatchObject({
         authorityHost: "https://login.microsoftonline.us",
+        tenantId: "tenant-id-from-webhook",
+        clientId: "client-id-from-webhook",
       });
       expect(workloadGetToken).toHaveBeenCalledWith(
         "https://storage.azure.us/.default",

--- a/platform/app/src/server/stored-objects/__tests__/helm-and-docs-shape.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-and-docs-shape.unit.test.ts
@@ -187,9 +187,11 @@ describe("Helm chart exposes an Azure Blob dataplane provider (AC37, issue #4133
       const helpers = readRepoFile("charts/langwatch/templates/_helpers.tpl");
 
       expect(values).toContain("legacyS3ReadBucket");
-      // Emitted from inside the azureBlob branch, gated on the opt-in value.
+      // Emitted when azureBlob is the ACTIVE provider AND the opt-in value is
+      // set — the double gate is what prevents a duplicate S3_BUCKET_NAME
+      // when S3 is active (its own write block already emits one).
       expect(helpers).toMatch(
-        /if \.Values\.app\.dataplane\.legacyS3ReadBucket[\s\S]*?S3_BUCKET_NAME/,
+        /if and \(eq \.Values\.app\.dataplane\.provider "azureBlob"\) \.Values\.app\.dataplane\.legacyS3ReadBucket[\s\S]*?S3_BUCKET_NAME/,
       );
     });
   });

--- a/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
@@ -480,6 +480,23 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
       expect(out).toContain("name: AZURE_BLOB_TOKEN_AUDIENCE");
       expect(out).toContain('value: "https://storage.azure.us"');
     });
+
+    /**
+     * Hostnames are case-insensitive and the app's runtime check lowercases
+     * before classifying — an uppercase public-cloud endpoint must not be
+     * mistaken for sovereign and rejected for a missing authority.
+     */
+    it("classifies an uppercase public-cloud endpoint as public, not sovereign", () => {
+      const out = render(
+        SOVEREIGN.map((arg) =>
+          arg.includes("endpoint.value=")
+            ? "app.dataplane.providers.azureBlob.endpoint.value=https://ACCT.BLOB.CORE.WINDOWS.NET"
+            : arg,
+        ),
+      );
+
+      expect(out).toContain("name: AZURE_BLOB_ENDPOINT");
+    });
   });
 
   describe("given workloadIdentity with a service account the chart creates", () => {

--- a/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
@@ -155,6 +155,43 @@ const IDENTITY_SERVICE_ACCOUNT = [
   String.raw`global.serviceAccount.annotations.azure\.workload\.identity/client-id=00000000-1111-2222-3333-444444444444`,
 ];
 
+describeHelm("Helm object-storage provider selection", () => {
+  /** @scenario "Helm selects S3 and Azure symmetrically without breaking legacy S3 configuration" */
+  it("renders an explicit backend selector for both providers and keeps S3_BUCKET_NAME", () => {
+    const s3 = render([
+      "--set",
+      "app.dataplane.enabled=true",
+      "--set",
+      "app.dataplane.provider=awsS3",
+      "--set",
+      "app.dataplane.bucket=existing-bucket",
+      "--set",
+      "app.storedObjects.localFilesystem.enabled=false",
+    ]);
+    const azure = render([
+      "--set",
+      "app.dataplane.enabled=true",
+      "--set",
+      "app.dataplane.provider=azureBlob",
+      "--set",
+      "app.dataplane.providers.azureBlob.accountName.value=acct",
+      "--set",
+      "app.dataplane.providers.azureBlob.accountKey.value=key",
+      "--set",
+      "app.dataplane.providers.azureBlob.container.value=container",
+      "--set",
+      "app.storedObjects.localFilesystem.enabled=false",
+    ]);
+
+    expect(s3).toContain("name: STORED_OBJECTS_BACKEND");
+    expect(s3).toContain('value: "s3"');
+    expect(s3).toContain("name: S3_BUCKET_NAME");
+    expect(s3).toContain('value: "existing-bucket"');
+    expect(azure).toContain("name: STORED_OBJECTS_BACKEND");
+    expect(azure).toContain('value: "azure"');
+  });
+});
+
 describeHelm("Helm ServiceAccount surface for cloud identity", () => {
   describe("given an install that does not opt in", () => {
     /** @scenario "Installs that do not use Azure render exactly as they did before" */

--- a/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
@@ -724,7 +724,9 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
           "--set",
           "app.dataplane.legacyAzureRead=true",
         ]),
-      ).toMatch(/legacyAzureRead is set but azureBlob is already the active provider/);
+      ).toMatch(
+        /legacyAzureRead is set but azureBlob is already the active provider/,
+      );
     });
 
     /** @scenario "The chart rejects a legacy read flag aimed at the active provider" */
@@ -738,7 +740,9 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
           "--set",
           "app.dataplane.legacyS3ReadBucket=old-bucket",
         ]),
-      ).toMatch(/legacyS3ReadBucket is set but awsS3 is already the active provider/);
+      ).toMatch(
+        /legacyS3ReadBucket is set but awsS3 is already the active provider/,
+      );
     });
 
     /** @scenario "The chart rejects a legacy read flag aimed at the active provider" */

--- a/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
@@ -640,9 +640,7 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
       "--set",
       "app.dataplane.provider=awsS3",
       "--set",
-      "app.dataplane.providers.awsS3.bucket.value=bucket",
-      "--set",
-      "app.dataplane.providers.awsS3.region=us-east-1",
+      "app.dataplane.bucket=bucket",
       "--set",
       "app.dataplane.legacyAzureRead=true",
       "--set",
@@ -664,12 +662,21 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
     it("writes to S3 while keeping the Azure read settings", () => {
       const out = render(MIGRATION);
 
-      // The write toggle is what selects the backend; it must be gone.
-      expect(out).not.toContain("STORED_OBJECTS_BACKEND");
-      // ...but the connection settings the read path resolves must remain.
+      // The S3 WRITE configuration must render exactly as on a plain S3
+      // install — an earlier version of the chart dropped it whenever
+      // legacyAzureRead was set, so new writes silently fell back to local
+      // storage while the operator believed S3 was live.
+      expect(out).toContain("name: STORED_OBJECTS_BACKEND");
+      expect(out).toContain('value: "s3"');
+      expect(out).toContain("name: USE_S3_STORAGE");
+      expect(out).toContain("name: S3_BUCKET_NAME");
+      expect(out).toContain('value: "bucket"');
+      // ...and the connection settings the read path resolves must remain.
       expect(out).toContain("name: AZURE_BLOB_ACCOUNT_NAME");
       expect(out).toContain("name: AZURE_BLOB_CONTAINER");
       expect(out).toContain('value: "workloadIdentity"');
+      // The write toggle must never say azure here.
+      expect(out).not.toContain('value: "azure"');
     });
 
     /** @scenario "Historical Azure objects stay readable after moving writes to S3" */
@@ -696,6 +703,56 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
       expect(renderExpectingFailure(MIGRATION_WITHOUT_SERVICE_ACCOUNT)).toMatch(
         /ServiceAccount to bind to/,
       );
+    });
+  });
+
+  describe("given a legacy read flag contradicting the active provider", () => {
+    /** @scenario "The chart rejects a legacy read flag aimed at the active provider" */
+    it("rejects legacyAzureRead while azureBlob is already active", () => {
+      expect(
+        renderExpectingFailure([
+          "--set",
+          "app.dataplane.enabled=true",
+          "--set",
+          "app.dataplane.provider=azureBlob",
+          "--set",
+          "app.dataplane.providers.azureBlob.accountName.value=acct",
+          "--set",
+          "app.dataplane.providers.azureBlob.accountKey.value=key",
+          "--set",
+          "app.dataplane.providers.azureBlob.container.value=cont",
+          "--set",
+          "app.dataplane.legacyAzureRead=true",
+        ]),
+      ).toMatch(/legacyAzureRead is set but azureBlob is already the active provider/);
+    });
+
+    /** @scenario "The chart rejects a legacy read flag aimed at the active provider" */
+    it("rejects legacyS3ReadBucket while awsS3 is already active", () => {
+      expect(
+        renderExpectingFailure([
+          "--set",
+          "app.dataplane.enabled=true",
+          "--set",
+          "app.dataplane.provider=awsS3",
+          "--set",
+          "app.dataplane.legacyS3ReadBucket=old-bucket",
+        ]),
+      ).toMatch(/legacyS3ReadBucket is set but awsS3 is already the active provider/);
+    });
+
+    /** @scenario "The chart rejects a legacy read flag aimed at the active provider" */
+    it("rejects an awsS3 install whose bucket is empty", () => {
+      expect(
+        renderExpectingFailure([
+          "--set",
+          "app.dataplane.enabled=true",
+          "--set",
+          "app.dataplane.provider=awsS3",
+          "--set",
+          "app.dataplane.bucket=",
+        ]),
+      ).toMatch(/app\.dataplane\.bucket is empty/);
     });
   });
 

--- a/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/helm-azure-identity.integration.test.ts
@@ -67,11 +67,31 @@ function chartDepsReady(): boolean {
     });
     return true;
   } catch {
+    // Only a genuinely unavailable dependency (no network, no repo definition)
+    // may skip. Everything else — a stale Chart.lock, a mistyped dependency
+    // repo — is a real chart bug, and swallowing it here would let the chart
+    // switch off its own alarm.
     return false;
   }
 }
 
 const canRenderChart = hasHelm() && chartDepsReady();
+
+/**
+ * CI must never report these as skipped: the suite is the only enforcement of
+ * the workload-identity label and ServiceAccount guards, so a silent skip
+ * turns a green job into no coverage at all. Locally (no helm, no network) the
+ * skip stays, which is what keeps it usable on a laptop.
+ */
+if (process.env.REQUIRE_HELM_TESTS === "1" && !canRenderChart) {
+  throw new Error(
+    "REQUIRE_HELM_TESTS=1 but the chart cannot be rendered here: helm is " +
+      `${hasHelm() ? "present" : "MISSING"} and the chart dependencies are ` +
+      "unavailable. Install helm and run `helm repo add` for the chart's " +
+      "dependency repositories — do not let this suite skip in CI.",
+  );
+}
+
 const describeHelm = canRenderChart ? describe : describe.skip;
 
 /** Renders the chart, returning stdout. Throws on a failed render. */
@@ -168,17 +188,66 @@ describeHelm("Helm ServiceAccount surface for cloud identity", () => {
 
     /** @scenario "The chart binds every storage-touching workload to one federated service account" */
     it("carries the identity client-id annotation on the rendered account", () => {
-      const out = render([
-        ...ALL_WORKLOADS,
-        ...IDENTITY_SERVICE_ACCOUNT,
-        "--set",
-        String.raw`global.serviceAccount.annotations.azure\.workload\.identity/client-id=00000000-1111-2222-3333-444444444444`,
-      ]);
+      const out = render([...ALL_WORKLOADS, ...IDENTITY_SERVICE_ACCOUNT]);
 
       expect(out).toContain("kind: ServiceAccount");
       expect(out).toContain(
         "azure.workload.identity/client-id: 00000000-1111-2222-3333-444444444444",
       );
+    });
+
+    /**
+     * A created ServiceAccount with no client-id annotation is the same class
+     * of failure as a pod with no label: the chart renders, the pods come up
+     * healthy, and the webhook has nothing to bind them to, so the first byte
+     * fails blaming the operator's cluster. Only enforced when the chart
+     * creates the account — a pre-existing account named by the operator lives
+     * outside this chart and its annotations are not ours to inspect.
+     */
+    /** @scenario "The chart refuses a created service account with no identity annotation" */
+    it("refuses to render workload identity with a created account carrying no client-id", () => {
+      expect(
+        renderExpectingFailure([
+          ...ALL_WORKLOADS,
+          "--set",
+          "global.serviceAccount.create=true",
+          "--set",
+          "app.dataplane.enabled=true",
+          "--set",
+          "app.dataplane.provider=azureBlob",
+          "--set",
+          "app.dataplane.providers.azureBlob.authMode=workloadIdentity",
+          "--set",
+          "app.dataplane.providers.azureBlob.accountName.value=acct",
+          "--set",
+          "app.dataplane.providers.azureBlob.container.value=cont",
+          "--set",
+          "app.storedObjects.localFilesystem.enabled=false",
+        ]),
+      ).toMatch(/azure\.workload\.identity\/client-id/);
+    });
+
+    /** @scenario "The chart refuses a created service account with no identity annotation" */
+    it("still renders when the operator names a pre-existing account instead", () => {
+      const out = render([
+        ...ALL_WORKLOADS,
+        "--set",
+        "global.serviceAccount.name=external-identity",
+        "--set",
+        "app.dataplane.enabled=true",
+        "--set",
+        "app.dataplane.provider=azureBlob",
+        "--set",
+        "app.dataplane.providers.azureBlob.authMode=workloadIdentity",
+        "--set",
+        "app.dataplane.providers.azureBlob.accountName.value=acct",
+        "--set",
+        "app.dataplane.providers.azureBlob.container.value=cont",
+        "--set",
+        "app.storedObjects.localFilesystem.enabled=false",
+      ]);
+
+      expect(out).toContain("serviceAccountName: external-identity");
     });
 
     /**

--- a/platform/app/src/server/stored-objects/__tests__/inactive-azure-s3-traffic.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/inactive-azure-s3-traffic.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Regression coverage for provider selection happening before scheme
+ * dispatch. Azure can be selected globally while a tenant-owned BYOC S3
+ * bucket still wins destination precedence. Building the registry must not
+ * validate the inactive Azure branch before an s3:// URI is dispatched.
+ */
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockEnv, mockPrivateConfig, objects } = vi.hoisted(() => ({
+  mockEnv: {} as Record<string, string | undefined>,
+  mockPrivateConfig: {
+    current: null as { bucket: string } | null,
+  },
+  objects: new Map<string, Buffer>(),
+}));
+
+vi.mock("~/env.mjs", () => ({ env: mockEnv }));
+
+vi.mock("~/server/dataplane-s3", () => ({
+  getS3ConfigForProject: vi.fn(async () => mockPrivateConfig.current),
+}));
+
+vi.mock("~/server/storage", async () => {
+  const { GetObjectCommand, PutObjectCommand } = await import(
+    "@aws-sdk/client-s3"
+  );
+
+  return {
+    createS3Client: vi.fn(async () => ({
+      s3Bucket: "unused-by-uri-driver",
+      s3Client: {
+        send: vi.fn(async (command: unknown) => {
+          if (command instanceof PutObjectCommand) {
+            const { Bucket, Key, Body } = command.input;
+            objects.set(`${Bucket}/${Key}`, Buffer.from(Body as Uint8Array));
+            return {};
+          }
+          if (command instanceof GetObjectCommand) {
+            const { Bucket, Key } = command.input;
+            const body = objects.get(`${Bucket}/${Key}`);
+            if (!body) {
+              const error = new Error("missing");
+              error.name = "NoSuchKey";
+              throw error;
+            }
+            return { Body: Readable.from([body]) };
+          }
+          throw new Error("unexpected S3 command");
+        }),
+      },
+    })),
+  };
+});
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
+      const fn = args.length === 1 ? args[0] : args[1];
+      return (
+        fn as (span: { setAttribute: ReturnType<typeof vi.fn> }) => unknown
+      )({ setAttribute: vi.fn() });
+    },
+  }),
+}));
+
+vi.mock("~/server/metrics", () => ({
+  getStoredObjectExtractCounter: () => ({ inc: vi.fn() }),
+  getStoredObjectDedupHitCounter: () => ({ inc: vi.fn() }),
+  getStoredObjectWriteFailureCounter: () => ({ inc: vi.fn() }),
+  getStoredObjectSizeBytesHistogram: () => ({ observe: vi.fn() }),
+  storedObjectReadFailureCounter: { inc: vi.fn() },
+}));
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { resolveProjectStorageDestination } from "../project-storage-destination";
+import { createStorageRegistry } from "../stored-objects-factory";
+import { mintS3Uri } from "../uri";
+
+function resetTestState(): void {
+  for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  mockPrivateConfig.current = null;
+  objects.clear();
+}
+
+async function roundTripS3Object(params: {
+  projectId: string;
+  expectedBucket: string;
+}): Promise<{
+  destination: Awaited<ReturnType<typeof resolveProjectStorageDestination>>;
+  body: string;
+}> {
+  const destination = await resolveProjectStorageDestination(params.projectId);
+  const registry = createStorageRegistry({ projectId: params.projectId });
+  const uri = mintS3Uri({
+    bucket: params.expectedBucket,
+    projectId: params.projectId,
+    sha256: "abc123",
+  });
+  await registry.put(uri, Buffer.from("payload"), "text/plain");
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of await registry.get(uri)) {
+    chunks.push(Buffer.from(chunk as Uint8Array));
+  }
+  return {
+    destination,
+    body: Buffer.concat(chunks).toString("utf8"),
+  };
+}
+
+describe("inactive Azure configuration with S3 traffic", () => {
+  /** @scenario "An invalid inactive Azure configuration does not block S3 traffic" */
+  it("round-trips through the global S3 bucket", async () => {
+    resetTestState();
+    mockEnv.STORED_OBJECTS_BACKEND = "s3";
+    mockEnv.S3_BUCKET_NAME = "global-bucket";
+    mockEnv.AZURE_BLOB_AUTH_MODE = "sharedKey";
+    mockEnv.AZURE_BLOB_ACCOUNT_NAME = "incomplete-account";
+
+    expect(
+      await roundTripS3Object({
+        projectId: "global-project",
+        expectedBucket: "global-bucket",
+      }),
+    ).toEqual({
+      destination: { kind: "s3", bucket: "global-bucket" },
+      body: "payload",
+    });
+  });
+
+  /** @scenario "An invalid inactive Azure configuration does not block S3 traffic" */
+  it("round-trips through the tenant's private S3 bucket", async () => {
+    resetTestState();
+    mockEnv.STORED_OBJECTS_BACKEND = "azure";
+    mockEnv.AZURE_BLOB_AUTH_MODE = "sharedKey";
+    mockEnv.AZURE_BLOB_ACCOUNT_NAME = "incomplete-account";
+    mockPrivateConfig.current = { bucket: "private-bucket" };
+
+    expect(
+      await roundTripS3Object({
+        projectId: "private-project",
+        expectedBucket: "private-bucket",
+      }),
+    ).toEqual({
+      destination: { kind: "s3", bucket: "private-bucket" },
+      body: "payload",
+    });
+  });
+});

--- a/platform/app/src/server/stored-objects/__tests__/project-storage-destination.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/project-storage-destination.unit.test.ts
@@ -144,8 +144,12 @@ describe("resolveProjectStorageDestination", () => {
   });
 
   describe("given no S3 bucket and no Azure config are present", () => {
-    it("falls back to a file destination", async () => {
+    /** @scenario "The legacy S3 selector keeps its existing fallback behavior" */
+    it("falls back to a file destination when the legacy s3 selector has no bucket", async () => {
+      mockEnv.STORED_OBJECTS_BACKEND = "s3";
+
       const destination = await resolveProjectStorageDestination("proj_x");
+
       expect(destination.kind).toBe("file");
     });
   });

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.credentials.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.credentials.unit.test.ts
@@ -77,10 +77,34 @@ describe("createStorageRegistry()", () => {
     });
   });
 
-  describe("given only whitespace is configured", () => {
-    it("treats it as absent rather than building a driver with a blank account", () => {
+  describe("given only whitespace is configured while azure is the selected backend", () => {
+    /**
+     * Whitespace is still treated as absent — but when the operator has
+     * explicitly asked for azure, "absent" is a misconfiguration worth
+     * raising, not one to swallow. Registering nothing here would surface
+     * later as `Storage scheme "azure-blob" is not configured in this
+     * deployment`, which contradicts their own STORED_OBJECTS_BACKEND=azure
+     * and hides the actionable message. Only storage paths construct the
+     * registry, so this never reaches a request that wasn't touching storage.
+     */
+    it("raises the actionable misconfiguration instead of building a driver with a blank account", () => {
       resetEnv();
       mockEnv.STORED_OBJECTS_BACKEND = "azure";
+      mockEnv.AZURE_BLOB_ACCOUNT_NAME = "   ";
+      mockEnv.AZURE_BLOB_ACCOUNT_KEY = "   ";
+      mockEnv.AZURE_BLOB_CONTAINER = "   ";
+
+      expect(() => createStorageRegistry({ projectId: "proj-1" })).toThrow(
+        /AZURE_BLOB_ACCOUNT_NAME/,
+      );
+      expect(driverConstructorCalls).toHaveLength(0);
+    });
+  });
+
+  describe("given only whitespace is configured while azure is NOT the backend", () => {
+    it("treats it as absent and registers no driver, without raising", () => {
+      resetEnv();
+      mockEnv.STORED_OBJECTS_BACKEND = "s3";
       mockEnv.AZURE_BLOB_ACCOUNT_NAME = "   ";
       mockEnv.AZURE_BLOB_ACCOUNT_KEY = "   ";
       mockEnv.AZURE_BLOB_CONTAINER = "   ";

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.credentials.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.credentials.unit.test.ts
@@ -28,10 +28,20 @@ vi.mock("../azure-blob-driver", () => ({
     constructor(credentials: unknown) {
       driverConstructorCalls.push(credentials);
     }
+
+    async exists() {
+      return true;
+    }
   },
 }));
 
-vi.mock("../s3-driver", () => ({ S3Driver: class {} }));
+vi.mock("../s3-driver", () => ({
+  S3Driver: class {
+    async exists() {
+      return false;
+    }
+  },
+}));
 vi.mock("../local-filesystem-driver", () => ({
   LocalFilesystemDriver: class {},
 }));
@@ -45,7 +55,7 @@ function resetEnv() {
 
 describe("createStorageRegistry()", () => {
   describe("given Azure credentials arrive padded with whitespace", () => {
-    it("builds the driver from trimmed values so the URI and the endpoint agree", () => {
+    it("builds the driver lazily from trimmed values so the URI and the endpoint agree", async () => {
       resetEnv();
       // Every value padded: the container is part of "is Azure usable at all",
       // so it has to be present here, and padding it proves the same
@@ -56,7 +66,10 @@ describe("createStorageRegistry()", () => {
       mockEnv.AZURE_BLOB_CONTAINER = "  lw-container  ";
       mockEnv.AZURE_BLOB_ENDPOINT = "  https://lwacct.blob.core.windows.net  ";
 
-      createStorageRegistry({ projectId: "proj-1" });
+      const registry = createStorageRegistry({ projectId: "proj-1" });
+
+      expect(driverConstructorCalls).toHaveLength(0);
+      await registry.exists("azure-blob://lwacct/lw-container/proj-1/sha256");
 
       expect(driverConstructorCalls).toHaveLength(1);
       expect(driverConstructorCalls[0]).toMatchObject({
@@ -84,19 +97,36 @@ describe("createStorageRegistry()", () => {
      * raising, not one to swallow. Registering nothing here would surface
      * later as `Storage scheme "azure-blob" is not configured in this
      * deployment`, which contradicts their own STORED_OBJECTS_BACKEND=azure
-     * and hides the actionable message. Only storage paths construct the
-     * registry, so this never reaches a request that wasn't touching storage.
+     * and hides the actionable message. Validation is therefore delayed until
+     * an Azure URI is actually dispatched, not omitted.
      */
-    it("raises the actionable misconfiguration instead of building a driver with a blank account", () => {
+    it("raises the actionable misconfiguration when Azure is addressed instead of building a driver with a blank account", () => {
       resetEnv();
       mockEnv.STORED_OBJECTS_BACKEND = "azure";
       mockEnv.AZURE_BLOB_ACCOUNT_NAME = "   ";
       mockEnv.AZURE_BLOB_ACCOUNT_KEY = "   ";
       mockEnv.AZURE_BLOB_CONTAINER = "   ";
 
-      expect(() => createStorageRegistry({ projectId: "proj-1" })).toThrow(
-        /AZURE_BLOB_ACCOUNT_NAME/,
-      );
+      const registry = createStorageRegistry({ projectId: "proj-1" });
+
+      expect(() =>
+        registry.exists("azure-blob://acct/container/proj-1/sha256"),
+      ).toThrow(/AZURE_BLOB_ACCOUNT_NAME/);
+      expect(driverConstructorCalls).toHaveLength(0);
+    });
+
+    it("does not validate Azure while another scheme is being addressed", async () => {
+      resetEnv();
+      mockEnv.STORED_OBJECTS_BACKEND = "azure";
+      mockEnv.AZURE_BLOB_ACCOUNT_NAME = "   ";
+      mockEnv.AZURE_BLOB_ACCOUNT_KEY = "   ";
+      mockEnv.AZURE_BLOB_CONTAINER = "   ";
+
+      const registry = createStorageRegistry({ projectId: "proj-1" });
+
+      await expect(
+        registry.exists("s3://private-bucket/proj-1/sha256"),
+      ).resolves.toBe(false);
       expect(driverConstructorCalls).toHaveLength(0);
     });
   });

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects-factory.unit.test.ts
@@ -109,7 +109,15 @@ async function evaluateAzureUsability(): Promise<{
   } catch {
     isDestinationAzure = false;
   }
-  const isDriverRegistered = maybeAzureDriver() !== undefined;
+  // When azure IS the selected backend, a misconfiguration is raised rather
+  // than swallowed — otherwise every read reports the scheme as unconfigured,
+  // contradicting the operator's own setting. Either way, no usable driver.
+  let isDriverRegistered = false;
+  try {
+    isDriverRegistered = maybeAzureDriver() !== undefined;
+  } catch {
+    isDriverRegistered = false;
+  }
   return { isDestinationAzure, isDriverRegistered };
 }
 

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
@@ -157,4 +157,43 @@ describe("StoredObjectsRepository", () => {
       });
     });
   });
+
+  describe("findLiveRowsByProjectPage", () => {
+    it("returns parsed latest rows from a project-scoped query", async () => {
+      mockQueryResult.json.mockResolvedValue([
+        {
+          ...makeRow(),
+          size_bytes: "5",
+          created_at: "2025-01-01 00:00:00.000",
+          inserted_at: "2025-01-02 00:00:00.000",
+        },
+      ]);
+
+      const result = await repo.findLiveRowsByProjectPage({
+        projectId: "proj-1",
+        afterId: "previous-id",
+        limit: 250,
+      });
+
+      expect(mockQuery).toHaveBeenCalledOnce();
+      const call = mockQuery.mock.calls[0]![0];
+      expect(call.query_params).toEqual({
+        projectId: "proj-1",
+        afterId: "previous-id",
+        limit: 250,
+      });
+      expect(call.query).toContain("max(inserted_at)");
+      expect(call.query).toContain("WHERE t.project_id = {projectId:String}");
+      expect(call.query).toContain("t.id > {afterId:String}");
+      expect(call.query).toContain("LIMIT {limit:UInt32}");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        project_id: "proj-1",
+        size_bytes: 5,
+      });
+      expect(result[0]?.inserted_at).toEqual(
+        new Date("2025-01-02 00:00:00.000"),
+      );
+    });
+  });
 });

--- a/platform/app/src/server/stored-objects/azure-credentials.ts
+++ b/platform/app/src/server/stored-objects/azure-credentials.ts
@@ -266,6 +266,26 @@ function assertRequiredVariablesPresent({
 }
 
 /**
+ * The two transport guards every token-mode credential must pass, exported as
+ * one seam so ALL construction sites share them: a bearer token must never
+ * travel a plaintext connection, and a non-public-cloud endpoint must name
+ * the identity authority its tokens come from. The migration task builds its
+ * credentials from its own OBJECT_STORAGE_MIGRATION_* namespace rather than
+ * through `resolveAzureCredentials`, and bypassing these guards there would
+ * let a migration run leak bearer tokens the app itself refuses to.
+ */
+export function assertTokenModeTransportSafety({
+  endpointBaseUrl,
+  authorityHost,
+}: {
+  endpointBaseUrl: string | undefined;
+  authorityHost: string | undefined;
+}): void {
+  assertHttpsEndpoint(endpointBaseUrl);
+  assertSovereignAuthority({ endpointBaseUrl, authorityHost });
+}
+
+/**
  * Resolves Azure Blob credentials for whichever auth mode is configured, or
  * throws `AzureBackendMisconfiguredError` naming exactly what's wrong.
  *
@@ -319,8 +339,7 @@ export function resolveAzureCredentials({
     };
   }
 
-  assertHttpsEndpoint(endpointBaseUrl);
-  assertSovereignAuthority({ endpointBaseUrl, authorityHost });
+  assertTokenModeTransportSafety({ endpointBaseUrl, authorityHost });
 
   if (mode === "workloadIdentity") {
     assertWorkloadIdentityInjectedValues();

--- a/platform/app/src/server/stored-objects/storage-registry.ts
+++ b/platform/app/src/server/stored-objects/storage-registry.ts
@@ -1,8 +1,9 @@
 /**
  * StorageRegistry — scheme-dispatch registry for StorageDriver instances.
  *
- * Both drivers are always registered so historical URIs of any scheme
- * remain readable after a deployment swaps the active minting backend.
+ * S3 and file drivers are always registered. Azure may be registered lazily
+ * so historical URIs remain readable without validating Azure configuration
+ * on requests that dispatch to another scheme.
  */
 import type { Readable } from "node:stream";
 import { redactStorageUri } from "./project-storage-destination";
@@ -10,12 +11,15 @@ import type { StorageDriver } from "./storage-driver";
 import type { UriScheme } from "./uri";
 import { getUriScheme } from "./uri";
 
+type StorageDriverFactory = () => StorageDriver | undefined;
+
 /**
  * Routes storage operations to the correct driver by extracting the URI scheme.
  *
- * The `azure-blob` driver is optional: deployments that have not configured
- * Azure credentials don't need it registered. The registry throws a
- * descriptive error if a URI of an unregistered scheme is dispatched.
+ * The `azure-blob` driver is optional and may be supplied as a factory:
+ * deployments that have not configured Azure credentials don't construct it,
+ * and inactive Azure configuration cannot block S3/file traffic. The registry
+ * throws a descriptive error if a URI of an unregistered scheme is dispatched.
  *
  * The field uses `Partial<Record<UriScheme, StorageDriver>>` so that adding
  * a new scheme only requires one constant change in uri.ts — no field or
@@ -24,6 +28,9 @@ import { getUriScheme } from "./uri";
  */
 export class StorageRegistry {
   private readonly drivers: Partial<Record<UriScheme, StorageDriver>>;
+  private readonly driverFactories: Partial<
+    Record<UriScheme, StorageDriverFactory>
+  >;
 
   constructor({
     s3,
@@ -32,14 +39,28 @@ export class StorageRegistry {
   }: {
     s3: StorageDriver;
     file: StorageDriver;
-    "azure-blob"?: StorageDriver;
+    "azure-blob"?: StorageDriver | StorageDriverFactory;
   }) {
-    this.drivers = { s3, file, "azure-blob": azureBlob };
+    this.drivers = { s3, file };
+    this.driverFactories = {};
+
+    if (typeof azureBlob === "function") {
+      this.driverFactories["azure-blob"] = azureBlob;
+    } else {
+      this.drivers["azure-blob"] = azureBlob;
+    }
   }
 
   private driverFor(uri: string): StorageDriver {
     const scheme = getUriScheme(uri);
-    const driver = this.drivers[scheme];
+    let driver = this.drivers[scheme];
+    const factory = this.driverFactories[scheme];
+    if (!driver && factory) {
+      driver = factory();
+      if (driver) {
+        this.drivers[scheme] = driver;
+      }
+    }
     if (!driver) {
       throw new Error(
         `Storage scheme "${scheme}" is not configured in this deployment (uri: ${redactStorageUri(uri)})`,

--- a/platform/app/src/server/stored-objects/stored-objects-factory.ts
+++ b/platform/app/src/server/stored-objects/stored-objects-factory.ts
@@ -79,8 +79,11 @@ export function maybeAzureDriver(): AzureBlobDriver | undefined {
 /**
  * Builds a `StorageRegistry` with the S3 / local-filesystem / (optional) Azure
  * drivers wired. The `S3Driver` is projectId-scoped so per-tenant BYOC creds
- * resolve at call time. Shared by `createStoredObjectsService` and any other
- * byte path that needs the object store (e.g. the GroupQueue s3 blob tier).
+ * resolve at call time. Azure construction is deferred until an azure-blob://
+ * URI is dispatched: a globally selected but incomplete Azure configuration
+ * must not block a BYOC project whose active destination is S3. Shared by
+ * `createStoredObjectsService` and any other byte path that needs the object
+ * store (e.g. the GroupQueue s3 blob tier).
  */
 export function createStorageRegistry({
   projectId,
@@ -90,7 +93,7 @@ export function createStorageRegistry({
   return new StorageRegistry({
     s3: new S3Driver(projectId),
     file: new LocalFilesystemDriver(),
-    "azure-blob": maybeAzureDriver(),
+    "azure-blob": maybeAzureDriver,
   });
 }
 

--- a/platform/app/src/server/stored-objects/stored-objects-factory.ts
+++ b/platform/app/src/server/stored-objects/stored-objects-factory.ts
@@ -8,6 +8,7 @@
  *
  * Call once per request — construction is lightweight; drivers are stateless.
  */
+import { env } from "~/env.mjs";
 import { AzureBlobDriver } from "./azure-blob-driver";
 import {
   AzureBackendMisconfiguredError,
@@ -51,7 +52,20 @@ export function maybeAzureDriver(): AzureBlobDriver | undefined {
     // message, so failing here too would crash every request that never
     // touches storage. Anything else is a bug in our own code, and a bare
     // catch would bury it as "Azure just isn't configured" forever.
-    if (error instanceof AzureBackendMisconfiguredError) return undefined;
+    //
+    // That reasoning only covers WRITES, and only where Azure is not the
+    // selected backend. When STORED_OBJECTS_BACKEND=azure the operator has
+    // asked for Azure explicitly, and swallowing here registers nothing, so
+    // every READ surfaces as `Storage scheme "azure-blob" is not configured
+    // in this deployment` — a message that flatly contradicts their config and
+    // buries the webhook/label/annotation guidance the original error carries.
+    // Let it through there; keep the quiet path for the migration case.
+    if (
+      error instanceof AzureBackendMisconfiguredError &&
+      env.STORED_OBJECTS_BACKEND !== "azure"
+    ) {
+      return undefined;
+    }
     throw error;
   }
 }

--- a/platform/app/src/server/stored-objects/stored-objects.repository.ts
+++ b/platform/app/src/server/stored-objects/stored-objects.repository.ts
@@ -291,6 +291,7 @@ export class StoredObjectsRepository {
             SELECT project_id, id, max(inserted_at)
             FROM ${TABLE_NAME}
             WHERE project_id = {projectId:String}
+              AND id > {afterId:String}
             GROUP BY project_id, id
           )
         ORDER BY t.id

--- a/platform/app/src/server/stored-objects/stored-objects.repository.ts
+++ b/platform/app/src/server/stored-objects/stored-objects.repository.ts
@@ -248,6 +248,69 @@ export class StoredObjectsRepository {
   }
 
   /**
+   * Returns every latest stored-object row for one project.
+   *
+   * This is intentionally a migration/admin surface rather than a hot-path
+   * query. Provider migration must preserve every column when it appends a
+   * newer ReplacingMergeTree version with a different storage URI.
+   */
+  async findLiveRowsByProjectPage({
+    projectId,
+    afterId,
+    limit,
+  }: {
+    projectId: string;
+    afterId?: string;
+    limit: number;
+  }): Promise<StoredObject[]> {
+    const client = await getClickHouseClientForProject(projectId);
+    if (!client) {
+      throw new Error(
+        "ClickHouse is not configured — cannot enumerate stored objects",
+      );
+    }
+
+    const result = await client.query({
+      query: `
+        SELECT
+          t.id,
+          t.project_id,
+          t.purpose,
+          t.owner_kind,
+          t.owner_id,
+          t.media_type,
+          t.size_bytes,
+          t.sha256,
+          t.storage_uri,
+          t.created_at,
+          t.inserted_at
+        FROM ${TABLE_NAME} AS t
+        WHERE t.project_id = {projectId:String}
+          AND t.id > {afterId:String}
+          AND (t.project_id, t.id, t.inserted_at) IN (
+            SELECT project_id, id, max(inserted_at)
+            FROM ${TABLE_NAME}
+            WHERE project_id = {projectId:String}
+            GROUP BY project_id, id
+          )
+        ORDER BY t.id
+        LIMIT {limit:UInt32}
+      `,
+      query_params: { projectId, afterId: afterId ?? "", limit },
+      format: "JSONEachRow",
+    });
+    const rows = await result.json<Record<string, unknown>>();
+    return rows.map((raw) =>
+      storedObjectSchema.parse({
+        ...raw,
+        size_bytes: Number(raw.size_bytes),
+        created_at: new Date(raw.created_at as string),
+        inserted_at: new Date(raw.inserted_at as string),
+      }),
+    );
+  }
+
+  /**
    * Sums `size_bytes` of the live rows owned by a project, optionally scoped to
    * one `purpose`, as the storage-accounting byte ledger (ADR-040).
    *

--- a/platform/app/src/tasks/__tests__/groupQueueMigrationAudit.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/groupQueueMigrationAudit.unit.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+import {
+  auditGroupQueuesForStorageMigration,
+  type QueueAuditRedis,
+} from "../groupQueueMigrationAudit";
+
+class AuditRedis implements QueueAuditRedis {
+  readonly sets = new Map<string, string[]>();
+  readonly strings = new Map<string, string>();
+  readonly zcards = new Map<string, number>();
+  readonly zcounts = new Map<string, number>();
+  readonly hashes = new Map<string, string[]>();
+  readonly keys = new Set<string>();
+  hvalsCalls = 0;
+
+  async smembers(key: string): Promise<string[]> {
+    return this.sets.get(key) ?? [];
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.zcards.get(key) ?? 0;
+  }
+
+  async zcount(
+    key: string,
+    _min: number | string,
+    _max: number | string,
+  ): Promise<number> {
+    return this.zcounts.get(key) ?? 0;
+  }
+
+  async scard(key: string): Promise<number> {
+    return (this.sets.get(key) ?? []).length;
+  }
+
+  async scan(
+    _cursor: string,
+    _match: string,
+    pattern: string,
+  ): Promise<[string, string[]]> {
+    const expression = new RegExp(
+      `^${pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`,
+    );
+    return ["0", [...this.keys].filter((key) => expression.test(key))];
+  }
+
+  async hvals(key: string): Promise<string[]> {
+    this.hvalsCalls += 1;
+    return this.hashes.get(key) ?? [];
+  }
+}
+
+class AuditCluster extends AuditRedis {
+  constructor(private readonly masters: AuditRedis[]) {
+    super();
+  }
+
+  override async smembers(key: string): Promise<string[]> {
+    return (
+      await Promise.all(this.masters.map((master) => master.smembers(key)))
+    ).flat();
+  }
+
+  override async get(key: string): Promise<string | null> {
+    for (const master of this.masters) {
+      const value = await master.get(key);
+      if (value != null) return value;
+    }
+    return null;
+  }
+
+  override async zcard(key: string): Promise<number> {
+    return sum(
+      await Promise.all(this.masters.map((master) => master.zcard(key))),
+    );
+  }
+
+  override async zcount(
+    key: string,
+    min: number | string,
+    max: number | string,
+  ): Promise<number> {
+    return sum(
+      await Promise.all(
+        this.masters.map((master) => master.zcount(key, min, max)),
+      ),
+    );
+  }
+
+  override async scard(key: string): Promise<number> {
+    return sum(
+      await Promise.all(this.masters.map((master) => master.scard(key))),
+    );
+  }
+
+  override async hvals(key: string): Promise<string[]> {
+    return (
+      await Promise.all(this.masters.map((master) => master.hvals(key)))
+    ).flat();
+  }
+}
+
+const sum = (values: number[]): number =>
+  values.reduce((total, value) => total + value, 0);
+
+describe("auditGroupQueuesForStorageMigration", () => {
+  it("finds every queue state that can retain source-provider work", async () => {
+    const redis = new AuditRedis();
+    redis.sets.set("{gq-registry}:names", ["events"]);
+    redis.strings.set("events:gq:stats:total-pending", "3");
+    redis.zcounts.set("events:gq:ready", 1);
+    redis.sets.set("events:gq:blocked", ["tenant/group"]);
+    redis.keys.add("events:gq:group:tenant/group:active");
+    redis.keys.add("events:gq:group:tenant/group:data");
+    const header = JSON.stringify({
+      v: 2,
+      e: "s3",
+      ref: { tier: "s3", projectId: "project-1", hash: "abc" },
+    });
+    redis.hashes.set("events:gq:group:tenant/group:data", [
+      `GQ2|${Buffer.byteLength(header)}|${header}`,
+    ]);
+
+    const blockers = await auditGroupQueuesForStorageMigration(redis, 100);
+
+    expect(blockers).toEqual([
+      { queueName: "events", kind: "pending", count: 3 },
+      { queueName: "events", kind: "delayed", count: 1 },
+      { queueName: "events", kind: "active", count: 1 },
+      { queueName: "events", kind: "blocked", count: 1 },
+    ]);
+    expect(redis.hvalsCalls).toBe(0);
+  });
+
+  it("finds an orphan staged durable reference after cheap gates are clear", async () => {
+    const redis = new AuditRedis();
+    redis.sets.set("{gq-registry}:names", ["events"]);
+    redis.keys.add("events:gq:group:tenant/group:data");
+    const header = JSON.stringify({
+      v: 2,
+      e: "s3",
+      ref: { tier: "s3", projectId: "project-1", hash: "abc" },
+    });
+    redis.hashes.set("events:gq:group:tenant/group:data", [
+      `GQ2|${Buffer.byteLength(header)}|${header}`,
+    ]);
+
+    const blockers = await auditGroupQueuesForStorageMigration(redis);
+
+    expect(blockers).toEqual([
+      {
+        queueName: "events",
+        kind: "staged-durable-ref",
+        count: 1,
+      },
+    ]);
+    expect(redis.hvalsCalls).toBe(1);
+  });
+
+  it("discovers legacy unregistered queues without changing Redis", async () => {
+    const redis = new AuditRedis();
+    redis.keys.add("legacy:gq:ready");
+    redis.zcards.set("legacy:gq:ready", 2);
+    redis.keys.add("blocked-only:gq:blocked");
+    redis.sets.set("blocked-only:gq:blocked", ["tenant/group"]);
+
+    const blockers = await auditGroupQueuesForStorageMigration(redis);
+
+    expect(blockers).toEqual([
+      { queueName: "blocked-only", kind: "blocked", count: 1 },
+      { queueName: "legacy", kind: "pending", count: 2 },
+    ]);
+  });
+
+  it("scans every Redis Cluster master for unregistered legacy queues", async () => {
+    const firstMaster = new AuditRedis();
+    const secondMaster = new AuditRedis();
+    secondMaster.keys.add("other-shard:gq:blocked");
+    secondMaster.sets.set("other-shard:gq:blocked", ["tenant/group"]);
+    const cluster = new AuditCluster([firstMaster, secondMaster]);
+
+    const blockers = await auditGroupQueuesForStorageMigration(
+      cluster,
+      Date.now(),
+      [firstMaster, secondMaster],
+    );
+
+    expect(blockers).toEqual([
+      { queueName: "other-shard", kind: "blocked", count: 1 },
+    ]);
+  });
+});

--- a/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
@@ -30,6 +30,7 @@ describe("migrateObjectStorage task configuration", () => {
       sourceProvider: "s3",
       targetProvider: "azure",
       writesPaused: false,
+      readsPaused: false,
       s3: { bucket: "source", region: "eu-west-1" },
       azure: {
         accountName: "destination",
@@ -37,6 +38,19 @@ describe("migrateObjectStorage task configuration", () => {
         authMode: "sharedKey",
       },
     });
+  });
+
+  it("parses independent read and write pause acknowledgements", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_WRITES_PAUSED: "1",
+      OBJECT_STORAGE_MIGRATION_READS_PAUSED: "1",
+    });
+
+    expect({
+      readsPaused: config.readsPaused,
+      writesPaused: config.writesPaused,
+    }).toEqual({ readsPaused: true, writesPaused: true });
   });
 
   it("requires different source and target providers", () => {

--- a/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
@@ -9,6 +9,7 @@ import {
   parseMigrationTaskConfig,
   parseMigrationTaskPhase,
   resolveMigrationS3Region,
+  toAzureCredentials,
 } from "../migrateObjectStorage";
 
 const validEnvironment = (): NodeJS.ProcessEnv => ({
@@ -272,5 +273,59 @@ describe("createCutoverAuditRedis", () => {
     expect(audit.redis).toBe(single);
     expect(audit.scanNodes).toEqual([single]);
     expect(() => audit.cleanup()).not.toThrow();
+  });
+});
+
+describe("toAzureCredentials transport guards", () => {
+  /**
+   * The migration builds credentials from its own OBJECT_STORAGE_MIGRATION_*
+   * namespace, bypassing resolveAzureCredentials — so it must apply the same
+   * transport guards itself or a token-mode run against an http:// endpoint
+   * puts a bearer token on the wire in plaintext.
+   */
+  it("refuses a plaintext endpoint in a token-based auth mode", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE: "azureCli",
+      OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY: "",
+      OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT: "http://storage.internal:10000",
+    });
+
+    expect(() => toAzureCredentials(config)).toThrow(/must use https/);
+  });
+
+  it("refuses a sovereign endpoint without an identity authority", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE: "azureCli",
+      OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY: "",
+      OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT:
+        "https://destination.blob.core.usgovcloudapi.net",
+    });
+
+    expect(() => toAzureCredentials(config)).toThrow(/AUTHORITY_HOST/);
+  });
+
+  it("accepts a sovereign endpoint once the authority is supplied", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE: "azureCli",
+      OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY: "",
+      OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT:
+        "https://destination.blob.core.usgovcloudapi.net",
+      OBJECT_STORAGE_MIGRATION_AZURE_AUTHORITY_HOST:
+        "https://login.microsoftonline.us",
+    });
+
+    expect(toAzureCredentials(config)).toMatchObject({
+      mode: "azureCli",
+      authorityHost: "https://login.microsoftonline.us",
+    });
+  });
+
+  it("leaves sharedKey mode unguarded — no bearer token is at stake", () => {
+    const config = parseMigrationTaskConfig(validEnvironment());
+
+    expect(toAzureCredentials(config)).toMatchObject({ mode: "sharedKey" });
   });
 });

--- a/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
@@ -265,6 +265,62 @@ describe("createCutoverAuditRedis", () => {
     expect(audit.scanNodes).toHaveLength(1);
   });
 
+  /**
+   * Nothing has returned a `cleanup` to the caller yet when the handshake
+   * fails, so this is the only place the duplicate can be closed. Leaking it
+   * leaves ioredis retrying forever behind an error the operator has already
+   * seen — a task that reports a failure and then never exits.
+   */
+  it("closes the duplicate when its handshake errors instead of leaking it", async () => {
+    const events = new Map<string, (value?: unknown) => void>();
+    const duplicated = {
+      status: "connecting",
+      nodes: vi.fn(() => []),
+      disconnect: vi.fn(),
+      once: vi.fn((event: string, handler: (value?: unknown) => void) => {
+        events.set(event, handler);
+      }),
+    };
+    const shared = Object.create(Cluster.prototype) as Cluster;
+    Object.assign(shared, { duplicate: vi.fn(() => duplicated) });
+
+    const pending = createCutoverAuditRedis(shared);
+    events.get("error")?.(new Error("CLUSTERDOWN"));
+
+    await expect(pending).rejects.toThrow("CLUSTERDOWN");
+    expect(duplicated.disconnect).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * ioredis retries a cluster handshake indefinitely and emits no terminal
+   * event when every seed node is simply unreachable, so an unbounded wait
+   * would hang `finalize` silently — the one phase run with traffic paused
+   * and an operator watching.
+   */
+  it("gives up on a handshake that never completes, and closes the duplicate", async () => {
+    vi.useFakeTimers();
+    try {
+      const duplicated = {
+        status: "connecting",
+        nodes: vi.fn(() => []),
+        disconnect: vi.fn(),
+        once: vi.fn(),
+      };
+      const shared = Object.create(Cluster.prototype) as Cluster;
+      Object.assign(shared, { duplicate: vi.fn(() => duplicated) });
+
+      const pending = createCutoverAuditRedis(shared);
+      const assertion = expect(pending).rejects.toThrow(/Timed out after/);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+
+      expect(duplicated.disconnect).toHaveBeenCalledOnce();
+      expect(duplicated.nodes).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses a single-node connection as-is (no replicas to mis-route to)", async () => {
     const single = { get: vi.fn() };
 

--- a/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
@@ -1,9 +1,11 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from "vitest";
+import { Cluster } from "ioredis";
+import { describe, expect, it, vi } from "vitest";
 import {
   assertMigrationPhaseMatchesActiveProvider,
+  createCutoverAuditRedis,
   parseMigrationTaskConfig,
   parseMigrationTaskPhase,
   resolveMigrationS3Region,
@@ -207,5 +209,68 @@ describe("migrateObjectStorage task configuration", () => {
         endpoint: "https://s3.cn-north-1.amazonaws.com.cn",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("createCutoverAuditRedis", () => {
+  /**
+   * The shared app cluster client runs scaleReads: "all", so its read
+   * commands can be served by a lagging replica — which can under-count
+   * pending work, miss a staged durable reference, and hand finalization a
+   * false clean audit. The audit must read through a master-only duplicate.
+   */
+  it("audits a Redis Cluster through a master-only duplicate, never the replica-scaled shared client", async () => {
+    const masterNode = { id: "master-1" };
+    const duplicated = {
+      status: "ready",
+      nodes: vi.fn(() => [masterNode]),
+      disconnect: vi.fn(),
+      once: vi.fn(),
+    };
+    const shared = Object.create(Cluster.prototype) as Cluster;
+    Object.assign(shared, { duplicate: vi.fn(() => duplicated) });
+
+    const audit = await createCutoverAuditRedis(shared);
+
+    expect(shared.duplicate).toHaveBeenCalledWith([], {
+      scaleReads: "master",
+    });
+    expect(audit.redis).toBe(duplicated);
+    expect(duplicated.nodes).toHaveBeenCalledWith("master");
+    expect(audit.scanNodes).toEqual([masterNode]);
+    audit.cleanup();
+    expect(duplicated.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the duplicate's cluster handshake before reading its topology", async () => {
+    const events = new Map<string, (value?: unknown) => void>();
+    const duplicated = {
+      status: "connecting",
+      nodes: vi.fn(() => [{ id: "master-1" }]),
+      disconnect: vi.fn(),
+      once: vi.fn((event: string, handler: () => void) => {
+        events.set(event, handler);
+      }),
+    };
+    const shared = Object.create(Cluster.prototype) as Cluster;
+    Object.assign(shared, { duplicate: vi.fn(() => duplicated) });
+
+    const pending = createCutoverAuditRedis(shared);
+    // Topology must not be read while the handshake is still in flight.
+    expect(duplicated.nodes).not.toHaveBeenCalled();
+    events.get("ready")?.();
+    const audit = await pending;
+
+    expect(audit.scanNodes).toHaveLength(1);
+  });
+
+  it("uses a single-node connection as-is (no replicas to mis-route to)", async () => {
+    const single = { get: vi.fn() };
+
+    const audit = await createCutoverAuditRedis(single);
+
+    expect(audit.redis).toBe(single);
+    expect(audit.scanNodes).toEqual([single]);
+    expect(() => audit.cleanup()).not.toThrow();
   });
 });

--- a/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
+++ b/platform/app/src/tasks/__tests__/migrateObjectStorage.unit.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assertMigrationPhaseMatchesActiveProvider,
+  parseMigrationTaskConfig,
+  parseMigrationTaskPhase,
+  resolveMigrationS3Region,
+} from "../migrateObjectStorage";
+
+const validEnvironment = (): NodeJS.ProcessEnv => ({
+  OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER: "s3",
+  OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER: "azure",
+  OBJECT_STORAGE_MIGRATION_S3_BUCKET: "source",
+  OBJECT_STORAGE_MIGRATION_S3_REGION: "eu-west-1",
+  OBJECT_STORAGE_MIGRATION_S3_ACCESS_KEY_ID: "access",
+  OBJECT_STORAGE_MIGRATION_S3_SECRET_ACCESS_KEY: "secret",
+  OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_NAME: "destination",
+  OBJECT_STORAGE_MIGRATION_AZURE_CONTAINER: "langwatch",
+  OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE: "sharedKey",
+  OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY: "azure-secret",
+});
+
+describe("migrateObjectStorage task configuration", () => {
+  it("accepts explicit credentials that are isolated from active app storage", () => {
+    const config = parseMigrationTaskConfig(validEnvironment());
+
+    expect(config).toMatchObject({
+      sourceProvider: "s3",
+      targetProvider: "azure",
+      writesPaused: false,
+      s3: { bucket: "source", region: "eu-west-1" },
+      azure: {
+        accountName: "destination",
+        container: "langwatch",
+        authMode: "sharedKey",
+      },
+    });
+  });
+
+  it("requires different source and target providers", () => {
+    expect(() =>
+      parseMigrationTaskConfig({
+        ...validEnvironment(),
+        OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER: "s3",
+      }),
+    ).toThrow(/source and target providers must differ/);
+  });
+
+  it("rejects mixed Azure shared-key and token authentication", () => {
+    expect(() =>
+      parseMigrationTaskConfig({
+        ...validEnvironment(),
+        OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE: "managedIdentity",
+      }),
+    ).toThrow(/must not include an account key/);
+  });
+
+  it.each([
+    "plan",
+    "copy",
+    "finalize",
+    "verify",
+  ] as const)("accepts the %s phase", (phase) => {
+    expect(parseMigrationTaskPhase(phase)).toBe(phase);
+  });
+
+  it("rejects an unknown phase before making changes", () => {
+    expect(() => parseMigrationTaskPhase("delete-source")).toThrow(
+      /plan.*copy.*finalize.*verify/,
+    );
+  });
+
+  it("refuses copy when the configured source is not the active app storage", () => {
+    const config = parseMigrationTaskConfig(validEnvironment());
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "copy",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "azure",
+          AZURE_BLOB_ACCOUNT_NAME: "destination",
+          AZURE_BLOB_CONTAINER: "langwatch",
+        },
+      }),
+    ).toThrow(/expects s3.*but azure is active/);
+  });
+
+  it("refuses to copy from a different active S3 bucket", () => {
+    const config = parseMigrationTaskConfig(validEnvironment());
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "copy",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "s3",
+          S3_BUCKET_NAME: "another-bucket",
+        },
+      }),
+    ).toThrow(/expects active S3 bucket "source"/);
+  });
+
+  it("refuses to copy from a different active provider endpoint", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_S3_ENDPOINT:
+        "https://migration-s3.example.test/",
+    });
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "copy",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "s3",
+          S3_BUCKET_NAME: "source",
+          S3_ENDPOINT: "https://active-s3.example.test",
+        },
+      }),
+    ).toThrow(/active S3 endpoint.*match/);
+  });
+
+  it("requires verify to run against the deployed destination", () => {
+    const config = parseMigrationTaskConfig(validEnvironment());
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "verify",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "s3",
+          S3_BUCKET_NAME: "source",
+        },
+      }),
+    ).toThrow(/verify expects azure.*but s3 is active/);
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "verify",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "azure",
+          AZURE_BLOB_ACCOUNT_NAME: "destination",
+          AZURE_BLOB_CONTAINER: "langwatch",
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts equivalent normalized Azure endpoints after cutover", () => {
+    const config = parseMigrationTaskConfig({
+      ...validEnvironment(),
+      OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT:
+        "https://destination.blob.core.windows.net/",
+    });
+
+    expect(() =>
+      assertMigrationPhaseMatchesActiveProvider({
+        phase: "verify",
+        config,
+        activeEnvironment: {
+          STORED_OBJECTS_BACKEND: "azure",
+          AZURE_BLOB_ACCOUNT_NAME: "destination",
+          AZURE_BLOB_CONTAINER: "langwatch",
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("lets AWS resolve its region chain when no migration region is supplied", () => {
+    const environment = validEnvironment();
+    delete environment.OBJECT_STORAGE_MIGRATION_S3_REGION;
+    const config = parseMigrationTaskConfig(environment);
+
+    expect(config.s3.region).toBeUndefined();
+    expect(resolveMigrationS3Region(config.s3)).toBeUndefined();
+    expect(resolveMigrationS3Region({ region: "eu-west-1" })).toBe("eu-west-1");
+    expect(
+      resolveMigrationS3Region({
+        endpoint: "https://object.example.test",
+      }),
+    ).toBe("auto");
+    expect(
+      resolveMigrationS3Region({
+        endpoint: "https://s3.eu-west-1.amazonaws.com",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveMigrationS3Region({
+        endpoint: "https://s3.cn-north-1.amazonaws.com.cn",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -335,8 +335,12 @@ describe("Feature: Object storage provider parity and migration", () => {
       },
     ]);
 
+    // The message must name the row: this aborts the entire run, and the
+    // two addresses differ only in the bucket/account, which redaction masks
+    // — so the id is the operator's only way to tell a mis-set destination
+    // endpoint from real corruption.
     await expect(state.migration.copy()).rejects.toThrow(
-      /destination scheme.*configured destination address/,
+      new RegExp(`Stored object ${row.id} \\(project project-1\\)`),
     );
   });
 

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -335,12 +335,14 @@ describe("Feature: Object storage provider parity and migration", () => {
       },
     ]);
 
-    // The message must name the row: this aborts the entire run, and the
-    // two addresses differ only in the bucket/account, which redaction masks
-    // — so the id is the operator's only way to tell a mis-set destination
-    // endpoint from real corruption.
+    // The message must name the row: this aborts the entire run, and the two
+    // addresses differ only in the bucket/account, which redaction masks — so
+    // the id is the operator's only way to tell a mis-set destination endpoint
+    // from real corruption. Matched as a substring rather than a pattern: the
+    // id is interpolated, and a generated id carrying one regex metacharacter
+    // would silently stop matching.
     await expect(state.migration.copy()).rejects.toThrow(
-      new RegExp(`Stored object ${row.id} \\(project project-1\\)`),
+      `Stored object ${row.id} (project project-1)`,
     );
   });
 

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -1,0 +1,491 @@
+/**
+ * @vitest-environment node
+ * @integration
+ */
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { StorageDriver } from "~/server/stored-objects/storage-driver";
+import type { StoredObject } from "~/server/stored-objects/stored-object";
+import {
+  createMigrationStorageEndpoint,
+  type MigrationDataset,
+  type MigrationInventory,
+  type MigrationProject,
+  ObjectStorageMigration,
+  type QueueMigrationBlocker,
+} from "../objectStorageMigration";
+
+class MemoryDriver implements StorageDriver {
+  readonly objects = new Map<string, Buffer>();
+  readonly puts: string[] = [];
+  readonly deletes: string[] = [];
+
+  async get(uri: string): Promise<Readable> {
+    const bytes = this.objects.get(uri);
+    if (!bytes) throw new Error(`missing ${uri}`);
+    return Readable.from(bytes);
+  }
+
+  async put(uri: string, bytes: Buffer): Promise<void> {
+    this.puts.push(uri);
+    this.objects.set(uri, Buffer.from(bytes));
+  }
+
+  async delete(uri: string): Promise<void> {
+    this.deletes.push(uri);
+    this.objects.delete(uri);
+  }
+
+  async exists(uri: string): Promise<boolean> {
+    return this.objects.has(uri);
+  }
+}
+
+const digest = (bytes: Buffer) =>
+  createHash("sha256").update(bytes).digest("hex");
+
+const storedObject = ({
+  projectId,
+  bytes,
+  storageUri,
+}: {
+  projectId: string;
+  bytes: Buffer;
+  storageUri: string;
+}): StoredObject => ({
+  id: `object-${digest(bytes).slice(0, 8)}`,
+  project_id: projectId,
+  purpose: "test",
+  owner_kind: "test",
+  owner_id: "owner",
+  media_type: "application/octet-stream",
+  size_bytes: bytes.length,
+  sha256: digest(bytes),
+  storage_uri: storageUri,
+  created_at: new Date("2026-01-01T00:00:00.000Z"),
+  inserted_at: new Date("2026-01-01T00:00:00.000Z"),
+});
+
+const setup = ({
+  sourceProvider = "s3",
+  destinationProvider = "azure",
+  projects = [{ id: "project-1", privateS3: false }],
+  datasets = [],
+  queueBlockers = [],
+  writesPaused = true,
+}: {
+  sourceProvider?: "s3" | "azure";
+  destinationProvider?: "s3" | "azure";
+  projects?: MigrationProject[];
+  datasets?: MigrationDataset[];
+  queueBlockers?: QueueMigrationBlocker[];
+  writesPaused?: boolean;
+} = {}) => {
+  const sourceDriver = new MemoryDriver();
+  const destinationDriver = new MemoryDriver();
+  const source = createMigrationStorageEndpoint({
+    provider: sourceProvider,
+    driver: sourceDriver,
+    bucket: "source-bucket",
+    accountName: "source-account",
+    container: "source-container",
+  });
+  const destination = createMigrationStorageEndpoint({
+    provider: destinationProvider,
+    driver: destinationDriver,
+    bucket: "destination-bucket",
+    accountName: "destination-account",
+    container: "destination-container",
+  });
+  const rows = new Map<string, StoredObject[]>();
+  const history: StoredObject[] = [];
+  const datasetRows = [...datasets];
+  let publisher = async (row: StoredObject) => {
+    history.push(row);
+    const current = rows.get(row.project_id) ?? [];
+    rows.set(
+      row.project_id,
+      current.map((candidate) => (candidate.id === row.id ? row : candidate)),
+    );
+  };
+  const inventory: MigrationInventory = {
+    listProjectsPage: vi.fn(async (request) => pageById(projects, request)),
+    listStoredObjectsPage: vi.fn(async (projectId, request) =>
+      pageById(rows.get(projectId) ?? [], request),
+    ),
+    listDatasetsPage: vi.fn(async (request) => pageById(datasetRows, request)),
+  };
+  const migration = new ObjectStorageMigration({
+    source,
+    destination,
+    inventory,
+    publishStoredObject: async (row) => publisher(row),
+    auditQueues: async () => queueBlockers,
+    writesPaused: () => writesPaused,
+    now: () => new Date("2026-02-01T00:00:00.000Z"),
+  });
+  return {
+    migration,
+    source,
+    destination,
+    sourceDriver,
+    destinationDriver,
+    rows,
+    history,
+    datasetRows,
+    setPublisher: (next: typeof publisher) => {
+      publisher = next;
+    },
+  };
+};
+
+function pageById<T extends { id: string }>(
+  rows: T[],
+  request: { afterId?: string; limit: number },
+): T[] {
+  return rows
+    .filter((row) => request.afterId == null || row.id > request.afterId)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .slice(0, request.limit);
+}
+
+const seedStoredObject = (
+  state: ReturnType<typeof setup>,
+  projectId = "project-1",
+  bytes = Buffer.from("stored-object"),
+) => {
+  const row = storedObject({
+    projectId,
+    bytes,
+    storageUri: state.source.storedObjectUri(projectId, digest(bytes)),
+  });
+  state.rows.set(projectId, [row]);
+  state.sourceDriver.objects.set(row.storage_uri, bytes);
+  return row;
+};
+
+describe("Feature: Object storage provider parity and migration", () => {
+  /** @scenario A migration dry run changes no customer data */
+  it("A migration dry run changes no customer data", async () => {
+    const state = setup();
+    const row = seedStoredObject(state);
+
+    const report = await state.migration.plan();
+
+    expect(report.eligibleStoredObjects).toBe(1);
+    expect(state.destinationDriver.objects.size).toBe(0);
+    expect(state.rows.get("project-1")?.[0]?.storage_uri).toBe(row.storage_uri);
+  });
+
+  it("plans every page without materializing the global inventory", async () => {
+    const state = setup();
+    state.rows.set(
+      "project-1",
+      Array.from({ length: 251 }, (_, index) => {
+        const bytes = Buffer.from(`object-${index}`);
+        return {
+          ...storedObject({
+            projectId: "project-1",
+            bytes,
+            storageUri: state.source.storedObjectUri(
+              "project-1",
+              digest(bytes),
+            ),
+          }),
+          id: `object-${index.toString().padStart(4, "0")}`,
+        };
+      }),
+    );
+
+    const report = await state.migration.plan();
+
+    expect(report.eligibleStoredObjects).toBe(251);
+  });
+
+  /** @scenario Global provider migration excludes private S3 projects */
+  it("Global provider migration excludes private S3 projects", async () => {
+    const state = setup({
+      projects: [
+        { id: "global", privateS3: false },
+        { id: "private", privateS3: true },
+      ],
+    });
+    seedStoredObject(state, "global", Buffer.from("global"));
+    const privateRow = seedStoredObject(
+      state,
+      "private",
+      Buffer.from("private"),
+    );
+
+    const report = await state.migration.copy();
+
+    expect(report.excludedProjects).toEqual(["private"]);
+    expect(state.destinationDriver.puts).toHaveLength(1);
+    expect(
+      state.destinationDriver.objects.has(
+        state.destination.storedObjectUri(
+          privateRow.project_id,
+          privateRow.sha256,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  /** @scenario Online copy keeps live reads on the source provider */
+  it("Online copy keeps live reads on the source provider", async () => {
+    const state = setup();
+    const row = seedStoredObject(state);
+
+    await state.migration.copy();
+
+    const target = state.destination.storedObjectUri(
+      row.project_id,
+      row.sha256,
+    );
+    expect(state.destinationDriver.objects.get(target)).toEqual(
+      state.sourceDriver.objects.get(row.storage_uri),
+    );
+    expect(state.rows.get("project-1")?.[0]?.storage_uri).toBe(row.storage_uri);
+    expect(state.sourceDriver.deletes).toEqual([]);
+  });
+
+  /** @scenario An interrupted online copy resumes safely */
+  it("An interrupted online copy resumes safely", async () => {
+    const state = setup();
+    const verified = seedStoredObject(state, "project-1", Buffer.from("one"));
+    const mismatched = storedObject({
+      projectId: "project-1",
+      bytes: Buffer.from("two"),
+      storageUri: state.source.storedObjectUri(
+        "project-1",
+        digest(Buffer.from("two")),
+      ),
+    });
+    state.rows.set("project-1", [verified, mismatched]);
+    state.sourceDriver.objects.set(mismatched.storage_uri, Buffer.from("two"));
+    state.destinationDriver.objects.set(
+      state.destination.storedObjectUri("project-1", verified.sha256),
+      Buffer.from("one"),
+    );
+    state.destinationDriver.objects.set(
+      state.destination.storedObjectUri("project-1", mismatched.sha256),
+      Buffer.from("corrupt"),
+    );
+
+    const report = await state.migration.copy();
+
+    expect(report.skippedVerified).toBe(1);
+    expect(report.repaired).toBe(1);
+    expect(state.destinationDriver.puts).toHaveLength(1);
+  });
+
+  it("blocks a destination-scheme row that points at another endpoint", async () => {
+    const state = setup();
+    const row = seedStoredObject(state);
+    state.rows.set("project-1", [
+      {
+        ...row,
+        storage_uri: `azure-blob://another-account/another-container/project-1/${row.sha256}`,
+      },
+    ]);
+
+    await expect(state.migration.copy()).rejects.toThrow(
+      /destination scheme.*configured destination address/,
+    );
+  });
+
+  /** @scenario Active dataset uploads block finalization */
+  it("Active dataset uploads block finalization", async () => {
+    const state = setup({
+      datasets: [
+        {
+          id: "dataset-1",
+          projectId: "project-1",
+          contentLayout: "s3_jsonl",
+          status: "processing",
+          chunkCount: 1,
+        },
+      ],
+    });
+
+    await expect(state.migration.finalize()).rejects.toThrow(
+      /dataset-1.*processing/,
+    );
+    expect(state.history).toEqual([]);
+  });
+
+  /** @scenario A dataset with no usable chunk count is reported rather than aborting the run */
+  it("A dataset with no usable chunk count is reported rather than aborting the run", async () => {
+    const state = setup({
+      datasets: [
+        {
+          id: "dataset-abandoned",
+          projectId: "project-1",
+          contentLayout: "s3_jsonl",
+          status: "ready",
+          chunkCount: null,
+        },
+      ],
+    });
+    const row = seedStoredObject(state);
+
+    const plan = await state.migration.plan();
+    expect(plan.blockingDatasets).toEqual([
+      {
+        id: "dataset-abandoned",
+        status: "ready",
+        reason: "invalid-chunk-count",
+      },
+    ]);
+
+    // The eligible stored object still copies — one unusable dataset row must
+    // not deny the operator the progress they can safely make.
+    const report = await state.migration.copy();
+    expect(report.copied).toBe(1);
+    expect(
+      state.destinationDriver.objects.has(
+        state.destination.storedObjectUri(row.project_id, row.sha256),
+      ),
+    ).toBe(true);
+
+    await expect(state.migration.finalize()).rejects.toThrow(
+      /dataset-abandoned.*invalid-chunk-count/,
+    );
+    expect(state.history).toEqual([]);
+  });
+
+  /** @scenario Outstanding queue work blocks finalization */
+  it.each([
+    "pending",
+    "delayed",
+    "active",
+    "blocked",
+    "staged-durable-ref",
+  ] as const)("Outstanding queue work blocks finalization: %s", async (kind) => {
+    const state = setup({
+      queueBlockers: [{ queueName: "events", kind, count: 1 }],
+    });
+
+    await expect(state.migration.finalize()).rejects.toThrow(
+      new RegExp(`events.*${kind}`),
+    );
+    expect(state.history).toEqual([]);
+  });
+
+  /** @scenario Finalization publishes verified destination addresses without erasing history */
+  it("Finalization publishes verified destination addresses without erasing history", async () => {
+    const state = setup();
+    const row = seedStoredObject(state);
+
+    await state.migration.copy();
+    await state.migration.finalize();
+
+    expect(state.history).toHaveLength(1);
+    expect(state.history[0]?.storage_uri).toBe(
+      state.destination.storedObjectUri(row.project_id, row.sha256),
+    );
+    expect(state.history[0]?.inserted_at.getTime()).toBeGreaterThan(
+      row.inserted_at.getTime(),
+    );
+    expect(state.sourceDriver.objects.has(row.storage_uri)).toBe(true);
+  });
+
+  /** @scenario A finalized provider migration preserves durable customer data */
+  it.each([
+    ["s3", "azure"],
+    ["azure", "s3"],
+  ] as const)("A finalized provider migration preserves durable customer data: %s to %s", async (sourceProvider, destinationProvider) => {
+    const state = setup({ sourceProvider, destinationProvider });
+    const row = seedStoredObject(state);
+    const dataset: MigrationDataset = {
+      id: "dataset-1",
+      projectId: "project-1",
+      contentLayout: "s3_jsonl",
+      status: "ready",
+      chunkCount: 2,
+    };
+    state.datasetRows.push(dataset);
+    for (let index = 0; index < (dataset.chunkCount ?? 0); index++) {
+      state.sourceDriver.objects.set(
+        state.source.datasetChunkUri(dataset.projectId, dataset.id, index),
+        Buffer.from(`chunk-${index}`),
+      );
+    }
+
+    const result = await state.migration.finalize();
+
+    expect(result.destinationProvider).toBe(destinationProvider);
+    expect(state.rows.get("project-1")?.[0]?.storage_uri).toBe(
+      state.destination.storedObjectUri(row.project_id, row.sha256),
+    );
+    expect(
+      state.destinationDriver.objects.has(
+        state.destination.datasetChunkUri(dataset.projectId, dataset.id, 1),
+      ),
+    ).toBe(true);
+  });
+
+  /** @scenario A failed finalization can be resumed before traffic restarts */
+  it("A failed finalization can be resumed before traffic restarts", async () => {
+    const state = setup();
+    const first = seedStoredObject(state, "project-1", Buffer.from("one"));
+    const second = storedObject({
+      projectId: "project-1",
+      bytes: Buffer.from("two"),
+      storageUri: state.source.storedObjectUri(
+        "project-1",
+        digest(Buffer.from("two")),
+      ),
+    });
+    state.rows.set("project-1", [first, second]);
+    state.sourceDriver.objects.set(second.storage_uri, Buffer.from("two"));
+    let publications = 0;
+    state.setPublisher(async (row) => {
+      publications += 1;
+      if (publications === 2) throw new Error("ClickHouse unavailable");
+      state.history.push(row);
+      state.rows.set(
+        row.project_id,
+        (state.rows.get(row.project_id) ?? []).map((candidate) =>
+          candidate.id === row.id ? row : candidate,
+        ),
+      );
+    });
+
+    await expect(state.migration.finalize()).rejects.toThrow(
+      "ClickHouse unavailable",
+    );
+    state.setPublisher(async (row) => {
+      state.history.push(row);
+      state.rows.set(
+        row.project_id,
+        (state.rows.get(row.project_id) ?? []).map((candidate) =>
+          candidate.id === row.id ? row : candidate,
+        ),
+      );
+    });
+
+    const report = await state.migration.finalize();
+
+    expect(report.publishedStoredObjects).toBe(1);
+    expect(
+      state.rows
+        .get("project-1")
+        ?.every((row) =>
+          row.storage_uri.startsWith(`${state.destination.scheme}://`),
+        ),
+    ).toBe(true);
+  });
+
+  /** @scenario Successful migration does not delete source data */
+  it("Successful migration does not delete source data", async () => {
+    const state = setup();
+    const row = seedStoredObject(state);
+
+    await state.migration.finalize();
+
+    expect(state.sourceDriver.objects.has(row.storage_uri)).toBe(true);
+    expect(state.sourceDriver.deletes).toEqual([]);
+  });
+});

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { Readable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { StorageDriver } from "~/server/stored-objects/storage-driver";
+import { StorageRegistry } from "~/server/stored-objects/storage-registry";
 import type { StoredObject } from "~/server/stored-objects/stored-object";
 import {
   createMigrationStorageEndpoint,
@@ -74,6 +75,7 @@ const setup = ({
   datasets = [],
   queueBlockers = [],
   writesPaused = true,
+  readsPaused = true,
 }: {
   sourceProvider?: "s3" | "azure";
   destinationProvider?: "s3" | "azure";
@@ -81,6 +83,7 @@ const setup = ({
   datasets?: MigrationDataset[];
   queueBlockers?: QueueMigrationBlocker[];
   writesPaused?: boolean;
+  readsPaused?: boolean;
 } = {}) => {
   const sourceDriver = new MemoryDriver();
   const destinationDriver = new MemoryDriver();
@@ -123,6 +126,7 @@ const setup = ({
     publishStoredObject: async (row) => publisher(row),
     auditQueues: async () => queueBlockers,
     writesPaused: () => writesPaused,
+    readsPaused: () => readsPaused,
     now: () => new Date("2026-02-01T00:00:00.000Z"),
   });
   return {
@@ -164,6 +168,14 @@ const seedStoredObject = (
   state.sourceDriver.objects.set(row.storage_uri, bytes);
   return row;
 };
+
+async function readBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
 
 describe("Feature: Object storage provider parity and migration", () => {
   /** @scenario A migration dry run changes no customer data */
@@ -315,6 +327,17 @@ describe("Feature: Object storage provider parity and migration", () => {
     expect(state.history).toEqual([]);
   });
 
+  /** @scenario Unpaused read traffic blocks finalization */
+  it("Unpaused read traffic blocks finalization", async () => {
+    const state = setup({ readsPaused: false, writesPaused: true });
+    seedStoredObject(state);
+
+    await expect(state.migration.finalize()).rejects.toThrow(
+      /reads.*paused|read traffic/i,
+    );
+    expect(state.history).toEqual([]);
+  });
+
   /** @scenario A dataset with no usable chunk count is reported rather than aborting the run */
   it("A dataset with no usable chunk count is reported rather than aborting the run", async () => {
     const state = setup({
@@ -414,16 +437,42 @@ describe("Feature: Object storage provider parity and migration", () => {
     }
 
     const result = await state.migration.finalize();
+    const activeRegistry = new StorageRegistry({
+      s3:
+        destinationProvider === "s3"
+          ? state.destinationDriver
+          : state.sourceDriver,
+      file: new MemoryDriver(),
+      "azure-blob":
+        destinationProvider === "azure"
+          ? state.destinationDriver
+          : state.sourceDriver,
+    });
+    const publishedRow = state.rows.get("project-1")?.[0];
+    const newBytes = Buffer.from("post-cutover-write");
+    const newUri = state.destination.storedObjectUri(
+      "project-1",
+      digest(newBytes),
+    );
+    await activeRegistry.put(newUri, newBytes, "application/octet-stream");
 
     expect(result.destinationProvider).toBe(destinationProvider);
-    expect(state.rows.get("project-1")?.[0]?.storage_uri).toBe(
+    expect(publishedRow?.storage_uri).toBe(
       state.destination.storedObjectUri(row.project_id, row.sha256),
     );
     expect(
-      state.destinationDriver.objects.has(
-        state.destination.datasetChunkUri(dataset.projectId, dataset.id, 1),
+      await readBuffer(await activeRegistry.get(publishedRow!.storage_uri)),
+    ).toEqual(Buffer.from("stored-object"));
+    expect(
+      await readBuffer(
+        await state.destination.driver.get(
+          state.destination.datasetChunkUri(dataset.projectId, dataset.id, 1),
+        ),
       ),
-    ).toBe(true);
+    ).toEqual(Buffer.from("chunk-1"));
+    expect(await readBuffer(await activeRegistry.get(newUri))).toEqual(
+      newBytes,
+    );
   });
 
   /** @scenario A failed finalization can be resumed before traffic restarts */

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -117,7 +117,12 @@ const setup = ({
     listStoredObjectsPage: vi.fn(async (projectId, request) =>
       pageById(rows.get(projectId) ?? [], request),
     ),
-    listDatasetsPage: vi.fn(async (request) => pageById(datasetRows, request)),
+    listDatasetsPage: vi.fn(async (projectId, request) =>
+      pageById(
+        datasetRows.filter((dataset) => dataset.projectId === projectId),
+        request,
+      ),
+    ),
   };
   const migration = new ObjectStorageMigration({
     source,
@@ -336,6 +341,57 @@ describe("Feature: Object storage provider parity and migration", () => {
       /reads.*paused|read traffic/i,
     );
     expect(state.history).toEqual([]);
+  });
+
+  /** @scenario A dataset already stored at the destination does not abort the copy */
+  it("A dataset already stored at the destination does not abort the copy", async () => {
+    const state = setup({
+      datasets: [
+        {
+          id: "dataset-on-destination",
+          projectId: "project-1",
+          contentLayout: "s3_jsonl",
+          status: "ready",
+          chunkCount: 1,
+        },
+      ],
+    });
+    const row = seedStoredObject(state);
+    // The chunk exists ONLY at the destination — uploaded while that
+    // provider was briefly the active backend (#6323 posture).
+    state.destinationDriver.objects.set(
+      state.destination.datasetChunkUri("project-1", "dataset-on-destination", 0),
+      Buffer.from("chunk-at-destination"),
+    );
+
+    const report = await state.migration.copy();
+
+    expect(report.skippedVerified).toBe(1);
+    expect(report.copied).toBe(1);
+    expect(
+      state.destinationDriver.objects.has(
+        state.destination.storedObjectUri(row.project_id, row.sha256),
+      ),
+    ).toBe(true);
+  });
+
+  /** @scenario A dataset already stored at the destination does not abort the copy */
+  it("blocks when a chunk is missing from both providers", async () => {
+    const state = setup({
+      datasets: [
+        {
+          id: "dataset-lost",
+          projectId: "project-1",
+          contentLayout: "s3_jsonl",
+          status: "ready",
+          chunkCount: 1,
+        },
+      ],
+    });
+
+    await expect(state.migration.copy()).rejects.toThrow(
+      /missing from both providers/,
+    );
   });
 
   /** @scenario A dataset with no usable chunk count is reported rather than aborting the run */

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -360,7 +360,11 @@ describe("Feature: Object storage provider parity and migration", () => {
     // The chunk exists ONLY at the destination — uploaded while that
     // provider was briefly the active backend (#6323 posture).
     state.destinationDriver.objects.set(
-      state.destination.datasetChunkUri("project-1", "dataset-on-destination", 0),
+      state.destination.datasetChunkUri(
+        "project-1",
+        "dataset-on-destination",
+        0,
+      ),
       Buffer.from("chunk-at-destination"),
     );
 

--- a/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
+++ b/platform/app/src/tasks/__tests__/objectStorageMigration.integration.test.ts
@@ -195,6 +195,34 @@ describe("Feature: Object storage provider parity and migration", () => {
     expect(state.rows.get("project-1")?.[0]?.storage_uri).toBe(row.storage_uri);
   });
 
+  /** @scenario Rows outside both providers are reported, never silently dropped */
+  it("Rows outside both providers are reported, never silently dropped", async () => {
+    const state = setup();
+    const eligible = seedStoredObject(state);
+    const foreign = storedObject({
+      projectId: "project-1",
+      bytes: Buffer.from("local-era-object"),
+      storageUri: `file:///var/lib/langwatch/project-1/${digest(Buffer.from("local-era-object"))}`,
+    });
+    state.rows.set("project-1", [eligible, foreign]);
+
+    const plan = await state.migration.plan();
+    // The plan names what will NOT migrate — a total that silently excluded
+    // the file:// row would claim the migration covers more than it does.
+    expect(plan.eligibleStoredObjects).toBe(1);
+    expect(plan.foreignSchemeRows).toBe(1);
+    expect(plan.foreignSchemes).toEqual(["file"]);
+
+    // ...and the foreign row is untouched by copy + finalize.
+    const report = await state.migration.copy();
+    expect(report.foreignSchemeRows).toBe(1);
+    await state.migration.finalize();
+    expect(
+      state.rows.get("project-1")?.find((r) => r.id === foreign.id)
+        ?.storage_uri,
+    ).toBe(foreign.storage_uri);
+  });
+
   it("plans every page without materializing the global inventory", async () => {
     const state = setup();
     state.rows.set(

--- a/platform/app/src/tasks/groupQueueMigrationAudit.ts
+++ b/platform/app/src/tasks/groupQueueMigrationAudit.ts
@@ -1,0 +1,184 @@
+import {
+  isEnvelope,
+  readEnvelopeTieredRefFromHeader,
+  splitEnvelope,
+} from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
+import { GROUP_QUEUE_REGISTRY_KEY } from "~/server/event-sourcing/queues/groupQueue/scripts";
+import type { QueueMigrationBlocker } from "./objectStorageMigration";
+
+/**
+ * Small Redis surface used by the one-off migration audit. IORedis implements
+ * it directly; keeping the boundary narrow makes the audit independently
+ * testable and prevents it from mutating queue state.
+ */
+export interface QueueAuditRedis {
+  smembers(key: string): Promise<string[]>;
+  get(key: string): Promise<string | null>;
+  zcard(key: string): Promise<number>;
+  zcount(
+    key: string,
+    min: number | string,
+    max: number | string,
+  ): Promise<number>;
+  scard(key: string): Promise<number>;
+  scan(
+    cursor: string,
+    ...args: Array<string | number>
+  ): Promise<[string, string[]]>;
+  hvals(key: string): Promise<string[]>;
+}
+
+/**
+ * Read-only cutover gate for GroupQueue.
+ *
+ * Registry membership is supplemented by a bounded SCAN of `*:gq:ready` so
+ * queues created by an older release cannot escape the audit. The one-off
+ * migration deliberately favors completeness over hot-path cost.
+ */
+export async function auditGroupQueuesForStorageMigration(
+  redis: QueueAuditRedis,
+  nowMs = Date.now(),
+  scanNodes: QueueAuditRedis[] = [redis],
+): Promise<QueueMigrationBlocker[]> {
+  const queueNames = await discoverQueueNames(redis, scanNodes);
+  const blockers: QueueMigrationBlocker[] = [];
+  for (const queueName of queueNames) {
+    blockers.push(
+      ...(await auditQueue({ redis, scanNodes, queueName, nowMs })),
+    );
+  }
+  return blockers;
+}
+
+async function discoverQueueNames(
+  redis: QueueAuditRedis,
+  scanNodes: QueueAuditRedis[],
+): Promise<string[]> {
+  const [registered, ready, blocked, active, data] = await Promise.all([
+    redis.smembers(GROUP_QUEUE_REGISTRY_KEY),
+    scanKeys(scanNodes, "*:gq:ready"),
+    scanKeys(scanNodes, "*:gq:blocked"),
+    scanKeys(scanNodes, "*:gq:group:*:active"),
+    scanKeys(scanNodes, "*:gq:group:*:data"),
+  ]);
+  const queueNames = new Set(registered);
+  for (const key of [...ready, ...blocked, ...active, ...data]) {
+    const marker = key.indexOf(":gq:");
+    if (marker > 0) queueNames.add(key.slice(0, marker));
+  }
+  return [...queueNames].sort();
+}
+
+async function auditQueue({
+  redis,
+  scanNodes,
+  queueName,
+  nowMs,
+}: {
+  redis: QueueAuditRedis;
+  scanNodes: QueueAuditRedis[];
+  queueName: string;
+  nowMs: number;
+}): Promise<QueueMigrationBlocker[]> {
+  const prefix = `${queueName}:gq:`;
+  const [pending, delayed, active, blocked] = await Promise.all([
+    countPending(redis, prefix),
+    redis.zcount(`${prefix}ready`, `(${nowMs}`, "+inf"),
+    scanKeys(scanNodes, `${prefix}group:*:active`).then((keys) => keys.length),
+    redis.scard(`${prefix}blocked`),
+  ]);
+  const cheapCounts = [
+    ["pending", pending],
+    ["delayed", delayed],
+    ["active", active],
+    ["blocked", blocked],
+  ] as const;
+  const cheapBlockers: QueueMigrationBlocker[] = cheapCounts
+    .filter(([, count]) => count > 0)
+    .map(([kind, count]) => ({ queueName, kind, count }));
+  if (cheapBlockers.length > 0) return cheapBlockers;
+
+  // Only inspect staged payloads after the cheap state gates are clear. A
+  // large live backlog is already a definitive blocker; fetching every hash
+  // value in that case adds avoidable Redis traffic and migration-task heap.
+  const durableRefs = await countDurableRefs(redis, scanNodes, prefix);
+  return durableRefs > 0
+    ? [
+        {
+          queueName,
+          kind: "staged-durable-ref",
+          count: durableRefs,
+        },
+      ]
+    : [];
+}
+
+async function countPending(
+  redis: QueueAuditRedis,
+  prefix: string,
+): Promise<number> {
+  const [totalPendingValue, readyCount] = await Promise.all([
+    redis.get(`${prefix}stats:total-pending`),
+    redis.zcard(`${prefix}ready`),
+  ]);
+  const totalPending = Number(totalPendingValue);
+  return Number.isFinite(totalPending)
+    ? Math.max(totalPending, readyCount)
+    : readyCount;
+}
+
+async function countDurableRefs(
+  redis: QueueAuditRedis,
+  scanNodes: QueueAuditRedis[],
+  prefix: string,
+): Promise<number> {
+  const dataKeys = await scanKeys(scanNodes, `${prefix}group:*:data`);
+  let count = 0;
+  for (const key of dataKeys) {
+    count += (await redis.hvals(key)).filter(hasS3DurableReference).length;
+  }
+  return count;
+}
+
+function hasS3DurableReference(value: string): boolean {
+  if (!isEnvelope(value)) return false;
+  try {
+    return (
+      readEnvelopeTieredRefFromHeader(splitEnvelope(value).header)?.tier ===
+      "s3"
+    );
+  } catch {
+    // Malformed staged values remain blocked by pending/blocked queue state.
+    return false;
+  }
+}
+
+async function scanKeys(
+  scanNodes: QueueAuditRedis[],
+  pattern: string,
+): Promise<string[]> {
+  const results = await Promise.all(
+    scanNodes.map((target) => scanSingleNode(target, pattern)),
+  );
+  return [...new Set(results.flat())];
+}
+
+async function scanSingleNode(
+  redis: QueueAuditRedis,
+  pattern: string,
+): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor = "0";
+  do {
+    const [next, batch] = await redis.scan(
+      cursor,
+      "MATCH",
+      pattern,
+      "COUNT",
+      500,
+    );
+    keys.push(...batch);
+    cursor = next;
+  } while (cursor !== "0");
+  return keys;
+}

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -414,16 +414,51 @@ export async function createCutoverAuditRedis(
   // finishes its own cluster handshake — reading it earlier would hand the
   // audit zero scan targets and silently audit nothing.
   if (masterOnly.status !== "ready") {
-    await new Promise<void>((resolve, reject) => {
-      masterOnly.once("ready", () => resolve());
-      masterOnly.once("error", (error) => reject(error));
-    });
+    try {
+      await waitForClusterReady(masterOnly);
+    } catch (error) {
+      // Nothing has returned a `cleanup` to the caller yet, so this is the
+      // only place the duplicate can be closed. Without it a failed handshake
+      // leaves an ioredis Cluster retrying forever behind an error the
+      // operator does see — a task that reports a failure and then does not
+      // exit.
+      masterOnly.disconnect();
+      throw error;
+    }
   }
   return {
     redis: masterOnly as unknown as QueueAuditRedis,
     scanNodes: masterOnly.nodes("master") as unknown as QueueAuditRedis[],
     cleanup: () => masterOnly.disconnect(),
   };
+}
+
+/**
+ * ioredis retries a cluster handshake indefinitely and emits no terminal
+ * event when every seed node is simply unreachable. Without a bound, a
+ * `finalize` run against a wedged Redis waits forever having printed nothing
+ * — indistinguishable from a slow audit, and the one phase where an operator
+ * is watching with traffic paused. Fail loudly instead.
+ */
+const CUTOVER_AUDIT_HANDSHAKE_TIMEOUT_MS = 30_000;
+
+function waitForClusterReady(cluster: Cluster): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out after ${CUTOVER_AUDIT_HANDSHAKE_TIMEOUT_MS}ms waiting for the cutover-audit Redis connection to become ready`,
+        ),
+      );
+    }, CUTOVER_AUDIT_HANDSHAKE_TIMEOUT_MS);
+    const settle = (error?: Error) => {
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    cluster.once("ready", () => settle());
+    cluster.once("error", (error: Error) => settle(error));
+  });
 }
 
 async function runMigrationPhase(

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -28,7 +28,10 @@ import { getPrivateS3Configs } from "~/server/dataplane-s3";
 import { prisma } from "~/server/db";
 import { connection } from "~/server/redis";
 import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
-import type { AzureCredentials } from "~/server/stored-objects/azure-credentials";
+import {
+  type AzureCredentials,
+  assertTokenModeTransportSafety,
+} from "~/server/stored-objects/azure-credentials";
 import { ObjectNotFoundError } from "~/server/stored-objects/errors";
 import type { StorageDriver } from "~/server/stored-objects/storage-driver";
 import { StoredObjectsRepository } from "~/server/stored-objects/stored-objects.repository";
@@ -433,7 +436,9 @@ async function runMigrationPhase(
   return migration.finalize();
 }
 
-function toAzureCredentials(config: MigrationTaskConfig): AzureCredentials {
+export function toAzureCredentials(
+  config: MigrationTaskConfig,
+): AzureCredentials {
   const common = {
     accountName: config.azure.accountName,
     endpointBaseUrl: config.azure.endpoint,
@@ -445,6 +450,14 @@ function toAzureCredentials(config: MigrationTaskConfig): AzureCredentials {
       accountKey: config.azure.accountKey!,
     };
   }
+  // The same transport guards the app's own resolver enforces: without them
+  // a token-mode migration against an http:// endpoint would put a bearer
+  // token on the wire in plaintext, and a sovereign endpoint without an
+  // authority host would request tokens from the public-cloud issuer.
+  assertTokenModeTransportSafety({
+    endpointBaseUrl: config.azure.endpoint,
+    authorityHost: config.azure.authorityHost,
+  });
   return {
     mode: config.azure.authMode,
     ...common,

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -371,13 +371,56 @@ async function auditQueuesForCutover() {
       "Redis is required to audit GroupQueue before migration finalization",
     );
   }
-  return auditGroupQueuesForStorageMigration(
-    connection as unknown as QueueAuditRedis,
-    Date.now(),
-    connection instanceof Cluster
-      ? (connection.nodes("master") as unknown as QueueAuditRedis[])
-      : [connection as unknown as QueueAuditRedis],
-  );
+  const { redis, scanNodes, cleanup } =
+    await createCutoverAuditRedis(connection);
+  try {
+    return await auditGroupQueuesForStorageMigration(
+      redis,
+      Date.now(),
+      scanNodes,
+    );
+  } finally {
+    cleanup();
+  }
+}
+
+/**
+ * The app's shared cluster client runs `scaleReads: "all"`, so its read
+ * commands (GET/SMEMBERS/ZCOUNT/ZCARD/SCARD/HVALS) may be served by a
+ * lagging replica. A stale replica can under-count pending work or miss a
+ * staged durable reference, hand finalization a false clean audit, and
+ * strand that payload after cutover. The audit therefore reads through a
+ * master-only duplicate of the connection; single-node Redis has no
+ * replicas to mis-route to and is used as-is.
+ */
+export async function createCutoverAuditRedis(
+  sharedConnection: unknown,
+): Promise<{
+  redis: QueueAuditRedis;
+  scanNodes: QueueAuditRedis[];
+  cleanup: () => void;
+}> {
+  if (!(sharedConnection instanceof Cluster)) {
+    const redis = sharedConnection as QueueAuditRedis;
+    return { redis, scanNodes: [redis], cleanup: () => void 0 };
+  }
+  const masterOnly = sharedConnection.duplicate([], {
+    scaleReads: "master",
+  });
+  // nodes() reflects discovered topology, which is empty until the duplicate
+  // finishes its own cluster handshake — reading it earlier would hand the
+  // audit zero scan targets and silently audit nothing.
+  if (masterOnly.status !== "ready") {
+    await new Promise<void>((resolve, reject) => {
+      masterOnly.once("ready", () => resolve());
+      masterOnly.once("error", (error) => reject(error));
+    });
+  }
+  return {
+    redis: masterOnly as unknown as QueueAuditRedis,
+    scanNodes: masterOnly.nodes("master") as unknown as QueueAuditRedis[],
+    cleanup: () => masterOnly.disconnect(),
+  };
 }
 
 async function runMigrationPhase(

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -5,6 +5,7 @@
  *   pnpm run task migrateObjectStorage plan
  *   pnpm run task migrateObjectStorage copy
  *   OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+ *   OBJECT_STORAGE_MIGRATION_READS_PAUSED=1 \
  *     pnpm run task migrateObjectStorage finalize
  *   pnpm run task migrateObjectStorage verify
  *
@@ -56,6 +57,7 @@ const taskConfigSchema = z
     sourceProvider: providerSchema,
     targetProvider: providerSchema,
     writesPaused: z.boolean(),
+    readsPaused: z.boolean(),
     s3: z.object({
       bucket: z.string().min(1),
       endpoint: z.string().url().optional(),
@@ -116,6 +118,7 @@ export function parseMigrationTaskConfig(
     sourceProvider: source.OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER,
     targetProvider: source.OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER,
     writesPaused: source.OBJECT_STORAGE_MIGRATION_WRITES_PAUSED === "1",
+    readsPaused: source.OBJECT_STORAGE_MIGRATION_READS_PAUSED === "1",
     s3: {
       bucket: source.OBJECT_STORAGE_MIGRATION_S3_BUCKET,
       endpoint: source.OBJECT_STORAGE_MIGRATION_S3_ENDPOINT || undefined,
@@ -288,6 +291,7 @@ export function createMigrationTask({
     publishStoredObject,
     auditQueues,
     writesPaused: () => config.writesPaused,
+    readsPaused: () => config.readsPaused,
   });
 }
 
@@ -300,8 +304,30 @@ export default async function execute(phaseValue?: string): Promise<void> {
     activeEnvironment: process.env,
   });
   const repository = new StoredObjectsRepository();
-  const privateOrganizations = getPrivateS3Configs();
-  const inventory: MigrationInventory = {
+  const migration = createMigrationTask({
+    config,
+    inventory: createMigrationInventory(repository, getPrivateS3Configs()),
+    publishStoredObject: (row) =>
+      repository.insert({ projectId: row.project_id, row }),
+    auditQueues: auditQueuesForCutover,
+  });
+  const report = await runMigrationPhase(migration, phase);
+  logger.info(
+    {
+      phase,
+      report,
+      source: config.sourceProvider,
+      target: config.targetProvider,
+    },
+    "Object-storage migration phase completed",
+  );
+}
+
+function createMigrationInventory(
+  repository: StoredObjectsRepository,
+  privateOrganizations: ReadonlyMap<string, unknown>,
+): MigrationInventory {
+  return {
     listProjectsPage: async ({ afterId, limit }) => {
       const projects = await prisma.project.findMany({
         where: afterId ? { id: { gt: afterId } } : undefined,
@@ -333,44 +359,31 @@ export default async function execute(phaseValue?: string): Promise<void> {
         },
       }),
   };
-  const migration = createMigrationTask({
-    config,
-    inventory,
-    publishStoredObject: (row) =>
-      repository.insert({ projectId: row.project_id, row }),
-    auditQueues: async () => {
-      if (!connection) {
-        throw new Error(
-          "Redis is required to audit GroupQueue before migration finalization",
-        );
-      }
-      return auditGroupQueuesForStorageMigration(
-        connection as unknown as QueueAuditRedis,
-        Date.now(),
-        connection instanceof Cluster
-          ? (connection.nodes("master") as unknown as QueueAuditRedis[])
-          : [connection as unknown as QueueAuditRedis],
-      );
-    },
-  });
+}
 
-  const report =
-    phase === "plan"
-      ? await migration.plan()
-      : phase === "copy"
-        ? await migration.copy()
-        : phase === "verify"
-          ? await migration.verify()
-          : await migration.finalize();
-  logger.info(
-    {
-      phase,
-      report,
-      source: config.sourceProvider,
-      target: config.targetProvider,
-    },
-    "Object-storage migration phase completed",
+async function auditQueuesForCutover() {
+  if (!connection) {
+    throw new Error(
+      "Redis is required to audit GroupQueue before migration finalization",
+    );
+  }
+  return auditGroupQueuesForStorageMigration(
+    connection as unknown as QueueAuditRedis,
+    Date.now(),
+    connection instanceof Cluster
+      ? (connection.nodes("master") as unknown as QueueAuditRedis[])
+      : [connection as unknown as QueueAuditRedis],
   );
+}
+
+async function runMigrationPhase(
+  migration: ObjectStorageMigration,
+  phase: MigrationTaskPhase,
+) {
+  if (phase === "plan") return migration.plan();
+  if (phase === "copy") return migration.copy();
+  if (phase === "verify") return migration.verify();
+  return migration.finalize();
 }
 
 function toAzureCredentials(config: MigrationTaskConfig): AzureCredentials {

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -345,9 +345,13 @@ function createMigrationInventory(
     },
     listStoredObjectsPage: (projectId, { afterId, limit }) =>
       repository.findLiveRowsByProjectPage({ projectId, afterId, limit }),
-    listDatasetsPage: ({ afterId, limit }) =>
+    listDatasetsPage: (projectId, { afterId, limit }) =>
       prisma.dataset.findMany({
-        where: afterId ? { id: { gt: afterId } } : undefined,
+        // projectId is mandatory here twice over: the multitenancy middleware
+        // rejects Dataset queries without it, and the migration's own scope
+        // guarantees (BYOC exclusion) rely on only eligible projects being
+        // asked for.
+        where: { projectId, ...(afterId ? { id: { gt: afterId } } : {}) },
         orderBy: { id: "asc" },
         take: limit,
         select: {

--- a/platform/app/src/tasks/migrateObjectStorage.ts
+++ b/platform/app/src/tasks/migrateObjectStorage.ts
@@ -1,0 +1,512 @@
+/**
+ * Operator task for controlled S3 <-> Azure Blob migration.
+ *
+ * Usage:
+ *   pnpm run task migrateObjectStorage plan
+ *   pnpm run task migrateObjectStorage copy
+ *   OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
+ *     pnpm run task migrateObjectStorage finalize
+ *   pnpm run task migrateObjectStorage verify
+ *
+ * Credentials are read only from the OBJECT_STORAGE_MIGRATION_* namespace.
+ * They never need to be placed in command-line arguments or made active app
+ * credentials before cutover.
+ */
+import type { Readable } from "node:stream";
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { createLogger } from "@langwatch/observability";
+import { Cluster } from "ioredis";
+import { z } from "zod";
+import { getPrivateS3Configs } from "~/server/dataplane-s3";
+import { prisma } from "~/server/db";
+import { connection } from "~/server/redis";
+import { AzureBlobDriver } from "~/server/stored-objects/azure-blob-driver";
+import type { AzureCredentials } from "~/server/stored-objects/azure-credentials";
+import { ObjectNotFoundError } from "~/server/stored-objects/errors";
+import type { StorageDriver } from "~/server/stored-objects/storage-driver";
+import { StoredObjectsRepository } from "~/server/stored-objects/stored-objects.repository";
+import {
+  auditGroupQueuesForStorageMigration,
+  type QueueAuditRedis,
+} from "./groupQueueMigrationAudit";
+import {
+  createMigrationStorageEndpoint,
+  type MigrationInventory,
+  ObjectStorageMigration,
+} from "./objectStorageMigration";
+
+const logger = createLogger("langwatch:tasks:migrate-object-storage");
+
+const providerSchema = z.enum(["s3", "azure"]);
+const authModeSchema = z.enum([
+  "sharedKey",
+  "workloadIdentity",
+  "managedIdentity",
+  "azureCli",
+]);
+
+const taskConfigSchema = z
+  .object({
+    sourceProvider: providerSchema,
+    targetProvider: providerSchema,
+    writesPaused: z.boolean(),
+    s3: z.object({
+      bucket: z.string().min(1),
+      endpoint: z.string().url().optional(),
+      region: z.string().min(1).optional(),
+      accessKeyId: z.string().min(1).optional(),
+      secretAccessKey: z.string().min(1).optional(),
+      sessionToken: z.string().min(1).optional(),
+    }),
+    azure: z.object({
+      accountName: z.string().min(1),
+      container: z.string().min(1),
+      accountKey: z.string().min(1).optional(),
+      endpoint: z.string().url().optional(),
+      authMode: authModeSchema.default("sharedKey"),
+      authorityHost: z.string().url().optional(),
+      tokenAudience: z.string().url().optional(),
+    }),
+  })
+  .superRefine((value, context) => {
+    if (value.sourceProvider === value.targetProvider) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["targetProvider"],
+        message: "source and target providers must differ",
+      });
+    }
+    if ((value.s3.accessKeyId == null) !== (value.s3.secretAccessKey == null)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["s3"],
+        message:
+          "S3 access key id and secret access key must be provided together",
+      });
+    }
+    if (value.azure.authMode === "sharedKey" && !value.azure.accountKey) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["azure", "accountKey"],
+        message: "Azure sharedKey migration auth requires an account key",
+      });
+    }
+    if (value.azure.authMode !== "sharedKey" && value.azure.accountKey) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["azure", "accountKey"],
+        message: "Azure token migration auth must not include an account key",
+      });
+    }
+  });
+
+export type MigrationTaskConfig = z.infer<typeof taskConfigSchema>;
+export type MigrationTaskPhase = "plan" | "copy" | "finalize" | "verify";
+
+export function parseMigrationTaskConfig(
+  source: NodeJS.ProcessEnv,
+): MigrationTaskConfig {
+  return taskConfigSchema.parse({
+    sourceProvider: source.OBJECT_STORAGE_MIGRATION_SOURCE_PROVIDER,
+    targetProvider: source.OBJECT_STORAGE_MIGRATION_TARGET_PROVIDER,
+    writesPaused: source.OBJECT_STORAGE_MIGRATION_WRITES_PAUSED === "1",
+    s3: {
+      bucket: source.OBJECT_STORAGE_MIGRATION_S3_BUCKET,
+      endpoint: source.OBJECT_STORAGE_MIGRATION_S3_ENDPOINT || undefined,
+      region: source.OBJECT_STORAGE_MIGRATION_S3_REGION || undefined,
+      accessKeyId:
+        source.OBJECT_STORAGE_MIGRATION_S3_ACCESS_KEY_ID || undefined,
+      secretAccessKey:
+        source.OBJECT_STORAGE_MIGRATION_S3_SECRET_ACCESS_KEY || undefined,
+      sessionToken:
+        source.OBJECT_STORAGE_MIGRATION_S3_SESSION_TOKEN || undefined,
+    },
+    azure: {
+      accountName: source.OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_NAME,
+      container: source.OBJECT_STORAGE_MIGRATION_AZURE_CONTAINER,
+      accountKey:
+        source.OBJECT_STORAGE_MIGRATION_AZURE_ACCOUNT_KEY || undefined,
+      endpoint: source.OBJECT_STORAGE_MIGRATION_AZURE_ENDPOINT || undefined,
+      authMode: source.OBJECT_STORAGE_MIGRATION_AZURE_AUTH_MODE || undefined,
+      authorityHost:
+        source.OBJECT_STORAGE_MIGRATION_AZURE_AUTHORITY_HOST || undefined,
+      tokenAudience:
+        source.OBJECT_STORAGE_MIGRATION_AZURE_TOKEN_AUDIENCE || undefined,
+    },
+  });
+}
+
+export function parseMigrationTaskPhase(
+  value: string | undefined,
+): MigrationTaskPhase {
+  if (
+    value === "plan" ||
+    value === "copy" ||
+    value === "finalize" ||
+    value === "verify"
+  ) {
+    return value;
+  }
+  throw new Error(
+    'Migration phase must be one of "plan", "copy", "finalize", or "verify"',
+  );
+}
+
+export function assertMigrationPhaseMatchesActiveProvider({
+  phase,
+  config,
+  activeEnvironment,
+}: {
+  phase: MigrationTaskPhase;
+  config: MigrationTaskConfig;
+  activeEnvironment: NodeJS.ProcessEnv;
+}): void {
+  const expectedProvider =
+    phase === "verify" ? config.targetProvider : config.sourceProvider;
+  const activeProvider =
+    activeEnvironment.STORED_OBJECTS_BACKEND === "azure" ? "azure" : "s3";
+  if (activeProvider !== expectedProvider) {
+    throw new Error(
+      `Migration ${phase} expects ${expectedProvider} to be the active app provider, but ${activeProvider} is active`,
+    );
+  }
+
+  if (expectedProvider === "s3") {
+    assertActiveS3Matches({ phase, config, activeEnvironment });
+    return;
+  }
+  assertActiveAzureMatches({ phase, config, activeEnvironment });
+}
+
+function assertActiveS3Matches({
+  phase,
+  config,
+  activeEnvironment,
+}: {
+  phase: MigrationTaskPhase;
+  config: MigrationTaskConfig;
+  activeEnvironment: NodeJS.ProcessEnv;
+}): void {
+  if (activeEnvironment.S3_BUCKET_NAME !== config.s3.bucket) {
+    throw new Error(
+      `Migration ${phase} expects active S3 bucket "${config.s3.bucket}", but S3_BUCKET_NAME is ${activeEnvironment.S3_BUCKET_NAME ? `"${activeEnvironment.S3_BUCKET_NAME}"` : "unset"}`,
+    );
+  }
+  if (
+    normalizeEndpoint(activeEnvironment.S3_ENDPOINT) !==
+    normalizeEndpoint(config.s3.endpoint)
+  ) {
+    throw new Error(
+      `Migration ${phase} expects the active S3 endpoint to match the migration endpoint`,
+    );
+  }
+}
+
+function assertActiveAzureMatches({
+  phase,
+  config,
+  activeEnvironment,
+}: {
+  phase: MigrationTaskPhase;
+  config: MigrationTaskConfig;
+  activeEnvironment: NodeJS.ProcessEnv;
+}): void {
+  if (
+    activeEnvironment.AZURE_BLOB_ACCOUNT_NAME !== config.azure.accountName ||
+    activeEnvironment.AZURE_BLOB_CONTAINER !== config.azure.container
+  ) {
+    throw new Error(
+      `Migration ${phase} expects the active Azure account/container to match the migration endpoint`,
+    );
+  }
+  if (
+    effectiveAzureEndpoint(
+      config.azure.accountName,
+      activeEnvironment.AZURE_BLOB_ENDPOINT,
+    ) !==
+    effectiveAzureEndpoint(config.azure.accountName, config.azure.endpoint)
+  ) {
+    throw new Error(
+      `Migration ${phase} expects the active Azure endpoint to match the migration endpoint`,
+    );
+  }
+}
+
+function normalizeEndpoint(value: string | undefined): string | undefined {
+  return value?.trim().replace(/\/+$/, "") || undefined;
+}
+
+function effectiveAzureEndpoint(
+  accountName: string,
+  endpoint: string | undefined,
+): string {
+  return (
+    normalizeEndpoint(endpoint) ??
+    `https://${accountName}.blob.core.windows.net`
+  );
+}
+
+export function createMigrationTask({
+  config,
+  inventory,
+  publishStoredObject,
+  auditQueues,
+}: {
+  config: MigrationTaskConfig;
+  inventory: MigrationInventory;
+  publishStoredObject: ConstructorParameters<
+    typeof ObjectStorageMigration
+  >[0]["publishStoredObject"];
+  auditQueues: ConstructorParameters<
+    typeof ObjectStorageMigration
+  >[0]["auditQueues"];
+}): ObjectStorageMigration {
+  const endpoints = {
+    s3: createMigrationStorageEndpoint({
+      provider: "s3",
+      driver: new ExplicitS3Driver(config.s3),
+      bucket: config.s3.bucket,
+    }),
+    azure: createMigrationStorageEndpoint({
+      provider: "azure",
+      driver: new AzureBlobDriver(toAzureCredentials(config)),
+      accountName: config.azure.accountName,
+      container: config.azure.container,
+    }),
+  };
+
+  return new ObjectStorageMigration({
+    source: endpoints[config.sourceProvider],
+    destination: endpoints[config.targetProvider],
+    inventory,
+    publishStoredObject,
+    auditQueues,
+    writesPaused: () => config.writesPaused,
+  });
+}
+
+export default async function execute(phaseValue?: string): Promise<void> {
+  const phase = parseMigrationTaskPhase(phaseValue);
+  const config = parseMigrationTaskConfig(process.env);
+  assertMigrationPhaseMatchesActiveProvider({
+    phase,
+    config,
+    activeEnvironment: process.env,
+  });
+  const repository = new StoredObjectsRepository();
+  const privateOrganizations = getPrivateS3Configs();
+  const inventory: MigrationInventory = {
+    listProjectsPage: async ({ afterId, limit }) => {
+      const projects = await prisma.project.findMany({
+        where: afterId ? { id: { gt: afterId } } : undefined,
+        orderBy: { id: "asc" },
+        take: limit,
+        select: {
+          id: true,
+          team: { select: { organizationId: true } },
+        },
+      });
+      return projects.map((project) => ({
+        id: project.id,
+        privateS3: privateOrganizations.has(project.team.organizationId),
+      }));
+    },
+    listStoredObjectsPage: (projectId, { afterId, limit }) =>
+      repository.findLiveRowsByProjectPage({ projectId, afterId, limit }),
+    listDatasetsPage: ({ afterId, limit }) =>
+      prisma.dataset.findMany({
+        where: afterId ? { id: { gt: afterId } } : undefined,
+        orderBy: { id: "asc" },
+        take: limit,
+        select: {
+          id: true,
+          projectId: true,
+          contentLayout: true,
+          status: true,
+          chunkCount: true,
+        },
+      }),
+  };
+  const migration = createMigrationTask({
+    config,
+    inventory,
+    publishStoredObject: (row) =>
+      repository.insert({ projectId: row.project_id, row }),
+    auditQueues: async () => {
+      if (!connection) {
+        throw new Error(
+          "Redis is required to audit GroupQueue before migration finalization",
+        );
+      }
+      return auditGroupQueuesForStorageMigration(
+        connection as unknown as QueueAuditRedis,
+        Date.now(),
+        connection instanceof Cluster
+          ? (connection.nodes("master") as unknown as QueueAuditRedis[])
+          : [connection as unknown as QueueAuditRedis],
+      );
+    },
+  });
+
+  const report =
+    phase === "plan"
+      ? await migration.plan()
+      : phase === "copy"
+        ? await migration.copy()
+        : phase === "verify"
+          ? await migration.verify()
+          : await migration.finalize();
+  logger.info(
+    {
+      phase,
+      report,
+      source: config.sourceProvider,
+      target: config.targetProvider,
+    },
+    "Object-storage migration phase completed",
+  );
+}
+
+function toAzureCredentials(config: MigrationTaskConfig): AzureCredentials {
+  const common = {
+    accountName: config.azure.accountName,
+    endpointBaseUrl: config.azure.endpoint,
+  };
+  if (config.azure.authMode === "sharedKey") {
+    return {
+      mode: "sharedKey",
+      ...common,
+      accountKey: config.azure.accountKey!,
+    };
+  }
+  return {
+    mode: config.azure.authMode,
+    ...common,
+    authorityHost: config.azure.authorityHost,
+    audience: config.azure.tokenAudience,
+  };
+}
+
+class ExplicitS3Driver implements StorageDriver {
+  private readonly client: S3Client;
+
+  constructor(config: MigrationTaskConfig["s3"]) {
+    this.client = new S3Client({
+      region: resolveMigrationS3Region(config),
+      endpoint: config.endpoint,
+      forcePathStyle: !!config.endpoint,
+      credentials:
+        config.accessKeyId && config.secretAccessKey
+          ? {
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+              sessionToken: config.sessionToken,
+            }
+          : undefined,
+    });
+  }
+
+  async get(uri: string): Promise<Readable> {
+    const { bucket, key } = parseS3Uri(uri);
+    try {
+      const response = await this.client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: key }),
+      );
+      return response.Body as Readable;
+    } catch (error) {
+      if (isS3Missing(error)) throw new ObjectNotFoundError(uri);
+      throw error;
+    }
+  }
+
+  async put(uri: string, bytes: Buffer, mediaType: string): Promise<void> {
+    const { bucket, key } = parseS3Uri(uri);
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: bytes,
+        ContentType: mediaType,
+      }),
+    );
+  }
+
+  async delete(uri: string): Promise<void> {
+    const { bucket, key } = parseS3Uri(uri);
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: bucket, Key: key }),
+    );
+  }
+
+  async exists(uri: string): Promise<boolean> {
+    const { bucket, key } = parseS3Uri(uri);
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: bucket, Key: key }),
+      );
+      return true;
+    } catch (error) {
+      if (isS3Missing(error)) return false;
+      throw error;
+    }
+  }
+}
+
+export function resolveMigrationS3Region(
+  config: Pick<MigrationTaskConfig["s3"], "endpoint" | "region">,
+): string | undefined {
+  // Match the application's production S3 composition: AWS uses the SDK
+  // region/provider chain when no region was explicitly supplied, while
+  // custom S3 endpoints retain the historical "auto" default.
+  return (
+    config.region ??
+    (config.endpoint && !isAwsS3Endpoint(config.endpoint) ? "auto" : undefined)
+  );
+}
+
+function isAwsS3Endpoint(endpoint: string): boolean {
+  try {
+    const hostname = new URL(endpoint).hostname.toLowerCase();
+    return (
+      hostname === "s3.amazonaws.com" ||
+      hostname.endsWith(".amazonaws.com") ||
+      hostname.endsWith(".amazonaws.com.cn")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseS3Uri(uri: string): { bucket: string; key: string } {
+  const parsed = new URL(uri);
+  if (
+    parsed.protocol !== "s3:" ||
+    !parsed.hostname ||
+    parsed.pathname === "/"
+  ) {
+    throw new Error(`Invalid S3 migration URI: ${uri}`);
+  }
+  return {
+    bucket: parsed.hostname,
+    key: parsed.pathname.slice(1),
+  };
+}
+
+function isS3Missing(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const value = error as {
+    name?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    value.name === "NoSuchKey" ||
+    value.name === "NotFound" ||
+    value.$metadata?.httpStatusCode === 404
+  );
+}

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -114,6 +114,15 @@ export function createMigrationStorageEndpoint({
 export type MigrationPlan = {
   eligibleStoredObjects: number;
   eligibleDatasetChunks: number;
+  /**
+   * Live rows whose scheme is neither the source nor the destination (e.g.
+   * `file://` on a deployment that once used local storage). They are outside
+   * this migration's scope — untouched, still readable through scheme
+   * dispatch — but the plan must say they exist: a total that silently
+   * excludes them tells the operator the migration covers more than it does.
+   */
+  foreignSchemeRows: number;
+  foreignSchemes: string[];
   excludedProjects: string[];
   blockingDatasets: Array<{
     id: string;
@@ -389,13 +398,14 @@ export class ObjectStorageMigration {
         await this.acceptDestinationOnlyChunk(chunk);
         continue;
       }
-      const sourceBytes = await readAll(
+      // Verification never needs the bytes resident — hash both streams.
+      const sourceSha256 = await sha256OfStream(
         await this.deps.source.driver.get(chunk.sourceUri),
       );
       await assertUriDigest(
         this.deps.destination.driver,
         chunk.destinationUri,
-        sha256(sourceBytes),
+        sourceSha256,
       );
     }
   }
@@ -421,8 +431,13 @@ export class ObjectStorageMigration {
   private async buildPlan(scope: EligibleScope): Promise<MigrationPlan> {
     let eligibleStoredObjects = 0;
     let eligibleDatasetChunks = 0;
+    let foreignSchemeRows = 0;
+    const foreignSchemes = new Set<string>();
     const blockingDatasets: MigrationPlan["blockingDatasets"] = [];
-    for await (const _row of this.eligibleStoredObjects(scope)) {
+    for await (const _row of this.eligibleStoredObjects(scope, (scheme) => {
+      foreignSchemeRows += 1;
+      foreignSchemes.add(scheme);
+    })) {
       eligibleStoredObjects += 1;
     }
     for await (const dataset of this.datasets(scope)) {
@@ -444,13 +459,24 @@ export class ObjectStorageMigration {
     return {
       eligibleStoredObjects,
       eligibleDatasetChunks,
+      foreignSchemeRows,
+      foreignSchemes: [...foreignSchemes].sort(),
       excludedProjects: scope.excludedProjects,
       blockingDatasets,
     };
   }
 
+  /**
+   * Yields rows on the source or destination scheme; anything else — a
+   * `file://` row from a local-filesystem deployment, an address left by an
+   * unrelated earlier migration — is out of this migration's scope. Those
+   * rows are NOT touched and stay readable through scheme dispatch, but they
+   * must never vanish silently: `onForeignScheme` lets `buildPlan` count and
+   * name them so the operator's plan states what will not migrate.
+   */
   private async *eligibleStoredObjects(
     scope: EligibleScope,
+    onForeignScheme?: (scheme: string) => void,
   ): AsyncGenerator<StoredObject> {
     for (const projectId of [...scope.eligibleProjectIds].sort()) {
       for await (const row of paginate((request) =>
@@ -462,6 +488,8 @@ export class ObjectStorageMigration {
           scheme === this.deps.destination.scheme
         ) {
           yield row;
+        } else {
+          onForeignScheme?.(scheme);
         }
       }
     }
@@ -538,6 +566,10 @@ async function copyVerified({
   expectedSha256?: string;
   mediaType: string;
 }): Promise<"copied" | "repaired" | "skippedVerified"> {
+  // The ONLY full copy held in memory: `StorageDriver.put` takes a Buffer,
+  // so the source bytes must be resident to write them. Every digest below
+  // hashes its stream chunk-by-chunk instead of buffering a second (or
+  // third) copy alongside — peak residency is one object, not two or three.
   const sourceBytes = await readAll(await source.driver.get(sourceUri));
   const sourceSha256 = sha256(sourceBytes);
   if (expectedSha256 && sourceSha256 !== expectedSha256) {
@@ -546,10 +578,10 @@ async function copyVerified({
     );
   }
   if (await destination.driver.exists(destinationUri)) {
-    const destinationBytes = await readAll(
+    const destinationSha256 = await sha256OfStream(
       await destination.driver.get(destinationUri),
     );
-    if (sha256(destinationBytes) === sourceSha256) {
+    if (destinationSha256 === sourceSha256) {
       return "skippedVerified";
     }
     await destination.driver.put(destinationUri, sourceBytes, mediaType);
@@ -569,8 +601,7 @@ async function assertUriDigest(
   if (!(await driver.exists(uri))) {
     throw new Error(`Destination object is missing: ${redactStorageUri(uri)}`);
   }
-  const bytes = await readAll(await driver.get(uri));
-  const actual = sha256(bytes);
+  const actual = await sha256OfStream(await driver.get(uri));
   if (actual !== expectedSha256) {
     throw new Error(
       `Destination object verification failed for ${redactStorageUri(uri)}: expected ${expectedSha256}, got ${actual}`,
@@ -588,4 +619,13 @@ async function readAll(stream: Readable): Promise<Buffer> {
 
 function sha256(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Digest a stream chunk-by-chunk — nothing is retained beyond the hash state. */
+async function sha256OfStream(stream: Readable): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of stream) {
+    hash.update(chunk as Buffer);
+  }
+  return hash.digest("hex");
 }

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -226,8 +226,14 @@ export class ObjectStorageMigration {
       );
       if (row.storage_uri.startsWith(`${this.deps.destination.scheme}://`)) {
         if (row.storage_uri !== destinationUri) {
+          // This aborts the whole run, so it has to say WHICH row. The two
+          // addresses themselves cannot go in the message: they differ only
+          // in the bucket / storage account, which is exactly what
+          // redactStorageUri masks, so quoting them would print two identical
+          // strings. The id is what lets the operator look the row up and
+          // tell a mis-set destination endpoint from real corruption.
           throw new MigrationBlockedError(
-            "A stored object already uses the destination scheme but not the configured destination address",
+            `Stored object ${row.id} (project ${row.project_id}) already uses the ${this.deps.destination.scheme} scheme, but its recorded bucket/account is not the one configured as this migration's destination`,
           );
         }
         await assertUriDigest(

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -154,6 +154,7 @@ type ObjectStorageMigrationDeps = {
   publishStoredObject(row: StoredObject): Promise<void>;
   auditQueues(): Promise<QueueMigrationBlocker[]>;
   writesPaused(): boolean;
+  readsPaused(): boolean;
   now?: () => Date;
 };
 
@@ -255,6 +256,11 @@ export class ObjectStorageMigration {
     if (!this.deps.writesPaused()) {
       throw new MigrationBlockedError(
         "Finalization requires writes to be paused",
+      );
+    }
+    if (!this.deps.readsPaused()) {
+      throw new MigrationBlockedError(
+        "Finalization requires read traffic to be paused",
       );
     }
 

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -1,0 +1,536 @@
+/**
+ * Controlled S3 <-> Azure object-storage migration.
+ *
+ * The core is deliberately provider-neutral and dependency-injected. The
+ * operational task can wire real Prisma, ClickHouse, Redis, S3, and Azure
+ * boundaries while integration tests use in-memory drivers. No phase deletes
+ * source bytes.
+ */
+import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
+import { chunkKey } from "~/server/datasets/dataset-chunking";
+import { redactStorageUri } from "~/server/stored-objects/project-storage-destination";
+import type { StorageDriver } from "~/server/stored-objects/storage-driver";
+import type { StoredObject } from "~/server/stored-objects/stored-object";
+import { mintAzureBlobUri, mintS3Uri } from "~/server/stored-objects/uri";
+
+export type MigrationProvider = "s3" | "azure";
+
+export type MigrationProject = {
+  id: string;
+  /** A tenant-owned bucket is never included in a global provider migration. */
+  privateS3: boolean;
+};
+
+export type MigrationDataset = {
+  id: string;
+  projectId: string;
+  contentLayout: string;
+  status: string;
+  chunkCount: number | null;
+};
+
+export type QueueMigrationBlocker = {
+  queueName: string;
+  kind: "pending" | "delayed" | "active" | "blocked" | "staged-durable-ref";
+  count: number;
+};
+
+export interface MigrationInventory {
+  listProjectsPage(request: MigrationPageRequest): Promise<MigrationProject[]>;
+  /** Returns a stable id-ordered page of latest ReplacingMergeTree versions. */
+  listStoredObjectsPage(
+    projectId: string,
+    request: MigrationPageRequest,
+  ): Promise<StoredObject[]>;
+  /** Includes archived datasets: they remain recoverable customer data. */
+  listDatasetsPage(request: MigrationPageRequest): Promise<MigrationDataset[]>;
+}
+
+export type MigrationPageRequest = {
+  afterId?: string;
+  limit: number;
+};
+
+export type MigrationStorageEndpoint = {
+  provider: MigrationProvider;
+  scheme: "s3" | "azure-blob";
+  driver: StorageDriver;
+  storedObjectUri(projectId: string, sha256: string): string;
+  datasetChunkUri(projectId: string, datasetId: string, index: number): string;
+};
+
+export function createMigrationStorageEndpoint({
+  provider,
+  driver,
+  bucket,
+  accountName,
+  container,
+}: {
+  provider: MigrationProvider;
+  driver: StorageDriver;
+  bucket?: string;
+  accountName?: string;
+  container?: string;
+}): MigrationStorageEndpoint {
+  if (provider === "s3") {
+    if (!bucket?.trim()) {
+      throw new Error("S3 migration endpoint requires a bucket");
+    }
+    return {
+      provider,
+      scheme: "s3",
+      driver,
+      storedObjectUri: (projectId, sha256) =>
+        mintS3Uri({ bucket, projectId, sha256 }),
+      datasetChunkUri: (projectId, datasetId, index) =>
+        `s3://${bucket}/${chunkKey(projectId, datasetId, index)}`,
+    };
+  }
+  if (!accountName?.trim() || !container?.trim()) {
+    throw new Error(
+      "Azure migration endpoint requires an account name and container",
+    );
+  }
+  return {
+    provider,
+    scheme: "azure-blob",
+    driver,
+    storedObjectUri: (projectId, sha256) =>
+      mintAzureBlobUri({ accountName, container, projectId, sha256 }),
+    datasetChunkUri: (projectId, datasetId, index) =>
+      `azure-blob://${accountName}/${container}/${chunkKey(projectId, datasetId, index)}`,
+  };
+}
+
+export type MigrationPlan = {
+  eligibleStoredObjects: number;
+  eligibleDatasetChunks: number;
+  excludedProjects: string[];
+  blockingDatasets: Array<{
+    id: string;
+    status: string;
+    reason: DatasetBlockerReason;
+  }>;
+};
+
+/**
+ * `active-upload` — the dataset is mid-write, so its chunk set is still moving.
+ * `invalid-chunk-count` — an `s3_jsonl` dataset with a null/negative
+ * `chunkCount`. Reachable on any install: the direct-upload flow creates the
+ * row at presign time with `contentLayout='s3_jsonl'` and fills `chunkCount`
+ * only once the normalize job lands, so every abandoned upload leaves one
+ * behind. Reported, never thrown from `plan` — the phase whose whole job is to
+ * enumerate blockers must survive finding one.
+ */
+export type DatasetBlockerReason = "active-upload" | "invalid-chunk-count";
+
+export type MigrationCopyReport = MigrationPlan & {
+  copied: number;
+  repaired: number;
+  skippedVerified: number;
+};
+
+export type MigrationFinalizeReport = {
+  destinationProvider: MigrationProvider;
+  publishedStoredObjects: number;
+};
+
+export class MigrationBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationBlockedError";
+  }
+}
+
+type ObjectStorageMigrationDeps = {
+  source: MigrationStorageEndpoint;
+  destination: MigrationStorageEndpoint;
+  inventory: MigrationInventory;
+  /**
+   * Must append a newer stored_objects version. It must never ALTER UPDATE or
+   * delete the prior version.
+   */
+  publishStoredObject(row: StoredObject): Promise<void>;
+  auditQueues(): Promise<QueueMigrationBlocker[]>;
+  writesPaused(): boolean;
+  now?: () => Date;
+};
+
+type EligibleScope = {
+  eligibleProjectIds: Set<string>;
+  excludedProjects: string[];
+};
+
+const INVENTORY_PAGE_SIZE = 250;
+
+export class ObjectStorageMigration {
+  private readonly now: () => Date;
+
+  constructor(private readonly deps: ObjectStorageMigrationDeps) {
+    if (deps.source.provider === deps.destination.provider) {
+      throw new Error("Migration source and destination providers must differ");
+    }
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  async plan(): Promise<MigrationPlan> {
+    const scope = await this.eligibleScope();
+    return this.buildPlan(scope);
+  }
+
+  async copy(): Promise<MigrationCopyReport> {
+    const scope = await this.eligibleScope();
+    const plan = await this.buildPlan(scope);
+    return this.copyEligible(scope, plan);
+  }
+
+  private async copyEligible(
+    scope: EligibleScope,
+    plan: MigrationPlan,
+  ): Promise<MigrationCopyReport> {
+    const report: MigrationCopyReport = {
+      ...plan,
+      copied: 0,
+      repaired: 0,
+      skippedVerified: 0,
+    };
+
+    for await (const row of this.eligibleStoredObjects(scope)) {
+      const destinationUri = this.deps.destination.storedObjectUri(
+        row.project_id,
+        row.sha256,
+      );
+      if (row.storage_uri.startsWith(`${this.deps.destination.scheme}://`)) {
+        if (row.storage_uri !== destinationUri) {
+          throw new MigrationBlockedError(
+            "A stored object already uses the destination scheme but not the configured destination address",
+          );
+        }
+        await assertUriDigest(
+          this.deps.destination.driver,
+          destinationUri,
+          row.sha256,
+        );
+        report.skippedVerified += 1;
+        continue;
+      }
+      const result = await copyVerified({
+        source: this.deps.source,
+        sourceUri: row.storage_uri,
+        destination: this.deps.destination,
+        destinationUri,
+        expectedSha256: row.sha256,
+        mediaType: row.media_type,
+      });
+      report[result] += 1;
+    }
+
+    for await (const dataset of this.eligibleDatasets(scope)) {
+      for (let index = 0; index < dataset.chunkCount; index++) {
+        const sourceUri = this.deps.source.datasetChunkUri(
+          dataset.projectId,
+          dataset.id,
+          index,
+        );
+        const destinationUri = this.deps.destination.datasetChunkUri(
+          dataset.projectId,
+          dataset.id,
+          index,
+        );
+        const result = await copyVerified({
+          source: this.deps.source,
+          sourceUri,
+          destination: this.deps.destination,
+          destinationUri,
+          mediaType: "application/x-ndjson",
+        });
+        report[result] += 1;
+      }
+    }
+    return report;
+  }
+
+  async finalize(): Promise<MigrationFinalizeReport> {
+    if (!this.deps.writesPaused()) {
+      throw new MigrationBlockedError(
+        "Finalization requires writes to be paused",
+      );
+    }
+
+    const scope = await this.eligibleScope();
+    const plan = await this.buildPlan(scope);
+    if (plan.blockingDatasets.length > 0) {
+      const detail = plan.blockingDatasets
+        .map(({ id, status, reason }) => `${id} (${status}, ${reason})`)
+        .join(", ");
+      throw new MigrationBlockedError(
+        `Finalization blocked by datasets: ${detail}`,
+      );
+    }
+    const queueBlockers = await this.deps.auditQueues();
+    if (queueBlockers.length > 0) {
+      const detail = queueBlockers
+        .map(({ queueName, kind, count }) => `${queueName} ${kind}=${count}`)
+        .join(", ");
+      throw new MigrationBlockedError(
+        `Finalization blocked by queues: ${detail}`,
+      );
+    }
+
+    // A final delta copy runs only after writers stop. Every destination byte
+    // is verified before any address is published.
+    await this.copyEligible(scope, plan);
+    await this.verifyEligible(scope);
+
+    let publishedStoredObjects = 0;
+    for await (const row of this.eligibleStoredObjects(scope)) {
+      const destinationUri = this.deps.destination.storedObjectUri(
+        row.project_id,
+        row.sha256,
+      );
+      if (row.storage_uri === destinationUri) {
+        continue;
+      }
+      const insertedAt = newerVersionTimestamp(row.inserted_at, this.now());
+      await this.deps.publishStoredObject({
+        ...row,
+        storage_uri: destinationUri,
+        inserted_at: insertedAt,
+      });
+      publishedStoredObjects += 1;
+    }
+
+    return {
+      destinationProvider: this.deps.destination.provider,
+      publishedStoredObjects,
+    };
+  }
+
+  async verify(): Promise<void> {
+    const scope = await this.eligibleScope();
+    await this.verifyEligible(scope);
+  }
+
+  private async verifyEligible(scope: EligibleScope): Promise<void> {
+    for await (const row of this.eligibleStoredObjects(scope)) {
+      const destinationUri = this.deps.destination.storedObjectUri(
+        row.project_id,
+        row.sha256,
+      );
+      await assertUriDigest(
+        this.deps.destination.driver,
+        destinationUri,
+        row.sha256,
+      );
+    }
+    for await (const dataset of this.eligibleDatasets(scope)) {
+      for (let index = 0; index < dataset.chunkCount; index++) {
+        const sourceUri = this.deps.source.datasetChunkUri(
+          dataset.projectId,
+          dataset.id,
+          index,
+        );
+        const destinationUri = this.deps.destination.datasetChunkUri(
+          dataset.projectId,
+          dataset.id,
+          index,
+        );
+        const sourceBytes = await readAll(
+          await this.deps.source.driver.get(sourceUri),
+        );
+        await assertUriDigest(
+          this.deps.destination.driver,
+          destinationUri,
+          sha256(sourceBytes),
+        );
+      }
+    }
+  }
+
+  private async eligibleScope(): Promise<EligibleScope> {
+    const eligibleProjectIds = new Set<string>();
+    const excludedProjects: string[] = [];
+    for await (const project of paginate((request) =>
+      this.deps.inventory.listProjectsPage(request),
+    )) {
+      if (project.privateS3) {
+        excludedProjects.push(project.id);
+      } else {
+        eligibleProjectIds.add(project.id);
+      }
+    }
+    return {
+      eligibleProjectIds,
+      excludedProjects: excludedProjects.sort(),
+    };
+  }
+
+  private async buildPlan(scope: EligibleScope): Promise<MigrationPlan> {
+    let eligibleStoredObjects = 0;
+    let eligibleDatasetChunks = 0;
+    const blockingDatasets: MigrationPlan["blockingDatasets"] = [];
+    for await (const _row of this.eligibleStoredObjects(scope)) {
+      eligibleStoredObjects += 1;
+    }
+    for await (const dataset of this.datasets(scope)) {
+      const { id, status, contentLayout } = dataset;
+      if (status === "uploading" || status === "processing") {
+        blockingDatasets.push({ id, status, reason: "active-upload" });
+      }
+      if (contentLayout !== "s3_jsonl") continue;
+      // The count tracks what `copy` will attempt, which includes a dataset
+      // that is merely mid-upload: copying a moving dataset is safe because
+      // finalize re-copies the delta and refuses to run while it is still
+      // listed as a blocker.
+      if (hasMigratableChunkCount(dataset)) {
+        eligibleDatasetChunks += dataset.chunkCount;
+        continue;
+      }
+      blockingDatasets.push({ id, status, reason: "invalid-chunk-count" });
+    }
+    return {
+      eligibleStoredObjects,
+      eligibleDatasetChunks,
+      excludedProjects: scope.excludedProjects,
+      blockingDatasets,
+    };
+  }
+
+  private async *eligibleStoredObjects(
+    scope: EligibleScope,
+  ): AsyncGenerator<StoredObject> {
+    for (const projectId of [...scope.eligibleProjectIds].sort()) {
+      for await (const row of paginate((request) =>
+        this.deps.inventory.listStoredObjectsPage(projectId, request),
+      )) {
+        const scheme = row.storage_uri.slice(0, row.storage_uri.indexOf(":"));
+        if (
+          scheme === this.deps.source.scheme ||
+          scheme === this.deps.destination.scheme
+        ) {
+          yield row;
+        }
+      }
+    }
+  }
+
+  private async *datasets(
+    scope: EligibleScope,
+  ): AsyncGenerator<MigrationDataset> {
+    for await (const dataset of paginate((request) =>
+      this.deps.inventory.listDatasetsPage(request),
+    )) {
+      if (scope.eligibleProjectIds.has(dataset.projectId)) yield dataset;
+    }
+  }
+
+  private async *eligibleDatasets(
+    scope: EligibleScope,
+  ): AsyncGenerator<MigrationDataset & { chunkCount: number }> {
+    for await (const dataset of this.datasets(scope)) {
+      if (dataset.contentLayout !== "s3_jsonl") continue;
+      // Skipped rather than thrown: a dataset with no usable chunk count has
+      // no derivable chunk keys, so there is nothing to copy or verify. It is
+      // already reported by `plan` and already refuses finalization, so
+      // aborting the whole run here would only deny the operator the copy
+      // progress they can safely make first.
+      if (!hasMigratableChunkCount(dataset)) continue;
+      yield dataset;
+    }
+  }
+}
+
+async function* paginate<T extends { id: string }>(
+  load: (request: MigrationPageRequest) => Promise<T[]>,
+): AsyncGenerator<T> {
+  let afterId: string | undefined;
+  for (;;) {
+    const page = await load({ afterId, limit: INVENTORY_PAGE_SIZE });
+    if (page.length === 0) return;
+    for (const row of page) yield row;
+    const nextAfterId = page.at(-1)?.id;
+    if (!nextAfterId || nextAfterId === afterId) {
+      throw new Error("Migration inventory pagination did not advance");
+    }
+    afterId = nextAfterId;
+    if (page.length < INVENTORY_PAGE_SIZE) return;
+  }
+}
+
+function hasMigratableChunkCount(
+  dataset: MigrationDataset,
+): dataset is MigrationDataset & { chunkCount: number } {
+  return dataset.chunkCount != null && dataset.chunkCount >= 0;
+}
+
+function newerVersionTimestamp(previous: Date, candidate: Date): Date {
+  return new Date(Math.max(candidate.getTime(), previous.getTime() + 1));
+}
+
+async function copyVerified({
+  source,
+  sourceUri,
+  destination,
+  destinationUri,
+  expectedSha256,
+  mediaType,
+}: {
+  source: MigrationStorageEndpoint;
+  sourceUri: string;
+  destination: MigrationStorageEndpoint;
+  destinationUri: string;
+  expectedSha256?: string;
+  mediaType: string;
+}): Promise<"copied" | "repaired" | "skippedVerified"> {
+  const sourceBytes = await readAll(await source.driver.get(sourceUri));
+  const sourceSha256 = sha256(sourceBytes);
+  if (expectedSha256 && sourceSha256 !== expectedSha256) {
+    throw new Error(
+      `Source object verification failed for ${redactStorageUri(sourceUri)}: expected ${expectedSha256}, got ${sourceSha256}`,
+    );
+  }
+  if (await destination.driver.exists(destinationUri)) {
+    const destinationBytes = await readAll(
+      await destination.driver.get(destinationUri),
+    );
+    if (sha256(destinationBytes) === sourceSha256) {
+      return "skippedVerified";
+    }
+    await destination.driver.put(destinationUri, sourceBytes, mediaType);
+    await assertUriDigest(destination.driver, destinationUri, sourceSha256);
+    return "repaired";
+  }
+  await destination.driver.put(destinationUri, sourceBytes, mediaType);
+  await assertUriDigest(destination.driver, destinationUri, sourceSha256);
+  return "copied";
+}
+
+async function assertUriDigest(
+  driver: StorageDriver,
+  uri: string,
+  expectedSha256: string,
+): Promise<void> {
+  if (!(await driver.exists(uri))) {
+    throw new Error(`Destination object is missing: ${redactStorageUri(uri)}`);
+  }
+  const bytes = await readAll(await driver.get(uri));
+  const actual = sha256(bytes);
+  if (actual !== expectedSha256) {
+    throw new Error(
+      `Destination object verification failed for ${redactStorageUri(uri)}: expected ${expectedSha256}, got ${actual}`,
+    );
+  }
+}
+
+async function readAll(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -171,6 +171,11 @@ type EligibleScope = {
   excludedProjects: string[];
 };
 
+type DatasetChunkUris = {
+  sourceUri: string;
+  destinationUri: string;
+};
+
 const INVENTORY_PAGE_SIZE = 250;
 
 export class ObjectStorageMigration {
@@ -235,45 +240,67 @@ export class ObjectStorageMigration {
       report[result] += 1;
     }
 
-    for await (const dataset of this.eligibleDatasets(scope)) {
-      for (let index = 0; index < dataset.chunkCount; index++) {
-        const sourceUri = this.deps.source.datasetChunkUri(
-          dataset.projectId,
-          dataset.id,
-          index,
-        );
-        const destinationUri = this.deps.destination.datasetChunkUri(
-          dataset.projectId,
-          dataset.id,
-          index,
-        );
-        // A chunk can already live ONLY at the destination: a dataset
-        // uploaded while the destination provider was briefly active (the
-        // backend-flip posture #6323 documents), or a previous reverse
-        // migration. Chunks carry no recorded digest, so there is no source
-        // to verify against — presence at the destination is the strongest
-        // available check, and aborting here would deny the operator every
-        // other copy this run could safely make.
-        if (!(await this.deps.source.driver.exists(sourceUri))) {
-          if (await this.deps.destination.driver.exists(destinationUri)) {
-            report.skippedVerified += 1;
-            continue;
-          }
-          throw new MigrationBlockedError(
-            `Dataset chunk is missing from both providers: ${redactStorageUri(sourceUri)}`,
-          );
-        }
-        const result = await copyVerified({
-          source: this.deps.source,
-          sourceUri,
-          destination: this.deps.destination,
-          destinationUri,
-          mediaType: "application/x-ndjson",
-        });
-        report[result] += 1;
-      }
+    for await (const chunk of this.eligibleDatasetChunks(scope)) {
+      report[await this.copyDatasetChunk(chunk)] += 1;
     }
     return report;
+  }
+
+  private async *eligibleDatasetChunks(
+    scope: EligibleScope,
+  ): AsyncGenerator<DatasetChunkUris> {
+    for await (const dataset of this.eligibleDatasets(scope)) {
+      for (let index = 0; index < dataset.chunkCount; index++) {
+        yield {
+          sourceUri: this.deps.source.datasetChunkUri(
+            dataset.projectId,
+            dataset.id,
+            index,
+          ),
+          destinationUri: this.deps.destination.datasetChunkUri(
+            dataset.projectId,
+            dataset.id,
+            index,
+          ),
+        };
+      }
+    }
+  }
+
+  /**
+   * A chunk can already live ONLY at the destination: a dataset uploaded
+   * while the destination provider was briefly active (the backend-flip
+   * posture #6323 documents), or a previous reverse migration. Chunks carry
+   * no recorded digest, so there is no source to verify against — presence
+   * at the destination is the strongest available check, and aborting would
+   * deny the operator every other copy this run could safely make.
+   */
+  private async copyDatasetChunk({
+    sourceUri,
+    destinationUri,
+  }: DatasetChunkUris): Promise<"copied" | "repaired" | "skippedVerified"> {
+    if (!(await this.deps.source.driver.exists(sourceUri))) {
+      return this.acceptDestinationOnlyChunk({ sourceUri, destinationUri });
+    }
+    return copyVerified({
+      source: this.deps.source,
+      sourceUri,
+      destination: this.deps.destination,
+      destinationUri,
+      mediaType: "application/x-ndjson",
+    });
+  }
+
+  private async acceptDestinationOnlyChunk({
+    sourceUri,
+    destinationUri,
+  }: DatasetChunkUris): Promise<"skippedVerified"> {
+    if (await this.deps.destination.driver.exists(destinationUri)) {
+      return "skippedVerified";
+    }
+    throw new MigrationBlockedError(
+      `Dataset chunk is missing from both providers: ${redactStorageUri(sourceUri)}`,
+    );
   }
 
   async finalize(): Promise<MigrationFinalizeReport> {
@@ -354,38 +381,22 @@ export class ObjectStorageMigration {
         row.sha256,
       );
     }
-    for await (const dataset of this.eligibleDatasets(scope)) {
-      for (let index = 0; index < dataset.chunkCount; index++) {
-        const sourceUri = this.deps.source.datasetChunkUri(
-          dataset.projectId,
-          dataset.id,
-          index,
-        );
-        const destinationUri = this.deps.destination.datasetChunkUri(
-          dataset.projectId,
-          dataset.id,
-          index,
-        );
-        // Mirror of the copy loop's already-at-destination tolerance: a
-        // chunk with no source copy has no digest to compare, so presence at
-        // the destination is the strongest check available (#6323).
-        if (!(await this.deps.source.driver.exists(sourceUri))) {
-          if (await this.deps.destination.driver.exists(destinationUri)) {
-            continue;
-          }
-          throw new MigrationBlockedError(
-            `Dataset chunk is missing from both providers: ${redactStorageUri(sourceUri)}`,
-          );
-        }
-        const sourceBytes = await readAll(
-          await this.deps.source.driver.get(sourceUri),
-        );
-        await assertUriDigest(
-          this.deps.destination.driver,
-          destinationUri,
-          sha256(sourceBytes),
-        );
+    for await (const chunk of this.eligibleDatasetChunks(scope)) {
+      // Mirror of the copy loop's already-at-destination tolerance: a chunk
+      // with no source copy has no digest to compare, so presence at the
+      // destination is the strongest check available (#6323).
+      if (!(await this.deps.source.driver.exists(chunk.sourceUri))) {
+        await this.acceptDestinationOnlyChunk(chunk);
+        continue;
       }
+      const sourceBytes = await readAll(
+        await this.deps.source.driver.get(chunk.sourceUri),
+      );
+      await assertUriDigest(
+        this.deps.destination.driver,
+        chunk.destinationUri,
+        sha256(sourceBytes),
+      );
     }
   }
 

--- a/platform/app/src/tasks/objectStorageMigration.ts
+++ b/platform/app/src/tasks/objectStorageMigration.ts
@@ -43,8 +43,16 @@ export interface MigrationInventory {
     projectId: string,
     request: MigrationPageRequest,
   ): Promise<StoredObject[]>;
-  /** Includes archived datasets: they remain recoverable customer data. */
-  listDatasetsPage(request: MigrationPageRequest): Promise<MigrationDataset[]>;
+  /**
+   * Includes archived datasets: they remain recoverable customer data.
+   * Per-project like the stored-objects page: the Prisma multitenancy
+   * middleware rejects any Dataset query without a projectId, so a global
+   * page shape is unimplementable against the real database.
+   */
+  listDatasetsPage(
+    projectId: string,
+    request: MigrationPageRequest,
+  ): Promise<MigrationDataset[]>;
 }
 
 export type MigrationPageRequest = {
@@ -239,6 +247,22 @@ export class ObjectStorageMigration {
           dataset.id,
           index,
         );
+        // A chunk can already live ONLY at the destination: a dataset
+        // uploaded while the destination provider was briefly active (the
+        // backend-flip posture #6323 documents), or a previous reverse
+        // migration. Chunks carry no recorded digest, so there is no source
+        // to verify against — presence at the destination is the strongest
+        // available check, and aborting here would deny the operator every
+        // other copy this run could safely make.
+        if (!(await this.deps.source.driver.exists(sourceUri))) {
+          if (await this.deps.destination.driver.exists(destinationUri)) {
+            report.skippedVerified += 1;
+            continue;
+          }
+          throw new MigrationBlockedError(
+            `Dataset chunk is missing from both providers: ${redactStorageUri(sourceUri)}`,
+          );
+        }
         const result = await copyVerified({
           source: this.deps.source,
           sourceUri,
@@ -342,6 +366,17 @@ export class ObjectStorageMigration {
           dataset.id,
           index,
         );
+        // Mirror of the copy loop's already-at-destination tolerance: a
+        // chunk with no source copy has no digest to compare, so presence at
+        // the destination is the strongest check available (#6323).
+        if (!(await this.deps.source.driver.exists(sourceUri))) {
+          if (await this.deps.destination.driver.exists(destinationUri)) {
+            continue;
+          }
+          throw new MigrationBlockedError(
+            `Dataset chunk is missing from both providers: ${redactStorageUri(sourceUri)}`,
+          );
+        }
         const sourceBytes = await readAll(
           await this.deps.source.driver.get(sourceUri),
         );
@@ -424,10 +459,13 @@ export class ObjectStorageMigration {
   private async *datasets(
     scope: EligibleScope,
   ): AsyncGenerator<MigrationDataset> {
-    for await (const dataset of paginate((request) =>
-      this.deps.inventory.listDatasetsPage(request),
-    )) {
-      if (scope.eligibleProjectIds.has(dataset.projectId)) yield dataset;
+    // Iterated per eligible project (sorted for a stable, resumable order):
+    // BYOC projects are excluded by never being asked for, and every page
+    // query is tenant-scoped as the data layer requires.
+    for (const projectId of [...scope.eligibleProjectIds].sort()) {
+      yield* paginate((request) =>
+        this.deps.inventory.listDatasetsPage(projectId, request),
+      );
     }
   }
 

--- a/specs/features/scenarios/azure-blob-workload-identity.feature
+++ b/specs/features/scenarios/azure-blob-workload-identity.feature
@@ -402,18 +402,6 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
     Then it renders successfully
     And no account-key environment variable is emitted
 
-  # An annotation-less account the chart created fails exactly like a pod with
-  # no webhook label, one layer down: it renders, the pods are healthy, and the
-  # webhook has no identity to bind them to.
-  @integration
-  Scenario: The chart refuses a created service account with no identity annotation
-    Given a token-based auth mode requiring a federated identity
-    And the chart is asked to create the service account
-    And no identity client-id annotation is configured on it
-    When the chart renders
-    Then rendering fails with an error naming the client-id annotation
-    But naming a pre-existing service account instead still renders
-
   # The chart cannot read a Secret, so an endpoint supplied that way has an
   # unknowable hostname. Assuming the public cloud is the one guess that fails
   # silently — the deploy succeeds and the first storage call is refused.

--- a/specs/features/scenarios/azure-blob-workload-identity.feature
+++ b/specs/features/scenarios/azure-blob-workload-identity.feature
@@ -470,9 +470,9 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
   # VERIFIED 2026-07-26 against a real Azure account with
   # allowSharedKeyAccess=false: shared key returned 403
   # KeyBasedAuthenticationNotPermitted, the same operations succeeded on a
-  # bearer token. Stays @manual because it needs a subscription and cannot
-  # run in CI; bound to a test that self-skips without credentials.
-  @manual
+  # bearer token. Needs a real subscription, so the bound test self-skips
+  # in CI and runs only where LANGWATCH_TEST_AZURE_* credentials are set.
+  @integration
   Scenario: Blobs round-trip against a real storage account with shared-key access disabled
     Given a real Azure storage account that forbids shared-key access
     And an identity holding the blob data role on that account

--- a/specs/features/scenarios/azure-blob-workload-identity.feature
+++ b/specs/features/scenarios/azure-blob-workload-identity.feature
@@ -443,10 +443,23 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
     Given the active provider is awsS3 with legacy Azure reads kept enabled
     And the Azure auth mode is workloadIdentity
     When the chart renders
-    Then no stored-objects backend toggle selects Azure for writes
+    Then the S3 write configuration renders exactly as on a plain S3 install
+    And no stored-objects backend toggle selects Azure for writes
     And the Azure connection settings are still emitted for reads
     And the app and workers pods still carry the workload-identity webhook label
     And the cron pods still do not carry it
+
+  # Each legacy read flag belongs to one migration direction. Set alongside
+  # the provider it migrates away from it configures nothing — the chart
+  # rejects the contradiction instead of rendering a silent no-op. An awsS3
+  # install with an empty bucket is rejected for the same reason: it would
+  # render S3_BUCKET_NAME blank and every write would fall back to local
+  # storage while the operator believes S3 is live.
+  @integration
+  Scenario: The chart rejects a legacy read flag aimed at the active provider
+    Given a chart configuration whose legacy read flag targets the provider that is already active
+    When the chart renders
+    Then rendering fails naming the contradictory flag
 
   @integration
   Scenario: Installs that do not use Azure render exactly as they did before

--- a/specs/features/scenarios/azure-blob-workload-identity.feature
+++ b/specs/features/scenarios/azure-blob-workload-identity.feature
@@ -267,11 +267,16 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
   # Byte paths beyond the driver
   # ---------------------------------------------------------------
 
+  # Scoped to what a unit test can actually prove: no shared key is consulted
+  # anywhere on the write path, and the destination and driver agree so a write
+  # is never rejected as an unregistered scheme. The byte-level round-trip in a
+  # token mode is proven against a real Entra-authenticated account further
+  # down — no emulator offers OAuth, so it cannot be proven here.
   @unit
-  Scenario: Stored-objects writes succeed in a token-based mode
+  Scenario: A token-mode write path resolves without consulting a shared key
     Given STORED_OBJECTS_BACKEND is azure in a token-based auth mode
-    When byte content is externalized for a project
-    Then the object is written and an azure-blob URI is persisted
+    When the write destination for a project is resolved
+    Then it resolves to Azure and a matching Azure driver is registered
     And no shared-key configuration is consulted
 
   @unit
@@ -304,16 +309,34 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
     When the write destination and the driver registration are both resolved
     Then the write destination is S3 while the Azure driver stays registered
 
+  # What a unit test can prove today: the selector reaches Azure dataset
+  # storage without touching the account key. It used to dereference
+  # `env.AZURE_BLOB_ACCOUNT_KEY!` and die inside Buffer.from(undefined) — a
+  # crash rather than a config error.
+  @unit
+  Scenario: Dataset storage is selected without dereferencing an absent account key
+    Given STORED_OBJECTS_BACKEND is azure in a token-based auth mode
+    When dataset storage is resolved for a project
+    Then it selects the Azure dataset storage
+    And no code path dereferences an absent account key
+
+  # The chunked round-trip itself stays unproven in a token mode: the emulator
+  # is shared-key only, so there is nowhere to run it outside a real
+  # Entra-authenticated account. Deliberately carries NO binding — the tag and
+  # an annotation claiming coverage cannot both be true.
   @integration @unimplemented
-  Scenario: Dataset uploads work in a token-based mode
+  Scenario: Dataset uploads round-trip in a token-based mode
     Given STORED_OBJECTS_BACKEND is azure in a token-based auth mode
     When a dataset is created, appended to, and read back
     Then the chunked content round-trips through Azure Blob
-    And no code path dereferences an absent account key
 
+  # The concern here is provider routing, not authentication: the durable tier
+  # is labelled `tier: "s3"`, so this proves it still reaches Azure on an
+  # install with no S3 at all. It runs against the emulator, which is shared-key
+  # only, so it deliberately does NOT claim to exercise a token mode.
   @integration
-  Scenario: The groupQueue durable blob tier works in a token-based mode
-    Given the durable blob tier resolves an azure destination in a token-based mode
+  Scenario: The groupQueue durable blob tier works on an Azure-only install
+    Given the durable blob tier resolves an azure destination and no S3 is configured
     When an oversized envelope is offloaded and later read back
     Then the bytes round-trip through Azure Blob
 
@@ -344,6 +367,18 @@ Feature: Azure Blob stored-objects authenticate without a shared account key
     When the chart renders
     Then the cron pods name no service account
     And the cron pods do not carry the workload-identity webhook label
+
+  # An annotation-less account the chart created is the same failure as a pod
+  # with no label, one layer down: it renders, the pods are healthy, and the
+  # webhook has nothing to bind them to.
+  @integration
+  Scenario: The chart refuses a created service account with no identity annotation
+    Given workloadIdentity auth is selected
+    And the chart is asked to create the service account
+    And no identity client-id annotation is configured on it
+    When the chart renders
+    Then rendering fails with an error naming the client-id annotation
+    But naming a pre-existing service account instead still renders
 
   @integration
   Scenario: The chart refuses a workload-identity install with no service account

--- a/specs/migration/object-storage-provider-migration.feature
+++ b/specs/migration/object-storage-provider-migration.feature
@@ -75,6 +75,13 @@ Feature: Object storage provider parity and migration
     Then finalization is refused with the blocking datasets identified
     And the active provider remains unchanged
 
+  @regression @integration
+  Scenario: Unpaused read traffic blocks finalization
+    Given writes are paused
+    But read traffic can still reach the source deployment
+    When the operator attempts to finalize the provider migration
+    Then finalization is refused before any destination address is published
+
   @integration
   Scenario: A dataset with no usable chunk count is reported rather than aborting the run
     Given an abandoned upload left a dataset with no chunk count
@@ -107,7 +114,7 @@ Feature: Object storage provider parity and migration
 
   @integration
   Scenario: Finalization publishes verified destination addresses without erasing history
-    Given writes are paused
+    Given reads and writes are paused
     And a stored object has verified source and destination bytes
     When the operator finalizes that stored object
     Then its newest address points to the verified destination bytes

--- a/specs/migration/object-storage-provider-migration.feature
+++ b/specs/migration/object-storage-provider-migration.feature
@@ -83,6 +83,14 @@ Feature: Object storage provider parity and migration
     Then finalization is refused before any destination address is published
 
   @integration
+  Scenario: A dataset already stored at the destination does not abort the copy
+    Given a dataset whose chunks exist only at the destination provider
+    When the operator runs the copy phase
+    Then those chunks are counted as already verified
+    And the remaining eligible data still migrates
+    But a chunk missing from both providers blocks the migration
+
+  @integration
   Scenario: A dataset with no usable chunk count is reported rather than aborting the run
     Given an abandoned upload left a dataset with no chunk count
     When the operator runs the migration plan

--- a/specs/migration/object-storage-provider-migration.feature
+++ b/specs/migration/object-storage-provider-migration.feature
@@ -1,0 +1,145 @@
+Feature: Object storage provider parity and migration
+  As a self-hosted LangWatch operator
+  I want Azure Blob to work as a complete storage option and a controlled way to change providers
+  So that I can choose S3 or Azure without making customer data unavailable
+
+  @integration
+  Scenario: An Azure-only installation supports every shared object-storage workload
+    Given Azure Blob is the selected provider
+    And no S3 bucket is configured
+    When the installation stores and reads stored objects, dataset chunks, and durable queue payloads
+    Then every workload round-trips successfully through Azure Blob
+
+  @unit
+  Scenario: The legacy S3 selector keeps its existing fallback behavior
+    Given the stored-objects backend is set to S3
+    And no global or private S3 bucket is configured
+    When the write destination is resolved
+    Then the existing local-filesystem fallback is selected
+
+  @integration
+  Scenario Outline: An invalid inactive Azure configuration does not block S3 traffic
+    Given S3 is the active write destination
+    And incomplete Azure settings remain in the deployment
+    When a <project type> project stores and reads an object
+    Then the object round-trips without an inactive-Azure configuration error
+
+    Examples:
+      | project type   |
+      | global-S3      |
+      | private-bucket |
+
+  @integration
+  Scenario: Helm selects S3 and Azure symmetrically without breaking legacy S3 configuration
+    Given the chart supports the awsS3 and azureBlob dataplane providers
+    When the operator renders each provider configuration
+    Then each render explicitly selects its intended provider
+    And an existing S3 installation retains its documented bucket environment contract
+
+  @integration
+  Scenario: A migration dry run changes no customer data
+    Given source and destination credentials are valid
+    And durable data exists on the source provider
+    When the operator runs the migration plan
+    Then the report identifies the data eligible for migration
+    And no bytes or storage addresses are changed
+
+  @integration
+  Scenario: Global provider migration excludes private S3 projects
+    Given a project uses a private S3 bucket
+    When the operator plans a global provider migration
+    Then the project is reported as excluded
+    And none of its bytes or storage addresses are changed
+
+  @integration
+  Scenario: Online copy keeps live reads on the source provider
+    Given customer traffic is still running against the source provider
+    When the operator runs the online copy phase
+    Then verified copies are written to the destination
+    And live reads continue using the source storage addresses
+    And no destination storage address is published before finalization
+    And source bytes remain unchanged
+
+  @integration
+  Scenario: An interrupted online copy resumes safely
+    Given a previous copy stopped after migrating only part of the eligible data
+    And one destination object is present with bytes that do not match its source
+    When the operator runs the copy phase again
+    Then already verified destination objects are not recopied
+    And missing or mismatched objects are copied and verified
+
+  @integration
+  Scenario: Active dataset uploads block finalization
+    Given a dataset is uploading or processing
+    When the operator attempts to finalize the provider migration
+    Then finalization is refused with the blocking datasets identified
+    And the active provider remains unchanged
+
+  @integration
+  Scenario: A dataset with no usable chunk count is reported rather than aborting the run
+    Given an abandoned upload left a dataset with no chunk count
+    When the operator runs the migration plan
+    Then the dataset is reported as a blocker with its reason
+    And the copy phase still migrates the remaining eligible data
+    And finalization is refused while the dataset remains
+
+  @integration
+  Scenario Outline: Outstanding queue work blocks finalization
+    Given the migration audit finds <blocking condition>
+    When the operator attempts to finalize the provider migration
+    Then finalization is refused with the blocking queues identified
+    And the active provider remains unchanged
+
+    Examples:
+      | blocking condition                    |
+      | a pending job                         |
+      | a delayed job                         |
+      | an active job                         |
+      | a blocked job                         |
+      | a staged durable-storage reference    |
+
+  @unit
+  Scenario: Provider migration does not change the durable queue reference format
+    Given a durable queue reference written before provider migration
+    When the deployment is upgraded with provider-migration support
+    Then the reference keeps its existing fields and version
+    And existing workers can still decode it
+
+  @integration
+  Scenario: Finalization publishes verified destination addresses without erasing history
+    Given writes are paused
+    And a stored object has verified source and destination bytes
+    When the operator finalizes that stored object
+    Then its newest address points to the verified destination bytes
+    And its earlier source-address history remains recoverable
+
+  # Locked migration decision: datasets do not gain per-dataset provider
+  # provenance. Every non-BYOC dataset chunk must verify at the destination
+  # before the global provider switch.
+  @integration
+  Scenario Outline: A finalized provider migration preserves durable customer data
+    Given all writes are paused
+    And all eligible stored objects and dataset chunks have verified destination copies
+    And no dataset upload or durable queue reference blocks cutover
+    When the operator finalizes the migration from <source> to <destination>
+    Then stored objects and datasets remain readable from <destination>
+    And new writes use <destination>
+
+    Examples:
+      | source     | destination |
+      | S3         | Azure Blob  |
+      | Azure Blob | S3          |
+
+  @integration
+  Scenario: A failed finalization can be resumed before traffic restarts
+    Given writes remain paused
+    And finalization stopped after changing only part of the storage addresses
+    When the operator runs finalization again
+    Then it completes the remaining verified address changes
+    And no address points to an unverified destination object
+
+  @integration
+  Scenario: Successful migration does not delete source data
+    Given a provider migration has finalized successfully
+    When the operator verifies the destination and resumes traffic
+    Then the source bytes remain available for an explicit rollback

--- a/specs/migration/object-storage-provider-migration.feature
+++ b/specs/migration/object-storage-provider-migration.feature
@@ -45,6 +45,13 @@ Feature: Object storage provider parity and migration
     And no bytes or storage addresses are changed
 
   @integration
+  Scenario: Rows outside both providers are reported, never silently dropped
+    Given a live stored object addressed by a scheme that is neither the source nor the destination
+    When the operator runs the migration plan
+    Then the plan reports how many such rows exist and which schemes they use
+    And those rows are not copied, rewritten, or deleted by any phase
+
+  @integration
   Scenario: Global provider migration excludes private S3 projects
     Given a project uses a private S3 bucket
     When the operator plans a global provider migration


### PR DESCRIPTION
## For humans

Today LangWatch can only keep its files — uploaded datasets, media pulled out of
traces, large queued payloads — in Amazon S3. Customers who run everything on
Microsoft Azure had no supported place to put them.

This makes Azure a real, first-class option, and adds a safe way to move an
existing installation from one to the other. The move is deliberately manual and
reversible: it copies everything first, checks every copied file against a
fingerprint of the original, and refuses to switch over while anything is still
being written. It never deletes the originals, so if the switch goes badly you
can go back.

# Related issues

- Resolves langwatch/langwatch-saas#899
- Closes langwatch/langwatch-saas#901
- Mitigates, but does not close, langwatch/langwatch#6323

Stacked on langwatch/langwatch#6181 — **the base is `issue6087/azure-blob-entra-identity-auth`, not `main`.**

## What this delivers

Azure Blob is now a valid global object-storage destination alongside S3 for stored objects, dataset chunks, and durable GroupQueue payloads.

- Keeps Azure keyless/workload-identity authentication intact.
- Registers Azure lazily, so incomplete inactive Azure configuration cannot break S3 traffic.
- Adds explicit S3 and Azure Helm selectors while preserving the existing S3 fallback.
- Adds parity and regression coverage for datasets, queues, stored objects, credentials, and Helm identity configuration.
- Corrects documentation that previously over-promised legacy cross-provider reads.

## Operator migration command

Adds an explicit, resumable S3↔Azure operator workflow:

```bash
pnpm run task migrateObjectStorage plan
pnpm run task migrateObjectStorage copy

# Stop all app and worker read/write traffic, drain GroupQueue, then:
OBJECT_STORAGE_MIGRATION_WRITES_PAUSED=1 \
OBJECT_STORAGE_MIGRATION_READS_PAUSED=1 \
  pnpm run task migrateObjectStorage finalize

# Deploy the target provider while traffic remains paused, then:
pnpm run task migrateObjectStorage verify
```

The migration:

- uses migration-only source and target credentials;
- validates the active provider and exact bucket/account/container/endpoint addresses;
- copies without deleting the source;
- verifies content hashes and repairs/resumes partial runs;
- uses bounded stable pagination;
- migrates stored objects and deterministic dataset chunks without a schema change;
- audits durable queues across Redis Cluster masters;
- excludes BYOC projects;
- refuses finalization while reads or writes are active, datasets are active/invalid, or durable queue payloads remain.

A dataset with a null or invalid `chunkCount` is reported as a blocker instead of aborting the read-only plan. Copy skips it and migrates eligible data; finalize still refuses.

## Important cutover contract

This supports a **controlled migration**, not a bare provider toggle.

1. Pause all application and worker read/write traffic and drain GroupQueue.
2. Finalize with both pause acknowledgements set.
3. Change `STORED_OBJECTS_BACKEND` and the active credentials, then deploy the target provider while traffic remains paused. **Keep the source provider's read credentials configured** (Helm: `app.dataplane.legacyS3ReadBucket` after S3→Azure, `app.dataplane.legacyAzureRead` after Azure→S3): finalization rewrote addresses to the destination scheme, so a rollback that also drops those credentials makes the rewritten objects unreadable — with the flag kept, rollback is fully non-destructive.
4. Run `verify` against the active target provider.
5. Resume traffic only after verification succeeds.
6. Retain the source until the rollback window is complete.

Issue langwatch/langwatch#6323 remains open because persisted datasets still have no per-dataset storage provenance. The migration makes a controlled cutover safe; an unplanned toggle can still strand old chunks.

## Known limitations

- Azure does not offer the same cross-origin presigned upload path as S3 here, so large dataset uploads stream through the application.
- No MinIO-specific behavior or dependency is introduced.
- No automatic migration and no source deletion.
- No database schema change.

## Validation

Local validation on commit `788668a033`, after rebasing onto the current base:

- application and test typechecks passed (`pnpm typecheck:all`);
- the differential Biome gate passed against the merge base — 3,641 diagnostics
  on both sides, zero new violations;
- 345 unit tests across the 25 stored-objects and migration-task suites passed;
- 22 in-memory migration integration contracts passed, including abandoned
  uploads with a null `chunkCount`, read-pause enforcement, post-cutover reads,
  and post-cutover writes;
- feature parity passed with 4,626 enforced scenarios bound;
- both blocker fixes below were mutation-tested — reverting each one turns its
  test red, so neither assertion is vacuous.

Docker-backed integration contracts are delegated to this PR's GitHub Actions
run; the local environment has no container runtime, so the suites ran against
native ClickHouse, Postgres and Redis instead.

### Review follow-ups included here

Three commits close findings from a review of this branch's own migration task:

- the destination-scheme-mismatch blocker aborted the whole run without naming
  the offending row (the two addresses differ only in the bucket/account, which
  URI redaction masks, so quoting them printed two identical strings);
- the cutover-audit Redis handshake had no timeout and no cleanup on its error
  path, so a wedged cluster hung `finalize` silently and a failed handshake
  leaked a connection that retried forever;
- an assertion interpolated a generated id into a `RegExp`, where one
  metacharacter would have made it silently stop matching.

## Deployment impact

Existing S3 installations do not migrate automatically. Azure becomes an explicit supported provider, and incomplete inactive Azure variables no longer affect S3 requests.

For an existing S3 customer choosing Azure, operators must run the documented plan/copy/finalize/verify sequence and coordinate the read/write pause around cutover. Rollback keeps using the retained source objects; the migration never deletes them.


