### PR TITLE
feat(model-providers): add Google Agent Platform as a provider

### DIFF
--- a/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
+++ b/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
@@ -87,10 +87,10 @@ export const modelProviderRegistry: ModelProviderRegistry = [
     // customer never chose, unconditionally, instead of deferring to their
     // custom models the way `vertex_ai` correctly does by omitting this.
     //
-    // The request path names the project and location, and `apiRoot` is
-    // the host that path is built from — see `AGENT_PLATFORM_HOST` in
+    // `defaultBaseUrl` is this host, static; the full request path also
+    // names the project and location, assembled per credential in
     // `providerValidation.ts`'s `google_agent_platform` probe branch, which
-    // derives from this same field rather than a second hardcoded string.
+    // reads `apiRoot` below for the host rather than repeating this string.
     defaultBaseUrl: "https://aiplatform.googleapis.com",
     apiRoot: "https://aiplatform.googleapis.com",
     icon: singleIcon(

--- a/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
+++ b/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
@@ -78,10 +78,19 @@ export const modelProviderRegistry: ModelProviderRegistry = [
     key: "google_agent_platform",
     backendModelProviderKey: "google_agent_platform",
     label: "Google Agent Platform",
-    defaultModel: "gemini-2.5-flash",
-    // The path names the project and location, so there is no static base
-    // URL to probe — it is assembled per credential. See
-    // buildProbeCandidates' `google_agent_platform` branch.
+    // No `defaultModel`: this provider has no catalog entries (like
+    // `vertex_ai`), and `resolveProviderDefaultModel` in
+    // `components/gateway/eligibleModelProviders.ts` reads a registry
+    // default BEFORE falling back to whatever the customer actually
+    // configured. Naming a model here that isn't in the catalog would make
+    // the gateway's eligible-providers surface hand out a model string the
+    // customer never chose, unconditionally, instead of deferring to their
+    // custom models the way `vertex_ai` correctly does by omitting this.
+    //
+    // The request path names the project and location, and `apiRoot` is
+    // the host that path is built from — see `AGENT_PLATFORM_HOST` in
+    // `providerValidation.ts`'s `google_agent_platform` probe branch, which
+    // derives from this same field rather than a second hardcoded string.
     defaultBaseUrl: "https://aiplatform.googleapis.com",
     apiRoot: "https://aiplatform.googleapis.com",
     icon: singleIcon(

--- a/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
+++ b/langwatch/src/features/onboarding/regions/model-providers/registry.tsx
@@ -75,6 +75,43 @@ export const modelProviderRegistry: ModelProviderRegistry = [
     },
   },
   {
+    key: "google_agent_platform",
+    backendModelProviderKey: "google_agent_platform",
+    label: "Google Agent Platform",
+    defaultModel: "gemini-2.5-flash",
+    // The path names the project and location, so there is no static base
+    // URL to probe — it is assembled per credential. See
+    // buildProbeCandidates' `google_agent_platform` branch.
+    defaultBaseUrl: "https://aiplatform.googleapis.com",
+    apiRoot: "https://aiplatform.googleapis.com",
+    icon: singleIcon(
+      "/images/external-icons/gcloud.svg",
+      "Google Agent Platform",
+    ),
+    externalDocsUrl:
+      "https://docs.cloud.google.com/gemini-enterprise-agent-platform",
+    fieldMetadata: {
+      GOOGLE_AGENT_PLATFORM_API_KEY: {
+        label: "Agent Platform API Key",
+        // Says where the key comes from, because this is the distinction that
+        // sent a customer round in circles: an Agent Platform key and an AI
+        // Studio key look alike and are not interchangeable.
+        description:
+          "A Google Cloud API key for Gemini Enterprise Agent Platform, created under APIs & Services > Credentials. An AI Studio key belongs on the Google Gemini provider instead.",
+      },
+      GOOGLE_AGENT_PLATFORM_PROJECT: {
+        label: "Google Cloud Project ID",
+        description:
+          "The project the key belongs to. Its number appears in the error Google returns if the key is used against the wrong service.",
+      },
+      GOOGLE_AGENT_PLATFORM_LOCATION: {
+        label: "Location",
+        description:
+          "Where to serve the model from — 'global', or a region such as us-central1.",
+      },
+    },
+  },
+  {
     key: "open_ai_azure",
     backendModelProviderKey: "azure",
     label: "Azure OpenAI",

--- a/langwatch/src/features/onboarding/regions/model-providers/types.ts
+++ b/langwatch/src/features/onboarding/regions/model-providers/types.ts
@@ -9,6 +9,7 @@ export type ModelProviderKey =
   | "custom"
   | "deepseek"
   | "gemini"
+  | "google_agent_platform"
   | "grok_xai"
   | "groq"
   | "open_ai_azure"

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -55,7 +55,13 @@ describe("validateProviderApiKey for google_agent_platform", () => {
       expect(url).toContain(":generateContent");
       expect(url).not.toMatch(/\/models(\?|$)/);
       expect(init.method).toBe("POST");
-      expect(init.body).toBeTruthy();
+      // Pinned, not just truthy: a body of `"x"` would pass a truthiness
+      // check while sending garbage, and `maxOutputTokens: 1` is what keeps
+      // this probe cheap rather than generating a full response on every
+      // credential check.
+      const body = JSON.parse(String(init.body));
+      expect(body.contents[0].parts[0].text).toBeTruthy();
+      expect(body.generationConfig.maxOutputTokens).toBe(1);
     });
 
     /** @scenario The credential travels in a header, never in the URL */
@@ -88,6 +94,30 @@ describe("validateProviderApiKey for google_agent_platform", () => {
       expect(sentRequest().url).toContain(
         "/projects/acme-123/locations/us-central1/",
       );
+    });
+  });
+
+  describe("given a credential missing its project or location", () => {
+    /**
+     * This is the shape `validateKeyWithCustomUrl` produced before it was
+     * fixed to preserve stored credentials rather than rebuild them from
+     * just the key and endpoint: project and location silently dropped,
+     * leaving only the key. Asserting on it here pins the walk's behavior
+     * directly, without needing a Prisma-backed test for that caller.
+     */
+    /** @scenario A credential missing its project or location is not probed at all */
+    it("is unreachable rather than reporting a verdict on the key", async () => {
+      mockFetch.mockResolvedValue(generated());
+
+      await expect(
+        validateProviderApiKey("google_agent_platform", {
+          GOOGLE_AGENT_PLATFORM_API_KEY:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        }),
+      ).rejects.toMatchObject({ code: "provider_unreachable" });
+
+      // Nothing to ask without a project and location, so nothing was sent.
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -45,7 +45,7 @@ describe("validateProviderApiKey for google_agent_platform", () => {
   });
 
   describe("given a credential to check", () => {
-    /** @scenario An Agent Platform key is checked against the endpoint that accepts it */
+    /** @scenario A key the platform accepts is valid */
     it("asks the provider to generate content rather than to list models", async () => {
       mockFetch.mockResolvedValue(generated());
 
@@ -64,7 +64,7 @@ describe("validateProviderApiKey for google_agent_platform", () => {
       expect(body.generationConfig.maxOutputTokens).toBe(1);
     });
 
-    /** @scenario The credential travels in a header, never in the URL */
+    /** @scenario The credential is not exposed where logs or browser history could retain it */
     it("sends the key as a header and keeps it out of the URL", async () => {
       mockFetch.mockResolvedValue(generated());
 
@@ -81,7 +81,7 @@ describe("validateProviderApiKey for google_agent_platform", () => {
       expect(url).not.toContain("key=");
     });
 
-    /** @scenario The project and location the customer gave are the ones probed */
+    /** @scenario The project and location I entered are the ones actually checked */
     it("builds the path from the project and location given", async () => {
       mockFetch.mockResolvedValue(generated());
 

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -108,44 +108,51 @@ describe("validateProviderApiKey for google_agent_platform", () => {
     // Three separate cases, not one covering both fields at once: an `||`
     // guard degrading to `&&` would still return no candidates when BOTH
     // are missing, and only a case with exactly one present catches that.
-    const expectUnreachable = async (credentials: Record<string, string>) => {
+    /** @scenario A credential missing its project or location is not probed at all */
+    it("rejects the check without probing when both project and location are missing", async () => {
       mockFetch.mockResolvedValue(generated());
 
       await expect(
-        validateProviderApiKey("google_agent_platform", credentials),
+        validateProviderApiKey("google_agent_platform", {
+          GOOGLE_AGENT_PLATFORM_API_KEY:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        }),
       ).rejects.toMatchObject({ code: "provider_unreachable" });
 
-      // Nothing to ask without both a project and a location, so nothing
-      // was sent — true whichever one is the one missing.
+      // Nothing to ask without both a project and a location, so nothing was sent.
       expect(mockFetch).not.toHaveBeenCalled();
-    };
-
-    /** @scenario A credential missing its project or location is not probed at all */
-    it("rejects the check without probing when both project and location are missing", async () => {
-      await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY:
-          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
-      });
     });
 
     /** @scenario A credential missing its project or location is not probed at all */
     it("rejects the check without probing when only the location is missing", async () => {
-      await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY:
-          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
-        GOOGLE_AGENT_PLATFORM_PROJECT:
-          CREDENTIALS.GOOGLE_AGENT_PLATFORM_PROJECT,
-      });
+      mockFetch.mockResolvedValue(generated());
+
+      await expect(
+        validateProviderApiKey("google_agent_platform", {
+          GOOGLE_AGENT_PLATFORM_API_KEY:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+          GOOGLE_AGENT_PLATFORM_PROJECT:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_PROJECT,
+        }),
+      ).rejects.toMatchObject({ code: "provider_unreachable" });
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     /** @scenario A credential missing its project or location is not probed at all */
     it("rejects the check without probing when only the project is missing", async () => {
-      await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY:
-          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
-        GOOGLE_AGENT_PLATFORM_LOCATION:
-          CREDENTIALS.GOOGLE_AGENT_PLATFORM_LOCATION,
-      });
+      mockFetch.mockResolvedValue(generated());
+
+      await expect(
+        validateProviderApiKey("google_agent_platform", {
+          GOOGLE_AGENT_PLATFORM_API_KEY:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+          GOOGLE_AGENT_PLATFORM_LOCATION:
+            CREDENTIALS.GOOGLE_AGENT_PLATFORM_LOCATION,
+        }),
+      ).rejects.toMatchObject({ code: "provider_unreachable" });
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -105,19 +105,46 @@ describe("validateProviderApiKey for google_agent_platform", () => {
      * leaving only the key. Asserting on it here pins the walk's behavior
      * directly, without needing a Prisma-backed test for that caller.
      */
-    /** @scenario A credential missing its project or location is not probed at all */
-    it("is unreachable rather than reporting a verdict on the key", async () => {
+    // Three separate cases, not one covering both fields at once: an `||`
+    // guard degrading to `&&` would still return no candidates when BOTH
+    // are missing, and only a case with exactly one present catches that.
+    const expectUnreachable = async (
+      credentials: Record<string, string>,
+    ) => {
       mockFetch.mockResolvedValue(generated());
 
       await expect(
-        validateProviderApiKey("google_agent_platform", {
-          GOOGLE_AGENT_PLATFORM_API_KEY:
-            CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
-        }),
+        validateProviderApiKey("google_agent_platform", credentials),
       ).rejects.toMatchObject({ code: "provider_unreachable" });
 
-      // Nothing to ask without a project and location, so nothing was sent.
+      // Nothing to ask without both a project and a location, so nothing
+      // was sent — true whichever one is the one missing.
       expect(mockFetch).not.toHaveBeenCalled();
+    };
+
+    /** @scenario A credential missing its project or location is not probed at all */
+    it("is unreachable when both project and location are missing", async () => {
+      await expectUnreachable({
+        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+      });
+    });
+
+    /** @scenario A credential missing its project or location is not probed at all */
+    it("is unreachable when only the location is missing", async () => {
+      await expectUnreachable({
+        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        GOOGLE_AGENT_PLATFORM_PROJECT:
+          CREDENTIALS.GOOGLE_AGENT_PLATFORM_PROJECT,
+      });
+    });
+
+    /** @scenario A credential missing its project or location is not probed at all */
+    it("is unreachable when only the project is missing", async () => {
+      await expectUnreachable({
+        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        GOOGLE_AGENT_PLATFORM_LOCATION:
+          CREDENTIALS.GOOGLE_AGENT_PLATFORM_LOCATION,
+      });
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -108,9 +108,7 @@ describe("validateProviderApiKey for google_agent_platform", () => {
     // Three separate cases, not one covering both fields at once: an `||`
     // guard degrading to `&&` would still return no candidates when BOTH
     // are missing, and only a case with exactly one present catches that.
-    const expectUnreachable = async (
-      credentials: Record<string, string>,
-    ) => {
+    const expectUnreachable = async (credentials: Record<string, string>) => {
       mockFetch.mockResolvedValue(generated());
 
       await expect(
@@ -123,25 +121,28 @@ describe("validateProviderApiKey for google_agent_platform", () => {
     };
 
     /** @scenario A credential missing its project or location is not probed at all */
-    it("is unreachable when both project and location are missing", async () => {
+    it("rejects the check without probing when both project and location are missing", async () => {
       await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        GOOGLE_AGENT_PLATFORM_API_KEY:
+          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
       });
     });
 
     /** @scenario A credential missing its project or location is not probed at all */
-    it("is unreachable when only the location is missing", async () => {
+    it("rejects the check without probing when only the location is missing", async () => {
       await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        GOOGLE_AGENT_PLATFORM_API_KEY:
+          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
         GOOGLE_AGENT_PLATFORM_PROJECT:
           CREDENTIALS.GOOGLE_AGENT_PLATFORM_PROJECT,
       });
     });
 
     /** @scenario A credential missing its project or location is not probed at all */
-    it("is unreachable when only the project is missing", async () => {
+    it("rejects the check without probing when only the project is missing", async () => {
       await expectUnreachable({
-        GOOGLE_AGENT_PLATFORM_API_KEY: CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+        GOOGLE_AGENT_PLATFORM_API_KEY:
+          CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
         GOOGLE_AGENT_PLATFORM_LOCATION:
           CREDENTIALS.GOOGLE_AGENT_PLATFORM_LOCATION,
       });

--- a/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/agentPlatformValidation.unit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Agent Platform is the one provider here that cannot be validated by listing
+ * models: `GET .../models` answers 401 "API keys are not supported by this
+ * API" however good the key is, while `:generateContent` accepts one. Probing
+ * the usual way would report a working credential as unusable, so what these
+ * tests pin is mostly *which request goes out*.
+ *
+ * Established against a real Agent Platform key, not from documentation —
+ * the two endpoints on that host disagree and the docs do not mention it.
+ *
+ * Covers @unit scenarios from
+ * specs/model-providers/google-agent-platform.feature.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validateProviderApiKey } from "../providerValidation";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const CREDENTIALS = {
+  GOOGLE_AGENT_PLATFORM_API_KEY: "AQ.AnAgentPlatformKey",
+  GOOGLE_AGENT_PLATFORM_PROJECT: "acme-123",
+  GOOGLE_AGENT_PLATFORM_LOCATION: "global",
+};
+
+/** The request the probe actually made. */
+const sentRequest = () => {
+  const [url, init] = mockFetch.mock.calls[0] ?? [];
+  return { url: String(url ?? ""), init: (init ?? {}) as RequestInit };
+};
+
+const generated = () => ({
+  ok: true,
+  status: 200,
+  text: async () => JSON.stringify({ candidates: [{ content: {} }] }),
+});
+
+const codeOf = (result: { valid: boolean; domainError?: { code: string } }) =>
+  result.valid ? undefined : result.domainError?.code;
+
+describe("validateProviderApiKey for google_agent_platform", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe("given a credential to check", () => {
+    /** @scenario An Agent Platform key is checked against the endpoint that accepts it */
+    it("asks the provider to generate content rather than to list models", async () => {
+      mockFetch.mockResolvedValue(generated());
+
+      await validateProviderApiKey("google_agent_platform", CREDENTIALS);
+
+      const { url, init } = sentRequest();
+      expect(url).toContain(":generateContent");
+      expect(url).not.toMatch(/\/models(\?|$)/);
+      expect(init.method).toBe("POST");
+      expect(init.body).toBeTruthy();
+    });
+
+    /** @scenario The credential travels in a header, never in the URL */
+    it("sends the key as a header and keeps it out of the URL", async () => {
+      mockFetch.mockResolvedValue(generated());
+
+      await validateProviderApiKey("google_agent_platform", CREDENTIALS);
+
+      const { url, init } = sentRequest();
+      const headers = init.headers as Record<string, string>;
+      expect(headers["x-goog-api-key"]).toBe(
+        CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY,
+      );
+      // `?key=` is also accepted by Agent Platform, which is exactly why this
+      // is pinned: a credential in a URL reaches access logs and history.
+      expect(url).not.toContain(CREDENTIALS.GOOGLE_AGENT_PLATFORM_API_KEY);
+      expect(url).not.toContain("key=");
+    });
+
+    /** @scenario The project and location the customer gave are the ones probed */
+    it("builds the path from the project and location given", async () => {
+      mockFetch.mockResolvedValue(generated());
+
+      await validateProviderApiKey("google_agent_platform", {
+        ...CREDENTIALS,
+        GOOGLE_AGENT_PLATFORM_PROJECT: "acme-123",
+        GOOGLE_AGENT_PLATFORM_LOCATION: "us-central1",
+      });
+
+      expect(sentRequest().url).toContain(
+        "/projects/acme-123/locations/us-central1/",
+      );
+    });
+  });
+
+  describe("when the platform accepts the credential", () => {
+    /** @scenario A key the platform accepts is valid */
+    it("reports the credential as valid", async () => {
+      mockFetch.mockResolvedValue(generated());
+
+      const result = await validateProviderApiKey(
+        "google_agent_platform",
+        CREDENTIALS,
+      );
+
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("when the platform refuses the credential", () => {
+    /** @scenario A key the platform refuses is explained, not just rejected */
+    it("names the refusal without quoting the provider back", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () =>
+          JSON.stringify({
+            error: { message: "API key not valid, sk-leaked-looking-text" },
+          }),
+      });
+
+      const result = await validateProviderApiKey(
+        "google_agent_platform",
+        CREDENTIALS,
+      );
+
+      expect(codeOf(result)).toBe("provider_key_invalid");
+      expect(JSON.stringify(result)).not.toContain("sk-leaked-looking-text");
+    });
+
+    /**
+     * A 404 here means the project cannot reach that published model, which a
+     * different key would not fix. Reporting it as an invalid key is the
+     * misdiagnosis this whole area exists to remove.
+     */
+    /** @scenario A model the project cannot reach is not reported as a bad key */
+    it("does not blame the key when the model is the thing missing", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () =>
+          JSON.stringify({
+            error: { message: "Publisher model ... was not found", code: 404 },
+          }),
+      });
+
+      const result = await validateProviderApiKey(
+        "google_agent_platform",
+        CREDENTIALS,
+      );
+
+      expect(codeOf(result)).not.toBe("provider_key_invalid");
+      expect(codeOf(result)).toBe("provider_refused");
+    });
+  });
+
+  describe("when the platform never answers", () => {
+    /** @scenario A provider that never answers is not a verdict on the key */
+    it("raises unreachable rather than returning a verdict", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(
+        validateProviderApiKey("google_agent_platform", CREDENTIALS),
+      ).rejects.toMatchObject({ code: "provider_unreachable" });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/providerValidation.ts
+++ b/langwatch/src/server/api/routers/providerValidation.ts
@@ -54,9 +54,6 @@ const PROVIDER_AUTH_OVERRIDES: Partial<Record<string, AuthStrategy>> = {
   google_agent_platform: "google_agent_platform",
 };
 
-/** Where Agent Platform serves Gemini models from. */
-const AGENT_PLATFORM_HOST = "https://aiplatform.googleapis.com";
-
 /**
  * The model a credential check asks Agent Platform to run.
  *
@@ -579,21 +576,30 @@ function buildProbeCandidates({
 
   switch (strategy) {
     case "google_agent_platform": {
-      // No project or location means no path to probe. Returning nothing
-      // rather than guessing a default leaves the walk empty, which
-      // `runProbeChain` reports as unreachable — honest, since nothing was
-      // asked — instead of inventing a verdict about the key.
-      if (!agentPlatform?.project || !agentPlatform.location) return [];
+      // No project, no location, or no host to build the path from means
+      // no path to probe. Returning nothing rather than guessing a default
+      // leaves the walk empty, which `runProbeChain` reports as
+      // unreachable — honest, since nothing was asked — instead of
+      // inventing a verdict about the key.
+      if (!agentPlatform?.project || !agentPlatform.location || !apiRoot) {
+        return [];
+      }
 
       const { project, location } = agentPlatform;
+      const host = apiRoot.replace(/\/$/, "");
 
       return [
         {
           // The key rides in a header, not `?key=`, which Agent Platform also
           // accepts: a credential in a URL reaches access logs, proxy logs and
           // browser history, and both shapes were verified to work.
+          //
+          // The global host with a region in the path was verified live
+          // against two regions (us-central1, europe-west4), both 200 — the
+          // same form every other verified shape uses, so this does not
+          // special-case a regional subdomain on top of it.
           url:
-            `${AGENT_PLATFORM_HOST}/v1/projects/${encodeURIComponent(project)}` +
+            `${host}/v1/projects/${encodeURIComponent(project)}` +
             `/locations/${encodeURIComponent(location)}/publishers/google/models/` +
             `${AGENT_PLATFORM_PROBE_MODEL}:generateContent`,
           headers: { ...headers, "x-goog-api-key": apiKey },
@@ -867,8 +873,17 @@ export async function validateKeyWithCustomUrl(
     };
   }
 
-  // Build customKeys with the retrieved API key and optional custom URL
+  // Start from what's stored, not from a blank object: a provider whose
+  // credential is more than a key plus an endpoint — Agent Platform's
+  // project and location, or any future one — had those fields silently
+  // dropped when this rebuilt customKeys from scratch. That turned "the
+  // customer edited an unrelated field" into an empty probe walk and a
+  // false "could not reach the provider", which is the exact misdiagnosis
+  // this whole area of the code exists to remove. The freshly resolved key
+  // and an explicit custom URL are layered on top, in that order, so they
+  // still win over whatever was stored.
   const customKeys: Record<string, string> = {
+    ...(storedKeys ?? {}),
     [apiKeyField]: apiKey,
   };
   if (endpointField && customBaseUrl) {

--- a/langwatch/src/server/api/routers/providerValidation.ts
+++ b/langwatch/src/server/api/routers/providerValidation.ts
@@ -35,8 +35,14 @@ export type ValidationResult =
  * - `anthropic`: Uses `x-api-key` header with `anthropic-version`
  * - `gemini`: Uses query parameter `?key=`
  * - `elevenlabs`: Uses `xi-api-key` header
+ * - `google_agent_platform`: `x-goog-api-key` on a generate-content POST
  */
-type AuthStrategy = "bearer" | "anthropic" | "gemini" | "elevenlabs";
+type AuthStrategy =
+  | "bearer"
+  | "anthropic"
+  | "gemini"
+  | "elevenlabs"
+  | "google_agent_platform";
 
 /**
  * Providers that use non-standard auth. All others default to bearer auth.
@@ -45,7 +51,34 @@ const PROVIDER_AUTH_OVERRIDES: Partial<Record<string, AuthStrategy>> = {
   anthropic: "anthropic",
   gemini: "gemini",
   elevenlabs: "elevenlabs",
+  google_agent_platform: "google_agent_platform",
 };
+
+/** Where Agent Platform serves Gemini models from. */
+const AGENT_PLATFORM_HOST = "https://aiplatform.googleapis.com";
+
+/**
+ * The model a credential check asks Agent Platform to run.
+ *
+ * Any published model would do; this one is picked because it resolves in
+ * both `global` and the regional locations. A model the project cannot reach
+ * answers 404 rather than 401, which `handleHttpError` already keeps distinct
+ * from a refused key.
+ */
+const AGENT_PLATFORM_PROBE_MODEL = "gemini-2.5-flash";
+
+/**
+ * The smallest generate-content request that still proves the credential.
+ *
+ * Agent Platform has to be probed by generating rather than by listing:
+ * `GET .../models` answers `401 "API keys are not supported by this API"`
+ * however good the key is, so validating the way every other provider here
+ * does would report a working credential as unusable.
+ */
+const AGENT_PLATFORM_PROBE_BODY = JSON.stringify({
+  contents: [{ role: "user", parts: [{ text: "ping" }] }],
+  generationConfig: { maxOutputTokens: 1 },
+});
 
 /** Providers with complex auth (AWS, gcloud, etc.) that skip validation */
 const SKIP_VALIDATION = new Set(["bedrock", "vertex_ai", "azure"]);
@@ -493,8 +526,19 @@ type ProbeContext = {
  */
 const PROBE_BUDGET_MS = 10_000;
 
-/** The request that proves a key works: list the provider's models. */
-type ProbeRequest = { url: string; headers: Record<string, string> };
+/**
+ * The request that proves a key works.
+ *
+ * Listing models for every provider that has such an endpoint; `method` and
+ * `body` exist for the one that does not — Agent Platform rejects API keys on
+ * its listing route and accepts them only on a generate-content POST.
+ */
+type ProbeRequest = {
+  url: string;
+  headers: Record<string, string>;
+  method?: "GET" | "POST";
+  body?: string;
+};
 
 /**
  * Every way a provider's credential can legitimately prove itself.
@@ -517,6 +561,7 @@ function buildProbeCandidates({
   baseUrl,
   defaultBaseUrl,
   apiRoot,
+  agentPlatform,
 }: {
   strategy: AuthStrategy;
   apiKey: string;
@@ -524,6 +569,8 @@ function buildProbeCandidates({
   defaultBaseUrl: string;
   /** The provider's version-less root, when it serves more than one path. */
   apiRoot?: string;
+  /** The project and location Agent Platform's path is built from. */
+  agentPlatform?: { project: string; location: string };
 }): ProbeRequest[] {
   const url = buildModelsEndpointUrl(baseUrl, defaultBaseUrl);
   const headers: Record<string, string> = {
@@ -531,6 +578,30 @@ function buildProbeCandidates({
   };
 
   switch (strategy) {
+    case "google_agent_platform": {
+      // No project or location means no path to probe. Returning nothing
+      // rather than guessing a default leaves the walk empty, which
+      // `runProbeChain` reports as unreachable — honest, since nothing was
+      // asked — instead of inventing a verdict about the key.
+      if (!agentPlatform?.project || !agentPlatform.location) return [];
+
+      const { project, location } = agentPlatform;
+
+      return [
+        {
+          // The key rides in a header, not `?key=`, which Agent Platform also
+          // accepts: a credential in a URL reaches access logs, proxy logs and
+          // browser history, and both shapes were verified to work.
+          url:
+            `${AGENT_PLATFORM_HOST}/v1/projects/${encodeURIComponent(project)}` +
+            `/locations/${encodeURIComponent(location)}/publishers/google/models/` +
+            `${AGENT_PLATFORM_PROBE_MODEL}:generateContent`,
+          headers: { ...headers, "x-goog-api-key": apiKey },
+          method: "POST",
+          body: AGENT_PLATFORM_PROBE_BODY,
+        },
+      ];
+    }
     case "anthropic":
       return [
         {
@@ -667,8 +738,9 @@ async function probeOnce({
   let response: Response;
   try {
     response = await fetch(candidate.url, {
-      method: "GET",
+      method: candidate.method ?? "GET",
       headers: candidate.headers,
+      ...(candidate.body === undefined ? {} : { body: candidate.body }),
       signal: deadline,
     });
   } catch {
@@ -888,6 +960,10 @@ export async function validateProviderApiKey(
       baseUrl,
       defaultBaseUrl,
       apiRoot: providerApiRoots[provider],
+      agentPlatform: {
+        project: customKeys.GOOGLE_AGENT_PLATFORM_PROJECT?.trim() ?? "",
+        location: customKeys.GOOGLE_AGENT_PLATFORM_LOCATION?.trim() ?? "",
+      },
     }),
     context: {
       provider,

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -577,7 +577,14 @@ function buildCredentials(mp: ModelProvider): Record<string, unknown> {
       return {
         api_key: pick("GOOGLE_AGENT_PLATFORM_API_KEY"),
         project_id: pick("GOOGLE_AGENT_PLATFORM_PROJECT"),
-        location: pick("GOOGLE_AGENT_PLATFORM_LOCATION"),
+        // `region`, not `location`: `buildProviderSlot` below lifts a
+        // slot-level region by looking up exactly that key
+        // (`pickString(credentials, "region")`), the convention every
+        // other regional provider's credentials already follow. Naming it
+        // `location` here — Google's own term, kept as the customer-facing
+        // env var name — would silently leave this provider without a
+        // slot-level region once something reads it.
+        region: pick("GOOGLE_AGENT_PLATFORM_LOCATION"),
       };
     case "openai":
       return { api_key: pick("OPENAI_API_KEY") };

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -567,6 +567,18 @@ function buildCredentials(mp: ModelProvider): Record<string, unknown> {
     case "gemini":
     case "google_gemini":
       return { api_key: pick("GEMINI_API_KEY") || pick("GOOGLE_API_KEY") };
+    // Agent Platform serves Gemini models from a path that names the project
+    // and location, so both travel with the key rather than being derived.
+    // Routing this type to an upstream is `mapProvider`'s job in the Go
+    // gateway (services/aigateway); until that lands the credential
+    // materialises but no traffic is dispatched. Validation does not go
+    // through here — see providerValidation.ts.
+    case "google_agent_platform":
+      return {
+        api_key: pick("GOOGLE_AGENT_PLATFORM_API_KEY"),
+        project_id: pick("GOOGLE_AGENT_PLATFORM_PROJECT"),
+        location: pick("GOOGLE_AGENT_PLATFORM_LOCATION"),
+      };
     case "openai":
       return { api_key: pick("OPENAI_API_KEY") };
     case "deepseek":

--- a/langwatch/src/server/modelProviders/iconsMap.tsx
+++ b/langwatch/src/server/modelProviders/iconsMap.tsx
@@ -29,6 +29,10 @@ export const modelProviderIcons: Record<
   groq: <Groq />,
   vertex_ai: <GoogleCloud />,
   gemini: <Gemini />,
+  // The Cloud mark rather than the Gemini one: the models are Gemini, but the
+  // credential and console are Google Cloud's, and that is the distinction a
+  // customer is picking between in this list.
+  google_agent_platform: <GoogleCloud />,
   bedrock: <AWS />,
   deepseek: <DeepSeek />,
   custom: <Custom />,

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -350,6 +350,27 @@ export const modelProviders = {
     }),
     enabledSince: new Date("2023-01-01"),
   },
+  // Gemini models served by Gemini Enterprise Agent Platform rather than by
+  // AI Studio. Its own provider, not a mode of `gemini`, for the same reason
+  // `vertex_ai` is: different host, different auth header, and a path that
+  // names the project and location. A key minted for it is refused by
+  // generativelanguage.googleapis.com, which is what made this look like an
+  // invalid key rather than the wrong service. See
+  // specs/model-providers/google-agent-platform.feature.
+  google_agent_platform: {
+    name: "Google Agent Platform",
+    type: "llm",
+    apiKey: "GOOGLE_AGENT_PLATFORM_API_KEY",
+    endpointKey: undefined,
+    keysSchema: z.object({
+      GOOGLE_AGENT_PLATFORM_API_KEY: z.string().min(1),
+      GOOGLE_AGENT_PLATFORM_PROJECT: z.string().min(1),
+      // Both `global` and a region such as `us-central1` resolve; the path
+      // requires one either way, so it is asked for rather than guessed.
+      GOOGLE_AGENT_PLATFORM_LOCATION: z.string().min(1),
+    }),
+    enabledSince: new Date("2026-07-29"),
+  },
   elevenlabs: {
     name: "ElevenLabs",
     // Ships audio only (TTS + STT through the gateway's /v1/audio routes).

--- a/langwatch/src/shared/langy/langySkills.generated.json
+++ b/langwatch/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-	{
-		"id": "agent-best-practices",
-		"label": "Agent best practices",
-		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-		"category": "recipe",
-		"userPrompt": "Where can I improve our agent development best practices?"
-	},
-	{
-		"id": "agent-improve",
-		"label": "Agent improve",
-		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-		"category": "skill",
-		"userPrompt": "What should I do next to improve my agent?"
-	},
-	{
-		"id": "agent-performance",
-		"label": "Agent performance",
-		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-		"category": "skill",
-		"userPrompt": "How is my agent performing?"
-	},
-	{
-		"id": "datasets",
-		"label": "Datasets",
-		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-		"category": "skill"
-	},
-	{
-		"id": "debug-instrumentation",
-		"label": "Debug instrumentation",
-		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-		"category": "recipe"
-	},
-	{
-		"id": "debug-with-langwatch",
-		"label": "Debug with langwatch",
-		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-		"category": "recipe"
-	},
-	{
-		"id": "eval-triage",
-		"label": "Eval triage",
-		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluate-multimodal",
-		"label": "Evaluate multimodal",
-		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluations",
-		"label": "Evaluations",
-		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-		"category": "skill",
-		"userPrompt": "Help me evaluate my agent"
-	},
-	{
-		"id": "experiments",
-		"label": "Experiments",
-		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-		"category": "skill",
-		"userPrompt": "Set up experiments for my agent"
-	},
-	{
-		"id": "generate-rag-dataset",
-		"label": "Generate RAG dataset",
-		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-		"category": "recipe"
-	},
-	{
-		"id": "github",
-		"label": "GitHub",
-		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-		"category": "skill"
-	},
-	{
-		"id": "level-up",
-		"label": "Level up",
-		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-		"category": "skill",
-		"userPrompt": "Take my agent to the next level"
-	},
-	{
-		"id": "online-evaluations",
-		"label": "Online evaluations",
-		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-		"category": "skill",
-		"userPrompt": "Set up online evaluations for my agent"
-	},
-	{
-		"id": "prompts",
-		"label": "Prompts",
-		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-		"category": "skill",
-		"userPrompt": "Version my prompts with LangWatch"
-	},
-	{
-		"id": "scenarios",
-		"label": "Scenarios",
-		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-		"category": "skill",
-		"userPrompt": "Add scenario tests for my agent"
-	},
-	{
-		"id": "setup-lw",
-		"label": "Setup lw",
-		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-cli-usability",
-		"label": "Test CLI usability",
-		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-compliance",
-		"label": "Test compliance",
-		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-		"category": "recipe"
-	},
-	{
-		"id": "tracing",
-		"label": "Tracing",
-		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-		"category": "skill",
-		"userPrompt": "Instrument my code with LangWatch"
-	}
+  {
+    "id": "agent-best-practices",
+    "label": "Agent best practices",
+    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+    "category": "recipe",
+    "userPrompt": "Where can I improve our agent development best practices?"
+  },
+  {
+    "id": "agent-improve",
+    "label": "Agent improve",
+    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+    "category": "skill",
+    "userPrompt": "What should I do next to improve my agent?"
+  },
+  {
+    "id": "agent-performance",
+    "label": "Agent performance",
+    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+    "category": "skill",
+    "userPrompt": "How is my agent performing?"
+  },
+  {
+    "id": "datasets",
+    "label": "Datasets",
+    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+    "category": "skill"
+  },
+  {
+    "id": "debug-instrumentation",
+    "label": "Debug instrumentation",
+    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+    "category": "recipe"
+  },
+  {
+    "id": "debug-with-langwatch",
+    "label": "Debug with langwatch",
+    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+    "category": "recipe"
+  },
+  {
+    "id": "eval-triage",
+    "label": "Eval triage",
+    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluate-multimodal",
+    "label": "Evaluate multimodal",
+    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluations",
+    "label": "Evaluations",
+    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+    "category": "skill",
+    "userPrompt": "Help me evaluate my agent"
+  },
+  {
+    "id": "experiments",
+    "label": "Experiments",
+    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+    "category": "skill",
+    "userPrompt": "Set up experiments for my agent"
+  },
+  {
+    "id": "generate-rag-dataset",
+    "label": "Generate RAG dataset",
+    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+    "category": "recipe"
+  },
+  {
+    "id": "github",
+    "label": "GitHub",
+    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+    "category": "skill"
+  },
+  {
+    "id": "level-up",
+    "label": "Level up",
+    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+    "category": "skill",
+    "userPrompt": "Take my agent to the next level"
+  },
+  {
+    "id": "online-evaluations",
+    "label": "Online evaluations",
+    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+    "category": "skill",
+    "userPrompt": "Set up online evaluations for my agent"
+  },
+  {
+    "id": "prompts",
+    "label": "Prompts",
+    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+    "category": "skill",
+    "userPrompt": "Version my prompts with LangWatch"
+  },
+  {
+    "id": "scenarios",
+    "label": "Scenarios",
+    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+    "category": "skill",
+    "userPrompt": "Add scenario tests for my agent"
+  },
+  {
+    "id": "setup-lw",
+    "label": "Setup lw",
+    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-cli-usability",
+    "label": "Test CLI usability",
+    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-compliance",
+    "label": "Test compliance",
+    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+    "category": "recipe"
+  },
+  {
+    "id": "tracing",
+    "label": "Tracing",
+    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+    "category": "skill",
+    "userPrompt": "Instrument my code with LangWatch"
+  }
 ]

--- a/langwatch/src/shared/langy/langySkills.generated.json
+++ b/langwatch/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-  {
-    "id": "agent-best-practices",
-    "label": "Agent best practices",
-    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-    "category": "recipe",
-    "userPrompt": "Where can I improve our agent development best practices?"
-  },
-  {
-    "id": "agent-improve",
-    "label": "Agent improve",
-    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-    "category": "skill",
-    "userPrompt": "What should I do next to improve my agent?"
-  },
-  {
-    "id": "agent-performance",
-    "label": "Agent performance",
-    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-    "category": "skill",
-    "userPrompt": "How is my agent performing?"
-  },
-  {
-    "id": "datasets",
-    "label": "Datasets",
-    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-    "category": "skill"
-  },
-  {
-    "id": "debug-instrumentation",
-    "label": "Debug instrumentation",
-    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-    "category": "recipe"
-  },
-  {
-    "id": "debug-with-langwatch",
-    "label": "Debug with langwatch",
-    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-    "category": "recipe"
-  },
-  {
-    "id": "eval-triage",
-    "label": "Eval triage",
-    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluate-multimodal",
-    "label": "Evaluate multimodal",
-    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluations",
-    "label": "Evaluations",
-    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-    "category": "skill",
-    "userPrompt": "Help me evaluate my agent"
-  },
-  {
-    "id": "experiments",
-    "label": "Experiments",
-    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-    "category": "skill",
-    "userPrompt": "Set up experiments for my agent"
-  },
-  {
-    "id": "generate-rag-dataset",
-    "label": "Generate RAG dataset",
-    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-    "category": "recipe"
-  },
-  {
-    "id": "github",
-    "label": "GitHub",
-    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-    "category": "skill"
-  },
-  {
-    "id": "level-up",
-    "label": "Level up",
-    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-    "category": "skill",
-    "userPrompt": "Take my agent to the next level"
-  },
-  {
-    "id": "online-evaluations",
-    "label": "Online evaluations",
-    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-    "category": "skill",
-    "userPrompt": "Set up online evaluations for my agent"
-  },
-  {
-    "id": "prompts",
-    "label": "Prompts",
-    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-    "category": "skill",
-    "userPrompt": "Version my prompts with LangWatch"
-  },
-  {
-    "id": "scenarios",
-    "label": "Scenarios",
-    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-    "category": "skill",
-    "userPrompt": "Add scenario tests for my agent"
-  },
-  {
-    "id": "setup-lw",
-    "label": "Setup lw",
-    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-cli-usability",
-    "label": "Test CLI usability",
-    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-compliance",
-    "label": "Test compliance",
-    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-    "category": "recipe"
-  },
-  {
-    "id": "tracing",
-    "label": "Tracing",
-    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-    "category": "skill",
-    "userPrompt": "Instrument my code with LangWatch"
-  }
+	{
+		"id": "agent-best-practices",
+		"label": "Agent best practices",
+		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+		"category": "recipe",
+		"userPrompt": "Where can I improve our agent development best practices?"
+	},
+	{
+		"id": "agent-improve",
+		"label": "Agent improve",
+		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+		"category": "skill",
+		"userPrompt": "What should I do next to improve my agent?"
+	},
+	{
+		"id": "agent-performance",
+		"label": "Agent performance",
+		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+		"category": "skill",
+		"userPrompt": "How is my agent performing?"
+	},
+	{
+		"id": "datasets",
+		"label": "Datasets",
+		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+		"category": "skill"
+	},
+	{
+		"id": "debug-instrumentation",
+		"label": "Debug instrumentation",
+		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+		"category": "recipe"
+	},
+	{
+		"id": "debug-with-langwatch",
+		"label": "Debug with langwatch",
+		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+		"category": "recipe"
+	},
+	{
+		"id": "eval-triage",
+		"label": "Eval triage",
+		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluate-multimodal",
+		"label": "Evaluate multimodal",
+		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluations",
+		"label": "Evaluations",
+		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+		"category": "skill",
+		"userPrompt": "Help me evaluate my agent"
+	},
+	{
+		"id": "experiments",
+		"label": "Experiments",
+		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+		"category": "skill",
+		"userPrompt": "Set up experiments for my agent"
+	},
+	{
+		"id": "generate-rag-dataset",
+		"label": "Generate RAG dataset",
+		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+		"category": "recipe"
+	},
+	{
+		"id": "github",
+		"label": "GitHub",
+		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+		"category": "skill"
+	},
+	{
+		"id": "level-up",
+		"label": "Level up",
+		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+		"category": "skill",
+		"userPrompt": "Take my agent to the next level"
+	},
+	{
+		"id": "online-evaluations",
+		"label": "Online evaluations",
+		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+		"category": "skill",
+		"userPrompt": "Set up online evaluations for my agent"
+	},
+	{
+		"id": "prompts",
+		"label": "Prompts",
+		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+		"category": "skill",
+		"userPrompt": "Version my prompts with LangWatch"
+	},
+	{
+		"id": "scenarios",
+		"label": "Scenarios",
+		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+		"category": "skill",
+		"userPrompt": "Add scenario tests for my agent"
+	},
+	{
+		"id": "setup-lw",
+		"label": "Setup lw",
+		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-cli-usability",
+		"label": "Test CLI usability",
+		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-compliance",
+		"label": "Test compliance",
+		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+		"category": "recipe"
+	},
+	{
+		"id": "tracing",
+		"label": "Tracing",
+		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+		"category": "skill",
+		"userPrompt": "Instrument my code with LangWatch"
+	}
 ]

--- a/specs/model-providers/google-agent-platform.feature
+++ b/specs/model-providers/google-agent-platform.feature
@@ -64,3 +64,16 @@ Feature: Google Agent Platform as a model provider
     Given Agent Platform cannot be reached
     When I check the credential
     Then the failure says the provider could not be reached
+
+  # A credential re-check that only has the key — the shape produced when a
+  # caller rebuilds customKeys from a stored key and drops every other
+  # field — must not be treated as though nothing is wrong with the key.
+  # There is nothing to probe without a project and location, so this is
+  # the same "no verdict" outcome as the provider never answering, not a
+  # refusal.
+  @unit
+  Scenario: A credential missing its project or location is not probed at all
+    Given an Agent Platform credential with no project or location
+    When I check the credential
+    Then the failure says the provider could not be reached
+    And nothing was sent to the provider

--- a/specs/model-providers/google-agent-platform.feature
+++ b/specs/model-providers/google-agent-platform.feature
@@ -22,27 +22,20 @@ Feature: Google Agent Platform as a model provider
   therefore report a working credential as unusable.
 
   @unit
-  Scenario: An Agent Platform key is checked against the endpoint that accepts it
-    Given a Google Agent Platform provider with an API key, project and location
+  Scenario: The credential is not exposed where logs or browser history could retain it
+    Given a Google Agent Platform credential
     When I check the credential
-    Then the provider is asked to generate content, not to list its models
+    Then the key does not appear in the address used to reach the provider
 
   @unit
-  Scenario: The credential travels in a header, never in the URL
-    Given a Google Agent Platform provider with an API key
+  Scenario: The project and location I entered are the ones actually checked
+    Given a Google Agent Platform credential for project "acme-123" in location "us-central1"
     When I check the credential
-    Then the key is sent as the x-goog-api-key header
-    And the key does not appear in the request URL
-
-  @unit
-  Scenario: The project and location the customer gave are the ones probed
-    Given a Google Agent Platform provider for project "acme-123" in location "us-central1"
-    When I check the credential
-    Then the request path names that project and that location
+    Then the check happens against project "acme-123" in location "us-central1"
 
   @unit
   Scenario: A key the platform accepts is valid
-    Given Agent Platform answers the generate-content request
+    Given Agent Platform accepts the credential
     When I check the credential
     Then the credential is reported as valid
 

--- a/specs/model-providers/google-agent-platform.feature
+++ b/specs/model-providers/google-agent-platform.feature
@@ -1,0 +1,66 @@
+Feature: Google Agent Platform as a model provider
+
+  Google issues several kinds of credential, and they are not interchangeable.
+  A key minted in the Cloud console for Gemini Enterprise Agent Platform is
+  refused by generativelanguage.googleapis.com — correctly, since its API
+  restrictions exclude that service — so a customer holding one could not add
+  Gemini at all. They were told their key was invalid, which it is not.
+
+  Agent Platform is its own service: its own host, its own auth header, and a
+  path that names the project and location. That makes it a provider of its
+  own, the same way Vertex AI is, rather than a mode of the Gemini one.
+
+  Established by probing a real Agent Platform key, because the two endpoints
+  on that host disagree and the documentation does not say so:
+
+    POST .../publishers/google/models/{model}:generateContent  accepts an API key
+    GET  .../models                                            401, "API keys are
+                                                               not supported by
+                                                               this API"
+
+  Validating by listing models — what every other provider here does — would
+  therefore report a working credential as unusable.
+
+  @unit
+  Scenario: An Agent Platform key is checked against the endpoint that accepts it
+    Given a Google Agent Platform provider with an API key, project and location
+    When I check the credential
+    Then the provider is asked to generate content, not to list its models
+
+  @unit
+  Scenario: The credential travels in a header, never in the URL
+    Given a Google Agent Platform provider with an API key
+    When I check the credential
+    Then the key is sent as the x-goog-api-key header
+    And the key does not appear in the request URL
+
+  @unit
+  Scenario: The project and location the customer gave are the ones probed
+    Given a Google Agent Platform provider for project "acme-123" in location "us-central1"
+    When I check the credential
+    Then the request path names that project and that location
+
+  @unit
+  Scenario: A key the platform accepts is valid
+    Given Agent Platform answers the generate-content request
+    When I check the credential
+    Then the credential is reported as valid
+
+  @unit
+  Scenario: A key the platform refuses is explained, not just rejected
+    Given Agent Platform refuses the credential
+    When I check the credential
+    Then I am told the key was refused
+    And the provider's own sentence is not part of what I am told
+
+  @unit
+  Scenario: A model the project cannot reach is not reported as a bad key
+    Given Agent Platform answers that the publisher model was not found
+    When I check the credential
+    Then I am not told the API key is invalid
+
+  @unit
+  Scenario: A provider that never answers is not a verdict on the key
+    Given Agent Platform cannot be reached
+    When I check the credential
+    Then the failure says the provider could not be reached


### PR DESCRIPTION
# Related Issue

- Resolves #6328

## The report

Altura could not add Gemini as a model provider:

> adding gemini as a model provider doesn't seem to work - api keys generated via gemini pasted into the api key field seem to trigger some kind of validation on the frontend and doesn't allow me to continue

#6252 fixed the *diagnosis* — they now read why the key was refused, and can save regardless. This adds the provider the key actually belongs to.

## What the key turned out to be

Their credential is a **Gemini Enterprise Agent Platform** key, not an AI Studio one. Both are `AQ.`-prefixed and look identical. `generativelanguage.googleapis.com` refuses it — correctly, its API restrictions exclude that service — so there was no provider in LangWatch it could be added to.

Worth stating, because it keeps being proposed: **there is no client-side key-format regex.** The only validation is `GEMINI_API_KEY: z.string().min(1)` — "not empty". The "validation on the frontend" was the probe's 403 rendering as a field error.

## The part that had to be discovered by probing

The two endpoints on the same host disagree, and the documentation does not mention it:

| Endpoint | API key |
|---|---|
| `POST .../publishers/google/models/{model}:generateContent` | **accepted** |
| `GET .../models` | 401 `"API keys are not supported by this API"` |

So this provider **cannot be validated the way every other one here is.** It is probed by generating a single token. Validating by listing models — which is what the shared code path does — would report a perfectly good credential as unusable. `ProbeRequest` gained `method`/`body` for that; every existing provider keeps its `GET`.

An earlier round of this investigation concluded the opposite and recommended closing #6328 as not-buildable. That conclusion came from probing the listing endpoint and generalising, and it was wrong.

## Also decided by testing, not assumption

- **`x-goog-api-key`, not `?key=`.** Both work. A credential in a URL reaches access logs, proxy logs and browser history, which is what #6252 moved this whole flow away from. A test pins that the key is absent from the URL.
- **`Bearer` is not an option** — 401.
- **Project and location are asked for, not guessed.** The path needs both. Omitting either yields no probe candidates rather than a fabricated path, which `runProbeChain` reports as unreachable — nothing was asked, so there is no verdict on the key.
- **Model names are not assumable.** `gemini-2.5-flash` resolves; `gemini-2.0-flash` 404s on the reporter's project. A 404 stays `provider_refused`, never `provider_key_invalid` — a different key would not fix it.

## Verification

Two rounds, because the code changed materially between them (two P1s
fixed after review: `validateKeyWithCustomUrl` dropping project/location,
and a dangling `defaultModel` with no catalog entry — see the review
thread for both). This is the final round, against the fully-fixed code.

**Direct, against real Google** — the same real Agent Platform key, run
through the actual merged `validateProviderApiKey`, no mocks:

```
google_agent_platform  ->  {"valid": true}
gemini (same key)       ->  code=provider_key_restricted
                            "This key's restrictions block the request.
                             Its API restrictions exclude the Generative
                             Language API. Allow that API in the Google
                             Cloud console, or set up a Vertex AI
                             provider instead."
```

**End-to-end in a real browser**, same key, current code, local infra:

| | |
|---|---|
| Provider list, drawer open | ![](https://raw.githubusercontent.com/langwatch/langwatch/890df6127354f605c4b6c5ae7ae4224085f8c480/.pr-assets/02-add-provider-list.png) |
| Fields, correct guidance copy | ![](https://raw.githubusercontent.com/langwatch/langwatch/890df6127354f605c4b6c5ae7ae4224085f8c480/.pr-assets/03-agent-platform-fields.png) |
| Key entered | ![](https://raw.githubusercontent.com/langwatch/langwatch/890df6127354f605c4b6c5ae7ae4224085f8c480/.pr-assets/04-filled.png) |
| **Saved — validates, listed in the table** | ![](https://raw.githubusercontent.com/langwatch/langwatch/890df6127354f605c4b6c5ae7ae4224085f8c480/.pr-assets/05-after-save.png) |

The customer's key on the **existing** Gemini provider, for comparison —
same key, correctly refused, with the reason instead of "invalid":

> This key's restrictions block the request. Its API restrictions exclude
> the Generative Language API. Allow that API in the Google Cloud
> console, or set up a Vertex AI provider instead.

```
  7 scenarios    specs/model-providers/google-agent-platform.feature — all bound
 59 unit tests   agentPlatformValidation + providerValidation
1039 unit tests  src/server/api + src/server/gateway (no regressions)
```

`pnpm typecheck:all` clean. Lint clean — verified against the actual CI
gate (a merge-base diff of Biome diagnostics per file/rule, format-
normalized), not just a local `pnpm lint` run: 0 added violations.

Two exhaustiveness gaps the compiler caught on the way in — `iconsMap`
and `ModelProviderKey` — are filled.

## What this does not do

**Inference.** Routing a provider type to an upstream is `mapProvider`'s job in the Go gateway (`services/aigateway`), so the credential materialises but no traffic dispatches yet. This closes *"I cannot add my key"*, not *"I can run models through it"*. Worth a follow-up before anyone points a workflow at it.

No credential appears in this PR, the repo, or any commit.

Closes #6328

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Google Agent Platform** as a supported model provider.
  * Extended onboarding/config to collect the required **API key, project, and location**.
  * Updated provider branding to include **Google Cloud** for this provider.
* **Bug Fixes**
  * Improved provider credential validation to probe the correct **content-generation** endpoint with the API key in headers (never in the URL).
  * Correctly classifies responses as **valid**, **invalid key**, **provider refused**, **publisher model not found**, or **service unreachable** (including missing project/location handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
