### PR TITLE
revert(clickhouse): unbind the evaluation_runs JOIN from a column that table does not have

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { TIME_PARTITIONED_TABLES } from "~/server/app-layer/clients/clickhouse/cold-scan-detector";
+import type { FilterField } from "../../../filters/types";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import type { AggregationTypes } from "../../types";
+import {
+  buildDataForFilterQuery,
+  buildTimeseriesQuery,
+} from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+
+/**
+ * Every table subquery the analytics builders emit sits inside a query over
+ * `trace_summaries`. ClickHouse resolves an identifier the inner table does not
+ * have against the OUTER scope rather than failing, so a range bound naming the
+ * wrong column silently becomes a correlated reference to `trace_summaries`.
+ * That is accepted in a plain read and only rejected once it lands inside an
+ * `IN`, at query time, with "Correlated subqueries are not supported as IN
+ * function arguments yet", so the mistake reaches production as a 500 on every
+ * evaluation graph rather than as a build or typecheck error.
+ *
+ * A range bound therefore has to name the bounded table's own partition column.
+ * {@link TIME_PARTITIONED_TABLES} holds those, and is itself kept honest against
+ * the migrations by `cold-scan-detector.coverage.unit.test.ts`.
+ */
+
+const RANGE_BOUND_OR_TABLE =
+  /\bFROM\s+([a-zA-Z_]\w*)|(?<![\w.`])([a-zA-Z_]\w*)\s*(?:>=|<=|>|<)\s*\{/g;
+
+/**
+ * Range bounds in `sql`, grouped by the table of the nearest preceding
+ * `FROM <table>`. Alias-qualified columns (`ts.OccurredAt`) belong to the outer
+ * scope by construction and are skipped; only bare identifiers can be captured
+ * by the wrong scope.
+ */
+function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
+  const byTable = new Map<string, Set<string>>();
+  let currentTable: string | null = null;
+
+  RANGE_BOUND_OR_TABLE.lastIndex = 0;
+  let match: RegExpExecArray | null = RANGE_BOUND_OR_TABLE.exec(sql);
+  while (match !== null) {
+    const [, table, column] = match;
+    if (table) {
+      currentTable = table;
+    } else if (column && currentTable) {
+      const columns = byTable.get(currentTable) ?? new Set<string>();
+      columns.add(column);
+      byTable.set(currentTable, columns);
+    }
+    match = RANGE_BOUND_OR_TABLE.exec(sql);
+  }
+
+  return byTable;
+}
+
+/** One message per bound that names a column the table is not partitioned by. */
+function partitionBoundViolations(sql: string): string[] {
+  const violations: string[] = [];
+
+  for (const [table, columns] of rangeBoundColumnsByTable(sql)) {
+    const partitionColumns = (
+      TIME_PARTITIONED_TABLES as Record<string, readonly string[] | undefined>
+    )[table];
+    if (!partitionColumns) continue;
+
+    for (const column of columns) {
+      if (partitionColumns.includes(column)) continue;
+      violations.push(
+        `${table} is bounded on ${column}, not one of its partition columns (${partitionColumns.join(", ")}); ClickHouse resolves ${column} against the outer trace_summaries scope instead of failing`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+const baseInput = {
+  projectId: "partition-bound-guard",
+  startDate: new Date("2025-01-01T00:00:00Z"),
+  endDate: new Date("2025-02-01T00:00:00Z"),
+  previousPeriodStartDate: new Date("2024-12-01T00:00:00Z"),
+};
+
+const COST_SERIES = {
+  metric: "performance.total_cost" as FlattenAnalyticsMetricsEnum,
+  aggregation: "sum" as AggregationTypes,
+};
+const EVAL_SERIES = {
+  metric: "evaluations.evaluation_pass_rate" as FlattenAnalyticsMetricsEnum,
+  aggregation: "avg" as AggregationTypes,
+  key: "some-evaluator",
+};
+
+describe("analytics JOIN time bounds", () => {
+  describe("given a timeseries query that joins evaluation_runs", () => {
+    /**
+     * @scenario Every range bound in generated analytics SQL names the bounded table's partition column
+     */
+    it("bounds each joined table only on its own partition column", () => {
+      const violations: string[] = [];
+
+      for (const timeScale of [1440, "full" as const]) {
+        for (const groupBy of [undefined, "metadata.model" as const]) {
+          resetParamCounter();
+          const { sql } = buildTimeseriesQuery({
+            ...baseInput,
+            timeScale,
+            groupBy,
+            series: [COST_SERIES, EVAL_SERIES],
+          });
+          violations.push(...partitionBoundViolations(sql));
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("given a filter-values query over evaluation_runs", () => {
+    /**
+     * @scenario Filter-value queries bound evaluation_runs on its own partition column
+     */
+    it("bounds each joined table only on its own partition column", () => {
+      const violations: string[] = [];
+
+      for (const field of [
+        "evaluations.evaluator_id",
+        "evaluations.evaluator_id.guardrails_only",
+        "evaluations.passed",
+      ] as FilterField[]) {
+        resetParamCounter();
+        const { sql } = buildDataForFilterQuery(
+          baseInput.projectId,
+          field,
+          baseInput.startDate,
+          baseInput.endDate,
+        );
+        violations.push(...partitionBoundViolations(sql));
+      }
+
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("given a query that joins stored_spans", () => {
+    /**
+     * @scenario The guard is non-vacuous: stored_spans really is bounded, on StartTime
+     */
+    it("bounds stored_spans on StartTime", () => {
+      resetParamCounter();
+      const { sql } = buildDataForFilterQuery(
+        baseInput.projectId,
+        "spans.model" as FilterField,
+        baseInput.startDate,
+        baseInput.endDate,
+      );
+
+      expect(sql).toContain("FROM stored_spans");
+      expect(rangeBoundColumnsByTable(sql).get("stored_spans")).toEqual(
+        new Set(["StartTime"]),
+      );
+      expect(partitionBoundViolations(sql)).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -80,17 +80,30 @@ const baseInput = {
   startDate: new Date("2025-01-01T00:00:00Z"),
   endDate: new Date("2025-02-01T00:00:00Z"),
   previousPeriodStartDate: new Date("2024-12-01T00:00:00Z"),
-};
+} as const;
 
 const COST_SERIES = {
   metric: "performance.total_cost" as FlattenAnalyticsMetricsEnum,
   aggregation: "sum" as AggregationTypes,
-};
+} as const;
 const EVAL_SERIES = {
   metric: "evaluations.evaluation_pass_rate" as FlattenAnalyticsMetricsEnum,
   aggregation: "avg" as AggregationTypes,
   key: "some-evaluator",
-};
+} as const;
+
+/**
+ * The bound check reports nothing when a query never reaches the table, so each
+ * case has to prove it emitted the subquery it claims to be guarding. Without
+ * this the suite passes just as happily on a build that stopped joining
+ * evaluation data at all.
+ */
+function missingJoinViolations(sql: string, table: string): string[] {
+  if (sql.includes(`FROM ${table}`)) return [];
+  return [
+    `generated SQL has no FROM ${table} subquery, so the partition-bound check inspected nothing`,
+  ];
+}
 
 describe("analytics JOIN time bounds", () => {
   describe("given a timeseries query that joins evaluation_runs", () => {
@@ -109,7 +122,10 @@ describe("analytics JOIN time bounds", () => {
             groupBy,
             series: [COST_SERIES, EVAL_SERIES],
           });
-          violations.push(...partitionBoundViolations(sql));
+          violations.push(
+            ...missingJoinViolations(sql, "evaluation_runs"),
+            ...partitionBoundViolations(sql),
+          );
         }
       }
 
@@ -127,7 +143,6 @@ describe("analytics JOIN time bounds", () => {
       for (const field of [
         "evaluations.evaluator_id",
         "evaluations.evaluator_id.guardrails_only",
-        "evaluations.passed",
       ] as FilterField[]) {
         resetParamCounter();
         const { sql } = buildDataForFilterQuery(
@@ -136,7 +151,10 @@ describe("analytics JOIN time bounds", () => {
           baseInput.startDate,
           baseInput.endDate,
         );
-        violations.push(...partitionBoundViolations(sql));
+        violations.push(
+          ...missingJoinViolations(sql, "evaluation_runs"),
+          ...partitionBoundViolations(sql),
+        );
       }
 
       expect(violations).toEqual([]);
@@ -156,7 +174,7 @@ describe("analytics JOIN time bounds", () => {
         baseInput.endDate,
       );
 
-      expect(sql).toContain("FROM stored_spans");
+      expect(missingJoinViolations(sql, "stored_spans")).toEqual([]);
       expect(rangeBoundColumnsByTable(sql).get("stored_spans")).toEqual(
         new Set(["StartTime"]),
       );

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -80,20 +80,6 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
 /**
- * The same envelope for `evaluation_runs`, whose partition column is
- * `OccurredAt`. Its JOIN took no bound at all until now, so every query
- * carrying an evaluation metric or filter cold-scanned the table twice — the
- * outer read plus the dedup's full-table GROUP BY. One constant per caller date
- * regime, mirroring the span pair above.
- */
-const EVAL_TIME_FILTER_BOTH_PERIODS =
-  "AND OccurredAt >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {currentEnd:DateTime64(3)} + INTERVAL 2 DAY";
-const EVAL_TIME_FILTER_START_END =
-  "AND OccurredAt >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
-  "AND OccurredAt < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
-
-/**
  * Returns a deduped FROM-clause expression for trace_summaries.
  *
  * trace_summaries uses ReplacingMergeTree(UpdatedAt) which can return
@@ -803,7 +789,6 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
-        evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
       });
     })
     .join("\n");
@@ -2293,7 +2278,6 @@ function buildDateBucketedPipelineQuery({
           table,
           requiredColumns,
           spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
-          evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
         });
       })
       .join("\n");
@@ -2745,7 +2729,6 @@ export function buildDataForFilterQuery(
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
     })
     .join("\n");
@@ -2842,7 +2825,6 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2869,7 +2851,6 @@ export function buildDataForFilterQuery(
         table: "stored_spans",
         requiredColumns: new Set(["SpanAttributes"]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
       sql = `
         SELECT
@@ -2893,10 +2874,7 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause({
-        table: "evaluation_runs",
-        evalTimeFilter: EVAL_TIME_FILTER_START_END,
-      });
+      joins = buildJoinClause({ table: "evaluation_runs" });
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -498,12 +498,10 @@ export function buildJoinClause({
   table,
   requiredColumns,
   spanTimeFilter,
-  evalTimeFilter,
 }: {
   table: CHTable;
   requiredColumns?: ReadonlySet<string>;
   spanTimeFilter?: string;
-  evalTimeFilter?: string;
 }): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
@@ -520,24 +518,13 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
-      // `evaluation_runs` is PARTITION BY the same OccurredAt envelope the outer
-      // read is already bounded to, so without a predicate here BOTH scopes walk
-      // every partition — the outer read and, more expensively, the dedup's
-      // full-table GROUP BY. Rendered into both so they prune identically.
-      //
-      // The bound goes on the dedup too, which windows "latest version" to the
-      // frame rather than all of history: an evaluation whose newest row landed
-      // outside it reads back one version stale. That is a read-only analytics
-      // path — stale numbers, never a wrong write — and the ±2-day cushion the
-      // caller supplies covers the drift this table actually exhibits.
-      const timeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
-        WHERE TenantId = {tenantId:String}${timeBound}
+        WHERE TenantId = {tenantId:String}
           AND (TenantId, EvaluationId, UpdatedAt) IN (
             SELECT TenantId, EvaluationId, max(UpdatedAt)
             FROM evaluation_runs
-            WHERE TenantId = {tenantId:String}${timeBound}
+            WHERE TenantId = {tenantId:String}
             GROUP BY TenantId, EvaluationId
           )
       ) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;


### PR DESCRIPTION
Reverts #6383. `main` has been red on `test-integration` shards 1, 2, 3, 5 and 6 (and therefore `langwatch-app-complete`) since it merged, so every open PR inherits the failure through the CI merge with base.

## Bisect

Reproduced on `origin/main` (1a7e5d0919), then reverted only #6383's two files to its parent (ee8a61b124) with the rest of the tree untouched:

| | result |
|---|---|
| `origin/main` | 14 failed, 34 passed |
| `origin/main` with `aa59f8da98`'s two files at its parent | 0 failed, 48 passed |

`aa59f8da98` ("perf(clickhouse): bound the evaluation_runs JOIN so it prunes partitions", #6383) is the culprit. Its own CI was red on the same shards when it was merged.

## The defect

#6383 added a partition-pruning bound to the `evaluation_runs` JOIN on `OccurredAt`, describing it as "the partition column". `evaluation_runs` has no `OccurredAt` column, and its partition key is `toYearWeek(ScheduledAt)`:

```
ENGINE = ReplacingMergeTree(UpdatedAt)
PARTITION BY toYearWeek(ScheduledAt)
ORDER BY (TenantId, EvaluationId)
```

The JOIN subquery runs inside a query over `trace_summaries`, which does have `OccurredAt`. ClickHouse resolves the unknown identifier against that outer scope instead of failing, so the bound becomes a correlated reference to the trace's timestamp. The outer read tolerates it; the dedup subquery, which sits inside an `IN`, does not:

```
Correlated subqueries are not supported as IN function arguments yet, but found in
expression: (TenantId, EvaluationId, UpdatedAt) IN (SELECT TenantId, EvaluationId,
max(UpdatedAt) FROM evaluation_runs WHERE (TenantId = '...') AND (OccurredAt >= ...)
AND (OccurredAt < ...) GROUP BY TenantId, EvaluationId)
```

That is the identical error behind all 51 test failures across all five shards. It also means every production analytics query carrying an evaluation metric or filter has been a hard 500 since the merge: custom graphs, evaluation filter option lists, and the guardrails variants. Zero rows returned, not slow rows.

The correct partition column was already in the tree, in the very detector that produced the cold-scan evidence #6383 cites: `TIME_PARTITIONED_TABLES` in `cold-scan-detector.ts` maps `evaluation_runs: ["ScheduledAt"]`, and a coverage test parses the migrations to keep it honest.

## Why revert instead of swapping the column

Swapping `OccurredAt` for `ScheduledAt` makes the SQL valid, and every test here would pass, but it would trade a loud failure for a silent wrong answer.

`ScheduledAt` is set once from the `EvaluationScheduled` event's `occurredAt`, so it records when the evaluation was scheduled, not when the trace happened. The JOIN matches on `TraceId`, and evaluations of historical traces are scheduled long after those traces occurred. Bounding `evaluation_runs` to the trace date window plus a 2-day cushion would silently drop them from graphs, which is exactly the disappearance `offline-experiment-evaluations-joinability` exists to pin. That is a data-correctness call, not a hotfix, so it belongs in a reopened #6383 rather than in a change whose job is to get `main` green.

The perf problem #6383 set out to solve is real and is not addressed here. #6383 is merged so it cannot be reopened; #6392 carries the problem forward with both viable approaches written up: bound on `ScheduledAt` and accept the semantics call, or rewrite the dedup as a single `argMax` pass that removes the second scan without any time bound at all.

## The regression guard

`join-time-bound-partition-column.unit.test.ts` asserts that every range bound in generated analytics SQL names a partition column of the table it bounds, reading the columns from the migration-verified `TIME_PARTITIONED_TABLES`. Re-applying `aa59f8da98` on top of it fails in under a second with no ClickHouse involved:

```
evaluation_runs is bounded on OccurredAt, not one of its partition columns
(ScheduledAt); ClickHouse resolves OccurredAt against the outer trace_summaries
scope instead of failing
```

## Evidence

All against native ClickHouse on :8124.

```
pnpm test:integration <the four shard-1 files> --watch=false --no-file-parallelism
  Test Files  4 passed (4)
       Tests  69 passed | 3 skipped (72)

pnpm test:integration cross-evaluator-groupby filter-evaluation-queries \
  score-only-evaluator-passed-groupby model-group-attribution --watch=false
  Test Files  4 passed (4)
       Tests  24 passed (24)

pnpm test:unit run src/server/analytics/clickhouse/__tests__/
  Test Files  12 passed (12)
       Tests  331 passed (331)
```

That covers every test that failed on shards 1, 2, 3, 5 and 6. No assertion was changed.

Lint: `.github/scripts/biome-new-violations.sh` reports no new violations, and `biome.jsonc` is untouched.


https://claude.ai/code/session_01KkQGRU4DFxEt7nubHeqz3p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics query accuracy by applying time boundaries according to each joined dataset’s partitioning rules.
  * Prevented evaluation data joins from applying incorrect time filters, while preserving appropriate filtering for stored span data.
  * Improved reliability for timeseries, evaluation filtering, and stored span analytics queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->