### PR TITLE
test(analytics): execute the evaluation_runs JOIN bounds, and let the guard see qualified ones

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
@@ -17,7 +17,8 @@
  *   it (the offline-experiment / re-run shape), still reaches the graph;
  * - row versions of one evaluation spread across weekly partitions, inserted
  *   out of `UpdatedAt` order, collapse to the newest and only the newest;
- * - two versions tied on `UpdatedAt` do not fan the evaluation out into two.
+ * - two versions tied on `UpdatedAt` both survive the dedup, which a distinct
+ *   count and an average absorb and a summed metric does not.
  *
  * @see https://github.com/langwatch/langwatch/issues/6392
  */
@@ -37,7 +38,10 @@ import {
   buildTimeseriesQuery,
 } from "../aggregation-builder";
 import { resetParamCounter } from "../filter-translator";
-import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
+import {
+  deleteEvaluationRunsByTenant,
+  deleteTraceSummariesByTenant,
+} from "./test-utils/clickhouse-cleanup";
 
 const TENANT_ID = "test-eval-join-bounds-6392";
 
@@ -184,6 +188,12 @@ describe("evaluation_runs JOIN time bounds", () => {
     const rawClient = getTestClickHouseClient();
     if (!rawClient) throw new Error("ClickHouse client not available");
     ch = wrapWithDefaultSettings(rawClient);
+
+    // Every assertion below is an exact count or an exact aggregate, so the
+    // tenant has to be empty before seeding: rows surviving an aborted run
+    // would join this one and inflate all of them.
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
+    await deleteTraceSummariesByTenant({ client: ch, tenantId: TENANT_ID });
 
     await ch.insert({
       table: "trace_summaries",
@@ -336,21 +346,30 @@ describe("evaluation_runs JOIN time bounds", () => {
   });
 
   describe("given two row versions of one evaluation tied on UpdatedAt", () => {
-    /** @scenario A tie on UpdatedAt does not fan one evaluation out into two */
-    it("counts the evaluation once and keeps its score", async () => {
+    /** @scenario A tie on UpdatedAt leaves both row versions in the join */
+    it("keeps the count and the average, and doubles a summed metric", async () => {
       const runs = await currentPeriodMetric(
         "evaluations.evaluation_runs",
         "cardinality",
         TIED_EVALUATOR,
       );
-      const score = await currentPeriodMetric(
+      const avg = await currentPeriodMetric(
         "evaluations.evaluation_score",
         "avg",
         TIED_EVALUATOR,
       );
+      const sum = await currentPeriodMetric(
+        "evaluations.evaluation_score",
+        "sum",
+        TIED_EVALUATOR,
+      );
 
+      // The dedup keeps every version whose UpdatedAt equals the max, so a tie
+      // keeps both. A distinct count and an average absorb that; a sum does
+      // not. The bounds do not change it either way: both versions clear them.
       expect(runs).toBe(1);
-      expect(score).toBeCloseTo(0.25, 10);
+      expect(avg).toBeCloseTo(0.25, 10);
+      expect(sum).toBeCloseTo(0.5, 10);
     });
   });
 });

--- a/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
@@ -160,11 +160,15 @@ function metricValue(rows: Row[], period: string): number {
 describe("evaluation_runs JOIN time bounds", () => {
   let ch: ClickHouseClient;
 
-  async function currentPeriodMetric(
-    metric: string,
-    aggregation: AggregationTypes,
-    evaluatorId: string,
-  ): Promise<number> {
+  async function currentPeriodMetric({
+    metric,
+    aggregation,
+    evaluatorId,
+  }: {
+    metric: string;
+    aggregation: AggregationTypes;
+    evaluatorId: string;
+  }): Promise<number> {
     resetParamCounter();
     const { sql, params } = buildTimeseriesQuery({
       ...baseInput,
@@ -285,22 +289,22 @@ describe("evaluation_runs JOIN time bounds", () => {
   describe("given an evaluation scheduled long after the queried window, on a trace inside it", () => {
     /** @scenario An evaluation scheduled after the queried window still scores its in-window trace */
     it("returns the evaluation score", async () => {
-      const score = await currentPeriodMetric(
-        "evaluations.evaluation_score",
-        "avg",
-        LATE_EVALUATOR,
-      );
+      const score = await currentPeriodMetric({
+        metric: "evaluations.evaluation_score",
+        aggregation: "avg",
+        evaluatorId: LATE_EVALUATOR,
+      });
 
       expect(score).toBeCloseTo(0.7, 10);
     });
 
     /** @scenario Both late-scheduled evaluations are counted, not just the nearest one */
     it("counts every late-scheduled evaluation", async () => {
-      const runs = await currentPeriodMetric(
-        "evaluations.evaluation_runs",
-        "cardinality",
-        LATE_EVALUATOR,
-      );
+      const runs = await currentPeriodMetric({
+        metric: "evaluations.evaluation_runs",
+        aggregation: "cardinality",
+        evaluatorId: LATE_EVALUATOR,
+      });
 
       expect(runs).toBe(2);
     });
@@ -329,16 +333,16 @@ describe("evaluation_runs JOIN time bounds", () => {
   describe("given one evaluation with row versions across weekly partitions, inserted out of UpdatedAt order", () => {
     /** @scenario The dedup keeps the newest version of an evaluation spread across partitions */
     it("scores the evaluation from its newest version only", async () => {
-      const avg = await currentPeriodMetric(
-        "evaluations.evaluation_score",
-        "avg",
-        VERSIONED_EVALUATOR,
-      );
-      const sum = await currentPeriodMetric(
-        "evaluations.evaluation_score",
-        "sum",
-        VERSIONED_EVALUATOR,
-      );
+      const avg = await currentPeriodMetric({
+        metric: "evaluations.evaluation_score",
+        aggregation: "avg",
+        evaluatorId: VERSIONED_EVALUATOR,
+      });
+      const sum = await currentPeriodMetric({
+        metric: "evaluations.evaluation_score",
+        aggregation: "sum",
+        evaluatorId: VERSIONED_EVALUATOR,
+      });
 
       expect(avg).toBeCloseTo(1, 10);
       expect(sum).toBeCloseTo(1, 10);
@@ -347,22 +351,22 @@ describe("evaluation_runs JOIN time bounds", () => {
 
   describe("given two row versions of one evaluation tied on UpdatedAt", () => {
     /** @scenario A tie on UpdatedAt leaves both row versions in the join */
-    it("keeps the count and the average, and doubles a summed metric", async () => {
-      const runs = await currentPeriodMetric(
-        "evaluations.evaluation_runs",
-        "cardinality",
-        TIED_EVALUATOR,
-      );
-      const avg = await currentPeriodMetric(
-        "evaluations.evaluation_score",
-        "avg",
-        TIED_EVALUATOR,
-      );
-      const sum = await currentPeriodMetric(
-        "evaluations.evaluation_score",
-        "sum",
-        TIED_EVALUATOR,
-      );
+    it("reads both tied versions when it queries the evaluator's runs and score", async () => {
+      const runs = await currentPeriodMetric({
+        metric: "evaluations.evaluation_runs",
+        aggregation: "cardinality",
+        evaluatorId: TIED_EVALUATOR,
+      });
+      const avg = await currentPeriodMetric({
+        metric: "evaluations.evaluation_score",
+        aggregation: "avg",
+        evaluatorId: TIED_EVALUATOR,
+      });
+      const sum = await currentPeriodMetric({
+        metric: "evaluations.evaluation_score",
+        aggregation: "sum",
+        evaluatorId: TIED_EVALUATOR,
+      });
 
       // The dedup keeps every version whose UpdatedAt equals the max, so a tie
       // keeps both. A distinct count and an average absorb that; a sum does

--- a/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Executed-SQL coverage for the `evaluation_runs` JOIN's partition bounds.
+ *
+ * The JOIN subquery and its IN-tuple dedup inner are both bounded below on
+ * `ScheduledAt` and `evaluation_runs.UpdatedAt`, so the weekly partitions prune
+ * instead of the tenant's whole evaluation history being walked on every graph.
+ * The bounds are lower-only, and that is the whole correctness argument: an
+ * evaluation is inserted at or after the trace it scores, but it can be
+ * scheduled arbitrarily later than the window the graph asks about, and a
+ * re-evaluation writes a newer row version later still.
+ *
+ * Every other analytics fixture schedules the evaluation at the same instant as
+ * its trace, so none of them can tell a lower bound from an upper one. These
+ * cases pin the shapes that can:
+ *
+ * - an evaluation scheduled months AFTER the queried window, on a trace inside
+ *   it (the offline-experiment / re-run shape), still reaches the graph;
+ * - row versions of one evaluation spread across weekly partitions, inserted
+ *   out of `UpdatedAt` order, collapse to the newest and only the newest;
+ * - two versions tied on `UpdatedAt` do not fan the evaluation out into two.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/6392
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import type { FilterField } from "../../../filters/types";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import type { AggregationTypes } from "../../types";
+import {
+  buildDataForFilterQuery,
+  buildTimeseriesQuery,
+} from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
+
+const TENANT_ID = "test-eval-join-bounds-6392";
+
+/**
+ * June 2025, with May as the comparison period. The generated bound sits 7 days
+ * below the previous period's start (2025-04-24), so anything the fixtures
+ * schedule after that date is inside the bound and anything before it is not.
+ */
+const baseInput = {
+  projectId: TENANT_ID,
+  startDate: new Date("2025-06-01T00:00:00Z"),
+  endDate: new Date("2025-07-01T00:00:00Z"),
+  previousPeriodStartDate: new Date("2025-05-01T00:00:00Z"),
+  timeScale: "full" as const,
+};
+
+const LATE_EVALUATOR = "eval-bounds-6392-late-scheduled";
+const VERSIONED_EVALUATOR = "eval-bounds-6392-versioned";
+const TIED_EVALUATOR = "eval-bounds-6392-tied";
+
+const TRACE_LATE_A = `${TENANT_ID}-trace-late-a`;
+const TRACE_LATE_B = `${TENANT_ID}-trace-late-b`;
+const TRACE_VERSIONED = `${TENANT_ID}-trace-versioned`;
+const TRACE_TIED = `${TENANT_ID}-trace-tied`;
+
+/** Every trace sits inside the queried window; only the evaluations move. */
+const traceOccurredAt: Record<string, string> = {
+  [TRACE_LATE_A]: "2025-06-10T12:00:00Z",
+  [TRACE_LATE_B]: "2025-06-11T12:00:00Z",
+  [TRACE_VERSIONED]: "2025-06-12T12:00:00Z",
+  [TRACE_TIED]: "2025-06-13T12:00:00Z",
+};
+
+function traceSummaryRow(traceId: string) {
+  const occurredAt = traceOccurredAt[traceId]!;
+  return {
+    ProjectionId: `proj-${traceId}`,
+    TenantId: TENANT_ID,
+    TraceId: traceId,
+    Version: "1",
+    Attributes: {},
+    OccurredAt: occurredAt,
+    CreatedAt: occurredAt,
+    UpdatedAt: occurredAt,
+    ComputedIOSchemaVersion: "",
+    ComputedInput: "",
+    ComputedOutput: "",
+    TotalDurationMs: 0,
+    SpanCount: 1,
+    ContainsErrorStatus: 0,
+    ContainsOKStatus: 1,
+    Models: [],
+    TotalCost: 0,
+    TokensEstimated: false,
+    // Backdated fixture: pin to the never-expire sentinel so the retention TTL
+    // does not delete the seed rows.
+    _retention_days: 0,
+  };
+}
+
+function evaluationRunRow({
+  evaluationId,
+  evaluatorId,
+  traceId,
+  scheduledAt,
+  updatedAt,
+  score,
+}: {
+  evaluationId: string;
+  evaluatorId: string;
+  traceId: string;
+  scheduledAt: string;
+  updatedAt: string;
+  score: number;
+}) {
+  return {
+    ProjectionId: `proj-${evaluationId}-${updatedAt}`,
+    TenantId: TENANT_ID,
+    EvaluationId: evaluationId,
+    Version: "1",
+    EvaluatorId: evaluatorId,
+    EvaluatorType: "custom",
+    TraceId: traceId,
+    Status: "processed",
+    Score: score,
+    Passed: null,
+    Label: null,
+    LastProcessedEventId: `evt-${evaluationId}-${updatedAt}`,
+    ScheduledAt: scheduledAt,
+    CreatedAt: scheduledAt,
+    UpdatedAt: updatedAt,
+    _retention_days: 0,
+  };
+}
+
+type Row = Record<string, unknown>;
+
+/**
+ * The metric column of a timeseries result. The alias is derived from the
+ * series, so the tests read it back rather than restating it.
+ */
+function metricValue(rows: Row[], period: string): number {
+  const row = rows.find((r) => r.period === period);
+  if (!row) {
+    throw new Error(`no ${period} row in ${JSON.stringify(rows)}`);
+  }
+  const key = Object.keys(row).find(
+    (k) => k !== "period" && k !== "date" && k !== "group_key",
+  );
+  if (!key) {
+    throw new Error(`no metric column in ${JSON.stringify(row)}`);
+  }
+  return Number(row[key]);
+}
+
+describe("evaluation_runs JOIN time bounds", () => {
+  let ch: ClickHouseClient;
+
+  async function currentPeriodMetric(
+    metric: string,
+    aggregation: AggregationTypes,
+    evaluatorId: string,
+  ): Promise<number> {
+    resetParamCounter();
+    const { sql, params } = buildTimeseriesQuery({
+      ...baseInput,
+      series: [
+        {
+          metric: metric as FlattenAnalyticsMetricsEnum,
+          aggregation,
+          key: evaluatorId,
+        },
+      ],
+    });
+    const result = await ch.query({
+      query: sql,
+      query_params: params,
+      format: "JSONEachRow",
+    });
+    return metricValue((await result.json()) as Row[], "current");
+  }
+
+  beforeAll(async () => {
+    const rawClient = getTestClickHouseClient();
+    if (!rawClient) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(rawClient);
+
+    await ch.insert({
+      table: "trace_summaries",
+      values: Object.keys(traceOccurredAt).map(traceSummaryRow),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+
+    await ch.insert({
+      table: "evaluation_runs",
+      values: [
+        // Scheduled months after the window the graph asks about, on traces
+        // inside it. An upper bound of any width would drop both.
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-late-a",
+          evaluatorId: LATE_EVALUATOR,
+          traceId: TRACE_LATE_A,
+          scheduledAt: "2025-09-15T08:00:00Z",
+          updatedAt: "2025-09-15T08:00:00Z",
+          score: 0.8,
+        }),
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-late-b",
+          evaluatorId: LATE_EVALUATOR,
+          traceId: TRACE_LATE_B,
+          scheduledAt: "2025-12-20T08:00:00Z",
+          updatedAt: "2025-12-20T08:00:00Z",
+          score: 0.6,
+        }),
+
+        // One evaluation, three row versions, three different weekly
+        // partitions, inserted newest first. ReplacingMergeTree collapses
+        // within a partition only, so all three survive on disk and the
+        // IN-tuple dedup is the only thing that picks the newest.
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-versioned",
+          evaluatorId: VERSIONED_EVALUATOR,
+          traceId: TRACE_VERSIONED,
+          scheduledAt: "2025-09-20T00:00:00Z",
+          updatedAt: "2025-09-21T00:00:00Z",
+          score: 1,
+        }),
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-versioned",
+          evaluatorId: VERSIONED_EVALUATOR,
+          traceId: TRACE_VERSIONED,
+          scheduledAt: "2025-06-12T12:00:00Z",
+          updatedAt: "2025-06-12T12:00:00Z",
+          score: 0,
+        }),
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-versioned",
+          evaluatorId: VERSIONED_EVALUATOR,
+          traceId: TRACE_VERSIONED,
+          scheduledAt: "2025-08-14T00:00:00Z",
+          updatedAt: "2025-08-15T00:00:00Z",
+          score: 0.5,
+        }),
+
+        // Two versions tied on UpdatedAt in separate partitions: both match
+        // max(UpdatedAt), so both reach the outer query.
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-tied",
+          evaluatorId: TIED_EVALUATOR,
+          traceId: TRACE_TIED,
+          scheduledAt: "2025-10-01T00:00:00Z",
+          updatedAt: "2025-10-01T00:00:00Z",
+          score: 0.25,
+        }),
+        evaluationRunRow({
+          evaluationId: "eval-bounds-6392-tied",
+          evaluatorId: TIED_EVALUATOR,
+          traceId: TRACE_TIED,
+          scheduledAt: "2025-11-05T00:00:00Z",
+          updatedAt: "2025-10-01T00:00:00Z",
+          score: 0.25,
+        }),
+      ],
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
+  });
+
+  describe("given an evaluation scheduled long after the queried window, on a trace inside it", () => {
+    /** @scenario An evaluation scheduled after the queried window still scores its in-window trace */
+    it("returns the evaluation score", async () => {
+      const score = await currentPeriodMetric(
+        "evaluations.evaluation_score",
+        "avg",
+        LATE_EVALUATOR,
+      );
+
+      expect(score).toBeCloseTo(0.7, 10);
+    });
+
+    /** @scenario Both late-scheduled evaluations are counted, not just the nearest one */
+    it("counts every late-scheduled evaluation", async () => {
+      const runs = await currentPeriodMetric(
+        "evaluations.evaluation_runs",
+        "cardinality",
+        LATE_EVALUATOR,
+      );
+
+      expect(runs).toBe(2);
+    });
+
+    /** @scenario A late-scheduled evaluator is still offered as a filter value */
+    it("lists the evaluator in the filter values for the window", async () => {
+      resetParamCounter();
+      const { sql, params } = buildDataForFilterQuery(
+        TENANT_ID,
+        "evaluations.evaluator_id" as FilterField,
+        baseInput.startDate,
+        baseInput.endDate,
+      );
+
+      const result = await ch.query({
+        query: sql,
+        query_params: params,
+        format: "JSONEachRow",
+      });
+      const fields = ((await result.json()) as Row[]).map((r) => r.field);
+
+      expect(fields).toContain(LATE_EVALUATOR);
+    });
+  });
+
+  describe("given one evaluation with row versions across weekly partitions, inserted out of UpdatedAt order", () => {
+    /** @scenario The dedup keeps the newest version of an evaluation spread across partitions */
+    it("scores the evaluation from its newest version only", async () => {
+      const avg = await currentPeriodMetric(
+        "evaluations.evaluation_score",
+        "avg",
+        VERSIONED_EVALUATOR,
+      );
+      const sum = await currentPeriodMetric(
+        "evaluations.evaluation_score",
+        "sum",
+        VERSIONED_EVALUATOR,
+      );
+
+      expect(avg).toBeCloseTo(1, 10);
+      expect(sum).toBeCloseTo(1, 10);
+    });
+  });
+
+  describe("given two row versions of one evaluation tied on UpdatedAt", () => {
+    /** @scenario A tie on UpdatedAt does not fan one evaluation out into two */
+    it("counts the evaluation once and keeps its score", async () => {
+      const runs = await currentPeriodMetric(
+        "evaluations.evaluation_runs",
+        "cardinality",
+        TIED_EVALUATOR,
+      );
+      const score = await currentPeriodMetric(
+        "evaluations.evaluation_score",
+        "avg",
+        TIED_EVALUATOR,
+      );
+
+      expect(runs).toBe(1);
+      expect(score).toBeCloseTo(0.25, 10);
+    });
+  });
+});

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -107,7 +107,7 @@ function partitionBoundViolations(sql: string): string[] {
     for (const column of columns) {
       if (prunable.includes(column)) continue;
       violations.push(
-        `${table} is bounded on ${column}, which is none of the columns it can prune on (${prunable.join(", ")}); ClickHouse resolves an unqualified ${column} against the outer trace_summaries scope instead of failing`,
+        `${table} is bounded on ${column}, which is none of the columns it can prune on (${prunable.join(", ")}); unqualified, ClickHouse resolves it against the outer trace_summaries scope instead of failing, and qualified it prunes nothing`,
       );
     }
   }

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -25,28 +25,63 @@ import { resetParamCounter } from "../filter-translator";
  */
 
 const RANGE_BOUND_OR_TABLE =
-  /\bFROM\s+([a-zA-Z_]\w*)|(?<![\w.`])([a-zA-Z_]\w*)\s*(?:>=|<=|>|<)\s*\{/g;
+  /\bFROM\s+([a-zA-Z_]\w*)|(?<![\w.`])(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\s*(?:>=|<=|>|<)\s*\{/g;
 
 /**
- * Range bounds in `sql`, grouped by the table of the nearest preceding
- * `FROM <table>`. Alias-qualified columns (`ts.OccurredAt`) belong to the outer
- * scope by construction and are skipped; only bare identifiers can be captured
- * by the wrong scope.
+ * Columns a table was partitioned by before the current DDL, which long-lived
+ * deployments still run on. A bound on one prunes nothing on the unified schema
+ * but is what makes the subquery prune on those installs, so it is allowed
+ * here. It does NOT belong in {@link TIME_PARTITIONED_TABLES}: that map tells
+ * the cold-scan detector which predicate is enough to prune today, and a legacy
+ * column there would clear the flag on queries that still scan everything.
+ */
+const LEGACY_PARTITION_COLUMNS: Record<string, readonly string[]> = {
+  evaluation_runs: ["UpdatedAt"],
+};
+
+/**
+ * The table a bound belongs to: its qualifier when that names a table, the
+ * enclosing `FROM` when the bound is bare, and nothing when the qualifier is an
+ * alias of the outer query.
+ */
+function boundedTable(
+  qualifier: string | undefined,
+  enclosingTable: string | null,
+  knownTables: ReadonlySet<string>,
+): string | null {
+  if (!qualifier) return enclosingTable;
+  return knownTables.has(qualifier) ? qualifier : null;
+}
+
+/**
+ * Range bounds in `sql`, grouped by the table they bound.
+ *
+ * A bare identifier belongs to the nearest preceding `FROM <table>` — that is
+ * the scope ClickHouse would resolve it in, or fail to. A qualified one belongs
+ * to its qualifier when the qualifier names a table, since qualifying pins the
+ * reference to that table's own column; any other qualifier is an alias of the
+ * outer query and is skipped.
  */
 function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
+  const knownTables = new Set(Object.keys(TIME_PARTITIONED_TABLES));
   const byTable = new Map<string, Set<string>>();
-  let currentTable: string | null = null;
+  let enclosingTable: string | null = null;
 
   RANGE_BOUND_OR_TABLE.lastIndex = 0;
   let match: RegExpExecArray | null = RANGE_BOUND_OR_TABLE.exec(sql);
   while (match !== null) {
-    const [, table, column] = match;
-    if (table) {
-      currentTable = table;
-    } else if (column && currentTable) {
-      const columns = byTable.get(currentTable) ?? new Set<string>();
+    const [, fromTable, qualifier, column] = match;
+    if (fromTable) {
+      enclosingTable = fromTable;
+    }
+    const table =
+      fromTable || !column
+        ? null
+        : boundedTable(qualifier, enclosingTable, knownTables);
+    if (table && column) {
+      const columns = byTable.get(table) ?? new Set<string>();
       columns.add(column);
-      byTable.set(currentTable, columns);
+      byTable.set(table, columns);
     }
     match = RANGE_BOUND_OR_TABLE.exec(sql);
   }
@@ -54,7 +89,7 @@ function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
   return byTable;
 }
 
-/** One message per bound that names a column the table is not partitioned by. */
+/** One message per bound that names a column the table cannot prune on. */
 function partitionBoundViolations(sql: string): string[] {
   const violations: string[] = [];
 
@@ -64,10 +99,15 @@ function partitionBoundViolations(sql: string): string[] {
     )[table];
     if (!partitionColumns) continue;
 
+    const prunable = [
+      ...partitionColumns,
+      ...(LEGACY_PARTITION_COLUMNS[table] ?? []),
+    ];
+
     for (const column of columns) {
-      if (partitionColumns.includes(column)) continue;
+      if (prunable.includes(column)) continue;
       violations.push(
-        `${table} is bounded on ${column}, not one of its partition columns (${partitionColumns.join(", ")}); ClickHouse resolves ${column} against the outer trace_summaries scope instead of failing`,
+        `${table} is bounded on ${column}, which is none of the columns it can prune on (${prunable.join(", ")}); ClickHouse resolves an unqualified ${column} against the outer trace_summaries scope instead of failing`,
       );
     }
   }
@@ -158,6 +198,48 @@ describe("analytics JOIN time bounds", () => {
       }
 
       expect(violations).toEqual([]);
+    });
+  });
+
+  describe("given an evaluation_runs bound qualified with the table's own name", () => {
+    /**
+     * @scenario Bounds qualified with the bounded table's own name are inspected, not skipped
+     */
+    it("sees both evaluation_runs bounds and allows the legacy one", () => {
+      resetParamCounter();
+      const { sql } = buildTimeseriesQuery({
+        ...baseInput,
+        timeScale: "full" as const,
+        series: [EVAL_SERIES],
+      });
+
+      expect(missingJoinViolations(sql, "evaluation_runs")).toEqual([]);
+      expect(rangeBoundColumnsByTable(sql).get("evaluation_runs")).toEqual(
+        new Set(["ScheduledAt", "UpdatedAt"]),
+      );
+      expect(partitionBoundViolations(sql)).toEqual([]);
+    });
+
+    /**
+     * @scenario A qualified bound on a column the table cannot prune on is still reported
+     */
+    it("reports a qualified bound on a non-partition column", () => {
+      const sql =
+        "SELECT 1 FROM evaluation_runs WHERE evaluation_runs.CreatedAt >= {startDate:DateTime64(3)}";
+
+      expect(partitionBoundViolations(sql)).toHaveLength(1);
+    });
+
+    /**
+     * @scenario A bound qualified with the outer query's alias stays out of the inner table's bounds
+     */
+    it("ignores a bound qualified with an alias rather than a table", () => {
+      const sql =
+        "SELECT 1 FROM evaluation_runs WHERE ts.OccurredAt >= {startDate:DateTime64(3)}";
+
+      expect(
+        rangeBoundColumnsByTable(sql).get("evaluation_runs"),
+      ).toBeUndefined();
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -53,8 +53,14 @@ function boundedTable(
   return knownTables.has(qualifier) ? qualifier : null;
 }
 
+interface RangeBound {
+  table: string;
+  column: string;
+  qualified: boolean;
+}
+
 /**
- * Range bounds in `sql`, grouped by the table they bound.
+ * Every range bound in `sql`, attributed to the table it bounds, deduped.
  *
  * A bare identifier belongs to the nearest preceding `FROM <table>` — that is
  * the scope ClickHouse would resolve it in, or fail to. A qualified one belongs
@@ -62,38 +68,63 @@ function boundedTable(
  * reference to that table's own column; any other qualifier is an alias of the
  * outer query and is skipped.
  */
-function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
+function boundOf(
+  match: RegExpExecArray,
+  enclosingTable: string | null,
+  knownTables: ReadonlySet<string>,
+): RangeBound | null {
+  const [, fromTable, qualifier, column] = match;
+  if (fromTable || !column) return null;
+
+  const table = boundedTable(qualifier, enclosingTable, knownTables);
+  if (!table) return null;
+
+  return { table, column, qualified: Boolean(qualifier) };
+}
+
+function rangeBounds(sql: string): RangeBound[] {
   const knownTables = new Set(Object.keys(TIME_PARTITIONED_TABLES));
-  const byTable = new Map<string, Set<string>>();
+  const bounds = new Map<string, RangeBound>();
   let enclosingTable: string | null = null;
 
   RANGE_BOUND_OR_TABLE.lastIndex = 0;
   let match: RegExpExecArray | null = RANGE_BOUND_OR_TABLE.exec(sql);
   while (match !== null) {
-    const [, fromTable, qualifier, column] = match;
-    if (fromTable) {
-      enclosingTable = fromTable;
-    }
-    const table =
-      fromTable || !column
-        ? null
-        : boundedTable(qualifier, enclosingTable, knownTables);
-    if (table && column) {
-      const columns = byTable.get(table) ?? new Set<string>();
-      columns.add(column);
-      byTable.set(table, columns);
+    enclosingTable = match[1] ?? enclosingTable;
+    const bound = boundOf(match, enclosingTable, knownTables);
+    if (bound) {
+      bounds.set(`${bound.table}.${bound.column}.${bound.qualified}`, bound);
     }
     match = RANGE_BOUND_OR_TABLE.exec(sql);
+  }
+
+  return [...bounds.values()];
+}
+
+/** Bound columns per table, for assertions that only care about which. */
+function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
+  const byTable = new Map<string, Set<string>>();
+
+  for (const { table, column } of rangeBounds(sql)) {
+    const columns = byTable.get(table) ?? new Set<string>();
+    columns.add(column);
+    byTable.set(table, columns);
   }
 
   return byTable;
 }
 
-/** One message per bound that names a column the table cannot prune on. */
+/**
+ * One message per bound that names a column the table cannot prune on, saying
+ * which of the two failures it is. A bare name the table lacks is the dangerous
+ * one: ClickHouse resolves it outward and the query dies at runtime. A
+ * qualified one cannot be captured by the outer scope, so it costs only the
+ * pruning it was written to buy.
+ */
 function partitionBoundViolations(sql: string): string[] {
   const violations: string[] = [];
 
-  for (const [table, columns] of rangeBoundColumnsByTable(sql)) {
+  for (const { table, column, qualified } of rangeBounds(sql)) {
     const partitionColumns = (
       TIME_PARTITIONED_TABLES as Record<string, readonly string[] | undefined>
     )[table];
@@ -103,13 +134,14 @@ function partitionBoundViolations(sql: string): string[] {
       ...partitionColumns,
       ...(LEGACY_PARTITION_COLUMNS[table] ?? []),
     ];
+    if (prunable.includes(column)) continue;
 
-    for (const column of columns) {
-      if (prunable.includes(column)) continue;
-      violations.push(
-        `${table} is bounded on ${column}, which is none of the columns it can prune on (${prunable.join(", ")}); unqualified, ClickHouse resolves it against the outer trace_summaries scope instead of failing, and qualified it prunes nothing`,
-      );
-    }
+    const consequence = qualified
+      ? `${table}.${column} is pinned to ${table}, so the bound prunes nothing`
+      : `ClickHouse resolves the bare ${column} against the outer trace_summaries scope instead of failing`;
+    violations.push(
+      `${table} is bounded on ${column}, which is none of the columns it can prune on (${prunable.join(", ")}); ${consequence}`,
+    );
   }
 
   return violations;
@@ -219,11 +251,23 @@ describe("analytics JOIN time bounds", () => {
     });
 
     /** @scenario A qualified bound on a column the table cannot prune on is still reported */
-    it("reports a qualified bound on a non-partition column", () => {
+    it("reports a qualified bound on a non-partition column, as a lost prune", () => {
       const sql =
         "SELECT 1 FROM evaluation_runs WHERE evaluation_runs.CreatedAt >= {startDate:DateTime64(3)}";
 
-      expect(partitionBoundViolations(sql)).toHaveLength(1);
+      expect(partitionBoundViolations(sql)).toEqual([
+        "evaluation_runs is bounded on CreatedAt, which is none of the columns it can prune on (ScheduledAt, UpdatedAt); evaluation_runs.CreatedAt is pinned to evaluation_runs, so the bound prunes nothing",
+      ]);
+    });
+
+    /** @scenario A bare bound on a column the table lacks is reported as an outward resolution */
+    it("reports a bare bound on a non-partition column, as an outward resolution", () => {
+      const sql =
+        "SELECT 1 FROM evaluation_runs WHERE OccurredAt >= {startDate:DateTime64(3)}";
+
+      expect(partitionBoundViolations(sql)).toEqual([
+        "evaluation_runs is bounded on OccurredAt, which is none of the columns it can prune on (ScheduledAt, UpdatedAt); ClickHouse resolves the bare OccurredAt against the outer trace_summaries scope instead of failing",
+      ]);
     });
 
     /** @scenario A bound qualified with the outer query's alias stays out of the inner table's bounds */

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -100,7 +100,7 @@ function boundedTable({
 interface RangeBound {
   table: string;
   column: string;
-  qualified: boolean;
+  isQualified: boolean;
 }
 
 /**
@@ -125,7 +125,7 @@ function boundOf({
   const table = boundedTable({ qualifier, scope });
   if (!table) return null;
 
-  return { table, column, qualified: Boolean(qualifier) };
+  return { table, column, isQualified: Boolean(qualifier) };
 }
 
 /** Record `FROM <table> <alias>`, ignoring the keywords that are not aliases. */
@@ -156,7 +156,7 @@ function rangeBounds(sql: string): RangeBound[] {
       scope: { enclosingTable, knownTables, aliasToTable },
     });
     if (bound) {
-      bounds.set(`${bound.table}.${bound.column}.${bound.qualified}`, bound);
+      bounds.set(`${bound.table}.${bound.column}.${bound.isQualified}`, bound);
     }
     match = RANGE_BOUND_OR_TABLE.exec(sql);
   }
@@ -187,7 +187,7 @@ function rangeBoundColumnsByTable(sql: string): Map<string, Set<string>> {
 function partitionBoundViolations(sql: string): string[] {
   const violations: string[] = [];
 
-  for (const { table, column, qualified } of rangeBounds(sql)) {
+  for (const { table, column, isQualified } of rangeBounds(sql)) {
     const partitionColumns = (
       TIME_PARTITIONED_TABLES as Record<string, readonly string[] | undefined>
     )[table];
@@ -199,7 +199,7 @@ function partitionBoundViolations(sql: string): string[] {
     ];
     if (prunable.includes(column)) continue;
 
-    const consequence = qualified
+    const consequence = isQualified
       ? `${table}.${column} is pinned to ${table}, so the bound prunes nothing`
       : `ClickHouse resolves the bare ${column} against the outer trace_summaries scope instead of failing`;
     violations.push(

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -25,7 +25,42 @@ import { resetParamCounter } from "../filter-translator";
  */
 
 const RANGE_BOUND_OR_TABLE =
-  /\bFROM\s+([a-zA-Z_]\w*)|(?<![\w.`])(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\s*(?:>=|<=|>|<)\s*\{/g;
+  /\bFROM\s+([a-zA-Z_]\w*)(?:\s+(?:AS\s+)?([a-zA-Z_]\w*))?|(?<![\w.`])(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\s*(?:>=|<=|>|<)\s*\{/g;
+
+/**
+ * Words that can follow a table name without being an alias for it. Without
+ * this, `FROM evaluation_runs WHERE ...` reads as an alias called `WHERE`,
+ * and a bound qualified with the word WHERE would resolve to the table.
+ */
+const NOT_AN_ALIAS = new Set([
+  "ALL",
+  "ANTI",
+  "ANY",
+  "ARRAY",
+  "ASOF",
+  "CROSS",
+  "FINAL",
+  "FORMAT",
+  "FULL",
+  "GROUP",
+  "HAVING",
+  "INNER",
+  "JOIN",
+  "LEFT",
+  "LIMIT",
+  "ON",
+  "ORDER",
+  "PREWHERE",
+  "RIGHT",
+  "SAMPLE",
+  "SELECT",
+  "SEMI",
+  "SETTINGS",
+  "UNION",
+  "USING",
+  "WHERE",
+  "WITH",
+]);
 
 /**
  * Columns a table was partitioned by before the current DDL, which long-lived
@@ -39,18 +74,27 @@ const LEGACY_PARTITION_COLUMNS: Record<string, readonly string[]> = {
   evaluation_runs: ["UpdatedAt"],
 };
 
+interface Scope {
+  enclosingTable: string | null;
+  knownTables: ReadonlySet<string>;
+  aliasToTable: ReadonlyMap<string, string>;
+}
+
 /**
- * The table a bound belongs to: its qualifier when that names a table, the
- * enclosing `FROM` when the bound is bare, and nothing when the qualifier is an
- * alias of the outer query.
+ * The table a bound belongs to: its qualifier when that names a table or an
+ * alias declared on one, the enclosing `FROM` when the bound is bare, and
+ * nothing when the qualifier belongs to the outer query.
  */
-function boundedTable(
-  qualifier: string | undefined,
-  enclosingTable: string | null,
-  knownTables: ReadonlySet<string>,
-): string | null {
-  if (!qualifier) return enclosingTable;
-  return knownTables.has(qualifier) ? qualifier : null;
+function boundedTable({
+  qualifier,
+  scope,
+}: {
+  qualifier: string | undefined;
+  scope: Scope;
+}): string | null {
+  if (!qualifier) return scope.enclosingTable;
+  if (scope.knownTables.has(qualifier)) return qualifier;
+  return scope.aliasToTable.get(qualifier) ?? null;
 }
 
 interface RangeBound {
@@ -60,30 +104,45 @@ interface RangeBound {
 }
 
 /**
- * Every range bound in `sql`, attributed to the table it bounds, deduped.
+ * The range bound a match represents, if it is one.
  *
  * A bare identifier belongs to the nearest preceding `FROM <table>` — that is
  * the scope ClickHouse would resolve it in, or fail to. A qualified one belongs
- * to its qualifier when the qualifier names a table, since qualifying pins the
- * reference to that table's own column; any other qualifier is an alias of the
- * outer query and is skipped.
+ * to its qualifier when the qualifier names a table or an alias of one, since
+ * qualifying pins the reference to that table's own column; any other qualifier
+ * is an alias of the outer query and is skipped.
  */
-function boundOf(
-  match: RegExpExecArray,
-  enclosingTable: string | null,
-  knownTables: ReadonlySet<string>,
-): RangeBound | null {
-  const [, fromTable, qualifier, column] = match;
+function boundOf({
+  match,
+  scope,
+}: {
+  match: RegExpExecArray;
+  scope: Scope;
+}): RangeBound | null {
+  const [, fromTable, , qualifier, column] = match;
   if (fromTable || !column) return null;
 
-  const table = boundedTable(qualifier, enclosingTable, knownTables);
+  const table = boundedTable({ qualifier, scope });
   if (!table) return null;
 
   return { table, column, qualified: Boolean(qualifier) };
 }
 
+/** Record `FROM <table> <alias>`, ignoring the keywords that are not aliases. */
+function rememberAlias(
+  aliasToTable: Map<string, string>,
+  table: string | undefined,
+  alias: string | undefined,
+): void {
+  if (!table || !alias) return;
+  if (NOT_AN_ALIAS.has(alias.toUpperCase())) return;
+  aliasToTable.set(alias, table);
+}
+
+/** Every range bound in `sql`, attributed to the table it bounds, deduped. */
 function rangeBounds(sql: string): RangeBound[] {
   const knownTables = new Set(Object.keys(TIME_PARTITIONED_TABLES));
+  const aliasToTable = new Map<string, string>();
   const bounds = new Map<string, RangeBound>();
   let enclosingTable: string | null = null;
 
@@ -91,7 +150,11 @@ function rangeBounds(sql: string): RangeBound[] {
   let match: RegExpExecArray | null = RANGE_BOUND_OR_TABLE.exec(sql);
   while (match !== null) {
     enclosingTable = match[1] ?? enclosingTable;
-    const bound = boundOf(match, enclosingTable, knownTables);
+    rememberAlias(aliasToTable, match[1], match[2]);
+    const bound = boundOf({
+      match,
+      scope: { enclosingTable, knownTables, aliasToTable },
+    });
     if (bound) {
       bounds.set(`${bound.table}.${bound.column}.${bound.qualified}`, bound);
     }
@@ -268,6 +331,17 @@ describe("analytics JOIN time bounds", () => {
       expect(partitionBoundViolations(sql)).toEqual([
         "evaluation_runs is bounded on OccurredAt, which is none of the columns it can prune on (ScheduledAt, UpdatedAt); ClickHouse resolves the bare OccurredAt against the outer trace_summaries scope instead of failing",
       ]);
+    });
+
+    /** @scenario A bound qualified with an alias of the bounded table is attributed to it */
+    it("resolves an alias declared on the bounded table's own FROM", () => {
+      const sql =
+        "SELECT 1 FROM evaluation_runs er WHERE er.CreatedAt >= {startDate:DateTime64(3)}";
+
+      expect(rangeBoundColumnsByTable(sql).get("evaluation_runs")).toEqual(
+        new Set(["CreatedAt"]),
+      );
+      expect(partitionBoundViolations(sql)).toHaveLength(1);
     });
 
     /** @scenario A bound qualified with the outer query's alias stays out of the inner table's bounds */

--- a/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -202,9 +202,7 @@ describe("analytics JOIN time bounds", () => {
   });
 
   describe("given an evaluation_runs bound qualified with the table's own name", () => {
-    /**
-     * @scenario Bounds qualified with the bounded table's own name are inspected, not skipped
-     */
+    /** @scenario Bounds qualified with the bounded table's own name are inspected, not skipped */
     it("sees both evaluation_runs bounds and allows the legacy one", () => {
       resetParamCounter();
       const { sql } = buildTimeseriesQuery({
@@ -220,9 +218,7 @@ describe("analytics JOIN time bounds", () => {
       expect(partitionBoundViolations(sql)).toEqual([]);
     });
 
-    /**
-     * @scenario A qualified bound on a column the table cannot prune on is still reported
-     */
+    /** @scenario A qualified bound on a column the table cannot prune on is still reported */
     it("reports a qualified bound on a non-partition column", () => {
       const sql =
         "SELECT 1 FROM evaluation_runs WHERE evaluation_runs.CreatedAt >= {startDate:DateTime64(3)}";
@@ -230,9 +226,7 @@ describe("analytics JOIN time bounds", () => {
       expect(partitionBoundViolations(sql)).toHaveLength(1);
     });
 
-    /**
-     * @scenario A bound qualified with the outer query's alias stays out of the inner table's bounds
-     */
+    /** @scenario A bound qualified with the outer query's alias stays out of the inner table's bounds */
     it("ignores a bound qualified with an alias rather than a table", () => {
       const sql =
         "SELECT 1 FROM evaluation_runs WHERE ts.OccurredAt >= {startDate:DateTime64(3)}";

--- a/langwatch/src/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup.ts
@@ -32,3 +32,26 @@ export async function deleteEvaluationRunsByTenant({
     query_params: { tenantId },
   });
 }
+
+/**
+ * Delete every `trace_summaries` row for a tenant, synchronously.
+ *
+ * `cleanupTestData` covers this table too, but issues the mutation without
+ * waiting for it. That is fine as teardown and not as setup: a fixture that
+ * asserts on exact counts has to know the table is empty before it seeds, or a
+ * previous run's surviving rows join this one and inflate every count.
+ */
+export async function deleteTraceSummariesByTenant({
+  client,
+  tenantId,
+}: {
+  client: ClickHouseClient | null | undefined;
+  tenantId: string;
+}): Promise<void> {
+  if (!client) return;
+
+  await client.exec({
+    query: `ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+    query_params: { tenantId },
+  });
+}

--- a/specs/analytics/evaluation-runs-join-time-bounds.feature
+++ b/specs/analytics/evaluation-runs-join-time-bounds.feature
@@ -1,0 +1,83 @@
+Feature: The evaluation_runs JOIN is bounded below, and only below
+  As someone reading a chart that carries an evaluation metric
+  I want the JOIN to prune partitions without dropping evaluations
+  So that the graph is both cheap and complete
+
+  # The analytics read path joins trace_summaries to evaluation_runs and dedups
+  # the join with an IN-tuple subquery. Both scans are bounded below on
+  # ScheduledAt, the partition column, and on the table's own UpdatedAt, which
+  # is the partition column on deployments predating the unified DDL.
+  #
+  # Lower-only is the whole design. The window belongs to the TRACE, and an
+  # evaluation is inserted at or after the trace it scores but can be scheduled
+  # arbitrarily later — an offline experiment or a rerun scores historical
+  # traces months on, and a re-evaluation writes a newer row version later
+  # still. An upper bound of any width silently empties those graphs.
+  #
+  # Both halves failed in production before. Filtering on TenantId alone walked
+  # the tenant's whole evaluation history on every graph, and the attempt to
+  # bound it on a column evaluation_runs does not have resolved outward to the
+  # enclosing trace_summaries scope instead of failing, turning the dedup into
+  # a correlated subquery that ClickHouse rejects at query time.
+
+  # ---------------------------------------------------------------------------
+  # Executed against ClickHouse: evaluations the window does not contain
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: An evaluation scheduled after the queried window still scores its in-window trace
+    Given a trace inside the queried window
+    And an evaluation of that trace scheduled months after the window ends
+    When the analytics layer queries that evaluator's score
+    Then the evaluation's score is included
+
+  @integration
+  Scenario: Both late-scheduled evaluations are counted, not just the nearest one
+    Given two in-window traces evaluated at different times long after the window
+    When the analytics layer counts that evaluator's runs
+    Then both evaluations are counted
+
+  @integration
+  Scenario: A late-scheduled evaluator is still offered as a filter value
+    Given an evaluator whose only runs are scheduled after the queried window
+    When the filter values for evaluator id are read for that window
+    Then the evaluator appears among them
+
+  # ---------------------------------------------------------------------------
+  # Executed against ClickHouse: the dedup across weekly partitions
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The dedup keeps the newest version of an evaluation spread across partitions
+    Given one evaluation whose row versions sit in different weekly partitions
+    And the versions were written out of UpdatedAt order
+    When the analytics layer queries that evaluator's score
+    Then only the newest version contributes
+
+  @integration
+  Scenario: A tie on UpdatedAt does not fan one evaluation out into two
+    Given two row versions of one evaluation carrying the same UpdatedAt
+    When the analytics layer counts that evaluator's runs
+    Then the evaluation counts once and keeps its score
+
+  # ---------------------------------------------------------------------------
+  # The guard over the generated SQL
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Bounds qualified with the bounded table's own name are inspected, not skipped
+    Given a bound qualified with the name of the table it bounds
+    When the generated SQL is checked for bounds on non-prunable columns
+    Then that bound is one of the ones inspected
+
+  @unit
+  Scenario: A qualified bound on a column the table cannot prune on is still reported
+    Given a bound qualified with its table's name, naming a column that cannot prune
+    When the generated SQL is checked for bounds on non-prunable columns
+    Then the bound is reported
+
+  @unit
+  Scenario: A bound qualified with the outer query's alias stays out of the inner table's bounds
+    Given a bound qualified with the outer query's alias
+    When the bounds of the inner table are collected
+    Then the outer query's bound is not among them

--- a/specs/analytics/evaluation-runs-join-time-bounds.feature
+++ b/specs/analytics/evaluation-runs-join-time-bounds.feature
@@ -15,10 +15,11 @@ Feature: The evaluation_runs JOIN is bounded below, and only below
   # still. An upper bound of any width silently empties those graphs.
   #
   # Both halves failed in production before. Filtering on TenantId alone walked
-  # the tenant's whole evaluation history on every graph, and the attempt to
-  # bound it on a column evaluation_runs does not have resolved outward to the
-  # enclosing trace_summaries scope instead of failing, turning the dedup into
-  # a correlated subquery that ClickHouse rejects at query time.
+  # the tenant's whole evaluation history on every graph. The attempt to bound
+  # it on OccurredAt, which evaluation_runs has not got, then took the read
+  # path down: an unqualified name the inner table lacks resolves against the
+  # enclosing trace_summaries scope rather than failing, which turned the dedup
+  # into a correlated subquery that ClickHouse rejects at query time.
 
   # ---------------------------------------------------------------------------
   # Executed against ClickHouse: evaluations the window does not contain
@@ -54,11 +55,14 @@ Feature: The evaluation_runs JOIN is bounded below, and only below
     When the analytics layer queries that evaluator's score
     Then only the newest version contributes
 
+  # A tie is not resolved by the dedup: both versions equal max(UpdatedAt), so
+  # both clear the IN and both reach the graph. Recorded as it behaves rather
+  # than as one would want it to, and unchanged by the bounds either way.
   @integration
-  Scenario: A tie on UpdatedAt does not fan one evaluation out into two
+  Scenario: A tie on UpdatedAt leaves both row versions in the join
     Given two row versions of one evaluation carrying the same UpdatedAt
-    When the analytics layer counts that evaluator's runs
-    Then the evaluation counts once and keeps its score
+    When the analytics layer reads that evaluator's runs and score
+    Then the count and the average are unaffected and a summed metric doubles
 
   # ---------------------------------------------------------------------------
   # The guard over the generated SQL

--- a/specs/analytics/evaluation-runs-join-time-bounds.feature
+++ b/specs/analytics/evaluation-runs-join-time-bounds.feature
@@ -78,7 +78,13 @@ Feature: The evaluation_runs JOIN is bounded below, and only below
   Scenario: A qualified bound on a column the table cannot prune on is still reported
     Given a bound qualified with its table's name, naming a column that cannot prune
     When the generated SQL is checked for bounds on non-prunable columns
-    Then the bound is reported
+    Then the bound is reported as a prune the query does not get
+
+  @unit
+  Scenario: A bare bound on a column the table lacks is reported as an outward resolution
+    Given a bare bound naming a column the bounded table has not got
+    When the generated SQL is checked for bounds on non-prunable columns
+    Then the bound is reported as resolving against the outer scope
 
   @unit
   Scenario: A bound qualified with the outer query's alias stays out of the inner table's bounds

--- a/specs/analytics/evaluation-runs-join-time-bounds.feature
+++ b/specs/analytics/evaluation-runs-join-time-bounds.feature
@@ -87,6 +87,12 @@ Feature: The evaluation_runs JOIN is bounded below, and only below
     Then the bound is reported as resolving against the outer scope
 
   @unit
+  Scenario: A bound qualified with an alias of the bounded table is attributed to it
+    Given a bound qualified with an alias the bounded table declares for itself
+    When the generated SQL is checked for bounds on non-prunable columns
+    Then the alias resolves to the table and the bound is reported
+
+  @unit
   Scenario: A bound qualified with the outer query's alias stays out of the inner table's bounds
     Given a bound qualified with the outer query's alias
     When the bounds of the inner table are collected


### PR DESCRIPTION
#6399 bounded the `evaluation_runs` JOIN below on `ScheduledAt` and `evaluation_runs.UpdatedAt` so the weekly partitions prune. It is correct: this PR verified it by execution before adding anything. What it did not have was a test that ever ran the SQL, or a guard that could see one of the two bounds.

## Verifying #6399 first

Against native ClickHouse 25.8, an isolated database with `evaluation_runs`/`trace_summaries` created `AS` the migrated tables (so engine, `PARTITION BY toYearWeek(ScheduledAt)` and `ORDER BY` are exact), seeded with 160k evaluation runs across **80 weekly partitions** and 12,832 in-window traces. Each generated query was run twice: as `main` emits it, and with the two bound fragments stripped, which is byte-for-byte the pre-#6399 SQL.

`EXPLAIN indexes = 1`, evaluation_runs scan inside the JOIN:

| | before | after |
|---|---|---|
| MinMax | `Condition: true`, Parts 80/80 | `ScheduledAt in ['1779667200', +Inf)`, Parts **8/80** |
| Partition | `Condition: true`, Parts 80/80 | `toYearWeek(ScheduledAt) in [202621, +Inf)`, Parts 8/8 |

Executed, on the same data:

| query | read_rows before | after | wall before | after |
|---|---|---|---|---|
| timeseries, daily buckets | 345,664 | 55,936 | 539ms | 198ms |
| timeseries, `timeScale: "full"` | 669,698 | 90,242 | 1337ms | 420ms |
| filter values, `evaluations.evaluator_id` | 330,112 | 24,256 | 727ms | 141ms |

The dedup inner is the scan that actually walked the history, so it was measured on its own too: **80/80 parts and 160,000 rows before, 8/80 parts and 15,136 rows after**. It also shows up inside the composed query without being isolated, as the size of the set the outer scan's PrimaryKey condition tests against: `EvaluationId in 160000-element set` before, `in 14848-element set` after. Both scans prune.

Results were identical before and after in all three queries.

## What this PR adds

**An executed-SQL integration test.** #6399's tests assert on the generated string, and every existing analytics fixture schedules an evaluation at the same instant as its trace, so none of them can tell a lower bound from an upper one. The new file runs the real builders against ClickHouse on the shapes that can:

- an evaluation scheduled months **after** the queried window, on a trace inside it (the offline-experiment and re-run shape, and the reason the bound is lower-only), scores that trace and is still offered as a filter value;
- three row versions of one evaluation in three different weekly partitions, inserted newest-first, collapse to the newest and only the newest (`ReplacingMergeTree` cannot merge across partitions, so the IN-tuple dedup is the only thing choosing);
- two versions tied on `UpdatedAt` both survive the dedup.

Adding an upper bound of any width to the builder turns all five red.

The tie case turned up something worth knowing. Executed, a summed metric over the tie returns **0.5, not 0.25**: both versions carry `UpdatedAt = max(UpdatedAt)`, so both clear the IN and both reach the outer query. A distinct count and an average absorb that; a sum does not. It is pre-existing, independent of #6399 (both versions clear the bounds either way), and pinned here as it behaves rather than as one would want it to. Breaking the tie means changing the dedup key in `buildJoinClause`, which is a production change and does not belong in a verification PR.

**The guard's blind spot.** The #6391 guard asserts every range bound names a partition column of the table it bounds, and `evaluation_runs` does map to `[ScheduledAt]` in `cold-scan-detector.ts`, so it was not vacuous — a bare `OccurredAt` bound, the #6383 shape, is still reported. But it skipped **every** qualified identifier as belonging to the outer scope. That holds for an alias (`ts.OccurredAt`) and not for a bound qualified with the bounded table's own name, so `evaluation_runs.UpdatedAt` was invisible to it: tolerated by not being looked at.

Confirmed by mutation. With the bound moved to `evaluation_runs.CreatedAt`, a column that table cannot prune on, the guard as merged passes 3/3. It now attributes a qualified bound to its qualifier when the qualifier names a table, and reports that mutation on 3 cases. The report also says which of the two failures it is, since they are not the same: a bare name the table lacks resolves against the outer scope and kills the query at runtime, while a qualified one is pinned to its table and only loses the prune.

`UpdatedAt` is then allowed explicitly, through a `LEGACY_PARTITION_COLUMNS` list carrying the reason: it is the partition column on deployments predating the unified DDL. It deliberately stays out of `TIME_PARTITIONED_TABLES`, which tells the cold-scan detector which predicate is enough to prune *today* — a legacy column there would clear the flag on queries that still scan everything.

## Not added

No fix, no rewrite, no doc. #6399 is correct and this PR does not touch it. The NULL-safety of the `ScheduledAt` bound is a legacy-schema property the local schema cannot exercise, and it is already covered at the string level. The measurement scripts were scratch and are not committed.

## Scope note

The lower-only bound rests on an evaluation being inserted at or after the trace it scores: `ScheduledAt` is `timestamps.inserted_at`. An in-window trace whose evaluation is scheduled more than 7 days *before* the window start would be dropped, which requires a trace timestamped later than the evaluation that scored it. Not reachable through the normal path, and out of scope here.

Closes #6392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured evaluations scheduled after a queried period remain visible in analytics metrics and filter values.
  * Correctly selects the latest evaluation versions across time partitions.
  * Prevented duplicate counts when evaluation versions share the same update timestamp.
  * Improved handling of qualified and legacy time-bound filters.
  * Improved accuracy for evaluation counts, averages, and sums when records span multiple time periods or contain tied updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->