### PR TITLE
feat(charts): alert when a ClickHouse backup stops succeeding

### DIFF
--- a/charts/clickhouse-serverless/Makefile
+++ b/charts/clickhouse-serverless/Makefile
@@ -19,6 +19,9 @@ template: lint
 	@helm template $(RELEASE) . -f tests/values-single.yaml > /dev/null && echo "OK"
 	@echo "--- replicated (3 nodes) ---"
 	@helm template $(RELEASE) . -f tests/values-replicated.yaml > /dev/null && echo "OK"
+	@echo "--- backup alerting rules ---"
+	@helm template $(RELEASE) . -f tests/values-backup-alerts.yaml > /dev/null && echo "OK"
+	@bash tests/backup-alerts.sh
 
 ## Deploy to Kind and run functional tests (requires: kind, helm, kubectl)
 test-e2e:

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -149,12 +149,27 @@ Runbook: [`dev/docs/runbooks/clickhouse-backup-alerts.md`](../../dev/docs/runboo
 | `backup.monitoring.prometheusRule.enabled` | Emit a `PrometheusRule` instead of a ConfigMap (needs prometheus-operator CRDs) | `false` |
 | `backup.monitoring.prometheusRule.labels` | Extra labels on the `PrometheusRule`, for the operator's `ruleSelector` | `{}` |
 | `backup.monitoring.configMapLabels` | Labels on the rules ConfigMap, for a rules sidecar to discover it | `{langwatch.ai/prometheus-rules: "true"}` |
-| `backup.monitoring.targets` | Backups to watch: `name`, `cronjob` (name suffix after the release fullname), `staleAfterHours` | full at 26h, incremental at 3h |
+| `backup.monitoring.targets` | Backups to watch: `name`, `cronjob` or `cronjobName`, `staleAfterHours` | full at 26h, incremental at 3h |
 
 Add an entry to `backup.monitoring.targets` for any other backup CronJob in the
-same namespace, including ones this chart does not create. A backup mechanism
-that is not a Kubernetes CronJob has no kube-state-metrics series and cannot be
-watched from here.
+same namespace, including ones this chart does not create. Name it either way:
+
+```yaml
+targets:
+  # CronJob created by this chart: give the suffix, the release fullname is
+  # prepended, so this matches <release>-clickhouse-backup-full.
+  - name: full
+    cronjob: backup-full
+    staleAfterHours: 26
+  # CronJob managed outside this chart: give the exact name, no prefix is added.
+  - name: ebs-snapshot
+    cronjobName: acme-ebs-snapshotter
+    staleAfterHours: 26
+```
+
+`cronjob` and `cronjobName` are mutually exclusive, and the render fails if a
+target sets both or neither. A backup mechanism that is not a Kubernetes CronJob
+has no kube-state-metrics series and cannot be watched from here.
 
 ### Authentication
 

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -118,6 +118,44 @@ Shared by cold storage and backups. Required when either `cold.enabled` or `back
 | `backup.full.schedule` | Cron schedule for full backups | `0 */12 * * *` |
 | `backup.incremental.schedule` | Cron schedule for incremental backups | `0 * * * *` |
 
+### Backup alerting
+
+Off by default. When enabled, the chart renders Prometheus alerting rules that
+watch the backup CronJobs through kube-state-metrics, so a Prometheus that
+scrapes kube-state-metrics is the only prerequisite.
+
+The alert to care about is `ClickHouseBackupStale`, which fires when a backup
+has no successful run inside its window. That is a different condition from "a
+job failed", and a stricter one: a CronJob that is suspended, deleted, or
+silently rescheduled never fails, it just stops producing backups. It also
+covers the case of a backup that has never succeeded even once, which has no
+`kube_cronjob_status_last_successful_time` series at all and so is invisible to
+the obvious form of the query.
+
+Each target additionally gets `ClickHouseBackupJobFailed` (faster, fires on a
+bad run rather than waiting out the window), `ClickHouseBackupCronJobSuspended`,
+and `ClickHouseBackupCronJobMissing` (the CronJob or kube-state-metrics itself
+has gone away, which would otherwise resolve every other rule into silence).
+
+Runbook: [`dev/docs/runbooks/clickhouse-backup-alerts.md`](../../dev/docs/runbooks/clickhouse-backup-alerts.md).
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `backup.monitoring.enabled` | Render the backup alerting rules (also requires `backup.enabled`) | `false` |
+| `backup.monitoring.runbookUrl` | Value for the `runbook_url` annotation on every alert | `""` |
+| `backup.monitoring.additionalLabels` | Labels merged into every alert, for Alertmanager or Grafana routing | `{}` |
+| `backup.monitoring.for` | How long a backup may look broken before the alert fires | `15m` |
+| `backup.monitoring.absentFor` | How long the CronJob's metrics may be missing before alerting | `30m` |
+| `backup.monitoring.prometheusRule.enabled` | Emit a `PrometheusRule` instead of a ConfigMap (needs prometheus-operator CRDs) | `false` |
+| `backup.monitoring.prometheusRule.labels` | Extra labels on the `PrometheusRule`, for the operator's `ruleSelector` | `{}` |
+| `backup.monitoring.configMapLabels` | Labels on the rules ConfigMap, for a rules sidecar to discover it | `{langwatch.ai/prometheus-rules: "true"}` |
+| `backup.monitoring.targets` | Backups to watch: `name`, `cronjob` (name suffix after the release fullname), `staleAfterHours` | full at 26h, incremental at 3h |
+
+Add an entry to `backup.monitoring.targets` for any other backup CronJob in the
+same namespace, including ones this chart does not create. A backup mechanism
+that is not a Kubernetes CronJob has no kube-state-metrics series and cannot be
+watched from here.
+
 ### Authentication
 
 | Name | Description | Default |

--- a/charts/clickhouse-serverless/templates/backup-alerts.yaml
+++ b/charts/clickhouse-serverless/templates/backup-alerts.yaml
@@ -1,0 +1,199 @@
+{{/*
+Prometheus alerting rules for the backup CronJobs.
+
+Everything here is derived from kube-state-metrics, so the rules see the
+CronJob and Job objects rather than anything the backup scripts report. That is
+deliberate: a backup that stops running produces no output to report on, and an
+alert built on the backup's own telemetry goes quiet at exactly the moment it
+matters.
+*/}}
+{{- define "clickhouse-serverless.backupAlertRules" -}}
+{{- $fullname := include "clickhouse-serverless.fullname" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- $mon := .Values.backup.monitoring -}}
+groups:
+  - name: {{ $fullname }}-backups
+    rules:
+    {{- range $target := $mon.targets }}
+    {{- $cronjob := printf "%s-%s" $fullname $target.cronjob }}
+    {{- $hours := $target.staleAfterHours | default 26 }}
+    {{- $seconds := mulf $hours 3600 | int64 }}
+    {{- $sel := printf "namespace=%q, cronjob=%q" $ns $cronjob }}
+
+      # Fires when this backup has no successful run inside its window, and also
+      # when it has never had one. The second case needs its own branch: a
+      # CronJob that has never succeeded has no
+      # kube_cronjob_status_last_successful_time series at all, so the
+      # subtraction below produces an empty vector and would never alert. That
+      # is the exact shape of a backup that was broken from the day it was
+      # deployed. The branch is gated on the CronJob being older than the window
+      # so a fresh install does not alert before its first run is due.
+      - alert: ClickHouseBackupStale
+        expr: |-
+          (
+            time() - max by (namespace, cronjob) (
+              kube_cronjob_status_last_successful_time{ {{- $sel }} }
+            ) > {{ $seconds }}
+          )
+          or
+          (
+            (
+              time() - max by (namespace, cronjob) (
+                kube_cronjob_created{ {{- $sel }} }
+              ) > {{ $seconds }}
+            )
+            unless
+            max by (namespace, cronjob) (
+              kube_cronjob_status_last_successful_time{ {{- $sel }} }
+            )
+          )
+        for: {{ $mon.for | default "15m" | quote }}
+        labels:
+          severity: critical
+          backup: {{ $target.name | quote }}
+          cronjob: {{ $cronjob | quote }}
+          {{- with $mon.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: {{ printf "ClickHouse %s backup has no successful run in %vh" $target.name $hours | quote }}
+          description: >-
+            CronJob {{ $cronjob }} in namespace {{ $ns }} last completed successfully
+            {{ `{{ $value | humanizeDuration }}` }} ago, past its {{ $hours }}h window.
+            If this backup has never succeeded at all, that figure is the age of the
+            CronJob itself. Either way there is no restorable {{ $target.name }} backup
+            from within the window, so the recovery point is older than intended.
+            Check the CronJob and its most recent Job with
+            `kubectl -n {{ $ns }} describe cronjob {{ $cronjob }}` and
+            `kubectl -n {{ $ns }} logs job/<most-recent-job>`.
+          {{- with $mon.runbookUrl }}
+          runbook_url: {{ . | quote }}
+          {{- end }}
+
+      # The fast signal. Scoped to Jobs created inside the staleness window,
+      # because failed Job objects are retained until a newer failure evicts
+      # them and an unscoped version would keep firing on a failure from months
+      # ago. Reads the Job's Failed condition rather than kube_job_status_failed,
+      # which counts failed pods and is non-zero for a Job that later succeeded
+      # on retry.
+      - alert: ClickHouseBackupJobFailed
+        expr: |-
+          count by (namespace) (
+            (kube_job_failed{namespace={{ $ns | quote }}, condition="true"} == 1)
+            and on (namespace, job_name)
+            (time() - kube_job_created{namespace={{ $ns | quote }}} < {{ $seconds }})
+            and on (namespace, job_name)
+            (kube_job_owner{namespace={{ $ns | quote }}, owner_kind="CronJob", owner_name={{ $cronjob | quote }}} == 1)
+          ) > 0
+        for: {{ $mon.for | default "15m" | quote }}
+        labels:
+          severity: warning
+          backup: {{ $target.name | quote }}
+          cronjob: {{ $cronjob | quote }}
+          {{- with $mon.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: {{ printf "ClickHouse %s backup job failed" $target.name | quote }}
+          description: >-
+            {{ `{{ $value }}` }} recent Job(s) owned by CronJob {{ $cronjob }} in
+            namespace {{ $ns }} ended with a Failed condition. The backup itself is
+            not yet outside its {{ $hours }}h window, so this is the early warning:
+            fix it before ClickHouseBackupStale escalates. Get the reason with
+            `kubectl -n {{ $ns }} logs job/<most-recent-job>`.
+          {{- with $mon.runbookUrl }}
+          runbook_url: {{ . | quote }}
+          {{- end }}
+
+      # A suspended backup never runs and never fails, so nothing else here
+      # would notice until the staleness window elapsed. Suspension is usually
+      # deliberate and temporary, which is exactly why it gets forgotten.
+      - alert: ClickHouseBackupCronJobSuspended
+        expr: |-
+          max by (namespace, cronjob) (
+            kube_cronjob_spec_suspend{ {{- $sel }} }
+          ) > 0
+        for: {{ $mon.for | default "15m" | quote }}
+        labels:
+          severity: warning
+          backup: {{ $target.name | quote }}
+          cronjob: {{ $cronjob | quote }}
+          {{- with $mon.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: {{ printf "ClickHouse %s backup CronJob is suspended" $target.name | quote }}
+          description: >-
+            CronJob {{ $cronjob }} in namespace {{ $ns }} has spec.suspend set, so it
+            is not scheduling runs and no {{ $target.name }} backup is being taken.
+            Resume it with
+            `kubectl -n {{ $ns }} patch cronjob {{ $cronjob }} -p '{"spec":{"suspend":false}}'`
+            or remove the backup from backup.monitoring.targets if it is retired.
+          {{- with $mon.runbookUrl }}
+          runbook_url: {{ . | quote }}
+          {{- end }}
+
+      # Every other rule here is written against series that disappear when the
+      # CronJob does. Deleting the CronJob, or losing kube-state-metrics, would
+      # therefore resolve all of them and leave the backup unwatched in silence.
+      # This is the rule that makes that state noisy instead.
+      - alert: ClickHouseBackupCronJobMissing
+        expr: absent(kube_cronjob_info{ {{- $sel }} })
+        for: {{ $mon.absentFor | default "30m" | quote }}
+        labels:
+          severity: critical
+          backup: {{ $target.name | quote }}
+          cronjob: {{ $cronjob | quote }}
+          {{- with $mon.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: {{ printf "ClickHouse %s backup CronJob is not reporting" $target.name | quote }}
+          description: >-
+            No kube_cronjob_info series for {{ $cronjob }} in namespace {{ $ns }}.
+            Either the CronJob was deleted, or kube-state-metrics is down or no
+            longer being scraped. The first means backups stopped; the second means
+            every other backup alert has gone blind. Confirm with
+            `kubectl -n {{ $ns }} get cronjob {{ $cronjob }}`.
+          {{- with $mon.runbookUrl }}
+          runbook_url: {{ . | quote }}
+          {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- if and .Values.backup.enabled .Values.backup.monitoring.enabled }}
+{{- $fullname := include "clickhouse-serverless.fullname" . }}
+{{- if not .Values.backup.monitoring.targets }}
+{{- fail "backup.monitoring.enabled is true but backup.monitoring.targets is empty: nothing would be watched" }}
+{{- end }}
+{{- if .Values.backup.monitoring.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $fullname }}-backup-alerts
+  labels:
+    {{- include "clickhouse-serverless.selectorLabels" . | nindent 4 }}
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+    {{- with .Values.backup.monitoring.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- include "clickhouse-serverless.backupAlertRules" . | nindent 2 }}
+{{- else }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-backup-alerts
+  labels:
+    {{- include "clickhouse-serverless.selectorLabels" . | nindent 4 }}
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+    {{- with .Values.backup.monitoring.configMapLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  backup-alerts.rules.yml: |
+    {{- include "clickhouse-serverless.backupAlertRules" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/clickhouse-serverless/templates/backup-alerts.yaml
+++ b/charts/clickhouse-serverless/templates/backup-alerts.yaml
@@ -15,7 +15,13 @@ groups:
   - name: {{ $fullname }}-backups
     rules:
     {{- range $target := $mon.targets }}
-    {{- $cronjob := printf "%s-%s" $fullname $target.cronjob }}
+    {{- if and $target.cronjob $target.cronjobName }}
+    {{- fail (printf "backup.monitoring.targets[%s]: set either cronjob (suffix after the release fullname) or cronjobName (exact), not both" $target.name) }}
+    {{- end }}
+    {{- if not (or $target.cronjob $target.cronjobName) }}
+    {{- fail (printf "backup.monitoring.targets[%s]: needs cronjob (suffix after the release fullname) or cronjobName (exact)" $target.name) }}
+    {{- end }}
+    {{- $cronjob := $target.cronjobName | default (printf "%s-%s" $fullname $target.cronjob) }}
     {{- $hours := $target.staleAfterHours | default 26 }}
     {{- $seconds := mulf $hours 3600 | int64 }}
     {{- $sel := printf "namespace=%q, cronjob=%q" $ns $cronjob }}

--- a/charts/clickhouse-serverless/tests/backup-alerts.sh
+++ b/charts/clickhouse-serverless/tests/backup-alerts.sh
@@ -26,19 +26,19 @@ assert_count() {
 
 echo "--- backup alerting rule assertions ---"
 
-# Two targets x four alerts.
-assert_count "- alert: " 8 "each target should render four alerts"
-assert_count "alert: ClickHouseBackupStale" 2 "every target needs a freshness alert"
-assert_count "alert: ClickHouseBackupJobFailed" 2 "every target needs a failure alert"
-assert_count "alert: ClickHouseBackupCronJobSuspended" 2 "every target needs a suspension alert"
-assert_count "alert: ClickHouseBackupCronJobMissing" 2 "every target needs an absent-metrics alert"
+# Three targets x four alerts.
+assert_count "- alert: " 12 "each target should render four alerts"
+assert_count "alert: ClickHouseBackupStale" 3 "every target needs a freshness alert"
+assert_count "alert: ClickHouseBackupJobFailed" 3 "every target needs a failure alert"
+assert_count "alert: ClickHouseBackupCronJobSuspended" 3 "every target needs a suspension alert"
+assert_count "alert: ClickHouseBackupCronJobMissing" 3 "every target needs an absent-metrics alert"
 
 # The freshness alert must keep its second branch. Without it a CronJob that has
 # never once succeeded has no kube_cronjob_status_last_successful_time series,
 # the subtraction yields an empty vector, and the backup is silently unwatched
 # for as long as it stays broken.
 assert_contains "kube_cronjob_created{" "freshness alert lost its never-succeeded branch"
-assert_count "unless" 2 "freshness alert lost its never-succeeded branch"
+assert_count "unless" 3 "freshness alert lost its never-succeeded branch"
 
 # The failure alert must stay scoped to recently created Jobs. Failed Job
 # objects are retained until a newer failure evicts them, so an unscoped version
@@ -50,26 +50,59 @@ assert_contains "kube_job_created{" "failure alert is not scoped to recent Jobs"
 assert_contains 'kube_job_failed{namespace="clickhouse", condition="true"}' \
   "failure alert should read the Job Failed condition"
 
-# Names are built from the release fullname, so they track the CronJobs.
+# A `cronjob` target is a suffix, so the release fullname is prepended.
 assert_contains 'cronjob="alert-test-clickhouse-backup-full"' "full backup target not wired to its CronJob"
 assert_contains 'cronjob="alert-test-clickhouse-backup-incremental"' "incremental target not wired to its CronJob"
+
+# A `cronjobName` target is exact, so a CronJob this chart does not create can
+# still be watched. Prefixing it would silently select a CronJob that does not
+# exist, and ClickHouseBackupCronJobMissing would then fire forever.
+assert_contains 'cronjob="acme-ebs-snapshotter"' "externally managed target should be matched by exact name"
+if grep -qF 'alert-test-clickhouse-acme-ebs-snapshotter' <<<"$RENDERED"; then
+  fail "cronjobName target should not have the release fullname prepended"
+fi
 
 # Thresholds come from staleAfterHours: 26h and 3h.
 assert_contains "> 93600" "full backup should go stale after 26h"
 assert_contains "> 10800" "incremental backup should go stale after 3h"
 
 # Every alert carries a runbook and the configured routing labels.
-assert_count "runbook_url:" 8 "every alert needs a runbook_url"
-assert_count "route: page" 8 "additionalLabels should reach every alert"
+assert_count "runbook_url:" 12 "every alert needs a runbook_url"
+assert_count "route: page" 12 "additionalLabels should reach every alert"
 
-# Off by default, and off whenever backups themselves are off.
+# The PrometheusRule output mode carries the same rules, just a different kind.
+PROM_RULE="$(helm template "$RELEASE" . -f tests/values-backup-alerts.yaml \
+  --namespace clickhouse --set backup.monitoring.prometheusRule.enabled=true \
+  --show-only templates/backup-alerts.yaml)"
+grep -qF "kind: PrometheusRule" <<<"$PROM_RULE" || fail "prometheusRule mode did not render a PrometheusRule"
+if grep -qF "kind: ConfigMap" <<<"$PROM_RULE"; then
+  fail "prometheusRule mode should not also render a ConfigMap"
+fi
+[ "$(grep -cF -- "- alert: " <<<"$PROM_RULE")" = "12" ] || fail "prometheusRule mode lost alerts"
+
+# Mutually exclusive naming: setting both, or neither, is a render-time error.
+for bad in \
+  "--set backup.monitoring.targets[0].cronjobName=x" \
+  "--set-string backup.monitoring.targets[0].cronjob= --set backup.monitoring.targets[0].cronjobName=" ; do
+  # shellcheck disable=SC2086
+  if helm template "$RELEASE" . -f tests/values-backup-alerts.yaml $bad >/dev/null 2>&1; then
+    fail "target naming should be rejected ($bad)"
+  fi
+done
+
+# Off by default, and off whenever backups themselves are off. Rendering the
+# whole chart rather than --show-only, so this asserts on the manifests that
+# come out instead of on how helm happens to report an empty selection.
 for args in \
   "--set backup.enabled=true --set backup.monitoring.enabled=false" \
   "--set backup.enabled=false --set backup.monitoring.enabled=true" ; do
   # shellcheck disable=SC2086
-  if helm template "$RELEASE" . -f tests/values-backup-alerts.yaml $args \
-      --show-only templates/backup-alerts.yaml >/dev/null 2>&1; then
+  disabled="$(helm template "$RELEASE" . -f tests/values-backup-alerts.yaml $args)"
+  if grep -qF "$RELEASE-clickhouse-backup-alerts" <<<"$disabled"; then
     fail "backup alerts rendered when they should not have ($args)"
+  fi
+  if grep -qF "alert: ClickHouseBackup" <<<"$disabled"; then
+    fail "backup alert rules leaked into another manifest ($args)"
   fi
 done
 

--- a/charts/clickhouse-serverless/tests/backup-alerts.sh
+++ b/charts/clickhouse-serverless/tests/backup-alerts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Asserts the properties of the rendered backup alerting rules that a
+# well-meaning simplification would quietly remove. Pure `helm template`, no
+# cluster required.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$CHART_DIR"
+
+RELEASE="alert-test"
+RENDERED="$(helm template "$RELEASE" . -f tests/values-backup-alerts.yaml \
+  --namespace clickhouse --show-only templates/backup-alerts.yaml)"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+assert_contains() {
+  local needle="$1" what="$2"
+  grep -qF -- "$needle" <<<"$RENDERED" || fail "$what (missing: $needle)"
+}
+
+assert_count() {
+  local needle="$1" want="$2" what="$3" got
+  got="$(grep -cF -- "$needle" <<<"$RENDERED" || true)"
+  [ "$got" = "$want" ] || fail "$what (expected $want occurrences of '$needle', got $got)"
+}
+
+echo "--- backup alerting rule assertions ---"
+
+# Two targets x four alerts.
+assert_count "- alert: " 8 "each target should render four alerts"
+assert_count "alert: ClickHouseBackupStale" 2 "every target needs a freshness alert"
+assert_count "alert: ClickHouseBackupJobFailed" 2 "every target needs a failure alert"
+assert_count "alert: ClickHouseBackupCronJobSuspended" 2 "every target needs a suspension alert"
+assert_count "alert: ClickHouseBackupCronJobMissing" 2 "every target needs an absent-metrics alert"
+
+# The freshness alert must keep its second branch. Without it a CronJob that has
+# never once succeeded has no kube_cronjob_status_last_successful_time series,
+# the subtraction yields an empty vector, and the backup is silently unwatched
+# for as long as it stays broken.
+assert_contains "kube_cronjob_created{" "freshness alert lost its never-succeeded branch"
+assert_count "unless" 2 "freshness alert lost its never-succeeded branch"
+
+# The failure alert must stay scoped to recently created Jobs. Failed Job
+# objects are retained until a newer failure evicts them, so an unscoped version
+# fires forever on a months-old failure and gets muted.
+assert_contains "kube_job_created{" "failure alert is not scoped to recent Jobs"
+
+# Reads the Job's Failed condition, not the failed-pod counter, which is
+# non-zero for a Job that succeeded on retry.
+assert_contains 'kube_job_failed{namespace="clickhouse", condition="true"}' \
+  "failure alert should read the Job Failed condition"
+
+# Names are built from the release fullname, so they track the CronJobs.
+assert_contains 'cronjob="alert-test-clickhouse-backup-full"' "full backup target not wired to its CronJob"
+assert_contains 'cronjob="alert-test-clickhouse-backup-incremental"' "incremental target not wired to its CronJob"
+
+# Thresholds come from staleAfterHours: 26h and 3h.
+assert_contains "> 93600" "full backup should go stale after 26h"
+assert_contains "> 10800" "incremental backup should go stale after 3h"
+
+# Every alert carries a runbook and the configured routing labels.
+assert_count "runbook_url:" 8 "every alert needs a runbook_url"
+assert_count "route: page" 8 "additionalLabels should reach every alert"
+
+# Off by default, and off whenever backups themselves are off.
+for args in \
+  "--set backup.enabled=true --set backup.monitoring.enabled=false" \
+  "--set backup.enabled=false --set backup.monitoring.enabled=true" ; do
+  # shellcheck disable=SC2086
+  if helm template "$RELEASE" . -f tests/values-backup-alerts.yaml $args \
+      --show-only templates/backup-alerts.yaml >/dev/null 2>&1; then
+    fail "backup alerts rendered when they should not have ($args)"
+  fi
+done
+
+echo "OK"

--- a/charts/clickhouse-serverless/tests/values-backup-alerts.yaml
+++ b/charts/clickhouse-serverless/tests/values-backup-alerts.yaml
@@ -34,3 +34,7 @@ backup:
       - name: incremental
         cronjob: backup-incremental
         staleAfterHours: 3
+      # Managed outside this chart, so it is named exactly and gets no prefix.
+      - name: ebs-snapshot
+        cronjobName: acme-ebs-snapshotter
+        staleAfterHours: 26

--- a/charts/clickhouse-serverless/tests/values-backup-alerts.yaml
+++ b/charts/clickhouse-serverless/tests/values-backup-alerts.yaml
@@ -1,0 +1,36 @@
+# Renders the backup alerting rules, which are off by default and so are not
+# covered by values-single.yaml or values-replicated.yaml. Exercises both a
+# CronJob shipped by this chart and one that is not, since the alerts are
+# expected to watch any CronJob in the release namespace.
+image:
+  tag: "next"
+  pullPolicy: Never
+replicas: 1
+memory: 1Gi
+cpu: "500m"
+storage:
+  size: 1Gi
+
+auth:
+  password: "e2etest"
+autogen:
+  enabled: true
+
+objectStorage:
+  bucket: "example-backups"
+  region: "eu-central-1"
+
+backup:
+  enabled: true
+  monitoring:
+    enabled: true
+    runbookUrl: "https://github.com/langwatch/langwatch/blob/main/dev/docs/runbooks/clickhouse-backup-alerts.md"
+    additionalLabels:
+      route: page
+    targets:
+      - name: full
+        cronjob: backup-full
+        staleAfterHours: 26
+      - name: incremental
+        cronjob: backup-incremental
+        staleAfterHours: 3

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -99,6 +99,9 @@ backup:
     #   name           label used in alert text and on the `backup` label
     #   cronjob        CronJob name suffix; the release fullname is prepended,
     #                  so `backup-full` matches `<release>-clickhouse-backup-full`
+    #   cronjobName    exact CronJob name, for a CronJob this chart does not
+    #                  create and whose name does not start with the release
+    #                  fullname. Mutually exclusive with `cronjob`.
     #   staleAfterHours  hours without a successful run before the backup counts
     #                  as broken. Keep it above two scheduling intervals so one
     #                  retried run does not page.

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -50,6 +50,69 @@ backup:
   incremental:
     schedule: "0 * * * *"          # every hour
 
+  # Alerting on backup freshness, rendered as Prometheus rules.
+  #
+  # The condition worth paging on is "no recent successful backup", which is not
+  # the same as "a job reported an error". A CronJob that is suspended, deleted,
+  # or silently rescheduled emits no failure event at all, so a failure-only
+  # alert stays quiet while backups stop happening. Every target below therefore
+  # gets a freshness alert as the primary signal; the failure alert is an extra,
+  # faster one that fires within a scrape of a bad run instead of waiting out the
+  # staleness window.
+  #
+  # Requires kube-state-metrics to be scraped by the Prometheus that loads these
+  # rules. Every expression is built from kube_cronjob_* and kube_job_* series;
+  # the chart adds no exporter of its own.
+  monitoring:
+    enabled: false
+
+    # Rendered into every alert as the runbook_url annotation. An alert whose
+    # recipient has nowhere to go gets muted, so this is worth setting.
+    runbookUrl: ""
+
+    # Merged into every alert's labels. Use it for Alertmanager or Grafana
+    # routing keys, e.g. {route: page, team: infra}.
+    additionalLabels: {}
+
+    # How long a backup may look broken before the alert fires. Applies to the
+    # freshness, suspension, and failure alerts.
+    for: "15m"
+
+    # How long the CronJob's metrics may be missing entirely before alerting.
+    # Longer than `for` because a kube-state-metrics restart briefly drops them.
+    absentFor: "30m"
+
+    # Emit a PrometheusRule instead of a plain ConfigMap. Needs the
+    # prometheus-operator CRDs; without them the manifest is rejected at install.
+    prometheusRule:
+      enabled: false
+      # Extra labels on the PrometheusRule object, for the operator's ruleSelector.
+      labels: {}
+
+    # Labels on the rules ConfigMap, for a rules sidecar or a Prometheus
+    # configmap mount to discover it.
+    configMapLabels:
+      langwatch.ai/prometheus-rules: "true"
+
+    # One entry per backup that has to stay fresh.
+    #
+    #   name           label used in alert text and on the `backup` label
+    #   cronjob        CronJob name suffix; the release fullname is prepended,
+    #                  so `backup-full` matches `<release>-clickhouse-backup-full`
+    #   staleAfterHours  hours without a successful run before the backup counts
+    #                  as broken. Keep it above two scheduling intervals so one
+    #                  retried run does not page.
+    #
+    # A backup mechanism that is not a CronJob in this namespace has no
+    # kube-state-metrics series and cannot be watched from here; see the runbook.
+    targets:
+      - name: full
+        cronjob: backup-full
+        staleAfterHours: 26        # schedule is every 12h
+      - name: incremental
+        cronjob: backup-incremental
+        staleAfterHours: 3         # schedule is hourly
+
 # Authentication
 auth:
   password: ""         # Used as autogen seed when autogen.enabled=true and this is unset

--- a/dev/docs/runbooks/clickhouse-backup-alerts.md
+++ b/dev/docs/runbooks/clickhouse-backup-alerts.md
@@ -1,0 +1,159 @@
+# ClickHouse backup alerts
+
+> **Why this exists**: the `clickhouse-serverless` chart takes backups on a
+> schedule, and for a long time nothing watched whether they worked. A cross
+> region sync job failed on every single run for 29 consecutive days and was
+> found by accident during unrelated work. These alerts exist so that the state
+> "backups are not happening" cannot be quiet. This page is what the
+> `runbook_url` annotation on each of them points at.
+
+Enable with `backup.monitoring.enabled=true` (see the chart README for the full
+value list). The rules read kube-state-metrics only, so the one prerequisite is
+a Prometheus that scrapes it.
+
+## The four alerts
+
+| Alert | Severity | Means |
+|---|---|---|
+| `ClickHouseBackupStale` | critical | No successful run inside the backup's window, or no successful run ever |
+| `ClickHouseBackupJobFailed` | warning | A Job created inside the window ended with a `Failed` condition |
+| `ClickHouseBackupCronJobSuspended` | warning | `spec.suspend` is set, so nothing is being scheduled |
+| `ClickHouseBackupCronJobMissing` | critical | No `kube_cronjob_info` series: the CronJob is gone, or kube-state-metrics is |
+
+`ClickHouseBackupStale` is the one that matters. The other three are there to
+name a cause faster than the staleness window elapses, or, in the case of
+`CronJobMissing`, to make sure the absence of data is itself an alert.
+
+Every alert carries `backup` and `cronjob` labels, so the alert text names which
+backup is broken and which object to look at.
+
+## Why freshness, not failure
+
+A failure alert answers "did a run report an error". That is not the question.
+The question is "is there a restorable backup from within the window", and
+several ways of losing backups produce no failure event at all:
+
+- the CronJob is suspended, so no Job is ever created
+- the CronJob is deleted, along with every metric a failure alert would read
+- the schedule is edited to something that fires rarely, or never
+- the Job succeeds while the backup it produced is empty or partial
+
+The first three are covered here. The fourth is not; see the gaps section.
+
+The freshness rule has two branches, and the second one is the important one:
+
+```promql
+time() - max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{...}) > N
+or
+(time() - max by (namespace, cronjob) (kube_cronjob_created{...}) > N)
+  unless max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{...})
+```
+
+A CronJob that has **never** succeeded has no
+`kube_cronjob_status_last_successful_time` series at all. The first branch is a
+subtraction against an empty vector, which is empty, so on its own it would stay
+quiet forever for a backup that was broken from the day it shipped. That is
+precisely the shape of the incident this page exists for. The second branch
+catches it by comparing against the CronJob's own age instead, gated so a fresh
+install does not alert before its first run is due.
+
+`tests/backup-alerts.sh` asserts both branches survive.
+
+## Responding to `ClickHouseBackupStale`
+
+The alert names the CronJob. Work down this list.
+
+**1. Is the CronJob scheduling at all?**
+
+```bash
+kubectl -n <namespace> get cronjob <cronjob>
+```
+
+`SUSPEND=True` means someone paused it. `LAST SCHEDULE=<none>` or a stale
+timestamp means the schedule is wrong or the controller is not firing it.
+Compare `SCHEDULE` against what the chart's values say it should be; a manual
+`kubectl patch` that never got folded back into the release is a common cause.
+
+**2. What did the most recent runs do?**
+
+```bash
+kubectl -n <namespace> get jobs --sort-by=.metadata.creationTimestamp | tail
+kubectl -n <namespace> logs job/<most-recent-job> --tail=200
+```
+
+`successfulJobsHistoryLimit`/`failedJobsHistoryLimit` are 1 on these CronJobs, so
+only the newest of each survives. If the failure is older than that, the logs are
+already gone and the next scheduled run is the fastest way to reproduce it.
+
+**3. Is it failing for a reason the logs bury?**
+
+Backup scripts that pipe a transfer tool's progress output produce megabytes of
+carriage-return spam, and a failure thousands of lines up does not appear at the
+tail. Search the whole log rather than reading the end of it:
+
+```bash
+kubectl -n <namespace> logs job/<most-recent-job> | grep -iE 'error|denied|failed|fatal'
+```
+
+A script running under `set -e` aborts at the first failure, so its final
+"completed" line never prints. The absence of a success line is a signal; the
+presence of a last line that looks like normal output is not.
+
+**4. Force a run to test a fix.**
+
+```bash
+kubectl -n <namespace> create job --from=cronjob/<cronjob> <cronjob>-manual-$(date +%s)
+```
+
+Delete the manual Job afterwards so it does not sit in the history.
+
+## Responding to `ClickHouseBackupCronJobMissing`
+
+Two very different causes, and the alert cannot tell them apart:
+
+```bash
+kubectl -n <namespace> get cronjob <cronjob>     # exists?
+kubectl -n <namespace> get pods -l app.kubernetes.io/name=kube-state-metrics -A
+```
+
+If the CronJob is there, kube-state-metrics is down or is no longer being
+scraped, and **every backup alert is blind for as long as that lasts**. Treat it
+with the same urgency as a missing backup, because you no longer know whether
+backups are running.
+
+If the CronJob is genuinely gone, either the release was deployed with
+`backup.enabled=false`, or the target is stale: a backup that was deliberately
+retired should be removed from `backup.monitoring.targets` in the same change
+that removes the CronJob, not left to alert.
+
+## Tuning
+
+`staleAfterHours` should be at least two scheduling intervals. One interval
+alerts on any single retried run; two plus a margin means a genuine gap. The
+defaults are 26h for a 12-hourly full backup and 3h for an hourly incremental.
+
+If an alert is noisy, raise the window or fix the backup. Do not silence it: a
+muted backup alert is indistinguishable from the state this page exists to
+prevent.
+
+## What these alerts do not cover
+
+Worth knowing, because it is tempting to read a green board as "backups are
+fine".
+
+- **Backup contents.** The alerts prove a Job reached a successful exit, not
+  that what it wrote is complete or restorable. A backup process that reports
+  success while silently skipping most of its data looks healthy here. Only a
+  restore test proves restorability.
+- **Restore.** Nothing here exercises the restore path. A backup that has never
+  been restored from is an untested backup.
+- **Retention and lifecycle.** If an object lifecycle rule expires backups
+  sooner than intended, or an incremental outlives the full backup it is based
+  on, every CronJob still succeeds and every alert here stays quiet.
+- **Non-CronJob backup mechanisms.** Anything that is not a Kubernetes CronJob
+  in the release namespace, such as a cloud-provider snapshot policy, publishes
+  no kube-state-metrics series and cannot be watched from these rules. It needs
+  a freshness signal from its own provider.
+- **The scrape path.** `ClickHouseBackupCronJobMissing` catches
+  kube-state-metrics disappearing, but if Prometheus itself stops evaluating
+  rules, nothing here notices. That belongs to whatever watches Prometheus.


### PR DESCRIPTION
## Why

The `langwatch-prod-clickhouse-backup-dr-sync` cronjob failed on every single run for 29 consecutive days and nobody found out. It was noticed by accident during unrelated work.

The specific job is being removed in a separate PR. The bug this PR fixes is the other half: nothing was watching, so a multi-week backup outage was silent. That has to be impossible regardless of what the backup design ends up being.

## What alerting existed before

For this chart, nothing. `charts/clickhouse-serverless` schedules full, incremental, and restore-template CronJobs and ships no monitoring of any kind. `charts/langwatch` sets `prometheus.alertmanager.enabled: false` with the comment "LangWatch does not use Prometheus alerting", and there are no alerting rules, `PrometheusRule` manifests, or `ServiceMonitor`s anywhere under `charts/`.

I also checked what actually protects the production cluster, and the honest answer is worse than "nothing in the chart". Findings are in the last section, because they need a companion change in the infra repo that is out of scope here.

## What this adds

Prometheus alerting rules for the backup CronJobs, off by default, enabled with `backup.monitoring.enabled=true`. Every expression is built from kube-state-metrics series, so the chart adds no exporter and no sidecar; a Prometheus that scrapes kube-state-metrics is the only prerequisite. Renders as a plain rules ConfigMap by default, or as a `PrometheusRule` for operator installs.

Four alerts per watched backup:

| Alert | Severity | Fires when |
|---|---|---|
| `ClickHouseBackupStale` | critical | No successful run inside the window, **or no successful run ever** |
| `ClickHouseBackupJobFailed` | warning | A Job created inside the window ended with a `Failed` condition |
| `ClickHouseBackupCronJobSuspended` | warning | `spec.suspend` is set, so nothing is being scheduled |
| `ClickHouseBackupCronJobMissing` | critical | No `kube_cronjob_info` series: the CronJob is gone, or kube-state-metrics is |

Alerts are actionable by construction. Each carries `backup` and `cronjob` labels, an annotation naming which backup is broken and how long since its last success (`{{ $value | humanizeDuration }}`), the exact `kubectl` commands to run next, and a `runbook_url` pointing at [`dev/docs/runbooks/clickhouse-backup-alerts.md`](dev/docs/runbooks/clickhouse-backup-alerts.md), which is new here.

### Freshness, not just failure

The primary rule is "no recent successful backup", which is a stricter condition than "a job reported an error". Several ways of losing backups produce no failure event at all: the CronJob is suspended, or deleted, or its schedule is quietly edited to something that fires rarely. A failure-only alert stays quiet through all of those while backups stop happening.

The rule needs two branches, and the second one is the one that would have caught this incident:

```promql
time() - max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{...}) > N
or
(time() - max by (namespace, cronjob) (kube_cronjob_created{...}) > N)
  unless max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{...})
```

A CronJob that has **never** succeeded has no `kube_cronjob_status_last_successful_time` series at all. The first branch is then a subtraction against an empty vector, which is empty, so on its own it would stay quiet forever for a backup that was broken from the day it shipped. That is exactly the shape of `dr-sync`, which has no such series in prod today. The second branch compares against the CronJob's own age instead, gated so a fresh install does not alert before its first run is due.

Two smaller decisions worth flagging, both anti-noise:

- The failure alert reads the Job's `Failed` **condition**, not `kube_job_status_failed`, which counts failed *pods* and is non-zero for a Job that succeeded on retry.
- It is scoped to Jobs created inside the staleness window. Failed Job objects are retained until a newer failure evicts them, and prod currently holds a failed Job from 106 days ago; an unscoped rule would fire on it forever and get muted.

## Verification

Rendered the rules with prod-shaped names (`helm template langwatch-prod -n clickhouse`) and evaluated all 12 expressions against the live prod Prometheus, read-only. `dr-sync` is included as a target here purely to demonstrate the incident being caught:

| Alert | Backup | Result |
|---|---|---|
| all four | full | quiet |
| all four | incremental | quiet |
| `ClickHouseBackupStale` | dr-sync | **FIRING**, value 10,792,944s (124.9 days, the CronJob's full age, because it has never once succeeded) |
| `ClickHouseBackupJobFailed` | dr-sync | **FIRING** |
| `ClickHouseBackupCronJobSuspended` / `Missing` | dr-sync | quiet |

So the rules would have fired 26 hours after `dr-sync` was first deployed, and stay quiet on the two backups that are actually healthy.

`tests/backup-alerts.sh` runs in the existing `make template` CI job (no cluster needed) and locks in the properties a well-meaning simplification would remove, in particular that the never-succeeded branch and the failure alert's recency scoping both survive.

## Failure modes covered, and not

Covered: a run that fails; a run that never starts; a suspended CronJob; a deleted CronJob; a silently edited schedule; a backup that has never succeeded even once; kube-state-metrics dying, which would otherwise resolve every other rule into silence.

**Not** covered, and worth stating plainly because a green board should not be read as "backups are fine":

- **Backup contents.** These prove a Job exited successfully, not that what it wrote is complete or restorable. A process that reports success while silently skipping most of its data looks healthy here. This is not hypothetical: `dr-sync` produced 28 daily copies that were each missing 96.9% of their bytes, and every one of those runs *did* exit non-zero, so it happens to be caught, but a variant that swallowed its exit code would not be.
- **Restore.** Nothing here exercises the restore path.
- **Retention and lifecycle.** An object lifecycle rule expiring backups early, or an incremental outliving the full backup it is based on, keeps every CronJob green.
- **Non-CronJob backup mechanisms.** Anything that is not a Kubernetes CronJob in the release namespace publishes no kube-state-metrics series and cannot be watched from these rules.
- **Prometheus itself.** If rule evaluation stops, nothing here notices.

## Deployment Impact

**Default `helm install` with no overrides: nothing changes.** `backup.monitoring.enabled` defaults to `false`, and the template is additionally gated on `backup.enabled`, which is itself `false` by default. With either off, `templates/backup-alerts.yaml` renders no objects at all. Existing releases upgrade to this chart version with an empty diff unless an operator opts in.

**Env vars:** none added or changed.

**Helm values added** (all under `backup.monitoring`, a new block; no existing key changed or removed, so this is backward compatible): `enabled`, `runbookUrl`, `additionalLabels`, `for`, `absentFor`, `prometheusRule.enabled`, `prometheusRule.labels`, `configMapLabels`, `targets`. Defaults and meanings are in the chart README.

**When an operator opts in**, the chart renders exactly one extra object: a ConfigMap named `<release>-clickhouse-backup-alerts` holding a Prometheus rule group, or, with `prometheusRule.enabled=true`, a `PrometheusRule` of the same name. No new workload, container, port, RBAC rule, ServiceAccount, or PVC. No change to the ClickHouse StatefulSet, the backup CronJobs, or any existing object.

**Prerequisites for the alerts to actually evaluate:** a Prometheus that scrapes kube-state-metrics, plus a way for it to load the rules. The ConfigMap form assumes a rules sidecar or a configmap mount and carries the `langwatch.ai/prometheus-rules: "true"` label for discovery; the `PrometheusRule` form requires the prometheus-operator CRDs and will be rejected at install time if they are absent. Neither is created by this chart, so enabling `backup.monitoring` on a cluster without one renders the rules but nothing evaluates them. The chart's own bundled Prometheus (`charts/langwatch`) has kube-state-metrics disabled by default and is not wired to these rules.

**Fail-fast:** enabling `backup.monitoring` with an empty `targets` list stops the render with a clear message rather than shipping a rule group that watches nothing.

**BYOC dataplane:** no impact. This adds no egress, no control-plane call, and no new image; the rules are inert YAML evaluated by the customer's own Prometheus if they choose to enable them.

**Rollback:** set `backup.monitoring.enabled=false` and upgrade; the ConfigMap or PrometheusRule is removed and nothing else is touched.

## Coordination

`backup-cronjobs.yaml` and the EBS snapshot work belong to langwatch/langwatch-saas#858 and are untouched here; the only shared file is `values.yaml`, where this adds a self-contained `backup.monitoring` block.

That PR is now up, and it resolves the open question in this one: **the EBS snapshot mechanism is an AWS Data Lifecycle Manager policy, not a Kubernetes CronJob.** So it publishes no kube-state-metrics series and these rules cannot see it, exactly the case flagged below. It is covered instead by two CloudWatch alarms in that PR (`SnapshotsCreateFailed` and `ResourcesTargeted` with missing data treated as breaching), which is the right place for it. I have reviewed those there.

Nothing is needed here for it, and nobody should later assume this chart is watching volume snapshots.

The `targets` list is still the extension point for any backup that *is* a CronJob, with no template change:

```yaml
backup:
  monitoring:
    targets:
      # created by this chart: suffix, release fullname is prepended
      - {name: full, cronjob: backup-full, staleAfterHours: 26}
      # created elsewhere: exact name, no prefix added
      - {name: ebs-snapshot, cronjobName: acme-ebs-snapshotter, staleAfterHours: 26}
```

`dr-sync` is not referenced anywhere in this chart, so its removal needs no change here.

## Note on the production cluster

Out of scope for this PR, but found while verifying and it should not sit unwritten.

Prod does not deploy these CronJobs from this chart. They come from `kubernetes_cron_job_v1` resources in the infra repo's Terraform, which is also why prod has a `dr-sync` job that this chart has never had. Prod alerting is Grafana-managed, and two backup rules exist there. Both are currently ineffective:

- `ClickHouse Backup Missing` queries `clickhouse_backup_last_success_timestamp_seconds`, an application-side gauge. That series has **zero samples in the last 14 days** in prod, so the expression evaluates to empty and the alert can never fire.
- Its companion `ClickHouse Backup Reporting Absent` **is firing right now**, as a warning on an 8h repeat, and has been for some time.
- Neither could ever have covered `dr-sync`, which runs `aws s3 sync` and never touches ClickHouse's `system.backup_log`, so nothing updates that gauge for it.
- The remediation text on the live alert names cronjobs that do not exist (`langwatch-prod-backup-full`, missing the `-clickhouse` segment), so a responder following it gets "not found".
- `kube_cronjob_*` and `kube_job_*` are already in prod Prometheus and unused by any alert or dashboard.

Also worth noting: the full backup job has failed silently too, not only `dr-sync`. Prod shows failed `backup-full` Jobs at roughly 67, 65, 31, 30, and 4 days ago.

I will follow up with a companion PR in the infra repo porting these same expressions into the Grafana rules, since that is what actually protects prod. This PR is the chart-side half and is what every self-hosted install gets.
