### PR TITLE
test(traces): pin the tab state preservation TraceDetails and PlaygroundContent rely on (#6349)

### DIFF
--- a/platform/app/src/components/ops/foundry/PlaygroundContent.tsx
+++ b/platform/app/src/components/ops/foundry/PlaygroundContent.tsx
@@ -46,11 +46,13 @@ export function PlaygroundContent({ compact = false }: { compact?: boolean }) {
           flexDirection="column"
           flex={1}
           overflow="hidden"
-          // lazyMount only (no unmountOnExit): the Editor tab renders
-          // SpanEditorPanel, whose Input/Textarea fields are live editing
-          // surfaces for the selected span. Unmounting on tab switch risks
-          // losing in-progress edits, so inactive tabs are only skipped
-          // until first opened, then kept mounted.
+          // lazyMount only (no unmountOnExit): the Editor tab holds a draft
+          // that lives in React rather than the store. SpanEditorPanel's own
+          // fields are controlled straight through to the traceStore on each
+          // keystroke, so those would survive a remount; the one that would
+          // not is AttributeEditor's `newKey`: an attribute name typed but
+          // not yet committed with Add. Inactive tabs are therefore only
+          // skipped until first opened, then kept mounted.
           lazyMount
         >
           <Tabs.List

--- a/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
+++ b/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
@@ -75,7 +75,7 @@ describe("PlaygroundContent tab state", () => {
   });
 
   describe("when an uncommitted attribute key is typed and the user leaves and returns to the Editor tab", () => {
-    it("still has the typed key in the input", async () => {
+    it("preserves the typed key in the input", async () => {
       renderPlaygroundWithSelectedSpan();
 
       await userEvent.type(newAttributeKeyInput(), NEW_ATTRIBUTE_KEY);
@@ -91,7 +91,7 @@ describe("PlaygroundContent tab state", () => {
   });
 
   describe("when the user leaves and returns to the Editor tab", () => {
-    it("keeps the Editor panel mounted rather than remounting it", async () => {
+    it("reuses the Editor panel DOM node rather than remounting it", async () => {
       renderPlaygroundWithSelectedSpan();
 
       const beforeSwitch = newAttributeKeyInput();
@@ -108,14 +108,26 @@ describe("PlaygroundContent tab state", () => {
     });
   });
 
-  describe("when a tab has never been opened", () => {
-    it("does not mount its panel", () => {
+  describe("given the Graph tab has never been opened", () => {
+    it("leaves the Graph panel unmounted", () => {
       renderPlaygroundWithSelectedSpan();
 
       // lazyMount's own half of the contract: the Graph tab pulls in
       // @xyflow/react, and the JSON tab a Monaco editor, so mounting them
       // before they are asked for is what #5588 set out to stop.
       expect(screen.queryByTestId("rf__wrapper")).toBeNull();
+    });
+
+    describe("when the user opens the Graph tab", () => {
+      it("mounts the Graph panel", async () => {
+        renderPlaygroundWithSelectedSpan();
+
+        await switchTo("Graph");
+
+        // Pairs with the assertion above: without it, a Graph view that never
+        // renders at all would read as lazyMount working.
+        expect(await screen.findByTestId("rf__wrapper")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
+++ b/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
@@ -74,36 +74,38 @@ describe("PlaygroundContent tab state", () => {
     cleanup();
   });
 
-  describe("when an uncommitted attribute key is typed and the user leaves and returns to the Editor tab", () => {
-    it("preserves the typed key in the input", async () => {
-      renderPlaygroundWithSelectedSpan();
+  describe("given a selected span", () => {
+    describe("when an uncommitted attribute key is typed and the user leaves and returns to the Editor tab", () => {
+      it("preserves the typed key in the input", async () => {
+        renderPlaygroundWithSelectedSpan();
 
-      await userEvent.type(newAttributeKeyInput(), NEW_ATTRIBUTE_KEY);
-      expect(newAttributeKeyInput()).toHaveValue(NEW_ATTRIBUTE_KEY);
-
-      await switchTo("Waterfall");
-      await switchTo("Editor");
-
-      await waitFor(() => {
+        await userEvent.type(newAttributeKeyInput(), NEW_ATTRIBUTE_KEY);
         expect(newAttributeKeyInput()).toHaveValue(NEW_ATTRIBUTE_KEY);
+
+        await switchTo("Waterfall");
+        await switchTo("Editor");
+
+        await waitFor(() => {
+          expect(newAttributeKeyInput()).toHaveValue(NEW_ATTRIBUTE_KEY);
+        });
       });
     });
-  });
 
-  describe("when the user leaves and returns to the Editor tab", () => {
-    it("reuses the Editor panel DOM node rather than remounting it", async () => {
-      renderPlaygroundWithSelectedSpan();
+    describe("when the user leaves and returns to the Editor tab", () => {
+      it("reuses the Editor panel DOM node rather than remounting it", async () => {
+        renderPlaygroundWithSelectedSpan();
 
-      const beforeSwitch = newAttributeKeyInput();
+        const beforeSwitch = newAttributeKeyInput();
 
-      await switchTo("Waterfall");
-      await switchTo("Editor");
+        await switchTo("Waterfall");
+        await switchTo("Editor");
 
-      // Same DOM node, not a fresh one: this is the mechanism the draft
-      // survival depends on, asserted directly so a failure says which of the
-      // two broke.
-      await waitFor(() => {
-        expect(newAttributeKeyInput()).toBe(beforeSwitch);
+        // Same DOM node, not a fresh one: this is the mechanism the draft
+        // survival depends on, asserted directly so a failure says which of the
+        // two broke.
+        await waitFor(() => {
+          expect(newAttributeKeyInput()).toBe(beforeSwitch);
+        });
       });
     });
   });

--- a/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
+++ b/platform/app/src/components/ops/foundry/__tests__/PlaygroundContent.tabStatePreservation.integration.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #5588 gave PlaygroundContent `lazyMount` without `unmountOnExit`, on the
+ * grounds that the Editor tab holds in-progress edits a remount would discard.
+ * Nothing enforced that: adding `unmountOnExit` in a later performance pass
+ * would silently throw the edit away.
+ *
+ * What is actually at risk is narrower than "the Input and Textarea fields".
+ * Every field in SpanEditorPanel and the LLM/RAG/Prompt editors is controlled
+ * straight through to the `traceStore` on each keystroke, so those survive a
+ * remount either way. The one piece of state that lives only in React is
+ * AttributeEditor's `newKey`, the name of an attribute typed but not yet
+ * committed with the Add button. That is the draft this test protects.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ConnectionSettings and ExecutionControls sit in the always-mounted left
+// sidebar and reach for the project and tRPC. Neither is under test.
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "test" },
+    organization: { id: "org-1" },
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    organization: {
+      getAll: { useQuery: () => ({ data: [], isLoading: false }) },
+    },
+  },
+}));
+
+import { PlaygroundContent } from "../PlaygroundContent";
+import { createDefaultTrace, useTraceStore } from "../traceStore";
+
+const NEW_ATTRIBUTE_KEY = "my.pending.attribute";
+
+function renderPlaygroundWithSelectedSpan() {
+  const trace = createDefaultTrace();
+  const firstSpan = trace.spans[0];
+  if (!firstSpan) throw new Error("default trace should seed one span");
+
+  useTraceStore.setState({ trace, selectedSpanId: firstSpan.id });
+
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PlaygroundContent />
+    </ChakraProvider>,
+  );
+}
+
+function newAttributeKeyInput() {
+  return screen.getByPlaceholderText("attribute.key");
+}
+
+async function switchTo(name: string) {
+  await userEvent.click(screen.getByRole("tab", { name }));
+}
+
+describe("PlaygroundContent tab state", () => {
+  beforeEach(() => {
+    useTraceStore.setState({
+      trace: createDefaultTrace(),
+      selectedSpanId: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when an uncommitted attribute key is typed and the user leaves and returns to the Editor tab", () => {
+    it("still has the typed key in the input", async () => {
+      renderPlaygroundWithSelectedSpan();
+
+      await userEvent.type(newAttributeKeyInput(), NEW_ATTRIBUTE_KEY);
+      expect(newAttributeKeyInput()).toHaveValue(NEW_ATTRIBUTE_KEY);
+
+      await switchTo("Waterfall");
+      await switchTo("Editor");
+
+      await waitFor(() => {
+        expect(newAttributeKeyInput()).toHaveValue(NEW_ATTRIBUTE_KEY);
+      });
+    });
+  });
+
+  describe("when the user leaves and returns to the Editor tab", () => {
+    it("keeps the Editor panel mounted rather than remounting it", async () => {
+      renderPlaygroundWithSelectedSpan();
+
+      const beforeSwitch = newAttributeKeyInput();
+
+      await switchTo("Waterfall");
+      await switchTo("Editor");
+
+      // Same DOM node, not a fresh one: this is the mechanism the draft
+      // survival depends on, asserted directly so a failure says which of the
+      // two broke.
+      await waitFor(() => {
+        expect(newAttributeKeyInput()).toBe(beforeSwitch);
+      });
+    });
+  });
+
+  describe("when a tab has never been opened", () => {
+    it("does not mount its panel", () => {
+      renderPlaygroundWithSelectedSpan();
+
+      // lazyMount's own half of the contract: the Graph tab pulls in
+      // @xyflow/react, and the JSON tab a Monaco editor, so mounting them
+      // before they are asked for is what #5588 set out to stop.
+      expect(screen.queryByTestId("rf__wrapper")).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/components/traces/__tests__/TraceDetails.tabStatePreservation.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TraceDetails.tabStatePreservation.integration.test.tsx
@@ -192,7 +192,7 @@ describe("TraceDetails tab state", () => {
   });
 
   describe("when a draft is typed on the Thread tab and the user leaves and returns", () => {
-    it("still has the typed draft", async () => {
+    it("preserves the typed draft", async () => {
       renderTraceDetails();
 
       await userEvent.type(draftInput(), TYPED_DRAFT);
@@ -208,7 +208,7 @@ describe("TraceDetails tab state", () => {
   });
 
   describe("when the user leaves and returns to the Thread tab", () => {
-    it("keeps the Thread panel mounted rather than remounting it", async () => {
+    it("reuses the Thread panel DOM node rather than remounting it", async () => {
       renderTraceDetails();
 
       const beforeSwitch = draftInput();
@@ -224,8 +224,8 @@ describe("TraceDetails tab state", () => {
     });
   });
 
-  describe("when a tab has never been opened", () => {
-    it("does not mount its panel", () => {
+  describe("given the User Events tab has never been opened", () => {
+    it("leaves the User Events panel unmounted", () => {
       renderTraceDetails();
 
       // lazyMount's own half of the contract, and the reason #5588 touched
@@ -236,12 +236,14 @@ describe("TraceDetails tab state", () => {
       expect(screen.queryByText(EVENTS_PANEL_BODY)).toBeNull();
     });
 
-    it("mounts its panel once it has been opened", async () => {
-      renderTraceDetails();
+    describe("when the user opens the User Events tab", () => {
+      it("mounts the User Events panel", async () => {
+        renderTraceDetails();
 
-      await switchTo(/User Events/);
+        await switchTo(/User Events/);
 
-      expect(screen.getByText(EVENTS_PANEL_BODY)).toBeInTheDocument();
+        expect(screen.getByText(EVENTS_PANEL_BODY)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/components/traces/__tests__/TraceDetails.tabStatePreservation.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TraceDetails.tabStatePreservation.integration.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #5588 gave TraceDetails `lazyMount` without `unmountOnExit`, on the grounds
+ * that the Thread tab reaches AnnotationComment's react-hook-form draft, which
+ * a remount would discard. That reasoning was arrived at by reading the code;
+ * nothing enforced it, so adding `unmountOnExit` in a later performance pass
+ * would silently throw a half-written annotation away (the state-loss class
+ * already hit once in #5456).
+ *
+ * Scope of this test: the container's mount behaviour, which is where the
+ * regression risk lives. The Thread tab's subtree is stubbed by a probe that
+ * holds local React state, standing in for the react-hook-form draft several
+ * levels below it. Mounting the real Conversation -> TraceMessages ->
+ * Annotations -> AnnotationComment chain would need a pile of tRPC and session
+ * mocks and would test those, not the tab. Asserting only that the props are
+ * set would be non-discriminating; this asserts the behaviour they buy.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { OrganizationUserRole } from "@prisma/client";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { Stub, NullStub } = vi.hoisted(() => ({
+  Stub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  NullStub: () => null,
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: {},
+    asPath: "/",
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(),
+}));
+
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: () => ({ isLiteMember: false }),
+}));
+
+vi.mock("~/hooks/useTraceDetailsState", () => ({
+  useTraceDetailsState: () => ({ trace: { data: null, isLoading: false } }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    drawerOpen: vi.fn(() => false),
+    goBack: vi.fn(),
+    canGoBack: false,
+  }),
+}));
+
+vi.mock("~/hooks/useAnnotationCommentStore", () => ({
+  useAnnotationCommentStore: () => ({
+    setCommentState: vi.fn(),
+    resetComment: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    traces: {
+      getEvaluations: { useQuery: () => ({ data: [], isLoading: false }) },
+    },
+    annotation: {
+      createQueueItem: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+    pinnedTrace: {
+      getPin: { useQuery: () => ({ data: null, isLoading: false }) },
+    },
+    ops: {
+      getScope: {
+        useQuery: () => ({ data: null, isLoading: false, isSuccess: false }),
+      },
+    },
+    useContext: () => ({
+      annotation: {
+        getPendingItemsCount: { invalidate: vi.fn() },
+        getAssignedItemsCount: { invalidate: vi.fn() },
+        getQueueItemsCounts: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+// The probe: local React state at the position AnnotationComment's
+// `useForm` draft occupies. If the Thread panel is unmounted on exit, this
+// state goes with it.
+const DRAFT_PLACEHOLDER = "annotation draft probe";
+// Deliberately not the tabs' own labels: querying for "User Events" or
+// "Sequence" would match the trigger buttons, and an assertion that a panel is
+// unmounted would pass for the wrong reason.
+const EVENTS_PANEL_BODY = "user events panel body";
+
+vi.mock("~/components/messages/Conversation", () => ({
+  Conversation: () => {
+    const [draft, setDraft] = useState("");
+    return (
+      <input
+        placeholder={DRAFT_PLACEHOLDER}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+      />
+    );
+  },
+}));
+
+vi.mock("~/components/traces/Evaluations", () => ({
+  Evaluations: () => <div>Evaluations</div>,
+  EvaluationsCount: NullStub,
+  Guardrails: NullStub,
+  Blocked: NullStub,
+}));
+vi.mock("~/components/traces/Events", () => ({
+  Events: () => <div>{EVENTS_PANEL_BODY}</div>,
+}));
+vi.mock("~/components/traces/SequenceDiagram", () => ({
+  SequenceDiagramContainer: () => <div>Sequence diagram</div>,
+}));
+vi.mock("~/components/traces/SpanTree", () => ({
+  SpanTree: () => <div>SpanTree</div>,
+}));
+vi.mock("~/components/traces/Summary", () => ({
+  TraceSummary: () => <div>Summary</div>,
+}));
+vi.mock("~/components/traces/PinButton", () => ({ PinButton: NullStub }));
+vi.mock("~/components/traces/AddParticipants", () => ({
+  AddParticipants: NullStub,
+}));
+vi.mock("~/components/AddAnnotationQueueDrawer", () => ({
+  AddAnnotationQueueDrawer: NullStub,
+}));
+vi.mock("~/components/ui/drawer", () => ({
+  Drawer: { CloseTrigger: NullStub },
+}));
+vi.mock("~/components/ui/link", () => ({ Link: Stub }));
+vi.mock("~/components/ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+vi.mock("~/components/ui/popover", () => ({
+  Popover: {
+    Root: Stub,
+    Trigger: Stub,
+    Content: Stub,
+    Arrow: NullStub,
+    CloseTrigger: NullStub,
+    Body: Stub,
+  },
+}));
+
+import { TraceDetails } from "~/components/traces/TraceDetails";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+
+const TYPED_DRAFT = "half-written annotation";
+
+function renderTraceDetails() {
+  vi.mocked(useOrganizationTeamProject).mockReturnValue({
+    project: { id: "proj-1", slug: "test" },
+    hasPermission: () => true,
+    organizationRole: OrganizationUserRole.MEMBER,
+  } as unknown as ReturnType<typeof useOrganizationTeamProject>);
+
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <TraceDetails traceId="trace-1" selectedTab="messages" />
+    </ChakraProvider>,
+  );
+}
+
+function draftInput() {
+  return screen.getByPlaceholderText(DRAFT_PLACEHOLDER);
+}
+
+async function switchTo(name: RegExp | string) {
+  await userEvent.click(screen.getByRole("tab", { name }));
+}
+
+describe("TraceDetails tab state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when a draft is typed on the Thread tab and the user leaves and returns", () => {
+    it("still has the typed draft", async () => {
+      renderTraceDetails();
+
+      await userEvent.type(draftInput(), TYPED_DRAFT);
+      expect(draftInput()).toHaveValue(TYPED_DRAFT);
+
+      await switchTo("Trace Details");
+      await switchTo("Thread");
+
+      await waitFor(() => {
+        expect(draftInput()).toHaveValue(TYPED_DRAFT);
+      });
+    });
+  });
+
+  describe("when the user leaves and returns to the Thread tab", () => {
+    it("keeps the Thread panel mounted rather than remounting it", async () => {
+      renderTraceDetails();
+
+      const beforeSwitch = draftInput();
+
+      await switchTo("Trace Details");
+      await switchTo("Thread");
+
+      // Same DOM node, not a fresh one: the mechanism the draft survival
+      // depends on, asserted directly so a failure names which half broke.
+      await waitFor(() => {
+        expect(draftInput()).toBe(beforeSwitch);
+      });
+    });
+  });
+
+  describe("when a tab has never been opened", () => {
+    it("does not mount its panel", () => {
+      renderTraceDetails();
+
+      // lazyMount's own half of the contract, and the reason #5588 touched
+      // this component at all. Asserted on the User Events panel rather than
+      // Trace Details or Sequence: those two are additionally hand-gated by an
+      // inner `selectedTab === ...` check, so they stay empty with or without
+      // lazyMount and would not notice the prop going away.
+      expect(screen.queryByText(EVENTS_PANEL_BODY)).toBeNull();
+    });
+
+    it("mounts its panel once it has been opened", async () => {
+      renderTraceDetails();
+
+      await switchTo(/User Events/);
+
+      expect(screen.getByText(EVENTS_PANEL_BODY)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

Closes #6349. #5588 gave `TraceDetails` and `PlaygroundContent` `lazyMount` without `unmountOnExit` because their tabs reach editable state a remount would discard. The reasoning was arrived at by reading the code and never confirmed by a test, so nothing fails today if a later performance pass adds `unmountOnExit` and silently throws a user's half-written work away.

## Change

Two integration tests, one per component, plus one comment correction.

Each test types into the draft, switches tab, switches back, and asserts the draft survived. Each also asserts the panel is the **same DOM node** after the round trip rather than a fresh one, so a failure says which of the two halves broke. And each asserts `lazyMount`'s own half of the contract: an unvisited panel is not mounted, and is once opened.

The ticket warns that a test which only asserts the props are set is non-discriminating. Neither test reads a prop; both drive the tabs through `userEvent` and observe what the props buy.

**The `PlaygroundContent` comment was wrong about what is at risk, and writing the test is what surfaced it.** It claimed `SpanEditorPanel`'s "Input/Textarea fields are live editing surfaces" that unmounting would lose. Every one of those fields, and every field in the LLM/RAG/Prompt editors, is controlled straight through to the `traceStore` on each keystroke, so all of them survive a remount either way. The only state that lives in React is `AttributeEditor`'s `newKey` (`span-editors/AttributeEditor.tsx:13`), an attribute name typed but not yet committed with the Add button. The conclusion `lazyMount`-without-`unmountOnExit` still stands; the stated reason did not. The comment now names the real draft, and the test protects that one specifically.

For `TraceDetails` the `lazyMount` assertion is on the **User Events** panel rather than Trace Details or Sequence. Those two carry an additional inner `selectedTab === ...` gate (`TraceDetails.tsx:418`, `:436`), so they stay empty with or without the prop and would not notice it being removed. My first draft asserted on Sequence and the mutation run below is what caught it.

## Evidence

**Ticket step 1, run the existing suites.** They run locally with testcontainers and were green before this change: 11 files, 56 tests.

```
pnpm test:integration run src/components/traces/__tests__ \
  src/components/__tests__/TraceDetailsDrawer.integration.test.tsx
Test Files  11 passed (11)
      Tests  56 passed (56)
```

None of them touched the claim. Across all 11, the only tab interaction is `TraceDetailsDrawer` passing `selectedTab="messages"` as a prop; nothing switches a tab, and `grep` for `lazyMount`/`unmountOnExit` across every test file in the repo returns one file, `DraggableTabsBrowser.inactiveTabUnmount.test.tsx`, which guards the opposite direction for a different component.

**Ticket step 2 confirmed:** `src/components/ops/foundry/__tests__/` did not exist. It does now.

**Ticket step 3, the tests discriminate.** Mutating the source and re-running, per component:

| Mutation | `TraceDetails` | `PlaygroundContent` |
|---|---|---|
| add `unmountOnExit` | 2 failed / 2 passed — the draft and node-identity tests fail | 2 failed / 1 passed — same two |
| remove `lazyMount` | 1 failed / 3 passed — the unvisited-panel test fails | 1 failed / 2 passed — same one |
| unmodified | 4 passed | 3 passed |

Each mutation is caught by exactly the assertions that describe it, and by no others.

**After:** 13 files, 63 tests, green.

```
pnpm test:integration run src/components/traces/__tests__ \
  src/components/__tests__/TraceDetailsDrawer.integration.test.tsx \
  src/components/ops/foundry/__tests__
Test Files  13 passed (13)
      Tests  63 passed (63)
```

`pnpm typecheck:all` clean (both halves, since this adds test files).

## What this does not cover

Stated plainly so the coverage is not read as wider than it is.

The `TraceDetails` test stubs the Thread tab's subtree with a probe holding local React state, standing in for the `useForm` draft inside `Conversation -> TraceMessages -> Annotations -> AnnotationComment`. Mounting that real chain needs tRPC, session and org/team/project mocks, and would end up testing those rather than the tab. What is under test is the container's mount behaviour, which is where the regression risk actually lives: the failure mode in the ticket is someone adding `unmountOnExit` to the `Tabs.Root`, and that is exactly what the mutation run above shows these tests catch. `PlaygroundContent` needed no such stand-in and drives the real `AttributeEditor` through the real store.

## Noticed while here, not in this PR

`src/pages/settings/governance/tool-catalog.tsx:60` is a third instance of the same hand-applied rule, with the same `lazyMount`-only comment shape and no test. Out of scope for a ticket that names two components; flagged on the issue.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved in-progress edits when switching between tabs in the Playground and Trace Details views.
  * Ensured editor and thread panels retain their state when revisited.
  * Kept secondary panels from loading until opened, improving initial performance.

* **Tests**
  * Added integration coverage for tab state preservation, panel reuse, and lazy loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->