### PR TITLE
fix(ops): let the keyspace sweep come due again

### DIFF
--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -57,7 +57,13 @@ class FakeRedis {
       const re = new RegExp(
         `^${pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`,
       );
-      const keys = [...this.zsets.keys()].filter((k) => re.test(k)).sort();
+      // Redis drops a collection when its last member goes, so a drained group
+      // has no key for SCAN to return. Modelling that matters here: it is what
+      // stops the sweep treating an empty group as something to adopt.
+      const keys = [...this.zsets.entries()]
+        .filter(([k, members]) => members.length > 0 && re.test(k))
+        .map(([k]) => k)
+        .sort();
       const offset = Number(cursor);
       const page = keys.slice(offset, offset + count);
       const next = offset + page.length;
@@ -670,6 +676,94 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         // Nothing was adopted, so the sweep backs off instead of paying the
         // keyspace walk on every pass.
         expect(redis.scan.mock.calls.length).toBe(afterFirst);
+      });
+    });
+  });
+
+  describe("given the sweep has backed off to its backstop interval", () => {
+    const BACKSTOP_MS = 60 * 60 * 1000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      redis.seedGroup({
+        groupId: "tenant-a/known",
+        jobCount: 1,
+        index: `${PREFIX}pending-groups`,
+        indexType: "set",
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Passes between sweeps, none of which should touch the deadline. */
+    const runPassesOver = async (totalMs: number, passes: number) => {
+      for (let i = 0; i < passes; i++) {
+        vi.advanceTimersByTime(Math.floor(totalMs / passes));
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+      }
+    };
+
+    describe("when reconciles keep running before the deadline", () => {
+      /** @scenario "Reconciles between sweeps do not postpone the scheduled sweep" */
+      it("still sweeps once the backstop elapses", async () => {
+        // First pass sweeps and finds nothing to adopt, so the next is scheduled
+        // a backstop away.
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+        const afterFirstSweep = redis.scan.mock.calls.length;
+        expect(afterFirstSweep).toBeGreaterThan(0);
+
+        // Passes covering most of the interval must leave the deadline alone.
+        await runPassesOver(BACKSTOP_MS - 60_000, 30);
+        expect(redis.scan.mock.calls.length).toBe(afterFirstSweep);
+
+        // Once the interval has genuinely elapsed, the sweep comes due.
+        vi.advanceTimersByTime(120_000);
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+
+        expect(redis.scan.mock.calls.length).toBeGreaterThan(afterFirstSweep);
+      });
+    });
+
+    describe("when a sweep finds a group the index does not list", () => {
+      /** @scenario "A sweep that adopts keeps sweeping on the next pass" */
+      it("sweeps again on the very next pass", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+        const afterFirstSweep = redis.scan.mock.calls.length;
+
+        // Arrives after the first sweep, indexed nowhere: the state a pod on the
+        // previous release leaves behind mid-rollout.
+        redis.zsets.set(`${PREFIX}group:tenant-a/late:jobs`, ["j1"]);
+        vi.advanceTimersByTime(BACKSTOP_MS + 1);
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+        const afterAdoptingSweep = redis.scan.mock.calls.length;
+        expect(afterAdoptingSweep).toBeGreaterThan(afterFirstSweep);
+
+        // That sweep adopted, so the next pass sweeps again without waiting.
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+
+        expect(redis.scan.mock.calls.length).toBeGreaterThan(
+          afterAdoptingSweep,
+        );
+      });
+    });
+
+    describe("when a drained group is still listed in a lifecycle index", () => {
+      /** @scenario "A drained group listed in a lifecycle index does not pin the sweep" */
+      it("does not keep the expensive walk running on it", async () => {
+        // Listed in ready with no jobs: adopted, pruned for being empty, and
+        // found again next pass. Counting it as an adoption would answer
+        // "sweep again" forever.
+        redis.zsets.set(`${PREFIX}ready`, ["tenant-a/drained"]);
+        redis.zsets.set(`${PREFIX}group:tenant-a/drained:jobs`, []);
+
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+        const afterFirstSweep = redis.scan.mock.calls.length;
+
+        await repo.reconcileTotalPending(QUEUE_NAME, 0);
+
+        expect(redis.scan.mock.calls.length).toBe(afterFirstSweep);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1835,10 +1835,15 @@ export class QueueRedisRepository implements QueueRepository {
     // The lifecycle legs only cover a group the pass actually saw, and a group
     // moving between them mid-read is seen by neither. The keyspace sweep is what
     // covers those, because it reads key existence rather than membership.
+    let sweptUnindexed: number | null = null;
     if (await this.isKeyspaceSweepDue(prefix)) {
       const swept = await this.sweepKeyspaceForGroups({ prefix, refreshLease });
       if (swept === null) return null;
-      for (const groupId of swept) groupIds.add(groupId);
+      sweptUnindexed = 0;
+      for (const groupId of swept) {
+        groupIds.add(groupId);
+        if (!alreadyIndexed.has(groupId)) sweptUnindexed += 1;
+      }
     }
 
     const toAdopt = Array.from(groupIds).filter(
@@ -1850,7 +1855,13 @@ export class QueueRedisRepository implements QueueRepository {
       refreshLease,
     });
     if (!held) return null;
-    await this.recordSweepOutcome({ prefix, adopted: toAdopt.length });
+
+    // Only a pass that actually swept may move the deadline. Rescheduling on
+    // every pass would push it out by a fresh backstop each time and the sweep
+    // would never come due again — the deadline would outrun the clock.
+    if (sweptUnindexed !== null) {
+      await this.recordSweepOutcome({ prefix, adopted: sweptUnindexed });
+    }
 
     return groupIds;
   }
@@ -1977,6 +1988,16 @@ export class QueueRedisRepository implements QueueRepository {
    * what this reconcile cost before the index existed and no more. Adopting
    * nothing means the index is complete, and the sweep drops back to a slow
    * backstop that only has to catch a writer nobody has noticed is missing.
+   *
+   * `adopted` counts what the SWEEP found unindexed, not everything the pass
+   * adopted. The lifecycle legs also turn up unindexed ids, but they include
+   * groups that hold no jobs at all — a drained group still listed in `ready` or
+   * `blocked` is adopted, pruned for being empty, and found again next pass.
+   * Counting those would answer "sweep again" forever and pin the queue to the
+   * expensive walk on a group with no pending work to find.
+   *
+   * Only ever called by a pass that swept. Calling it otherwise moves the
+   * deadline without the walk that earns it, and the sweep stops coming due.
    */
   private async recordSweepOutcome(params: {
     prefix: string;

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -136,3 +136,28 @@ Feature: GroupQueue pending counter ground-truth reconcile
     When the reconcile runs
     Then its jobs are counted
     And it is added to the pending index for later passes
+
+  # The keyspace walk is the only enumeration that cannot miss a group, so it is
+  # kept as a backstop long after the index has caught up. A backstop that is
+  # rescheduled by passes which never ran it is not a backstop: the deadline
+  # outruns the clock and the walk never comes due again.
+  @unit
+  Scenario: Reconciles between sweeps do not postpone the scheduled sweep
+    Given a sweep has run and found nothing to adopt
+    When reconciles keep running before the next sweep is due
+    Then the sweep still runs once its interval has elapsed
+
+  @unit
+  Scenario: A sweep that adopts keeps sweeping on the next pass
+    Given a sweep finds a group holding jobs that the index does not list
+    When the next reconcile runs
+    Then it sweeps again without waiting for the interval
+
+  # A group listed in a lifecycle index while holding no jobs is adopted, pruned
+  # for being empty, and found again on the next pass. Treating that as progress
+  # would answer "sweep again" forever over work that does not exist.
+  @unit
+  Scenario: A drained group listed in a lifecycle index does not pin the sweep
+    Given a group listed in a lifecycle index whose jobs have all gone
+    When reconciles keep running
+    Then the sweep still backs off to its interval


### PR DESCRIPTION
## For humans

The pending-jobs counter is recomputed every minute from an index of which groups hold work. As a safety net, it occasionally does a slower, thorough sweep that reads the data directly — the one check that cannot miss a group, kept in case something ever goes missing from the index.

That safety net had stopped running. Every minute the counter recomputed, it also pushed the sweep's next run an hour further out — including the minutes when it hadn't swept at all. Since it recomputes far more often than once an hour, the next run was always being moved further away than time was moving forward, so after the first sweep no later one ever happened. Anything the fast path missed would have stayed missed indefinitely.

Now only a run that actually sweeps moves the next one, so the safety net fires on schedule again.

## The defect

`collectPendingGroupIds` called `recordSweepOutcome` unconditionally, outside the `isKeyspaceSweepDue` branch. In steady state `adopted` is 0, so every pass wrote `now + PENDING_RECONCILE_SWEEP_BACKSTOP_MS` into the due key. With passes arriving on a much shorter cadence than the backstop, the deadline advanced faster than the clock and `isKeyspaceSweepDue` never returned true again.

Consequence: the keyspace walk — the only enumeration indifferent to which lifecycle index a group is in, and therefore the only one that cannot miss a group moving between them — ran once and never again. A group missed by the lifecycle reads would stay undiscovered for as long as the queue kept reconciling.

## The fix

Track whether a sweep ran, and reschedule only then.

The reschedule signal is also narrowed from "everything this pass adopted" to "what the sweep found unindexed". The lifecycle legs turn up groups holding no jobs at all — a drained group still listed in `ready` or `blocked` is adopted, pruned for being empty by the same pass, and found again on the next one. Counting those as progress answers "sweep again" forever and pins the queue to the expensive walk over work that does not exist. That is a live-lock the previous signal permitted, so it is fixed here rather than left for the next reader to find.

## Tests

Three unit scenarios on fake timers, all bound in `specs/ops/pending-counter-reconcile.feature`:

- reconciles running through most of the interval leave the deadline alone, and the sweep still fires once the interval genuinely elapses
- a sweep that adopts something sweeps again on the very next pass, without waiting
- a drained group listed in a lifecycle index does not keep the walk running

Verified against the merged code: the first and third fail there (`expected 1 to be greater than 1`, `expected 2 to be 1`), so they fail for the reason they exist. The second passes on both, and is kept because it pins the branch the fix must not break.

One fixture fidelity fix came out of this: the in-memory Redis fake kept zero-length zsets as live keys, where Redis drops a collection with its last member. The drained-group case depends on that difference, so the fake now models it.

Results: unit 25/25, reconcile integration 13/13 against a real Redis, `pnpm typecheck:all` clean, feature-parity 19/19 bound, Biome gate reports no new violations.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-job reconciliation to ensure scheduled sweeps run when due.
  * Prevented newly discovered jobs from indefinitely delaying follow-up sweeps.
  * Avoided repeated processing of drained job groups.

* **Tests**
  * Added coverage for sweep scheduling, job adoption, drained groups, and interval backoff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->