### PR TITLE
fix(prompts): scope the version-drift refetch trade-off to the N-mounted callers (#6292)

### DIFF
--- a/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
+++ b/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
@@ -12,8 +12,8 @@ import { SecretsIndicator } from "../SecretsIndicator";
 let mockSecrets: Array<{ id: string; name: string }> = [];
 let mockIsLoading = false;
 
-// Reads the options argument rather than discarding it, so the popover's
-// `enabled: open` gating is observable to the assertions below.
+// Records each call's options argument instead of discarding it, so the
+// popover's `enabled: open` gating is observable to the assertions below.
 const { mockSecretsListQuery } = vi.hoisted(() => ({
   mockSecretsListQuery: vi.fn(),
 }));

--- a/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
+++ b/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
@@ -46,26 +46,20 @@ function renderIndicator({
   );
 }
 
-describe("<SecretsIndicator />", () => {
-  beforeEach(() => {
-    mockSecrets = [];
-    mockIsLoading = false;
-    mockOnInsertSecret.mockClear();
-    mockSecretsListQuery.mockReset();
-    mockSecretsListQuery.mockImplementation(() => ({
-      data: mockSecrets,
-      isLoading: mockIsLoading,
-    }));
-  });
+beforeEach(() => {
+  mockSecrets = [];
+  mockIsLoading = false;
+  mockOnInsertSecret.mockClear();
+  mockSecretsListQuery.mockReset();
+  mockSecretsListQuery.mockImplementation(() => ({
+    data: mockSecrets,
+    isLoading: mockIsLoading,
+  }));
+});
 
-  it("renders the trigger button with key icon", () => {
-    renderIndicator();
-    expect(screen.getByTestId("secrets-indicator")).toBeInTheDocument();
-    expect(screen.getByText("Secrets")).toBeInTheDocument();
-  });
-
+describe("<SecretsIndicator /> secrets query", () => {
   describe("when the popover has not been opened", () => {
-    it("does not enable the secrets query", () => {
+    it("does not enable the query", () => {
       renderIndicator();
 
       expect(mockSecretsListQuery).toHaveBeenCalledWith(
@@ -75,8 +69,8 @@ describe("<SecretsIndicator />", () => {
     });
   });
 
-  describe("when clicked", () => {
-    it("enables the secrets query", async () => {
+  describe("when the popover is opened", () => {
+    it("enables the query", async () => {
       const user = userEvent.setup();
       renderIndicator();
 
@@ -89,7 +83,17 @@ describe("<SecretsIndicator />", () => {
         );
       });
     });
+  });
+});
 
+describe("<SecretsIndicator />", () => {
+  it("renders the trigger button with key icon", () => {
+    renderIndicator();
+    expect(screen.getByTestId("secrets-indicator")).toBeInTheDocument();
+    expect(screen.getByText("Secrets")).toBeInTheDocument();
+  });
+
+  describe("when clicked", () => {
     it("shows usage hint at the bottom of the popover", async () => {
       const user = userEvent.setup();
       renderIndicator();

--- a/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
+++ b/langwatch/src/components/secrets/__tests__/SecretsIndicator.integration.test.tsx
@@ -12,14 +12,16 @@ import { SecretsIndicator } from "../SecretsIndicator";
 let mockSecrets: Array<{ id: string; name: string }> = [];
 let mockIsLoading = false;
 
+// Reads the options argument rather than discarding it, so the popover's
+// `enabled: open` gating is observable to the assertions below.
+const { mockSecretsListQuery } = vi.hoisted(() => ({
+  mockSecretsListQuery: vi.fn(),
+}));
 vi.mock("~/utils/api", () => ({
   api: {
     secrets: {
       list: {
-        useQuery: vi.fn(() => ({
-          data: mockSecrets,
-          isLoading: mockIsLoading,
-        })),
+        useQuery: mockSecretsListQuery,
       },
     },
   },
@@ -49,6 +51,11 @@ describe("<SecretsIndicator />", () => {
     mockSecrets = [];
     mockIsLoading = false;
     mockOnInsertSecret.mockClear();
+    mockSecretsListQuery.mockReset();
+    mockSecretsListQuery.mockImplementation(() => ({
+      data: mockSecrets,
+      isLoading: mockIsLoading,
+    }));
   });
 
   it("renders the trigger button with key icon", () => {
@@ -57,7 +64,32 @@ describe("<SecretsIndicator />", () => {
     expect(screen.getByText("Secrets")).toBeInTheDocument();
   });
 
+  describe("when the popover has not been opened", () => {
+    it("does not enable the secrets query", () => {
+      renderIndicator();
+
+      expect(mockSecretsListQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "test-project-id" }),
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+  });
+
   describe("when clicked", () => {
+    it("enables the secrets query", async () => {
+      const user = userEvent.setup();
+      renderIndicator();
+
+      await user.click(screen.getByTestId("secrets-indicator"));
+
+      await waitFor(() => {
+        expect(mockSecretsListQuery).toHaveBeenLastCalledWith(
+          expect.objectContaining({ projectId: "test-project-id" }),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
+    });
+
     it("shows usage hint at the bottom of the popover", async () => {
       const user = userEvent.setup();
       renderIndicator();

--- a/langwatch/src/experiments-v3/components/TargetSection/TargetHeader.tsx
+++ b/langwatch/src/experiments-v3/components/TargetSection/TargetHeader.tsx
@@ -288,7 +288,7 @@ export const TargetHeader = memo(function TargetHeader({
       target.type === "prompt" ? target.promptVersionNumber : undefined,
     // One instance per target column, all always mounted — same N-mounted
     // storm shape as the prompt tab labels (#5585).
-    liveRefetch: false,
+    isLiveRefetchEnabled: false,
   });
 
   // Check if this target is effectively at "latest" version

--- a/langwatch/src/experiments-v3/components/TargetSection/TargetHeader.tsx
+++ b/langwatch/src/experiments-v3/components/TargetSection/TargetHeader.tsx
@@ -286,6 +286,9 @@ export const TargetHeader = memo(function TargetHeader({
     configId: target.type === "prompt" ? target.promptId : undefined,
     currentVersion:
       target.type === "prompt" ? target.promptVersionNumber : undefined,
+    // One instance per target column, all always mounted — same N-mounted
+    // storm shape as the prompt tab labels (#5585).
+    liveRefetch: false,
   });
 
   // Check if this target is effectively at "latest" version

--- a/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
+++ b/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
@@ -58,7 +58,7 @@ describe("useLatestPromptVersion", () => {
         useLatestPromptVersion({
           configId: "config-123",
           currentVersion: 3,
-          liveRefetch: false,
+          isLiveRefetchEnabled: false,
         }),
       );
 

--- a/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
+++ b/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
@@ -46,8 +46,34 @@ describe("useLatestPromptVersion", () => {
     });
   });
 
-  describe("when configured for the always-mounted tab label", () => {
-    it("disables window-focus refetch so N open tabs don't re-storm", () => {
+  describe("when the caller opts out of live refetch", () => {
+    it("disables window-focus refetch so N mounted instances don't re-storm", () => {
+      mockUseQuery.mockReturnValue({
+        data: { version: 3 },
+        isLoading: false,
+        isFetching: false,
+      });
+
+      renderHook(() =>
+        useLatestPromptVersion({
+          configId: "config-123",
+          currentVersion: 3,
+          liveRefetch: false,
+        }),
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ idOrHandle: "config-123" }),
+        expect.objectContaining({
+          refetchOnWindowFocus: false,
+          staleTime: 30_000,
+        }),
+      );
+    });
+  });
+
+  describe("when the caller leaves live refetch at its default", () => {
+    it("keeps window-focus refetch so another session's version still lands", () => {
       mockUseQuery.mockReturnValue({
         data: { version: 3 },
         isLoading: false,
@@ -60,7 +86,10 @@ describe("useLatestPromptVersion", () => {
 
       expect(mockUseQuery).toHaveBeenCalledWith(
         expect.objectContaining({ idOrHandle: "config-123" }),
-        expect.objectContaining({ refetchOnWindowFocus: false }),
+        expect.objectContaining({
+          refetchOnWindowFocus: true,
+          staleTime: 0,
+        }),
       );
     });
   });

--- a/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
+++ b/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
@@ -20,6 +20,18 @@ type UseLatestPromptVersionOptions = {
   configId: string | undefined;
   /** The current version number */
   currentVersion: number | undefined;
+  /**
+   * Whether this instance keeps the latest version live by re-fetching on
+   * window focus. Defaults to `true`.
+   *
+   * Pass `false` where the hook is mounted once per open tab or per table
+   * column. N always-mounted instances each re-firing a full-prompt fetch on
+   * every window focus was the query storm #5585 fixed. A gated instance is
+   * save-driven instead: `useHandleSavePrompt` invalidates this key, so
+   * same-app version bumps still move the badge, but another session's new
+   * version isn't reflected until the next save or reload.
+   */
+  liveRefetch?: boolean;
 };
 
 /**
@@ -33,6 +45,7 @@ type UseLatestPromptVersionOptions = {
 export const useLatestPromptVersion = ({
   configId,
   currentVersion,
+  liveRefetch = true,
 }: UseLatestPromptVersionOptions): UseLatestPromptVersionResult => {
   const { project } = useOrganizationTeamProject();
 
@@ -50,17 +63,15 @@ export const useLatestPromptVersion = ({
     },
     {
       enabled: !!configId && !!project?.id,
-      // Runs in every open tab's always-mounted label (for the outdated
-      // badge). Deliberately save-driven, not focus-live: a save invalidates
-      // this key (see useHandleSavePrompt), so same-app version bumps update
-      // the badge, but we don't re-fetch for every open tab on each window
-      // focus — that was the N-tab storm this fix targets, and matches the
-      // codebase convention for dashboard queries (see useFilterParams).
-      // Tradeoff: a *different session's* new version isn't reflected until
-      // the next save/reload; true cross-session liveness would need a
+      // Live by default so "the prompt was updated in another tab/session"
+      // stays observable without a reload — that is the whole point of the
+      // drift check for the single-instance callers (save button, editor
+      // drawer). The N-mounted callers opt out with `liveRefetch: false`,
+      // matching the codebase convention for dashboard queries (see
+      // useFilterParams). True cross-session liveness for those would need a
       // lightweight version-number endpoint (noted in #5585).
-      staleTime: 30_000,
-      refetchOnWindowFocus: false,
+      staleTime: liveRefetch ? 0 : 30_000,
+      refetchOnWindowFocus: liveRefetch,
     },
   );
 
@@ -73,7 +84,8 @@ export const useLatestPromptVersion = ({
     // Initial load - not outdated yet
     isOutdated = false;
   } else if (isFetching) {
-    // Refetch (e.g., window focus) - keep previous value to prevent flicker
+    // Refetch in flight (window focus when live, cache invalidation after a
+    // save otherwise) - keep previous value to prevent flicker
     isOutdated = lastOutdatedRef.current;
   } else {
     // Fresh data available

--- a/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
+++ b/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
@@ -30,8 +30,14 @@ type UseLatestPromptVersionOptions = {
    * save-driven instead: `useHandleSavePrompt` invalidates this key, so
    * same-app version bumps still move the badge, but another session's new
    * version isn't reflected until the next save or reload.
+   *
+   * The callers left live are bounded by open *editors*, not by tab count:
+   * one prompt editor drawer, and one editor per browser window in Compare
+   * mode (a window renders only its active tab's content — the tab panels are
+   * `lazyMount unmountOnExit`). So focus costs one refetch per prompt being
+   * edited, and the two hooks inside a window share one query key.
    */
-  liveRefetch?: boolean;
+  isLiveRefetchEnabled?: boolean;
 };
 
 /**
@@ -45,7 +51,7 @@ type UseLatestPromptVersionOptions = {
 export const useLatestPromptVersion = ({
   configId,
   currentVersion,
-  liveRefetch = true,
+  isLiveRefetchEnabled = true,
 }: UseLatestPromptVersionOptions): UseLatestPromptVersionResult => {
   const { project } = useOrganizationTeamProject();
 
@@ -66,12 +72,13 @@ export const useLatestPromptVersion = ({
       // Live by default so "the prompt was updated in another tab/session"
       // stays observable without a reload — that is the whole point of the
       // drift check for the single-instance callers (save button, editor
-      // drawer). The N-mounted callers opt out with `liveRefetch: false`,
-      // matching the codebase convention for dashboard queries (see
-      // useFilterParams). True cross-session liveness for those would need a
-      // lightweight version-number endpoint (noted in #5585).
-      staleTime: liveRefetch ? 0 : 30_000,
-      refetchOnWindowFocus: liveRefetch,
+      // drawer). The N-mounted callers opt out with
+      // `isLiveRefetchEnabled: false`, matching the codebase convention for
+      // dashboard queries (see useFilterParams). True cross-session liveness
+      // for those would need a lightweight version-number endpoint (noted in
+      // #5585).
+      staleTime: isLiveRefetchEnabled ? 0 : 30_000,
+      refetchOnWindowFocus: isLiveRefetchEnabled,
     },
   );
 

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/tab/usePromptTabSummary.ts
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/tab/usePromptTabSummary.ts
@@ -41,6 +41,9 @@ export function usePromptTabSummary(tabId: string): PromptTabSummary {
   const { latestVersion, isOutdated } = useLatestPromptVersion({
     configId,
     currentVersion: versionNumber,
+    // One instance per open tab, all always mounted: keeping them focus-live
+    // is the N-tab query storm from #5585.
+    liveRefetch: false,
   });
 
   // Derived inside the selector so it returns a boolean. Returning the tab

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/tab/usePromptTabSummary.ts
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/tab/usePromptTabSummary.ts
@@ -43,7 +43,7 @@ export function usePromptTabSummary(tabId: string): PromptTabSummary {
     currentVersion: versionNumber,
     // One instance per open tab, all always mounted: keeping them focus-live
     // is the N-tab query storm from #5585.
-    liveRefetch: false,
+    isLiveRefetchEnabled: false,
   });
 
   // Derived inside the selector so it returns a boolean. Returning the tab


### PR DESCRIPTION
# Related Issue

- Resolves #6292

## For humans

When you have a prompt open and someone else saves a new version of it, the save button is supposed to notice and offer you the newer version. A performance fix in #5588 accidentally switched that noticing off — not just for the screens causing the performance problem, but for every screen using the same shared code. Nothing was ever lost or overwritten; the button just showed a stale version number until you saved or reloaded.

This puts the noticing back where it belongs and keeps the performance fix where it was actually needed: the prompt tab strip and the evaluations table headers, which render one copy of this check per open tab / per column. Those are the ones that caused the traffic storm; everything else goes back to staying up to date.

Also fixes a test that could not fail — it claimed to prove a "only fetch when the menu opens" optimization while ignoring the very argument that controls it.

## Why

Resolves #6292 — the review findings left unresolved when #5588 merged.

#5588 put `staleTime: 30_000` + `refetchOnWindowFocus: false` inside `useLatestPromptVersion` itself. The hook has five callers, but only two of them are the N-instance case the fix targeted:

| Caller | Mounted N times? |
|---|---|
| `usePromptTabSummary` (prompt tab label) | yes — one per open tab |
| `TargetHeader` (evaluations v3) | yes — one per target column |
| `SavePromptButton` | no — one per open editor |
| `PromptEditorDrawer` | no — one drawer at a time |
| `useHandleSavePrompt` | no — one per open editor |

"Open editor" means the prompt editor drawer, or one per browser window in Compare mode: a window renders only its active tab's content, since the tab panels are `lazyMount unmountOnExit`. So the live set is bounded by prompts being edited, not by tabs open — and the two hooks inside one window share a `configId`, so React Query merges them onto a single key and a single refetch.

The three single-instance callers paid the cost with nothing to gain. Window-focus refetch was the only passive path that made cross-session drift visible — there is no `refetchInterval`, websocket, or other invalidation for prompts — so `SavePromptButton`'s own docstring ("to handle cases where the prompt was updated in another tab/session") no longer described what the code did.

## What changed

**1. `isLiveRefetchEnabled` option, default `true`.** `useLatestPromptVersion` is focus-live again for everyone except the two N-mounted callers, which now pass `isLiveRefetchEnabled: false` explicitly with the reason inline. The storm fix from #5585 is unchanged where it mattered; the three single-instance callers get drift detection back.

**2. The `SecretsIndicator` gating test can now fail.** Its mock was `useQuery: vi.fn(() => ({ data, isLoading }))` — the options argument was discarded, so every assertion passed whether or not the query was gated on `open`. #5588's description cited this file as end-to-end proof of a behaviour it could not observe. It now records the options and asserts `enabled: false` before open / `true` after, mirroring `SaveAndRunMenu.integration.test.tsx` from that same PR.

**3. Stale comment corrected.** The flicker guard still cited window focus as its refetch trigger after #5588 turned focus refetch off.

## How it works

`staleTime: isLiveRefetchEnabled ? 0 : 30_000` and `refetchOnWindowFocus: isLiveRefetchEnabled`. `staleTime: 0` is React Query's own default, so the un-gated callers are back to exactly their pre-#5588 behaviour rather than to a third, new one.

No data-correctness stake either way: the server derives the next version from a fresh `MAX(version)` at commit time (`llm-config-versions.repository.ts:224`) and the client never forwards `nextVersion`. The only thing at risk was a stale label.

## Test plan

Every new assertion was verified to fail against a mutated source, not just to pass:

| Check | Result |
|---|---|
| `useLatestPromptVersion.test.ts` — gated caller gets `refetchOnWindowFocus: false` + `staleTime: 30_000` | pass |
| `useLatestPromptVersion.test.ts` — default caller keeps `refetchOnWindowFocus: true` + `staleTime: 0` | pass; **fails** when the option is hardcoded back to `false` |
| `SecretsIndicator.integration.test.tsx` — `enabled: false` closed, `true` after click | pass; both **fail** when `enabled: open` is removed from the component |
| `pnpm test:unit run src/prompts …` + `PromptEditorDrawer`, `TargetHeader` | pass |
| `pnpm test:integration run src/components/secrets/…` | 8 passed |
| `pnpm typecheck:all` (src **and** tests) | clean |

## Review follow-ups

Settled after the first review pass, in `5a0d200d6`:

- The option was `liveRefetch`, which reads as a noun at the call site; renamed to `isLiveRefetchEnabled` across all four sites via the language server, local binding included, per `require-boolean-name-prefix-ts`.
- The caller table understated the bound on the three live callers — corrected above, and the same bound is now stated in the option's doc comment. `tslsp-cli references` confirms the list is complete at five call sites.
- The mock comment claimed it "reads" the options argument; `vi.fn()` records them and the assertions inspect them.
- `useHandleSavePrompt` is deliberately left live: it shares a query key with the live `SavePromptButton` in the same window, so gating it would save no fetch while making the save path read staler data.

## Anything surprising?

`TargetHeader` was not named in the issue's caller table as a candidate to keep live — it reads as a single header, but it is rendered once per target column via `TargetHeaderFromMeta`, so it has the same N-mounted shape as the tab labels and is gated alongside them.

The third item in #6292's "residual verification gap" note is **not** addressed here: `TraceDetails` / `PlaygroundContent` still rely on reading rather than on their ClickHouse-backed integration tests having been run. Out of scope for this change, still open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary prompt version refetching by disabling live, window-focus refresh in target columns and prompt tabs where appropriate.
  - Added an option to control live refresh behavior for prompt versions (enabled by default; can switch to less frequent, save-driven refresh).
- **Bug Fixes**
  - Ensured the secrets list query only runs while the secrets popover is open.
- **Tests**
  - Expanded assertions to verify secrets query gating and the correct query refresh settings for both live and non-live modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->