### PR TITLE
fix(event-sourcing): bound the re-fold event_log reads so they prune partitions

### DIFF
--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { TIME_PARTITIONED_TABLES } from "../cold-scan-detector";
@@ -47,14 +47,17 @@ describe("cold-scan detector coverage", () => {
       if (!file.endsWith(".sql")) continue;
 
       const raw = readFileSync(resolve(migrationDir, file), "utf-8");
-      // Drop comment lines: a commented-out CREATE in a Down section is not a
-      // live table, and counting it would demand coverage for something that
-      // does not exist.
-      const body = raw
+      // Split on the Down marker BEFORE stripping comments. The marker is
+      // itself a comment line (`-- +goose Down`) in every migration, so
+      // stripping first would delete it and leave `split` matching nothing —
+      // the "Up section" would silently be the whole file, Down included.
+      const upSection = raw.split(/^\s*--\s*\+goose Down/m)[0] ?? raw;
+      // Then drop comment lines: a commented-out CREATE is not a live table,
+      // and counting it would demand coverage for something that does not exist.
+      const up = upSection
         .split("\n")
         .filter((line) => !line.trim().startsWith("--"))
         .join("\n");
-      const up = body.split("+goose Down")[0] ?? body;
 
       const createRe = /CREATE TABLE[^(]*?[.`]?(\w+)[\s`]*?\(/gi;
       let match: RegExpExecArray | null;
@@ -74,6 +77,11 @@ describe("cold-scan detector coverage", () => {
     /** @scenario Every partitioned table is known to the cold-scan detector */
     it("is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged", () => {
       const partitioned = partitionedTablesFromMigrations();
+      // Guard against a vacuous pass: if the migration directory ever moved,
+      // or the CREATE regex stopped matching, `partitioned` would be empty and
+      // "nothing is uncovered" would be trivially true — the exact silent
+      // failure this whole file exists to prevent.
+      expect(partitioned.size).toBeGreaterThan(0);
       const known = new Set(Object.keys(TIME_PARTITIONED_TABLES));
 
       const uncovered = [...partitioned.keys()]
@@ -99,7 +107,9 @@ describe("cold-scan detector coverage", () => {
           new RegExp(`\\b${column}\\b`, "i").test(expression),
         );
         if (!anyMatches) {
-          wrong.push(`${table}: declares [${columns.join(", ")}], partitioned by ${expression}`);
+          wrong.push(
+            `${table}: declares [${columns.join(", ")}], partitioned by ${expression}`,
+          );
         }
       }
 
@@ -108,12 +118,11 @@ describe("cold-scan detector coverage", () => {
   });
 
   describe("given a table is listed in the detector", () => {
-    /**
-     * @scenario The map carries no table that is not partitioned
-     *
+    /*
      * A stale entry makes the detector demand a time predicate on a table that
      * cannot prune by one — noise that trains people to ignore the warning.
      */
+    /** @scenario The map carries no table that is not partitioned */
     it("is a table that really is partitioned", () => {
       const partitioned = partitionedTablesFromMigrations();
 

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -18,61 +18,107 @@ import { TIME_PARTITIONED_TABLES } from "../cold-scan-detector";
  * A comment saying "keep in sync" could not have caught that, so this parses the
  * migrations and asserts the map matches.
  */
-describe("cold-scan detector coverage", () => {
-  const migrationDir = resolve(
-    process.cwd(),
-    "src/server/clickhouse/migrations",
-  );
+const migrationDir = resolve(process.cwd(), "src/server/clickhouse/migrations");
 
-  /**
-   * Tables created and later dropped. Their CREATE still exists in history —
-   * migrations are immutable — but they are gone, so the detector must not
-   * carry them.
-   */
-  const DROPPED = new Set<string>(["gateway_activity_events"]);
+/**
+ * Tables created and later dropped. Their CREATE still exists in history —
+ * migrations are immutable — but they are gone, so the detector must not
+ * carry them.
+ */
+const DROPPED = new Set<string>(["gateway_activity_events"]);
 
-  /**
-   * Scratch/rebuild tables that mirror a live table's schema. Queried only by
-   * the migration that builds them, never on a request path.
-   */
-  const NOT_ON_A_READ_PATH = new Set<string>([
-    "gateway_budget_scope_totals_rebuild",
-  ]);
+/**
+ * Scratch/rebuild tables that mirror a live table's schema. Queried only by
+ * the migration that builds them, never on a request path.
+ */
+const NOT_ON_A_READ_PATH = new Set<string>([
+  "gateway_budget_scope_totals_rebuild",
+]);
 
-  /** Every table whose Up section declares a PARTITION BY, mapped to it. */
-  function partitionedTablesFromMigrations(): Map<string, string> {
-    const found = new Map<string, string>();
+/**
+ * A migration's Up section, comments removed.
+ *
+ * Order matters: split on the Down marker BEFORE stripping comments. The
+ * marker is itself a comment line (`-- +goose Down`) in every migration, so
+ * stripping first would delete it and leave `split` matching nothing — the
+ * "Up section" would silently be the whole file, Down included.
+ *
+ * Comments go second because a commented-out CREATE is not a live table, and
+ * counting it would demand coverage for something that does not exist.
+ */
+function upSectionOf(raw: string): string {
+  const up = raw.split(/^\s*--\s*\+goose Down/m)[0] ?? raw;
+  return up
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n");
+}
 
-    for (const file of readdirSync(migrationDir).sort()) {
-      if (!file.endsWith(".sql")) continue;
+/** Tables one Up section creates with a PARTITION BY, mapped to it. */
+function partitionedTablesIn(up: string): Map<string, string> {
+  const found = new Map<string, string>();
+  const createRe = /CREATE TABLE[^(]*?[.`]?(\w+)[\s`]*?\(/gi;
 
-      const raw = readFileSync(resolve(migrationDir, file), "utf-8");
-      // Split on the Down marker BEFORE stripping comments. The marker is
-      // itself a comment line (`-- +goose Down`) in every migration, so
-      // stripping first would delete it and leave `split` matching nothing —
-      // the "Up section" would silently be the whole file, Down included.
-      const upSection = raw.split(/^\s*--\s*\+goose Down/m)[0] ?? raw;
-      // Then drop comment lines: a commented-out CREATE is not a live table,
-      // and counting it would demand coverage for something that does not exist.
-      const up = upSection
-        .split("\n")
-        .filter((line) => !line.trim().startsWith("--"))
-        .join("\n");
-
-      const createRe = /CREATE TABLE[^(]*?[.`]?(\w+)[\s`]*?\(/gi;
-      let match: RegExpExecArray | null;
-      while ((match = createRe.exec(up)) !== null) {
-        const table = match[1];
-        if (!table) continue;
-        const tail = up.slice(match.index, match.index + 6000);
-        const partitionBy = /PARTITION BY\s+([^\n]+)/i.exec(tail);
-        if (partitionBy?.[1]) found.set(table, partitionBy[1].trim());
-      }
-    }
-
-    return found;
+  let match: RegExpExecArray | null;
+  while ((match = createRe.exec(up)) !== null) {
+    const table = match[1];
+    if (!table) continue;
+    const tail = up.slice(match.index, match.index + 6000);
+    const partitionBy = /PARTITION BY\s+([^\n]+)/i.exec(tail);
+    if (partitionBy?.[1]) found.set(table, partitionBy[1].trim());
   }
 
+  return found;
+}
+
+/** Every table whose Up section declares a PARTITION BY, mapped to it. */
+function partitionedTablesFromMigrations(): Map<string, string> {
+  const found = new Map<string, string>();
+
+  for (const file of readdirSync(migrationDir).sort()) {
+    if (!file.endsWith(".sql")) continue;
+    const raw = readFileSync(resolve(migrationDir, file), "utf-8");
+    for (const [table, expression] of partitionedTablesIn(upSectionOf(raw))) {
+      found.set(table, expression);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * At least one declared column must appear in the PARTITION BY expression,
+ * else the detector is looking for a predicate that could never prune.
+ */
+function declaresAUsableColumn(
+  columns: readonly string[],
+  expression: string,
+): boolean {
+  return columns.some((column) =>
+    new RegExp(`\\b${column}\\b`, "i").test(expression),
+  );
+}
+
+/**
+ * Entries whose declared columns appear nowhere in the table's real PARTITION
+ * BY, rendered for the failure message.
+ */
+function pruneColumnMismatches(
+  partitioned: ReadonlyMap<string, string>,
+): string[] {
+  return Object.entries(TIME_PARTITIONED_TABLES)
+    .map(([table, columns]) => {
+      const expression = partitioned.get(table);
+      if (!expression) return null;
+      if (declaresAUsableColumn(columns as readonly string[], expression)) {
+        return null;
+      }
+      return `${table}: declares [${columns.join(", ")}], partitioned by ${expression}`;
+    })
+    .filter((entry): entry is string => entry !== null);
+}
+
+describe("cold-scan detector coverage", () => {
   describe("given a table is partitioned by a time expression", () => {
     /** @scenario Every partitioned table is known to the cold-scan detector */
     it("is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged", () => {
@@ -95,23 +141,7 @@ describe("cold-scan detector coverage", () => {
 
     /** @scenario The declared prune column actually appears in the PARTITION BY */
     it("declares a prune column the PARTITION BY expression really uses", () => {
-      const partitioned = partitionedTablesFromMigrations();
-      const wrong: string[] = [];
-
-      for (const [table, columns] of Object.entries(TIME_PARTITIONED_TABLES)) {
-        const expression = partitioned.get(table);
-        if (!expression) continue;
-        // At least one declared column must appear in the expression, else the
-        // detector is looking for a predicate that could never prune anything.
-        const anyMatches = (columns as readonly string[]).some((column) =>
-          new RegExp(`\\b${column}\\b`, "i").test(expression),
-        );
-        if (!anyMatches) {
-          wrong.push(
-            `${table}: declares [${columns.join(", ")}], partitioned by ${expression}`,
-          );
-        }
-      }
+      const wrong = pruneColumnMismatches(partitionedTablesFromMigrations());
 
       expect(wrong).toEqual([]);
     });

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -36,15 +36,17 @@ const NOT_ON_A_READ_PATH = new Set<string>([
 ]);
 
 /**
- * A migration's Up section, comments removed.
+ * A migration's Up section, with `--` line comments removed.
  *
  * Order matters: split on the Down marker BEFORE stripping comments. The
  * marker is itself a comment line (`-- +goose Down`) in every migration, so
  * stripping first would delete it and leave `split` matching nothing — the
  * "Up section" would silently be the whole file, Down included.
  *
- * Comments go second because a commented-out CREATE is not a live table, and
- * counting it would demand coverage for something that does not exist.
+ * `--` comments go second because a commented-out CREATE is not a live table,
+ * and counting it would demand coverage for something that does not exist.
+ * Block comments are not stripped: no migration uses them, and every
+ * commented-out CREATE in the tree is a `--` line.
  */
 function upSectionOf(raw: string): string {
   const up = raw.split(/^\s*--\s*\+goose Down/m)[0] ?? raw;
@@ -52,6 +54,31 @@ function upSectionOf(raw: string): string {
     .split("\n")
     .filter((line) => !line.trim().startsWith("--"))
     .join("\n");
+}
+
+/**
+ * The single CREATE statement starting at `from`, ending at whichever comes
+ * first: its terminating `;` or the next `CREATE TABLE`.
+ *
+ * A fixed-width window instead of a real boundary is what makes this test lie:
+ * an unpartitioned table followed closely enough by a partitioned one would
+ * pick up the neighbour's `PARTITION BY` and be recorded as partitioned. Every
+ * assertion below would then pass against an entry describing a table that
+ * cannot prune — the exact silent gap this file exists to close.
+ */
+function statementAt(up: string, from: number): string {
+  const rest = up.slice(from);
+  const semicolon = rest.indexOf(";");
+  // Searched from index 1 so the match that opened this statement is skipped.
+  const nextCreate = rest.slice(1).search(/CREATE\s+TABLE/i);
+
+  return rest.slice(
+    0,
+    Math.min(
+      semicolon === -1 ? rest.length : semicolon,
+      nextCreate === -1 ? rest.length : nextCreate + 1,
+    ),
+  );
 }
 
 /** Tables one Up section creates with a PARTITION BY, mapped to it. */
@@ -63,8 +90,9 @@ function partitionedTablesIn(up: string): Map<string, string> {
   while ((match = createRe.exec(up)) !== null) {
     const table = match[1];
     if (!table) continue;
-    const tail = up.slice(match.index, match.index + 6000);
-    const partitionBy = /PARTITION BY\s+([^\n]+)/i.exec(tail);
+    const partitionBy = /PARTITION BY\s+([^\n]+)/i.exec(
+      statementAt(up, match.index),
+    );
     if (partitionBy?.[1]) found.set(table, partitionBy[1].trim());
   }
 
@@ -120,7 +148,7 @@ function pruneColumnMismatches(
 
 describe("cold-scan detector coverage", () => {
   describe("given a table is partitioned by a time expression", () => {
-    /** @scenario Every partitioned table is known to the cold-scan detector */
+    /** @scenario The detector knows every table the schema partitions by time */
     it("is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged", () => {
       const partitioned = partitionedTablesFromMigrations();
       // Guard against a vacuous pass: if the migration directory ever moved,
@@ -139,7 +167,7 @@ describe("cold-scan detector coverage", () => {
       expect(uncovered).toEqual([]);
     });
 
-    /** @scenario The declared prune column actually appears in the PARTITION BY */
+    /** @scenario The predicate the detector asks for is one that can prune */
     it("declares a prune column the PARTITION BY expression really uses", () => {
       const wrong = pruneColumnMismatches(partitionedTablesFromMigrations());
 
@@ -152,7 +180,7 @@ describe("cold-scan detector coverage", () => {
      * A stale entry makes the detector demand a time predicate on a table that
      * cannot prune by one — noise that trains people to ignore the warning.
      */
-    /** @scenario The map carries no table that is not partitioned */
+    /** @scenario The detector never demands a predicate that cannot prune */
     it("is a table that really is partitioned", () => {
       const partitioned = partitionedTablesFromMigrations();
 

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TIME_PARTITIONED_TABLES } from "../cold-scan-detector";
+
+/**
+ * The cold-scan detector fails OPEN: `detectColdScan` only inspects tables
+ * listed in {@link TIME_PARTITIONED_TABLES}, so a partitioned table missing from
+ * that map is silently treated as un-partitioned and never flagged, however
+ * expensively it is queried.
+ *
+ * That default cost real money and real availability: the map covered 11 of 35
+ * partitioned tables, and the 24 missing ones included `trace_analytics` and
+ * `trace_summaries`, whose unwindowed reads ran as undetected cold scans at
+ * ~350/min against a ClickHouse already at its memory ceiling. The gap was
+ * invisible precisely because the detector reported nothing.
+ *
+ * A comment saying "keep in sync" could not have caught that, so this parses the
+ * migrations and asserts the map matches.
+ */
+describe("cold-scan detector coverage", () => {
+  const migrationDir = resolve(
+    process.cwd(),
+    "src/server/clickhouse/migrations",
+  );
+
+  /**
+   * Tables created and later dropped. Their CREATE still exists in history —
+   * migrations are immutable — but they are gone, so the detector must not
+   * carry them.
+   */
+  const DROPPED = new Set<string>(["gateway_activity_events"]);
+
+  /**
+   * Scratch/rebuild tables that mirror a live table's schema. Queried only by
+   * the migration that builds them, never on a request path.
+   */
+  const NOT_ON_A_READ_PATH = new Set<string>([
+    "gateway_budget_scope_totals_rebuild",
+  ]);
+
+  /** Every table whose Up section declares a PARTITION BY, mapped to it. */
+  function partitionedTablesFromMigrations(): Map<string, string> {
+    const found = new Map<string, string>();
+
+    for (const file of readdirSync(migrationDir).sort()) {
+      if (!file.endsWith(".sql")) continue;
+
+      const raw = readFileSync(resolve(migrationDir, file), "utf-8");
+      // Drop comment lines: a commented-out CREATE in a Down section is not a
+      // live table, and counting it would demand coverage for something that
+      // does not exist.
+      const body = raw
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("--"))
+        .join("\n");
+      const up = body.split("+goose Down")[0] ?? body;
+
+      const createRe = /CREATE TABLE[^(]*?[.`]?(\w+)[\s`]*?\(/gi;
+      let match: RegExpExecArray | null;
+      while ((match = createRe.exec(up)) !== null) {
+        const table = match[1];
+        if (!table) continue;
+        const tail = up.slice(match.index, match.index + 6000);
+        const partitionBy = /PARTITION BY\s+([^\n]+)/i.exec(tail);
+        if (partitionBy?.[1]) found.set(table, partitionBy[1].trim());
+      }
+    }
+
+    return found;
+  }
+
+  describe("given a table is partitioned by a time expression", () => {
+    /** @scenario Every partitioned table is known to the cold-scan detector */
+    it("is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged", () => {
+      const partitioned = partitionedTablesFromMigrations();
+      const known = new Set(Object.keys(TIME_PARTITIONED_TABLES));
+
+      const uncovered = [...partitioned.keys()]
+        .filter((table) => !known.has(table))
+        .filter((table) => !DROPPED.has(table))
+        .filter((table) => !NOT_ON_A_READ_PATH.has(table))
+        .sort();
+
+      expect(uncovered).toEqual([]);
+    });
+
+    /** @scenario The declared prune column actually appears in the PARTITION BY */
+    it("declares a prune column the PARTITION BY expression really uses", () => {
+      const partitioned = partitionedTablesFromMigrations();
+      const wrong: string[] = [];
+
+      for (const [table, columns] of Object.entries(TIME_PARTITIONED_TABLES)) {
+        const expression = partitioned.get(table);
+        if (!expression) continue;
+        // At least one declared column must appear in the expression, else the
+        // detector is looking for a predicate that could never prune anything.
+        const anyMatches = (columns as readonly string[]).some((column) =>
+          new RegExp(`\\b${column}\\b`, "i").test(expression),
+        );
+        if (!anyMatches) {
+          wrong.push(`${table}: declares [${columns.join(", ")}], partitioned by ${expression}`);
+        }
+      }
+
+      expect(wrong).toEqual([]);
+    });
+  });
+
+  describe("given a table is listed in the detector", () => {
+    /**
+     * @scenario The map carries no table that is not partitioned
+     *
+     * A stale entry makes the detector demand a time predicate on a table that
+     * cannot prune by one — noise that trains people to ignore the warning.
+     */
+    it("is a table that really is partitioned", () => {
+      const partitioned = partitionedTablesFromMigrations();
+
+      const notPartitioned = Object.keys(TIME_PARTITIONED_TABLES)
+        .filter((table) => !partitioned.has(table))
+        .sort();
+
+      expect(notPartitioned).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
@@ -16,12 +16,22 @@
  * Tables partitioned by a time expression, mapped to the column names that, when
  * used in a WHERE/PREWHERE comparison, let ClickHouse prune partitions.
  *
- * Keep in sync with the ClickHouse migrations (PARTITION BY clauses). A table
- * absent from this map is treated as not time-partitioned and never flagged.
+ * Kept in sync with the ClickHouse migrations by
+ * `__tests__/cold-scan-detector.coverage.unit.test.ts`, which parses every
+ * `PARTITION BY` out of the migration files and fails when one is missing here.
+ * That test exists because the failure mode is SILENT: a table absent from this
+ * map is treated as not time-partitioned and is never flagged, so a new table
+ * gets no cold-scan detection at all and nobody finds out.
+ *
+ * Not hypothetical — this map covered 11 of 35 partitioned tables until the
+ * coverage test was added, and the 24 missing ones included `trace_analytics`
+ * and `trace_summaries`, whose unwindowed reads were running as UNDETECTED cold
+ * scans at ~350/min in production.
  */
 export const TIME_PARTITIONED_TABLES = {
   stored_spans: ["StartTime"],
   stored_log_records: ["TimeUnixMs"],
+  stored_metric_records: ["TimeUnixMs"],
   log_records: ["TimeUnixMs"],
   metric_data_points: ["TimeUnixMs"],
   metric_series: ["LastSeenAt"],
@@ -31,6 +41,35 @@ export const TIME_PARTITIONED_TABLES = {
   event_log: ["EventOccurredAt"],
   billable_events: ["EventTimestamp"],
   governance_ocsf_events: ["EventTime"],
+
+  // Fold / projection tables. Read by aggregate id, which is NOT a sort-key
+  // prefix on several of them, so an unwindowed read is a tenant-wide scan
+  // across every partition — exactly what this detector exists to surface.
+  trace_analytics: ["OccurredAt"],
+  trace_analytics_rollup: ["BucketStart"],
+  trace_summaries: ["OccurredAt"],
+  evaluation_analytics: ["OccurredAt"],
+  evaluation_analytics_rollup: ["BucketStart"],
+  evaluation_runs: ["ScheduledAt"],
+  coding_agent_sessions: ["StartedAt"],
+  coding_agent_trace_sessions: ["OccurredAt"],
+  session_metric_series: ["AsOf"],
+
+  // Run / experiment tables.
+  experiment_runs: ["StartedAt"],
+  experiment_run_items: ["OccurredAt"],
+  simulation_runs: ["StartedAt"],
+  suite_runs: ["StartedAt"],
+  dspy_steps: ["CreatedAt"],
+
+  // Gateway / governance / misc.
+  gateway_budget_ledger_events: ["OccurredAt"],
+  gateway_budget_scope_totals: ["PeriodStart"],
+  governance_kpis: ["HourBucket"],
+  automation_audit: ["OccurredAt"],
+  langy_analytics_events: ["OccurredAt"],
+  langy_messages: ["CreatedAt"],
+  stored_objects: ["created_at"],
 } as const satisfies Record<string, readonly string[]>;
 
 /** Strip line and block comments so they can't hide or fake a predicate. */

--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
@@ -20,168 +20,138 @@ import { EventRepositoryClickHouse } from "../repositories/eventRepositoryClickH
  *
  * `getEvents` already passed this bound; these two paths were the holdouts.
  */
-describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
-  const tenantId = createTenantId("test-tenant");
-  const OCCURRED_AT = 1_700_000_000_000;
+const tenantId = createTenantId("test-tenant");
+const OCCURRED_AT = 1_700_000_000_000;
+const TIME_LOCAL: AggregateType = "trace";
 
-  let queryMock: ReturnType<typeof vi.fn>;
-  let store: EventStoreClickHouse;
+let queryMock: ReturnType<typeof vi.fn>;
+let store: EventStoreClickHouse;
 
-  beforeEach(() => {
-    queryMock = vi.fn().mockResolvedValue({ json: async () => [] });
-    store = new EventStoreClickHouse(
-      new EventRepositoryClickHouse(
-        async () => ({ query: queryMock }) as unknown as ClickHouseClient,
-      ),
+beforeEach(() => {
+  queryMock = vi.fn().mockResolvedValue({ json: async () => [] });
+  store = new EventStoreClickHouse(
+    new EventRepositoryClickHouse(
+      async () => ({ query: queryMock }) as unknown as ClickHouseClient,
+    ),
+  );
+});
+
+const upToEvent = {
+  id: "event-1",
+  createdAt: 1000,
+  occurredAt: OCCURRED_AT,
+} as unknown as Event;
+
+// Genuinely the LAST call, not `calls[0]`: today each test issues exactly one
+// query so the two coincide, but a helper named `lastCall` that silently
+// returns the first would start lying the moment a read takes two queries.
+const lastCall = () =>
+  queryMock.mock.calls.at(-1)![0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+  };
+
+describe("re-fold reads prune partitions — unpaged, time-local aggregate", () => {
+  it("filters on EventOccurredAt so ClickHouse can prune partitions", async () => {
+    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
+
+    expect(lastCall().query).toContain("EventOccurredAt >=");
+  });
+
+  it("anchors the window on the triggering event, one window back", async () => {
+    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
+
+    expect(lastCall().query_params.occurredAtFromMs).toBe(
+      OCCURRED_AT - REHYDRATION_WINDOW_MS,
     );
   });
 
-  const upToEvent = {
-    id: "event-1",
-    createdAt: 1000,
-    occurredAt: OCCURRED_AT,
-  } as unknown as Event;
+  it("keeps rows with an unknown occurred time, so the bound can never drop one", async () => {
+    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
 
-  // Genuinely the LAST call, not `calls[0]`: today each test issues exactly one
-  // query so the two coincide, but a helper named `lastCall` that silently
-  // returns the first would start lying the moment a read takes two queries.
-  const lastCall = () =>
-    queryMock.mock.calls.at(-1)![0] as {
-      query: string;
-      query_params: Record<string, unknown>;
-    };
+    expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
+  });
+});
 
-  describe("given a time-local aggregate type", () => {
-    const aggregateType: AggregateType = "trace";
+describe("re-fold reads prune partitions — paged, time-local aggregate", () => {
+  const pagedRequest = {
+    aggregateId: "trace-1",
+    context: { tenantId },
+    aggregateType: TIME_LOCAL,
+    upToEvent,
+    after: { timestamp: 500, eventId: "event-0" },
+    limit: 100,
+  };
 
-    describe("when getEventsUpTo runs", () => {
-      it("filters on EventOccurredAt so ClickHouse can prune partitions", async () => {
-        await store.getEventsUpTo(
-          "trace-1",
-          { tenantId },
-          aggregateType,
-          upToEvent,
-        );
+  it("bounds every page, not just the first", async () => {
+    // Unbounded, the cost is paid once PER PAGE rather than once per
+    // re-fold — every page re-opens every partition.
+    await store.getEventsUpToPaged?.(pagedRequest);
 
-        expect(lastCall().query).toContain("EventOccurredAt >=");
-      });
-
-      it("anchors the window on the triggering event, one window back", async () => {
-        await store.getEventsUpTo(
-          "trace-1",
-          { tenantId },
-          aggregateType,
-          upToEvent,
-        );
-
-        expect(lastCall().query_params.occurredAtFromMs).toBe(
-          OCCURRED_AT - REHYDRATION_WINDOW_MS,
-        );
-      });
-
-      it("keeps rows with an unknown occurred time, so the bound can never drop one", async () => {
-        await store.getEventsUpTo(
-          "trace-1",
-          { tenantId },
-          aggregateType,
-          upToEvent,
-        );
-
-        expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
-      });
-    });
-
-    describe("when the paginated re-fold runs", () => {
-      it("bounds every page, not just the first", async () => {
-        // Unbounded, the cost is paid once PER PAGE rather than once per
-        // re-fold — every page re-opens every partition.
-        await store.getEventsUpToPaged?.({
-          aggregateId: "trace-1",
-          context: { tenantId },
-          aggregateType,
-          upToEvent,
-          after: { timestamp: 500, eventId: "event-0" },
-          limit: 100,
-        });
-
-        expect(lastCall().query).toContain("EventOccurredAt >=");
-        expect(lastCall().query_params.occurredAtFromMs).toBe(
-          OCCURRED_AT - REHYDRATION_WINDOW_MS,
-        );
-      });
-
-      it("keeps rows with an unknown occurred time on the paged path too", async () => {
-        // The paged builder renders its own copy of the filter string rather
-        // than sharing one, so the escape hatch has to be asserted separately —
-        // dropping it from just this copy would otherwise pass every test.
-        await store.getEventsUpToPaged?.({
-          aggregateId: "trace-1",
-          context: { tenantId },
-          aggregateType,
-          upToEvent,
-          after: { timestamp: 500, eventId: "event-0" },
-          limit: 100,
-        });
-
-        expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
-      });
-    });
+    expect(lastCall().query).toContain("EventOccurredAt >=");
+    expect(lastCall().query_params.occurredAtFromMs).toBe(
+      OCCURRED_AT - REHYDRATION_WINDOW_MS,
+    );
   });
 
-  /**
-   * The safety half of the contract. `global` and `billing_report` aggregate
-   * over arbitrary time ranges, so a window around any single event WOULD drop
-   * their history. `rehydrationLowerBoundMs` returns undefined for them and the
-   * read must stay unbounded — slow, but correct.
-   */
-  describe("given a long-lived aggregate type", () => {
-    it("issues no lower bound, leaving the scan unbounded", async () => {
-      await store.getEventsUpTo(
-        "global-1",
-        { tenantId },
-        "global" as AggregateType,
-        upToEvent,
-      );
+  it("keeps rows with an unknown occurred time on the paged path too", async () => {
+    // The paged builder renders its own copy of the filter string rather than
+    // sharing one, so the escape hatch has to be asserted separately —
+    // dropping it from just this copy would otherwise pass every test.
+    await store.getEventsUpToPaged?.(pagedRequest);
 
-      expect(lastCall().query).not.toContain("EventOccurredAt >=");
-      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
-    });
+    expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
+  });
+});
 
-    it("leaves the paged scan unbounded too", async () => {
-      // The paged path computes the bound with its own call to
-      // `rehydrationLowerBoundMs`, so the unbounded half of the contract has to
-      // be proven here as well as on the unpaged read.
-      await store.getEventsUpToPaged?.({
-        aggregateId: "global-1",
-        context: { tenantId },
-        aggregateType: "global" as AggregateType,
-        upToEvent,
-        after: undefined,
-        limit: 100,
-      });
+/**
+ * The safety half of the contract. `global` and `billing_report` aggregate
+ * over arbitrary time ranges, so a window around any single event WOULD drop
+ * their history. `rehydrationLowerBoundMs` returns undefined for them and the
+ * read must stay unbounded — slow, but correct.
+ */
+describe("re-fold reads prune partitions — long-lived aggregate type", () => {
+  it("issues no lower bound, leaving the scan unbounded", async () => {
+    await store.getEventsUpTo(
+      "global-1",
+      { tenantId },
+      "global" as AggregateType,
+      upToEvent,
+    );
 
-      expect(lastCall().query).not.toContain("EventOccurredAt >=");
-      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
-    });
+    expect(lastCall().query).not.toContain("EventOccurredAt >=");
+    expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
   });
 
-  describe("given an event with no usable occurred time", () => {
-    it("issues no lower bound rather than anchoring on zero", async () => {
-      // Anchoring on 0 would produce a bound in 1970 and prune nothing, or
-      // worse, a negative bound. Better to skip it.
-      await store.getEventsUpTo(
-        "trace-1",
-        { tenantId },
-        "trace" as AggregateType,
-        {
-          id: "event-1",
-          createdAt: 1000,
-          occurredAt: 0,
-        } as unknown as Event,
-      );
-
-      expect(lastCall().query).not.toContain("EventOccurredAt >=");
-      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
+  it("leaves the paged scan unbounded too", async () => {
+    // The paged path computes the bound with its own call to
+    // `rehydrationLowerBoundMs`, so the unbounded half of the contract has to
+    // be proven here as well as on the unpaged read.
+    await store.getEventsUpToPaged?.({
+      aggregateId: "global-1",
+      context: { tenantId },
+      aggregateType: "global" as AggregateType,
+      upToEvent,
+      after: undefined,
+      limit: 100,
     });
+
+    expect(lastCall().query).not.toContain("EventOccurredAt >=");
+    expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
+  });
+});
+
+describe("re-fold reads prune partitions — event with no usable occurred time", () => {
+  it("issues no lower bound rather than anchoring on zero", async () => {
+    // Anchoring on 0 would produce a bound in 1970 and prune nothing, or
+    // worse, a negative bound. Better to skip it.
+    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, {
+      id: "event-1",
+      createdAt: 1000,
+      occurredAt: 0,
+    } as unknown as Event);
+
+    expect(lastCall().query).not.toContain("EventOccurredAt >=");
+    expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
   });
 });

--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
@@ -42,23 +42,37 @@ describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
     occurredAt: OCCURRED_AT,
   } as unknown as Event;
 
-  const lastCall = () => queryMock.mock.calls[0]![0] as {
-    query: string;
-    query_params: Record<string, unknown>;
-  };
+  // Genuinely the LAST call, not `calls[0]`: today each test issues exactly one
+  // query so the two coincide, but a helper named `lastCall` that silently
+  // returns the first would start lying the moment a read takes two queries.
+  const lastCall = () =>
+    queryMock.mock.calls.at(-1)![0] as {
+      query: string;
+      query_params: Record<string, unknown>;
+    };
 
   describe("given a time-local aggregate type", () => {
     const aggregateType: AggregateType = "trace";
 
     describe("when getEventsUpTo runs", () => {
       it("filters on EventOccurredAt so ClickHouse can prune partitions", async () => {
-        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+        await store.getEventsUpTo(
+          "trace-1",
+          { tenantId },
+          aggregateType,
+          upToEvent,
+        );
 
         expect(lastCall().query).toContain("EventOccurredAt >=");
       });
 
       it("anchors the window on the triggering event, one window back", async () => {
-        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+        await store.getEventsUpTo(
+          "trace-1",
+          { tenantId },
+          aggregateType,
+          upToEvent,
+        );
 
         expect(lastCall().query_params.occurredAtFromMs).toBe(
           OCCURRED_AT - REHYDRATION_WINDOW_MS,
@@ -66,7 +80,12 @@ describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
       });
 
       it("keeps rows with an unknown occurred time, so the bound can never drop one", async () => {
-        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+        await store.getEventsUpTo(
+          "trace-1",
+          { tenantId },
+          aggregateType,
+          upToEvent,
+        );
 
         expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
       });
@@ -90,6 +109,22 @@ describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
           OCCURRED_AT - REHYDRATION_WINDOW_MS,
         );
       });
+
+      it("keeps rows with an unknown occurred time on the paged path too", async () => {
+        // The paged builder renders its own copy of the filter string rather
+        // than sharing one, so the escape hatch has to be asserted separately —
+        // dropping it from just this copy would otherwise pass every test.
+        await store.getEventsUpToPaged?.({
+          aggregateId: "trace-1",
+          context: { tenantId },
+          aggregateType,
+          upToEvent,
+          after: { timestamp: 500, eventId: "event-0" },
+          limit: 100,
+        });
+
+        expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
+      });
     });
   });
 
@@ -111,17 +146,39 @@ describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
       expect(lastCall().query).not.toContain("EventOccurredAt >=");
       expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
     });
+
+    it("leaves the paged scan unbounded too", async () => {
+      // The paged path computes the bound with its own call to
+      // `rehydrationLowerBoundMs`, so the unbounded half of the contract has to
+      // be proven here as well as on the unpaged read.
+      await store.getEventsUpToPaged?.({
+        aggregateId: "global-1",
+        context: { tenantId },
+        aggregateType: "global" as AggregateType,
+        upToEvent,
+        after: undefined,
+        limit: 100,
+      });
+
+      expect(lastCall().query).not.toContain("EventOccurredAt >=");
+      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
+    });
   });
 
   describe("given an event with no usable occurred time", () => {
     it("issues no lower bound rather than anchoring on zero", async () => {
       // Anchoring on 0 would produce a bound in 1970 and prune nothing, or
       // worse, a negative bound. Better to skip it.
-      await store.getEventsUpTo("trace-1", { tenantId }, "trace" as AggregateType, {
-        id: "event-1",
-        createdAt: 1000,
-        occurredAt: 0,
-      } as unknown as Event);
+      await store.getEventsUpTo(
+        "trace-1",
+        { tenantId },
+        "trace" as AggregateType,
+        {
+          id: "event-1",
+          createdAt: 1000,
+          occurredAt: 0,
+        } as unknown as Event,
+      );
 
       expect(lastCall().query).not.toContain("EventOccurredAt >=");
       expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();

--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
@@ -1,0 +1,130 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AggregateType } from "../../";
+import { createTenantId } from "../../domain/tenantId";
+import type { Event } from "../../domain/types";
+import { EventStoreClickHouse } from "../eventStoreClickHouse";
+import { REHYDRATION_WINDOW_MS } from "../rehydrationWindow";
+import { EventRepositoryClickHouse } from "../repositories/eventRepositoryClickHouse";
+
+/**
+ * `event_log` is `PARTITION BY toYearWeek(EventOccurredAt)`, but the re-fold
+ * reads bound on `EventTimestamp` — acceptance order, NOT the partition key. So
+ * without a predicate on `EventOccurredAt` the read cannot prune, and walks
+ * every weekly partition ever written including the cold tier on S3.
+ *
+ * Measured in production before this bound existed: `event_log` was the ONLY
+ * table cold-scanning (198 scans in 15 minutes across 3 pods), all of it from
+ * these two loaders, against a table taking ~1M trace events/day with tenant
+ * retentions up to 1827 days.
+ *
+ * `getEvents` already passed this bound; these two paths were the holdouts.
+ */
+describe("EventStoreClickHouse — re-fold reads prune partitions", () => {
+  const tenantId = createTenantId("test-tenant");
+  const OCCURRED_AT = 1_700_000_000_000;
+
+  let queryMock: ReturnType<typeof vi.fn>;
+  let store: EventStoreClickHouse;
+
+  beforeEach(() => {
+    queryMock = vi.fn().mockResolvedValue({ json: async () => [] });
+    store = new EventStoreClickHouse(
+      new EventRepositoryClickHouse(
+        async () => ({ query: queryMock }) as unknown as ClickHouseClient,
+      ),
+    );
+  });
+
+  const upToEvent = {
+    id: "event-1",
+    createdAt: 1000,
+    occurredAt: OCCURRED_AT,
+  } as unknown as Event;
+
+  const lastCall = () => queryMock.mock.calls[0]![0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+  };
+
+  describe("given a time-local aggregate type", () => {
+    const aggregateType: AggregateType = "trace";
+
+    describe("when getEventsUpTo runs", () => {
+      it("filters on EventOccurredAt so ClickHouse can prune partitions", async () => {
+        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+
+        expect(lastCall().query).toContain("EventOccurredAt >=");
+      });
+
+      it("anchors the window on the triggering event, one window back", async () => {
+        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+
+        expect(lastCall().query_params.occurredAtFromMs).toBe(
+          OCCURRED_AT - REHYDRATION_WINDOW_MS,
+        );
+      });
+
+      it("keeps rows with an unknown occurred time, so the bound can never drop one", async () => {
+        await store.getEventsUpTo("trace-1", { tenantId }, aggregateType, upToEvent);
+
+        expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
+      });
+    });
+
+    describe("when the paginated re-fold runs", () => {
+      it("bounds every page, not just the first", async () => {
+        // Unbounded, the cost is paid once PER PAGE rather than once per
+        // re-fold — every page re-opens every partition.
+        await store.getEventsUpToPaged?.({
+          aggregateId: "trace-1",
+          context: { tenantId },
+          aggregateType,
+          upToEvent,
+          after: { timestamp: 500, eventId: "event-0" },
+          limit: 100,
+        });
+
+        expect(lastCall().query).toContain("EventOccurredAt >=");
+        expect(lastCall().query_params.occurredAtFromMs).toBe(
+          OCCURRED_AT - REHYDRATION_WINDOW_MS,
+        );
+      });
+    });
+  });
+
+  /**
+   * The safety half of the contract. `global` and `billing_report` aggregate
+   * over arbitrary time ranges, so a window around any single event WOULD drop
+   * their history. `rehydrationLowerBoundMs` returns undefined for them and the
+   * read must stay unbounded — slow, but correct.
+   */
+  describe("given a long-lived aggregate type", () => {
+    it("issues no lower bound, leaving the scan unbounded", async () => {
+      await store.getEventsUpTo(
+        "global-1",
+        { tenantId },
+        "global" as AggregateType,
+        upToEvent,
+      );
+
+      expect(lastCall().query).not.toContain("EventOccurredAt >=");
+      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
+    });
+  });
+
+  describe("given an event with no usable occurred time", () => {
+    it("issues no lower bound rather than anchoring on zero", async () => {
+      // Anchoring on 0 would produce a bound in 1970 and prune nothing, or
+      // worse, a negative bound. Better to skip it.
+      await store.getEventsUpTo("trace-1", { tenantId }, "trace" as AggregateType, {
+        id: "event-1",
+        createdAt: 1000,
+        occurredAt: 0,
+      } as unknown as Event);
+
+      expect(lastCall().query).not.toContain("EventOccurredAt >=");
+      expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
+++ b/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
@@ -292,6 +292,13 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
             aggregateId,
             upToEvent.createdAt,
             upToEvent.id,
+            // Anchor on the triggering event's own occurred time. For a
+            // time-local aggregate every sibling event falls inside the
+            // aggregate's lifetime — seconds to hours — so a 45-day window
+            // around the anchor cannot exclude one. `rehydrationLowerBoundMs`
+            // returns undefined for long-lived types and for a missing anchor,
+            // leaving those reads unbounded exactly as before.
+            rehydrationLowerBoundMs(aggregateType, upToEvent.occurredAt),
           );
 
           const events = records.map((record) =>
@@ -388,6 +395,13 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
             upToEventId: upToEvent.id,
             after,
             limit,
+            // Same bound as the unpaged read. It matters MORE here: without it
+            // every page re-opens every partition, so the cost is paid once per
+            // page rather than once per re-fold.
+            occurredAtFromMs: rehydrationLowerBoundMs(
+              aggregateType,
+              upToEvent.occurredAt,
+            ),
           });
 
           const events = records.map((record) =>

--- a/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
+++ b/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
@@ -286,20 +286,23 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       },
       async () => {
         try {
-          const records = await this.repository.getEventRecordsUpTo(
-            context.tenantId,
+          const records = await this.repository.getEventRecordsUpTo({
+            tenantId: context.tenantId,
             aggregateType,
             aggregateId,
-            upToEvent.createdAt,
-            upToEvent.id,
+            upToTimestamp: upToEvent.createdAt,
+            upToEventId: upToEvent.id,
             // Anchor on the triggering event's own occurred time. For a
             // time-local aggregate every sibling event falls inside the
             // aggregate's lifetime — seconds to hours — so a 45-day window
             // around the anchor cannot exclude one. `rehydrationLowerBoundMs`
             // returns undefined for long-lived types and for a missing anchor,
             // leaving those reads unbounded exactly as before.
-            rehydrationLowerBoundMs(aggregateType, upToEvent.occurredAt),
-          );
+            occurredAtFromMs: rehydrationLowerBoundMs(
+              aggregateType,
+              upToEvent.occurredAt,
+            ),
+          });
 
           const events = records.map((record) =>
             recordToEvent<EventType>(record, aggregateId),

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { EventRecord } from "../eventRepository.types";
+import { EventRepositoryMemory } from "../eventRepositoryMemory";
+
+/**
+ * The re-fold reads (`getEventRecordsUpTo` and its paged twin) take an
+ * `occurredAtFromMs` lower bound so ClickHouse can prune `event_log`'s weekly
+ * partitions. The in-memory repository mirrors that filter ON PURPOSE: a window
+ * too small to cover an aggregate's lifetime must drop events HERE, in tests,
+ * rather than only in production against real data.
+ *
+ * That mirror is the whole safety argument, so it needs its own tests — without
+ * them an inverted comparison or a dropped unknown-time check would pass every
+ * suite and the mirror would quietly stop mirroring.
+ *
+ * Unknown occurred times are kept: the SQL says `EventOccurredAt = 0 OR ...`,
+ * and the memory record type also allows null, so both spellings of "unknown"
+ * survive the bound.
+ */
+function record(eventId: string, occurredAt: number | null): EventRecord {
+  return {
+    TenantId: "tenant",
+    AggregateType: "trace",
+    AggregateId: "agg",
+    EventId: eventId,
+    // Kept distinct from EventOccurredAt: the upper bound is on EventTimestamp
+    // (acceptance order) and must not be what the lower bound is read from.
+    EventTimestamp: 1000,
+    EventOccurredAt: occurredAt,
+    EventType: "test.event",
+    EventVersion: "1",
+    EventPayload: {},
+    ProcessingTraceparent: "",
+    IdempotencyKey: eventId,
+  };
+}
+
+describe("EventRepositoryMemory re-fold reads mirror the ClickHouse lower bound", () => {
+  const bound = 1_700_000_000_000;
+
+  async function seeded() {
+    const repo = new EventRepositoryMemory();
+    await repo.insertEventRecords([
+      record("before", bound - 1000), // older than the bound
+      record("at", bound), // exactly at the bound
+      record("after", bound + 1000), // newer than the bound
+      record("unknown-zero", 0), // unknown occurred time, as ClickHouse spells it
+      record("unknown-null", null), // unknown occurred time, as the memory type allows
+    ]);
+    return repo;
+  }
+
+  // Above every record's EventTimestamp, so the upper bound excludes nothing
+  // and each assertion below is about the lower bound alone.
+  const upToTimestamp = 2000;
+  const upToEventId = "zzz";
+
+  describe("given getEventRecordsUpTo", () => {
+    it("returns every event when no lower bound is passed", async () => {
+      const repo = await seeded();
+
+      const ids = (
+        await repo.getEventRecordsUpTo(
+          "tenant",
+          "trace",
+          "agg",
+          upToTimestamp,
+          upToEventId,
+        )
+      ).map((r) => r.EventId);
+
+      expect(new Set(ids)).toEqual(
+        new Set(["before", "at", "after", "unknown-zero", "unknown-null"]),
+      );
+    });
+
+    it("drops events older than the bound and keeps unknown occurred times", async () => {
+      const repo = await seeded();
+
+      const ids = (
+        await repo.getEventRecordsUpTo(
+          "tenant",
+          "trace",
+          "agg",
+          upToTimestamp,
+          upToEventId,
+          bound,
+        )
+      ).map((r) => r.EventId);
+
+      expect(new Set(ids)).toEqual(
+        new Set(["at", "after", "unknown-zero", "unknown-null"]),
+      );
+      expect(ids).not.toContain("before");
+    });
+  });
+
+  describe("given the paged re-fold", () => {
+    it("returns every event when no lower bound is passed", async () => {
+      const repo = await seeded();
+
+      const ids = (
+        await repo.getEventRecordsUpToPaged({
+          tenantId: "tenant",
+          aggregateType: "trace",
+          aggregateId: "agg",
+          upToTimestamp,
+          upToEventId,
+          after: undefined,
+          limit: 100,
+        })
+      ).map((r) => r.EventId);
+
+      expect(new Set(ids)).toEqual(
+        new Set(["before", "at", "after", "unknown-zero", "unknown-null"]),
+      );
+    });
+
+    it("applies the same bound as the unpaged read", async () => {
+      const repo = await seeded();
+
+      const ids = (
+        await repo.getEventRecordsUpToPaged({
+          tenantId: "tenant",
+          aggregateType: "trace",
+          aggregateId: "agg",
+          upToTimestamp,
+          upToEventId,
+          after: undefined,
+          limit: 100,
+          occurredAtFromMs: bound,
+        })
+      ).map((r) => r.EventId);
+
+      expect(new Set(ids)).toEqual(
+        new Set(["at", "after", "unknown-zero", "unknown-null"]),
+      );
+      expect(ids).not.toContain("before");
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
@@ -35,107 +35,100 @@ function record(eventId: string, occurredAt: number | null): EventRecord {
   };
 }
 
-describe("EventRepositoryMemory re-fold reads mirror the ClickHouse lower bound", () => {
-  const bound = 1_700_000_000_000;
+const bound = 1_700_000_000_000;
 
-  async function seeded() {
-    const repo = new EventRepositoryMemory();
-    await repo.insertEventRecords([
-      record("before", bound - 1000), // older than the bound
-      record("at", bound), // exactly at the bound
-      record("after", bound + 1000), // newer than the bound
-      record("unknown-zero", 0), // unknown occurred time, as ClickHouse spells it
-      record("unknown-null", null), // unknown occurred time, as the memory type allows
-    ]);
-    return repo;
-  }
+async function seeded() {
+  const repo = new EventRepositoryMemory();
+  await repo.insertEventRecords([
+    record("before", bound - 1000), // older than the bound
+    record("at", bound), // exactly at the bound
+    record("after", bound + 1000), // newer than the bound
+    record("unknown-zero", 0), // unknown occurred time, as ClickHouse spells it
+    record("unknown-null", null), // unknown occurred time, as the memory type allows
+  ]);
+  return repo;
+}
 
-  // Above every record's EventTimestamp, so the upper bound excludes nothing
-  // and each assertion below is about the lower bound alone.
-  const upToTimestamp = 2000;
-  const upToEventId = "zzz";
+// Above every record's EventTimestamp, so the upper bound excludes nothing
+// and each assertion below is about the lower bound alone.
+const upToTimestamp = 2000;
+const upToEventId = "zzz";
 
-  describe("given getEventRecordsUpTo", () => {
-    it("returns every event when no lower bound is passed", async () => {
-      const repo = await seeded();
+const ALL_IDS = ["before", "at", "after", "unknown-zero", "unknown-null"];
+const WITHIN_BOUND = ["at", "after", "unknown-zero", "unknown-null"];
 
-      const ids = (
-        await repo.getEventRecordsUpTo(
-          "tenant",
-          "trace",
-          "agg",
-          upToTimestamp,
-          upToEventId,
-        )
-      ).map((r) => r.EventId);
+describe("EventRepositoryMemory.getEventRecordsUpTo mirrors the lower bound", () => {
+  it("returns every event when no lower bound is passed", async () => {
+    const repo = await seeded();
 
-      expect(new Set(ids)).toEqual(
-        new Set(["before", "at", "after", "unknown-zero", "unknown-null"]),
-      );
-    });
+    const ids = (
+      await repo.getEventRecordsUpTo(
+        "tenant",
+        "trace",
+        "agg",
+        upToTimestamp,
+        upToEventId,
+      )
+    ).map((r) => r.EventId);
 
-    it("drops events older than the bound and keeps unknown occurred times", async () => {
-      const repo = await seeded();
-
-      const ids = (
-        await repo.getEventRecordsUpTo(
-          "tenant",
-          "trace",
-          "agg",
-          upToTimestamp,
-          upToEventId,
-          bound,
-        )
-      ).map((r) => r.EventId);
-
-      expect(new Set(ids)).toEqual(
-        new Set(["at", "after", "unknown-zero", "unknown-null"]),
-      );
-      expect(ids).not.toContain("before");
-    });
+    expect(new Set(ids)).toEqual(new Set(ALL_IDS));
   });
 
-  describe("given the paged re-fold", () => {
-    it("returns every event when no lower bound is passed", async () => {
-      const repo = await seeded();
+  it("drops events older than the bound and keeps unknown occurred times", async () => {
+    const repo = await seeded();
 
-      const ids = (
-        await repo.getEventRecordsUpToPaged({
-          tenantId: "tenant",
-          aggregateType: "trace",
-          aggregateId: "agg",
-          upToTimestamp,
-          upToEventId,
-          after: undefined,
-          limit: 100,
-        })
-      ).map((r) => r.EventId);
+    const ids = (
+      await repo.getEventRecordsUpTo(
+        "tenant",
+        "trace",
+        "agg",
+        upToTimestamp,
+        upToEventId,
+        bound,
+      )
+    ).map((r) => r.EventId);
 
-      expect(new Set(ids)).toEqual(
-        new Set(["before", "at", "after", "unknown-zero", "unknown-null"]),
-      );
-    });
+    expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
+    expect(ids).not.toContain("before");
+  });
+});
 
-    it("applies the same bound as the unpaged read", async () => {
-      const repo = await seeded();
+describe("EventRepositoryMemory paged re-fold mirrors the lower bound", () => {
+  it("returns every event when no lower bound is passed", async () => {
+    const repo = await seeded();
 
-      const ids = (
-        await repo.getEventRecordsUpToPaged({
-          tenantId: "tenant",
-          aggregateType: "trace",
-          aggregateId: "agg",
-          upToTimestamp,
-          upToEventId,
-          after: undefined,
-          limit: 100,
-          occurredAtFromMs: bound,
-        })
-      ).map((r) => r.EventId);
+    const ids = (
+      await repo.getEventRecordsUpToPaged({
+        tenantId: "tenant",
+        aggregateType: "trace",
+        aggregateId: "agg",
+        upToTimestamp,
+        upToEventId,
+        after: undefined,
+        limit: 100,
+      })
+    ).map((r) => r.EventId);
 
-      expect(new Set(ids)).toEqual(
-        new Set(["at", "after", "unknown-zero", "unknown-null"]),
-      );
-      expect(ids).not.toContain("before");
-    });
+    expect(new Set(ids)).toEqual(new Set(ALL_IDS));
+  });
+
+  it("applies the same bound as the unpaged read", async () => {
+    const repo = await seeded();
+
+    const ids = (
+      await repo.getEventRecordsUpToPaged({
+        tenantId: "tenant",
+        aggregateType: "trace",
+        aggregateId: "agg",
+        upToTimestamp,
+        upToEventId,
+        after: undefined,
+        limit: 100,
+        occurredAtFromMs: bound,
+      })
+    ).map((r) => r.EventId);
+
+    expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
+    expect(ids).not.toContain("before");
   });
 });

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.refoldLowerBound.unit.test.ts
@@ -17,7 +17,13 @@ import { EventRepositoryMemory } from "../eventRepositoryMemory";
  * and the memory record type also allows null, so both spellings of "unknown"
  * survive the bound.
  */
-function record(eventId: string, occurredAt: number | null): EventRecord {
+function record({
+  eventId,
+  occurredAt,
+}: {
+  eventId: string;
+  occurredAt: number | null;
+}): EventRecord {
   return {
     TenantId: "tenant",
     AggregateType: "trace",
@@ -40,11 +46,13 @@ const bound = 1_700_000_000_000;
 async function seeded() {
   const repo = new EventRepositoryMemory();
   await repo.insertEventRecords([
-    record("before", bound - 1000), // older than the bound
-    record("at", bound), // exactly at the bound
-    record("after", bound + 1000), // newer than the bound
-    record("unknown-zero", 0), // unknown occurred time, as ClickHouse spells it
-    record("unknown-null", null), // unknown occurred time, as the memory type allows
+    record({ eventId: "before", occurredAt: bound - 1000 }), // older than the bound
+    record({ eventId: "at", occurredAt: bound }), // exactly at the bound
+    record({ eventId: "after", occurredAt: bound + 1000 }), // newer than the bound
+    // Unknown occurred time, as ClickHouse spells it
+    record({ eventId: "unknown-zero", occurredAt: 0 }),
+    // Unknown occurred time, as the memory type allows
+    record({ eventId: "unknown-null", occurredAt: null }),
   ]);
   return repo;
 }
@@ -57,78 +65,72 @@ const upToEventId = "zzz";
 const ALL_IDS = ["before", "at", "after", "unknown-zero", "unknown-null"];
 const WITHIN_BOUND = ["at", "after", "unknown-zero", "unknown-null"];
 
-describe("EventRepositoryMemory.getEventRecordsUpTo mirrors the lower bound", () => {
-  it("returns every event when no lower bound is passed", async () => {
-    const repo = await seeded();
-
-    const ids = (
-      await repo.getEventRecordsUpTo(
-        "tenant",
-        "trace",
-        "agg",
-        upToTimestamp,
-        upToEventId,
-      )
-    ).map((r) => r.EventId);
-
-    expect(new Set(ids)).toEqual(new Set(ALL_IDS));
+async function readUnpaged(
+  repo: EventRepositoryMemory,
+  occurredAtFromMs?: number,
+): Promise<string[]> {
+  const records = await repo.getEventRecordsUpTo({
+    tenantId: "tenant",
+    aggregateType: "trace",
+    aggregateId: "agg",
+    upToTimestamp,
+    upToEventId,
+    occurredAtFromMs,
   });
+  return records.map((r) => r.EventId);
+}
 
-  it("drops events older than the bound and keeps unknown occurred times", async () => {
-    const repo = await seeded();
-
-    const ids = (
-      await repo.getEventRecordsUpTo(
-        "tenant",
-        "trace",
-        "agg",
-        upToTimestamp,
-        upToEventId,
-        bound,
-      )
-    ).map((r) => r.EventId);
-
-    expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
-    expect(ids).not.toContain("before");
+async function readPaged(
+  repo: EventRepositoryMemory,
+  occurredAtFromMs?: number,
+): Promise<string[]> {
+  const records = await repo.getEventRecordsUpToPaged({
+    tenantId: "tenant",
+    aggregateType: "trace",
+    aggregateId: "agg",
+    upToTimestamp,
+    upToEventId,
+    after: undefined,
+    limit: 100,
+    occurredAtFromMs,
   });
-});
+  return records.map((r) => r.EventId);
+}
 
-describe("EventRepositoryMemory paged re-fold mirrors the lower bound", () => {
-  it("returns every event when no lower bound is passed", async () => {
-    const repo = await seeded();
+describe("EventRepositoryMemory mirrors the re-fold lower bound", () => {
+  describe("given events seeded either side of the bound, and two with an unknown occurred time", () => {
+    describe("when getEventRecordsUpTo reads without a lower bound", () => {
+      it("returns every event", async () => {
+        const ids = await readUnpaged(await seeded());
 
-    const ids = (
-      await repo.getEventRecordsUpToPaged({
-        tenantId: "tenant",
-        aggregateType: "trace",
-        aggregateId: "agg",
-        upToTimestamp,
-        upToEventId,
-        after: undefined,
-        limit: 100,
-      })
-    ).map((r) => r.EventId);
+        expect(new Set(ids)).toEqual(new Set(ALL_IDS));
+      });
+    });
 
-    expect(new Set(ids)).toEqual(new Set(ALL_IDS));
-  });
+    describe("when getEventRecordsUpTo reads with the lower bound", () => {
+      it("drops events older than the bound and keeps unknown occurred times", async () => {
+        const ids = await readUnpaged(await seeded(), bound);
 
-  it("applies the same bound as the unpaged read", async () => {
-    const repo = await seeded();
+        expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
+        expect(ids).not.toContain("before");
+      });
+    });
 
-    const ids = (
-      await repo.getEventRecordsUpToPaged({
-        tenantId: "tenant",
-        aggregateType: "trace",
-        aggregateId: "agg",
-        upToTimestamp,
-        upToEventId,
-        after: undefined,
-        limit: 100,
-        occurredAtFromMs: bound,
-      })
-    ).map((r) => r.EventId);
+    describe("when getEventRecordsUpToPaged reads without a lower bound", () => {
+      it("returns every event", async () => {
+        const ids = await readPaged(await seeded());
 
-    expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
-    expect(ids).not.toContain("before");
+        expect(new Set(ids)).toEqual(new Set(ALL_IDS));
+      });
+    });
+
+    describe("when getEventRecordsUpToPaged reads with the lower bound", () => {
+      it("applies the same bound as the unpaged read", async () => {
+        const ids = await readPaged(await seeded(), bound);
+
+        expect(new Set(ids)).toEqual(new Set(WITHIN_BOUND));
+        expect(ids).not.toContain("before");
+      });
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
@@ -50,6 +50,12 @@ export interface EventRepository {
    * Events are filtered where:
    * - timestamp < upToTimestamp, OR
    * - timestamp = upToTimestamp AND eventId <= upToEventId
+   *
+   * `occurredAtFromMs` carries the same meaning and the same caveats as on
+   * {@link EventRepository.getEventRecords}: a partition-pruning lower bound on
+   * `EventOccurredAt`, supplied by `rehydrationLowerBoundMs`. The upper bound
+   * above is on EventTimestamp, which is NOT the partition key, so without this
+   * the read walks every weekly partition ever written.
    */
   getEventRecordsUpTo(
     tenantId: string,
@@ -57,6 +63,7 @@ export interface EventRepository {
     aggregateId: string,
     upToTimestamp: number,
     upToEventId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]>;
 
   /**
@@ -79,6 +86,8 @@ export interface EventRepository {
     upToEventId: string;
     after: { timestamp: number; eventId: string } | undefined;
     limit: number;
+    /** Partition-pruning lower bound — see {@link EventRepository.getEventRecordsUpTo}. */
+    occurredAtFromMs?: number;
   }): Promise<EventRecord[]>;
 
   /**

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
@@ -57,14 +57,14 @@ export interface EventRepository {
    * above is on EventTimestamp, which is NOT the partition key, so without this
    * the read walks every weekly partition ever written.
    */
-  getEventRecordsUpTo(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    upToTimestamp: number,
-    upToEventId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]>;
+  getEventRecordsUpTo(request: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    upToTimestamp: number;
+    upToEventId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]>;
 
   /**
    * Cursor-paginated variant of `getEventRecordsUpTo`: returns at most `limit`

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
@@ -176,9 +176,20 @@ export class EventRepositoryClickHouse implements EventRepository {
     aggregateId: string,
     upToTimestamp: number,
     upToEventId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]> {
     try {
       const client = await this.getClient(tenantId);
+      // Same partition-pruning bound as `getEventRecords`, and for the same
+      // reason: the upper bound is on EventTimestamp (acceptance order), but the
+      // table is PARTITION BY toYearWeek(EventOccurredAt), so ONLY an
+      // EventOccurredAt predicate prunes. Without one this walks every weekly
+      // partition ever written, including the cold tier on S3.
+      const hasLowerBound =
+        typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+      const occurredAtFilter = hasLowerBound
+        ? "AND (EventOccurredAt = 0 OR EventOccurredAt >= {occurredAtFromMs:UInt64})"
+        : "";
       const result = await client.query({
         query: `
           SELECT
@@ -194,6 +205,7 @@ export class EventRepositoryClickHouse implements EventRepository {
           WHERE TenantId = {tenantId:String}
             AND AggregateType = {aggregateType:String}
             AND AggregateId = {aggregateId:String}
+            ${occurredAtFilter}
             AND (
               EventTimestamp < {upToTimestamp:UInt64}
               OR (
@@ -209,6 +221,7 @@ export class EventRepositoryClickHouse implements EventRepository {
           aggregateId: String(aggregateId),
           upToTimestamp,
           upToEventId,
+          ...(hasLowerBound ? { occurredAtFromMs } : {}),
         },
         format: "JSONEachRow",
       });
@@ -273,6 +286,7 @@ export class EventRepositoryClickHouse implements EventRepository {
     upToEventId: string;
     after: { timestamp: number; eventId: string } | undefined;
     limit: number;
+    occurredAtFromMs?: number;
   }): Promise<EventRecord[]> {
     const { tenantId, aggregateType, aggregateId } = request;
     try {
@@ -303,6 +317,7 @@ export class EventRepositoryClickHouse implements EventRepository {
     upToEventId: string;
     after: { timestamp: number; eventId: string } | undefined;
     limit: number;
+    occurredAtFromMs?: number;
   }): { query: string; query_params: Record<string, unknown> } {
     const {
       tenantId,
@@ -312,6 +327,7 @@ export class EventRepositoryClickHouse implements EventRepository {
       upToEventId,
       after,
       limit,
+      occurredAtFromMs,
     } = request;
     const afterClause = after
       ? `AND (
@@ -321,6 +337,13 @@ export class EventRepositoryClickHouse implements EventRepository {
               AND EventId > {afterEventId:String}
             )
           )`
+      : "";
+    // The cursor and the upper bound are both on EventTimestamp, which is NOT
+    // the partition key — so neither prunes. Only EventOccurredAt does.
+    const hasLowerBound =
+      typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+    const occurredAtFilter = hasLowerBound
+      ? "AND (EventOccurredAt = 0 OR EventOccurredAt >= {occurredAtFromMs:UInt64})"
       : "";
     return {
       query: `
@@ -337,6 +360,7 @@ export class EventRepositoryClickHouse implements EventRepository {
         WHERE TenantId = {tenantId:String}
           AND AggregateType = {aggregateType:String}
           AND AggregateId = {aggregateId:String}
+          ${occurredAtFilter}
           AND (
             EventTimestamp < {upToTimestamp:UInt64}
             OR (
@@ -354,6 +378,7 @@ export class EventRepositoryClickHouse implements EventRepository {
         aggregateId: String(aggregateId),
         upToTimestamp,
         upToEventId,
+        ...(hasLowerBound ? { occurredAtFromMs } : {}),
         ...(after
           ? { afterTimestamp: after.timestamp, afterEventId: after.eventId }
           : {}),

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
@@ -170,14 +170,22 @@ export class EventRepositoryClickHouse implements EventRepository {
     }
   }
 
-  async getEventRecordsUpTo(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    upToTimestamp: number,
-    upToEventId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]> {
+  async getEventRecordsUpTo(request: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    upToTimestamp: number;
+    upToEventId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]> {
+    const {
+      tenantId,
+      aggregateType,
+      aggregateId,
+      upToTimestamp,
+      upToEventId,
+      occurredAtFromMs,
+    } = request;
     try {
       const client = await this.getClient(tenantId);
       // Same partition-pruning bound as `getEventRecords`, and for the same

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
@@ -39,14 +39,22 @@ export class EventRepositoryMemory implements EventRepository {
     return filtered.map((record) => ({ ...record }));
   }
 
-  async getEventRecordsUpTo(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    upToTimestamp: number,
-    upToEventId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]> {
+  async getEventRecordsUpTo(request: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    upToTimestamp: number;
+    upToEventId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]> {
+    const {
+      tenantId,
+      aggregateType,
+      aggregateId,
+      upToTimestamp,
+      upToEventId,
+      occurredAtFromMs,
+    } = request;
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
 
@@ -56,8 +64,6 @@ export class EventRepositoryMemory implements EventRepository {
     const hasLowerBound =
       typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
 
-    // Filter events up to and including the specified event
-    // Events where: timestamp < upToTimestamp OR (timestamp = upToTimestamp AND eventId <= upToEventId)
     const filteredRecords = records.filter((record) => {
       // Records with an unknown occurred time are always kept, exactly as the
       // SQL does, so the bound can never drop one. Null and 0 are both

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
@@ -45,13 +45,32 @@ export class EventRepositoryMemory implements EventRepository {
     aggregateId: string,
     upToTimestamp: number,
     upToEventId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]> {
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
 
+    // Mirrors the ClickHouse lower bound so a window that would drop events in
+    // production drops them here too — otherwise a too-small window passes
+    // every test and only fails against real data.
+    const hasLowerBound =
+      typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+
     // Filter events up to and including the specified event
     // Events where: timestamp < upToTimestamp OR (timestamp = upToTimestamp AND eventId <= upToEventId)
     const filteredRecords = records.filter((record) => {
+      // Records with an unknown occurred time are always kept, exactly as the
+      // SQL does, so the bound can never drop one. Null and 0 are both
+      // "unknown" here — the column is non-null in ClickHouse, but the memory
+      // record type allows null.
+      if (
+        hasLowerBound &&
+        record.EventOccurredAt != null &&
+        record.EventOccurredAt !== 0 &&
+        record.EventOccurredAt < occurredAtFromMs
+      ) {
+        return false;
+      }
       if (record.EventTimestamp < upToTimestamp) {
         return true;
       }
@@ -88,6 +107,7 @@ export class EventRepositoryMemory implements EventRepository {
     upToEventId: string;
     after: { timestamp: number; eventId: string } | undefined;
     limit: number;
+    occurredAtFromMs?: number;
   }): Promise<EventRecord[]> {
     const {
       tenantId,
@@ -97,9 +117,20 @@ export class EventRepositoryMemory implements EventRepository {
       upToEventId,
       after,
       limit,
+      occurredAtFromMs,
     } = request;
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
+
+    const hasLowerBound =
+      typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+
+    // Mirrors the ClickHouse lower bound; unknown occurred times are kept.
+    const withinLowerBound = (record: EventRecord): boolean =>
+      !hasLowerBound ||
+      record.EventOccurredAt == null ||
+      record.EventOccurredAt === 0 ||
+      record.EventOccurredAt >= occurredAtFromMs;
 
     const withinUpperBound = (record: EventRecord): boolean =>
       record.EventTimestamp < upToTimestamp ||
@@ -117,7 +148,10 @@ export class EventRepositoryMemory implements EventRepository {
     };
 
     const filtered = records.filter(
-      (record) => withinUpperBound(record) && afterCursor(record),
+      (record) =>
+        withinLowerBound(record) &&
+        withinUpperBound(record) &&
+        afterCursor(record),
     );
 
     // Plain relational comparison, not localeCompare: withinUpperBound and

--- a/langwatch/src/server/stored-objects/__tests__/no-retention-gc.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/no-retention-gc.unit.test.ts
@@ -89,6 +89,11 @@ const SCAN_ALLOWLIST: ReadonlyArray<RegExp> = [
   // clickhouse/metrics.ts lists stored_objects in MONITORED_TABLES for the
   // ops size gauges. Audited: read-only system.parts aggregation.
   /^src\/server\/clickhouse\/metrics\.ts$/,
+  // cold-scan-detector.ts lists stored_objects in TIME_PARTITIONED_TABLES,
+  // mapping it to the column that lets an unpruned READ be flagged. Audited:
+  // a static table -> column map used to inspect outbound query text; the
+  // module issues no query of its own, so no delete/update/truncate.
+  /^src\/server\/app-layer\/clients\/clickhouse\/cold-scan-detector\.ts$/,
   // storage.ts and dataset-storage.ts mention the STORED_OBJECTS_BACKEND
   // env toggle (issue #4133) in comments and a config-error message —
   // matched by this scan only because the var name contains

--- a/specs/ops/clickhouse-cold-scan-coverage.feature
+++ b/specs/ops/clickhouse-cold-scan-coverage.feature
@@ -1,33 +1,34 @@
 Feature: Cold-scan detector covers every partitioned ClickHouse table
   As an operator of a ClickHouse cluster running at its memory ceiling
-  I want every time-partitioned table to be known to the cold-scan detector
-  So that an unpruned read is flagged instead of quietly scanning the cold tier
+  I want an unpruned read of a partitioned table to be flagged
+  So that a cold scan surfaces instead of quietly scanning the cold tier
 
-  # The detector fails OPEN: `detectColdScan` only inspects tables listed in
-  # TIME_PARTITIONED_TABLES, so a partitioned table missing from that map is
-  # treated as un-partitioned and never flagged, however expensively it is
-  # queried. The gap is invisible precisely because the detector reports
-  # nothing — the map covered 11 of 35 partitioned tables, and the 24 missing
-  # ones included `trace_analytics` and `trace_summaries`, whose unwindowed
-  # reads ran as undetected cold scans at ~350/min.
+  # The detector fails OPEN: it only inspects tables it already knows are
+  # partitioned, so a partitioned table it does not know about is treated as
+  # un-partitioned and never flagged, however expensively it is queried. The
+  # gap is invisible precisely because the detector reports nothing — it knew
+  # 11 of 35 partitioned tables, and the 24 it missed included the ones behind
+  # `trace_analytics` and `trace_summaries`, whose unwindowed reads ran as
+  # undetected cold scans at ~350/min.
   #
-  # A comment saying "keep in sync" cannot catch that, so these scenarios parse
-  # the migrations and assert the map matches them in both directions.
+  # A comment saying "keep in sync" cannot catch that, so these scenarios hold
+  # the detector's view of the schema against the schema itself, in both
+  # directions.
 
   @unit
-  Scenario: Every partitioned table is known to the cold-scan detector
-    Given a ClickHouse migration declares a table with a PARTITION BY expression
-    When the cold-scan detector's table map is compared against the migrations
-    Then that table is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged
+  Scenario: The detector knows every table the schema partitions by time
+    Given the schema partitions a table by time
+    When the detector's view of the schema is held against the schema itself
+    Then the detector knows that table, so its unpruned reads are flagged
 
   @unit
-  Scenario: The declared prune column actually appears in the PARTITION BY
-    Given a table listed in the cold-scan detector declares one or more prune columns
-    When each declared column is checked against the table's PARTITION BY expression
-    Then at least one declared column appears in that expression, so a predicate on it can prune
+  Scenario: The predicate the detector asks for is one that can prune
+    Given the detector will demand a time predicate on a table
+    When that column is checked against how the table is really partitioned
+    Then the partitioning uses it, so a predicate on it narrows the read
 
   @unit
-  Scenario: The map carries no table that is not partitioned
-    Given a table is listed in the cold-scan detector's table map
-    When the migrations are parsed for PARTITION BY declarations
-    Then that table really is partitioned, so the detector never demands a predicate that cannot prune
+  Scenario: The detector never demands a predicate that cannot prune
+    Given the detector treats a table as partitioned
+    When that table is checked against how the schema really partitions it
+    Then the table really is partitioned, so the warning keeps meaning something

--- a/specs/ops/clickhouse-cold-scan-coverage.feature
+++ b/specs/ops/clickhouse-cold-scan-coverage.feature
@@ -1,0 +1,33 @@
+Feature: Cold-scan detector covers every partitioned ClickHouse table
+  As an operator of a ClickHouse cluster running at its memory ceiling
+  I want every time-partitioned table to be known to the cold-scan detector
+  So that an unpruned read is flagged instead of quietly scanning the cold tier
+
+  # The detector fails OPEN: `detectColdScan` only inspects tables listed in
+  # TIME_PARTITIONED_TABLES, so a partitioned table missing from that map is
+  # treated as un-partitioned and never flagged, however expensively it is
+  # queried. The gap is invisible precisely because the detector reports
+  # nothing — the map covered 11 of 35 partitioned tables, and the 24 missing
+  # ones included `trace_analytics` and `trace_summaries`, whose unwindowed
+  # reads ran as undetected cold scans at ~350/min.
+  #
+  # A comment saying "keep in sync" cannot catch that, so these scenarios parse
+  # the migrations and assert the map matches them in both directions.
+
+  @unit
+  Scenario: Every partitioned table is known to the cold-scan detector
+    Given a ClickHouse migration declares a table with a PARTITION BY expression
+    When the cold-scan detector's table map is compared against the migrations
+    Then that table is listed in TIME_PARTITIONED_TABLES so its unpruned reads get flagged
+
+  @unit
+  Scenario: The declared prune column actually appears in the PARTITION BY
+    Given a table listed in the cold-scan detector declares one or more prune columns
+    When each declared column is checked against the table's PARTITION BY expression
+    Then at least one declared column appears in that expression, so a predicate on it can prune
+
+  @unit
+  Scenario: The map carries no table that is not partitioned
+    Given a table is listed in the cold-scan detector's table map
+    When the migrations are parsed for PARTITION BY declarations
+    Then that table really is partitioned, so the detector never demands a predicate that cannot prune


### PR DESCRIPTION
`event_log` is `PARTITION BY toYearWeek(EventOccurredAt)`, but both re-fold loaders bound only on `EventTimestamp` — acceptance order, **not** the partition key. Neither passed an `EventOccurredAt` predicate, so every re-fold walked every weekly partition ever written, including the cold tier on S3.

## Measured in production

`event_log` was the **only** table cold-scanning — **198 scans in 15 minutes across 3 pods** (~30k/day), from exactly two param signatures:

```
151×  aggregateId, aggregateType, limit, tenantId, upToEventId, upToTimestamp   → eventLoaderUpToPaged
 47×  aggregateId, aggregateType,        tenantId, upToEventId, upToTimestamp   → eventLoaderUpTo
```

Note what is absent from both: `occurredAtFromMs`. The bug is visible in the parameter list.

Every other time-partitioned table (`stored_spans`, `log_records`, `trace_analytics`, `trace_summaries`, …) is already bounded and never trips the cold-scan detector. These two were the only holdouts.

Scale of what they were walking: `event_log` takes ~1M `trace` events/day across ~150k aggregates, with tenant retentions up to **1827 days**.

## The fix

Nothing new is introduced — the bound and its correctness contract already existed and simply weren't wired to these callers:

- `getEvents` has passed `rehydrationLowerBoundMs` since the window was added
- the repository already accepted `occurredAtFromMs` and rendered the filter
- `TIME_LOCAL_AGGREGATE_TYPES` already whitelists the types whose events all fall inside the aggregate's own lifetime

**Safe by construction, in both directions:**

- Long-lived types (`global`, `billing_report`) and events with no usable occurred time get `undefined` back and stay unbounded, exactly as today
- Rows with an unknown occurred time (`EventOccurredAt = 0`) are always kept, so the bound can never drop an event
- The 45-day window is far wider than any time-local aggregate's lifetime — a trace spans seconds to hours — and a short read still falls back to the unbounded scan

The paginated path matters more than the unpaged one: unbounded, every **page** re-opens every partition, so the cost is paid per page rather than per re-fold.

The in-memory repository mirrors the filter deliberately, so a window that would drop events in production drops them in tests too. Otherwise a too-small window passes every test and only fails against real data.

## Why it matters right now

This sits upstream of a ClickHouse instance pinned at its **3.50 GiB ceiling** and rejecting inserts:

```
memory limit exceeded: current RSS: 3.50 GiB, maximum: 3.50 GiB
OvercommitTracker decision: Query was selected to stop
```

which drives `spanStorage` retries (81/min), worker liveness failures, and blocked groups across four pipelines.

## Follow-ups, not in this PR

- **93.1% of 962 sampled re-folds returned exactly what the queue already delivered** (`refoldEventCount == deliveredCount`). Those scans contribute nothing. This PR makes them cheap; skipping them outright is the larger win, and needs care — the remaining 3.4% are genuine rebuilds (`1 → 91`, `1 → 47`), so a naive "skip on store miss" would write partial state over real history.
- **`_retention_days = 0` on 567k rows in two days.** That TTL branch resolves to `2106-01-01`, i.e. never prunes, so ~18% of volume accumulates forever and scans degrade over time regardless of windowing.

## Verification

`pnpm typecheck` and `pnpm typecheck:tests` pass. **7,490 event-sourcing unit tests pass across 243 files**, including the new ones covering: the filter is emitted, the anchor is one window back from the triggering event, unknown occurred times are retained, every page is bounded, long-lived types stay unbounded, and a zero occurred time produces no bound rather than a 1970 anchor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduce unnecessary ClickHouse partition scans during event re-folding by applying an optional `EventOccurredAt` lower bound.
  * Ensure consistent pruning behavior for both paginated and in-memory reads.
* **New Features**
  * Expanded cold-scan detection coverage for additional time-partitioned tables and their prune-column mappings.
* **Bug Fixes**
  * Preserve events with unknown occurrence times while still enabling partition-pruning optimizations.
* **Tests**
  * Added unit and specification coverage to keep cold-scan table/partition mappings aligned with migrations and to verify pruning filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
