### PR TITLE
fix(billing): clear endDate on subscription reactivation

### DIFF
--- a/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
@@ -37,4 +37,45 @@ describe("PrismaSubscriptionRepository", () => {
       }
     });
   });
+
+  describe("activate", () => {
+    /** @scenario Reactivation clears stale endDate left by a prior cancellation */
+    it("clears endDate when reactivating a subscription", async () => {
+      await repo.activate({ id: "sub_456", previousStatus: SubscriptionStatus.CANCELLED });
+
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+      const call = prisma.subscription.update.mock.calls[0]?.[0] as {
+        where: { id: string };
+        data: Record<string, unknown>;
+      };
+
+      expect(call.where).toEqual({ id: "sub_456" });
+      expect(call.data.status).toBe(SubscriptionStatus.ACTIVE);
+      expect(call.data.endDate).toBeNull();
+      expect(call.data.lastPaymentFailedDate).toBeNull();
+    });
+  });
+
+  describe("updateQuantities", () => {
+    /** @scenario Quantity update clears stale endDate left by a prior cancellation */
+    it("clears endDate when updating subscription quantities", async () => {
+      await repo.updateQuantities({
+        id: "sub_789",
+        maxMembers: 10,
+        maxMessagesPerMonth: 5000,
+      });
+
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+      const call = prisma.subscription.update.mock.calls[0]?.[0] as {
+        where: { id: string };
+        data: Record<string, unknown>;
+      };
+
+      expect(call.where).toEqual({ id: "sub_789" });
+      expect(call.data.status).toBe(SubscriptionStatus.ACTIVE);
+      expect(call.data.endDate).toBeNull();
+      expect(call.data.maxMembers).toBe(10);
+      expect(call.data.maxMessagesPerMonth).toBe(5000);
+    });
+  });
 });

--- a/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
@@ -54,6 +54,22 @@ describe("PrismaSubscriptionRepository", () => {
       expect(call.data.endDate).toBeNull();
       expect(call.data.lastPaymentFailedDate).toBeNull();
     });
+
+    /** @scenario Updating an already active subscription preserves its original start date */
+    it("clears endDate without resetting startDate for an active subscription", async () => {
+      await repo.activate({ id: "sub_789", previousStatus: SubscriptionStatus.ACTIVE });
+
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+      const call = prisma.subscription.update.mock.calls[0]?.[0] as {
+        where: { id: string };
+        data: Record<string, unknown>;
+      };
+
+      expect(call.where).toEqual({ id: "sub_789" });
+      expect(call.data.status).toBe(SubscriptionStatus.ACTIVE);
+      expect(call.data.endDate).toBeNull();
+      expect(call.data).not.toHaveProperty("startDate");
+    });
   });
 
   describe("when updating subscription quantities", () => {

--- a/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/subscription.repository.unit.test.ts
@@ -38,7 +38,7 @@ describe("PrismaSubscriptionRepository", () => {
     });
   });
 
-  describe("activate", () => {
+  describe("when activating a subscription", () => {
     /** @scenario Reactivation clears stale endDate left by a prior cancellation */
     it("clears endDate when reactivating a subscription", async () => {
       await repo.activate({ id: "sub_456", previousStatus: SubscriptionStatus.CANCELLED });
@@ -56,7 +56,7 @@ describe("PrismaSubscriptionRepository", () => {
     });
   });
 
-  describe("updateQuantities", () => {
+  describe("when updating subscription quantities", () => {
     /** @scenario Quantity update clears stale endDate left by a prior cancellation */
     it("clears endDate when updating subscription quantities", async () => {
       await repo.updateQuantities({

--- a/platform/app/ee/billing/services/subscription.repository.ts
+++ b/platform/app/ee/billing/services/subscription.repository.ts
@@ -95,6 +95,7 @@ export class PrismaSubscriptionRepository implements SubscriptionRepository {
           startDate: new Date(),
         }),
         lastPaymentFailedDate: null,
+        endDate: null,
       },
       include: { organization: true },
     });
@@ -189,6 +190,7 @@ export class PrismaSubscriptionRepository implements SubscriptionRepository {
       data: {
         status: SubscriptionStatus.ACTIVE as PrismaSubscriptionStatus,
         lastPaymentFailedDate: null,
+        endDate: null,
         maxMembers: input.maxMembers,
         maxMessagesPerMonth: input.maxMessagesPerMonth,
       },


### PR DESCRIPTION
Closes #6365

## Problem

`activate()` and `updateQuantities()` set `status = ACTIVE` but never clear `endDate`. After a cancel-then-reactivate cycle, the row carries a stale `endDate` from the cancellation — which can even precede `startDate`.

## Fix

Add `endDate: null` to both methods, matching the pattern already used by `seatEventSubscription.ts` in its reactivation path.

## Changes

- `langwatch/ee/billing/services/subscription.repository.ts`: Add `endDate: null` to the update payloads in `activate()` and `updateQuantities()`
- `langwatch/ee/billing/__tests__/subscription.repository.unit.test.ts`: Add unit tests verifying both methods clear `endDate`

## Testing

Added two unit test cases:
- `activate` clears endDate when reactivating a subscription
- `updateQuantities` clears endDate when updating subscription quantities

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reactivated subscriptions no longer retain outdated end dates.
  * Updating subscription quantities now clears stale end-date information.
  * Reactivated subscriptions correctly return to an active status and remove outdated payment-failure details.

* **Tests**
  * Added coverage for subscription reactivation and quantity updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->