### PR TITLE
perf(event-sourcing): coalesce span appends, excluding spooled spans

### DIFF
--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -33,6 +33,7 @@ import { GroupQueueProcessor } from "./queues/groupQueue/groupQueue";
 import { EventSourcedQueueProcessorMemory } from "./queues/memory";
 import { EventSourcingPipeline } from "./runtimePipeline";
 import type { JobRegistryEntry } from "./services/queues/queueManager";
+import { resolveCoalesceMaxBatch } from "./services/queues/queueManager";
 import type { EventStore } from "./stores/eventStore.types";
 import { EventStoreClickHouse } from "./stores/eventStoreClickHouse";
 import { EventStoreMemory } from "./stores/eventStoreMemory";
@@ -503,7 +504,10 @@ export class EventSourcing {
       },
       coalesceMaxBatch: (payload: Record<string, unknown>) => {
         const result = this.lookupEntry(payload);
-        return result?.entry.coalesceMaxBatch ?? 1;
+        if (!result) return 1;
+        // `clean`, not `payload`: a resolver sees the same shape the handler
+        // will, without this queue's routing metadata.
+        return resolveCoalesceMaxBatch(result.entry, result.clean);
       },
       coalesceMaxBytes: (payload: Record<string, unknown>) => {
         // Resolve the same way as coalesceMaxBatch: per-job via routing meta.

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
@@ -40,7 +40,7 @@ export interface KillSwitchOptions {
  * for these fields lives in a single place; both interfaces extend it rather
  * than hand-syncing two copies.
  */
-export interface CommandSerializationOptions {
+export interface CommandSerializationOptions<Payload = any> {
   /**
    * Serialize this command with every other command that enables the option
    * for the same tenant and aggregate. This keeps command handling, event
@@ -55,8 +55,13 @@ export interface CommandSerializationOptions {
    * fold into a single multi-row insert. Leave unset (or ≤ 1) for a low-fan-in
    * producer where one aggregate appends at most one event per human action:
    * those append immediately, with the per-job path unchanged.
+   *
+   * Pass a resolver when the bound depends on the individual payload. The
+   * drain's byte budget weighs each job by its QUEUED size, so a payload that
+   * expands after dequeue — one carrying a reference whose content is fetched
+   * during handling — is invisible to that budget and must cap itself at 1.
    */
-  coalesceMaxBatch?: number;
+  coalesceMaxBatch?: number | ((payload: Payload) => number);
   /**
    * Optional byte cap for a coalesced batch (ADR-066 pillar 2). The drain stops
    * before a job that would push the batch past this size, keeping one insert
@@ -71,7 +76,7 @@ export interface CommandSerializationOptions {
  * Options for configuring a command handler in a static pipeline definition.
  */
 export interface CommandHandlerOptions<Payload = any>
-  extends CommandSerializationOptions {
+  extends CommandSerializationOptions<Payload> {
   getAggregateId?: (payload: Payload) => string;
   getGroupKey?: (payload: Payload) => string;
   makeJobId?: (payload: Payload) => string;

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
@@ -1,0 +1,383 @@
+/**
+ * ADR-066 pillar 2 for recordSpan: a trace's spans share one queue group, so a
+ * busy trace appends one tiny insert per span unless the group's queued spans
+ * are folded into a single multi-row append.
+ *
+ * The interesting case is the ADR-022 spool. An over-threshold span is queued as
+ * a spoolRef with its attributes cleared, so its queued size — the only size the
+ * drain's byte budget can weigh — is a few hundred bytes, while the span the
+ * handler reconstitutes from object storage is over 256 KB and unbounded above.
+ * The bound is therefore resolved per span so a spooled one caps itself at 1.
+ *
+ * See specs/event-sourcing/producer-append-coalescing.feature.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import { processCommandBatch } from "../../../services/commands/commandDispatcher";
+import {
+  RECORD_SPAN_DEDUPLICATION,
+  RecordSpanCommand,
+} from "../commands/recordSpanCommand";
+import {
+  createTraceProcessingPipeline,
+  type TraceProcessingPipelineDeps,
+} from "../pipeline";
+import type { RecordSpanCommandData } from "../schemas/commands";
+import {
+  RECORD_SPAN_COALESCE_MAX_BATCH,
+  RECORD_SPAN_COMMAND_TYPE,
+  SPAN_RECEIVED_EVENT_TYPE,
+} from "../schemas/constants";
+
+vi.mock("../../../utils/killSwitch", () => ({
+  isComponentDisabled: vi.fn().mockResolvedValue(false),
+}));
+
+import { isComponentDisabled } from "../../../utils/killSwitch";
+
+const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
+
+const TENANT_ID = "tenant-span-coalescing";
+const TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
+
+const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
+
+function buildTraceDeps(
+  overrides: Partial<TraceProcessingPipelineDeps> = {},
+): TraceProcessingPipelineDeps {
+  const store = {} as any;
+  return {
+    spanAppendStore: store,
+    traceSummaryStore: store,
+    traceAnalyticsStore: store,
+    traceAnalyticsRollupAppendStore: store,
+    originGateReactor: reactorStub("originGate"),
+    evaluationTriggerReactor: reactorStub("evaluationTrigger"),
+    customEvaluationSyncReactor: reactorStub("customEvaluationSync"),
+    traceUpdateBroadcastReactor: reactorStub("traceUpdateBroadcast"),
+    projectMetadataReactor: reactorStub("projectMetadata"),
+    simulationMetricsSyncReactor: reactorStub("simulationMetricsSync"),
+    experimentMetricsSyncReactor: reactorStub("experimentMetricsSync"),
+    automations: {
+      triggerMatchHandler: vi.fn().mockResolvedValue(undefined),
+      graphActivityHandler: vi.fn().mockResolvedValue(undefined),
+    },
+    spanStorageBroadcastReactor: reactorStub("spanStorageBroadcast"),
+    ...overrides,
+  };
+}
+
+function recordSpanRegistration(
+  deps: Partial<TraceProcessingPipelineDeps> = {},
+) {
+  return createTraceProcessingPipeline(buildTraceDeps(deps)).commands.find(
+    (candidate) => candidate.name === "recordSpan",
+  );
+}
+
+/**
+ * The coalescing bound the composition root installed on recordSpan, as the
+ * resolver it is expected to be. A missing registration surfaces as a failed
+ * call rather than a silent undefined.
+ */
+function coalesceResolverOf(deps: Partial<TraceProcessingPipelineDeps> = {}) {
+  return recordSpanRegistration(deps)?.options?.coalesceMaxBatch as (
+    payload: RecordSpanCommandData,
+  ) => number;
+}
+
+function spanPayload({
+  spanId,
+  spoolRef,
+}: {
+  spanId: string;
+  spoolRef?: string;
+}): RecordSpanCommandData {
+  return {
+    tenantId: TENANT_ID,
+    occurredAt: 1_700_000_000_000,
+    ...(spoolRef ? { spoolRef } : {}),
+    span: {
+      traceId: TRACE_ID,
+      spanId,
+      name: "test-span",
+      kind: 1,
+      startTimeUnixNano: { low: 0, high: 0 },
+      endTimeUnixNano: { low: 1_000_000, high: 0 },
+      attributes: [],
+      events: [],
+      links: [],
+      status: {},
+      droppedAttributesCount: 0,
+      droppedEventsCount: 0,
+      droppedLinksCount: 0,
+    },
+    resource: null,
+    instrumentationScope: null,
+  } as unknown as RecordSpanCommandData;
+}
+
+function spanId(index: number): string {
+  return (index + 1).toString(16).padStart(16, "0");
+}
+
+/** A handler with every enrichment stubbed out — only the fold is under test. */
+function stubbedHandler(blobStore?: unknown) {
+  return new RecordSpanCommand({
+    piiRedactionService: { redactSpan: async () => {} },
+    costEnrichmentService: { enrichSpan: async () => {} },
+    tokenEstimationService: { estimateSpanTokens: async () => {} },
+    contentDropService: {
+      dropSpanContent: async () => ({ droppedCount: 0, droppedCategories: [] }),
+    },
+    ...(blobStore ? { blobStore } : {}),
+  } as never);
+}
+
+function batchParamsFor({
+  payloads,
+  storeEventsFn,
+  handler = stubbedHandler(),
+}: {
+  payloads: RecordSpanCommandData[];
+  storeEventsFn: (events: Event[], context: unknown) => Promise<void>;
+  handler?: RecordSpanCommand;
+}) {
+  return {
+    payloads: payloads as unknown as Record<string, unknown>[],
+    commandType: RECORD_SPAN_COMMAND_TYPE,
+    commandSchema: RecordSpanCommand.schema,
+    handler,
+    getAggregateId: RecordSpanCommand.getAggregateId,
+    storeEventsFn: storeEventsFn as never,
+    aggregateType: "trace" as const,
+    commandName: "recordSpan",
+    pipelineName: "trace_processing",
+  };
+}
+
+describe("recordSpan append coalescing", () => {
+  beforeEach(() => {
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("given the trace-processing pipeline is defined", () => {
+    describe("when recordSpan is registered without sharding", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      it("installs a bound resolved per span rather than one fixed for the command", () => {
+        expect(typeof recordSpanRegistration()?.options?.coalesceMaxBatch).toBe(
+          "function",
+        );
+      });
+
+      it("folds an inline span up to the span batch bound", () => {
+        const bound = coalesceResolverOf();
+
+        expect(bound(spanPayload({ spanId: spanId(0) }))).toBe(
+          RECORD_SPAN_COALESCE_MAX_BATCH,
+        );
+      });
+
+      /** @scenario 'a single oversized item is appended on its own' */
+      it("caps a spooled span at one, since its queued size hides what it becomes", () => {
+        const bound = coalesceResolverOf();
+
+        expect(
+          bound(spanPayload({ spanId: spanId(0), spoolRef: "spool/abc" })),
+        ).toBe(1);
+      });
+
+      it("leaves the existing span deduplication untouched", () => {
+        expect(recordSpanRegistration()?.options?.deduplication).toBe(
+          RECORD_SPAN_DEDUPLICATION,
+        );
+      });
+    });
+
+    describe("when recordSpan is registered with sharding enabled", () => {
+      it("keeps the same per-span bound alongside the shard routing", () => {
+        const bound = coalesceResolverOf({ spanCommandShardCount: 8 });
+
+        expect(bound(spanPayload({ spanId: spanId(0) }))).toBe(
+          RECORD_SPAN_COALESCE_MAX_BATCH,
+        );
+        expect(
+          bound(spanPayload({ spanId: spanId(0), spoolRef: "spool/abc" })),
+        ).toBe(1);
+      });
+    });
+  });
+
+  describe("given several queued spans from one trace", () => {
+    describe("when the coalesced batch is processed", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      /** @scenario 'coalescing preserves every item' */
+      it("appends them as one insert holding every span in dispatch order", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2, 3].map((index) =>
+          spanPayload({ spanId: spanId(index) }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        const [events, context] = storeEventsFn.mock.calls[0]!;
+        expect(
+          (events as Event[]).map((event) => event.metadata?.spanId),
+        ).toEqual(payloads.map((payload) => payload.span.spanId));
+        expect(
+          (events as Event[]).every(
+            (event) => event.type === SPAN_RECEIVED_EVENT_TYPE,
+          ),
+        ).toBe(true);
+        expect(context).toEqual({ tenantId: TENANT_ID });
+      });
+
+      /** @scenario 'coalescing preserves every item' */
+      it("keeps each span's idempotency key so a retry cannot duplicate it", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1].map((index) =>
+          spanPayload({ spanId: spanId(index) }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect(
+          (events as Event[]).map((event) => event.idempotencyKey),
+        ).toEqual(
+          payloads.map(
+            (payload) => `${TENANT_ID}:${TRACE_ID}:${payload.span.spanId}`,
+          ),
+        );
+      });
+
+      /** @scenario 'many items for one aggregate become one insert' */
+      it("emits every span's event as a single trace aggregate", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2].map((index) =>
+          spanPayload({ spanId: spanId(index) }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect(
+          new Set((events as Event[]).map((event) => event.aggregateId)),
+        ).toEqual(new Set([TRACE_ID]));
+      });
+    });
+
+    describe("when the command is killed for the tenant", () => {
+      it("appends nothing for the whole batch", async () => {
+        mockedIsComponentDisabled.mockResolvedValue(true);
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2].map((index) =>
+          spanPayload({ spanId: spanId(index) }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // The spool is deleted only once the event carrying it is durable. Folding
+  // must not turn that per-command guarantee into a per-batch one, or a batch
+  // that fails after one span's spool was dropped could never be retried.
+  describe("given spooled spans that reached the batch anyway", () => {
+    describe("when the batch is stored", () => {
+      it("deletes each span's spool once, after the single append", async () => {
+        const order: string[] = [];
+        const deleteSpool = vi.fn(async (ref: string) => {
+          order.push(`delete:${ref}`);
+        });
+        const blobStore = {
+          getSpool: async (ref: string) =>
+            Buffer.from(
+              JSON.stringify({
+                span: spanPayload({ spanId: ref.slice(-16) }).span,
+                resource: null,
+                instrumentationScope: null,
+              }),
+              "utf-8",
+            ),
+          deleteSpool,
+        };
+        const storeEventsFn = vi.fn(async () => {
+          order.push("store");
+        });
+        const payloads = [0, 1].map((index) =>
+          spanPayload({
+            spanId: spanId(index),
+            spoolRef: `spool/${spanId(index)}`,
+          }),
+        );
+
+        await processCommandBatch(
+          batchParamsFor({
+            payloads,
+            storeEventsFn,
+            handler: stubbedHandler(blobStore),
+          }),
+        );
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        expect(deleteSpool).toHaveBeenCalledTimes(2);
+        expect(order).toEqual([
+          "store",
+          `delete:spool/${spanId(0)}`,
+          `delete:spool/${spanId(1)}`,
+        ]);
+      });
+    });
+
+    describe("when a handler throws partway through the batch", () => {
+      it("appends nothing and drops no spool, leaving the batch retryable", async () => {
+        const deleteSpool = vi.fn().mockResolvedValue(undefined);
+        const blobStore = {
+          getSpool: vi.fn(async (ref: string) => {
+            if (ref.endsWith(spanId(1))) {
+              throw new Error("spool fetch failed");
+            }
+            return Buffer.from(
+              JSON.stringify({
+                span: spanPayload({ spanId: spanId(0) }).span,
+                resource: null,
+                instrumentationScope: null,
+              }),
+              "utf-8",
+            );
+          }),
+          deleteSpool,
+        };
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1].map((index) =>
+          spanPayload({
+            spanId: spanId(index),
+            spoolRef: `spool/${spanId(index)}`,
+          }),
+        );
+
+        await expect(
+          processCommandBatch(
+            batchParamsFor({
+              payloads,
+              storeEventsFn,
+              handler: stubbedHandler(blobStore),
+            }),
+          ),
+        ).rejects.toThrow("spool fetch failed");
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+        expect(deleteSpool).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandCoalescing.unit.test.ts
@@ -29,6 +29,13 @@ import {
   RECORD_SPAN_COMMAND_TYPE,
   SPAN_RECEIVED_EVENT_TYPE,
 } from "../schemas/constants";
+import {
+  buildTraceDeps,
+  FIXTURE_TENANT_ID,
+  FIXTURE_TRACE_ID,
+  spanId,
+  spanPayload,
+} from "./support/traceProcessingFixtures";
 
 vi.mock("../../../utils/killSwitch", () => ({
   isComponentDisabled: vi.fn().mockResolvedValue(false),
@@ -37,36 +44,6 @@ vi.mock("../../../utils/killSwitch", () => ({
 import { isComponentDisabled } from "../../../utils/killSwitch";
 
 const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
-
-const TENANT_ID = "tenant-span-coalescing";
-const TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
-
-const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
-
-function buildTraceDeps(
-  overrides: Partial<TraceProcessingPipelineDeps> = {},
-): TraceProcessingPipelineDeps {
-  const store = {} as any;
-  return {
-    spanAppendStore: store,
-    traceSummaryStore: store,
-    traceAnalyticsStore: store,
-    traceAnalyticsRollupAppendStore: store,
-    originGateReactor: reactorStub("originGate"),
-    evaluationTriggerReactor: reactorStub("evaluationTrigger"),
-    customEvaluationSyncReactor: reactorStub("customEvaluationSync"),
-    traceUpdateBroadcastReactor: reactorStub("traceUpdateBroadcast"),
-    projectMetadataReactor: reactorStub("projectMetadata"),
-    simulationMetricsSyncReactor: reactorStub("simulationMetricsSync"),
-    experimentMetricsSyncReactor: reactorStub("experimentMetricsSync"),
-    automations: {
-      triggerMatchHandler: vi.fn().mockResolvedValue(undefined),
-      graphActivityHandler: vi.fn().mockResolvedValue(undefined),
-    },
-    spanStorageBroadcastReactor: reactorStub("spanStorageBroadcast"),
-    ...overrides,
-  };
-}
 
 function recordSpanRegistration(
   deps: Partial<TraceProcessingPipelineDeps> = {},
@@ -85,41 +62,6 @@ function coalesceResolverOf(deps: Partial<TraceProcessingPipelineDeps> = {}) {
   return recordSpanRegistration(deps)?.options?.coalesceMaxBatch as (
     payload: RecordSpanCommandData,
   ) => number;
-}
-
-function spanPayload({
-  spanId,
-  spoolRef,
-}: {
-  spanId: string;
-  spoolRef?: string;
-}): RecordSpanCommandData {
-  return {
-    tenantId: TENANT_ID,
-    occurredAt: 1_700_000_000_000,
-    ...(spoolRef ? { spoolRef } : {}),
-    span: {
-      traceId: TRACE_ID,
-      spanId,
-      name: "test-span",
-      kind: 1,
-      startTimeUnixNano: { low: 0, high: 0 },
-      endTimeUnixNano: { low: 1_000_000, high: 0 },
-      attributes: [],
-      events: [],
-      links: [],
-      status: {},
-      droppedAttributesCount: 0,
-      droppedEventsCount: 0,
-      droppedLinksCount: 0,
-    },
-    resource: null,
-    instrumentationScope: null,
-  } as unknown as RecordSpanCommandData;
-}
-
-function spanId(index: number): string {
-  return (index + 1).toString(16).padStart(16, "0");
 }
 
 /** A handler with every enrichment stubbed out — only the fold is under test. */
@@ -235,7 +177,7 @@ describe("recordSpan append coalescing", () => {
             (event) => event.type === SPAN_RECEIVED_EVENT_TYPE,
           ),
         ).toBe(true);
-        expect(context).toEqual({ tenantId: TENANT_ID });
+        expect(context).toEqual({ tenantId: FIXTURE_TENANT_ID });
       });
 
       /** @scenario 'coalescing preserves every item' */
@@ -252,7 +194,8 @@ describe("recordSpan append coalescing", () => {
           (events as Event[]).map((event) => event.idempotencyKey),
         ).toEqual(
           payloads.map(
-            (payload) => `${TENANT_ID}:${TRACE_ID}:${payload.span.spanId}`,
+            (payload) =>
+              `${FIXTURE_TENANT_ID}:${FIXTURE_TRACE_ID}:${payload.span.spanId}`,
           ),
         );
       });
@@ -269,7 +212,7 @@ describe("recordSpan append coalescing", () => {
         const [events] = storeEventsFn.mock.calls[0]!;
         expect(
           new Set((events as Event[]).map((event) => event.aggregateId)),
-        ).toEqual(new Set([TRACE_ID]));
+        ).toEqual(new Set([FIXTURE_TRACE_ID]));
       });
     });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
@@ -9,6 +9,7 @@ import {
   type TraceProcessingPipelineDeps,
 } from "../pipeline";
 import type { RecordSpanCommandData } from "../schemas/commands";
+import { buildTraceDeps } from "./support/traceProcessingFixtures";
 
 // The blobStore registration branch eagerly constructs `new RecordSpanCommand`,
 // whose default-dependency path does `require("~/server/db")` (an alias vitest's
@@ -45,33 +46,6 @@ vi.mock("../commands/recordSpanCommand", async (importOriginal) => {
  * trace-summary fold keyed per trace. `build()` only stores references, so no
  * store / reactor is ever invoked.
  */
-
-const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
-
-function buildTraceDeps(
-  overrides: Partial<TraceProcessingPipelineDeps> = {},
-): TraceProcessingPipelineDeps {
-  const store = {} as any;
-  return {
-    spanAppendStore: store,
-    traceSummaryStore: store,
-    traceAnalyticsStore: store,
-    traceAnalyticsRollupAppendStore: store,
-    originGateReactor: reactorStub("originGate"),
-    evaluationTriggerReactor: reactorStub("evaluationTrigger"),
-    customEvaluationSyncReactor: reactorStub("customEvaluationSync"),
-    traceUpdateBroadcastReactor: reactorStub("traceUpdateBroadcast"),
-    projectMetadataReactor: reactorStub("projectMetadata"),
-    simulationMetricsSyncReactor: reactorStub("simulationMetricsSync"),
-    experimentMetricsSyncReactor: reactorStub("experimentMetricsSync"),
-    automations: {
-      triggerMatchHandler: vi.fn().mockResolvedValue(undefined),
-      graphActivityHandler: vi.fn().mockResolvedValue(undefined),
-    },
-    spanStorageBroadcastReactor: reactorStub("spanStorageBroadcast"),
-    ...overrides,
-  };
-}
 
 const TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/support/traceProcessingFixtures.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/support/traceProcessingFixtures.ts
@@ -1,0 +1,73 @@
+import { vi } from "vitest";
+import type { TraceProcessingPipelineDeps } from "../../pipeline";
+import type { RecordSpanCommandData } from "../../schemas/commands";
+
+const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
+
+/**
+ * Deps for building the REAL trace-processing pipeline in a wiring test.
+ * `build()` only stores references, so no store or reactor is ever invoked.
+ */
+export function buildTraceDeps(
+  overrides: Partial<TraceProcessingPipelineDeps> = {},
+): TraceProcessingPipelineDeps {
+  const store = {} as any;
+  return {
+    spanAppendStore: store,
+    traceSummaryStore: store,
+    traceAnalyticsStore: store,
+    traceAnalyticsRollupAppendStore: store,
+    originGateReactor: reactorStub("originGate"),
+    evaluationTriggerReactor: reactorStub("evaluationTrigger"),
+    customEvaluationSyncReactor: reactorStub("customEvaluationSync"),
+    traceUpdateBroadcastReactor: reactorStub("traceUpdateBroadcast"),
+    projectMetadataReactor: reactorStub("projectMetadata"),
+    simulationMetricsSyncReactor: reactorStub("simulationMetricsSync"),
+    experimentMetricsSyncReactor: reactorStub("experimentMetricsSync"),
+    automations: {
+      triggerMatchHandler: vi.fn().mockResolvedValue(undefined),
+      graphActivityHandler: vi.fn().mockResolvedValue(undefined),
+    },
+    spanStorageBroadcastReactor: reactorStub("spanStorageBroadcast"),
+    ...overrides,
+  };
+}
+
+export const FIXTURE_TENANT_ID = "tenant-span-coalescing";
+export const FIXTURE_TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
+
+export function spanId(index: number): string {
+  return (index + 1).toString(16).padStart(16, "0");
+}
+
+/** A schema-valid recordSpan payload; `spoolRef` makes it the oversized shape. */
+export function spanPayload({
+  spanId: id,
+  spoolRef,
+}: {
+  spanId: string;
+  spoolRef?: string;
+}): RecordSpanCommandData {
+  return {
+    tenantId: FIXTURE_TENANT_ID,
+    occurredAt: 1_700_000_000_000,
+    ...(spoolRef ? { spoolRef } : {}),
+    span: {
+      traceId: FIXTURE_TRACE_ID,
+      spanId: id,
+      name: "test-span",
+      kind: 1,
+      startTimeUnixNano: { low: 0, high: 0 },
+      endTimeUnixNano: { low: 1_000_000, high: 0 },
+      attributes: [],
+      events: [],
+      links: [],
+      status: {},
+      droppedAttributesCount: 0,
+      droppedEventsCount: 0,
+      droppedLinksCount: 0,
+    },
+    resource: null,
+    instrumentationScope: null,
+  } as unknown as RecordSpanCommandData;
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -41,6 +41,7 @@ import { TraceSummaryFoldProjection } from "./projections/traceSummary.foldProje
 import type { RecordSpanCommandData } from "./schemas/commands";
 import {
   ORIGIN_RESOLVED_EVENT_TYPE,
+  RECORD_SPAN_COALESCE_MAX_BATCH,
   SPAN_RECEIVED_EVENT_TYPE,
 } from "./schemas/constants";
 import type { TraceProcessingEvent } from "./schemas/events";
@@ -282,10 +283,31 @@ export function createTraceProcessingPipeline(
   const spanCommandShardCount = clampSpanShardCount(
     deps.spanCommandShardCount ?? 1,
   );
+  // ADR-066 pillar 2: a trace's spans all land in one group (or one of its
+  // shards), so a busy trace appends one tiny insert per span. Coalesce the
+  // group's queued spans into one multi-row insert instead.
+  //
+  // The bound is a resolver, not a constant, because of the ADR-022 spool. An
+  // over-threshold span is queued as a spoolRef with its attributes cleared, so
+  // its QUEUED size — the only size the drain's byte budget can weigh — is a few
+  // hundred bytes, while the span the handler reconstitutes from object storage
+  // is over 256 KB and has no upper bound. Folding those by count would let the
+  // byte budget wave through a batch whose true size it never saw. A spooled
+  // span therefore caps itself at 1 and is appended on its own, exactly as the
+  // oversized-item case is meant to behave; inline spans are bounded by
+  // COMMAND_INLINE_THRESHOLD, so for them the byte budget is honest and does the
+  // real work. The handler derives its event from its own command alone and
+  // never reads back a same-batch append, and its post-store spool cleanup runs
+  // per command, so both are safe to fold.
   const recordSpanOptions: {
     deduplication: typeof RECORD_SPAN_DEDUPLICATION;
     getGroupKey?: (payload: RecordSpanCommandData) => string;
-  } = { deduplication: RECORD_SPAN_DEDUPLICATION };
+    coalesceMaxBatch: (payload: RecordSpanCommandData) => number;
+  } = {
+    deduplication: RECORD_SPAN_DEDUPLICATION,
+    coalesceMaxBatch: (payload) =>
+      payload.spoolRef ? 1 : RECORD_SPAN_COALESCE_MAX_BATCH,
+  };
   if (spanCommandShardCount > 1) {
     recordSpanOptions.getGroupKey = (payload) => {
       const { traceId, spanId } = TraceRequestUtils.normalizeOtlpSpanIds(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/constants.ts
@@ -187,3 +187,18 @@ export const TRACE_SUMMARY_PROJECTION_VERSIONS = [
   "2026-04-23",
   TRACE_SUMMARY_PROJECTION_VERSION_LATEST,
 ] as const;
+
+/**
+ * Append-coalescing bound for an INLINE recordSpan (ADR-066 pillar 2). A trace's
+ * spans share one queue group (or one of its shards), so a busy trace appends
+ * one tiny event_log insert per span; folding the group's queued spans into a
+ * single multi-row insert keeps the producer off the per-item write path.
+ *
+ * Lower than the log/metric record bounds on purpose. An inline span is capped
+ * at COMMAND_INLINE_THRESHOLD (256 KB) — an order of magnitude fatter than a log
+ * record — so the drain's byte budget is what genuinely bounds a span batch, and
+ * this count only has to stop a burst of small spans from growing unboundedly.
+ * A spooled span is excluded from coalescing entirely; see the resolver in
+ * pipeline.ts for why.
+ */
+export const RECORD_SPAN_COALESCE_MAX_BATCH = 64;

--- a/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -473,7 +473,7 @@ export async function processCommandBatch<EventType extends Event>(
  * Options for configuring a command handler.
  */
 export interface CommandHandlerOptions<Payload>
-  extends CommandSerializationOptions {
+  extends CommandSerializationOptions<Payload> {
   getAggregateId?: (payload: Payload) => string;
   getGroupKey?: (payload: Payload) => string;
   delay?: number;

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
@@ -473,6 +473,108 @@ describe("QueueManager.initializeCommandQueues append coalescing", () => {
       });
     });
   });
+
+  // A producer whose foldability depends on the individual job supplies a
+  // resolver instead of a constant. Its presence is the opt-in — the value is
+  // only known at dispatch, so registration cannot compare it against 1.
+  describe("given a command whose coalescing bound is resolved per payload", () => {
+    describe("when the command queue is initialized", () => {
+      it("wires processBatch and carries the resolver onto the registry entry", () => {
+        const { manager, globalJobRegistry } = buildManager();
+        const bound = (payload: any) => (payload.oversized ? 1 : 64);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "hot",
+              handlerClass: createMockCommandHandlerClass("hot"),
+              options: { serializeByAggregate: true, coalesceMaxBatch: bound },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        const entry = globalJobRegistry.get("test-pipeline:command:hot");
+        expect(entry?.processBatch).toBeDefined();
+        expect(entry?.coalesceMaxBatch).toBe(bound);
+      });
+
+      it("does not emit the un-coalesced visibility record", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "hot",
+              handlerClass: createMockCommandHandlerClass("hot"),
+              options: {
+                serializeByAggregate: true,
+                coalesceMaxBatch: () => 64,
+              },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).not.toHaveBeenCalledWith(
+          expect.anything(),
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+
+      // recordSpan's own shape: sharded onto a group key, and folding only the
+      // payloads it can weigh honestly.
+      it("stays silent for a group-keyed producer too", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "sharded",
+              handlerClass:
+                createMockCommandHandlerClassWithGroupKey("sharded"),
+              options: { coalesceMaxBatch: (p: any) => (p.oversized ? 1 : 64) },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).not.toHaveBeenCalledWith(
+          expect.anything(),
+          UNCOALESCED_PRODUCER_MESSAGE,
+        );
+      });
+    });
+  });
+
+  describe("given a command whose coalescing bound is exactly one", () => {
+    describe("when the command queue is initialized", () => {
+      it("leaves processBatch unset so the per-job path is unchanged", () => {
+        const { manager, globalJobRegistry } = buildManager();
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "cold",
+              handlerClass: createMockCommandHandlerClass("cold"),
+              options: { serializeByAggregate: true, coalesceMaxBatch: 1 },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(
+          globalJobRegistry.get("test-pipeline:command:cold")?.processBatch,
+        ).toBeUndefined();
+      });
+    });
+  });
 });
 
 describe("QueueManager.initializeHandlerQueues with groupKeyFn", () => {

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/resolveCoalesceMaxBatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/resolveCoalesceMaxBatch.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveCoalesceMaxBatch } from "../queueManager";
+
+describe("resolveCoalesceMaxBatch", () => {
+  describe("given an entry with no coalescing bound", () => {
+    it("answers one, leaving the job on the per-job path", () => {
+      expect(resolveCoalesceMaxBatch({}, { id: "a" })).toBe(1);
+    });
+  });
+
+  describe("given an entry with a constant bound", () => {
+    it("answers the same number for every job", () => {
+      const entry = { coalesceMaxBatch: 200 };
+
+      expect(resolveCoalesceMaxBatch(entry, { id: "a" })).toBe(200);
+      expect(resolveCoalesceMaxBatch(entry, { id: "b" })).toBe(200);
+    });
+  });
+
+  describe("given an entry whose bound is resolved per payload", () => {
+    it("answers what the resolver says about this job", () => {
+      const entry = {
+        coalesceMaxBatch: (payload: any) => (payload.oversized ? 1 : 64),
+      };
+
+      expect(resolveCoalesceMaxBatch(entry, { oversized: true })).toBe(1);
+      expect(resolveCoalesceMaxBatch(entry, { oversized: false })).toBe(64);
+    });
+
+    it("hands the resolver the payload it was asked about", () => {
+      const coalesceMaxBatch = vi.fn().mockReturnValue(64);
+      const payload = { id: "a", oversized: false };
+
+      resolveCoalesceMaxBatch({ coalesceMaxBatch }, payload);
+
+      expect(coalesceMaxBatch).toHaveBeenCalledWith(payload);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -47,13 +47,36 @@ export interface JobRegistryEntry {
   /**
    * Max number of same-group jobs to coalesce into one `processBatch` call
    * (including the dispatched job). Defaults to 1 (no coalescing).
+   *
+   * A resolver form is available for producers whose foldability depends on the
+   * individual job — a payload that will expand far beyond its queued size
+   * returns 1 and is processed on its own, because the drain's byte budget
+   * measures the QUEUED bytes and cannot see that expansion.
    */
-  coalesceMaxBatch?: number;
+  coalesceMaxBatch?: number | ((payload: any) => number);
   /**
    * Optional byte cap for a coalesced batch (ADR-066 pillar 2). Resolved by the
    * global queue per job; undefined falls back to the GroupQueue default.
    */
   coalesceMaxBytes?: number;
+}
+
+/**
+ * How many same-group jobs this entry may fold in alongside the given one.
+ *
+ * A constant answers for every job; a resolver is asked about this one, which is
+ * how a producer excludes the payloads it cannot safely fold. Absent means 1 —
+ * no coalescing, the per-job path.
+ */
+export function resolveCoalesceMaxBatch(
+  entry: Pick<JobRegistryEntry, "coalesceMaxBatch">,
+  payload: Record<string, unknown>,
+): number {
+  const bound = entry.coalesceMaxBatch;
+  if (typeof bound === "function") {
+    return bound(payload);
+  }
+  return bound ?? 1;
 }
 
 interface QueuedEventConsumerDefinition<E extends Event> {
@@ -588,6 +611,10 @@ export class QueueManager<EventType extends Event = Event> {
         },
       });
       const coalesceMaxBatch = cmdEntry.options.coalesceMaxBatch;
+      // A resolver decides per payload, so whether it coalesces is only known at
+      // dispatch — its presence is the opt-in. A plain number opts in above 1.
+      const coalescesAppends =
+        typeof coalesceMaxBatch === "function" || (coalesceMaxBatch ?? 1) > 1;
 
       // ADR-066 pillar 2 visibility: a producer whose jobs funnel into a shared
       // queue group and does NOT coalesce can still flood the event log one tiny
@@ -600,7 +627,7 @@ export class QueueManager<EventType extends Event = Event> {
       const isGroupedProducer =
         Boolean(cmdEntry.options.serializeByAggregate) ||
         Boolean(cmdEntry.getGroupKey);
-      if (isGroupedProducer && !(coalesceMaxBatch && coalesceMaxBatch > 1)) {
+      if (isGroupedProducer && !coalescesAppends) {
         this.logger.info(
           { pipeline: this.pipelineName, command: cmdName },
           "grouped command producer registered without append coalescing",
@@ -635,15 +662,14 @@ export class QueueManager<EventType extends Event = Event> {
         // aggregate's queued same-command jobs into one multi-row insert. The
         // GroupQueue only drains same-`__jobName` siblings, so every payload
         // here is this command type. Left undefined otherwise (per-job path).
-        processBatch:
-          coalesceMaxBatch && coalesceMaxBatch > 1
-            ? async (payloads: any[]) => {
-                await processCommandBatch({
-                  ...commandProcessParams,
-                  payloads,
-                });
-              }
-            : undefined,
+        processBatch: coalescesAppends
+          ? async (payloads: any[]) => {
+              await processCommandBatch({
+                ...commandProcessParams,
+                payloads,
+              });
+            }
+          : undefined,
         coalesceMaxBatch,
         coalesceMaxBytes: cmdEntry.options.coalesceMaxBytes,
         delay: cmdEntry.options.delay,


### PR DESCRIPTION
## For humans

When a trace comes in, each of its spans was saved to the database on its own — one trip per span. Now the spans that are waiting together are grouped and saved together, in one trip.

There is one exception, and it is the interesting part. A span too big to fit in the queue is parked in file storage and only a small note about it goes on the queue. That note looks tiny right up until the moment we open it, so grouping by "these all look small" would quietly assemble something enormous. Those oversized spans keep being saved one at a time, exactly as before.

Nothing about what gets stored changes: the same spans land, in the same order, with the same de-duplication, and the same off switch still works.

## Why the bound is a resolver, not a number

This is the safety analysis the follow-up asked for, and it is the reason this PR is shaped the way it is.

The queue drain already has a byte budget that stops a batch from growing too large. It weighs each job by its **queued** size. For an ordinary span that is honest — an inline span is capped at `COMMAND_INLINE_THRESHOLD` (256 KB), so the byte budget sees what it is getting.

For a spooled span (ADR-022) it is not. `maybeSpool` writes the full payload to object storage and queues a stand-in with `spoolRef` set and `span.attributes` cleared, so the queued job is a few hundred bytes. The handler then fetches the real span back — over 256 KB by definition, with no upper bound. Folding by count would let the byte budget wave through a batch whose true size it never measured, materialising all of it at once and shipping it as one insert.

So the bound is resolved per span: a payload carrying a `spoolRef` answers `1` and is appended on its own; an inline payload answers `RECORD_SPAN_COALESCE_MAX_BATCH`. That is not a special case bolted on — it is precisely the "a single oversized item is appended on its own" scenario the existing spec already describes.

Supporting that meant widening `coalesceMaxBatch` from `number` to `number | ((payload) => number)` through the option type and the job-registry entry. The GroupQueue already typed **its own** knob as a per-payload function; only the layers in between had flattened it to a constant, so this restores the contract rather than inventing one. One consequence worth flagging for review: registration could no longer test `coalesceMaxBatch > 1` to decide whether to wire `processBatch`, because a function is truthy but not greater than 1 — that comparison would have silently left coalescing switched off. Presence of a resolver is now the opt-in.

## Why recordSpan is safe to fold

- **Statelessness** — the batch path runs every handler *before* the single end-of-batch store, so a handler must not read back its own or a sibling's just-appended events. `RecordSpanCommand.handle` derives its event from its own command only. It reads external state (custom cost rates, privacy policy, feature flags), never same-batch appends.
- **The spool cleanup** — the crux of the follow-up. `cleanupAfterStore` deletes the spool only once the event is durable. `persistBatch` calls the single store first and then runs cleanup per handled command, and `cleanupAfterStore` already reads `spoolRef` from the command argument rather than instance state (it was made that way when a single handler instance began serving parallel jobs). So the per-command guarantee survives folding: no plain `coalesceMaxBatch` hazard here, and a batch that fails before the store drops no spool and stays retryable. Both are pinned by tests.
- **Ordering** — the drain takes the group head in score order and recordSpan scores by `occurredAt`, so per-group ordering is preserved.
- **Kill switch** — checked per payload inside the batch loop, exactly as the single path does.
- **Deduplication** — `RECORD_SPAN_DEDUPLICATION` is untouched; it acts when a job is staged, coalescing acts when jobs are drained.
- **Sharding** — shard counts are not changed. Coalescing works the same sharded (group = `traceId:<shard>`) or not (group = `traceId`).

## The evaluation pipeline: analysed, deliberately not included

`command/evaluation` is the queue lane, not a command — the `evaluation_processing` pipeline registers four: `executeEvaluation`, `startEvaluation`, `completeEvaluation`, `reportEvaluation`. None of them is worth coalescing, for a structural reason rather than a safety one.

Every one keys its aggregate on `evaluationId`, and callers mint a fresh KSUID per dispatch. The group therefore holds exactly one job for its whole life, so a drain would find no siblings and save no inserts. That is the structural opposite of a foldable producer like `recordTriggerMatch`, whose aggregate is a long-lived trigger that accumulates matches.

`reportEvaluation` is the one with real fan-in (an experiment run fires it per dataset row × evaluator) and its handler is trivially stateless, so it is the only candidate worth revisiting — but it would need a wider `getGroupKey`, which means turning off `serializeByAggregate` and rewriting the per-evaluation lifecycle-ordering invariant that `evaluationProcessing.liveOrdering.unit.test.ts` asserts. That is a design change, not a perf knob, and does not belong in this PR.

`executeEvaluation` additionally has a genuine safety blocker: it calls a non-idempotent cost recorder (`prisma.cost.create` with a generated id) and runs paid evaluator calls. Whole-batch retry — which is how the batch path handles failure — would duplicate billed rows and re-run those calls. It must not coalesce until that path is idempotent.

## Specs

`specs/event-sourcing/producer-append-coalescing.feature` already covers this behavior, including the oversized-item scenario this PR leans on. No new spec; the new tests are bound to its existing scenarios by `@scenario` annotations.

## Tests

- New `spanCommandCoalescing.unit.test.ts`: the registration installs a resolver; an inline span folds to the batch bound and a spooled one to 1 (both with and without sharding); a batch becomes one insert with spans in dispatch order, one trace aggregate, idempotency keys preserved; the kill switch still suppresses the whole batch; spool deletion happens once per command *after* the single append; and a handler failure partway leaves nothing stored and no spool dropped.
- New `resolveCoalesceMaxBatch.unit.test.ts` covering the widened bound: absent, constant, and resolver forms, and that the resolver is handed the payload it was asked about.
- Extended `queueManager.commandGroupKey.test.ts`: a resolver-valued bound wires `processBatch` and suppresses the un-coalesced warning; an explicit bound of 1 leaves the per-job path alone.
- `pnpm test:unit run src/server/event-sourcing`: 251 files, 7563 tests passing.
- `pnpm typecheck` and `pnpm typecheck:tests` clean; `biome check` clean on touched files.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved batching of span-processing events, allowing inline spans to be grouped efficiently while preserving safe handling for larger spooled spans.
  - Added payload-aware batch limits, with a maximum of 64 inline span events per batch.
  - Maintained deduplication, ordering, retry safety, and shard routing behavior.

- **Bug Fixes**
  - Improved queue handling for commands with payload-dependent batching rules.
  - Unknown or non-coalesced commands continue to use single-item batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->