### PR TITLE
fix(traces): free-text search reaches trace and span names

### DIFF
--- a/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
@@ -153,7 +153,7 @@ const VALUE_ROWS: ReadonlyArray<{
   {
     form: "Free text",
     example: '"refund policy"',
-    notes: "Wrap multi-word phrases in quotes",
+    notes: "Searches input, output, trace and span names",
   },
 ];
 

--- a/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
@@ -153,7 +153,8 @@ const VALUE_ROWS: ReadonlyArray<{
   {
     form: "Free text",
     example: '"refund policy"',
-    notes: "Searches input, output, trace and span names",
+    notes:
+      "Searches input, output, trace name, and span names. Quote multi-word phrases.",
   },
 ];
 

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
@@ -499,6 +499,19 @@ const cases: Case[] = [
     trace: makeTrace({ computedInput: "hello", computedOutput: "world" }),
     expected: true,
   },
+  {
+    // Same narrowing, positive direction: dispatch cannot surface a trace whose
+    // only match would have come from a span name it never loaded. The SQL side
+    // does surface it, which is exactly the asymmetry the spec pins.
+    name: "free text without loaded spans misses a span-name-only match",
+    query: "codex",
+    trace: makeTrace({
+      traceName: "checkout flow",
+      computedInput: "hello",
+      computedOutput: "world",
+    }),
+    expected: false,
+  },
   // Boolean composition
   {
     name: "AND requires both sides",
@@ -850,6 +863,11 @@ describe("free text compiled to ClickHouse", () => {
     expect(sql).toContain("ifNull(TraceName, '') ILIKE");
     expect(sql).toContain("FROM stored_spans");
     expect(sql).toContain("SpanName ILIKE");
+    // The span subquery crosses into another table, so its tenant predicate is
+    // the one whose regression leaks across tenants rather than just returning
+    // the wrong rows. Pin it here even though `boundedSubquery` owns it.
+    expect(sql).toContain("TenantId = {tenantId:String}");
+    expect(compiled!.params).toMatchObject({ tenantId: "tenant-1" });
     expect(Object.values(compiled!.params)).toContain("%codex%");
   });
 

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
@@ -845,6 +845,54 @@ describe("queryNeeds", () => {
   });
 });
 
+describe("the in-memory free-text narrowing", () => {
+  // Dispatch passes `spans: null` (confirmSettledMatch), so the mirror answers
+  // free text from the summary alone. These two pin both directions of that.
+
+  /** @scenario A trigger's in-memory re-check cannot see span names */
+  it("misses a span-name-only match while the SQL side finds it", () => {
+    // Nothing in the summary mentions codex; only an unloaded span would.
+    const trace = makeTrace({
+      traceName: "checkout flow",
+      computedInput: "summarise the quarterly report",
+      computedOutput: "here is the summary",
+    });
+    expect(trace.spans).toBeUndefined();
+    expect(evaluateQueryInMemory("codex", trace)).toBe(false);
+
+    // The same filter compiled for ClickHouse does reach span names, which is
+    // the asymmetry the spec records.
+    const compiled = translateFilterToClickHouse("codex", "tenant-1", {
+      from: 0,
+      to: 1,
+    });
+    expect(compiled!.sql).toContain("FROM stored_spans");
+    expect(compiled!.sql).toContain("SpanName ILIKE");
+
+    // Loading the spans closes the gap with no change to the evaluator.
+    expect(
+      evaluateQueryInMemory("codex", {
+        ...trace,
+        spans: [{ name: "Codex.Exec", statusCode: 1, attributes: {} }],
+      }),
+    ).toBe(true);
+  });
+
+  /** @scenario The in-memory re-check still matches on the trace name */
+  it("still matches on the trace name, which travels with the fold state", () => {
+    expect(
+      evaluateQueryInMemory(
+        "codex",
+        makeTrace({
+          traceName: "codex exec",
+          computedInput: "run the migration script",
+          computedOutput: "migration finished",
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("free text compiled to ClickHouse", () => {
   function compile(query: string) {
     return translateFilterToClickHouse(query, "tenant-1", {

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
@@ -421,6 +421,84 @@ const cases: Case[] = [
     trace: makeTrace({ computedInput: null, computedOutput: "refund please" }),
     expected: false,
   },
+  // Free text over names (issue #6356). A tool or agent identifier usually
+  // lives on the span, not in the captured I/O, so free text has to reach the
+  // trace name (the root span's name) and the span names too.
+  {
+    name: "free text matches the trace name when the IO columns miss",
+    query: "codex",
+    trace: makeTrace({
+      traceName: "codex exec",
+      computedInput: "nothing relevant",
+      computedOutput: "still nothing",
+    }),
+    expected: true,
+  },
+  {
+    name: "free text matches the trace name case-insensitively",
+    query: "CODEX",
+    trace: makeTrace({ traceName: "Codex.Exec" }),
+    expected: true,
+  },
+  {
+    name: "free text matches a loaded span name when the IO columns miss",
+    query: "codex",
+    trace: makeTrace(
+      { computedInput: "nothing relevant", computedOutput: "still nothing" },
+      { spans: [{ name: "codex", statusCode: 1, attributes: {} }] },
+    ),
+    expected: true,
+  },
+  {
+    name: "free text matches a loaded span name as a substring",
+    query: "codex",
+    trace: makeTrace(
+      { computedInput: "nothing relevant", computedOutput: "still nothing" },
+      { spans: [{ name: "Codex.Exec", statusCode: 1, attributes: {} }] },
+    ),
+    expected: true,
+  },
+  {
+    name: "free text misses when no name or IO column contains the term",
+    query: "codex",
+    trace: makeTrace(
+      {
+        traceName: "checkout",
+        computedInput: "nothing relevant",
+        computedOutput: "still nothing",
+      },
+      { spans: [{ name: "http.request", statusCode: 1, attributes: {} }] },
+    ),
+    expected: false,
+  },
+  {
+    name: "negated free text excludes a trace name match",
+    query: "NOT codex",
+    trace: makeTrace({
+      traceName: "codex exec",
+      computedInput: "hello",
+      computedOutput: "world",
+    }),
+    expected: false,
+  },
+  {
+    name: "negated free text excludes a loaded span name match",
+    query: "NOT codex",
+    trace: makeTrace(
+      { computedInput: "hello", computedOutput: "world" },
+      { spans: [{ name: "codex", statusCode: 1, attributes: {} }] },
+    ),
+    expected: false,
+  },
+  {
+    // The documented narrowing: without span rows the mirror cannot see a
+    // span-name-only match, so it answers from the columns it does have rather
+    // than failing the tag closed and breaking every negated free-text filter.
+    name: "free text without loaded spans answers from the summary columns alone",
+    query: "NOT codex",
+    trace: makeTrace({ computedInput: "hello", computedOutput: "world" }),
+    expected: true,
+  },
   // Boolean composition
   {
     name: "AND requires both sides",
@@ -724,6 +802,13 @@ describe("queryNeeds", () => {
       expect(queryNeeds("span.attribute.k:v").has("spans")).toBe(true);
     });
 
+    // Free text reaches span names through a stored_spans subquery, so a
+    // dispatcher has to know it needs the span rows to answer it exactly.
+    it("collects spans for free text", () => {
+      expect(queryNeeds("codex").has("spans")).toBe(true);
+      expect(queryNeeds('"refund policy"').has("spans")).toBe(true);
+    });
+
     it("resolves has/none value-polymorphic needs", () => {
       expect([...queryNeeds("has:eval")]).toEqual(["evaluations"]);
       expect([...queryNeeds("none:feedback")]).toEqual(["events"]);
@@ -744,5 +829,51 @@ describe("queryNeeds", () => {
     it("returns an empty set for an unparseable query", () => {
       expect(queryNeeds("((").size).toBe(0);
     });
+  });
+});
+
+describe("free text compiled to ClickHouse", () => {
+  function compile(query: string) {
+    return translateFilterToClickHouse(query, "tenant-1", {
+      from: 1000,
+      to: 2000,
+    });
+  }
+
+  it("searches the computed IO columns, the trace name, and span names", () => {
+    const compiled = compile("codex");
+    expect(compiled).not.toBeNull();
+    const sql = compiled!.sql;
+
+    expect(sql).toContain("ComputedInput ILIKE");
+    expect(sql).toContain("ComputedOutput ILIKE");
+    expect(sql).toContain("ifNull(TraceName, '') ILIKE");
+    expect(sql).toContain("FROM stored_spans");
+    expect(sql).toContain("SpanName ILIKE");
+    expect(Object.values(compiled!.params)).toContain("%codex%");
+  });
+
+  it("binds one parameter reused across every branch", () => {
+    const compiled = compile("codex");
+    const freeTextParams = Object.keys(compiled!.params).filter((k) =>
+      k.startsWith("freeText"),
+    );
+    expect(freeTextParams).toHaveLength(1);
+    // Four branches: input, output, trace name, span name.
+    const name = freeTextParams[0]!;
+    const occurrences = compiled!.sql.split(`{${name}:String}`).length - 1;
+    expect(occurrences).toBe(4);
+  });
+
+  it("bounds the span subquery to the query time window for partition pruning", () => {
+    const compiled = compile("codex");
+    expect(compiled!.sql).toContain("StartTime >=");
+    expect(compiled!.sql).toContain("StartTime <=");
+    expect(compiled!.params).toMatchObject({ timeFrom: 1000, timeTo: 2000 });
+  });
+
+  it("negates the whole clause, not just the IO columns", () => {
+    const compiled = compile("NOT codex");
+    expect(compiled!.sql.trim()).toMatch(/^NOT \(/);
   });
 });

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
@@ -289,10 +289,13 @@ function translateFreeText(
   // off `trace_summaries`; the subquery covers every other span via
   // `stored_spans.SpanName` (backed by `idx_span_name`).
   //
-  // Both name branches are compared through a definite expression rather than
-  // a bare Nullable column, so they can only be true or false. That keeps the
-  // clause's three-valued logic exactly as it was when a computed I/O column
-  // is NULL, which the parity suite pins.
+  // `TraceName` is `String DEFAULT ''`, so the `ifNull` wrapper is belt-and-
+  // braces rather than load-bearing; it matches how `meta-handlers.ts` already
+  // reads the column. What matters is that both name branches evaluate to a
+  // definite true/false, never a NULL, so the clause's three-valued logic when a
+  // computed I/O column is NULL stays exactly as it was. The parity suite pins
+  // that. The span subquery is tenant-scoped and time-bounded by
+  // `boundedSubquery`.
   const clause = `(ComputedInput ILIKE ${p} OR ComputedOutput ILIKE ${p} OR ifNull(TraceName, '') ILIKE ${p} OR ${boundedSubquery(
     "stored_spans",
     "StartTime",

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
@@ -281,7 +281,22 @@ function translateFreeText(
   validateValueLength(value);
   const paramName = nextParam(ctx, "freeText");
   ctx.params[paramName] = `%${value}%`;
+  const p = `{${paramName}:String}`;
 
-  const clause = `(ComputedInput ILIKE {${paramName}:String} OR ComputedOutput ILIKE {${paramName}:String})`;
+  // Span names are part of free text, not just the captured I/O: the name is
+  // often the only place a tool or agent identifier appears, so a query like
+  // `codex` has to reach it. `TraceName` covers the root span's name straight
+  // off `trace_summaries`; the subquery covers every other span via
+  // `stored_spans.SpanName` (backed by `idx_span_name`).
+  //
+  // Both name branches are compared through a definite expression rather than
+  // a bare Nullable column, so they can only be true or false. That keeps the
+  // clause's three-valued logic exactly as it was when a computed I/O column
+  // is NULL, which the parity suite pins.
+  const clause = `(ComputedInput ILIKE ${p} OR ComputedOutput ILIKE ${p} OR ifNull(TraceName, '') ILIKE ${p} OR ${boundedSubquery(
+    "stored_spans",
+    "StartTime",
+    `SpanName ILIKE ${p}`,
+  )})`;
   return negated ? `NOT ${clause}` : clause;
 }

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
@@ -236,7 +236,13 @@ function evaluateFreeText(
   const value = extractStringValue(tag).toLowerCase();
   const inputMatch = ilikeContains(trace.summary.computedInput, value);
   const outputMatch = ilikeContains(trace.summary.computedOutput, value);
-  const nameMatch = trace.summary.traceName.toLowerCase().includes(value);
+  // `?? ""` rather than a bare deref: the type says string, but the only place
+  // that coalesce actually happens is the analytics repository's row mapping, so
+  // a summary built from a fold state that predates the field would throw here
+  // and take the whole evaluation (including trigger dispatch) down with it.
+  const nameMatch = (trace.summary.traceName ?? "")
+    .toLowerCase()
+    .includes(value);
   const spanMatch =
     trace.spans?.some((s) => s.name.toLowerCase().includes(value)) ?? false;
 

--- a/langwatch/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
+++ b/langwatch/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
@@ -215,17 +215,33 @@ function evaluateFreeText(
   trace: InMemoryTrace,
 ): boolean {
   // Mirrors `translateFreeText`'s `(ComputedInput ILIKE %v% OR ComputedOutput
-  // ILIKE %v%)` — including ClickHouse's three-valued logic over the
-  // Nullable(String) columns: `NULL ILIKE …` is NULL, `NULL OR true` is true,
-  // `NULL OR false` is NULL, `NOT NULL` is NULL, and a NULL predicate excludes
-  // the row. So a match on one column counts even when the other is NULL, but
-  // a negated free-text filter never matches a trace whose non-matching side
-  // includes a NULL column.
+  // ILIKE %v% OR ifNull(TraceName,'') ILIKE %v% OR <span-name subquery>)`,
+  // including ClickHouse's three-valued logic over the Nullable(String) I/O
+  // columns: `NULL ILIKE …` is NULL, `NULL OR true` is true, `NULL OR false` is
+  // NULL, `NOT NULL` is NULL, and a NULL predicate excludes the row. So a match
+  // on one column counts even when the other is NULL, but a negated free-text
+  // filter never matches a trace whose non-matching side includes a NULL column.
+  //
+  // `traceName` mirrors the SQL side's `ifNull(...)` wrapper: a definite
+  // true/false, never a NULL that propagates.
+  //
+  // Span names are the one branch that needs rows the dispatcher may not have
+  // loaded (`queryNeeds` asks for them; today's callers still pass none). When
+  // they are absent this mirror is deliberately NARROWER than the SQL clause:
+  // it can miss a span-name-only match. The alternative, treating unloaded
+  // spans as unknown and failing the tag closed, would make every negated
+  // free-text filter stop matching, which is a live dispatch behaviour. Missing
+  // the narrow span-name-only case costs less than breaking that, and a
+  // dispatcher that starts loading spans becomes exact with no change here.
   const value = extractStringValue(tag).toLowerCase();
   const inputMatch = ilikeContains(trace.summary.computedInput, value);
   const outputMatch = ilikeContains(trace.summary.computedOutput, value);
+  const nameMatch = trace.summary.traceName.toLowerCase().includes(value);
+  const spanMatch =
+    trace.spans?.some((s) => s.name.toLowerCase().includes(value)) ?? false;
+
   const matched =
-    inputMatch === true || outputMatch === true
+    inputMatch === true || outputMatch === true || nameMatch || spanMatch
       ? true
       : inputMatch === null || outputMatch === null
         ? null
@@ -311,7 +327,12 @@ function collectNeeds(node: LiqeQuery, needs: Set<FieldNeeds>): void {
 }
 
 function collectTagNeeds(tag: TagToken, needs: Set<FieldNeeds>): void {
-  if (tag.field.type === "ImplicitField") return;
+  // Free text reaches span names through a `stored_spans` subquery, so the
+  // in-memory mirror needs the span rows to answer it without failing closed.
+  if (tag.field.type === "ImplicitField") {
+    needs.add("spans");
+    return;
+  }
   const fieldName = tag.field.name;
 
   if (fieldName.startsWith(TRACE_ATTRIBUTE_PREFIX)) return;

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -530,6 +530,94 @@ describe("ClickHouseTraceService", () => {
           "%100\\% success\\_rate%",
         );
       });
+
+      // Issue #6356: a tool or agent identifier usually lives on the span
+      // name, not in the captured I/O, so free text has to reach the trace
+      // name and the span names as well.
+      it.each([
+        ["count", 0],
+        ["data", 1],
+      ])("searches the trace name in the %s query", async (_label, callIdx) => {
+        setupMocksForQueryTest();
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getAllTracesForProject(
+          { ...baseInput, query: "codex" } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        const call = mockClickHouseQuery.mock.calls[callIdx as number]!;
+        expect(call[0].query).toContain(
+          "lower(ifNull(ts.TraceName, '')) LIKE {searchQuery:String}",
+        );
+      });
+
+      it.each([
+        ["count", 0],
+        ["data", 1],
+      ])("searches span names in the %s query", async (_label, callIdx) => {
+        setupMocksForQueryTest();
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getAllTracesForProject(
+          { ...baseInput, query: "codex" } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        const sql = mockClickHouseQuery.mock.calls[callIdx as number]![0].query;
+        expect(sql).toContain("FROM stored_spans sp");
+        expect(sql).toContain("lower(sp.SpanName) LIKE {searchQuery:String}");
+        // Correlated on the outer row and bounded, so it prunes partitions
+        // instead of cold-scanning every weekly partition.
+        expect(sql).toContain("sp.TraceId = ts.TraceId");
+        expect(sql).toContain(
+          "sp.StartTime >= fromUnixTimestamp64Milli({startDate:UInt64})",
+        );
+      });
+
+      it("ORs the name branches with the IO branches rather than replacing them", async () => {
+        setupMocksForQueryTest();
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getAllTracesForProject(
+          { ...baseInput, query: "codex" } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        const sql = mockClickHouseQuery.mock.calls[0]![0].query;
+        expect(sql).toContain("lower(ifNull(ts.ComputedInput, ''))");
+        expect(sql).toContain("lower(ifNull(ts.ComputedOutput, ''))");
+        expect(sql).toContain("lower(ifNull(ts.TraceName, ''))");
+        expect(sql).toContain("lower(sp.SpanName)");
+      });
+
+      // The 3-char floor exists because the ngrambf_v1 skip indexes are
+      // n=3; adding name branches must not start issuing queries below it.
+      it("still no-ops below the three-character floor", async () => {
+        setupMocksForQueryTest();
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getAllTracesForProject(
+          { ...baseInput, query: "co" } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        const call = mockClickHouseQuery.mock.calls[0]!;
+        expect(call[0].query_params.searchQuery).toBeUndefined();
+        expect(call[0].query).not.toContain("lower(sp.SpanName)");
+      });
     });
 
     describe("when user cannot see input or output", () => {

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -598,6 +598,20 @@ describe("ClickHouseTraceService", () => {
         expect(sql).toContain("lower(ifNull(ts.ComputedOutput, ''))");
         expect(sql).toContain("lower(ifNull(ts.TraceName, ''))");
         expect(sql).toContain("lower(sp.SpanName)");
+
+        // Presence alone would pass just as happily if the branches were
+        // AND-joined, which is the actual regression to fear: an AND of four
+        // substring tests matches nothing. Pin the join operator. The slice
+        // stops at EXISTS so the span subquery's own internal ANDs (its tenant,
+        // trace and time predicates) stay out of the assertion.
+        const columnBranches = sql.slice(
+          sql.indexOf("lower(ifNull(ts.ComputedInput, ''))"),
+          sql.indexOf("EXISTS ("),
+        );
+        expect(columnBranches).toContain(" OR ");
+        expect(columnBranches).not.toContain(" AND ");
+        // ...and the span branch is OR-ed onto them, not AND-ed.
+        expect(sql).toContain("OR EXISTS (");
       });
 
       // The 3-char floor exists because the ngrambf_v1 skip indexes are
@@ -617,6 +631,29 @@ describe("ClickHouseTraceService", () => {
         const call = mockClickHouseQuery.mock.calls[0]!;
         expect(call[0].query_params.searchQuery).toBeUndefined();
         expect(call[0].query).not.toContain("lower(sp.SpanName)");
+      });
+
+      // The privacy-relevant asymmetry in this change: the two Computed*
+      // branches stay gated on the I/O protections, while trace and span names
+      // are operation names already visible in the list and so are searched
+      // either way. Pin it so neither half drifts.
+      it("drops a redacted IO column but keeps the name branches", async () => {
+        setupMocksForQueryTest();
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getAllTracesForProject(
+          { ...baseInput, query: "codex" } as GetAllTracesForProjectInput,
+          { ...protections, canSeeCapturedOutput: false },
+        );
+
+        const sql = mockClickHouseQuery.mock.calls[0]![0].query;
+        expect(sql).not.toContain("lower(ifNull(ts.ComputedOutput, ''))");
+        expect(sql).toContain("lower(ifNull(ts.ComputedInput, ''))");
+        expect(sql).toContain("lower(ifNull(ts.TraceName, ''))");
+        expect(sql).toContain("lower(sp.SpanName)");
       });
     });
 

--- a/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Integration coverage for issue #6356: free-text trace search has to reach
+ * span names, not just the captured I/O.
+ *
+ * Proves `specs/traces-v2/search.feature`'s "Free text matches span names as
+ * well as captured I/O" rule against real ClickHouse, for BOTH free-text paths:
+ *
+ *   Path A, the traces-v2 search bar (also what Langy searches through):
+ *            `translateFilterToClickHouse` compiles the query and the generated
+ *            SQL is executed here, so an invalid subquery or a mis-bound param
+ *            fails the test rather than passing a string assertion.
+ *   Path B, the legacy messages list and public search endpoint, driven
+ *            through `ClickHouseTraceService.getAllTracesForProject`.
+ *
+ * The fixtures are built so each trace can only be found through ONE field.
+ * A trace whose span name is the sole occurrence of the term is the exact case
+ * that used to be invisible, and the "no match anywhere" trace guards against
+ * a clause that accidentally matches everything.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
+import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { prisma } from "~/server/db";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type { GetAllTracesForProjectInput } from "../types";
+import { openProtections } from "./open-protections";
+
+const tenantId = `test-spanname-${nanoid()}`;
+const now = Date.now();
+
+// Each trace carries the term in exactly one place.
+const BY_SPAN_NAME = `trace-by-span-${nanoid()}`;
+const BY_TRACE_NAME = `trace-by-name-${nanoid()}`;
+const BY_INPUT = `trace-by-input-${nanoid()}`;
+const BY_OUTPUT = `trace-by-output-${nanoid()}`;
+const NO_MATCH = `trace-no-match-${nanoid()}`;
+
+const TERM = "codex";
+
+function traceRow({
+  traceId,
+  traceName = "checkout flow",
+  input = "nothing relevant here",
+  output = "nothing relevant either",
+}: {
+  traceId: string;
+  traceName?: string;
+  input?: string | null;
+  output?: string | null;
+}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    LastEventOccurredAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput:
+      input === null ? null : JSON.stringify({ type: "text", value: input }),
+    ComputedOutput:
+      output === null ? null : JSON.stringify({ type: "text", value: output }),
+    TotalDurationMs: 100,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    Models: [],
+    TraceName: traceName,
+  };
+}
+
+function spanRow({ traceId, spanName }: { traceId: string; spanName: string }) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    SpanId: `span-${nanoid()}`,
+    ParentSpanId: null,
+    Sampled: 1,
+    StartTime: new Date(now),
+    EndTime: new Date(now + 5),
+    DurationMs: 5,
+    SpanName: spanName,
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: {},
+    StatusCode: 1,
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+  };
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: { findUnique: vi.fn().mockResolvedValue({}) },
+    annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    annotationScore: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+/**
+ * Path A: compile the free-text query the search bar would send, then RUN the
+ * generated SQL against the seeded data and return the trace ids it selects.
+ */
+async function searchViaCompiledFilter(query: string): Promise<string[]> {
+  const compiled = translateFilterToClickHouse(query, tenantId, {
+    from: now - 60_000,
+    to: now + 60_000,
+  });
+  expect(compiled).not.toBeNull();
+
+  const result = await ch.query({
+    query: `
+      SELECT DISTINCT TraceId
+      FROM trace_summaries
+      WHERE TenantId = {tenantId:String}
+        AND OccurredAt >= fromUnixTimestamp64Milli({timeFrom:Int64})
+        AND OccurredAt <= fromUnixTimestamp64Milli({timeTo:Int64})
+        AND (${compiled!.sql})
+    `,
+    query_params: compiled!.params,
+    format: "JSONEachRow",
+  });
+  const rows = await result.json<{ TraceId: string }>();
+  return rows.map((r) => r.TraceId).sort();
+}
+
+/** Path B: the legacy list search, all the way through the service. */
+async function searchViaLegacyList(query: string): Promise<string[]> {
+  const input: GetAllTracesForProjectInput = {
+    projectId: tenantId,
+    startDate: now - 60_000,
+    endDate: now + 60_000,
+    filters: {},
+    pageSize: 100,
+    query,
+  } as GetAllTracesForProjectInput;
+
+  const results = await service.getAllTracesForProject(input, openProtections);
+  expect(results).not.toBeNull();
+  return results!.groups
+    .flat()
+    .map((t) => t.trace_id)
+    .sort();
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      // The regression case: the term exists ONLY on a child span's name.
+      traceRow({ traceId: BY_SPAN_NAME }),
+      // The term is the trace name (the root span's name).
+      traceRow({ traceId: BY_TRACE_NAME, traceName: `${TERM} exec` }),
+      // Controls that already worked before the fix.
+      traceRow({ traceId: BY_INPUT, input: `please run ${TERM} for me` }),
+      traceRow({ traceId: BY_OUTPUT, output: `${TERM} finished cleanly` }),
+      // Must never match.
+      traceRow({ traceId: NO_MATCH }),
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+
+  await ch.insert({
+    table: "stored_spans",
+    values: [
+      // Mixed case on purpose: matching must be case-insensitive.
+      spanRow({ traceId: BY_SPAN_NAME, spanName: "Codex.Exec" }),
+      spanRow({ traceId: BY_TRACE_NAME, spanName: "http.request" }),
+      spanRow({ traceId: BY_INPUT, spanName: "http.request" }),
+      spanRow({ traceId: BY_OUTPUT, spanName: "http.request" }),
+      spanRow({ traceId: NO_MATCH, spanName: "http.request" }),
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    for (const table of ["trace_summaries", "stored_spans"]) {
+      await ch.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId },
+      });
+    }
+  }
+  await stopTestContainers();
+});
+
+describe("free-text search over span names (integration)", () => {
+  describe("given a trace whose span name is the only place the term appears", () => {
+    it("surfaces it through the traces-v2 search bar", async () => {
+      const found = await searchViaCompiledFilter(TERM);
+      expect(found).toContain(BY_SPAN_NAME);
+    });
+
+    it("surfaces it through the legacy list search", async () => {
+      const found = await searchViaLegacyList(TERM);
+      expect(found).toContain(BY_SPAN_NAME);
+    });
+  });
+
+  describe("given a trace whose name is the only place the term appears", () => {
+    it("surfaces it through the traces-v2 search bar", async () => {
+      const found = await searchViaCompiledFilter(TERM);
+      expect(found).toContain(BY_TRACE_NAME);
+    });
+
+    it("surfaces it through the legacy list search", async () => {
+      const found = await searchViaLegacyList(TERM);
+      expect(found).toContain(BY_TRACE_NAME);
+    });
+  });
+
+  describe("when the term is searched", () => {
+    it("still finds the captured I/O matches it always found", async () => {
+      const found = await searchViaCompiledFilter(TERM);
+      expect(found).toContain(BY_INPUT);
+      expect(found).toContain(BY_OUTPUT);
+    });
+
+    it("finds every matching trace and nothing else", async () => {
+      const found = await searchViaCompiledFilter(TERM);
+      expect(found).toEqual(
+        [BY_SPAN_NAME, BY_TRACE_NAME, BY_INPUT, BY_OUTPUT].sort(),
+      );
+    });
+
+    it("leaves a trace with no occurrence anywhere out", async () => {
+      expect(await searchViaCompiledFilter(TERM)).not.toContain(NO_MATCH);
+      expect(await searchViaLegacyList(TERM)).not.toContain(NO_MATCH);
+    });
+  });
+
+  describe("when the term is negated", () => {
+    it("excludes the span-name and trace-name matches", async () => {
+      const found = await searchViaCompiledFilter(`NOT ${TERM}`);
+      expect(found).not.toContain(BY_SPAN_NAME);
+      expect(found).not.toContain(BY_TRACE_NAME);
+      // NOT over a trace with non-null, non-matching I/O keeps it in.
+      expect(found).toContain(NO_MATCH);
+    });
+  });
+
+  describe("when a term matches no trace at all", () => {
+    it("returns nothing rather than everything", async () => {
+      expect(await searchViaCompiledFilter("zzz-nonexistent-zzz")).toEqual([]);
+      expect(await searchViaLegacyList("zzz-nonexistent-zzz")).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
@@ -125,7 +125,9 @@ async function searchViaCompiledFilter(query: string): Promise<string[]> {
     from: now - 60_000,
     to: now + 60_000,
   });
-  expect(compiled).not.toBeNull();
+  // A guard rather than an assertion: this is a helper, not a test body, and
+  // a null compile here means the fixture query itself is wrong.
+  if (!compiled) throw new Error(`query compiled to no filter: ${query}`);
 
   const result = await ch.query({
     query: `
@@ -134,9 +136,9 @@ async function searchViaCompiledFilter(query: string): Promise<string[]> {
       WHERE TenantId = {tenantId:String}
         AND OccurredAt >= fromUnixTimestamp64Milli({timeFrom:Int64})
         AND OccurredAt <= fromUnixTimestamp64Milli({timeTo:Int64})
-        AND (${compiled!.sql})
+        AND (${compiled.sql})
     `,
-    query_params: compiled!.params,
+    query_params: compiled.params,
     format: "JSONEachRow",
   });
   const rows = await result.json<{ TraceId: string }>();
@@ -155,8 +157,8 @@ async function searchViaLegacyList(query: string): Promise<string[]> {
   } as GetAllTracesForProjectInput;
 
   const results = await service.getAllTracesForProject(input, openProtections);
-  expect(results).not.toBeNull();
-  return results!.groups
+  if (!results) throw new Error(`legacy list returned nothing for: ${query}`);
+  return results.groups
     .flat()
     .map((t) => t.trace_id)
     .sort();

--- a/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
@@ -79,13 +79,26 @@ function traceRow({
   };
 }
 
-function spanRow({ traceId, spanName }: { traceId: string; spanName: string }) {
+/**
+ * `parentSpanId` matters: `TraceName` covers the root span's name, so the
+ * subquery only earns its keep on NON-root spans. A fixture where every span is
+ * a root would pass on the trace-name branch alone and never exercise it.
+ */
+function spanRow({
+  traceId,
+  spanName,
+  parentSpanId = null,
+}: {
+  traceId: string;
+  spanName: string;
+  parentSpanId?: string | null;
+}) {
   return {
     ProjectionId: `proj-${nanoid()}`,
     TenantId: tenantId,
     TraceId: traceId,
     SpanId: `span-${nanoid()}`,
-    ParentSpanId: null,
+    ParentSpanId: parentSpanId,
     Sampled: 1,
     StartTime: new Date(now),
     EndTime: new Date(now + 5),
@@ -192,8 +205,15 @@ beforeAll(async () => {
   await ch.insert({
     table: "stored_spans",
     values: [
-      // Mixed case on purpose: matching must be case-insensitive.
-      spanRow({ traceId: BY_SPAN_NAME, spanName: "Codex.Exec" }),
+      // The regression case, as a genuine CHILD span (its trace's own name is
+      // "checkout flow", so only the subquery can find it) and mixed case on
+      // purpose, since matching must be case-insensitive.
+      spanRow({ traceId: BY_SPAN_NAME, spanName: "root" }),
+      spanRow({
+        traceId: BY_SPAN_NAME,
+        spanName: "Codex.Exec",
+        parentSpanId: "span-root-checkout",
+      }),
       spanRow({ traceId: BY_TRACE_NAME, spanName: "http.request" }),
       spanRow({ traceId: BY_INPUT, spanName: "http.request" }),
       spanRow({ traceId: BY_OUTPUT, spanName: "http.request" }),
@@ -218,6 +238,26 @@ afterAll(async () => {
 
 describe("free-text search over span names (integration)", () => {
   describe("given a trace whose span name is the only place the term appears", () => {
+    // Guards the fixture itself: if the matching span were a root, the
+    // trace-name branch could carry these tests and the subquery would go
+    // untested. Its trace is named "checkout flow", so only the subquery matches.
+    it("has the matching span as a non-root span", async () => {
+      const rows = await (
+        await ch.query({
+          query: `SELECT SpanName, isNull(ParentSpanId) AS is_root
+                  FROM stored_spans
+                  WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+                    AND lower(SpanName) LIKE '%codex%'`,
+          query_params: { tenantId, traceId: BY_SPAN_NAME },
+          format: "JSONEachRow",
+        })
+      ).json<{ SpanName: string; is_root: number }>();
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.SpanName).toBe("Codex.Exec");
+      expect(Number(rows[0]!.is_root)).toBe(0);
+    });
+
     it("surfaces it through the traces-v2 search bar", async () => {
       const found = await searchViaCompiledFilter(TERM);
       expect(found).toContain(BY_SPAN_NAME);

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1711,6 +1711,12 @@ export class ClickHouseTraceService {
           return { traces: [], totalHits: 0, lastTrace: null };
         }
 
+        // Trace and span names are operation names rather than captured
+        // content, and a tool or agent identifier is often only there, so free
+        // text has to reach them too. They ride alongside the I/O columns
+        // instead of replacing them, and `searchQuery` is already lowercased
+        // and LIKE-escaped, so `lower(...)` on each side is the whole contract.
+        // Whether captured I/O may be searched at all is still decided above.
         const searchableColumns = [
           ...(protections.canSeeCapturedInput !== false
             ? ["lower(ifNull(ts.ComputedInput, ''))"]
@@ -1718,10 +1724,29 @@ export class ClickHouseTraceService {
           ...(protections.canSeeCapturedOutput !== false
             ? ["lower(ifNull(ts.ComputedOutput, ''))"]
             : []),
+          "lower(ifNull(ts.TraceName, ''))",
         ];
 
+        // Non-root span names live in `stored_spans`, probed with the same
+        // correlated EXISTS shape the span filters in `filter-conditions.ts`
+        // use. The StartTime bound keeps it partition-pruned instead of
+        // cold-scanning every weekly partition, matching `buildSpanTimeBound`.
+        const spanNameSearch = `EXISTS (
+                    SELECT 1 FROM stored_spans sp
+                    WHERE sp.TenantId = ts.TenantId
+                      AND sp.TraceId = ts.TraceId
+                      AND sp.StartTime >= fromUnixTimestamp64Milli({startDate:UInt64})
+                      AND sp.StartTime <= fromUnixTimestamp64Milli({endDate:UInt64})
+                      AND lower(sp.SpanName) LIKE {searchQuery:String}
+                  )`;
+
         const searchFilter = effectiveQuery
-          ? ` AND (${searchableColumns.map((col) => `${col} LIKE {searchQuery:String}`).join(" OR ")})`
+          ? ` AND (${[
+              ...searchableColumns.map(
+                (col) => `${col} LIKE {searchQuery:String}`,
+              ),
+              spanNameSearch,
+            ].join(" OR ")})`
           : "";
 
         // Date axis.

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -251,9 +251,11 @@ Rule: Query syntax
 # stored_spans, matched as a case-insensitive substring the way the I/O
 # columns already are.
 Rule: Free text matches span names as well as captured I/O
-  A free-text term is looked for in the trace input, the trace output, the
-  trace name, and the names of the trace's spans. Any one of them matching
-  surfaces the trace.
+  When a query is answered from stored data, a free-text term is looked for in
+  the trace input, the trace output, the trace name, and the names of the
+  trace's spans. Any one of them matching surfaces the trace. The in-memory
+  evaluator that automation dispatch uses is narrower, and the last scenario
+  in this rule pins how.
 
   Background:
     Given the user is authenticated with "traces:view" permission
@@ -300,6 +302,28 @@ Rule: Free text matches span names as well as captured I/O
     Given several traces match "codex" by span name and by input content
     When the user searches for "codex"
     Then the results are ordered newest first, not by which field matched
+
+  # The one place the two sides of the query language do not agree. A trigger's
+  # filter is re-checked in memory at dispatch time against the settled fold
+  # state, which carries the trace name but no span rows. Treating the missing
+  # spans as unknown and failing the tag closed would stop every negated
+  # free-text trigger from matching, so the narrower answer is the deliberate
+  # choice: it can miss a match that only a span name would have made. A
+  # dispatcher that starts deriving spans becomes exact with no change needed.
+  @unit
+  Scenario: A trigger's in-memory re-check cannot see span names
+    Given an automation whose filter is the free text "codex"
+    And a trace whose only occurrence of "codex" is a span name
+    When the filter is re-checked in memory at dispatch time, with no span rows loaded
+    Then the trace does not match
+    But the same filter run against stored data does surface that trace
+
+  @unit
+  Scenario: The in-memory re-check still matches on the trace name
+    Given an automation whose filter is the free text "codex"
+    And a trace named "codex exec" with no occurrence of "codex" in its input or output
+    When the filter is re-checked in memory at dispatch time
+    Then the trace matches, because the trace name travels with the fold state
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -190,6 +190,7 @@ Rule: Query syntax
   Scenario: Free text search in quotes
     When the user searches for "refund policy"
     Then traces with "refund policy" in their input or output content are shown
+    And traces whose trace name or any span name contains "refund policy" are shown
 
   Scenario: Negation with NOT
     When the user searches for "NOT @status:error"
@@ -235,6 +236,70 @@ Rule: Query syntax
   Scenario: Unquoted free text is treated as full-text search
     When the user types "timeout" without quotes or @ prefix
     Then it is treated as a full-text search across trace content
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FREE TEXT REACHES SPAN NAMES
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Free text used to match only ComputedInput and ComputedOutput, so a trace
+# whose span name was the only place the query appeared was invisible to the
+# search box. Searching "codex" returned nothing even though Codex traces
+# existed, because the tool name lives on the span, not in the captured I/O.
+# Span names are now part of the same free-text clause: the trace's own name
+# (the root span's name, held on trace_summaries) plus every span name in
+# stored_spans, matched as a case-insensitive substring the way the I/O
+# columns already are.
+Rule: Free text matches span names as well as captured I/O
+  A free-text term is looked for in the trace input, the trace output, the
+  trace name, and the names of the trace's spans. Any one of them matching
+  surfaces the trace.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the project has traces
+
+  Scenario: A term that appears only in a span name still finds the trace
+    Given a trace has a span named "codex" and no occurrence of "codex" in its input or output
+    When the user searches for "codex"
+    Then that trace is in the results
+
+  Scenario: A term that appears only in the trace name still finds the trace
+    Given a trace is named "codex exec" and no occurrence of "codex" in its input or output
+    When the user searches for "codex"
+    Then that trace is in the results
+
+  Scenario: Span name matching is case-insensitive substring matching
+    Given a trace has a span named "Codex.Exec"
+    When the user searches for "codex"
+    Then that trace is in the results
+
+  Scenario: A term in no field at all does not match
+    Given a trace has no occurrence of "codex" in its input, output, trace name, or any span name
+    When the user searches for "codex"
+    Then that trace is not in the results
+
+  Scenario: Negated free text excludes a span-name match
+    Given a trace has a span named "codex"
+    When the user searches for "NOT codex"
+    Then that trace is not in the results
+
+  # Both free-text paths carry the same promise: the traces-v2 search bar
+  # (which is also what Langy searches through) and the legacy messages list
+  # and public search endpoint.
+  Scenario: The legacy messages list search also reaches span names
+    Given a trace has a span named "codex" and no occurrence of "codex" in its input or output
+    When the same term is searched through the legacy messages list search
+    Then that trace is in the results
+
+  # Ranking is deliberately unchanged. Neither free-text path scores results:
+  # they are boolean SQL filters and the list stays ordered newest-first, so
+  # "prioritising" a span-name match means including it in the match set at
+  # all rather than assigning it a relevance weight.
+  Scenario: Results stay in chronological order
+    Given several traces match "codex" by span name and by input content
+    When the user searches for "codex"
+    Then the results are ordered newest first, not by which field matched
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Free-text trace search only matched `ComputedInput` and `ComputedOutput`, so a trace whose **span name** was the only place the query appeared never surfaced. Searching `codex` came back empty even though Codex traces existed, because the tool name lives on the span rather than in the captured I/O. That is how this was reported: Langy concluded there were no Codex traces while trace `0f2f2375caa81fcdfdcf6a7e1a636bb5` was one.

The trace name had the same gap. It is the root span's name and sits right there on `trace_summaries`, but free text never looked at it either.

Worth noting that `@spanName:` already worked as a structured filter. The gap was specifically free text, which is what both the search box and Langy use by default.

## What changed

Both free-text paths now match the trace name and every span name, alongside the captured I/O they already searched.

**Path A, the traces-v2 search bar** (`filter-to-clickhouse/ast.ts`). `translateFreeText` gains two branches:

```sql
(ComputedInput ILIKE {p} OR ComputedOutput ILIKE {p}
 OR ifNull(TraceName, '') ILIKE {p}
 OR TraceId IN (SELECT DISTINCT TraceId FROM stored_spans
                WHERE TenantId = ... AND StartTime BETWEEN ... AND SpanName ILIKE {p}))
```

The span lookup reuses the existing `boundedSubquery` helper, so it prunes partitions the same way the other span-scoped filters do and leans on the `idx_span_name` index. One bound parameter is reused across all four branches.

This is the path `tracesV2.list` uses, which is what Langy searches through.

**Path B, the legacy messages list and public search endpoint** (`clickhouse-trace.service.ts`). The same two branches OR alongside the permitted I/O columns, using the correlated `EXISTS` shape the other span filters in this path already use rather than a second subquery style.

**The in-memory mirror** (`filter-to-clickhouse/evaluate.ts`). This module deliberately keeps a ClickHouse compiler and an in-memory evaluator in step, so `evaluateFreeText` was updated to match, and `queryNeeds` now declares that free text needs span rows.

## The one deliberate asymmetry

The in-memory evaluator is used at automation dispatch time, where the caller passes `spans: null` (deriving spans there is a later phase). So when span rows are absent, the mirror answers from the columns it does have and can miss a span-name-only match.

The alternative was to treat unloaded spans as unknown and fail the tag closed. That upholds the module's never-guess-true rule, but because spans are never loaded today it would make **every negated free-text filter stop matching**, which is live dispatch behaviour with an existing test pinning it (`negated free text matches when both columns miss`). Missing the narrow span-name-only case costs less than breaking that, so the narrowing is the documented choice, with a comment and a test naming it. A dispatcher that starts loading spans becomes exact with no further change.

Flagging it explicitly since it is the judgement call in this PR and worth a second opinion.

## What is intentionally unchanged

**Privacy.** Whether captured I/O may be searched at all is still decided by the existing `canSeeCapturedInput` / `canSeeCapturedOutput` check, untouched. Trace and span names are operation names already visible in the list rather than captured content, but widening the redacted-user search path is a product call and does not belong here.

**Ranking.** The issue asks for span names to carry enough relevance weight to surface. Neither path scores results: they are boolean SQL filters and the list stays ordered newest-first. So surfacing a span-name match means including it in the match set, not assigning it a weight. Adding real relevance ranking would mean introducing scoring and reworking cursor pagination, which is a much larger change than this bug needs. Called out in the spec so the decision is not lost.

**The three-character floor.** Path B still no-ops below three characters, since the `ngrambf_v1` skip indexes are n=3. A test pins that the name branches did not quietly lower it.

## QA

Dogfooded in a real browser against a seeded project where `codex` appears in exactly one field per trace, so what surfaces proves which branch of the clause fired.

Searching `codex`. `checkout flow` is the case this PR fixes: its visible Input and Output contain no `codex` at all, its only occurrence is the span named `Codex.Exec`. `codex exec` matches on the trace name, `support chat` on the input, and `billing sync` is correctly absent.

![codex results](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/search/codex-results.png)

The four fixtures unfiltered, showing that the I/O of the span-name trace really has nothing to match on:

![fixtures](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/fixtures/all-four-fixtures.png)

`NOT codex` excludes all three matches, including the span-name one, and keeps `billing sync`. The count drops from 103 to 100, which is the three matches removed:

![not codex](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/search/not-codex.png)

A term that matches nothing still gives the empty state rather than falling back to showing everything, which is the failure mode a too-broad OR would have produced:

![no match](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/search/no-match-empty-state.png)

Dark mode, same query:

![dark mode](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/search/codex-results-dark.png)

The syntax docs drawer now names the searched fields:

![syntax help](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6358/docs/syntax-help-free-text.png)

One thing QA turned up that is worth knowing even though it is not a change here: the span subquery is bounded on `StartTime`, so a span whose timestamp sits outside the query window is not matched even when its trace is. That is pre-existing `boundedSubquery` behaviour shared with the other span-scoped filters, and it is what keeps these lookups partition-pruned. It only bit me because my first seeding pass wrote local time into UTC columns, putting the rows in the future.

## Tests

Real infrastructure, no database mocks.

`free-text-span-name-search.integration.test.ts` (new, 9 tests) runs against real ClickHouse. Fixtures are built so each trace is findable through exactly one field: one by span name only, one by trace name only, one by input, one by output, and one that matches nothing. For path A the compiled SQL is **executed**, so an invalid subquery or mis-bound parameter fails the test rather than sneaking past a string assertion. Path B goes through the service.

Verified the tests actually catch the bug: reverting only the source changes fails 6 of the 9, with the 3 controls still passing.

Unit coverage: 10 new cases in `evaluate.parity.unit.test.ts` (span name, trace name, case-insensitivity, negation, the documented narrowing, `queryNeeds`, plus SQL-shape assertions) and 5 in `clickhouse-trace.service.unit.test.ts`. Both suites confirmed failing without the fix. All 8 pre-existing free-text parity cases still pass unchanged.

Full unit suite green, typecheck clean, biome clean.

## Spec

`specs/traces-v2/search.feature` gained a "Free text matches span names as well as captured I/O" rule. The old wording said free text matched "input or output content", so this was specified behaviour and not just an oversight, which is why the spec change comes with it. The chronological-ordering decision is recorded there too.

Closes #6356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded free-text trace search to include trace names and span names, alongside captured input and output.
  - Case-insensitive substring matching now applies to trace and span names.
  - Quoted free-text now matches across trace names and span names as well.
  - Updated search guidance to reflect the expanded matching behavior.

- **Bug Fixes**
  - Improved consistency of search results (including negation and quoted phrases) across supported search paths, with newest-first ordering preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->