### PR TITLE
fix(cli): surface Comparison verdicts in experiment results and --filter failed

### DIFF
--- a/specs/typescript-sdk/cli-experiment-results.feature
+++ b/specs/typescript-sdk/cli-experiment-results.feature
@@ -45,6 +45,37 @@ Feature: CLI evaluation results command
     And the JSON output is valid and parseable
     And the CLI exits with status 0
 
+  # A Comparison evaluator judges the whole field of targets in one verdict, so
+  # its results are recorded against the comparison itself rather than against
+  # any one target. The command builds its output by walking the dataset — one
+  # entry per (row, target) — so anything not tied to a target had no row to
+  # attach to and never reached stdout. The run summary still reported the
+  # comparison, which made the omission read as "the judge produced nothing"
+  # rather than "the CLI dropped it".
+
+  @integration @unimplemented
+  Scenario: A comparison verdict reaches the CLI even though it belongs to no single target
+    Given an experiment whose latest run includes a Comparison evaluator over several targets
+    When I run `langwatch experiment results <experiment>`
+    Then the output includes the comparison's verdict for each judged row
+    And each verdict names the winning target and the judge's reasoning
+    And the CLI exits with status 0
+
+  @integration @unimplemented
+  Scenario: Comparison verdicts follow the rows that survive filtering
+    Given an experiment whose latest run includes a Comparison evaluator
+    When I run `langwatch experiment results <experiment> --limit 5`
+    Then the output includes comparison verdicts only for the rows shown
+    And no verdict is reported for a row that was filtered out
+
+  @integration @unimplemented
+  Scenario: Narrowing to one evaluator excludes the comparison
+    Given an experiment whose latest run includes both a Comparison evaluator and a scoring evaluator
+    When I run `langwatch experiment results <experiment> --evaluator quality`
+    Then no comparison verdict is reported
+    # The filter names one evaluator; honouring it matters more than
+    # surfacing the comparison.
+
   @integration @unimplemented
   Scenario: User views a run that is still running
     Given an experiment whose latest run has not finished yet but has logged some rows

--- a/specs/typescript-sdk/cli-experiment-results.feature
+++ b/specs/typescript-sdk/cli-experiment-results.feature
@@ -25,6 +25,13 @@ Feature: CLI evaluation results command
     And the CLI exits with status 0
 
   @integration @unimplemented
+  Scenario: A row whose only failure is the comparison is still a failed row
+    Given every target on a row produced output and passed its own evaluations
+    But the comparison judging that row errored
+    When I run `langwatch experiment results <experiment> --filter failed`
+    Then that row is shown
+    And the comparison's failure is shown with it
+
   Scenario: User filters the table to only failed rows
     Given an experiment whose latest run has both passing and failing rows
     When I run `langwatch experiment results <experiment> --filter failed`

--- a/typescript-sdk/src/cli/commands/experiment/__tests__/results.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/experiment/__tests__/results.unit.test.ts
@@ -409,3 +409,85 @@ describe("experimentResultsCommand()", () => {
     });
   });
 });
+
+/**
+ * A run where the ONLY failure is the comparison itself. Every target
+ * produced output and every per-target evaluation passed; the comparison
+ * errored. `--filter failed` has to be able to show that row.
+ */
+const comparisonFailedResults = {
+  experimentId: "exp_3",
+  runId: "run_3",
+  projectId: "proj_1",
+  progress: 2,
+  total: 2,
+  dataset: [
+    { index: 0, targetId: "target_a", entry: { input: "q1" } },
+    { index: 0, targetId: "target_b", entry: { input: "q1" } },
+  ],
+  evaluations: [
+    { evaluator: "quality", targetId: "target_a", index: 0, status: "processed", score: 0.9, passed: true },
+    { evaluator: "quality", targetId: "target_b", index: 0, status: "processed", score: 0.8, passed: true },
+    // Row-independent, and the only thing that went wrong.
+    { evaluator: "target_comparison", targetId: "target_comparison", index: 0, status: "error", details: "judge timed out" },
+  ],
+  timestamps: { createdAt: 0, updatedAt: 0 },
+};
+
+describe("experimentResultsCommand() — failures the row join cannot see", () => {
+  let mockGetRunResults2: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRunResults2 = vi.fn().mockResolvedValue(comparisonFailedResults);
+    vi.mocked(ExperimentsApiService).mockImplementation(function () {
+      return {
+        startRun: vi.fn(),
+        getRunStatus: vi.fn(),
+        getRunResults: mockGetRunResults2,
+        listRuns: vi.fn().mockResolvedValue({ runs: [{ runId: "run_3" }] }),
+      } as unknown as ExperimentsApiService;
+    });
+    vi.spyOn(console, "log").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+    mockProcessExit();
+  });
+
+  describe("given only the comparison failed", () => {
+    it("still surfaces the row under --filter failed", async () => {
+      // The failure filter walks the dataset join, and a comparison verdict
+      // has no dataset entry to hang off — so a row that failed ONLY on the
+      // comparison was silently filtered out. That is the evaluator this
+      // command was just taught to display.
+      const result = (await experimentResultsCommand({
+        experimentSlug: "exp",
+        options: { filter: "failed" },
+      })) as { data: { dataset: unknown[]; evaluations: { evaluator: string }[] } };
+
+      expect(result.data.dataset.length).toBeGreaterThan(0);
+      expect(
+        result.data.evaluations.some((e) => e.evaluator === "target_comparison"),
+      ).toBe(true);
+    });
+  });
+
+  describe("given nothing failed at all", () => {
+    it("shows no rows under --filter failed", async () => {
+      mockGetRunResults2.mockResolvedValue({
+        ...comparisonFailedResults,
+        evaluations: comparisonFailedResults.evaluations.map((e) =>
+          e.status === "error"
+            ? { ...e, status: "processed", score: 1, label: "target_a" }
+            : e,
+        ),
+      });
+
+      const result = (await experimentResultsCommand({
+        experimentSlug: "exp",
+        options: { filter: "failed" },
+      })) as { data: { dataset: unknown[] } };
+
+      expect(result.data.dataset.length).toBe(0);
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/experiment/__tests__/results.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/experiment/__tests__/results.unit.test.ts
@@ -66,6 +66,37 @@ const sampleResults = {
   timestamps: { createdAt: 0, updatedAt: 0 },
 };
 
+/**
+ * A run with a Comparison evaluator.
+ *
+ * The shape is the point: dataset entries are per (row, target), and the
+ * comparison's verdict is per row only — recorded against its own id, which
+ * is not one of the targets. Anything keyed that way has no dataset entry to
+ * hang off, which is exactly how 60 real verdicts went missing on a live run
+ * while the run summary still advertised the comparison.
+ */
+const comparisonResults = {
+  experimentId: "exp_2",
+  runId: "run_2",
+  projectId: "proj_1",
+  progress: 4,
+  total: 4,
+  dataset: [
+    { index: 0, targetId: "target_a", entry: { input: "q1" } },
+    { index: 0, targetId: "target_b", entry: { input: "q1" } },
+    { index: 1, targetId: "target_a", entry: { input: "q2" } },
+    { index: 1, targetId: "target_b", entry: { input: "q2" } },
+  ],
+  evaluations: [
+    { evaluator: "quality", targetId: "target_a", index: 0, status: "processed", score: 0.9, passed: true },
+    { evaluator: "quality", targetId: "target_b", index: 0, status: "processed", score: 0.4, passed: true },
+    // Keyed to the comparison, not to a target — no dataset row matches this.
+    { evaluator: "target_comparison", targetId: "target_comparison", index: 0, status: "processed", score: 1, label: "target_a", details: "A was clearer." },
+    { evaluator: "target_comparison", targetId: "target_comparison", index: 1, status: "processed", score: 1, label: "target_b", details: "B was more accurate." },
+  ],
+  timestamps: { createdAt: 0, updatedAt: 0 },
+};
+
 describe("experimentResultsCommand()", () => {
   let mockGetRunResults: ReturnType<typeof vi.fn>;
   let mockListRuns: ReturnType<typeof vi.fn>;
@@ -281,6 +312,80 @@ describe("experimentResultsCommand()", () => {
         expect(printed).toContain("interrupted");
         expect(printed).not.toContain("No rows matched the filter");
         expect(printed).not.toContain("still in progress");
+      });
+    });
+  });
+
+  describe("given a run with a Comparison evaluator", () => {
+    describe("when the results are returned", () => {
+      it("keeps the verdicts that belong to no single target", async () => {
+        mockGetRunResults.mockResolvedValue(comparisonResults);
+
+        const result = await experimentResultsCommand({
+          experimentSlug: "doc-qa",
+        });
+
+        const evaluations = (result as any).data.evaluations;
+        const verdicts = evaluations.filter(
+          (e: any) => e.evaluator === "target_comparison",
+        );
+        expect(verdicts).toHaveLength(2);
+        expect(verdicts.map((v: any) => v.label)).toEqual([
+          "target_a",
+          "target_b",
+        ]);
+        // The judge's reasoning is the reason to reach for this at all.
+        expect(verdicts[0].details).toBe("A was clearer.");
+      });
+
+      it("still reports every target-scoped evaluation", async () => {
+        // The comparison must be additive — a fix that surfaced verdicts by
+        // displacing the per-target scores would trade one gap for another.
+        mockGetRunResults.mockResolvedValue(comparisonResults);
+
+        const result = await experimentResultsCommand({
+          experimentSlug: "doc-qa",
+        });
+
+        const evaluations = (result as any).data.evaluations;
+        expect(
+          evaluations.filter((e: any) => e.evaluator === "quality"),
+        ).toHaveLength(2);
+      });
+    });
+
+    describe("when --limit drops some rows", () => {
+      it("reports verdicts only for the rows still shown", async () => {
+        mockGetRunResults.mockResolvedValue(comparisonResults);
+
+        const result = await experimentResultsCommand({
+          experimentSlug: "doc-qa",
+          options: { limit: "2" },
+        });
+
+        // limit=2 keeps the two row-0 entries, so only row 0's verdict.
+        const evaluations = (result as any).data.evaluations;
+        const verdicts = evaluations.filter(
+          (e: any) => e.evaluator === "target_comparison",
+        );
+        expect(verdicts).toHaveLength(1);
+        expect(verdicts[0].index).toBe(0);
+      });
+    });
+
+    describe("when --evaluator names a different evaluator", () => {
+      it("excludes the comparison", async () => {
+        mockGetRunResults.mockResolvedValue(comparisonResults);
+
+        const result = await experimentResultsCommand({
+          experimentSlug: "doc-qa",
+          options: { evaluator: "quality" },
+        });
+
+        const evaluations = (result as any).data.evaluations;
+        expect(
+          evaluations.some((e: any) => e.evaluator === "target_comparison"),
+        ).toBe(false);
       });
     });
   });

--- a/typescript-sdk/src/cli/commands/experiment/results.ts
+++ b/typescript-sdk/src/cli/commands/experiment/results.ts
@@ -111,6 +111,30 @@ export const experimentResultsCommand = async ({
       evaluationsByRow.set(key, list);
     }
 
+    // Evaluations that belong to no dataset entry.
+    //
+    // The dataset is one entry per (row, target), and the join below walks it.
+    // A Comparison evaluator judges the whole field of targets in a single
+    // verdict, so its result is recorded against the comparison itself rather
+    // than any one target — leaving it with no (row, target) pair to attach
+    // to. Walking the dataset alone therefore drops it without a word, which
+    // is how a real four-way run reported 240 of its 300 evaluations while the
+    // run summary still advertised the comparison.
+    //
+    // These are keyed by row instead, and follow whichever rows survive the
+    // filter and limit below.
+    const datasetKeys = new Set(
+      results.dataset.map((entry) => rowKey(entry.index, entry.targetId)),
+    );
+    const rowIndependentEvaluations = results.evaluations.filter(
+      (evaluation) => {
+        if (evaluatorFilter && evaluation.evaluator !== evaluatorFilter) {
+          return false;
+        }
+        return !datasetKeys.has(rowKey(evaluation.index, evaluation.targetId));
+      },
+    );
+
     // Determine evaluator columns to show
     const evaluatorNames = evaluatorFilter
       ? [evaluatorFilter]
@@ -133,11 +157,21 @@ export const experimentResultsCommand = async ({
     const truncated = rows.length > limit;
     rows = rows.slice(0, limit);
 
+    // Carry a row-independent evaluation only when its row is still on screen,
+    // so a verdict never describes a row the caller cannot see.
+    const shownIndices = new Set(rows.map((row) => row.entry.index));
+    const shownRowIndependent = rowIndependentEvaluations.filter((evaluation) =>
+      shownIndices.has(evaluation.index),
+    );
+
     return {
       data: {
         ...results,
         dataset: rows.map((row) => row.entry),
-        evaluations: rows.flatMap((row) => row.evaluations),
+        evaluations: [
+          ...rows.flatMap((row) => row.evaluations),
+          ...shownRowIndependent,
+        ],
         meta: {
           totalMatching,
           truncated,

--- a/typescript-sdk/src/cli/commands/experiment/results.ts
+++ b/typescript-sdk/src/cli/commands/experiment/results.ts
@@ -147,9 +147,34 @@ export const experimentResultsCommand = async ({
       evaluations: evaluationsByRow.get(rowKey(entry.index, entry.targetId)) ?? [],
     }));
 
+    // A row's failures are not all reachable through the dataset join.
+    //
+    // `isFailedRow` was handed only the evaluations keyed to that (row,
+    // target), so a row whose ONLY failure was the comparison — every target
+    // produced output, every per-target evaluation passed, and the judge
+    // errored — looked clean and was filtered out. That is the evaluator this
+    // command was just taught to display, so `--filter failed` could hide
+    // exactly the failure a caller came to find.
+    //
+    // Grouped by row index because that is all a row-independent evaluation
+    // has. Every target-row of that index carries it, which is right: the
+    // comparison covers the whole field on that row, so the row failed.
+    const rowIndependentByIndex = new Map<number, ExperimentRunEvaluation[]>();
+    for (const evaluation of rowIndependentEvaluations) {
+      const list = rowIndependentByIndex.get(evaluation.index) ?? [];
+      list.push(evaluation);
+      rowIndependentByIndex.set(evaluation.index, list);
+    }
+
     if (filter === "failed") {
       rows = rows.filter((r) =>
-        isFailedRow({ entry: r.entry, evaluations: r.evaluations }),
+        isFailedRow({
+          entry: r.entry,
+          evaluations: [
+            ...r.evaluations,
+            ...(rowIndependentByIndex.get(r.entry.index) ?? []),
+          ],
+        }),
       );
     }
 


### PR DESCRIPTION
## What & why

Split out of #6110. These two CLI fixes are Comparison-adjacent, which is how they ended up riding along with the leaderboard work, but they live in a different package (`typescript-sdk`) with their own spec file and their own test suite — a separate surface deserving its own review.

Clean cherry-pick onto `main`, zero conflicts, no code changes from the version in #6110.

## The two fixes

**1. Comparison verdicts were dropped from experiment results.** The results reader only understood evaluators that emit a numeric score. A Comparison emits a verdict — which variant won — so `langwatch experiment results` simply omitted them, and a run whose whole point was a pairwise comparison printed as though it had produced nothing.

**2. `--filter failed` could not see a failed comparison.** Same root cause one layer up: the filter predicate keyed on the numeric-score shape, so a Comparison that failed was invisible to the one flag whose entire job is surfacing failures. Worse than a missing row — the user asked specifically for failures and was told there were none.

## Tests

`results.unit.test.ts` covers both paths; **17 tests pass** on this branch alone. Scenarios are bound in `specs/typescript-sdk/cli-experiment-results.feature`.

## Merge order

Independent of #6110 — no leaderboard file touches the CLI. If #6110 merges first these arrive with it and this PR closes as already-applied; either order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experiment results now display comparison verdicts in CLI output.
  * Added support for filtering results by row limits and evaluators.
  * Comparison-only failures are included when filtering for failed rows.
  * Evaluations remain correctly associated with displayed rows, including when they are independent of specific dataset rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->