### PR TITLE
fix(automations): serialize graph-trigger sweeps in one lane per tenant

### DIFF
--- a/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
@@ -127,6 +127,27 @@ describe("StaticPipelineBuilder validations", () => {
       );
     });
 
+    it("threads a custom groupKeyFn through to the raw subscriber definition", () => {
+      // Without the pass-through, a subscriber spec's groupKeyFn silently
+      // vanished and the queue fell back to per-aggregate groups — the gap
+      // behind the 2026-07-31 parallel sweep storm (dedup bounded staging,
+      // nothing bounded concurrency).
+      const laneFn = (e: Event) => `lane:${e.tenantId}`;
+      const pipeline = definePipeline<Event>()
+        .withName("test-pipeline")
+        .withAggregateType("trace")
+        .withSubscriber("settle", {
+          events: ["trace_received"],
+          groupKeyFn: laneFn,
+          handler: vi.fn(),
+        })
+        .build();
+
+      const options = pipeline.eventSubscribers.get("settle")?.options;
+      expect(options?.groupKeyFn).toBe(laneFn);
+      expect(options?.groupKeyFn?.(event)).toBe("lane:project-1");
+    });
+
     it("preserves the full deduplication contract on a raw subscriber", () => {
       const pipeline = definePipeline<Event>()
         .withName("test-pipeline")

--- a/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
@@ -166,8 +166,8 @@ describe("StaticPipelineBuilder validations", () => {
         })
         .build();
 
-      const reactorGroupKeyFn = pipeline.foldReactors?.get("settle")?.definition
-        .options?.groupKeyFn;
+      const reactorGroupKeyFn =
+        pipeline.foldReactors?.get("settle")?.definition.options?.groupKeyFn;
       expect(reactorGroupKeyFn?.({ event, foldState: {} })).toBe(
         "lane:project-1",
       );

--- a/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.unit.test.ts
@@ -148,6 +148,31 @@ describe("StaticPipelineBuilder validations", () => {
       expect(options?.groupKeyFn?.(event)).toBe("lane:project-1");
     });
 
+    it("adapts a custom groupKeyFn onto a fold subscriber's reactor payload", () => {
+      // Fold/map subscribers dispatch with a { event, foldState } payload;
+      // the spec's event-shaped key must be adapted, not silently dropped —
+      // dropping it recreates the raw-subscriber gap on the reactor path.
+      const laneFn = (e: Event) => `lane:${e.tenantId}`;
+      const fold = createMockFoldProjectionDefinition<Event>("summary");
+      const pipeline = definePipeline<Event>()
+        .withName("test-pipeline")
+        .withAggregateType("trace")
+        .withFoldProjection("summary", fold)
+        .withSubscriber("settle", {
+          fold: "summary",
+          events: ["trace_received"],
+          groupKeyFn: laneFn,
+          handler: vi.fn(),
+        })
+        .build();
+
+      const reactorGroupKeyFn = pipeline.foldReactors?.get("settle")?.definition
+        .options?.groupKeyFn;
+      expect(reactorGroupKeyFn?.({ event, foldState: {} })).toBe(
+        "lane:project-1",
+      );
+    });
+
     it("preserves the full deduplication contract on a raw subscriber", () => {
       const pipeline = definePipeline<Event>()
         .withName("test-pipeline")

--- a/langwatch/src/server/event-sourcing/pipeline/processManagerDefinition.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/processManagerDefinition.ts
@@ -19,6 +19,20 @@ export interface TriggerOptions<E extends Event = Event> {
   dedup?: DeduplicationStrategy<E>;
   dedupId?: (event: E) => string;
   when?: (event: E) => boolean;
+  /**
+   * Domain key for the subscriber's GroupQueue group. Default is
+   * per-aggregate (`<aggregateType>:<aggregateId>`), which maximizes
+   * parallelism — and means dedup bounds how fast jobs are BORN, not how many
+   * run at once: jobs staged across successive dedup windows land in
+   * different groups and dispatch concurrently. A subscriber whose handler is
+   * expensive and idempotent per tenant (a sweep that evaluates current
+   * state) should key by tenant so queued deliveries serialize in one lane
+   * instead of stacking into a parallel storm (2026-07-31: ~85 concurrent
+   * trigger sweeps for one tenant where the 5s debounce intended 0.2/s).
+   * The queue prefixes `<tenantId>/subscriber/<name>/` around this key, so
+   * tenant scoping holds regardless.
+   */
+  groupKeyFn?: (event: E) => string;
 }
 
 export interface TriggerContext<State = unknown> {

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
@@ -401,6 +401,7 @@ export class StaticPipelineBuilderWithNameAndType<
       eventTypes: spec.events ?? [],
       options: {
         delay: spec.delay,
+        groupKeyFn: spec.groupKeyFn,
         deduplication:
           spec.dedup ??
           (spec.dedupId

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
@@ -376,6 +376,13 @@ export class StaticPipelineBuilderWithNameAndType<
             };
           })(),
           delay: spec.delay ?? 0,
+          // Reactor payloads wrap the event; adapt the spec's event-shaped
+          // key so fold/map subscribers get the same lane semantics as raw
+          // ones instead of a silently dropped option.
+          groupKeyFn: spec.groupKeyFn
+            ? (payload: { event: Event; foldState: unknown }) =>
+                spec.groupKeyFn!(payload.event as EventType)
+            : undefined,
         },
         // Pre-enqueue rejection: a filtered event never pays serialization.
         shouldReact: passes,

--- a/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/__tests__/graphTriggerActivity.groupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/__tests__/graphTriggerActivity.groupKey.unit.test.ts
@@ -31,4 +31,25 @@ describe("graphTriggerActivityGroupKey", () => {
       "graph-trigger-activity:project_x",
     );
   });
+
+  describe("when the trace and evaluation pipelines wake the sweep for one tenant", () => {
+    it("both land in the same final lane — the group id carries no pipeline segment", () => {
+      // A sweep evaluates ALL of the tenant's graph triggers regardless of
+      // which event kind (span vs evaluation) woke it, so the two pipelines'
+      // registrations must converge on one serialized lane per tenant.
+      const fromTrace = {
+        tenantId: "project_x",
+        aggregateId: "trace_1",
+        type: "lw.obs.trace.span_received",
+      } as never;
+      const fromEvaluation = {
+        tenantId: "project_x",
+        aggregateId: "eval_1",
+        type: "lw.obs.evaluation.completed",
+      } as never;
+      expect(graphTriggerActivityGroupKey(fromTrace)).toBe(
+        graphTriggerActivityGroupKey(fromEvaluation),
+      );
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/__tests__/graphTriggerActivity.groupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/__tests__/graphTriggerActivity.groupKey.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { graphTriggerActivityGroupKey } from "../graphTriggerActivity.subscriber";
+
+/**
+ * The sweep lane must be tenant-keyed and aggregate-independent: all of a
+ * tenant's sweep jobs serialize in one group, so the 5s dedup's staging
+ * bound is matched by a concurrency bound of 1. A key that varies by trace
+ * or event id regresses to the 2026-07-31 parallel sweep storm.
+ */
+describe("graphTriggerActivityGroupKey", () => {
+  describe("when events for the same tenant come from different traces", () => {
+    it("routes them to the same lane", () => {
+      const a = { tenantId: "project_x", aggregateId: "trace_1" } as never;
+      const b = { tenantId: "project_x", aggregateId: "trace_2" } as never;
+      expect(graphTriggerActivityGroupKey(a)).toBe(
+        graphTriggerActivityGroupKey(b),
+      );
+    });
+  });
+
+  describe("when events belong to different tenants", () => {
+    it("routes them to different lanes", () => {
+      expect(graphTriggerActivityGroupKey({ tenantId: "project_x" })).not.toBe(
+        graphTriggerActivityGroupKey({ tenantId: "project_y" }),
+      );
+    });
+  });
+
+  it("matches the dedup id family so lane and dedup describe the same unit", () => {
+    expect(graphTriggerActivityGroupKey({ tenantId: "project_x" })).toBe(
+      "graph-trigger-activity:project_x",
+    );
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber.ts
@@ -10,6 +10,29 @@ const logger = createLogger(
 /** Locked ADR-034 Phase 5 real-time debounce. */
 export const GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS = 5_000;
 
+/**
+ * One queue lane per tenant for graph-trigger sweeps.
+ *
+ * Without this the subscriber inherited per-aggregate (per-trace) groups, so
+ * the 5s dedup only bounded how fast sweep jobs were STAGED — jobs staged
+ * across successive windows landed in different trace-keyed groups and
+ * dispatched concurrently. Under sustained traffic that stacked into a
+ * parallel sweep storm: measured 2026-07-31, ~85 concurrent sweeps for one
+ * tenant (~8/s where the debounce intends 0.2/s), each a multi-hundred-MiB
+ * analytics query, saturating ClickHouse selects fleet-wide.
+ *
+ * A sweep evaluates the tenant's CURRENT trigger state — running two
+ * concurrently is pure waste — so all of a tenant's sweeps belong in one
+ * serialized lane. Queued deliveries then drain one at a time, and a backlog
+ * of stale sweep jobs degrades to cheap sequential re-evaluations. The queue
+ * prefixes `<tenantId>/subscriber/graphTriggerActivity/` around this key.
+ */
+export function graphTriggerActivityGroupKey(event: {
+  tenantId: string;
+}): string {
+  return `graph-trigger-activity:${event.tenantId}`;
+}
+
 export interface GraphTriggerActivityDeps {
   triggers: TriggerService;
   evaluateGraphTrigger: (params: {

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -1,5 +1,8 @@
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
-import { GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS } from "~/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber";
+import {
+  GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS,
+  graphTriggerActivityGroupKey,
+} from "~/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber";
 import { definePipeline } from "../../";
 import type { TriggerContext } from "../../pipeline/processManagerDefinition";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
@@ -104,6 +107,11 @@ export function createEvaluationProcessingPipeline(
         extend: false,
         replace: false,
       },
+      // Same tenant lane as the trace-processing registration: the group id
+      // carries no pipeline segment, so both pipelines' sweeps serialize in
+      // ONE lane per tenant — a sweep evaluates all of the tenant's graph
+      // triggers regardless of which event kind woke it.
+      groupKeyFn: graphTriggerActivityGroupKey,
       handler: (event, context) =>
         deps.automations.graphActivityHandler(event, context),
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -1,6 +1,9 @@
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import { GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS } from "~/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber";
+import {
+  GRAPH_TRIGGER_REAL_TIME_DEBOUNCE_MS,
+  graphTriggerActivityGroupKey,
+} from "~/server/event-sourcing/pipelines/automations/subscribers/graphTriggerActivity.subscriber";
 import { definePipeline } from "../../";
 import type { TriggerContext } from "../../pipeline/processManagerDefinition";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
@@ -206,6 +209,11 @@ export function createTraceProcessingPipeline(
         extend: false,
         replace: false,
       },
+      // One lane per tenant: the dedup bounds staging rate, the lane bounds
+      // CONCURRENCY — without it, sweeps staged across successive windows sat
+      // in per-trace groups and ran as a parallel storm (see
+      // graphTriggerActivityGroupKey).
+      groupKeyFn: graphTriggerActivityGroupKey,
       handler: (event, context) =>
         deps.automations.graphActivityHandler(event, context),
     })


### PR DESCRIPTION
## For humans

When a customer's traffic surges, our alert-checking sweeps for that customer were piling up in the queue and then all running at once — dozens of copies of the same expensive database query, asking the same question. This makes them run one at a time per customer, which is all a sweep ever needs: each one evaluates the *current* state.

## What

- `graphTriggerActivity` gets a **tenant-keyed queue lane** (`graphTriggerActivityGroupKey`, same key family as its dedup id) instead of the inherited per-trace groups.
- Plumbing: `TriggerOptions.groupKeyFn` added and threaded through `staticBuilder` — the router (`projectionRouter.ts:336`) and queue (`queueManager.buildGroupKey`) already supported it end-to-end; only the builder spec dropped it. The queue still prefixes `<tenantId>/subscriber/graphTriggerActivity/`, so tenant scoping is unchanged.

## Why (measured, 2026-07-31 ~14:30 UTC)

The 5s debounce dedup bounds how fast sweep jobs are **staged**, not how many **run at once**. Each staged job landed in its own per-trace group; when one paying tenant's traffic rose ~18×, their queued sweeps drained as **~85 concurrent executions (~8/s where the design intends 0.2/s)** from 9–10 worker pods simultaneously — 99.3% of the ClickHouse select saturation window (avg 97ms → 1,507ms), reversing the fleet-wide queue drain. Killed on the way: dashboard refresh (all sources were worker pods), retry amplification (zero retries), trigger-config changes (unchanged since 07-29).

## Behavior change

Per tenant, sweep concurrency drops from unbounded to 1. Cross-tenant parallelism is unchanged (one lane per tenant). Rollout: in-flight per-trace groups drain under their old keys; new events route to the tenant lane — both key families are valid concurrently, and running one old and one new sweep in parallel is the status quo, not a regression.

## Tests

- Builder pass-through pinned (a spec's `groupKeyFn` reaches the subscriber definition — the exact gap that caused this).
- Lane key pinned: same tenant/different traces → same lane; different tenants → different lanes; exact key format.
- 141 test files / 6,566 tests green across pipeline + automations + trace-processing; `typecheck` + `typecheck:tests` clean.

## Deployment Impact

- **Env vars / Helm values / default Helm behavior:** none — no new configuration surface.
- **BYOC dataplane:** no impact beyond the image upgrade; internal queue routing only.
- **Rollback:** revert restores per-trace groups; no data-shape or migration concerns.

Related: #6412 (the trigger-eval cost work: parallelize per-trigger loop, skip unused previous period — this PR fixes the *concurrency* axis, that one the *per-execution cost* axis).

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-based grouping for graph-trigger activity processing.
  * Added support for custom event grouping keys, enabling serialized processing by tenant or other business identifiers.

* **Bug Fixes**
  * Improved consistency between event grouping and deduplication behavior, helping keep related activity processing isolated and orderly.

* **Tests**
  * Added coverage for custom grouping keys, tenant isolation, cross-pipeline behavior, and grouping consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->