### PR TITLE
perf(clickhouse): bound the evaluation_runs JOIN so it prunes partitions

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -80,6 +80,20 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
 /**
+ * The same envelope for `evaluation_runs`, whose partition column is
+ * `OccurredAt`. Its JOIN took no bound at all until now, so every query
+ * carrying an evaluation metric or filter cold-scanned the table twice — the
+ * outer read plus the dedup's full-table GROUP BY. One constant per caller date
+ * regime, mirroring the span pair above.
+ */
+const EVAL_TIME_FILTER_BOTH_PERIODS =
+  "AND OccurredAt >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY " +
+  "AND OccurredAt < {currentEnd:DateTime64(3)} + INTERVAL 2 DAY";
+const EVAL_TIME_FILTER_START_END =
+  "AND OccurredAt >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
+  "AND OccurredAt < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
+
+/**
  * Returns a deduped FROM-clause expression for trace_summaries.
  *
  * trace_summaries uses ReplacingMergeTree(UpdatedAt) which can return
@@ -789,6 +803,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+        evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
       });
     })
     .join("\n");
@@ -2278,6 +2293,7 @@ function buildDateBucketedPipelineQuery({
           table,
           requiredColumns,
           spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+          evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
         });
       })
       .join("\n");
@@ -2729,6 +2745,7 @@ export function buildDataForFilterQuery(
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
     })
     .join("\n");
@@ -2825,6 +2842,7 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2851,6 +2869,7 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2874,7 +2893,10 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause({ table: "evaluation_runs" });
+      joins = buildJoinClause({
+        table: "evaluation_runs",
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
+      });
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -498,10 +498,12 @@ export function buildJoinClause({
   table,
   requiredColumns,
   spanTimeFilter,
+  evalTimeFilter,
 }: {
   table: CHTable;
   requiredColumns?: ReadonlySet<string>;
   spanTimeFilter?: string;
+  evalTimeFilter?: string;
 }): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
@@ -518,13 +520,24 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
+      // `evaluation_runs` is PARTITION BY the same OccurredAt envelope the outer
+      // read is already bounded to, so without a predicate here BOTH scopes walk
+      // every partition — the outer read and, more expensively, the dedup's
+      // full-table GROUP BY. Rendered into both so they prune identically.
+      //
+      // The bound goes on the dedup too, which windows "latest version" to the
+      // frame rather than all of history: an evaluation whose newest row landed
+      // outside it reads back one version stale. That is a read-only analytics
+      // path — stale numbers, never a wrong write — and the ±2-day cushion the
+      // caller supplies covers the drift this table actually exhibits.
+      const timeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
-        WHERE TenantId = {tenantId:String}
+        WHERE TenantId = {tenantId:String}${timeBound}
           AND (TenantId, EvaluationId, UpdatedAt) IN (
             SELECT TenantId, EvaluationId, max(UpdatedAt)
             FROM evaluation_runs
-            WHERE TenantId = {tenantId:String}
+            WHERE TenantId = {tenantId:String}${timeBound}
             GROUP BY TenantId, EvaluationId
           )
       ) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;


### PR DESCRIPTION
## The bug

`buildJoinClause` accepts a `spanTimeFilter` and wires it into the `stored_spans` branch only. The `evaluation_runs` branch ignored it entirely:

```sql
JOIN (
  SELECT ... FROM evaluation_runs
  WHERE TenantId = {tenantId:String}              -- no time filter
    AND (TenantId, EvaluationId, UpdatedAt) IN (
      SELECT TenantId, EvaluationId, max(UpdatedAt)
      FROM evaluation_runs
      WHERE TenantId = {tenantId:String}          -- no time filter either
      GROUP BY TenantId, EvaluationId
    )
)
```

So every query carrying an evaluation metric or filter scans `evaluation_runs` **twice** with no partition pruning — the outer read, plus the dedup's full-table `GROUP BY`, which is the more expensive of the two. The outer `WHERE` bounds `ts.OccurredAt` on `trace_summaries`, which is why the emitted SQL *looks* time-bounded while the joined table is not.

## Why it matters now

This is currently the dominant read cost in production. `graphTriggerActivity` stages ~24/s across `trace_processing` and `evaluation_processing`, and each invocation logs:

```
"coldScan":true,"coldScanTable":"evaluation_runs","durationMs":4839..7504
"msg":"ClickHouse cold-scan query: cold scan of evaluation_runs (no time filter, walks S3 partitions)"
```

At ~24/s × 5–7s, this alone needs ~120–170 concurrent slots. It is invisible to `clickhouse_windowed_read_total` because this legacy path (`legacy.shim.ts` → `aggregation-builder`) never goes through `queryWindowed`, so it does not appear on any of the fold dashboards.

## The fix

`EVAL_TIME_FILTER_BOTH_PERIODS` / `EVAL_TIME_FILTER_START_END`, mirroring the existing span pair but on `OccurredAt` (the partition column), rendered into **both** the outer read and the dedup subquery so they prune identically. All six `buildJoinClause` call sites now pass the constant matching their date regime — two both-periods, four start/end. One of them (`evaluations.evaluator_id` filter options) previously passed no filter at all.

## Trade-off, stated explicitly

Bounding the dedup windows "latest version" to the frame rather than all history, so an evaluation whose newest row landed outside it reads back one version stale. This is a read-only analytics path — stale numbers, never a wrong write — and it carries the same ±2-day cushion the span filter has always used. This is deliberately *not* the same call as the `trace_analytics` fold read-back, where the dedup stays unwindowed because a stale version there gets resumed from and rewritten.

## Verification

162 unit tests pass across `aggregation-builder`, `field-mappings`, `aggregation-builder-dedup-safety` and `column-pruning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved analytics query performance by applying evaluation time bounds consistently across timeseries, filtering, and data lookup queries.
  * Reduced unnecessary evaluation data processing while preserving accurate results, including guardrail-related analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->