### PR TITLE
perf(event-sourcing): coalesce traceSummary fold and coding-agent maps (drain O(n²) → O(n))

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/mapCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/mapCoalescing.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { CODING_AGENT_MAP_COALESCE_MAX_BATCH } from "../../schemas/constants";
+import { CodingAgentTraceSessionsMapProjection } from "../codingAgentTraceSessions.mapProjection";
+import { SessionMetricSeriesMapProjection } from "../sessionMetricSeries.mapProjection";
+import {
+  CodingAgentTraceSessionAppendStore,
+  SessionMetricSeriesAppendStore,
+} from "../stores";
+
+/**
+ * A backed-up group without coalescing pays one append per queued event —
+ * the O(n²) drain pattern this pipeline's maps showed during the 2026-07-31
+ * backlog (one-event-per-job at ~90 busy slots). These tests pin the batch
+ * ceiling so a refactor cannot silently drop the option back to the
+ * framework default of 1.
+ */
+describe("coding-agent map coalescing", () => {
+  describe("when the trace-sessions map projection is constructed", () => {
+    it("declares the shared map coalesce ceiling", () => {
+      const projection = new CodingAgentTraceSessionsMapProjection({
+        store: new CodingAgentTraceSessionAppendStore({
+          insertMany: async () => undefined,
+        } as never),
+      });
+      expect(projection.options?.coalesceMaxBatch).toBe(
+        CODING_AGENT_MAP_COALESCE_MAX_BATCH,
+      );
+    });
+
+    it("backs the ceiling with a bulkAppend-capable store", () => {
+      const store = new CodingAgentTraceSessionAppendStore({
+        insertMany: async () => undefined,
+      } as never);
+      expect(typeof store.bulkAppend).toBe("function");
+    });
+  });
+
+  describe("when the session-metric-series map projection is constructed", () => {
+    it("declares the shared map coalesce ceiling", () => {
+      const projection = new SessionMetricSeriesMapProjection({
+        store: new SessionMetricSeriesAppendStore({
+          insertMany: async () => undefined,
+        } as never),
+      });
+      expect(projection.options?.coalesceMaxBatch).toBe(
+        CODING_AGENT_MAP_COALESCE_MAX_BATCH,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentTraceSessions.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentTraceSessions.mapProjection.ts
@@ -3,6 +3,7 @@ import {
   type MapEventHandlers,
 } from "../../../projections/abstractMapProjection";
 import type { AppendStore } from "../../../projections/mapProjection.types";
+import { CODING_AGENT_MAP_COALESCE_MAX_BATCH } from "../schemas/constants";
 import {
   type LogFactsContributedEvent,
   logFactsContributedEventSchema,
@@ -40,6 +41,9 @@ export class CodingAgentTraceSessionsMapProjection
   constructor(deps: { store: AppendStore<CodingAgentTraceSessionRecord> }) {
     super();
     this.store = deps.store;
+    this.options = {
+      coalesceMaxBatch: CODING_AGENT_MAP_COALESCE_MAX_BATCH,
+    };
   }
 
   mapCodingAgentSessionSpanFactsContributed(

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/sessionMetricSeries.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/sessionMetricSeries.mapProjection.ts
@@ -3,6 +3,7 @@ import {
   type MapEventHandlers,
 } from "../../../projections/abstractMapProjection";
 import type { AppendStore } from "../../../projections/mapProjection.types";
+import { CODING_AGENT_MAP_COALESCE_MAX_BATCH } from "../schemas/constants";
 import {
   type MetricFactsContributedEvent,
   metricFactsContributedEventSchema,
@@ -51,6 +52,9 @@ export class SessionMetricSeriesMapProjection
   constructor(deps: { store: AppendStore<SessionMetricSeriesRecord> }) {
     super();
     this.store = deps.store;
+    this.options = {
+      coalesceMaxBatch: CODING_AGENT_MAP_COALESCE_MAX_BATCH,
+    };
   }
 
   mapCodingAgentSessionMetricFactsContributed(

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
@@ -36,3 +36,18 @@ export const CODING_AGENT_PROCESSING_COMMAND_TYPES = [
   CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
   CONTRIBUTE_METRIC_FACTS_COMMAND_TYPE,
 ] as const;
+
+/**
+ * How many same-group events the pipeline's map projections persist through
+ * one `bulkAppend` call when a group is backed up. Without it the framework
+ * default is 1 — one append per queued event — which is the O(n²) drain
+ * pattern these maps showed during the 2026-07-31 backlog (one-event-per-job
+ * at ~90 busy fleet slots). 256 matches the log/metric map ceilings
+ * (`LOG_MAP_COALESCE_MAX_BATCH`, `METRIC_MAP_COALESCE_MAX_BATCH`): both
+ * stores append into ClickHouse via `insertMany`, so the batch lands as one
+ * insert either way — the ceiling only bounds payload size per dispatch.
+ * Unlike `CODING_AGENT_SESSION_COALESCE_MAX_BATCH` (128), no per-row
+ * watermark is persisted by these maps, so the session fold's tighter bound
+ * does not apply.
+ */
+export const CODING_AGENT_MAP_COALESCE_MAX_BATCH = 256;

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummary.coalesce.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummary.coalesce.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { MAX_APPLIED_EVENT_IDS } from "../../../../projections/foldCache/foldCacheEntry";
+import {
+  TRACE_SUMMARY_COALESCE_MAX_BATCH,
+  TraceSummaryFoldProjection,
+} from "../traceSummary.foldProjection";
+
+/**
+ * traceSummary is the hottest fold in the system — every trace event routes
+ * through it and fans out to its reactor subscribers. Without a coalesce
+ * ceiling the framework default is 1: one load/apply/store cycle per queued
+ * event, the O(n²) drain pattern measured during the 2026-07-31 backlog.
+ * These tests pin the ceiling and its safety bound.
+ */
+describe("traceSummary fold coalescing", () => {
+  describe("when the fold projection is constructed", () => {
+    it("declares a coalesce ceiling above the framework default of 1", () => {
+      const projection = new TraceSummaryFoldProjection({
+        store: {} as never,
+      });
+      expect(projection.options.coalesceMaxBatch).toBe(
+        TRACE_SUMMARY_COALESCE_MAX_BATCH,
+      );
+      expect(TRACE_SUMMARY_COALESCE_MAX_BATCH).toBeGreaterThan(1);
+    });
+
+    it("stays below the applied-event-id watermark cap that redelivery dedup depends on", () => {
+      expect(TRACE_SUMMARY_COALESCE_MAX_BATCH).toBeLessThan(
+        MAX_APPLIED_EVENT_IDS,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -101,6 +101,23 @@ export const MAX_PROCESSED_SPANS = 512;
 export const TRACE_SUMMARY_READ_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * How many same-trace events one load/apply/store cycle may coalesce.
+ *
+ * Without this the framework default is 1: a trace whose group backed up to
+ * N events paid N full load/apply/store cycles — the O(n²) drain pattern
+ * measured during the 2026-07-30/31 backlog, where hot traces queued
+ * hundreds of recordSpan-derived events and traceSummary held ~46 busy
+ * fleet slots processing them one at a time. Coalescing drains a backed-up
+ * trace in 128-event bites: one state read, N in-memory applies, one write.
+ *
+ * 128 mirrors `CODING_AGENT_SESSION_COALESCE_MAX_BATCH` (the proven fold
+ * ceiling) and stays well under `MAX_APPLIED_EVENT_IDS` (1000), the
+ * redelivery-dedup watermark cap the projection router validates at
+ * registration.
+ */
+export const TRACE_SUMMARY_COALESCE_MAX_BATCH = 128;
+
+/**
  * Reserved trace-summary attribute keys holding cache / reasoning token
  * SUMS across the whole trace. The per-span `gen_ai.usage.cache_*` numbers
  * never reach the trace-level attribute map (the accumulation allowlist
@@ -499,6 +516,7 @@ export class TraceSummaryFoldProjection
     refoldOnOutOfOrder: false,
     trustAbsentMiss: true,
     readWindow: { widthMs: TRACE_SUMMARY_READ_WINDOW_MS },
+    coalesceMaxBatch: TRACE_SUMMARY_COALESCE_MAX_BATCH,
   } as const;
 
   protected readonly events = traceSummaryEvents;


### PR DESCRIPTION
## For humans

When the event queue backs up, some processors were handling their pile one item at a time — reading state, applying one event, writing state, 500 times for 500 events. This change lets them grab the whole pile and apply it in one go (one read, one write). It's why the backlog today drained fast at first and then crawled: what remained was exactly the un-batched work.

## What

Three projections gain a `coalesceMaxBatch` ceiling (framework default is 1 = no batching):

- `traceSummary` fold → **128**. The hottest fold in the system had no ceiling: a hot trace with N queued events paid N full load/apply/store cycles. 128 mirrors `CODING_AGENT_SESSION_COALESCE_MAX_BATCH` and stays under the `MAX_APPLIED_EVENT_IDS` (1000) redelivery-dedup cap the projection router validates at registration.
- `codingAgentTraceSessions` map → **256** (new shared `CODING_AGENT_MAP_COALESCE_MAX_BATCH`).
- `sessionMetricSeries` map → **256**. Both stores already implement `bulkAppend` (one ClickHouse `insertMany`) — the queue-side option was the only missing piece.

Unit tests pin all three ceilings.

## Why now

Measured during the 2026-07-31 backlog (145k+ groups): after the ClickHouse fixes (#6399) the queue drained 140k→11k in minutes, then plateaued at ~40k — the un-coalesced tail, where the two coding-agent maps alone held ~90 of ~1,030 busy fleet slots processing one event per job, and traceSummary held ~46. Ops levers (pods, concurrency, tenant cap) were all exhausted against this floor; the remaining cost is per-item, which only batching cuts. Same mechanism as the previous night's "drains then stops at 700k".

## Scope note

`spanStorage` map is deliberately untouched: its group key is per-span (`span:${id}`), so groups never hold more than one event and coalescing is a no-op there — batching spans needs a group-key redesign (ADR-066 follow-up), not a ceiling.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved event processing efficiency for coding-agent sessions and metrics by batching related updates.
  * Improved trace summary processing by handling larger batches of events in each cycle.

* **Tests**
  * Added coverage to verify batching limits and append-store capabilities across event-processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->