### PR TITLE
fix: surface structured AI SDK output in trace spans

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
@@ -43,6 +43,26 @@ function createTestSpan(
 }
 
 describe("TraceIOExtractionService", () => {
+  describe("when gen_ai.output.messages contains a structured JSON result", () => {
+    it("keeps assistant content as readable JSON text", () => {
+      const output = { greeting: "Hallo" };
+      const messages = [{ role: "assistant", content: JSON.stringify(output) }];
+      const span = createTestSpan({
+        spanAttributes: {
+          "gen_ai.output.messages": messages,
+        },
+      });
+
+      const result = service.extractRichIOFromSpan(span, "output");
+
+      expect(result).toEqual({
+        raw: messages,
+        text: JSON.stringify(output),
+        source: "gen_ai",
+      });
+    });
+  });
+
   describe("extractRichIOFromSpan", () => {
     describe("when langwatch.input is a JSON object with 'input' key", () => {
       it("extracts the text from the input key", () => {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/__tests__/structuredIO.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/__tests__/structuredIO.test.ts
@@ -6,7 +6,28 @@ const service = new CanonicalizeSpanAttributesService();
 
 const stubSpan = makeStubSpan();
 
-describe("CanonicalizeSpanAttributesService — structured IO", () => {
+describe("CanonicalizeSpanAttributesService: structured IO", () => {
+  describe("when the AI SDK emits a flat structured response", () => {
+    it("lifts ai.response.object into canonical output messages for embedded scopes", () => {
+      const objectPayload = { greeting: "Hallo" };
+      const result = service.canonicalize(
+        {
+          "ai.response.object": JSON.stringify(objectPayload),
+        },
+        [],
+        makeStubSpan({
+          name: "ai.generateText",
+          instrumentationScope: { name: "opencode", version: null },
+        }),
+      );
+
+      expect(result.attributes["langwatch.span.type"]).toBe("llm");
+      expect(result.attributes["gen_ai.output.messages"]).toEqual([
+        { role: "assistant", content: JSON.stringify(objectPayload) },
+      ]);
+    });
+  });
+
   describe("when input type is chat_messages", () => {
     it("sets gen_ai.input.messages from value array (stripping trailing assistant — post-call capture leak)", () => {
       const result = service.canonicalize(

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
@@ -181,6 +181,26 @@ describe("VercelExtractor", () => {
       ]);
     });
 
+    it("falls back to response text when the response attribute is empty", () => {
+      const objectPayload = { greeting: "Hallo" };
+      const ctx = createExtractorContext(
+        {
+          [ATTR_KEYS.AI_RESPONSE]: "",
+          [ATTR_KEYS.AI_RESPONSE_TEXT]: JSON.stringify(objectPayload),
+        },
+        {
+          name: "ai.generateText",
+          instrumentationScope: { name: "opencode", version: null },
+        },
+      );
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+        { role: "assistant", content: JSON.stringify(objectPayload) },
+      ]);
+    });
+
     it("handles a parsed JSON response text value", () => {
       const objectPayload = { text: "structured field" };
       const ctx = createExtractorContext(

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
@@ -140,6 +140,65 @@ describe("VercelExtractor", () => {
       expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBe("llm");
       expect(ctx.out[ATTR_KEYS.GEN_AI_REQUEST_MODEL]).toBe("openai/gpt-4");
     });
+
+    it("lifts flat structured output from a non-ai instrumentation scope", () => {
+      const objectPayload = { greeting: "Hallo" };
+      const ctx = createExtractorContext(
+        {
+          [ATTR_KEYS.AI_RESPONSE_OBJECT]: objectPayload,
+        },
+        {
+          name: "ai.generateText",
+          instrumentationScope: { name: "opencode", version: null },
+        },
+      );
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBe("llm");
+      expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+        { role: "assistant", content: JSON.stringify(objectPayload) },
+      ]);
+    });
+
+    it("uses structured output when the text attribute is empty", () => {
+      const objectPayload = { greeting: "Hallo" };
+      const ctx = createExtractorContext(
+        {
+          [ATTR_KEYS.AI_RESPONSE_TEXT]: "",
+          [ATTR_KEYS.AI_RESPONSE_OBJECT]: objectPayload,
+        },
+        {
+          name: "ai.generateText",
+          instrumentationScope: { name: "opencode", version: null },
+        },
+      );
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+        { role: "assistant", content: JSON.stringify(objectPayload) },
+      ]);
+    });
+
+    it("handles a parsed JSON response text value", () => {
+      const objectPayload = { text: "structured field" };
+      const ctx = createExtractorContext(
+        {
+          [ATTR_KEYS.AI_RESPONSE_TEXT]: objectPayload,
+        },
+        {
+          name: "ai.generateText",
+          instrumentationScope: { name: "opencode", version: null },
+        },
+      );
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+        { role: "assistant", content: JSON.stringify(objectPayload) },
+      ]);
+    });
   });
 
   describe("when scope is unrelated AND no ai.* attrs are present", () => {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
@@ -286,11 +286,12 @@ export class VercelExtractor implements CanonicalAttributesExtractor {
     // ─────────────────────────────────────────────────────────────────────────
     if (!attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES)) {
       const responseAttr = attrs.take(ATTR_KEYS.AI_RESPONSE);
-      const responseTextAttr =
-        responseAttr === undefined || responseAttr === null
-          ? attrs.take(ATTR_KEYS.AI_RESPONSE_TEXT)
-          : undefined;
-      const response = responseAttr ?? responseTextAttr;
+      const hasUsableResponse =
+        isNonEmptyString(responseAttr) || isRecord(responseAttr);
+      const responseTextAttr = !hasUsableResponse
+        ? attrs.take(ATTR_KEYS.AI_RESPONSE_TEXT)
+        : undefined;
+      const response = hasUsableResponse ? responseAttr : responseTextAttr;
       const parsedResponseText =
         responseTextAttr !== undefined &&
         (isRecord(responseTextAttr) || Array.isArray(responseTextAttr));

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
@@ -8,15 +8,15 @@
  * from OTel GenAI conventions. This extractor normalises those to canonical
  * attributes.
  *
- * Detection: Presence of ai.prompt, ai.prompt.messages, ai.response, ai.model,
- * or ai.usage attributes
+ * Detection: Presence of ai.prompt, ai.prompt.messages, ai.response,
+ * ai.response.text, ai.response.object, ai.model, or ai.usage attributes
  *
  * Canonical attributes produced:
  * - langwatch.span.type (llm / tool)
  * - gen_ai.request.model / gen_ai.response.model (from ai.model)
  * - gen_ai.usage.input_tokens / gen_ai.usage.output_tokens (from ai.usage)
  * - gen_ai.input.messages (from ai.prompt / ai.prompt.messages)
- * - gen_ai.output.messages (from ai.response / ai.response.text)
+ * - gen_ai.output.messages (from ai.response / ai.response.text / ai.response.object)
  * - gen_ai.tool.name + langwatch.input/output (from ai.toolCall.* on tool spans)
  *
  * Special handling:
@@ -86,6 +86,7 @@ export class VercelExtractor implements CanonicalAttributesExtractor {
       attrs.has(ATTR_KEYS.AI_PROMPT) ||
       attrs.has(ATTR_KEYS.AI_RESPONSE) ||
       attrs.has(ATTR_KEYS.AI_RESPONSE_TEXT) ||
+      attrs.has(ATTR_KEYS.AI_RESPONSE_OBJECT) ||
       attrs.has(ATTR_KEYS.AI_USAGE) ||
       // AI SDK v5 emits usage as flat-dotted attributes rather than the
       // ai.usage object, and embedders (opencode) re-export under their own
@@ -284,11 +285,27 @@ export class VercelExtractor implements CanonicalAttributesExtractor {
     // Note: Custom handling required for toolCalls extraction
     // ─────────────────────────────────────────────────────────────────────────
     if (!attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES)) {
-      const response =
-        attrs.take(ATTR_KEYS.AI_RESPONSE) ??
-        attrs.take(ATTR_KEYS.AI_RESPONSE_TEXT);
+      const responseAttr = attrs.take(ATTR_KEYS.AI_RESPONSE);
+      const responseTextAttr =
+        responseAttr === undefined || responseAttr === null
+          ? attrs.take(ATTR_KEYS.AI_RESPONSE_TEXT)
+          : undefined;
+      const response = responseAttr ?? responseTextAttr;
+      const parsedResponseText =
+        responseTextAttr !== undefined &&
+        (isRecord(responseTextAttr) || Array.isArray(responseTextAttr));
 
-      if (isRecord(response)) {
+      if (parsedResponseText) {
+        ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, [
+          {
+            role: "assistant",
+            content: JSON.stringify(responseTextAttr),
+          },
+        ]);
+        ctx.recordRule(
+          `${this.id}:ai.response.text(parsed)->gen_ai.output.messages`,
+        );
+      } else if (isRecord(response)) {
         const responseObj = response as Record<string, unknown>;
         const messages: unknown[] = [];
 
@@ -319,7 +336,7 @@ export class VercelExtractor implements CanonicalAttributesExtractor {
           ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);
           ctx.recordRule(`${this.id}:ai.response->gen_ai.output.messages`);
         }
-      } else if (typeof response === "string") {
+      } else if (isNonEmptyString(response)) {
         // Simple string response
         ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, [
           { role: "assistant", content: response },

--- a/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
@@ -599,8 +599,15 @@ function normalizeChatPayload(
     }
     // Otherwise: walk every property, normalizing in place.
     const out: Record<string, unknown> = {};
+    const isChatMessage = typeof obj.role === "string";
     for (const [k, v] of Object.entries(obj)) {
-      out[k] = normalizeChatPayload(v, seen);
+      // A chat message's content is user/model text, so a JSON-looking string
+      // must stay text. Structured AI responses commonly use this shape and
+      // are intentionally displayed as JSON in the trace output.
+      out[k] =
+        isChatMessage && k === "content" && typeof v === "string"
+          ? v
+          : normalizeChatPayload(v, seen);
     }
     return out;
   }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
@@ -59,8 +59,12 @@ function buildSpan(
     endTimeUnixNano: (startTimeUnixNano + 100_000_000n).toString(),
     attributes: [
       {
-        key: "ai.response.text",
+        key: "ai.response.object",
         value: { stringValue: response },
+      },
+      {
+        key: "ai.response.text",
+        value: { stringValue: "" },
       },
       {
         key: "ai.prompt",
@@ -109,7 +113,7 @@ describe.skipIf(!hasTestcontainers)(
       await cleanupTestDataForTenant(tenantIdString);
     });
 
-    it("persists structured output on the LLM span and trace summary", async () => {
+    it("persists flat structured output when text is empty", async () => {
       const currentTenantIdString = tenantIdString;
       if (!currentTenantIdString) {
         throw new Error("Test tenant was not initialized.");

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
@@ -84,7 +84,7 @@ describe.skipIf(!hasTestcontainers)(
   "AI SDK structured output through trace processing",
   () => {
     let tenantId: ReturnType<typeof createTestTenantId>;
-    let tenantIdString: string;
+    let tenantIdString: string | undefined;
     let traceSummaryStore: TraceSummaryStore;
     let spanStorageService: SpanStorageService;
 
@@ -105,10 +105,16 @@ describe.skipIf(!hasTestcontainers)(
     });
 
     afterEach(async () => {
+      if (!tenantIdString) return;
       await cleanupTestDataForTenant(tenantIdString);
     });
 
     it("persists structured output on the LLM span and trace summary", async () => {
+      const currentTenantIdString = tenantIdString;
+      if (!currentTenantIdString) {
+        throw new Error("Test tenant was not initialized.");
+      }
+
       const traceId = `trace-ai-sdk-${Date.now()}`;
       const spanId = `span-ai-sdk-${Date.now()}`;
       const occurredAt = Date.now();
@@ -116,7 +122,7 @@ describe.skipIf(!hasTestcontainers)(
       const [event] = await command.handle({
         type: RECORD_SPAN_COMMAND_TYPE,
         aggregateId: traceId,
-        tenantId: tenantIdString,
+        tenantId: currentTenantIdString,
         data: {
           span: buildSpan(traceId, spanId, occurredAt),
           resource: null,
@@ -157,7 +163,7 @@ describe.skipIf(!hasTestcontainers)(
       );
 
       const storedSpans = await spanStorageService.getSpansByTraceId({
-        tenantId: tenantIdString,
+        tenantId: currentTenantIdString,
         traceId,
       });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/aiSdkStructuredOutput.integration.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
+import { getTestClickHouseClient } from "../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "../../../__tests__/integration/testHelpers";
+import { FoldProjectionExecutor } from "../../../projections/foldProjectionExecutor";
+import { RecordSpanCommand } from "../commands/recordSpanCommand";
+import { SpanStorageMapProjection } from "../projections/spanStorage.mapProjection";
+import { SpanAppendStore } from "../projections/spanStorage.store";
+import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import { TraceSummaryFoldProjection } from "../projections/traceSummary.foldProjection";
+import { TraceSummaryStore } from "../projections/traceSummary.store";
+import {
+  RECORD_SPAN_COMMAND_TYPE,
+  SPAN_RECEIVED_EVENT_TYPE,
+} from "../schemas/constants";
+import type { OtlpSpan } from "../schemas/otlp";
+
+class TestRecordSpanCommand extends RecordSpanCommand {
+  static override readonly schema = RecordSpanCommand.schema;
+
+  constructor() {
+    super({
+      piiRedactionService: { redactSpan: async () => {} },
+      costEnrichmentService: { enrichSpan: async () => {} },
+      tokenEstimationService: { estimateSpanTokens: async () => {} },
+      contentDropService: {
+        dropSpanContent: async () => ({
+          droppedCount: 0,
+          droppedCategories: [],
+          droppedAttributeKeys: [],
+        }),
+      },
+    });
+  }
+}
+
+function buildSpan(
+  traceId: string,
+  spanId: string,
+  startTimeMs: number,
+): OtlpSpan {
+  const response = JSON.stringify({ greeting: "Hallo" });
+  const startTimeUnixNano = BigInt(startTimeMs) * 1_000_000n;
+
+  return {
+    traceId,
+    spanId,
+    parentSpanId: null,
+    name: "ai.generateText",
+    kind: 1,
+    startTimeUnixNano: startTimeUnixNano.toString(),
+    endTimeUnixNano: (startTimeUnixNano + 100_000_000n).toString(),
+    attributes: [
+      {
+        key: "ai.response.text",
+        value: { stringValue: response },
+      },
+      {
+        key: "ai.prompt",
+        value: { stringValue: "Translate Hello to Dutch" },
+      },
+    ],
+    events: [],
+    links: [],
+    status: { code: 1, message: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+describe.skipIf(!hasTestcontainers)(
+  "AI SDK structured output through trace processing",
+  () => {
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+    let traceSummaryStore: TraceSummaryStore;
+    let spanStorageService: SpanStorageService;
+
+    beforeEach(() => {
+      const clickHouseClient = getTestClickHouseClient();
+      if (!clickHouseClient) throw new Error("ClickHouse client required.");
+
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      traceSummaryStore = new TraceSummaryStore(
+        new TraceSummaryService(
+          new TraceSummaryClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+      spanStorageService = new SpanStorageService(
+        new SpanStorageClickHouseRepository(async () => clickHouseClient),
+      );
+    });
+
+    afterEach(async () => {
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    it("persists structured output on the LLM span and trace summary", async () => {
+      const traceId = `trace-ai-sdk-${Date.now()}`;
+      const spanId = `span-ai-sdk-${Date.now()}`;
+      const occurredAt = Date.now();
+      const command = new TestRecordSpanCommand();
+      const [event] = await command.handle({
+        type: RECORD_SPAN_COMMAND_TYPE,
+        aggregateId: traceId,
+        tenantId: tenantIdString,
+        data: {
+          span: buildSpan(traceId, spanId, occurredAt),
+          resource: null,
+          instrumentationScope: {
+            name: "embedded-ai",
+            version: "6.0.0",
+          },
+          piiRedactionLevel: "DISABLED",
+          occurredAt,
+        },
+      } as never);
+
+      expect(event?.type).toBe(SPAN_RECEIVED_EVENT_TYPE);
+
+      const context = {
+        aggregateId: traceId,
+        tenantId,
+        key: traceId,
+      };
+      const fold = new TraceSummaryFoldProjection({
+        store: traceSummaryStore,
+      });
+      const folded = (await new FoldProjectionExecutor().executeBatch(
+        fold as never,
+        [event] as never,
+        context,
+      )) as TraceSummaryData;
+
+      expect(folded.computedOutput).toBe('{"greeting":"Hallo"}');
+
+      const mapProjection = new SpanStorageMapProjection({
+        store: new SpanAppendStore(spanStorageService.repository),
+      });
+      const normalizedSpan = mapProjection.mapTraceSpanReceived(event!);
+      await new SpanAppendStore(spanStorageService.repository).append(
+        normalizedSpan,
+        context,
+      );
+
+      const storedSpans = await spanStorageService.getSpansByTraceId({
+        tenantId: tenantIdString,
+        traceId,
+      });
+
+      expect(storedSpans).toHaveLength(1);
+      expect(storedSpans[0]?.type).toBe("llm");
+      expect(storedSpans[0]?.output).toEqual({
+        type: "chat_messages",
+        value: [{ role: "assistant", content: '{"greeting":"Hallo"}' }],
+      });
+
+      const persistedSummary = await traceSummaryStore.get(traceId, context);
+      expect(persistedSummary?.computedOutput).toBe('{"greeting":"Hallo"}');
+    }, 45_000);
+  },
+);

--- a/specs/traces/trace-io-extraction.feature
+++ b/specs/traces/trace-io-extraction.feature
@@ -83,3 +83,9 @@ Feature: Trace primary input/output extraction
     And the span has langwatch.input = "from langwatch"
     When the service extracts the primary input
     Then the primary input text is "from gen_ai"
+
+  Scenario: AI SDK structured output is surfaced as the primary output
+    Given the span is named "ai.generateText" from the AI SDK
+    And the span has ai.response.object = { "greeting": "Hallo" }
+    When the service extracts the primary output
+    Then the primary output text is "{\"greeting\":\"Hallo\"}"


### PR DESCRIPTION
## Summary

- Surface structured AI SDK output when response data arrives as an object or JSON text.
- Keep JSON-looking assistant content as text so trace summaries and Output panels remain populated.
- Add a BDD scenario, focused unit coverage, and a real storage-backed integration test.

## Validation

- Focused Vitest suite: 85 tests passed.
- Real storage-backed integration test: 1 test passed.
- `pnpm run typecheck` passed.
- `pnpm run typecheck:tests` passed.
- Biome check passed with existing complexity warnings.

## Real dogfood QA

- A temporary Vercel AI SDK micro-app made a live `generateText` call with `Output.object`, `@ai-sdk/openai`, and the local `OPENAI_API_KEY`.
- LangWatch telemetry was exported to the local server, persisted in ClickHouse, and verified in the trace list and drawer.
- The trace showed `ai.generateText` output as `{ "greeting": "Hallo" }`.

![Real AI SDK structured output in trace drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6422/structured-output/real-ai-sdk-trace-drawer.png)

Fixes #6339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of structured AI SDK responses, including cases where response text is empty.
  * Structured outputs are now consistently serialized as readable JSON assistant messages.
  * Preserved JSON-looking chat content without incorrectly transforming it.
  * Added fallback handling for alternate response formats and empty values.

* **Tests**
  * Expanded unit, integration, and behavior coverage for structured AI outputs and Vercel AI SDK traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->