### PR TITLE
fix(analytics): drop the evaluation_runs bound on a column that table has not got

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -79,19 +79,12 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
-/**
- * The same envelope for `evaluation_runs`, whose partition column is
- * `OccurredAt`. Its JOIN took no bound at all until now, so every query
- * carrying an evaluation metric or filter cold-scanned the table twice — the
- * outer read plus the dedup's full-table GROUP BY. One constant per caller date
- * regime, mirroring the span pair above.
+/*
+ * There is deliberately no equivalent pair for `evaluation_runs`. See the note
+ * in `buildJoinClause` (field-mappings.ts): that table has no `OccurredAt`, and
+ * the column it is actually partitioned by, `ScheduledAt`, does not track the
+ * trace date range these constants carry.
  */
-const EVAL_TIME_FILTER_BOTH_PERIODS =
-  "AND OccurredAt >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {currentEnd:DateTime64(3)} + INTERVAL 2 DAY";
-const EVAL_TIME_FILTER_START_END =
-  "AND OccurredAt >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
 /**
  * Returns a deduped FROM-clause expression for trace_summaries.
@@ -803,7 +796,6 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
-        evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
       });
     })
     .join("\n");
@@ -2293,7 +2285,6 @@ function buildDateBucketedPipelineQuery({
           table,
           requiredColumns,
           spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
-          evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
         });
       })
       .join("\n");
@@ -2745,7 +2736,6 @@ export function buildDataForFilterQuery(
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
     })
     .join("\n");
@@ -2842,7 +2832,6 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2869,7 +2858,6 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2893,10 +2881,7 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause({
-        table: "evaluation_runs",
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
-      });
+      joins = buildJoinClause({ table: "evaluation_runs" });
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -498,12 +498,10 @@ export function buildJoinClause({
   table,
   requiredColumns,
   spanTimeFilter,
-  evalTimeFilter,
 }: {
   table: CHTable;
   requiredColumns?: ReadonlySet<string>;
   spanTimeFilter?: string;
-  evalTimeFilter?: string;
 }): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
@@ -520,24 +518,28 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
-      // `evaluation_runs` is PARTITION BY the same OccurredAt envelope the outer
-      // read is already bounded to, so without a predicate here BOTH scopes walk
-      // every partition — the outer read and, more expensively, the dedup's
-      // full-table GROUP BY. Rendered into both so they prune identically.
+      // No time bound here, deliberately. #6383 added one on `OccurredAt` to
+      // prune partitions; `evaluation_runs` has no such column — it is
+      // PARTITION BY toYearWeek(ScheduledAt). Inside this subquery the name
+      // therefore resolved against the enclosing `trace_summaries` scope, which
+      // does have `OccurredAt`, making the dedup a correlated subquery that
+      // ClickHouse rejects outright ("Correlated subqueries are not supported as
+      // IN function arguments yet"). Every analytics query carrying an
+      // evaluation metric or filter failed with it.
       //
-      // The bound goes on the dedup too, which windows "latest version" to the
-      // frame rather than all of history: an evaluation whose newest row landed
-      // outside it reads back one version stale. That is a read-only analytics
-      // path — stale numbers, never a wrong write — and the ±2-day cushion the
-      // caller supplies covers the drift this table actually exhibits.
-      const timeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
+      // The pruning win is real and still on the table, but it has to bound
+      // `ScheduledAt`, and that is not a rename: the outer date range is the
+      // TRACE's, and an evaluation can be scheduled long after the trace it
+      // grades (offline experiments, re-runs over historical traces). A ±2-day
+      // envelope would silently drop those rows. Left unbounded until that
+      // envelope is chosen deliberately.
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
-        WHERE TenantId = {tenantId:String}${timeBound}
+        WHERE TenantId = {tenantId:String}
           AND (TenantId, EvaluationId, UpdatedAt) IN (
             SELECT TenantId, EvaluationId, max(UpdatedAt)
             FROM evaluation_runs
-            WHERE TenantId = {tenantId:String}${timeBound}
+            WHERE TenantId = {tenantId:String}
             GROUP BY TenantId, EvaluationId
           )
       ) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.unit.test.ts
@@ -2,12 +2,14 @@
  * @vitest-environment node
  *
  * CI runs in UTC, where a correct DateTime64 parse and a locally-anchored one
- * agree, so the decode suite below forces a non-UTC zone before importing
- * anything that touches Date. Kolkata is deliberate: its +05:30 offset also
- * catches a parse that happens to align on whole hours. The stamp suite is
- * unaffected — it works in raw epoch numbers.
+ * agree, so the decode suite below forces a non-UTC zone. The helper re-applies
+ * it per test and guards that it took — see it for why the module-scope
+ * assignment alone was not enough under the unit pool's `isolate: false`. The
+ * stamp suite is unaffected — it works in raw epoch numbers.
  */
-process.env.TZ = "Asia/Kolkata";
+import { useNonUtcTimezone } from "~/test-utils/nonUtcTimezone";
+
+useNonUtcTimezone();
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import { register } from "prom-client";

--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-analytics.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-analytics.clickhouse.repository.unit.test.ts
@@ -11,11 +11,13 @@
  * than merely displaying a wrong time.
  *
  * CI runs in UTC, where the broken and correct parses agree, so this suite
- * forces a non-UTC zone before importing anything that touches Date. Kolkata
- * is deliberate: its +05:30 offset also catches a parse that happens to align
- * on whole hours.
+ * forces a non-UTC zone. The helper re-applies it per test and guards that it
+ * took — see it for why the module-scope assignment alone was not enough under
+ * the unit pool's `isolate: false`.
  */
-process.env.TZ = "Asia/Kolkata";
+import { useNonUtcTimezone } from "~/test-utils/nonUtcTimezone";
+
+useNonUtcTimezone();
 
 import { describe, expect, it } from "vitest";
 import type { EvaluationAnalyticsRow } from "~/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection";
@@ -80,10 +82,8 @@ describe("EvaluationAnalyticsClickHouseRepository DateTime64 decode", () => {
   describe("given a row whose DateTime64 columns carry no timezone suffix", () => {
     describe("when it is read back on a host that is not on UTC", () => {
       it("decodes them as UTC rather than the host's local time", async () => {
-        // Guards the guard: if Node ever stops honouring a runtime TZ change,
-        // this suite would pass vacuously under CI's UTC.
-        expect(new Date().getTimezoneOffset()).not.toBe(0);
-
+        // The "is the zone actually non-UTC" guard lives in useNonUtcTimezone's
+        // beforeEach, so it covers every test here rather than just this one.
         const repository = makeRepositoryReturning({
           TenantId: TENANT_ID,
           EvaluationId: EVALUATION_ID,

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-analytics.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-analytics.clickhouse.repository.unit.test.ts
@@ -13,11 +13,13 @@
  * and TTL anchor.
  *
  * CI runs in UTC, where the broken and correct parses agree, so this suite
- * forces a non-UTC zone before importing anything that touches Date. Kolkata
- * is deliberate: its +05:30 offset also catches a parse that happens to align
- * on whole hours.
+ * forces a non-UTC zone. The helper re-applies it per test and guards that it
+ * took — see it for why the module-scope assignment alone was not enough under
+ * the unit pool's `isolate: false`.
  */
-process.env.TZ = "Asia/Kolkata";
+import { useNonUtcTimezone } from "~/test-utils/nonUtcTimezone";
+
+useNonUtcTimezone();
 
 import { describe, expect, it } from "vitest";
 import type { TraceAnalyticsRow } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.foldProjection";

--- a/langwatch/src/test-utils/nonUtcTimezone.ts
+++ b/langwatch/src/test-utils/nonUtcTimezone.ts
@@ -1,0 +1,49 @@
+import { beforeEach, expect } from "vitest";
+
+/**
+ * Kolkata is deliberate: its +05:30 offset also catches a parse that happens to
+ * align on whole hours, which a zone like Etc/GMT-5 would let through.
+ */
+const DEFAULT_ZONE = "Asia/Kolkata";
+
+/**
+ * Pin the process to a non-UTC zone for a DateTime64-decode suite.
+ *
+ * ClickHouse emits DateTime64(3) without a zone suffix
+ * ("2026-07-24 12:00:00.123") and V8 reads a bare datetime as LOCAL time, so
+ * `new Date(str)` silently skews every timestamp by the host's UTC offset. CI
+ * runs in UTC, where the broken and the correct parse agree — the assertion
+ * only has teeth in a non-UTC zone, which is why each of these suites carries a
+ * module-scope `process.env.TZ` assignment.
+ *
+ * Module scope alone is not enough. The unit pool runs `isolate: false`
+ * (vitest.config.ts), so one process and one reused VM context carry every file
+ * a worker picks up. The module-scope assignment lands once, when the file is
+ * first evaluated, and whatever a neighbouring file does to `process.env`
+ * afterwards outlives it — which is how one of these three suites, and only
+ * one, came back as "expected +0 not to be +0" on a CI shard while its
+ * identical siblings passed.
+ *
+ * Re-applying immediately before each test removes the dependency on file
+ * order. V8 re-reads the zone on the next `Date` construction, so a late
+ * assignment is worth exactly as much as an early one — verified on both linux
+ * and darwin, including inside an already-warm vm context.
+ *
+ * The guard stays: if the zone will not take, these suites are asserting
+ * nothing, and that should be loud rather than green.
+ */
+export function useNonUtcTimezone(zone: string = DEFAULT_ZONE): void {
+  process.env.TZ = zone;
+
+  beforeEach(() => {
+    process.env.TZ = zone;
+
+    expect(
+      new Date().getTimezoneOffset(),
+      `TZ=${zone} did not take hold, so a bare DateTime64 string parses the ` +
+        `same whether or not the decoder anchors it to UTC and this suite ` +
+        `proves nothing. Check the pool in vitest.config.ts still gives each ` +
+        `worker its own process.`,
+    ).not.toBe(0);
+  });
+}


### PR DESCRIPTION
Fixes the 16 test failures currently red on `main` (surfaced on #6375, which is charts-only and did not cause them).

## The 15 ClickHouse failures

`aa59f8da98` (#6383, merged 2026-07-30) bounded the `evaluation_runs` JOIN **and its dedup subquery** on `OccurredAt` to prune partitions. That table has no `OccurredAt` column — it is `PARTITION BY toYearWeek(ScheduledAt)`.

The name did not fail as an unknown identifier. Inside the subquery it resolved *outward* to the enclosing `trace_summaries` scope, which does have `OccurredAt`, turning the IN-tuple dedup into a correlated subquery that ClickHouse refuses:

```
Correlated subqueries are not supported as IN function arguments yet, but found in expression:
(TenantId, EvaluationId, UpdatedAt) IN (SELECT TenantId, EvaluationId, max(UpdatedAt) FROM evaluation_runs ...)
```

**This is a live read-path outage, not just red CI** — every analytics query carrying an evaluation metric or filter throws. #6383 merged with four of six integration shards already failing, so the suite did catch it.

### Why reverted, not renamed to `ScheduledAt`

Renaming looks like the obvious fix and is a data-loss bug. The outer date range is the **trace's**, and `ScheduledAt` does not track it:

- No production path emits `EvaluationScheduledEvent` — it is dead plumbing kept for the fold's exhaustiveness check — so `scheduledAt` stays null and the repository falls back to `createdAt`, i.e. wall-clock write time.
- Evaluations V3 **"Rerun"** replays months-old trace ids at today's clock (`experiments-v3/execution/orchestrator.ts`).

A ±2-day envelope would silently drop those rows. Online evals and guardrails are fine (seconds of drift); the problem is one table serving both regimes with nothing distinguishing them. The pruning win is real, still unclaimed, and left in a comment rather than smuggled in as a rename.

The repo already agrees on the column — `cold-scan-detector.ts` maps `evaluation_runs: ["ScheduledAt"]` and `filters/clickhouse/query-helpers.ts` bounds it that way. **No other call site had the bug.**

## The 1 timezone failure (unrelated flake)

Three DateTime64-decode suites force `TZ=Asia/Kolkata` at module scope, because the assertion only has teeth off UTC. The unit pool runs `isolate: false`, so one process and VM context carry every file a worker picks up and a neighbour can clobber that assignment.

Evidence it is nondeterministic rather than a code change: `test-unit (1)` **passed** on #6383's run and **failed** on #6375's run, same files, nothing touching them in between — and only one of the three identical suites failed.

`useNonUtcTimezone` re-applies the zone per test and moves the did-it-take guard into a `beforeEach`, so it covers every test rather than one. Verified on linux and darwin that a late re-application works even inside an already-warm vm context.

I could not reproduce this one locally (it passes standalone, in shard 1/4, and single-worker), so the mechanism is inferred from the above rather than directly observed. The re-application is harmless either way, and the guard still fails loudly if the zone ever stops taking.

## Verification

- Reproduced the exact CI error against ClickHouse `25.10.2.65` (CI's pin) on unmodified `main`, then confirmed green with the fix — a real before/after control, not just an after.
- All 7 originally-failing integration files pass; whole `analytics/clickhouse` + `app-layer/analytics` + `app-layer/evaluations` integration suites green (93 + 48 tests).
- Unit shard 1/4 green; `typecheck` **and** `typecheck:tests` clean; biome clean on changed files.
- Confirmed the guard still fails loudly when the zone does not take.

## Left alone, deliberately

`monitor-performance.clickhouse.repository.ts:86-87` carries this same ±2-day `ScheduledAt` bound on the same false premise ("runs are scheduled after their trace occurs"). Pre-existing, narrower blast radius (scoped to monitor evaluator ids), out of scope here — but it is the same bug and worth a follow-up.

## Deployment Impact

**Env vars added/changed:** none.

**Behaviour:** restores evaluation analytics to its pre-#6383 (working) state. Queries lose the partition-pruning attempt that never functioned — it errored rather than pruned — so there is no performance regression relative to what is actually running.

**Rollback:** revert this commit; that restores the broken query.