### PR TITLE
perf(event-sourcing): coalesce log and metric record appends

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/log-processing/__tests__/logCommandCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/log-processing/__tests__/logCommandCoalescing.unit.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import { processCommandBatch } from "../../../services/commands/commandDispatcher";
+import { RecordCanonicalLogCommand } from "../commands/recordCanonicalLogCommand";
+import { createLogProcessingPipeline } from "../pipeline";
+import {
+  CANONICAL_LOG_RECORD_RECEIVED_EVENT_TYPE,
+  LOG_COMMAND_COALESCE_MAX_BATCH,
+  RECORD_CANONICAL_LOG_COMMAND_TYPE,
+} from "../schemas/constants";
+import type { CanonicalLogRecord } from "../schemas/logRecord";
+
+vi.mock("../../../utils/killSwitch", () => ({
+  isComponentDisabled: vi.fn().mockResolvedValue(false),
+}));
+
+import { isComponentDisabled } from "../../../utils/killSwitch";
+
+const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
+
+const TENANT_ID = "project_log_coalescing";
+
+/** A schema-valid canonical record; only the identity fields vary per item. */
+function logRecord({ index }: { index: number }): CanonicalLogRecord {
+  return {
+    tenantId: TENANT_ID,
+    organizationId: "organization-1",
+    recordId: index.toString(16).padStart(64, "0"),
+    resourceSchemaUrl: "",
+    resourceAttributesJson: "[]",
+    resourceAttributesFlatJson: "{}",
+    resourceAttributeKeys: [],
+    resourceDroppedAttributesCount: 0,
+    scopeSchemaUrl: "",
+    scopeName: "scope",
+    scopeVersion: "",
+    scopeAttributesJson: "[]",
+    scopeAttributeKeys: [],
+    scopeDroppedAttributesCount: 0,
+    wireTraceId: "",
+    wireSpanId: "",
+    correlationTraceId: "",
+    correlationSpanId: "",
+    correlationSource: "none",
+    timeUnixNano: "1",
+    observedTimeUnixNano: "1",
+    timeUnixMs: 1_800_000_000_000 + index,
+    severityNumber: 9,
+    severityText: "INFO",
+    bodyType: "string",
+    bodyJson: '"body"',
+    bodyText: "body",
+    attributesJson: "[]",
+    attributesFlatJson: "{}",
+    attributeKeys: [],
+    droppedAttributesCount: 0,
+    flags: 0,
+    eventName: "",
+    providerKind: "generic",
+    providerEventKind: "",
+    providerEventSequence: "",
+    providerSessionId: "",
+    providerConversationId: "",
+    providerPromptId: "",
+    piiRedactionLevel: "STRICT",
+    canonicalPayload: "{}",
+    canonicalSizeBytes: 2,
+    occurredAt: 1_800_000_000_000 + index,
+    acceptedAt: 1_800_000_000_000 + index,
+  };
+}
+
+function batchParamsFor({
+  payloads,
+  storeEventsFn,
+}: {
+  payloads: CanonicalLogRecord[];
+  storeEventsFn: (events: Event[], context: unknown) => Promise<void>;
+}) {
+  return {
+    payloads: payloads as unknown as Record<string, unknown>[],
+    commandType: RECORD_CANONICAL_LOG_COMMAND_TYPE,
+    commandSchema: RecordCanonicalLogCommand.schema,
+    handler: new RecordCanonicalLogCommand(),
+    getAggregateId: RecordCanonicalLogCommand.getAggregateId,
+    storeEventsFn: storeEventsFn as never,
+    aggregateType: "log" as const,
+    commandName: "recordLogRecord",
+    pipelineName: "log_processing",
+  };
+}
+
+describe("log command append coalescing", () => {
+  beforeEach(() => {
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("given the log-processing pipeline is defined", () => {
+    describe("when recordLogRecord is registered", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      it("carries an append-coalescing bound alongside its shard routing", () => {
+        const pipeline = createLogProcessingPipeline({
+          canonicalLogAppendStore: {} as never,
+          logCommandShardCount: 8,
+        });
+
+        const command = pipeline.commands.find(
+          (candidate) => candidate.name === "recordLogRecord",
+        );
+
+        expect(command?.options?.coalesceMaxBatch).toBe(
+          LOG_COMMAND_COALESCE_MAX_BATCH,
+        );
+        expect(command?.options?.getGroupKey).toBeDefined();
+      });
+    });
+  });
+
+  describe("given several queued records from one shard", () => {
+    describe("when the coalesced batch is processed", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      /** @scenario 'coalescing preserves every item' */
+      it("appends them as one insert holding every record in dispatch order", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2, 3].map((index) => logRecord({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        const [events, context] = storeEventsFn.mock.calls[0]!;
+        expect((events as Event[]).map((event) => event.aggregateId)).toEqual(
+          payloads.map((payload) => payload.recordId),
+        );
+        expect(
+          (events as Event[]).every(
+            (event) => event.type === CANONICAL_LOG_RECORD_RECEIVED_EVENT_TYPE,
+          ),
+        ).toBe(true);
+        expect(context).toEqual({ tenantId: TENANT_ID });
+      });
+
+      /** @scenario 'coalescing preserves every item' */
+      it("keeps each record's idempotency key so a retry cannot duplicate it", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1].map((index) => logRecord({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect(
+          (events as Event[]).map((event) => event.idempotencyKey),
+        ).toEqual(
+          payloads.map((payload) => `${TENANT_ID}:${payload.recordId}`),
+        );
+      });
+    });
+
+    describe("when the command is killed for the tenant", () => {
+      it("appends nothing for the whole batch", async () => {
+        mockedIsComponentDisabled.mockResolvedValue(true);
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2].map((index) => logRecord({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/log-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/log-processing/pipeline.ts
@@ -4,6 +4,7 @@ import type { EventSubscriberDefinition } from "../../subscribers/eventSubscribe
 import { logCommandGroupKey } from "./canonicalLog";
 import { RecordCanonicalLogCommand } from "./commands/recordCanonicalLogCommand";
 import { CanonicalLogStorageMapProjection } from "./projections/canonicalLogStorage.mapProjection";
+import { LOG_COMMAND_COALESCE_MAX_BATCH } from "./schemas/constants";
 import type { LogProcessingEvent } from "./schemas/events";
 import type { CanonicalLogRecord } from "./schemas/logRecord";
 
@@ -34,6 +35,12 @@ export function createLogProcessingPipeline(deps: LogProcessingPipelineDeps) {
     .withCommand("recordLogRecord", RecordCanonicalLogCommand, {
       getGroupKey: (payload) =>
         logCommandGroupKey(payload.recordId, deps.logCommandShardCount),
+      // ADR-066 pillar 2: a shard funnels many records into one group, so a
+      // backed-up shard appends one tiny insert per record. Coalesce its queued
+      // records into one multi-row insert instead. Safe to fold: the handler
+      // derives its event from its own command alone and never reads back a
+      // same-batch append.
+      coalesceMaxBatch: LOG_COMMAND_COALESCE_MAX_BATCH,
     })
     .build();
 }

--- a/langwatch/src/server/event-sourcing/pipelines/log-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/log-processing/schemas/constants.ts
@@ -18,3 +18,15 @@ export const DEFAULT_LOG_COMMAND_SHARDS = 16;
 export const MIN_LOG_COMMAND_SHARDS = 1;
 export const MAX_LOG_COMMAND_SHARDS = 128;
 export const LOG_MAP_COALESCE_MAX_BATCH = 256;
+
+/**
+ * Append-coalescing bound for recordLogRecord (ADR-066 pillar 2). Log records
+ * arrive one command per record and are sharded onto a fixed set of group keys,
+ * so a busy exporter parks many records behind one shard — one tiny event_log
+ * insert each, which floods the log with small parts. Folding a shard's queued
+ * records into a single multi-row insert keeps the producer off the per-item
+ * write path. Matches {@link LOG_MAP_COALESCE_MAX_BATCH} so both stages of this
+ * pipeline fold at the same width; the drain's byte bound backs it up, and binds
+ * first for records near {@link MAX_CANONICAL_LOG_PAYLOAD_BYTES}.
+ */
+export const LOG_COMMAND_COALESCE_MAX_BATCH = 256;

--- a/langwatch/src/server/event-sourcing/pipelines/log-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/log-processing/schemas/constants.ts
@@ -26,7 +26,14 @@ export const LOG_MAP_COALESCE_MAX_BATCH = 256;
  * insert each, which floods the log with small parts. Folding a shard's queued
  * records into a single multi-row insert keeps the producer off the per-item
  * write path. Matches {@link LOG_MAP_COALESCE_MAX_BATCH} so both stages of this
- * pipeline fold at the same width; the drain's byte bound backs it up, and binds
- * first for records near {@link MAX_CANONICAL_LOG_PAYLOAD_BYTES}.
+ * pipeline fold at the same width.
+ *
+ * The count is the only bound you can rely on here. The drain's byte budget
+ * sums the *stored* size of each staged job, so it does not see a body the
+ * envelope offloaded to the blob store — a batch of records near
+ * {@link MAX_CANONICAL_LOG_PAYLOAD_BYTES} is bounded by this count, not by
+ * bytes, whenever envelope writes are on. Pre-existing and shared with the map
+ * stage above; making the budget payload-aware is a groupQueue change that has
+ * to cover both.
  */
 export const LOG_COMMAND_COALESCE_MAX_BATCH = 256;

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/__tests__/metricCommandCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/__tests__/metricCommandCoalescing.unit.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import { processCommandBatch } from "../../../services/commands/commandDispatcher";
+import { RecordMetricDataPointCommand } from "../commands/recordMetricDataPointCommand";
+import { createMetricProcessingPipeline } from "../pipeline";
+import {
+  METRIC_COMMAND_COALESCE_MAX_BATCH,
+  METRIC_DATA_POINT_RECEIVED_EVENT_TYPE,
+  RECORD_METRIC_DATA_POINT_COMMAND_TYPE,
+} from "../schemas/constants";
+import type { CanonicalMetricDataPoint } from "../schemas/metricDataPoint";
+import { point } from "./fixtures/metric-point.fixtures";
+
+vi.mock("../../../utils/killSwitch", () => ({
+  isComponentDisabled: vi.fn().mockResolvedValue(false),
+}));
+
+import { isComponentDisabled } from "../../../utils/killSwitch";
+
+const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
+
+const TENANT_ID = "project_metric_coalescing";
+
+function dataPoint({ index }: { index: number }): CanonicalMetricDataPoint {
+  return point({
+    tenantId: TENANT_ID,
+    timeUnixMs: 1_800_000_000_000 + index,
+    pointId: index.toString(16).padStart(64, "0"),
+    valueDouble: index,
+  });
+}
+
+function batchParamsFor({
+  payloads,
+  storeEventsFn,
+}: {
+  payloads: CanonicalMetricDataPoint[];
+  storeEventsFn: (events: Event[], context: unknown) => Promise<void>;
+}) {
+  return {
+    payloads: payloads as unknown as Record<string, unknown>[],
+    commandType: RECORD_METRIC_DATA_POINT_COMMAND_TYPE,
+    commandSchema: RecordMetricDataPointCommand.schema,
+    handler: new RecordMetricDataPointCommand(),
+    getAggregateId: RecordMetricDataPointCommand.getAggregateId,
+    storeEventsFn: storeEventsFn as never,
+    aggregateType: "metric" as const,
+    commandName: "recordDataPoint",
+    pipelineName: "metric_processing",
+  };
+}
+
+function buildPipeline() {
+  const store = {} as never;
+  return createMetricProcessingPipeline({
+    metricDataPointAppendStore: store,
+    metricSeriesCatalogAppendStore: store,
+    metricTimeRollupAppendStore: store,
+    metricCommandShardCount: 8,
+  });
+}
+
+describe("metric command append coalescing", () => {
+  beforeEach(() => {
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("given the metric-processing pipeline is defined", () => {
+    describe("when recordDataPoint is registered", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      it("carries an append-coalescing bound alongside its shard routing", () => {
+        const command = buildPipeline().commands.find(
+          (candidate) => candidate.name === "recordDataPoint",
+        );
+
+        expect(command?.options?.coalesceMaxBatch).toBe(
+          METRIC_COMMAND_COALESCE_MAX_BATCH,
+        );
+        expect(command?.options?.getGroupKey).toBeDefined();
+      });
+    });
+  });
+
+  describe("given several queued data points from one shard", () => {
+    describe("when the coalesced batch is processed", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      /** @scenario 'coalescing preserves every item' */
+      it("appends them as one insert holding every point in dispatch order", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2, 3].map((index) => dataPoint({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        const [events, context] = storeEventsFn.mock.calls[0]!;
+        expect((events as Event[]).map((event) => event.aggregateId)).toEqual(
+          payloads.map((payload) => payload.pointId),
+        );
+        expect(
+          (events as Event[]).every(
+            (event) => event.type === METRIC_DATA_POINT_RECEIVED_EVENT_TYPE,
+          ),
+        ).toBe(true);
+        expect(context).toEqual({ tenantId: TENANT_ID });
+      });
+
+      /** @scenario 'coalescing preserves every item' */
+      it("keeps each point's idempotency key so a retry cannot duplicate it", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1].map((index) => dataPoint({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect(
+          (events as Event[]).map((event) => event.idempotencyKey),
+        ).toEqual(payloads.map((payload) => `${TENANT_ID}:${payload.pointId}`));
+      });
+    });
+
+    describe("when the command is killed for the tenant", () => {
+      it("appends nothing for the whole batch", async () => {
+        mockedIsComponentDisabled.mockResolvedValue(true);
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2].map((index) => dataPoint({ index }));
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/pipeline.ts
@@ -6,6 +6,7 @@ import { RecordMetricDataPointCommand } from "./commands/recordMetricDataPointCo
 import { MetricDataPointStorageMapProjection } from "./projections/metricDataPointStorage.mapProjection";
 import { MetricSeriesCatalogMapProjection } from "./projections/metricSeriesCatalog.mapProjection";
 import { MetricTimeRollupMapProjection } from "./projections/metricTimeRollup.mapProjection";
+import { METRIC_COMMAND_COALESCE_MAX_BATCH } from "./schemas/constants";
 import type { MetricProcessingEvent } from "./schemas/events";
 import type { CanonicalMetricDataPoint } from "./schemas/metricDataPoint";
 
@@ -57,6 +58,12 @@ export function createMetricProcessingPipeline(
           pointId: payload.pointId,
           shardCount: deps.metricCommandShardCount,
         }),
+      // ADR-066 pillar 2: a shard funnels many data points into one group, so a
+      // backed-up shard appends one tiny insert per point. Coalesce its queued
+      // points into one multi-row insert instead. Safe to fold: the handler
+      // derives its event from its own command alone and never reads back a
+      // same-batch append.
+      coalesceMaxBatch: METRIC_COMMAND_COALESCE_MAX_BATCH,
     })
     .build();
 }

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/schemas/constants.ts
@@ -16,6 +16,17 @@ export const METRIC_PROCESSING_COMMAND_TYPES = [
 
 export const METRIC_ROLLUP_INTERVAL_MS = 30_000;
 export const METRIC_MAP_COALESCE_MAX_BATCH = 256;
+
+/**
+ * Append-coalescing bound for recordDataPoint (ADR-066 pillar 2). Data points
+ * arrive one command per point and are sharded onto a fixed set of group keys,
+ * so a busy exporter parks many points behind one shard — one tiny event_log
+ * insert each, which floods the log with small parts. Folding a shard's queued
+ * points into a single multi-row insert keeps the producer off the per-item
+ * write path. Matches {@link METRIC_MAP_COALESCE_MAX_BATCH} so both stages of
+ * this pipeline fold at the same width; the drain's byte bound backs it up.
+ */
+export const METRIC_COMMAND_COALESCE_MAX_BATCH = 256;
 export const MAX_CANONICAL_METRIC_PAYLOAD_BYTES = 256 * 1024;
 export const DEFAULT_METRIC_COMMAND_SHARDS = 16;
 export const MIN_METRIC_COMMAND_SHARDS = 1;

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/schemas/constants.ts
@@ -24,7 +24,15 @@ export const METRIC_MAP_COALESCE_MAX_BATCH = 256;
  * insert each, which floods the log with small parts. Folding a shard's queued
  * points into a single multi-row insert keeps the producer off the per-item
  * write path. Matches {@link METRIC_MAP_COALESCE_MAX_BATCH} so both stages of
- * this pipeline fold at the same width; the drain's byte bound backs it up.
+ * this pipeline fold at the same width.
+ *
+ * The count is the only bound you can rely on here. The drain's byte budget
+ * sums the *stored* size of each staged job, so it does not see a body the
+ * envelope offloaded to the blob store — a batch of points near
+ * {@link MAX_CANONICAL_METRIC_PAYLOAD_BYTES} is bounded by this count, not by
+ * bytes, whenever envelope writes are on. Pre-existing and shared with the map
+ * stage above; making the budget payload-aware is a groupQueue change that has
+ * to cover both.
  */
 export const METRIC_COMMAND_COALESCE_MAX_BATCH = 256;
 export const MAX_CANONICAL_METRIC_PAYLOAD_BYTES = 256 * 1024;

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
@@ -222,6 +222,9 @@ describe("QueueManager.initializeCommandQueues with getGroupKey", () => {
   });
 });
 
+const UNCOALESCED_PRODUCER_MESSAGE =
+  "grouped command producer registered without append coalescing";
+
 // ADR-066 pillar 2 — append coalescing wiring + the un-coalesced-producer
 // visibility record. See specs/event-sourcing/producer-append-coalescing.feature.
 describe("QueueManager.initializeCommandQueues append coalescing", () => {
@@ -330,7 +333,7 @@ describe("QueueManager.initializeCommandQueues append coalescing", () => {
 
         expect(infoSpy).toHaveBeenCalledWith(
           { pipeline: "test-pipeline", command: "cold" },
-          "serialized command producer registered without append coalescing",
+          UNCOALESCED_PRODUCER_MESSAGE,
         );
       });
     });
@@ -356,7 +359,116 @@ describe("QueueManager.initializeCommandQueues append coalescing", () => {
 
         expect(infoSpy).not.toHaveBeenCalledWith(
           expect.anything(),
-          "serialized command producer registered without append coalescing",
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+    });
+  });
+
+  // A shard/bucket group key funnels many aggregates into one consumer just as
+  // serializeByAggregate funnels many commands into one aggregate — the same
+  // producer shape, so the same gap has to be visible.
+  describe("given a group-keyed producer registered without coalescing", () => {
+    describe("when the group key comes from the command class", () => {
+      /** @scenario 'an un-coalesced high-fan-in producer is visible, not silent' */
+      it("emits a record naming the producer and its pipeline", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "sharded",
+              handlerClass:
+                createMockCommandHandlerClassWithGroupKey("sharded"),
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).toHaveBeenCalledWith(
+          { pipeline: "test-pipeline", command: "sharded" },
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+    });
+
+    describe("when the group key comes from the registration options", () => {
+      /** @scenario 'an un-coalesced high-fan-in producer is visible, not silent' */
+      it("emits a record naming the producer and its pipeline", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "sharded",
+              handlerClass: createMockCommandHandlerClass("sharded"),
+              options: {
+                getGroupKey: (payload: any) => `shard:${payload.index}`,
+              },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).toHaveBeenCalledWith(
+          { pipeline: "test-pipeline", command: "sharded" },
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+    });
+  });
+
+  describe("given a group-keyed producer that DOES coalesce", () => {
+    describe("when the command queue is initialized", () => {
+      it("does not emit the un-coalesced visibility record", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "sharded",
+              handlerClass:
+                createMockCommandHandlerClassWithGroupKey("sharded"),
+              options: { coalesceMaxBatch: 256 },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).not.toHaveBeenCalledWith(
+          expect.anything(),
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+    });
+  });
+
+  describe("given a producer keyed only by its own aggregate", () => {
+    describe("when the command queue is initialized", () => {
+      it("stays silent — one aggregate per job is not a funnel", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "perAggregate",
+              handlerClass: createMockCommandHandlerClass("perAggregate"),
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).not.toHaveBeenCalledWith(
+          expect.anything(),
+          UNCOALESCED_PRODUCER_MESSAGE,
         );
       });
     });

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -597,10 +597,10 @@ export class QueueManager<EventType extends Event = Event> {
       // funnel, not the key that names it, is what parks items behind one
       // consumer. Record the gap at registration so it can be found and closed,
       // instead of surfacing only as ClickHouse small-parts pressure.
-      const groupsJobs =
+      const isGroupedProducer =
         Boolean(cmdEntry.options.serializeByAggregate) ||
         Boolean(cmdEntry.getGroupKey);
-      if (groupsJobs && !(coalesceMaxBatch && coalesceMaxBatch > 1)) {
+      if (isGroupedProducer && !(coalesceMaxBatch && coalesceMaxBatch > 1)) {
         this.logger.info(
           { pipeline: this.pipelineName, command: cmdName },
           "grouped command producer registered without append coalescing",

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -589,17 +589,21 @@ export class QueueManager<EventType extends Event = Event> {
       });
       const coalesceMaxBatch = cmdEntry.options.coalesceMaxBatch;
 
-      // ADR-066 pillar 2 visibility: a serialized producer that does NOT
-      // coalesce can still flood the event log one tiny insert per item under
-      // high fan-in. Record the gap at registration so it can be found and
-      // closed, instead of surfacing only as ClickHouse small-parts pressure.
-      if (
-        cmdEntry.options.serializeByAggregate &&
-        !(coalesceMaxBatch && coalesceMaxBatch > 1)
-      ) {
+      // ADR-066 pillar 2 visibility: a producer whose jobs funnel into a shared
+      // queue group and does NOT coalesce can still flood the event log one tiny
+      // insert per item under high fan-in. Both grouping shapes qualify —
+      // `serializeByAggregate` (many commands, one aggregate) and an explicit
+      // `getGroupKey` (many aggregates, one shard or bucket) — because the
+      // funnel, not the key that names it, is what parks items behind one
+      // consumer. Record the gap at registration so it can be found and closed,
+      // instead of surfacing only as ClickHouse small-parts pressure.
+      const groupsJobs =
+        Boolean(cmdEntry.options.serializeByAggregate) ||
+        Boolean(cmdEntry.getGroupKey);
+      if (groupsJobs && !(coalesceMaxBatch && coalesceMaxBatch > 1)) {
         this.logger.info(
           { pipeline: this.pipelineName, command: cmdName },
-          "serialized command producer registered without append coalescing",
+          "grouped command producer registered without append coalescing",
         );
       }
 


### PR DESCRIPTION
## For humans

Log records and metric data points were written to the database one row at a time — every single record paid for its own trip. Now the ones that are waiting together get grouped and written together, in one trip.

Nothing about what gets stored changes. The same records land, in the same order, with the same de-duplication, and the same off switch still works. Only the number of writes goes down.

## What changed

Both `recordLogRecord` and `recordDataPoint` spread their queue jobs across a fixed set of shard keys, so a busy exporter parks many records behind one shard. Each of those jobs was processed on its own: its own schema validation, its own single-row `event_log` insert. That is precisely the "many tiny inserts" pattern ADR-066 pillar 2 exists to prevent, and the machinery to prevent it was already in place and already used by the automations pipeline — these two pipelines just never opted in.

- **Both commands now declare `coalesceMaxBatch`.** The queue dispatcher drains a shard's queued same-command jobs and hands the worker one ordered batch; `processCommandBatch` validates and handles each payload, then persists all their events in a single multi-row append. The bound matches each pipeline's existing map-projection fold width, and the drain's byte budget backs the count bound up.
- **The un-coalesced-producer detector was extended.** It previously keyed only on `serializeByAggregate`, which is exactly why these two shipped unbatched without anyone noticing. A shard or bucket group key funnels many aggregates into one consumer just as `serializeByAggregate` funnels many commands into one aggregate — the same producer shape, and the same gap — so the detector now covers both. The one command this newly surfaces is `recordSpan` under span sharding: real signal, deliberately left for its own change since it carries a blob-spool cleanup step that needs separate analysis.

## Safety

- **Statelessness.** The batch path runs every handler *before* the single end-of-batch store, so a handler must not read back its own or a sibling's just-appended events. Both handlers here derive their event purely from their own command — verified, not assumed.
- **Ordering.** The drain takes the group head in score order, and these commands score by `occurredAt`, so per-group ordering is preserved.
- **Kill switch.** The batch path checks the kill switch per payload, exactly as the single path does. A killed command still appends nothing.
- **Tenant isolation.** A queue group is tenant-scoped by construction, and the batch path additionally refuses a batch that mixes tenants.
- **Out of scope.** Shard counts (`LOG_PROCESSING_SHARDS` / `METRIC_PROCESSING_SHARDS`) are untouched.

## Specs

`specs/event-sourcing/producer-append-coalescing.feature` already covers this behavior; no new spec. New tests are bound to its existing scenarios via `@scenario` annotations.

## Tests

- New: `logCommandCoalescing.unit.test.ts` and `metricCommandCoalescing.unit.test.ts` — registration carries the bound, N jobs fold into one insert with events in dispatch order, idempotency keys preserved, kill switch still honored.
- Extended: `queueManager.commandGroupKey.test.ts` — the detector fires for a group-keyed producer (from either the class or the registration options), stays quiet when it coalesces, and stays quiet for a plain per-aggregate command.
- `pnpm test:unit` over `services/`, `log-processing/`, `metric-processing/`, `trace-processing/`: 89 files, 1058 tests passing.
- `pnpm typecheck` and `pnpm typecheck:tests` clean; `biome check` clean on touched files.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Log records and metric points are now grouped into batches of up to 256 items, improving processing efficiency.

* **Reliability**
  * Batched processing preserves event order, tenant context, and idempotency information.
  * Tenant-level safeguards continue to prevent storage when disabled.

* **Monitoring**
  * Queue registration visibility now more accurately reflects grouped and non-grouped processing behavior.

* **Tests**
  * Added coverage for batching, ordering, context propagation, idempotency, safeguards, and queue visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->