### PR TITLE
docs(analytics): ADR-084 + spec for contextual slice interpretation

### DIFF
--- a/dev/docs/adr/084-contextual-slice-interpretation.md
+++ b/dev/docs/adr/084-contextual-slice-interpretation.md
@@ -1,0 +1,184 @@
+# ADR-084: Contextual slice interpretation
+
+**Date:** 2026-07-30
+
+**Status:** Proposed
+
+**Behavioural contract:** [specs/analytics/slice-interpretation.feature](../../../specs/analytics/slice-interpretation.feature)
+
+**Builds on:** [ADR-034](./034-event-sourced-analytics-materialization.md) (the slim + rollup analytics tables this reads),
+[ADR-055](./055-canonical-otlp-metric-and-log-pipelines.md) (metric_data_points / log_records),
+[ADR-051](./051-event-sourced-topic-clustering.md) (topic ids on the slim row),
+[ADR-068](./068-windowed-clickhouse-reads.md) (every read here is windowed),
+[ADR-052](./052-automations-on-process-manager-substrate.md) (the scheduler is a process manager, not new infra).
+
+## Context
+
+We hold metrics, logs, spans, evaluations and topics for every tenant, and today a human reads them by picking a chart, picking a filter, and eyeballing a line. That works when you already know what you're looking for. It does not answer the question people actually ask, which is "what happened to this customer last night, and does it matter".
+
+Answering that needs 3 different things and they are usually mashed into one:
+
+- **what happened** - statistics over a window, exact and cheap
+- **why** - which sub-slice moved, and what changed around the same time
+- **does it matter** - a judgement against who this customer is and what normal looks like for them
+
+The tempting shape is to embed everything, stuff it in a vector store, and ask a model. That fails here for reasons we can name in advance: a vector over mixed telemetry has no meaningful distance, a claim built from it can not be attributed back to a row, and when the answer is wrong you can not tell which stage was wrong. We sell observability for LLM apps, shipping an unattributable LLM feature is not a good look, imo.
+
+So the constraint is: deterministic wherever determinism is possible, learned only where patterns genuinely recur, generative only at the last mile and only over evidence that was already computed.
+
+There is prior art in the repo to reuse rather than re-invent. The AnomalyDetector (specs/event-sourcing/anomaly-detection.feature) already does per-tenant baselines with a p95 over 7 days, a 1h baseline cache, a short-TTL "not enough data" verdict and a kill-switch flag, and every one of those exists because of a production lesson. The analytics read routing (`pickAnalyticsTable`) already knows which group-bys are parity-safe on which table. ADR-044's scheduled reports already own the delivery calendar.
+
+## Decision
+
+We will build a pipeline of 6 named stages, each with its own storage, its own failure mode and its own test level.
+
+```mermaid
+flowchart LR
+  A[telemetry<br/>spans / logs / metrics / evals] --> B[slice vectors<br/>fixed feature families]
+  B --> C[baselines<br/>robust + seasonal]
+  C --> D[signals<br/>closed vocabulary]
+  D --> E[episodes<br/>event-sourced aggregate]
+  E --> F[evidence bundle<br/>attribution + context + precedent]
+  F --> G[interpretation<br/>LLM, grounded + validated]
+  G --> H[brief<br/>Langy / report / automation / API]
+```
+
+### 1. Slice vectors
+
+**Addressing:** `SliceKey = (TenantId, EntityKind, EntityId, Grain, WindowStart)`. TenantId first, always, per the multitenancy rule. EntityKind is one of `project | customer | user | topic | model | prompt_version | origin | trace_name | conversation_cohort`. Grain is `5m | 1h | 1d`, aligned to UTC boundaries.
+
+**Features come in families with a fixed, versioned schema.** A feature is declared as a name, a kind and an extractor, nothing else. The kind is load bearing, it decides both how the feature merges across windows and which statistical test applies:
+
+| kind | examples | merges by | deviation test |
+|------|----------|-----------|----------------|
+| counter | trace count, error count, log count by severity | sum | rate ratio against a negative-binomial tail |
+| gauge sketch | p95 duration, cost per trace, TTFT | t-digest merge | robust z on median + MAD |
+| distribution | topic mix, model mix, error-class mix | vector add, then renormalise | Jensen-Shannon divergence against the baseline mix |
+| text centroid | error-text centroid, output centroid | count-weighted mean + dispersion | cosine distance to the baseline centroid |
+
+**Everything is mergeable, this is not decoration.** We compute once at 5m, and 1h and 1d are merges of the finer grain. Without that the cost is grain × entity × feature and it does not survive contact with a real tenant list.
+
+**Where the families read from:** volume / cost / latency / error come off `trace_analytics` and `trace_analytics_rollup` via the existing router, quality off `evaluation_analytics`, severity and error-class off `log_records`, custom and infra series off `metric_data_points`, topic mix off the TopicId already stamped on the slim row. Reads go through `queryWindowed` (ADR-068), and group-bys go through `pickAnalyticsTable` rather than a hand-rolled query, so we inherit the parity rules instead of re-deriving them badly.
+
+**Text centroids only ever embed already-redacted text**, respecting `PiiRedactionLevel` on the log record and the tenant egress rules (ADR-043 / ADR-053). The embedder id is stored on every vector, so a generation change partitions the index instead of silently degrading neighbour lookups.
+
+### 2. Baselines
+
+Per (entity, feature) robust baseline with an hour-of-week seasonal profile. Median + MAD, not mean + standard deviation, telemetry is heavy tailed and a single bad hour poisons a mean.
+
+3 guards, each of which is the difference between useful and unusable:
+
+- **a baseline excludes windows covered by an open episode.** otherwise a sustained regression becomes the new normal, the deviation decays to 0, and the system quietly heals its own alert while the customer is still broken. this is the single most common bug in this class of system
+- **minimum support refuses rather than guesses.** below N observations the verdict is `insufficient_data`, cached with a short TTL so a ramping entity still gets a baseline within minutes. straight from the AnomalyDetector's lesson
+- **multiplicity is controlled.** features × entities × windows is thousands of tests an hour, so at any per-test threshold you get a steady drip of pure noise. Benjamini-Hochberg across each (tenant, grain) tick, plus a hard per-entity daily signal budget spent on the largest magnitudes first. skip this and the feature is a spam machine that everyone mutes in week 1
+
+### 3. Signals
+
+A deviation that survives the guards becomes a typed Signal: `(SignalType, entity, feature, direction, magnitude, onset, support, evidenceRef)`. **The vocabulary is closed.** 4 things downstream reason over it - the LLM prompt, the precedent index, the automation trigger surface and the eval suite - and none of them are implementable over free text.
+
+Onset comes from change-point detection on the feature's own series, not from "the current window is off". People want "started 03:10", not "it is bad now".
+
+### 4. Episodes
+
+Signals sharing an entity and overlapping in time collapse into an Episode, an event-sourced aggregate with a lifecycle: `open → confirmed → resolved | expired | dismissed`. Assembly is a process manager on the existing substrate (ADR-049 / ADR-051 / ADR-052).
+
+Why an aggregate rather than a stream of alerts: one thing being wrong should be 1 episode and not 400 notifications, an interpretation needs a stable id so a brief can be revised in place rather than re-sent, a dismissal is a training label and needs somewhere to live, and a human needs a single object to mute.
+
+### 5. Evidence bundle
+
+Assembled deterministically, before any model is involved. 4 parts:
+
+**Attribution.** When a top-line feature moves, decompose the delta across the dimensions available on the slim table - model, topic, origin, trace name, prompt version, customer - and sort the contributions. This is pure arithmetic and it is ~80% of "why", it is also exactly the 20 minutes of dashboard clicking an engineer does by hand, so it is the highest leverage thing in the whole design. Only decompose over dimensions the router says are parity-safe, ADR-034 documents why `metadata.model` on the rollup is not.
+
+**Context events.** The half that turns description into explanation. Joined from the control plane by (tenant, time): prompt version published, model config or provider changed, evaluator enabled or disabled, monitor edited, key created or rotated, plan or limit changed, retention changed, SDK version first seen, experiment or dataset run started, plus the customer's own deploy markers if they send them. Ranked by proximity to the signal's **onset**, not to the window, a config change 4 minutes before onset is worth far more than one 4 hours before. This is the input that gets skipped, and it is the whole difference between "cost is up 40%" and "cost is up 40% since prompt v12 published at 03:08".
+
+**Precedent.** Represent the episode as a vector - signal-set indicator, normalised magnitudes, top attribution dimensions, text centroid - and ANN lookup over past episodes. Within tenant first. Cross-tenant is allowed but only over **structural** features, never text and never entity ids, and only above a k-anonymity threshold, because a provider degradation looks identical in every tenant and that is real signal we should not throw away. If a near neighbour has a recorded resolution, it goes to the top of the bundle, "this shape happened on the 3rd, it was X, you fixed it with Y" beats anything a model can infer.
+
+**Refusals.** What we could not compute and why. The bundle carries its own holes, so the interpretation can say "no baseline for this evaluator yet" instead of inventing around the gap.
+
+### 6. Interpretation
+
+The model receives a sealed bundle and returns a structured object, not prose:
+
+| field | contents |
+|-------|----------|
+| claim | 1 sentence, the "means z" |
+| confidence | high / medium / low, **with the reason it is not higher** |
+| because[] | ordered, each item citing a signal id, attribution row or context event id |
+| alternative | the honest second reading |
+| action | from a closed catalogue: open filtered view, create monitor, roll back prompt version, add evaluator, notify, or nothing |
+
+2 hard constraints on this stage.
+
+**Grounding is validated mechanically.** Every number and entity id in the output must appear in the bundle. Fail → 1 retry → fall back to a deterministic template rendering of the signals and attribution. The fallback matters: the feature degrades to "the statistics, plainly stated", which is still worth reading, rather than degrading to fiction.
+
+**No query access, but a bounded drill-down.** The model may request up to N pre-registered drill-downs from a closed catalogue - "sample 5 traces from the worst sub-slice", "error-class histogram for topic T" - each a parameterised query, results join the bundle, 1 round only. That keeps the useful part of agentic exploration without unbounded cost or an unreproducible run.
+
+Cheap model by default, escalate only on high-severity episodes or a failed grounding check.
+
+### Compute tiering
+
+We can not compute every entity × window, so 3 tiers:
+
+| tier | what | when |
+|------|------|------|
+| continuous | project-grain features at 1h | always, all tenants - nearly free off the existing rollup |
+| implicated | fine-grained entity slices | only when a coarser signal names the entity, e.g. drill into the customers inside a project cost spike |
+| subscribed | a watchlist entity (this customer, this prompt version) | on schedule, regardless of signal |
+
+LLM spend is bounded by episodes, not slices. Slices are numerous, episodes should be rare, and if they are not then the multiplicity control is misconfigured and that is the bug to fix.
+
+### Evaluating it
+
+This is an LLM app, so it goes through our own product. Every interpretation is a trace, the bundle is the input, confirmations and dismissals are labels, and known past incidents are the regression set. 4 metrics:
+
+- **episode precision** per signal type, dismissed over total. a signal type past a dismissal threshold gets auto-demoted to silent, which is what keeps the thing honest without a human curating thresholds forever
+- **grounding violation rate**, which should sit near 0, it is a bug not a metric
+- **time to detection** against the incident record
+- **action rate**, did anyone click. the only one that really tells us the feature works
+
+## Rationale / Trade-offs
+
+**Splitting what / why / does-it-matter into separate stages** costs more moving parts than one model call over a context dump. We take it because each stage has a different failure mode and a different test level, and a bundled design gives you no way to tell which part was wrong when the output is wrong. It also means stage 1-5 ship without any model at all.
+
+**Fixed feature families instead of embedding everything** gives up the ability to spot a pattern nobody declared a feature for. We take it because attributable arithmetic is worth more than unattributable similarity here, and because adding a feature is cheap - a name, a kind, an extractor.
+
+**Mergeable sketches** constrain what a feature can be, e.g. an exact distinct count is out, a HLL is in. Worth it, it is the only reason multi-grain is affordable.
+
+**Closed signal + action vocabularies** mean a new kind of finding needs a code change rather than a prompt change. That is deliberate, the alternative makes the precedent index, the trigger surface and the eval suite all unimplementable.
+
+**Cross-tenant precedent** is the one place we deliberately let information cross a tenant boundary, structurally and above a k-anonymity threshold. Rejecting it entirely would be safer and would also throw away the clearest signal we have for provider-side degradation. If that trade is not acceptable it is a config flag away from being off, and everything else still works.
+
+## Consequences
+
+**Positive.** Attribution and context-event join alone answer most of the "why" questions people currently ask in Slack, and they ship before any model is involved. Episodes give us a dedup boundary the current trigger surface does not have. The evidence bundle is reusable as-is by Langy, by scheduled reports (ADR-044) and by the public API, so 3 surfaces render 1 object.
+
+**Negative.** Cold start is real: a new customer has no baseline and no precedent, so the system is close to mute for their first few weeks, which is exactly when they want it most. Partial mitigation is cross-tenant structural precedent plus a population baseline over a same-shaped cohort, and we should say "not enough history yet" rather than paper over it. The text-centroid family is the weakest of the 4 and should land last.
+
+**Neutral.** Correlation is not cause. Context-event proximity is suggestive and the copy must never assert more than the evidence carries, that is what the confidence field and the alternative reading are for.
+
+**New storage.** A slice-vector table, a baseline store, an episode aggregate, and an ANN index for precedent. The first 3 are ordinary projections on the existing substrate. The ANN index is the only genuinely new piece of infrastructure and it can start as a brute-force scan over a bounded episode history before it needs to be anything cleverer.
+
+### Build order
+
+1. slice vectors + baselines + signals at project grain, no UI, just the table and a debug view. testable against historical replay
+2. attribution + context events. still no LLM, and a purely deterministic brief is already useful enough to ship
+3. episodes, lifecycle, dismissal
+4. interpretation + grounding validator + template fallback
+5. precedent index
+6. text centroids, cross-tenant precedent
+
+Phase 2 shipping with no model in it is the important part of that sequence. It de-risks the rest, and if the deterministic brief is not useful then no amount of LLM on top is going to save it.
+
+## Open questions
+
+- **entity cardinality** for the `user` and `conversation_cohort` kinds. bounded to top-K by volume plus watchlist, but K is unpicked and it wants a real tenant's distribution to choose
+- **who owns the context-event feed.** the control-plane half is ours, customer deploy markers need a shape - OTLP event, webhook, or an SDK call
+- **episode-to-incident relationship.** ADR-044 has condition-triggered incidents already, an episode is adjacent but not the same thing, and we should decide whether they merge or stay separate before phase 3
+- **retention** on slice vectors. baselines want 7-30 days of history, the vectors themselves are small but there are a lot of them
+
+## References
+
+- Related ADRs: [034](./034-event-sourced-analytics-materialization.md), [044](./044-scheduled-reports-automation-kind.md), [049](./049-langy-projection-independent-reactions.md), [051](./051-event-sourced-topic-clustering.md), [052](./052-automations-on-process-manager-substrate.md), [053](./053-tenant-aware-egress-and-workload-isolation.md), [055](./055-canonical-otlp-metric-and-log-pipelines.md), [068](./068-windowed-clickhouse-reads.md)
+- [specs/event-sourcing/anomaly-detection.feature](../../../specs/event-sourcing/anomaly-detection.feature) - the baseline / cache / kill-switch lessons this reuses
+- [dev/docs/best_practices/clickhouse-queries.md](../best_practices/clickhouse-queries.md)

--- a/specs/analytics/slice-interpretation.feature
+++ b/specs/analytics/slice-interpretation.feature
@@ -1,0 +1,274 @@
+# See dev/docs/adr/084-contextual-slice-interpretation.md for the architectural rationale.
+Feature: Contextual slice interpretation
+
+  A human asks "what happened to this customer last night, and does it matter".
+  Answering it needs 3 separable things, and this feature keeps them separable:
+    - what happened: statistics over a fixed feature schema, exact and cheap
+    - why: which sub-slice moved, and what changed around the same time
+    - does it matter: a judgement against what normal looks like for THIS entity
+
+  The pipeline is slice vector -> baseline -> signal -> episode -> evidence
+  bundle -> interpretation. Only the last stage involves a model, and it only
+  ever sees evidence the earlier stages already computed.
+
+  Background:
+    Given a tenant with at least 7 days of telemetry history
+    And slice vectors are addressed by tenant, entity kind, entity id, grain and window start
+
+  Rule: A slice vector is a fixed feature schema, and coarser grains are merges of finer ones
+
+    @unit
+    Scenario: A 1h slice is the merge of its 5m slices
+      Given the 12 five-minute slices covering one hour have been computed
+      When the 1h slice for that window is requested
+      Then it is produced by merging those slices
+      And the underlying telemetry is not re-scanned
+
+    @unit
+    Scenario Outline: Each feature kind merges by its own rule
+      Given a feature of kind "<kind>" with values in 2 adjacent windows
+      When the 2 windows are merged
+      Then the merged value is the "<merge>" of the parts
+
+      Examples:
+        | kind         | merge                        |
+        | counter      | sum                          |
+        | gauge sketch | t-digest merge               |
+        | distribution | vector add then renormalise  |
+        | text centroid| count-weighted mean          |
+
+    @unit
+    Scenario: A feature declares a name, a kind and an extractor and nothing else
+      Given a new feature is added to a family
+      When the slice vector is computed
+      Then the feature merges and baselines according to its declared kind
+      And no merge or baseline logic is written for that feature specifically
+
+    @integration
+    Scenario: Group-bys route through the analytics table router
+      Given a slice vector needs a metric grouped by a dimension
+      When the extractor builds its query
+      Then the table is chosen by the existing analytics routing
+      And a dimension the router treats as parity-unsafe is not decomposed over
+
+  Rule: A baseline describes what is normal for one entity, and refuses when it cannot
+
+    @unit
+    Scenario: The baseline is robust to a single extreme window
+      Given an entity with a stable series and one extreme outlier window
+      When the baseline is computed
+      Then the location and scale are barely moved by the outlier
+
+    @unit
+    Scenario: Normal is seasonal
+      Given an entity whose traffic is 10x higher on weekday mornings
+      When a weekday morning window is compared to its baseline
+      Then it is compared against the weekday-morning profile
+      And it does not deviate
+
+    # Without this a sustained regression becomes the new normal, the deviation
+    # decays to 0, and the system quietly heals its own alert while the customer
+    # is still broken.
+    @unit
+    Scenario: Windows inside an open episode do not feed the baseline
+      Given an entity with an open episode covering the last 6 hours
+      When the baseline is recomputed
+      Then the windows covered by the open episode are excluded
+      And the deviation for the current window is still reported
+
+    @unit
+    Scenario: Too little history refuses instead of guessing
+      Given an entity with fewer observations than the minimum support
+      When a signal is evaluated for it
+      Then the verdict is insufficient data
+      And no signal is emitted
+      And the verdict is cached with a short expiry so a ramping entity is picked up within minutes
+
+  Rule: Multiplicity is controlled, so a tick does not emit noise
+
+    @unit
+    Scenario: False-discovery control is applied per tick
+      Given a tick evaluates many features across many entities
+      When deviations are converted to signals
+      Then the batch is corrected for multiple comparisons
+      And borderline deviations that would pass a per-test threshold alone are not emitted
+
+    @unit
+    Scenario: An entity has a daily signal budget
+      Given an entity has already emitted its budgeted signals today
+      When a further deviation is detected
+      Then it is emitted only if it displaces a smaller-magnitude signal
+      And the total emitted for that entity stays within budget
+
+  Rule: A signal names what moved, by how much, and when it started
+
+    @unit
+    Scenario: Onset comes from the change point, not from the current window
+      Given a feature that stepped up at 03:10 and has been elevated since
+      When a signal is emitted at 06:00
+      Then its onset is reported as 03:10
+
+    @unit
+    Scenario: Signal types come from a closed vocabulary
+      Given a deviation that does not correspond to any declared signal type
+      When signals are emitted
+      Then no signal is produced for it
+      And the gap is recorded as a refusal rather than as free text
+
+  Rule: Overlapping signals for one entity are one episode
+
+    @integration
+    Scenario: Repeated ticks over the same problem do not repeat the finding
+      Given an entity with a sustained regression across many ticks
+      When signals are emitted on every tick
+      Then a single episode stays open
+      And the finding is revised in place rather than re-emitted
+
+    @integration
+    Scenario: An episode closes when the signals stop
+      Given an open episode whose signals no longer fire
+      When the tick runs
+      Then the episode is resolved
+      And the windows it covered become eligible for the baseline again
+
+    @integration
+    Scenario: A dismissal is recorded as a label
+      Given an open episode
+      When a human dismisses it
+      Then the episode is closed as dismissed
+      And the dismissal is attributed to its signal types for precision tracking
+
+    @unit
+    Scenario: A signal type that is dismissed too often is demoted
+      Given a signal type whose dismissal rate is above the demotion threshold
+      When it next fires
+      Then it is recorded silently
+      And it does not open an episode on its own
+
+  Rule: The evidence bundle is assembled deterministically, before any model runs
+
+    @integration
+    Scenario: A moved metric is decomposed across its sub-slices
+      Given a top-line metric that rose over the window
+      When the bundle is assembled
+      Then each contributing sub-slice is listed with its share of the delta
+      And the shares are ordered largest first
+
+    @unit
+    Scenario: Context events are ranked by proximity to onset
+      Given a signal with an onset at 03:10
+      And a prompt version published at 03:08
+      And a model provider changed at 23:00 the previous day
+      When context events are attached
+      Then the prompt version publication is ranked first
+
+    @unit
+    Scenario: The bundle carries its own holes
+      Given a feature that could not be baselined for lack of history
+      When the bundle is assembled
+      Then the refusal is included in the bundle
+
+    @integration
+    Scenario: A matching past episode is offered as precedent
+      Given a past episode for the same tenant with a similar signal set and a recorded resolution
+      When the bundle is assembled
+      Then that episode is included as precedent
+      And its resolution is included with it
+
+    @unit
+    Scenario: Cross-tenant precedent carries structure only
+      Given a matching episode belongs to a different tenant
+      When it is included as precedent
+      Then only structural features are carried
+      And no text, entity id or raw value from the other tenant is included
+
+    @unit
+    Scenario: Cross-tenant precedent needs more than one neighbour
+      Given a cross-tenant match exists but fewer neighbours than the anonymity threshold
+      When the bundle is assembled
+      Then no cross-tenant precedent is included
+
+  Rule: The interpretation may only say what the bundle supports
+
+    @integration
+    Scenario: An interpretation cites its evidence
+      Given a bundle with signals, attribution rows and context events
+      When the interpretation is produced
+      Then every supporting point cites a signal, attribution row or context event from the bundle
+      And it states a claim, a confidence, and the reason the confidence is not higher
+
+    @integration
+    Scenario: An interpretation offers a second reading
+      Given a bundle that supports more than one explanation
+      When the interpretation is produced
+      Then an alternative reading is included
+
+    @integration
+    Scenario: An ungrounded number is rejected
+      Given the model returns a figure that does not appear in the bundle
+      When the interpretation is validated
+      Then it is rejected and retried once
+
+    @integration
+    Scenario: A repeatedly ungrounded interpretation degrades to the statistics
+      Given the retry is also rejected by the validator
+      When the brief is rendered
+      Then it renders the signals and attribution from a deterministic template
+      And no model-authored prose is shown
+
+    @integration
+    Scenario: Drill-downs are chosen by the model but defined by us
+      Given the model asks for more detail before interpreting
+      When the request is served
+      Then only pre-registered drill-downs are run
+      And their results join the bundle
+      And no second round of drill-downs is served
+
+    @unit
+    Scenario: A suggested action comes from the catalogue
+      Given an interpretation proposes what to do next
+      When the brief is rendered
+      Then the action is one of the catalogued actions
+      And an action outside the catalogue is dropped
+
+  Rule: Compute is tiered, so cost tracks attention rather than tenant count
+
+    @integration
+    Scenario: Fine-grained slices are computed only for implicated entities
+      Given a project-grain signal names a subset of customers
+      When the tick continues
+      Then slices are computed for the named customers
+      And customers with no implicating signal are not computed
+
+    @integration
+    Scenario: A watchlist entity is computed regardless of signal
+      Given a human has subscribed to an entity
+      When the tick runs and no signal names it
+      Then its slice is still computed on schedule
+
+    @unit
+    Scenario: The model runs per episode, not per slice
+      Given many slices are computed in a tick and no episode opens
+      When the tick completes
+      Then no interpretation is requested
+
+  Rule: Customer text never leaves the boundaries it already has
+
+    @unit
+    Scenario: Only redacted text is embedded
+      Given log records carrying a PII redaction level
+      When a text centroid is computed
+      Then only the redacted form is embedded
+
+    @unit
+    Scenario: An embedding records which embedder produced it
+      Given a text centroid is stored
+      When the embedder generation later changes
+      Then vectors from the previous generation are not compared against the new ones
+
+    @unit
+    Scenario: Interpretation respects tenant egress rules
+      Given a tenant whose egress rules forbid the configured interpretation model
+      When an episode opens for that tenant
+      Then no bundle is sent to that model
+      And the brief renders from the deterministic template


### PR DESCRIPTION
Design only, no code. ADR + behavioural spec for a system that reads a slice of time for one entity and says what it means - "this customer, given x, and the data looking like y, means z".

- `dev/docs/adr/084-contextual-slice-interpretation.md`
- `specs/analytics/slice-interpretation.feature`

## Shape

`slice vector -> baseline -> signal -> episode -> evidence bundle -> interpretation`

6 stages, each with its own storage, failure mode and test level. Deterministic wherever determinism is possible, learned only for text similarity and episode recurrence, generative only at the last mile and only over evidence the earlier stages already computed. The point of the split is that when the output is wrong you can tell which stage was wrong, which you cannot do with one model call over a context dump.

## The load-bearing decisions

- **fixed feature families, not embed-everything.** a feature is a name, a kind and an extractor. the kind (counter / gauge sketch / distribution / text centroid) decides both how it merges across grains and which statistical test applies
- **everything merges.** compute once at 5m, 1h and 1d are merges. otherwise cost is grain x entity x feature and it does not survive a real tenant list
- **baselines exclude windows inside an open episode.** otherwise a sustained regression becomes the new normal and the system heals its own alert while the customer is still broken
- **multiplicity is controlled** (Benjamini-Hochberg per tick + a per-entity daily budget). features x entities x windows is thousands of tests an hour, skip this and it is a spam machine
- **context events ranked by proximity to onset, not to the window.** this is the difference between "cost is up 40%" and "cost is up 40% since prompt v12 published at 03:08"
- **the model gets a sealed bundle, no query access,** but may request up to N pre-registered drill-downs, 1 round. grounding is validated mechanically, and a failed validation degrades to a deterministic template rendering of the statistics rather than to fiction
- **cross-tenant precedent carries structural features only,** above a k-anonymity threshold, because a provider degradation looks identical everywhere and that is real signal

## Build order

Phases 1-3 (slice vectors, baselines, signals, attribution, context events, episodes) contain no model at all, and a purely deterministic brief is already useful. That is deliberate - if the deterministic brief is not useful, no amount of LLM on top saves it.

## Reuse

Reads ADR-034's slim + rollup through the existing `pickAnalyticsTable` router and ADR-068 windowed reads, picks up ADR-051's topic ids off the slim row and ADR-055's canonical metrics/logs, schedules on ADR-052's process-manager substrate, and inherits the baseline / cache / kill-switch / insufficient-data lessons already encoded in `specs/event-sourcing/anomaly-detection.feature`. The only genuinely new infrastructure is the ANN index for precedent, and that can start as a brute-force scan over bounded history.

## Open questions

In the ADR - entity cardinality bound for user/conversation kinds, who owns the customer-side context-event feed, whether an episode merges with ADR-044's incidents, and retention on slice vectors.