### PR TITLE
perf(event-sourcing): give level-triggered reactors a real firing window

### DIFF
--- a/langwatch/ee/governance/reactors/__tests__/governanceKpisSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/governanceKpisSync.reactor.unit.test.ts
@@ -334,7 +334,7 @@ describe("governanceKpisSync reactor", () => {
   });
 
   describe("dedup contract", () => {
-    it("declares a per-(tenant, trace) job-id for BullMQ debounce", () => {
+    it("declares a per-(tenant, trace) job-id for the queue's dedup", () => {
       const { deps } = mockDeps();
       const reactor = createGovernanceKpisSyncReactor(deps);
       expect(reactor.options?.makeJobId).toBeDefined();
@@ -342,7 +342,7 @@ describe("governanceKpisSync reactor", () => {
         event: { tenantId: "t-1", aggregateId: "trace-x" },
       } as any);
       expect(jobId).toBe("governance-kpis-sync-t-1-trace-x");
-      expect(reactor.options?.ttl).toBeGreaterThan(0);
+      expect(reactor.options?.deduplication?.ttlMs).toBeGreaterThan(0);
     });
   });
 });

--- a/langwatch/ee/governance/reactors/__tests__/governanceOcsfEventsSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/governanceOcsfEventsSync.reactor.unit.test.ts
@@ -382,7 +382,7 @@ describe("governanceOcsfEventsSync reactor", () => {
   });
 
   describe("dedup contract", () => {
-    it("declares a per-(tenant, trace) job-id for BullMQ debounce", () => {
+    it("declares a per-(tenant, trace) job-id for the queue's dedup", () => {
       const { deps } = mockDeps();
       const reactor = createGovernanceOcsfEventsSyncReactor(deps);
       expect(reactor.options?.makeJobId).toBeDefined();
@@ -390,7 +390,7 @@ describe("governanceOcsfEventsSync reactor", () => {
         event: { tenantId: "t-1", aggregateId: "trace-x" },
       } as any);
       expect(jobId).toBe("governance-ocsf-events-sync-t-1-trace-x");
-      expect(reactor.options?.ttl).toBeGreaterThan(0);
+      expect(reactor.options?.deduplication?.ttlMs).toBeGreaterThan(0);
     });
   });
 });

--- a/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
@@ -77,7 +77,7 @@ export function createGovernanceKpisSyncReactor(
       isGovernanceOriginTrace(context.foldState.attributes),
     options: {
       // Level-triggered: the row carries the fold's running totals, so the
-      // LAST event of a trace must always land. surviveDispatch stays off.
+      // LAST event of a trace must always land. shouldSurviveDispatch stays off.
       ...throttledPerWindow({
         makeJobId: (payload) =>
           `governance-kpis-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,

--- a/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
@@ -76,6 +76,14 @@ export function createGovernanceKpisSyncReactor(
     shouldReact: (_event, context) =>
       isGovernanceOriginTrace(context.foldState.attributes),
     options: {
+      // NOTE: the handler swallows repository failures by design (see its
+      // catch, and the test pinning it). The window makes that cheaper to get
+      // wrong: a burst now leaves ONE job, so a failed write is retried by
+      // the NEXT window rather than by the next span, and a failure in a
+      // trace's final window is not retried at all. Whether these should
+      // rethrow is an open question — rethrowing retries the job under Redis,
+      // but on the in-memory queue `send` awaits completion, so it would
+      // surface as fold redelivery instead.
       // Level-triggered: the row carries the fold's running totals, so the
       // LAST event of a trace must always land. shouldSurviveDispatch stays off.
       ...throttledPerWindow({

--- a/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceKpisSync.reactor.ts
@@ -15,6 +15,7 @@ import type {
   ReactorContext,
   ReactorDefinition,
 } from "~/server/event-sourcing/reactors/reactor.types";
+import { throttledPerWindow } from "~/server/event-sourcing/reactors/throttleWindow";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 
 const logger = createLogger(
@@ -29,7 +30,12 @@ const logger = createLogger(
  * (TenantId, SourceId, HourBucket, TraceId) — replays collapse to the
  * latest version of the same row.
  */
-export const GOVERNANCE_KPIS_SYNC_DEBOUNCE_TTL_MS = 5 * 60_000;
+/**
+ * KPI rows are hour-bucketed and read only by a periodic evaluator, so holding
+ * a trace's contributions for half a minute costs the consumer nothing while
+ * collapsing a whole trace's spans into one write.
+ */
+export const GOVERNANCE_KPIS_SYNC_WINDOW_MS = 30_000;
 
 const ATTR_INGESTION_SOURCE_ID = GOVERNANCE_ATTR.INGESTION_SOURCE_ID;
 const ATTR_INGESTION_SOURCE_TYPE = GOVERNANCE_ATTR.INGESTION_SOURCE_TYPE;
@@ -70,9 +76,13 @@ export function createGovernanceKpisSyncReactor(
     shouldReact: (_event, context) =>
       isGovernanceOriginTrace(context.foldState.attributes),
     options: {
-      makeJobId: (payload) =>
-        `governance-kpis-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
-      ttl: GOVERNANCE_KPIS_SYNC_DEBOUNCE_TTL_MS,
+      // Level-triggered: the row carries the fold's running totals, so the
+      // LAST event of a trace must always land. surviveDispatch stays off.
+      ...throttledPerWindow({
+        makeJobId: (payload) =>
+          `governance-kpis-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
+        windowMs: GOVERNANCE_KPIS_SYNC_WINDOW_MS,
+      }),
     },
 
     async handle(

--- a/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
@@ -166,6 +166,14 @@ export function createGovernanceOcsfEventsSyncReactor(
     shouldReact: (_event, context) =>
       isGovernanceOriginTrace(context.foldState.attributes),
     options: {
+      // NOTE: the handler swallows repository failures by design (see its
+      // catch, and the test pinning it). The window makes that cheaper to get
+      // wrong: a burst now leaves ONE job, so a failed write is retried by
+      // the NEXT window rather than by the next span, and a failure in a
+      // trace's final window is not retried at all. Whether these should
+      // rethrow is an open question — rethrowing retries the job under Redis,
+      // but on the in-memory queue `send` awaits completion, so it would
+      // surface as fold redelivery instead.
       // Level-triggered: the envelope is rebuilt from the fold's current
       // state, so the LAST event of a trace must always land.
       ...throttledPerWindow({

--- a/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/governanceOcsfEventsSync.reactor.ts
@@ -13,6 +13,7 @@ import type {
   ReactorContext,
   ReactorDefinition,
 } from "~/server/event-sourcing/reactors/reactor.types";
+import { throttledPerWindow } from "~/server/event-sourcing/reactors/throttleWindow";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 
 const logger = createLogger(
@@ -27,7 +28,12 @@ const logger = createLogger(
  * (TenantId, EventId) — replays collapse to the latest version of
  * the same row.
  */
-export const GOVERNANCE_OCSF_EVENTS_SYNC_DEBOUNCE_TTL_MS = 5 * 60_000;
+/**
+ * OCSF rows are pulled by cursor-paginated SIEM consumers that keep their own
+ * watermark, so a row landing half a minute later is picked up by the next
+ * pull rather than missed.
+ */
+export const GOVERNANCE_OCSF_EVENTS_SYNC_WINDOW_MS = 30_000;
 
 import {
   GOVERNANCE_ATTR,
@@ -160,9 +166,13 @@ export function createGovernanceOcsfEventsSyncReactor(
     shouldReact: (_event, context) =>
       isGovernanceOriginTrace(context.foldState.attributes),
     options: {
-      makeJobId: (payload) =>
-        `governance-ocsf-events-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
-      ttl: GOVERNANCE_OCSF_EVENTS_SYNC_DEBOUNCE_TTL_MS,
+      // Level-triggered: the envelope is rebuilt from the fold's current
+      // state, so the LAST event of a trace must always land.
+      ...throttledPerWindow({
+        makeJobId: (payload) =>
+          `governance-ocsf-events-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
+        windowMs: GOVERNANCE_OCSF_EVENTS_SYNC_WINDOW_MS,
+      }),
     },
 
     async handle(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -24,6 +24,7 @@ import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createProjectMetadataReactor,
+  PROJECT_METADATA_WINDOW_MS,
   type ProjectMetadataReactorDeps,
 } from "../projectMetadata.reactor";
 
@@ -644,10 +645,13 @@ describe("createProjectMetadataReactor()", () => {
     expect(jobId).toBe(`project-meta:${tenantId}`);
   });
 
-  it("has a 60-second dedup TTL", () => {
+  it("holds events for one onboarding poll before writing", () => {
     const reactor = createProjectMetadataReactor(deps);
 
-    expect(reactor.options!.ttl).toBe(60_000);
+    expect(reactor.options!.delay).toBe(PROJECT_METADATA_WINDOW_MS);
+    expect(reactor.options!.deduplication?.ttlMs).toBe(
+      PROJECT_METADATA_WINDOW_MS,
+    );
   });
 
   it("runs only in worker", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -645,7 +645,7 @@ describe("createProjectMetadataReactor()", () => {
     expect(jobId).toBe(`project-meta:${tenantId}`);
   });
 
-  it("holds events for one onboarding poll before writing", () => {
+  it("configures a window and dedup ttl of one onboarding poll", () => {
     const reactor = createProjectMetadataReactor(deps);
 
     expect(reactor.options!.delay).toBe(PROJECT_METADATA_WINDOW_MS);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -5,12 +5,19 @@ import type {
   ReactorContext,
   ReactorDefinition,
 } from "../../../reactors/reactor.types";
+import { throttledPerWindow } from "../../../reactors/throttleWindow";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../schemas/events";
 
 const logger = createLogger(
   "langwatch:trace-processing:project-metadata-reactor",
 );
+
+/**
+ * Roughly one poll of the onboarding screen that waits on these flags, so a
+ * user who has just sent their first trace waits at most one extra cycle.
+ */
+export const PROJECT_METADATA_WINDOW_MS = 3_000;
 
 export interface ProjectMetadataReactorDeps {
   projects: ProjectService;
@@ -112,8 +119,20 @@ export function createProjectMetadataReactor(
     options: {
       runIn: ["worker"],
       groupKeyFn: (payload) => projectMetadataGroupKey(payload.event),
-      makeJobId: (payload) => `project-meta:${payload.event.tenantId}`,
-      ttl: 60_000, // 60s dedup — avoid repeated writes for the same project
+      // Held to roughly one onboarding poll. This reactor flips the flags an
+      // onboarding screen waits on, and one of those screens reads them once
+      // without polling at all, so a long window would leave a user who has
+      // already sent a trace looking at the "connect your app" guide. One
+      // extra poll of latency buys collapsing an entire trace's spans, which
+      // for an established project are all no-ops anyway.
+      //
+      // The lane above and the window here are the two halves of one
+      // behaviour: the lane lets a project's concurrent traces share a dedup
+      // key at all, the window gives that key long enough to collapse them.
+      ...throttledPerWindow({
+        makeJobId: (payload) => `project-meta:${payload.event.tenantId}`,
+        windowMs: PROJECT_METADATA_WINDOW_MS,
+      }),
     },
 
     async handle(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
@@ -4,6 +4,7 @@ import type {
   ReactorContext,
   ReactorDefinition,
 } from "../../../reactors/reactor.types";
+import { throttledPerWindow } from "../../../reactors/throttleWindow";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../schemas/events";
 
@@ -15,6 +16,9 @@ export interface TraceUpdateBroadcastReactorDeps {
   broadcast: BroadcastService;
   hasRedis?: boolean;
 }
+
+/** Mirrors the listener-side debounce so the two windows do not stack. */
+export const TRACE_UPDATE_BROADCAST_WINDOW_MS = 2_000;
 
 /**
  * Reactor that broadcasts trace updates to connected SSE clients.
@@ -32,9 +36,17 @@ export function createTraceUpdateBroadcastReactor(
       runIn: ["worker"],
       // Without Redis, worker-to-web pub/sub bridge is unavailable
       disabled: deps.hasRedis === false,
-      makeJobId: (payload) =>
-        `trace-update:${payload.event.tenantId}:${payload.event.aggregateId}`,
-      ttl: 30_000, // Debounce broadcasts — frontend already debounces duplicate events
+      // Deliberately short. Nothing polls behind this while the live stream is
+      // connected, so the window is the whole latency a watching user sees;
+      // it matches the debounce the listener already applies, which puts the
+      // collapsing on the side that can drop the work instead of the side that
+      // has already paid to deliver it. Level-triggered, so surviveDispatch
+      // stays off and the final update always arrives.
+      ...throttledPerWindow({
+        makeJobId: (payload) =>
+          `trace-update:${payload.event.tenantId}:${payload.event.aggregateId}`,
+        windowMs: TRACE_UPDATE_BROADCAST_WINDOW_MS,
+      }),
     },
 
     async handle(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
@@ -40,7 +40,7 @@ export function createTraceUpdateBroadcastReactor(
       // connected, so the window is the whole latency a watching user sees;
       // it matches the debounce the listener already applies, which puts the
       // collapsing on the side that can drop the work instead of the side that
-      // has already paid to deliver it. Level-triggered, so surviveDispatch
+      // has already paid to deliver it. Level-triggered, so shouldSurviveDispatch
       // stays off and the final update always arrives.
       ...throttledPerWindow({
         makeJobId: (payload) =>

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor.ts
@@ -17,7 +17,13 @@ export interface TraceUpdateBroadcastReactorDeps {
   hasRedis?: boolean;
 }
 
-/** Mirrors the listener-side debounce so the two windows do not stack. */
+/**
+ * Sized to match the debounce the listener already applies, so neither side
+ * dominates. The two are sequential, not shared: this window can hold a
+ * broadcast for up to 2s and the listener can then debounce it for up to 2s
+ * more, so a watching user sees at most ~4s between a span landing and the
+ * view reacting. That is the number to weigh before widening either one.
+ */
 export const TRACE_UPDATE_BROADCAST_WINDOW_MS = 2_000;
 
 /**
@@ -36,12 +42,13 @@ export function createTraceUpdateBroadcastReactor(
       runIn: ["worker"],
       // Without Redis, worker-to-web pub/sub bridge is unavailable
       disabled: deps.hasRedis === false,
-      // Deliberately short. Nothing polls behind this while the live stream is
-      // connected, so the window is the whole latency a watching user sees;
-      // it matches the debounce the listener already applies, which puts the
-      // collapsing on the side that can drop the work instead of the side that
-      // has already paid to deliver it. Level-triggered, so shouldSurviveDispatch
-      // stays off and the final update always arrives.
+      // Deliberately short. Nothing polls behind this while the live stream
+      // is connected, so this window plus the listener's own debounce is the
+      // whole latency a watching user sees — see the constant for the
+      // combined figure. Collapsing here rather than only in the listener
+      // puts it on the side that can skip the work instead of the side that
+      // has already paid to deliver it. Level-triggered, so
+      // shouldSurviveDispatch stays off and the final update always arrives.
       ...throttledPerWindow({
         makeJobId: (payload) =>
           `trace-update:${payload.event.tenantId}:${payload.event.aggregateId}`,

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
@@ -328,17 +328,22 @@ describe("billingMeterDispatchReactor", () => {
   });
 
   describe("options", () => {
-    it("configures runIn, makeJobId, and ttl", async () => {
-      const { createBillingMeterDispatchReactor } = await import(
-        "../billingMeterDispatch.reactor"
-      );
+    it("configures runIn, makeJobId, and its suppression window", async () => {
+      const {
+        BILLING_METER_DISPATCH_SUPPRESS_MS,
+        BILLING_METER_DISPATCH_WINDOW_MS,
+        createBillingMeterDispatchReactor,
+      } = await import("../billingMeterDispatch.reactor");
 
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => vi.fn(),
       });
 
       expect(reactor.options?.runIn).toEqual(["worker"]);
-      expect(reactor.options?.ttl).toBe(300_000);
+      expect(reactor.options?.delay).toBe(BILLING_METER_DISPATCH_WINDOW_MS);
+      expect(reactor.options?.deduplication?.ttlMs).toBe(
+        BILLING_METER_DISPATCH_SUPPRESS_MS,
+      );
 
       const payload = { event: makeEvent("proj-1"), foldState: {} };
       expect(reactor.options?.makeJobId?.(payload)).toBe(

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
@@ -328,10 +328,9 @@ describe("billingMeterDispatchReactor", () => {
   });
 
   describe("options", () => {
-    it("configures runIn, makeJobId, and its suppression window", async () => {
+    it("configures runIn, makeJobId, and an immediate per-project dedup", async () => {
       const {
         BILLING_METER_DISPATCH_SUPPRESS_MS,
-        BILLING_METER_DISPATCH_WINDOW_MS,
         createBillingMeterDispatchReactor,
       } = await import("../billingMeterDispatch.reactor");
 
@@ -340,10 +339,10 @@ describe("billingMeterDispatchReactor", () => {
       });
 
       expect(reactor.options?.runIn).toEqual(["worker"]);
-      expect(reactor.options?.delay).toBe(BILLING_METER_DISPATCH_WINDOW_MS);
-      expect(reactor.options?.deduplication?.ttlMs).toBe(
-        BILLING_METER_DISPATCH_SUPPRESS_MS,
-      );
+      // No delay: the handler derives its billing month from the clock, so
+      // holding a trigger would move the decision along with the work.
+      expect(reactor.options?.delay ?? 0).toBe(0);
+      expect(reactor.options?.ttl).toBe(BILLING_METER_DISPATCH_SUPPRESS_MS);
 
       const payload = { event: makeEvent("proj-1"), foldState: {} };
       expect(reactor.options?.makeJobId?.(payload)).toBe(

--- a/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
@@ -86,7 +86,7 @@ export function createBillingMeterDispatchReactor(deps: {
         makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
         windowMs: BILLING_METER_DISPATCH_WINDOW_MS,
         dedupTtlMs: BILLING_METER_DISPATCH_SUPPRESS_MS,
-        surviveDispatch: true,
+        shouldSurviveDispatch: true,
       }),
     },
 

--- a/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
@@ -7,19 +7,15 @@ import {
 import type { Event } from "../../domain/types";
 import type { ReportUsageForMonthCommandData } from "../../pipelines/billing-reporting/schemas/commands";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
-import { throttledPerWindow } from "../../reactors/throttleWindow";
 
 const logger = createLogger("langwatch:billing:meterDispatch");
 
 /** Number of days at the start of a new month to also check the previous month. */
 const GRACE_PERIOD_DAYS = 3;
 
-/** How long a project's events are held before one dispatch is sent. */
-export const BILLING_METER_DISPATCH_WINDOW_MS = 30_000;
-
 /**
- * How long a project stays suppressed after dispatching. Sized to the
- * downstream command's own dedup window so the two agree on the rate.
+ * How long a project's dedup key lives. Sized to the downstream command's own
+ * dedup window so the two agree on the rate.
  */
 export const BILLING_METER_DISPATCH_SUPPRESS_MS = 300_000;
 
@@ -70,24 +66,21 @@ export function createBillingMeterDispatchReactor(deps: {
     options: {
       runIn: ["worker"],
       groupKeyFn: (payload) => billingMeterDispatchGroupKey(payload.event),
-      // The only reactor here that may keep suppressing after it fires. The
-      // handler reads nothing from the event it was handed — it resolves the
-      // org and the current billing month from the clock — so every trigger
-      // in the window is genuinely the same work, and discarding the later
-      // ones cannot strand any state. That makes the per-project suppression
-      // this reactor always documented finally take effect: without it the
-      // dedup key is dropped the moment the job dispatches and the very next
-      // event re-triggers.
+      // Deliberately fires immediately, unlike the other level-triggered
+      // reactors. `handle` decides which billing months to report by reading
+      // the WALL CLOCK at the moment it runs, not the event it was given, so
+      // holding a trigger moves the decision as well as the work. A trigger
+      // arriving in the last seconds of the third grace day would run on the
+      // fourth and silently drop the previous month's dispatch — a missed
+      // report rather than a late one, since the next grace window covers a
+      // different month.
       //
-      // The lane above and the window here are the two halves of one
-      // behaviour: the lane lets a project's concurrent traces share a dedup
-      // key at all, the window gives that key long enough to collapse them.
-      ...throttledPerWindow({
-        makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
-        windowMs: BILLING_METER_DISPATCH_WINDOW_MS,
-        dedupTtlMs: BILLING_METER_DISPATCH_SUPPRESS_MS,
-        shouldSurviveDispatch: true,
-      }),
+      // A window here is safe once the month and grace decision come from the
+      // triggering event instead of the clock. Until then this reactor relies
+      // on the per-project lane above, which collapses a project's concurrent
+      // traces without deferring anything.
+      makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
+      ttl: BILLING_METER_DISPATCH_SUPPRESS_MS,
     },
 
     async handle(event, context) {

--- a/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/billingMeterDispatch.reactor.ts
@@ -7,11 +7,21 @@ import {
 import type { Event } from "../../domain/types";
 import type { ReportUsageForMonthCommandData } from "../../pipelines/billing-reporting/schemas/commands";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
+import { throttledPerWindow } from "../../reactors/throttleWindow";
 
 const logger = createLogger("langwatch:billing:meterDispatch");
 
 /** Number of days at the start of a new month to also check the previous month. */
 const GRACE_PERIOD_DAYS = 3;
+
+/** How long a project's events are held before one dispatch is sent. */
+export const BILLING_METER_DISPATCH_WINDOW_MS = 30_000;
+
+/**
+ * How long a project stays suppressed after dispatching. Sized to the
+ * downstream command's own dedup window so the two agree on the rate.
+ */
+export const BILLING_METER_DISPATCH_SUPPRESS_MS = 300_000;
 
 /**
  * One queue lane per project, matching this reactor's per-project dedup id.
@@ -60,8 +70,24 @@ export function createBillingMeterDispatchReactor(deps: {
     options: {
       runIn: ["worker"],
       groupKeyFn: (payload) => billingMeterDispatchGroupKey(payload.event),
-      makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
-      ttl: 300_000,
+      // The only reactor here that may keep suppressing after it fires. The
+      // handler reads nothing from the event it was handed — it resolves the
+      // org and the current billing month from the clock — so every trigger
+      // in the window is genuinely the same work, and discarding the later
+      // ones cannot strand any state. That makes the per-project suppression
+      // this reactor always documented finally take effect: without it the
+      // dedup key is dropped the moment the job dispatches and the very next
+      // event re-triggers.
+      //
+      // The lane above and the window here are the two halves of one
+      // behaviour: the lane lets a project's concurrent traces share a dedup
+      // key at all, the window gives that key long enough to collapse them.
+      ...throttledPerWindow({
+        makeJobId: (payload) => `billing_dispatch_${payload.event.tenantId}`,
+        windowMs: BILLING_METER_DISPATCH_WINDOW_MS,
+        dedupTtlMs: BILLING_METER_DISPATCH_SUPPRESS_MS,
+        surviveDispatch: true,
+      }),
     },
 
     async handle(event, context) {

--- a/langwatch/src/server/event-sourcing/queues/__tests__/memory.throttleWindow.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/__tests__/memory.throttleWindow.unit.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { EventSourcedQueueProcessorMemory } from "../memory";
+
+type Payload = { id: string; value: string };
+
+const settle = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The throttle contract the reactors rely on has to hold on the in-memory
+ * queue too, not only on the Redis one — memory mode is a supported
+ * single-process deployment, and a window that silently does nothing there
+ * would let every event through while the code reads as if it were throttled.
+ *
+ * These drive the queue itself rather than asserting on option objects: what
+ * matters is which payloads the processor is actually handed, and when.
+ */
+describe("EventSourcedQueueProcessorMemory throttle window", () => {
+  function createQueue({
+    windowMs,
+    ttlMs = windowMs,
+    extend = false,
+    shouldSurviveDispatch = false,
+    concurrency = 5,
+  }: {
+    windowMs: number;
+    ttlMs?: number;
+    extend?: boolean;
+    shouldSurviveDispatch?: boolean;
+    concurrency?: number;
+  }) {
+    const processed: string[] = [];
+    const queue = new EventSourcedQueueProcessorMemory<Payload>({
+      name: "test-queue",
+      process: async (payload) => {
+        processed.push(payload.value);
+      },
+      delay: windowMs,
+      deduplication: {
+        makeId: (payload) => payload.id,
+        ttlMs,
+        extend,
+        replace: true,
+        shouldSurviveDispatch,
+      },
+      options: { concurrency },
+    });
+    return { queue, processed };
+  }
+
+  describe("given two sends sharing a dedup id inside the window", () => {
+    describe("when the window elapses", () => {
+      it("hands the processor only the latest payload", async () => {
+        const { queue, processed } = createQueue({ windowMs: 60 });
+
+        // Not awaited individually: a send settles when its job finishes, so
+        // awaiting the first would close the window before the second lands.
+        const sends = Promise.all([
+          queue.send({ id: "same", value: "first" }),
+          queue.send({ id: "same", value: "latest" }),
+        ]);
+
+        await settle(150);
+        await sends;
+
+        expect(processed).toEqual(["latest"]);
+        await queue.close();
+      });
+    });
+  });
+
+  describe("given sends with different dedup ids", () => {
+    it("keeps them as separate jobs", async () => {
+      const { queue, processed } = createQueue({ windowMs: 40 });
+
+      const sends = Promise.all([
+        queue.send({ id: "a", value: "a" }),
+        queue.send({ id: "b", value: "b" }),
+      ]);
+
+      await settle(140);
+      await sends;
+
+      expect(processed.sort()).toEqual(["a", "b"]);
+      await queue.close();
+    });
+  });
+
+  describe("given a job is still waiting out its window", () => {
+    it("does not hold a concurrency slot while it waits", async () => {
+      // One slot, one delayed job. An undelayed job sent afterwards must
+      // still run: if the delayed one occupied the slot while sleeping it
+      // would block everything behind it for the whole window.
+      const processed: string[] = [];
+      const queue = new EventSourcedQueueProcessorMemory<Payload>({
+        name: "test-queue",
+        process: async (payload) => {
+          processed.push(payload.value);
+        },
+        options: { concurrency: 1 },
+      });
+
+      const delayed = queue
+        .send({ id: "slow", value: "delayed" }, { delay: 200 })
+        .catch(() => {
+          // Rejected by close() below; the point is only that it never
+          // blocked the slot.
+        });
+      await queue.send({ id: "fast", value: "immediate" });
+
+      await settle(60);
+
+      expect(processed).toEqual(["immediate"]);
+      await queue.close();
+      await delayed;
+    });
+  });
+
+  describe("given the window is pinned rather than extending", () => {
+    it("fires once even while sends keep arriving", async () => {
+      // A stream arriving faster than the window must not defer its own job
+      // forever. With extend off the deadline stays where the first send put
+      // it, so the job lands mid-stream.
+      const { queue, processed } = createQueue({ windowMs: 80 });
+
+      const stream = (async () => {
+        for (let i = 0; i < 8; i++) {
+          await queue.send({ id: "same", value: `v${i}` });
+          await settle(20);
+        }
+      })();
+
+      await settle(140);
+      expect(processed.length).toBeGreaterThan(0);
+
+      await stream;
+      await queue.close();
+    });
+  });
+
+  describe("given a send arrives after its job dispatched", () => {
+    describe("when the dedup id does not survive dispatch", () => {
+      it("stages a genuinely new job", async () => {
+        const { queue, processed } = createQueue({ windowMs: 30 });
+
+        await queue.send({ id: "same", value: "first" });
+        await settle(120);
+        const second = queue.send({ id: "same", value: "second" });
+        await settle(120);
+        await second;
+
+        expect(processed).toEqual(["first", "second"]);
+        await queue.close();
+      });
+    });
+
+    describe("when the dedup id survives dispatch", () => {
+      it("discards the send for the rest of the ttl", async () => {
+        // The suppression has to outlast the firing window for there to be
+        // anything to suppress, which is exactly how the real caller sizes it.
+        const { queue, processed } = createQueue({
+          windowMs: 30,
+          ttlMs: 500,
+          shouldSurviveDispatch: true,
+        });
+
+        const first = queue.send({ id: "same", value: "first" });
+        await settle(120);
+        await first;
+
+        await queue.send({ id: "same", value: "suppressed" });
+        await settle(120);
+
+        expect(processed).toEqual(["first"]);
+        await queue.close();
+      });
+    });
+  });
+
+  describe("given the processor rejects", () => {
+    it("rejects the send so the caller can retry the collapsed job", async () => {
+      // The window leaves one job standing for a whole burst, so a swallowed
+      // failure loses the burst rather than one attempt at it.
+      const queue = new EventSourcedQueueProcessorMemory<Payload>({
+        name: "test-queue",
+        process: async () => {
+          throw new Error("insert failed");
+        },
+        delay: 20,
+        deduplication: { makeId: (payload) => payload.id, ttlMs: 20 },
+      });
+
+      await expect(queue.send({ id: "same", value: "only" })).rejects.toThrow(
+        "insert failed",
+      );
+
+      await queue.close();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/memory.ts
+++ b/langwatch/src/server/event-sourcing/queues/memory.ts
@@ -13,7 +13,15 @@ interface QueuedJob<Payload> {
   payload: Payload;
   jobId: string;
   deduplicationId?: string;
-  delay?: number;
+  /**
+   * Wall-clock time this job becomes eligible to run. A delayed job WAITS IN
+   * THE QUEUE rather than in a worker slot, so it stays visible to the dedup
+   * map for its whole window and cannot squat on the concurrency limit.
+   */
+  dispatchAt: number;
+  /** Wall-clock time the dedup id stops absorbing new sends. */
+  dedupExpiresAt?: number;
+  shouldSurviveDispatch?: boolean;
   resolve: () => void;
   reject: (error: Error) => void;
 }
@@ -52,7 +60,15 @@ export class EventSourcedQueueProcessorMemory<
     string,
     QueuedJob<Payload>
   >();
+  /**
+   * Dedup ids whose job already dispatched but whose TTL is still running,
+   * for senders that asked to survive dispatch. Mirrors the GroupQueue Lua's
+   * opt-in branch: without it a dispatched key is stale and restages.
+   */
+  private readonly suppressedUntilByDeduplicationId = new Map<string, number>();
   private activeCount = 0;
+  private dispatchTimer: ReturnType<typeof setTimeout> | null = null;
+  private dispatchTimerAt = Number.POSITIVE_INFINITY;
 
   constructor(definition: EventSourcedQueueDefinition<Payload>) {
     const { name, process, spanAttributes, deduplication, delay, options } =
@@ -96,24 +112,53 @@ export class EventSourcedQueueProcessorMemory<
     const jobId = this.generateJobId(payload);
     const deduplicationId = dedup?.makeId(payload);
 
+    const now = Date.now();
+    const dispatchAt = now + (effectiveDelay ?? 0);
+    const dedupExpiresAt =
+      dedup?.ttlMs === undefined ? undefined : now + dedup.ttlMs;
+
     // Simple job deduplication: squash onto existing job with same deduplication ID
     if (deduplicationId) {
+      const suppressedUntil =
+        this.suppressedUntilByDeduplicationId.get(deduplicationId);
+      if (suppressedUntil !== undefined) {
+        if (suppressedUntil > now) {
+          this.logger.debug(
+            { queueName: this.queueName, jobId, deduplicationId },
+            "Discarded send: dedup id still suppressed after dispatch",
+          );
+          return;
+        }
+        this.suppressedUntilByDeduplicationId.delete(deduplicationId);
+      }
+
       const existingJob =
         this.pendingJobsByDeduplicationId.get(deduplicationId);
       if (existingJob) {
-        const shouldReplace = dedup?.replace !== false;
-        const shouldExtend = dedup?.extend !== false;
-        if (shouldReplace) {
-          existingJob.payload = payload;
+        const expired =
+          existingJob.dedupExpiresAt !== undefined &&
+          existingJob.dedupExpiresAt <= now;
+        if (expired) {
+          // The window closed while the job waited. It still runs, but it
+          // stops absorbing sends so this one stages as genuinely new.
+          this.pendingJobsByDeduplicationId.delete(deduplicationId);
+        } else {
+          if (dedup?.replace !== false) {
+            existingJob.payload = payload;
+          }
+          // `extend` moves the DEADLINE, matching GroupQueue. Left off, the
+          // window stays pinned to the send that opened it, so a continuous
+          // stream cannot defer its own job indefinitely.
+          if (dedup?.extend !== false) {
+            existingJob.dispatchAt = dispatchAt;
+            existingJob.dedupExpiresAt = dedupExpiresAt;
+          }
+          this.logger.debug(
+            { queueName: this.queueName, jobId, deduplicationId },
+            "Squashed onto existing job with same deduplication ID",
+          );
+          return;
         }
-        if (shouldExtend) {
-          existingJob.delay = effectiveDelay;
-        }
-        this.logger.debug(
-          { queueName: this.queueName, jobId, deduplicationId },
-          "Squashed onto existing job with same deduplication ID",
-        );
-        return;
       }
     }
 
@@ -123,7 +168,9 @@ export class EventSourcedQueueProcessorMemory<
         payload,
         jobId,
         deduplicationId,
-        delay: effectiveDelay,
+        dispatchAt,
+        dedupExpiresAt,
+        shouldSurviveDispatch: dedup?.shouldSurviveDispatch === true,
         resolve,
         reject,
       };
@@ -155,16 +202,30 @@ export class EventSourcedQueueProcessorMemory<
       return;
     }
 
-    const job = this.queue.shift();
+    const now = Date.now();
+    const { readyIndex, earliestPending } = this.findDueJob(now);
+
+    if (readyIndex === -1) {
+      this.scheduleWake(earliestPending - now);
+      return;
+    }
+
+    const [job] = this.queue.splice(readyIndex, 1);
     if (!job) {
       return;
     }
 
-    // Remove dedup entry when job leaves staging — new sends with the same
-    // dedup ID should create a genuinely new job, not squash onto a job
-    // that's already being processed (same TOCTOU fix as GroupQueue Lua).
+    // Release the dedup entry only now, as the job actually leaves staging —
+    // new sends with the same id should squash for the whole window and only
+    // then create a genuinely new job (same TOCTOU fix as GroupQueue Lua).
     if (job.deduplicationId) {
       this.pendingJobsByDeduplicationId.delete(job.deduplicationId);
+      if (job.shouldSurviveDispatch && job.dedupExpiresAt !== undefined) {
+        this.suppressedUntilByDeduplicationId.set(
+          job.deduplicationId,
+          job.dedupExpiresAt,
+        );
+      }
     }
 
     this.activeCount++;
@@ -176,15 +237,57 @@ export class EventSourcedQueueProcessorMemory<
   }
 
   /**
-   * Processes a single job with tracing and error handling.
+   * First job whose deadline has passed, keeping FIFO among the ready ones,
+   * plus when the earliest not-yet-due job becomes eligible.
+   *
+   * A job that is not due yet stays in the queue: waiting inside a worker slot
+   * would hold the slot for the whole delay and, on a queue shared by every
+   * handler in memory mode, starve everything behind it.
+   */
+  private findDueJob(now: number): {
+    readyIndex: number;
+    earliestPending: number;
+  } {
+    let earliestPending = Number.POSITIVE_INFINITY;
+    for (const [index, queued] of this.queue.entries()) {
+      if (queued.dispatchAt <= now) {
+        return { readyIndex: index, earliestPending };
+      }
+      earliestPending = Math.min(earliestPending, queued.dispatchAt);
+    }
+    return { readyIndex: -1, earliestPending };
+  }
+
+  /**
+   * Wakes the scheduler when the earliest not-yet-due job becomes eligible.
+   * Keeps at most one timer, moving it earlier when a nearer job arrives.
+   */
+  private scheduleWake(delayMs: number): void {
+    const wakeAt = Date.now() + Math.max(0, delayMs);
+    if (this.dispatchTimer !== null && this.dispatchTimerAt <= wakeAt) {
+      return;
+    }
+    if (this.dispatchTimer !== null) {
+      clearTimeout(this.dispatchTimer);
+    }
+    this.dispatchTimerAt = wakeAt;
+    this.dispatchTimer = setTimeout(
+      () => {
+        this.dispatchTimer = null;
+        this.dispatchTimerAt = Number.POSITIVE_INFINITY;
+        this.tryProcessNext();
+      },
+      Math.max(0, delayMs),
+    );
+    // Never hold the process open just to fire a delayed job.
+    this.dispatchTimer.unref?.();
+  }
+
+  /**
+   * Processes a single job with tracing and error handling. The delay is
+   * already spent — the scheduler holds a job in the queue until it is due.
    */
   private async processJob(job: QueuedJob<Payload>): Promise<void> {
-    // Apply delay if configured (per-job delay takes precedence over instance delay)
-    const delay = job.delay;
-    if (delay && delay > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delay));
-    }
-
     const baseAttributes: Record<string, string | number | boolean> = {
       "queue.name": this.queueName,
       "queue.job_id": job.jobId ?? "unknown",
@@ -267,6 +370,12 @@ export class EventSourcedQueueProcessorMemory<
       "Closing memory queue processor",
     );
 
+    if (this.dispatchTimer !== null) {
+      clearTimeout(this.dispatchTimer);
+      this.dispatchTimer = null;
+      this.dispatchTimerAt = Number.POSITIVE_INFINITY;
+    }
+
     // Wait for active jobs to complete (simple polling since we don't track promises)
     while (this.activeCount > 0) {
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -282,6 +391,7 @@ export class EventSourcedQueueProcessorMemory<
     }
     this.queue.length = 0;
     this.pendingJobsByDeduplicationId.clear();
+    this.suppressedUntilByDeduplicationId.clear();
 
     this.logger.debug(
       { queueName: this.queueName },

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
@@ -20,46 +20,90 @@ import type { ReactorDefinition } from "../reactor.types";
 
 const anyDeps = {} as never;
 
-/** Every reactor that holds events in a window, with the window it uses. */
-const windowed: { name: string; reactor: ReactorDefinition<never, never> }[] = [
+/** The policy only ever reads `options`, so the generic parameters do not matter. */
+type AnyReactor = ReactorDefinition<never, never>;
+
+/**
+ * Every reactor that holds events in a window, with the window it must use.
+ *
+ * The numbers are the point of the policy, not an implementation detail: each
+ * one was chosen against a specific consumer's tolerance, and widening it
+ * silently is how a reactor starts costing a user latency nobody signed off
+ * on. They are written as literals here so changing one has to change this
+ * table too, next to the reason it is what it is.
+ */
+const windowed = [
   {
     name: "traceUpdateBroadcast",
+    // Nothing polls behind it while the live stream is connected.
+    windowMs: 2_000,
+    dedupTtlMs: 2_000,
     reactor: createTraceUpdateBroadcastReactor({
       broadcast: anyDeps,
       hasRedis: true,
-    }) as never,
+    }) as unknown as AnyReactor,
   },
   {
     name: "projectMetadata",
-    reactor: createProjectMetadataReactor({ projects: anyDeps }) as never,
+    // Roughly one poll of the onboarding screen waiting on its flags.
+    windowMs: 3_000,
+    dedupTtlMs: 3_000,
+    reactor: createProjectMetadataReactor({
+      projects: anyDeps,
+    }) as unknown as AnyReactor,
   },
   {
     name: "governanceKpisSync",
-    reactor: createGovernanceKpisSyncReactor(anyDeps) as never,
+    // Hour-bucketed rows read by a five-minute worker.
+    windowMs: 30_000,
+    dedupTtlMs: 30_000,
+    reactor: createGovernanceKpisSyncReactor(anyDeps) as unknown as AnyReactor,
   },
   {
     name: "governanceOcsfEventsSync",
-    reactor: createGovernanceOcsfEventsSyncReactor(anyDeps) as never,
+    // Cursor-paginated export pulls pick up a late row on the next pass.
+    windowMs: 30_000,
+    dedupTtlMs: 30_000,
+    reactor: createGovernanceOcsfEventsSyncReactor(
+      anyDeps,
+    ) as unknown as AnyReactor,
   },
   {
     name: "billingMeterDispatch",
+    // Suppression outlives the window here, sized to the downstream command's
+    // own dedup so the two agree on the rate.
+    windowMs: 30_000,
+    dedupTtlMs: 300_000,
     reactor: createBillingMeterDispatchReactor({
       getDispatch: () => async () => {},
-    }) as never,
+    }) as unknown as AnyReactor,
   },
-];
+] as const satisfies readonly {
+  name: string;
+  windowMs: number;
+  dedupTtlMs: number;
+  reactor: AnyReactor;
+}[];
 
 describe("reactor throttle policy", () => {
-  describe.each(windowed)("given the $name reactor", ({ reactor }) => {
-    it("holds events for a window instead of firing on every event", () => {
-      expect(reactor.options?.delay).toBeGreaterThan(0);
+  describe.each(windowed)("given the $name reactor", ({
+    reactor,
+    windowMs,
+    dedupTtlMs,
+  }) => {
+    it("holds events for exactly the window the policy assigns it", () => {
+      expect(reactor.options?.delay).toBe(windowMs);
     });
 
     it("pins the window's deadline so a continuous stream cannot defer it forever", () => {
       expect(reactor.options?.deduplication?.extend).toBe(false);
     });
 
-    it("keeps a dedup ttl at least as long as the window, so the key outlives the wait", () => {
+    it("keeps its dedup key alive for exactly the suppression the policy assigns it", () => {
+      expect(reactor.options?.deduplication?.ttlMs).toBe(dedupTtlMs);
+    });
+
+    it("never lets the key expire before the job it is holding dispatches", () => {
       const { delay, deduplication } = reactor.options!;
       expect(deduplication?.ttlMs).toBeGreaterThanOrEqual(delay!);
     });

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
@@ -141,5 +141,20 @@ describe("reactor throttle policy", () => {
 
       expect(reactor.options?.delay ?? 0).toBe(0);
     });
+
+    it("never suppresses a billing trigger after one has dispatched", () => {
+      // Its dedup TTL outlives a dispatch, so if the key ALSO survived
+      // dispatch a trigger just after a UTC month rollover could be discarded
+      // and that month's first report skipped. Post-dispatch suppression is
+      // opt-in, and this reactor must never opt in while the handler decides
+      // its billing month from the clock.
+      const reactor = createBillingMeterDispatchReactor({
+        getDispatch: () => async () => {},
+      });
+
+      expect(
+        reactor.options?.deduplication?.shouldSurviveDispatch ?? false,
+      ).toBe(false);
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { createGatewayBudgetSyncReactor } from "@ee/governance/reactors/gatewayBudgetSync.reactor";
+import { createGovernanceKpisSyncReactor } from "@ee/governance/reactors/governanceKpisSync.reactor";
+import { createGovernanceOcsfEventsSyncReactor } from "@ee/governance/reactors/governanceOcsfEventsSync.reactor";
+import { createProjectMetadataReactor } from "../../pipelines/trace-processing/reactors/projectMetadata.reactor";
+import { createSpanStorageBroadcastReactor } from "../../pipelines/trace-processing/reactors/spanStorageBroadcast.reactor";
+import { createTraceUpdateBroadcastReactor } from "../../pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor";
+import { createBillingMeterDispatchReactor } from "../../projections/global/billingMeterDispatch.reactor";
+import type { ReactorDefinition } from "../reactor.types";
+
+const anyDeps = {} as never;
+
+/** Every reactor that holds events in a window, with the window it uses. */
+const windowed: { name: string; reactor: ReactorDefinition<never, never> }[] = [
+  {
+    name: "traceUpdateBroadcast",
+    reactor: createTraceUpdateBroadcastReactor({
+      broadcast: anyDeps,
+      hasRedis: true,
+    }) as never,
+  },
+  {
+    name: "projectMetadata",
+    reactor: createProjectMetadataReactor({ projects: anyDeps }) as never,
+  },
+  {
+    name: "governanceKpisSync",
+    reactor: createGovernanceKpisSyncReactor(anyDeps) as never,
+  },
+  {
+    name: "governanceOcsfEventsSync",
+    reactor: createGovernanceOcsfEventsSyncReactor(anyDeps) as never,
+  },
+  {
+    name: "billingMeterDispatch",
+    reactor: createBillingMeterDispatchReactor({
+      getDispatch: () => async () => {},
+    }) as never,
+  },
+];
+
+describe("reactor throttle policy", () => {
+  describe.each(windowed)("given the $name reactor", ({ reactor }) => {
+    it("holds events for a window instead of firing on every event", () => {
+      expect(reactor.options?.delay).toBeGreaterThan(0);
+    });
+
+    it("pins the window's deadline so a continuous stream cannot defer it forever", () => {
+      expect(reactor.options?.deduplication?.extend).toBe(false);
+    });
+
+    it("keeps a dedup ttl at least as long as the window, so the key outlives the wait", () => {
+      const { delay, deduplication } = reactor.options!;
+      expect(deduplication?.ttlMs).toBeGreaterThanOrEqual(delay!);
+    });
+
+    it("collapses on the same job id the router collapses on", () => {
+      expect(reactor.options?.makeJobId).toBe(
+        reactor.options?.deduplication?.makeId,
+      );
+    });
+  });
+
+  describe("given work whose result depends on the event that triggered it", () => {
+    // These rebuild their output from the fold's running state, or notify a
+    // client that the state moved. Dropping the LAST event of an aggregate
+    // would leave the previous partial write as the final answer.
+    const levelTriggered = windowed.filter(
+      ({ name }) => name !== "billingMeterDispatch",
+    );
+
+    it.each(levelTriggered)("lets $name re-trigger after it fires", ({
+      reactor,
+    }) => {
+      expect(reactor.options?.deduplication?.shouldSurviveDispatch).toBe(false);
+    });
+  });
+
+  describe("given work that reads nothing from its triggering event", () => {
+    it("keeps billingMeterDispatch suppressed for the rest of its window", () => {
+      const reactor = createBillingMeterDispatchReactor({
+        getDispatch: () => async () => {},
+      });
+
+      expect(reactor.options?.deduplication?.shouldSurviveDispatch).toBe(true);
+    });
+  });
+
+  describe("given a consumer that cannot absorb added latency", () => {
+    // Both are deliberately excluded. Read the comment on each reactor before
+    // adding a window here — the reasons are specific, not incidental.
+    it("leaves gatewayBudgetSync firing immediately, because a budget block reads what it writes", () => {
+      const reactor = createGatewayBudgetSyncReactor(anyDeps);
+
+      expect(reactor.options?.delay ?? 0).toBe(0);
+    });
+
+    it("leaves spanStorageBroadcast firing immediately, because nothing polls behind it while a trace is open", () => {
+      const reactor = createSpanStorageBroadcastReactor({
+        broadcast: anyDeps,
+        hasRedis: true,
+      });
+
+      expect(reactor.options?.delay ?? 0).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/reactorThrottlePolicy.unit.test.ts
@@ -68,16 +68,6 @@ const windowed = [
       anyDeps,
     ) as unknown as AnyReactor,
   },
-  {
-    name: "billingMeterDispatch",
-    // Suppression outlives the window here, sized to the downstream command's
-    // own dedup so the two agree on the rate.
-    windowMs: 30_000,
-    dedupTtlMs: 300_000,
-    reactor: createBillingMeterDispatchReactor({
-      getDispatch: () => async () => {},
-    }) as unknown as AnyReactor,
-  },
 ] as const satisfies readonly {
   name: string;
   windowMs: number;
@@ -119,24 +109,8 @@ describe("reactor throttle policy", () => {
     // These rebuild their output from the fold's running state, or notify a
     // client that the state moved. Dropping the LAST event of an aggregate
     // would leave the previous partial write as the final answer.
-    const levelTriggered = windowed.filter(
-      ({ name }) => name !== "billingMeterDispatch",
-    );
-
-    it.each(levelTriggered)("lets $name re-trigger after it fires", ({
-      reactor,
-    }) => {
+    it.each(windowed)("lets $name re-trigger after it fires", ({ reactor }) => {
       expect(reactor.options?.deduplication?.shouldSurviveDispatch).toBe(false);
-    });
-  });
-
-  describe("given work that reads nothing from its triggering event", () => {
-    it("keeps billingMeterDispatch suppressed for the rest of its window", () => {
-      const reactor = createBillingMeterDispatchReactor({
-        getDispatch: () => async () => {},
-      });
-
-      expect(reactor.options?.deduplication?.shouldSurviveDispatch).toBe(true);
     });
   });
 
@@ -153,6 +127,16 @@ describe("reactor throttle policy", () => {
       const reactor = createSpanStorageBroadcastReactor({
         broadcast: anyDeps,
         hasRedis: true,
+      });
+
+      expect(reactor.options?.delay ?? 0).toBe(0);
+    });
+
+    it("leaves billingMeterDispatch firing immediately, because its handler reads the clock rather than the event", () => {
+      // Holding a trigger moves the billing-month and grace-period decision
+      // with it, so a delay can turn a late report into a missing one.
+      const reactor = createBillingMeterDispatchReactor({
+        getDispatch: () => async () => {},
       });
 
       expect(reactor.options?.delay ?? 0).toBe(0);

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/throttleWindow.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/throttleWindow.unit.test.ts
@@ -82,7 +82,7 @@ describe("throttledPerWindow", () => {
         throttledPerWindow({
           makeJobId,
           windowMs: 5_000,
-          surviveDispatch: true,
+          shouldSurviveDispatch: true,
         }).deduplication?.shouldSurviveDispatch,
       ).toBe(true);
     });

--- a/langwatch/src/server/event-sourcing/reactors/__tests__/throttleWindow.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/reactors/__tests__/throttleWindow.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { ReactorJobPayload } from "../throttleWindow";
+import { throttledPerWindow } from "../throttleWindow";
+
+const makeJobId = (payload: ReactorJobPayload) =>
+  `job:${payload.event.tenantId}`;
+
+describe("throttledPerWindow", () => {
+  describe("given a window", () => {
+    it("delays dispatch by the window so events have something to collapse into", () => {
+      expect(throttledPerWindow({ makeJobId, windowMs: 5_000 }).delay).toBe(
+        5_000,
+      );
+    });
+
+    it("defaults the dedup ttl to the window", () => {
+      expect(
+        throttledPerWindow({ makeJobId, windowMs: 5_000 }).deduplication?.ttlMs,
+      ).toBe(5_000);
+    });
+
+    describe("when the suppression must outlast the firing delay", () => {
+      it("takes an explicit ttl", () => {
+        expect(
+          throttledPerWindow({
+            makeJobId,
+            windowMs: 30_000,
+            dedupTtlMs: 300_000,
+          }).deduplication?.ttlMs,
+        ).toBe(300_000);
+      });
+    });
+  });
+
+  describe("given a queue score pinned to the event's own timestamp", () => {
+    it("pins the deadline to the event that opened the window", () => {
+      // Extending would re-arm the deadline against each newer event, so an
+      // aggregate receiving a continuous stream would defer its own job for
+      // as long as the stream lasts and the reactor would never fire.
+      expect(
+        throttledPerWindow({ makeJobId, windowMs: 5_000 }).deduplication
+          ?.extend,
+      ).toBe(false);
+    });
+
+    it("still carries the newest payload when it fires", () => {
+      expect(
+        throttledPerWindow({ makeJobId, windowMs: 5_000 }).deduplication
+          ?.replace,
+      ).toBe(true);
+    });
+  });
+
+  describe("given two layers read the job id independently", () => {
+    it("hands both the very same function", () => {
+      // The router collapses a coalesced batch by `makeJobId` before staging;
+      // the queue squashes by `deduplication.makeId` after. If they ever
+      // disagreed, the queue would stage duplicates the collapse believed it
+      // had already removed.
+      const options = throttledPerWindow({ makeJobId, windowMs: 5_000 });
+
+      expect(options.makeJobId).toBe(options.deduplication?.makeId);
+      expect(options.makeJobId).toBe(makeJobId);
+    });
+  });
+
+  describe("given post-dispatch suppression is not requested", () => {
+    it("lets a later trigger open a fresh window", () => {
+      // Level-triggered work must converge on the final state: suppressing
+      // after dispatch would leave whatever partial state the dispatched job
+      // wrote as the last word.
+      expect(
+        throttledPerWindow({ makeJobId, windowMs: 5_000 }).deduplication
+          ?.shouldSurviveDispatch,
+      ).toBe(false);
+    });
+  });
+
+  describe("given post-dispatch suppression is requested", () => {
+    it("honors it", () => {
+      expect(
+        throttledPerWindow({
+          makeJobId,
+          windowMs: 5_000,
+          surviveDispatch: true,
+        }).deduplication?.shouldSurviveDispatch,
+      ).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/reactors/throttleWindow.ts
+++ b/langwatch/src/server/event-sourcing/reactors/throttleWindow.ts
@@ -23,7 +23,7 @@ export type ReactorJobPayload = { event: Event; foldState: unknown };
  * first event, carrying the newest payload (`replace` stays on), and the next
  * event opens a fresh window.
  *
- * `surviveDispatch` defaults to false, and callers should think hard before
+ * `shouldSurviveDispatch` defaults to false, and callers should think hard before
  * setting it. It discards triggers that arrive after dispatch while the TTL
  * runs, which is right for work that must not repeat, and wrong for anything
  * level-triggered: dropping the LAST event of an aggregate leaves whatever
@@ -41,14 +41,14 @@ export function throttledPerWindow({
   makeJobId,
   windowMs,
   dedupTtlMs = windowMs,
-  surviveDispatch = false,
+  shouldSurviveDispatch = false,
 }: {
   makeJobId: (payload: ReactorJobPayload) => string;
   /** How long to hold events before firing, and the default dedup TTL. */
   windowMs: number;
   /** Override when the suppression window must outlast the firing delay. */
   dedupTtlMs?: number;
-  surviveDispatch?: boolean;
+  shouldSurviveDispatch?: boolean;
 }): Pick<ReactorOptions, "delay" | "makeJobId" | "deduplication"> {
   return {
     delay: windowMs,
@@ -60,7 +60,7 @@ export function throttledPerWindow({
       ttlMs: dedupTtlMs,
       extend: false,
       replace: true,
-      shouldSurviveDispatch: surviveDispatch,
+      shouldSurviveDispatch,
     },
   };
 }

--- a/langwatch/src/server/event-sourcing/reactors/throttleWindow.ts
+++ b/langwatch/src/server/event-sourcing/reactors/throttleWindow.ts
@@ -1,0 +1,66 @@
+import type { Event } from "../domain/types";
+import type { ReactorOptions } from "./reactor.types";
+
+/** The payload a reactor's job-id and group-key functions receive. */
+export type ReactorJobPayload = { event: Event; foldState: unknown };
+
+/**
+ * Options that make a reactor fire at most once per window per job id.
+ *
+ * A reactor that sets only `makeJobId` + `ttl` does NOT get a window. Its
+ * `delay` is 0, so the job dispatches on the first event; dispatch takes the
+ * job out of staging, the next event's dedup lookup therefore misses, and the
+ * key is deleted and restaged. Every event gets its own job and the TTL never
+ * bites. A window needs a `delay` — the dedup key is what collapses events,
+ * but only for as long as the job is still waiting to dispatch.
+ *
+ * `extend: false` is the load-bearing choice. A reactor's queue score is the
+ * event's own `createdAt`, so dispatch lands at `createdAt + delay`. Extending
+ * on every event would re-arm that deadline against the newest event and a
+ * continuously-streaming aggregate would push its own job forward forever,
+ * never firing while the stream lasts. Pinning the deadline to the event that
+ * opened the window turns it into a throttle: it fires `windowMs` after the
+ * first event, carrying the newest payload (`replace` stays on), and the next
+ * event opens a fresh window.
+ *
+ * `surviveDispatch` defaults to false, and callers should think hard before
+ * setting it. It discards triggers that arrive after dispatch while the TTL
+ * runs, which is right for work that must not repeat, and wrong for anything
+ * level-triggered: dropping the LAST event of an aggregate leaves whatever
+ * partial state the previous one wrote as the final answer. Only set it when
+ * the handler reads nothing from the event it was given.
+ *
+ * `makeJobId` is deliberately reused as the deduplication id. They are read by
+ * two different layers — the router collapses a coalesced batch by `makeJobId`
+ * before staging, the queue squashes by `deduplication.makeId` after — and the
+ * two layers disagreeing would silently stage duplicates the collapse thought
+ * it had already removed. Taking one function and using it for both makes them
+ * impossible to drift apart.
+ */
+export function throttledPerWindow({
+  makeJobId,
+  windowMs,
+  dedupTtlMs = windowMs,
+  surviveDispatch = false,
+}: {
+  makeJobId: (payload: ReactorJobPayload) => string;
+  /** How long to hold events before firing, and the default dedup TTL. */
+  windowMs: number;
+  /** Override when the suppression window must outlast the firing delay. */
+  dedupTtlMs?: number;
+  surviveDispatch?: boolean;
+}): Pick<ReactorOptions, "delay" | "makeJobId" | "deduplication"> {
+  return {
+    delay: windowMs,
+    // Kept alongside `deduplication` on purpose: the queue reads the latter,
+    // but the router's pre-staging batch collapse only knows about this one.
+    makeJobId,
+    deduplication: {
+      makeId: makeJobId,
+      ttlMs: dedupTtlMs,
+      extend: false,
+      replace: true,
+      shouldSurviveDispatch: surviveDispatch,
+    },
+  };
+}


### PR DESCRIPTION
## For humans

A handful of background jobs were written to "wait a bit, then run once" — for example, tell the browser a trace changed, or write a governance summary row. The waiting part was never actually switched on, so they ran once **per span** instead. A trace with 50 spans did the same work 50 times, and each repeat took its own slot in the work queue.

This turns the waiting on. Each of these jobs now collects everything that happens in a short window and does the work once at the end of it. Nothing is skipped — the last thing that happens in a trace still gets processed.

Two jobs are deliberately **left alone**, because waiting would be visible to someone:

- The AI-gateway budget job — a spending limit is checked against exactly what this writes, so delaying it would let a maxed-out key keep spending.
- The span notification that drives the open trace view — nothing else refreshes that screen while it is live, so any delay is felt directly by whoever is watching.

## What was wrong

`traceUpdateBroadcast`, `projectMetadata`, `spanStorageBroadcast`, the three governance reactors and `billingMeterDispatch` all set `makeJobId` + `ttl` in the shape of a debounce, but left `delay` unset.

With no delay the job dispatches on the first event. Dispatch takes it out of staging, so the next event's dedup lookup (`ZRANK` against the group's job set in `STAGE_LUA`) misses, the key is treated as stale and **deleted**, and a fresh job stages. Every event gets its own job; the TTL never bites. A 5-minute TTL and a 15-second one behaved identically: not at all.

## The fix

A shared `throttledPerWindow` helper (`src/server/event-sourcing/reactors/throttleWindow.ts`), adopted where the consumer can absorb the wait.

**`extend: false` is the load-bearing choice.** A reactor's queue score is the event's own `createdAt`, so dispatch lands at `createdAt + delay`. Extending on every event would re-arm that deadline against the newest event, and a continuously-streaming aggregate would push its own job forward for as long as the stream lasted — never firing. Pinning the deadline to the event that opened the window turns it into a throttle: fires once per window carrying the newest payload, next event opens a fresh one. This is the same trap `graphTriggerActivity` documents.

The helper also hands **one function** to both `makeJobId` and `deduplication.makeId`. Two layers read them independently — `ProjectionRouter.collapseByJobId` collapses a coalesced batch before staging, the queue squashes after — and drift between them would stage duplicates the collapse believed it had already removed.

## Per-reactor windows

| Reactor | Window | Survives dispatch | Why this number |
|---|---|---|---|
| `traceUpdateBroadcast` | **2s** | no | Nothing polls behind it while the live stream is connected. Sized to match the debounce the listener already applies; the two are sequential, so the combined worst case a watching user sees is ~4s. |
| `projectMetadata` | **3s** | no | Flips the flags an onboarding screen waits on. That screen polls every 3s, and a second screen reads the same flags **once with no polling**, so a long window would leave a user who has already sent a trace looking at the "connect your app" guide. One extra poll of latency. |
| `governanceKpisSync` | **30s** | no | Rows are hour-bucketed and read only by a periodic evaluator that ticks every 5 minutes. 30s is sub-noise. |
| `governanceOcsfEventsSync` | **30s** | no | Read only by cursor-paginated SIEM pulls that keep their own watermark, so a late row is picked up by the next pull rather than missed. |
| `billingMeterDispatch` | **excluded** | — | Removed in review. See below. |
| `gatewayBudgetSync` | **excluded** | — | See below. |
| `spanStorageBroadcast` | **excluded** | — | See below. |

## `shouldSurviveDispatch` is now on no reactor

It discards triggers arriving after dispatch while the TTL runs. That is wrong for everything that rebuilds its output from the fold's **running** state (the governance rows carry running cost and token totals) or notifies a client that the state moved: discarding an aggregate's **last** event would leave whatever partial write the dispatched job made as the permanent final answer — a trace's cost frozen mid-flight, or a live view that never receives its final update.

It was originally set on `billingMeterDispatch`, the one reactor that read nothing from its event. Review found that the same property made it unsafe for a different reason (below), so that reactor is excluded entirely and the flag is now off everywhere. A test asserts it.

## The two exclusions

**`gatewayBudgetSync`** — excluded, and not symmetric with the other six. It does not only write the ClickHouse debit row: the same `handle` then appends a `BUDGET_UPDATED` change event that the gateway's `/changes` subscriber consumes to evict cached auth bundles. The EC4 comment block in that file spells out the consequence — without the eviction, `Bundle.Config.Budget.SpentMicroUSD` stays frozen at `populateConfig` time and the on-breach=block precheck does not fire until the JWT TTL (~15min) rolls. Propagation today is ~0-2s via a long-poll change feed. A window would therefore add directly to the interval in which an over-budget key still gets served, *and* defer the mechanism that exists to close it. That is a different kind of cost from the freshness the other reactors trade away, so it is out of scope here.

The right fix for its fan-out is already named in that same comment block as a v2 TODO: dedupe the **change-event emission** to at most once per `(projectId, budgetId)` per ~10s window, so the debit row and the block decision stay immediate while the L1 cache sweep stops firing per request. That is a separate change against the enforcement path and wants its own review.

**`billingMeterDispatch`** — excluded during review, not in the original design. Its handler derives the billing month and the grace-period branch from `new Date()` at execution time, reading nothing from the triggering event. A window therefore moves the **decision** along with the work: a trigger arriving in the final seconds of the third grace day runs on the fourth, and the previous month's dispatch is **skipped rather than deferred**, because the next grace window covers a different month. Narrow, but it is a billing under-report path. It keeps the per-project lane from #6460, which collapses concurrent traces without deferring anything. The event-time fix that would make a window safe is filed as #6474.

**`spanStorageBroadcast`** — drives the open trace drawer's span stream. While the live stream is connected the per-hook `refetchInterval` is switched off entirely, so there is no polling safety net and any delay is felt 1:1. Its fan-out is better addressed where it is actually created: the router dispatches map reactors one event at a time, so a drained 256-span batch sends 256 notifications where one would do. That is a separate change.

Both exclusions are pinned by tests, so they are not quietly reversed by someone reading the table above and assuming the list was meant to be uniform.

## Coordination

Stacked behind #6461 (`shouldReact` hoist on the same three governance reactors) — that one lands first and this rebases onto it. Scoped to `options` blocks only, touching no `shouldReact`, no handler body and no early-return guard, so the two do not collide.

The changes compound rather than overlap, with no double-counting: #6461's predicate drops jobs pre-enqueue for projects without the feature, this collapses the per-span fan-out for the traces that legitimately pass it. Different populations.

## Verification

- `pnpm test:unit` — 35 new tests; full `src/server/event-sourcing` + `ee/governance` sweep green at **274 files / 7,771 tests**
- Three existing tests updated: they asserted `options.ttl`, which now lives at `options.deduplication.ttlMs`
- `pnpm typecheck` and `pnpm typecheck:tests` — both clean
- `pnpm exec biome check` — new files clean; the 5 warnings on touched files are `noExcessiveCognitiveComplexity` / `noExcessiveLinesPerFunction` on `handle` bodies this PR does not modify, confirmed identical on `main`

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Rapid updates are now grouped into predictable processing windows.
  * Project metadata updates are processed within approximately 3 seconds.
  * Trace update broadcasts are delivered within approximately 2 seconds while preserving the latest update.
  * Governance synchronization is processed within approximately 30 seconds.
  * Billing meter dispatching now responds immediately while suppressing duplicate activity for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
