### PR TITLE
fix(event-sourcing): bind the fold contract scenarios #6347 left unwritten, and refuse a trusted windowed absence on a long-lived aggregate

### DIFF
--- a/langwatch/src/server/app-layer/analytics/__tests__/slim-rollup-builders.unit.test.ts
+++ b/langwatch/src/server/app-layer/analytics/__tests__/slim-rollup-builders.unit.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { TRACE_ANALYTICS_HAS_SIGNAL_SQL } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.foldProjection";
 import { buildRollupTimeseriesQuery } from "../query-builders/rollup-timeseries-query";
 import { buildSlimTimeseriesQuery } from "../query-builders/slim-timeseries-query";
 
@@ -145,6 +146,18 @@ describe("buildSlimTimeseriesQuery", () => {
 
   it("filters on TenantId first", () => {
     expect(sql).toMatch(/ta\.TenantId\s*=\s*\{tenantId:String\}/);
+  });
+
+  /**
+   * The fold's store writes a row for every state it is handed, including one
+   * whose only signal is a topic or an annotation, because that is what makes
+   * an absent row proof the trace was never committed. Every row on this table
+   * counts as A TRACE to the aggregates below, so this predicate is the only
+   * thing standing between the always-write row and the product's numbers.
+   */
+  /** @scenario absence is authoritative because nothing is ever gated out */
+  it("keeps dimension-only rows out via the has-signal predicate", () => {
+    expect(sql).toContain(TRACE_ANALYTICS_HAS_SIGNAL_SQL);
   });
 
   it("filters on the partition column OccurredAt for partition pruning", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/__tests__/foldProjection.contract.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/__tests__/foldProjection.contract.unit.test.ts
@@ -81,15 +81,18 @@ describe("fold projection contracts", () => {
     });
 
     /**
-     * @scenario a trusted fold's windowed read is backed by a time-local lifetime
-     *
      * Trusting a windowed absence claims the row can never sit outside the
-     * window — a bet on the aggregate's LIFETIME, the same one
+     * window, a bet on the aggregate's LIFETIME, the same one
      * `rehydrationLowerBoundMs` makes when bounding event reads. A fold bound
      * to a long-lived aggregate (a coding-agent session spanning weeks) may
      * declare a readWindow for pruning, but it must NOT trust the window's
      * misses: its rows legitimately outlive any width.
+     *
+     * The router refuses such a registration outright
+     * (projectionRouter.registrationGuard.unit.test.ts); this asserts the
+     * shipped folds are on the right side of that refusal.
      */
+    /** @scenario a trusted fold's windowed read is backed by a time-local lifetime */
     it("binds only to TIME_LOCAL aggregate types when it also declares a readWindow", () => {
       for (const fold of trusted) {
         if (fold.projection.options?.readWindow === undefined) continue;
@@ -101,12 +104,16 @@ describe("fold projection contracts", () => {
     });
 
     /**
-     * @scenario trusting absence must not orphan the undecodable net
-     *
      * A get()-only store can never answer `undecodable` (the executor stamps
      * its nulls `absent`), so under trustAbsentMiss its `refoldOnStoreMiss`
-     * would never fire again — dead config that reads like a safety net.
+     * would never fire again: dead config that reads like a safety net.
+     *
+     * The pairing is only visible here. By the time a fold reaches the router
+     * its store is wrapped in `RedisCachedFoldStore`, which declares
+     * `getWithApplied` whatever the durable tier behind it can do, so
+     * registration cannot tell the two apart.
      */
+    /** @scenario trusting absence must not orphan the undecodable net */
     it("pairs refoldOnStoreMiss with a store that can distinguish undecodable", () => {
       for (const fold of trusted) {
         if (fold.projection.options?.refoldOnStoreMiss !== true) continue;
@@ -150,12 +157,11 @@ describe("fold projection contracts", () => {
     });
 
     /**
-     * @scenario the redelivery watermark survives the write path
-     *
      * The executor dedups a redelivered batch against the ids persisted NEXT
      * TO the row. A store that drops them re-applies the batch on the next
-     * cold-cache retry — silent double-count, no error anywhere.
+     * cold-cache retry: silent double-count, no error anywhere.
      */
+    /** @scenario the redelivery watermark survives the write path */
     it("persists the applied-event-id watermark next to the row", async () => {
       const repo = makeRepo();
       const store = new TraceAnalyticsStore(repo as never);
@@ -185,12 +191,11 @@ describe("fold projection contracts", () => {
     });
 
     /**
-     * @scenario absence is authoritative because nothing is ever gated out
-     *
      * `trustAbsentMiss` on the fold is only sound while this holds. If a
      * write-gate returns, absence goes back to meaning "maybe declined" and
      * the executor overwrites live dimension state with init().
      */
+    /** @scenario absence is authoritative because nothing is ever gated out */
     it("writes a dimension-only state too, flagged HasSignal=false", async () => {
       const repo = makeRepo();
       const store = new TraceAnalyticsStore(repo as never);
@@ -246,11 +251,10 @@ describe("fold projection contracts", () => {
     });
 
     /**
-     * @scenario no state is unwritable — identity falls back to the aggregate id
-     *
      * The old gate refused a state with no identity; the aggregate-id stamp
      * makes one, so nothing is gated and absence stays authoritative.
      */
+    /** @scenario no state is unwritable, identity falls back to the aggregate id */
     it("writes a state with no identity of its own, stamped from the aggregate id", async () => {
       const repo = makeRepo();
       const store = new EvaluationAnalyticsStore(repo as never);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceAnalytics.readBack.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceAnalytics.readBack.unit.test.ts
@@ -501,15 +501,12 @@ describe("TraceAnalyticsStore dimension-only signal", () => {
   describe("given a trace whose only signal so far is an assigned topic", () => {
     describe("when its cached state is lost and a later span arrives", () => {
       /**
-       * @scenario a signal with nothing else to store is not lost to a cold cache
-       *
-       * Until the always-write change this protection came from `refoldOnStoreMiss`
-       * rebuilding the topic out of `event_log` — the row was simply not
-       * written. Now the row IS written (readers derive hasSignal=false to keep it out of
-       * analytics) and the later span resumes from the read-back directly:
-       * same guarantee, no event_log replay, which is what lets the fold
-       * declare `trustAbsentMiss`.
+       * The row carries the classification, so the later span resumes from the
+       * read-back directly: no `event_log` replay, which is what lets the fold
+       * declare `trustAbsentMiss`. Readers derive hasSignal=false and keep the
+       * row out of analytics, so writing it costs the product nothing.
        */
+      /** @scenario a signal with nothing else to store is not lost to a cold cache */
       it("resumes the classification from the committed row instead of losing it", async () => {
         const { repo, rows } = recordingRepo();
         const fold = new TraceAnalyticsFoldProjection({
@@ -519,7 +516,7 @@ describe("TraceAnalyticsStore dimension-only signal", () => {
         // the whole point of the always-write row is that it never needs to.
         fold.eventLoaderUpTo = async () => {
           throw new Error(
-            "event_log must not be read — the row carries the state",
+            "event_log must not be read: the row carries the state",
           );
         };
         const executor = new FoldProjectionExecutor();

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -101,6 +101,14 @@ export const MAX_PROCESSED_SPANS = 512;
 export const TRACE_SUMMARY_READ_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * Matches TRACE_ANALYTICS_COALESCE_MAX_BATCH: this fold was the only one in the
+ * pipeline that never declared a ceiling, so it took one delivery — and one
+ * read-back — per event while its sibling folded 128 at a time. Must stay below
+ * MAX_APPLIED_EVENT_IDS; the projection router rejects a config at or above it.
+ */
+export const TRACE_SUMMARY_COALESCE_MAX_BATCH = 128;
+
+/**
  * Reserved trace-summary attribute keys holding cache / reasoning token
  * SUMS across the whole trace. The per-span `gen_ai.usage.cache_*` numbers
  * never reach the trace-level attribute map (the accumulation allowlist
@@ -499,6 +507,7 @@ export class TraceSummaryFoldProjection
     refoldOnOutOfOrder: false,
     trustAbsentMiss: true,
     readWindow: { widthMs: TRACE_SUMMARY_READ_WINDOW_MS },
+    coalesceMaxBatch: TRACE_SUMMARY_COALESCE_MAX_BATCH,
   } as const;
 
   protected readonly events = traceSummaryEvents;

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -101,14 +101,6 @@ export const MAX_PROCESSED_SPANS = 512;
 export const TRACE_SUMMARY_READ_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Matches TRACE_ANALYTICS_COALESCE_MAX_BATCH: this fold was the only one in the
- * pipeline that never declared a ceiling, so it took one delivery — and one
- * read-back — per event while its sibling folded 128 at a time. Must stay below
- * MAX_APPLIED_EVENT_IDS; the projection router rejects a config at or above it.
- */
-export const TRACE_SUMMARY_COALESCE_MAX_BATCH = 128;
-
-/**
  * Reserved trace-summary attribute keys holding cache / reasoning token
  * SUMS across the whole trace. The per-span `gen_ai.usage.cache_*` numbers
  * never reach the trace-level attribute map (the accumulation allowlist
@@ -507,7 +499,6 @@ export class TraceSummaryFoldProjection
     refoldOnOutOfOrder: false,
     trustAbsentMiss: true,
     readWindow: { widthMs: TRACE_SUMMARY_READ_WINDOW_MS },
-    coalesceMaxBatch: TRACE_SUMMARY_COALESCE_MAX_BATCH,
   } as const;
 
   protected readonly events = traceSummaryEvents;

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.registrationGuard.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.registrationGuard.unit.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AggregateType } from "../../domain/aggregateType";
 import {
   createMockFoldProjectionDefinition,
   createMockFoldProjectionStore,
   createMockQueueManager,
   TEST_CONSTANTS,
 } from "../../services/__tests__/testHelpers";
+import { TIME_LOCAL_AGGREGATE_TYPES } from "../../stores/rehydrationWindow";
 import { MAX_APPLIED_EVENT_IDS } from "../foldCache/foldCacheEntry";
 import type { FoldProjectionStore } from "../foldProjection.types";
 import { ProjectionRouter } from "../projectionRouter";
+
+/** An aggregate whose rows accumulate over its whole life, so no window bounds them. */
+const LONG_LIVED_AGGREGATE_TYPE =
+  "simulation_set" as const satisfies AggregateType;
+const READ_WINDOW = { widthMs: 7 * 24 * 60 * 60 * 1000 } as const;
 
 /**
  * A store carrying a durable applied-event-id watermark: it answers reads with
@@ -23,9 +30,11 @@ function createDurableWatermarkStore<State>(): FoldProjectionStore<State> {
   } as FoldProjectionStore<State>;
 }
 
-function createRouter() {
+function createRouter(
+  aggregateType: AggregateType = TEST_CONSTANTS.AGGREGATE_TYPE,
+) {
   return new ProjectionRouter(
-    TEST_CONSTANTS.AGGREGATE_TYPE,
+    aggregateType,
     TEST_CONSTANTS.PIPELINE_NAME,
     createMockQueueManager(),
   );
@@ -80,6 +89,69 @@ describe("ProjectionRouter registration guard", () => {
         });
 
         expect(() => createRouter().registerFoldProjection(fold)).not.toThrow();
+      });
+    });
+  });
+
+  describe("given a fold that trusts an absent miss on a windowed read", () => {
+    const trustedWindowedFold = (name: string) =>
+      createMockFoldProjectionDefinition(name, {
+        options: { trustAbsentMiss: true, readWindow: READ_WINDOW },
+      });
+
+    describe("when the aggregate it is registered under can stay live indefinitely", () => {
+      /**
+       * The window is the whole basis of the trust. On an aggregate whose rows
+       * legitimately age past any width, an absent windowed read means "outside
+       * the window", not "never committed", and folding on from `init()` wipes
+       * live state. Nothing downstream can tell the two apart, so the only
+       * place to stop it is before the fold ever runs.
+       */
+      /** @scenario a trusted fold's windowed read is backed by a time-local lifetime */
+      it("refuses the registration", () => {
+        expect(() =>
+          createRouter(LONG_LIVED_AGGREGATE_TYPE).registerFoldProjection(
+            trustedWindowedFold("trusted-on-long-lived"),
+          ),
+        ).toThrow(/is not time-local/);
+      });
+
+      it("names the fold and the aggregate type in the error", () => {
+        expect(() =>
+          createRouter(LONG_LIVED_AGGREGATE_TYPE).registerFoldProjection(
+            trustedWindowedFold("trusted-on-long-lived"),
+          ),
+        ).toThrow(
+          new RegExp(`trusted-on-long-lived.*${LONG_LIVED_AGGREGATE_TYPE}`),
+        );
+      });
+    });
+
+    describe("when the aggregate it is registered under is time-local", () => {
+      it("registers the fold", () => {
+        expect(
+          TIME_LOCAL_AGGREGATE_TYPES.has(TEST_CONSTANTS.AGGREGATE_TYPE),
+        ).toBe(true);
+
+        expect(() =>
+          createRouter().registerFoldProjection(
+            trustedWindowedFold("trusted-on-time-local"),
+          ),
+        ).not.toThrow();
+      });
+    });
+  });
+
+  describe("given a fold that trusts an absent miss without declaring a read window", () => {
+    describe("when the aggregate it is registered under can stay live indefinitely", () => {
+      it("registers the fold, since an unwindowed absence hides nothing", () => {
+        const fold = createMockFoldProjectionDefinition("trusted-unwindowed", {
+          options: { trustAbsentMiss: true },
+        });
+
+        expect(() =>
+          createRouter(LONG_LIVED_AGGREGATE_TYPE).registerFoldProjection(fold),
+        ).not.toThrow();
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -37,6 +37,7 @@ import {
 } from "../services/errorHandling";
 import type { QueueManager } from "../services/queues/queueManager";
 import type { EventStoreReadContext } from "../stores/eventStore.types";
+import { TIME_LOCAL_AGGREGATE_TYPES } from "../stores/rehydrationWindow";
 import type { EventSubscriberDefinition } from "../subscribers/eventSubscriber.types";
 import { EventUtils } from "../utils/event.utils";
 import { isComponentDisabled } from "../utils/killSwitch";
@@ -157,7 +158,39 @@ export class ProjectionRouter<
       );
     }
     this.assertCoalesceWithinAppliedIdCap(projection);
+    this.assertTrustedAbsenceIsTimeLocal(projection);
     this.foldProjections.set(projection.name, projection);
+  }
+
+  /**
+   * Rejects a fold that trusts a WINDOWED absence on an aggregate whose rows
+   * can outlive the window.
+   *
+   * `trustAbsentMiss` retires the unwindowed retry: an absent windowed read is
+   * taken as proof nothing was ever committed, and the fold restarts from
+   * `init()`. That is only true while every row of the aggregate stays inside
+   * the window, which is a bet on the aggregate's LIFETIME, the same one
+   * `rehydrationLowerBoundMs` makes when it bounds an event scan. A long-lived
+   * aggregate (a session spanning weeks) may declare a `readWindow` for
+   * partition pruning, but trusting its misses would silently overwrite live
+   * state with an empty one. Unwindowed folds are untouched: with no window
+   * there is nothing an absence could be hiding behind.
+   */
+  private assertTrustedAbsenceIsTimeLocal(
+    projection: FoldProjectionDefinition<any, EventType>,
+  ): void {
+    if (projection.options?.trustAbsentMiss !== true) return;
+    if (projection.options.readWindow === undefined) return;
+    if (TIME_LOCAL_AGGREGATE_TYPES.has(this.aggregateType)) return;
+
+    throw new ConfigurationError(
+      "ProjectionRouter",
+      `Fold projection "${projection.name}" trusts an absent windowed read but its aggregate type "${this.aggregateType}" is not time-local: rows of such an aggregate outlive any window width, so an absent read is not proof the state was never committed.`,
+      {
+        projectionName: projection.name,
+        aggregateType: this.aggregateType,
+      },
+    );
   }
 
   /**

--- a/specs/event-sourcing/fold-read-back-store.feature
+++ b/specs/event-sourcing/fold-read-back-store.feature
@@ -125,7 +125,7 @@ Feature: Fold projections read back their own state
     But live delivery never reads the event log to fold
 
   # For a fold to treat a missing row as proof that nothing was committed, the
-  # store must never decline to write a state it was handed — otherwise absence
+  # store must never decline to write a state it was handed. Otherwise absence
   # means either "new" or "declined" and proves neither. So a state with only a
   # dimension, or with no identity of its own, still gets a row; readers that
   # want only aggregates carrying real signal filter on what the row records
@@ -138,7 +138,7 @@ Feature: Fold projections read back their own state
     And a reader asking for aggregates with real signal does not see it
     And a missing row therefore proves the aggregate was never committed
 
-  Scenario: no state is unwritable — identity falls back to the aggregate id
+  Scenario: no state is unwritable, identity falls back to the aggregate id
     Given a committed state that carries no identity of its own
     When the fold commits it
     Then the row is written under the aggregate's id

--- a/specs/event-sourcing/fold-read-back-store.feature
+++ b/specs/event-sourcing/fold-read-back-store.feature
@@ -123,3 +123,38 @@ Feature: Fold projections read back their own state
     When an operator replays the projection
     Then the fold rebuilds from the event log
     But live delivery never reads the event log to fold
+
+  # For a fold to treat a missing row as proof that nothing was committed, the
+  # store must never decline to write a state it was handed — otherwise absence
+  # means either "new" or "declined" and proves neither. So a state with only a
+  # dimension, or with no identity of its own, still gets a row; readers that
+  # want only aggregates carrying real signal filter on what the row records
+  # rather than on whether it exists.
+
+  Scenario: absence is authoritative because nothing is ever gated out
+    Given an aggregate whose only signal so far is a dimension attached to it
+    When the fold commits that state
+    Then a row is written for it, flagged as carrying no signal of its own
+    And a reader asking for aggregates with real signal does not see it
+    And a missing row therefore proves the aggregate was never committed
+
+  Scenario: no state is unwritable — identity falls back to the aggregate id
+    Given a committed state that carries no identity of its own
+    When the fold commits it
+    Then the row is written under the aggregate's id
+    And no state is ever dropped for lacking an identity
+
+  Scenario: the redelivery watermark survives the write path
+    Given a fold that persists its applied-event set durably next to its state
+    When it commits a state after folding a batch
+    Then the applied-event set is stored alongside the row, not only in the cache
+
+  Scenario: the watermark round-trips through the read-back
+    Given a committed state whose applied-event set was stored with it
+    When the fold reads that state back from its store
+    Then it recovers the same applied-event set it committed
+
+  Scenario: the watermark survives the eval write path too
+    Given an evaluation fold that persists its applied-event set next to its state
+    When it commits a state after folding a batch
+    Then the applied-event set is stored alongside the row exactly as the trace fold's is

--- a/specs/event-sourcing/fold-read-back-store.feature
+++ b/specs/event-sourcing/fold-read-back-store.feature
@@ -130,16 +130,24 @@ Feature: Fold projections read back their own state
   # dimension, or with no identity of its own, still gets a row; readers that
   # want only aggregates carrying real signal filter on what the row records
   # rather than on whether it exists.
+  #
+  # This binds the folds whose row is the only durable home of their working
+  # state, which is what makes a declined write a lost classification. A fold
+  # that still declines one is making the narrower claim that what it declines
+  # holds nothing it would ever need back, and it reads its own absence as
+  # proof of that and nothing more.
 
   Scenario: absence is authoritative because nothing is ever gated out
-    Given an aggregate whose only signal so far is a dimension attached to it
+    Given a fold whose row is the only durable home of its working state
+    And an aggregate whose only signal so far is a dimension attached to it
     When the fold commits that state
     Then a row is written for it, flagged as carrying no signal of its own
     And a reader asking for aggregates with real signal does not see it
     And a missing row therefore proves the aggregate was never committed
 
   Scenario: no state is unwritable, identity falls back to the aggregate id
-    Given a committed state that carries no identity of its own
+    Given a fold whose row is the only durable home of its working state
+    And a committed state that carries no identity of its own
     When the fold commits it
     Then the row is written under the aggregate's id
     And no state is ever dropped for lacking an identity

--- a/specs/event-sourcing/fold-read-window.feature
+++ b/specs/event-sourcing/fold-read-window.feature
@@ -103,3 +103,20 @@ Feature: Fold read windows are declared, not hand-rolled
     Given the fold declares a read window and does not mention trusting absence
     When an event is folded and the store reports the state absent
     Then the unwindowed retry still happens
+
+  # Trusting absence is only sound for a fold whose aggregates stay near the
+  # window in time, and only while a refusal remains distinguishable from an
+  # absence. Both are structural, so they are checked when a fold registers
+  # rather than discovered when a row goes missing.
+
+  Scenario: a trusted fold's windowed read is backed by a time-local lifetime
+    Given a fold that trusts an absent miss
+    When the platform registers it
+    Then the registration is refused unless the fold's aggregates are time-local
+    And a fold whose aggregate can stay live indefinitely may not trust absence
+
+  Scenario: trusting absence must not orphan the undecodable net
+    Given a fold that replays its history when the store misses
+    When the platform registers it
+    Then the registration is refused unless its store can report a row it refused
+    And a refusal keeps the replay that a trusted absence skips

--- a/specs/event-sourcing/fold-read-window.feature
+++ b/specs/event-sourcing/fold-read-window.feature
@@ -106,17 +106,22 @@ Feature: Fold read windows are declared, not hand-rolled
 
   # Trusting absence is only sound for a fold whose aggregates stay near the
   # window in time, and only while a refusal remains distinguishable from an
-  # absence. Both are structural, so they are checked when a fold registers
-  # rather than discovered when a row goes missing.
+  # absence. Both are structural, so both are settled before any event is
+  # folded rather than discovered when a row goes missing.
 
   Scenario: a trusted fold's windowed read is backed by a time-local lifetime
-    Given a fold that trusts an absent miss
+    Given a fold that trusts an absent miss on a windowed read
     When the platform registers it
     Then the registration is refused unless the fold's aggregates are time-local
     And a fold whose aggregate can stay live indefinitely may not trust absence
 
+  # Registration cannot settle the second one: by then the fold's store is
+  # behind the shared cache wrapper, which answers for a durable tier it may
+  # not have. So the pairing is checked against the store the pipeline names,
+  # and the build is what refuses it.
+
   Scenario: trusting absence must not orphan the undecodable net
-    Given a fold that replays its history when the store misses
-    When the platform registers it
-    Then the registration is refused unless its store can report a row it refused
+    Given a fold that trusts an absent miss and replays its history when the store misses
+    When the fold is paired with the store the pipeline gives it
+    Then the pairing is refused unless that store can report a row it refused
     And a refusal keeps the replay that a trusted absence skips


### PR DESCRIPTION
Follow-up to #6347, which merged while this was still in flight. With #6381 merged, this is the last piece of main's two reds: it clears `feature-parity`.

## What was actually broken

#6347 added nine `@scenario` tags. On main the checker reports `1 unbound scenario, 2 unknown annotation(s)`, which undercounts the damage, because seven of the nine tags are invisible to it entirely.

The reason is the annotation regex:

```
/@scenario[ \t]+(?:"([^"\n]+)"|'([^'\n]+)'|([^\n*]+?))[ \t]*(?:\*\/|$)/gm
```

A match ends either at the comment's closing `*/` or at end of line. The proximity scan that follows skips whitespace and whole `/* ... */` comments, but a bare `*` continuation line is neither, so it stops there and drops the tag. In practice `@scenario` binds only when it closes its own comment. A tag with more JSDoc prose under it silently resolves to nothing, and reads exactly like one that works.

So the seven tags written in that shape never registered as bindings at all, and the two written in the single-line shape registered as bindings to scenarios no `.feature` file had yet. Writing the missing scenarios (the first commit here) fixed the two and left the seven still dark.

Every tag now uses the single-line form directly above its `it(...)`, the shape the rest of the suite already uses, with the prose kept in the block above it.

## Two scenarios described enforcement that did not exist

Both were written as registration-time refusals. One now is one; the other cannot be.

**The time-local rule is now enforced where the spec says it is.** `ProjectionRouter.registerFoldProjection` refuses a fold that trusts an absent WINDOWED read on an aggregate whose rows outlive any window width. There an absent read means "outside the window", not "never committed", and folding on from `init()` wipes live state, which nothing downstream can detect. It sits next to the applied-id cap guard and reads the same way. All three trusted folds are on `trace` / `evaluation`, both time-local, so nothing shipping changes; unwindowed trusted folds are untouched, since with no window an absence hides nothing.

**The undecodable pairing cannot be settled at registration.** By then the fold's store is behind `RedisCachedFoldStore`, which declares `getWithApplied` whatever the durable tier behind it can do, so registration cannot tell a store that can report a refusal from one that cannot. A guard there would never fire. The scenario now says what the check is, and stays bound to the contract test that inspects the store class the pipeline names, which is the only place the distinction is visible.

## Scope corrections to the spec text

`traceSummary` trusts an absent miss while `TraceSummaryStore.store` still opens with `if (!hasPersistableSignal(state)) return;`, so the always-write promise as written did not hold for every fold in the feature. Its trust is the narrower one its own `options` docstring describes: no `refoldOnStoreMiss`, so an absent read always folded from `init()` anyway, and the states its gate declines carry none of the fold's accumulators. The two scenarios that assert always-write now carry `Given a fold whose row is the only durable home of its working state`.

The reader half of that promise was also unbound: `TRACE_ANALYTICS_HAS_SIGNAL_SQL` in `dedupedSlim` is the only thing standing between an always-write dimension-only row and the product's trace counts, and nothing asserted the query still carried it.

## Dropped: the traceSummary coalesce change

The premise was that a fold declaring no `coalesceMaxBatch` coalesces at 1. It does not. `initializeFoldQueues` resolves an undeclared ceiling to `DEFAULT_FOLD_COALESCE_MAX_BATCH`, which is 500:

```ts
coalesceMaxBatch:
  fold.options?.coalesceMaxBatch ?? DEFAULT_FOLD_COALESCE_MAX_BATCH,
```

The `?? 1` in the same file belongs to `initializeStateProjectionQueues`, a different queue. Verified by capturing what the router hands the queue manager for a fold with no options: 500.

Pinning traceSummary to 128 therefore lowered this fold's coalescing rather than raising it, roughly 4x more dispatch cycles to drain a backed-up group, shipped under a perf title. Reverted. The unwindowed-read cost the original measurement pointed at was already addressed by `trustAbsentMiss` in #6347; coalescing was never the lever for it.

## Verification

- `pnpm check:feature-parity` green: 3730 enforced scenarios bound, 0 unbound, 0 unknown annotations. Green in CI too.
- `pnpm lint` exits 0 on this branch now that it sits on #6381.
- `pnpm typecheck` and `pnpm typecheck:tests` clean.
- Event-sourcing + analytics unit suites: 254 files, 7638 tests, all passing.
- Every binding mutation-checked. Reinstating the write gate, dropping the has-signal predicate, dropping the identity stamp, dropping the applied-id payload, removing the router guard, rebinding a trusted fold to a long-lived aggregate, and stripping `getWithApplied` from the store each fail the test bound to that scenario.
- Biome violation counts per (file, rule) on `projectionRouter.ts` are identical to main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened fold read-back durability: “missing row is proof” is now only trusted when the store cannot decline persistence.
  * Persisted the fold redelivery watermark alongside committed state, ensuring correct round-trip behavior (including evaluation paths).
  * Ensured committed states are written under the aggregate id even with partial/absent identity or signal details.
  * Excluded dimension-only records from signal-based analytics SQL results.
  * Added configuration safeguards to reject unsafe `trustAbsentMiss` + `readWindow` setups for non–time-local aggregates.
* **Tests**
  * Expanded contract and unit coverage for trusted-absence edge cases, watermark write/read-back, registration-guard validation, and analytics SQL assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->