### PR TITLE
perf(clickhouse): recent-window partition-hint resolvers + off-loop worker liveness

### DIFF
--- a/langwatch/src/server/app-layer/clients/clickhouse/windowed-read.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/windowed-read.ts
@@ -12,6 +12,20 @@ import { incrementWindowedReadCount } from "~/server/clickhouse/metrics";
 export const DEFAULT_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
 
 /**
+ * Lookback for the recent-first probe that partition-hint RESOLVERS run
+ * before falling back to an unbounded seek.
+ *
+ * The resolvers (`resolveScheduledAtMs`, `resolveTraceOccurredAtMs`) exist to
+ * find the partition-key value that lets the heavy read prune — but without a
+ * bound of their own they walk every weekly partition's index, including
+ * S3-tiered cold ones (measured 0.7–1.2s per call on the worker job paths,
+ * which only ever resolve minutes-old aggregates). 35 days ≈ five weekly
+ * partitions, comfortably on local disk, while the unbounded fallback keeps
+ * old aggregates correct.
+ */
+export const RESOLVER_RECENT_WINDOW_MS = 35 * 24 * 60 * 60 * 1000;
+
+/**
  * The time predicate for one windowed read attempt. A `null` fragment (never a
  * `WindowFragment`) means an unbounded read — no time predicate, the wide scan.
  */

--- a/langwatch/src/server/app-layer/clients/clickhouse/windowed-read.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/windowed-read.ts
@@ -18,10 +18,11 @@ export const DEFAULT_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
  * The resolvers (`resolveScheduledAtMs`, `resolveTraceOccurredAtMs`) exist to
  * find the partition-key value that lets the heavy read prune — but without a
  * bound of their own they walk every weekly partition's index, including
- * S3-tiered cold ones (measured 0.7–1.2s per call on the worker job paths,
- * which only ever resolve minutes-old aggregates). 35 days ≈ five weekly
- * partitions, comfortably on local disk, while the unbounded fallback keeps
- * old aggregates correct.
+ * S3-tiered cold ones — turning a point seek into a cold scan costing whole
+ * seconds. The dominant callers are worker jobs resolving minutes-old
+ * aggregates, but callers may resolve records of any age: 35 days ≈ five
+ * weekly partitions, comfortably on local disk, and anything older pays one
+ * extra probe before the unbounded fallback answers it correctly.
  */
 export const RESOLVER_RECENT_WINDOW_MS = 35 * 24 * 60 * 60 * 1000;
 

--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.resolver-window.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.resolver-window.unit.test.ts
@@ -4,9 +4,8 @@
  * Pins the two-phase partition-hint resolver on `getByEvaluationId`: the
  * ScheduledAt seek must probe the recent window first (local-disk partitions)
  * and only fall back to an unbounded scan when the probe misses. Without the
- * bound the resolver itself walks every weekly partition incl. cold S3 —
- * measured 768ms × 5k calls/45min fleet-wide during the 2026-08-03 queue
- * saturation, on lookups for evaluations scheduled minutes earlier.
+ * bound the resolver itself walks every weekly partition incl. cold S3,
+ * costing whole seconds per lookup for evaluations scheduled minutes earlier.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EvaluationRunClickHouseRepository } from "../evaluation-run.clickhouse.repository";

--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.resolver-window.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.resolver-window.unit.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment node
+ *
+ * Pins the two-phase partition-hint resolver on `getByEvaluationId`: the
+ * ScheduledAt seek must probe the recent window first (local-disk partitions)
+ * and only fall back to an unbounded scan when the probe misses. Without the
+ * bound the resolver itself walks every weekly partition incl. cold S3 —
+ * measured 768ms × 5k calls/45min fleet-wide during the 2026-08-03 queue
+ * saturation, on lookups for evaluations scheduled minutes earlier.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EvaluationRunClickHouseRepository } from "../evaluation-run.clickhouse.repository";
+
+function createCapturingClient(
+  resolverResponses: Array<string | number | null>,
+) {
+  const queries: Array<{
+    query: string;
+    query_params: Record<string, unknown>;
+  }> = [];
+  let resolverCall = 0;
+  const client = {
+    query: vi.fn(async (args: { query: string; query_params: never }) => {
+      queries.push(args);
+      if (args.query.includes("argMax(ScheduledAt")) {
+        const value = resolverResponses[resolverCall] ?? null;
+        resolverCall += 1;
+        return {
+          json: async () => [{ scheduledAtMs: value }],
+        };
+      }
+      // The heavy read: return no rows; this test only cares about the
+      // resolver phases and the partition predicate it produces.
+      return { json: async () => [] };
+    }),
+  };
+  return { client, queries };
+}
+
+describe("EvaluationRunClickHouseRepository ScheduledAt resolver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-03T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("when the evaluation is recent", () => {
+    it("resolves from the windowed probe and never scans unbounded", async () => {
+      const scheduledAtMs = Date.now() - 60_000;
+      const { client, queries } = createCapturingClient([scheduledAtMs]);
+      const repo = new EvaluationRunClickHouseRepository(
+        async () => client as never,
+      );
+
+      await repo.getByEvaluationId({
+        tenantId: "project_test",
+        evaluationId: "eval_recent",
+      });
+
+      const resolverQueries = queries.filter((q) =>
+        q.query.includes("argMax(ScheduledAt"),
+      );
+      expect(resolverQueries).toHaveLength(1);
+      expect(resolverQueries[0]!.query).toContain(
+        "ScheduledAt >= fromUnixTimestamp64Milli({sinceMs:Int64})",
+      );
+      expect(resolverQueries[0]!.query_params).toMatchObject({
+        sinceMs: expect.any(Number),
+      });
+    });
+  });
+
+  describe("when the windowed probe misses", () => {
+    it("falls back to the unbounded seek so old evaluations stay resolvable", async () => {
+      const oldScheduledAtMs = Date.now() - 200 * 24 * 60 * 60 * 1000;
+      const { client, queries } = createCapturingClient([
+        null,
+        oldScheduledAtMs,
+      ]);
+      const repo = new EvaluationRunClickHouseRepository(
+        async () => client as never,
+      );
+
+      await repo.getByEvaluationId({
+        tenantId: "project_test",
+        evaluationId: "eval_old",
+      });
+
+      const resolverQueries = queries.filter((q) =>
+        q.query.includes("argMax(ScheduledAt"),
+      );
+      expect(resolverQueries).toHaveLength(2);
+      expect(resolverQueries[0]!.query).toContain("ScheduledAt >=");
+      expect(resolverQueries[1]!.query).not.toContain("ScheduledAt >=");
+      // The resolved (old) ScheduledAt still reaches the heavy read as a
+      // partition bound.
+      const heavyRead = queries.find((q) => q.query.includes("PREWHERE"));
+      expect(heavyRead?.query).toContain("t.ScheduledAt >=");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@langwatch/observability";
+import { RESOLVER_RECENT_WINDOW_MS } from "~/server/app-layer/clients/clickhouse/windowed-read";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type { WithDateWrites } from "~/server/clickhouse/types";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
@@ -173,20 +174,48 @@ export class EvaluationRunClickHouseRepository
    * `argMax(ScheduledAt, UpdatedAt)` takes the ScheduledAt of the latest
    * version (the same row the dedup keeps). Returns undefined when the
    * evaluation isn't in the table, where the caller stays unbounded.
+   *
+   * Two-phase probe: without a ScheduledAt predicate this seek itself walks
+   * every weekly partition's index — including S3-tiered cold ones — which
+   * measured 768ms avg × 5k calls/45min fleet-wide during the 2026-08-03
+   * saturation (the job paths call this for evaluations scheduled minutes
+   * ago). Probing the recent window first keeps the hot path on local-disk
+   * partitions; only a miss (old or unknown evaluation) pays the unbounded
+   * fallback.
    */
   private async resolveScheduledAtMs(
     tenantId: string,
     evaluationId: string,
   ): Promise<number | undefined> {
+    const recent = await this.queryScheduledAtMs(tenantId, evaluationId, {
+      sinceMs: Date.now() - RESOLVER_RECENT_WINDOW_MS,
+    });
+    if (recent !== undefined) return recent;
+    return this.queryScheduledAtMs(tenantId, evaluationId, {});
+  }
+
+  private async queryScheduledAtMs(
+    tenantId: string,
+    evaluationId: string,
+    { sinceMs }: { sinceMs?: number },
+  ): Promise<number | undefined> {
     const client = await this.resolveClient(tenantId);
+    const windowPredicate =
+      sinceMs !== undefined
+        ? "AND ScheduledAt >= fromUnixTimestamp64Milli({sinceMs:Int64})"
+        : "";
     const result = await client.query({
       query: `
         SELECT toUnixTimestamp64Milli(argMax(ScheduledAt, UpdatedAt)) AS scheduledAtMs
         FROM ${TABLE_NAME}
         WHERE TenantId = {tenantId:String}
           AND EvaluationId = {evaluationId:String}
+          ${windowPredicate}
       `,
-      query_params: { tenantId, evaluationId },
+      query_params:
+        sinceMs !== undefined
+          ? { tenantId, evaluationId, sinceMs }
+          : { tenantId, evaluationId },
       format: "JSONEachRow",
     });
     const rows = (await result.json()) as Array<{

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -176,29 +176,34 @@ export class EvaluationRunClickHouseRepository
    * evaluation isn't in the table, where the caller stays unbounded.
    *
    * Two-phase probe: without a ScheduledAt predicate this seek itself walks
-   * every weekly partition's index — including S3-tiered cold ones — which
-   * measured 768ms avg × 5k calls/45min fleet-wide during the 2026-08-03
-   * saturation (the job paths call this for evaluations scheduled minutes
-   * ago). Probing the recent window first keeps the hot path on local-disk
-   * partitions; only a miss (old or unknown evaluation) pays the unbounded
-   * fallback.
+   * every weekly partition's index — including S3-tiered cold ones — costing
+   * whole seconds per call, while the job paths call it for evaluations
+   * scheduled minutes ago. Probing the recent window first keeps the hot
+   * path on local-disk partitions; only a miss (old or unknown evaluation)
+   * pays the unbounded fallback.
    */
   private async resolveScheduledAtMs(
     tenantId: string,
     evaluationId: string,
   ): Promise<number | undefined> {
-    const recent = await this.queryScheduledAtMs(tenantId, evaluationId, {
+    const recent = await this.queryScheduledAtMs({
+      tenantId,
+      evaluationId,
       sinceMs: Date.now() - RESOLVER_RECENT_WINDOW_MS,
     });
     if (recent !== undefined) return recent;
-    return this.queryScheduledAtMs(tenantId, evaluationId, {});
+    return this.queryScheduledAtMs({ tenantId, evaluationId });
   }
 
-  private async queryScheduledAtMs(
-    tenantId: string,
-    evaluationId: string,
-    { sinceMs }: { sinceMs?: number },
-  ): Promise<number | undefined> {
+  private async queryScheduledAtMs({
+    tenantId,
+    evaluationId,
+    sinceMs,
+  }: {
+    tenantId: string;
+    evaluationId: string;
+    sinceMs?: number;
+  }): Promise<number | undefined> {
     const client = await this.resolveClient(tenantId);
     const windowPredicate =
       sinceMs !== undefined

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.resolver-window.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.resolver-window.unit.test.ts
@@ -4,8 +4,8 @@
  * Pins the two-phase partition-hint resolver behind the hint-less span reads:
  * the trace OccurredAt seek on `trace_summaries` must probe the recent window
  * first and only fall back to an unbounded scan on a miss. Without the bound
- * the resolver walks every weekly partition incl. cold S3 (measured ~0.9s avg
- * during the 2026-08-03 queue saturation, on traces minutes old).
+ * the resolver walks every weekly partition incl. cold S3, costing whole
+ * seconds per lookup for traces that are minutes old.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SpanStorageClickHouseRepository } from "../span-storage.clickhouse.repository";
@@ -68,7 +68,11 @@ describe("SpanStorageClickHouseRepository trace OccurredAt resolver", () => {
 
   describe("when the windowed probe misses", () => {
     it("falls back to the unbounded seek so old traces stay resolvable", async () => {
-      const { client, queries } = createCapturingClient([null, null]);
+      const oldOccurredAtMs = Date.now() - 200 * 24 * 60 * 60 * 1000;
+      const { client, queries } = createCapturingClient([
+        null,
+        oldOccurredAtMs,
+      ]);
       const repo = new SpanStorageClickHouseRepository(
         async () => client as never,
       );
@@ -85,6 +89,20 @@ describe("SpanStorageClickHouseRepository trace OccurredAt resolver", () => {
       expect(resolverQueries).toHaveLength(2);
       expect(resolverQueries[0]!.query).toContain("OccurredAt >=");
       expect(resolverQueries[1]!.query).not.toContain("OccurredAt >=");
+      // The fallback's resolved timestamp must reach the span read as a
+      // partition window centred on the old trace, not just be discarded.
+      const spanRead = queries.find((q) => q.query.includes("SpanId"));
+      expect(spanRead).toBeDefined();
+      expect(spanRead!.query_params).toMatchObject({
+        fromMs: expect.any(Number),
+        toMs: expect.any(Number),
+      });
+      const { fromMs, toMs } = spanRead!.query_params as {
+        fromMs: number;
+        toMs: number;
+      };
+      expect(fromMs).toBeLessThanOrEqual(oldOccurredAtMs);
+      expect(toMs).toBeGreaterThanOrEqual(oldOccurredAtMs);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.resolver-window.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.resolver-window.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment node
+ *
+ * Pins the two-phase partition-hint resolver behind the hint-less span reads:
+ * the trace OccurredAt seek on `trace_summaries` must probe the recent window
+ * first and only fall back to an unbounded scan on a miss. Without the bound
+ * the resolver walks every weekly partition incl. cold S3 (measured ~0.9s avg
+ * during the 2026-08-03 queue saturation, on traces minutes old).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SpanStorageClickHouseRepository } from "../span-storage.clickhouse.repository";
+
+function createCapturingClient(
+  resolverResponses: Array<string | number | null>,
+) {
+  const queries: Array<{
+    query: string;
+    query_params: Record<string, unknown>;
+  }> = [];
+  let resolverCall = 0;
+  const client = {
+    query: vi.fn(async (args: { query: string; query_params: never }) => {
+      queries.push(args);
+      if (args.query.includes("min(OccurredAt)")) {
+        const value = resolverResponses[resolverCall] ?? null;
+        resolverCall += 1;
+        return { json: async () => [{ occurredAtMs: value }] };
+      }
+      return { json: async () => [] };
+    }),
+  };
+  return { client, queries };
+}
+
+describe("SpanStorageClickHouseRepository trace OccurredAt resolver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-03T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("when the trace is recent", () => {
+    it("resolves from the windowed probe and never scans unbounded", async () => {
+      const occurredAtMs = Date.now() - 60_000;
+      const { client, queries } = createCapturingClient([occurredAtMs]);
+      const repo = new SpanStorageClickHouseRepository(
+        async () => client as never,
+      );
+
+      await repo.getSpanByIds({
+        tenantId: "project_test",
+        traceId: "trace_recent",
+        spanId: "span_1",
+      });
+
+      const resolverQueries = queries.filter((q) =>
+        q.query.includes("min(OccurredAt)"),
+      );
+      expect(resolverQueries).toHaveLength(1);
+      expect(resolverQueries[0]!.query).toContain(
+        "OccurredAt >= fromUnixTimestamp64Milli({sinceMs:Int64})",
+      );
+    });
+  });
+
+  describe("when the windowed probe misses", () => {
+    it("falls back to the unbounded seek so old traces stay resolvable", async () => {
+      const { client, queries } = createCapturingClient([null, null]);
+      const repo = new SpanStorageClickHouseRepository(
+        async () => client as never,
+      );
+
+      await repo.getSpanByIds({
+        tenantId: "project_test",
+        traceId: "trace_old",
+        spanId: "span_1",
+      });
+
+      const resolverQueries = queries.filter((q) =>
+        q.query.includes("min(OccurredAt)"),
+      );
+      expect(resolverQueries).toHaveLength(2);
+      expect(resolverQueries[0]!.query).toContain("OccurredAt >=");
+      expect(resolverQueries[1]!.query).not.toContain("OccurredAt >=");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1240,27 +1240,33 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
   /**
    * Two-phase probe: without an OccurredAt predicate this seek walks every
    * weekly partition's index on `trace_summaries` — including S3-tiered cold
-   * ones — even though the worker job paths only ever resolve minutes-old
-   * traces (measured 0.9s avg during the 2026-08-03 saturation). The recent
-   * window keeps the hot path on local-disk partitions; a miss (old trace)
-   * pays the unbounded fallback and stays correct.
+   * ones — costing whole seconds per call, while the worker job paths mostly
+   * resolve minutes-old traces. The recent window keeps the hot path on
+   * local-disk partitions; a miss (old trace) pays the unbounded fallback
+   * and stays correct.
    */
   private async resolveTraceOccurredAtMs(
     tenantId: string,
     traceId: string,
   ): Promise<number | undefined> {
-    const recent = await this.queryTraceOccurredAtMs(tenantId, traceId, {
+    const recent = await this.queryTraceOccurredAtMs({
+      tenantId,
+      traceId,
       sinceMs: Date.now() - RESOLVER_RECENT_WINDOW_MS,
     });
     if (recent !== undefined) return recent;
-    return this.queryTraceOccurredAtMs(tenantId, traceId, {});
+    return this.queryTraceOccurredAtMs({ tenantId, traceId });
   }
 
-  private async queryTraceOccurredAtMs(
-    tenantId: string,
-    traceId: string,
-    { sinceMs }: { sinceMs?: number },
-  ): Promise<number | undefined> {
+  private async queryTraceOccurredAtMs({
+    tenantId,
+    traceId,
+    sinceMs,
+  }: {
+    tenantId: string;
+    traceId: string;
+    sinceMs?: number;
+  }): Promise<number | undefined> {
     const client = await this.resolveClient(tenantId);
     const windowPredicate =
       sinceMs !== undefined

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@langwatch/observability";
 import {
   DEFAULT_PARTITION_WINDOW_MS,
   queryWindowed,
+  RESOLVER_RECENT_WINDOW_MS,
   type WindowFragment,
 } from "~/server/app-layer/clients/clickhouse/windowed-read";
 import { ATTR_KEYS } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
@@ -1236,19 +1237,47 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
    * `trace_summaries` at all (orphan / not-yet-projected), where the read keeps
    * its previous unbounded behaviour.
    */
+  /**
+   * Two-phase probe: without an OccurredAt predicate this seek walks every
+   * weekly partition's index on `trace_summaries` — including S3-tiered cold
+   * ones — even though the worker job paths only ever resolve minutes-old
+   * traces (measured 0.9s avg during the 2026-08-03 saturation). The recent
+   * window keeps the hot path on local-disk partitions; a miss (old trace)
+   * pays the unbounded fallback and stays correct.
+   */
   private async resolveTraceOccurredAtMs(
     tenantId: string,
     traceId: string,
   ): Promise<number | undefined> {
+    const recent = await this.queryTraceOccurredAtMs(tenantId, traceId, {
+      sinceMs: Date.now() - RESOLVER_RECENT_WINDOW_MS,
+    });
+    if (recent !== undefined) return recent;
+    return this.queryTraceOccurredAtMs(tenantId, traceId, {});
+  }
+
+  private async queryTraceOccurredAtMs(
+    tenantId: string,
+    traceId: string,
+    { sinceMs }: { sinceMs?: number },
+  ): Promise<number | undefined> {
     const client = await this.resolveClient(tenantId);
+    const windowPredicate =
+      sinceMs !== undefined
+        ? "AND OccurredAt >= fromUnixTimestamp64Milli({sinceMs:Int64})"
+        : "";
     const result = await client.query({
       query: `
         SELECT toUnixTimestamp64Milli(min(OccurredAt)) AS occurredAtMs
         FROM trace_summaries
         WHERE TenantId = {tenantId:String}
           AND TraceId = {traceId:String}
+          ${windowPredicate}
       `,
-      query_params: { tenantId, traceId },
+      query_params:
+        sinceMs !== undefined
+          ? { tenantId, traceId, sinceMs }
+          : { tenantId, traceId },
       format: "JSONEachRow",
     });
     const rows = (await result.json()) as Array<{

--- a/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment node
+ *
+ * Boots the real liveness thread (LIVENESS_THREAD_SOURCE, eval'd exactly as
+ * production does) against a shared heartbeat and asserts the property the
+ * 2026-08-03 incident demands: `/healthz` answers from the thread using the
+ * heartbeat's age — a saturated-but-alive main loop stays 200, a loop stalled
+ * past the budget goes 503 — and non-liveness paths proxy to the parent.
+ */
+import http from "node:http";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it } from "vitest";
+import { LIVENESS_THREAD_SOURCE, WORKER_LIVENESS_PATH } from "../startWorkers";
+
+const STALL_BUDGET_MS = 5 * 60 * 1000;
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = http.createServer();
+    srv.listen(0, () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function fetchStatus(
+  port: number,
+  path: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get({ port, path, timeout: 2_000 }, (res) => {
+        let body = "";
+        res.on("data", (c: Buffer) => (body += c.toString()));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+      })
+      .on("error", reject);
+  });
+}
+
+describe("worker liveness thread", () => {
+  let thread: Worker | undefined;
+
+  afterEach(async () => {
+    await thread?.terminate();
+    thread = undefined;
+  });
+
+  async function bootThread(heartbeat: Float64Array): Promise<number> {
+    const port = await getFreePort();
+    thread = new Worker(LIVENESS_THREAD_SOURCE, {
+      eval: true,
+      workerData: {
+        port,
+        livenessPath: WORKER_LIVENESS_PATH,
+        heartbeat: heartbeat.buffer,
+        stallBudgetMs: STALL_BUDGET_MS,
+        proxyTimeoutMs: 500,
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      thread!.once("error", reject);
+      thread!.on("message", (msg: { listening?: boolean }) => {
+        if (msg.listening) resolve();
+      });
+    });
+    return port;
+  }
+
+  describe("when the main loop heartbeat is fresh", () => {
+    /** @scenario A busy-but-alive main loop still passes liveness */
+    it("answers 200 on the liveness path", async () => {
+      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = Date.now();
+      const port = await bootThread(heartbeat);
+
+      const res = await fetchStatus(port, WORKER_LIVENESS_PATH);
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("ok");
+    });
+  });
+
+  describe("when the heartbeat is stalled past the budget", () => {
+    /** @scenario A main loop stalled past the budget fails liveness */
+    it("answers 503 so a genuinely dead main loop still gets restarted", async () => {
+      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = Date.now() - STALL_BUDGET_MS - 60_000;
+      const port = await bootThread(heartbeat);
+
+      const res = await fetchStatus(port, WORKER_LIVENESS_PATH);
+      expect(res.status).toBe(503);
+      expect(res.body).toContain("stalled");
+    });
+  });
+
+  describe("when a non-liveness path is requested", () => {
+    /** @scenario Metrics proxy through to the main thread with a timeout */
+    it("proxies to the parent and serves its reply", async () => {
+      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = Date.now();
+      const port = await bootThread(heartbeat);
+      thread!.on(
+        "message",
+        (msg: { id?: number; url?: string; authorization?: string | null }) => {
+          if (msg.id === undefined) return;
+          thread!.postMessage({
+            id: msg.id,
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+            body: `proxied:${msg.url}`,
+          });
+        },
+      );
+
+      const res = await fetchStatus(port, "/metrics");
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("proxied:/metrics");
+    });
+
+    it("answers 503 when the parent never replies (stalled main loop)", async () => {
+      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = Date.now();
+      const port = await bootThread(heartbeat);
+
+      const res = await fetchStatus(port, "/metrics");
+      expect(res.status).toBe(503);
+    });
+  });
+});

--- a/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
@@ -119,7 +119,6 @@ describe("worker liveness thread", () => {
     });
 
     /** @scenario A metrics request fails when the main thread never replies */
-    /** @scenario A metrics request fails when the main thread never replies */
     it("answers 503 when the parent never replies (stalled main loop)", async () => {
       const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
       heartbeat[0] = BigInt(Date.now());

--- a/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
@@ -10,9 +10,11 @@
 import http from "node:http";
 import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it } from "vitest";
-import { LIVENESS_THREAD_SOURCE, WORKER_LIVENESS_PATH } from "../startWorkers";
-
-const STALL_BUDGET_MS = 5 * 60 * 1000;
+import {
+  LIVENESS_THREAD_SOURCE,
+  WORKER_HEARTBEAT_STALL_BUDGET_MS as STALL_BUDGET_MS,
+  WORKER_LIVENESS_PATH,
+} from "../startWorkers";
 
 async function getFreePort(): Promise<number> {
   return new Promise((resolve) => {

--- a/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/livenessThread.unit.test.ts
@@ -2,10 +2,10 @@
  * @vitest-environment node
  *
  * Boots the real liveness thread (LIVENESS_THREAD_SOURCE, eval'd exactly as
- * production does) against a shared heartbeat and asserts the property the
- * 2026-08-03 incident demands: `/healthz` answers from the thread using the
- * heartbeat's age — a saturated-but-alive main loop stays 200, a loop stalled
- * past the budget goes 503 — and non-liveness paths proxy to the parent.
+ * production does) against a shared heartbeat: `/healthz` answers from the
+ * thread using the heartbeat's age — a saturated-but-alive main loop stays
+ * 200, a loop stalled past the budget goes 503 — and non-liveness paths
+ * proxy to the parent.
  */
 import http from "node:http";
 import { Worker } from "node:worker_threads";
@@ -47,7 +47,7 @@ describe("worker liveness thread", () => {
     thread = undefined;
   });
 
-  async function bootThread(heartbeat: Float64Array): Promise<number> {
+  async function bootThread(heartbeat: BigInt64Array): Promise<number> {
     const port = await getFreePort();
     thread = new Worker(LIVENESS_THREAD_SOURCE, {
       eval: true,
@@ -61,8 +61,8 @@ describe("worker liveness thread", () => {
     });
     await new Promise<void>((resolve, reject) => {
       thread!.once("error", reject);
-      thread!.on("message", (msg: { listening?: boolean }) => {
-        if (msg.listening) resolve();
+      thread!.on("message", (msg: { isListening?: boolean }) => {
+        if (msg.isListening) resolve();
       });
     });
     return port;
@@ -71,8 +71,8 @@ describe("worker liveness thread", () => {
   describe("when the main loop heartbeat is fresh", () => {
     /** @scenario A busy-but-alive main loop still passes liveness */
     it("answers 200 on the liveness path", async () => {
-      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
-      heartbeat[0] = Date.now();
+      const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = BigInt(Date.now());
       const port = await bootThread(heartbeat);
 
       const res = await fetchStatus(port, WORKER_LIVENESS_PATH);
@@ -84,8 +84,8 @@ describe("worker liveness thread", () => {
   describe("when the heartbeat is stalled past the budget", () => {
     /** @scenario A main loop stalled past the budget fails liveness */
     it("answers 503 so a genuinely dead main loop still gets restarted", async () => {
-      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
-      heartbeat[0] = Date.now() - STALL_BUDGET_MS - 60_000;
+      const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = BigInt(Date.now() - STALL_BUDGET_MS - 60_000);
       const port = await bootThread(heartbeat);
 
       const res = await fetchStatus(port, WORKER_LIVENESS_PATH);
@@ -95,10 +95,10 @@ describe("worker liveness thread", () => {
   });
 
   describe("when a non-liveness path is requested", () => {
-    /** @scenario Metrics proxy through to the main thread with a timeout */
+    /** @scenario Metrics proxy through to the main thread */
     it("proxies to the parent and serves its reply", async () => {
-      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
-      heartbeat[0] = Date.now();
+      const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = BigInt(Date.now());
       const port = await bootThread(heartbeat);
       thread!.on(
         "message",
@@ -118,9 +118,11 @@ describe("worker liveness thread", () => {
       expect(res.body).toBe("proxied:/metrics");
     });
 
+    /** @scenario A metrics request fails when the main thread never replies */
+    /** @scenario A metrics request fails when the main thread never replies */
     it("answers 503 when the parent never replies (stalled main loop)", async () => {
-      const heartbeat = new Float64Array(new SharedArrayBuffer(8));
-      heartbeat[0] = Date.now();
+      const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
+      heartbeat[0] = BigInt(Date.now());
       const port = await bootThread(heartbeat);
 
       const res = await fetchStatus(port, "/metrics");

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -152,8 +152,51 @@ async function bootUsageStatsWorker(
 export const WORKER_LIVENESS_PATH = "/healthz";
 
 /**
+ * The single bearer gate + registry fetch for the worker's `/metrics`,
+ * transport-agnostic so the in-loop HTTP handler and the liveness thread's
+ * proxy share ONE copy of the security decision (two copies drift).
+ */
+async function evaluateMetricsRequest({
+  url,
+  request,
+  isMetricsAuthorized,
+}: {
+  url: string | undefined;
+  /** The auth input, shaped like the parts of IncomingMessage the gate reads. */
+  request: Pick<IncomingMessage, "headers">;
+  isMetricsAuthorized: (req: IncomingMessage) => boolean;
+}): Promise<{
+  status: number;
+  headers?: Record<string, string>;
+  body?: string;
+}> {
+  if (url !== "/metrics") return { status: 404 };
+  try {
+    if (!isMetricsAuthorized(request as IncomingMessage))
+      return { status: 401 };
+  } catch (error) {
+    // Fail closed when METRICS_API_KEY is unset in production.
+    logger.error({ error }, "worker metrics auth misconfigured");
+    return { status: 500 };
+  }
+  try {
+    const metrics = await register.metrics();
+    return {
+      status: 200,
+      headers: { "Content-Type": register.contentType },
+      body: metrics,
+    };
+  } catch (error) {
+    logger.error({ error }, "error getting worker metrics");
+    return { status: 500 };
+  }
+}
+
+/**
  * The worker metrics server's request handler, split out so the routing and
- * auth branches are testable without binding a port.
+ * auth branches are testable without binding a port. Used directly only on
+ * the fallback path (liveness thread failed to start); the normal path serves
+ * the same decisions through the thread proxy.
  */
 export function createWorkerMetricsHandler(
   isMetricsAuthorized: (req: IncomingMessage) => boolean,
@@ -163,29 +206,13 @@ export function createWorkerMetricsHandler(
       res.writeHead(200, { "Content-Type": "text/plain" }).end("ok");
       return;
     }
-    if (req.url !== "/metrics") {
-      res.writeHead(404).end();
-      return;
-    }
-    try {
-      if (!isMetricsAuthorized(req)) {
-        res.writeHead(401).end();
-        return;
-      }
-    } catch (error) {
-      // Fail closed when METRICS_API_KEY is unset in production.
-      logger.error({ error }, "worker metrics auth misconfigured");
-      res.writeHead(500).end();
-      return;
-    }
-    res.setHeader("Content-Type", register.contentType);
-    register
-      .metrics()
-      .then((metrics) => res.end(metrics))
-      .catch((error) => {
-        logger.error({ error }, "error getting worker metrics");
-        res.writeHead(500).end();
-      });
+    void evaluateMetricsRequest({
+      url: req.url,
+      request: req,
+      isMetricsAuthorized,
+    }).then(({ status, headers, body }) => {
+      res.writeHead(status, headers ?? {}).end(body ?? "");
+    });
   };
 }
 
@@ -203,14 +230,15 @@ export function createWorkerMetricsHandler(
  * How often the main event loop stamps its heartbeat, and how stale that
  * stamp may get before the liveness thread reports the process dead.
  *
- * The 2026-08-03 incident: a worker saturated with queue catch-up pins the
- * event loop for 60–90s of legitimate work, `/healthz` (served on that same
- * loop) misses even a 10s×6 probe budget, and Kubernetes kills exactly the
- * busiest pods — requeueing their in-flight jobs and deepening the backlog.
- * Serving liveness from a worker thread with a loop heartbeat separates the
- * two questions: "is the process alive" (thread answers instantly, always)
- * and "is the main loop moving" (heartbeat age, judged against a budget far
- * beyond any legitimate saturation but well short of "restart never comes").
+ * A worker saturated with queue catch-up can pin the event loop for over a
+ * minute of legitimate work; `/healthz` served on that same loop then misses
+ * any realistic kubelet probe budget, and Kubernetes kills exactly the
+ * busiest pods — requeueing their in-flight jobs and deepening the backlog
+ * that caused the saturation. Serving liveness from a worker thread with a
+ * loop heartbeat separates the two questions: "is the process alive" (thread
+ * answers instantly, always) and "is the main loop moving" (heartbeat age,
+ * judged against a budget far beyond any legitimate saturation but well
+ * short of "restart never comes").
  */
 export const WORKER_HEARTBEAT_INTERVAL_MS = 1_000;
 export const WORKER_HEARTBEAT_STALL_BUDGET_MS = 5 * 60 * 1000;
@@ -228,7 +256,10 @@ const METRICS_PROXY_TIMEOUT_MS = 10_000;
 export const LIVENESS_THREAD_SOURCE = `
 const http = require("node:http");
 const { parentPort, workerData } = require("node:worker_threads");
-const heartbeat = new Float64Array(workerData.heartbeat);
+// BigInt64 + Atomics: plain cross-thread Float64Array access has no atomicity
+// guarantee (a torn read yields a garbage timestamp); Atomics only supports
+// integer typed arrays, and epoch millis fit BigInt64 exactly.
+const heartbeat = new BigInt64Array(workerData.heartbeat);
 const pending = new Map();
 let nextId = 1;
 parentPort.on("message", (msg) => {
@@ -240,7 +271,7 @@ parentPort.on("message", (msg) => {
 });
 const server = http.createServer((req, res) => {
   if (req.url === workerData.livenessPath) {
-    const stalledMs = Date.now() - heartbeat[0];
+    const stalledMs = Date.now() - Number(Atomics.load(heartbeat, 0));
     if (stalledMs > workerData.stallBudgetMs) {
       res.writeHead(503, { "Content-Type": "text/plain" })
         .end("main loop stalled " + Math.round(stalledMs / 1000) + "s");
@@ -261,7 +292,7 @@ const server = http.createServer((req, res) => {
     authorization: req.headers.authorization ?? null,
   });
 });
-server.listen(workerData.port, () => parentPort.postMessage({ listening: true }));
+server.listen(workerData.port, () => parentPort.postMessage({ isListening: true }));
 `;
 
 // The metrics port is bound by the liveness thread (LIVENESS_THREAD_SOURCE)
@@ -271,20 +302,25 @@ server.listen(workerData.port, () => parentPort.postMessage({ listening: true })
 async function bootMetricsServer(
   shutdownHandles: ShutdownHandles,
 ): Promise<void> {
+  // Deferred like every boot dependency in this file: keeps the worker's
+  // module graph (and prom-client registry construction) off the process
+  // import path until the metrics server actually boots.
   const { getWorkerMetricsPort, isMetricsAuthorized } = await import(
     "~/server/metrics"
   );
   const metricsPort = getWorkerMetricsPort();
 
-  const heartbeat = new Float64Array(new SharedArrayBuffer(8));
-  heartbeat[0] = Date.now();
+  // BigInt64 + Atomics — see the note in LIVENESS_THREAD_SOURCE.
+  const heartbeat = new BigInt64Array(new SharedArrayBuffer(8));
+  Atomics.store(heartbeat, 0, BigInt(Date.now()));
   const heartbeatTimer = setInterval(() => {
-    heartbeat[0] = Date.now();
+    Atomics.store(heartbeat, 0, BigInt(Date.now()));
   }, WORKER_HEARTBEAT_INTERVAL_MS);
   heartbeatTimer.unref();
 
+  let thread: Worker | undefined;
   try {
-    const thread = new Worker(LIVENESS_THREAD_SOURCE, {
+    thread = new Worker(LIVENESS_THREAD_SOURCE, {
       eval: true,
       workerData: {
         port: metricsPort,
@@ -294,32 +330,50 @@ async function bootMetricsServer(
         proxyTimeoutMs: METRICS_PROXY_TIMEOUT_MS,
       },
     });
+    const startedThread = thread;
     await new Promise<void>((resolve, reject) => {
-      thread.once("error", reject);
-      thread.on("message", (msg: { listening?: boolean; id?: number }) => {
-        if (msg.listening) {
-          thread.removeListener("error", reject);
-          resolve();
-          return;
-        }
-        if (msg.id === undefined) return;
-        void respondToLivenessThread(
-          thread,
-          msg as { id: number; url: string; authorization: string | null },
-          isMetricsAuthorized,
-        );
-      });
+      startedThread.once("error", reject);
+      startedThread.on(
+        "message",
+        (msg: { isListening?: boolean; id?: number }) => {
+          if (msg.isListening) {
+            startedThread.removeListener("error", reject);
+            resolve();
+            return;
+          }
+          if (msg.id === undefined) return;
+          void respondToLivenessThread(
+            startedThread,
+            msg as { id: number; url: string; authorization: string | null },
+            isMetricsAuthorized,
+          );
+        },
+      );
+    });
+    // Post-startup lifecycle: an unhandled Worker "error" would re-throw on
+    // the main thread and kill the process. Log instead — a dead thread stops
+    // answering the port, probes fail, and the pod restarts through the
+    // normal Kubernetes path.
+    startedThread.on("error", (error) => {
+      logger.error({ error }, "worker liveness thread errored");
+    });
+    startedThread.on("exit", (code) => {
+      if (code !== 0) {
+        logger.error({ code }, "worker liveness thread exited unexpectedly");
+      }
     });
     logger.info(
       `worker liveness thread serving port ${metricsPort} (heartbeat budget ${WORKER_HEARTBEAT_STALL_BUDGET_MS}ms)`,
     );
     shutdownHandles.push(async () => {
       clearInterval(heartbeatTimer);
-      await thread.terminate();
+      await startedThread.terminate();
     });
   } catch (error) {
-    // The fallback server has no heartbeat consumer, so stop stamping it.
+    // The fallback server has no heartbeat consumer, so stop stamping it —
+    // and reap the thread if it was spawned but failed before listening.
     clearInterval(heartbeatTimer);
+    await thread?.terminate().catch(() => undefined);
     logger.warn(
       { error },
       "liveness thread failed to start; serving metrics/liveness on the main loop",
@@ -352,36 +406,12 @@ async function respondToLivenessThread(
   msg: { id: number; url: string; authorization: string | null },
   isMetricsAuthorized: (req: IncomingMessage) => boolean,
 ): Promise<void> {
-  const reply = (
-    status: number,
-    headers?: Record<string, string>,
-    body?: string,
-  ) => thread.postMessage({ id: msg.id, status, headers, body });
-  if (msg.url !== "/metrics") {
-    reply(404);
-    return;
-  }
-  try {
-    const fakeReq = {
-      headers: { authorization: msg.authorization ?? undefined },
-    } as IncomingMessage;
-    if (!isMetricsAuthorized(fakeReq)) {
-      reply(401);
-      return;
-    }
-  } catch (error) {
-    // Fail closed when METRICS_API_KEY is unset in production.
-    logger.error({ error }, "worker metrics auth misconfigured");
-    reply(500);
-    return;
-  }
-  try {
-    const metrics = await register.metrics();
-    reply(200, { "Content-Type": register.contentType }, metrics);
-  } catch (error) {
-    logger.error({ error }, "error getting worker metrics");
-    reply(500);
-  }
+  const { status, headers, body } = await evaluateMetricsRequest({
+    url: msg.url,
+    request: { headers: { authorization: msg.authorization ?? undefined } },
+    isMetricsAuthorized,
+  });
+  thread.postMessage({ id: msg.id, status, headers, body });
 }
 
 /**

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -318,6 +318,8 @@ async function bootMetricsServer(
       await thread.terminate();
     });
   } catch (error) {
+    // The fallback server has no heartbeat consumer, so stop stamping it.
+    clearInterval(heartbeatTimer);
     logger.warn(
       { error },
       "liveness thread failed to start; serving metrics/liveness on the main loop",

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -366,10 +366,19 @@ async function wireLivenessThread(
   isMetricsAuthorized: (req: IncomingMessage) => boolean,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
+    // Reject on early exit too: a thread that dies before listening without
+    // emitting "error" would otherwise leave this promise pending forever
+    // and the fallback server would never start.
+    const rejectOnEarlyExit = (code: number) =>
+      reject(
+        new Error(`liveness thread exited before listening (code ${code})`),
+      );
     thread.once("error", reject);
+    thread.once("exit", rejectOnEarlyExit);
     thread.on("message", (msg: { isListening?: boolean; id?: number }) => {
       if (msg.isListening) {
         thread.removeListener("error", reject);
+        thread.removeListener("exit", rejectOnEarlyExit);
         resolve();
         return;
       }

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -3,6 +3,7 @@ import { createLogger } from "@langwatch/observability";
 import type { IncomingMessage, RequestListener, ServerResponse } from "http";
 import http from "http";
 import { register } from "prom-client";
+import { getWorkerMetricsPort, isMetricsAuthorized } from "~/server/metrics";
 import { assertRedisReady } from "~/server/redis";
 
 const logger = createLogger("langwatch:workers");
@@ -302,12 +303,6 @@ server.listen(workerData.port, () => parentPort.postMessage({ isListening: true 
 async function bootMetricsServer(
   shutdownHandles: ShutdownHandles,
 ): Promise<void> {
-  // Deferred like every boot dependency in this file: keeps the worker's
-  // module graph (and prom-client registry construction) off the process
-  // import path until the metrics server actually boots.
-  const { getWorkerMetricsPort, isMetricsAuthorized } = await import(
-    "~/server/metrics"
-  );
   const metricsPort = getWorkerMetricsPort();
 
   // BigInt64 + Atomics — see the note in LIVENESS_THREAD_SOURCE.
@@ -330,43 +325,16 @@ async function bootMetricsServer(
         proxyTimeoutMs: METRICS_PROXY_TIMEOUT_MS,
       },
     });
+    await wireLivenessThread(thread, isMetricsAuthorized);
     const startedThread = thread;
-    await new Promise<void>((resolve, reject) => {
-      startedThread.once("error", reject);
-      startedThread.on(
-        "message",
-        (msg: { isListening?: boolean; id?: number }) => {
-          if (msg.isListening) {
-            startedThread.removeListener("error", reject);
-            resolve();
-            return;
-          }
-          if (msg.id === undefined) return;
-          void respondToLivenessThread(
-            startedThread,
-            msg as { id: number; url: string; authorization: string | null },
-            isMetricsAuthorized,
-          );
-        },
-      );
-    });
-    // Post-startup lifecycle: an unhandled Worker "error" would re-throw on
-    // the main thread and kill the process. Log instead — a dead thread stops
-    // answering the port, probes fail, and the pod restarts through the
-    // normal Kubernetes path.
-    startedThread.on("error", (error) => {
-      logger.error({ error }, "worker liveness thread errored");
-    });
-    startedThread.on("exit", (code) => {
-      if (code !== 0) {
-        logger.error({ code }, "worker liveness thread exited unexpectedly");
-      }
-    });
     logger.info(
       `worker liveness thread serving port ${metricsPort} (heartbeat budget ${WORKER_HEARTBEAT_STALL_BUDGET_MS}ms)`,
     );
     shutdownHandles.push(async () => {
       clearInterval(heartbeatTimer);
+      // terminate() itself emits a non-zero "exit"; that's a graceful
+      // shutdown, not the unexpected-death case the listener reports.
+      startedThread.removeAllListeners("exit");
       await startedThread.terminate();
     });
   } catch (error) {
@@ -378,22 +346,75 @@ async function bootMetricsServer(
       { error },
       "liveness thread failed to start; serving metrics/liveness on the main loop",
     );
-    const metricsServer = http.createServer(
-      createWorkerMetricsHandler(isMetricsAuthorized),
-    );
-    await new Promise<void>((resolve, reject) => {
-      metricsServer.once("error", reject);
-      metricsServer.listen(metricsPort, () => {
-        metricsServer.removeListener("error", reject);
-        logger.info(`worker metrics server listening on port ${metricsPort}`);
-        resolve();
-      });
+    await bootFallbackMetricsServer({
+      metricsPort,
+      isMetricsAuthorized,
+      shutdownHandles,
     });
-    shutdownHandles.push(
-      () =>
-        new Promise<void>((resolve) => metricsServer.close(() => resolve())),
-    );
   }
+}
+
+/**
+ * Wires the liveness thread's lifecycle: resolves once it is listening,
+ * routes its proxy messages, and installs the post-startup error/exit
+ * listeners (an unhandled Worker "error" would re-throw on the main thread
+ * and kill the process; a dead thread instead stops answering the port,
+ * probes fail, and the pod restarts through the normal Kubernetes path).
+ */
+async function wireLivenessThread(
+  thread: Worker,
+  isMetricsAuthorized: (req: IncomingMessage) => boolean,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    thread.once("error", reject);
+    thread.on("message", (msg: { isListening?: boolean; id?: number }) => {
+      if (msg.isListening) {
+        thread.removeListener("error", reject);
+        resolve();
+        return;
+      }
+      if (msg.id === undefined) return;
+      void respondToLivenessThread(
+        thread,
+        msg as { id: number; url: string; authorization: string | null },
+        isMetricsAuthorized,
+      );
+    });
+  });
+  thread.on("error", (error) => {
+    logger.error({ error }, "worker liveness thread errored");
+  });
+  thread.on("exit", (code) => {
+    if (code !== 0) {
+      logger.error({ code }, "worker liveness thread exited unexpectedly");
+    }
+  });
+}
+
+/** The pre-thread in-loop server, kept as the fallback when the thread cannot start. */
+async function bootFallbackMetricsServer({
+  metricsPort,
+  isMetricsAuthorized,
+  shutdownHandles,
+}: {
+  metricsPort: number;
+  isMetricsAuthorized: (req: IncomingMessage) => boolean;
+  shutdownHandles: ShutdownHandles;
+}): Promise<void> {
+  const metricsServer = http.createServer(
+    createWorkerMetricsHandler(isMetricsAuthorized),
+  );
+  await new Promise<void>((resolve, reject) => {
+    metricsServer.once("error", reject);
+    metricsServer.listen(metricsPort, () => {
+      metricsServer.removeListener("error", reject);
+      logger.info(`worker metrics server listening on port ${metricsPort}`);
+      resolve();
+    });
+  });
+  shutdownHandles.push(
+    () => new Promise<void>((resolve) => metricsServer.close(() => resolve())),
+  );
 }
 
 /**

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -1,3 +1,4 @@
+import { Worker } from "node:worker_threads";
 import { createLogger } from "@langwatch/observability";
 import type { IncomingMessage, RequestListener, ServerResponse } from "http";
 import http from "http";
@@ -198,8 +199,75 @@ export function createWorkerMetricsHandler(
 // In that in-process mode this listener is skipped entirely; the web server
 // serves the same shared registry at /metrics.
 //
-// The same listener serves the unauthenticated liveness path the chart's
-// probes call.
+/**
+ * How often the main event loop stamps its heartbeat, and how stale that
+ * stamp may get before the liveness thread reports the process dead.
+ *
+ * The 2026-08-03 incident: a worker saturated with queue catch-up pins the
+ * event loop for 60–90s of legitimate work, `/healthz` (served on that same
+ * loop) misses even a 10s×6 probe budget, and Kubernetes kills exactly the
+ * busiest pods — requeueing their in-flight jobs and deepening the backlog.
+ * Serving liveness from a worker thread with a loop heartbeat separates the
+ * two questions: "is the process alive" (thread answers instantly, always)
+ * and "is the main loop moving" (heartbeat age, judged against a budget far
+ * beyond any legitimate saturation but well short of "restart never comes").
+ */
+export const WORKER_HEARTBEAT_INTERVAL_MS = 1_000;
+export const WORKER_HEARTBEAT_STALL_BUDGET_MS = 5 * 60 * 1000;
+const METRICS_PROXY_TIMEOUT_MS = 10_000;
+
+/**
+ * Source for the liveness thread, evaluated via `new Worker(src, {eval:true})`
+ * so it survives every bundler/runtime (no file to resolve). Plain CommonJS,
+ * Node built-ins only. It owns the metrics port: `/healthz` is answered
+ * in-thread from the shared heartbeat; anything else is proxied to the main
+ * thread over `parentPort` (metrics bodies come from the prom-client registry,
+ * which lives there) with a timeout so a stalled loop fails the scrape, never
+ * the probe.
+ */
+export const LIVENESS_THREAD_SOURCE = `
+const http = require("node:http");
+const { parentPort, workerData } = require("node:worker_threads");
+const heartbeat = new Float64Array(workerData.heartbeat);
+const pending = new Map();
+let nextId = 1;
+parentPort.on("message", (msg) => {
+  const entry = pending.get(msg.id);
+  if (!entry) return;
+  pending.delete(msg.id);
+  clearTimeout(entry.timer);
+  entry.res.writeHead(msg.status, msg.headers ?? {}).end(msg.body ?? "");
+});
+const server = http.createServer((req, res) => {
+  if (req.url === workerData.livenessPath) {
+    const stalledMs = Date.now() - heartbeat[0];
+    if (stalledMs > workerData.stallBudgetMs) {
+      res.writeHead(503, { "Content-Type": "text/plain" })
+        .end("main loop stalled " + Math.round(stalledMs / 1000) + "s");
+    } else {
+      res.writeHead(200, { "Content-Type": "text/plain" }).end("ok");
+    }
+    return;
+  }
+  const id = nextId++;
+  const timer = setTimeout(() => {
+    pending.delete(id);
+    res.writeHead(503).end();
+  }, workerData.proxyTimeoutMs);
+  pending.set(id, { res, timer });
+  parentPort.postMessage({
+    id,
+    url: req.url,
+    authorization: req.headers.authorization ?? null,
+  });
+});
+server.listen(workerData.port, () => parentPort.postMessage({ listening: true }));
+`;
+
+// The metrics port is bound by the liveness thread (LIVENESS_THREAD_SOURCE)
+// so `/healthz` keeps answering while the main loop is saturated. If the
+// thread cannot start, fall back to the old in-loop server rather than boot
+// with no probe target at all.
 async function bootMetricsServer(
   shutdownHandles: ShutdownHandles,
 ): Promise<void> {
@@ -207,20 +275,111 @@ async function bootMetricsServer(
     "~/server/metrics"
   );
   const metricsPort = getWorkerMetricsPort();
-  const metricsServer = http.createServer(
-    createWorkerMetricsHandler(isMetricsAuthorized),
-  );
-  await new Promise<void>((resolve, reject) => {
-    metricsServer.once("error", reject);
-    metricsServer.listen(metricsPort, () => {
-      metricsServer.removeListener("error", reject);
-      logger.info(`worker metrics server listening on port ${metricsPort}`);
-      resolve();
+
+  const heartbeat = new Float64Array(new SharedArrayBuffer(8));
+  heartbeat[0] = Date.now();
+  const heartbeatTimer = setInterval(() => {
+    heartbeat[0] = Date.now();
+  }, WORKER_HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref();
+
+  try {
+    const thread = new Worker(LIVENESS_THREAD_SOURCE, {
+      eval: true,
+      workerData: {
+        port: metricsPort,
+        livenessPath: WORKER_LIVENESS_PATH,
+        heartbeat: heartbeat.buffer,
+        stallBudgetMs: WORKER_HEARTBEAT_STALL_BUDGET_MS,
+        proxyTimeoutMs: METRICS_PROXY_TIMEOUT_MS,
+      },
     });
-  });
-  shutdownHandles.push(
-    () => new Promise<void>((resolve) => metricsServer.close(() => resolve())),
-  );
+    await new Promise<void>((resolve, reject) => {
+      thread.once("error", reject);
+      thread.on("message", (msg: { listening?: boolean; id?: number }) => {
+        if (msg.listening) {
+          thread.removeListener("error", reject);
+          resolve();
+          return;
+        }
+        if (msg.id === undefined) return;
+        void respondToLivenessThread(
+          thread,
+          msg as { id: number; url: string; authorization: string | null },
+          isMetricsAuthorized,
+        );
+      });
+    });
+    logger.info(
+      `worker liveness thread serving port ${metricsPort} (heartbeat budget ${WORKER_HEARTBEAT_STALL_BUDGET_MS}ms)`,
+    );
+    shutdownHandles.push(async () => {
+      clearInterval(heartbeatTimer);
+      await thread.terminate();
+    });
+  } catch (error) {
+    logger.warn(
+      { error },
+      "liveness thread failed to start; serving metrics/liveness on the main loop",
+    );
+    const metricsServer = http.createServer(
+      createWorkerMetricsHandler(isMetricsAuthorized),
+    );
+    await new Promise<void>((resolve, reject) => {
+      metricsServer.once("error", reject);
+      metricsServer.listen(metricsPort, () => {
+        metricsServer.removeListener("error", reject);
+        logger.info(`worker metrics server listening on port ${metricsPort}`);
+        resolve();
+      });
+    });
+    shutdownHandles.push(
+      () =>
+        new Promise<void>((resolve) => metricsServer.close(() => resolve())),
+    );
+  }
+}
+
+/**
+ * Main-thread side of the liveness thread's proxy: only `/metrics` exists,
+ * with the same bearer gate and fail-closed auth semantics as the in-loop
+ * handler.
+ */
+async function respondToLivenessThread(
+  thread: Worker,
+  msg: { id: number; url: string; authorization: string | null },
+  isMetricsAuthorized: (req: IncomingMessage) => boolean,
+): Promise<void> {
+  const reply = (
+    status: number,
+    headers?: Record<string, string>,
+    body?: string,
+  ) => thread.postMessage({ id: msg.id, status, headers, body });
+  if (msg.url !== "/metrics") {
+    reply(404);
+    return;
+  }
+  try {
+    const fakeReq = {
+      headers: { authorization: msg.authorization ?? undefined },
+    } as IncomingMessage;
+    if (!isMetricsAuthorized(fakeReq)) {
+      reply(401);
+      return;
+    }
+  } catch (error) {
+    // Fail closed when METRICS_API_KEY is unset in production.
+    logger.error({ error }, "worker metrics auth misconfigured");
+    reply(500);
+    return;
+  }
+  try {
+    const metrics = await register.metrics();
+    reply(200, { "Content-Type": register.contentType }, metrics);
+  } catch (error) {
+    logger.error({ error }, "error getting worker metrics");
+    reply(500);
+  }
 }
 
 /**

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -86,6 +86,34 @@ Feature: Worker liveness probe endpoint
       When a caller requests "/not-a-real-path"
       Then the response status is 404
 
+  Rule: Liveness answers even while the main event loop is saturated
+
+    # A worker saturated with legitimate queue catch-up can pin the Node event
+    # loop for over a minute; when /healthz shared that loop, Kubernetes
+    # killed exactly the busiest pods and requeued their in-flight work
+    # (2026-08-03 incident). Liveness is served from a dedicated thread that
+    # judges the main loop by a shared heartbeat instead.
+
+    @unit
+    Scenario: A busy-but-alive main loop still passes liveness
+      Given the main loop's heartbeat is fresher than the stall budget
+      When the kubelet requests "/healthz"
+      Then the response status is 200
+
+    @unit
+    Scenario: A main loop stalled past the budget fails liveness
+      Given the main loop's heartbeat is older than the stall budget
+      When the kubelet requests "/healthz"
+      Then the response status is 503
+      # A genuinely wedged worker is still restarted — the budget separates
+      # "saturated for a minute" from "dead".
+
+    @unit
+    Scenario: Metrics proxy through to the main thread with a timeout
+      Given the liveness thread is serving the metrics port
+      When a caller requests "/metrics" and the main thread replies
+      Then the reply is served with the main thread's status and body
+
   Rule: The chart probes the liveness endpoint, not the metrics endpoint
 
     @e2e @unimplemented

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -90,9 +90,9 @@ Feature: Worker liveness probe endpoint
 
     # A worker saturated with legitimate queue catch-up can pin the Node event
     # loop for over a minute; when /healthz shared that loop, Kubernetes
-    # killed exactly the busiest pods and requeued their in-flight work
-    # (2026-08-03 incident). Liveness is served from a dedicated thread that
-    # judges the main loop by a shared heartbeat instead.
+    # killed exactly the busiest pods and requeued their in-flight work.
+    # Liveness is served from a dedicated thread that judges the main loop by
+    # a shared heartbeat instead.
 
     @unit
     Scenario: A busy-but-alive main loop still passes liveness
@@ -109,10 +109,18 @@ Feature: Worker liveness probe endpoint
       # "saturated for a minute" from "dead".
 
     @unit
-    Scenario: Metrics proxy through to the main thread with a timeout
+    Scenario: Metrics proxy through to the main thread
       Given the liveness thread is serving the metrics port
       When a caller requests "/metrics" and the main thread replies
       Then the reply is served with the main thread's status and body
+
+    @unit
+    Scenario: A metrics request fails when the main thread never replies
+      Given the liveness thread is serving the metrics port
+      And the main thread is stalled and never answers the proxy
+      When a caller requests "/metrics"
+      Then the response status is 503
+      # A stalled loop fails the scrape, never the probe.
 
   Rule: The chart probes the liveness endpoint, not the metrics endpoint
 


### PR DESCRIPTION
## For humans

When the queue backs up, workers spend their time on two ClickHouse lookups that search months of archived data to answer questions about things that happened minutes ago — and while saturated with that work, Kubernetes kills them for "not responding", which requeues everything in flight and deepens the very backlog causing the saturation. This PR makes those lookups ~20× cheaper and makes a busy worker impossible to mistake for a dead one. Pillar 1 of langwatch-saas#856.

## What

**1. Recent-window-first partition-hint resolvers.** `resolveScheduledAtMs` (evaluation_runs) and `resolveTraceOccurredAtMs` (trace_summaries) exist to give the heavy reads a partition bound — but were themselves unbounded, walking every weekly partition's index including S3-tiered cold ones, costing whole seconds per call on lookups whose subjects are minutes old. Both now probe `>= now() - 35 days` first (five weekly partitions, local disk) and run the unbounded seek only when the probe misses (old or unknown aggregate) — correctness unchanged.

**2. Liveness off the event loop.** The metrics port is now bound by a small worker thread (`LIVENESS_THREAD_SOURCE`, eval'd — no bundler-resolved file). `/healthz` answers in-thread from a shared heartbeat the main loop stamps every second (BigInt64 + Atomics — cross-thread float reads can tear): 200 while the loop is merely saturated, 503 only once it has been silent past a 5-minute budget — a genuinely wedged worker still restarts, but a worker pinned by a minute of legitimate catch-up work no longer gets SIGTERM'd, losing its in-flight jobs. `/metrics` proxies to the main thread through one shared bearer-gate function with a 10s timeout — a stalled loop fails the scrape, never the probe. If the thread cannot start, boot falls back to the previous in-loop server.

## Why it matters

Worker throughput is `slots ÷ job latency`, and job latency was dominated by these per-job reads (measured 0.7–1.2s each at thousands of calls per hour, fleet-wide, with CPU nearly idle). Cutting them to local-disk point seeks multiplies fleet capacity without adding a pod. The probe change removes the failure mode where saturation itself triggers kills that amplify the backlog.

## Tests

- `evaluation-run.resolver-window.unit.test.ts` — windowed probe first, no unbounded scan on a hit; a miss falls back and the resolved timestamp still reaches the heavy read as a partition bound.
- `span-storage.resolver-window.unit.test.ts` — same contract for the trace resolver, including the fallback value reaching the span read's window.
- `livenessThread.unit.test.ts` — boots the real thread: fresh heartbeat → 200; stalled past budget → 503; `/metrics` proxies the parent's reply and 503s when the parent never answers.
- `specs/server/worker-liveness-probe.feature` — new rule "Liveness answers even while the main event loop is saturated", scenarios bound to the tests above.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


Closes #6455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved evaluation and trace lookups by checking recent data first while retaining fallback access to older records.
  * Added bounded lookup behavior to reduce unnecessary scanning and improve response times for recent data.

* **Reliability**
  * Added an independent liveness monitor that reports service health even when the main process is busy.
  * Health checks now return an error when the application is unresponsive, while metrics requests continue to be proxied with timeout protection.
  * Added a fallback to the existing metrics server if the liveness monitor cannot start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->