### PR TITLE
fix(components): clear scheduled timers so nothing runs after unmount

### DIFF
--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -334,7 +334,6 @@ const LEGACY_INERT: string[] = [
   "specs/coding-agent/personal-usage.feature",
   "specs/coding-agent/terminal-view.feature",
   "specs/components/code-block-editor.feature",
-  "specs/components/hoverable-big-text-overflow.feature",
   "specs/data-retention/data-size-metering.feature",
   "specs/data-retention/ingestion-stamping.feature",
   "specs/data-retention/monitoring.feature",

--- a/langwatch/src/components/AddOrEditDatasetDrawer.tsx
+++ b/langwatch/src/components/AddOrEditDatasetDrawer.tsx
@@ -163,8 +163,9 @@ export function AddOrEditDatasetDrawer(props: AddDatasetDrawerProps) {
     });
 
   useEffect(() => {
+    let resetTimeout: ReturnType<typeof setTimeout> | undefined;
     if (props.datasetToSave) {
-      setTimeout(() => {
+      resetTimeout = setTimeout(() => {
         reset({
           name: props.datasetToSave!.name ?? "",
           columnTypes: props.datasetToSave!.columnTypes,
@@ -177,6 +178,9 @@ export function AddOrEditDatasetDrawer(props: AddDatasetDrawerProps) {
       });
     }
     resetSlugInfo();
+    return () => {
+      if (resetTimeout) clearTimeout(resetTimeout);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!props.open]);
 

--- a/langwatch/src/components/Delayed.tsx
+++ b/langwatch/src/components/Delayed.tsx
@@ -11,7 +11,8 @@ export function Delayed({
 }) {
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
-    setTimeout(() => setIsMounted(true), delay);
+    const mountTimeout = setTimeout(() => setIsMounted(true), delay);
+    return () => clearTimeout(mountTimeout);
   }, [delay]);
 
   return isMounted ? (

--- a/langwatch/src/components/HoverableBigText.tsx
+++ b/langwatch/src/components/HoverableBigText.tsx
@@ -1,5 +1,5 @@
 import { Box, type BoxProps, HStack, Text, VStack } from "@chakra-ui/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { isJson } from "../utils/isJson";
 import { Markdown } from "./Markdown";
 import { RenderInputOutput } from "./traces/RenderInputOutput";
@@ -90,8 +90,13 @@ export function HoverableBigText({
     );
   };
 
-  // Check on every rerender
-  setTimeout(checkOverflow, 100);
+  // Re-measure after every render, once the browser has laid the box out.
+  // The handle is cleared on unmount and before the next render's probe, so a
+  // pending measurement can never run against a torn-down document.
+  useEffect(() => {
+    const timeout = setTimeout(checkOverflow, 100);
+    return () => clearTimeout(timeout);
+  });
 
   return (
     <>

--- a/langwatch/src/components/LoadingScreen.tsx
+++ b/langwatch/src/components/LoadingScreen.tsx
@@ -44,12 +44,17 @@ export const LoadingScreen = () => {
   reduceMotionRef.current = reduceMotion;
 
   useEffect(() => {
-    setTimeout(() => {
+    let logoSettledTimeout: ReturnType<typeof setTimeout> | undefined;
+    const showLogoTimeout = setTimeout(() => {
       setShowLogo(true);
-      setTimeout(() => {
+      logoSettledTimeout = setTimeout(() => {
         logoVisibleOnce = true;
       }, 500);
     }, 50);
+    return () => {
+      clearTimeout(showLogoTimeout);
+      if (logoSettledTimeout) clearTimeout(logoSettledTimeout);
+    };
   }, []);
 
   useIsomorphicLayoutEffect(() => {

--- a/langwatch/src/components/__tests__/HoverableBigText.unmount.integration.test.tsx
+++ b/langwatch/src/components/__tests__/HoverableBigText.unmount.integration.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * HoverableBigText measures its own box on a timer, because the measurement is
+ * only meaningful once the browser has laid the box out. A measurement left
+ * scheduled after the component is gone is not a leak that costs memory, it is
+ * a test-suite failure with no signal: the callback lands after the jsdom
+ * environment has been torn down, throws `window is not defined` outside any
+ * test's stack, and the shard exits non-zero while its own summary reports
+ * every test as passing. Whichever file happens to be running at that moment
+ * wears the blame.
+ *
+ * Spec: specs/components/hoverable-big-text-overflow.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HoverableBigText } from "../HoverableBigText";
+
+const renderText = () =>
+  render(<HoverableBigText>a very long value</HoverableBigText>, {
+    wrapper: ({ children }) => (
+      <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+    ),
+  });
+
+describe("HoverableBigText overflow probe lifetime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  describe("given the text is on the page with a measurement pending", () => {
+    describe("when it is unmounted before the measurement runs", () => {
+      /** @scenario The overflow measurement is dropped when the text is unmounted */
+      it("leaves nothing scheduled that could run after the page is gone", () => {
+        const view = renderText();
+        expect(
+          vi.getTimerCount(),
+          "the probe must be scheduled for this test to mean anything",
+        ).toBeGreaterThan(0);
+
+        view.unmount();
+
+        expect(
+          vi.getTimerCount(),
+          "no measurement may outlive the component",
+        ).toBe(0);
+        expect(() => vi.runAllTimers()).not.toThrow();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/experiments/BatchEvaluationV2.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2.tsx
@@ -16,7 +16,13 @@ import type { Experiment, Project } from "@prisma/client";
 import type { TRPCClientErrorLike } from "@trpc/client";
 import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
 import type { inferRouterOutputs } from "@trpc/server";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Download, ExternalLink } from "react-feather";
 import { useRouter } from "~/utils/compat/next-router";
 import { Link } from "../../components/ui/link";
@@ -205,16 +211,35 @@ export const useBatchEvaluationState = ({
     return { selectedRunId_, selectedRun };
   }, [selectedRunId, router.query.runId, batchEvaluationRuns.data?.runs]);
 
+  // The polling data in the deps churns while we wait, so the timeout is armed
+  // once through a ref instead of being re-armed on every re-run, which would
+  // push the deadline out forever.
+  const keepFetchingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
   useEffect(() => {
     if (selectedRunId && !selectedRun) {
       setKeepFetching(true);
-      setTimeout(() => {
-        setKeepFetching(false);
-      }, 5_000);
+      if (!keepFetchingTimerRef.current) {
+        keepFetchingTimerRef.current = setTimeout(() => {
+          keepFetchingTimerRef.current = null;
+          setKeepFetching(false);
+        }, 5_000);
+      }
     } else {
       setKeepFetching(false);
     }
   }, [batchEvaluationRuns.data?.runs, selectedRunId, selectedRun]);
+
+  useEffect(
+    () => () => {
+      if (keepFetchingTimerRef.current) {
+        clearTimeout(keepFetchingTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const setSelectedRunId_ = useCallback(
     (runId: string) => {

--- a/langwatch/src/components/experiments/BatchEvaluationV2.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2.tsx
@@ -172,6 +172,45 @@ export function BatchEvaluationV2({
   );
 }
 
+/**
+ * Polls as fast as the query allows while a selected run is missing from the
+ * fetched list, and gives up after a deadline.
+ *
+ * The deadline is armed once per wait, on a ref, rather than on every re-run:
+ * the run list churns while we wait, and re-arming on each change would push
+ * the deadline out for as long as the churn lasts, which is exactly the case
+ * it exists to stop.
+ */
+function useKeepFetchingWhileRunIsMissing(
+  isRunMissing: boolean,
+  setKeepFetching: (keepFetching: boolean) => void,
+) {
+  const deadlineRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isRunMissing) {
+      setKeepFetching(false);
+      return;
+    }
+    setKeepFetching(true);
+    if (!deadlineRef.current) {
+      deadlineRef.current = setTimeout(() => {
+        deadlineRef.current = null;
+        setKeepFetching(false);
+      }, 5_000);
+    }
+  }, [isRunMissing, setKeepFetching]);
+
+  useEffect(
+    () => () => {
+      if (deadlineRef.current) {
+        clearTimeout(deadlineRef.current);
+      }
+    },
+    [],
+  );
+}
+
 export const useBatchEvaluationState = ({
   project,
   experiment,
@@ -211,34 +250,9 @@ export const useBatchEvaluationState = ({
     return { selectedRunId_, selectedRun };
   }, [selectedRunId, router.query.runId, batchEvaluationRuns.data?.runs]);
 
-  // The polling data in the deps churns while we wait, so the timeout is armed
-  // once through a ref instead of being re-armed on every re-run, which would
-  // push the deadline out forever.
-  const keepFetchingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  useEffect(() => {
-    if (selectedRunId && !selectedRun) {
-      setKeepFetching(true);
-      if (!keepFetchingTimerRef.current) {
-        keepFetchingTimerRef.current = setTimeout(() => {
-          keepFetchingTimerRef.current = null;
-          setKeepFetching(false);
-        }, 5_000);
-      }
-    } else {
-      setKeepFetching(false);
-    }
-  }, [batchEvaluationRuns.data?.runs, selectedRunId, selectedRun]);
-
-  useEffect(
-    () => () => {
-      if (keepFetchingTimerRef.current) {
-        clearTimeout(keepFetchingTimerRef.current);
-      }
-    },
-    [],
+  useKeepFetchingWhileRunIsMissing(
+    !!selectedRunId && !selectedRun,
+    setKeepFetching,
   );
 
   const setSelectedRunId_ = useCallback(

--- a/langwatch/src/components/experiments/BatchEvaluationV2.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2.tsx
@@ -181,10 +181,13 @@ export function BatchEvaluationV2({
  * the deadline out for as long as the churn lasts, which is exactly the case
  * it exists to stop.
  */
-function useKeepFetchingWhileRunIsMissing(
-  isRunMissing: boolean,
-  setKeepFetching: (keepFetching: boolean) => void,
-) {
+function useKeepFetchingWhileRunIsMissing({
+  isRunMissing,
+  setKeepFetching,
+}: {
+  isRunMissing: boolean;
+  setKeepFetching: (isKeepFetching: boolean) => void;
+}) {
   const deadlineRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -250,10 +253,10 @@ export const useBatchEvaluationState = ({
     return { selectedRunId_, selectedRun };
   }, [selectedRunId, router.query.runId, batchEvaluationRuns.data?.runs]);
 
-  useKeepFetchingWhileRunIsMissing(
-    !!selectedRunId && !selectedRun,
+  useKeepFetchingWhileRunIsMissing({
+    isRunMissing: !!selectedRunId && !selectedRun,
     setKeepFetching,
-  );
+  });
 
   const setSelectedRunId_ = useCallback(
     (runId: string) => {

--- a/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
@@ -54,9 +54,10 @@ export const useBatchEvaluationResults = ({
 
   useEffect(() => {
     if (isFinished) {
-      setTimeout(() => {
+      const stopRefetchingTimeout = setTimeout(() => {
         setKeepRefetching(false);
       }, 2_000);
+      return () => clearTimeout(stopRefetchingTimeout);
     } else {
       setKeepRefetching(true);
     }

--- a/langwatch/src/components/messages/ExportProgress.tsx
+++ b/langwatch/src/components/messages/ExportProgress.tsx
@@ -28,12 +28,16 @@ export function ExportProgress({
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    let slideInFrame: number | undefined;
     if (isExporting) {
       // Trigger slide-in on next frame so transition applies
-      requestAnimationFrame(() => setVisible(true));
+      slideInFrame = requestAnimationFrame(() => setVisible(true));
     } else {
       setVisible(false);
     }
+    return () => {
+      if (slideInFrame !== undefined) cancelAnimationFrame(slideInFrame);
+    };
   }, [isExporting]);
 
   if (!isExporting) {

--- a/langwatch/src/components/messages/MessagesList.tsx
+++ b/langwatch/src/components/messages/MessagesList.tsx
@@ -244,7 +244,11 @@ const ExpandableMessages = React.memo(
         }
       });
       setCardHeights(newHeights);
-      setTimeout(() => setTransitionsEnabled(true), 100);
+      const enableTransitionsTimeout = setTimeout(
+        () => setTransitionsEnabled(true),
+        100,
+      );
+      return () => clearTimeout(enableTransitionsTimeout);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [traceGroups]);
 

--- a/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
+++ b/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
@@ -153,16 +153,23 @@ export default function OptimizationStudio() {
     }
   };
 
+  // The effect below clears the request it just handled, so its own dependency
+  // flips mid-flight and an effect-scoped cleanup would cut the expand
+  // animation short. The frame is tracked on a ref and cancelled on unmount.
+  const expandFrameRef = useRef<number | null>(null);
+
   useEffect(() => {
     if (openResultsPanelRequest === "evaluations") {
       panelRef.current?.expand(0);
       panelRef.current?.resize(6);
 
       const step = () => {
-        const size = panelRef.current?.getSize() ?? 0;
+        const panel = panelRef.current;
+        if (!panel) return;
+        const size = panel.getSize();
         if (size < 70) {
-          panelRef.current?.resize(size + 10);
-          window.requestAnimationFrame(step);
+          panel.resize(size + 10);
+          expandFrameRef.current = window.requestAnimationFrame(step);
         }
       };
       step();
@@ -173,6 +180,15 @@ export default function OptimizationStudio() {
     setOpenResultsPanelRequest(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openResultsPanelRequest]);
+
+  useEffect(
+    () => () => {
+      if (expandFrameRef.current !== null) {
+        window.cancelAnimationFrame(expandFrameRef.current);
+      }
+    },
+    [],
+  );
 
   // The Crisp bubble policy keeps the support bubble hidden app-wide unless
   // deliberately opened; re-assert on entering the studio so it can never

--- a/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
+++ b/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
@@ -155,10 +155,23 @@ export default function OptimizationStudio() {
 
   // The effect below clears the request it just handled, so its own dependency
   // flips mid-flight and an effect-scoped cleanup would cut the expand
-  // animation short. The frame is tracked on a ref and cancelled on unmount.
+  // animation short. The frame is tracked on a ref instead, cancelled on
+  // unmount and whenever a fresh request arrives.
   const expandFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
+    // A new request supersedes whatever the last one was still animating
+    // towards. Without this an in-flight expand keeps resizing the panel back
+    // up while a "closed" request is collapsing it. The cleared request that
+    // this effect writes at the end is not a new one, so it must not cancel.
+    if (
+      openResultsPanelRequest !== undefined &&
+      expandFrameRef.current !== null
+    ) {
+      window.cancelAnimationFrame(expandFrameRef.current);
+      expandFrameRef.current = null;
+    }
+
     if (openResultsPanelRequest === "evaluations") {
       panelRef.current?.expand(0);
       panelRef.current?.resize(6);

--- a/langwatch/src/optimization_studio/components/ResultsPanel.tsx
+++ b/langwatch/src/optimization_studio/components/ResultsPanel.tsx
@@ -135,12 +135,13 @@ export function EvaluationResults({
     if (evaluationState?.status === "running" && !experiment.data) {
       setKeepFetching(true);
     } else {
-      setTimeout(
+      const stopFetchingTimeout = setTimeout(
         () => {
           setKeepFetching(false);
         },
         experiment.data ? 0 : 15_000,
       );
+      return () => clearTimeout(stopFetchingTimeout);
     }
   }, [evaluationState?.status, experiment.data]);
 

--- a/langwatch/src/optimization_studio/components/UndoRedo.tsx
+++ b/langwatch/src/optimization_studio/components/UndoRedo.tsx
@@ -35,14 +35,18 @@ export function UndoRedo() {
 
   // Fix for initial state
   useEffect(() => {
+    let resumeTimeout: ReturnType<typeof setTimeout> | undefined;
     if (workflow.isFetched) {
-      setTimeout(() => {
+      resumeTimeout = setTimeout(() => {
         resume();
         clear();
       }, 1000);
     } else {
       pause();
     }
+    return () => {
+      if (resumeTimeout) clearTimeout(resumeTimeout);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflow.isFetched]);
 

--- a/langwatch/src/optimization_studio/components/VersionToBeUsed.tsx
+++ b/langwatch/src/optimization_studio/components/VersionToBeUsed.tsx
@@ -108,6 +108,13 @@ export function NewVersionFields({
 
   const userEditedCommitMessage = useRef(false);
   const hasTriggeredGeneration = useRef(false);
+  // The generation is one-shot, so the effect that schedules it never re-arms
+  // on a re-run. The handle therefore lives on a ref and is only dropped on
+  // unmount; clearing it per effect run would swallow the generation whenever
+  // the deps changed before the timeout fired.
+  const generateCommitMessageTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   const generateCommitMessageCallback = useCallback(
     (prevDsl: Workflow, newDsl: Workflow, options?: { force?: boolean }) => {
@@ -162,7 +169,8 @@ export function NewVersionFields({
         shouldDirty: true,
       });
       if (isModelConfigured) {
-        setTimeout(() => {
+        generateCommitMessageTimerRef.current = setTimeout(() => {
+          generateCommitMessageTimerRef.current = null;
           debouncedGenerateCommitMessage(previousVersion.dsl!, getWorkflow());
         }, 0);
       }
@@ -179,6 +187,15 @@ export function NewVersionFields({
     resolvedDefault.isFetched,
     isModelConfigured,
   ]);
+
+  useEffect(
+    () => () => {
+      if (generateCommitMessageTimerRef.current) {
+        clearTimeout(generateCommitMessageTimerRef.current);
+      }
+    },
+    [],
+  );
 
   // Only redden the fields once the user has actually attempted to submit.
   // The description is required and starts empty, so keying the ring on the

--- a/langwatch/src/optimization_studio/components/nodes/CustomNode.tsx
+++ b/langwatch/src/optimization_studio/components/nodes/CustomNode.tsx
@@ -30,9 +30,10 @@ const LatestComponentVersionCheck = ({
   useEffect(() => {
     if (currentVersion) {
       // Small timeout to ensure the DOM has updated
-      setTimeout(() => {
+      const updateInternalsTimeout = setTimeout(() => {
         updateNodeInternals(node.id);
       }, 0);
+      return () => clearTimeout(updateInternalsTimeout);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentVersion]);

--- a/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
@@ -152,9 +152,10 @@ export function FieldsDefinition({
     if (formSignature === fieldsSignature) return;
     replace(currentFields);
 
-    setTimeout(() => {
+    const updateInternalsTimeout = setTimeout(() => {
       updateNodeInternals(node.id);
     }, 0);
+    return () => clearTimeout(updateInternalsTimeout);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fieldsSignature]);
 

--- a/langwatch/src/pages/auth/error.tsx
+++ b/langwatch/src/pages/auth/error.tsx
@@ -104,7 +104,7 @@ export default function Error() {
       return;
     }
 
-    setTimeout(() => {
+    const redirectTimeout = setTimeout(() => {
       if (typeof window !== "undefined" && typeof document !== "undefined") {
         if (isAuth0) {
           const referrer = document.referrer;
@@ -121,6 +121,8 @@ export default function Error() {
         }
       }
     }, 5000);
+
+    return () => clearTimeout(redirectTimeout);
   }, [publicEnv.data, isAuth0, isAzureAD, session, error]);
 
   if (error) {

--- a/langwatch/src/pages/auth/signin.tsx
+++ b/langwatch/src/pages/auth/signin.tsx
@@ -49,19 +49,25 @@ export default function SignIn() {
       return;
     }
 
+    let signInTimeout: ReturnType<typeof setTimeout> | undefined;
+
     // Don't auto-redirect back to the identity provider on a stable failure
     // (wrong method / account collision): the IdP still holds a live session
     // for the failing identity, so re-initiating sign-in silently re-auths it
     // and traps the user in a loop. Those errors render SignInError with a
     // federated-logout recovery instead.
     if (!isStableAuthError(error) && isSocialProvider) {
-      setTimeout(
+      signInTimeout = setTimeout(
         () => {
           void signIn(isAuthProvider, { callbackUrl });
         },
         error ? 2000 : 0,
       );
     }
+
+    return () => {
+      if (signInTimeout) clearTimeout(signInTimeout);
+    };
   }, [
     publicEnv.data,
     session,

--- a/specs/components/hoverable-big-text-overflow.feature
+++ b/specs/components/hoverable-big-text-overflow.feature
@@ -45,3 +45,14 @@ Feature: Expanded text dialog handles overflow for large content
     Given a large JSON object displayed in the ExpandedTextDialog
     When I toggle the "Formatted" switch off
     Then all content is accessible within the dialog
+
+  # ============================================================================
+  # The overflow probe never outlives the component
+  # ============================================================================
+
+  @integration
+  Scenario: The overflow measurement is dropped when the text is unmounted
+    Given a HoverableBigText is on the page with its overflow probe pending
+    When the component is unmounted before the probe runs
+    Then no measurement remains scheduled
+    And running every pending timer raises nothing


### PR DESCRIPTION
Fixes #6384

`HoverableBigText` scheduled its overflow probe with a bare `setTimeout` in the **render body**, so every render armed a measurement that nothing could cancel:

```js
// Check on every rerender
setTimeout(checkOverflow, 100);
```

When a shard ran slowly the probe landed after jsdom teardown and threw `window is not defined` outside any test's stack. The shard exited 1 while its own summary reported all 950 tests across 122 files as passing, and the blame fell on whichever file happened to be running, most recently `EvaluationStatusItem.error.integration.test.tsx`, which has nothing to do with the component.

That is worse than an ordinary flake. A failure that reports everything green makes rerunning-until-it-passes the only sane response, and a real failure hiding behind the same exit code reads identically.

The probe now lives in an effect that clears its handle. Same cadence (no dependency array, so it still re-measures after every render), with the side benefit that a burst of renders collapses into one measurement instead of one per render.

## The sweep

An AST pass over every component and hook under `src/` classified all 380 `setTimeout` / `setInterval` / `requestAnimationFrame` / observer sites by whether the scheduled work can outlive the component.

**Scheduled directly in a render body: 1.** `HoverableBigText` was the only one, and re-running the sweep against this branch reports 0. That shape is the worst of the class because it is unconditional, unclearable, and fires in every test that renders the component.

**Armed in an effect with no cleanup: 31.** Each was read in context. 15 could genuinely outlive unmount and are fixed here. Three needed more than a clear-on-rerun and carry a comment saying why:

- **`OptimizationStudio`** read the panel size through a null ref after unmount (`panelRef.current?.getSize() ?? 0`), so its `size < 70` test stayed true and it **rescheduled a frame forever**: a per-frame callback that never stops, dereferencing `window` each iteration. It now bails on a missing panel, cancels on unmount, and drops an in-flight expand when a new panel request arrives (that last one from review: a `"closed"` request used to collapse the panel while the running expand kept pushing it back up).
- **`BatchEvaluationV2`** and **`VersionToBeUsed`** re-run while their deadline is pending, so an effect-scoped cleanup would push the deadline out forever, or swallow a one-shot commit-message generation. Both track the handle on a ref and clear it on unmount. Same pattern `useLangyTurnRecovery` already uses.

**Deliberately left: 14.** Re-running the sweep against this branch reports 18 remaining effect-armed sites; 4 of those are the ref-tracked ones above, which the scanner cannot see through because their clear lives in a separate unmount effect. The other 14 were each checked individually rather than waved through. The recurring reason is that the callback's first reachable statement dereferences a ref React sets to `null` during the unmount commit (`inputRef.current?.focus()`, `if (!containerRef.current) return;`, the `useImperativeHandle` panel handles in `PaneLayout`, whose recursion is bounded to 4 attempts), or it writes nothing but a ref field. Not "the delay is short", which is not a reason: a 0ms timer still fires in a later macrotask and can outlive an unmount.

**Observers: all clean.** Every `ResizeObserver`, `IntersectionObserver` and `MutationObserver` in the tree already disconnects, either in an effect cleanup or, in `WaterfallView`, via a callback ref that disconnects when React passes `null`.

## Tests

`src/components/__tests__/HoverableBigText.unmount.integration.test.tsx` renders, unmounts before the probe fires, and asserts nothing is left scheduled and that draining the queue raises nothing. Verified to fail against the old component:

```
AssertionError: no measurement may outlive the component: expected 1 to be +0
```

One scenario added to `specs/components/hoverable-big-text-overflow.feature` and bound. That file was previously inert (every scenario `@unimplemented`), so it comes off `LEGACY_INERT` in `check-feature-parity.ts`: the ratchet clicking, as that list documents.

Locally green: `pnpm typecheck`, `pnpm typecheck:tests`, `pnpm lint` (0 errors, and `.github/scripts/biome-new-violations.sh` run locally against `origin/main` reports no new violations; `biome.jsonc` is untouched), `pnpm check:feature-parity`, and 91 integration files / 636 tests across every suite touching the changed files (`src/components/__tests__`, `src/components/messages`, `src/components/experiments`, `src/components/traces`, `src/components/batch-evaluation-results`, `src/pages/auth`, `src/optimization_studio/components`, `src/experiments-v3`).

No UI change, so no screenshot: every edit is a cleanup path that runs at unmount, and the rendered output is byte-identical.


## Inherited CI

The `test-integration` shards are red on this branch and equally red on `main`, failing on `Correlated subqueries are not supported as IN function arguments yet ... FROM evaluation_runs`. That is #6383, which bounded the `evaluation_runs` JOIN on a column that table does not have; #6391 is the revert. Not chased here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of delayed actions during navigation, unmounting, and state changes.
  * Stabilized polling, animations, redirects, exports, dataset interactions, and optimization workflows.
  * Prevented stale updates and unexpected errors in evaluation and optimization features.

* **Tests**
  * Added coverage confirming overflow measurement is safely canceled when text components are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->