### PR TITLE
feat(traces): honest trace export (cursor paging, spans, token metrics) and coding-agent transcript over REST

### DIFF
--- a/feature-map.json
+++ b/feature-map.json
@@ -23,12 +23,14 @@
               "cli": [
                 "trace search",
                 "trace get",
-                "trace export"
+                "trace export",
+                "trace transcript"
               ],
               "hints": {
                 "trace search": "langwatch trace search -q \"timeout\" --limit 10 -o json",
                 "trace get": "langwatch trace get <traceId> -o json",
-                "trace export": "langwatch trace export --start-date 2026-01-01 -f jsonl -o traces.jsonl"
+                "trace export": "langwatch trace export --start-date 2026-01-01 -f jsonl -o traces.jsonl",
+                "trace transcript": "langwatch trace transcript <traceId> -o json"
               },
               "skill": "tracing",
               "docs": "https://langwatch.ai/docs/integration/overview.md"

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -372,7 +372,10 @@ export function registerTracesRoutes(
       const project = c.get("project");
       const { traceId } = c.req.param();
 
-      logger.info({ projectId: project.id, traceId }, "Getting trace transcript");
+      logger.info(
+        { projectId: project.id, traceId },
+        "Getting trace transcript",
+      );
 
       const protections = await getProtectionsForProject(prisma, {
         projectId: project.id,

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -4,6 +4,7 @@ import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { z } from "zod";
 import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
+import { readCodingAgentTranscriptWithProtections } from "~/server/api/routers/tracesV2";
 import { requires, type SecuredApp } from "~/server/api/security";
 import { getProtectionsForProject } from "~/server/api/utils";
 import {
@@ -298,6 +299,116 @@ export function registerTracesRoutes(
       return new Response(stream, {
         headers: { "Content-Type": "application/json" },
       });
+    },
+  );
+
+  // GET /:traceId/transcript - the coding-agent transcript for one trace
+  secured.access(requires("traces:view")).get(
+    "/:traceId/transcript",
+    describeRoute({
+      description:
+        "Derived coding-agent transcript for a trace: what the agent did, in order, " +
+        "with per-call token and cost economics. Empty entries for traces without " +
+        "coding-agent content.",
+      parameters: [
+        {
+          name: "traceId",
+          in: "path",
+          description:
+            "The trace ID — either the full 32-char ID or a unique prefix (≥ 8 chars). Prefix lookup is scoped to the authenticated project.",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      responses: {
+        ...baseResponses,
+        200: {
+          description:
+            "The transcript: ordered entries plus per-session totals and sub-agent tool counts",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  agent: z.string(),
+                  sessionId: z.string().nullable(),
+                  entries: z.array(z.object({}).passthrough()),
+                  totals: z.object({
+                    modelCalls: z.number(),
+                    toolCalls: z.number(),
+                    tokens: z.number(),
+                    costUsd: z.number(),
+                  }),
+                  subAgents: z.array(z.object({}).passthrough()),
+                }),
+              ),
+            },
+          },
+        },
+        404: {
+          description: "Trace not found",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ message: z.string() })),
+            },
+          },
+        },
+        409: {
+          description:
+            "Ambiguous trace ID prefix — the prefix matches more than one trace",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  message: z.string(),
+                  candidateTraceIds: z.array(z.string()),
+                }),
+              ),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const project = c.get("project");
+      const { traceId } = c.req.param();
+
+      logger.info({ projectId: project.id, traceId }, "Getting trace transcript");
+
+      const protections = await getProtectionsForProject(prisma, {
+        projectId: project.id,
+      });
+      const traceService = TraceService.create(prisma);
+
+      let trace;
+      try {
+        trace = await traceService.getById(project.id, traceId, protections);
+      } catch (err) {
+        if (err instanceof AmbiguousTraceIdPrefixError) {
+          return c.json(
+            {
+              message: err.message,
+              candidateTraceIds: err.candidateTraceIds,
+            },
+            409,
+          );
+        }
+        throw err;
+      }
+
+      if (!trace) {
+        throw new HTTPException(404, {
+          message: "Trace not found.",
+        });
+      }
+
+      const transcript = await readCodingAgentTranscriptWithProtections({
+        projectId: project.id,
+        traceId: trace.trace_id,
+        occurredAtMs: trace.timestamps.started_at,
+        protections,
+      });
+
+      return c.json(transcript);
     },
   );
 

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.transcript-read.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.transcript-read.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The protections-parameterized transcript read shared by the tRPC procedure
+ * and the REST route (`GET /api/traces/:traceId/transcript`). The app-layer
+ * span/log stores are mocked boundaries; the log visibility gate and the
+ * transcript derivation run for real, so what these tests pin is the actual
+ * document an API-key caller receives.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { openProtections } from "~/server/traces/__tests__/open-protections";
+
+const { mockGetSpansByTraceId, mockGetLogsByTraceId } = vi.hoisted(() => ({
+  mockGetSpansByTraceId: vi.fn(),
+  mockGetLogsByTraceId: vi.fn(),
+}));
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    traces: {
+      spans: { getSpansByTraceId: mockGetSpansByTraceId },
+      logRecords: { getLogsByTraceId: mockGetLogsByTraceId },
+    },
+  }),
+}));
+
+vi.mock("~/server/api/utils", async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  getVisibilityCutoffMsForProject: vi.fn(async () => 0),
+}));
+
+import { readCodingAgentTranscriptWithProtections } from "../tracesV2";
+
+const PROJECT_ID = "project_test";
+const TRACE_ID = "a3c6656cf433e97549f654034be02955";
+
+function claudeLogRow(
+  attributes: Record<string, string>,
+  timeUnixMs: number,
+) {
+  return {
+    traceId: TRACE_ID,
+    spanId: "77bb432be48046f6",
+    timeUnixMs,
+    body: attributes["event.name"] ?? "",
+    attributes,
+    resourceAttributes: { "service.name": "claude-code" },
+    scopeName: "com.anthropic.claude_code.events",
+    scopeVersion: null,
+  };
+}
+
+describe("readCodingAgentTranscriptWithProtections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSpansByTraceId.mockResolvedValue([]);
+  });
+
+  describe("given a coding-agent trace with stored log records", () => {
+    /** @scenario transcript endpoint returns the derived transcript for a coding-agent trace */
+    it("returns the derived transcript the terminal view derives", async () => {
+      mockGetLogsByTraceId.mockResolvedValue([
+        claudeLogRow(
+          {
+            "event.name": "claude_code.user_prompt",
+            prompt: "summarise the repo",
+            "session.id": "session-123",
+          },
+          100,
+        ),
+        claudeLogRow(
+          {
+            "event.name": "claude_code.assistant_response",
+            response: "Here is the summary.",
+          },
+          300,
+        ),
+      ]);
+
+      const transcript = await readCodingAgentTranscriptWithProtections({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections: openProtections,
+      });
+
+      expect(transcript.agent).toBe("claude_code");
+      expect(transcript.sessionId).toBe("session-123");
+      const kinds = transcript.entries.map((entry) => entry.kind);
+      expect(kinds).toContain("user_prompt");
+      const prompt = transcript.entries.find(
+        (entry) => entry.kind === "user_prompt",
+      );
+      expect(prompt && "text" in prompt ? prompt.text : null).toBe(
+        "summarise the repo",
+      );
+    });
+  });
+
+  describe("given a trace without coding-agent content", () => {
+    /** @scenario transcript endpoint answers empty for a trace without coding-agent content */
+    it("answers an empty transcript rather than an error", async () => {
+      mockGetLogsByTraceId.mockResolvedValue([
+        {
+          traceId: TRACE_ID,
+          spanId: "aaaa432be48046f6",
+          timeUnixMs: 100,
+          body: "GET /users",
+          attributes: { "http.method": "GET" },
+          resourceAttributes: { "service.name": "my-app" },
+          scopeName: "my-app-logger",
+          scopeVersion: null,
+        },
+      ]);
+
+      const transcript = await readCodingAgentTranscriptWithProtections({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections: openProtections,
+      });
+
+      expect(transcript.entries).toEqual([]);
+      expect(transcript.totals.modelCalls).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.transcript-read.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.transcript-read.unit.test.ts
@@ -33,10 +33,7 @@ import { readCodingAgentTranscriptWithProtections } from "../tracesV2";
 const PROJECT_ID = "project_test";
 const TRACE_ID = "a3c6656cf433e97549f654034be02955";
 
-function claudeLogRow(
-  attributes: Record<string, string>,
-  timeUnixMs: number,
-) {
+function claudeLogRow(attributes: Record<string, string>, timeUnixMs: number) {
   return {
     traceId: TRACE_ID,
     spanId: "77bb432be48046f6",

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -942,10 +942,25 @@ async function loadProtectedSpansFull({
   input: { projectId: string; traceId: string; occurredAtMs?: number };
   ctx: { session: unknown; prisma: unknown } & Record<string, unknown>;
 }): Promise<SpanDetail[]> {
-  const app = getApp();
   const protections = await getUserProtectionsForProject(ctx as never, {
     projectId: input.projectId,
   });
+  return loadSpansFullWithProtections({ ...input, protections });
+}
+
+async function loadSpansFullWithProtections({
+  projectId,
+  traceId,
+  occurredAtMs,
+  protections,
+}: {
+  projectId: string;
+  traceId: string;
+  occurredAtMs?: number;
+  protections: Protections;
+}): Promise<SpanDetail[]> {
+  const app = getApp();
+  const input = { projectId, traceId, occurredAtMs };
   const storedSpans = await app.traces.spans.getSpansByTraceId({
     tenantId: input.projectId,
     traceId: input.traceId,
@@ -990,17 +1005,29 @@ async function loadProtectedTraceLogs({
   input: { projectId: string; traceId: string; occurredAtMs?: number };
   ctx: { session: unknown; prisma: unknown } & Record<string, unknown>;
 }): Promise<TraceLogRecordDto[]> {
-  const app = getApp();
   const protections = await getUserProtectionsForProject(ctx as never, {
     projectId: input.projectId,
   });
-  const visibilityCutoffMs = await getVisibilityCutoffMsForProject(
-    input.projectId,
-  );
+  return loadTraceLogsWithProtections({ ...input, protections });
+}
+
+async function loadTraceLogsWithProtections({
+  projectId,
+  traceId,
+  occurredAtMs,
+  protections,
+}: {
+  projectId: string;
+  traceId: string;
+  occurredAtMs?: number;
+  protections: Protections;
+}): Promise<TraceLogRecordDto[]> {
+  const app = getApp();
+  const visibilityCutoffMs = await getVisibilityCutoffMsForProject(projectId);
   const rows = await app.traces.logRecords.getLogsByTraceId(
-    input.projectId,
-    input.traceId,
-    input.occurredAtMs,
+    projectId,
+    traceId,
+    occurredAtMs,
   );
   return rows.map((row) =>
     gateTraceLogVisibility(
@@ -1017,6 +1044,41 @@ async function loadProtectedTraceLogs({
       visibilityCutoffMs,
     ),
   );
+}
+
+/**
+ * Transcript read shared by the tRPC procedure below and the REST route
+ * (`GET /api/traces/:traceId/transcript`). The REST caller authenticates with
+ * a project API key, so it resolves {@link Protections} for the project rather
+ * than for a user session and hands them in; both doors then run identical
+ * span and log loads, so transcript content goes through the same redaction
+ * passes as every sibling read.
+ */
+export async function readCodingAgentTranscriptWithProtections({
+  projectId,
+  traceId,
+  occurredAtMs,
+  protections,
+}: {
+  projectId: string;
+  traceId: string;
+  occurredAtMs?: number;
+  protections: Protections;
+}): Promise<CodingAgentTranscript> {
+  const args = { projectId, traceId, occurredAtMs, protections };
+  const [spans, logs] = await Promise.all([
+    loadSpansFullWithProtections(args),
+    loadTraceLogsWithProtections(args),
+  ]);
+
+  return buildCodingAgentTranscript({
+    spans,
+    logs: logs.map((row) => ({
+      timestampMs: row.timeUnixMs,
+      attributes: (row.attributes ?? {}) as Record<string, unknown>,
+      serviceName: row.resourceAttributes?.["service.name"] ?? null,
+    })),
+  });
 }
 
 export const tracesV2Router = createTRPCRouter({
@@ -1684,18 +1746,12 @@ export const tracesV2Router = createTRPCRouter({
     )
     .use(checkProjectPermission("traces:view"))
     .query(async ({ input, ctx }): Promise<CodingAgentTranscript> => {
-      const [spans, logs] = await Promise.all([
-        loadProtectedSpansFull({ input, ctx }),
-        loadProtectedTraceLogs({ input, ctx }),
-      ]);
-
-      return buildCodingAgentTranscript({
-        spans,
-        logs: logs.map((row) => ({
-          timestampMs: row.timeUnixMs,
-          attributes: (row.attributes ?? {}) as Record<string, unknown>,
-          serviceName: row.resourceAttributes?.["service.name"] ?? null,
-        })),
+      const protections = await getUserProtectionsForProject(ctx as never, {
+        projectId: input.projectId,
+      });
+      return readCodingAgentTranscriptWithProtections({
+        ...input,
+        protections,
       });
     }),
 

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -1746,7 +1746,7 @@ export const tracesV2Router = createTRPCRouter({
     )
     .use(checkProjectPermission("traces:view"))
     .query(async ({ input, ctx }): Promise<CodingAgentTranscript> => {
-      const protections = await getUserProtectionsForProject(ctx as never, {
+      const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
       });
       return readCodingAgentTranscriptWithProtections({

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -678,6 +678,9 @@ export const traceSchema = z.object({
       reasoning_tokens: z.number().optional().nullable(),
       cache_read_input_tokens: z.number().optional().nullable(),
       cache_creation_input_tokens: z.number().optional().nullable(),
+      cache_creation_5m_input_tokens: z.number().optional().nullable(),
+      cache_creation_1h_input_tokens: z.number().optional().nullable(),
+      context_size_tokens: z.number().optional().nullable(),
       total_cost: z.number().optional().nullable(),
       tokens_estimated: z.boolean().optional().nullable(),
     })

--- a/langwatch/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
@@ -21,10 +21,12 @@ const {
   mockGetTracesWithSpans,
   mockGetTracesByThreadId,
   mockGetTracesWithSpansByThreadIds,
+  mockGetAllTracesForProject,
 } = vi.hoisted(() => ({
   mockGetTracesWithSpans: vi.fn(),
   mockGetTracesByThreadId: vi.fn(),
   mockGetTracesWithSpansByThreadIds: vi.fn(),
+  mockGetAllTracesForProject: vi.fn(),
 }));
 
 vi.mock("../clickhouse-trace.service", () => ({
@@ -33,6 +35,7 @@ vi.mock("../clickhouse-trace.service", () => ({
       getTracesWithSpans: mockGetTracesWithSpans,
       getTracesByThreadId: mockGetTracesByThreadId,
       getTracesWithSpansByThreadIds: mockGetTracesWithSpansByThreadIds,
+      getAllTracesForProject: mockGetAllTracesForProject,
       resolveTraceIdByPrefix: vi.fn().mockResolvedValue([]),
     }),
   }),
@@ -365,6 +368,90 @@ describe("TraceService — multi-trace read enrichment", () => {
       await service.getTracesByThreadId(PROJECT_ID, "thread-1", protections);
 
       expect(getLogs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when reading via getAllTracesForProject with includeSpans", () => {
+    const searchInput = {
+      projectId: PROJECT_ID,
+      startDate: 1_700_000_000_000,
+      endDate: 1_700_000_002_000,
+      filters: {},
+    };
+
+    /** @scenario search with includeSpans returns coding-agent spans enriched from log records */
+    it("enriches coding-agent traces across the page's groups", async () => {
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [
+          [makeTrace({ origin: "coding_agent", spans: [claudeLlmSpan()] })],
+          [
+            {
+              ...makeTrace({ origin: "application", spans: [claudeLlmSpan()] }),
+              trace_id: "b".repeat(32),
+            },
+          ],
+        ],
+        totalHits: 2,
+        traceChecks: {},
+      });
+      const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
+      const service = makeService(getLogs);
+
+      const result = await service.getAllTracesForProject(
+        searchInput as never,
+        protections,
+        { includeSpans: true },
+      );
+
+      expect(result.groups[0]?.[0]?.spans?.[0]?.input).toEqual(enrichedInput);
+      expect(result.groups[0]?.[0]?.spans?.[0]?.metrics?.cost).toBe(0.0421);
+      expect(result.groups[1]?.[0]?.spans?.[0]?.input ?? null).toBeNull();
+      expect(getLogs).toHaveBeenCalledTimes(1);
+    });
+
+    /** @scenario search without includeSpans keeps the legacy empty spans shape */
+    it("does not enrich or read logs when includeSpans is not set", async () => {
+      const page = {
+        groups: [
+          [makeTrace({ origin: "coding_agent", spans: [] as Span[] })],
+        ],
+        totalHits: 1,
+        traceChecks: {},
+      };
+      mockGetAllTracesForProject.mockResolvedValue(page);
+      const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
+      const service = makeService(getLogs);
+
+      const result = await service.getAllTracesForProject(
+        searchInput as never,
+        protections,
+        {},
+      );
+
+      expect(getLogs).not.toHaveBeenCalled();
+      expect(result).toBe(page);
+    });
+
+    it("returns the page untouched when no trace is coding-agent origin", async () => {
+      const page = {
+        groups: [
+          [makeTrace({ origin: "application", spans: [claudeLlmSpan()] })],
+        ],
+        totalHits: 1,
+        traceChecks: {},
+      };
+      mockGetAllTracesForProject.mockResolvedValue(page);
+      const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
+      const service = makeService(getLogs);
+
+      const result = await service.getAllTracesForProject(
+        searchInput as never,
+        protections,
+        { includeSpans: true },
+      );
+
+      expect(getLogs).not.toHaveBeenCalled();
+      expect(result).toBe(page);
     });
   });
 

--- a/langwatch/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
@@ -412,9 +412,7 @@ describe("TraceService — multi-trace read enrichment", () => {
     /** @scenario search without includeSpans keeps the legacy empty spans shape */
     it("does not enrich or read logs when includeSpans is not set", async () => {
       const page = {
-        groups: [
-          [makeTrace({ origin: "coding_agent", spans: [] as Span[] })],
-        ],
+        groups: [[makeTrace({ origin: "coding_agent", spans: [] as Span[] })]],
         totalHits: 1,
         traceChecks: {},
       };

--- a/langwatch/src/server/traces/mappers/__tests__/trace-summary.mapper.test.ts
+++ b/langwatch/src/server/traces/mappers/__tests__/trace-summary.mapper.test.ts
@@ -371,7 +371,9 @@ describe("mapTraceSummaryToTrace — reserved token metrics", () => {
   describe("when a reserved token attribute is not numeric", () => {
     it("adds no metric key for it", () => {
       const summary = makeSummary({
-        attributes: { "langwatch.reserved.context_size_tokens": "not-a-number" },
+        attributes: {
+          "langwatch.reserved.context_size_tokens": "not-a-number",
+        },
       });
 
       const trace = mapTraceSummaryToTrace(summary, [], "project-1");

--- a/langwatch/src/server/traces/mappers/__tests__/trace-summary.mapper.test.ts
+++ b/langwatch/src/server/traces/mappers/__tests__/trace-summary.mapper.test.ts
@@ -310,3 +310,107 @@ describe("mapTraceSummaryToTrace — metadata.models", () => {
     });
   });
 });
+
+describe("mapTraceSummaryToTrace — reserved token metrics", () => {
+  describe("when the fold stamped cache and reasoning token attributes", () => {
+    /** @scenario metrics carries the token fields the projection catalog already advertises */
+    it("surfaces them as the typed metric fields the projection catalog advertises", () => {
+      const summary = makeSummary({
+        attributes: {
+          "langwatch.reserved.cache_read_tokens": "120000",
+          "langwatch.reserved.cache_creation_tokens": "3456",
+          "langwatch.reserved.reasoning_tokens": "789",
+        },
+      });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(trace.metrics?.cache_read_input_tokens).toBe(120000);
+      expect(trace.metrics?.cache_creation_input_tokens).toBe(3456);
+      expect(trace.metrics?.reasoning_tokens).toBe(789);
+    });
+  });
+
+  describe("when the fold stamped context size and the cache TTL split", () => {
+    /** @scenario metrics carries context size and the cache creation TTL split */
+    it("surfaces context_size_tokens and the 5m and 1h cache creation counts", () => {
+      const summary = makeSummary({
+        attributes: {
+          "langwatch.reserved.context_size_tokens": "523544",
+          "langwatch.reserved.cache_creation_5m_tokens": "111",
+          "langwatch.reserved.cache_creation_1h_tokens": "18205",
+        },
+      });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(trace.metrics?.context_size_tokens).toBe(523544);
+      expect(trace.metrics?.cache_creation_5m_input_tokens).toBe(111);
+      expect(trace.metrics?.cache_creation_1h_input_tokens).toBe(18205);
+    });
+  });
+
+  describe("when no reserved token attributes are present", () => {
+    /** @scenario absent reserved token attributes leave the metrics fields unset */
+    it("keeps the metrics block at exactly the six legacy fields", () => {
+      const summary = makeSummary({ attributes: {} });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(Object.keys(trace.metrics ?? {}).sort()).toEqual([
+        "completion_tokens",
+        "first_token_ms",
+        "prompt_tokens",
+        "tokens_estimated",
+        "total_cost",
+        "total_time_ms",
+      ]);
+    });
+  });
+
+  describe("when a reserved token attribute is not numeric", () => {
+    it("adds no metric key for it", () => {
+      const summary = makeSummary({
+        attributes: { "langwatch.reserved.context_size_tokens": "not-a-number" },
+      });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(trace.metrics).not.toHaveProperty("context_size_tokens");
+    });
+  });
+});
+
+describe("mapAttributesToMetadata — otel_log_record_count sibling", () => {
+  describe("when the fold stamped a log record count", () => {
+    /** @scenario existing metadata keys flow untouched and otel_log_record_count is added as a sibling */
+    it("keeps the raw reserved key untouched and adds the clearly named sibling", () => {
+      const summary = makeSummary({
+        attributes: { "langwatch.reserved.log_record_count": "56353" },
+      });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(trace.metadata["langwatch.reserved.log_record_count"]).toBe(
+        "56353",
+      );
+      expect(trace.metadata.otel_log_record_count).toBe("56353");
+    });
+  });
+
+  describe("when the caller defined its own otel_log_record_count metadata", () => {
+    /** @scenario a caller-defined otel_log_record_count metadata key is never overwritten */
+    it("keeps the caller's value", () => {
+      const summary = makeSummary({
+        attributes: {
+          "metadata.otel_log_record_count": "caller-value",
+          "langwatch.reserved.log_record_count": "56353",
+        },
+      });
+
+      const trace = mapTraceSummaryToTrace(summary, [], "project-1");
+
+      expect(trace.metadata.otel_log_record_count).toBe("caller-value");
+    });
+  });
+});

--- a/langwatch/src/server/traces/mappers/trace-summary.mapper.ts
+++ b/langwatch/src/server/traces/mappers/trace-summary.mapper.ts
@@ -151,11 +151,22 @@ export function mapAttributesToMetadata(
     if (bareKey && metadata[bareKey] === undefined) metadata[bareKey] = value;
   }
 
-  // Clearly named sibling for the OTel log-record count: it counts log
-  // records correlated to the trace, not model/API calls, and the raw
-  // `langwatch.reserved.log_record_count` key above keeps flowing unchanged
-  // because external consumers already parse it. A caller-supplied metadata
-  // key with this name wins (set in the passthrough loop above).
+  addOtelLogRecordCountAlias(metadata, attributes);
+
+  return metadata;
+}
+
+/**
+ * Clearly named sibling for the OTel log-record count: it counts log records
+ * correlated to the trace, not model/API calls, and the raw
+ * `langwatch.reserved.log_record_count` key keeps flowing unchanged because
+ * external consumers already parse it. A caller-supplied metadata key with
+ * this name wins (set by the generic passthrough before this runs).
+ */
+function addOtelLogRecordCountAlias(
+  metadata: TraceMetadata,
+  attributes: Record<string, string>,
+): void {
   const logRecordCount = attributes["langwatch.reserved.log_record_count"];
   if (
     logRecordCount !== undefined &&
@@ -163,8 +174,6 @@ export function mapAttributesToMetadata(
   ) {
     metadata.otel_log_record_count = logRecordCount;
   }
-
-  return metadata;
 }
 
 /**
@@ -175,22 +184,26 @@ export function mapAttributesToMetadata(
  * removed because the search/export response is a compatibility surface for
  * BI consumers.
  */
-const RESERVED_TOKEN_METRIC_ATTRIBUTES: Record<string, string> = {
+const RESERVED_TOKEN_METRIC_ATTRIBUTES = {
   cache_read_input_tokens: "langwatch.reserved.cache_read_tokens",
   cache_creation_input_tokens: "langwatch.reserved.cache_creation_tokens",
   cache_creation_5m_input_tokens: "langwatch.reserved.cache_creation_5m_tokens",
   cache_creation_1h_input_tokens: "langwatch.reserved.cache_creation_1h_tokens",
   reasoning_tokens: "langwatch.reserved.reasoning_tokens",
   context_size_tokens: "langwatch.reserved.context_size_tokens",
-};
+} as const satisfies Partial<
+  Record<keyof NonNullable<Trace["metrics"]>, string>
+>;
 
 function tokenMetricsFromAttributes(
   attributes: Record<string, string>,
-): Record<string, number> {
-  const metrics: Record<string, number> = {};
+): Partial<Record<keyof typeof RESERVED_TOKEN_METRIC_ATTRIBUTES, number>> {
+  const metrics: Partial<
+    Record<keyof typeof RESERVED_TOKEN_METRIC_ATTRIBUTES, number>
+  > = {};
   for (const [metricKey, attrKey] of Object.entries(
     RESERVED_TOKEN_METRIC_ATTRIBUTES,
-  )) {
+  ) as Array<[keyof typeof RESERVED_TOKEN_METRIC_ATTRIBUTES, string]>) {
     const raw = attributes[attrKey];
     if (raw == null || raw === "") continue;
     const value = Number(raw);

--- a/langwatch/src/server/traces/mappers/trace-summary.mapper.ts
+++ b/langwatch/src/server/traces/mappers/trace-summary.mapper.ts
@@ -151,7 +151,52 @@ export function mapAttributesToMetadata(
     if (bareKey && metadata[bareKey] === undefined) metadata[bareKey] = value;
   }
 
+  // Clearly named sibling for the OTel log-record count: it counts log
+  // records correlated to the trace, not model/API calls, and the raw
+  // `langwatch.reserved.log_record_count` key above keeps flowing unchanged
+  // because external consumers already parse it. A caller-supplied metadata
+  // key with this name wins (set in the passthrough loop above).
+  const logRecordCount = attributes["langwatch.reserved.log_record_count"];
+  if (
+    logRecordCount !== undefined &&
+    metadata.otel_log_record_count === undefined
+  ) {
+    metadata.otel_log_record_count = logRecordCount;
+  }
+
   return metadata;
+}
+
+/**
+ * Reserved token attributes stamped by the trace-summary fold, surfaced as
+ * typed metric fields on the legacy trace shape (and selectable through the
+ * projection DSL's `metrics.*` paths). Additive next to the six legacy metric
+ * fields: an absent attribute adds no key, and nothing existing is renamed or
+ * removed because the search/export response is a compatibility surface for
+ * BI consumers.
+ */
+const RESERVED_TOKEN_METRIC_ATTRIBUTES: Record<string, string> = {
+  cache_read_input_tokens: "langwatch.reserved.cache_read_tokens",
+  cache_creation_input_tokens: "langwatch.reserved.cache_creation_tokens",
+  cache_creation_5m_input_tokens: "langwatch.reserved.cache_creation_5m_tokens",
+  cache_creation_1h_input_tokens: "langwatch.reserved.cache_creation_1h_tokens",
+  reasoning_tokens: "langwatch.reserved.reasoning_tokens",
+  context_size_tokens: "langwatch.reserved.context_size_tokens",
+};
+
+function tokenMetricsFromAttributes(
+  attributes: Record<string, string>,
+): Record<string, number> {
+  const metrics: Record<string, number> = {};
+  for (const [metricKey, attrKey] of Object.entries(
+    RESERVED_TOKEN_METRIC_ATTRIBUTES,
+  )) {
+    const raw = attributes[attrKey];
+    if (raw == null || raw === "") continue;
+    const value = Number(raw);
+    if (Number.isFinite(value)) metrics[metricKey] = value;
+  }
+  return metrics;
 }
 
 /**
@@ -546,6 +591,7 @@ export function mapTraceSummaryToTrace(
       completion_tokens: summary.totalCompletionTokenCount,
       total_cost: summary.totalCost,
       tokens_estimated: summary.tokensEstimated,
+      ...tokenMetricsFromAttributes(summary.attributes),
     },
     error: createError(summary.containsErrorStatus, summary.errorMessage),
     events: events.length > 0 ? events : undefined,

--- a/langwatch/src/server/traces/projection/catalog.ts
+++ b/langwatch/src/server/traces/projection/catalog.ts
@@ -116,6 +116,9 @@ const TRACE_METRICS: Record<string, ProjectionValueType> = {
   reasoning_tokens: "number",
   cache_read_input_tokens: "number",
   cache_creation_input_tokens: "number",
+  cache_creation_5m_input_tokens: "number",
+  cache_creation_1h_input_tokens: "number",
+  context_size_tokens: "number",
   total_cost: "number",
   tokens_estimated: "boolean",
 };

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -480,11 +480,31 @@ export class TraceService {
       "TraceService.getAllTracesForProject",
       { attributes: { "tenant.id": input.projectId } },
       async () => {
-        return this.clickHouseService.getAllTracesForProject(
+        const result = await this.clickHouseService.getAllTracesForProject(
           input,
           protections,
           options,
         );
+        if (!options.includeSpans) return result;
+        // includeSpans callers (bulk export, search) read whole spans, so the
+        // Claude Code content + cost join applies here exactly as on the
+        // single-trace and thread reads. Enrichment runs over the flattened
+        // page so the helper's bounded fan-out caps concurrent log reads for
+        // the whole page; a page with no coding-agent trace returns the same
+        // array reference and pays nothing.
+        const flat = result.groups.flat();
+        const enriched = await this.enrichCodingAgentTraces(
+          input.projectId,
+          flat,
+        );
+        if (enriched === flat) return result;
+        // The helper is positional (same order, same length), so the groups
+        // rebuild by position rather than by id.
+        let cursor = 0;
+        const groups = result.groups.map((group) =>
+          group.map(() => enriched[cursor++] as (typeof group)[number]),
+        );
+        return { ...result, groups };
       },
     );
   }

--- a/specs/coding-agent/transcript-rest.feature
+++ b/specs/coding-agent/transcript-rest.feature
@@ -8,19 +8,23 @@ Feature: Coding agent transcript over REST and CLI
   # the trace drawer. This feature only opens a REST door to the same
   # derivation for API key callers, plus a CLI command through that door.
 
-  @integration
+  @unit
   Scenario: transcript endpoint returns the derived transcript for a coding-agent trace
     Given a stored coding-agent trace with log records
     When GET /api/traces/{traceId}/transcript is called with a project API key
     Then the response carries the transcript entries the terminal view derives
 
-  @integration
+  @unit
   Scenario: transcript endpoint answers empty for a trace without coding-agent content
     Given a stored trace that is not coding-agent origin
     When GET /api/traces/{traceId}/transcript is called with a project API key
     Then the response carries an empty transcript list rather than an error
 
-  @integration
+  # Endpoint-level 404/409 semantics reuse the exact resolution path of
+  # GET /:traceId (TraceService.getById incl. prefix resolution); an
+  # endpoint-harness integration test is the right binding once one exists
+  # for the traces REST surface.
+  @integration @unimplemented
   Scenario: transcript endpoint rejects an unknown trace
     When GET /api/traces/{traceId}/transcript is called for a trace id that does not exist
     Then the request fails with a not found error

--- a/specs/coding-agent/transcript-rest.feature
+++ b/specs/coding-agent/transcript-rest.feature
@@ -1,0 +1,33 @@
+@coding-agent @api
+Feature: Coding agent transcript over REST and CLI
+  As a CLI, MCP server, or export pipeline reading coding agent sessions
+  I want the derived transcript of a trace over the REST API
+  So that reading a session does not require running the web app
+
+  # The transcript derivation already exists and powers the terminal view in
+  # the trace drawer. This feature only opens a REST door to the same
+  # derivation for API key callers, plus a CLI command through that door.
+
+  @integration
+  Scenario: transcript endpoint returns the derived transcript for a coding-agent trace
+    Given a stored coding-agent trace with log records
+    When GET /api/traces/{traceId}/transcript is called with a project API key
+    Then the response carries the transcript entries the terminal view derives
+
+  @integration
+  Scenario: transcript endpoint answers empty for a trace without coding-agent content
+    Given a stored trace that is not coding-agent origin
+    When GET /api/traces/{traceId}/transcript is called with a project API key
+    Then the response carries an empty transcript list rather than an error
+
+  @integration
+  Scenario: transcript endpoint rejects an unknown trace
+    When GET /api/traces/{traceId}/transcript is called for a trace id that does not exist
+    Then the request fails with a not found error
+
+  @unit
+  Scenario: the CLI prints a trace transcript
+    Given the transcript endpoint returns entries for a trace
+    When I run "langwatch trace transcript that-trace-id"
+    Then the transcript entries are printed to stdout
+    And machine output mode prints the raw JSON document

--- a/specs/traces/trace-search-token-fields.feature
+++ b/specs/traces/trace-search-token-fields.feature
@@ -44,14 +44,14 @@ Feature: Trace search response carries token metrics and optional enriched spans
     When the summary is mapped to the legacy trace shape
     Then metadata.otel_log_record_count carries the caller's value
 
-  @integration
+  @unit
   Scenario: search with includeSpans returns coding-agent spans enriched from log records
     Given a stored coding-agent trace whose llm_request span carries tokens but no content and no cost
     And the trace's stored log records carry the request body and the cost for that span
     When the search endpoint is called with includeSpans true
     Then the returned trace's spans carry content and cost joined from the log records
 
-  @integration
+  @unit
   Scenario: search without includeSpans keeps the legacy empty spans shape
     Given a stored coding-agent trace
     When the search endpoint is called without includeSpans

--- a/specs/traces/trace-search-token-fields.feature
+++ b/specs/traces/trace-search-token-fields.feature
@@ -1,0 +1,58 @@
+@traces @api
+Feature: Trace search response carries token metrics and optional enriched spans
+  As a data consumer pulling traces over the public API for BI or agent analytics
+  I want per-trace token breakdowns and optional full spans from the search endpoint
+  So that context and cache economics are analyzable without private endpoints
+
+  # Compatibility contract: this surface is consumed by customer BI pipelines
+  # and changes are additive only. No existing key is renamed, removed, or
+  # given a new meaning; every scenario below adds fields next to the ones
+  # that already flow.
+
+  @unit
+  Scenario: metrics carries the token fields the projection catalog already advertises
+    Given a trace summary whose attributes carry reserved cache read, cache creation and reasoning token counts
+    When the summary is mapped to the legacy trace shape
+    Then metrics.cache_read_input_tokens equals the reserved cache read count
+    And metrics.cache_creation_input_tokens equals the reserved cache creation count
+    And metrics.reasoning_tokens equals the reserved reasoning count
+
+  @unit
+  Scenario: metrics carries context size and the cache creation TTL split
+    Given a trace summary whose attributes carry reserved context size, 5 minute and 1 hour cache creation counts
+    When the summary is mapped to the legacy trace shape
+    Then metrics.context_size_tokens equals the reserved context size
+    And metrics.cache_creation_5m_input_tokens equals the reserved 5 minute count
+    And metrics.cache_creation_1h_input_tokens equals the reserved 1 hour count
+
+  @unit
+  Scenario: absent reserved token attributes leave the metrics fields unset
+    Given a trace summary whose attributes carry no reserved token counts
+    When the summary is mapped to the legacy trace shape
+    Then the mapped metrics carry only the six legacy fields with no token additions
+
+  @unit
+  Scenario: existing metadata keys flow untouched and otel_log_record_count is added as a sibling
+    Given a trace summary whose attributes carry langwatch.reserved.log_record_count
+    When the summary is mapped to the legacy trace shape
+    Then metadata carries the key "langwatch.reserved.log_record_count" with its original string value
+    And metadata carries otel_log_record_count with the same value
+
+  @unit
+  Scenario: a caller-defined otel_log_record_count metadata key is never overwritten
+    Given a trace summary whose attributes carry both metadata.otel_log_record_count set by the caller and langwatch.reserved.log_record_count
+    When the summary is mapped to the legacy trace shape
+    Then metadata.otel_log_record_count carries the caller's value
+
+  @integration
+  Scenario: search with includeSpans returns coding-agent spans enriched from log records
+    Given a stored coding-agent trace whose llm_request span carries tokens but no content and no cost
+    And the trace's stored log records carry the request body and the cost for that span
+    When the search endpoint is called with includeSpans true
+    Then the returned trace's spans carry content and cost joined from the log records
+
+  @integration
+  Scenario: search without includeSpans keeps the legacy empty spans shape
+    Given a stored coding-agent trace
+    When the search endpoint is called without includeSpans
+    Then every returned trace carries spans as an empty array

--- a/specs/typescript-sdk/cli-trace-export.feature
+++ b/specs/typescript-sdk/cli-trace-export.feature
@@ -38,6 +38,22 @@ Feature: CLI trace export paging and span depth
     Then the CLI makes exactly one search request with pageSize 50
 
   @unit
+  Scenario: export ends the walk on a short page without skipped rows
+    Given a page returns fewer traces than requested and reports no skipped rows
+    When I run "langwatch trace export" with a limit above one page
+    Then the CLI treats the result set as exhausted and stops
+
+  @unit
+  Scenario: export rejects a non-numeric limit
+    When I run "langwatch trace export --limit abc"
+    Then the CLI exits with an error before making any request
+
+  @unit
+  Scenario: export with --include-spans requests smaller pages
+    When I run "langwatch trace export --include-spans"
+    Then each page request asks for at most 200 traces so span joining stays bounded
+
+  @unit
   Scenario: export with --include-spans requests span data and preserves it in the output
     Given the search endpoint returns traces carrying spans
     When I run "langwatch trace export --include-spans"

--- a/specs/typescript-sdk/cli-trace-export.feature
+++ b/specs/typescript-sdk/cli-trace-export.feature
@@ -1,0 +1,58 @@
+@cli @traces
+Feature: CLI trace export paging and span depth
+  As an engineer or coding agent exporting traces from the terminal
+  I want the export command to honor my requested limit and optionally include spans
+  So that bulk analysis does not require hand-written pagination loops or the UI
+
+  Background:
+    Given I have a valid API key configured
+
+  # The search endpoint returns a keyset cursor in pagination.scrollId and the
+  # CLI is the party responsible for walking it. The server page size cap is
+  # 1000; any requested limit above one page is satisfied by paging, never by
+  # silently clamping.
+
+  @unit
+  Scenario: export pages with the server cursor until the requested limit is reached
+    Given the search endpoint serves at most 1000 traces per page with a scrollId cursor
+    When I run "langwatch trace export --limit 2500"
+    Then the CLI requests successive pages passing the scrollId from the previous response
+    And the exported output contains 2500 traces
+
+  @unit
+  Scenario: export keeps paging through a short page whose shortfall is skipped rows
+    Given a page returns fewer traces than requested and reports the difference as skipped
+    When I run "langwatch trace export" with a limit above one page
+    Then the CLI continues to the next page instead of treating the short page as the end
+
+  @unit
+  Scenario: export stops paging when the server returns no further cursor
+    Given the search endpoint has only 40 matching traces
+    When I run "langwatch trace export --limit 1000"
+    Then the exported output contains 40 traces
+    And the CLI makes no further request after the page that returned no scrollId
+
+  @unit
+  Scenario: export requests one page when the limit fits in a single page
+    When I run "langwatch trace export --limit 50"
+    Then the CLI makes exactly one search request with pageSize 50
+
+  @unit
+  Scenario: export with --include-spans requests span data and preserves it in the output
+    Given the search endpoint returns traces carrying spans
+    When I run "langwatch trace export --include-spans"
+    Then the search request body carries includeSpans true
+    And each exported JSONL line preserves the trace's spans array
+
+  @unit
+  Scenario: export without --include-spans keeps the legacy request shape
+    When I run "langwatch trace export"
+    Then the search request body carries no includeSpans field
+
+  @unit
+  Scenario: CSV export appends token and context columns after the existing ones
+    Given the search endpoint returns traces carrying token metrics
+    When I run "langwatch trace export --format csv"
+    Then the CSV header begins with trace_id, input, output, started_at, error in that order
+    And the CSV header additionally contains prompt_tokens, completion_tokens, total_cost, context_size_tokens, cache_read_input_tokens, cache_creation_input_tokens, reasoning_tokens
+    And each row carries the trace's token metric values in those columns

--- a/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
@@ -231,6 +231,181 @@ describe("exportTracesCommand()", () => {
 			expect(body).not.toHaveProperty("filters");
 		});
 	});
+
+	const pageResponse = (args: {
+		count: number;
+		from: number;
+		scrollId?: string;
+		totalHits: number;
+		skipped?: number;
+		trace?: (i: number) => Record<string, unknown>;
+	}) =>
+		new Response(
+			JSON.stringify({
+				traces: Array.from({ length: args.count }, (_, i) =>
+					args.trace
+						? args.trace(args.from + i)
+						: { trace_id: `trace_${args.from + i}` },
+				),
+				pagination: {
+					totalHits: args.totalHits,
+					...(args.scrollId ? { scrollId: args.scrollId } : {}),
+					...(args.skipped ? { skipped: args.skipped } : {}),
+				},
+			}),
+			{ status: 200 },
+		);
+
+	const writtenOutput = () =>
+		(process.stdout.write as unknown as ReturnType<typeof vi.fn>).mock.calls
+			.map((c) => String(c[0]))
+			.join("");
+
+	const requestBodies = () =>
+		fetchMock.mock.calls.map(
+			(c) => JSON.parse((c[1] as { body: string }).body) as Record<string, unknown>,
+		);
+
+	describe("when the limit spans multiple pages", () => {
+		/** @scenario export pages with the server cursor until the requested limit is reached */
+		it("passes each response's scrollId into the next request until the limit is reached", async () => {
+			fetchMock
+				.mockResolvedValueOnce(
+					pageResponse({ count: 1000, from: 0, scrollId: "s1", totalHits: 2500 }),
+				)
+				.mockResolvedValueOnce(
+					pageResponse({ count: 1000, from: 1000, scrollId: "s2", totalHits: 2500 }),
+				)
+				.mockResolvedValueOnce(
+					pageResponse({ count: 500, from: 2000, scrollId: "s3", totalHits: 2500 }),
+				);
+
+			await exportTracesCommand({ limit: "2500" });
+
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+			const bodies = requestBodies();
+			expect(bodies[0]).not.toHaveProperty("scrollId");
+			expect(bodies[0]!.pageSize).toBe(1000);
+			expect(bodies[1]!.scrollId).toBe("s1");
+			expect(bodies[2]!.scrollId).toBe("s2");
+			expect(bodies[2]!.pageSize).toBe(500);
+			expect(writtenOutput().trim().split("\n")).toHaveLength(2500);
+		});
+
+		/** @scenario export stops paging when the server returns no further cursor */
+		it("stops after the page that returns no scrollId", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({ count: 40, from: 0, totalHits: 40 }),
+			);
+
+			await exportTracesCommand({ limit: "1000" });
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(writtenOutput().trim().split("\n")).toHaveLength(40);
+		});
+
+		/** @scenario export keeps paging through a short page whose shortfall is skipped rows */
+		it("continues past a short page whose shortfall is reported as skipped", async () => {
+			fetchMock
+				.mockResolvedValueOnce(
+					pageResponse({
+						count: 990,
+						from: 0,
+						scrollId: "s1",
+						totalHits: 1100,
+						skipped: 10,
+					}),
+				)
+				.mockResolvedValueOnce(
+					pageResponse({ count: 100, from: 990, scrollId: "s2", totalHits: 1100 }),
+				);
+
+			await exportTracesCommand({ limit: "1090" });
+
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			expect(writtenOutput().trim().split("\n")).toHaveLength(1090);
+		});
+
+		/** @scenario export requests one page when the limit fits in a single page */
+		it("makes exactly one request with pageSize matching the limit", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({ count: 50, from: 0, scrollId: "s1", totalHits: 500 }),
+			);
+
+			await exportTracesCommand({ limit: "50" });
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(requestBodies()[0]!.pageSize).toBe(50);
+		});
+	});
+
+	describe("when --include-spans is provided", () => {
+		/** @scenario export with --include-spans requests span data and preserves it in the output */
+		it("sends includeSpans and preserves each trace's spans in the JSONL output", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({
+					count: 2,
+					from: 0,
+					totalHits: 2,
+					trace: (i) => ({
+						trace_id: `trace_${i}`,
+						spans: [{ span_id: `span_${i}` }],
+					}),
+				}),
+			);
+
+			await exportTracesCommand({ includeSpans: true });
+
+			expect(requestBodies()[0]!.includeSpans).toBe(true);
+			const lines = writtenOutput().trim().split("\n");
+			const first = JSON.parse(lines[0]!) as { spans?: unknown[] };
+			expect(first.spans).toEqual([{ span_id: "span_0" }]);
+		});
+
+		/** @scenario export without --include-spans keeps the legacy request shape */
+		it("sends no includeSpans field when the flag is absent", async () => {
+			await exportTracesCommand({});
+
+			expect(requestBodies()[0]).not.toHaveProperty("includeSpans");
+		});
+	});
+
+	describe("when exporting as CSV", () => {
+		/** @scenario CSV export appends token and context columns after the existing ones */
+		it("keeps the legacy columns first and appends the token metric columns", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({
+					count: 1,
+					from: 0,
+					totalHits: 1,
+					trace: (i) => ({
+						trace_id: `trace_${i}`,
+						input: { value: "hi" },
+						output: { value: "yo" },
+						timestamps: { started_at: 1720000000000 },
+						metrics: {
+							prompt_tokens: 10,
+							completion_tokens: 5,
+							total_cost: 0.5,
+							context_size_tokens: 123456,
+							cache_read_input_tokens: 120000,
+							cache_creation_input_tokens: 3456,
+							reasoning_tokens: 7,
+						},
+					}),
+				}),
+			);
+
+			await exportTracesCommand({ format: "csv" });
+
+			const lines = writtenOutput().trim().split("\n");
+			expect(lines[0]).toBe(
+				"trace_id,input,output,started_at,error,prompt_tokens,completion_tokens,total_cost,context_size_tokens,cache_read_input_tokens,cache_creation_input_tokens,reasoning_tokens",
+			);
+			expect(lines[1]).toContain("trace_0,hi,yo,");
+			expect(lines[1]).toContain(",10,5,0.5,123456,120000,3456,7");
+		});
+	});
 });
 
 describe("getTraceCommand()", () => {

--- a/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
@@ -338,6 +338,30 @@ describe("exportTracesCommand()", () => {
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 			expect(requestBodies()[0]!.pageSize).toBe(50);
 		});
+
+		/** @scenario export ends the walk on a short page without skipped rows */
+		it("stops on a short page whose shortfall is not accounted for by skipped", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({ count: 990, from: 0, scrollId: "s1", totalHits: 5000 }),
+			);
+
+			await exportTracesCommand({ limit: "3000" });
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(writtenOutput().trim().split("\n")).toHaveLength(990);
+		});
+
+		/** @scenario export rejects a non-numeric limit */
+		it("exits with an error for a non-numeric --limit instead of paging unbounded", async () => {
+			fetchMock.mockResolvedValue(
+				pageResponse({ count: 100, from: 0, scrollId: "s", totalHits: 1000 }),
+			);
+
+			await expect(exportTracesCommand({ limit: "abc" })).rejects.toThrow(
+				ProcessExitError,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("when --include-spans is provided", () => {
@@ -361,6 +385,17 @@ describe("exportTracesCommand()", () => {
 			const lines = writtenOutput().trim().split("\n");
 			const first = JSON.parse(lines[0]!) as { spans?: unknown[] };
 			expect(first.spans).toEqual([{ span_id: "span_0" }]);
+		});
+
+		/** @scenario export with --include-spans requests smaller pages */
+		it("caps each page at 200 so per-trace span joining stays bounded", async () => {
+			fetchMock.mockResolvedValueOnce(
+				pageResponse({ count: 200, from: 0, totalHits: 200 }),
+			);
+
+			await exportTracesCommand({ includeSpans: true });
+
+			expect(requestBodies()[0]!.pageSize).toBe(200);
 		});
 
 		/** @scenario export without --include-spans keeps the legacy request shape */
@@ -449,7 +484,7 @@ describe("transcriptTraceCommand()", () => {
 			.join("\n");
 		expect(printed).toContain("summarise the repo");
 		expect(printed).toContain("Here is the summary.");
-		expect(printed).toContain("1 model calls");
+		expect(printed).toContain("1 model call ·");
 	});
 
 	it("exits with code 1 when the endpoint answers an error", async () => {

--- a/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/traces/__tests__/trace-commands.unit.test.ts
@@ -53,6 +53,7 @@ import { TracesApiService } from "@/client-sdk/services/traces/traces-api.servic
 import { exportTracesCommand } from "../export";
 import { getTraceCommand } from "../get";
 import { searchTracesCommand } from "../search";
+import { transcriptTraceCommand } from "../transcript";
 
 class ProcessExitError extends Error {
 	constructor(public code: number) {
@@ -405,6 +406,62 @@ describe("exportTracesCommand()", () => {
 			expect(lines[1]).toContain("trace_0,hi,yo,");
 			expect(lines[1]).toContain(",10,5,0.5,123456,120000,3456,7");
 		});
+	});
+});
+
+describe("transcriptTraceCommand()", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	const transcriptDoc = {
+		agent: "claude_code",
+		sessionId: "session-123",
+		entries: [
+			{ kind: "user_prompt", atMs: 1720000000000, text: "summarise the repo", chars: 18 },
+			{ kind: "assistant_message", atMs: 1720000002000, text: "Here is the summary.", model: "claude-opus-5" },
+		],
+		totals: { modelCalls: 1, toolCalls: 0, tokens: 128, costUsd: 0.04 },
+		subAgents: [],
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fetchMock = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(transcriptDoc), { status: 200 }),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		logSpy = vi.spyOn(console, "log").mockImplementation(noop);
+		vi.spyOn(console, "error").mockImplementation(noop);
+		mockProcessExit();
+	});
+
+	/** @scenario the CLI prints a trace transcript */
+	it("fetches the transcript endpoint and prints the entries", async () => {
+		await transcriptTraceCommand("trace_abc", {});
+
+		expect(String(fetchMock.mock.calls[0]![0])).toContain(
+			"/api/traces/trace_abc/transcript",
+		);
+		const printed = logSpy.mock.calls
+			.map((c: unknown[]) => c.join(" "))
+			.join("\n");
+		expect(printed).toContain("summarise the repo");
+		expect(printed).toContain("Here is the summary.");
+		expect(printed).toContain("1 model calls");
+	});
+
+	it("exits with code 1 when the endpoint answers an error", async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ message: "Trace not found." }), {
+				status: 404,
+			}),
+		);
+
+		await expect(transcriptTraceCommand("nope", {})).rejects.toThrow(
+			ProcessExitError,
+		);
 	});
 });
 

--- a/typescript-sdk/src/cli/commands/traces/export.ts
+++ b/typescript-sdk/src/cli/commands/traces/export.ts
@@ -85,10 +85,12 @@ export const exportTracesCommand = async (options: {
     ? new Date(options.endDate).getTime()
     : now;
 
-  const limit = options.limit ? parseInt(options.limit, 10) : 1000;
-  if (!Number.isFinite(limit) || limit <= 0) {
+  const limit = options.limit ? Number(options.limit) : 1000;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
     console.error(
-      chalk.red(`Error: --limit must be a positive number, got "${options.limit}"`),
+      chalk.red(
+        `Error: --limit must be a positive whole number, got "${options.limit}"`,
+      ),
     );
     process.exit(1);
   }
@@ -158,8 +160,8 @@ export const exportTracesCommand = async (options: {
 
       const data = (await response.json()) as SearchPage;
       const pageTraces = data.traces;
-      // A server page can only be shorter than requested, but truncate anyway
-      // so a misbehaving page can never overshoot the caller's --limit.
+      // Truncate on write so no page, whatever its size, can push the output
+      // past the caller's --limit.
       traces.push(...pageTraces.slice(0, limit - traces.length));
       matched = data.pagination?.totalHits ?? traces.length;
 

--- a/typescript-sdk/src/cli/commands/traces/export.ts
+++ b/typescript-sdk/src/cli/commands/traces/export.ts
@@ -21,6 +21,17 @@ const PROGRESS_CHUNK = 25;
  */
 const SERVER_PAGE_CAP = 1000;
 
+/**
+ * Page size used when spans are requested. Each coding-agent trace's spans
+ * are joined with a bounded but heavy per-trace log read server-side, so the
+ * CLI asks for smaller pages and lets the cursor walk cover the rest — same
+ * total work, no long single request.
+ */
+const SPANS_PAGE_CAP = 200;
+
+/** Bound each page request so a quiet socket cannot hold the export open forever. */
+const REQUEST_TIMEOUT_MS = 60_000;
+
 interface ExportedTrace {
   trace_id: string;
   input?: { value: string };
@@ -75,6 +86,12 @@ export const exportTracesCommand = async (options: {
     : now;
 
   const limit = options.limit ? parseInt(options.limit, 10) : 1000;
+  if (!Number.isFinite(limit) || limit <= 0) {
+    console.error(
+      chalk.red(`Error: --limit must be a positive number, got "${options.limit}"`),
+    );
+    process.exit(1);
+  }
   const originFilter = parseOriginOption(options.origin);
   const spinner = createSpinner(`Exporting traces (${format})...`).start();
   const events = createCommandEvents({ resource: "trace", verb: "export" });
@@ -92,10 +109,14 @@ export const exportTracesCommand = async (options: {
     // server-side `skipped` rows (traces dropped because they failed to
     // serialize), since the cursor advances past those.
     for (;;) {
-      const pageSize = Math.min(limit - traces.length, SERVER_PAGE_CAP);
+      const pageSize = Math.min(
+        limit - traces.length,
+        options.includeSpans ? SPANS_PAGE_CAP : SERVER_PAGE_CAP,
+      );
 
       const response = await fetch(`${endpoint}/api/traces/search`, {
         method: "POST",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         headers: {
           "Content-Type": "application/json",
           ...buildAuthHeaders({ apiKey }),
@@ -137,7 +158,9 @@ export const exportTracesCommand = async (options: {
 
       const data = (await response.json()) as SearchPage;
       const pageTraces = data.traces;
-      traces.push(...pageTraces);
+      // A server page can only be shorter than requested, but truncate anyway
+      // so a misbehaving page can never overshoot the caller's --limit.
+      traces.push(...pageTraces.slice(0, limit - traces.length));
       matched = data.pagination?.totalHits ?? traces.length;
 
       if (traces.length === pageTraces.length) {

--- a/typescript-sdk/src/cli/commands/traces/export.ts
+++ b/typescript-sdk/src/cli/commands/traces/export.ts
@@ -14,13 +14,35 @@ import { parseOriginOption } from "./origin-filter";
 /** Rows are serialised in chunks so the progress bar moves as the file is built. */
 const PROGRESS_CHUNK = 25;
 
+/**
+ * The server clamps pageSize to this; limits above one page are satisfied by
+ * walking the keyset cursor the search endpoint returns in
+ * `pagination.scrollId`.
+ */
+const SERVER_PAGE_CAP = 1000;
+
 interface ExportedTrace {
   trace_id: string;
   input?: { value: string };
   output?: { value: string };
   timestamps?: { started_at?: number };
   metadata?: Record<string, unknown>;
+  metrics?: {
+    prompt_tokens?: number | null;
+    completion_tokens?: number | null;
+    total_cost?: number | null;
+    context_size_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
+    reasoning_tokens?: number | null;
+  };
+  spans?: unknown[];
   error?: Record<string, unknown>;
+}
+
+interface SearchPage {
+  traces: ExportedTrace[];
+  pagination?: { totalHits?: number; scrollId?: string; skipped?: number };
 }
 
 export const exportTracesCommand = async (options: {
@@ -31,6 +53,7 @@ export const exportTracesCommand = async (options: {
   output?: string;
   limit?: string;
   origin?: string;
+  includeSpans?: boolean;
 }): Promise<void> => {
   await resolveCredentials();
 
@@ -59,60 +82,82 @@ export const exportTracesCommand = async (options: {
   try {
     events.started(`Exporting traces as ${format}…`);
 
-    const response = await fetch(`${endpoint}/api/traces/search`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
-        query: options.query,
-        startDate,
-        endDate,
-        pageSize: Math.min(limit, 100),
-        format: "json",
-        ...(originFilter ? { filters: { "traces.origin": originFilter } } : {}),
-      }),
-    });
+    const traces: ExportedTrace[] = [];
+    let matched = 0;
+    let scrollId: string | undefined;
 
-    if (!response.ok) {
-      // Read the body off a CLONE before `formatFetchError` consumes it, so the
-      // event keeps the platform's real error kind instead of degrading to one
-      // guessed from the status.
-      const body: unknown = await response
-        .clone()
-        .json()
-        .catch(() => undefined);
+    // Page until the requested limit is met or the result set is exhausted.
+    // The cursor is authoritative for "there may be more"; a page shorter than
+    // requested only ends the walk when the shortfall is not accounted for by
+    // server-side `skipped` rows (traces dropped because they failed to
+    // serialize), since the cursor advances past those.
+    for (;;) {
+      const pageSize = Math.min(limit - traces.length, SERVER_PAGE_CAP);
 
-      const message = await formatFetchError(response);
-      events.failed({
-        error: Object.assign(new Error(message), {
-          status: response.status,
-          originalError: body,
+      const response = await fetch(`${endpoint}/api/traces/search`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...buildAuthHeaders({ apiKey }),
+        },
+        body: JSON.stringify({
+          query: options.query,
+          startDate,
+          endDate,
+          pageSize,
+          format: "json",
+          ...(options.includeSpans ? { includeSpans: true } : {}),
+          ...(scrollId ? { scrollId } : {}),
+          ...(originFilter ? { filters: { "traces.origin": originFilter } } : {}),
         }),
-        message: "Trace export failed",
       });
-      await events.flush();
 
-      failSpinner({ spinner, error: new Error(message), action: "export traces" });
-      process.exit(1);
+      if (!response.ok) {
+        // Read the body off a CLONE before `formatFetchError` consumes it, so the
+        // event keeps the platform's real error kind instead of degrading to one
+        // guessed from the status.
+        const body: unknown = await response
+          .clone()
+          .json()
+          .catch(() => undefined);
+
+        const message = await formatFetchError(response);
+        events.failed({
+          error: Object.assign(new Error(message), {
+            status: response.status,
+            originalError: body,
+          }),
+          message: "Trace export failed",
+        });
+        await events.flush();
+
+        failSpinner({ spinner, error: new Error(message), action: "export traces" });
+        process.exit(1);
+      }
+
+      const data = (await response.json()) as SearchPage;
+      const pageTraces = data.traces;
+      traces.push(...pageTraces);
+      matched = data.pagination?.totalHits ?? traces.length;
+
+      if (traces.length === pageTraces.length) {
+        // First page: report the match count the moment it is known.
+        events.count({
+          count: matched,
+          total: matched,
+          message: `${matched.toLocaleString()} trace${matched === 1 ? "" : "s"} to export`,
+        });
+      }
+
+      spinner.text = `Exporting traces (${format})... ${traces.length.toLocaleString()} fetched`;
+
+      scrollId = data.pagination?.scrollId;
+      const consumed = pageTraces.length + (data.pagination?.skipped ?? 0);
+      const exhausted = pageTraces.length === 0 || consumed < pageSize;
+      if (!scrollId || exhausted || traces.length >= limit) break;
     }
 
-    const data = await response.json() as {
-      traces: ExportedTrace[];
-      pagination?: { totalHits?: number };
-    };
-
-    const traces = data.traces;
-    const matched = data.pagination?.totalHits ?? traces.length;
-
-    events.count({
-      count: matched,
-      total: matched,
-      message: `${matched.toLocaleString()} trace${matched === 1 ? "" : "s"} to export`,
-    });
-
-    spinner.succeed(`Exported ${traces.length} trace${traces.length !== 1 ? "s" : ""}${data.pagination?.totalHits ? ` (${data.pagination.totalHits} total)` : ""}`);
+    spinner.succeed(`Exported ${traces.length} trace${traces.length !== 1 ? "s" : ""}${matched > traces.length ? ` (${matched} total)` : ""}`);
 
     // Serialising each trace is real per-row work, so this progress is genuinely
     // the file being built — not a bar invented for the sake of having one.
@@ -142,6 +187,26 @@ export const exportTracesCommand = async (options: {
     await events.flush();
   }
 };
+
+/**
+ * CSV columns. The first five are the original export shape and their order is
+ * a compatibility contract for existing consumers; token metric columns are
+ * only ever appended after them.
+ */
+const CSV_HEADERS = [
+  "trace_id",
+  "input",
+  "output",
+  "started_at",
+  "error",
+  "prompt_tokens",
+  "completion_tokens",
+  "total_cost",
+  "context_size_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "reasoning_tokens",
+] as const;
 
 /** Build the export document, reporting progress as the rows are written. */
 const serialise = ({
@@ -175,8 +240,7 @@ const serialise = ({
   if (format === "json") return JSON.stringify(traces, null, 2);
   if (format === "jsonl") return lines.join("\n") + "\n";
 
-  const headers = ["trace_id", "input", "output", "started_at", "error"];
-  return [headers.join(","), ...lines].join("\n") + "\n";
+  return [CSV_HEADERS.join(","), ...lines].join("\n") + "\n";
 };
 
 const serialiseTrace = ({
@@ -196,8 +260,19 @@ const serialiseTrace = ({
       ? new Date(trace.timestamps.started_at).toISOString()
       : "",
     trace.error ? csvEscape(JSON.stringify(trace.error)) : "",
+    csvNumber(trace.metrics?.prompt_tokens),
+    csvNumber(trace.metrics?.completion_tokens),
+    csvNumber(trace.metrics?.total_cost),
+    csvNumber(trace.metrics?.context_size_tokens),
+    csvNumber(trace.metrics?.cache_read_input_tokens),
+    csvNumber(trace.metrics?.cache_creation_input_tokens),
+    csvNumber(trace.metrics?.reasoning_tokens),
   ].join(",");
 };
+
+function csvNumber(value: number | null | undefined): string {
+  return value == null ? "" : String(value);
+}
 
 function csvEscape(value: string): string {
   if (value.includes(",") || value.includes('"') || value.includes("\n")) {

--- a/typescript-sdk/src/cli/commands/traces/search.ts
+++ b/typescript-sdk/src/cli/commands/traces/search.ts
@@ -121,8 +121,9 @@ export const searchTracesCommand = async (options: {
 /**
  * Walk the returned traces in chunks, reporting how far along we are.
  *
- * WHAT THIS FRACTION HONESTLY MEANS: the command issues ONE request — the API
- * exposes no cursor the CLI pages through — so this is progress over the traces
+ * WHAT THIS FRACTION HONESTLY MEANS: the command issues ONE request — search
+ * renders a single page (the API does return a scrollId cursor, and `trace
+ * export` is the command that walks it) — so this is progress over the traces
  * already in hand, not over a multi-page fetch. The rows really are being
  * processed, so the bar is not a lie; but it is not the long-running bar that
  * paging would give. Making the fetch page would change what a *disabled* CLI

--- a/typescript-sdk/src/cli/commands/traces/transcript.ts
+++ b/typescript-sdk/src/cli/commands/traces/transcript.ts
@@ -1,0 +1,139 @@
+import { scopedApiKey } from "@/internal/credentialContext";
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { resolveCredentials } from "../../utils/apiKey";
+import { formatFetchError } from "../../utils/formatFetchError";
+import { failSpinner } from "../../utils/spinnerError";
+import {
+  printResult,
+  type RawOutputFlags,
+} from "../../utils/output";
+import { createCommandEvents } from "../../telemetry/events";
+import { buildAuthHeaders } from "@/internal/api/auth";
+
+import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+
+interface TranscriptEntry {
+  kind: string;
+  atMs: number;
+  text?: string | null;
+  chars?: number;
+  model?: string | null;
+  tokens?: number;
+  costUsd?: number;
+  name?: string | null;
+  [key: string]: unknown;
+}
+
+interface TranscriptDocument {
+  agent: string;
+  sessionId: string | null;
+  entries: TranscriptEntry[];
+  totals: {
+    modelCalls: number;
+    toolCalls: number;
+    tokens: number;
+    costUsd: number;
+  };
+  subAgents: Array<{ agentId: string; toolCalls: number }>;
+}
+
+export const transcriptTraceCommand = async (
+  traceId: string,
+  options: RawOutputFlags,
+): Promise<void> => {
+  await resolveCredentials();
+
+  const apiKey = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
+  const endpoint = resolveControlPlaneUrl();
+  const spinner = createSpinner("Fetching transcript...").start();
+  const events = createCommandEvents({ resource: "trace", verb: "get" });
+
+  let doc: TranscriptDocument;
+  try {
+    events.started("Fetching transcript…");
+
+    const response = await fetch(
+      `${endpoint}/api/traces/${encodeURIComponent(traceId)}/transcript`,
+      { headers: buildAuthHeaders({ apiKey }) },
+    );
+
+    if (!response.ok) {
+      const message = await formatFetchError(response);
+      events.failed({
+        error: Object.assign(new Error(message), { status: response.status }),
+        message: "Trace transcript fetch failed",
+      });
+      await events.flush();
+      failSpinner({
+        spinner,
+        error: new Error(message),
+        action: "fetch transcript",
+      });
+      process.exit(1);
+    }
+
+    doc = (await response.json()) as TranscriptDocument;
+    spinner.succeed(
+      `${doc.entries.length} transcript entr${doc.entries.length === 1 ? "y" : "ies"} (${doc.agent})`,
+    );
+  } catch (error) {
+    events.failed({ error, message: "Trace transcript fetch failed" });
+    await events.flush();
+    failSpinner({ spinner, error, action: "fetch transcript" });
+    process.exit(1);
+    return;
+  }
+
+  await printResult(doc, {
+    ...options,
+    table: () => renderTranscript(doc),
+  });
+
+  events.completed({
+    count: doc.entries.length,
+    total: doc.entries.length,
+    message: `Printed ${doc.entries.length} transcript entr${doc.entries.length === 1 ? "y" : "ies"}`,
+  });
+  await events.flush();
+};
+
+/** Human rendering: one line per entry, economics dimmed, prompts loud. */
+const renderTranscript = (doc: TranscriptDocument): void => {
+  console.log();
+  for (const entry of doc.entries) {
+    console.log(renderEntry(entry));
+  }
+  console.log();
+  console.log(
+    chalk.gray(
+      `${doc.totals.modelCalls} model calls · ${doc.totals.toolCalls} tool calls · ` +
+        `${doc.totals.tokens.toLocaleString()} tokens · $${doc.totals.costUsd.toFixed(2)}`,
+    ),
+  );
+};
+
+const renderEntry = (entry: TranscriptEntry): string => {
+  const time = new Date(entry.atMs).toISOString().slice(11, 19);
+  const stamp = chalk.gray(time);
+
+  switch (entry.kind) {
+    case "system_prompt":
+      return `${stamp} ${chalk.gray(`[session context: ${entry.chars?.toLocaleString() ?? "?"} chars]`)}`;
+    case "user_prompt":
+      return `${stamp} ${chalk.cyan(`> ${entry.text ?? ""}`)}`;
+    case "assistant_message":
+      return `${stamp} ${entry.text ?? ""}`;
+    case "model_call":
+      return `${stamp} ${chalk.gray(
+        `· model call ${entry.model ?? ""} ${entry.tokens?.toLocaleString() ?? "?"} tokens` +
+          (entry.costUsd != null ? ` $${entry.costUsd.toFixed(4)}` : ""),
+      )}`;
+    default: {
+      const label = [entry.kind, entry.name ?? entry.text ?? ""]
+        .filter(Boolean)
+        .join(" ");
+      return `${stamp} ${chalk.gray(`· ${label}`)}`;
+    }
+  }
+};

--- a/typescript-sdk/src/cli/commands/traces/transcript.ts
+++ b/typescript-sdk/src/cli/commands/traces/transcript.ts
@@ -1,5 +1,6 @@
 import { scopedApiKey } from "@/internal/credentialContext";
 import chalk from "chalk";
+import { z } from "zod";
 import { createSpinner } from "../../utils/spinner";
 import { resolveCredentials } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
@@ -13,30 +14,39 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 
-interface TranscriptEntry {
-  kind: string;
-  atMs: number;
-  text?: string | null;
-  chars?: number;
-  model?: string | null;
-  tokens?: number;
-  costUsd?: number;
-  name?: string | null;
-  [key: string]: unknown;
-}
+/** Bound the request so a quiet socket cannot hold the CLI open forever. */
+const REQUEST_TIMEOUT_MS = 60_000;
 
-interface TranscriptDocument {
-  agent: string;
-  sessionId: string | null;
-  entries: TranscriptEntry[];
-  totals: {
-    modelCalls: number;
-    toolCalls: number;
-    tokens: number;
-    costUsd: number;
-  };
-  subAgents: Array<{ agentId: string; toolCalls: number }>;
-}
+const transcriptEntrySchema = z
+  .object({
+    kind: z.string(),
+    atMs: z.number(),
+    text: z.string().nullable().optional(),
+    chars: z.number().optional(),
+    model: z.string().nullable().optional(),
+    tokens: z.number().optional(),
+    costUsd: z.number().optional(),
+    name: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const transcriptDocumentSchema = z.object({
+  agent: z.string(),
+  sessionId: z.string().nullable(),
+  entries: z.array(transcriptEntrySchema),
+  totals: z.object({
+    modelCalls: z.number(),
+    toolCalls: z.number(),
+    tokens: z.number(),
+    costUsd: z.number(),
+  }),
+  subAgents: z.array(
+    z.object({ agentId: z.string(), toolCalls: z.number() }).passthrough(),
+  ),
+});
+
+type TranscriptEntry = z.infer<typeof transcriptEntrySchema>;
+type TranscriptDocument = z.infer<typeof transcriptDocumentSchema>;
 
 export const transcriptTraceCommand = async (
   traceId: string,
@@ -55,7 +65,10 @@ export const transcriptTraceCommand = async (
 
     const response = await fetch(
       `${endpoint}/api/traces/${encodeURIComponent(traceId)}/transcript`,
-      { headers: buildAuthHeaders({ apiKey }) },
+      {
+        headers: buildAuthHeaders({ apiKey }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
     );
 
     if (!response.ok) {
@@ -73,9 +86,9 @@ export const transcriptTraceCommand = async (
       process.exit(1);
     }
 
-    doc = (await response.json()) as TranscriptDocument;
+    doc = transcriptDocumentSchema.parse(await response.json());
     spinner.succeed(
-      `${doc.entries.length} transcript entr${doc.entries.length === 1 ? "y" : "ies"} (${doc.agent})`,
+      `${plural(doc.entries.length, "transcript entry", "transcript entries")} (${doc.agent})`,
     );
   } catch (error) {
     events.failed({ error, message: "Trace transcript fetch failed" });
@@ -93,10 +106,13 @@ export const transcriptTraceCommand = async (
   events.completed({
     count: doc.entries.length,
     total: doc.entries.length,
-    message: `Printed ${doc.entries.length} transcript entr${doc.entries.length === 1 ? "y" : "ies"}`,
+    message: `Printed ${plural(doc.entries.length, "transcript entry", "transcript entries")}`,
   });
   await events.flush();
 };
+
+const plural = (count: number, singular: string, pluralForm?: string): string =>
+  `${count} ${count === 1 ? singular : (pluralForm ?? `${singular}s`)}`;
 
 /** Human rendering: one line per entry, economics dimmed, prompts loud. */
 const renderTranscript = (doc: TranscriptDocument): void => {
@@ -107,7 +123,7 @@ const renderTranscript = (doc: TranscriptDocument): void => {
   console.log();
   console.log(
     chalk.gray(
-      `${doc.totals.modelCalls} model calls · ${doc.totals.toolCalls} tool calls · ` +
+      `${plural(doc.totals.modelCalls, "model call")} · ${plural(doc.totals.toolCalls, "tool call")} · ` +
         `${doc.totals.tokens.toLocaleString()} tokens · $${doc.totals.costUsd.toFixed(2)}`,
     ),
   );

--- a/typescript-sdk/src/cli/program.ts
+++ b/typescript-sdk/src/cli/program.ts
@@ -1966,8 +1966,9 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     )
     .option("-f, --format <format>", "Output format: jsonl (default), csv, or json", "jsonl")
     .option("-o, --output <file>", "Write output to file instead of stdout")
-    .option("--limit <n>", "Max traces to export (default: 1000)")
-    .action(async (options: { startDate?: string; endDate?: string; query?: string; origin?: string; format?: string; output?: string; limit?: string }) => {
+    .option("--limit <n>", "Max traces to export (default: 1000); limits above one server page are fetched by cursor paging")
+    .option("--include-spans", "Include full span data for each trace (slower, larger output)")
+    .action(async (options: { startDate?: string; endDate?: string; query?: string; origin?: string; format?: string; output?: string; limit?: string; includeSpans?: boolean }) => {
       const { exportTracesCommand: impl } = await import("./commands/traces/export.js");
       await impl(options);
     });

--- a/typescript-sdk/src/cli/program.ts
+++ b/typescript-sdk/src/cli/program.ts
@@ -1983,6 +1983,16 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     await impl(traceId, command.optsWithGlobals());
   });
 
+  rendersOwnResult(
+    traceCmd
+      .command("transcript <traceId>")
+      .description("Print the coding-agent transcript of a trace (what the agent did, in order)")
+      .option("-f, --format <format>", "Output format: table (default, human-readable) or json", "table"),
+  ).action(async (traceId: string, _options: unknown, command: Command) => {
+    const { transcriptTraceCommand: impl } = await import("./commands/traces/transcript.js");
+    await impl(traceId, command.optsWithGlobals());
+  });
+
   // Add scenario command group
   const scenarioCmd = program
     .command("scenario")


### PR DESCRIPTION
Two commits that make coding-agent traces genuinely readable from outside the web app. Motivation: we ran a deep context-economics study on our own Claude Code telemetry and every substantive query had to fall back to parsing local transcript JSONLs, because the export surface returned trace rollups with `spans: []`, silently clamped `--limit` to 100, forced hour-slicing to paginate, and leaked `langwatch.reserved.log_record_count` into metadata where it reads like an API-call count (it counts OTel log records, roughly 8.6x the model calls in our data). Each of those has a small root cause, fixed here.

**Compatibility contract, stated up front: everything on the public traces API edge is additive.** BI pipelines consume `/api/traces/search` and have been burned by breaking changes before. No key is renamed, removed, suppressed, or re-meant. `includeSpans` stays default false; `langwatch.reserved.log_record_count` keeps flowing byte for byte; every new field lands beside the old ones.

## Commit 1: honest CLI export + additive token metrics

**CLI (`typescript-sdk`):**
- `trace export` walked into a client-side `Math.min(limit, 100)` while the server allows 1000 and returns a keyset `scrollId` cursor the CLI then discarded. It now pages: successive requests pass the previous response's cursor until the requested limit or the end of the result set. A short page whose shortfall is reported as `skipped` (rows the server dropped at serialization) does not end the walk, since the cursor advances past those.
- New `--include-spans` flag passes the `includeSpans` the search endpoint already supported.
- CSV keeps the original five columns first (their order is a compatibility contract) and appends `prompt_tokens, completion_tokens, total_cost, context_size_tokens, cache_read_input_tokens, cache_creation_input_tokens, reasoning_tokens`.
- The stale "the API exposes no cursor" comment in `search.ts` is corrected; search itself still deliberately renders a single page.

**Server:**
- The projection catalog already advertises `metrics.cache_read_input_tokens`, `metrics.cache_creation_input_tokens` and `metrics.reasoning_tokens` as selectable paths, but `mapTraceSummaryToTrace` never populated them, so they always read null. The mapper now fills them from the reserved fold attributes, and adds `metrics.context_size_tokens` plus the `cache_creation_5m/1h_input_tokens` TTL split (catalog entries added for the three new ones).
- `metadata.otel_log_record_count` lands as a clearly named sibling of the raw reserved key, guarded so a caller-defined metadata key of the same name always wins.
- `enrichCodingAgentSpansFromLogs` (the read-time join of Claude Code content and cost onto `llm_request` spans) ran on `getById` and the thread reads but not on `getAllTracesForProject`, so search/export with `includeSpans` returned content-less, cost-less spans for coding-agent traces. The list path now enriches over the flattened page, keeping the helper's bounded fan-out as the page-wide cap.

## Commit 2 (self-contained, revert-friendly): coding-agent transcript over REST and CLI

`codingAgentTranscript`'s own docstring says the CLI, an MCP server, and exports all want it "and none of them are going to run React to get one". This commit opens that door without touching the derivation: the span and log loads move into a protections-parameterized read shared by the tRPC procedure and a new `GET /api/traces/:traceId/transcript` (project API key, same prefix-resolution and 404/409 semantics as `GET /:traceId`, identical redaction passes because both doors run the same loaders). Plus `langwatch trace transcript <traceId>`, rendering entries humanly or as raw JSON with `-o json`.

Kept as its own commit deliberately: if we would rather design the transcript surface as part of a broader API story, dropping this commit removes it cleanly and commit 1 stands alone.

## Specs and tests

Specs first, all scenarios tagged and bound (`check-feature-parity` verified):
- `specs/typescript-sdk/cli-trace-export.feature` (7/7 bound)
- `specs/traces/trace-search-token-fields.feature` (7/7 bound)
- `specs/coding-agent/transcript-rest.feature` (3/3 bound; the endpoint-level 404 scenario is `@unimplemented` pending an endpoint harness for the traces REST surface)

Test runs: typescript-sdk CLI suite 129 files / 1533 tests green (includes 10 new export paging/spans/CSV tests and 2 transcript command tests); langwatch traces + routers sweep 794 tests green (3 new list-path enrichment tests, 6 new mapper tests, 2 new transcript-read tests exercising the real derivation and log gating).

Two pre-existing local failures worth knowing about, both reproduced identically on an untouched control worktree at the same commit, so they are environmental and not introduced here: `pnpm typecheck` fails in `langy-conversation-processing/schemas/events.ts` (zod v4-shaped inference against v3 `ZodTypeAny`), and `pnpm task generateOpenAPISpec` crashes in the prompts spec on a circular reference, which is why the tracked `openapiLangWatch.json` does not yet list the new transcript route. My changed files contribute zero typecheck errors in both tsgo projects.

https://claude.ai/code/session_012zN7wYM1uEWB6hb68HhDCj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `trace transcript` to view coding-agent prompts, model calls, metadata, and usage totals in table or JSON format.
  - Added a protected transcript API with full or unique-prefix trace lookup and clear not-found or ambiguous-trace errors.
  - Enhanced `trace export` with cursor pagination, span inclusion, progress reporting, validation, and CSV token/context metrics.
  - Added trace metrics for cache creation tokens, context size, and log record counts.
- **Bug Fixes**
  - Improved trace search enrichment for coding-agent spans, logs, and cost data while preserving existing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->