### PR TITLE
fix(ops): stop the pending reconcile and blob sweep scaling with the keyspace

### DIFF
--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -351,6 +351,37 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
     });
   });
 
+  describe("given a group the pending index has not learned about yet", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario "A group known only to the lifecycle indexes is adopted into the pending index" */
+      it("counts it and adopts it, so later passes read it from the index", async () => {
+        const indexKey = `${queueName}:gq:pending-groups`;
+
+        await redis.del(markerKey);
+
+        // The shape left by a pod on the previous release, or by anything staged
+        // before the index existed: jobs and lifecycle membership, no index entry.
+        await redis.zadd(
+          `${queueName}:gq:group:legacy-group:jobs`,
+          1,
+          "j1",
+          2,
+          "j2",
+        );
+        await redis.zadd(`${queueName}:gq:ready`, 1, "legacy-group");
+        await redis.set(`${queueName}:gq:stats:total-pending`, "0");
+
+        expect(await redis.exists(indexKey)).toBe(0);
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(2);
+        // Adopted, so it no longer depends on the sequential lifecycle read.
+        expect(await redis.sismember(indexKey, "legacy-group")).toBe(1);
+      });
+    });
+  });
+
   describe("given another instance holds the single-flight marker", () => {
     describe("when a reconcile is declined", () => {
       /** @scenario A declined reconcile leaves the holder's marker untouched */

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -289,6 +289,68 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
     });
   });
 
+  describe("given a group listed only in the pending index", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario "A group counted from the pending index needs no lifecycle membership" */
+      it("counts its jobs without it appearing in ready, blocked or parked", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        await redis.del(markerKey);
+
+        // Exactly the state a group is in while it moves between lifecycle
+        // indexes: holding jobs, in none of them.
+        await redis.zadd(
+          `${queueName}:gq:group:tenant-a/in-flight-move:jobs`,
+          1,
+          "j1",
+          2,
+          "j2",
+          3,
+          "j3",
+        );
+        await redis.sadd(
+          `${queueName}:gq:pending-groups`,
+          "tenant-a/in-flight-move",
+        );
+        await redis.set(counterKey, "0");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(3);
+        expect(await redis.get(counterKey)).toBe("3");
+      });
+    });
+  });
+
+  describe("given a drained group still listed in the pending index", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario "A drained group is dropped from the pending index" */
+      it("prunes the drained group but keeps one that still holds jobs", async () => {
+        const indexKey = `${queueName}:gq:pending-groups`;
+
+        await redis.del(markerKey);
+
+        // No jobs zset at all: the shape left behind when the safety-net TTL
+        // expires a group's jobs without any script running.
+        await redis.sadd(indexKey, "tenant-a/drained");
+        await redis.zadd(
+          `${queueName}:gq:group:tenant-a/live:jobs`,
+          1,
+          "still-here",
+        );
+        await redis.sadd(indexKey, "tenant-a/live");
+        await redis.set(`${queueName}:gq:stats:total-pending`, "0");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(1);
+        expect((await redis.smembers(indexKey)).sort()).toEqual([
+          "tenant-a/live",
+        ]);
+      });
+    });
+  });
+
   describe("given another instance holds the single-flight marker", () => {
     describe("when a reconcile is declined", () => {
       /** @scenario A declined reconcile leaves the holder's marker untouched */

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -84,6 +84,7 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         // Seed: 2 jobs in one group, counter = 2 (no drift)
         await redis.zadd(groupJobsKey, 1000, "job-x1", 1001, "job-x2");
+        await redis.zadd(`${queueName}:gq:ready`, 1, "groupX");
         await redis.set(counterKey, "2");
 
         const result = await repo.reconcileTotalPending(queueName);
@@ -109,6 +110,7 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         // Seed: 1 job, counter = 999 (drifted)
         await redis.zadd(groupJobsKey, 1000, "job-y1");
+        await redis.zadd(`${queueName}:gq:ready`, 1, "groupY");
         await redis.set(counterKey, "999");
 
         // First call — heals the counter
@@ -147,6 +149,7 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         );
         await redis.zadd(`${queueName}:gq:group:gb:jobs`, 4, "j4", 5, "j5");
         await redis.zadd(`${queueName}:gq:group:gc:jobs`, 6, "j6", 7, "j7");
+        await redis.zadd(`${queueName}:gq:ready`, 1, "ga", 1, "gb", 1, "gc");
 
         // SET counter = 3 (under-counted)
         await redis.set(counterKey, "3");
@@ -184,6 +187,119 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         // Counter must be healed to zero
         expect(await redis.get(counterKey)).toBe("0");
+      });
+    });
+  });
+
+  describe("given groups held outside the ready set", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile counts blocked and parked groups alongside ready ones */
+      it("counts the jobs of ready, blocked and parked groups", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        await redis.del(markerKey);
+
+        // A live group in ready, one held for operator triage in blocked, and
+        // one deferred by the per-tenant cap into its tenant's parked set.
+        await redis.zadd(`${queueName}:gq:group:tenant-a/ready:jobs`, 1, "j1");
+        await redis.zadd(`${queueName}:gq:ready`, 1, "tenant-a/ready");
+
+        await redis.zadd(
+          `${queueName}:gq:group:tenant-a/blocked:jobs`,
+          1,
+          "j2",
+          2,
+          "j3",
+        );
+        await redis.sadd(`${queueName}:gq:blocked`, "tenant-a/blocked");
+
+        await redis.zadd(
+          `${queueName}:gq:group:tenant-b/parked:jobs`,
+          1,
+          "j4",
+          2,
+          "j5",
+          3,
+          "j6",
+        );
+        await redis.zadd(
+          `${queueName}:gq:parked:tenant-b`,
+          1,
+          "tenant-b/parked",
+        );
+        await redis.sadd(`${queueName}:gq:parked-tenants`, "tenant-b");
+
+        await redis.set(counterKey, "0");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(6);
+        expect(await redis.get(counterKey)).toBe("6");
+      });
+    });
+  });
+
+  describe("given a group that is in both the ready and blocked indexes", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile counts a group listed in two indexes only once */
+      it("counts the group's jobs once", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        await redis.del(markerKey);
+
+        await redis.zadd(
+          `${queueName}:gq:group:groupDup:jobs`,
+          1,
+          "j1",
+          2,
+          "j2",
+        );
+        await redis.zadd(`${queueName}:gq:ready`, 1, "groupDup");
+        await redis.sadd(`${queueName}:gq:blocked`, "groupDup");
+        await redis.set(counterKey, "0");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(2);
+      });
+    });
+  });
+
+  describe("given a pass that ran past its single-flight window", () => {
+    describe("when reconcile completes", () => {
+      /** @scenario An overrunning reconcile releases the marker instead of holding it past the window */
+      it("releases the marker so the next cycle can start immediately", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        await redis.del(markerKey);
+        await redis.zadd(`${queueName}:gq:group:groupZ:jobs`, 1, "j1");
+        await redis.zadd(`${queueName}:gq:ready`, 1, "groupZ");
+        await redis.set(counterKey, "9");
+
+        // A zero-length window is the same state a pass reaches by outliving
+        // its window: nothing of it remains to hand back.
+        const result = await repo.reconcileTotalPending(queueName, 0);
+
+        expect(result).not.toBeNull();
+        expect(await redis.exists(markerKey)).toBe(0);
+
+        // The next cycle is free to run rather than being told to wait.
+        expect(await repo.reconcileTotalPending(queueName)).not.toBeNull();
+      });
+    });
+  });
+
+  describe("given another instance holds the single-flight marker", () => {
+    describe("when a reconcile is declined", () => {
+      /** @scenario A declined reconcile leaves the holder's marker untouched */
+      it("leaves the holder's marker and its expiry alone", async () => {
+        await redis.set(markerKey, "other-instance-token", "PX", 30_000);
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result).toBeNull();
+        expect(await redis.get(markerKey)).toBe("other-instance-token");
+        expect(await redis.pttl(markerKey)).toBeGreaterThan(0);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -328,7 +328,7 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
       it("prunes the drained group but keeps one that still holds jobs", async () => {
         const indexKey = `${queueName}:gq:pending-groups`;
 
-        await redis.del(markerKey);
+        await redis.del(markerKey, indexKey);
 
         // No jobs zset at all: the shape left behind when the safety-net TTL
         // expires a group's jobs without any script running.
@@ -357,7 +357,9 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
       it("counts it and adopts it, so later passes read it from the index", async () => {
         const indexKey = `${queueName}:gq:pending-groups`;
 
-        await redis.del(markerKey);
+        // Queue names repeat across runs of this suite, so clear the index this
+        // test asserts is empty rather than trusting a previous run left nothing.
+        await redis.del(markerKey, indexKey);
 
         // The shape left by a pod on the previous release, or by anything staged
         // before the index existed: jobs and lifecycle membership, no index entry.
@@ -378,6 +380,35 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         expect(result!.groundTruth).toBe(2);
         // Adopted, so it no longer depends on the sequential lifecycle read.
         expect(await redis.sismember(indexKey, "legacy-group")).toBe(1);
+      });
+    });
+  });
+
+  describe("given a group that no index lists at all", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario "A group no index lists is still counted and adopted" */
+      it("finds it in the keyspace, counts it, and adopts it", async () => {
+        const indexKey = `${queueName}:gq:pending-groups`;
+
+        await redis.del(markerKey, indexKey);
+
+        // Holding jobs, in neither the pending index nor any lifecycle index —
+        // the state a group passes through while it moves between them.
+        await redis.zadd(
+          `${queueName}:gq:group:orphan-mover:jobs`,
+          1,
+          "j1",
+          2,
+          "j2",
+          3,
+          "j3",
+        );
+        await redis.set(`${queueName}:gq:stats:total-pending`, "0");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result!.groundTruth).toBe(3);
+        expect(await redis.sismember(indexKey, "orphan-mover")).toBe(1);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -32,8 +32,20 @@ class FakeRedis {
   /** Runs after every pipeline `exec`, so a test can simulate a slow pass. */
   onPipelineExec: (() => void) | null = null;
 
+  /**
+   * Ordered log of lease re-arms and ZCARD batches, so a test can tell which
+   * phase of the pass a re-arm belongs to.
+   */
+  readonly events: ("lease-refresh" | "zcard-batch")[] = [];
+
   readonly scan = vi.fn(async () => ["0", [] as string[]] as const);
-  readonly evalshaCalls: { key: string; token: string; ttlMs: number }[] = [];
+  readonly evalshaCalls: {
+    key: string;
+    token: string;
+    ttlMs: number;
+    /** Whether the marker still carried the caller's token at that moment. */
+    isHeldByCaller: boolean;
+  }[] = [];
 
   async set(
     key: string,
@@ -101,6 +113,7 @@ class FakeRedis {
             ? [new Error("ZCARD failed"), null]
             : [null, (self.zsets.get(key) ?? []).length],
         );
+        self.events.push("zcard-batch");
         self.onPipelineExec?.();
         return results;
       },
@@ -115,8 +128,15 @@ class FakeRedis {
     token: string,
     ttlMs: number,
   ): Promise<number> {
-    this.evalshaCalls.push({ key, token, ttlMs: Number(ttlMs) });
-    if (this.strings.get(key) !== token) return 0;
+    const isHeldByCaller = this.strings.get(key) === token;
+    this.evalshaCalls.push({
+      key,
+      token,
+      ttlMs: Number(ttlMs),
+      isHeldByCaller,
+    });
+    if (Number(ttlMs) === LEASE_MS) this.events.push("lease-refresh");
+    if (!isHeldByCaller) return 0;
     if (Number(ttlMs) <= 0) {
       this.strings.delete(key);
       this.expiries.delete(key);
@@ -245,13 +265,38 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
       it("re-arms the single-flight marker after each ZCARD batch", async () => {
         await repo.reconcileTotalPending(QUEUE_NAME);
 
+        const batches = redis.events.filter(
+          (event) => event === "zcard-batch",
+        ).length;
+        expect(batches).toBe(3);
+
+        // One re-arm per batch, each landing after its batch.
+        const refreshesAfterFirstBatch = redis.events
+          .slice(redis.events.indexOf("zcard-batch"))
+          .filter((event) => event === "lease-refresh").length;
+        expect(refreshesAfterFirstBatch).toBe(batches);
+
         const leaseRefreshes = redis.evalshaCalls.filter(
           (call) => call.ttlMs === LEASE_MS,
         );
-        expect(leaseRefreshes).toHaveLength(3);
         expect(leaseRefreshes.every((call) => call.key === MARKER_KEY)).toBe(
           true,
         );
+      });
+
+      it("re-arms the single-flight marker while paging the indexes, before any ZCARD runs", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME);
+
+        // Collection is a paging walk of its own and on a large queue can outlast
+        // a lease before the first ZCARD is ever issued. If nothing re-armed
+        // during that phase, the marker could lapse and another instance could
+        // start a second pass over the same counter.
+        const firstBatchAt = redis.events.indexOf("zcard-batch");
+        const refreshesBeforeAnyBatch = redis.events
+          .slice(0, firstBatchAt)
+          .filter((event) => event === "lease-refresh").length;
+
+        expect(refreshesBeforeAnyBatch).toBeGreaterThan(0);
       });
     });
   });
@@ -323,12 +368,14 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
       it("holds the marker for the whole pass rather than letting it lapse mid-pass", async () => {
         await repo.reconcileTotalPending(QUEUE_NAME, SINGLE_FLIGHT_WINDOW_MS);
 
-        // The refresh lands after the batch that overran the window, so the
-        // marker is still this pass's own when the pass releases it.
+        // Ownership is the claim, not the call count: every re-arm has to find
+        // this pass's own token still on the marker. A count-only assertion
+        // could not fail for the reason this test exists.
         const refreshes = redis.evalshaCalls.filter(
           (call) => call.ttlMs === LEASE_MS,
         );
         expect(refreshes.length).toBeGreaterThan(0);
+        expect(refreshes.every((call) => call.isHeldByCaller)).toBe(true);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -1,0 +1,360 @@
+import type { Redis } from "ioredis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueueRedisRepository } from "../queue.redis.repository";
+
+const QUEUE_NAME = "test-queue";
+const PREFIX = `${QUEUE_NAME}:gq:`;
+const COUNTER_KEY = `${PREFIX}stats:total-pending`;
+const MARKER_KEY = `${PREFIX}stats:pending-recon-ts`;
+const SINGLE_FLIGHT_WINDOW_MS = 55_000;
+const LEASE_MS = 30_000;
+
+/**
+ * Minimal in-memory stand-in for the Redis commands a reconcile pass issues.
+ *
+ * `zscan`/`sscan` page for real (a page holds at most COUNT entries) so the
+ * paging loops are exercised rather than short-circuited, and `scan` is a spy
+ * that records any keyspace walk so a test can assert none happens.
+ *
+ * `evalsha` models the marker-TTL script rather than running it; the Lua itself
+ * is covered against a real Redis in
+ * `__tests__/integration/pending-counter-reconcile.integration.test.ts`.
+ */
+class FakeRedis {
+  readonly strings = new Map<string, string>();
+  readonly expiries = new Map<string, number>();
+  readonly zsets = new Map<string, string[]>();
+  readonly sets = new Map<string, string[]>();
+
+  /** ZCARD keys whose pipeline entry resolves to an error instead of a count. */
+  readonly failingZcardKeys = new Set<string>();
+
+  /** Runs after every pipeline `exec`, so a test can simulate a slow pass. */
+  onPipelineExec: (() => void) | null = null;
+
+  readonly scan = vi.fn(async () => ["0", [] as string[]] as const);
+  readonly evalshaCalls: { key: string; token: string; ttlMs: number }[] = [];
+
+  async set(
+    key: string,
+    value: string,
+    ...options: (string | number)[]
+  ): Promise<string | null> {
+    if (options.includes("NX") && this.strings.has(key)) return null;
+    this.strings.set(key, value);
+    const pxIndex = options.indexOf("PX");
+    if (pxIndex >= 0) {
+      this.expiries.set(key, Number(options[pxIndex + 1]));
+    }
+    return "OK";
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async zscan(
+    key: string,
+    cursor: string,
+    _count: "COUNT",
+    count: number,
+  ): Promise<[string, string[]]> {
+    const members = this.zsets.get(key) ?? [];
+    const [nextCursor, page] = this.page(members, cursor, count);
+    // A ZSCAN page alternates [member, score, member, score, ...].
+    return [nextCursor, page.flatMap((member) => [member, "1"])];
+  }
+
+  async sscan(
+    key: string,
+    cursor: string,
+    _count: "COUNT",
+    count: number,
+  ): Promise<[string, string[]]> {
+    return this.page(this.sets.get(key) ?? [], cursor, count);
+  }
+
+  private page(
+    members: string[],
+    cursor: string,
+    count: number,
+  ): [string, string[]] {
+    const offset = Number(cursor);
+    const page = members.slice(offset, offset + count);
+    const next = offset + page.length;
+    return [next >= members.length ? "0" : String(next), page];
+  }
+
+  pipeline() {
+    const keys: string[] = [];
+    const self = this;
+    return {
+      zcard(key: string) {
+        keys.push(key);
+        return this;
+      },
+      async exec(): Promise<[Error | null, unknown][]> {
+        const results = keys.map((key): [Error | null, unknown] =>
+          self.failingZcardKeys.has(key)
+            ? [new Error("ZCARD failed"), null]
+            : [null, (self.zsets.get(key) ?? []).length],
+        );
+        self.onPipelineExec?.();
+        return results;
+      },
+    };
+  }
+
+  async evalsha(
+    _sha: string,
+    _numKeys: number,
+    key: string,
+    token: string,
+    ttlMs: number,
+  ): Promise<number> {
+    this.evalshaCalls.push({ key, token, ttlMs: Number(ttlMs) });
+    if (this.strings.get(key) !== token) return 0;
+    if (Number(ttlMs) <= 0) {
+      this.strings.delete(key);
+      this.expiries.delete(key);
+      return 1;
+    }
+    this.expiries.set(key, Number(ttlMs));
+    return 1;
+  }
+
+  /** Seeds a group with `jobCount` staged jobs, indexed under `index`. */
+  seedGroup(params: {
+    groupId: string;
+    jobCount: number;
+    index: string;
+    indexType: "zset" | "set";
+  }): void {
+    const jobs = Array.from(
+      { length: params.jobCount },
+      (_, i) => `${params.groupId}-job-${i}`,
+    );
+    this.zsets.set(`${PREFIX}group:${params.groupId}:jobs`, jobs);
+    const container =
+      params.indexType === "zset"
+        ? (this.zsets.get(params.index) ?? [])
+        : (this.sets.get(params.index) ?? []);
+    container.push(params.groupId);
+    if (params.indexType === "zset") this.zsets.set(params.index, container);
+    else this.sets.set(params.index, container);
+  }
+
+  asRedis(): Redis {
+    return this as unknown as Redis;
+  }
+}
+
+describe("QueueRedisRepository.reconcileTotalPending", () => {
+  let redis: FakeRedis;
+  let repo: QueueRedisRepository;
+
+  beforeEach(() => {
+    redis = new FakeRedis();
+    repo = new QueueRedisRepository(redis.asRedis());
+  });
+
+  describe("given groups indexed under ready, blocked and parked", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/ready-group",
+        jobCount: 3,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.seedGroup({
+        groupId: "tenant-a/blocked-group",
+        jobCount: 2,
+        index: `${PREFIX}blocked`,
+        indexType: "set",
+      });
+      redis.sets.set(`${PREFIX}parked-tenants`, ["tenant-b"]);
+      redis.seedGroup({
+        groupId: "tenant-b/parked-group",
+        jobCount: 4,
+        index: `${PREFIX}parked:tenant-b`,
+        indexType: "zset",
+      });
+      redis.strings.set(COUNTER_KEY, "100");
+    });
+
+    describe("when reconcile runs", () => {
+      it("sums the jobs of every indexed group and heals the counter", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toEqual({ counter: 100, groundTruth: 9, drift: 91 });
+        expect(redis.strings.get(COUNTER_KEY)).toBe("9");
+      });
+
+      it("reads the group indexes instead of walking the keyspace", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(redis.scan).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a group listed in two indexes at once", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/moving-group",
+        jobCount: 5,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.sets.set(`${PREFIX}blocked`, ["tenant-a/moving-group"]);
+    });
+
+    describe("when reconcile runs", () => {
+      it("counts the group's jobs once", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(5);
+      });
+    });
+  });
+
+  describe("given more groups than fit in one index page or ZCARD batch", () => {
+    const groupCount = 2500;
+
+    beforeEach(() => {
+      for (let i = 0; i < groupCount; i++) {
+        redis.seedGroup({
+          groupId: `tenant-a/group-${i}`,
+          jobCount: 1,
+          index: `${PREFIX}ready`,
+          indexType: "zset",
+        });
+      }
+    });
+
+    describe("when reconcile runs", () => {
+      it("counts every group across all pages", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(groupCount);
+      });
+
+      it("re-arms the single-flight marker after each ZCARD batch", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME);
+
+        const leaseRefreshes = redis.evalshaCalls.filter(
+          (call) => call.ttlMs === LEASE_MS,
+        );
+        expect(leaseRefreshes).toHaveLength(3);
+        expect(leaseRefreshes.every((call) => call.key === MARKER_KEY)).toBe(
+          true,
+        );
+      });
+    });
+  });
+
+  describe("given a reconcile pass is already running on another instance", () => {
+    beforeEach(() => {
+      redis.strings.set(MARKER_KEY, "other-instance-token");
+      redis.strings.set(COUNTER_KEY, "42");
+    });
+
+    describe("when reconcile runs", () => {
+      it("declines the pass and leaves the counter untouched", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toBeNull();
+        expect(redis.strings.get(COUNTER_KEY)).toBe("42");
+        expect(redis.strings.get(MARKER_KEY)).toBe("other-instance-token");
+      });
+    });
+  });
+
+  describe("given a pass that finishes inside the single-flight window", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/group",
+        jobCount: 1,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+    });
+
+    describe("when reconcile completes", () => {
+      it("leaves the marker holding the unspent remainder of the window", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME, SINGLE_FLIGHT_WINDOW_MS);
+
+        expect(redis.strings.has(MARKER_KEY)).toBe(true);
+        const remainder = redis.expiries.get(MARKER_KEY)!;
+        expect(remainder).toBeGreaterThan(SINGLE_FLIGHT_WINDOW_MS - 1_000);
+        expect(remainder).toBeLessThanOrEqual(SINGLE_FLIGHT_WINDOW_MS);
+      });
+    });
+  });
+
+  describe("given a pass that outlives the single-flight window", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      redis.seedGroup({
+        groupId: "tenant-a/group",
+        jobCount: 1,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.onPipelineExec = () => {
+        vi.advanceTimersByTime(SINGLE_FLIGHT_WINDOW_MS * 2);
+      };
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe("when reconcile completes", () => {
+      it("releases the marker so the next cycle is not made to wait", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME, SINGLE_FLIGHT_WINDOW_MS);
+
+        expect(redis.strings.has(MARKER_KEY)).toBe(false);
+      });
+
+      it("holds the marker for the whole pass rather than letting it lapse mid-pass", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME, SINGLE_FLIGHT_WINDOW_MS);
+
+        // The refresh lands after the batch that overran the window, so the
+        // marker is still this pass's own when the pass releases it.
+        const refreshes = redis.evalshaCalls.filter(
+          (call) => call.ttlMs === LEASE_MS,
+        );
+        expect(refreshes.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("given a ZCARD in the pipeline fails", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/good-group",
+        jobCount: 3,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.seedGroup({
+        groupId: "tenant-a/flaky-group",
+        jobCount: 4,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.failingZcardKeys.add(`${PREFIX}group:tenant-a/flaky-group:jobs`);
+      redis.strings.set(COUNTER_KEY, "77");
+    });
+
+    describe("when reconcile runs", () => {
+      it("aborts without writing a partial under-count", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toBeNull();
+        expect(redis.strings.get(COUNTER_KEY)).toBe("77");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -142,6 +142,7 @@ class FakeRedis {
    * counter write and the marker re-arm both act on the marker (and are then
    * separated by arity), while the prune acts on the pending index.
    */
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional evalsha signature
   async evalsha(
     _sha: string,
     _numKeys: number,

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -68,6 +68,18 @@ class FakeRedis {
     return this.strings.get(key) ?? null;
   }
 
+  async sadd(key: string, ...members: string[]): Promise<number> {
+    const existing = this.sets.get(key) ?? [];
+    let added = 0;
+    for (const member of members) {
+      if (existing.includes(member)) continue;
+      existing.push(member);
+      added += 1;
+    }
+    this.sets.set(key, existing);
+    return added;
+  }
+
   // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional zscan signature
   async zscan(
     key: string,
@@ -538,6 +550,33 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         const result = await repo.reconcileTotalPending(QUEUE_NAME);
 
         expect(result?.groundTruth).toBe(6);
+      });
+    });
+  });
+
+  describe("given a group known only to the lifecycle indexes", () => {
+    beforeEach(() => {
+      // No pending-index entry: staged before the index existed, or by a pod on
+      // the previous release during a rollout.
+      redis.seedGroup({
+        groupId: "tenant-a/legacy",
+        jobCount: 4,
+        index: `${PREFIX}ready`,
+        indexType: "zset",
+      });
+      redis.strings.set(COUNTER_KEY, "0");
+    });
+
+    describe("when reconcile runs", () => {
+      it("counts it and adopts it into the pending index", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(4);
+        // Adopted on first sight, so later passes no longer depend on reading the
+        // lifecycle indexes in sequence to find it.
+        expect(redis.sets.get(`${PREFIX}pending-groups`)).toContain(
+          "tenant-a/legacy",
+        );
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -53,6 +53,7 @@ class FakeRedis {
     return this.strings.get(key) ?? null;
   }
 
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional zscan signature
   async zscan(
     key: string,
     cursor: string,
@@ -65,6 +66,7 @@ class FakeRedis {
     return [nextCursor, page.flatMap((member) => [member, "1"])];
   }
 
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional sscan signature
   async sscan(
     key: string,
     cursor: string,
@@ -105,6 +107,7 @@ class FakeRedis {
     };
   }
 
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional evalsha signature
   async evalsha(
     _sha: string,
     _numKeys: number,

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -32,6 +32,9 @@ class FakeRedis {
   /** Runs after every pipeline `exec`, so a test can simulate a slow pass. */
   onPipelineExec: (() => void) | null = null;
 
+  /** Runs between the last lease re-arm and the fenced counter write. */
+  onBeforeFencedWrite: (() => void) | null = null;
+
   /**
    * Ordered log of lease re-arms and ZCARD batches, so a test can tell which
    * phase of the pass a re-arm belongs to.
@@ -120,14 +123,66 @@ class FakeRedis {
     };
   }
 
-  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional evalsha signature
+  /**
+   * Replace the marker as another instance would: a different token, so the
+   * holder's compare-and-set no longer matches.
+   */
+  stealMarker(key: string): void {
+    this.strings.set(key, "other-instance-token");
+  }
+
+  /** Expire the marker as a lapsed lease would, leaving it unowned. */
+  expireKey(key: string): void {
+    this.strings.delete(key);
+    this.expiries.delete(key);
+  }
+
+  /**
+   * Models the three cached scripts, told apart by their first key: the fenced
+   * counter write and the marker re-arm both act on the marker (and are then
+   * separated by arity), while the prune acts on the pending index.
+   */
   async evalsha(
     _sha: string,
     _numKeys: number,
     key: string,
-    token: string,
-    ttlMs: number,
+    ...rest: (string | number)[]
   ): Promise<number> {
+    if (key.endsWith("pending-groups")) {
+      return this.applyPrune(key, rest as string[]);
+    }
+    if (rest.length === 3) {
+      // Fires in the one window the fence exists for: after the last lease
+      // re-arm succeeded, before the write lands.
+      this.onBeforeFencedWrite?.();
+      const [counterKey, token, value] = rest as [string, string, string];
+      if (this.strings.get(key) !== token) return 0;
+      this.strings.set(counterKey, String(value));
+      return 1;
+    }
+    const [token, ttlMs] = rest as [string, number];
+    return this.applyMarkerTtl(key, token, Number(ttlMs));
+  }
+
+  /** SREM each id whose jobs zset re-reads as empty, atomically per the script. */
+  private applyPrune(indexKey: string, args: string[]): number {
+    const members = this.sets.get(indexKey) ?? [];
+    let pruned = 0;
+    for (let i = 0; i < args.length; i += 2) {
+      const groupId = args[i]!;
+      const jobsKey = args[i + 1]!;
+      if ((this.zsets.get(jobsKey) ?? []).length > 0) continue;
+      const at = members.indexOf(groupId);
+      if (at >= 0) {
+        members.splice(at, 1);
+        pruned += 1;
+      }
+    }
+    this.sets.set(indexKey, members);
+    return pruned;
+  }
+
+  private applyMarkerTtl(key: string, token: string, ttlMs: number): number {
     const isHeldByCaller = this.strings.get(key) === token;
     this.evalshaCalls.push({
       key,
@@ -376,6 +431,129 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         );
         expect(refreshes.length).toBeGreaterThan(0);
         expect(refreshes.every((call) => call.isHeldByCaller)).toBe(true);
+      });
+    });
+  });
+
+  describe("given the pass loses its marker to another instance mid-pass", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/group",
+        jobCount: 4,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+      redis.strings.set(COUNTER_KEY, "99");
+      // The marker changes hands while this pass is between batches, which is
+      // what happens when a lease lapses and another instance acquires it.
+      redis.onPipelineExec = () => redis.stealMarker(MARKER_KEY);
+    });
+
+    describe("when reconcile finishes computing", () => {
+      /** @scenario "A pass that loses the marker mid-run publishes nothing" */
+      it("discards the pass instead of publishing its count", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toBeNull();
+      });
+
+      it("leaves the counter for the instance that now holds the marker", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME);
+
+        // Writing 4 here would put this pass's count over whatever the newer
+        // holder has since published.
+        expect(redis.strings.get(COUNTER_KEY)).toBe("99");
+      });
+    });
+  });
+
+  describe("given the marker changes hands after the last lease check", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/group",
+        jobCount: 7,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+      redis.strings.set(COUNTER_KEY, "42");
+      // Every lease re-arm succeeds, so the pass runs to completion believing it
+      // still holds the marker. It changes hands in the gap the re-arms cannot
+      // cover: after the final one, before the write.
+      redis.onBeforeFencedWrite = () => redis.stealMarker(MARKER_KEY);
+    });
+
+    describe("when reconcile goes to write its result", () => {
+      /** @scenario "The counter write itself refuses to run without the marker" */
+      it("does not publish, because the write itself checks ownership", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toBeNull();
+        expect(redis.strings.get(COUNTER_KEY)).toBe("42");
+      });
+    });
+  });
+
+  describe("given the marker expires mid-pass and nobody else takes it", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/group",
+        jobCount: 2,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+      redis.strings.set(COUNTER_KEY, "50");
+      redis.onPipelineExec = () => redis.expireKey(MARKER_KEY);
+    });
+
+    describe("when reconcile finishes computing", () => {
+      /** @scenario "A pass whose marker lapses unclaimed publishes nothing" */
+      it("still declines to write, having lost the right to", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result).toBeNull();
+        expect(redis.strings.get(COUNTER_KEY)).toBe("50");
+      });
+    });
+  });
+
+  describe("given a group that moves between lifecycle indexes during the pass", () => {
+    beforeEach(() => {
+      // The pending index is what the group is counted from. It is written with
+      // the job itself, so it holds the group no matter which lifecycle index the
+      // group happens to be sitting in when each of those is read.
+      redis.seedGroup({
+        groupId: "tenant-a/moving-group",
+        jobCount: 6,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+      // In no lifecycle index at all: mid-transition, in neither the one already
+      // read nor the one still to be read.
+      redis.strings.set(COUNTER_KEY, "0");
+    });
+
+    describe("when reconcile runs", () => {
+      it("still counts the group's jobs", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(6);
+      });
+    });
+  });
+
+  describe("given a group in the pending index whose jobs have drained", () => {
+    beforeEach(() => {
+      redis.sets.set(`${PREFIX}pending-groups`, ["tenant-a/drained"]);
+      redis.zsets.set(`${PREFIX}group:tenant-a/drained:jobs`, []);
+      redis.strings.set(COUNTER_KEY, "3");
+    });
+
+    describe("when reconcile runs", () => {
+      it("counts it as zero and prunes it from the index", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(0);
+        expect(redis.sets.get(`${PREFIX}pending-groups`)).toEqual([]);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -41,7 +41,29 @@ class FakeRedis {
    */
   readonly events: ("lease-refresh" | "zcard-batch")[] = [];
 
-  readonly scan = vi.fn(async () => ["0", [] as string[]] as const);
+  /**
+   * Keyspace SCAN over the jobs keys the fake holds, paged like the real one.
+   * Matches on key existence, so it finds a group whatever index it is in.
+   */
+  readonly scan = vi.fn(
+    // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional scan signature
+    async (
+      cursor: string,
+      _match: "MATCH",
+      pattern: string,
+      _count: "COUNT",
+      count: number,
+    ): Promise<[string, string[]]> => {
+      const re = new RegExp(
+        `^${pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`,
+      );
+      const keys = [...this.zsets.keys()].filter((k) => re.test(k)).sort();
+      const offset = Number(cursor);
+      const page = keys.slice(offset, offset + count);
+      const next = offset + page.length;
+      return [next >= keys.length ? "0" : String(next), page];
+    },
+  );
   readonly evalshaCalls: {
     key: string;
     token: string;
@@ -68,6 +90,12 @@ class FakeRedis {
     return this.strings.get(key) ?? null;
   }
 
+  /** Runs after every `sadd`, so a test can disturb a multi-batch adoption. */
+  onSadd: (() => void) | null = null;
+
+  /** How many SADD batches adoption issued, to show when it stopped. */
+  saddBatches = 0;
+
   async sadd(key: string, ...members: string[]): Promise<number> {
     const existing = this.sets.get(key) ?? [];
     let added = 0;
@@ -77,6 +105,8 @@ class FakeRedis {
       added += 1;
     }
     this.sets.set(key, existing);
+    this.saddBatches += 1;
+    this.onSadd?.();
     return added;
   }
 
@@ -281,7 +311,16 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         expect(redis.strings.get(COUNTER_KEY)).toBe("9");
       });
 
-      it("reads the group indexes instead of walking the keyspace", async () => {
+      it("reads the indexes instead of walking the keyspace once adoption is done", async () => {
+        // The steady state, which is what the cost claim rests on: with nothing
+        // left to adopt the sweep is not due, and a pass touches only the
+        // indexes. The keyspace walk is reserved for adopting groups the index
+        // does not know about yet.
+        redis.strings.set(
+          `${PREFIX}stats:pending-recon-sweep-due`,
+          String(Date.now() + 60_000),
+        );
+
         await repo.reconcileTotalPending(QUEUE_NAME);
 
         expect(redis.scan).not.toHaveBeenCalled();
@@ -577,6 +616,91 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         expect(redis.sets.get(`${PREFIX}pending-groups`)).toContain(
           "tenant-a/legacy",
         );
+      });
+    });
+  });
+
+  describe("given an unindexed group that moves between the lifecycle reads", () => {
+    beforeEach(() => {
+      // The counterexample the lifecycle legs cannot cover: holding jobs, in the
+      // pending index nowhere, and in no lifecycle index at the moment each of
+      // those is read — unblocked into an already-scanned `ready` before
+      // `blocked` was reached.
+      redis.zsets.set(`${PREFIX}group:tenant-a/mover:jobs`, [
+        "j1",
+        "j2",
+        "j3",
+        "j4",
+        "j5",
+      ]);
+      redis.strings.set(COUNTER_KEY, "0");
+    });
+
+    describe("when reconcile runs", () => {
+      /** @scenario "A group no index lists is still counted and adopted" */
+      it("counts it from the keyspace and adopts it for later passes", async () => {
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(result?.groundTruth).toBe(5);
+        expect(redis.sets.get(`${PREFIX}pending-groups`)).toContain(
+          "tenant-a/mover",
+        );
+      });
+    });
+  });
+
+  describe("given the keyspace sweep has nothing left to adopt", () => {
+    beforeEach(() => {
+      redis.seedGroup({
+        groupId: "tenant-a/known",
+        jobCount: 1,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+    });
+
+    describe("when reconcile runs twice", () => {
+      it("stops walking the keyspace once the index is complete", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+        const afterFirst = redis.scan.mock.calls.length;
+        expect(afterFirst).toBeGreaterThan(0);
+
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+
+        // Nothing was adopted, so the sweep backs off instead of paying the
+        // keyspace walk on every pass.
+        expect(redis.scan.mock.calls.length).toBe(afterFirst);
+      });
+    });
+  });
+
+  describe("given the lease is lost while adopting a multi-batch backlog", () => {
+    beforeEach(() => {
+      for (let i = 0; i < 2500; i++) {
+        redis.seedGroup({
+          groupId: `tenant-a/legacy-${i}`,
+          jobCount: 1,
+          index: `${PREFIX}ready`,
+          indexType: "zset",
+        });
+      }
+      redis.strings.set(COUNTER_KEY, "9999");
+      // Adoption spans several SADD batches; the marker changes hands during it.
+      redis.onSadd = () => redis.stealMarker(MARKER_KEY);
+    });
+
+    describe("when reconcile runs", () => {
+      it("stops adopting instead of finishing the batches on someone else's marker", async () => {
+        // 2500 groups is three SADD batches. The publish is already safe without
+        // this check — summation re-arms the lease and would abort before writing
+        // — so what is under test is that the work stops, rather than the pass
+        // grinding through the rest of a backlog for an instance that has moved
+        // on. That overlap is the cost the marker exists to prevent.
+        const result = await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(redis.saddBatches).toBe(1);
+        expect(result).toBeNull();
+        expect(redis.strings.get(COUNTER_KEY)).toBe("9999");
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -349,6 +349,24 @@ const PENDING_RECONCILE_ZCARD_BATCH = 1000;
  */
 const PENDING_RECONCILE_LEASE_MS = 30_000;
 
+/**
+ * How long the keyspace sweep waits once it has nothing left to adopt.
+ *
+ * At that point every group is in the pending index and the sweep is a backstop
+ * against a writer nobody noticed was missing, so it can be rare. While it is
+ * still adopting — through a rollout, or on a queue that predates the index — it
+ * runs every pass instead, which is what this reconcile cost before the index
+ * existed. See {@link QueueRedisRepository.sweepKeyspaceForGroups}.
+ */
+const PENDING_RECONCILE_SWEEP_BACKSTOP_MS = 60 * 60 * 1000;
+
+/** Suffix of the key holding when the next keyspace sweep is due. */
+const SWEEP_DUE_KEY_SUFFIX = "stats:pending-recon-sweep-due";
+
+function isClusterClient(client: IORedis | Cluster): client is Cluster {
+  return typeof (client as Cluster).nodes === "function";
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 /**
@@ -1727,7 +1745,7 @@ export class QueueRedisRepository implements QueueRepository {
         return null;
       }
 
-      await this.prunePendingIndex({ prefix, emptyJobsKeys });
+      await this.prunePendingIndex({ prefix, emptyJobsKeys, refreshLease });
 
       return { counter, groundTruth, drift };
     } finally {
@@ -1814,10 +1832,25 @@ export class QueueRedisRepository implements QueueRepository {
       if (!held) return null;
     }
 
-    await this.backfillPendingIndex({
+    // The lifecycle legs only cover a group the pass actually saw, and a group
+    // moving between them mid-read is seen by neither. The keyspace sweep is what
+    // covers those, because it reads key existence rather than membership.
+    if (await this.isKeyspaceSweepDue(prefix)) {
+      const swept = await this.sweepKeyspaceForGroups({ prefix, refreshLease });
+      if (swept === null) return null;
+      for (const groupId of swept) groupIds.add(groupId);
+    }
+
+    const toAdopt = Array.from(groupIds).filter(
+      (id) => !alreadyIndexed.has(id),
+    );
+    const held = await this.backfillPendingIndex({
       prefix,
-      groupIds: Array.from(groupIds).filter((id) => !alreadyIndexed.has(id)),
+      groupIds: toAdopt,
+      refreshLease,
     });
+    if (!held) return null;
+    await this.recordSweepOutcome({ prefix, adopted: toAdopt.length });
 
     return groupIds;
   }
@@ -1827,19 +1860,19 @@ export class QueueRedisRepository implements QueueRepository {
    *
    * Until a group is in the index it is counted by reading the lifecycle indexes
    * in sequence, and a group moving between them mid-read can be missed. Writing
-   * it in on first sight closes that for every later pass, so a group staged
-   * before the index existed — or by a pod on the previous release mid-rollout —
-   * is exposed for at most the passes before something first observes it.
+   * it in on first sight closes that for every later pass.
    *
-   * Best-effort: adding is what makes later passes safe, and failing to add only
-   * leaves the group where it already was. Over-inclusion is harmless, and the
-   * prune removes anything that turns out to be empty.
+   * Returns false when the lease was lost, which aborts the pass: this runs
+   * inside the pass's marker and can span several round trips, so it has to hold
+   * the lease like every other phase rather than run on a marker that has since
+   * moved to another instance.
    */
   private async backfillPendingIndex(params: {
     prefix: string;
     groupIds: string[];
-  }): Promise<void> {
-    if (params.groupIds.length === 0) return;
+    refreshLease: () => Promise<boolean>;
+  }): Promise<boolean> {
+    if (params.groupIds.length === 0) return true;
     const indexKey = pendingGroupsKey(params.prefix);
     try {
       for (
@@ -1854,6 +1887,7 @@ export class QueueRedisRepository implements QueueRepository {
             offset + PENDING_RECONCILE_ZCARD_BATCH,
           ),
         );
+        if (!(await params.refreshLease())) return false;
       }
     } catch (err) {
       logger.warn(
@@ -1861,6 +1895,101 @@ export class QueueRedisRepository implements QueueRepository {
         "Failed to adopt lifecycle-index groups into the pending index",
       );
     }
+    return true;
+  }
+
+  /**
+   * Walk the keyspace for `group:<id>:jobs` keys and adopt every group into the
+   * pending index.
+   *
+   * This is the one enumeration that cannot miss a group: it reads key existence,
+   * so a group is found whatever lifecycle index it is in and however it moves
+   * between them. That is what makes it the right tool for the groups the index
+   * does not know about — everything staged before the index existed, and
+   * everything staged by a pod on the previous release during a rollout. Reading
+   * the lifecycle indexes cannot cover those safely, and adopting on sight only
+   * helps a group the pass actually saw.
+   *
+   * It is also the expensive one — SCAN walks every key in the database
+   * regardless of MATCH — which is why it is not how the counter is normally
+   * enumerated. It runs when the queue has groups the index has not learned yet
+   * (so, repeatedly through a rollout, at the cost this reconcile had before the
+   * index existed and no more) and drops back to a slow backstop cadence once a
+   * sweep finds nothing new to adopt.
+   *
+   * Returns null when the lease was lost.
+   */
+  private async sweepKeyspaceForGroups(params: {
+    prefix: string;
+    refreshLease: () => Promise<boolean>;
+  }): Promise<Set<string> | null> {
+    const pattern = `${params.prefix}group:*:jobs`;
+    const groupKeyPrefix = `${params.prefix}group:`;
+    const found = new Set<string>();
+
+    // SCAN is keyless, so on a cluster ioredis routes it to an arbitrary node and
+    // one call sees one node's keyspace. Fanning out over the masters is what
+    // makes "cannot miss a group" true there too.
+    const nodes: { scan: IORedis["scan"] }[] = isClusterClient(this.redis)
+      ? this.redis.nodes("master")
+      : [this.redis];
+
+    for (const node of nodes) {
+      let cursor = "0";
+      do {
+        const [nextCursor, keys] = await node.scan(
+          cursor,
+          "MATCH",
+          pattern,
+          "COUNT",
+          PENDING_RECONCILE_PAGE_SIZE,
+        );
+        cursor = nextCursor;
+        for (const key of keys) {
+          found.add(key.slice(groupKeyPrefix.length, -":jobs".length));
+        }
+        if (!(await params.refreshLease())) return null;
+      } while (cursor !== "0");
+    }
+
+    return found;
+  }
+
+  /**
+   * Whether a keyspace sweep is due.
+   *
+   * Due when one has never run, or when the stored due time has passed. The due
+   * time is written by {@link recordSweepOutcome}, which keeps sweeping every
+   * pass while sweeps are still finding groups to adopt.
+   */
+  private async isKeyspaceSweepDue(prefix: string): Promise<boolean> {
+    const raw = await this.redis.get(`${prefix}${SWEEP_DUE_KEY_SUFFIX}`);
+    if (raw === null) return true;
+    const dueAt = Number(raw);
+    return !Number.isFinite(dueAt) || Date.now() >= dueAt;
+  }
+
+  /**
+   * Schedule the next keyspace sweep from what this one adopted.
+   *
+   * Adopting something means the index is still behind — a rollout is in flight,
+   * or the queue predates the index — so the next pass sweeps again, which costs
+   * what this reconcile cost before the index existed and no more. Adopting
+   * nothing means the index is complete, and the sweep drops back to a slow
+   * backstop that only has to catch a writer nobody has noticed is missing.
+   */
+  private async recordSweepOutcome(params: {
+    prefix: string;
+    adopted: number;
+  }): Promise<void> {
+    const nextDueAt =
+      params.adopted > 0
+        ? Date.now()
+        : Date.now() + PENDING_RECONCILE_SWEEP_BACKSTOP_MS;
+    await this.redis.set(
+      `${params.prefix}${SWEEP_DUE_KEY_SUFFIX}`,
+      String(nextDueAt),
+    );
   }
 
   /**
@@ -1989,6 +2118,7 @@ export class QueueRedisRepository implements QueueRepository {
   private async prunePendingIndex(params: {
     prefix: string;
     emptyJobsKeys: string[];
+    refreshLease: () => Promise<boolean>;
   }): Promise<void> {
     if (params.emptyJobsKeys.length === 0) return;
     const indexKey = pendingGroupsKey(params.prefix);
@@ -2011,6 +2141,11 @@ export class QueueRedisRepository implements QueueRepository {
       }
       try {
         await pendingIndexPruneScript.run(this.redis, 1, indexKey, ...args);
+        // Pruning runs after the counter is published, so losing the lease here
+        // cannot corrupt a result — but it can leave this pass working on a
+        // marker another instance now owns, which is the overlap the marker
+        // exists to stop. Stop rather than press on.
+        if (!(await params.refreshLease())) return;
       } catch (err) {
         logger.warn(
           { error: err },

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -15,6 +15,8 @@ import { RedisJobBlobStore } from "~/server/event-sourcing/queues/groupQueue/red
 import {
   GROUP_QUEUE_REGISTRY_KEY,
   PARK_HELPER_LUA,
+  PENDING_INDEX_HELPER_LUA,
+  pendingGroupsKey,
   TTL_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
 import { TieredBlobStore } from "~/server/event-sourcing/queues/groupQueue/tieredBlobStore";
@@ -204,6 +206,7 @@ return count
 `;
 
 const REPLAY_FROM_DLQ_LUA =
+  PENDING_INDEX_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
   `
@@ -224,6 +227,9 @@ if count > 0 then
   for i = 1, #jobs, 2 do
     redis.call("ZADD", dstJobsKey, jobs[i+1], jobs[i])
   end
+  -- Replaying puts jobs back on the live group, so it is a pending-index write
+  -- like any other stage. Same atomic step as the ZADD above.
+  gqMarkPending(parkKeyPrefixOf(readyKey), groupId)
 end
 
 local data = redis.call("HGETALL", dlqDataKey)
@@ -267,6 +273,41 @@ if ttlMs <= 0 then return redis.call("DEL", markerKey) end
 return redis.call("PEXPIRE", markerKey, ttlMs)
 `;
 
+// Write the reconciled counter only while this pass still holds the marker.
+//
+// Losing the marker means another pass has started and may already have written
+// a fresher value; a late write from the old pass would put a stale count back.
+// The check and the write have to be one step, so a marker lost between them
+// cannot leave the stale write to land anyway.
+const RECONCILE_WRITE_LUA = `
+local markerKey  = KEYS[1]
+local counterKey = KEYS[2]
+local holderToken = ARGV[1]
+local groundTruth = ARGV[2]
+
+if redis.call("GET", markerKey) ~= holderToken then return 0 end
+redis.call("SET", counterKey, groundTruth)
+return 1
+`;
+
+// Drop a group from the pending index, but only while its jobs zset is still
+// empty. The reconcile decides what to prune from a ZCARD it read earlier, and a
+// group can be staged again in between; re-reading inside the script is what
+// stops a live group being dropped on the strength of a stale observation.
+// Losing a group from this index would hide its jobs from every later pass.
+const PENDING_INDEX_PRUNE_LUA = `
+local indexKey = KEYS[1]
+local pruned = 0
+for i = 1, #ARGV, 2 do
+  local groupId = ARGV[i]
+  local jobsKey = ARGV[i + 1]
+  if redis.call("ZCARD", jobsKey) == 0 then
+    pruned = pruned + redis.call("SREM", indexKey, groupId)
+  end
+end
+return pruned
+`;
+
 // ── Cached scripts ───────────────────────────────────────────────────
 //
 // EVALSHA, not EVAL: plain EVAL re-transfers and re-hashes the full source on
@@ -281,6 +322,8 @@ const drainGroupScript = new CachedLuaScript(DRAIN_GROUP_LUA);
 const moveToDlqScript = new CachedLuaScript(MOVE_TO_DLQ_LUA);
 const replayFromDlqScript = new CachedLuaScript(REPLAY_FROM_DLQ_LUA);
 const reconcileMarkerTtlScript = new CachedLuaScript(RECONCILE_MARKER_TTL_LUA);
+const reconcileWriteScript = new CachedLuaScript(RECONCILE_WRITE_LUA);
+const pendingIndexPruneScript = new CachedLuaScript(PENDING_INDEX_PRUNE_LUA);
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -1634,33 +1677,57 @@ export class QueueRedisRepository implements QueueRepository {
       const raw = await this.redis.get(counterKey);
       const counter = Math.max(0, parseInt(raw ?? "0", 10) || 0);
 
-      // Collection is itself a paging walk over several indexes, so it re-arms
-      // the lease as it goes. Without that a pass on a large queue could spend
-      // its whole lease before the first ZCARD batch and lose the marker to
-      // another instance mid-pass.
-      const refreshLease = () =>
-        this.setReconcileMarkerTtl({
+      // Collection is itself a paging walk, so it re-arms the lease as it goes.
+      // Without that a pass on a large queue could spend its whole lease before
+      // the first ZCARD batch and lose the marker to another instance mid-pass.
+      //
+      // Losing it aborts the pass. A pass that no longer holds the marker cannot
+      // know whether a newer one has already written, so anything it computed is
+      // a candidate for overwriting fresher state with staler state.
+      const refreshLease = async (): Promise<boolean> =>
+        await this.setReconcileMarkerTtl({
           markerKey,
           holderToken,
           ttlMs: PENDING_RECONCILE_LEASE_MS,
         });
 
-      const jobsKeys = await this.collectGroupJobsKeys({
+      const groupIds = await this.collectPendingGroupIds({
         prefix,
         refreshLease,
       });
+      if (groupIds === null) return null;
 
-      const groundTruth = await this.sumPendingJobs({
-        jobsKeys,
-        markerKey,
-        holderToken,
-      });
-      if (groundTruth === null) return null;
+      const jobsKeys = Array.from(
+        groupIds,
+        (groupId) => `${prefix}group:${groupId}:jobs`,
+      );
+
+      const summed = await this.sumPendingJobs({ jobsKeys, refreshLease });
+      if (summed === null) return null;
+      const { groundTruth, emptyJobsKeys } = summed;
 
       const drift = counter - groundTruth;
 
-      // Overwrite the counter with the ground truth.
-      await this.redis.set(counterKey, String(groundTruth));
+      // Fenced write: a pass that lost the marker must not put its count back
+      // over a newer pass's. `0` means the marker moved on, so this pass reports
+      // nothing rather than a result it did not manage to publish.
+      const wrote = await reconcileWriteScript.run(
+        this.redis,
+        2,
+        markerKey,
+        counterKey,
+        holderToken,
+        String(groundTruth),
+      );
+      if (Number(wrote) !== 1) {
+        logger.warn(
+          { queueName },
+          "Pending reconcile lost its single-flight marker before writing — discarding the pass",
+        );
+        return null;
+      }
+
+      await this.prunePendingIndex({ prefix, emptyJobsKeys });
 
       return { counter, groundTruth, drift };
     } finally {
@@ -1677,132 +1744,132 @@ export class QueueRedisRepository implements QueueRepository {
   }
 
   /**
-   * Collect the `group:<id>:jobs` key of every group that can be holding a
-   * pending job, read from the queue's own group indexes.
+   * Collect the ids of every group that can be holding a pending job.
    *
    * Deliberately not a keyspace SCAN: SCAN walks every key in the database
    * regardless of MATCH, so the cost of a pass would track the size of the whole
-   * Redis instance rather than the number of groups in this queue. The indexes
-   * below hold group ids, so paging them costs what the queue actually contains.
+   * Redis instance rather than the number of groups in this queue.
    *
-   * They are exhaustive for any group with jobs. A live group stays a member of
-   * `ready` even while its job is in flight (dispatch re-scores it into the
-   * future rather than removing it); the only other places a group can be are
-   * `parked:<tenant>`, for one deferred by the per-tenant cap, and `blocked`,
-   * for one held for operator triage. Every path that takes a group out of
-   * `ready` either puts it into one of those two or does so precisely because
-   * its `:jobs` zset is empty, so no group can hold jobs while absent from all
-   * three. DLQ jobs live under a separate `dlq:` prefix and are not pending.
+   * The authority is `pending-groups`, written atomically with every job insert
+   * (see PENDING_INDEX_HELPER_LUA). It is read as a single index, so no group can
+   * slip between two reads the way it can between the lifecycle indexes.
    *
-   * A group can briefly appear in two indexes while it moves between them, so
-   * ids are deduplicated before keys are built — counting one twice would be
-   * written to the counter as ground truth.
+   * The lifecycle indexes are still read, and are now additive only. They cover
+   * groups staged before this index existed, which would otherwise stay invisible
+   * until something next wrote to them. A surplus id costs nothing — its ZCARD is
+   * 0 — so folding them in can only help, and their own read-ordering race can no
+   * longer undercount now that correctness rests on `pending-groups`. They can be
+   * dropped once no queue predates the index.
+   *
+   * Returns null when the pass lost its single-flight marker partway.
    */
-  private async collectGroupJobsKeys(params: {
+  private async collectPendingGroupIds(params: {
     prefix: string;
-    refreshLease: () => Promise<void>;
-  }): Promise<string[]> {
+    refreshLease: () => Promise<boolean>;
+  }): Promise<Set<string> | null> {
     const { prefix, refreshLease } = params;
     const groupIds = new Set<string>();
 
-    await this.collectZsetGroupIds({
-      key: `${prefix}ready`,
-      into: groupIds,
-      refreshLease,
-    });
-    await this.collectSetMembers({
-      key: `${prefix}blocked`,
-      into: groupIds,
-      refreshLease,
-    });
-
-    // One entry per tenant currently over cap — empty in the steady state where
-    // the cap is off, so the parked leg usually costs a single SSCAN.
     const parkedTenants = new Set<string>();
-    await this.collectSetMembers({
+    const heldThroughTenants = await this.collectIndexMembers({
       key: `${prefix}parked-tenants`,
+      type: "set",
       into: parkedTenants,
       refreshLease,
     });
-    for (const tenantId of parkedTenants) {
-      await this.collectZsetGroupIds({
+    if (!heldThroughTenants) return null;
+
+    const legs: { key: string; type: "zset" | "set" }[] = [
+      { key: pendingGroupsKey(prefix), type: "set" },
+      { key: `${prefix}ready`, type: "zset" },
+      { key: `${prefix}blocked`, type: "set" },
+      ...Array.from(parkedTenants, (tenantId) => ({
         key: `${prefix}parked:${tenantId}`,
+        type: "zset" as const,
+      })),
+    ];
+
+    for (const leg of legs) {
+      const held = await this.collectIndexMembers({
+        key: leg.key,
+        type: leg.type,
         into: groupIds,
         refreshLease,
       });
+      if (!held) return null;
     }
 
-    return Array.from(groupIds, (groupId) => `${prefix}group:${groupId}:jobs`);
+    return groupIds;
   }
 
-  /** Page a zset of group ids with ZSCAN, adding every member into `into`. */
-  private async collectZsetGroupIds(params: {
+  /**
+   * Page one index into `into`, re-arming the lease after each page.
+   *
+   * Returns false when the lease was lost, which aborts the pass: a pass that no
+   * longer owns the marker must not go on to publish a count.
+   */
+  private async collectIndexMembers(params: {
     key: string;
+    type: "zset" | "set";
     into: Set<string>;
-    refreshLease: () => Promise<void>;
-  }): Promise<void> {
+    refreshLease: () => Promise<boolean>;
+  }): Promise<boolean> {
+    // A ZSCAN page alternates [member, score, ...]; an SSCAN page is members only.
+    const stride = params.type === "zset" ? 2 : 1;
     let cursor = "0";
     do {
-      const [nextCursor, members] = await this.redis.zscan(
-        params.key,
-        cursor,
-        "COUNT",
-        PENDING_RECONCILE_PAGE_SIZE,
-      );
+      const [nextCursor, members] =
+        params.type === "zset"
+          ? await this.redis.zscan(
+              params.key,
+              cursor,
+              "COUNT",
+              PENDING_RECONCILE_PAGE_SIZE,
+            )
+          : await this.redis.sscan(
+              params.key,
+              cursor,
+              "COUNT",
+              PENDING_RECONCILE_PAGE_SIZE,
+            );
       cursor = nextCursor;
-      // A ZSCAN page alternates [member, score, member, score, ...].
-      for (let i = 0; i < members.length; i += 2) {
+      for (let i = 0; i < members.length; i += stride) {
         params.into.add(members[i]!);
       }
-      await params.refreshLease();
+      if (!(await params.refreshLease())) return false;
     } while (cursor !== "0");
-  }
-
-  /** Page a set with SSCAN, adding every member into `into`. */
-  private async collectSetMembers(params: {
-    key: string;
-    into: Set<string>;
-    refreshLease: () => Promise<void>;
-  }): Promise<void> {
-    let cursor = "0";
-    do {
-      const [nextCursor, members] = await this.redis.sscan(
-        params.key,
-        cursor,
-        "COUNT",
-        PENDING_RECONCILE_PAGE_SIZE,
-      );
-      cursor = nextCursor;
-      for (const member of members) {
-        params.into.add(member);
-      }
-      await params.refreshLease();
-    } while (cursor !== "0");
+    return true;
   }
 
   /**
    * Sum ZCARD over the collected keys in batches, re-arming the single-flight
    * lease between batches so a long pass keeps its hold.
    *
-   * Returns null if ANY pipeline entry errors — a flaky ZCARD must never write
-   * a partial under-count as ground truth; the next cycle retries.
+   * Returns null if any pipeline entry errors, if the whole batch fails, or if
+   * the lease was lost — a flaky ZCARD must never write a partial under-count as
+   * ground truth, and a pass that lost the marker must not write at all. The next
+   * cycle retries.
+   *
+   * Also reports the keys observed empty, which the caller may prune from the
+   * pending index.
    */
   private async sumPendingJobs(params: {
     jobsKeys: string[];
-    markerKey: string;
-    holderToken: string;
-  }): Promise<number | null> {
+    refreshLease: () => Promise<boolean>;
+  }): Promise<{ groundTruth: number; emptyJobsKeys: string[] } | null> {
     let groundTruth = 0;
+    const emptyJobsKeys: string[] = [];
     for (
       let offset = 0;
       offset < params.jobsKeys.length;
       offset += PENDING_RECONCILE_ZCARD_BATCH
     ) {
-      const pipeline = this.redis.pipeline();
-      for (const key of params.jobsKeys.slice(
+      const batch = params.jobsKeys.slice(
         offset,
         offset + PENDING_RECONCILE_ZCARD_BATCH,
-      )) {
+      );
+      const pipeline = this.redis.pipeline();
+      for (const key of batch) {
         pipeline.zcard(key);
       }
       const results = await pipeline.exec();
@@ -1816,7 +1883,7 @@ export class QueueRedisRepository implements QueueRepository {
         );
         return null;
       }
-      for (const [err, val] of results) {
+      for (const [index, [err, val]] of results.entries()) {
         if (err) {
           logger.warn(
             { error: err },
@@ -1824,43 +1891,86 @@ export class QueueRedisRepository implements QueueRepository {
           );
           return null;
         }
-        groundTruth += Number(val) || 0;
+        const count = Number(val) || 0;
+        groundTruth += count;
+        if (count === 0) emptyJobsKeys.push(batch[index]!);
       }
-      await this.setReconcileMarkerTtl({
-        markerKey: params.markerKey,
-        holderToken: params.holderToken,
-        ttlMs: PENDING_RECONCILE_LEASE_MS,
-      });
+      if (!(await params.refreshLease())) return null;
     }
-    return groundTruth;
+    return { groundTruth, emptyJobsKeys };
+  }
+
+  /**
+   * Drop groups this pass observed empty from the pending index.
+   *
+   * Best-effort and never fatal: the index is allowed to over-report, so a failed
+   * prune costs a few wasted ZCARDs on later passes and nothing else. The script
+   * re-reads each zset atomically, so a group staged since the observation stays.
+   */
+  private async prunePendingIndex(params: {
+    prefix: string;
+    emptyJobsKeys: string[];
+  }): Promise<void> {
+    if (params.emptyJobsKeys.length === 0) return;
+    const indexKey = pendingGroupsKey(params.prefix);
+    const groupKeyPrefix = `${params.prefix}group:`;
+    for (
+      let offset = 0;
+      offset < params.emptyJobsKeys.length;
+      offset += PENDING_RECONCILE_ZCARD_BATCH
+    ) {
+      const args: string[] = [];
+      for (const jobsKey of params.emptyJobsKeys.slice(
+        offset,
+        offset + PENDING_RECONCILE_ZCARD_BATCH,
+      )) {
+        // The script needs both the id to remove and the key to re-read.
+        args.push(
+          jobsKey.slice(groupKeyPrefix.length, -":jobs".length),
+          jobsKey,
+        );
+      }
+      try {
+        await pendingIndexPruneScript.run(this.redis, 1, indexKey, ...args);
+      } catch (err) {
+        logger.warn(
+          { error: err },
+          "Failed to prune drained groups from the pending index",
+        );
+        return;
+      }
+    }
   }
 
   /**
    * Re-arm the single-flight marker this pass holds, or drop it when the
    * requested TTL has already run out.
    *
-   * Never throws: losing the marker mid-pass at worst lets a second pass start,
-   * and the pass in hand still produces a correct count, so a failure here must
-   * not take down a reconcile that otherwise succeeded.
+   * Returns whether this pass still owned the marker. A false is the signal to
+   * abort: the marker has moved to another instance, so anything this pass went
+   * on to write could overwrite fresher state. An error reports the same way —
+   * being unable to prove ownership is not the same as holding it.
    */
   private async setReconcileMarkerTtl(params: {
     markerKey: string;
     holderToken: string;
     ttlMs: number;
-  }): Promise<void> {
+  }): Promise<boolean> {
     try {
-      await reconcileMarkerTtlScript.run(
+      const held = await reconcileMarkerTtlScript.run(
         this.redis,
         1,
         params.markerKey,
         params.holderToken,
         Math.trunc(params.ttlMs),
       );
+      return Number(held) === 1;
     } catch (err) {
       logger.warn(
         { error: err },
         "Failed to re-arm the pending reconcile single-flight marker",
       );
+      return false;
     }
   }
 

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1779,6 +1779,9 @@ export class QueueRedisRepository implements QueueRepository {
     });
     if (!heldThroughTenants) return null;
 
+    // TODO(cleanup): the three lifecycle legs below are additive only and exist
+    // solely to cover groups staged before the pending index did. Removable once
+    // no queue predates it — the index alone is what makes the count correct.
     const legs: { key: string; type: "zset" | "set" }[] = [
       { key: pendingGroupsKey(prefix), type: "set" },
       { key: `${prefix}ready`, type: "zset" },
@@ -1864,40 +1867,58 @@ export class QueueRedisRepository implements QueueRepository {
       offset < params.jobsKeys.length;
       offset += PENDING_RECONCILE_ZCARD_BATCH
     ) {
-      const batch = params.jobsKeys.slice(
+      const batch = await this.countOneBatch(
+        params.jobsKeys.slice(offset, offset + PENDING_RECONCILE_ZCARD_BATCH),
         offset,
-        offset + PENDING_RECONCILE_ZCARD_BATCH,
       );
-      const pipeline = this.redis.pipeline();
-      for (const key of batch) {
-        pipeline.zcard(key);
-      }
-      const results = await pipeline.exec();
-      // A null exec is the whole batch failing, not an empty batch. Treating it
-      // as empty would contribute 0 for every key in it and write the shortfall
-      // out as ground truth — the same under-count the per-entry check refuses.
-      if (results === null) {
-        logger.warn(
-          { batchOffset: offset },
-          "ZCARD pipeline returned no results during pending reconcile — aborting to avoid under-count",
-        );
-        return null;
-      }
-      for (const [index, [err, val]] of results.entries()) {
-        if (err) {
-          logger.warn(
-            { error: err },
-            "ZCARD pipeline error during pending reconcile — aborting to avoid under-count",
-          );
-          return null;
-        }
-        const count = Number(val) || 0;
-        groundTruth += count;
-        if (count === 0) emptyJobsKeys.push(batch[index]!);
-      }
+      if (batch === null) return null;
+      groundTruth += batch.sum;
+      emptyJobsKeys.push(...batch.emptyKeys);
       if (!(await params.refreshLease())) return null;
     }
     return { groundTruth, emptyJobsKeys };
+  }
+
+  /**
+   * ZCARD one batch of keys in a single round trip.
+   *
+   * Returns null on any failure — whole-batch or single-entry — so the caller
+   * abandons the pass rather than folding a shortfall into the total.
+   */
+  private async countOneBatch(
+    jobsKeys: string[],
+    batchOffset: number,
+  ): Promise<{ sum: number; emptyKeys: string[] } | null> {
+    const pipeline = this.redis.pipeline();
+    for (const key of jobsKeys) {
+      pipeline.zcard(key);
+    }
+    const results = await pipeline.exec();
+    // A null exec is the whole batch failing, not an empty batch. Treating it as
+    // empty would contribute 0 for every key in it and write the shortfall out as
+    // ground truth — the same under-count the per-entry check refuses.
+    if (results === null) {
+      logger.warn(
+        { batchOffset },
+        "ZCARD pipeline returned no results during pending reconcile — aborting to avoid under-count",
+      );
+      return null;
+    }
+    let sum = 0;
+    const emptyKeys: string[] = [];
+    for (const [index, [err, val]] of results.entries()) {
+      if (err) {
+        logger.warn(
+          { error: err },
+          "ZCARD pipeline error during pending reconcile — aborting to avoid under-count",
+        );
+        return null;
+      }
+      const count = Number(val) || 0;
+      sum += count;
+      if (count === 0) emptyKeys.push(jobsKeys[index]!);
+    }
+    return { sum, emptyKeys };
   }
 
   /**

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { createLogger } from "@langwatch/observability";
 import type IORedis from "ioredis";
 import type { ChainableCommander, Cluster } from "ioredis";
@@ -249,6 +251,22 @@ redis.call("LTRIM", signalKey, 0, 999)
 return count
 `;
 
+// Re-arm (or drop, when the requested TTL is not positive) the pending-reconcile
+// single-flight marker, but only while the caller still holds it. A marker that
+// lapsed mid-pass may already have been re-acquired by another instance, and
+// extending or dropping that one would put two reconcile passes on the same
+// counter at once — exactly what the marker exists to prevent. GET-then-act is
+// safe only inside a script, where nothing else can run in between.
+const RECONCILE_MARKER_TTL_LUA = `
+local markerKey  = KEYS[1]
+local holderToken = ARGV[1]
+local ttlMs       = tonumber(ARGV[2])
+
+if redis.call("GET", markerKey) ~= holderToken then return 0 end
+if ttlMs <= 0 then return redis.call("DEL", markerKey) end
+return redis.call("PEXPIRE", markerKey, ttlMs)
+`;
+
 // ── Cached scripts ───────────────────────────────────────────────────
 //
 // EVALSHA, not EVAL: plain EVAL re-transfers and re-hashes the full source on
@@ -262,13 +280,29 @@ const unblockScript = new CachedLuaScript(UNBLOCK_LUA);
 const drainGroupScript = new CachedLuaScript(DRAIN_GROUP_LUA);
 const moveToDlqScript = new CachedLuaScript(MOVE_TO_DLQ_LUA);
 const replayFromDlqScript = new CachedLuaScript(REPLAY_FROM_DLQ_LUA);
+const reconcileMarkerTtlScript = new CachedLuaScript(RECONCILE_MARKER_TTL_LUA);
 
 // ── Constants ────────────────────────────────────────────────────────
 
 const SUMMARY_TOP_N = 200;
 const DLQ_TTL_SECONDS = 604800;
 const SSCAN_BATCH = 500;
-const PENDING_RECONCILE_SCAN_COUNT = 1000;
+
+/** Page size for the index reads that enumerate a queue's groups. */
+const PENDING_RECONCILE_PAGE_SIZE = 1000;
+
+/** Number of ZCARDs sent per pipeline round trip during a reconcile pass. */
+const PENDING_RECONCILE_ZCARD_BATCH = 1000;
+
+/**
+ * How long the single-flight marker survives without a refresh.
+ *
+ * The marker is re-armed to this after every ZCARD batch, so a pass holds it for
+ * as long as it runs no matter how long that is. It bounds the other direction
+ * instead: an instance that dies mid-pass strands the marker for at most this
+ * long before another instance may take over.
+ */
+const PENDING_RECONCILE_LEASE_MS = 30_000;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -1551,9 +1585,9 @@ export class QueueRedisRepository implements QueueRepository {
    * (drives the dashboard "pending" tile), overwriting it with the ZCARD-derived
    * ground truth is safe and does not affect dispatch correctness.
    *
-   * The ground truth is the authoritative Σ ZCARD over ALL `group:*:jobs` keys
-   * for this queue — intentionally the complete count, distinct from the top-N
-   * sampled per-group dashboard tile.
+   * The ground truth is the authoritative Σ ZCARD over the `:jobs` zset of every
+   * group this queue knows about — intentionally the complete count, distinct
+   * from the top-N sampled per-group dashboard tile.
    *
    * A small re-drift from concurrent dispatch/complete INCR/DECR during the SET
    * window is acceptable and self-corrects on the next scheduled cycle.
@@ -1563,7 +1597,11 @@ export class QueueRedisRepository implements QueueRepository {
    * against multi-pod overlap.
    *
    * The reconcile is single-flighted per `singleFlightWindowMs` so only one
-   * pod recomputes per window. It is intentionally off the hot dispatch path.
+   * pod recomputes per window. The marker is held for the whole pass and only
+   * then downgraded to the remainder of the window, so a pass that outlives the
+   * window cannot be joined by a second one — the regime where a stacked pass
+   * would hurt most is exactly the regime where passes run long. It is
+   * intentionally off the hot dispatch path.
    *
    * See issue #4683.
    */
@@ -1574,51 +1612,47 @@ export class QueueRedisRepository implements QueueRepository {
     const prefix = `${queueName}:gq:`;
     const counterKey = `${prefix}stats:total-pending`;
     const markerKey = `${prefix}stats:pending-recon-ts`;
+    const holderToken = randomUUID();
+    const startedAtMs = Date.now();
 
-    // Single-flight gate: only one pod/cycle runs per window.
+    // Single-flight gate: only one pod/cycle runs per window. The marker is
+    // taken on a refreshable lease rather than for the full window so a pod that
+    // dies mid-pass cannot wedge the reconcile until the window elapses.
     const acquired = await this.redis.set(
       markerKey,
-      String(Date.now()),
+      holderToken,
       "PX",
-      singleFlightWindowMs,
+      PENDING_RECONCILE_LEASE_MS,
       "NX",
     );
     if (acquired !== "OK") return null;
 
-    // Read the pre-reconcile counter.
-    const raw = await this.redis.get(counterKey);
-    const counter = Math.max(0, parseInt(raw ?? "0", 10) || 0);
+    try {
+      // Read the pre-reconcile counter.
+      const raw = await this.redis.get(counterKey);
+      const counter = Math.max(0, parseInt(raw ?? "0", 10) || 0);
 
-    // Enumerate all group-jobs zsets via SCAN.
-    const jobsKeys: string[] = [];
-    const matchPattern = `${prefix}group:*:jobs`;
-    let cursor = "0";
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        "MATCH",
-        matchPattern,
-        "COUNT",
-        PENDING_RECONCILE_SCAN_COUNT,
-      );
-      cursor = nextCursor;
-      for (const key of keys) {
-        jobsKeys.push(key);
-      }
-    } while (cursor !== "0");
+      const jobsKeys = await this.collectGroupJobsKeys(prefix);
 
-    // Pipeline ZCARD for every collected key and sum the results.
-    // If ANY pipeline entry errors, abort — a flaky ZCARD must never write
-    // a partial under-count as ground truth; the next cycle retries.
-    let groundTruth = 0;
-    if (jobsKeys.length > 0) {
-      const pipeline = this.redis.pipeline();
-      for (const key of jobsKeys) {
-        pipeline.zcard(key);
-      }
-      const results = await pipeline.exec();
-      if (results) {
-        for (const [err, val] of results) {
+      // Pipeline ZCARD for every collected key and sum the results, re-arming
+      // the single-flight lease between batches so a long pass keeps its hold.
+      // If ANY pipeline entry errors, abort — a flaky ZCARD must never write
+      // a partial under-count as ground truth; the next cycle retries.
+      let groundTruth = 0;
+      for (
+        let offset = 0;
+        offset < jobsKeys.length;
+        offset += PENDING_RECONCILE_ZCARD_BATCH
+      ) {
+        const pipeline = this.redis.pipeline();
+        for (const key of jobsKeys.slice(
+          offset,
+          offset + PENDING_RECONCILE_ZCARD_BATCH,
+        )) {
+          pipeline.zcard(key);
+        }
+        const results = await pipeline.exec();
+        for (const [err, val] of results ?? []) {
           if (err) {
             logger.warn(
               { error: err },
@@ -1628,15 +1662,149 @@ export class QueueRedisRepository implements QueueRepository {
           }
           groundTruth += Number(val) || 0;
         }
+        await this.setReconcileMarkerTtl({
+          markerKey,
+          holderToken,
+          ttlMs: PENDING_RECONCILE_LEASE_MS,
+        });
       }
+
+      const drift = counter - groundTruth;
+
+      // Overwrite the counter with the ground truth.
+      await this.redis.set(counterKey, String(groundTruth));
+
+      return { counter, groundTruth, drift };
+    } finally {
+      // Hand the marker back as the unspent remainder of the window, so the
+      // cadence stays one reconcile per window measured from when this pass
+      // started. A pass that already outlived the window drops it outright and
+      // the next scheduled cycle may run immediately.
+      await this.setReconcileMarkerTtl({
+        markerKey,
+        holderToken,
+        ttlMs: singleFlightWindowMs - (Date.now() - startedAtMs),
+      });
+    }
+  }
+
+  /**
+   * Collect the `group:<id>:jobs` key of every group that can be holding a
+   * pending job, read from the queue's own group indexes.
+   *
+   * Deliberately not a keyspace SCAN: SCAN walks every key in the database
+   * regardless of MATCH, so the cost of a pass would track the size of the whole
+   * Redis instance rather than the number of groups in this queue. The indexes
+   * below hold group ids, so paging them costs what the queue actually contains.
+   *
+   * They are exhaustive for any group with jobs. A live group stays a member of
+   * `ready` even while its job is in flight (dispatch re-scores it into the
+   * future rather than removing it); the only other places a group can be are
+   * `parked:<tenant>`, for one deferred by the per-tenant cap, and `blocked`,
+   * for one held for operator triage. Every path that takes a group out of
+   * `ready` either puts it into one of those two or does so precisely because
+   * its `:jobs` zset is empty, so no group can hold jobs while absent from all
+   * three. DLQ jobs live under a separate `dlq:` prefix and are not pending.
+   *
+   * A group can briefly appear in two indexes while it moves between them, so
+   * ids are deduplicated before keys are built — counting one twice would be
+   * written to the counter as ground truth.
+   */
+  private async collectGroupJobsKeys(prefix: string): Promise<string[]> {
+    const groupIds = new Set<string>();
+
+    let readyCursor = "0";
+    do {
+      const [nextCursor, members] = await this.redis.zscan(
+        `${prefix}ready`,
+        readyCursor,
+        "COUNT",
+        PENDING_RECONCILE_PAGE_SIZE,
+      );
+      readyCursor = nextCursor;
+      // A ZSCAN page alternates [member, score, member, score, ...].
+      for (let i = 0; i < members.length; i += 2) {
+        groupIds.add(members[i]!);
+      }
+    } while (readyCursor !== "0");
+
+    let blockedCursor = "0";
+    do {
+      const [nextCursor, members] = await this.redis.sscan(
+        `${prefix}blocked`,
+        blockedCursor,
+        "COUNT",
+        PENDING_RECONCILE_PAGE_SIZE,
+      );
+      blockedCursor = nextCursor;
+      for (const groupId of members) {
+        groupIds.add(groupId);
+      }
+    } while (blockedCursor !== "0");
+
+    // One entry per tenant currently over cap — empty in the steady state where
+    // the cap is off, so the parked leg usually costs a single SSCAN.
+    const parkedTenants = new Set<string>();
+    let tenantCursor = "0";
+    do {
+      const [nextCursor, members] = await this.redis.sscan(
+        `${prefix}parked-tenants`,
+        tenantCursor,
+        "COUNT",
+        PENDING_RECONCILE_PAGE_SIZE,
+      );
+      tenantCursor = nextCursor;
+      for (const tenantId of members) {
+        parkedTenants.add(tenantId);
+      }
+    } while (tenantCursor !== "0");
+
+    for (const tenantId of parkedTenants) {
+      let parkedCursor = "0";
+      do {
+        const [nextCursor, members] = await this.redis.zscan(
+          `${prefix}parked:${tenantId}`,
+          parkedCursor,
+          "COUNT",
+          PENDING_RECONCILE_PAGE_SIZE,
+        );
+        parkedCursor = nextCursor;
+        for (let i = 0; i < members.length; i += 2) {
+          groupIds.add(members[i]!);
+        }
+      } while (parkedCursor !== "0");
     }
 
-    const drift = counter - groundTruth;
+    return Array.from(groupIds, (groupId) => `${prefix}group:${groupId}:jobs`);
+  }
 
-    // Overwrite the counter with the ground truth.
-    await this.redis.set(counterKey, String(groundTruth));
-
-    return { counter, groundTruth, drift };
+  /**
+   * Re-arm the single-flight marker this pass holds, or drop it when the
+   * requested TTL has already run out.
+   *
+   * Never throws: losing the marker mid-pass at worst lets a second pass start,
+   * and the pass in hand still produces a correct count, so a failure here must
+   * not take down a reconcile that otherwise succeeded.
+   */
+  private async setReconcileMarkerTtl(params: {
+    markerKey: string;
+    holderToken: string;
+    ttlMs: number;
+  }): Promise<void> {
+    try {
+      await reconcileMarkerTtlScript.run(
+        this.redis,
+        1,
+        params.markerKey,
+        params.holderToken,
+        Math.trunc(params.ttlMs),
+      );
+    } catch (err) {
+      logger.warn(
+        { error: err },
+        "Failed to re-arm the pending reconcile single-flight marker",
+      );
+    }
   }
 
   // ── Private Filter Helpers ──────────────────────────────────────

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -297,10 +297,12 @@ const PENDING_RECONCILE_ZCARD_BATCH = 1000;
 /**
  * How long the single-flight marker survives without a refresh.
  *
- * The marker is re-armed to this after every ZCARD batch, so a pass holds it for
- * as long as it runs no matter how long that is. It bounds the other direction
- * instead: an instance that dies mid-pass strands the marker for at most this
- * long before another instance may take over.
+ * The marker is re-armed to this after every index page and every ZCARD batch,
+ * so a pass holds it for as long as it runs no matter how long that is — both
+ * phases refresh, since collection is itself a paging walk and on a large queue
+ * can outlast a lease on its own. It bounds the other direction instead: an
+ * instance that dies mid-pass strands the marker for at most this long before
+ * another instance may take over.
  */
 const PENDING_RECONCILE_LEASE_MS = 30_000;
 
@@ -1632,7 +1634,21 @@ export class QueueRedisRepository implements QueueRepository {
       const raw = await this.redis.get(counterKey);
       const counter = Math.max(0, parseInt(raw ?? "0", 10) || 0);
 
-      const jobsKeys = await this.collectGroupJobsKeys(prefix);
+      // Collection is itself a paging walk over several indexes, so it re-arms
+      // the lease as it goes. Without that a pass on a large queue could spend
+      // its whole lease before the first ZCARD batch and lose the marker to
+      // another instance mid-pass.
+      const refreshLease = () =>
+        this.setReconcileMarkerTtl({
+          markerKey,
+          holderToken,
+          ttlMs: PENDING_RECONCILE_LEASE_MS,
+        });
+
+      const jobsKeys = await this.collectGroupJobsKeys({
+        prefix,
+        refreshLease,
+      });
 
       const groundTruth = await this.sumPendingJobs({
         jobsKeys,
@@ -1682,11 +1698,23 @@ export class QueueRedisRepository implements QueueRepository {
    * ids are deduplicated before keys are built — counting one twice would be
    * written to the counter as ground truth.
    */
-  private async collectGroupJobsKeys(prefix: string): Promise<string[]> {
+  private async collectGroupJobsKeys(params: {
+    prefix: string;
+    refreshLease: () => Promise<void>;
+  }): Promise<string[]> {
+    const { prefix, refreshLease } = params;
     const groupIds = new Set<string>();
 
-    await this.collectZsetGroupIds({ key: `${prefix}ready`, into: groupIds });
-    await this.collectSetMembers({ key: `${prefix}blocked`, into: groupIds });
+    await this.collectZsetGroupIds({
+      key: `${prefix}ready`,
+      into: groupIds,
+      refreshLease,
+    });
+    await this.collectSetMembers({
+      key: `${prefix}blocked`,
+      into: groupIds,
+      refreshLease,
+    });
 
     // One entry per tenant currently over cap — empty in the steady state where
     // the cap is off, so the parked leg usually costs a single SSCAN.
@@ -1694,11 +1722,13 @@ export class QueueRedisRepository implements QueueRepository {
     await this.collectSetMembers({
       key: `${prefix}parked-tenants`,
       into: parkedTenants,
+      refreshLease,
     });
     for (const tenantId of parkedTenants) {
       await this.collectZsetGroupIds({
         key: `${prefix}parked:${tenantId}`,
         into: groupIds,
+        refreshLease,
       });
     }
 
@@ -1709,6 +1739,7 @@ export class QueueRedisRepository implements QueueRepository {
   private async collectZsetGroupIds(params: {
     key: string;
     into: Set<string>;
+    refreshLease: () => Promise<void>;
   }): Promise<void> {
     let cursor = "0";
     do {
@@ -1723,6 +1754,7 @@ export class QueueRedisRepository implements QueueRepository {
       for (let i = 0; i < members.length; i += 2) {
         params.into.add(members[i]!);
       }
+      await params.refreshLease();
     } while (cursor !== "0");
   }
 
@@ -1730,6 +1762,7 @@ export class QueueRedisRepository implements QueueRepository {
   private async collectSetMembers(params: {
     key: string;
     into: Set<string>;
+    refreshLease: () => Promise<void>;
   }): Promise<void> {
     let cursor = "0";
     do {
@@ -1743,6 +1776,7 @@ export class QueueRedisRepository implements QueueRepository {
       for (const member of members) {
         params.into.add(member);
       }
+      await params.refreshLease();
     } while (cursor !== "0");
   }
 
@@ -1772,7 +1806,17 @@ export class QueueRedisRepository implements QueueRepository {
         pipeline.zcard(key);
       }
       const results = await pipeline.exec();
-      for (const [err, val] of results ?? []) {
+      // A null exec is the whole batch failing, not an empty batch. Treating it
+      // as empty would contribute 0 for every key in it and write the shortfall
+      // out as ground truth — the same under-count the per-entry check refuses.
+      if (results === null) {
+        logger.warn(
+          { batchOffset: offset },
+          "ZCARD pipeline returned no results during pending reconcile — aborting to avoid under-count",
+        );
+        return null;
+      }
+      for (const [err, val] of results) {
         if (err) {
           logger.warn(
             { error: err },

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1754,12 +1754,16 @@ export class QueueRedisRepository implements QueueRepository {
    * (see PENDING_INDEX_HELPER_LUA). It is read as a single index, so no group can
    * slip between two reads the way it can between the lifecycle indexes.
    *
-   * The lifecycle indexes are still read, and are now additive only. They cover
-   * groups staged before this index existed, which would otherwise stay invisible
-   * until something next wrote to them. A surplus id costs nothing — its ZCARD is
-   * 0 — so folding them in can only help, and their own read-ordering race can no
-   * longer undercount now that correctness rests on `pending-groups`. They can be
-   * dropped once no queue predates the index.
+   * The lifecycle indexes are still read, and cover the groups the index does not
+   * yet know about: everything staged before it existed, and everything staged by
+   * a pod on the previous release while a rollout is in progress. Those groups are
+   * still exposed to the sequential-read race the index exists to remove, so any
+   * id found there is written into the index as it is read. One observation is
+   * enough — from then on the group is counted from the index and is immune,
+   * which bounds the exposure at "until first seen" rather than "until drained".
+   *
+   * The legs can be dropped once no queue predates the index and no pod predates
+   * the writers.
    *
    * Returns null when the pass lost its single-flight marker partway.
    */
@@ -1779,11 +1783,19 @@ export class QueueRedisRepository implements QueueRepository {
     });
     if (!heldThroughTenants) return null;
 
-    // TODO(cleanup): the three lifecycle legs below are additive only and exist
-    // solely to cover groups staged before the pending index did. Removable once
-    // no queue predates it — the index alone is what makes the count correct.
-    const legs: { key: string; type: "zset" | "set" }[] = [
-      { key: pendingGroupsKey(prefix), type: "set" },
+    const indexed = await this.collectIndexMembers({
+      key: pendingGroupsKey(prefix),
+      type: "set",
+      into: groupIds,
+      refreshLease,
+    });
+    if (!indexed) return null;
+    const alreadyIndexed = new Set(groupIds);
+
+    // TODO(cleanup): the lifecycle legs below exist only for groups the index has
+    // not learned about yet. Removable once no queue predates the index and no pod
+    // predates the writers.
+    const legacyLegs: { key: string; type: "zset" | "set" }[] = [
       { key: `${prefix}ready`, type: "zset" },
       { key: `${prefix}blocked`, type: "set" },
       ...Array.from(parkedTenants, (tenantId) => ({
@@ -1792,7 +1804,7 @@ export class QueueRedisRepository implements QueueRepository {
       })),
     ];
 
-    for (const leg of legs) {
+    for (const leg of legacyLegs) {
       const held = await this.collectIndexMembers({
         key: leg.key,
         type: leg.type,
@@ -1802,7 +1814,53 @@ export class QueueRedisRepository implements QueueRepository {
       if (!held) return null;
     }
 
+    await this.backfillPendingIndex({
+      prefix,
+      groupIds: Array.from(groupIds).filter((id) => !alreadyIndexed.has(id)),
+    });
+
     return groupIds;
+  }
+
+  /**
+   * Adopt groups the lifecycle indexes know about but the pending index does not.
+   *
+   * Until a group is in the index it is counted by reading the lifecycle indexes
+   * in sequence, and a group moving between them mid-read can be missed. Writing
+   * it in on first sight closes that for every later pass, so a group staged
+   * before the index existed — or by a pod on the previous release mid-rollout —
+   * is exposed for at most the passes before something first observes it.
+   *
+   * Best-effort: adding is what makes later passes safe, and failing to add only
+   * leaves the group where it already was. Over-inclusion is harmless, and the
+   * prune removes anything that turns out to be empty.
+   */
+  private async backfillPendingIndex(params: {
+    prefix: string;
+    groupIds: string[];
+  }): Promise<void> {
+    if (params.groupIds.length === 0) return;
+    const indexKey = pendingGroupsKey(params.prefix);
+    try {
+      for (
+        let offset = 0;
+        offset < params.groupIds.length;
+        offset += PENDING_RECONCILE_ZCARD_BATCH
+      ) {
+        await this.redis.sadd(
+          indexKey,
+          ...params.groupIds.slice(
+            offset,
+            offset + PENDING_RECONCILE_ZCARD_BATCH,
+          ),
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        { error: err },
+        "Failed to adopt lifecycle-index groups into the pending index",
+      );
+    }
   }
 
   /**

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1634,40 +1634,12 @@ export class QueueRedisRepository implements QueueRepository {
 
       const jobsKeys = await this.collectGroupJobsKeys(prefix);
 
-      // Pipeline ZCARD for every collected key and sum the results, re-arming
-      // the single-flight lease between batches so a long pass keeps its hold.
-      // If ANY pipeline entry errors, abort — a flaky ZCARD must never write
-      // a partial under-count as ground truth; the next cycle retries.
-      let groundTruth = 0;
-      for (
-        let offset = 0;
-        offset < jobsKeys.length;
-        offset += PENDING_RECONCILE_ZCARD_BATCH
-      ) {
-        const pipeline = this.redis.pipeline();
-        for (const key of jobsKeys.slice(
-          offset,
-          offset + PENDING_RECONCILE_ZCARD_BATCH,
-        )) {
-          pipeline.zcard(key);
-        }
-        const results = await pipeline.exec();
-        for (const [err, val] of results ?? []) {
-          if (err) {
-            logger.warn(
-              { error: err },
-              "ZCARD pipeline error during pending reconcile — aborting to avoid under-count",
-            );
-            return null;
-          }
-          groundTruth += Number(val) || 0;
-        }
-        await this.setReconcileMarkerTtl({
-          markerKey,
-          holderToken,
-          ttlMs: PENDING_RECONCILE_LEASE_MS,
-        });
-      }
+      const groundTruth = await this.sumPendingJobs({
+        jobsKeys,
+        markerKey,
+        holderToken,
+      });
+      if (groundTruth === null) return null;
 
       const drift = counter - groundTruth;
 
@@ -1713,69 +1685,110 @@ export class QueueRedisRepository implements QueueRepository {
   private async collectGroupJobsKeys(prefix: string): Promise<string[]> {
     const groupIds = new Set<string>();
 
-    let readyCursor = "0";
-    do {
-      const [nextCursor, members] = await this.redis.zscan(
-        `${prefix}ready`,
-        readyCursor,
-        "COUNT",
-        PENDING_RECONCILE_PAGE_SIZE,
-      );
-      readyCursor = nextCursor;
-      // A ZSCAN page alternates [member, score, member, score, ...].
-      for (let i = 0; i < members.length; i += 2) {
-        groupIds.add(members[i]!);
-      }
-    } while (readyCursor !== "0");
-
-    let blockedCursor = "0";
-    do {
-      const [nextCursor, members] = await this.redis.sscan(
-        `${prefix}blocked`,
-        blockedCursor,
-        "COUNT",
-        PENDING_RECONCILE_PAGE_SIZE,
-      );
-      blockedCursor = nextCursor;
-      for (const groupId of members) {
-        groupIds.add(groupId);
-      }
-    } while (blockedCursor !== "0");
+    await this.collectZsetGroupIds({ key: `${prefix}ready`, into: groupIds });
+    await this.collectSetMembers({ key: `${prefix}blocked`, into: groupIds });
 
     // One entry per tenant currently over cap — empty in the steady state where
     // the cap is off, so the parked leg usually costs a single SSCAN.
     const parkedTenants = new Set<string>();
-    let tenantCursor = "0";
-    do {
-      const [nextCursor, members] = await this.redis.sscan(
-        `${prefix}parked-tenants`,
-        tenantCursor,
-        "COUNT",
-        PENDING_RECONCILE_PAGE_SIZE,
-      );
-      tenantCursor = nextCursor;
-      for (const tenantId of members) {
-        parkedTenants.add(tenantId);
-      }
-    } while (tenantCursor !== "0");
-
+    await this.collectSetMembers({
+      key: `${prefix}parked-tenants`,
+      into: parkedTenants,
+    });
     for (const tenantId of parkedTenants) {
-      let parkedCursor = "0";
-      do {
-        const [nextCursor, members] = await this.redis.zscan(
-          `${prefix}parked:${tenantId}`,
-          parkedCursor,
-          "COUNT",
-          PENDING_RECONCILE_PAGE_SIZE,
-        );
-        parkedCursor = nextCursor;
-        for (let i = 0; i < members.length; i += 2) {
-          groupIds.add(members[i]!);
-        }
-      } while (parkedCursor !== "0");
+      await this.collectZsetGroupIds({
+        key: `${prefix}parked:${tenantId}`,
+        into: groupIds,
+      });
     }
 
     return Array.from(groupIds, (groupId) => `${prefix}group:${groupId}:jobs`);
+  }
+
+  /** Page a zset of group ids with ZSCAN, adding every member into `into`. */
+  private async collectZsetGroupIds(params: {
+    key: string;
+    into: Set<string>;
+  }): Promise<void> {
+    let cursor = "0";
+    do {
+      const [nextCursor, members] = await this.redis.zscan(
+        params.key,
+        cursor,
+        "COUNT",
+        PENDING_RECONCILE_PAGE_SIZE,
+      );
+      cursor = nextCursor;
+      // A ZSCAN page alternates [member, score, member, score, ...].
+      for (let i = 0; i < members.length; i += 2) {
+        params.into.add(members[i]!);
+      }
+    } while (cursor !== "0");
+  }
+
+  /** Page a set with SSCAN, adding every member into `into`. */
+  private async collectSetMembers(params: {
+    key: string;
+    into: Set<string>;
+  }): Promise<void> {
+    let cursor = "0";
+    do {
+      const [nextCursor, members] = await this.redis.sscan(
+        params.key,
+        cursor,
+        "COUNT",
+        PENDING_RECONCILE_PAGE_SIZE,
+      );
+      cursor = nextCursor;
+      for (const member of members) {
+        params.into.add(member);
+      }
+    } while (cursor !== "0");
+  }
+
+  /**
+   * Sum ZCARD over the collected keys in batches, re-arming the single-flight
+   * lease between batches so a long pass keeps its hold.
+   *
+   * Returns null if ANY pipeline entry errors — a flaky ZCARD must never write
+   * a partial under-count as ground truth; the next cycle retries.
+   */
+  private async sumPendingJobs(params: {
+    jobsKeys: string[];
+    markerKey: string;
+    holderToken: string;
+  }): Promise<number | null> {
+    let groundTruth = 0;
+    for (
+      let offset = 0;
+      offset < params.jobsKeys.length;
+      offset += PENDING_RECONCILE_ZCARD_BATCH
+    ) {
+      const pipeline = this.redis.pipeline();
+      for (const key of params.jobsKeys.slice(
+        offset,
+        offset + PENDING_RECONCILE_ZCARD_BATCH,
+      )) {
+        pipeline.zcard(key);
+      }
+      const results = await pipeline.exec();
+      for (const [err, val] of results ?? []) {
+        if (err) {
+          logger.warn(
+            { error: err },
+            "ZCARD pipeline error during pending reconcile — aborting to avoid under-count",
+          );
+          return null;
+        }
+        groundTruth += Number(val) || 0;
+      }
+      await this.setReconcileMarkerTtl({
+        markerKey: params.markerKey,
+        holderToken: params.holderToken,
+        ttlMs: PENDING_RECONCILE_LEASE_MS,
+      });
+    }
+    return groundTruth;
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/pipelines/blob-maintenance/process-manager/blobCleanup.process.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/blob-maintenance/process-manager/blobCleanup.process.ts
@@ -68,12 +68,14 @@ export function runBlobCleanup(deps: BlobCleanupDeps) {
         "Blob cleanup sweep reclaimed unreferenced blobs",
       );
     }
-    // A sweep that never finishes the keyspace looks exactly like a healthy one
-    // in the totals, so it gets its own line rather than a field nobody filters.
+    // Partial coverage looks exactly like full coverage in the totals, so it
+    // gets its own line rather than a field nobody filters. The next tick
+    // resumes from this one's cursor, so this is progress reporting on a
+    // keyspace bigger than one tick's ceiling, not a failure.
     if (report.totals.truncated) {
-      logger.warn(
+      logger.info(
         { scanned: report.totals.scanned },
-        "Blob cleanup hit its per-queue scan ceiling; keyspace not fully covered this tick",
+        "Blob cleanup hit its per-queue scan ceiling; resuming from this cursor next tick",
       );
     }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
@@ -262,6 +262,70 @@ describe("BlobSweeper", () => {
     });
   });
 
+  describe("given a dry run over more blobs than one sweep's ceiling", () => {
+    describe("when the runner sweeps in dry-run mode and then for real", () => {
+      /** @scenario "A dry run does not advance the cursor past blobs it only inspected" */
+      it("leaves the cursor untouched, and only a real sweep parks one", async () => {
+        const cursorKey = `${PREFIX}blob-sweep-cursor`;
+        for (const hash of ["d01", "d02", "d03", "d04"]) {
+          await redis.set(
+            blobKey(hash),
+            "body",
+            "EX",
+            BLOB_BACKSTOP_TTL_SECONDS,
+          );
+        }
+
+        // A ceiling below the blob count guarantees the walk stops partway, so
+        // there is a real cursor position to park or discard.
+        const pacedSweeper = new BlobSweeper({ redis, maxKeysPerQueue: 1 });
+
+        const dryTally = await pacedSweeper.sweepQueue({
+          queueName: QUEUE_NAME,
+          dryRun: true,
+        });
+
+        expect(dryTally.truncated).toBe(true);
+        // Nothing was judged, so nothing may be marked as covered.
+        expect(await redis.exists(cursorKey)).toBe(0);
+
+        await pacedSweeper.sweepQueue({ queueName: QUEUE_NAME });
+
+        expect(await redis.exists(cursorKey)).toBe(1);
+      });
+    });
+  });
+
+  describe("given a keyspace where almost nothing matches the blob pattern", () => {
+    describe("when the runner sweeps", () => {
+      /** @scenario "A sweep is bounded by the work it does, not only by the matches it finds" */
+      it("stops on its scan-call budget instead of walking the whole keyspace", async () => {
+        // Matches are what the key ceiling counts, so a keyspace with almost none
+        // would run the walk to the end of the database on every tick. Only a
+        // budget on the calls themselves bounds that.
+        const filler = redis.pipeline();
+        for (let i = 0; i < 3000; i++) {
+          filler.set(`${PREFIX}sweep-filler:${i}`, "x", "EX", 300);
+        }
+        await filler.exec();
+        await redis.set(blobKey(), "body", "EX", BLOB_BACKSTOP_TTL_SECONDS);
+
+        const budgetedSweeper = new BlobSweeper({
+          redis,
+          maxScanCallsPerQueue: 2,
+        });
+
+        const tally = await budgetedSweeper.sweepQueue({
+          queueName: QUEUE_NAME,
+        });
+
+        // Two SCAN calls cannot cross this keyspace, so the walk reports itself
+        // unfinished rather than having run to the end.
+        expect(tally.truncated).toBe(true);
+      });
+    });
+  });
+
   describe("given several queues registered in the group-queue registry", () => {
     describe("when the runner sweeps everything", () => {
       it("discovers the queue from the registry rather than a hardcoded name", async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
@@ -43,6 +43,50 @@ describe("BlobSweeper", () => {
   const sweepOnce = (dryRun = false) =>
     sweeper.sweepQueue({ queueName: QUEUE_NAME, dryRun });
 
+  /** Bytes on the full backstop, no lease and no holder: the shape repair acts on. */
+  const giveBackstopBlobs = async (hashes: string[]) => {
+    for (const hash of hashes) {
+      await redis.set(blobKey(hash), "body", "EX", BLOB_BACKSTOP_TTL_SECONDS);
+    }
+  };
+
+  /**
+   * Pad the keyspace past several SCAN pages.
+   *
+   * SCAN pages by buckets and filters by MATCH afterwards, so a handful of keys
+   * come back in one call and a single tick would cover them however the cursor
+   * behaved. The padding is what makes a tick stop partway. It shares the suite
+   * prefix so teardown removes it, and carries no "<project>/<hash>" segment so
+   * the blob glob skips it.
+   */
+  const padKeyspace = async (count: number) => {
+    const filler = redis.pipeline();
+    for (let i = 0; i < count; i++) {
+      filler.set(`${PREFIX}sweep-filler:${i}`, "x", "EX", 300);
+    }
+    await filler.exec();
+  };
+
+  const sweepRepeatedly = async (
+    sweeperUnderTest: BlobSweeper,
+    ticks: number,
+  ) => {
+    for (let tick = 0; tick < ticks; tick++) {
+      await sweeperUnderTest.sweepQueue({ queueName: QUEUE_NAME });
+    }
+  };
+
+  /**
+   * TTLs of the given blobs, for a caller to assert on. Returns rather than
+   * asserts so the expectations stay in the test that owns them.
+   */
+  const blobTtls = async (hashes: string[]) =>
+    await Promise.all(hashes.map((hash) => redis.ttl(blobKey(hash))));
+
+  /** A blob the runner has judged sits on the grace window, not the backstop. */
+  const notOnGraceWindow = (ttls: number[]) =>
+    ttls.filter((ttl) => ttl <= 0 || ttl > BLOB_RELEASE_GRACE_TTL_SECONDS);
+
   beforeAll(() => {
     redis = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379", {
       maxRetriesPerRequest: 0,
@@ -192,48 +236,18 @@ describe("BlobSweeper", () => {
       /** @scenario "Successive sweeps reach the blobs the previous ones stopped short of" */
       it("reaches every blob across successive sweeps rather than only the first slice", async () => {
         const hashes = ["h01", "h02", "h03", "h04", "h05", "h06"];
-        for (const hash of hashes) {
-          // Bytes on the full backstop with no lease and no holder: the shape
-          // the repair pass pulls onto the grace window.
-          await redis.set(
-            blobKey(hash),
-            "body",
-            "EX",
-            BLOB_BACKSTOP_TTL_SECONDS,
-          );
-        }
+        await giveBackstopBlobs(hashes);
+        await padKeyspace(3000);
 
-        // SCAN pages by buckets, not by matches, so a handful of keys would all
-        // come back in one call and a single tick would cover them however the
-        // cursor behaved. Padding the keyspace past several pages is what forces
-        // a tick to stop partway and makes resumption the thing under test.
-        // The filler shares the suite prefix so it is torn down with everything
-        // else, and carries no "<project>/<hash>" segment so the blob glob skips it.
-        const filler = redis.pipeline();
-        for (let i = 0; i < 3000; i++) {
-          filler.set(`${PREFIX}sweep-filler:${i}`, "x", "EX", 300);
-        }
-        await filler.exec();
-
-        const ceiling = 2;
-        const pacedSweeper = new BlobSweeper({
-          redis,
-          maxKeysPerQueue: ceiling,
-        });
+        const pacedSweeper = new BlobSweeper({ redis, maxKeysPerQueue: 2 });
 
         // Enough ticks to cover the keyspace at this ceiling, with headroom for
         // SCAN returning short pages.
-        for (let tick = 0; tick < hashes.length * 3; tick++) {
-          await pacedSweeper.sweepQueue({ queueName: QUEUE_NAME });
-        }
+        await sweepRepeatedly(pacedSweeper, hashes.length * 3);
 
-        // Every blob was reached, so every one is on the grace window rather
-        // than still sitting on the backstop.
-        for (const hash of hashes) {
-          const ttl = await redis.ttl(blobKey(hash));
-          expect(ttl).toBeGreaterThan(0);
-          expect(ttl).toBeLessThanOrEqual(BLOB_RELEASE_GRACE_TTL_SECONDS);
-        }
+        // Naming the offenders rather than asserting a bare boolean, so a
+        // failure says which blob was left behind and on what TTL.
+        expect(notOnGraceWindow(await blobTtls(hashes))).toEqual([]);
       });
 
       /** @scenario "Once every blob has been judged the runner begins again" */
@@ -267,14 +281,7 @@ describe("BlobSweeper", () => {
       /** @scenario "A dry run leaves the blobs it inspected for the next real sweep" */
       it("leaves the cursor untouched, and only a real sweep parks one", async () => {
         const cursorKey = `${PREFIX}blob-sweep-cursor`;
-        for (const hash of ["d01", "d02", "d03", "d04"]) {
-          await redis.set(
-            blobKey(hash),
-            "body",
-            "EX",
-            BLOB_BACKSTOP_TTL_SECONDS,
-          );
-        }
+        await giveBackstopBlobs(["d01", "d02", "d03", "d04"]);
 
         // A ceiling below the blob count guarantees the walk stops partway, so
         // there is a real cursor position to park or discard.
@@ -303,11 +310,7 @@ describe("BlobSweeper", () => {
         // Matches are what the key ceiling counts, so a keyspace with almost none
         // would run the walk to the end of the database on every tick. Only a
         // budget on the calls themselves bounds that.
-        const filler = redis.pipeline();
-        for (let i = 0; i < 3000; i++) {
-          filler.set(`${PREFIX}sweep-filler:${i}`, "x", "EX", 300);
-        }
-        await filler.exec();
+        await padKeyspace(3000);
         await redis.set(blobKey(), "body", "EX", BLOB_BACKSTOP_TTL_SECONDS);
 
         const budgetedSweeper = new BlobSweeper({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
@@ -189,7 +189,7 @@ describe("BlobSweeper", () => {
      * sweep in the totals while the bytes accumulate.
      */
     describe("when the runner sweeps repeatedly", () => {
-      /** @scenario "Successive sweeps advance through the keyspace instead of re-walking its first slice" */
+      /** @scenario "Successive sweeps reach the blobs the previous ones stopped short of" */
       it("reaches every blob across successive sweeps rather than only the first slice", async () => {
         const hashes = ["h01", "h02", "h03", "h04", "h05", "h06"];
         for (const hash of hashes) {
@@ -236,7 +236,7 @@ describe("BlobSweeper", () => {
         }
       });
 
-      /** @scenario "A completed cycle rewinds so newly written blobs are picked up" */
+      /** @scenario "Once every blob has been judged the runner begins again" */
       it("rewinds to the start once the keyspace is exhausted", async () => {
         await redis.set(blobKey(), "body", "EX", BLOB_BACKSTOP_TTL_SECONDS);
 
@@ -264,7 +264,7 @@ describe("BlobSweeper", () => {
 
   describe("given a dry run over more blobs than one sweep's ceiling", () => {
     describe("when the runner sweeps in dry-run mode and then for real", () => {
-      /** @scenario "A dry run does not advance the cursor past blobs it only inspected" */
+      /** @scenario "A dry run leaves the blobs it inspected for the next real sweep" */
       it("leaves the cursor untouched, and only a real sweep parks one", async () => {
         const cursorKey = `${PREFIX}blob-sweep-cursor`;
         for (const hash of ["d01", "d02", "d03", "d04"]) {
@@ -298,7 +298,7 @@ describe("BlobSweeper", () => {
 
   describe("given a keyspace where almost nothing matches the blob pattern", () => {
     describe("when the runner sweeps", () => {
-      /** @scenario "A sweep is bounded by the work it does, not only by the matches it finds" */
+      /** @scenario "A sweep stays bounded even when it finds almost nothing to judge" */
       it("stops on its scan-call budget instead of walking the whole keyspace", async () => {
         // Matches are what the key ceiling counts, so a keyspace with almost none
         // would run the walk to the end of the database on every tick. Only a

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobSweeper.integration.test.ts
@@ -180,6 +180,88 @@ describe("BlobSweeper", () => {
     });
   });
 
+  describe("given more unreferenced blobs than one sweep's ceiling", () => {
+    /**
+     * The ceiling only bounds a tick if the walk resumes where it stopped. When
+     * it restarts at the beginning every tick it re-judges the same leading
+     * slice forever, and every blob past that slice is left to the 4-day
+     * backstop no matter how often the sweep runs — which reads as a healthy
+     * sweep in the totals while the bytes accumulate.
+     */
+    describe("when the runner sweeps repeatedly", () => {
+      /** @scenario "Successive sweeps advance through the keyspace instead of re-walking its first slice" */
+      it("reaches every blob across successive sweeps rather than only the first slice", async () => {
+        const hashes = ["h01", "h02", "h03", "h04", "h05", "h06"];
+        for (const hash of hashes) {
+          // Bytes on the full backstop with no lease and no holder: the shape
+          // the repair pass pulls onto the grace window.
+          await redis.set(
+            blobKey(hash),
+            "body",
+            "EX",
+            BLOB_BACKSTOP_TTL_SECONDS,
+          );
+        }
+
+        // SCAN pages by buckets, not by matches, so a handful of keys would all
+        // come back in one call and a single tick would cover them however the
+        // cursor behaved. Padding the keyspace past several pages is what forces
+        // a tick to stop partway and makes resumption the thing under test.
+        // The filler shares the suite prefix so it is torn down with everything
+        // else, and carries no "<project>/<hash>" segment so the blob glob skips it.
+        const filler = redis.pipeline();
+        for (let i = 0; i < 3000; i++) {
+          filler.set(`${PREFIX}sweep-filler:${i}`, "x", "EX", 300);
+        }
+        await filler.exec();
+
+        const ceiling = 2;
+        const pacedSweeper = new BlobSweeper({
+          redis,
+          maxKeysPerQueue: ceiling,
+        });
+
+        // Enough ticks to cover the keyspace at this ceiling, with headroom for
+        // SCAN returning short pages.
+        for (let tick = 0; tick < hashes.length * 3; tick++) {
+          await pacedSweeper.sweepQueue({ queueName: QUEUE_NAME });
+        }
+
+        // Every blob was reached, so every one is on the grace window rather
+        // than still sitting on the backstop.
+        for (const hash of hashes) {
+          const ttl = await redis.ttl(blobKey(hash));
+          expect(ttl).toBeGreaterThan(0);
+          expect(ttl).toBeLessThanOrEqual(BLOB_RELEASE_GRACE_TTL_SECONDS);
+        }
+      });
+
+      /** @scenario "A completed cycle rewinds so newly written blobs are picked up" */
+      it("rewinds to the start once the keyspace is exhausted", async () => {
+        await redis.set(blobKey(), "body", "EX", BLOB_BACKSTOP_TTL_SECONDS);
+
+        // A ceiling above the keyspace finishes the walk in one tick.
+        const roomySweeper = new BlobSweeper({ redis, maxKeysPerQueue: 1000 });
+        const tally = await roomySweeper.sweepQueue({ queueName: QUEUE_NAME });
+        expect(tally.truncated).toBe(false);
+
+        // A blob written after that cycle finished is still found next tick,
+        // which only holds if the exhausted cursor rewound to "0".
+        await redis.set(
+          blobKey("later"),
+          "body",
+          "EX",
+          BLOB_BACKSTOP_TTL_SECONDS,
+        );
+        await roomySweeper.sweepQueue({ queueName: QUEUE_NAME });
+
+        const ttl = await redis.ttl(blobKey("later"));
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(BLOB_RELEASE_GRACE_TTL_SECONDS);
+      });
+    });
+  });
+
   describe("given several queues registered in the group-queue registry", () => {
     describe("when the runner sweeps everything", () => {
       it("discovers the queue from the registry rather than a hardcoded name", async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -98,6 +98,46 @@ describe.skipIf(!hasTestcontainers)(
     }
 
     describe("send()", () => {
+      describe("when jobs are staged faster than they are processed", () => {
+        /** @scenario "Staging a job records its group as holding pending work" */
+        it("records the group in the pending index", async () => {
+          // The ops reconcile counts jobs by asking this index which groups to
+          // look at, and it is written by the staging script itself. Held here
+          // by a processor that never finishes the first job, so the siblings
+          // stay staged for the assertion.
+          let releaseFirst: (() => void) | undefined;
+          const firstJobHeld = new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+          const queueName = `{test/gqmain/${crypto.randomUUID().slice(0, 8)}}`;
+          const queue = createQueue(
+            async () => {
+              await firstJobHeld;
+            },
+            { name: queueName },
+          );
+          await queue.waitUntilReady();
+
+          for (const id of ["p1", "p2", "p3"]) {
+            await queue.send({ id, groupId: "pending-group", value: id });
+          }
+
+          await vi.waitFor(
+            async () => {
+              expect(
+                await redis.sismember(
+                  `${queueName}:gq:pending-groups`,
+                  "pending-group",
+                ),
+              ).toBe(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          releaseFirst?.();
+        });
+      });
+
       describe("when a job is sent", () => {
         it("stages and processes the job with correct payload", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -122,19 +122,24 @@ describe.skipIf(!hasTestcontainers)(
             await queue.send({ id, groupId: "pending-group", value: id });
           }
 
-          await vi.waitFor(
-            async () => {
-              expect(
-                await redis.sismember(
-                  `${queueName}:gq:pending-groups`,
-                  "pending-group",
-                ),
-              ).toBe(1);
-            },
-            { timeout: 5000, interval: 50 },
-          );
-
-          releaseFirst?.();
+          try {
+            await vi.waitFor(
+              async () => {
+                expect(
+                  await redis.sismember(
+                    `${queueName}:gq:pending-groups`,
+                    "pending-group",
+                  ),
+                ).toBe(1);
+              },
+              { timeout: 5000, interval: 50 },
+            );
+          } finally {
+            // Unblock the processor even when the assertion fails, so teardown
+            // closes a queue that is idle rather than waiting out its shutdown
+            // timeout and charging the delay to whichever test runs next.
+            releaseFirst?.();
+          }
         });
       });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobSweeper.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobSweeper.ts
@@ -28,13 +28,44 @@ const SCAN_COUNT = 256;
  * Ceiling on blobs examined per queue per sweep, so one pass can never turn into
  * an unbounded walk of a multi-million-key keyspace. Work not reached this tick
  * is reached the next one; the sweep is periodic, not transactional.
+ *
+ * That promise only holds because the SCAN cursor is carried across ticks (see
+ * {@link blobSweepCursorKey}). A ceiling on a walk that always restarts at the
+ * beginning is not a rate limit, it is a blind spot: it would pin every sweep to
+ * the same leading slice of the keyspace and leave everything past it to the
+ * backstop TTL, however often the sweep ran.
  */
 const DEFAULT_MAX_KEYS_PER_QUEUE = 50_000;
+
+/**
+ * Where the last sweep of a queue stopped, so the next one resumes there instead
+ * of re-walking the slice it already judged.
+ *
+ * A SCAN cursor stays valid indefinitely, so parking one between ticks is safe:
+ * a full cycle still returns every key that exists for the whole of it. Keys
+ * created mid-cycle may not be seen until the following one, which is the normal
+ * SCAN guarantee and is what a periodic reclaim pass already assumes.
+ *
+ * It lives in Redis rather than in the process so progress survives a restart
+ * and is shared by whichever pod runs the tick. One field per node, because in
+ * cluster mode each master is iterated separately and a cursor only means
+ * anything against the node that issued it.
+ */
+function blobSweepCursorKey(queueName: string): string {
+  return `${queueName}:gq:blob-sweep-cursor`;
+}
+
+/** Cursor field for a non-clustered client, which has exactly one keyspace. */
+const SINGLE_NODE_CURSOR_FIELD = "single";
 
 export interface BlobSweepTally extends Record<BlobSweepOutcome, number> {
   /** Blobs examined, i.e. the sum of every outcome. */
   scanned: number;
-  /** True when the per-queue ceiling stopped the walk before the keyspace ended. */
+  /**
+   * True when the per-queue ceiling stopped the walk before the keyspace ended.
+   * The next tick resumes from where this one stopped, so on a keyspace larger
+   * than the ceiling this is the steady state, not a fault.
+   */
   truncated: boolean;
 }
 
@@ -61,27 +92,33 @@ function isCluster(client: IORedis | Cluster): client is Cluster {
  * script touches but does nothing for iteration, so the fan-out over masters is
  * required for correctness, not throughput.
  */
-async function scanNode(
-  node: { scan: IORedis["scan"] },
-  pattern: string,
-  limit: number,
-): Promise<{ keys: string[]; truncated: boolean }> {
+async function scanNode(params: {
+  node: { scan: IORedis["scan"] };
+  pattern: string;
+  limit: number;
+  /** Cursor the previous tick stopped at; "0" starts a fresh cycle. */
+  cursor: string;
+}): Promise<{ keys: string[]; cursor: string; truncated: boolean }> {
   const keys: string[] = [];
-  let cursor = "0";
+  let cursor = params.cursor;
   do {
-    const [nextCursor, batch] = await node.scan(
+    const [nextCursor, batch] = await params.node.scan(
       cursor,
       "MATCH",
-      pattern,
+      params.pattern,
       "COUNT",
       SCAN_COUNT,
     );
     cursor = nextCursor;
     keys.push(...batch);
-    if (keys.length >= limit)
-      return { keys: keys.slice(0, limit), truncated: true };
+    // Every key the cursor has moved past is kept, so the batch that crosses the
+    // ceiling is not trimmed. Trimming it would drop keys the returned cursor has
+    // already passed, and the next tick — resuming from that cursor — would never
+    // come back for them. Overshooting the ceiling by at most one page is the
+    // cheaper side of that trade.
+    if (keys.length >= params.limit) return { keys, cursor, truncated: true };
   } while (cursor !== "0");
-  return { keys, truncated: false };
+  return { keys, cursor: "0", truncated: false };
 }
 
 /**
@@ -150,19 +187,41 @@ export class BlobSweeper {
     queueName: string,
   ): Promise<{ keys: string[]; truncated: boolean }> {
     const pattern = this.blobScanPattern(queueName);
+    const cursorKey = blobSweepCursorKey(queueName);
+    const parked = await this.redis.hgetall(cursorKey);
+
     if (!isCluster(this.redis)) {
-      return scanNode(this.redis, pattern, this.maxKeysPerQueue);
+      const result = await scanNode({
+        node: this.redis,
+        pattern,
+        limit: this.maxKeysPerQueue,
+        cursor: parked[SINGLE_NODE_CURSOR_FIELD] ?? "0",
+      });
+      await this.redis.hset(cursorKey, SINGLE_NODE_CURSOR_FIELD, result.cursor);
+      return { keys: result.keys, truncated: result.truncated };
     }
+
     const seen = new Set<string>();
+    const resumeFrom: Record<string, string> = {};
     let truncated = false;
     const nodes = this.redis.nodes("master");
     await Promise.all(
       nodes.map(async (node) => {
-        const result = await scanNode(node, pattern, this.maxKeysPerQueue);
+        const nodeField = `${node.options.host ?? "?"}:${node.options.port ?? "?"}`;
+        const result = await scanNode({
+          node,
+          pattern,
+          limit: this.maxKeysPerQueue,
+          cursor: parked[nodeField] ?? "0",
+        });
         if (result.truncated) truncated = true;
+        resumeFrom[nodeField] = result.cursor;
         for (const key of result.keys) seen.add(key);
       }),
     );
+    if (Object.keys(resumeFrom).length > 0) {
+      await this.redis.hset(cursorKey, resumeFrom);
+    }
     return { keys: Array.from(seen), truncated };
   }
 
@@ -259,8 +318,9 @@ export class BlobSweeper {
           truncated: totals.truncated,
           durationMs: report.durationMs,
         },
-        // Truncation is called out because a sweep that never finishes the
-        // keyspace is the failure mode that looks like success.
+        // Truncation is reported so the covered fraction of a large keyspace
+        // stays visible: one tick judges a slice, and the cycle is only as fast
+        // as the ceiling and the interval together allow.
         "Blob sweep completed",
       );
     }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobSweeper.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobSweeper.ts
@@ -38,6 +38,20 @@ const SCAN_COUNT = 256;
 const DEFAULT_MAX_KEYS_PER_QUEUE = 50_000;
 
 /**
+ * Ceiling on SCAN calls per queue per sweep, bounding the walk by work done
+ * rather than by matches found.
+ *
+ * The matched-key ceiling alone does not bound a tick: SCAN pages by buckets and
+ * `MATCH` filters afterwards, so when few keys match, a tick walks the entire
+ * keyspace to collect its quota however large that keyspace is — the cost is
+ * paid whether or not anything comes back. `COUNT` is a work hint, not a
+ * guarantee, so the number of calls to cross a keyspace is not fixed either.
+ * Stopping on either ceiling makes one tick's cost bounded in both regimes, and
+ * the parked cursor means the budget defers work rather than dropping it.
+ */
+const DEFAULT_MAX_SCAN_CALLS_PER_QUEUE = 2_000;
+
+/**
  * Where the last sweep of a queue stopped, so the next one resumes there instead
  * of re-walking the slice it already judged.
  *
@@ -96,11 +110,13 @@ async function scanNode(params: {
   node: { scan: IORedis["scan"] };
   pattern: string;
   limit: number;
+  callBudget: number;
   /** Cursor the previous tick stopped at; "0" starts a fresh cycle. */
   cursor: string;
 }): Promise<{ keys: string[]; cursor: string; truncated: boolean }> {
   const keys: string[] = [];
   let cursor = params.cursor;
+  let calls = 0;
   do {
     const [nextCursor, batch] = await params.node.scan(
       cursor,
@@ -110,13 +126,16 @@ async function scanNode(params: {
       SCAN_COUNT,
     );
     cursor = nextCursor;
+    calls += 1;
     keys.push(...batch);
-    // Every key the cursor has moved past is kept, so the batch that crosses the
+    // Every key the cursor has moved past is kept, so the batch that crosses a
     // ceiling is not trimmed. Trimming it would drop keys the returned cursor has
     // already passed, and the next tick — resuming from that cursor — would never
     // come back for them. Overshooting the ceiling by at most one page is the
     // cheaper side of that trade.
-    if (keys.length >= params.limit) return { keys, cursor, truncated: true };
+    if (keys.length >= params.limit || calls >= params.callBudget) {
+      return { keys, cursor, truncated: true };
+    }
   } while (cursor !== "0");
   return { keys, cursor: "0", truncated: false };
 }
@@ -140,15 +159,20 @@ export class BlobSweeper {
   private readonly redis: IORedis | Cluster;
   private readonly maxKeysPerQueue: number;
 
+  private readonly maxScanCallsPerQueue: number;
+
   constructor({
     redis,
     maxKeysPerQueue = DEFAULT_MAX_KEYS_PER_QUEUE,
+    maxScanCallsPerQueue = DEFAULT_MAX_SCAN_CALLS_PER_QUEUE,
   }: {
     redis: IORedis | Cluster;
     maxKeysPerQueue?: number;
+    maxScanCallsPerQueue?: number;
   }) {
     this.redis = redis;
     this.maxKeysPerQueue = maxKeysPerQueue;
+    this.maxScanCallsPerQueue = maxScanCallsPerQueue;
   }
 
   /** Queue names the group queue has registered itself under. */
@@ -183,22 +207,36 @@ export class BlobSweeper {
     };
   }
 
-  private async scanBlobKeys(
-    queueName: string,
-  ): Promise<{ keys: string[]; truncated: boolean }> {
+  /**
+   * Read this queue's blob keys, resuming from the parked cursor.
+   *
+   * Returns where each node stopped rather than storing it: the cursor is only
+   * safe to advance once the blobs it covers have actually been judged, so the
+   * caller commits it after the sweep and never on a dry run. Advancing here
+   * would let a dry run — or a sweep that died before judging the batch — skip
+   * that slice until the cursor wrapped all the way around.
+   */
+  private async scanBlobKeys(queueName: string): Promise<{
+    keys: string[];
+    truncated: boolean;
+    resumeFrom: Record<string, string>;
+  }> {
     const pattern = this.blobScanPattern(queueName);
-    const cursorKey = blobSweepCursorKey(queueName);
-    const parked = await this.redis.hgetall(cursorKey);
+    const parked = await this.redis.hgetall(blobSweepCursorKey(queueName));
 
     if (!isCluster(this.redis)) {
       const result = await scanNode({
         node: this.redis,
         pattern,
         limit: this.maxKeysPerQueue,
+        callBudget: this.maxScanCallsPerQueue,
         cursor: parked[SINGLE_NODE_CURSOR_FIELD] ?? "0",
       });
-      await this.redis.hset(cursorKey, SINGLE_NODE_CURSOR_FIELD, result.cursor);
-      return { keys: result.keys, truncated: result.truncated };
+      return {
+        keys: result.keys,
+        truncated: result.truncated,
+        resumeFrom: { [SINGLE_NODE_CURSOR_FIELD]: result.cursor },
+      };
     }
 
     const seen = new Set<string>();
@@ -212,6 +250,7 @@ export class BlobSweeper {
           node,
           pattern,
           limit: this.maxKeysPerQueue,
+          callBudget: this.maxScanCallsPerQueue,
           cursor: parked[nodeField] ?? "0",
         });
         if (result.truncated) truncated = true;
@@ -219,10 +258,7 @@ export class BlobSweeper {
         for (const key of result.keys) seen.add(key);
       }),
     );
-    if (Object.keys(resumeFrom).length > 0) {
-      await this.redis.hset(cursorKey, resumeFrom);
-    }
-    return { keys: Array.from(seen), truncated };
+    return { keys: Array.from(seen), truncated, resumeFrom };
   }
 
   async sweepQueue({
@@ -233,7 +269,7 @@ export class BlobSweeper {
     dryRun?: boolean;
   }): Promise<BlobSweepTally> {
     const tally = emptyTally();
-    const { keys, truncated } = await this.scanBlobKeys(queueName);
+    const { keys, truncated, resumeFrom } = await this.scanBlobKeys(queueName);
     tally.truncated = truncated;
 
     for (const key of keys) {
@@ -268,7 +304,11 @@ export class BlobSweeper {
           gqBlobSweepTotal.inc({ queue_name: queueName, outcome });
         }
       } catch (err) {
-        // One unreadable blob must not abort the sweep; the next tick retries it.
+        // One unreadable blob must not abort the sweep. The cursor still moves
+        // past it, so it is retried when the cursor next comes around rather
+        // than on the next tick — deliberately, because holding the cursor for a
+        // blob that fails every time would stall the whole walk behind it. Its
+        // bytes stay bounded by the backstop TTL in the meantime.
         logger.warn(
           {
             queueName,
@@ -278,6 +318,14 @@ export class BlobSweeper {
           "Blob sweep failed for one blob; continuing",
         );
       }
+    }
+
+    // Commit the cursor only now, and never for a dry run: until the blobs this
+    // page covers have actually been judged, advancing past them would skip them
+    // for a whole cycle. A sweep that dies before here leaves the cursor where it
+    // was and the next tick re-judges the same page, which is idempotent.
+    if (!dryRun && Object.keys(resumeFrom).length > 0) {
+      await this.redis.hset(blobSweepCursorKey(queueName), resumeFrom);
     }
     return tally;
   }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -534,7 +534,36 @@ local function gqReclaimDiscardedNew(keyPrefix, value)
 end
 `;
 
+/**
+ * Set of groups that may hold a pending job, written atomically with every
+ * insert into a `group:<id>:jobs` zset.
+ *
+ * The reconcile counts jobs by asking which groups to look at. Asking the
+ * lifecycle indexes (`ready`, `blocked`, `parked:<tenant>`) cannot answer that
+ * safely: they have to be read one after another, and a group moving between
+ * them mid-read — from one not yet visited into one already visited — is in none
+ * of the reads even though it never stopped holding jobs. Transitions go both
+ * ways, so no scan order avoids it.
+ *
+ * This index is keyed on the property actually being counted, "has jobs", which
+ * no lifecycle transition changes. A group is added in the same atomic script
+ * that adds its job, so any group holding a job for the whole of a pass is in
+ * the index for the whole of that pass, whatever it does between states.
+ *
+ * Membership is deliberately a SUPERSET. Over-inclusion is free — a group that
+ * has since drained contributes ZCARD 0 — so removal can be lazy, which is what
+ * lets the `:jobs` safety-net TTL expire a group without corrupting the index.
+ * The reconcile prunes what it observes empty, under a check that re-reads the
+ * zset atomically so a group that gained a job in the meantime is never dropped.
+ */
+export const PENDING_INDEX_HELPER_LUA = `
+local function gqMarkPending(keyPrefix, groupId)
+  redis.call("SADD", keyPrefix .. "pending-groups", groupId)
+end
+`;
+
 const STAGE_LUA =
+  PENDING_INDEX_HELPER_LUA +
   BLOB_LEASE_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
@@ -602,6 +631,7 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       local orphanedValue = jobDataJson
       if shouldExtend == 1 then
         redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
+        gqMarkPending(parkKeyPrefixOf(readyKey), groupId)
       end
       if shouldReplace == 1 then
         orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
@@ -636,6 +666,7 @@ if dedupId ~= "" and dedupTtlMs > 0 then
 end
 
 local inserted = redis.call("ZADD", groupJobsKey, dispatchAfter, stagedJobId)
+gqMarkPending(parkKeyPrefixOf(readyKey), groupId)
 redis.call("HSET", dataKey, stagedJobId, jobDataJson)
 local stagedLease = gqParseLease(jobDataJson)
 if stagedLease and stagedLease.kind == "gq2" and stagedLease.projectId == parkTenantOf(groupId) then
@@ -669,6 +700,7 @@ return {1, ""}
 `;
 
 const STAGE_BATCH_LUA =
+  PENDING_INDEX_HELPER_LUA +
   BLOB_LEASE_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
@@ -731,6 +763,7 @@ for i = 1, count do
         orphanedValue = jobDataJson
         if shouldExtend == 1 then
           redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
+          gqMarkPending(keyPrefix, groupId)
         end
         if shouldReplace == 1 then
           orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
@@ -765,6 +798,7 @@ for i = 1, count do
     -- the same payload twice in one batch — updates in place and must not
     -- inflate newStagedCount, which feeds the total-pending INCRBY below.
     local inserted = redis.call("ZADD", groupJobsKey, dispatchAfter, stagedJobId)
+    gqMarkPending(keyPrefix, groupId)
     redis.call("HSET", dataKey, stagedJobId, jobDataJson)
     local stagedLease = gqParseLease(jobDataJson)
     if stagedLease and stagedLease.kind == "gq2" and stagedLease.projectId == gqTenantOf(groupId) then
@@ -1292,6 +1326,7 @@ return 0
 `;
 
 const RESTAGE_AND_BLOCK_LUA =
+  PENDING_INDEX_HELPER_LUA +
   BLOB_LEASE_HELPER_LUA +
   ROUTING_META_HELPER_LUA +
   `
@@ -1323,6 +1358,7 @@ redis.call("SADD", blockedKey, groupId)
 -- 2. Re-stage the failed job under the id it was dispatched under (ADR-080).
 --    Its member was ZREMed at claim time, so this insert lands on an absent one.
 local inserted = redis.call("ZADD", groupJobsKey, score, newStagedJobId)
+gqMarkPending(keyPrefix, groupId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
 local stagedLease = gqParseLease(jobDataJson)
 if stagedLease and stagedLease.kind == "gq2" and stagedLease.projectId == gqTenantOf(groupId) then
@@ -1373,6 +1409,7 @@ return 1
 `;
 
 const RETRY_RESTAGE_LUA =
+  PENDING_INDEX_HELPER_LUA +
   BLOB_LEASE_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
@@ -1420,6 +1457,7 @@ end
 local groupJobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
 local groupDataKey = keyPrefix .. "group:" .. groupId .. ":data"
 local inserted = redis.call("ZADD", groupJobsKey, dispatchAfterMs, newStagedJobId)
+gqMarkPending(keyPrefix, groupId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
 local stagedLease = gqParseLease(jobDataJson)
 if stagedLease and stagedLease.kind == "gq2" and stagedLease.projectId == gqTenantOf(groupId) then
@@ -2345,4 +2383,12 @@ export class GroupStagingScripts {
   getKeyPrefix(): string {
     return this.keyPrefix;
   }
+}
+
+/**
+ * Key of the pending-groups index, from a queue's key prefix (`<name>:gq:`).
+ * Mirrors what `gqMarkPending` builds; see PENDING_INDEX_HELPER_LUA.
+ */
+export function pendingGroupsKey(keyPrefix: string): string {
+  return `${keyPrefix}pending-groups`;
 }

--- a/specs/event-sourcing/payload-store-content-addressed.feature
+++ b/specs/event-sourcing/payload-store-content-addressed.feature
@@ -400,42 +400,42 @@ Feature: GroupQueue content-addressed tiered payload store
     And the runner reports it as eligible for reclaim
 
   @integration @track6
-  # The per-sweep ceiling bounds one tick's work and hands the rest to the next
-  # one. That only holds if the walk carries its position between ticks: a walk
-  # that restarts at the beginning re-judges the same leading slice every time,
-  # and the blobs behind it are left to the four-day backstop no matter how often
-  # the runner is scheduled — which reads as a healthy sweep in the totals.
-  Scenario: Successive sweeps advance through the keyspace instead of re-walking its first slice
-    Given more unreferenced Redis-tier blobs than one sweep's ceiling
+  # A sweep judges only so many blobs before it stops, and hands the rest to the
+  # next one. That only holds if each sweep takes over where the last left off. A
+  # runner that always begins again at the same place re-judges the same blobs
+  # forever, and the ones behind them keep their full backstop however often it
+  # runs — which looks like a healthy sweep in the totals.
+  Scenario: Successive sweeps reach the blobs the previous ones stopped short of
+    Given more unreferenced Redis-tier blobs than one sweep judges
     When the reclaim runner sweeps enough times to cover them all
     Then every blob has been put on the grace window
     And none is left on its four-day backstop
 
   @integration @track6
-  Scenario: A completed cycle rewinds so newly written blobs are picked up
-    Given the reclaim runner has finished a full pass of the blob keyspace
+  Scenario: Once every blob has been judged the runner begins again
+    Given the reclaim runner has judged every blob it can see
     When a new unreferenced blob is written and the runner sweeps again
     Then the new blob is put on the grace window
 
   @integration @track6
-  # A dry run is an operator asking what would happen. If it advanced the walk's
-  # position, asking the question would silently cost the next real sweep a slice
-  # of the keyspace.
-  Scenario: A dry run does not advance the cursor past blobs it only inspected
-    Given more unreferenced Redis-tier blobs than one sweep's ceiling
+  # A dry run is an operator asking what would happen. If it counted the blobs it
+  # only looked at as judged, asking the question would silently cost the next
+  # real sweep the chance to act on them.
+  Scenario: A dry run leaves the blobs it inspected for the next real sweep
+    Given more unreferenced Redis-tier blobs than one sweep judges
     When the runner sweeps in dry-run mode
-    Then no cursor is parked for the next sweep
-    And only a real sweep parks one
+    Then it records no progress for the next sweep to resume from
+    And only a real sweep records any
 
   @integration @track6
-  # The per-sweep ceiling counts blobs found, and SCAN pages by buckets rather
-  # than by matches, so a keyspace where almost nothing matches would be walked
-  # end to end every tick to fill a quota that never fills.
-  Scenario: A sweep is bounded by the work it does, not only by the matches it finds
-    Given a blob keyspace where almost nothing matches the blob pattern
-    When the runner sweeps
-    Then the walk stops on its own budget
-    And it reports itself as unfinished rather than having reached the end
+  # How much a sweep costs is decided by how far it looks, not by how much it
+  # finds. Capping only what it finds leaves it unbounded whenever there is
+  # little to find, which is the state the runner is meant to reach.
+  Scenario: A sweep stays bounded even when it finds almost nothing to judge
+    Given a blob store holding almost nothing the runner can judge
+    When the reclaim runner sweeps
+    Then the sweep still stops at a limit of its own
+    And it reports itself unfinished so the next one carries on
 
   @scheduled @track6
   Scenario: The runner is driven by the schedule, not by a request
@@ -518,6 +518,12 @@ Feature: GroupQueue content-addressed tiered payload store
   #     -> A dry run reports what it would reclaim without deleting anything
   #   AC6.6 "The sweep is scheduled and singly-executed"
   #     -> The runner is driven by the schedule, not by a request
+  #   AC6.7 "Each sweep resumes where the last one stopped"
+  #     -> Successive sweeps reach the blobs the previous ones stopped short of
+  #     -> Once every blob has been judged the runner begins again
+  #     -> A dry run leaves the blobs it inspected for the next real sweep
+  #   AC6.8 "A sweep is bounded by how far it looks, not by what it finds"
+  #     -> A sweep stays bounded even when it finds almost nothing to judge
   #
   # Count: 21 ADR-029 ACs -> 21 scenarios (@unimplemented pending the Outside-In
   # TDD pass), plus 6 Track 5 amendment ACs and 6 Track 6 reclaim ACs -> 12

--- a/specs/event-sourcing/payload-store-content-addressed.feature
+++ b/specs/event-sourcing/payload-store-content-addressed.feature
@@ -417,6 +417,26 @@ Feature: GroupQueue content-addressed tiered payload store
     When a new unreferenced blob is written and the runner sweeps again
     Then the new blob is put on the grace window
 
+  @integration @track6
+  # A dry run is an operator asking what would happen. If it advanced the walk's
+  # position, asking the question would silently cost the next real sweep a slice
+  # of the keyspace.
+  Scenario: A dry run does not advance the cursor past blobs it only inspected
+    Given more unreferenced Redis-tier blobs than one sweep's ceiling
+    When the runner sweeps in dry-run mode
+    Then no cursor is parked for the next sweep
+    And only a real sweep parks one
+
+  @integration @track6
+  # The per-sweep ceiling counts blobs found, and SCAN pages by buckets rather
+  # than by matches, so a keyspace where almost nothing matches would be walked
+  # end to end every tick to fill a quota that never fills.
+  Scenario: A sweep is bounded by the work it does, not only by the matches it finds
+    Given a blob keyspace where almost nothing matches the blob pattern
+    When the runner sweeps
+    Then the walk stops on its own budget
+    And it reports itself as unfinished rather than having reached the end
+
   @scheduled @track6
   Scenario: The runner is driven by the schedule, not by a request
     Given the reclaim runner is on its cleanup schedule

--- a/specs/event-sourcing/payload-store-content-addressed.feature
+++ b/specs/event-sourcing/payload-store-content-addressed.feature
@@ -399,6 +399,24 @@ Feature: GroupQueue content-addressed tiered payload store
     Then the blob is still readable
     And the runner reports it as eligible for reclaim
 
+  @integration @track6
+  # The per-sweep ceiling bounds one tick's work and hands the rest to the next
+  # one. That only holds if the walk carries its position between ticks: a walk
+  # that restarts at the beginning re-judges the same leading slice every time,
+  # and the blobs behind it are left to the four-day backstop no matter how often
+  # the runner is scheduled — which reads as a healthy sweep in the totals.
+  Scenario: Successive sweeps advance through the keyspace instead of re-walking its first slice
+    Given more unreferenced Redis-tier blobs than one sweep's ceiling
+    When the reclaim runner sweeps enough times to cover them all
+    Then every blob has been put on the grace window
+    And none is left on its four-day backstop
+
+  @integration @track6
+  Scenario: A completed cycle rewinds so newly written blobs are picked up
+    Given the reclaim runner has finished a full pass of the blob keyspace
+    When a new unreferenced blob is written and the runner sweeps again
+    Then the new blob is put on the grace window
+
   @scheduled @track6
   Scenario: The runner is driven by the schedule, not by a request
     Given the reclaim runner is on its cleanup schedule

--- a/specs/event-sourcing/pending-counter-conservation.feature
+++ b/specs/event-sourcing/pending-counter-conservation.feature
@@ -66,3 +66,11 @@ Feature: Pending counter conservation across job lifecycle
     Given a group with several staged jobs (INCR at stage)
     When the coalescing path drains some of them in one call
     Then the counter is decremented once per drained job (same as dispatch)
+
+  # The ops reconcile counts jobs by asking this index which groups to look at,
+  # so a staged job that never reached it would be invisible to the count.
+  @integration
+  Scenario: Staging a job records its group as holding pending work
+    Given a queue whose processor has not finished its first job
+    When further jobs are staged for the same group
+    Then the group is recorded as holding pending work

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -44,3 +44,29 @@ Feature: GroupQueue pending counter ground-truth reconcile
     When the reconcile is triggered again immediately within the same window
     Then the second call is skipped
     And the counter remains as healed by the first call
+
+  @integration
+  Scenario: Reconcile counts blocked and parked groups alongside ready ones
+    Given jobs are spread across ready, blocked, and parked groups
+    When the reconcile runs
+    Then the pending counter equals the sum of jobs across all three group indexes
+
+  @integration
+  Scenario: Reconcile counts a group listed in two indexes only once
+    Given a group appears in more than one group index at the same time
+    When the reconcile runs
+    Then that group's jobs are counted exactly once
+
+  @integration
+  Scenario: An overrunning reconcile releases the marker instead of holding it past the window
+    Given a reconcile pass that takes longer than the single-flight window
+    When the pass completes
+    Then the single-flight marker is released
+    And the next trigger may start a fresh reconcile immediately
+
+  @integration
+  Scenario: A declined reconcile leaves the holder's marker untouched
+    Given another instance currently holds the single-flight marker
+    When a reconcile is triggered
+    Then the trigger declines without running
+    And the holder's marker and its expiry are left untouched

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -70,3 +70,45 @@ Feature: GroupQueue pending counter ground-truth reconcile
     When a reconcile is triggered
     Then the trigger declines without running
     And the holder's marker and its expiry are left untouched
+
+  # The reconcile has to decide which groups to count. Asking the lifecycle
+  # indexes cannot answer that safely: they are read one after another, and a
+  # group moving between them mid-read is in none of the reads even though it
+  # never stopped holding jobs. The pending index is keyed on holding jobs
+  # instead, which no lifecycle transition changes.
+  @integration
+  Scenario: A group counted from the pending index needs no lifecycle membership
+    Given a group holding jobs while it moves between lifecycle states
+    When the reconcile runs
+    Then its jobs are still counted
+
+  @integration
+  Scenario: A drained group is dropped from the pending index
+    Given a group listed as pending whose jobs have all gone
+    And another listed group that still holds jobs
+    When the reconcile runs
+    Then the drained group is dropped from the index
+    And the group that still holds jobs is kept
+
+  # Two passes must never both publish. A pass that lost the marker cannot know
+  # whether a newer one has already written, so its count is only safe to
+  # discard — publishing it would put a stale number back over a fresh one.
+  @unit
+  Scenario: A pass that loses the marker mid-run publishes nothing
+    Given a reconcile pass that is overtaken by another instance
+    When it finishes computing its count
+    Then it discards the pass
+    And the counter is left for the instance that now holds the marker
+
+  @unit
+  Scenario: A pass whose marker lapses unclaimed publishes nothing
+    Given a reconcile pass whose marker expires with nobody taking it
+    When it finishes computing its count
+    Then it declines to write
+
+  @unit
+  Scenario: The counter write itself refuses to run without the marker
+    Given a reconcile pass that keeps the marker until its final check
+    And the marker changes hands before the write lands
+    When the pass goes to write its result
+    Then nothing is published

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -124,3 +124,15 @@ Feature: GroupQueue pending counter ground-truth reconcile
     When the reconcile runs
     Then its jobs are counted
     And it is added to the pending index for later passes
+
+  # Adoption only helps a group the pass actually saw, and the lifecycle indexes
+  # are read one after another, so a group moving between them is seen by
+  # neither. Reading the keyspace finds a group by the existence of its jobs,
+  # which no movement between indexes changes — the one enumeration that cannot
+  # miss one, kept for exactly the groups the index has not learned yet.
+  @integration
+  Scenario: A group no index lists is still counted and adopted
+    Given a group holding jobs that no index lists
+    When the reconcile runs
+    Then its jobs are counted
+    And it is added to the pending index for later passes

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -112,3 +112,15 @@ Feature: GroupQueue pending counter ground-truth reconcile
     And the marker changes hands before the write lands
     When the pass goes to write its result
     Then nothing is published
+
+  # Until a group is in the pending index it is found by reading the lifecycle
+  # indexes in sequence, which is the read a moving group can slip through.
+  # Adopting it on first sight bounds that exposure at "until first seen" rather
+  # than "until the group drains", which matters through a rolling deploy where
+  # pods on the previous release are still staging jobs.
+  @integration
+  Scenario: A group known only to the lifecycle indexes is adopted into the pending index
+    Given a group holding jobs that the pending index does not list
+    When the reconcile runs
+    Then its jobs are counted
+    And it is added to the pending index for later passes


### PR DESCRIPTION
## For humans

Two pieces of Redis housekeeping that were quietly not doing their job.

**The pending counter.** The ops dashboard shows how many queued jobs are waiting, kept as a running counter that a background pass recomputes every minute. To find the queue's groups, that pass asked Redis to walk **every key in the database** looking for matches — so its cost scaled with how much data Redis was holding overall rather than with the size of the queue it was measuring. The fuller Redis got, the more expensive the once-a-minute bookkeeping became. Separately, the lock that stops two servers recomputing at once expired after a fixed 55 seconds set at the start, so a pass slower than that lost its lock mid-flight and others piled on — worst exactly when the system was already strained.

**The blob cleanup.** Large job payloads are stored separately and swept every 5 minutes to delete ones nothing references any more. The sweep stops after 50,000 items and is supposed to carry on from there next time, but it forgot its place and started from the beginning every single time. It kept re-checking the same first slice and never reached anything beyond it. Those unreached items were only cleaned up by a 4-day fallback timer instead of the intended ~1 hour, so they accumulated.

Now the counter pass asks the queue which groups it has instead of searching the whole database, holds its lock for as long as it actually runs, and the blob sweep remembers where it stopped. None of the reported numbers change; what changes is the cost of producing them and whether the cleanup finishes.

## 1. Pending-counter reconcile (`reconcileTotalPending`)

**Enumeration.** `SCAN MATCH <prefix>group:*:jobs` is gone. Groups are counted from `<prefix>pending-groups`, a set written in the same atomic script as every insert into a `group:<id>:jobs` zset (`gqMarkPending`, wired into STAGE, STAGE_BATCH, RESTAGE_AND_BLOCK, RETRY_RESTAGE and REPLAY_FROM_DLQ).

*Why not the lifecycle indexes.* An earlier revision read `ready`, `blocked` and each `parked:<tenant>` in sequence. Those have to be read one after another, and with `T_ready < T_blocked < T_parked` a group is missed exactly when it is outside `ready` at `T_ready`, outside `blocked` at `T_blocked`, and outside `parked` at `T_parked`. Transitions are atomic and the invariant is that a group is in exactly one of the three, so this is reachable: a group parked at `T_ready` that unparks into `ready` before `T_blocked` (the atomic `ZREM`/`ZADD` in `unparkUpTo`) is in none of the three reads while never ceasing to hold jobs, and its jobs are then written out as an undercount. Transitions run both directions — `ready↔parked` and `ready↔blocked` — so no scan order removes it, and re-scanning an earlier index only shrinks the window: the group can move again between the re-scan and the end.

*Why this closes it.* `pending-groups` is keyed on the property being counted — holding jobs — which no lifecycle transition changes. The marker is written in the same atomic script as the job, so if a group holds a job at some instant it is in the index from that instant, and it is only ever removed under a check that the zset is empty. A group holding a job for the whole of a pass is therefore in the index for the whole of that pass, wherever it moves between states. Being one index also means one read, so there is no second read for it to fall between.

*Why lazy removal is safe.* Membership is deliberately a superset. A surplus id costs one ZCARD returning 0, so removal need not be atomic with draining — which matters because the `:jobs` safety-net TTL expires groups with no script running at all, and any index requiring exact removal would drift permanently there. Pruning happens in `PENDING_INDEX_PRUNE_LUA`, which re-reads the zset inside the script, so a group staged between the observation and the prune is never dropped; dropping one would hide its jobs from every later pass.

*Transition.* Two populations are not in the index: groups staged before it existed, and groups staged by a pod on the previous release mid-rollout. Adoption alone does not cover them, because it only helps a group the pass actually saw, and a group moving between lifecycle indexes is seen by none of those reads.

They are covered instead by a keyspace walk, which reads the existence of a jobs key and so is indifferent to which index a group is in or how it moves between them — the one enumeration that cannot miss a group. It is scheduled by outcome rather than by clock: while a sweep is still adopting, the next pass sweeps again, which costs what this reconcile cost before the index existed and no more; once a sweep finds nothing new, it drops to an hourly backstop. So a rollout is covered at the old cost for its duration, and the steady state is the new one — with the index complete, a pass touches only the indexes. The walk and the lifecycle legs both go once no queue predates the index and no pod predates the writers.

**Single-flight.** The marker is taken with a refreshable `PENDING_RECONCILE_LEASE_MS` (30s) lease instead of the full window, re-armed after every ZCARD batch, and in a `finally` handed back as `singleFlightWindowMs - elapsed` — so the one-pass-per-window cadence measured from pass start is unchanged, a pass that outlives the window releases the marker outright, and no pass can be joined by another however long it runs. Taking it on a lease also means an instance that dies mid-pass strands the marker for at most 30s instead of the full window.

Re-arm and release go through `RECONCILE_MARKER_TTL_LUA`, a compare-and-set on a per-pass `randomUUID` token: a marker that lapsed and was re-acquired by another instance must never be extended or dropped by the previous holder. The helper never throws — losing the marker does not invalidate the count in hand.

The lease is re-armed after every index page as well as every ZCARD batch. Collection is itself a paging walk over `ready`, `blocked` and each parked tenant, so on a large queue it can outlast a lease before the first ZCARD runs; refreshing only in the ZCARD loop would have let the marker lapse mid-pass.

A null `pipeline.exec()` aborts the pass. Reading it as an empty batch would contribute zero for every key in it and write the shortfall out as ground truth — the same under-count the per-entry error check refuses.

A pass that loses its marker publishes nothing. `setReconcileMarkerTtl` reports ownership rather than swallowing both a `0` and an error, and losing it aborts the pass — a pass that no longer holds the marker cannot know whether a newer one has already written, so its count is only safe to discard. The counter write is `RECONCILE_WRITE_LUA`, a compare-and-set on the holder token, so a marker lost in the gap between the final check and the write cannot let the stale write land anyway.

**Unchanged:** pipelined `ZCARD` (now chunked at 1000 per round trip so the lease can be re-armed between batches), abort on any pipeline error so a partial under-count is never written, and the `SET` of ground truth onto the counter.

## 2. Blob sweep cursor (`blobSweeper.ts`)

`scanNode` started every walk at cursor `"0"` and held the cursor in a local, so nothing carried it between ticks. With a keyspace larger than `DEFAULT_MAX_KEYS_PER_QUEUE` (50,000 **matched** keys), every 5-minute tick re-judged the same leading slice and never examined anything past it.

Two comments already promised the behavior the code did not implement — `DEFAULT_MAX_KEYS_PER_QUEUE` says "work not reached this tick is reached the next one", and `BLOB_SWEEP_INTERVAL_MS` claims the practical retention bound for an unreferenced blob is ~1 hour rather than the 4-day backstop. Neither held past the first slice. Because `repaired` is what arms the 1-hour grace window (`EXPIRE` in `blobSweepLua.ts`), blobs beyond the slice were never even put on the clock and fell back to the 4-day backstop.

The cursor is now parked in Redis per queue (`<queueName>:gq:blob-sweep-cursor`, one hash field per node) and resumed. It lives in Redis rather than the process so progress survives a restart and is shared by whichever pod runs the tick; an exhausted walk stores `"0"` so the next cycle rewinds and picks up newly written blobs.

The batch that crosses the ceiling is no longer trimmed: trimming dropped keys the returned cursor had already passed, which was harmless when every tick restarted and would now skip them for a whole cycle. Overshooting the ceiling by at most one SCAN page is the cheaper side of that trade. Truncation is logged at info rather than warn — with the cursor resuming it is the steady state for any keyspace larger than one tick's ceiling, not a fault.

The walk is bounded by scan calls as well as by matches (`DEFAULT_MAX_SCAN_CALLS_PER_QUEUE`). The matched-key ceiling alone does not bound a tick: SCAN pages by buckets and `MATCH` filters afterwards, so on a keyspace where little matches, a tick walks to the end to fill a quota that never fills, and `COUNT` is only a work hint. Stopping on either ceiling bounds a tick in both regimes, and the parked cursor means a budget defers work rather than dropping it.

The cursor is committed after the blobs it covers have been judged, and never on a dry run — asking what a sweep would do must not cost the next real sweep a slice of the keyspace, and a sweep that dies before the commit re-judges its page rather than skipping it. A blob whose script call throws is still passed over: holding the cursor for one that fails every time would stall the whole walk behind it, and its bytes stay bounded by the backstop TTL.

## Tests

- New `queue.redis.repository.reconcile-pending.unit.test.ts` (10 tests) against an in-memory Redis fake whose `zscan`/`sscan` page for real: sums across ready + blocked + parked, asserts `scan` is never called, counts a group in two indexes once, covers 2500 groups across multiple index pages and ZCARD batches, asserts the lease is re-armed per batch, the remainder handed back on completion, the marker released when the pass outlives the window, and the abort-without-writing path.
- `pending-counter-reconcile.integration.test.ts` grew from 5 to 9 scenarios against a real Redis, covering blocked/parked enumeration, dedup, marker release on overrun, and a declined pass leaving another holder's marker and TTL intact. Four existing scenarios seeded `group:*:jobs` keys without indexing the groups — a shape the queue never produces — and now seed `ready` the way the queue itself does.
- `blobSweeper.integration.test.ts` gains 2 scenarios: successive sweeps reach every blob rather than only the first slice, and an exhausted cycle rewinds to pick up newly written blobs. The first pads the keyspace past several SCAN pages, because a handful of keys come back in one call and would pass regardless of cursor behavior. Verified as a real regression test by reverting `blobSweeper.ts` and re-running: it fails with `expected 345600 to be less than or equal to 3600` — the blob still on the 4-day backstop instead of the 1-hour grace window.

- `specs/event-sourcing/payload-store-content-addressed.feature` gains the two matching `@integration @track6` scenarios, so both new tests are bound rather than vacuously annotated (`check-feature-parity.ts` reports 15/15 bound).

- Review follow-ups add coverage for each new guarantee: the lease is re-armed during index collection before any ZCARD runs, a dry run parks no cursor while a real sweep does, and a sweep on a sparse keyspace stops on its call budget. The two sweeper ones were verified against pre-fix code and fail there (`expected 1 to be +0` for the dry-run cursor, `expected false to be true` for the budget).

Results: reconcile unit 11/11, blob-maintenance unit 5/5, integration 20/20 (native Redis), `pnpm typecheck` and `pnpm typecheck:tests` clean, `biome ci` clean on all touched files.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy and reliability of pending-job counts across ready, blocked, and parked queues.
  - Prevented duplicate counting across queue states.
  - Improved handling of interrupted, overlapping, or declined reconciliations.
  - Prevented partial counter updates when queue data cannot be read.
  - Improved reliability during large reconciliations through batched processing and lease-based progress tracking.
  - Improved blob cleanup coverage by resuming scans across scheduled sweeps.
  - Clarified cleanup progress messages when scans are truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->