### PR TITLE
perf(automations): widen the graph-trigger real-time debounce to 15s

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber.ts
@@ -7,8 +7,24 @@ const logger = createLogger(
   "langwatch:triggers:graph-trigger-activity-subscriber",
 );
 
-/** Locked ADR-034 Phase 5 real-time debounce. */
-export const GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS = 5_000;
+/**
+ * Real-time debounce (ADR-034 Phase 5), widened from the original 5s.
+ *
+ * The handler below evaluates EVERY active graph trigger on the project, one
+ * analytics query each, serially — so a sweep costs `N triggers` queries and
+ * the steady-state load is `Σ(active graph triggers) ÷ this window`, a figure
+ * that scales with how many alerts customers configure rather than with
+ * traffic. At 5s a project holding ~100 graph alerts contributes ~20 queries a
+ * second on its own, whether or not anything happened.
+ *
+ * 15s keeps this path meaningfully ahead of the 30s `graphAlertSweep` backstop
+ * (GRAPH_TRIGGER_HEARTBEAT_INTERVAL_MS) — which is the latency floor the system
+ * already guarantees — while cutting the query rate to a third. It is a dial,
+ * not a fix: the shape stays O(triggers) until the sweep either batches its
+ * queries or gates them on whether the delivered event could move the trigger
+ * at all.
+ */
+export const GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS = 15_000;
 
 export interface GraphTriggerActivityDeps {
   triggers: TriggerService;


### PR DESCRIPTION
## Why

`graphTriggerActivity` was the dominant ClickHouse read source tonight — every log line in the incident sample was one of its `evaluation_runs` cold scans at 4.8–7.5s. #6383 made each of those queries prune partitions. This addresses the *other* half: how many of them there are.

The handler does:

```js
const triggers = await deps.triggers.getActiveGraphTriggersForProject(projectId);
for (const trigger of triggers) {
  await deps.evaluateGraphTrigger({ triggerId, projectId, reason: "real-time" });
}
```

`getActiveGraphTriggersForProject` is `loadAll(projectId)` + `.filter()` — **no cap, no limit** — and each `evaluateGraphTrigger` builds its own `timeseriesInput` from that trigger's stored graph config and runs its own analytics query.

So steady-state load is:

```
Σ (active graph triggers across all projects) ÷ debounce window
```

Nothing in that expression depends on traffic. It's set by how many alerts customers have configured. At a 5s window a project holding ~100 graph alerts contributes ~20 queries/second on its own, permanently, whether or not anything happened — which is why the observed load was flat rather than proportional to ingest.

Corroboration from the incident logs: ~16 distinct `m_evaluatorId_*` values in a single 60s slice, with `metaValue_*` bind-param indices running 1026→1223.

## What this changes

`GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS` 5s → 15s. Query rate to a third.

15s is chosen against the backstop, not arbitrarily: `graphAlertSweep` runs every 30s (`GRAPH_TRIGGER_HEARTBEAT_INTERVAL_MS`), so 30s is the alert latency the system already guarantees. 15s keeps the real-time path meaningfully ahead of that floor while giving up the 5s–15s band.

The constant feeds both the queue `delay` and the dedup `ttlMs` in the trace and evaluation pipelines, so one change moves both consistently.

## What this does NOT fix

The shape stays `O(triggers)`. The real fixes, in value order:

1. **Batch the sweep** — N triggers per project become one query grouped by evaluator instead of N. Not a quick change: each trigger's `timeseriesInput` is built from its own `CustomGraphInput`, so they're genuinely distinct queries today, not one query with N filters.
2. **Gate on relevance** — the subscriber already holds the event; most triggers can't be affected by it. A `shouldReact`-style predicate would skip the majority before any query runs.

Worth deciding whether the ADR-034 Phase 5 note calling 5s "locked" should be updated, or whether this should be reverted in favour of going straight at (1).

## Verification

13 wiring tests pass across the trace and evaluation pipeline subscriber suites.