### PR TITLE
docs: move the Langy group to the bottom of the Self Hosting nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -817,16 +817,6 @@
             ]
           },
           {
-            "group": "Langy",
-            "pages": [
-              "self-hosting/langy/overview",
-              "self-hosting/langy/setup",
-              "self-hosting/langy/github-app",
-              "self-hosting/langy/environment-variables",
-              "self-hosting/langy/networking-and-egress"
-            ]
-          },
-          {
             "group": "Deployment",
             "pages": [
               "self-hosting/deployment/docker-compose",
@@ -861,6 +851,16 @@
               "self-hosting/ops/projection-replay",
               "self-hosting/ops/dejaview",
               "self-hosting/ops/foundry"
+            ]
+          },
+          {
+            "group": "Langy",
+            "pages": [
+              "self-hosting/langy/overview",
+              "self-hosting/langy/setup",
+              "self-hosting/langy/github-app",
+              "self-hosting/langy/environment-variables",
+              "self-hosting/langy/networking-and-egress"
             ]
           }
         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -568,14 +568,6 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Observability & Monitoring](https://langwatch.ai/docs/self-hosting/configuration/observability.md): Monitor LangWatch infrastructure with Prometheus, Grafana, and health checks
 - [Third-Party Integrations](https://langwatch.ai/docs/self-hosting/configuration/third-party-integrations.md): Configure email, error tracking, analytics, and external services for LangWatch
 
-## Langy
-
-- [Self-Hosting Langy](https://langwatch.ai/docs/self-hosting/langy/overview.md): Requirements and architecture for running Langy on your own Kubernetes cluster, including the separate agent pod and the gVisor requirement.
-- [Langy Assistant](https://langwatch.ai/docs/self-hosting/langy/setup.md): Run LangWatch's in-product AI assistant on your own cluster
-- [Register the Langy GitHub App](https://langwatch.ai/docs/self-hosting/langy/github-app.md): Deployment-time guide for the GitHub App that lets Langy open bot-authored pull requests, covering registration, permissions, the GITHUB_LANGY env vars, install, verify, and disconnect.
-- [Langy Environment Variables](https://langwatch.ai/docs/self-hosting/langy/environment-variables.md): The environment variable reference for the Langy agent pod and its control-plane integration, grouped by core, workers, egress, mirror lane, and GitHub.
-- [Langy Networking and Egress](https://langwatch.ai/docs/self-hosting/langy/networking-and-egress.md): The NetworkPolicy and L7 egress adapter that govern what the Langy agent pod can reach, the GitHub FQDN floor, and the cooperative-vs-mandatory enforcement limit.
-
 ## Deployment
 
 - [Docker Compose](https://langwatch.ai/docs/self-hosting/deployment/docker-compose.md): Get LangWatch running locally in minutes with Docker Compose
@@ -604,6 +596,14 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Projection Replay](https://langwatch.ai/docs/self-hosting/ops/projection-replay.md): Rebuild projection state by replaying events from ClickHouse
 - [Deja View](https://langwatch.ai/docs/self-hosting/ops/dejaview.md): Time-travel debugger for event-sourced aggregates
 - [The Foundry](https://langwatch.ai/docs/self-hosting/ops/foundry.md): Interactive trace playground for building and sending synthetic traces
+
+## Langy
+
+- [Self-Hosting Langy](https://langwatch.ai/docs/self-hosting/langy/overview.md): Requirements and architecture for running Langy on your own Kubernetes cluster, including the separate agent pod and the gVisor requirement.
+- [Langy Assistant](https://langwatch.ai/docs/self-hosting/langy/setup.md): Run LangWatch's in-product AI assistant on your own cluster
+- [Register the Langy GitHub App](https://langwatch.ai/docs/self-hosting/langy/github-app.md): Deployment-time guide for the GitHub App that lets Langy open bot-authored pull requests, covering registration, permissions, the GITHUB_LANGY env vars, install, verify, and disconnect.
+- [Langy Environment Variables](https://langwatch.ai/docs/self-hosting/langy/environment-variables.md): The environment variable reference for the Langy agent pod and its control-plane integration, grouped by core, workers, egress, mirror lane, and GitHub.
+- [Langy Networking and Egress](https://langwatch.ai/docs/self-hosting/langy/networking-and-egress.md): The NetworkPolicy and L7 egress adapter that govern what the Langy agent pod can reach, the GitHub FQDN floor, and the cooperative-vs-mandatory enforcement limit.
 
 # API Reference
 


### PR DESCRIPTION
## What

Moves the **Langy** group to the bottom of the Self Hosting sidebar, after Ops Console.

Group order in the Self Hosting anchor:

| Before | After |
|---|---|
| Overview, Configuration, **Langy**, Deployment, Infrastructure, Operations, Ops Console | Overview, Configuration, Deployment, Infrastructure, Operations, Ops Console, **Langy** |

Langy sat between Configuration and Deployment, splitting the core self-hosting path (configure, then deploy, then operate) with an optional add-on. Moving it last keeps that path uninterrupted.

No pages were added, removed, or renamed, so no URLs change. `llms.txt` is regenerated by the pre-commit hook to match the new order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Self Hosting navigation by moving the Langy section from Configuration to Ops Console.
  * Updated the documentation index to match the new section placement.
  * Existing pages, content, and links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->