### PR TITLE
fix(event-sourcing): give per-project reactors a per-project queue lane

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.groupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.groupKey.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import type { ProjectMetadataReactorDeps } from "../projectMetadata.reactor";
+import {
+  createProjectMetadataReactor,
+  projectMetadataGroupKey,
+} from "../projectMetadata.reactor";
+
+/**
+ * The lane and the dedup id must describe the same unit of work. The queue
+ * only squashes a duplicate when the dedup key's existing job is found in the
+ * group being staged into, so a per-project dedup id under a per-trace lane
+ * never collapses anything — it leaves one live job per concurrent trace and
+ * deletes the guard on the job already pending elsewhere.
+ */
+describe("projectMetadataGroupKey", () => {
+  describe("given two events for the same project", () => {
+    describe("when they come from different traces", () => {
+      it("routes them to the same lane", () => {
+        expect(projectMetadataGroupKey({ tenantId: "project_x" })).toBe(
+          projectMetadataGroupKey({ tenantId: "project_x" }),
+        );
+      });
+    });
+  });
+
+  describe("given events for different projects", () => {
+    it("routes them to different lanes", () => {
+      expect(projectMetadataGroupKey({ tenantId: "project_x" })).not.toBe(
+        projectMetadataGroupKey({ tenantId: "project_y" }),
+      );
+    });
+  });
+
+  it("keys the lane on the project alone", () => {
+    expect(projectMetadataGroupKey({ tenantId: "project_x" })).toBe(
+      "project-metadata:project_x",
+    );
+  });
+});
+
+describe("createProjectMetadataReactor lane wiring", () => {
+  const reactor = createProjectMetadataReactor({
+    projects: {},
+  } as unknown as ProjectMetadataReactorDeps);
+
+  function payloadFor({
+    tenantId,
+    aggregateId,
+  }: {
+    tenantId: string;
+    aggregateId: string;
+  }) {
+    return {
+      event: { tenantId, aggregateId, aggregateType: "trace" },
+      foldState: {},
+    } as unknown as Parameters<
+      NonNullable<NonNullable<typeof reactor.options>["groupKeyFn"]>
+    >[0];
+  }
+
+  describe("given a project ingesting several traces at once", () => {
+    describe("when each trace dispatches the reactor", () => {
+      it("assigns every dispatch the same lane", () => {
+        const groupKeyFn = reactor.options?.groupKeyFn;
+        expect(groupKeyFn).toBeDefined();
+
+        const lanes = ["trace_1", "trace_2", "trace_3"].map((aggregateId) =>
+          groupKeyFn!(payloadFor({ tenantId: "project_x", aggregateId })),
+        );
+
+        expect(new Set(lanes).size).toBe(1);
+      });
+
+      it("assigns every dispatch the same dedup id", () => {
+        const makeJobId = reactor.options?.makeJobId;
+        expect(makeJobId).toBeDefined();
+
+        const jobIds = ["trace_1", "trace_2", "trace_3"].map((aggregateId) =>
+          makeJobId!(payloadFor({ tenantId: "project_x", aggregateId })),
+        );
+
+        expect(new Set(jobIds).size).toBe(1);
+      });
+    });
+  });
+
+  describe("given two projects ingesting concurrently", () => {
+    it("keeps their lanes separate so one project cannot serialize behind another", () => {
+      const groupKeyFn = reactor.options!.groupKeyFn!;
+
+      expect(
+        groupKeyFn(payloadFor({ tenantId: "project_x", aggregateId: "t1" })),
+      ).not.toBe(
+        groupKeyFn(payloadFor({ tenantId: "project_y", aggregateId: "t1" })),
+      );
+    });
+  });
+
+  describe("given the lane and the dedup id are both derived from a payload", () => {
+    it("varies them over exactly the same inputs", () => {
+      const groupKeyFn = reactor.options!.groupKeyFn!;
+      const makeJobId = reactor.options!.makeJobId!;
+
+      const sameProjectDifferentTrace = [
+        payloadFor({ tenantId: "project_x", aggregateId: "trace_1" }),
+        payloadFor({ tenantId: "project_x", aggregateId: "trace_2" }),
+      ] as const;
+      const differentProject = payloadFor({
+        tenantId: "project_y",
+        aggregateId: "trace_1",
+      });
+
+      // Both collapse across traces...
+      expect(groupKeyFn(sameProjectDifferentTrace[0])).toBe(
+        groupKeyFn(sameProjectDifferentTrace[1]),
+      );
+      expect(makeJobId(sameProjectDifferentTrace[0])).toBe(
+        makeJobId(sameProjectDifferentTrace[1]),
+      );
+
+      // ...and both split across projects.
+      expect(groupKeyFn(sameProjectDifferentTrace[0])).not.toBe(
+        groupKeyFn(differentProject),
+      );
+      expect(makeJobId(sameProjectDifferentTrace[0])).not.toBe(
+        makeJobId(differentProject),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -31,6 +31,28 @@ export interface ProjectMetadataReactorDeps {
 }
 
 /**
+ * One queue lane per project, matching this reactor's per-project dedup id.
+ *
+ * The queue's dedup key is global to the queue, but the check that decides
+ * whether a duplicate is still squashable looks the existing job up in the
+ * CURRENT group's job set. So a dedup id that spans groups never squashes:
+ * the lookup misses, the key is treated as stale, and it is deleted before a
+ * fresh job stages — which also drops the guard protecting the pending job in
+ * the other group. A per-project dedup id therefore only bites under a
+ * per-project lane, and inheriting the default per-trace lane silently turns
+ * the dedup into a no-op that leaves one live job per concurrent trace.
+ *
+ * This reactor's work is per-project and level-triggered — it asserts the
+ * project's metadata from whichever trace happens to carry it — so all of a
+ * project's jobs belong in one serialized lane where the dedup collapses them
+ * to one. The queue prefixes `<tenantId>/fold/traceSummary/reactor/
+ * projectMetadata/` around this key.
+ */
+export function projectMetadataGroupKey(event: { tenantId: string }): string {
+  return `project-metadata:${event.tenantId}`;
+}
+
+/**
  * Reactor that marks the project as having received its first message.
  *
  * Sets project.firstMessage = true, project.integrated (unless optimization_studio),
@@ -89,6 +111,7 @@ export function createProjectMetadataReactor(
     shouldReact: (_event, context) => isRealFirstIngest(context.foldState),
     options: {
       runIn: ["worker"],
+      groupKeyFn: (payload) => projectMetadataGroupKey(payload.event),
       makeJobId: (payload) => `project-meta:${payload.event.tenantId}`,
       ttl: 60_000, // 60s dedup — avoid repeated writes for the same project
     },

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.groupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.groupKey.unit.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  billingMeterDispatchGroupKey,
+  createBillingMeterDispatchReactor,
+} from "../billingMeterDispatch.reactor";
+
+/**
+ * The lane and the dedup id must describe the same unit of work. The queue
+ * only squashes a duplicate when the dedup key's existing job is found in the
+ * group being staged into, so a per-project dedup id under a per-trace lane
+ * never collapses anything — it leaves one live job per concurrent trace and
+ * deletes the guard on the job already pending elsewhere.
+ */
+describe("billingMeterDispatchGroupKey", () => {
+  describe("given two events for the same project", () => {
+    describe("when they come from different traces", () => {
+      it("routes them to the same lane", () => {
+        expect(billingMeterDispatchGroupKey({ tenantId: "project_x" })).toBe(
+          billingMeterDispatchGroupKey({ tenantId: "project_x" }),
+        );
+      });
+    });
+  });
+
+  describe("given events for different projects", () => {
+    it("routes them to different lanes", () => {
+      expect(billingMeterDispatchGroupKey({ tenantId: "project_x" })).not.toBe(
+        billingMeterDispatchGroupKey({ tenantId: "project_y" }),
+      );
+    });
+  });
+
+  it("keys the lane on the project alone", () => {
+    expect(billingMeterDispatchGroupKey({ tenantId: "project_x" })).toBe(
+      "billing-meter-dispatch:project_x",
+    );
+  });
+});
+
+describe("createBillingMeterDispatchReactor lane wiring", () => {
+  const reactor = createBillingMeterDispatchReactor({
+    getDispatch: () => async () => {},
+  });
+
+  function payloadFor({
+    tenantId,
+    aggregateId,
+  }: {
+    tenantId: string;
+    aggregateId: string;
+  }) {
+    return {
+      event: { tenantId, aggregateId, aggregateType: "trace" },
+      foldState: {},
+    } as unknown as Parameters<
+      NonNullable<NonNullable<typeof reactor.options>["groupKeyFn"]>
+    >[0];
+  }
+
+  describe("given a project ingesting several traces at once", () => {
+    describe("when each trace dispatches the reactor", () => {
+      it("assigns every dispatch the same lane", () => {
+        const groupKeyFn = reactor.options?.groupKeyFn;
+        expect(groupKeyFn).toBeDefined();
+
+        const lanes = ["trace_1", "trace_2", "trace_3"].map((aggregateId) =>
+          groupKeyFn!(payloadFor({ tenantId: "project_x", aggregateId })),
+        );
+
+        expect(new Set(lanes).size).toBe(1);
+      });
+
+      it("assigns every dispatch the same dedup id", () => {
+        const makeJobId = reactor.options?.makeJobId;
+        expect(makeJobId).toBeDefined();
+
+        const jobIds = ["trace_1", "trace_2", "trace_3"].map((aggregateId) =>
+          makeJobId!(payloadFor({ tenantId: "project_x", aggregateId })),
+        );
+
+        expect(new Set(jobIds).size).toBe(1);
+      });
+    });
+  });
+
+  describe("given two projects ingesting concurrently", () => {
+    it("keeps their lanes separate so one project cannot serialize behind another", () => {
+      const groupKeyFn = reactor.options!.groupKeyFn!;
+
+      expect(
+        groupKeyFn(payloadFor({ tenantId: "project_x", aggregateId: "t1" })),
+      ).not.toBe(
+        groupKeyFn(payloadFor({ tenantId: "project_y", aggregateId: "t1" })),
+      );
+    });
+  });
+
+  describe("given the lane and the dedup id are both derived from a payload", () => {
+    it("varies them over exactly the same inputs", () => {
+      const groupKeyFn = reactor.options!.groupKeyFn!;
+      const makeJobId = reactor.options!.makeJobId!;
+
+      const sameProjectDifferentTrace = [
+        payloadFor({ tenantId: "project_x", aggregateId: "trace_1" }),
+        payloadFor({ tenantId: "project_x", aggregateId: "trace_2" }),
+      ] as const;
+      const differentProject = payloadFor({
+        tenantId: "project_y",
+        aggregateId: "trace_1",
+      });
+
+      // Both collapse across traces...
+      expect(groupKeyFn(sameProjectDifferentTrace[0])).toBe(
+        groupKeyFn(sameProjectDifferentTrace[1]),
+      );
+      expect(makeJobId(sameProjectDifferentTrace[0])).toBe(
+        makeJobId(sameProjectDifferentTrace[1]),
+      );
+
+      // ...and both split across projects.
+      expect(groupKeyFn(sameProjectDifferentTrace[0])).not.toBe(
+        groupKeyFn(differentProject),
+      );
+      expect(makeJobId(sameProjectDifferentTrace[0])).not.toBe(
+        makeJobId(differentProject),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
@@ -14,11 +14,36 @@ const logger = createLogger("langwatch:billing:meterDispatch");
 const GRACE_PERIOD_DAYS = 3;
 
 /**
+ * One queue lane per project, matching this reactor's per-project dedup id.
+ *
+ * The queue's dedup key is global to the queue, but the check that decides
+ * whether a duplicate is still squashable looks the existing job up in the
+ * CURRENT group's job set. So a dedup id that spans groups never squashes:
+ * the lookup misses, the key is treated as stale, and it is deleted before a
+ * fresh job stages — which also drops the guard protecting the pending job in
+ * the other group. A per-project dedup id therefore only bites under a
+ * per-project lane, and inheriting the default per-trace lane silently turns
+ * the dedup into a no-op that leaves one live job per concurrent trace.
+ *
+ * Nothing here reads the triggering event: the dispatch is derived from the
+ * project's organization and the current billing month, so every one of a
+ * project's jobs is interchangeable and they belong in one serialized lane.
+ * The queue prefixes `<tenantId>/map/orgBillableEventsMeter/reactor/
+ * billingMeterDispatch/` around this key.
+ */
+export function billingMeterDispatchGroupKey(event: {
+  tenantId: string;
+}): string {
+  return `billing-meter-dispatch:${event.tenantId}`;
+}
+
+/**
  * Reactor that dispatches billing usage reporting commands after
  * the orgBillableEventsMeter map projection succeeds.
  *
  * Two dedup layers:
- * - Reactor-level per-project: makeJobId creates one reactor job per project.
+ * - Reactor-level per-project: makeJobId creates one reactor job per project,
+ *   collapsed into one pending job by the per-project lane above.
  *   An org with N active projects creates N reactor jobs but each project
  *   only triggers one within the TTL window.
  * - Framework per-org: command dedup via makeId `${orgId}:${billingMonth}`, 310s TTL
@@ -34,6 +59,7 @@ export function createBillingMeterDispatchReactor(deps: {
     name: "billingMeterDispatch",
     options: {
       runIn: ["worker"],
+      groupKeyFn: (payload) => billingMeterDispatchGroupKey(payload.event),
       makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
       ttl: 300_000,
     },


### PR DESCRIPTION
## For humans

Two background jobs — one that marks a project as "has received its first trace", one that kicks off billing usage reporting — are meant to run **once per project**. They were accidentally running **once per trace**.

Each one had a correct "only do this once per project" guard, but that guard was being checked in the wrong place, so it never actually matched and never suppressed anything. Every trace a project ingested opened its own separate work queue holding one job that mostly had nothing to do. A busy project could have thousands of these open at once, and because the queue only works on a limited number of queues at a time, they crowded out real work.

This change puts all of a project's jobs for these two into a single queue, which is what the existing guard always assumed. No behaviour changes for users — the same work still happens, just once instead of thousands of times.

## What was wrong

Both reactors build a **per-project** dedup id but inherited the framework's default **per-trace** group key:

- `projectMetadata` — `makeJobId: project-meta:${tenantId}`
- `billingMeterDispatch` — `makeJobId: billing_dispatch_${tenantId}`

The queue's dedup key is global to the queue, but the check deciding whether a duplicate is still squashable looks the existing job up in **the group being staged into** (`groupQueue/scripts.ts`, `STAGE_LUA`):

```lua
local existingJobId = redis.call("GET", dedupKey)   -- queue-global
if existingJobId then
  local rank = redis.call("ZRANK", groupJobsKey, existingJobId)  -- THIS group only
  if rank then ... squash in place ... end
  -- not found -> treated as already dispatched
  redis.call("DEL", dedupKey)
```

A dedup id spanning groups always misses that `ZRANK`. The key is read as stale and **deleted** before a fresh job stages — which also drops the guard protecting the job still pending in the other group. So the dedup was not merely inert, it was actively tearing itself down: one live job per concurrent trace, each holding its own serialized lane, for work that is per-project by construction.

## The fix

Route both through a per-project `groupKeyFn` so the lane and the dedup id describe the same unit. This is the same lane fix already applied to `graphTriggerActivity`.

## Why squashing is safe here

The team asked specifically whether a pending dedup key can now drop legitimately distinct work. It cannot, for either reactor:

- **`projectMetadata`** is level-triggered. It asserts the project's metadata (first-message flag, integrated flag, SDK language) from whichever trace happens to carry it, and re-fires on the project's next trace. Its `shouldReact` filters sample traces *before* enqueue, so a sample payload can never replace a real one in the squash.
- **`billingMeterDispatch`** reads nothing from the triggering event. The dispatch is derived from the project's organization and the current billing month, so every one of a project's jobs is interchangeable.

Two further details checked against the Lua:

- **No starvation from `shouldExtend`.** The default squash extends the dispatch score, but a reactor's score is the event's `createdAt` with no delay configured, so the score is always in the past and the job stays immediately eligible. (This is why `graphTriggerActivity` needed a non-extending window and these do not — its window is a real forward-dated debounce.)
- **Tenant parking and blob leases are unaffected.** `parkTenantOf` takes everything before the first `/`, and the framework still prefixes `${tenantId}/${jobPath}/`, so the tenant segment is unchanged. `ReactorContext.aggregateId` comes from `event.aggregateId`, not the group key, so handlers see exactly what they saw before.

## Tests

New unit tests assert the lane collapses across traces, splits across projects, and — the invariant whose violation caused this — that `groupKeyFn` and `makeJobId` vary over exactly the same inputs. If someone later changes one to a different granularity without the other, that test fails.

## Verification

- `pnpm test:unit` — 14 new tests pass; adjacent suites green (4 files / 61 tests), and an event-sourcing sweep of `projections` + `queues` green (47 files / 433 tests)
- `pnpm typecheck` and `pnpm typecheck:tests` — both clean
- `pnpm exec biome check` on the four touched files — one warning, `noExcessiveCognitiveComplexity` on `projectMetadata`'s `handle`, confirmed **pre-existing on `main`** at the identical score of 31 in a function this PR does not touch

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project metadata processing by isolating events per project for more reliable sequencing.
  * Improved billing meter dispatch so each project’s events are processed independently and consistently.

* **Tests**
  * Added coverage validating project isolation, event ordering, deduplication, and queue behavior across traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->