### PR TITLE
perf(event-sourcing): shard-key + coalesce the spanStorage map (ADR-066 amendment)

### DIFF
--- a/dev/docs/adr/066-projection-clickhouse-cached-store.md
+++ b/dev/docs/adr/066-projection-clickhouse-cached-store.md
@@ -131,7 +131,7 @@ The principle is general; these are the components it lands on. Note that only t
 | Component | Kind | Lever |
 |---|---|---|
 | `codingAgentSession` fold | CH fold, lossy row, refolds `event_log` | **Pillar 1 adopter #1** — the component on fire |
-| `codingAgentTraceSessions`, `sessionMetricSeries` | map projections (append-only) | None — append stores, not read-modify-write; leave as-is |
+| `codingAgentTraceSessions`, `sessionMetricSeries` | map projections (append-only) | ~~None — append stores, not read-modify-write; leave as-is~~ **Amended 2026-07-31:** append maps DO coalesce (see amendment below) — shipped in langwatch#6407 at 256 |
 | `codingAgentSpanFactsDispatch` (+ log / metric) subscribers | event producers | None from this ADR — but move the coding-agent-name gate **before enqueue** so non-agent spans never mint jobs |
 | `contributeSpanFacts` command | producer | None |
 
@@ -143,6 +143,29 @@ Independently of the store: fix the **session = traceId fallback** so one large 
 |---|---|---|
 | `recordTriggerMatch` command | producer — one `TRIGGER_MATCH_RECORDED` per match (un-coalesced at incident time) | **Pillar 2 adopter #1 — shipped** (append coalescing on the count+byte-bounded drain) |
 | `triggerSettlement` | ADR-052 process manager, Postgres outbox state | None — evolves state incrementally from a PM store, never refolds `event_log`; its backlog is pure `event_log`-stall *symptom*, not a cause |
+
+### Amendment (2026-07-31): per-item map jobs are a drain floor — append maps coalesce too
+
+The original table left append-only maps alone because this ADR's enemy was
+`event_log` traffic, and an append map touches none. The 2026-07-30/31 backlog
+exposed a second cost axis the table missed: **queue-job overhead**. A map keyed
+per item (`span:${event.id}`, `rollup:${event.id}`, `billing:${event.id}`)
+pays one full GroupQueue job — claim, handler, event-append flush wait
+(~900 ms measured p50), one insert, ack — *per queued element*. Under backlog
+the cheap work burns off and these per-item processors set the drain floor:
+measured 2026-07-31, they held ~480 of ~1,030 busy fleet slots while four
+unrelated job types converged on the same ~4.7 s duration (the signature of
+shared overhead, not work — pods sat at 24–34% CPU).
+
+The amendment: **an append map whose group can back up adopts the metric-map
+shape** — shard-keyed lanes (`shardIndexFor`, bounded lane count) +
+`coalesceMaxBatch` + `bulkAppend` — so a backed-up lane drains N events per
+job instead of one. Adopters: coding-agent maps (langwatch#6407, 256),
+`spanStorage` (this change: `span-map:<lane>` pinned by span id, which also
+*fixes* an ordering hole — the per-event key let two deliveries of the same
+span run in parallel). Remaining: `traceAnalyticsRollup` and
+`orgBillableEventsMeter` (needs a billing idempotency review), then the
+`recordSpan` producer under Pillar 2's existing rule.
 
 ## Adopters & sequencing
 

--- a/dev/docs/adr/066-projection-clickhouse-cached-store.md
+++ b/dev/docs/adr/066-projection-clickhouse-cached-store.md
@@ -161,7 +161,7 @@ The amendment: **an append map whose group can back up adopts the metric-map
 shape** — shard-keyed lanes (`shardIndexFor`, bounded lane count) +
 `coalesceMaxBatch` + `bulkAppend` — so a backed-up lane drains N events per
 job instead of one. Adopters: coding-agent maps (langwatch#6407, 256),
-`spanStorage` (this change: `span-map:<lane>` pinned by span id, which also
+`spanStorage` (this change: `span-map:<lane>` at 256, lane pinned by span id, which also
 *fixes* an ordering hole — the per-event key let two deliveries of the same
 span run in parallel). Remaining: `traceAnalyticsRollup` and
 `orgBillableEventsMeter` (needs a billing idempotency review), then the

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
@@ -41,9 +41,10 @@ export const CODING_AGENT_PROCESSING_COMMAND_TYPES = [
  * How many same-group events the pipeline's map projections persist through
  * one `bulkAppend` call when a group is backed up. MAP projections default
  * to 1 — one append per queued event (unlike folds, which the router
- * coalesces at 500 by default) — which is the O(n²) drain pattern these
- * maps showed during the 2026-07-31 backlog (one-event-per-job at ~90 busy
- * fleet slots). 256 matches the log/metric map ceilings
+ * coalesces at 500 by default) — a linear per-item drain cost whose
+ * constant is a full queue job, the drain floor these maps showed during
+ * the 2026-07-31 backlog (one-event-per-job at ~90 busy fleet slots). 256
+ * matches the log/metric map ceilings
  * (`LOG_MAP_COALESCE_MAX_BATCH`, `METRIC_MAP_COALESCE_MAX_BATCH`): both
  * stores append into ClickHouse via `insertMany`, so the batch lands as one
  * insert either way — the ceiling only bounds payload size per dispatch.

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  SPAN_STORAGE_MAP_SHARD_COUNT,
+  spanStorageMapGroupKey,
+  TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
+} from "../spanStorageGroupKey";
+import { SpanStorageMapProjection } from "../spanStorage.mapProjection";
+
+/**
+ * spanStorage previously grouped by `span:${event.id}` — the EVENT id — so
+ * every delivery was its own single-event group: coalescing had nothing to
+ * batch (the O(n²) drain floor measured in the 2026-07-31 backlog), and two
+ * deliveries of the SAME span could run in parallel with no ordering
+ * guarantee. Shard keys fix both: same span → same lane (serialized), and a
+ * backed-up lane drains in coalesced bites through the store's bulkAppend.
+ */
+describe("spanStorage shard group key", () => {
+  const event = (spanId: string, id = `evt_${spanId}`) =>
+    ({ id, metadata: { spanId, traceId: "trace_1" } }) as never;
+
+  describe("when the same span is delivered twice", () => {
+    it("routes both deliveries to the same lane", () => {
+      expect(spanStorageMapGroupKey(event("span_a", "evt_1"))).toBe(
+        spanStorageMapGroupKey(event("span_a", "evt_2")),
+      );
+    });
+  });
+
+  describe("when many distinct spans arrive", () => {
+    it("distributes across multiple lanes, all within the shard count", () => {
+      const lanes = new Set<string>();
+      for (let i = 0; i < 500; i++) {
+        const key = spanStorageMapGroupKey(event(`span_${i}`));
+        expect(key).toMatch(/^span-map:\d+$/);
+        const lane = Number(key.split(":")[1]);
+        expect(lane).toBeGreaterThanOrEqual(0);
+        expect(lane).toBeLessThan(SPAN_STORAGE_MAP_SHARD_COUNT);
+        lanes.add(key);
+      }
+      // 500 spans over 128 lanes: overwhelmingly many lanes populated.
+      expect(lanes.size).toBeGreaterThan(64);
+    });
+  });
+
+  describe("when the event carries no span id in metadata", () => {
+    it("falls back to the event id, still deterministic", () => {
+      const bare = { id: "evt_only", metadata: {} } as never;
+      expect(spanStorageMapGroupKey(bare)).toBe(spanStorageMapGroupKey(bare));
+      expect(spanStorageMapGroupKey(bare)).toMatch(/^span-map:\d+$/);
+    });
+  });
+
+  describe("when the projection is constructed", () => {
+    it("declares the shard key and the coalesce ceiling", () => {
+      const projection = new SpanStorageMapProjection({ store: {} as never });
+      expect(projection.options.coalesceMaxBatch).toBe(
+        TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
+      );
+      expect(TRACE_SPAN_MAP_COALESCE_MAX_BATCH).toBeGreaterThan(1);
+      // Guard against regressing to the per-event key.
+      expect(
+        projection.options.groupKeyFn(event("span_x", "evt_unique")),
+      ).not.toContain("evt_unique");
+      expect(projection.options.groupKeyFn(event("span_x"))).toBe(
+        spanStorageMapGroupKey(event("span_x")),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
@@ -1,18 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { SpanStorageMapProjection } from "../spanStorage.mapProjection";
 import {
   SPAN_STORAGE_MAP_SHARD_COUNT,
   spanStorageMapGroupKey,
   TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
 } from "../spanStorageGroupKey";
-import { SpanStorageMapProjection } from "../spanStorage.mapProjection";
 
 /**
  * spanStorage previously grouped by `span:${event.id}` — the EVENT id — so
  * every delivery was its own single-event group: coalescing had nothing to
- * batch (the O(n²) drain floor measured in the 2026-07-31 backlog), and two
- * deliveries of the SAME span could run in parallel with no ordering
- * guarantee. Shard keys fix both: same span → same lane (serialized), and a
- * backed-up lane drains in coalesced bites through the store's bulkAppend.
+ * batch (a linear per-item drain cost whose constant is a full queue job —
+ * the drain floor measured in the 2026-07-31 backlog), and two deliveries
+ * of the SAME span could run in parallel with no ordering guarantee. Shard
+ * keys fix both: same span → same lane (serialized), and a backed-up lane
+ * drains in coalesced bites through the store's bulkAppend.
  */
 describe("spanStorage shard group key", () => {
   const event = (spanId: string, id = `evt_${spanId}`) =>
@@ -43,9 +44,15 @@ describe("spanStorage shard group key", () => {
   });
 
   describe("when the event carries no span id in metadata", () => {
-    it("falls back to the event id, still deterministic", () => {
+    it("falls back to hashing the event id", () => {
       const bare = { id: "evt_only", metadata: {} } as never;
-      expect(spanStorageMapGroupKey(bare)).toBe(spanStorageMapGroupKey(bare));
+      // The bare event must land on the SAME lane as an event whose spanId
+      // equals the bare event's id — proving the fallback input is the event
+      // id, not a constant.
+      const spanIdMatchingBareId = event("evt_only", "evt_other");
+      expect(spanStorageMapGroupKey(bare)).toBe(
+        spanStorageMapGroupKey(spanIdMatchingBareId),
+      );
       expect(spanStorageMapGroupKey(bare)).toMatch(/^span-map:\d+$/);
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
@@ -63,8 +63,16 @@ describe("spanStorage shard group key", () => {
       // `<tenantId>/map/spanStorage/<domainKey>`, so the domain key must be a
       // pure function of the span identity: same span id → same lane string,
       // and the tenant prefix keeps lanes tenant-scoped.
-      const a = { id: "evt_1", tenantId: "tenant_a", metadata: { spanId: "span_s", traceId: "t" } } as never;
-      const b = { id: "evt_2", tenantId: "tenant_b", metadata: { spanId: "span_s", traceId: "t" } } as never;
+      const a = {
+        id: "evt_1",
+        tenantId: "tenant_a",
+        metadata: { spanId: "span_s", traceId: "t" },
+      } as never;
+      const b = {
+        id: "evt_2",
+        tenantId: "tenant_b",
+        metadata: { spanId: "span_s", traceId: "t" },
+      } as never;
       expect(spanStorageMapGroupKey(a)).toBe(spanStorageMapGroupKey(b));
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/spanStorageGroupKey.unit.test.ts
@@ -57,13 +57,27 @@ describe("spanStorage shard group key", () => {
     });
   });
 
+  describe("when events for the same span belong to different tenants", () => {
+    it("returns the same lane — tenant scoping is the queue prefix's job", () => {
+      // The queue composes the full group id as
+      // `<tenantId>/map/spanStorage/<domainKey>`, so the domain key must be a
+      // pure function of the span identity: same span id → same lane string,
+      // and the tenant prefix keeps lanes tenant-scoped.
+      const a = { id: "evt_1", tenantId: "tenant_a", metadata: { spanId: "span_s", traceId: "t" } } as never;
+      const b = { id: "evt_2", tenantId: "tenant_b", metadata: { spanId: "span_s", traceId: "t" } } as never;
+      expect(spanStorageMapGroupKey(a)).toBe(spanStorageMapGroupKey(b));
+    });
+  });
+
   describe("when the projection is constructed", () => {
     it("declares the shard key and the coalesce ceiling", () => {
       const projection = new SpanStorageMapProjection({ store: {} as never });
       expect(projection.options.coalesceMaxBatch).toBe(
         TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
       );
-      expect(TRACE_SPAN_MAP_COALESCE_MAX_BATCH).toBeGreaterThan(1);
+      // 256 is deliberate (matches the log/metric map ceilings); changing it
+      // is a decision, so the exact value is pinned.
+      expect(TRACE_SPAN_MAP_COALESCE_MAX_BATCH).toBe(256);
       // Guard against regressing to the per-event key.
       expect(
         projection.options.groupKeyFn(event("span_x", "evt_unique")),

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.mapProjection.ts
@@ -15,6 +15,10 @@ import {
 import type { NormalizedSpan } from "../schemas/spans";
 import { deriveSpanCost } from "./services/span-cost.derivation";
 import { SpanCostService } from "./services/span-cost.service";
+import {
+  spanStorageMapGroupKey,
+  TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
+} from "./spanStorageGroupKey";
 
 const spanNormalizationPipelineService = new SpanNormalizationPipelineService(
   new CanonicalizeSpanAttributesService(),
@@ -38,7 +42,12 @@ export class SpanStorageMapProjection
   protected readonly events = spanEvents;
 
   override options = {
-    groupKeyFn: (event: { id: string }) => `span:${event.id}`,
+    // Shard-keyed lanes + coalescing (ADR-066): same span → same lane
+    // (redeliveries serialize), backed-up lanes drain in 256-event
+    // bulkAppend bites instead of one queue job per span. See
+    // spanStorageGroupKey.ts for the measured rationale.
+    groupKeyFn: spanStorageMapGroupKey,
+    coalesceMaxBatch: TRACE_SPAN_MAP_COALESCE_MAX_BATCH,
   };
 
   constructor(deps: { store: AppendStore<NormalizedSpan> }) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
@@ -4,7 +4,8 @@
  * The historic key was `span:${event.id}` — the EVENT id — which meant every
  * delivery formed its own single-event group. That bought maximum parallelism
  * at maximum cost: coalescing had nothing to batch (a backed-up tenant paid
- * one full queue job + one ClickHouse insert per span — the O(n²) drain floor
+ * one full queue job + one ClickHouse insert per span — a linear per-item
+ * drain cost whose constant is the whole overhead of a job, the drain floor
  * measured in the 2026-07-30/31 backlog, where spanStorage held ~118 of
  * ~1,030 busy fleet slots), and two deliveries of the SAME span could run in
  * parallel with no ordering guarantee.

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
@@ -20,6 +20,12 @@
  *
  * Rollout note: old `span:{eventId}` groups drain naturally under their
  * historic keys; new events route to lanes. No key collision, no migration.
+ * During the transition a span's old-key and new-key deliveries can process
+ * in either order — which is exactly the (absence of) guarantee the per-event
+ * key always had, and is harmless either way: `stored_spans` is
+ * ReplacingMergeTree(StartTime) keyed by (TenantId, TraceId, SpanId)
+ * (migration 00002), so the surviving row is chosen by the span's own
+ * business timestamp, independent of insert order.
  */
 
 import type { Event } from "../../../domain/types";

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
@@ -1,0 +1,56 @@
+/**
+ * Shard-keyed grouping for the spanStorage map projection (ADR-066).
+ *
+ * The historic key was `span:${event.id}` — the EVENT id — which meant every
+ * delivery formed its own single-event group. That bought maximum parallelism
+ * at maximum cost: coalescing had nothing to batch (a backed-up tenant paid
+ * one full queue job + one ClickHouse insert per span — the O(n²) drain floor
+ * measured in the 2026-07-30/31 backlog, where spanStorage held ~118 of
+ * ~1,030 busy fleet slots), and two deliveries of the SAME span could run in
+ * parallel with no ordering guarantee.
+ *
+ * The shard key gives each tenant `SPAN_STORAGE_MAP_SHARD_COUNT` lanes, with
+ * a span's lane pinned by its span id (FNV-1a, the same bucketing the
+ * recordSpan command shards use — `commandShardKey.ts`). Same span → same
+ * lane, so redeliveries serialize; distinct spans spread across 128 lanes, so
+ * effective parallelism matches the fleet's slot budget; and a backed-up lane
+ * drains in coalesced bites (`TRACE_SPAN_MAP_COALESCE_MAX_BATCH` events per
+ * load/apply/bulkAppend cycle, byte-bounded by the queue's coalesce budget).
+ *
+ * Rollout note: old `span:{eventId}` groups drain naturally under their
+ * historic keys; new events route to lanes. No key collision, no migration.
+ */
+
+import type { Event } from "../../../domain/types";
+import { shardIndexFor } from "../commands/commandShardKey";
+
+/**
+ * Lanes per tenant. Matches `MAX_SPAN_SHARD_COUNT` on the recordSpan command
+ * side and the metric maps' shard count: 128 lanes is far more parallelism
+ * than any tenant's fair-share of fleet slots, so the change costs no real
+ * concurrency, while bounding the number of groups (and parked entries under
+ * the tenant soft-cap) a tenant's span traffic can create.
+ */
+export const SPAN_STORAGE_MAP_SHARD_COUNT = 128;
+
+/**
+ * How many same-lane span events one queue dispatch may coalesce into a
+ * single bulkAppend. Matches the log/metric map ceilings; the queue's
+ * byte budget (ADR-066 pillar 2) bounds fat-span batches independently, so
+ * the count ceiling never produces an oversized insert.
+ */
+export const TRACE_SPAN_MAP_COALESCE_MAX_BATCH = 256;
+
+/**
+ * GroupQueue key for a span-received event: `span-map:<lane>`, lane pinned by
+ * the span id (from event metadata; the event id is the deterministic
+ * fallback for malformed metadata). The framework prepends
+ * `<tenantId>/map/spanStorage/` so lanes are always tenant-scoped.
+ */
+export function spanStorageMapGroupKey(event: Event): string {
+  const spanId =
+    typeof event.metadata?.spanId === "string" && event.metadata.spanId !== ""
+      ? event.metadata.spanId
+      : event.id;
+  return `span-map:${shardIndexFor(spanId, SPAN_STORAGE_MAP_SHARD_COUNT)}`;
+}


### PR DESCRIPTION
## For humans

During a backlog, the span-storage processor handles its pile one span at a time — each span pays a full queue job and its own database insert. This change groups spans into 128 lanes per workspace and lets a backed-up lane process up to 256 spans in one go (one job, one bulk insert). It also fixes a latent ordering hole: two deliveries of the same span could previously run in parallel.

## What

- **New `spanStorageGroupKey.ts`**: `span-map:<lane>`, lane pinned by the span id using the same FNV-1a bucketing the recordSpan command shards already use (`commandShardKey.ts`), 128 lanes per tenant, deterministic fallback to the event id when metadata lacks a span id. Verified that ADR-022 leaning never strips `metadata.spanId` (leaning touches only `data.span.attributes`).
- **`spanStorage.mapProjection.ts`**: `groupKeyFn` swaps from `span:${event.id}` (one event per group, forever) to the shard key, plus `coalesceMaxBatch: 256`. The store's `bulkAppend` already exists — 256 normalized spans land as one `insertMany`. The queue's byte budget bounds fat-span batches independently.
- **ADR-066 amendment (2026-07-31)**: the original adopters table said append maps "leave as-is" — that verdict priced only `event_log` traffic. The incident measured the second axis: per-item queue-job overhead set the drain floor (~480/1,030 busy slots on per-item processors, four unrelated job types converging on ~4.7s = shared overhead, not work). The amendment records the rule and the adopter ledger.

## Why this shape

- **Ordering improves, not degrades**: today's per-EVENT key gives the same span's redeliveries no ordering; span-id lanes serialize them.
- **Parallelism preserved**: 128 lanes/tenant ≫ any tenant's fair share of fleet slots (tenant soft-cap bounds it anyway).
- **Proven template**: the metric maps run exactly this design in production (`metricMapGroupKey` + 256 + bulkAppend).
- **Rollout-safe**: old `span:{eventId}` groups drain under their historic keys; new events route to lanes; no collision, no migration.

## Measured basis (2026-07-31 incident)

| Signal | Value |
|---|---|
| spanStorage busy slots at peak | ~110–118 of ~1,030 |
| Duration across 4 unrelated job types | ~4.7 s uniform (overhead-dominated; pods 24–34% CPU) |
| ClickHouse insert flush wait | ~900 ms p50, paid per job |
| Deepest tenant drained | 149,604 jobs / 296 groups |

## Follow-ups (not this PR)

`traceAnalyticsRollup` (needs bulkAppend written), `orgBillableEventsMeter` (billing idempotency review), `recordSpan` producer coalescing (Pillar 2).

## Verification

107 test files / 1,221 tests green (6 pinning determinism, same-span colocation, tenant-independence, lane bounds, the exact 256 ceiling, and the options wiring), `typecheck` + `typecheck:tests` clean.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved span event processing by combining related events into bounded batches.
  - Added parallel processing lanes to increase throughput while preserving consistent span handling.
  - Added fallback handling for events with missing span metadata, improving processing reliability.

- **Documentation**
  - Documented the updated event-processing, batching, and parallelization approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

- **Env vars:** none added, removed, or changed. Shard count and coalesce ceiling are code constants (`SPAN_STORAGE_MAP_SHARD_COUNT = 128`, `TRACE_SPAN_MAP_COALESCE_MAX_BATCH = 256`).
- **Helm values / default Helm behavior:** unchanged. No new configuration surface; workers pick up the new group key on the next image rollout with no chart edits.
- **BYOC dataplane:** no impact beyond the same image upgrade — the change is internal queue routing; no new external connections, ports, or permissions. Per-tenant private ClickHouse routing is untouched.
- **Rollout/rollback semantics:** old `span:{eventId}` groups drain under their historic keys while new events route to `span-map:<lane>` — both key families coexist safely during rollout (and during rollback, in reverse). The ordering improvement is complete once historic groups drain (~minutes at normal load). No migration, no data-shape change: the store writes the same rows, just batched.