### PR TITLE
fix(clickhouse): stop metering tables that have no _size_bytes column

### DIFF
--- a/platform/app/src/server/data-retention/metering/__tests__/storageMeter.integration.test.ts
+++ b/platform/app/src/server/data-retention/metering/__tests__/storageMeter.integration.test.ts
@@ -46,7 +46,9 @@ afterAll(async () => {
 });
 
 describe("given the production-metered table list", () => {
-  it("is not empty, so a passing suite means something", () => {
+  // Guards the suite itself: every table-driven case below is an it.each over
+  // this list, so an empty list would make them all vacuously pass.
+  it("names at least one table to meter", () => {
     expect(PRODUCTION_STORAGE_METER_TABLES.length).toBeGreaterThan(0);
   });
 
@@ -110,7 +112,7 @@ describe("given the analytics projections that never declared _size_bytes", () =
 
   it.each(
     tablesWithoutSizeColumn,
-  )("%s stays retention-managed but out of metering", (table) => {
+  )("keeps %s retention-managed while excluding it from metering", (table) => {
     expect(RETENTION_MANAGED_TABLES).toContain(table);
     expect(PRODUCTION_STORAGE_METER_TABLES).not.toContain(table);
   });

--- a/platform/app/src/server/data-retention/metering/__tests__/storageMeter.integration.test.ts
+++ b/platform/app/src/server/data-retention/metering/__tests__/storageMeter.integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Checks the storage meter against a real migrated ClickHouse schema rather
+ * than a mocked client.
+ *
+ * Metering enrolls a table by listing it in the retention map, but summing
+ * `_size_bytes` only works if that table's migration declared the column. The
+ * two are independent, nothing connected them, and four tables were enrolled
+ * without the column: every metering call then raised UNKNOWN_IDENTIFIER,
+ * failed the single-query total, and fell back to the per-table path. A mocked
+ * client cannot see that, because the mock answers whatever it is asked.
+ *
+ * So the guard here is deliberately schema-level: every metered table must
+ * actually answer the query the service builds for it.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import {
+  PRODUCTION_STORAGE_METER_TABLES,
+  RETENTION_MANAGED_TABLES,
+} from "../../retentionPolicy.schema";
+import { StorageMeterService } from "../storageMeter.service";
+
+let ch: ClickHouseClient;
+let meter: StorageMeterService;
+
+const tenantId = `${nanoid()}-project`;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  meter = new StorageMeterService({
+    resolveClickHouseClient: async () => ch,
+  });
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+describe("given the production-metered table list", () => {
+  it("is not empty, so a passing suite means something", () => {
+    expect(PRODUCTION_STORAGE_METER_TABLES.length).toBeGreaterThan(0);
+  });
+
+  describe("when each table is asked for its metered size", () => {
+    it.each(
+      PRODUCTION_STORAGE_METER_TABLES,
+    )("%s answers sum(_size_bytes)", async (table) => {
+      const result = await ch.query({
+        query: `SELECT sum(_size_bytes) AS total FROM ${table} WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId },
+        format: "JSONEachRow",
+      });
+      const rows = (await result.json()) as Array<{ total: string }>;
+
+      expect(Number(rows[0]?.total ?? 0)).toBe(0);
+    });
+  });
+
+  describe("when they are summed the way the meter does it", () => {
+    it("answers as one aggregate instead of failing to the per-table path", async () => {
+      // The shape queryTotalBytes builds: pre-aggregate per table, then sum one
+      // scalar per table. One table that cannot answer fails the whole query,
+      // which is the regression this pins.
+      const unions = PRODUCTION_STORAGE_METER_TABLES.map(
+        (table) =>
+          `SELECT sum(_size_bytes) AS t FROM ${table} WHERE TenantId = {tenantId:String}`,
+      ).join("\n  UNION ALL\n  ");
+      const result = await ch.query({
+        query: `SELECT sum(t) AS total FROM (\n  ${unions}\n)`,
+        query_params: { tenantId },
+        format: "JSONEachRow",
+      });
+      const rows = (await result.json()) as Array<{ total: string }>;
+
+      expect(Number(rows[0]?.total ?? 0)).toBe(0);
+    });
+  });
+
+  describe("when the service reports a breakdown", () => {
+    it("returns every category without degrading a table to zero", async () => {
+      const breakdown = await meter.getStorageBreakdown({ tenantId });
+
+      expect(breakdown).toEqual({
+        totalBytes: 0,
+        byCategory: { traces: 0, scenarios: 0, experiments: 0 },
+      });
+    });
+  });
+});
+
+describe("given the analytics projections that never declared _size_bytes", () => {
+  // Named rather than derived from the metered list, which would only restate
+  // how that list was built. These four are the ADR-034 projections created by
+  // migrations 00038 to 00041.
+  const tablesWithoutSizeColumn = [
+    "trace_analytics",
+    "trace_analytics_rollup",
+    "evaluation_analytics",
+    "evaluation_analytics_rollup",
+  ] as const;
+
+  it.each(
+    tablesWithoutSizeColumn,
+  )("%s stays retention-managed but out of metering", (table) => {
+    expect(RETENTION_MANAGED_TABLES).toContain(table);
+    expect(PRODUCTION_STORAGE_METER_TABLES).not.toContain(table);
+  });
+
+  describe("when one is asked for its metered size anyway", () => {
+    it.each(
+      tablesWithoutSizeColumn,
+    )("%s rejects the query rather than reporting zero", async (table) => {
+      await expect(
+        ch.query({
+          query: `SELECT sum(_size_bytes) AS total FROM ${table} WHERE TenantId = {tenantId:String}`,
+          query_params: { tenantId },
+          format: "JSONEachRow",
+        }),
+      ).rejects.toThrow(/_size_bytes/);
+    });
+  });
+});

--- a/platform/app/src/server/data-retention/retentionPolicy.schema.ts
+++ b/platform/app/src/server/data-retention/retentionPolicy.schema.ts
@@ -310,6 +310,38 @@ const SHADOW_METRIC_STORAGE_TABLES = new Set<RetentionManagedTable>([
   "metric_time_rollups",
 ]);
 
+/**
+ * Retention-managed tables that carry no `_size_bytes` column, so nothing can
+ * meter them.
+ *
+ * Migration 00032 added `_size_bytes` to every table that existed then, and
+ * tables created afterwards declare it themselves (00047, 00049, 00050). The
+ * ADR-034 analytics projections are the gap: they were added to the retention
+ * map, which is what enrolls a table in metering, but their migrations
+ * (00038 to 00041) never declared the column.
+ *
+ * Metering them therefore raises UNKNOWN_IDENTIFIER rather than returning a
+ * number. That is not contained to the four tables: they are summed in one
+ * UNION ALL with everything else, so the single-query total fails outright and
+ * every call falls back to the per-table breakdown, which is the path whose
+ * `byteSize(...)` recompute on un-materialized parts is the known memory and
+ * timeout hazard. The four then fail again individually and degrade to zero.
+ *
+ * Excluding them here leaves every tenant's reported total exactly as it is
+ * today (the failing queries already contribute zero) and restores the single
+ * aggregate for the tables that can answer. Metering them for real means
+ * adding the column and deciding whether their bytes should be billed, which
+ * is tracked separately.
+ */
+const TABLES_WITHOUT_SIZE_COLUMN = new Set<RetentionManagedTable>([
+  "trace_analytics",
+  "trace_analytics_rollup",
+  "evaluation_analytics",
+  "evaluation_analytics_rollup",
+]);
+
 export const PRODUCTION_STORAGE_METER_TABLES = RETENTION_MANAGED_TABLES.filter(
-  (table) => !SHADOW_METRIC_STORAGE_TABLES.has(table),
+  (table) =>
+    !SHADOW_METRIC_STORAGE_TABLES.has(table) &&
+    !TABLES_WITHOUT_SIZE_COLUMN.has(table),
 );


### PR DESCRIPTION
## Evidence

Production ClickHouse is refusing the storage-metering query several times a day, with `Code: 47 UNKNOWN_IDENTIFIER`:

```
Unknown expression or function identifier `_size_bytes`
  in scope SELECT sum(_size_bytes) AS t FROM trace_analytics WHERE TenantId = '<redacted>'
```

Counted over a 72h window, filtered to that identifier, the failures land on exactly four tables and nothing else:

| Table | Failures |
| --- | --- |
| `trace_analytics` | 4 |
| `trace_analytics_rollup` | 2 |
| `evaluation_analytics` | 2 |
| `evaluation_analytics_rollup` | 2 |

The count is low because metering is cached and single-flighted per tenant, not because the failure is intermittent. It is deterministic: these tables can never answer this query.

## Suspected cause

A table is enrolled in metering by appearing in `RETENTION_TABLE_CATEGORY_MAP`, and `PRODUCTION_STORAGE_METER_TABLES` is derived from it. Whether the table actually has a `_size_bytes` column is decided somewhere else entirely, in its migration. Nothing ties the two together.

Migration 00032 added `_size_bytes` to every table that existed at the time, and tables created since declare it themselves (00047, 00049, 00050). The four ADR-034 analytics projections are the gap: 00038 to 00041 create them without the column, and they were later added to the retention map, which silently enrolled them in metering too.

The damage is wider than those four tables, because of how they are summed. `queryTotalBytes` pre-aggregates each table inside one `UNION ALL`:

```sql
SELECT sum(t) AS total FROM (
  SELECT sum(_size_bytes) AS t FROM event_log WHERE TenantId = {tenantId:String}
  UNION ALL
  ...
)
```

One table that cannot answer fails the entire query. So the fast path fails on every call for every tenant, and the `catch` falls through to `getStorageBreakdown`, which re-queries all tables one at a time. That is the path this repo already documents as the memory and timeout hazard, because `_size_bytes` is `MATERIALIZED byteSize(...)` and gets recomputed over heavy payload columns on parts where it was never materialized. The four tables then fail individually too, and their `catch` degrades each to zero.

Net effect today: the cheap aggregate never runs, the expensive fallback always runs, and the four tables contribute nothing to the total anyway.

## Proposed fix

Exclude the four tables from the metered set, next to the existing shadow-metric exclusion and with the reasoning written down.

Deliberately conservative on the number itself: every tenant's reported total is **unchanged**, because these tables already contribute zero through the `catch`. What changes is that the single aggregate can run again for the tables that can answer, and metering stops taking the fallback path on every call.

Metering them for real is a separate change, and not one to fold in here: it needs the column added to all four, and a decision about whether their bytes should count toward billed storage, which would raise customer-visible totals. Filed separately as #6454.

The tables stay in `RETENTION_TABLE_CATEGORY_MAP`, so TTL and retention still manage them exactly as before. This is a metering exclusion, not a retention change, and the test asserts that distinction.

## Expected impact

- Storage metering stops emitting `UNKNOWN_IDENTIFIER` in production.
- The per-tenant total goes back to one query instead of one per metered table, so it stops routinely exercising the `byteSize(...)` recompute path that the 45s guardrail exists to contain.
- Reported storage numbers do not move.

## Test plan

New `storageMeter.integration.test.ts`, against a real migrated ClickHouse via testcontainers. The existing meter tests mock the client, which is precisely why this went unnoticed: a mock answers whatever it is asked, so only a real schema can catch it.

It asserts every table in `PRODUCTION_STORAGE_METER_TABLES` answers `sum(_size_bytes)`, that the `UNION ALL` total the service builds succeeds as one query, that `getStorageBreakdown` returns all three categories, and that excluded tables are still retention-managed.

Verified it catches the original bug: putting the four tables back makes it fail with the same error seen in production.

```
× trace_analytics answers sum(_size_bytes)              type: 'UNKNOWN_IDENTIFIER'
× trace_analytics_rollup answers sum(_size_bytes)       type: 'UNKNOWN_IDENTIFIER'
× evaluation_analytics answers sum(_size_bytes)         type: 'UNKNOWN_IDENTIFIER'
× evaluation_analytics_rollup answers sum(_size_bytes)  type: 'UNKNOWN_IDENTIFIER'
```

Because it iterates the list rather than naming tables, any table enrolled in metering in future without the column fails here instead of in production.

17 passed. Also run: data-retention unit tests (114 passed), typecheck, lint, feature-parity.

## EXPLAIN check

Not applicable in the usual form: the old shape has no query plan, because it fails at name resolution before planning. The comparison that matters is the one in the test, where the same `UNION ALL` fails with the four tables included and succeeds without them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage metering reliability by excluding analytics tables that do not support size-based queries.
  * Ensured storage breakdowns accurately cover all supported production-metered tables.
  * Prevented unsupported metering queries for retention-managed analytics data.
  * Added validation to improve the accuracy and consistency of reported storage usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->