### PR TITLE
fix(clickhouse): replicate the rollup tables a Replicated database was silently fragmenting

### DIFF
--- a/dev/docs/runbooks/analytics-rollup-replay.md
+++ b/dev/docs/runbooks/analytics-rollup-replay.md
@@ -53,21 +53,24 @@ surface (`getReplayStatus`, `getReplayHistory`, `cancelReplay`). The map-path
 replay appends increments per event; because the migration left the tables
 empty, appending reconstructs exact totals. Do not run the replay twice
 concurrently and do not re-run it after a successful pass without truncating
-first (the table's contract is replay-rebuilds-truncate-first, see 00038).
+first (both tables' contract is replay-rebuilds-truncate-first, see 00038 for
+the trace rollup and 00040 for the evaluation rollup).
 
 ## How to verify
 
-Row counts must be identical on every replica once replication catches up
-(query each replica directly, not through the load balancer):
+The logical totals must be identical on every replica once replication
+catches up. Compare SUMS, not raw row counts: the table is an
+AggregatingMergeTree, so each replica may hold a different merge state
+(different physical row counts) while the summed values agree.
 
 ```sql
-SELECT hostName(), count(), sum(SpanCount)
+SELECT hostName(), sum(SpanCount), sum(TraceCount), round(sum(CostSum), 6)
 FROM clusterAllReplicas('langwatch', currentDatabase(), 'trace_analytics_rollup')
 GROUP BY hostName();
 ```
 
 Same shape for `evaluation_analytics_rollup` with `EvalCount`. Every replica
-must report the same numbers; divergence means the table is still on a plain
+must report the same sums; divergence means the table is still on a plain
 engine somewhere (check `SELECT engine FROM system.tables WHERE name = 'trace_analytics_rollup'`
 on each replica, all must say `ReplicatedAggregatingMergeTree`).
 

--- a/dev/docs/runbooks/analytics-rollup-replay.md
+++ b/dev/docs/runbooks/analytics-rollup-replay.md
@@ -1,0 +1,89 @@
+# Analytics rollup replay after the Replicated-engine conversion
+
+> **Why this exists**: migrations 00065 and 00066 convert
+> `trace_analytics_rollup` and `evaluation_analytics_rollup` from plain
+> `AggregatingMergeTree` to the Replicated engine. On clustered deployments
+> (`CLICKHOUSE_CLUSTER` set) the old per-replica content is unusable as a
+> rebuild source (each replica held a private fraction), so both tables come
+> out of the migration EMPTY there and history must be rebuilt by the
+> event-sourcing replay. On single-node deployments the migration carries the
+> data over and none of this runbook is needed.
+
+## What rebuilds what
+
+| Table | Rebuilt by | Source |
+|---|---|---|
+| `gateway_budget_scope_totals` | migration 00064 itself | `gateway_budget_ledger_events` (replicated), no operator action |
+| `trace_analytics_rollup` | replay of projection `traceAnalyticsRollup` | `SpanReceivedEvent`s in `event_log` (replicated) |
+| `evaluation_analytics_rollup` | replay of projection `evaluationAnalyticsRollup` | terminal evaluation events in `event_log` (replicated) |
+
+The rollup rows are produced by TypeScript map projections
+(`traceAnalyticsRollup.mapProjection.ts`,
+`evaluationAnalyticsRollup.mapProjection.ts`): span normalization, canonical
+model extraction, token-accumulation gating and pricing. That logic has no SQL
+equivalent, which is why the migration cannot rebuild these two tables the way
+00064 rebuilds the budget rollup. Replay-path fidelity is covered by
+`src/server/event-sourcing/replay/__tests__/replay-projection-parity.integration.test.ts`.
+
+## When to run
+
+Once, after a deploy containing 00065/00066 lands on a clustered deployment.
+There is no urgency window for correctness: new increments replicate correctly
+from the moment the migration swaps the tables. Until the replay runs, rollup
+reads simply show no pre-deploy history (the pre-deploy state was a random
+per-replica fraction, so there is nothing to preserve).
+
+## How to run
+
+The replay is driven through the ops surface (`ops.startReplay`, ops manage
+permission required). One run covers both projections:
+
+```jsonc
+{
+  "projectionNames": ["traceAnalyticsRollup", "evaluationAnalyticsRollup"],
+  // ISO timestamp at or before the oldest retention window still served.
+  // Epoch is safe: discovery is bounded by what event_log still holds.
+  "since": "1970-01-01T00:00:00.000Z",
+  "description": "rebuild analytics rollups after Replicated-engine conversion (00065/00066)"
+}
+```
+
+Replay progress, history and cancellation are available on the same ops
+surface (`getReplayStatus`, `getReplayHistory`, `cancelReplay`). The map-path
+replay appends increments per event; because the migration left the tables
+empty, appending reconstructs exact totals. Do not run the replay twice
+concurrently and do not re-run it after a successful pass without truncating
+first (the table's contract is replay-rebuilds-truncate-first, see 00038).
+
+## How to verify
+
+Row counts must be identical on every replica once replication catches up
+(query each replica directly, not through the load balancer):
+
+```sql
+SELECT hostName(), count(), sum(SpanCount)
+FROM clusterAllReplicas('langwatch', currentDatabase(), 'trace_analytics_rollup')
+GROUP BY hostName();
+```
+
+Same shape for `evaluation_analytics_rollup` with `EvalCount`. Every replica
+must report the same numbers; divergence means the table is still on a plain
+engine somewhere (check `SELECT engine FROM system.tables WHERE name = 'trace_analytics_rollup'`
+on each replica, all must say `ReplicatedAggregatingMergeTree`).
+
+Spot-check one busy tenant hour against the slim table, which was never
+fragmented (it uses the Replicated engine substitution). The two are close,
+not identical by construction: the slim fold caps spans per trace
+(MAX_PROCESSED_SPANS) and buckets by a different time column, so expect
+tracking numbers, not equality.
+
+```sql
+SELECT sum(SpanCount) FROM trace_analytics_rollup
+WHERE TenantId = {tenant:String}
+  AND BucketStart >= {hour:DateTime64} AND BucketStart < {hourEnd:DateTime64};
+
+SELECT sum(SpanCount) FROM trace_analytics
+WHERE TenantId = {tenant:String}
+  AND OccurredAt >= {hour:DateTime64} AND OccurredAt < {hourEnd:DateTime64};
+```
+

--- a/dev/docs/runbooks/analytics-rollup-replay.md
+++ b/dev/docs/runbooks/analytics-rollup-replay.md
@@ -44,17 +44,49 @@ permission required). One run covers both projections:
   // ISO timestamp at or before the oldest retention window still served.
   // Epoch is safe: discovery is bounded by what event_log still holds.
   "since": "1970-01-01T00:00:00.000Z",
+  // Required here. See "Why fullRebuild" below.
+  "fullRebuild": true,
   "description": "rebuild analytics rollups after Replicated-engine conversion (00065/00066)"
 }
 ```
 
+The ops projections page runs the same thing: tick "Rebuild from scratch"
+before starting the replay.
+
 Replay progress, history and cancellation are available on the same ops
 surface (`getReplayStatus`, `getReplayHistory`, `cancelReplay`). The map-path
 replay appends increments per event; because the migration left the tables
-empty, appending reconstructs exact totals. Do not run the replay twice
-concurrently and do not re-run it after a successful pass without truncating
-first (both tables' contract is replay-rebuilds-truncate-first, see 00038 for
-the trace rollup and 00040 for the evaluation rollup).
+empty, appending reconstructs exact totals.
+
+### Why fullRebuild
+
+A replay records every aggregate it finishes in a Redis completed set, and a
+run that fails or is cancelled leaves those entries behind on purpose so a
+plain re-run resumes instead of repeating work. Discovery skips whatever is
+in that set.
+
+That is the wrong default here. If any earlier replay of these projections
+finished some tenants and then stopped, its completed entries are still there
+while 00065/00066 have swapped the tables empty underneath them. A plain
+`startReplay` would report a clean run and leave those tenants with no
+pre-deploy history at all, with nothing in the result to say so.
+
+`fullRebuild` clears the selected projections' markers under the replay lock,
+before discovery, so the run covers every discovered aggregate. It is only
+safe against empty tables: these are append projections, so replaying an
+aggregate whose rows are still in place double counts it.
+
+### If the rebuild fails partway
+
+Re-run it with `fullRebuild` OFF. The markers the failed run left behind now
+describe rows it actually wrote, so the resume picks up exactly where it
+stopped. Running a second `fullRebuild` over a half-populated table double
+counts everything the first pass wrote.
+
+Reach for `fullRebuild` again only after truncating both tables (their
+contract is replay-rebuilds-truncate-first, see 00038 for the trace rollup and
+00040 for the evaluation rollup). Do not run two replays concurrently; the ops
+lock rejects the second one.
 
 ## How to verify
 

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -363,7 +363,6 @@ const LEGACY_INERT: string[] = [
   "specs/event-sourcing/poison-group-park-guard.feature",
   "specs/event-sourcing/process-roles.feature",
   "specs/event-sourcing/producer-append-coalescing.feature",
-  "specs/event-sourcing/projection-replay.feature",
   "specs/event-sourcing/reactors.feature",
   "specs/event-sourcing/redis-fold-cache.feature",
   "specs/event-sourcing/work-conserving-fair-dispatch.feature",

--- a/langwatch/src/components/ops/projections/BulkReplayWizard.tsx
+++ b/langwatch/src/components/ops/projections/BulkReplayWizard.tsx
@@ -37,6 +37,7 @@ export function BulkReplayWizard({
     new Set(),
   );
   const [description, setDescription] = useState("");
+  const [fullRebuild, setFullRebuild] = useState(false);
 
   const projectionsQuery = api.ops.listProjections.useQuery();
   const statusQuery = useReplayStatus();
@@ -158,6 +159,7 @@ export function BulkReplayWizard({
       projectionNames: [...selectedProjections],
       since,
       tenantIds: allTenants ? [] : tenantIds,
+      fullRebuild,
       description: description || "Manual replay",
     });
   }
@@ -425,6 +427,24 @@ export function BulkReplayWizard({
                         rows={2}
                       />
                     </Box>
+                    <Box>
+                      <Checkbox
+                        checked={fullRebuild}
+                        onCheckedChange={(e) => setFullRebuild(!!e.checked)}
+                      >
+                        <Text textStyle="sm">Rebuild from scratch</Text>
+                      </Checkbox>
+                      <Text
+                        textStyle="xs"
+                        color="fg.muted"
+                        marginTop={1}
+                        marginLeft={6}
+                      >
+                        For targets that were truncated or swapped empty. Off,
+                        the run resumes and skips whatever an earlier run
+                        finished.
+                      </Text>
+                    </Box>
                     <HStack gap={2}>
                       <Button
                         size="sm"
@@ -433,7 +453,9 @@ export function BulkReplayWizard({
                         loading={startReplayMutation.isPending}
                         onClick={handleStartReplay}
                       >
-                        Start Full Replay
+                        {fullRebuild
+                          ? "Start Full Rebuild"
+                          : "Start Full Replay"}
                       </Button>
                       <Button
                         size="sm"

--- a/langwatch/src/components/ops/projections/BulkReplayWizard.tsx
+++ b/langwatch/src/components/ops/projections/BulkReplayWizard.tsx
@@ -440,9 +440,9 @@ export function BulkReplayWizard({
                         marginTop={1}
                         marginLeft={6}
                       >
-                        For targets that were truncated or swapped empty. Off,
-                        the run resumes and skips whatever an earlier run
-                        finished.
+                        Clears replay markers first. Use it when the target
+                        table was truncated or swapped empty; otherwise the run
+                        resumes and skips finished aggregates.
                       </Text>
                     </Box>
                     <HStack gap={2}>

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -449,6 +449,7 @@ export const opsRouter = createTRPCRouter({
         since: z.string(),
         tenantIds: z.array(z.string()).optional(),
         aggregateIds: z.array(z.string()).optional(),
+        fullRebuild: z.boolean().optional(),
         description: z.string(),
       }),
     )
@@ -464,6 +465,7 @@ export const opsRouter = createTRPCRouter({
           since: input.since,
           tenantIds: input.tenantIds ?? [],
           aggregateIds: input.aggregateIds,
+          fullRebuild: input.fullRebuild,
           description: input.description,
           userName,
         });

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -33,6 +33,8 @@ const DROPPED = new Set<string>(["gateway_activity_events"]);
  */
 const NOT_ON_A_READ_PATH = new Set<string>([
   "gateway_budget_scope_totals_rebuild",
+  "trace_analytics_rollup_rebuild",
+  "evaluation_analytics_rollup_rebuild",
 ]);
 
 /**

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
@@ -236,11 +236,16 @@ async function startAndAwaitReplay(params: {
     userName: "integration-test",
   });
 
+  // Throwing rather than asserting: vi.waitFor retries on a throw, and the
+  // run's outcome is asserted in the test that started it.
   await vi.waitFor(
     async () => {
       const status = await opsReplay.getStatus();
-      expect(status.runId).toBe(runId);
-      expect(status.state).not.toBe("running");
+      if (status.runId !== runId || status.state === "running") {
+        throw new Error(
+          `run ${runId} has not finished (status ${status.state} for ${status.runId})`,
+        );
+      }
     },
     { timeout: 30_000, interval: 100 },
   );

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Integration test for the ops full-rebuild replay path.
+ *
+ * A replay that is cancelled or fails leaves its completed markers in Redis on
+ * purpose, so a plain re-run resumes instead of repeating work. When the target
+ * table has meanwhile been emptied (migrations 00065/00066 swap the analytics
+ * rollups to Replicated engines and come out empty on clustered deployments),
+ * that same behaviour makes the rebuild report success while silently skipping
+ * every aggregate the earlier run had finished. `fullRebuild` clears those
+ * markers under the replay lock, before discovery, so the rebuild covers them.
+ *
+ * Everything below the ops entry point is real: the Redis-backed replay
+ * repository (lock, status, history), the event-sourcing replay service and its
+ * optimized path, the real `traceAnalyticsRollup` projection and its ClickHouse
+ * append store. Only `createReplayRuntime` is substituted, because the
+ * production factory resolves ClickHouse through the app registry; the runtime
+ * it returns here is built from the same real classes.
+ *
+ * BDD structure: describe("given X") → describe("when Y") → it("…").
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { Redis } from "ioredis";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { TraceAnalyticsRollupClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-analytics-rollup.clickhouse.repository";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import {
+  generateTestAggregateId,
+  generateTestTenantId,
+} from "~/server/event-sourcing/__tests__/integration/testHelpers";
+import { createSpanReceivedEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/__tests__/fixtures/trace-summary-test.fixtures";
+import { TraceAnalyticsRollupMapProjection } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceAnalyticsRollup.mapProjection";
+import { TraceAnalyticsRollupAppendStore } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceAnalyticsRollup.store";
+import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import {
+  aggregateKey,
+  cleanupAll,
+  getCompletedSet,
+  unmarkBatch,
+} from "~/server/event-sourcing/replay/replayMarkers";
+import { createReplayRuntime } from "~/server/event-sourcing/replay/replayPreset";
+import { ReplayService as EventSourcingReplayService } from "~/server/event-sourcing/replay/replayService";
+import type { RegisteredMapProjection } from "~/server/event-sourcing/replay/types";
+import { ReplayService } from "../../replay.service";
+import { ReplayRedisRepository } from "../../repositories/replay.redis.repository";
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      _opts: unknown,
+      fn: (span: {
+        setAttribute: () => void;
+        setAttributes: () => void;
+        addEvent: () => void;
+      }) => unknown,
+    ) =>
+      fn({
+        setAttribute: () => {},
+        setAttributes: () => {},
+        addEvent: () => {},
+      }),
+  }),
+}));
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("~/server/event-sourcing/replay/replayPreset", () => ({
+  createReplayRuntime: vi.fn(),
+}));
+
+const mockedCreateReplayRuntime = vi.mocked(createReplayRuntime);
+
+const PROJECTION_NAME = "traceAnalyticsRollup";
+const AGGREGATE_TYPE = "trace";
+const SINCE = new Date(0).toISOString();
+
+/** Minute-aligned base a day in the past, inside every retention window. */
+const baseMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
+const nano = (offset: number) => `${baseMs + offset}000000`;
+
+let client: ClickHouseClient;
+let redis: Redis;
+let opsReplay: ReplayService;
+
+/** No surviving marker, default run: pins that the fixture replays at all. */
+let witnessTenantId: string;
+let witnessTraceId: string;
+/** Surviving marker, default run: the silent skip. */
+let skippedTenantId: string;
+let skippedTraceId: string;
+/** Surviving marker, fullRebuild run: the fix. */
+let rebuiltTenantId: string;
+let rebuiltTraceId: string;
+
+/**
+ * Two spans on one trace: an LLM root carrying the trace and its tokens, and a
+ * child that only adds a span count. Enough shape for the rollup to be visibly
+ * present or visibly absent.
+ */
+function buildEvents(tenantId: string, traceId: string) {
+  return [
+    createSpanReceivedEvent({
+      eventId: `evt-${traceId}-root`,
+      tenantId,
+      traceId,
+      spanId: "aaaa000000000001",
+      parentSpanId: null,
+      occurredAt: baseMs,
+      startTimeUnixNano: nano(0),
+      endTimeUnixNano: nano(1_500),
+      attributes: {
+        "gen_ai.response.model": "gpt-4o-2024-08-06",
+        "langwatch.span.type": "llm",
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 20,
+      },
+    }),
+    createSpanReceivedEvent({
+      eventId: `evt-${traceId}-child`,
+      tenantId,
+      traceId,
+      spanId: "aaaa000000000002",
+      parentSpanId: "aaaa000000000001",
+      occurredAt: baseMs + 1_000,
+      startTimeUnixNano: nano(10_000),
+      endTimeUnixNano: nano(11_000),
+    }),
+  ];
+}
+
+async function seedEventLog(tenantId: string, traceId: string): Promise<void> {
+  const records = buildEvents(tenantId, traceId).map((event) => ({
+    TenantId: tenantId,
+    AggregateType: AGGREGATE_TYPE,
+    AggregateId: event.aggregateId,
+    EventId: event.id,
+    EventType: SPAN_RECEIVED_EVENT_TYPE,
+    EventTimestamp: event.occurredAt,
+    EventOccurredAt: event.occurredAt,
+    EventVersion: "2025-12-14",
+    EventPayload: JSON.stringify(event.data),
+    IdempotencyKey: event.id,
+    // Never-expire sentinel so the table TTL cannot reap the fixture.
+    _retention_days: 0,
+  }));
+
+  await client.insert({
+    table: "event_log",
+    values: records,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
+  });
+}
+
+/**
+ * Leave behind exactly what an aborted run leaves: the aggregate recorded in
+ * the projection's completed set, written by the same helper the replay uses.
+ */
+async function seedCompletedMarker(
+  tenantId: string,
+  traceId: string,
+): Promise<void> {
+  await unmarkBatch({
+    redis,
+    projectionName: PROJECTION_NAME,
+    aggKeys: [
+      aggregateKey({
+        tenantId,
+        aggregateType: AGGREGATE_TYPE,
+        aggregateId: traceId,
+      }),
+    ],
+  });
+}
+
+async function readRollupTotals(
+  tenantId: string,
+): Promise<{ spanCount: number; traceCount: number; rowCount: number }> {
+  const result = await client.query({
+    query: `
+      SELECT
+        sum(SpanCount) AS spanCount,
+        sum(TraceCount) AS traceCount,
+        count() AS rowCount
+      FROM trace_analytics_rollup
+      WHERE TenantId = {tenantId:String}
+    `,
+    query_params: { tenantId },
+    format: "JSONEachRow",
+  });
+  const rows = await result.json<{
+    spanCount: string;
+    traceCount: string;
+    rowCount: string;
+  }>();
+  const row = rows[0];
+  return {
+    spanCount: Number(row?.spanCount ?? 0),
+    traceCount: Number(row?.traceCount ?? 0),
+    rowCount: Number(row?.rowCount ?? 0),
+  };
+}
+
+/** Start a run through the ops entry point and wait for it to leave "running". */
+async function startAndAwaitReplay(params: {
+  tenantIds: string[];
+  fullRebuild?: boolean;
+}) {
+  const { runId } = await opsReplay.startReplay({
+    projectionNames: [PROJECTION_NAME],
+    since: SINCE,
+    tenantIds: params.tenantIds,
+    fullRebuild: params.fullRebuild,
+    description: "rebuild analytics rollup after the Replicated-engine swap",
+    userName: "integration-test",
+  });
+
+  await vi.waitFor(
+    async () => {
+      const status = await opsReplay.getStatus();
+      expect(status.runId).toBe(runId);
+      expect(status.state).not.toBe("running");
+    },
+    { timeout: 30_000, interval: 100 },
+  );
+
+  return opsReplay.getStatus();
+}
+
+describe("given a completed replay marker that survived an aborted run", () => {
+  beforeAll(async () => {
+    await startTestContainers();
+    client = getTestClickHouseClient()!;
+    redis = getTestRedisConnection()!;
+
+    witnessTenantId = generateTestTenantId();
+    witnessTraceId = generateTestAggregateId("rebuild-witness");
+    skippedTenantId = generateTestTenantId();
+    skippedTraceId = generateTestAggregateId("rebuild-skipped");
+    rebuiltTenantId = generateTestTenantId();
+    rebuiltTraceId = generateTestAggregateId("rebuild-full");
+
+    // Identical fixtures per tenant, so the marker and the flag are the only
+    // variables between the three runs below.
+    await seedEventLog(witnessTenantId, witnessTraceId);
+    await seedEventLog(skippedTenantId, skippedTraceId);
+    await seedEventLog(rebuiltTenantId, rebuiltTraceId);
+
+    const projection = new TraceAnalyticsRollupMapProjection({
+      store: new TraceAnalyticsRollupAppendStore(
+        new TraceAnalyticsRollupClickHouseRepository(async () => client),
+      ),
+    });
+    const registered: RegisteredMapProjection = {
+      projectionName: PROJECTION_NAME,
+      pipelineName: "trace-processing",
+      aggregateType: AGGREGATE_TYPE,
+      source: "pipeline",
+      definition: projection,
+      pauseKey: `trace-processing/handler/${PROJECTION_NAME}`,
+      kind: "map",
+      targetTable: "trace_analytics_rollup",
+    };
+
+    mockedCreateReplayRuntime.mockReturnValue({
+      projections: [],
+      mapProjections: [registered],
+      stateProjections: [],
+      service: new EventSourcingReplayService({
+        clickhouseClientResolver: async () => client,
+        redis,
+      }),
+      // The connection is shared with the suite, so closing is the harness's job.
+      close: async () => {},
+    });
+
+    opsReplay = new ReplayService(new ReplayRedisRepository(redis));
+  });
+
+  beforeEach(async () => {
+    const keys = await redis.keys("ops:replay:*");
+    if (keys.length > 0) await redis.del(...keys);
+    await cleanupAll({ redis, projectionName: PROJECTION_NAME });
+  });
+
+  afterAll(async () => {
+    await cleanupAll({ redis, projectionName: PROJECTION_NAME });
+    for (const tenantId of [
+      witnessTenantId,
+      skippedTenantId,
+      rebuiltTenantId,
+    ]) {
+      for (const table of ["event_log", "trace_analytics_rollup"]) {
+        try {
+          await client.exec({
+            query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String}`,
+            query_params: { tenantId },
+          });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+    await stopTestContainers();
+  });
+
+  describe("when a default replay runs for an aggregate with no marker", () => {
+    it("rebuilds the rollup rows, so the fixture is replayable", async () => {
+      const status = await startAndAwaitReplay({
+        tenantIds: [witnessTenantId],
+      });
+
+      expect(status.state).toBe("completed");
+      expect(status.error).toBeNull();
+
+      const totals = await readRollupTotals(witnessTenantId);
+      expect(totals.spanCount).toBe(2);
+      expect(totals.traceCount).toBe(1);
+    });
+  });
+
+  describe("when a default replay runs for the marked aggregate", () => {
+    it("reports a successful run that wrote nothing", async () => {
+      await seedCompletedMarker(skippedTenantId, skippedTraceId);
+
+      const status = await startAndAwaitReplay({
+        tenantIds: [skippedTenantId],
+      });
+
+      expect(status.state).toBe("completed");
+      expect(status.error).toBeNull();
+      expect(await readRollupTotals(skippedTenantId)).toEqual({
+        spanCount: 0,
+        traceCount: 0,
+        rowCount: 0,
+      });
+    });
+  });
+
+  describe("when a full rebuild runs for the marked aggregate", () => {
+    /** @scenario A full rebuild replays aggregates an interrupted run had completed */
+    it("clears the marker and rebuilds the rollup rows", async () => {
+      await seedCompletedMarker(rebuiltTenantId, rebuiltTraceId);
+
+      const status = await startAndAwaitReplay({
+        tenantIds: [rebuiltTenantId],
+        fullRebuild: true,
+      });
+
+      expect(status.state).toBe("completed");
+      expect(status.error).toBeNull();
+
+      const totals = await readRollupTotals(rebuiltTenantId);
+      expect(totals.spanCount).toBe(2);
+      expect(totals.traceCount).toBe(1);
+
+      // The run owns the markers end to end: cleared before discovery, and
+      // cleared again by the replay path once every batch completed.
+      expect(
+        await getCompletedSet({ redis, projectionName: PROJECTION_NAME }),
+      ).toEqual(new Set());
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/replay-full-rebuild.integration.test.ts
@@ -248,7 +248,7 @@ async function startAndAwaitReplay(params: {
   return opsReplay.getStatus();
 }
 
-describe("given a completed replay marker that survived an aborted run", () => {
+describe("given identical span history for tenants whose rollup is empty", () => {
   beforeAll(async () => {
     await startTestContainers();
     client = getTestClickHouseClient()!;

--- a/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
@@ -64,6 +64,11 @@ type StubbedRuntime = ReturnType<typeof createReplayRuntime>;
 function stubRuntime(
   replayOptimized: StubbedRuntime["service"]["replayOptimized"],
 ) {
+  const cleanup = vi.fn(async () => undefined);
+  const checkPreviousRun = vi.fn(async () => ({
+    completedCount: 7,
+    markerCount: 0,
+  }));
   mockedCreateReplayRuntime.mockReturnValue({
     projections: [
       {
@@ -78,9 +83,14 @@ function stubRuntime(
     ],
     mapProjections: [],
     stateProjections: [],
-    service: { replayOptimized } as StubbedRuntime["service"],
+    service: {
+      replayOptimized,
+      cleanup,
+      checkPreviousRun,
+    } as unknown as StubbedRuntime["service"],
     close: vi.fn(async () => undefined),
   } satisfies StubbedRuntime);
+  return { cleanup };
 }
 
 function stubStateRuntime(replay: StubbedRuntime["service"]["replay"]) {
@@ -135,6 +145,100 @@ function buildProgress(
 }
 
 describe("ops ReplayService", () => {
+  describe("given replay markers left behind by an earlier run", () => {
+    describe("when a full rebuild starts", () => {
+      it("clears the selected projections' markers before replaying", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+        const callOrder: string[] = [];
+        const { cleanup } = stubRuntime(
+          vi.fn(async () => {
+            callOrder.push("replay");
+            return {
+              aggregatesReplayed: 1,
+              totalEvents: 3,
+              batchErrors: 0,
+            };
+          }),
+        );
+        cleanup.mockImplementation(async () => {
+          callOrder.push("cleanup");
+        });
+
+        await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          fullRebuild: true,
+          description: "post-migration rebuild",
+          userName: "tester",
+        });
+
+        await vi.waitFor(async () => {
+          expect((await service.getStatus()).state).toBe("completed");
+        });
+        expect(cleanup).toHaveBeenCalledWith("traceSummary");
+        expect(callOrder).toEqual(["cleanup", "replay"]);
+      });
+    });
+
+    describe("when clearing the markers fails", () => {
+      it("fails the run instead of replaying against them", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+        const replayOptimized = vi.fn(async () => ({
+          aggregatesReplayed: 1,
+          totalEvents: 3,
+          batchErrors: 0,
+        }));
+        const { cleanup } = stubRuntime(replayOptimized);
+        cleanup.mockRejectedValue(new Error("redis unavailable"));
+
+        await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          fullRebuild: true,
+          description: "post-migration rebuild",
+          userName: "tester",
+        });
+
+        await vi.waitFor(async () => {
+          expect((await service.getStatus()).state).toBe("failed");
+        });
+        expect((await service.getStatus()).error).toBe("redis unavailable");
+        expect(replayOptimized).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a default run starts", () => {
+      it("preserves the markers so the run resumes where it stopped", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+        const { cleanup } = stubRuntime(
+          vi.fn(async () => ({
+            aggregatesReplayed: 1,
+            totalEvents: 3,
+            batchErrors: 0,
+          })),
+        );
+
+        await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          description: "resume",
+          userName: "tester",
+        });
+
+        await vi.waitFor(async () => {
+          expect((await service.getStatus()).state).toBe("completed");
+        });
+        expect(cleanup).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   it("routes operational state projections through the safe normal replay path", async () => {
     const repo = createFakeRepo();
     const service = new ReplayService(repo);

--- a/langwatch/src/server/app-layer/ops/replay.service.ts
+++ b/langwatch/src/server/app-layer/ops/replay.service.ts
@@ -53,6 +53,25 @@ export class ReplayService {
     since: string;
     tenantIds: string[];
     aggregateIds?: string[];
+    /**
+     * Rebuild from scratch instead of resuming: clear the selected
+     * projections' replay markers (completed set and in-flight cutoffs) under
+     * the replay lock, before discovery, so every discovered aggregate is
+     * replayed rather than skipped as already done.
+     *
+     * Required whenever the target tables no longer hold the rows those
+     * markers vouch for: tables truncated by hand, or swapped empty by a
+     * migration. Markers from an earlier aborted run survive on purpose so a
+     * plain re-run resumes where it stopped; against emptied tables that same
+     * behaviour drops the skipped aggregates' history with a successful-looking
+     * run and no error.
+     *
+     * Only safe when the target tables are empty for the replayed scope: map
+     * projections append increments, so replaying an aggregate whose rows are
+     * still present double counts. Leave unset to resume a partially failed
+     * run whose written rows are still in place.
+     */
+    fullRebuild?: boolean;
     description: string;
     userName: string;
   }): Promise<{ runId: string }> {
@@ -118,6 +137,7 @@ export class ReplayService {
     since: string;
     tenantIds: string[];
     aggregateIds?: string[];
+    fullRebuild?: boolean;
     description: string;
     userName: string;
   }): Promise<void> {
@@ -171,6 +191,33 @@ export class ReplayService {
           historyCtx: params,
         });
         return;
+      }
+
+      if (params.fullRebuild) {
+        // Under the replay lock and before discovery: drop the markers a
+        // resume would consult, so no aggregate is skipped as already done.
+        // See the fullRebuild doc on startReplay for when this is required.
+        // A failure here aborts the run rather than replaying against stale
+        // markers, which is the silent-skip this flag exists to prevent.
+        for (const projection of [
+          ...selectedProjections,
+          ...selectedMapProjections,
+          ...selectedStateProjections,
+        ]) {
+          const projectionName = projection.projectionName;
+          const cleared =
+            await runtime.service.checkPreviousRun(projectionName);
+          await runtime.service.cleanup(projectionName);
+          logger.info(
+            {
+              runId: params.runId,
+              projectionName,
+              completedMarkersCleared: cleared.completedCount,
+              inFlightMarkersCleared: cleared.markerCount,
+            },
+            "Cleared replay markers for full rebuild",
+          );
+        }
       }
 
       let cancelledFlag = false;

--- a/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
@@ -129,11 +129,18 @@ function collectEngineDeclarations(): EngineDeclaration[] {
       // A materialized view with a TO target has no engine of its own; the
       // engine that matters is the target table's.
       if (!engine) continue;
+      // The engine expression ends where the next table clause begins, so a
+      // single-line `ENGINE = X() ORDER BY ...` is judged on X() alone.
+      const engineText = engine[1]!
+        .split(
+          /\s+(?:ORDER\s+BY|PARTITION\s+BY|PRIMARY\s+KEY|SETTINGS|TTL|AS)\s/i,
+        )[0]!
+        .trim();
       declarations.push({
         file,
         objectType: create[1]!.replace(/\s+/g, " ").toUpperCase(),
         objectName: create[2]!.replace("${CLICKHOUSE_DATABASE}.", ""),
-        engine: engine[1]!.trim(),
+        engine: engineText,
       });
     }
   }

--- a/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
@@ -35,6 +35,20 @@ const GOOSE_SOURCE = readFileSync(
   "utf8",
 );
 
+/**
+ * The body of buildMigrationEnvVars, so the provisioning assertion below can
+ * only be satisfied by an actual key in the vars object, never by a mention
+ * in a comment or another function.
+ */
+const ENV_VARS_BODY = (() => {
+  const start = GOOSE_SOURCE.indexOf("function buildMigrationEnvVars");
+  if (start < 0) {
+    throw new Error("buildMigrationEnvVars not found in goose.ts");
+  }
+  const end = GOOSE_SOURCE.indexOf("\n}", start);
+  return GOOSE_SOURCE.slice(start, end);
+})();
+
 const APPROVED_ENGINE_PATTERNS: { name: string; pattern: RegExp }[] = [
   {
     name: "${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}<VersionColumn>)",
@@ -125,7 +139,11 @@ function collectEngineDeclarations(): EngineDeclaration[] {
         /CREATE\s+(TABLE|MATERIALIZED\s+VIEW)\s+(?:IF\s+NOT\s+EXISTS\s+)?([^\s(]+)/i,
       );
       if (!create) continue;
-      const engine = statement.match(/ENGINE\s*=\s*([^\n]+)/);
+      // Case-insensitive so a lowercase `engine =` cannot slip a declaration
+      // past the guard entirely. Lowercase spellings of the APPROVED patterns
+      // then fail the (case-sensitive) approval below, which is the correct
+      // failure direction: flagged, not skipped.
+      const engine = statement.match(/ENGINE\s*=\s*([^\n]+)/i);
       // A materialized view with a TO target has no engine of its own; the
       // engine that matters is the target table's.
       if (!engine) continue;
@@ -233,7 +251,7 @@ describe("ClickHouse migration engine guard", () => {
 
     for (const name of [...referenced].sort()) {
       expect(
-        GOOSE_SOURCE.includes(`${name}:`),
+        new RegExp(`^\\s*${name}:`, "m").test(ENV_VARS_BODY),
         `migrations reference \${${name}} but buildMigrationEnvVars in goose.ts does not provide it; ` +
           `the ENVSUB default would silently apply on every deployment, including production`,
       ).toBe(true);

--- a/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
@@ -36,9 +36,11 @@ const GOOSE_SOURCE = readFileSync(
 );
 
 /**
- * The body of buildMigrationEnvVars, so the provisioning assertion below can
- * only be satisfied by an actual key in the vars object, never by a mention
- * in a comment or another function.
+ * The source of buildMigrationEnvVars with its comments removed, so the
+ * provisioning assertion below is scoped to that function and a mention in a
+ * comment (anywhere) or elsewhere in the file cannot satisfy it. Text-based
+ * on purpose: the function is a flat object literal, and the assertion's
+ * `^\s*NAME:` shape matches only key positions in it.
  */
 const ENV_VARS_BODY = (() => {
   const start = GOOSE_SOURCE.indexOf("function buildMigrationEnvVars");
@@ -46,7 +48,12 @@ const ENV_VARS_BODY = (() => {
     throw new Error("buildMigrationEnvVars not found in goose.ts");
   }
   const end = GOOSE_SOURCE.indexOf("\n}", start);
-  return GOOSE_SOURCE.slice(start, end);
+  if (end < 0) {
+    throw new Error("buildMigrationEnvVars closing brace not found");
+  }
+  return GOOSE_SOURCE.slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
 })();
 
 const APPROVED_ENGINE_PATTERNS: { name: string; pattern: RegExp }[] = [

--- a/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -35,25 +36,58 @@ const GOOSE_SOURCE = readFileSync(
   "utf8",
 );
 
+function propertyName(
+  property: ts.ObjectLiteralElementLike,
+): string | undefined {
+  if (
+    !ts.isPropertyAssignment(property) &&
+    !ts.isShorthandPropertyAssignment(property)
+  ) {
+    return undefined;
+  }
+  const name = property.name;
+  return ts.isIdentifier(name) || ts.isStringLiteral(name)
+    ? name.text
+    : undefined;
+}
+
+function collectObjectLiteralKeys(node: ts.Node, keys: Set<string>): void {
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const property of node.properties) {
+      const name = propertyName(property);
+      if (name !== undefined) keys.add(name);
+    }
+  }
+  ts.forEachChild(node, (child) => collectObjectLiteralKeys(child, keys));
+}
+
 /**
- * The source of buildMigrationEnvVars with its comments removed, so the
- * provisioning assertion below is scoped to that function and a mention in a
- * comment (anywhere) or elsewhere in the file cannot satisfy it. Text-based
- * on purpose: the function is a flat object literal, and the assertion's
- * `^\s*NAME:` shape matches only key positions in it.
+ * The property names of the object literals buildMigrationEnvVars declares,
+ * read from the TypeScript AST so only real object keys count: comments,
+ * string contents, and code elsewhere in goose.ts cannot satisfy the
+ * provisioning assertion below.
  */
-const ENV_VARS_BODY = (() => {
-  const start = GOOSE_SOURCE.indexOf("function buildMigrationEnvVars");
-  if (start < 0) {
+const ENV_VAR_KEYS = (() => {
+  const sourceFile = ts.createSourceFile(
+    "goose.ts",
+    GOOSE_SOURCE,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const fn = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) &&
+      statement.name?.text === "buildMigrationEnvVars",
+  );
+  if (!fn) {
     throw new Error("buildMigrationEnvVars not found in goose.ts");
   }
-  const end = GOOSE_SOURCE.indexOf("\n}", start);
-  if (end < 0) {
-    throw new Error("buildMigrationEnvVars closing brace not found");
+  const keys = new Set<string>();
+  collectObjectLiteralKeys(fn, keys);
+  if (keys.size === 0) {
+    throw new Error("buildMigrationEnvVars declares no object literal keys");
   }
-  return GOOSE_SOURCE.slice(start, end)
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/[^\n]*/g, "");
+  return keys;
 })();
 
 const APPROVED_ENGINE_PATTERNS: { name: string; pattern: RegExp }[] = [
@@ -258,7 +292,7 @@ describe("ClickHouse migration engine guard", () => {
 
     for (const name of [...referenced].sort()) {
       expect(
-        new RegExp(`^\\s*${name}:`, "m").test(ENV_VARS_BODY),
+        ENV_VAR_KEYS.has(name),
         `migrations reference \${${name}} but buildMigrationEnvVars in goose.ts does not provide it; ` +
           `the ENVSUB default would silently apply on every deployment, including production`,
       ).toBe(true);

--- a/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/replicatedEngineGuard.unit.test.ts
@@ -1,0 +1,235 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guard: every MergeTree-family engine declared by a ClickHouse migration must
+ * use the deployment-substitutable engine pattern.
+ *
+ * The production database engine is `Replicated` (00001, CLICKHOUSE_CLUSTER
+ * set). That engine replicates DDL to every node but NOT data: table data only
+ * replicates through Replicated*MergeTree table engines. A migration that
+ * hardcodes a plain engine (`AggregatingMergeTree()`, `MergeTree()`, ...)
+ * therefore creates a table whose DDL exists on every replica while every
+ * insert stays on the one replica that received it: each node accumulates a
+ * private, divergent copy and reads through the load balancer return whichever
+ * fraction they happen to hit. Nothing at runtime detects this; this test is
+ * the only thing that does.
+ *
+ * The inverse hardcoding is just as wrong: a literal `Replicated...MergeTree`
+ * breaks single-node deployments that run without Keeper. The substitutable
+ * pattern serves both worlds, resolved by buildMigrationEnvVars (goose.ts)
+ * from CLICKHOUSE_CLUSTER:
+ *
+ *   ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}Ver)
+ *   ENGINE = ${CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree()}
+ *   ENGINE = ${CLICKHOUSE_ENGINE_MERGETREE:-MergeTree()}
+ */
+
+const MIGRATIONS_DIR = resolve(
+  process.cwd(),
+  "src/server/clickhouse/migrations",
+);
+const GOOSE_SOURCE = readFileSync(
+  resolve(process.cwd(), "src/server/clickhouse/goose.ts"),
+  "utf8",
+);
+
+const APPROVED_ENGINE_PATTERNS: { name: string; pattern: RegExp }[] = [
+  {
+    name: "${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}<VersionColumn>)",
+    pattern:
+      /^\$\{CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree\(\}[A-Za-z_][A-Za-z0-9_]*\)$/,
+  },
+  {
+    name: "${CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree()}",
+    pattern: /^\$\{CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree\(\)\}$/,
+  },
+  {
+    name: "${CLICKHOUSE_ENGINE_MERGETREE:-MergeTree()}",
+    pattern: /^\$\{CLICKHOUSE_ENGINE_MERGETREE:-MergeTree\(\)\}$/,
+  },
+];
+
+/**
+ * Migrations that are already applied in production and declared plain
+ * engines before this guard existed. They are frozen history: goose never
+ * re-runs an applied file, so editing them would change nothing deployed.
+ * Each entry is remediated by a later migration that swaps the table to the
+ * substitutable engine (00064 / 00065 / 00066); 00058's entries are scratch
+ * tables that were created and dropped within that same migration.
+ *
+ * DO NOT add new entries. A scratch table in a NEW migration qualifies for a
+ * plain engine only if it is created and dropped within that one migration
+ * AND its data flows into a Replicated table before the migration ends,
+ * through the single connection goose runs on; anything else maroons data on
+ * one replica. Even then, prefer the substitutable pattern (00064 does this
+ * for its scratch tables): it costs nothing and needs no exemption here.
+ */
+const HISTORICAL_PLAIN_ENGINES: { file: string; table: string }[] = [
+  {
+    file: "00017_create_gateway_budget_ledger.sql",
+    table: "gateway_budget_scope_totals",
+  },
+  {
+    file: "00038_create_trace_analytics_rollup.sql",
+    table: "trace_analytics_rollup",
+  },
+  {
+    file: "00040_create_evaluation_analytics_rollup.sql",
+    table: "evaluation_analytics_rollup",
+  },
+  {
+    file: "00058_gateway_budget_scope_totals_utc.sql",
+    table: "gateway_budget_scope_totals_rebuild",
+  },
+  {
+    file: "00058_gateway_budget_scope_totals_utc.sql",
+    table: "gateway_budget_scope_totals_recon",
+  },
+];
+
+interface EngineDeclaration {
+  file: string;
+  objectType: string;
+  objectName: string;
+  engine: string;
+}
+
+/** Strip `-- ...` line comments so commented-out DDL is never scanned. */
+function stripLineComments(sql: string): string {
+  return sql
+    .split("\n")
+    .map((line) => {
+      const idx = line.indexOf("--");
+      return idx >= 0 ? line.slice(0, idx) : line;
+    })
+    .join("\n");
+}
+
+function collectEngineDeclarations(): EngineDeclaration[] {
+  const declarations: EngineDeclaration[] = [];
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  if (files.length === 0) {
+    throw new Error(`no migration files found in ${MIGRATIONS_DIR}`);
+  }
+
+  for (const file of files) {
+    const sql = stripLineComments(
+      readFileSync(resolve(MIGRATIONS_DIR, file), "utf8"),
+    );
+    for (const statement of sql.split(";")) {
+      const create = statement.match(
+        /CREATE\s+(TABLE|MATERIALIZED\s+VIEW)\s+(?:IF\s+NOT\s+EXISTS\s+)?([^\s(]+)/i,
+      );
+      if (!create) continue;
+      const engine = statement.match(/ENGINE\s*=\s*([^\n]+)/);
+      // A materialized view with a TO target has no engine of its own; the
+      // engine that matters is the target table's.
+      if (!engine) continue;
+      declarations.push({
+        file,
+        objectType: create[1]!.replace(/\s+/g, " ").toUpperCase(),
+        objectName: create[2]!.replace("${CLICKHOUSE_DATABASE}.", ""),
+        engine: engine[1]!.trim(),
+      });
+    }
+  }
+  return declarations;
+}
+
+function isMergeTreeFamily(engine: string): boolean {
+  return /MergeTree/i.test(engine);
+}
+
+function isApproved(engine: string): boolean {
+  return APPROVED_ENGINE_PATTERNS.some(({ pattern }) => pattern.test(engine));
+}
+
+function isHistoricalException(declaration: EngineDeclaration): boolean {
+  return HISTORICAL_PLAIN_ENGINES.some(
+    (entry) =>
+      entry.file === declaration.file && entry.table === declaration.objectName,
+  );
+}
+
+describe("ClickHouse migration engine guard", () => {
+  const declarations = collectEngineDeclarations();
+
+  it("every MergeTree-family engine uses the deployment-substitutable pattern", () => {
+    const violations = declarations.filter(
+      (d) =>
+        isMergeTreeFamily(d.engine) &&
+        !isApproved(d.engine) &&
+        !isHistoricalException(d),
+    );
+
+    const report = violations
+      .map(
+        (d) =>
+          `${d.file}: ${d.objectType} ${d.objectName} declares\n` +
+          `    ENGINE = ${d.engine}\n` +
+          `  which will not replicate its data on clustered deployments.\n` +
+          `  The production database engine is Replicated: DDL replicates to every\n` +
+          `  node, data does NOT. With this engine every replica keeps a private,\n` +
+          `  divergent copy of the table (each insert stays on the node that\n` +
+          `  received it), and a hardcoded Replicated* engine would instead break\n` +
+          `  single-node deployments. Declare the engine through the substitution\n` +
+          `  goose.ts resolves per deployment:\n` +
+          APPROVED_ENGINE_PATTERNS.map((p) => `    ENGINE = ${p.name}`).join(
+            "\n",
+          ),
+      )
+      .join("\n\n");
+
+    expect(violations, `\n${report}\n`).toEqual([]);
+  });
+
+  it("the historical plain-engine list stays exact", () => {
+    // Every exemption must still point at a real plain-engine declaration.
+    // If one of these files is ever rewritten to conform (or removed), the
+    // stale entry must go too, so the list never quietly widens.
+    for (const entry of HISTORICAL_PLAIN_ENGINES) {
+      const match = declarations.find(
+        (d) =>
+          d.file === entry.file &&
+          d.objectName === entry.table &&
+          isMergeTreeFamily(d.engine) &&
+          !isApproved(d.engine),
+      );
+      expect(
+        match,
+        `${entry.file} no longer declares a plain engine for ${entry.table}; remove the stale exemption`,
+      ).toBeDefined();
+    }
+  });
+
+  it("every substitution variable used by migrations is provided by buildMigrationEnvVars", () => {
+    // ENVSUB defaults make a missing variable INVISIBLE: ${X:-PlainEngine()}
+    // silently expands to the plain engine on every deployment when goose.ts
+    // does not provide X, which is exactly the unreplicated-table defect the
+    // engine guard above exists to prevent.
+    const files = readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    const referenced = new Set<string>();
+    for (const file of files) {
+      const sql = readFileSync(resolve(MIGRATIONS_DIR, file), "utf8");
+      for (const match of sql.matchAll(/\$\{(CLICKHOUSE_[A-Z0-9_]+)/g)) {
+        referenced.add(match[1]!);
+      }
+    }
+    expect(referenced.size).toBeGreaterThan(0);
+    expect(referenced).toContain("CLICKHOUSE_ENGINE_AGGREGATING");
+
+    for (const name of [...referenced].sort()) {
+      expect(
+        GOOSE_SOURCE.includes(`${name}:`),
+        `migrations reference \${${name}} but buildMigrationEnvVars in goose.ts does not provide it; ` +
+          `the ENVSUB default would silently apply on every deployment, including production`,
+      ).toBe(true);
+    }
+  });
+});

--- a/langwatch/src/server/clickhouse/goose.ts
+++ b/langwatch/src/server/clickhouse/goose.ts
@@ -360,6 +360,14 @@ function buildMigrationEnvVars(config: ClickHouseConfig): NodeJS.ProcessEnv {
     CLICKHOUSE_ENGINE_REPLACING_PREFIX: config.clusterName
       ? "ReplicatedReplacingMergeTree("
       : "ReplacingMergeTree(",
+    CLICKHOUSE_ENGINE_AGGREGATING: config.clusterName
+      ? "ReplicatedAggregatingMergeTree()"
+      : "AggregatingMergeTree()",
+    // "1" when table data must go through Replicated engines to reach every
+    // replica. Migrations use this to gate statements that are only correct
+    // when a single node holds the complete dataset (e.g. carrying rows over
+    // from a plain-engine table, whose content is per-replica when clustered).
+    CLICKHOUSE_IS_REPLICATED: config.clusterName ? "1" : "0",
 
     // Storage policy: use 'local_primary' if available (production with S3 tiering),
     // otherwise omit the setting (uses ClickHouse default policy)

--- a/langwatch/src/server/clickhouse/migrations/00064_replicate_gateway_budget_scope_totals.sql
+++ b/langwatch/src/server/clickhouse/migrations/00064_replicate_gateway_budget_scope_totals.sql
@@ -1,0 +1,291 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- gateway_budget_scope_totals: move to the Replicated engine and rebuild
+-- from the ledger.
+--
+-- When CLICKHOUSE_CLUSTER is set the database engine is Replicated (00001),
+-- which replicates DDL to every node but NOT table data: data only
+-- replicates through Replicated*MergeTree table engines. This table was
+-- created with a plain AggregatingMergeTree, so on a multi-replica cluster
+-- every replica accumulates a PRIVATE copy: the materialized view folds a
+-- debit only on the replica whose connection received the ledger insert,
+-- and reads through the load balancer return whichever replica they happen
+-- to hit. Budget enforcement reads this table, so a cap can be checked
+-- against a fraction of the true spend. The engine below substitutes to
+-- ReplicatedAggregatingMergeTree on clustered deployments (the same
+-- mechanism every ReplacingMergeTree table uses via
+-- CLICKHOUSE_ENGINE_REPLACING_PREFIX), so a single fold on the
+-- insert-receiving replica replicates to all nodes.
+--
+-- Engine aside, the rebuild + swap + reconciliation below is 00058's
+-- statement order, and its exactly-once argument carries over unchanged:
+--
+--   1. The rebuild lands in a scratch table, so the live rollup serves
+--      reads until the swap; there is no instant where reads see an
+--      empty or missing table.
+--   2. The view is dropped before the rebuild's ledger snapshot, so no
+--      fold runs concurrently with the snapshot. Debits inserted while
+--      no view exists land only in the ledger, losing nothing.
+--   3. EXCHANGE TABLES swaps the rebuilt rollup in atomically.
+--   4. The view is recreated; folding resumes against the rebuilt table.
+--   5. Reconciliation: the ledger is re-aggregated into a scratch
+--      snapshot, then a delta insert adds, per rollup key, exactly the
+--      amount present in the ledger but not yet in the rollup. A debit
+--      that landed between the rebuild snapshot and the view creation is
+--      added here exactly once; a debit folded by the recreated view
+--      contributes a zero delta. The ledger snapshot is taken in its own
+--      statement, strictly before the rollup is read, and a fold is
+--      synchronous with its ledger insert, so a concurrently folded
+--      debit is always seen on the rollup side too and never re-added.
+--      Deltas clamp at zero: the insert only ever adds spend the rollup
+--      is missing. The one drift this cannot repair is a key that
+--      receives debits both inside the swap interval (two DDL
+--      statements) and inside the reconciliation pass itself; the
+--      shortfall is bounded by those debits, the ledger keeps them, and
+--      the drift expires with the period bucket.
+--
+-- Single-connection correctness on a cluster: goose runs every statement
+-- through one connection, i.e. on one replica. The DDL statements
+-- (CREATE / DROP / EXCHANGE) replicate through the database engine. The
+-- INSERT ... SELECT statements execute only on the connected replica, but
+-- they read gateway_budget_ledger_events, which is a Replicated engine and
+-- therefore identical on every replica, and they write into Replicated
+-- tables, so the rebuilt rows replicate to every node. No statement reads
+-- from the pre-swap rollup: on a cluster its per-replica content is
+-- partial by construction, so the ledger is the only source used. (The
+-- reconciliation's LEFT JOIN reads the rollup only AFTER the swap, when
+-- it holds the rebuilt, replicated content.)
+--
+-- Re-run safety (the runner may re-apply a partially executed file after
+-- a crash): the scratch tables are DROPPED and recreated rather than
+-- truncated and reused. This matters because the migration converts the
+-- engine: after a crash between the EXCHANGE and the final drops, the
+-- scratch NAME holds the old plain-engine table, and truncating and
+-- reusing it would rebuild into the wrong engine and swap the plain
+-- engine back in. Dropping always recreates the scratch with the correct
+-- engine, the rebuild re-derives its content from the current ledger, and
+-- the reconciliation re-derives its delta, so every complete run
+-- converges to the same state.
+--
+-- On a single-node deployment (CLICKHOUSE_CLUSTER unset) the engine
+-- substitutions resolve to the plain engines, the rebuild reproduces the
+-- same totals the table already holds, and the swap is a behavioral
+-- no-op.
+-- ============================================================================
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_rebuild
+(
+    TenantId String CODEC(ZSTD(1)),
+    Scope LowCardinality(String),
+    ScopeId String CODEC(ZSTD(1)),
+    Window LowCardinality(String),
+    PeriodStart DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    SpendUSD AggregateFunction(sum, Decimal(18, 6)),
+    TokensInput AggregateFunction(sum, UInt64),
+    TokensOutput AggregateFunction(sum, UInt64),
+    TokensCacheRead AggregateFunction(sum, UInt64),
+    TokensCacheWrite AggregateFunction(sum, UInt64),
+    RequestCount AggregateFunction(count, UInt64),
+
+    UpdatedAt DateTime64(3) DEFAULT now64(3) CODEC(Delta(8), ZSTD(1))
+)
+ENGINE = ${CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree()}
+PARTITION BY toYYYYMM(PeriodStart)
+ORDER BY (TenantId, Scope, ScopeId, Window, PeriodStart)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_mv;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_rebuild
+    (TenantId, Scope, ScopeId, Window, PeriodStart, SpendUSD, TokensInput, TokensOutput, TokensCacheRead, TokensCacheWrite, RequestCount)
+SELECT
+    TenantId,
+    Scope,
+    ScopeId,
+    Window,
+    multiIf(
+        Window = 'MINUTE', toDateTime64(toStartOfMinute(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'HOUR',   toDateTime64(toStartOfHour(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'DAY',    toDateTime64(toStartOfDay(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'WEEK',   toDateTime64(toStartOfWeek(OccurredAt, 1, 'UTC'), 3, 'UTC'),
+        Window = 'MONTH',  toDateTime64(toStartOfMonth(OccurredAt, 'UTC'), 3, 'UTC'),
+                           toDateTime64(0, 3, 'UTC')
+    ) AS PeriodStart,
+    sumState(AmountUSD) AS SpendUSD,
+    sumState(toUInt64(TokensInput)) AS TokensInput,
+    sumState(toUInt64(TokensOutput)) AS TokensOutput,
+    sumState(toUInt64(TokensCacheRead)) AS TokensCacheRead,
+    sumState(toUInt64(TokensCacheWrite)) AS TokensCacheWrite,
+    countState() AS RequestCount
+FROM ${CLICKHOUSE_DATABASE}.gateway_budget_ledger_events FINAL
+WHERE Status = 'success'
+GROUP BY TenantId, Scope, ScopeId, Window, PeriodStart;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals AND ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_mv
+TO ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals
+AS
+SELECT
+    TenantId,
+    Scope,
+    ScopeId,
+    Window,
+    -- All branches must return DateTime64(3) to match the target column,
+    -- and every function names 'UTC' so the boundary truncated to is the
+    -- one the reader computes, on any server. The outer toDateTime64 needs
+    -- the timezone too: toStartOfWeek and toStartOfMonth return a Date,
+    -- and converting a Date to DateTime64 without one re-interprets
+    -- midnight in the server timezone, which puts the drift right back.
+    -- toStartOfWeek mode 1 is Monday, matching the reader's ISO week.
+    multiIf(
+        Window = 'MINUTE', toDateTime64(toStartOfMinute(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'HOUR',   toDateTime64(toStartOfHour(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'DAY',    toDateTime64(toStartOfDay(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'WEEK',   toDateTime64(toStartOfWeek(OccurredAt, 1, 'UTC'), 3, 'UTC'),
+        Window = 'MONTH',  toDateTime64(toStartOfMonth(OccurredAt, 'UTC'), 3, 'UTC'),
+        -- TOTAL and anything unrecognised: one lifetime bucket.
+                           toDateTime64(0, 3, 'UTC')
+    ) AS PeriodStart,
+    sumState(AmountUSD) AS SpendUSD,
+    sumState(toUInt64(TokensInput)) AS TokensInput,
+    sumState(toUInt64(TokensOutput)) AS TokensOutput,
+    sumState(toUInt64(TokensCacheRead)) AS TokensCacheRead,
+    sumState(toUInt64(TokensCacheWrite)) AS TokensCacheWrite,
+    countState() AS RequestCount
+FROM ${CLICKHOUSE_DATABASE}.gateway_budget_ledger_events
+WHERE Status = 'success'
+GROUP BY TenantId, Scope, ScopeId, Window, PeriodStart;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_recon;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_recon
+(
+    TenantId String CODEC(ZSTD(1)),
+    Scope LowCardinality(String),
+    ScopeId String CODEC(ZSTD(1)),
+    Window LowCardinality(String),
+    PeriodStart DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    TrueSpendUSD Decimal(38, 6),
+    TrueTokensInput UInt64,
+    TrueTokensOutput UInt64,
+    TrueTokensCacheRead UInt64,
+    TrueTokensCacheWrite UInt64,
+    TrueRequestCount UInt64
+)
+ENGINE = ${CLICKHOUSE_ENGINE_MERGETREE:-MergeTree()}
+ORDER BY (TenantId, Scope, ScopeId, Window, PeriodStart)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_recon
+SELECT
+    TenantId,
+    Scope,
+    ScopeId,
+    Window,
+    multiIf(
+        Window = 'MINUTE', toDateTime64(toStartOfMinute(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'HOUR',   toDateTime64(toStartOfHour(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'DAY',    toDateTime64(toStartOfDay(OccurredAt, 'UTC'), 3, 'UTC'),
+        Window = 'WEEK',   toDateTime64(toStartOfWeek(OccurredAt, 1, 'UTC'), 3, 'UTC'),
+        Window = 'MONTH',  toDateTime64(toStartOfMonth(OccurredAt, 'UTC'), 3, 'UTC'),
+                           toDateTime64(0, 3, 'UTC')
+    ) AS PeriodStart,
+    sum(AmountUSD) AS TrueSpendUSD,
+    sum(toUInt64(TokensInput)) AS TrueTokensInput,
+    sum(toUInt64(TokensOutput)) AS TrueTokensOutput,
+    sum(toUInt64(TokensCacheRead)) AS TrueTokensCacheRead,
+    sum(toUInt64(TokensCacheWrite)) AS TrueTokensCacheWrite,
+    count() AS TrueRequestCount
+FROM ${CLICKHOUSE_DATABASE}.gateway_budget_ledger_events FINAL
+WHERE Status = 'success'
+GROUP BY TenantId, Scope, ScopeId, Window, PeriodStart;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals
+    (TenantId, Scope, ScopeId, Window, PeriodStart, SpendUSD, TokensInput, TokensOutput, TokensCacheRead, TokensCacheWrite, RequestCount)
+SELECT
+    r.TenantId,
+    r.Scope,
+    r.ScopeId,
+    r.Window,
+    r.PeriodStart,
+    arrayReduce('sumState', [toDecimal64(greatest(r.TrueSpendUSD - c.CurSpendUSD, 0), 6)]),
+    arrayReduce('sumState', [toUInt64(greatest(toInt64(r.TrueTokensInput) - toInt64(c.CurTokensInput), 0))]),
+    arrayReduce('sumState', [toUInt64(greatest(toInt64(r.TrueTokensOutput) - toInt64(c.CurTokensOutput), 0))]),
+    arrayReduce('sumState', [toUInt64(greatest(toInt64(r.TrueTokensCacheRead) - toInt64(c.CurTokensCacheRead), 0))]),
+    arrayReduce('sumState', [toUInt64(greatest(toInt64(r.TrueTokensCacheWrite) - toInt64(c.CurTokensCacheWrite), 0))]),
+    arrayReduce('countState', range(toUInt64(greatest(toInt64(r.TrueRequestCount) - toInt64(c.CurRequestCount), 0))))
+FROM ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_recon AS r
+LEFT JOIN (
+    SELECT
+        TenantId, Scope, ScopeId, Window, PeriodStart,
+        sumMerge(SpendUSD) AS CurSpendUSD,
+        sumMerge(TokensInput) AS CurTokensInput,
+        sumMerge(TokensOutput) AS CurTokensOutput,
+        sumMerge(TokensCacheRead) AS CurTokensCacheRead,
+        sumMerge(TokensCacheWrite) AS CurTokensCacheWrite,
+        countMerge(RequestCount) AS CurRequestCount
+    FROM ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals
+    GROUP BY TenantId, Scope, ScopeId, Window, PeriodStart
+) AS c USING (TenantId, Scope, ScopeId, Window, PeriodStart)
+WHERE r.TrueSpendUSD > c.CurSpendUSD
+   OR r.TrueRequestCount > c.CurRequestCount
+   OR r.TrueTokensInput > c.CurTokensInput
+   OR r.TrueTokensOutput > c.CurTokensOutput
+   OR r.TrueTokensCacheRead > c.CurTokensCacheRead
+   OR r.TrueTokensCacheWrite > c.CurTokensCacheWrite
+-- The delta arithmetic and the WHERE filter both rely on an unmatched
+-- LEFT JOIN row carrying zero-valued Cur* columns. A server or profile
+-- with join_use_nulls = 1 would make them NULL instead, so the setting
+-- is pinned on the statement.
+SETTINGS join_use_nulls = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_recon;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- +goose ENVSUB ON
+
+-- IRREVERSIBLE: the swap discards the plain-engine table this migration
+-- replaces, and moving back to a plain engine on a cluster would resume
+-- scattering folds across replicas. Rollback statements stay commented
+-- out and must be applied manually if ever needed.
+
+-- +goose StatementBegin
+-- DROP VIEW IF EXISTS ${CLICKHOUSE_DATABASE}.gateway_budget_scope_totals_mv;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/clickhouse/migrations/00065_replicate_trace_analytics_rollup.sql
+++ b/langwatch/src/server/clickhouse/migrations/00065_replicate_trace_analytics_rollup.sql
@@ -1,0 +1,138 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- trace_analytics_rollup: move to the Replicated engine.
+--
+-- When CLICKHOUSE_CLUSTER is set the database engine is Replicated (00001),
+-- which replicates DDL to every node but NOT table data: data only
+-- replicates through Replicated*MergeTree table engines. This table was
+-- created with a plain AggregatingMergeTree, so on a multi-replica cluster
+-- every replica accumulates a PRIVATE copy: the app-side map projection
+-- (traceAnalyticsRollup.mapProjection.ts) inserts through the load
+-- balancer, each increment lands on exactly one replica and never
+-- replicates, and reads return whichever replica's fraction they happen to
+-- hit. The engine below substitutes to ReplicatedAggregatingMergeTree on
+-- clustered deployments (the same mechanism every ReplacingMergeTree table
+-- uses via CLICKHOUSE_ENGINE_REPLACING_PREFIX), so an insert received by
+-- any replica replicates to all nodes.
+--
+-- Contents, per deployment shape:
+--
+--   * Single node (CLICKHOUSE_IS_REPLICATED=0): the existing table holds
+--     the complete dataset, so the carry-over INSERT below copies it into
+--     the replacement verbatim and the swap is a behavioral no-op.
+--   * Cluster (CLICKHOUSE_IS_REPLICATED=1): the carry-over predicate is
+--     constant-false, so nothing reads the old table (each replica's
+--     content is a partial private fraction, unusable as a source) and
+--     the replacement starts EMPTY. A SQL rebuild is not possible here:
+--     rows are produced by the TypeScript map projection (span
+--     normalization, canonical model extraction, token-accumulation
+--     gates, pricing) from SpanReceivedEvents in event_log, logic that
+--     has no SQL equivalent. event_log IS replicated, so the
+--     event-sourcing replay (ops replay, projection
+--     `traceAnalyticsRollup`) rebuilds the true content through any
+--     node, and with this engine the rebuilt rows replicate. The
+--     table's contract has always been replay-rebuilds-truncate-first
+--     (00038); after this migration the truncation has already
+--     happened.
+--
+-- Single-connection correctness on a cluster: goose runs every statement
+-- through one connection. CREATE / EXCHANGE / DROP are DDL and replicate
+-- through the database engine; the carry-over INSERT (single-node only)
+-- runs where the complete dataset lives.
+--
+-- Mid-migration inserts: an increment inserted between the carry-over
+-- SELECT and the EXCHANGE lands in the outgoing table and is dropped with
+-- it. The window is the sub-second gap between two statements, the rollup
+-- explicitly tolerates single-increment drift (00038 accepts re-delivery
+-- over-count), and a replay rebuild erases the drift entirely. From the
+-- EXCHANGE onward inserts land in the replacement table and are kept.
+--
+-- Re-run safety (the runner may re-apply a partially executed file after
+-- a crash): the scratch is DROPPED and recreated rather than truncated
+-- and reused. This matters because the migration converts the engine:
+-- after a crash between the EXCHANGE and the final drop, the scratch NAME
+-- holds the old plain-engine table, and truncating and reusing it would
+-- swap the plain engine back in. A re-run after such a crash discards
+-- increments accrued since the first EXCHANGE (bounded by the
+-- crash-to-rerun gap); the replay rebuild recovers them on a cluster, and
+-- on a single node the re-run's carry-over re-copies the live table, so
+-- only the crash-window increments are lost.
+-- ============================================================================
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild
+(
+    -- Column-for-column the 00038 schema; only the engine changes.
+    TenantId String CODEC(ZSTD(1)),
+    BucketStart DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+    Model LowCardinality(String),
+    SpanType LowCardinality(String),
+
+    SpanCount SimpleAggregateFunction(sum, UInt64),
+    TraceCount SimpleAggregateFunction(sum, UInt64),
+    ErrorCount SimpleAggregateFunction(sum, UInt64),
+
+    CostSum SimpleAggregateFunction(sum, Float64),
+    NonBilledCostSum SimpleAggregateFunction(sum, Float64),
+
+    DurationSum SimpleAggregateFunction(sum, Int64),
+
+    PromptTokensSum SimpleAggregateFunction(sum, UInt64),
+    CompletionTokensSum SimpleAggregateFunction(sum, UInt64),
+    CacheReadTokensSum SimpleAggregateFunction(sum, UInt64),
+    CacheWriteTokensSum SimpleAggregateFunction(sum, UInt64),
+    ReasoningTokensSum SimpleAggregateFunction(sum, UInt64),
+
+    `_retention_days` UInt16 DEFAULT 308 CODEC(Delta(2), ZSTD(1))
+)
+ENGINE = ${CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree()}
+PARTITION BY toYearWeek(toDate(BucketStart))
+ORDER BY (TenantId, BucketStart, Model, SpanType)
+TTL IF(_retention_days > 0, toDateTime(BucketStart) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Single-node carry-over. On a cluster the predicate is constant-false:
+-- the plain-engine table's content is per-replica and must not be read.
+INSERT INTO ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild
+    (TenantId, BucketStart, Model, SpanType, SpanCount, TraceCount, ErrorCount,
+     CostSum, NonBilledCostSum, DurationSum, PromptTokensSum, CompletionTokensSum,
+     CacheReadTokensSum, CacheWriteTokensSum, ReasoningTokensSum, _retention_days)
+SELECT
+    TenantId, BucketStart, Model, SpanType, SpanCount, TraceCount, ErrorCount,
+    CostSum, NonBilledCostSum, DurationSum, PromptTokensSum, CompletionTokensSum,
+    CacheReadTokensSum, CacheWriteTokensSum, ReasoningTokensSum, _retention_days
+FROM ${CLICKHOUSE_DATABASE}.trace_analytics_rollup
+WHERE ${CLICKHOUSE_IS_REPLICATED:-0} = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.trace_analytics_rollup AND ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- +goose ENVSUB ON
+
+-- IRREVERSIBLE: the swap discards the plain-engine table this migration
+-- replaces, and moving back to a plain engine on a cluster would resume
+-- marooning each insert on one replica. Rollback statements stay
+-- commented out and must be applied manually if ever needed.
+
+-- +goose StatementBegin
+-- DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/clickhouse/migrations/00065_replicate_trace_analytics_rollup.sql
+++ b/langwatch/src/server/clickhouse/migrations/00065_replicate_trace_analytics_rollup.sql
@@ -35,7 +35,8 @@
 --     node, and with this engine the rebuilt rows replicate. The
 --     table's contract has always been replay-rebuilds-truncate-first
 --     (00038); after this migration the truncation has already
---     happened.
+--     happened. Operator steps and verification:
+--     dev/docs/runbooks/analytics-rollup-replay.md.
 --
 -- Single-connection correctness on a cluster: goose runs every statement
 -- through one connection. CREATE / EXCHANGE / DROP are DDL and replicate
@@ -101,6 +102,10 @@ SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
 -- +goose StatementBegin
 -- Single-node carry-over. On a cluster the predicate is constant-false:
 -- the plain-engine table's content is per-replica and must not be read.
+-- The ENVSUB fallback is 1 (skip the copy): an environment that runs
+-- migrations without buildMigrationEnvVars must fail towards an empty,
+-- replay-recoverable table, never towards planting one node's private
+-- fraction as content.
 INSERT INTO ${CLICKHOUSE_DATABASE}.trace_analytics_rollup_rebuild
     (TenantId, BucketStart, Model, SpanType, SpanCount, TraceCount, ErrorCount,
      CostSum, NonBilledCostSum, DurationSum, PromptTokensSum, CompletionTokensSum,
@@ -110,7 +115,7 @@ SELECT
     CostSum, NonBilledCostSum, DurationSum, PromptTokensSum, CompletionTokensSum,
     CacheReadTokensSum, CacheWriteTokensSum, ReasoningTokensSum, _retention_days
 FROM ${CLICKHOUSE_DATABASE}.trace_analytics_rollup
-WHERE ${CLICKHOUSE_IS_REPLICATED:-0} = 0;
+WHERE ${CLICKHOUSE_IS_REPLICATED:-1} = 0;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/langwatch/src/server/clickhouse/migrations/00066_replicate_evaluation_analytics_rollup.sql
+++ b/langwatch/src/server/clickhouse/migrations/00066_replicate_evaluation_analytics_rollup.sql
@@ -1,0 +1,110 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- evaluation_analytics_rollup: move to the Replicated engine.
+--
+-- Same defect and same remedy as trace_analytics_rollup (00065): a plain
+-- AggregatingMergeTree inside a Replicated database replicates its DDL but
+-- not its data, so on a multi-replica cluster the app-side map projection
+-- (evaluationAnalyticsRollup.mapProjection.ts) marooned each increment on
+-- the replica that received the insert, and reads returned whichever
+-- replica's fraction they hit. The engine below substitutes to
+-- ReplicatedAggregatingMergeTree on clustered deployments so an insert
+-- received by any replica replicates to all nodes.
+--
+-- Contents, per deployment shape:
+--
+--   * Single node (CLICKHOUSE_IS_REPLICATED=0): the existing table holds
+--     the complete dataset, so the carry-over INSERT below copies it into
+--     the replacement verbatim and the swap is a behavioral no-op.
+--   * Cluster (CLICKHOUSE_IS_REPLICATED=1): the carry-over predicate is
+--     constant-false, so nothing reads the old table and the replacement
+--     starts EMPTY. Rows are produced by the TypeScript map projection
+--     from terminal evaluation events in event_log (canonical status,
+--     pass/fail, score and cost extraction), logic with no SQL
+--     equivalent, so the rebuild path is the event-sourcing replay (ops
+--     replay, projection `evaluationAnalyticsRollup`) over the
+--     replicated event_log, matching the table's
+--     replay-rebuilds-truncate-first contract (00040).
+--
+-- Single-connection correctness, mid-migration insert bounds, and re-run
+-- safety (drop-not-truncate scratch, because a crash past the EXCHANGE
+-- leaves the OLD plain-engine table under the scratch name) are identical
+-- to 00065; see that migration's header.
+-- ============================================================================
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild
+(
+    -- Column-for-column the 00040 schema; only the engine changes.
+    TenantId String CODEC(ZSTD(1)),
+    BucketStart DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+    EvaluatorType LowCardinality(String),
+    Status LowCardinality(String),
+
+    EvalCount SimpleAggregateFunction(sum, UInt64),
+    PassCount SimpleAggregateFunction(sum, UInt64),
+    FailCount SimpleAggregateFunction(sum, UInt64),
+    ErrorCount SimpleAggregateFunction(sum, UInt64),
+    SkippedCount SimpleAggregateFunction(sum, UInt64),
+
+    ScoreSum SimpleAggregateFunction(sum, Float64),
+    ScoreCount SimpleAggregateFunction(sum, UInt64),
+
+    DurationSum SimpleAggregateFunction(sum, Int64),
+
+    CostSum SimpleAggregateFunction(sum, Float64),
+    NonBilledCostSum SimpleAggregateFunction(sum, Float64),
+
+    `_retention_days` UInt16 DEFAULT 308 CODEC(Delta(2), ZSTD(1))
+)
+ENGINE = ${CLICKHOUSE_ENGINE_AGGREGATING:-AggregatingMergeTree()}
+PARTITION BY toYearWeek(toDate(BucketStart))
+ORDER BY (TenantId, BucketStart, EvaluatorType, Status)
+TTL IF(_retention_days > 0, toDateTime(BucketStart) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Single-node carry-over. On a cluster the predicate is constant-false:
+-- the plain-engine table's content is per-replica and must not be read.
+INSERT INTO ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild
+    (TenantId, BucketStart, EvaluatorType, Status, EvalCount, PassCount, FailCount,
+     ErrorCount, SkippedCount, ScoreSum, ScoreCount, DurationSum, CostSum,
+     NonBilledCostSum, _retention_days)
+SELECT
+    TenantId, BucketStart, EvaluatorType, Status, EvalCount, PassCount, FailCount,
+    ErrorCount, SkippedCount, ScoreSum, ScoreCount, DurationSum, CostSum,
+    NonBilledCostSum, _retention_days
+FROM ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup
+WHERE ${CLICKHOUSE_IS_REPLICATED:-0} = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup AND ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- +goose ENVSUB ON
+
+-- IRREVERSIBLE: the swap discards the plain-engine table this migration
+-- replaces, and moving back to a plain engine on a cluster would resume
+-- marooning each insert on one replica. Rollback statements stay
+-- commented out and must be applied manually if ever needed.
+
+-- +goose StatementBegin
+-- DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/clickhouse/migrations/00066_replicate_evaluation_analytics_rollup.sql
+++ b/langwatch/src/server/clickhouse/migrations/00066_replicate_evaluation_analytics_rollup.sql
@@ -26,7 +26,8 @@
 --     equivalent, so the rebuild path is the event-sourcing replay (ops
 --     replay, projection `evaluationAnalyticsRollup`) over the
 --     replicated event_log, matching the table's
---     replay-rebuilds-truncate-first contract (00040).
+--     replay-rebuilds-truncate-first contract (00040). Operator steps
+--     and verification: dev/docs/runbooks/analytics-rollup-replay.md.
 --
 -- Single-connection correctness, mid-migration insert bounds, and re-run
 -- safety (drop-not-truncate scratch, because a crash past the EXCHANGE
@@ -73,6 +74,10 @@ SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
 -- +goose StatementBegin
 -- Single-node carry-over. On a cluster the predicate is constant-false:
 -- the plain-engine table's content is per-replica and must not be read.
+-- The ENVSUB fallback is 1 (skip the copy): an environment that runs
+-- migrations without buildMigrationEnvVars must fail towards an empty,
+-- replay-recoverable table, never towards planting one node's private
+-- fraction as content.
 INSERT INTO ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup_rebuild
     (TenantId, BucketStart, EvaluatorType, Status, EvalCount, PassCount, FailCount,
      ErrorCount, SkippedCount, ScoreSum, ScoreCount, DurationSum, CostSum,
@@ -82,7 +87,7 @@ SELECT
     ErrorCount, SkippedCount, ScoreSum, ScoreCount, DurationSum, CostSum,
     NonBilledCostSum, _retention_days
 FROM ${CLICKHOUSE_DATABASE}.evaluation_analytics_rollup
-WHERE ${CLICKHOUSE_IS_REPLICATED:-0} = 0;
+WHERE ${CLICKHOUSE_IS_REPLICATED:-1} = 0;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/langwatch/src/server/event-sourcing/replay/__tests__/traceAnalyticsRollupReplay.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/traceAnalyticsRollupReplay.integration.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Integration test for the replay path that rebuilds `trace_analytics_rollup`.
+ *
+ * Migration 00065 converts the rollup to the Replicated engine; on clustered
+ * deployments it comes out EMPTY and its history is reconstructed by replaying
+ * the `traceAnalyticsRollup` map projection over `event_log`
+ * (dev/docs/runbooks/analytics-rollup-replay.md). This test pins that recovery
+ * path end to end: events seeded into `event_log` are replayed through the
+ * REAL replay executor (`replayMapProjection` — discovery, batch loading,
+ * leaning, the projection's own map handler, and the ClickHouse append store),
+ * and the reconstructed rollup rows are asserted against both literal expected
+ * values and the projection's direct output for the same events.
+ *
+ * BDD structure: describe("given X") → describe("when Y") → it("…").
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { TraceAnalyticsRollupClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-analytics-rollup.clickhouse.repository";
+import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../__tests__/integration/testContainers";
+import {
+  generateTestAggregateId,
+  generateTestTenantId,
+} from "../../__tests__/integration/testHelpers";
+import { createSpanReceivedEvent } from "../../pipelines/trace-processing/projections/__tests__/fixtures/trace-summary-test.fixtures";
+import { TraceAnalyticsRollupMapProjection } from "../../pipelines/trace-processing/projections/traceAnalyticsRollup.mapProjection";
+import { TraceAnalyticsRollupAppendStore } from "../../pipelines/trace-processing/projections/traceAnalyticsRollup.store";
+import { nullLog } from "../replayLog";
+import { replayMapProjection } from "../replayMapPath";
+import { cleanupAll } from "../replayMarkers";
+import type { RegisteredMapProjection } from "../types";
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      _opts: unknown,
+      fn: (span: {
+        setAttribute: () => void;
+        setAttributes: () => void;
+        addEvent: () => void;
+      }) => unknown,
+    ) =>
+      fn({
+        setAttribute: () => {},
+        setAttributes: () => {},
+        addEvent: () => {},
+      }),
+  }),
+}));
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const PROJECTION_NAME = "traceAnalyticsRollup";
+
+/** Minute-aligned base a day in the past, inside every retention window. */
+const baseMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
+const ms = (offset: number) => baseMs + offset;
+const nano = (offset: number) => `${ms(offset)}000000`;
+
+interface RollupTotalsRow {
+  bucketMs: number;
+  model: string;
+  spanType: string;
+  spanCount: number;
+  traceCount: number;
+  errorCount: number;
+  durationSum: number;
+  promptTokens: number;
+  completionTokens: number;
+}
+
+/** Rollup totals for the tenant, one normalized row per (bucket, model, type). */
+async function readRollupTotals(
+  client: ClickHouseClient,
+  tenantId: string,
+): Promise<RollupTotalsRow[]> {
+  const readBack = await client.query({
+    query: `
+      SELECT
+        toUnixTimestamp64Milli(BucketStart) AS bucketMs,
+        Model AS model,
+        SpanType AS spanType,
+        sum(SpanCount) AS spanCount,
+        sum(TraceCount) AS traceCount,
+        sum(ErrorCount) AS errorCount,
+        sum(DurationSum) AS durationSum,
+        sum(PromptTokensSum) AS promptTokens,
+        sum(CompletionTokensSum) AS completionTokens
+      FROM trace_analytics_rollup
+      WHERE TenantId = {tenantId:String}
+      GROUP BY bucketMs, Model, SpanType
+      ORDER BY bucketMs, Model, SpanType
+    `,
+    query_params: { tenantId },
+    format: "JSONEachRow",
+  });
+  const rows = await readBack.json<Record<keyof RollupTotalsRow, string>>();
+  return rows.map((r) => ({
+    bucketMs: Number(r.bucketMs),
+    model: r.model,
+    spanType: r.spanType,
+    spanCount: Number(r.spanCount),
+    traceCount: Number(r.traceCount),
+    errorCount: Number(r.errorCount),
+    durationSum: Number(r.durationSum),
+    promptTokens: Number(r.promptTokens),
+    completionTokens: Number(r.completionTokens),
+  }));
+}
+
+/** Best-effort teardown: replay markers plus the tenant's fixture rows. */
+async function cleanupTenantData(
+  client: ClickHouseClient | undefined,
+  tenantId: string,
+): Promise<void> {
+  const redis = getTestRedisConnection();
+  if (redis) {
+    await cleanupAll({ redis, projectionName: PROJECTION_NAME });
+  }
+  if (!client) return;
+  for (const table of ["event_log", "trace_analytics_rollup"]) {
+    try {
+      await client.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId },
+      });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+/** Additive totals over rows, for the replay-vs-direct parity comparison. */
+function additiveTotals(
+  rows: readonly {
+    spanCount: number;
+    traceCount: number;
+    errorCount: number;
+    durationSum: number;
+  }[],
+) {
+  return rows.reduce(
+    (a, r) => ({
+      spanCount: a.spanCount + r.spanCount,
+      traceCount: a.traceCount + r.traceCount,
+      errorCount: a.errorCount + r.errorCount,
+      durationSum: a.durationSum + r.durationSum,
+    }),
+    { spanCount: 0, traceCount: 0, errorCount: 0, durationSum: 0 },
+  );
+}
+
+describe("given span events in event_log for a tenant whose rollup is empty", () => {
+  let client: ClickHouseClient;
+  let tenantId: string;
+  let traceA: string;
+  let traceB: string;
+
+  /**
+   * Three spans across two traces, shaped by the same fixture the projection's
+   * unit tests use, so the raw OTLP payload exercises the real normalization:
+   *   - trace A root: response model + span type + tokens, 1500 ms duration.
+   *   - trace A child: no model, no type, contributes only its span count.
+   *   - trace B root: ERROR status, second minute bucket, 500 ms duration.
+   */
+  const buildEvents = () => [
+    createSpanReceivedEvent({
+      eventId: "evt-rollup-replay-001",
+      tenantId,
+      traceId: traceA,
+      spanId: "aaaa000000000001",
+      parentSpanId: null,
+      occurredAt: ms(0),
+      startTimeUnixNano: nano(0),
+      endTimeUnixNano: nano(1_500),
+      attributes: {
+        "gen_ai.request.model": "gpt-4o-mini",
+        "gen_ai.response.model": "gpt-4o-2024-08-06",
+        "langwatch.span.type": "llm",
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 20,
+      },
+    }),
+    createSpanReceivedEvent({
+      eventId: "evt-rollup-replay-002",
+      tenantId,
+      traceId: traceA,
+      spanId: "aaaa000000000002",
+      parentSpanId: "aaaa000000000001",
+      occurredAt: ms(1_000),
+      startTimeUnixNano: nano(10_000),
+      endTimeUnixNano: nano(11_000),
+    }),
+    createSpanReceivedEvent({
+      eventId: "evt-rollup-replay-003",
+      tenantId,
+      traceId: traceB,
+      spanId: "cccc000000000001",
+      parentSpanId: null,
+      occurredAt: ms(2_000),
+      startTimeUnixNano: nano(120_000),
+      endTimeUnixNano: nano(120_500),
+      statusCode: 2,
+    }),
+  ];
+
+  beforeAll(async () => {
+    await startTestContainers();
+    client = getTestClickHouseClient()!;
+    tenantId = generateTestTenantId();
+    traceA = generateTestAggregateId("rollup-replay-a");
+    traceB = generateTestAggregateId("rollup-replay-b");
+
+    const records = buildEvents().map((event) => ({
+      TenantId: tenantId,
+      AggregateType: "trace",
+      AggregateId: event.aggregateId,
+      EventId: event.id,
+      EventType: SPAN_RECEIVED_EVENT_TYPE,
+      EventTimestamp: event.occurredAt,
+      EventOccurredAt: event.occurredAt,
+      EventVersion: "2025-12-14",
+      // Production stores only the event's DATA here (eventStoreUtils
+      // .eventToRecord); the replay loader rebuilds the envelope from the
+      // row's own columns and parses this straight into `event.data`.
+      EventPayload: JSON.stringify(event.data),
+      IdempotencyKey: event.id,
+      // Never-expire sentinel so the table TTL cannot reap the fixture.
+      _retention_days: 0,
+    }));
+
+    await client.insert({
+      table: "event_log",
+      values: records,
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTenantData(client, tenantId);
+    await stopTestContainers();
+  });
+
+  describe("when the traceAnalyticsRollup projection is replayed through the real replay path", () => {
+    it("reconstructs the rollup rows the live projection would have written", async () => {
+      const redis = getTestRedisConnection()!;
+      // A completed-set entry from an earlier run must not skip this one.
+      await cleanupAll({ redis, projectionName: PROJECTION_NAME });
+
+      const projection = new TraceAnalyticsRollupMapProjection({
+        store: new TraceAnalyticsRollupAppendStore(
+          new TraceAnalyticsRollupClickHouseRepository(async () => client),
+        ),
+      });
+      const registered: RegisteredMapProjection = {
+        projectionName: PROJECTION_NAME,
+        pipelineName: "trace-processing",
+        aggregateType: "trace",
+        source: "pipeline",
+        definition: projection,
+        pauseKey: `trace-processing/handler/${PROJECTION_NAME}`,
+        kind: "map",
+        targetTable: "trace_analytics_rollup",
+      };
+
+      const result = await replayMapProjection({
+        ctx: {
+          redis,
+          resolveClient: async () => client,
+          accumulatorOpts: {},
+        },
+        projection: registered,
+        projectionIndex: 0,
+        totalProjections: 1,
+        tenantIds: [tenantId],
+        since: new Date(0).toISOString(),
+        batchSize: 100,
+        aggregateBatchSize: 10,
+        dryRun: false,
+        log: nullLog,
+      });
+
+      expect(result.firstError).toBeUndefined();
+      expect(result.batchErrors).toBe(0);
+      expect(result.aggregatesReplayed).toBe(2);
+      expect(result.totalEvents).toBe(3);
+      expect(result.touchedTenants).toEqual([tenantId]);
+
+      const rows = await readRollupTotals(client, tenantId);
+
+      // Literal expectations: the root of trace A keys on the RESPONSE model
+      // and its span type, carries the trace count and wall-clock duration and
+      // the token sums; the child contributes one span to the ('', '') bucket
+      // of the same minute; the ERROR root of trace B lands in the next minute
+      // bucket with its error count.
+      expect(rows).toEqual([
+        {
+          bucketMs: ms(0),
+          model: "",
+          spanType: "",
+          spanCount: 1,
+          traceCount: 0,
+          errorCount: 0,
+          durationSum: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+        },
+        {
+          bucketMs: ms(0),
+          model: "gpt-4o-2024-08-06",
+          spanType: "llm",
+          spanCount: 1,
+          traceCount: 1,
+          errorCount: 0,
+          durationSum: 1_500,
+          promptTokens: 100,
+          completionTokens: 20,
+        },
+        {
+          bucketMs: ms(120_000),
+          model: "",
+          spanType: "",
+          spanCount: 1,
+          traceCount: 1,
+          errorCount: 1,
+          durationSum: 500,
+          promptTokens: 0,
+          completionTokens: 0,
+        },
+      ]);
+
+      // Parity with the projection's direct output: replay must feed the map
+      // handler the same events live dispatch would, so summing the rows the
+      // projection emits for the same fixture reproduces the table exactly.
+      const direct = buildEvents().map((event) =>
+        projection.mapTraceSpanReceived(event),
+      );
+      expect(additiveTotals(rows)).toEqual(additiveTotals(direct));
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/replay/replayService.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayService.ts
@@ -217,6 +217,13 @@ export class ReplayService {
     return replayOptimized({ ctx: this.ctx, config, callbacks });
   }
 
+  /**
+   * Drop the projection's replay markers: the completed set and the in-flight
+   * cutoff hash. Every replay path already does this when it finishes cleanly;
+   * calling it before a run turns that run into a rebuild from scratch, since
+   * the completed set is what makes discovery skip aggregates an earlier
+   * (possibly aborted) run had finished.
+   */
   async cleanup(projectionName: string): Promise<void> {
     await cleanupAll({ redis: this.ctx.redis, projectionName });
   }

--- a/specs/event-sourcing/projection-replay.feature
+++ b/specs/event-sourcing/projection-replay.feature
@@ -40,6 +40,14 @@ Feature: Projection replay
     Then aggregates that already completed are not replayed again
     And the remaining aggregates are replayed to completion
 
+  @integration
+  Scenario: A full rebuild replays aggregates an interrupted run had completed
+    Given a replay of a projection was interrupted after completing some aggregates
+    And the projection's stored records were then emptied
+    When the operator starts a full rebuild of that projection
+    Then the aggregates the interrupted run had completed are replayed again
+    And their records are restored from the event history
+
   Scenario: Replaying fold and map projections together
     Given a registered fold projection "traceSummary" for aggregate type "trace"
     When an operator starts a replay covering both "traceSummary" and "spanStorage"


### PR DESCRIPTION
## Why

Production data-integrity incident. Three ClickHouse tables were created by migrations with PLAIN MergeTree-family engines inside the production `Replicated` database on the 3-replica cluster. The Replicated database engine replicates DDL only; table data replicates only through `Replicated*MergeTree` table engines. So each of these tables exists on every replica but holds a private, divergent copy, with writes and reads scattering through the load balancer:

- `gateway_budget_scope_totals` (budget spend rollup, fed by `gateway_budget_scope_totals_mv` from `gateway_budget_ledger_events`). Proven divergence for one org bucket: replica0 $18.60 / 13,666 requests, replica1 $1.64 / 1,356, replica2 $2.43 / 2,164. The true value from the ledger is $22.35 / 20,576 events. The ledger itself (Replicated engine via the substitution pattern) is byte-identical across replicas, so the source of truth is intact. The critical consequence: budget ENFORCEMENT reads this table, so caps currently check against a random fraction of true spend.
- `trace_analytics_rollup`: 748,563 / 723,473 / 765,752 rows per replica.
- `evaluation_analytics_rollup`: 190,350 / 191,721 / 196,841 rows per replica.

It got worse than simple divergence for the budget rollup: migration 00058's rebuild ran its `TRUNCATE` and `EXCHANGE TABLES` as DDL (replicated to all three nodes) while its `INSERT ... SELECT` rebuild ran only on the connected node. The other two replicas atomically swapped in EMPTY rebuild tables, wiping the partial rollups they had. That is why replica0 has full history and replicas 1 and 2 only carry folds accrued since that deploy.

The mechanism in one line: a plain engine inside a Replicated database means DDL replicates, data does not, and a materialized view folds an insert only on the replica that received it.

## What changed

Three migrations, one goose.ts substitution variable, and a guard test.

**`goose.ts`** now provides `CLICKHOUSE_ENGINE_AGGREGATING` (resolves to `ReplicatedAggregatingMergeTree()` when `CLICKHOUSE_CLUSTER` is set, `AggregatingMergeTree()` otherwise) and `CLICKHOUSE_IS_REPLICATED` (`1`/`0`), alongside the existing `CLICKHOUSE_ENGINE_REPLACING_PREFIX` mechanism that every correctly-replicated table already uses. The offending tables hardcoded plain engines, bypassing that mechanism.

**`00064_replicate_gateway_budget_scope_totals.sql`** converts the budget rollup to the Replicated engine and rebuilds it from the ledger, reusing 00058's proven statement order: scratch rebuild, drop MV, snapshot rebuild from `gateway_budget_ledger_events FINAL`, `EXCHANGE TABLES`, recreate MV, delta reconciliation, drop scratches. Every INSERT reads only the replicated ledger (or the post-swap rollup); nothing reads the old fragmented rollup. With a Replicated scratch, the single-connection INSERT now replicates, which is exactly what 00058 was missing.

**`00065_replicate_trace_analytics_rollup.sql`** and **`00066_replicate_evaluation_analytics_rollup.sql`** convert the two analytics rollups the same way (scratch with the substituted engine, `EXCHANGE`, drop). Their contents cannot be rebuilt in SQL, deliberately not attempted: rows are produced by TypeScript map projections (`traceAnalyticsRollup.mapProjection.ts`, `evaluationAnalyticsRollup.mapProjection.ts`) that run span normalization, canonical model extraction, token-accumulation gating and pricing over events from `event_log`. On clustered deployments the new tables start EMPTY and are rebuilt by the event-sourcing replay (see deployment notes). On single-node deployments the old table is the complete dataset and is carried over verbatim, gated by `CLICKHOUSE_IS_REPLICATED`, so the swap is a behavioral no-op there.

**`replicatedEngineGuard.unit.test.ts`** is the guard, as important as the fix: it parses every migration file and fails if any `CREATE TABLE` or `CREATE MATERIALIZED VIEW` declares a MergeTree-family engine that is not one of the three deployment-substitutable patterns. The failure message names the file, the table, the engine found, and the required pattern, and explains the replication mechanics. Exactly five historical declarations are exempt (the three offenders plus 00058's two scratch tables), pinned by an exactness test so the list can never quietly widen or go stale. A third test closes the meta-loophole: every `${CLICKHOUSE_*}` variable referenced by any migration must be provided by `buildMigrationEnvVars`, because an unprovided variable would silently expand to its plain-engine ENVSUB default on every deployment, which is this same defect wearing a different hat.

## How it works

Single-connection correctness on the cluster: goose runs all statements through one connection (one replica). DDL (`CREATE`, `DROP`, `EXCHANGE`) replicates through the database engine. `INSERT ... SELECT` executes on the connected replica only, but it reads replicated sources and writes into Replicated tables, so the rebuilt rows reach every node. This is stated in each migration header.

Mid-migration insert safety for the budget rollup is 00058's argument, unchanged: the MV is dropped before the ledger snapshot (debits land only in the ledger, losing nothing), the swap is atomic, and the reconciliation pass adds per key exactly the spend present in the ledger but missing from the rollup, clamped at zero. Re-run safety differs from 00058 in one deliberate way: scratch tables are DROPPED and recreated rather than truncated, because after a crash between the `EXCHANGE` and the final drops the scratch name holds the OLD plain-engine table, and truncate-and-reuse would swap the plain engine back in.

The engine substitution shape (`ReplicatedAggregatingMergeTree()` with no arguments, Keeper paths auto-assigned by the Replicated database) is the exact shape already proven in production by `ReplicatedReplacingMergeTree(...)` on every other table and by goose.ts's own `goose_db_version` bootstrap.

## Test plan

- New guard unit test passes and its exactness test proves the parser detects all five historical plain-engine declarations.
- Local migration verification against native ClickHouse (fresh databases):
  - Fresh install: 00001 through 00066 applies clean; tables and MV exist with the locally-resolved plain engines.
  - Upgrade path: migrate to 00063, seed the ledger plus all three plain rollups, apply 00064-00066. Budget totals read back identical to both the pre-migration read and the ledger truth; both analytics rollups carry identical content; all scratch tables dropped.
  - Post-swap MV fold: a new ledger debit lands in the replaced table ($1.25 + $2.50 + $4.00 = $7.75, 3 requests, matching the ledger).
  - Re-run idempotency: re-applying 00064-00066 converges to identical content.
- Integration suites (native services, full migration chain in setup): `budget.clickhouse.repository.periodStart` + `budgetEnforcement` + `gatewayBudgetSync.reactor` (37 tests) and `trace-analytics-rollup` + `evaluation-analytics` + `route-table` (13 tests). All green.
- New full-rebuild integration test (added during review): drives the REAL ops entry point (`ReplayService.startReplay`) against real Redis and real ClickHouse over three cells with identical fixtures, so the surviving marker and the flag are the only variables. No marker plus a default run rebuilds the rows; a surviving marker plus a default run reports `completed` and writes nothing (the reported failure mode); a surviving marker plus `fullRebuild` rebuilds the rows and leaves the markers empty. Disabling the clearing block makes the third cell fail, so the test pins the fix and not the fixture.
- New replay integration test (added during review): seeds span events into `event_log` and replays the `traceAnalyticsRollup` projection through the real replay path (discovery, batch load, lean, real map handler, real ClickHouse store), then asserts the reconstructed rollup rows against literal expected values and against the projection's direct output. Proves the deployment-notes replay actually restores history.
- `cmd/migrationorder` passes against origin/main.

## Deployment notes

- Production (3 replicas): the budget rollup is fully rebuilt from the ledger inside the migration; rebuild cost is two ledger scans, trivial at current volume. The two analytics rollups start empty and need one event-sourcing replay to restore history: ops replay with `projectionNames: ["traceAnalyticsRollup", "evaluationAnalyticsRollup"]`, `since` at or before the oldest retention window, and `fullRebuild: true`. That last flag is not optional: a replay records finished aggregates in a Redis completed set with no TTL, a cancelled or failed run leaves those entries behind on purpose so a re-run resumes, and against the emptied tables that would skip those tenants while reporting a clean run. `fullRebuild` clears the markers under the replay lock before discovery. If the rebuild itself fails partway, re-run it with the flag OFF: its markers now describe rows that really are there, and a second full rebuild would double count them. `event_log` is replicated, so the replay folds true content through any node and it now replicates. Until the replay runs, analytics charts show only post-deploy data for the rollup-served reads; note that pre-deploy reads were already returning a roughly one-third fraction that varied per request, so there is no state to preserve.
- Single-node self-hosted: behavioral no-op. The engine substitutions resolve to the same plain engines, the budget rebuild reproduces identical totals, and the analytics rollups are carried over verbatim. The only theoretical loss is increments inserted during the sub-second window between the carry-over SELECT and the atomic swap.
- A hand-configured deployment with `CLICKHOUSE_CLUSTER` set over a single replica takes the clustered path: its analytics rollups start empty (its data was never fragmented, but the migration cannot distinguish that case) and the same replay restores them.

## Anything surprising?

- Rollup inflation caveat, out of scope here, flagged as follow-up: the budget MV does not dedup, and duplicate fold triggers (multi-pod reactor races within the debounce window, probe-read-vs-insert replica lag, resilient-client insert retries after a server-side commit) permanently inflate the rollup between rebuilds. The ledger collapses duplicates (ReplacingMergeTree), so this rebuild resets any accumulated inflation, but fold idempotency itself is a separate fix.
- The three historical migration files are left byte-for-byte untouched: goose never re-runs an applied file, so editing them would change nothing deployed while making the files lie about what production actually ran. Fresh clustered installs create the plain tables and convert them within the same goose run, before any traffic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for replicated ClickHouse engines across gateway budget, trace analytics, and evaluation analytics rollups.
  * Migrations now adapt automatically to replicated or non-replicated deployment environments.
  * Rollup rebuilds preserve existing data where supported and maintain consistent analytics results.

* **Bug Fixes**
  * Added safeguards to validate migration compatibility and required deployment configuration before rollout.
  * Added replay verification to help ensure analytics data is reconstructed accurately.

* **Documentation**
  * Added operational guidance for rebuilding analytics rollups and verifying replication after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->