### PR TITLE
perf(event-sourcing): collapse map-reactor dispatch across a coalesced batch

### DIFF
--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.mapReactorCollapse.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.mapReactorCollapse.unit.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsReactorTotal: vi.fn(),
+    incrementEsReactorCollapsedTotal: vi.fn(),
+    incrementEsMapProjectionTotal: vi.fn(),
+    observeEsMapProjectionDuration: vi.fn(),
+  };
+});
+
+import { incrementEsReactorCollapsedTotal } from "~/server/metrics";
+import type { Event } from "../../domain/types";
+import type { ReactorDefinition } from "../../reactors/reactor.types";
+import {
+  createMockAppendStore,
+  createMockMapProjectionDefinition,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import { ProjectionRouter } from "../projectionRouter";
+
+/**
+ * The map batch path used to dispatch one event at a time, so the per-reactor
+ * collapse never saw more than one event and could not fire. A drained batch
+ * therefore staged a job per event for reactors keyed on the aggregate, and
+ * the queue squashed all but the last — after every one of those sends had
+ * already been serialized, gzipped and written.
+ *
+ * A map differs from a fold in one way that matters here: it produces a
+ * separate record per event rather than one accumulated state for the batch,
+ * so a survivor has to keep the record its own event produced.
+ */
+describe("ProjectionRouter map-reactor dispatch over a coalesced batch", () => {
+  const tenantId = createTestTenantId();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const BATCH_SIZE = 5;
+
+  /** Five events for one aggregate, already in occurredAt order. */
+  const batch = (): Event[] =>
+    Array.from({ length: BATCH_SIZE }, (_, i) =>
+      createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+        undefined,
+        1_000 + i,
+        undefined,
+        undefined,
+        `event-${i}`,
+      ),
+    );
+
+  /**
+   * Drives one coalesced batch through the map queue's batch callback and
+   * returns the payloads the reactor's queue received. Each event maps to a
+   * record naming it, so a payload's record identifies the event it was
+   * paired with.
+   */
+  async function dispatchMapBatch(
+    reactor: ReactorDefinition<Event>,
+    events: Event[],
+    map: (event: Event) => unknown = (event) => ({
+      recordFor: event.id,
+    }),
+  ): Promise<Array<{ event: Event; foldState: unknown }>> {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const queueManager = createMockQueueManager({
+      hasReactorQueues: true,
+      getReactorQueue: vi.fn().mockReturnValue({ send }),
+    });
+
+    const router = new ProjectionRouter<Event>(
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      TEST_CONSTANTS.PIPELINE_NAME,
+      queueManager,
+    );
+
+    const mapProj = createMockMapProjectionDefinition("spans", {
+      store: createMockAppendStore<Record<string, unknown>>(),
+      eventTypes: [],
+      map,
+    });
+
+    router.registerMapProjection(mapProj);
+    router.registerMapReactor("spans", reactor);
+    router.initializeMapQueues();
+
+    const initialize = queueManager.initializeHandlerQueues as ReturnType<
+      typeof vi.fn
+    >;
+    const handlerDefs = initialize.mock.calls[0]?.[0] as Record<
+      string,
+      { handler: { handleBatch: (events: Event[]) => Promise<void> } }
+    >;
+
+    await handlerDefs.spans!.handler.handleBatch(events);
+
+    return send.mock.calls.map(([payload]) => payload);
+  }
+
+  describe("when the reactor's deduplication id is the same for every event", () => {
+    it("dispatches once, with the last event in occurredAt order", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "spanStorageBroadcast",
+        options: {
+          makeJobId: (payload) =>
+            `span-stored:${payload.event.tenantId}:${payload.event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]!.event.id).toBe(`event-${BATCH_SIZE - 1}`);
+    });
+
+    it("keeps the record the surviving event produced", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "spanStorageBroadcast",
+        options: {
+          makeJobId: (payload) => `span-stored:${payload.event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch());
+
+      // Not the first event's record, and not some single record standing in
+      // for the whole batch — the one belonging to the event that survived.
+      expect(payloads[0]!.foldState).toEqual({
+        recordFor: `event-${BATCH_SIZE - 1}`,
+      });
+    });
+
+    it("counts the sends it avoided", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "spanStorageBroadcast",
+        options: {
+          makeJobId: (payload) => `span-stored:${payload.event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await dispatchMapBatch(reactor, batch());
+
+      expect(incrementEsReactorCollapsedTotal).toHaveBeenCalledWith(
+        TEST_CONSTANTS.PIPELINE_NAME,
+        "spanStorageBroadcast",
+        BATCH_SIZE - 1,
+      );
+    });
+  });
+
+  describe("when the reactor's deduplication id varies per event", () => {
+    it("dispatches every event, each with its own record", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "perEvent",
+        options: {
+          makeJobId: (payload) => `per-event:${payload.event.id}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(BATCH_SIZE);
+      expect(payloads.map((p) => p.foldState)).toEqual(
+        payloads.map((p) => ({ recordFor: p.event.id })),
+      );
+    });
+  });
+
+  describe("when the reactor declares no deduplication id", () => {
+    it("dispatches every event", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "unkeyed",
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(BATCH_SIZE);
+    });
+  });
+
+  describe("when a shouldReact predicate filters part of the batch", () => {
+    it("reads each event's own record", async () => {
+      const seen: unknown[] = [];
+      const reactor: ReactorDefinition<Event> = {
+        name: "picky",
+        shouldReact: (_event, context) => {
+          seen.push(context.foldState);
+          return true;
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await dispatchMapBatch(reactor, batch());
+
+      expect(seen).toEqual(batch().map((event) => ({ recordFor: event.id })));
+    });
+
+    it("collapses only what survived the predicate", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "picky",
+        shouldReact: (event) => event.id !== `event-${BATCH_SIZE - 1}`,
+        options: {
+          makeJobId: (payload) => `picky:${payload.event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch());
+
+      // The batch's last event was filtered, so the survivor is the last
+      // RELEVANT one — and it still carries its own record.
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]!.event.id).toBe(`event-${BATCH_SIZE - 2}`);
+      expect(payloads[0]!.foldState).toEqual({
+        recordFor: `event-${BATCH_SIZE - 2}`,
+      });
+    });
+  });
+
+  describe("when the projection maps some events to nothing", () => {
+    it("dispatches only for events that produced a record", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "perEvent",
+        options: {
+          makeJobId: (payload) => `per-event:${payload.event.id}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchMapBatch(reactor, batch(), (event) =>
+        event.id === "event-0" || event.id === "event-1"
+          ? { recordFor: event.id }
+          : null,
+      );
+
+      expect(payloads.map((p) => p.event.id)).toEqual(["event-0", "event-1"]);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -90,6 +90,16 @@ const MAX_LOGGED_EVENT_IDS = 10;
 const LIVE_DISPATCH_IS_REPLAY = false;
 
 /**
+ * One event paired with the projection state a reactor should see for it.
+ *
+ * A fold repeats the same accumulated state across a batch; a map produces a
+ * distinct record per event. Pairing them here lets both dispatch through one
+ * path without a map batch having to pick a single record to stand for all of
+ * its events. It is also exactly the queue job's payload shape.
+ */
+type ReactorDelivery<E extends Event> = { event: E; foldState: unknown };
+
+/**
  * Central router that registers fold and map projections and dispatches events.
  *
  * - FoldProjections: enqueued to GroupQueue (per-aggregate ordering), incremental only
@@ -727,8 +737,7 @@ export class ProjectionRouter<
               await this.dispatchToReactors({
                 foldName: name,
                 reactors: mapReactors,
-                events: [event],
-                foldState: record,
+                deliveries: [{ event, foldState: record }],
               });
             }
           },
@@ -788,14 +797,22 @@ export class ProjectionRouter<
 
             const mapReactors = this.reactorsForMap.get(name);
             if (mapReactors && mapReactors.length > 0) {
-              for (const { event, record } of mapped) {
-                await this.dispatchToReactors({
-                  foldName: name,
-                  reactors: mapReactors,
-                  events: [event],
+              // One dispatch for the whole batch, not one per mapped event.
+              // Dispatching per event put each send in its own call, so the
+              // per-reactor collapse only ever saw a single event and could
+              // never fire — a drained batch sent one job per event for
+              // reactors keyed on the aggregate, and the queue then squashed
+              // all but the last. Each delivery keeps its own record, so a
+              // reactor that reads one still sees the record its event
+              // produced.
+              await this.dispatchToReactors({
+                foldName: name,
+                reactors: mapReactors,
+                deliveries: mapped.map(({ event, record }) => ({
+                  event,
                   foldState: record,
-                });
-              }
+                })),
+              });
             }
           },
         },
@@ -1186,8 +1203,7 @@ export class ProjectionRouter<
               await this.dispatchToReactors({
                 foldName: name,
                 reactors: mapReactors,
-                events: [event],
-                foldState: record,
+                deliveries: [{ event, foldState: record }],
               });
             }
           } catch (error) {
@@ -1673,8 +1689,7 @@ export class ProjectionRouter<
       await this.dispatchToReactors({
         foldName: projectionName,
         reactors,
-        events,
-        foldState,
+        deliveries: events.map((event) => ({ event, foldState })),
       });
     } catch (error) {
       this.recordPostStoreFailure({
@@ -1918,54 +1933,57 @@ export class ProjectionRouter<
    *
    * Reactors keyed per event (`…:${event.id}`) collapse to nothing and are
    * dispatched for every event, as are reactors with no job id at all.
+   *
+   * Each delivery carries its own state because a map batch has no single one:
+   * a fold hands the same accumulated state to every event, but a map produces
+   * a separate record per event, and the survivor must keep the record it was
+   * actually paired with.
    */
   private collapseByJobId({
     reactor,
-    events,
-    foldState,
+    deliveries,
   }: {
     reactor: ReactorDefinition<EventType>;
-    events: EventType[];
-    foldState: unknown;
-  }): EventType[] {
+    deliveries: ReactorDelivery<EventType>[];
+  }): ReactorDelivery<EventType>[] {
     const makeJobId = reactor.options?.makeJobId;
-    if (!makeJobId || events.length < 2) return events;
+    if (!makeJobId || deliveries.length < 2) return deliveries;
 
     try {
-      // Keep the LAST event per job id — the one the queue's dedup squash would
-      // have left behind (STAGE_LUA overwrites the stored value when
+      // Keep the LAST delivery per job id — the one the queue's dedup squash
+      // would have left behind (STAGE_LUA overwrites the stored value when
       // `shouldReplace`, which every reactor here defaults to).
       //
       // A Map alone would order the survivors by each job id's FIRST
       // occurrence while holding its last value, so a batch carrying two job
       // ids could dispatch a later event before an earlier one. Re-sort by the
-      // surviving event's position so dispatch really is in occurredAt order —
-      // `events` arrives sorted, so the index IS that order.
+      // surviving delivery's position so dispatch really is in occurredAt
+      // order — deliveries arrive sorted, so the index IS that order.
       const lastIndexPerJobId = new Map<string, number>();
-      events.forEach((event, index) => {
-        lastIndexPerJobId.set(makeJobId({ event, foldState }), index);
+      deliveries.forEach((delivery, index) => {
+        lastIndexPerJobId.set(makeJobId(delivery), index);
       });
       const survivors = [...lastIndexPerJobId.values()].sort((a, b) => a - b);
-      if (survivors.length === events.length) return events;
+      if (survivors.length === deliveries.length) return deliveries;
 
       incrementEsReactorCollapsedTotal(
         this.pipelineName,
         reactor.name,
-        events.length - survivors.length,
+        deliveries.length - survivors.length,
       );
-      return survivors.map((index) => events[index]!);
+      return survivors.map((index) => deliveries[index]!);
     } catch (error) {
       // Fail open, like `shouldReact`: a throwing job-id function must never
       // drop a side effect. Worst case is the un-collapsed fan-out we had before.
       this.logger.error(
         {
           reactorName: reactor.name,
-          eventCount: events.length,
+          eventCount: deliveries.length,
           error: error instanceof Error ? error.message : String(error),
         },
         "Reactor makeJobId threw while collapsing a batch — dispatching every event",
       );
-      return events;
+      return deliveries;
     }
   }
 
@@ -1981,13 +1999,11 @@ export class ProjectionRouter<
   private async dispatchToReactors({
     foldName,
     reactors,
-    events,
-    foldState,
+    deliveries,
   }: {
     foldName: string;
     reactors: ReactorDefinition<EventType>[];
-    events: EventType[];
-    foldState: unknown;
+    deliveries: ReactorDelivery<EventType>[];
   }): Promise<void> {
     const errors: Error[] = [];
 
@@ -1995,20 +2011,21 @@ export class ProjectionRouter<
       if (reactor.options?.disabled) continue;
       if (this.isReactorExcluded(reactor)) continue;
 
-      const relevant: EventType[] = [];
-      for (const event of events) {
-        if (this.reactorShouldReact(reactor, event, foldState)) {
-          relevant.push(event);
+      const relevant: ReactorDelivery<EventType>[] = [];
+      for (const delivery of deliveries) {
+        if (
+          this.reactorShouldReact(reactor, delivery.event, delivery.foldState)
+        ) {
+          relevant.push(delivery);
         } else {
           incrementEsReactorTotal(this.pipelineName, reactor.name, "skipped");
         }
       }
       if (relevant.length === 0) continue;
 
-      for (const event of this.collapseByJobId({
+      for (const { event, foldState } of this.collapseByJobId({
         reactor,
-        events: relevant,
-        foldState,
+        deliveries: relevant,
       })) {
         await this.dispatchOneToReactor({
           foldName,


### PR DESCRIPTION
## For humans

When a burst of spans arrives together, we already process them as one batch. But the follow-up notification job — "tell the browser this trace changed" — was still being queued once per span. A batch of 256 spans queued 256 identical notifications, and the queue then threw away 255 of them, after we had already paid to build and store each one.

This queues one instead. The equivalent fix has been in place for the other half of the system since it was written; this half was simply missed.

## What was wrong

`ProjectionRouter` collapses a reactor's dispatches across a coalesced batch: a reactor's `makeJobId` is its collapse key, so N sends carrying one job id leave exactly one job behind, and sending all N is pure waste — each one serializes `{event, foldState}`, gzips it, and past the envelope's inline ceiling writes a content-addressed Redis blob that the queue's own dedup squash immediately reclaims.

The **fold** batch path passes the whole batch to `dispatchToReactors` and gets that collapse. The **map** batch path looped instead:

```ts
for (const { event, record } of mapped) {
  await this.dispatchToReactors({ ..., events: [event], foldState: record });
}
```

One event per call means `collapseByJobId` never saw more than one event and could never fire. `spanStorage` is the map projection that actually batches — `coalesceMaxBatch: 256`, group key `traceId:<shard>` — so a coalesced batch is same-trace, `spanStorageBroadcast`'s job id (`span-stored:<tenant>:<trace>`) is constant across it, and the collapse ratio available was **256:1**.

## Semantics: which record does the survivor see?

This is the one place a map genuinely differs from a fold, and it drove the shape of the fix.

A fold hands the same accumulated state to every event in a batch. A map produces a **separate record per event** (`executeBatch` returns `Array<{event, record}>`). So there is no single state to hand the reactor, and passing one representative record would have been a silent lie for any reactor that reads it.

Instead, `dispatchToReactors` and `collapseByJobId` now take **event/state pairs**. A fold repeats its state across the pairs; a map gives each event the record it produced; a survivor keeps its own. The rule stays the fold path's: **last delivery per job id wins**, matching what the queue's dedup squash would have left behind, ordered by the surviving event's position so dispatch is still in `occurredAt` order.

Neither map reactor reads the record today — `spanStorageBroadcast` does not even declare a `context` parameter, and `billingMeterDispatch` uses only `context.tenantId`. But `makeJobId`, `shouldReact` and `handle` are all handed it, so pairing correctly costs nothing and removes a trap for the next map reactor. Also verified: `executeBatch` is **not** index-aligned with its input (it drops idempotency-key duplicates and `null` maps), which is why the fix maps over its output rather than zipping against the input events.

## Relationship to #6463

This is the correct fix for `spanStorageBroadcast`'s fan-out, which I deliberately excluded from the reactor-window change in #6463 — its consumer is the open trace drawer, which has no polling fallback while the live stream is connected, so a delay there is felt 1:1 by whoever is watching. Collapsing a batch costs no latency at all: the surviving notification fires as soon as the batch finishes, exactly as the last one does today. Independent of #6463 and #6460; no shared files.

## Tests

The map batch → reactor path had **no test coverage at all**. New file pins: collapse to one dispatch carrying the last event; the survivor keeping its own record; the collapse metric; per-event job ids and unkeyed reactors dispatching every event; `shouldReact` seeing each event's own record and filtering before the collapse; and events whose map returned nothing never reaching a reactor.

Checked against the old code rather than assumed: the four collapse-specific tests **fail** on `main`'s router, while the four asserting already-correct behavior pass.

## Verification

- `pnpm test:unit` — 8 new tests; full `src/server/event-sourcing` sweep green at **250 files / 7,553 tests**, including the fold-path collapse suite that pins the semantics this refactor had to preserve
- `pnpm typecheck` and `pnpm typecheck:tests` — both clean
- `pnpm exec biome check` — `projectionRouter.ts` carries **20** warnings before and after, all pre-existing and none in the changed lines; new test file clean

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batched event processing to preserve the correct mapped records and fold state for each event.
  * Ensured collapsed batches retain the latest event for each job while maintaining event order.
  * Added safeguards so dispatch continues when job identification fails.
  * Improved filtering for events that should not trigger reactions or produce no mapped record.

* **Tests**
  * Added comprehensive coverage for batching, collapsing, filtering, metrics, and per-event dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->