### PR TITLE
perf(clickhouse): let the rollup point seeks defer their columns

### DIFF
--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -365,3 +365,98 @@ describe("given a cumulative series long enough to span several rollup buckets",
     });
   });
 });
+
+describe("given a differencing predecessor stored as two acceptances", () => {
+  // The predecessor seek reads without FINAL and re-creates FINAL's choice with
+  // an ORDER BY tiebreak, so this pins the two to the same row. DedupVersion is
+  // MAX_UINT64 - acceptedAt, which makes the earlier acceptance the winner.
+  const supersededSeriesId = "9".repeat(64);
+
+  function supersedablePoint({
+    timeUnixMs,
+    value,
+    acceptedAt: acceptedAtOverride,
+  }: {
+    timeUnixMs: number;
+    value: number;
+    acceptedAt: number;
+  }): CanonicalMetricDataPoint {
+    return point({
+      tenantId,
+      organizationId,
+      seriesId: supersededSeriesId,
+      timeUnixMs,
+      metricKind: "sum",
+      aggregationTemporality: "cumulative",
+      isMonotonic: true,
+      valueDouble: value,
+      acceptedAt: acceptedAtOverride,
+    });
+  }
+
+  beforeAll(async () => {
+    // A background merge collapses the two versions, after which the seek
+    // returns the winner whatever it ordered by. That is precisely the state
+    // that cannot catch a regression, so merges stay off for this case.
+    await ch.exec({ query: "SYSTEM STOP MERGES metric_data_points" });
+
+    await repo.recomputeAffectedRollupsMany({
+      points: [
+        supersedablePoint({
+          timeUnixMs: bucket0 + 5_000,
+          value: 10,
+          acceptedAt,
+        }),
+      ],
+    });
+    // Same point, accepted later, so it loses and must never be differenced
+    // against.
+    await repo.recomputeAffectedRollupsMany({
+      points: [
+        supersedablePoint({
+          timeUnixMs: bucket0 + 5_000,
+          value: 999,
+          acceptedAt: acceptedAt + 60_000,
+        }),
+      ],
+    });
+    // Lands in the next bucket, so its delta is taken against whichever
+    // version of the bucket0 point the predecessor seek returns.
+    await repo.recomputeAffectedRollupsMany({
+      points: [
+        supersedablePoint({
+          timeUnixMs: bucket1 + 5_000,
+          value: 12,
+          acceptedAt,
+        }),
+      ],
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await ch.exec({ query: "SYSTEM START MERGES metric_data_points" });
+  });
+
+  it("differences the next bucket against the winning version", async () => {
+    const rollups = await readRollups(supersededSeriesId);
+
+    // 12 - 10 = 2. Had the seek returned the superseded 999, the delta would
+    // have gone negative and folded as a reset (sum 12, resetCount 1).
+    expect(rollups).toEqual([
+      {
+        bucketStartMs: bucket0,
+        sum: 10,
+        count: 1,
+        resetCount: 0,
+        sourcePointCount: 1,
+      },
+      {
+        bucketStartMs: bucket1,
+        sum: 2,
+        count: 1,
+        resetCount: 0,
+        sourcePointCount: 1,
+      },
+    ]);
+  });
+});

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -51,6 +51,39 @@ const INSERT_SETTINGS = { async_insert: 1, wait_for_async_insert: 1 } as const;
  */
 const SEEKS_PER_QUERY = 64;
 
+/**
+ * Why the `LIMIT 1` seeks below order by `DedupVersion DESC` rather than
+ * reading FINAL.
+ *
+ * `metric_data_points` is `ReplacingMergeTree(DedupVersion)` whose dedup key is
+ * exactly its sort key `(TenantId, SeriesId, TimeUnixMs, TimeUnixNano,
+ * PointId)`, and it declares no `is_deleted` column. So for a seek that keeps
+ * one row per key, "the row FINAL would have kept" is just "the highest
+ * DedupVersion among rows sharing that key", which the sort key plus this
+ * tiebreak already picks. The two are equivalent here; they would not be on a
+ * table whose dedup key was narrower than its sort key, or one that could
+ * delete rows outright.
+ *
+ * The difference is what ClickHouse reads to get there. `ORDER BY ... LIMIT n`
+ * qualifies for the LazilyRead optimisation, which resolves the ordering from
+ * sort-key columns and only then fetches the remaining columns, for the rows
+ * that survive the LIMIT. FINAL disqualifies it, because the replacing merge
+ * has to see whole rows: every row in the seek range is materialised across
+ * every selected column to return one of them. EXPLAIN shows a `LazilyRead`
+ * step that disappears the moment FINAL is added to an otherwise identical
+ * seek.
+ *
+ * Narrowing the projection (SEEK_SELECT, and dropping the payload column from
+ * AUTHORITATIVE_SELECT) cut the per-row cost of that, but the seeks still pay
+ * it per row scanned rather than per row returned, and folding many seeks into
+ * one statement multiplies it within a single query's memory budget.
+ *
+ * Reads that return every row in their range keep FINAL: they have nothing to
+ * defer, so it costs them nothing and stays the clearer way to say "latest
+ * version".
+ */
+const LATEST_VERSION_TIEBREAK = "DedupVersion DESC";
+
 function chunked<T>(items: readonly T[], size: number): T[][] {
   const chunks: T[][] = [];
   for (let index = 0; index < items.length; index += size) {
@@ -441,16 +474,17 @@ export class MetricDataPointClickHouseRepository
         params[`time${index}`] = new Date(point.timeUnixMs);
         params[`nano${index}`] = point.timeUnixNano;
         params[`point${index}`] = point.pointId;
-        // SEEK_SELECT, never the full row: each branch runs FINAL over its
-        // series, and materialising the megabyte-scale payload column across
+        // SEEK_SELECT, never the full row: the seek only exists to order
+        // points and locate buckets, and materialising anything wider across
         // SEEKS_PER_QUERY branches is what pushed one query past the server's
         // per-query memory cap (MEMORY_LIMIT_EXCEEDED in ReplacingSorted).
-        // The seek only exists to order points and locate buckets.
+        // Reading without FINAL lets even these columns be fetched per row
+        // returned rather than per row scanned (LATEST_VERSION_TIEBREAK).
         return `(SELECT ${SEEK_SELECT}
-          FROM metric_data_points FINAL
+          FROM metric_data_points
           WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
             AND (metric_data_points.TimeUnixMs > {time${index}:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time${index}:DateTime64(3)} AND (TimeUnixNano > {nano${index}:UInt64} OR (TimeUnixNano = {nano${index}:UInt64} AND PointId > {point${index}:String}))))
-          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC LIMIT 1)`;
+          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC, ${LATEST_VERSION_TIEBREAK} LIMIT 1)`;
       });
       const result = await client.query({
         query: selects.join("\n UNION ALL\n"),
@@ -515,14 +549,20 @@ export class MetricDataPointClickHouseRepository
         );
         // AUTHORITATIVE_SELECT: everything the fold reads, without the
         // payload column — the fold never touches it, and it is the column
-        // that made these FINAL reads memory-heavy.
+        // that made these reads memory-heavy.
+        //
+        // The predecessor seek returns one row out of a range that spans the
+        // retention window, so it reads without FINAL and lets the remaining
+        // columns be fetched for that row alone (LATEST_VERSION_TIEBREAK). The
+        // bucket range below returns everything it reads, so FINAL costs it
+        // nothing and stays.
         return [
           `(SELECT ${AUTHORITATIVE_SELECT}
-            FROM metric_data_points FINAL
+            FROM metric_data_points
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
               AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
               AND metric_data_points.TimeUnixMs >= {cutoff${index}:DateTime64(3)}
-            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
+            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC, ${LATEST_VERSION_TIEBREAK} LIMIT 1)`,
           `(SELECT ${AUTHORITATIVE_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}


### PR DESCRIPTION
> Rewritten on top of #6493 and #6487. The original version of this PR targeted the pre-fold code and conflicted; it has been reset onto `main` and re-measured. What follows is current.

## Evidence

The rollup fold is exhausting the 3.50 GiB per-query memory cap in production, and it has got substantially worse since the read folding landed:

| Window | Per-query `MEMORY_LIMIT_EXCEEDED` |
| --- | --- |
| 20h, before the fold | 60 |
| 24h, now | **1616** |

Every one of them is `metric_data_points`. The columns named in the failures track what the fold still reads after #6493 removed the payload column:

| Column named in the failure | Count |
| --- | --- |
| `CanonicalPayload` | 368 |
| `PointAttributesJson` | 56 |
| `ResourceAttributesJson` | 12 |
| `NegativeBucketCounts`, `MetricDescription`, `BucketCounts`, `SummaryQuantilesJson`, others | 30 |
| (no column named, failed in `MergeTreeSelect` / `ReplacingSorted`) | 1148 |

The `CanonicalPayload` entries are pods still serving the pre-#6493 image during rollout; the current shape no longer selects it, which the captured SQL confirms.

Structure of one failing statement, parsed from the exception:

```
total branches: 64
  LIMIT 1 branches: 32   |  non-LIMIT branches: 32
  wide AUTHORITATIVE_SELECT branches: 64
  branch0 predicate: TimeUnixMs < '...'      (predecessor seek)
  branch1 predicate: TimeUnixMs >= '...'     (bucket range)
```

So one query is 32 buckets, each contributing a predecessor seek and a bucket range, all 64 selecting the wide column list, all 64 running `FINAL`, and all sharing one 3.50 GiB budget.

## Suspected cause

`FINAL` disqualifies ClickHouse's `LazilyRead` optimisation.

`LazilyRead` resolves an ordering from sort-key columns and only then fetches the remaining columns, for the rows that survive the `LIMIT`. `FINAL` cannot use it, because the replacing merge has to see whole rows. So a `LIMIT 1` seek under `FINAL` materialises every selected column for every row in its seek range in order to return one of them.

#6493 attacked the same root cause from the other side, by making the rows narrower: `SEEK_SELECT` for the successor seek, and `AUTHORITATIVE_SELECT` (everything except the payload) for the fold. That helped, but it changed the constant, not the shape. The seeks still pay per row *scanned* rather than per row *returned*, and the predecessor seek's range is bounded only by the retention window, which defaults to 308 days. #6487 then folded many seeks into one statement, so that per-branch waste is now multiplied by 32 inside a single query's budget, which is why the failure count moved by more than an order of magnitude rather than down.

`EXPLAIN PLAN` on the production table, on the exact deployed predecessor shape (retention-cutoff bound included), differing only in `FINAL`:

```
deployed (FINAL)                          proposed (no FINAL)
  Expression                                Expression
    Limit (preliminary LIMIT)                 LazilyRead (Lazily Read)      <--
      Sorting (Sorting for ORDER BY)            Limit (preliminary LIMIT)
        Expression                                Sorting (Sorting for ORDER BY)
          Filter                                    Expression
            ReadFromMergeTree                         Expression
                                                        ReadFromMergeTree
```

## Proposed fix

Drop `FINAL` from the two `LIMIT 1` seeks and order by `DedupVersion DESC` as a final tiebreak.

The equivalence is specific to this table: `metric_data_points` is `ReplacingMergeTree(DedupVersion)` whose dedup key is exactly its sort key `(TenantId, SeriesId, TimeUnixMs, TimeUnixNano, PointId)`, and it declares no `is_deleted` column. So "the row `FINAL` would have kept" is just "the highest `DedupVersion` among rows sharing that key", which the sort key plus the tiebreak already picks. It would not hold on a table whose dedup key was narrower than its sort key, or one that could delete rows outright, and the code says so where it matters.

The bucket range keeps `FINAL`: it returns every row it reads, so it has nothing to defer and `FINAL` stays the clearer way to say "latest version".

This composes with #6493 rather than replacing it. The projections stay narrow; this stops even the narrow ones being materialised across the whole seek range.

## Expected impact

Each of the 32 predecessor branches per query fetches its non-key columns for one row instead of for every row it scans. Partition and granule counts are unchanged and are not the point: the same granules are examined either way, the difference is how much of each row is decompressed.

Expect the per-query 3.50 GiB failures on this shape to stop, and the rollup recomputes they are currently killing to complete. This is a write-path fold, so user-visible read latency is not the target.

## Test plan

`metric-data-point.clickhouse.repository.integration.test.ts` (real ClickHouse via testcontainers) gains a case where one point is accepted twice with different values, and a later sample differences against it.

It discriminates in both directions, which is what makes it worth having:

- with this PR's shape (no `FINAL` + tiebreak): passes
- with the currently deployed shape (`FINAL`): passes, so it pins semantics rather than implementation
- with `FINAL` removed and **no** tiebreak, which is what a careless version of this change looks like: fails, reading the superseded value so the delta goes negative and folds as a reset

```
-     "resetCount": 0,        -     "sum": 2,
+     "resetCount": 1,        +     "sum": 12,
```

It stops merges on the table for the duration, because a background merge collapses the two versions and then the seek returns the winner whatever it ordered by, which is exactly the state that cannot catch a regression.

9/9 integration pass. Also run: metric unit and pipeline tests (58 passed), typecheck, lint.

## EXPLAIN check

Run against the production table with a real tenant and series. Output above. Index analysis is unchanged between the two shapes, as intended for a change that alters what is read per granule rather than which granules are read.
