### PR TITLE
fix(settings): resolve the ambient team to one the member is actually on

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -46,7 +46,10 @@ import { GlobalTraceV2DrawerMount } from "../features/traces-v2/components/Globa
 import { useDrawer } from "../hooks/useDrawer";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { useLiteMemberGuard } from "../hooks/useLiteMemberGuard";
-import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
+import {
+  useOrganizationTeamProject,
+  userBelongsToTeam,
+} from "../hooks/useOrganizationTeamProject";
 import { useOrgQueryParamSelection } from "../hooks/useOrgQueryParamSelection";
 import { usePlanManagementUrl } from "../hooks/usePlanManagementUrl";
 import { usePostHogIdentify } from "../hooks/usePostHogIdentify";
@@ -621,7 +624,9 @@ export const DashboardLayout = ({
     // path on personal-project URLs.
     isPersonalScopeRoute ||
     isDemoProject ||
-    (team?.members?.some((member) => member.userId === user?.id) ?? false) ||
+    // Same predicate the ambient team resolution prefers on, so the team the
+    // app picks and the team the chrome will render for cannot diverge.
+    (!!team && !!user?.id && userBelongsToTeam(team, user.id)) ||
     // Org admins created via RoleBinding-only flow have no TeamUser row but still
     // have full team access - mirrors server-side org-scoped ADMIN RoleBinding logic.
     organizationRole === OrganizationUserRole.ADMIN;

--- a/langwatch/src/components/me/PersonalTracesEmptyState.tsx
+++ b/langwatch/src/components/me/PersonalTracesEmptyState.tsx
@@ -15,6 +15,7 @@ import { Bot, KeyRound, Webhook } from "lucide-react";
 import type React from "react";
 import { Link } from "~/components/ui/link";
 import { IntegratePaneShell } from "~/features/traces-v2/components/TracesPage/IntegratePaneShell";
+import { API_KEYS_SETTINGS_PATH } from "~/pages/settings/api-keys/apiKeyAnchor";
 
 /** Anchor ids the offers scroll to — set on the matching /me sections. */
 export const PERSONAL_AI_TOOLS_ANCHOR = "me-ai-tools";
@@ -123,7 +124,7 @@ export function PersonalTracesEmptyState({
       title: "Create an API key",
       description: "Authenticate the LangWatch SDK or your own integration.",
       ...(projectSlug
-        ? { href: `/${projectSlug}/settings/api-keys` }
+        ? { href: API_KEYS_SETTINGS_PATH }
         : { onClick: () => scrollToId(PERSONAL_TRACE_INGEST_ANCHOR) }),
     },
   ];

--- a/langwatch/src/components/me/__tests__/PersonalRecentTracesTable.integration.test.tsx
+++ b/langwatch/src/components/me/__tests__/PersonalRecentTracesTable.integration.test.tsx
@@ -51,13 +51,14 @@ describe("PersonalRecentTracesTable", () => {
       expect(screen.queryByText(/Skills\s+and\s+MCP/i)).toBeNull();
     });
 
-    it("links the API-key offer to the personal project's api-keys settings", () => {
+    it("links the API-key offer to the api-keys settings page", () => {
       renderEmpty("jane-personal");
 
       const link = screen.getByText("Create an API key").closest("a");
-      expect(link?.getAttribute("href")).toBe(
-        "/jane-personal/settings/api-keys",
-      );
+      // Settings is a top-level route. A project-slug prefix has no route
+      // behind it and lands the reader on a 404 or, for a member whose
+      // ambient team resolves elsewhere, on a refusal.
+      expect(link?.getAttribute("href")).toBe("/settings/api-keys");
     });
 
     it("renders the two in-page offers as buttons (scroll to the matching section)", () => {

--- a/langwatch/src/components/ui/PIIRedactionNotice.tsx
+++ b/langwatch/src/components/ui/PIIRedactionNotice.tsx
@@ -1,6 +1,5 @@
 import { Alert, Link } from "@chakra-ui/react";
 import { hasRedactionMarker } from "@langwatch/redaction";
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import NextLink from "~/utils/compat/next-link";
 
 /**
@@ -21,12 +20,8 @@ export function PIIRedactionNotice({
 }: {
   content: string | null | undefined;
 }) {
-  const { project } = useOrganizationTeamProject();
-
   if (!hasRedactionMarker(content)) return null;
-  const settingsHref = project?.slug
-    ? `/${project.slug}/settings`
-    : "/settings";
+  const settingsHref = "/settings/data-privacy";
 
   return (
     <Alert.Root status="info" size="sm" variant="subtle" width="full">

--- a/langwatch/src/components/ui/__tests__/PIIRedactionNotice.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/PIIRedactionNotice.integration.test.tsx
@@ -5,12 +5,6 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { slug: "acme" },
-  }),
-}));
-
 vi.mock("~/utils/compat/next-link", () => ({
   default: ({
     href,
@@ -63,7 +57,11 @@ describe("PIIRedactionNotice", () => {
       const link = screen.getByRole("link", {
         name: /Settings/i,
       });
-      expect(link.getAttribute("href")).toBe("/acme/settings");
+      // The banner names privacy settings, so it links to the page that
+      // holds them. Settings is a top-level route: a project-slug prefix
+      // has no route behind it and lands the reader on a 404 or, for a
+      // member whose ambient team resolves elsewhere, on a refusal.
+      expect(link.getAttribute("href")).toBe("/settings/data-privacy");
     });
 
     it("renders the banner for a secret marker", () => {

--- a/langwatch/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The teams list the app resolves against carries the whole organization, not
+ * just the caller's corner of it, so an ambient pick expressed purely as "the
+ * first team shaped like X" hands a member a team they are not on as soon as
+ * an organization has more than one. Every page without a project in its
+ * address bar reads that pick, `/settings/*` included, and the chrome refuses
+ * a page outright when the resolved team holds no membership for the caller:
+ * "You are not part of any team in this organization".
+ *
+ * These tests execute the real hook. Only its boundaries are stubbed: the
+ * tRPC queries it reads, the router, the session, and localStorage. The
+ * resolution chain under test runs for real.
+ *
+ * Spec: specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrganizationsQuery, mockRouter, mockLocalStorage, idleQuery } =
+  vi.hoisted(() => ({
+    mockOrganizationsQuery: vi.fn(),
+    idleQuery: () => ({
+      data: undefined,
+      isLoading: false,
+      isFetched: true,
+    }),
+    mockRouter: {
+      query: {} as Record<string, string>,
+      route: "/settings/api-keys",
+      pathname: "/settings/api-keys",
+      asPath: "/settings/api-keys",
+      push: vi.fn(),
+      replace: vi.fn(),
+    },
+    mockLocalStorage: {
+      selectedOrganizationId: "",
+      selectedTeamId: "",
+      selectedProjectSlug: "",
+      lastVisitedHomeKind: "",
+    } as Record<string, string>,
+  }));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    organization: { getAll: { useQuery: mockOrganizationsQuery } },
+    sharedTrace: { get: { useQuery: idleQuery } },
+    publicEnv: { useQuery: idleQuery },
+    modelProvider: { getAllForProject: { useQuery: idleQuery } },
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: MEMBER_ID } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useLocalStorage: (key: string, initial: string) => [
+    mockLocalStorage[key] ?? initial,
+    (value: string) => {
+      mockLocalStorage[key] = value;
+    },
+  ],
+}));
+
+import { useOrganizationTeamProject } from "../useOrganizationTeamProject";
+
+const MEMBER_ID = "user-member";
+
+/** The team the member is NOT on. Listed first, so ordering alone elects it. */
+const OTHER_TEAM = {
+  id: "team-platform",
+  name: "ACME Platform",
+  slug: "acme-platform",
+  isPersonal: false,
+  ownerUserId: null,
+  members: [] as { userId: string; role: string }[],
+  projects: [
+    { id: "proj-platform", name: "Platform App", slug: "platform-app" },
+  ],
+};
+
+/** The owning team, where the member holds a real membership row. */
+const OWNING_TEAM = {
+  id: "team-data",
+  name: "ACME Data",
+  slug: "acme-data",
+  isPersonal: false,
+  ownerUserId: null,
+  members: [{ userId: MEMBER_ID, role: "MEMBER" }],
+  projects: [{ id: "proj-data", name: "Data App", slug: "data-app" }],
+};
+
+function organizationWith(teams: unknown[]) {
+  return {
+    data: [
+      {
+        id: "org-acme",
+        name: "ACME",
+        slug: "acme",
+        primaryIntent: null,
+        members: [{ role: "MEMBER" }],
+        teams,
+      },
+    ],
+    isLoading: false,
+    isFetched: true,
+    isRefetching: false,
+  };
+}
+
+function renderResolution() {
+  return renderHook(() =>
+    useOrganizationTeamProject({
+      redirectToOnboarding: false,
+      redirectToProjectOnboarding: false,
+    }),
+  );
+}
+
+/**
+ * The predicate `DashboardLayout` gates every page body on. Asserting it here
+ * keeps the test honest about what the resolution has to produce: not merely
+ * "a team", but one the caller can be shown a page for.
+ */
+function chromeWouldRefuse(
+  team: { members?: { userId: string }[] } | undefined,
+) {
+  return !(
+    team?.members?.some((member) => member.userId === MEMBER_ID) ?? false
+  );
+}
+
+describe("useOrganizationTeamProject team-membership resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouter.query = {};
+    mockRouter.route = "/settings/api-keys";
+    mockRouter.pathname = "/settings/api-keys";
+    mockRouter.asPath = "/settings/api-keys";
+    for (const key of Object.keys(mockLocalStorage)) {
+      mockLocalStorage[key] = "";
+    }
+    mockOrganizationsQuery.mockReturnValue(
+      organizationWith([OTHER_TEAM, OWNING_TEAM]),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given a member of one team in an organization that has several", () => {
+    describe("when they open a settings page with nothing selected yet", () => {
+      /** @scenario A member resolves the team they are on, not the first one listed */
+      it("resolves the team the member is on, not the one that sorts first", () => {
+        const { result } = renderResolution();
+
+        expect(result.current.team?.id).toBe("team-data");
+        expect(chromeWouldRefuse(result.current.team)).toBe(false);
+      });
+
+      /** @scenario The ambient project belongs to the team the member is on */
+      it("resolves that team's project, which is what settings writes against", () => {
+        const { result } = renderResolution();
+
+        expect(result.current.project?.slug).toBe("data-app");
+      });
+    });
+
+    describe("when a selection remembered from another context names a team they are not on", () => {
+      /** @scenario A remembered team the member is not on does not win */
+      it("ignores the remembered team and resolves the one they hold", () => {
+        mockLocalStorage.selectedTeamId = "team-platform";
+        mockLocalStorage.selectedProjectSlug = "platform-app";
+
+        const { result } = renderResolution();
+
+        expect(result.current.team?.id).toBe("team-data");
+        expect(result.current.project?.slug).toBe("data-app");
+        expect(chromeWouldRefuse(result.current.team)).toBe(false);
+      });
+
+      /** @scenario The remembered selection heals to the team the member is on */
+      it("re-persists the resolved selection so the stale one heals", () => {
+        mockLocalStorage.selectedTeamId = "team-platform";
+        mockLocalStorage.selectedProjectSlug = "platform-app";
+
+        renderResolution();
+
+        expect(mockLocalStorage.selectedTeamId).toBe("team-data");
+        expect(mockLocalStorage.selectedProjectSlug).toBe("data-app");
+      });
+    });
+  });
+
+  describe("given someone who belongs to no team in the organization", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith([OTHER_TEAM, { ...OWNING_TEAM, members: [] }]),
+      );
+    });
+
+    describe("when they open a settings page", () => {
+      /** @scenario A genuine non-member is still refused */
+      it("still resolves a context, and the chrome still refuses them", () => {
+        const { result } = renderResolution();
+
+        // A resolved context is what lets the chrome render the refusal at
+        // all; leaving it undefined would hang the page on a loading screen.
+        expect(result.current.team).toBeDefined();
+        expect(chromeWouldRefuse(result.current.team)).toBe(true);
+      });
+    });
+  });
+
+  describe("given a project named in the address bar that belongs to another team", () => {
+    describe("when the member opens it", () => {
+      /** @scenario A project named in the URL still resolves its own team */
+      it("resolves the addressed team, refusal and all", () => {
+        mockRouter.query = { project: "platform-app" };
+        mockRouter.route = "/[project]";
+        mockRouter.pathname = "/[project]";
+        mockRouter.asPath = "/platform-app";
+
+        const { result } = renderResolution();
+
+        expect(result.current.team?.id).toBe("team-platform");
+        expect(chromeWouldRefuse(result.current.team)).toBe(true);
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
@@ -127,9 +127,12 @@ function renderResolution() {
 }
 
 /**
- * The predicate `DashboardLayout` gates every page body on. Asserting it here
- * keeps the test honest about what the resolution has to produce: not merely
- * "a team", but one the caller can be shown a page for.
+ * The predicate `DashboardLayout` gates every page body on, restated here
+ * rather than imported. What the resolution has to produce is not merely "a
+ * team" but one the caller can be shown a page for, and an independent
+ * statement of that is what makes the assertion mean anything: calling the
+ * hook's own exported predicate would let the two drift together and still
+ * agree, which is exactly the failure this covers.
  */
 function chromeWouldRefuse(
   team: { members?: { userId: string }[] } | undefined,

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -303,19 +303,26 @@ export const useOrganizationTeamProject = (
       ),
   );
 
+  // A slug can name a project in more than one team, so prefer a match on a
+  // team the caller is on before falling back to the first one.
+  const slugMatches = projectsTeamsOrganizationsMatchingSlug ?? [];
+  const slugMatch =
+    (userId
+      ? slugMatches.find((match) => userBelongsToTeam(match.team, userId))
+      : undefined) ?? slugMatches[0];
+
   // A slug that resolved off the persisted selection rather than off the URL
   // is stickiness, not intent: it survives from the last visit to
   // /[some-slug]/* into every organization-scoped page that carries no project
-  // of its own. Two kinds have to be dropped there — a personal workspace,
-  // which is a private context the caller never asked to work in, and a team
-  // the caller does not belong to, which the chrome refuses outright. Both let
-  // the ambient resolution below pick again, which also re-persists what it
-  // picks so the stale selection heals itself.
+  // of its own. Two kinds have to be dropped there. A personal workspace is a
+  // private context the caller never asked to work in, and a team the caller
+  // does not belong to is one the chrome refuses outright. Both let the
+  // ambient resolution below pick again, which also re-persists what it picks
+  // so the stale selection heals itself.
   //
   // A slug named in the address bar keeps resolving exactly as before,
   // including into a team the caller is not on: the refusal that follows is
   // the honest answer to typing someone else's project into the URL.
-  const slugMatch = projectsTeamsOrganizationsMatchingSlug?.[0];
   const stickySlugIsUnusable =
     !!slugMatch &&
     !isAddressedBySlug &&
@@ -368,10 +375,10 @@ export const useOrganizationTeamProject = (
     : undefined;
 
   // The remembered selection carries the same membership requirement as the
-  // ambient pick below. A team id persisted before that pick was membership
-  // aware — or carried over from an admin session on a shared machine — would
-  // otherwise keep resolving a team the caller is not on, long after the
-  // resolution itself stopped producing one.
+  // ambient pick below. Without it a persisted team id keeps resolving a team
+  // the caller is not on, long after the resolution itself stopped producing
+  // one: the selection is written from whatever last resolved, so a bad pick
+  // outlives the page that made it.
   const rememberedTeam = organization?.teams.find(
     (team) =>
       team.id == localStorageTeamId &&

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -41,9 +41,35 @@ export function isOrgScopedPermission(permission: Permission): boolean {
 }
 
 /**
- * Ambient team for organization-level work, in order of preference: a shared
- * team that already holds a project, then any shared team, then whatever is
- * left.
+ * Whether the caller holds a membership on this team.
+ *
+ * `organization.getAll` returns every team in the organization but narrows
+ * `team.members` to the caller's own row, synthesizing one from a RoleBinding
+ * when the legacy TeamUser row is absent. A match here is therefore the same
+ * membership the app chrome gates on before it will render a page at all.
+ *
+ * @internal Exported for testing only
+ */
+export function userBelongsToTeam<T extends { members?: { userId: string }[] }>(
+  team: T,
+  userId: string,
+): boolean {
+  return team.members?.some((member) => member.userId === userId) ?? false;
+}
+/**
+ * Ambient team for organization-level work.
+ *
+ * Membership decides first. The teams list carries the whole organization,
+ * not just the caller's corner of it, so any preference expressed purely as
+ * "the first team shaped like X" hands members a team they are not on the
+ * moment an organization has more than one. The chrome then refuses the page
+ * outright with "You are not part of any team in this organization", and the
+ * settings surfaces that write against the ambient project aim at a project
+ * in someone else's team.
+ *
+ * Within the teams the caller does belong to, the order of preference is: a
+ * shared team that already holds a project, then any shared team, then
+ * whatever is left.
  *
  * Personal workspaces sort last because they are a private context — one
  * project, owned by one person — while everything the app scopes to the
@@ -55,19 +81,31 @@ export function isOrgScopedPermission(permission: Permission): boolean {
  * sorts first.
  *
  * An organization whose only team is personal still resolves to it, so a solo
- * user is never left without a context.
+ * user is never left without a context. Someone who belongs to no team at all
+ * falls through to the same preference order over every team, which keeps the
+ * chrome on a resolved context so it can render the refusal instead of
+ * hanging on a loading screen forever.
  *
  * @internal Exported for testing only
  */
 export function selectAmbientTeam<
-  T extends { isPersonal?: boolean | null; projects: unknown[] },
->(teams: T[]): T | undefined {
-  return (
-    teams.find((team) => !team.isPersonal && team.projects.length > 0) ??
-    teams.find((team) => !team.isPersonal) ??
-    teams.find((team) => team.projects.length > 0) ??
-    teams[0]
-  );
+  T extends {
+    isPersonal?: boolean | null;
+    projects: unknown[];
+    members?: { userId: string }[];
+  },
+>(teams: T[], userId?: string): T | undefined {
+  const byPreference = (candidates: T[]) =>
+    candidates.find((team) => !team.isPersonal && team.projects.length > 0) ??
+    candidates.find((team) => !team.isPersonal) ??
+    candidates.find((team) => team.projects.length > 0) ??
+    candidates[0];
+
+  const own = userId
+    ? teams.filter((team) => userBelongsToTeam(team, userId))
+    : teams;
+
+  return byPreference(own) ?? byPreference(teams);
 }
 
 /** @internal Exported for testing only */
@@ -109,6 +147,7 @@ export const useOrganizationTeamProject = (
   },
 ) => {
   const session = useRequiredSession();
+  const userId = session.data?.user.id;
 
   const router = useRouter();
   const publicEnv = usePublicEnv();
@@ -264,15 +303,25 @@ export const useOrganizationTeamProject = (
       ),
   );
 
-  // The slug that resolved a personal workspace off the persisted selection
-  // rather than off the URL is stickiness, not intent: it survives from the
-  // last visit to /[personal-slug]/* into every organization-scoped page that
-  // carries no project of its own. Drop it there and let the ambient
-  // resolution below pick a shared team, which also re-persists the shared
-  // project so the stale selection heals itself.
+  // A slug that resolved off the persisted selection rather than off the URL
+  // is stickiness, not intent: it survives from the last visit to
+  // /[some-slug]/* into every organization-scoped page that carries no project
+  // of its own. Two kinds have to be dropped there — a personal workspace,
+  // which is a private context the caller never asked to work in, and a team
+  // the caller does not belong to, which the chrome refuses outright. Both let
+  // the ambient resolution below pick again, which also re-persists what it
+  // picks so the stale selection heals itself.
+  //
+  // A slug named in the address bar keeps resolving exactly as before,
+  // including into a team the caller is not on: the refusal that follows is
+  // the honest answer to typing someone else's project into the URL.
   const slugMatch = projectsTeamsOrganizationsMatchingSlug?.[0];
-  const resolvedSlugMatch =
-    slugMatch?.team.isPersonal && !isAddressedBySlug ? undefined : slugMatch;
+  const stickySlugIsUnusable =
+    !!slugMatch &&
+    !isAddressedBySlug &&
+    (!!slugMatch.team.isPersonal ||
+      (!!userId && !userBelongsToTeam(slugMatch.team, userId)));
+  const resolvedSlugMatch = stickySlugIsUnusable ? undefined : slugMatch;
 
   // For demo mode, find the organization that contains the demo project
   // (backend returns all user orgs + demo org, so we need to find the one with demo project)
@@ -314,24 +363,34 @@ export const useOrganizationTeamProject = (
   const isPersonalScopeRoute = router.pathname.startsWith("/me");
   const ownPersonalTeam = isPersonalScopeRoute
     ? organization?.teams.find(
-        (team) => team.isPersonal && team.ownerUserId === session.data?.user.id,
+        (team) => team.isPersonal && team.ownerUserId === userId,
       )
     : undefined;
+
+  // The remembered selection carries the same membership requirement as the
+  // ambient pick below. A team id persisted before that pick was membership
+  // aware — or carried over from an admin session on a shared machine — would
+  // otherwise keep resolving a team the caller is not on, long after the
+  // resolution itself stopped producing one.
+  const rememberedTeam = organization?.teams.find(
+    (team) =>
+      team.id == localStorageTeamId &&
+      !team.isPersonal &&
+      (!userId || userBelongsToTeam(team, userId)),
+  );
 
   const team = isDemo
     ? (organization?.teams.find((t) =>
         t.projects.some(
           (project) => project.slug === publicEnv.data?.DEMO_PROJECT_SLUG,
         ),
-      ) ?? selectAmbientTeam(organization?.teams ?? [])) // The team holding the demo project, else the ambient one
+      ) ?? selectAmbientTeam(organization?.teams ?? [], userId)) // The team holding the demo project, else the ambient one
     : resolvedSlugMatch
       ? resolvedSlugMatch.team
       : ownPersonalTeam
         ? ownPersonalTeam
         : organization
-          ? (organization.teams.find(
-              (team) => team.id == localStorageTeamId && !team.isPersonal,
-            ) ?? selectAmbientTeam(organization.teams))
+          ? (rememberedTeam ?? selectAmbientTeam(organization.teams, userId))
           : undefined;
 
   // For demo mode, find the project with the demo slug

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -45,10 +45,11 @@ export function isOrgScopedPermission(permission: Permission): boolean {
  *
  * `organization.getAll` returns every team in the organization but narrows
  * `team.members` to the caller's own row, synthesizing one from a RoleBinding
- * when the legacy TeamUser row is absent. A match here is therefore the same
- * membership the app chrome gates on before it will render a page at all.
+ * when the legacy TeamUser row is absent.
  *
- * @internal Exported for testing only
+ * Shared with `DashboardLayout`, which gates the page body on it: the team the
+ * ambient resolution picks and the team the chrome will render for have to be
+ * decided the same way, or the app resolves a context it then refuses.
  */
 export function userBelongsToTeam<T extends { members?: { userId: string }[] }>(
   team: T,

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -59,6 +59,70 @@ Feature: A personal workspace is never the ambient context for organization work
       # writes somewhere private.
 
   # ============================================================================
+  # The ambient context is a team the caller is actually on
+  # ============================================================================
+
+  Rule: the ambient team is one the caller holds a membership on
+
+    The teams the app resolves against are the organization's, not the
+    caller's: a member is handed every shared team in the organization, and
+    only their own membership row inside each. A preference expressed purely
+    as "the first team shaped like X" therefore elects a team the member is
+    not on the moment an organization has more than one, and the chrome then
+    refuses the page outright with "You are not part of any team in this
+    organization". The settings surfaces are where it bites, because they
+    write against the ambient project, so the refusal replaces every
+    /settings page at once and the alternative to refusing would be writing
+    into another team's project.
+
+    Background:
+      Given "ACME" has a second shared team "ACME Platform", listed first
+      And mia belongs to the shared team holding "acme-app", and not to
+        "ACME Platform"
+
+    @integration
+    Scenario: A member resolves the team they are on, not the first one listed
+      Given mia has not opened any project yet
+      When mia opens an organization-scoped settings page
+      Then the ambient team is the shared team she belongs to
+      And the page renders instead of refusing her
+
+    @integration
+    Scenario: The ambient project belongs to the team the member is on
+      When mia opens an organization-scoped settings page
+      Then the ambient project is "acme-app"
+
+    @integration
+    Scenario: A remembered team the member is not on does not win
+      Given mia's remembered selection names "ACME Platform"
+      When mia opens an organization-scoped settings page
+      Then the ambient team is still the shared team she belongs to
+
+    @integration
+    Scenario: The remembered selection heals to the team the member is on
+      Given mia's remembered selection names "ACME Platform"
+      When mia opens an organization-scoped settings page
+      Then the remembered team and project become the ones she belongs to
+
+    @integration
+    Scenario: A genuine non-member is still refused
+      Given mia belongs to no team in "ACME"
+      When mia opens an organization-scoped settings page
+      Then a context still resolves
+      And she is told she is not part of any team
+      # The refusal needs a resolved context to render inside. Leaving the
+      # context undefined replaces it with a loading screen that never ends.
+
+    @integration
+    Scenario: A project named in the URL still resolves its own team
+      When mia opens "ACME Platform"'s project by its own address
+      Then the ambient team is "ACME Platform"
+      And she is told she is not part of any team
+      # Typing someone else's project into the address bar is a question
+      # with an honest answer. Only the sticky, unasked-for selection is
+      # held to the membership test.
+
+  # ============================================================================
   # The address bar still decides
   # ============================================================================
 


### PR DESCRIPTION
Fixes #6385

A member who holds a real membership on the team that owns a project was told **"You are not part of any team in this organization"** on `/settings/*`, while the same session worked everywhere else.

## Root cause

The teams list the app resolves against carries the whole organization, not just the caller's corner of it. `organization.getAll` returns every shared team to a MEMBER and narrows `team.members` to the caller's own row (synthesizing one from a RoleBinding when the legacy `TeamUser` row is absent).

`selectAmbientTeam` in `src/hooks/useOrganizationTeamProject.ts` then picked "the first non-personal team that has a project" with no reference to membership. As soon as an organization has more than one shared team, that elects a team the member is not on, `team.members` comes back empty, and `DashboardLayout` replaces the whole page body with the refusal.

Nothing about the failure was specific to API keys. Every page without a project slug in the address bar reads the same pick, and `SettingsLayout` mounts `DashboardLayout` without `orgScope`, so the refusal covers all of `/settings/*` at once. The model providers page is the sharp edge: it writes credentials against the ambient project, which before this could be a project in a team the member does not belong to.

## What else shares the shape

- **Every `/settings/*` page**, through the one shared resolution. Verified in the browser on `/settings/api-keys` and `/settings/model-providers`.
- **The remembered selection.** A team id or project slug persisted from a bad pick kept resolving a foreign team, so the wrong state was sticky. Both now carry the same membership test and heal on the next page.
- **Two in-app links to the legacy `/<project-slug>/settings/...` shape**, which has no route behind it and 404s. That is how a reader reached the URL in the report. `PersonalTracesEmptyState` and `PIIRedactionNotice` now point at the live top-level routes.

## The fix

Membership decides first, with the existing shared-before-personal preference applied within the teams the caller belongs to. Deliberately preserved:

- **Org admins are unaffected.** An admin created through the RoleBinding-only flow has no `TeamUser` row anywhere, so the membership filter yields nothing and the pick falls through to today's order.
- **A genuine non-member still gets a resolved context**, so the chrome renders the refusal instead of hanging on a loading screen forever.
- **A slug named in the address bar still resolves its own team**, refusal included. Typing someone else's project into the URL is a question with an honest answer; only the sticky, unasked-for selection is held to the membership test.

## Evidence

Dogfooded on a seeded non-admin `MEMBER` with a real `TeamUser` row on the owning team, in an organization holding two shared teams where the one the member is *not* on sorts first. Admin sessions mask this entirely, since `organizationRole === ADMIN` short-circuits the same predicate.

Both directions were checked in the browser, not just the passing one. Dropping the member's `TeamUser` row and reloading brings the refusal straight back, on a resolved context (the chrome renders the message instead of hanging), and restoring the row clears it again. That is what rules out a fix that merely always-allows.

**Before** (desktop, member session): the header resolves "Platform App", the other team's project, and the page body is gone.

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6385-project-settings-team-scope/6385-before-desktop.png)

**After** (desktop): the ambient context resolves "Data App", the member's own team's project, and the page renders.

![after desktop](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6385-project-settings-team-scope/6385-after-desktop.png)

**After** (390px):

![after mobile](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6385-project-settings-team-scope/6385-after-mobile.png)

## Tests

`src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx` runs the real resolution chain and encodes the exact predicate `DashboardLayout` gates on, so the assertion is "the member can be shown a page", not merely "a team resolved". Four of its six cases fail against the old code; the other two are the regression guards that must keep passing either way.

Six scenarios added to `specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature`, all bound (`pnpm check:feature-parity`: 19/19 on that file).

`pnpm typecheck`, `pnpm typecheck:tests` and `pnpm lint` are clean. Two existing tests were pinning the dead `/<project-slug>/settings/...` URLs and now assert the live routes.

Note: jsdom does no layout, so every visual claim above comes from the browser, not from the passing RTL tests.


## Inherited CI

The `test-integration` shards are red on this branch and equally red on `main`, failing on `Correlated subqueries are not supported as IN function arguments yet ... FROM evaluation_runs`. That is #6383, which bounded the `evaluation_runs` JOIN on a column that table does not have; #6391 is the revert. Not chased here. Shard numbering moves between runs, so the specific shard ids differ from main's; the failure is the same query.