### PR TITLE
fix(gateway): collapse redundant BUDGET_UPDATED change events per project

### DIFF
--- a/langwatch/ee/governance/reactors/__tests__/gatewayBudgetSync.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/gatewayBudgetSync.reactor.unit.test.ts
@@ -427,4 +427,143 @@ describe("gatewayBudgetSync reactor", () => {
       });
     });
   });
+
+  describe("BUDGET_UPDATED change-event dedupe", () => {
+    /**
+     * The change event is what makes the gateway drop its cached bundles and
+     * re-read spend. Deduping it is safe only where nothing enforces on the
+     * number it refreshes, so these pin the two halves of that split.
+     */
+    function dedupeDeps({
+      onBreach,
+      shouldEmit,
+    }: {
+      onBreach: "BLOCK" | "WARN";
+      shouldEmit: (params: { projectId: string }) => Promise<boolean>;
+    }) {
+      const budget = {
+        id: "budget-1",
+        scopeType: "PROJECT",
+        scopeId: "project-1",
+        window: "MONTH",
+        onBreach,
+      } as GatewayBudget;
+
+      const { deps } = mockDeps(
+        { id: "vk-1", organizationId: "org-1", principalUserId: null },
+        {
+          id: "project-1",
+          teamId: "team-1",
+          team: { organizationId: "org-1" },
+        },
+        [budget],
+      );
+
+      const create = vi.fn().mockResolvedValue({ revision: 1n });
+      (deps.prisma as any).gatewayChangeEvent = { create };
+
+      return {
+        deps: { ...deps, changeEventDedupe: { shouldEmit } },
+        create,
+      };
+    }
+
+    const gatewayFold = () =>
+      ctx(
+        createFoldState({
+          "langwatch.virtual_key_id": "vk-1",
+          "langwatch.gateway_request_id": "req-1",
+        }),
+      );
+
+    describe("given a budget that blocks on breach", () => {
+      describe("when a debit lands inside an already-claimed window", () => {
+        /** @scenario "A blocking budget's spend update is never held back" */
+        it("emits anyway — an enforcement decision is never held back", async () => {
+          const shouldEmit = vi.fn().mockResolvedValue(false);
+          const { deps, create } = dedupeDeps({
+            onBreach: "BLOCK",
+            shouldEmit,
+          });
+
+          await createGatewayBudgetSyncReactor(deps).handle(
+            event,
+            gatewayFold(),
+          );
+
+          expect(create).toHaveBeenCalledTimes(1);
+          // Not even asked: the dedupe is not on the blocking path at all,
+          // so its window can never become the dominant term in how fast a
+          // block decision propagates.
+          expect(shouldEmit).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given a budget that only warns on breach", () => {
+      describe("when the window is already claimed", () => {
+        /** @scenario "Repeat updates for a warn-only budget collapse into one" */
+        it("suppresses the redundant emission", async () => {
+          const shouldEmit = vi.fn().mockResolvedValue(false);
+          const { deps, create } = dedupeDeps({ onBreach: "WARN", shouldEmit });
+
+          await createGatewayBudgetSyncReactor(deps).handle(
+            event,
+            gatewayFold(),
+          );
+
+          expect(shouldEmit).toHaveBeenCalledWith({ projectId: "project-1" });
+          expect(create).not.toHaveBeenCalled();
+        });
+
+        /** @scenario "Repeat updates for a warn-only budget collapse into one" */
+        it("still writes the debit row — only the invalidation is deduped", async () => {
+          const shouldEmit = vi.fn().mockResolvedValue(false);
+          const { deps } = dedupeDeps({ onBreach: "WARN", shouldEmit });
+          const insertDebit = deps.budgetCHRepository.insertDebit as ReturnType<
+            typeof vi.fn
+          >;
+
+          await createGatewayBudgetSyncReactor(deps).handle(
+            event,
+            gatewayFold(),
+          );
+
+          expect(insertDebit).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe("when the window is free", () => {
+        it("emits the change event", async () => {
+          const shouldEmit = vi.fn().mockResolvedValue(true);
+          const { deps, create } = dedupeDeps({ onBreach: "WARN", shouldEmit });
+
+          await createGatewayBudgetSyncReactor(deps).handle(
+            event,
+            gatewayFold(),
+          );
+
+          expect(create).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe("given no dedupe service is wired", () => {
+      describe("when a debit lands", () => {
+        it("emits every time, as it did before the dedupe existed", async () => {
+          const shouldEmit = vi.fn(async () => true);
+          const { deps, create } = dedupeDeps({ onBreach: "WARN", shouldEmit });
+          const { changeEventDedupe: _omitted, ...withoutDedupe } = deps;
+
+          await createGatewayBudgetSyncReactor(withoutDedupe).handle(
+            event,
+            gatewayFold(),
+          );
+
+          expect(create).toHaveBeenCalledTimes(1);
+          expect(shouldEmit).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });

--- a/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
+++ b/langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts
@@ -16,6 +16,7 @@ import type {
   ApplicableScopes,
   GatewayBudgetRepository,
 } from "~/server/gateway/budget.repository";
+import type { BudgetChangeEventDedupeService } from "~/server/gateway/budgetChangeEventDedupe.service";
 import { budgetAppliesToProvider } from "~/server/gateway/budgetResolution.service";
 import { ChangeEventRepository } from "~/server/gateway/changeEvent.repository";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
@@ -52,6 +53,11 @@ export interface GatewayBudgetSyncReactorDeps {
   prisma: PrismaClient;
   budgetRepository: GatewayBudgetRepository;
   budgetCHRepository: GatewayBudgetClickHouseRepository;
+  /**
+   * Gates redundant BUDGET_UPDATED emissions. Optional: without it every
+   * fold emits, which is what this reactor did before the dedupe existed.
+   */
+  changeEventDedupe?: BudgetChangeEventDedupeService;
 }
 
 /** The VK a gateway trace debits against, as this reactor needs it. */
@@ -277,39 +283,75 @@ function buildDebitRows({
 }
 
 /**
+ * Whether a debit against these budgets can change an enforcement decision.
+ *
+ * A BLOCK budget's spend feeds the gateway's pre-request precheck, so its
+ * change event has to reach the gateway promptly or an over-limit key keeps
+ * being served from a cached bundle. A WARN budget's spend only drives
+ * advisory signal, where the same delay costs freshness and nothing else.
+ *
+ * That asymmetry is the whole basis for deduping one and not the other:
+ * they are not the same currency, and a single window cannot price both.
+ */
+function affectsEnforcementDecision(
+  budgets: Awaited<ReturnType<typeof resolveApplicableBudgets>>,
+): boolean {
+  return budgets.some(({ budget }) => budget.onBreach === "BLOCK");
+}
+
+/**
  * EC4 — emit a BUDGET_UPDATED change event so the gateway's /changes
  * subscriber (services/aigateway/adapters/authresolver) evicts cached
  * bundles for this project and the next request re-resolves with fresh
  * spend. Without this, Bundle.Config.Budget.SpentMicroUSD stays frozen at
  * populateConfig time and the on-breach=block precheck never fires until
- * the JWT TTL (~15min) rolls.
+ * the JWT TTL rolls.
  *
- * v2 TODO: dedupe — emit at most once per (projectId, budgetId) per ~10s
- * window to avoid every gateway request triggering an L1 sweep + cold-miss
- * on every other VK in the project. At single-tenant scale the
- * unconditional emit is correct, just noisier than ideal.
+ * Every gateway request used to emit one of these, and each emission evicts
+ * every bundle in the project — an L1 sweep plus a cold miss for every other
+ * virtual key in it. The emissions are redundant with each other because the
+ * event carries no spend figure: it asks for an eviction, and the
+ * re-materialise it provokes reads current spend for every budget. One
+ * eviction per window achieves what N did.
+ *
+ * The dedupe is skipped entirely when any applicable budget blocks on breach,
+ * so an emission that could change an enforcement decision is never held
+ * back. This is why the window cannot become the dominant term in
+ * block-decision propagation: it is not on that path at all.
+ *
+ * Known limit, deliberate: this is a leading-edge window with no trailing
+ * flush. If advisory traffic stops mid-window, the last debit's refresh waits
+ * for the next debit or the bundle TTL. That is acceptable for a signal
+ * nothing enforces on, and it cannot happen on the blocking path.
  *
  * Best-effort: the CH ledger row already landed, so a failure here leaves
  * the gateway's cache staler than it could be rather than corrupting state.
  */
 async function emitBudgetUpdatedChangeEvent({
   prisma,
+  changeEventDedupe,
   project,
   projectId,
   vk,
   gatewayRequestId,
-  budgetIds,
+  budgets,
   amountUsd,
 }: {
   prisma: PrismaClient;
+  changeEventDedupe?: BudgetChangeEventDedupeService;
   project: GatewayFoldProject;
   projectId: string;
   vk: GatewayVirtualKey;
   gatewayRequestId: string;
-  budgetIds: string[];
+  budgets: Awaited<ReturnType<typeof resolveApplicableBudgets>>;
   amountUsd: string;
 }): Promise<void> {
   try {
+    if (changeEventDedupe && !affectsEnforcementDecision(budgets)) {
+      const emit = await changeEventDedupe.shouldEmit({ projectId });
+      if (!emit) return;
+    }
+
     const changeEvents = new ChangeEventRepository(prisma);
     await changeEvents.append({
       organizationId: project.organizationId,
@@ -318,7 +360,7 @@ async function emitBudgetUpdatedChangeEvent({
       payload: {
         gatewayRequestId,
         virtualKeyId: vk.id,
-        budgetIds,
+        budgetIds: budgets.map((r) => r.budget.id),
         amountUsd,
       },
     });
@@ -399,11 +441,12 @@ async function foldGatewayTraceIntoLedger({
 
   await emitBudgetUpdatedChangeEvent({
     prisma: deps.prisma,
+    changeEventDedupe: deps.changeEventDedupe,
     project,
     projectId,
     vk,
     gatewayRequestId,
-    budgetIds: budgets.map((r) => r.budget.id),
+    budgets,
     amountUsd,
   });
 }

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -31,6 +31,7 @@ import type { LangyConversationProcessingEvent } from "~/server/event-sourcing/p
 import { getFeatureFlagStore } from "~/server/featureFlag/featureFlagStore.postgres";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { GatewayBudgetRepository } from "~/server/gateway/budget.repository";
+import { createBudgetChangeEventDedupeService } from "~/server/gateway/budgetChangeEventDedupe.service";
 import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { getEdgeSpoolFailOpenCounter } from "~/server/metrics";
 import {
@@ -750,6 +751,7 @@ export function initializeDefaultApp(options?: {
         budgetCHRepository: new GatewayBudgetClickHouseRepository(
           resolveClickHouseClient,
         ),
+        changeEventDedupe: createBudgetChangeEventDedupeService(redis),
       }
     : undefined;
 

--- a/langwatch/src/server/gateway/__tests__/budgetChangeEventDedupe.service.unit.test.ts
+++ b/langwatch/src/server/gateway/__tests__/budgetChangeEventDedupe.service.unit.test.ts
@@ -1,0 +1,121 @@
+import type IORedis from "ioredis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUDGET_CHANGE_EVENT_WINDOW_SECONDS,
+  createBudgetChangeEventDedupeService,
+  RedisBudgetChangeEventDedupeService,
+} from "../budgetChangeEventDedupe.service";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function redisStub(set: ReturnType<typeof vi.fn>) {
+  return { set } as unknown as IORedis;
+}
+
+describe("budget change-event dedupe", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given a project with no emission in the current window", () => {
+    describe("when the fold asks whether to emit", () => {
+      it("allows the emission", async () => {
+        const set = vi.fn().mockResolvedValue("OK");
+        const service = new RedisBudgetChangeEventDedupeService(redisStub(set));
+
+        await expect(
+          service.shouldEmit({ projectId: "project-1" }),
+        ).resolves.toBe(true);
+      });
+
+      it("claims the window with a fixed expiry, not a sliding one", async () => {
+        const set = vi.fn().mockResolvedValue("OK");
+        const service = new RedisBudgetChangeEventDedupeService(redisStub(set));
+
+        await service.shouldEmit({ projectId: "project-1" });
+
+        // NX means a busy project cannot push its own refresh back by
+        // re-claiming the key on every request.
+        expect(set).toHaveBeenCalledWith(
+          "gateway_budget_change:project-1",
+          "1",
+          "EX",
+          BUDGET_CHANGE_EVENT_WINDOW_SECONDS,
+          "NX",
+        );
+      });
+    });
+  });
+
+  describe("given a project that already emitted inside the window", () => {
+    describe("when a later fold asks whether to emit", () => {
+      it("declines the redundant emission", async () => {
+        const set = vi.fn().mockResolvedValue(null);
+        const service = new RedisBudgetChangeEventDedupeService(redisStub(set));
+
+        await expect(
+          service.shouldEmit({ projectId: "project-1" }),
+        ).resolves.toBe(false);
+      });
+    });
+
+    describe("when a different project asks in the same window", () => {
+      it("keys them apart", async () => {
+        const set = vi.fn().mockResolvedValue("OK");
+        const service = new RedisBudgetChangeEventDedupeService(redisStub(set));
+
+        await service.shouldEmit({ projectId: "project-1" });
+        await service.shouldEmit({ projectId: "project-2" });
+
+        expect(set.mock.calls[0]?.[0]).toBe("gateway_budget_change:project-1");
+        expect(set.mock.calls[1]?.[0]).toBe("gateway_budget_change:project-2");
+      });
+    });
+  });
+
+  describe("given Redis is unavailable", () => {
+    describe("when the fold asks whether to emit", () => {
+      it("fails toward emitting rather than withholding an invalidation", async () => {
+        const set = vi.fn().mockRejectedValue(new Error("connection refused"));
+        const service = new RedisBudgetChangeEventDedupeService(redisStub(set));
+
+        await expect(
+          service.shouldEmit({ projectId: "project-1" }),
+        ).resolves.toBe(true);
+      });
+    });
+  });
+
+  describe("given no Redis connection at all", () => {
+    describe("when the fold asks whether to emit", () => {
+      it("emits every time, matching the pre-dedupe behavior", async () => {
+        const service = createBudgetChangeEventDedupeService(null);
+
+        await expect(
+          service.shouldEmit({ projectId: "project-1" }),
+        ).resolves.toBe(true);
+        await expect(
+          service.shouldEmit({ projectId: "project-1" }),
+        ).resolves.toBe(true);
+      });
+    });
+  });
+
+  describe("window sizing", () => {
+    it("is at least the change-feed poll granularity", () => {
+      // The /changes loop re-reads every 2s, so a window below that would
+      // suppress nothing the consumer had not already coalesced.
+      expect(BUDGET_CHANGE_EVENT_WINDOW_SECONDS).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does not exceed the long-poll hold it is matched to", () => {
+      // Matched to the default `timeout_s` hold: one eviction per poll cycle.
+      expect(BUDGET_CHANGE_EVENT_WINDOW_SECONDS).toBeLessThanOrEqual(10);
+    });
+  });
+});

--- a/langwatch/src/server/gateway/budgetChangeEventDedupe.service.ts
+++ b/langwatch/src/server/gateway/budgetChangeEventDedupe.service.ts
@@ -1,0 +1,97 @@
+import { createLogger } from "@langwatch/observability";
+import type IORedis from "ioredis";
+import type { Cluster } from "ioredis";
+
+const logger = createLogger("langwatch:gateway:budget-change-event-dedupe");
+
+const BUDGET_CHANGE_EVENT_KEY_PREFIX = "gateway_budget_change:";
+
+/**
+ * How long one advisory BUDGET_UPDATED emission stands in for the ones that
+ * follow it.
+ *
+ * Matched to the `/changes` long-poll hold (`timeout_s`, default 10s) so a
+ * project under continuous traffic causes at most one project-wide eviction
+ * per poll cycle rather than one per request.
+ *
+ * A fixed window from the first emission, not a sliding one: the key is set
+ * once and left to expire, so a busy project still refreshes on a fixed
+ * cadence instead of having its refresh pushed back by its own traffic.
+ */
+export const BUDGET_CHANGE_EVENT_WINDOW_SECONDS = 10;
+
+export interface BudgetChangeEventDedupeService {
+  /**
+   * Whether this fold should emit a BUDGET_UPDATED change event.
+   *
+   * Keyed on the project alone, because that is the granularity the consumer
+   * invalidates at: the gateway's change-feed subscriber evicts every bundle
+   * whose `ProjectID` matches and ignores `budget_id` entirely for this kind.
+   * A second event for a different budget in the same project would therefore
+   * evict exactly what the first already evicted, and the re-materialise that
+   * follows reads current spend for every budget, not just the one named.
+   */
+  shouldEmit(params: { projectId: string }): Promise<boolean>;
+}
+
+/** No Redis (tests, SKIP_REDIS, dev without Redis): emit every time. */
+class NullBudgetChangeEventDedupeService
+  implements BudgetChangeEventDedupeService
+{
+  async shouldEmit(): Promise<boolean> {
+    return true;
+  }
+}
+
+/**
+ * Redis `SET NX` with a TTL, mirroring the span- and share-view dedupe
+ * services.
+ *
+ * The change event is an invalidation signal, not a data carrier: it tells the
+ * gateway to drop its cached bundles, and the spend figure itself is read from
+ * ClickHouse when the bundle is re-materialised. Emissions inside one window
+ * are therefore redundant with each other — the eviction they ask for has
+ * already been asked for, and the read it triggers already sees every debit
+ * written since.
+ *
+ * This service must only gate *advisory* emissions. Suppressing an emission
+ * that carries a budget into breach would leave an over-limit key served from
+ * a cached bundle, which is a different kind of cost entirely; the caller owns
+ * that distinction.
+ */
+export class RedisBudgetChangeEventDedupeService
+  implements BudgetChangeEventDedupeService
+{
+  constructor(private readonly redis: IORedis | Cluster) {}
+
+  async shouldEmit({ projectId }: { projectId: string }): Promise<boolean> {
+    const key = `${BUDGET_CHANGE_EVENT_KEY_PREFIX}${projectId}`;
+    try {
+      const result = await this.redis.set(
+        key,
+        "1",
+        "EX",
+        BUDGET_CHANGE_EVENT_WINDOW_SECONDS,
+        "NX",
+      );
+      return result === "OK";
+    } catch (error) {
+      // Fail toward emitting. Emitting is what this code did before the
+      // dedupe existed and is always correct, only noisier; suppressing is
+      // the optimization. A Redis outage must not be a way to hold back a
+      // cache invalidation the gateway is waiting on.
+      logger.warn(
+        { projectId, error },
+        "budget change-event dedupe unavailable; emitting this change event",
+      );
+      return true;
+    }
+  }
+}
+
+export function createBudgetChangeEventDedupeService(
+  redis: IORedis | Cluster | null,
+): BudgetChangeEventDedupeService {
+  if (!redis) return new NullBudgetChangeEventDedupeService();
+  return new RedisBudgetChangeEventDedupeService(redis);
+}

--- a/specs/ai-gateway/budgets.feature
+++ b/specs/ai-gateway/budgets.feature
@@ -262,6 +262,37 @@ Feature: AI Gateway — Budgets
     And the response carries a budget warning
 
   # ============================================================================
+  # Keeping the gateway's cached spend fresh
+  # ============================================================================
+  #
+  # After each gateway request the platform tells the gateway to drop the spend
+  # figures it has cached, so the next request re-reads them. Every request
+  # doing that costs every other key in the project a cache miss, and the
+  # notices are interchangeable — one of them refreshes everything the rest
+  # would have. So they are collapsed to one per project per short window.
+  #
+  # Collapsing them is only safe where nothing is being enforced on the number.
+  # A budget that blocks decides whether the next request is refused, so its
+  # notice is never held back; a budget that only warns is advisory, and a
+  # slightly later warning costs nothing anyone acts on.
+
+  @unit
+  Scenario: A blocking budget's spend update is never held back
+    Given a project whose budget refuses requests once it is exceeded
+    And the project already sent a spend update moments ago
+    When another request records spend against that budget
+    Then the gateway is told immediately that the spend changed
+    And how fast a refusal takes effect is unchanged
+
+  @unit
+  Scenario: Repeat updates for a warn-only budget collapse into one
+    Given a project whose budget only warns when it is exceeded
+    And the project already sent a spend update moments ago
+    When another request records spend against that budget
+    Then no second update is sent for it
+    And the spend itself is still recorded in full
+
+  # ============================================================================
   # Provider-filtered budgets
   # ============================================================================
   #


### PR DESCRIPTION
Closes langwatch/langwatch-saas#895

## For humans

After every request through the AI Gateway, the platform sends the gateway a note saying "this project's spending changed, throw away what you cached." The gateway reacts by dropping the cached settings for *every* key in that project, so the next request for each of them has to be rebuilt from scratch.

The notes were being sent one per request, and they're interchangeable — the note carries no numbers, it just says "go re-read." One note refreshes everything the next ten would have. So a busy project was making every one of its own keys slower, repeatedly, to deliver the same message.

This collapses them to one note per project per ten seconds.

The catch, and the reason this needed care: some budgets *refuse* requests once you go over them, and that refusal depends on the gateway having fresh numbers. Holding one of those notes back would mean an over-budget key keeps getting served. So notes for budgets that block are never held back — only notes for budgets that just warn you, where arriving a few seconds later costs nothing anyone acts on.

## Why per project, not per (project, budget)

The follow-up was originally scoped as "dedupe per (projectId, budgetId)". Reading the consumer changed that: for this event kind the gateway's change-feed subscriber evicts every bundle whose `ProjectID` matches and never reads `budget_id` at all (`services/aigateway/adapters/authresolver/service.go`, the `ChangeKindBudgetUpdated` case). A second event naming a different budget in the same project therefore evicts exactly what the first already evicted.

Keying on the budget as well would have under-deduped by roughly the number of applicable budgets while buying nothing, so the key is the project alone.

## Why blocking budgets are exempt, and what that buys

The enforcement chain is: reactor writes the debit row to ClickHouse → reactor emits `BUDGET_UPDATED` → gateway's `/changes` poll sees it → gateway evicts the project's bundles → next request re-materialises → `GatewayConfigMaterialiser` reads current spend from ClickHouse → Go precheck compares spend against the limit and returns 402 when `on_breach=block`.

The event is an *invalidation signal, not a data carrier*. That is what makes deduping sound at all: the number the gateway ends up with comes from ClickHouse at re-materialise time, so it already includes every debit written since the event that triggered the read.

It also means suppressing an event is only harmful when nothing else forces a re-read before spend crosses a limit. That is exactly the blocking case, so blocking is exempt:

- **Any budget with `onBreach = BLOCK` among the applicable budgets → emit immediately, dedupe not consulted.**
- All-warn → dedupe applies.

The invariant that makes this safe is that a BLOCK budget's spend can only change when a debit row is written for it, and that write always goes through this reactor with that budget in hand — so it always emits. There is no path where a blocking budget's spend moves silently.

This is also the answer to "make sure the window never dominates block-decision propagation": it structurally cannot, because the dedupe is not on that path. Block propagation stays at the pre-existing ceiling, which is the `/changes` inner poll granularity.

## The window, measured rather than assumed

Measured from the code rather than picked:

- `GET /api/internal/gateway/changes` (`src/server/routes/gateway-internal.ts`) loops re-reading the event table, sleeping **2s** between reads, holding for `timeout_s` — **default 10s**, clamped to 1..25 — then returning 204.
- The Go client (`changeFeedLoop`) re-polls immediately on success; its own 2s sleep is on the error path only.
- That client asks for the 10s hold explicitly — `q.Set("timeout_s", "10")` in `services/aigateway/adapters/controlplane/client.go:205` — so the hold is a real figure from the only caller in the tree, not merely the server-side default it happens to match.

So an emitted event is detected within about 2s, and 10s is the longest a single held poll runs.

`BUDGET_CHANGE_EVENT_WINDOW_SECONDS = 10` follows: below 2s the window would suppress nothing the consumer had not already coalesced, and 10s matches the hold, so a project under continuous advisory traffic causes at most one eviction per poll cycle instead of one per request. Both bounds are pinned by tests so the constant cannot drift away from the cadence it was derived from.

## Known limit, deliberate

This is a leading-edge window with no trailing flush. If advisory traffic stops mid-window, the last debit's refresh waits for the next debit or the bundle TTL rather than arriving at window end.

That is acceptable because nothing enforces on an advisory number, and it cannot occur on the blocking path, which never dedupes. A trailing flush would need a scheduled job on the enforcement path; that cost is not worth paying for a warning banner. Calling it out explicitly because a leading-edge-only throttle that *did* cover the blocking path would be a correctness bug, not a tuning choice.

## What changed

- `langwatch/src/server/gateway/budgetChangeEventDedupe.service.ts` (new) — Redis `SET NX` + TTL, so the window holds across pods. Interface / null / Redis / factory shape copied from `share-view-dedupe.service.ts`. Fails toward **emitting**: emitting is the pre-dedupe behavior and always correct, only noisier, so a Redis outage must not withhold an invalidation the gateway is waiting on.
- `langwatch/ee/governance/reactors/gatewayBudgetSync.reactor.ts` — new `affectsEnforcementDecision` predicate; `emitBudgetUpdatedChangeEvent` consults the dedupe only for all-warn folds. Dependency is optional, so an unwired caller behaves exactly as before. Replaces the `v2 TODO` this PR implements.
- `langwatch/src/server/app-layer/presets.ts` — wires the service from the existing `redis` connection.
- `specs/ai-gateway/budgets.feature` — two `@unit` scenarios for the two halves of the split, each bound by a `@scenario` annotation. `check-feature-parity.ts` reports 33/33 bound.

## Tests

`pnpm test:unit run ee/governance/reactors/__tests__/ src/server/gateway/__tests__/budgetChangeEventDedupe.service.unit.test.ts` — 53 passed across 5 files.

The load-bearing one is that a blocking budget emits even when the dedupe is primed to suppress, and that the dedupe is not even *consulted* on that path. Verified as a real regression test rather than an accident: stubbing `affectsEnforcementDecision` to `false` fails that assertion specifically, and it was restored before committing.

Also covered: warn-only suppression, that suppression never touches the debit row itself (only the invalidation is deduped), fail-toward-emitting on a Redis error, the no-Redis path emitting every time, and the two window bounds against the measured poll cadence.

`pnpm typecheck` and `pnpm typecheck:tests` clean. `pnpm exec biome check` reports no errors on the touched files.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J
