### PR TITLE
fix(analytics): bound the evaluation_runs JOIN so it prunes partitions; env-driven ClickHouse pool size

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -175,6 +175,42 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("1__evaluations_evaluation_pass_rate__avg");
     });
 
+    // The query windows on trace OccurredAt, but evaluation_runs partitions on
+    // ScheduledAt (UpdatedAt on older deployments) — an OccurredAt filter prunes
+    // nothing there, so an unbounded JOIN subquery walks the tenant's ENTIRE
+    // evaluation history across every partition, including S3-tiered cold ones.
+    // Measured in production at ~900 executions / 6,400s of query time per
+    // 30min on a single worker pod before the bound existed.
+    it("bounds the evaluation_runs JOIN subquery on both candidate partition columns", () => {
+      const input = {
+        ...baseInput,
+        series: [
+          {
+            metric:
+              "evaluations.evaluation_pass_rate" as FlattenAnalyticsMetricsEnum,
+            aggregation: "avg" as const,
+            key: "my-evaluator",
+          },
+        ],
+      };
+      const result = buildTimeseriesQuery(input);
+
+      expect(result.sql).toContain(
+        "ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY",
+      );
+      // Table-qualified: trace_summaries also has UpdatedAt, and a bare
+      // identifier would silently resolve against the outer scope.
+      expect(result.sql).toContain(
+        "evaluation_runs.UpdatedAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY",
+      );
+      // The bound must reach the dedup inner scan too — it appears once in the
+      // outer subquery WHERE and once inside the IN-tuple dedup subquery.
+      const scheduledBounds =
+        result.sql.split("ScheduledAt >= {previousStart:DateTime64(3)}")
+          .length - 1;
+      expect(scheduledBounds).toBeGreaterThanOrEqual(2);
+    });
+
     // @regression issue #3088: When timeScale is "full" (summary widgets) with mixed eval and
     // trace metrics, the previous routing fell through to buildSubqueryTimeseriesQuery which
     // still joined evaluation_runs directly and inflated sum(ts.TotalCost) by the number of

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -195,8 +195,11 @@ describe("aggregation-builder", () => {
       };
       const result = buildTimeseriesQuery(input);
 
+      // NULL-safe: legacy deployments carry ScheduledAt Nullable(DateTime64(3)),
+      // where a bare `ScheduledAt >= x` evaluates NULL for NULL rows and
+      // silently drops those evaluations from every graph.
       expect(result.sql).toContain(
-        "ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY",
+        "(ScheduledAt IS NULL OR ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY)",
       );
       // Table-qualified: trace_summaries also has UpdatedAt, and a bare
       // identifier would silently resolve against the outer scope.

--- a/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
@@ -229,6 +229,35 @@ describe("field-mappings", () => {
       });
       expect(join).not.toContain("StartTime");
     });
+
+    it("applies the eval time filter to BOTH the evaluation_runs subquery and its dedup inner", () => {
+      const filter =
+        "AND ScheduledAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY " +
+        "AND UpdatedAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY";
+      const join = buildJoinClause({
+        table: "evaluation_runs",
+        evalTimeFilter: filter,
+      });
+      // The dedup inner GROUP BY is the scan that walks partitions — a bound
+      // only on the outer subquery would leave the full-history scan in place.
+      const occurrences = join.split(filter).length - 1;
+      expect(occurrences).toBe(2);
+    });
+
+    it("leaves the evaluation_runs JOIN unbounded when no eval filter is passed", () => {
+      const join = buildJoinClause({ table: "evaluation_runs" });
+      expect(join).not.toContain("ScheduledAt >=");
+      expect(join).not.toContain("UpdatedAt >= {");
+    });
+
+    it("ignores the eval time filter for stored_spans", () => {
+      const filter = "AND ScheduledAt >= {startDate:DateTime64(3)}";
+      const join = buildJoinClause({
+        table: "stored_spans",
+        evalTimeFilter: filter,
+      });
+      expect(join).not.toContain("ScheduledAt");
+    });
   });
 
   describe("qualifiedColumn", () => {

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -102,11 +102,20 @@ const SPAN_TIME_FILTER_START_END =
 // pins the reference to evaluation_runs' own column so neither ClickHouse nor
 // the guard has to guess. ScheduledAt stays bare: it is evaluation_runs' own
 // partition column per the migrations and does not exist on trace_summaries.
+//
+// The ScheduledAt bound is NULL-safe. On the unified schema (00002) the column
+// is `DateTime64(3) DEFAULT now64(3)` and the IS NULL branch is statically
+// false, so partition pruning is unaffected. But long-lived deployments that
+// predate the unified DDL carry `ScheduledAt Nullable(DateTime64(3))`, where a
+// bare `ScheduledAt >= x` evaluates to NULL for NULL rows and silently DROPS
+// those evaluations from every graph — a correctness regression, not a missed
+// optimisation. NULL rows on such deployments are still bounded by the
+// UpdatedAt predicate, which is their actual partition column anyway.
 const EVAL_TIME_FILTER_BOTH_PERIODS =
-  "AND ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND (ScheduledAt IS NULL OR ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY) " +
   "AND evaluation_runs.UpdatedAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY";
 const EVAL_TIME_FILTER_START_END =
-  "AND ScheduledAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND (ScheduledAt IS NULL OR ScheduledAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY) " +
   "AND evaluation_runs.UpdatedAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY";
 
 /**

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -79,6 +79,36 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
+// Partition-pruning bounds for the evaluation_runs JOIN subquery. The query
+// windows on trace OccurredAt, but evaluation_runs is partitioned by
+// ScheduledAt per the migrations (and by UpdatedAt on long-lived deployments
+// that predate that DDL), so an OccurredAt filter prunes nothing there —
+// without these bounds the JOIN's dedup subquery walks the tenant's entire
+// history across every weekly partition, including the S3-tiered cold ones.
+//
+// Lower bounds only, on BOTH candidate partition columns, so pruning works on
+// either partitioning scheme. Safe as a superset: an evaluation joined to an
+// in-window trace is scheduled at/after that trace occurs, and every row
+// version's UpdatedAt >= its ScheduledAt, so both columns are >= the window
+// start minus scheduling skew — far inside the 7-day margin (partitions are
+// weekly, so the margin costs at most one extra partition). No upper bound:
+// a re-evaluation updates rows long after the window, and the IN-tuple dedup
+// must still see that latest version.
+//
+// UpdatedAt is table-qualified. trace_summaries (the outer scope) also has an
+// UpdatedAt column, and ClickHouse resolves a bare identifier the inner table
+// lacks against the OUTER scope instead of failing — the hazard
+// `join-time-bound-partition-column.unit.test.ts` guards against. Qualifying
+// pins the reference to evaluation_runs' own column so neither ClickHouse nor
+// the guard has to guess. ScheduledAt stays bare: it is evaluation_runs' own
+// partition column per the migrations and does not exist on trace_summaries.
+const EVAL_TIME_FILTER_BOTH_PERIODS =
+  "AND ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND evaluation_runs.UpdatedAt >= {previousStart:DateTime64(3)} - INTERVAL 7 DAY";
+const EVAL_TIME_FILTER_START_END =
+  "AND ScheduledAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY " +
+  "AND evaluation_runs.UpdatedAt >= {startDate:DateTime64(3)} - INTERVAL 7 DAY";
+
 /**
  * Returns a deduped FROM-clause expression for trace_summaries.
  *
@@ -783,12 +813,14 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   const joinClauses = Array.from(allJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, allExpressions);
-      // Both-periods regime: bound the stored_spans JOIN to the same StartTime
-      // envelope as the outer OccurredAt filter so it prunes partitions.
+      // Both-periods regime: bound the stored_spans / evaluation_runs JOINs to
+      // the same date envelope as the outer OccurredAt filter so they prune
+      // partitions.
       return buildJoinClause({
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+        evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
       });
     })
     .join("\n");
@@ -2273,11 +2305,13 @@ function buildDateBucketedPipelineQuery({
     const simpleJoinClauses = Array.from(simpleJoins)
       .map((table) => {
         const requiredColumns = resolveRequiredColumns(table, allSimpleExprs);
-        // Both-periods regime: bound the stored_spans JOIN to the date envelope.
+        // Both-periods regime: bound the stored_spans / evaluation_runs JOINs
+        // to the date envelope.
         return buildJoinClause({
           table,
           requiredColumns,
           spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+          evalTimeFilter: EVAL_TIME_FILTER_BOTH_PERIODS,
         });
       })
       .join("\n");
@@ -2724,11 +2758,13 @@ export function buildDataForFilterQuery(
   const filterJoins = Array.from(filterTranslation.requiredJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, filterExpressions);
-      // Start/end regime: bound the stored_spans JOIN to the date envelope.
+      // Start/end regime: bound the stored_spans / evaluation_runs JOINs to
+      // the date envelope.
       return buildJoinClause({
         table,
         requiredColumns,
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
       });
     })
     .join("\n");
@@ -2874,7 +2910,10 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause({ table: "evaluation_runs" });
+      joins = buildJoinClause({
+        table: "evaluation_runs",
+        evalTimeFilter: EVAL_TIME_FILTER_START_END,
+      });
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -493,15 +493,25 @@ export function getTableAlias(table: CHTable): string {
  *   on `TenantId` only and cold-scans every weekly partition (incl. S3-tiered
  *   ones). The caller passes the fragment matching its date regime; the referenced
  *   params are bound by the outer query. Ignored for non-`stored_spans` tables.
+ * @param evalTimeFilter - Optional SQL fragment bounding the `evaluation_runs`
+ *   subquery's partition column (e.g. `AND ScheduledAt >= {startDate} - INTERVAL
+ *   7 DAY AND UpdatedAt >= {startDate} - INTERVAL 7 DAY`). Same disease as
+ *   `spanTimeFilter`: without it the subquery — and its IN-tuple dedup inner —
+ *   filter on `TenantId` only and walk the tenant's entire history across every
+ *   partition. Applied to BOTH the outer subquery and the dedup inner, since the
+ *   inner GROUP BY is the scan that actually walks the partitions. Ignored for
+ *   non-`evaluation_runs` tables.
  */
 export function buildJoinClause({
   table,
   requiredColumns,
   spanTimeFilter,
+  evalTimeFilter,
 }: {
   table: CHTable;
   requiredColumns?: ReadonlySet<string>;
   spanTimeFilter?: string;
+  evalTimeFilter?: string;
 }): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
@@ -518,13 +528,14 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
+      const evalTimeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
-        WHERE TenantId = {tenantId:String}
+        WHERE TenantId = {tenantId:String}${evalTimeBound}
           AND (TenantId, EvaluationId, UpdatedAt) IN (
             SELECT TenantId, EvaluationId, max(UpdatedAt)
             FROM evaluation_runs
-            WHERE TenantId = {tenantId:String}
+            WHERE TenantId = {tenantId:String}${evalTimeBound}
             GROUP BY TenantId, EvaluationId
           )
       ) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;

--- a/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@clickhouse/client";
 import { ClickHouseLogger } from "~/server/clickhouse/clickhouseLogger";
+import { getClickHouseMaxOpenConnections } from "~/server/clickhouse/connectionPool";
 import type { ResilientClickHouseClient } from "./clickhouse/resilient-client";
 import { createResilientClickHouseClient } from "./clickhouse.resilient";
 
@@ -23,7 +24,7 @@ export function createClickHouseClientFromConfig(
   const raw = createClient({
     url,
     clickhouse_settings: { date_time_input_format: "best_effort" },
-    max_open_connections: 25,
+    max_open_connections: getClickHouseMaxOpenConnections(),
     keep_alive: {
       enabled: true,
       idle_socket_ttl: 1500,

--- a/langwatch/src/server/clickhouse/__tests__/connectionPool.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/connectionPool.unit.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getClickHouseMaxOpenConnections } from "../connectionPool";
+
+describe("getClickHouseMaxOpenConnections", () => {
+  const original = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+    } else {
+      process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS = original;
+    }
+  });
+
+  describe("when the env var is unset", () => {
+    it("returns the default of 64", () => {
+      delete process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+      expect(getClickHouseMaxOpenConnections()).toBe(64);
+    });
+  });
+
+  describe("when the env var holds a valid integer", () => {
+    it("returns that value", () => {
+      process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS = "128";
+      expect(getClickHouseMaxOpenConnections()).toBe(128);
+    });
+
+    it("accepts the lower bound of 1", () => {
+      process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS = "1";
+      expect(getClickHouseMaxOpenConnections()).toBe(1);
+    });
+  });
+
+  describe("when the env var is invalid", () => {
+    it.each([
+      ["non-numeric", "lots"],
+      ["zero", "0"],
+      ["negative", "-5"],
+      ["fractional", "2.5"],
+      ["above the hard cap", "5000"],
+      ["empty string", ""],
+    ])("falls back to the default for %s", (_label, raw) => {
+      process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS = raw;
+      expect(getClickHouseMaxOpenConnections()).toBe(64);
+    });
+  });
+});

--- a/langwatch/src/server/clickhouse/client.ts
+++ b/langwatch/src/server/clickhouse/client.ts
@@ -2,6 +2,7 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import { createLogger } from "@langwatch/observability";
 import { createResilientClickHouseClient } from "~/server/app-layer/clients/clickhouse.resilient";
 import { ClickHouseLogger } from "./clickhouseLogger";
+import { getClickHouseMaxOpenConnections } from "./connectionPool";
 import { wrapWithDefaultSettings } from "./safeClickhouseClient";
 
 const logger = createLogger("langwatch:clickhouse:client");
@@ -62,7 +63,7 @@ function getClickHouseClient(): ClickHouseClient | null {
       clickhouse_settings: {
         date_time_input_format: "best_effort",
       },
-      max_open_connections: 25,
+      max_open_connections: getClickHouseMaxOpenConnections(),
       keep_alive: {
         enabled: true,
         idle_socket_ttl: 1500,

--- a/langwatch/src/server/clickhouse/connectionPool.ts
+++ b/langwatch/src/server/clickhouse/connectionPool.ts
@@ -3,20 +3,24 @@ import { createLogger } from "@langwatch/observability";
 const logger = createLogger("langwatch:clickhouse:connection-pool");
 
 /**
- * Default HTTP connection pool size per ClickHouse client.
+ * Default HTTP connection pool size per ClickHouse client INSTANCE — each
+ * `createClient` call (`~/server/clickhouse/client.ts` and
+ * `~/server/app-layer/clients/clickhouse.factory.ts`) gets its own pool, so a
+ * process holding both can open up to 2x this value. The server budget must
+ * therefore sum every client pool across every pod.
  *
- * Sizing note: the pool bounds this process's concurrent in-flight queries.
- * The historical value of 25 predated the event-sourcing dispatch concurrency
- * (GLOBAL_QUEUE_CONCURRENCY=256 in production) and became the system
- * bottleneck: with 4 worker pods the server showed exactly 4 x 25 = 100 open
- * connections pinned at cap while sitting at a third of its
+ * Sizing note: the historical value of 25 predated the event-sourcing dispatch
+ * concurrency (GLOBAL_QUEUE_CONCURRENCY=256 in production) and became the
+ * system bottleneck: with 4 worker pods the server showed exactly 4 x 25 = 100
+ * open connections pinned at cap while sitting at a third of its
  * `max_concurrent_queries` (300) and answering in ~55ms — workers measured
  * multi-second latency for those same queries, all of it client-side queueing
  * for a pooled socket.
  *
- * 64 keeps a 4-pod worker fleet (256 potential concurrent queries) within the
- * server's 300-query ceiling. Deployments with more replicas or a different
- * server budget tune CLICKHOUSE_MAX_OPEN_CONNECTIONS instead of editing code.
+ * 64 keeps a 4-pod worker fleet driving one hot client each (256 potential
+ * concurrent queries) within the server's 300-query ceiling. Deployments with
+ * more replicas, both clients hot, or a different server budget tune
+ * CLICKHOUSE_MAX_OPEN_CONNECTIONS instead of editing code.
  */
 const DEFAULT_MAX_OPEN_CONNECTIONS = 64;
 

--- a/langwatch/src/server/clickhouse/connectionPool.ts
+++ b/langwatch/src/server/clickhouse/connectionPool.ts
@@ -1,0 +1,46 @@
+import { createLogger } from "@langwatch/observability";
+
+const logger = createLogger("langwatch:clickhouse:connection-pool");
+
+/**
+ * Default HTTP connection pool size per ClickHouse client.
+ *
+ * Sizing note: the pool bounds this process's concurrent in-flight queries.
+ * The historical value of 25 predated the event-sourcing dispatch concurrency
+ * (GLOBAL_QUEUE_CONCURRENCY=256 in production) and became the system
+ * bottleneck: with 4 worker pods the server showed exactly 4 x 25 = 100 open
+ * connections pinned at cap while sitting at a third of its
+ * `max_concurrent_queries` (300) and answering in ~55ms — workers measured
+ * multi-second latency for those same queries, all of it client-side queueing
+ * for a pooled socket.
+ *
+ * 64 keeps a 4-pod worker fleet (256 potential concurrent queries) within the
+ * server's 300-query ceiling. Deployments with more replicas or a different
+ * server budget tune CLICKHOUSE_MAX_OPEN_CONNECTIONS instead of editing code.
+ */
+const DEFAULT_MAX_OPEN_CONNECTIONS = 64;
+
+/** Hard bounds so a typo'd env value cannot melt the server or re-choke the client. */
+const MIN_POOL = 1;
+const MAX_POOL = 1024;
+
+/**
+ * Resolve the ClickHouse client pool size from
+ * `CLICKHOUSE_MAX_OPEN_CONNECTIONS`, falling back to the default when unset
+ * or invalid. Shared by every ClickHouse client construction site so the
+ * knob stays one env var.
+ */
+export function getClickHouseMaxOpenConnections(): number {
+  const raw = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+  if (raw === undefined || raw === "") return DEFAULT_MAX_OPEN_CONNECTIONS;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < MIN_POOL || parsed > MAX_POOL) {
+    logger.warn(
+      { raw, default: DEFAULT_MAX_OPEN_CONNECTIONS },
+      "Invalid CLICKHOUSE_MAX_OPEN_CONNECTIONS; using default",
+    );
+    return DEFAULT_MAX_OPEN_CONNECTIONS;
+  }
+  return parsed;
+}


### PR DESCRIPTION
## For humans

Production has been degrading every business morning: the event-sourcing queue backs up, trace visibility lags by minutes, and the `/api/health/processor` monitor fires. Two compounding causes, both fixed here:

1. **Evaluation analytics queries were reading the tenant's entire evaluation history on every run.** The date filter they carried couldn't prune anything, because it filtered a column the table isn't partitioned by. One worker pod was measured spending 6,400 seconds of ClickHouse time per half hour on ~900 of these.
2. **Every process capped itself at 25 ClickHouse connections** — sized years before today's dispatch concurrency (256). Workers queued multi-second for queries the server answered in 55ms while the server sat at a third of its capacity.

## What changed

**1. `buildJoinClause` gains an `evalTimeFilter`** (mirroring the existing `spanTimeFilter` fix for `stored_spans`), applied to both the `evaluation_runs` JOIN subquery **and its IN-tuple dedup inner scan** — the inner scan is what actually walks the partitions. All call sites (both-periods regime, start/end regime, and the evaluator facet queries) pass lower bounds on **both** candidate partition columns:

- `ScheduledAt` — the partition column per the migrations
- `evaluation_runs.UpdatedAt` — the partition column on longer-lived deployments that predate that DDL (schema drift observed in production)

Lower bounds only, 7-day margin: an evaluation joined to an in-window trace is scheduled at/after the trace occurs, and every row version's `UpdatedAt >= ScheduledAt`, so the bound is a strict superset of correct results. No upper bound — re-evaluations update rows after the window and the dedup must still see the latest version. `UpdatedAt` is table-qualified because `trace_summaries` also has one and ClickHouse silently resolves a bare unknown identifier against the outer scope (the exact hazard the `join-time-bound-partition-column` guard test exists for — that guard now passes with the qualified form).

**2. `max_open_connections` is env-driven** via `CLICKHOUSE_MAX_OPEN_CONNECTIONS` (default 64, clamped to [1,1024]) from one shared helper (`src/server/clickhouse/connectionPool.ts`), replacing the hardcoded 25 in both construction sites. 64 keeps a 4-pod worker fleet within the server's `max_concurrent_queries` ceiling of 300.

## Evidence (production, 2026-07-31)

| | 05:00 (healthy) | 06:00 (degraded) |
|---|---|---|
| eval analytics executions | 167 | 6,188 |
| bytes read by that shape | 29 GiB | 1.19 TiB |
| ClickHouse SELECT p95 | 58ms | 2,016ms |
| queue completed/s | 198 | 133–169 |

Server-side HTTP connections sat at exactly 100 = 4 pods × 25 while workers self-measured 5,747ms for scans ClickHouse served in 55ms — pure client-side pool queueing.

## Tests

- `field-mappings.test.ts`: bound applied to both outer subquery and dedup inner; absent when not passed; ignored for other tables
- `aggregation-builder.test.ts`: generated SQL carries both partition-column bounds, dedup inner included
- `connectionPool.unit.test.ts`: default / valid / invalid env parsing
- Existing guard `join-time-bound-partition-column.unit.test.ts` passes (it rejected the unqualified first draft — working as designed)
- Integration suites (`filter-evaluation-queries`, `cross-evaluator-groupby`, `evaluation-passed-score-only`) pass against real ClickHouse — the new bounds execute inside the IN-dedup without the correlated-subquery failure
- `pnpm typecheck` + `pnpm typecheck:tests` clean

## Not in this PR (follow-ups from the same incident)

- Workload isolation: separate CH client/user for analytics (`CLICKHOUSE_ANALYTICS_URL`)
- Append-coalescing for rollup pipelines (6k executions/hr is re-computation, not load)
- HPA scales workers on CPU, which drops during I/O-bound backlogs — scale on queue depth instead
- Worker liveness probe kills on downstream slowness (restart storms drop in-flight work)
- Schema drift: production `evaluation_runs` partitions by `UpdatedAt`, migrations say `ScheduledAt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved analytics query performance with more precise evaluation-run time boundaries and partition pruning.
  * Added configurable ClickHouse connection pooling with safe defaults, validation, and support for environment-based sizing.

* **Bug Fixes**
  * Improved consistency when applying evaluation-run time filters across analytics queries.
  * Preserved results for records without scheduled times.

* **Tests**
  * Added coverage for analytics time filtering, query optimization, and connection-pool configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->