### PR TITLE
fix(analytics): bound the evaluation_runs JOIN on ScheduledAt, the column it has

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -80,18 +80,33 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
 /**
- * The same envelope for `evaluation_runs`, whose partition column is
- * `OccurredAt`. Its JOIN took no bound at all until now, so every query
- * carrying an evaluation metric or filter cold-scanned the table twice — the
- * outer read plus the dedup's full-table GROUP BY. One constant per caller date
- * regime, mirroring the span pair above.
+ * The same envelope for `evaluation_runs`, whose JOIN took no bound at all
+ * until now, so every query carrying an evaluation metric or filter cold-scanned
+ * the table twice — the outer read plus the dedup's full-table GROUP BY. One
+ * constant per caller date regime, mirroring the span pair above.
+ *
+ * The column is `ScheduledAt`: the table is `PARTITION BY toYearWeek(ScheduledAt)`
+ * and has no `OccurredAt` at all. That name belongs to `trace_summaries`, the
+ * outer scope these subqueries nest inside, so writing it here does not fail
+ * loudly — it resolves outward, which correlates the dedup subquery, which
+ * ClickHouse rejects outright.
+ *
+ * The cushion is 7 days, not the spans' 2. A span's StartTime sits inside its
+ * trace's lifetime, so that bound cannot drop a row; an evaluation is only
+ * scheduled *after* its trace arrives, and how long after is the lifecycle's
+ * business, so this cushion has to cover scheduling lag rather than clock skew.
+ * `EVALUATION_ANALYTICS_READ_WINDOW_MS` (evaluationAnalytics.foldProjection.ts)
+ * already pegs that lag at ±7 days for the same domain, and weekly partitions
+ * make the wider cushion ~1 extra partition per side. An evaluation scheduled
+ * further out than that drops from the range — the trade this bound accepts for
+ * pruning, and why it tracks the fold's number rather than inventing its own.
  */
 const EVAL_TIME_FILTER_BOTH_PERIODS =
-  "AND OccurredAt >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {currentEnd:DateTime64(3)} + INTERVAL 2 DAY";
+  "AND ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND ScheduledAt < {currentEnd:DateTime64(3)} + INTERVAL 7 DAY";
 const EVAL_TIME_FILTER_START_END =
-  "AND OccurredAt >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
+  "AND ScheduledAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND ScheduledAt < {endDate:DateTime64(3)} + INTERVAL 7 DAY";
 
 /**
  * Returns a deduped FROM-clause expression for trace_summaries.

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -520,16 +520,22 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
-      // `evaluation_runs` is PARTITION BY the same OccurredAt envelope the outer
-      // read is already bounded to, so without a predicate here BOTH scopes walk
-      // every partition — the outer read and, more expensively, the dedup's
-      // full-table GROUP BY. Rendered into both so they prune identically.
+      // `evaluation_runs` is PARTITION BY toYearWeek(ScheduledAt), so without a
+      // predicate on that column BOTH scopes walk every partition — the outer
+      // read and, more expensively, the dedup's full-table GROUP BY. Rendered
+      // into both so they prune identically.
+      //
+      // The predicate must name a column this table actually has. These
+      // subqueries nest inside a scope whose base table is `trace_summaries`, so
+      // a stray identifier does not fail loudly — it resolves outward to the
+      // trace's column, and an outward reference inside the IN makes the dedup a
+      // correlated subquery, which ClickHouse rejects (NOT_IMPLEMENTED).
       //
       // The bound goes on the dedup too, which windows "latest version" to the
       // frame rather than all of history: an evaluation whose newest row landed
       // outside it reads back one version stale. That is a read-only analytics
-      // path — stale numbers, never a wrong write — and the ±2-day cushion the
-      // caller supplies covers the drift this table actually exhibits.
+      // path — stale numbers, never a wrong write — and the ±7-day cushion the
+      // caller supplies covers the scheduling lag this table actually exhibits.
       const timeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs


### PR DESCRIPTION
## What

#6383 bounded the `evaluation_runs` JOIN and its dedup subquery on `OccurredAt`, described as "the partition column". `evaluation_runs` has no `OccurredAt` — it is `PARTITION BY toYearWeek(ScheduledAt)`.

The wrong name did not fail loudly. These subqueries nest inside a scope whose base table is `trace_summaries`, which *does* have `OccurredAt`, so the identifier resolved outward — and an outward reference inside the `IN` makes the dedup a correlated subquery, which ClickHouse refuses:

```
Correlated subqueries are not supported as IN function arguments yet, but found in
expression: (TenantId, EvaluationId, UpdatedAt) IN (SELECT TenantId, EvaluationId,
max(UpdatedAt) FROM evaluation_runs WHERE (TenantId = '…') AND (OccurredAt >= …))
```

Every analytics query carrying an evaluation metric or filter raised it.

## Fix

Bound `ScheduledAt`. `EXPLAIN indexes=1` against a real ClickHouse 25.10 confirms the pruning the original PR was after survives — the partition key *and* `idx_scheduled_at`'s minmax both narrow the read.

The cushion widens from the spans' 2 days to 7. A span's `StartTime` sits inside its trace's lifetime, so that bound cannot drop a row; an evaluation is only scheduled *after* its trace arrives, so this bound has to cover scheduling lag rather than clock skew. `EVALUATION_ANALYTICS_READ_WINDOW_MS` already pegs that lag at ±7 days for the same domain, so this tracks the fold's number instead of inventing one. Weekly partitions make it ~1 extra partition per side.

An evaluation scheduled further out than that window drops from the range — the trade the bound accepts for pruning, now stated where it is made rather than asserted as free.

## Verification

Native local ClickHouse/Redis/Postgres, `src/server/analytics/clickhouse/__tests__/`:

| | Test files | Tests |
|---|---|---|
| Before (main @ 80f7a818c2) | **7 failed** / 1 passed | **24 failed** / 69 passed |
| After | 8 passed | 93 passed, 3 skipped |

Also green: `pnpm test:unit src/server/analytics/` — 15 files, 365 tests. Biome clean on both files (only the file's pre-existing complexity warnings remain).

## Note for a follow-up, not fixed here

The integration suite catches this the moment it runs, so it is worth a look at why it landed green. On a non-heavy PR the integration job runs `pnpm test:integration --changed origin/main`, and #6383 touched exactly the two files these tests import.