### PR TITLE
fix(lint): clear the biome errors #6347 landed on main

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/trace-analytics.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-analytics.clickhouse.repository.ts
@@ -522,11 +522,11 @@ function fromRecord(record: Record<string, unknown>): TraceAnalyticsRow {
       asNumber(record.SpanCount) > 0 ||
       asNumber(record.EarliestSpanStartMs) > 0 ||
       !["", "0"].includes(
-        asStringMap(record.Attributes)[
-          "langwatch.reserved.log_record_count"
-        ] ?? "",
+        asStringMap(record.Attributes)["langwatch.reserved.log_record_count"] ??
+          "",
       ) ||
-      String(record.Version ?? "") < TRACE_ANALYTICS_PROJECTION_VERSION_PRE_SPLIT,
+      String(record.Version ?? "") <
+        TRACE_ANALYTICS_PROJECTION_VERSION_PRE_SPLIT,
 
     spanCount: asNumber(record.SpanCount),
     annotationIds: asStringArray(record.AnnotationIds),

--- a/langwatch/src/server/event-sourcing/pipelines/__tests__/foldProjection.contract.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/__tests__/foldProjection.contract.unit.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AggregateType } from "../../domain/aggregateType";
 import type { ProjectionStoreContext } from "../../projections/projectionStoreContext";
-import { TIME_LOCAL_AGGREGATE_TYPES } from "../../stores/rehydrationWindow";
 import { createMockFoldProjectionStore } from "../../services/__tests__/testHelpers";
+import { TIME_LOCAL_AGGREGATE_TYPES } from "../../stores/rehydrationWindow";
 import {
   EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST,
-  EvaluationAnalyticsFoldProjection,
   type EvaluationAnalyticsData,
+  EvaluationAnalyticsFoldProjection,
 } from "../evaluation-processing/projections/evaluationAnalytics.foldProjection";
 import { EvaluationAnalyticsStore } from "../evaluation-processing/projections/evaluationAnalytics.store";
 import {
-  TraceAnalyticsFoldProjection,
   type TraceAnalyticsData,
+  TraceAnalyticsFoldProjection,
 } from "../trace-processing/projections/traceAnalytics.foldProjection";
 import { TraceAnalyticsStore } from "../trace-processing/projections/traceAnalytics.store";
 import { TraceSummaryFoldProjection } from "../trace-processing/projections/traceSummary.foldProjection";
@@ -119,9 +119,7 @@ describe("fold projection contracts", () => {
   });
 
   describe("given the trace-analytics store commits a state", () => {
-    const context = (
-      appliedEventIds?: string[],
-    ): ProjectionStoreContext => ({
+    const context = (appliedEventIds?: string[]): ProjectionStoreContext => ({
       aggregateId: "trace-1",
       tenantId: "tenant-1" as ProjectionStoreContext["tenantId"],
       ...(appliedEventIds ? { appliedEventIds } : {}),
@@ -220,9 +218,7 @@ describe("fold projection contracts", () => {
   });
 
   describe("given the evaluation-analytics store commits a state", () => {
-    const context = (
-      appliedEventIds?: string[],
-    ): ProjectionStoreContext => ({
+    const context = (appliedEventIds?: string[]): ProjectionStoreContext => ({
       aggregateId: "eval-1",
       tenantId: "tenant-1" as ProjectionStoreContext["tenantId"],
       ...(appliedEventIds ? { appliedEventIds } : {}),

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.store.ts
@@ -171,4 +171,3 @@ export class EvaluationAnalyticsStore
     return (await this.getWithApplied(aggregateId, context)).state;
   }
 }
-

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceAnalytics.readBack.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceAnalytics.readBack.unit.test.ts
@@ -518,7 +518,9 @@ describe("TraceAnalyticsStore dimension-only signal", () => {
         // A loader that fails the test if the executor still replays history:
         // the whole point of the always-write row is that it never needs to.
         fold.eventLoaderUpTo = async () => {
-          throw new Error("event_log must not be read — the row carries the state");
+          throw new Error(
+            "event_log must not be read — the row carries the state",
+          );
         };
         const executor = new FoldProjectionExecutor();
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.store.ts
@@ -211,4 +211,3 @@ export class TraceAnalyticsStore
     return (await this.getWithApplied(aggregateId, context)).state;
   }
 }
-

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.trustAbsentMiss.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.trustAbsentMiss.unit.test.ts
@@ -139,9 +139,11 @@ describe("FoldProjectionExecutor trustAbsentMiss", () => {
           refoldable: true,
           history: [eventAt(OCCURRED_AT - 5_000)],
         });
-        store.getWithApplied = vi
-          .fn()
-          .mockResolvedValue({ state: null, appliedEventIds: [], miss: "absent" });
+        store.getWithApplied = vi.fn().mockResolvedValue({
+          state: null,
+          appliedEventIds: [],
+          miss: "absent",
+        });
 
         const state = await executor.execute(
           fold,
@@ -164,9 +166,11 @@ describe("FoldProjectionExecutor trustAbsentMiss", () => {
           refoldable: true,
           history: [eventAt(OCCURRED_AT - 5_000)],
         });
-        store.getWithApplied = vi
-          .fn()
-          .mockResolvedValue({ state: null, appliedEventIds: [], miss: "absent" });
+        store.getWithApplied = vi.fn().mockResolvedValue({
+          state: null,
+          appliedEventIds: [],
+          miss: "absent",
+        });
 
         const state = await executor.executeBatch(
           fold,
@@ -237,9 +241,11 @@ describe("FoldProjectionExecutor trustAbsentMiss", () => {
           refoldable: true,
           history: [eventAt(OCCURRED_AT - 5_000)],
         });
-        store.getWithApplied = vi
-          .fn()
-          .mockResolvedValue({ state: null, appliedEventIds: [], miss: "absent" });
+        store.getWithApplied = vi.fn().mockResolvedValue({
+          state: null,
+          appliedEventIds: [],
+          miss: "absent",
+        });
 
         await executor.execute(fold, eventAt(OCCURRED_AT), context);
 

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -9,10 +9,7 @@ import {
 } from "~/server/metrics";
 import type { Event } from "../domain/types";
 import { mergeAppliedEventIds } from "./foldCache/foldCacheEntry";
-import type {
-  FoldProjectionDefinition,
-  FoldProjectionStore,
-} from "./foldProjection.types";
+import type { FoldProjectionDefinition } from "./foldProjection.types";
 import {
   type ProjectionStoreContext,
   readWindowAround,
@@ -374,14 +371,16 @@ export class FoldProjectionExecutor {
     // shortcut: there a complete row EXISTS and the re-fold is what makes
     // refusing it safe.
     const absentTrusted =
-      loaded === null &&
-      miss === "absent" &&
-      this.trustsAbsentMiss(projection);
+      loaded === null && miss === "absent" && this.trustsAbsentMiss(projection);
     if (absentTrusted && this.shouldRefoldOnMiss(projection)) {
       incrementEsFoldAbsentMissTrustedTotal(projection.name, "refold");
     }
 
-    if (loaded === null && !absentTrusted && this.shouldRefoldOnMiss(projection)) {
+    if (
+      loaded === null &&
+      !absentTrusted &&
+      this.shouldRefoldOnMiss(projection)
+    ) {
       const refolded = await this.refoldUpToDelivered(
         projection,
         [event],
@@ -548,14 +547,16 @@ export class FoldProjectionExecutor {
 
     // Same trusted-absent shortcut as the single-event path above.
     const absentTrusted =
-      loaded === null &&
-      miss === "absent" &&
-      this.trustsAbsentMiss(projection);
+      loaded === null && miss === "absent" && this.trustsAbsentMiss(projection);
     if (absentTrusted && this.shouldRefoldOnMiss(projection)) {
       incrementEsFoldAbsentMissTrustedTotal(projection.name, "refold");
     }
 
-    if (loaded === null && !absentTrusted && this.shouldRefoldOnMiss(projection)) {
+    if (
+      loaded === null &&
+      !absentTrusted &&
+      this.shouldRefoldOnMiss(projection)
+    ) {
       const refolded = await this.refoldUpToDelivered(
         projection,
         ordered,


### PR DESCRIPTION
`main` is red on the `lint` job at 8bf69c5 and has been since #6347 merged, so every open PR inherits the failure. This is the autofix.

`pnpm lint` (`biome check`) reports 9 error-severity diagnostics on main:

- formatter output in `foldProjectionExecutor.ts`, `traceAnalytics.store.ts`, `evaluationAnalytics.store.ts`, `foldProjection.contract.unit.test.ts`, `foldProjectionExecutor.trustAbsentMiss.unit.test.ts`, `traceAnalytics.readBack.unit.test.ts` and `trace-analytics.clickhouse.repository.ts`
- `assist/source/organizeImports` in `foldProjection.contract.unit.test.ts`
- `lint/correctness/noUnusedImports` for `FoldProjectionStore` in `foldProjectionExecutor.ts` (imported, referenced nowhere)

Everything here is `biome format --write` plus `biome check --write`, except the unused type import, which I removed by hand because biome classifies that fix as unsafe. No behavior changes.

Verified at 635d5c4:

- `biome check --diagnostic-level=error` over the seven CI paths: 0 errors, down from 9
- `pnpm test:unit` over the three changed test files: 33 passed

This does not touch the `feature-parity` failure #6347 also left on main. #6380 is already fixing that half.

https://claude.ai/code/session_01KkQGRU4DFxEt7nubHeqz3p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined event projection processing for more consistent handling of missing data during trace and evaluation analytics updates.
  - Improved internal signal detection and projection flow readability without changing existing results.

- **Tests**
  - Expanded validation around cached analytics reads, missing projection data, and batch processing scenarios.
  - Updated test coverage and formatting to support continued reliability of analytics processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->