### PR TITLE
fix(event-sourcing): decline governance reactors before enqueue, not after

### DIFF
--- a/langwatch/ee/governance/reactors/__tests__/gatewayBudgetSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/gatewayBudgetSync.reactor.unit.test.ts
@@ -169,6 +169,45 @@ describe("gatewayBudgetSync reactor", () => {
     });
   });
 
+  describe("pre-enqueue gate", () => {
+    describe("when the trace lacks either gateway attribute", () => {
+      it("declines before a job is packed", () => {
+        const { deps } = mockDeps(null, null, []);
+        const reactor = createGatewayBudgetSyncReactor(deps);
+
+        expect(reactor.shouldReact).toBeDefined();
+        expect(reactor.shouldReact!(event, ctx(createFoldState({})))).toBe(
+          false,
+        );
+        expect(
+          reactor.shouldReact!(
+            event,
+            ctx(createFoldState({ "langwatch.virtual_key_id": "vk-1" })),
+          ),
+        ).toBe(false);
+        expect(
+          reactor.shouldReact!(
+            event,
+            ctx(createFoldState({ "langwatch.gateway_request_id": "greq-1" })),
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the trace carries both gateway attributes", () => {
+      it("accepts the event", () => {
+        const { deps } = mockDeps(null, null, []);
+        const reactor = createGatewayBudgetSyncReactor(deps);
+        const state = createFoldState({
+          "langwatch.virtual_key_id": "vk-1",
+          "langwatch.gateway_request_id": "greq-1",
+        });
+
+        expect(reactor.shouldReact!(event, ctx(state))).toBe(true);
+      });
+    });
+  });
+
   describe("when the VK is unknown", () => {
     it("logs + skips without writing to CH", async () => {
       const { deps, insertDebit } = mockDeps(null, null, []);

--- a/langwatch/ee/governance/reactors/__tests__/governanceKpisSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/governanceKpisSync.reactor.unit.test.ts
@@ -300,6 +300,39 @@ describe("governanceKpisSync reactor", () => {
     });
   });
 
+  describe("pre-enqueue gate", () => {
+    describe("when the trace carries no governance origin", () => {
+      it("declines before a job is packed", () => {
+        const { deps } = mockDeps();
+        const reactor = createGovernanceKpisSyncReactor(deps);
+
+        expect(reactor.shouldReact).toBeDefined();
+        expect(reactor.shouldReact!(event, ctx(createFoldState({})))).toBe(
+          false,
+        );
+        expect(
+          reactor.shouldReact!(
+            event,
+            ctx(createFoldState({ "langwatch.origin.kind": "gateway" })),
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the trace came from an ingestion source", () => {
+      it("accepts the event", () => {
+        const { deps } = mockDeps();
+        const reactor = createGovernanceKpisSyncReactor(deps);
+        const state = createFoldState({
+          "langwatch.origin.kind": "ingestion_source",
+          "langwatch.ingestion_source.id": "is-1",
+        });
+
+        expect(reactor.shouldReact!(event, ctx(state))).toBe(true);
+      });
+    });
+  });
+
   describe("dedup contract", () => {
     it("declares a per-(tenant, trace) job-id for BullMQ debounce", () => {
       const { deps } = mockDeps();

--- a/langwatch/ee/governance/reactors/__tests__/governanceOcsfEventsSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/governanceOcsfEventsSync.reactor.unit.test.ts
@@ -348,6 +348,39 @@ describe("governanceOcsfEventsSync reactor", () => {
     });
   });
 
+  describe("pre-enqueue gate", () => {
+    describe("when the trace carries no governance origin", () => {
+      it("declines before a job is packed", () => {
+        const { deps } = mockDeps();
+        const reactor = createGovernanceOcsfEventsSyncReactor(deps);
+
+        expect(reactor.shouldReact).toBeDefined();
+        expect(reactor.shouldReact!(event, ctx(createFoldState({})))).toBe(
+          false,
+        );
+        expect(
+          reactor.shouldReact!(
+            event,
+            ctx(createFoldState({ "langwatch.origin.kind": "gateway" })),
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the trace came from an ingestion source", () => {
+      it("accepts the event", () => {
+        const { deps } = mockDeps();
+        const reactor = createGovernanceOcsfEventsSyncReactor(deps);
+        const state = createFoldState({
+          "langwatch.origin.kind": "ingestion_source",
+          "langwatch.ingestion_source.id": "is-1",
+        });
+
+        expect(reactor.shouldReact!(event, ctx(state))).toBe(true);
+      });
+    });
+  });
+
   describe("dedup contract", () => {
     it("declares a per-(tenant, trace) job-id for BullMQ debounce", () => {
       const { deps } = mockDeps();

--- a/langwatch/ee/governance/reactors/__tests__/governanceReactorsPreEnqueueGate.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/governanceReactorsPreEnqueueGate.unit.test.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The three governance reactors are registered on the trace_processing
+ * pipeline, so they fan out on every trace fold completion — but each one
+ * only does work for its own slice of traffic (gateway traces for
+ * gatewayBudgetSync, ingestion-source traces for the other two).
+ *
+ * That relevance check belongs in `shouldReact`, which the router evaluates
+ * BEFORE a job is packed and queued (ADR-026). A check that lives only
+ * inside `handle` still passes a per-reactor test — the handler no-ops
+ * either way — while the job is serialized, queued, dispatched and unpacked
+ * first, and counts as a success rather than a skip in
+ * `es_reactor_total`.
+ *
+ * So the unit under test here is the router with the real reactors
+ * registered: no job enqueued, no handler run, and the skip counter moved.
+ */
+
+import { createGatewayBudgetSyncReactor } from "@ee/governance/reactors/gatewayBudgetSync.reactor";
+import { createGovernanceKpisSyncReactor } from "@ee/governance/reactors/governanceKpisSync.reactor";
+import { createGovernanceOcsfEventsSyncReactor } from "@ee/governance/reactors/governanceOcsfEventsSync.reactor";
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { Event } from "~/server/event-sourcing/domain/types";
+import { ProjectionRouter } from "~/server/event-sourcing/projections/projectionRouter";
+import type { ReactorDefinition } from "~/server/event-sourcing/reactors/reactor.types";
+import {
+  createMockFoldProjectionDefinition,
+  createMockFoldProjectionStore,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "~/server/event-sourcing/services/__tests__/testHelpers";
+import { incrementEsReactorTotal } from "~/server/metrics";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsReactorTotal: vi.fn(),
+  };
+});
+
+const FOLD_NAME = "trace-summary";
+
+function createFoldState(attributes: Record<string, string>): TraceSummaryData {
+  return {
+    traceId: "trace-1",
+    spanCount: 1,
+    totalDurationMs: 120,
+    models: ["gpt-5-mini"],
+    totalCost: 0.001,
+    totalPromptTokenCount: 10,
+    totalCompletionTokenCount: 5,
+    blockedByGuardrail: false,
+    containsErrorStatus: false,
+    occurredAt: 1_700_000_000_000,
+    attributes,
+  } as unknown as TraceSummaryData;
+}
+
+function createGovernanceReactors(): ReactorDefinition<Event>[] {
+  return [
+    createGatewayBudgetSyncReactor({
+      prisma: {
+        virtualKey: { findUnique: vi.fn(), update: vi.fn() },
+        project: { findUnique: vi.fn() },
+      } as unknown as PrismaClient,
+      budgetRepository: { resolveForRequest: vi.fn() } as any,
+      budgetCHRepository: { insertDebit: vi.fn() } as any,
+    }),
+    createGovernanceKpisSyncReactor({
+      governanceKpisRepository: { insertContribution: vi.fn() } as any,
+    }),
+    createGovernanceOcsfEventsSyncReactor({
+      governanceOcsfEventsRepository: { insertEvent: vi.fn() } as any,
+    }),
+  ] as unknown as ReactorDefinition<Event>[];
+}
+
+function createRouterWithGovernanceReactors(foldState: TraceSummaryData) {
+  const send = vi.fn().mockResolvedValue(undefined);
+  const queueManager = createMockQueueManager({
+    hasReactorQueues: true,
+    getReactorQueue: vi.fn().mockReturnValue({ send }),
+  });
+  const router = new ProjectionRouter(
+    TEST_CONSTANTS.AGGREGATE_TYPE,
+    TEST_CONSTANTS.PIPELINE_NAME,
+    queueManager,
+  );
+
+  const store = createMockFoldProjectionStore<TraceSummaryData>();
+  (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  router.registerFoldProjection(
+    createMockFoldProjectionDefinition(FOLD_NAME, {
+      store,
+      init: () => foldState,
+      apply: () => foldState,
+    }),
+  );
+
+  for (const reactor of createGovernanceReactors()) {
+    router.registerReactor(FOLD_NAME, reactor);
+  }
+
+  return { router, send };
+}
+
+describe("governance reactors on the trace-processing router", () => {
+  const tenantId = createTestTenantId();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given a trace that is neither gateway nor governance traffic", () => {
+    describe("when the fold completes", () => {
+      it("enqueues no reactor job", async () => {
+        const { router, send } = createRouterWithGovernanceReactors(
+          createFoldState({ "langwatch.origin": "app" }),
+        );
+
+        await router.dispatch(
+          [
+            createTestEvent(
+              TEST_CONSTANTS.AGGREGATE_ID,
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+            ),
+          ],
+          { tenantId },
+        );
+
+        expect(send).not.toHaveBeenCalled();
+      });
+
+      it("counts each reactor as skipped rather than succeeded", async () => {
+        const { router } = createRouterWithGovernanceReactors(
+          createFoldState({ "langwatch.origin": "app" }),
+        );
+
+        await router.dispatch(
+          [
+            createTestEvent(
+              TEST_CONSTANTS.AGGREGATE_ID,
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+            ),
+          ],
+          { tenantId },
+        );
+
+        for (const reactorName of [
+          "gatewayBudgetSync",
+          "governanceKpisSync",
+          "governanceOcsfEventsSync",
+        ]) {
+          expect(incrementEsReactorTotal).toHaveBeenCalledWith(
+            TEST_CONSTANTS.PIPELINE_NAME,
+            reactorName,
+            "skipped",
+          );
+        }
+        expect(incrementEsReactorTotal).not.toHaveBeenCalledWith(
+          TEST_CONSTANTS.PIPELINE_NAME,
+          expect.anything(),
+          "success",
+        );
+      });
+    });
+  });
+
+  describe("given a governance-origin trace", () => {
+    describe("when the fold completes", () => {
+      it("enqueues the two governance reactors and still declines the gateway one", async () => {
+        const { router, send } = createRouterWithGovernanceReactors(
+          createFoldState({
+            "langwatch.origin.kind": "ingestion_source",
+            "langwatch.ingestion_source.id": "is-1",
+          }),
+        );
+
+        await router.dispatch(
+          [
+            createTestEvent(
+              TEST_CONSTANTS.AGGREGATE_ID,
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+            ),
+          ],
+          { tenantId },
+        );
+
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(incrementEsReactorTotal).toHaveBeenCalledWith(
+          TEST_CONSTANTS.PIPELINE_NAME,
+          "gatewayBudgetSync",
+          "skipped",
+        );
+      });
+    });
+  });
+
+  describe("given a gateway trace", () => {
+    describe("when the fold completes", () => {
+      it("enqueues the budget reactor and declines the governance ones", async () => {
+        const { router, send } = createRouterWithGovernanceReactors(
+          createFoldState({
+            "langwatch.virtual_key_id": "vk-1",
+            "langwatch.gateway_request_id": "greq-1",
+          }),
+        );
+
+        await router.dispatch(
+          [
+            createTestEvent(
+              TEST_CONSTANTS.AGGREGATE_ID,
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+            ),
+          ],
+          { tenantId },
+        );
+
+        expect(send).toHaveBeenCalledTimes(1);
+        for (const reactorName of [
+          "governanceKpisSync",
+          "governanceOcsfEventsSync",
+        ]) {
+          expect(incrementEsReactorTotal).toHaveBeenCalledWith(
+            TEST_CONSTANTS.PIPELINE_NAME,
+            reactorName,
+            "skipped",
+          );
+        }
+      });
+    });
+  });
+});

--- a/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
@@ -54,6 +54,360 @@ export interface GatewayBudgetSyncReactorDeps {
   budgetCHRepository: GatewayBudgetClickHouseRepository;
 }
 
+/** The VK a gateway trace debits against, as this reactor needs it. */
+interface GatewayVirtualKey {
+  id: string;
+  organizationId: string;
+  principalUserId: string | null;
+  lastUsedAt: Date | null;
+}
+
+/** The tenant project a gateway trace belongs to, with its owning org. */
+interface GatewayFoldProject {
+  id: string;
+  teamId: string;
+  organizationId: string;
+}
+
+/**
+ * Loads the VK the trace names, or null when it does not exist — a gateway
+ * trace referencing a VK we cannot find is a fold we must not attribute.
+ */
+async function findGatewayVirtualKey({
+  prisma,
+  projectId,
+  virtualKeyId,
+  gatewayRequestId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  virtualKeyId: string;
+  gatewayRequestId: string;
+}): Promise<GatewayVirtualKey | null> {
+  const vk = await prisma.virtualKey.findUnique({
+    where: { id: virtualKeyId },
+    select: {
+      id: true,
+      organizationId: true,
+      principalUserId: true,
+      lastUsedAt: true,
+    },
+  });
+  if (!vk) {
+    logger.warn(
+      { projectId, virtualKeyId, gatewayRequestId },
+      "gateway trace references unknown VK — skipping fold",
+    );
+  }
+  return vk;
+}
+
+/**
+ * EC6 — touch lastUsedAt on every gateway trace, regardless of whether the
+ * VK has applicable budgets. The /budget/check hook in gateway-internal.ts
+ * only fires when the gateway calls it (which it skips when there are no
+ * budgets to precheck), so VKs without budgets had `lastUsedAt = null`
+ * forever and admin oversight ("when did this user last use their personal
+ * VK") was broken on the most common case.
+ *
+ * 60s throttle mirrors the /budget/check fix — admin dashboards refresh on
+ * minute-scale, no need to thrash the row on every request.
+ *
+ * Best-effort: a row update failure here must not poison the budget fold,
+ * and the /budget/check hook is a fallback for the budgeted-VK case.
+ */
+async function touchVirtualKeyLastUsed({
+  prisma,
+  projectId,
+  vk,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  vk: GatewayVirtualKey;
+}): Promise<void> {
+  const now = new Date();
+  const shouldTouch =
+    !vk.lastUsedAt || now.getTime() - vk.lastUsedAt.getTime() > 60 * 1000;
+  logger.info(
+    {
+      projectId,
+      virtualKeyId: vk.id,
+      previousLastUsedAt: vk.lastUsedAt,
+      shouldTouch,
+    },
+    "EC6 lastUsedAt touch decision",
+  );
+  if (!shouldTouch) return;
+
+  try {
+    // Post-collapse VirtualKey is org-scoped in SCOPED_MODELS; the dbMTP
+    // guard accepts a row id as tenancy proof for single-row writes, so the
+    // bare id-only where clause is valid.
+    await prisma.virtualKey.update({
+      where: { id: vk.id },
+      data: { lastUsedAt: now },
+    });
+    logger.info(
+      { projectId, virtualKeyId: vk.id, touchedAt: now.toISOString() },
+      "EC6 lastUsedAt touched",
+    );
+  } catch (touchErr) {
+    logger.warn(
+      { projectId, virtualKeyId: vk.id, error: touchErr },
+      "failed to touch virtualKey.lastUsedAt during gateway trace fold",
+    );
+  }
+}
+
+/**
+ * Loads the trace's tenant project, or null when the fold must not proceed.
+ *
+ * Cross-tenant guard: post-collapse VKs carry organizationId only, so the
+ * trace's tenant project must live under the same org as the VK it debits.
+ */
+async function findProjectForGatewayFold({
+  prisma,
+  projectId,
+  vk,
+  gatewayRequestId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  vk: GatewayVirtualKey;
+  gatewayRequestId: string;
+}): Promise<GatewayFoldProject | null> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      teamId: true,
+      team: { select: { organizationId: true } },
+    },
+  });
+  if (!project?.team) {
+    logger.warn(
+      { projectId, virtualKeyId: vk.id },
+      "project missing team relation — skipping gateway budget fold",
+    );
+    return null;
+  }
+  if (project.team.organizationId !== vk.organizationId) {
+    logger.warn(
+      { projectId, virtualKeyId: vk.id, gatewayRequestId },
+      "gateway trace references cross-tenant VK — skipping fold",
+    );
+    return null;
+  }
+  return {
+    id: project.id,
+    teamId: project.teamId,
+    organizationId: project.team.organizationId,
+  };
+}
+
+/**
+ * The budgets this dispatch actually accrues against.
+ *
+ * `dispatchedProviderKey` is the provider the gateway dispatched to, absent
+ * on gateways that predate the field — in which case only unfiltered budgets
+ * accrue. Attributing an unknown dispatch to a provider-filtered budget would
+ * be a guess, and a guess here silently mis-bills a governance control.
+ */
+async function resolveApplicableBudgets({
+  budgetRepository,
+  scopes,
+  dispatchedProviderKey,
+}: {
+  budgetRepository: GatewayBudgetRepository;
+  scopes: ApplicableScopes;
+  dispatchedProviderKey: string | null;
+}) {
+  const resolved = await budgetRepository.resolveForRequest(scopes);
+  return resolved.filter((r) =>
+    budgetAppliesToProvider(r.budget, dispatchedProviderKey),
+  );
+}
+
+/**
+ * One debit row per applicable budget. Cost, tokens and duration come from
+ * the fold state (post cost-enrichment) rather than being recomputed here.
+ */
+function buildDebitRows({
+  projectId,
+  foldState,
+  vk,
+  gatewayRequestId,
+  dispatchedProviderKey,
+  budgets,
+  amountUsd,
+}: {
+  projectId: string;
+  foldState: TraceSummaryData;
+  vk: GatewayVirtualKey;
+  gatewayRequestId: string;
+  dispatchedProviderKey: string | null;
+  budgets: Awaited<ReturnType<typeof resolveApplicableBudgets>>;
+  amountUsd: string;
+}): BudgetDebitRow[] {
+  const status: GatewayBudgetLedgerStatus = foldState.blockedByGuardrail
+    ? "BLOCKED_BY_GUARDRAIL"
+    : foldState.containsErrorStatus
+      ? "PROVIDER_ERROR"
+      : "SUCCESS";
+
+  return budgets.map(({ budget: b, bucketScopeId }) => ({
+    tenantId: projectId,
+    budgetId: b.id,
+    scope: b.scopeType,
+    scopeId: bucketScopeId,
+    window: b.window,
+    virtualKeyId: vk.id,
+    providerKey: dispatchedProviderKey,
+    gatewayRequestId,
+    amountUsd,
+    tokensInput: foldState.totalPromptTokenCount ?? 0,
+    tokensOutput: foldState.totalCompletionTokenCount ?? 0,
+    tokensCacheRead: 0,
+    tokensCacheWrite: 0,
+    model: foldState.models[0] ?? "unknown",
+    durationMs: Math.round(foldState.totalDurationMs ?? 0),
+    status,
+    occurredAt: new Date(foldState.occurredAt),
+  }));
+}
+
+/**
+ * EC4 — emit a BUDGET_UPDATED change event so the gateway's /changes
+ * subscriber (services/aigateway/adapters/authresolver) evicts cached
+ * bundles for this project and the next request re-resolves with fresh
+ * spend. Without this, Bundle.Config.Budget.SpentMicroUSD stays frozen at
+ * populateConfig time and the on-breach=block precheck never fires until
+ * the JWT TTL (~15min) rolls.
+ *
+ * v2 TODO: dedupe — emit at most once per (projectId, budgetId) per ~10s
+ * window to avoid every gateway request triggering an L1 sweep + cold-miss
+ * on every other VK in the project. At single-tenant scale the
+ * unconditional emit is correct, just noisier than ideal.
+ *
+ * Best-effort: the CH ledger row already landed, so a failure here leaves
+ * the gateway's cache staler than it could be rather than corrupting state.
+ */
+async function emitBudgetUpdatedChangeEvent({
+  prisma,
+  project,
+  projectId,
+  vk,
+  gatewayRequestId,
+  budgetIds,
+  amountUsd,
+}: {
+  prisma: PrismaClient;
+  project: GatewayFoldProject;
+  projectId: string;
+  vk: GatewayVirtualKey;
+  gatewayRequestId: string;
+  budgetIds: string[];
+  amountUsd: string;
+}): Promise<void> {
+  try {
+    const changeEvents = new ChangeEventRepository(prisma);
+    await changeEvents.append({
+      organizationId: project.organizationId,
+      projectId,
+      kind: "BUDGET_UPDATED",
+      payload: {
+        gatewayRequestId,
+        virtualKeyId: vk.id,
+        budgetIds,
+        amountUsd,
+      },
+    });
+  } catch (changeErr) {
+    logger.warn(
+      { projectId, virtualKeyId: vk.id, gatewayRequestId, error: changeErr },
+      "failed to emit BUDGET_UPDATED change event after fold",
+    );
+  }
+}
+
+/**
+ * The fold itself: resolve who the trace belongs to, which budgets it
+ * accrues against, write the debit rows, and tell the gateway its cached
+ * spend is stale. Every step that can legitimately decline the trace
+ * returns early; anything unexpected throws to the caller's catch.
+ */
+async function foldGatewayTraceIntoLedger({
+  deps,
+  projectId,
+  foldState,
+  virtualKeyId,
+  gatewayRequestId,
+}: {
+  deps: GatewayBudgetSyncReactorDeps;
+  projectId: string;
+  foldState: TraceSummaryData;
+  virtualKeyId: string;
+  gatewayRequestId: string;
+}): Promise<void> {
+  const vk = await findGatewayVirtualKey({
+    prisma: deps.prisma,
+    projectId,
+    virtualKeyId,
+    gatewayRequestId,
+  });
+  if (!vk) return;
+
+  await touchVirtualKeyLastUsed({ prisma: deps.prisma, projectId, vk });
+
+  const project = await findProjectForGatewayFold({
+    prisma: deps.prisma,
+    projectId,
+    vk,
+    gatewayRequestId,
+  });
+  if (!project) return;
+
+  const scopes: ApplicableScopes = {
+    organizationId: project.organizationId,
+    teamId: project.teamId,
+    projectId: project.id,
+    virtualKeyId: vk.id,
+    principalUserId: vk.principalUserId,
+  };
+  const dispatchedProviderKey =
+    foldState.attributes["langwatch.model_provider_id"] ?? null;
+
+  const budgets = await resolveApplicableBudgets({
+    budgetRepository: deps.budgetRepository,
+    scopes,
+    dispatchedProviderKey,
+  });
+  if (budgets.length === 0) return;
+
+  const amountUsd = formatDecimal(foldState.totalCost ?? 0);
+  await deps.budgetCHRepository.insertDebit(
+    buildDebitRows({
+      projectId,
+      foldState,
+      vk,
+      gatewayRequestId,
+      dispatchedProviderKey,
+      budgets,
+      amountUsd,
+    }),
+  );
+
+  await emitBudgetUpdatedChangeEvent({
+    prisma: deps.prisma,
+    project,
+    projectId,
+    vk,
+    gatewayRequestId,
+    budgetIds: budgets.map((r) => r.budget.id),
+    amountUsd,
+  });
+}
+
 /**
  * Fold completed gateway traces into per-budget ClickHouse debit rows.
  *
@@ -108,186 +462,13 @@ export function createGatewayBudgetSyncReactor(
       const gatewayRequestId = foldState.attributes[ATTR_GATEWAY_REQUEST_ID]!;
 
       try {
-        const vk = await deps.prisma.virtualKey.findUnique({
-          where: { id: virtualKeyId },
-          select: {
-            id: true,
-            organizationId: true,
-            principalUserId: true,
-            lastUsedAt: true,
-          },
+        await foldGatewayTraceIntoLedger({
+          deps,
+          projectId,
+          foldState,
+          virtualKeyId,
+          gatewayRequestId,
         });
-        if (!vk) {
-          logger.warn(
-            { projectId, virtualKeyId, gatewayRequestId },
-            "gateway trace references unknown VK — skipping fold",
-          );
-          return;
-        }
-
-        // EC6 — touch lastUsedAt on every gateway trace, regardless of
-        // whether the VK has applicable budgets. The /budget/check
-        // hook in gateway-internal.ts only fires when the gateway
-        // calls it (which it skips when there are no budgets to
-        // precheck), so VKs without budgets had `lastUsedAt = null`
-        // forever and admin oversight ("when did this user last
-        // use their personal VK") was broken on the most common case.
-        //
-        // 60s throttle mirrors the /budget/check fix — admin
-        // dashboards refresh on minute-scale, no need to thrash the
-        // row on every request.
-        const now = new Date();
-        const shouldTouch =
-          !vk.lastUsedAt || now.getTime() - vk.lastUsedAt.getTime() > 60 * 1000;
-        logger.info(
-          {
-            projectId,
-            virtualKeyId,
-            previousLastUsedAt: vk.lastUsedAt,
-            shouldTouch,
-          },
-          "EC6 lastUsedAt touch decision",
-        );
-        if (shouldTouch) {
-          try {
-            // Post-collapse VirtualKey is org-scoped in SCOPED_MODELS; the
-            // dbMTP guard accepts a row id as tenancy proof for single-row
-            // writes, so the bare id-only where clause is valid.
-            await deps.prisma.virtualKey.update({
-              where: { id: vk.id },
-              data: { lastUsedAt: now },
-            });
-            logger.info(
-              { projectId, virtualKeyId, touchedAt: now.toISOString() },
-              "EC6 lastUsedAt touched",
-            );
-          } catch (touchErr) {
-            // Best-effort: a row update failure here doesn't poison
-            // the budget fold below, and the /budget/check hook is
-            // a fallback for the budgeted-VK case.
-            logger.warn(
-              { projectId, virtualKeyId, error: touchErr },
-              "failed to touch virtualKey.lastUsedAt during gateway trace fold",
-            );
-          }
-        }
-
-        const project = await deps.prisma.project.findUnique({
-          where: { id: projectId },
-          select: {
-            id: true,
-            teamId: true,
-            team: { select: { organizationId: true } },
-          },
-        });
-        if (!project?.team) {
-          logger.warn(
-            { projectId, virtualKeyId },
-            "project missing team relation — skipping gateway budget fold",
-          );
-          return;
-        }
-        // Cross-tenant guard: post-collapse VKs carry organizationId only;
-        // the trace's tenant project must live under the same org.
-        if (project.team.organizationId !== vk.organizationId) {
-          logger.warn(
-            { projectId, virtualKeyId, gatewayRequestId },
-            "gateway trace references cross-tenant VK — skipping fold",
-          );
-          return;
-        }
-
-        const scopes: ApplicableScopes = {
-          organizationId: project.team.organizationId,
-          teamId: project.teamId,
-          projectId: project.id,
-          virtualKeyId: vk.id,
-          principalUserId: vk.principalUserId,
-        };
-        // The provider the gateway actually dispatched to. Absent on
-        // gateways that predate the field, in which case only unfiltered
-        // budgets accrue: attributing an unknown dispatch to a provider-
-        // filtered budget would be a guess, and a guess here silently
-        // mis-bills a governance control.
-        const dispatchedProviderKey =
-          foldState.attributes["langwatch.model_provider_id"] ?? null;
-
-        const resolved = await deps.budgetRepository.resolveForRequest(scopes);
-        const budgets = resolved.filter((r) =>
-          budgetAppliesToProvider(r.budget, dispatchedProviderKey),
-        );
-        if (budgets.length === 0) return;
-
-        const amountUsd = formatDecimal(foldState.totalCost ?? 0);
-        const tokensInput = foldState.totalPromptTokenCount ?? 0;
-        const tokensOutput = foldState.totalCompletionTokenCount ?? 0;
-        const model = foldState.models[0] ?? "unknown";
-        const status: GatewayBudgetLedgerStatus = foldState.blockedByGuardrail
-          ? "BLOCKED_BY_GUARDRAIL"
-          : foldState.containsErrorStatus
-            ? "PROVIDER_ERROR"
-            : "SUCCESS";
-        const occurredAt = new Date(foldState.occurredAt);
-
-        const rows: BudgetDebitRow[] = budgets.map(
-          ({ budget: b, bucketScopeId }) => ({
-            tenantId: projectId,
-            budgetId: b.id,
-            scope: b.scopeType,
-            scopeId: bucketScopeId,
-            window: b.window,
-            virtualKeyId: vk.id,
-            providerKey: dispatchedProviderKey,
-            gatewayRequestId,
-            amountUsd,
-            tokensInput,
-            tokensOutput,
-            tokensCacheRead: 0,
-            tokensCacheWrite: 0,
-            model,
-            durationMs: Math.round(foldState.totalDurationMs ?? 0),
-            status,
-            occurredAt,
-          }),
-        );
-
-        await deps.budgetCHRepository.insertDebit(rows);
-
-        // EC4 — emit a BUDGET_UPDATED change event so the gateway's
-        // /changes subscriber (services/aigateway/adapters/authresolver)
-        // evicts cached bundles for this project and the next request
-        // re-resolves with fresh spend. Without this, Bundle.Config.
-        // Budget.SpentMicroUSD stays frozen at populateConfig time and
-        // the on-breach=block precheck never fires until the JWT TTL
-        // (~15min) rolls.
-        //
-        // v2 TODO: dedupe — emit at most once per (projectId, budgetId)
-        // per ~10s window to avoid every gateway request triggering an
-        // L1 sweep + cold-miss on every other VK in the project. For
-        // current dogfood / single-tenant scale the unconditional emit
-        // is correct (just noisier than ideal).
-        try {
-          const changeEvents = new ChangeEventRepository(deps.prisma);
-          await changeEvents.append({
-            organizationId: project.team.organizationId,
-            projectId,
-            kind: "BUDGET_UPDATED",
-            payload: {
-              gatewayRequestId,
-              virtualKeyId: vk.id,
-              budgetIds: budgets.map((r) => r.budget.id),
-              amountUsd,
-            },
-          });
-        } catch (changeErr) {
-          // Best-effort. The CH ledger row already landed; failing the
-          // change event would just leave the gateway's cache slightly
-          // staler than it could be, not corrupt any state.
-          logger.warn(
-            { projectId, virtualKeyId, gatewayRequestId, error: changeErr },
-            "failed to emit BUDGET_UPDATED change event after fold",
-          );
-        }
       } catch (error) {
         logger.error(
           {

--- a/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
@@ -32,6 +32,22 @@ const logger = createLogger(
  */
 export const GATEWAY_BUDGET_SYNC_DEBOUNCE_TTL_MS = 5 * 60_000;
 
+const ATTR_VIRTUAL_KEY_ID = "langwatch.virtual_key_id";
+const ATTR_GATEWAY_REQUEST_ID = "langwatch.gateway_request_id";
+
+/**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path): only traces the gateway produced carry both a virtual
+ * key and a gateway request id, and only those can debit a budget. The
+ * budget resolution itself is stateful and stays in handle.
+ */
+function isGatewayTrace(foldState: TraceSummaryData): boolean {
+  const attributes = foldState.attributes ?? {};
+  return Boolean(
+    attributes[ATTR_VIRTUAL_KEY_ID] && attributes[ATTR_GATEWAY_REQUEST_ID],
+  );
+}
+
 export interface GatewayBudgetSyncReactorDeps {
   prisma: PrismaClient;
   budgetRepository: GatewayBudgetRepository;
@@ -45,7 +61,8 @@ export interface GatewayBudgetSyncReactorDeps {
  * Reads `langwatch.virtual_key_id` + `langwatch.gateway_request_id` off
  * the fold state attributes — stamped by the gateway's customer trace
  * bridge (services/aigateway/adapters/customertracebridge/emitter.go).
- * Traces without those attributes are skipped (not gateway traffic).
+ * Traces without those attributes are not gateway traffic and are
+ * declined before a job is enqueued.
  *
  * Cost + tokens are taken from the fold state (post cost-enrichment
  * service) so this reactor trusts the authoritative platform-side
@@ -58,6 +75,15 @@ export function createGatewayBudgetSyncReactor(
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "gatewayBudgetSync",
+    // Pre-enqueue (ADR-026). The attribute check is pure and reads the exact
+    // payload the handler receives, so deciding here is equivalent to the
+    // early-return below — except a non-gateway trace never pays a serialize
+    // + queue round-trip for a job that would immediately no-op. Every trace
+    // in a project fans this reactor out; gateway traffic is a slice of it.
+    // Kept in `handle` too: the queue is not the only caller (inline mode), a
+    // fail-open `shouldReact` may dispatch anyway, and a job queued before
+    // this gate existed still reaches the handler.
+    shouldReact: (_event, context) => isGatewayTrace(context.foldState),
     options: {
       // Dedup per (tenant, trace) — one gateway trace = one debit burst.
       // Structural idempotency in the CH ReplacingMergeTree
@@ -74,13 +100,12 @@ export function createGatewayBudgetSyncReactor(
     ): Promise<void> {
       const { tenantId: projectId, foldState } = context;
 
-      const virtualKeyId = foldState.attributes["langwatch.virtual_key_id"];
-      const gatewayRequestId =
-        foldState.attributes["langwatch.gateway_request_id"];
-
-      if (!virtualKeyId || !gatewayRequestId) {
+      if (!isGatewayTrace(foldState)) {
         return;
       }
+
+      const virtualKeyId = foldState.attributes[ATTR_VIRTUAL_KEY_ID]!;
+      const gatewayRequestId = foldState.attributes[ATTR_GATEWAY_REQUEST_ID]!;
 
       try {
         const vk = await deps.prisma.virtualKey.findUnique({

--- a/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
@@ -2,7 +2,7 @@
 
 import {
   GOVERNANCE_ATTR,
-  GOVERNANCE_ORIGIN_KIND_VALUE,
+  isGovernanceOriginTrace,
 } from "@ee/governance/services/governanceAttributeKeys";
 import type {
   GovernanceKpiContribution,
@@ -31,10 +31,8 @@ const logger = createLogger(
  */
 export const GOVERNANCE_KPIS_SYNC_DEBOUNCE_TTL_MS = 5 * 60_000;
 
-const ATTR_ORIGIN_KIND = GOVERNANCE_ATTR.ORIGIN_KIND;
 const ATTR_INGESTION_SOURCE_ID = GOVERNANCE_ATTR.INGESTION_SOURCE_ID;
 const ATTR_INGESTION_SOURCE_TYPE = GOVERNANCE_ATTR.INGESTION_SOURCE_TYPE;
-const ORIGIN_KIND_VALUE = GOVERNANCE_ORIGIN_KIND_VALUE;
 
 export interface GovernanceKpisSyncReactorDeps {
   governanceKpisRepository: GovernanceKpisClickHouseRepository;
@@ -51,8 +49,8 @@ export interface GovernanceKpisSyncReactorDeps {
  * traceSummary fold. Reads the governance origin attributes off the
  * fold state (hoisted from spans into trace_summaries.Attributes by
  * the SPAN_ATTR_MAPPINGS edit shipped in step 3a / fd118131c). Traces
- * without `langwatch.origin.kind = "ingestion_source"` are skipped —
- * not governance traffic.
+ * without `langwatch.origin.kind = "ingestion_source"` are not
+ * governance traffic and are declined before a job is enqueued.
  *
  * Spec: specs/ai-gateway/governance/folds.feature
  */
@@ -61,6 +59,16 @@ export function createGovernanceKpisSyncReactor(
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "governanceKpisSync",
+    // Pre-enqueue (ADR-026). The origin check is a pure read of the same
+    // payload the handler receives, so deciding here is equivalent to the
+    // early-return below — except a non-governance trace never pays a
+    // serialize + queue round-trip for a job that would immediately no-op.
+    // Every trace in a project fans this reactor out, and governance traffic
+    // is a small slice of it. Kept in `handle` too: the queue is not the only
+    // caller (inline mode), a fail-open `shouldReact` may dispatch anyway,
+    // and an already-queued job may predate this gate.
+    shouldReact: (_event, context) =>
+      isGovernanceOriginTrace(context.foldState.attributes),
     options: {
       makeJobId: (payload) =>
         `governance-kpis-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
@@ -73,8 +81,7 @@ export function createGovernanceKpisSyncReactor(
     ): Promise<void> {
       const { tenantId, foldState } = context;
 
-      const originKind = foldState.attributes[ATTR_ORIGIN_KIND];
-      if (originKind !== ORIGIN_KIND_VALUE) {
+      if (!isGovernanceOriginTrace(foldState.attributes)) {
         return;
       }
 

--- a/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
@@ -31,10 +31,9 @@ export const GOVERNANCE_OCSF_EVENTS_SYNC_DEBOUNCE_TTL_MS = 5 * 60_000;
 
 import {
   GOVERNANCE_ATTR,
-  GOVERNANCE_ORIGIN_KIND_VALUE,
+  isGovernanceOriginTrace,
 } from "../services/governanceAttributeKeys";
 
-const ATTR_ORIGIN_KIND = GOVERNANCE_ATTR.ORIGIN_KIND;
 const ATTR_INGESTION_SOURCE_ID = GOVERNANCE_ATTR.INGESTION_SOURCE_ID;
 const ATTR_INGESTION_SOURCE_TYPE = GOVERNANCE_ATTR.INGESTION_SOURCE_TYPE;
 const ATTR_USER_ID = GOVERNANCE_ATTR.USER_ID;
@@ -43,7 +42,6 @@ const ATTR_ENDUSER_ID = "enduser.id";
 const ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
 const ATTR_TOOL_NAME = "tool.name";
 const ATTR_ANOMALY_ALERT_ID = GOVERNANCE_ATTR.ANOMALY_ALERT_ID;
-const ORIGIN_KIND_VALUE = GOVERNANCE_ORIGIN_KIND_VALUE;
 
 export interface GovernanceOcsfEventsSyncReactorDeps {
   governanceOcsfEventsRepository: GovernanceOcsfEventsClickHouseRepository;
@@ -60,8 +58,8 @@ export interface GovernanceOcsfEventsSyncReactorDeps {
  * Registered on the trace_processing pipeline downstream of the
  * traceSummary fold. Reads governance origin attributes + actor
  * identity + target model off the fold state. Traces without
- * `langwatch.origin.kind = "ingestion_source"` are skipped — not
- * governance traffic.
+ * `langwatch.origin.kind = "ingestion_source"` are not governance
+ * traffic and are declined before a job is enqueued.
  *
  * Severity is INFO by default; elevated to MEDIUM (warning tier)
  * when `langwatch.governance.anomaly_alert_id` is set per the spec.
@@ -73,6 +71,13 @@ export function createGovernanceOcsfEventsSyncReactor(
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "governanceOcsfEventsSync",
+    // Pre-enqueue (ADR-026). See governanceKpisSync for the reasoning: the
+    // origin check is pure, reads the payload the handler would receive, and
+    // rejects the bulk of trace traffic before a job is packed. Kept in
+    // `handle` too — inline mode, fail-open dispatch, and jobs queued before
+    // this gate existed all still reach the handler.
+    shouldReact: (_event, context) =>
+      isGovernanceOriginTrace(context.foldState.attributes),
     options: {
       makeJobId: (payload) =>
         `governance-ocsf-events-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
@@ -85,8 +90,7 @@ export function createGovernanceOcsfEventsSyncReactor(
     ): Promise<void> {
       const { tenantId, foldState } = context;
 
-      const originKind = foldState.attributes[ATTR_ORIGIN_KIND];
-      if (originKind !== ORIGIN_KIND_VALUE) {
+      if (!isGovernanceOriginTrace(foldState.attributes)) {
         return;
       }
 

--- a/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
@@ -48,6 +48,88 @@ export interface GovernanceOcsfEventsSyncReactorDeps {
 }
 
 /**
+ * Projects one governance trace onto an OCSF v1.1 row.
+ *
+ * Action prefers the trace's tool invocation as the verb; non-LLM activity
+ * (agent CRUD, plain traces) falls back to a generic "trace.recorded",
+ * which is better than an empty operation.
+ *
+ * Target prefers `gen_ai.request.model`, falling back to the rolled-up
+ * Models[0] on the fold state. For non-LLM events Models[] may be empty —
+ * an empty target is acceptable per the OCSF spec, where it is optional.
+ *
+ * Severity is INFO unless the trace carries an anomaly alert, which
+ * elevates it to MEDIUM per the spec.
+ */
+function buildOcsfEventRow({
+  tenantId,
+  foldState,
+  sourceId,
+  occurredAtMs,
+}: {
+  tenantId: string;
+  foldState: TraceSummaryData;
+  sourceId: string;
+  occurredAtMs: number;
+}): GovernanceOcsfEventInput {
+  const sourceType =
+    foldState.attributes[ATTR_INGESTION_SOURCE_TYPE] ?? "unknown";
+  const actorUserId = foldState.attributes[ATTR_USER_ID] ?? "";
+  const actorEmail = foldState.attributes[ATTR_USER_EMAIL] ?? "";
+  const actorEnduserId = foldState.attributes[ATTR_ENDUSER_ID] ?? "";
+  const actionName = foldState.attributes[ATTR_TOOL_NAME] ?? "trace.recorded";
+  const targetName =
+    foldState.attributes[ATTR_GEN_AI_REQUEST_MODEL] ??
+    foldState.models[0] ??
+    "";
+  const anomalyAlertId = foldState.attributes[ATTR_ANOMALY_ALERT_ID] ?? "";
+  const severityId = anomalyAlertId ? OCSF_SEVERITY.MEDIUM : OCSF_SEVERITY.INFO;
+
+  const rawOcsfJson = JSON.stringify({
+    class_uid: 6003,
+    category_uid: 6,
+    activity_id: OCSF_ACTIVITY.INVOKE,
+    type_uid: 6003 * 100 + OCSF_ACTIVITY.INVOKE,
+    severity_id: severityId,
+    time: occurredAtMs,
+    actor: {
+      user: { uid: actorUserId, email_addr: actorEmail },
+      enduser: { uid: actorEnduserId },
+    },
+    api: { operation: actionName },
+    dst_endpoint: { name: targetName },
+    metadata: {
+      product: { name: "LangWatch", vendor_name: "LangWatch" },
+      extension: {
+        uid: "langwatch.governance",
+        source_type: sourceType,
+        source_id: sourceId,
+        trace_id: foldState.traceId,
+        anomaly_alert_id: anomalyAlertId || undefined,
+      },
+    },
+  });
+
+  return {
+    tenantId,
+    eventId: foldState.traceId,
+    traceId: foldState.traceId,
+    sourceId,
+    sourceType,
+    activityId: OCSF_ACTIVITY.INVOKE,
+    severityId,
+    eventTime: new Date(occurredAtMs),
+    actorUserId,
+    actorEmail,
+    actorEnduserId,
+    actionName,
+    targetName,
+    anomalyAlertId,
+    rawOcsfJson,
+  };
+}
+
+/**
  * Folds completed governance-origin traces into per-event OCSF v1.1
  * rows in ClickHouse. Each trace produces ONE row keyed by
  * (TenantId, EventId) where EventId = traceId (we use traceId as
@@ -61,8 +143,7 @@ export interface GovernanceOcsfEventsSyncReactorDeps {
  * `langwatch.origin.kind = "ingestion_source"` are not governance
  * traffic and are declined before a job is enqueued.
  *
- * Severity is INFO by default; elevated to MEDIUM (warning tier)
- * when `langwatch.governance.anomaly_alert_id` is set per the spec.
+ * The row itself is built by `buildOcsfEventRow`.
  *
  * Spec: specs/ai-gateway/governance/folds.feature §"governance_ocsf_events"
  */
@@ -112,78 +193,9 @@ export function createGovernanceOcsfEventsSyncReactor(
       }
 
       try {
-        const sourceType =
-          foldState.attributes[ATTR_INGESTION_SOURCE_TYPE] ?? "unknown";
-        const actorUserId = foldState.attributes[ATTR_USER_ID] ?? "";
-        const actorEmail = foldState.attributes[ATTR_USER_EMAIL] ?? "";
-        const actorEnduserId = foldState.attributes[ATTR_ENDUSER_ID] ?? "";
-
-        // Action: prefer the trace's first model invocation as the verb.
-        // For non-LLM activity (tool calls, agent CRUD), action will fall
-        // back to a generic "trace.recorded" — better than empty.
-        const actionName =
-          foldState.attributes[ATTR_TOOL_NAME] ?? "trace.recorded";
-
-        // Target: prefer gen_ai.request.model for LLM invocations; fall
-        // back to the rolled-up Models[0] from the fold state. For
-        // non-LLM events, Models[] may be empty — empty target is
-        // acceptable per OCSF spec (target is optional).
-        const targetName =
-          foldState.attributes[ATTR_GEN_AI_REQUEST_MODEL] ??
-          foldState.models[0] ??
-          "";
-
-        const anomalyAlertId =
-          foldState.attributes[ATTR_ANOMALY_ALERT_ID] ?? "";
-        const severityId = anomalyAlertId
-          ? OCSF_SEVERITY.MEDIUM
-          : OCSF_SEVERITY.INFO;
-
-        const eventTime = new Date(occurredAtMs);
-        const rawOcsfJson = JSON.stringify({
-          class_uid: 6003,
-          category_uid: 6,
-          activity_id: OCSF_ACTIVITY.INVOKE,
-          type_uid: 6003 * 100 + OCSF_ACTIVITY.INVOKE,
-          severity_id: severityId,
-          time: occurredAtMs,
-          actor: {
-            user: { uid: actorUserId, email_addr: actorEmail },
-            enduser: { uid: actorEnduserId },
-          },
-          api: { operation: actionName },
-          dst_endpoint: { name: targetName },
-          metadata: {
-            product: { name: "LangWatch", vendor_name: "LangWatch" },
-            extension: {
-              uid: "langwatch.governance",
-              source_type: sourceType,
-              source_id: sourceId,
-              trace_id: foldState.traceId,
-              anomaly_alert_id: anomalyAlertId || undefined,
-            },
-          },
-        });
-
-        const row: GovernanceOcsfEventInput = {
-          tenantId,
-          eventId: foldState.traceId,
-          traceId: foldState.traceId,
-          sourceId,
-          sourceType,
-          activityId: OCSF_ACTIVITY.INVOKE,
-          severityId,
-          eventTime,
-          actorUserId,
-          actorEmail,
-          actorEnduserId,
-          actionName,
-          targetName,
-          anomalyAlertId,
-          rawOcsfJson,
-        };
-
-        await deps.governanceOcsfEventsRepository.insertEvent(row);
+        await deps.governanceOcsfEventsRepository.insertEvent(
+          buildOcsfEventRow({ tenantId, foldState, sourceId, occurredAtMs }),
+        );
       } catch (error) {
         logger.error(
           {

--- a/langwatch/ee/governance/services/governanceAttributeKeys.ts
+++ b/langwatch/ee/governance/services/governanceAttributeKeys.ts
@@ -39,3 +39,20 @@ export const GOVERNANCE_ATTR = {
 
 export type GovernanceAttrKey =
   (typeof GOVERNANCE_ATTR)[keyof typeof GOVERNANCE_ATTR];
+
+/**
+ * True when a trace's accumulated attributes mark it as governance
+ * traffic. Pure and synchronous so the governance reactors can use it
+ * as their `shouldReact` predicate (pre-enqueue) as well as their
+ * in-handler guard; see ADR-026.
+ *
+ * Tolerates a missing attribute bag: a fold state that has not
+ * accumulated any attributes yet is simply not governance traffic.
+ */
+export function isGovernanceOriginTrace(
+  attributes: Record<string, string> | undefined,
+): boolean {
+  return (
+    attributes?.[GOVERNANCE_ATTR.ORIGIN_KIND] === GOVERNANCE_ORIGIN_KIND_VALUE
+  );
+}


### PR DESCRIPTION
## For humans

Three background jobs were being created for every single trace we receive, then thrown away the moment they were opened. They only ever apply to two narrow kinds of traffic (AI Gateway requests, and traces from a governance ingestion source), but the check for "is this my kind of traffic?" happened *after* the job had already been packaged, put on the queue, picked up by a worker and unpacked. For a project sending neither kind, that is pure waste — three round-trips per trace, every trace, all discarded on arrival.

This moves the check to before the job is created. Nothing changes about which traces get processed; the ones that were being dropped are simply now declined up front instead of at the end.

It also fixes why nobody noticed. Our reactor counter has a "skipped" bucket, but it only counts work declined *before* the queue. A reactor that quietly gave up inside the job was recorded as a success, so the dashboards showed three healthy reactors doing their job rather than three reactors discarding almost everything. After this change the declines show up as declines.

## What changed

- `langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts` — extracted the "does this trace carry both `langwatch.virtual_key_id` and `langwatch.gateway_request_id`" check into a pure `isGatewayTrace(foldState)` helper, declared it as `shouldReact`, and kept it as the handler's first guard.
- `langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts`, `langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts` — same hoist for the `langwatch.origin.kind = "ingestion_source"` check.
- `langwatch/ee/governance/services/governanceAttributeKeys.ts` — new `isGovernanceOriginTrace(attributes)` predicate, shared by the two governance reactors. That module is already the single source of truth for these attribute keys, so the predicate that reads them belongs there rather than duplicated in both reactors.

The handler early-returns stay. `shouldReact` is not the only path into `handle`: inline (non-queued) mode calls the handler directly, the router deliberately fails open when a predicate throws, and a job enqueued before this change still has to be handled safely on arrival.

This follows the idiom already used by six sibling reactors — `experimentMetricsSync`, `simulationMetricsSync`, `projectMetadata`, `customEvaluationSync`, `evaluationTrigger`, and everything built on `defineOriginGuardedTraceReactor` — where one pure named guard is referenced from both `shouldReact` and `handle`.

## Follow-up: the two long handlers, split (commit 2)

Biome's `noExcessiveLinesPerFunction` flagged `gatewayBudgetSync`'s handler (121 lines) and `governanceOcsfEventsSync`'s (77) via reviewdog. Both were long before this branch — the hoist touched lines inside them, which is what surfaced them — so the second commit splits them rather than leaving a known warning on lines this PR edited.

`gatewayBudgetSync` now reads as the sequence it always was, each step a named function owning its own guard and its own explanatory comment: `findGatewayVirtualKey`, `touchVirtualKeyLastUsed`, `findProjectForGatewayFold`, `resolveApplicableBudgets`, `buildDebitRows`, `emitBudgetUpdatedChangeEvent`, composed by `foldGatewayTraceIntoLedger`. `handle` keeps only the relevance gate and the catch that reports and swallows — the part the reactor contract actually owns. Call order is unchanged, and deliberately so: `lastUsedAt` is still touched between the virtual-key and project lookups, so a trace whose project resolution fails still records the key as used (EC6).

`governanceOcsfEventsSync` gains `buildOcsfEventRow`, a pure projection from fold state to OCSF row. The field-precedence rules (action verb, target fallback, severity elevation) now sit on the function implementing them instead of being split between the factory docstring and inline comments.

No behavior change: same lookups, same order, same early returns, same rows. The existing unit tests cover the branches (unknown virtual key, cross-tenant virtual key, no applicable budgets, project-scoped budget, per-member group budget, guardrail-blocked) and pass unchanged.

## Tests

- `langwatch/ee/governance/reactors/__tests__/governanceReactorsPreEnqueueGate.unit.test.ts` (new) drives the real `ProjectionRouter` with the three reactors registered and mocked queues, asserting that an irrelevant trace enqueues no job and increments `es_reactor_total{status="skipped"}` for each reactor, and that a gateway trace enqueues exactly one job while the two governance reactors are declined (and vice versa). The router is the right unit here: a gate living only in `handle` passes a per-reactor test while still queueing a job per trace. Verified as a real regression test by removing one `shouldReact` — three assertions fail, including the skip counter.
- The three existing reactor unit test files each gained a `pre-enqueue gate` block covering the accept and decline cases of the predicate directly.

`pnpm test:unit run ee/governance/reactors/__tests__/ src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts` — 68 passed. `pnpm typecheck` and `pnpm typecheck:tests` clean. `pnpm exec biome check` on the touched files reports no errors on these lines.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved governance event filtering so only relevant ingestion and gateway traces are processed.
  * Prevented unrelated traces from creating unnecessary background jobs.
  * Added validation for required gateway attributes before processing.

* **Tests**
  * Expanded coverage for governance and gateway event routing, filtering, and skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
