### PR TITLE
fix(event-sourcing): budget coalesced batches by payload bytes, not stored bytes

### DIFF
--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
@@ -75,16 +75,25 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
     processFn,
     consumerEnabled,
     objectStore = new InMemoryObjectStore(),
+    processBatch,
+    coalesceMaxBatch,
+    coalesceMaxBytes,
   }: {
     processFn: (payload: TestPayload) => Promise<void>;
     consumerEnabled: boolean;
     objectStore?: ObjectStore;
+    processBatch?: (payloads: TestPayload[]) => Promise<void>;
+    coalesceMaxBatch?: (payload: TestPayload) => number | undefined;
+    coalesceMaxBytes?: (payload: TestPayload) => number | undefined;
   }): { queue: GroupQueueProcessor<TestPayload>; name: string } {
     const name = `{test/gq2/${crypto.randomUUID().slice(0, 8)}}`;
     const definition: EventSourcedQueueDefinition<TestPayload> = {
       name,
       groupKey: (p) => p.groupId,
       process: processFn,
+      ...(processBatch ? { processBatch } : {}),
+      ...(coalesceMaxBatch ? { coalesceMaxBatch } : {}),
+      ...(coalesceMaxBytes ? { coalesceMaxBytes } : {}),
     };
     const queue = new GroupQueueProcessor<TestPayload>(definition, redis, {
       consumerEnabled,
@@ -100,6 +109,60 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
 
   const blobKeys = (name: string) => redis.keys(`${name}:gq:blob:*`);
   const leaseKeys = (name: string) => redis.keys(`${name}:gq:blobleases:*`);
+
+  // The regression this guards (ADR-066 pillar 2): the drain's byte budget used
+  // to measure the STORED value, which for an offloaded body is a ~250-byte
+  // reference. A burst of megabyte payloads therefore folded whole no matter
+  // what budget was set — the exact backlog the coalescing was built for was the
+  // one where the byte bound stopped existing.
+  describe("given a burst of jobs whose payloads are all offloaded", () => {
+    describe("when a byte budget smaller than the burst is set", () => {
+      it("bounds the batch by payload bytes, not by the reference's stored size", async () => {
+        const batches: TestPayload[][] = [];
+        const singles: TestPayload[] = [];
+        const { queue } = createQueue({
+          processFn: async (p) => {
+            singles.push(p);
+          },
+          processBatch: async (ps) => {
+            batches.push(ps);
+          },
+          consumerEnabled: true,
+          // Count alone would fold all six; the budget fits two 8 KiB payloads.
+          coalesceMaxBatch: () => 50,
+          coalesceMaxBytes: () => 20 * 1024,
+        });
+        await queue.waitUntilReady();
+
+        await queue.sendBatch(
+          Array.from({ length: 6 }, (_, i) => ({
+            id: `j${i}`,
+            groupId: TENANT_GROUP,
+            value: OFFLOADED_VALUE,
+          })),
+        );
+
+        await vi.waitFor(
+          () => {
+            const total =
+              batches.reduce((n, b) => n + b.length, 0) + singles.length;
+            expect(total).toBe(6);
+          },
+          { timeout: 30000, interval: 50 },
+        );
+
+        // Six references sum to ~1.5 KiB, so the old accounting put the whole
+        // burst inside a 20 KiB budget. Six 8 KiB payloads do not fit.
+        const maxBatch =
+          batches.length > 0 ? Math.max(...batches.map((b) => b.length)) : 0;
+        expect(maxBatch).toBeLessThanOrEqual(2);
+        // Every payload was still resolved in full, and delivered exactly once.
+        const all = [...batches.flat(), ...singles];
+        expect(new Set(all.map((p) => p.id)).size).toBe(6);
+        expect(all.every((p) => p.value === OFFLOADED_VALUE)).toBe(true);
+      });
+    });
+  });
 
   describe("given a job whose payload exceeds the inline ceiling", () => {
     describe("when it is processed to completion", () => {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
@@ -155,7 +155,11 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
         // burst inside a 20 KiB budget. Six 8 KiB payloads do not fit.
         const maxBatch =
           batches.length > 0 ? Math.max(...batches.map((b) => b.length)) : 0;
-        expect(maxBatch).toBeLessThanOrEqual(2);
+        // Exactly two, not "at most two": an upper bound alone also passes when
+        // coalescing stops happening at all (maxBatch 0), which would be as
+        // wrong as a six-wide batch. The budget fits two 8 KiB payloads, and
+        // all six are staged before the consumer drains, so two is the answer.
+        expect(maxBatch).toBe(2);
         // Every payload was still resolved in full, and delivered exactly once.
         const all = [...batches.flat(), ...singles];
         expect(new Set(all.map((p) => p.id)).size).toBe(6);

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
@@ -117,6 +117,7 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
   // one where the byte bound stopped existing.
   describe("given a burst of jobs whose payloads are all offloaded", () => {
     describe("when a byte budget smaller than the burst is set", () => {
+      /** @scenario an offloaded payload's reference advertises its true cost */
       it("bounds the batch by payload bytes, not by the reference's stored size", async () => {
         const batches: TestPayload[][] = [];
         const singles: TestPayload[] = [];

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -507,6 +507,21 @@ describe("jobEnvelope", () => {
           expect(readJobPayloadBytes(legacy)).toBe(MAX_BLOB_BYTES);
         });
 
+        // A recorded size that is not a byte count must not be able to talk the
+        // budget down. `1e999` is the one that matters: it is valid JSON, parses
+        // to Infinity, and would reach the Lua drain as an unparseable ARGV.
+        // Written as raw header text because JSON.stringify cannot emit these.
+        const SIZES = ["1e999", "0.1", "-1", '"4096"', "null"];
+
+        it.each(
+          SIZES,
+        )("ignores a recorded size of %s, costing the cap", (s) => {
+          const header = `{"v":2,"e":"redis","s":${s}}`;
+          const value = `GQ2|${Buffer.byteLength(header)}|${header}`;
+
+          expect(readJobPayloadBytes(value)).toBe(MAX_BLOB_BYTES);
+        });
+
         it("keeps the stored length for a plain inline body", async () => {
           const { tieredBlobs } = makeTiered();
           const encoded = await encodeJobEnvelope({

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -11,6 +11,7 @@ import {
   PayloadTooLargeError,
   readEnvelopeLease,
   readEnvelopeRetirement,
+  readJobPayloadBytes,
   readJobRoutingMeta,
 } from "../jobEnvelope";
 import { TieredBlobStore } from "../tieredBlobStore";
@@ -406,6 +407,57 @@ describe("jobEnvelope", () => {
         await expect(
           decodeJobEnvelope({ value: encoded, tieredBlobs: bombStore }),
         ).rejects.toThrow();
+      });
+    });
+
+    // ADR-066 pillar 2: what a coalesced batch will weigh cannot be read off the
+    // stored value once a body is compressed or offloaded, so the encoder
+    // records it in the header and the drain's byte budget reads it there.
+    describe("when the recorded payload size is read back", () => {
+      it("reports the pre-offload payload size for an offloaded body", async () => {
+        const { tieredBlobs } = makeTiered();
+        const jobData = {
+          __jobName: "spanReceived",
+          bulk: "z".repeat(64 * 1024),
+        };
+
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        // The stored value is a small reference; the payload is not.
+        expect(Buffer.byteLength(encoded)).toBeLessThan(1024);
+        expect(readJobPayloadBytes(encoded)).toBeGreaterThan(64 * 1024);
+      });
+
+      it("reports the uncompressed payload size for a compressed inline body", async () => {
+        const { tieredBlobs } = makeTiered();
+        // Over the compression threshold, under the inline ceiling: stays in the
+        // envelope, but stored far smaller than it will be in a worker's hands.
+        const jobData = { __jobName: "tiny", bulk: "z".repeat(3 * 1024) };
+
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(readJobPayloadBytes(encoded)).toBeGreaterThan(
+          Buffer.byteLength(encoded),
+        );
+        expect(readJobPayloadBytes(encoded)).toBeGreaterThan(3 * 1024);
+      });
+
+      it("falls back to the stored length for legacy bare JSON", () => {
+        const value = JSON.stringify({ hello: "world" });
+
+        expect(readJobPayloadBytes(value)).toBe(Buffer.byteLength(value));
+      });
+
+      it("falls back to the stored length for a corrupt value", () => {
+        expect(readJobPayloadBytes("GQ2|not-a-length|{}")).toBe(19);
       });
     });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -459,6 +459,67 @@ describe("jobEnvelope", () => {
       it("falls back to the stored length for a corrupt value", () => {
         expect(readJobPayloadBytes("GQ2|not-a-length|{}")).toBe(19);
       });
+
+      // Old workers keep staging pre-`s` envelopes for the length of a rolling
+      // deploy. For those, the stored length is honest only when the body is
+      // inline and uncompressed; anything else is a fraction of the payload
+      // with nothing in the value saying by how much.
+      describe("when the envelope predates the recorded size", () => {
+        /** Strips `s` back out of an encoded envelope, leaving the rest intact. */
+        const withoutRecordedSize = (value: string): string => {
+          const buf = Buffer.from(value, "utf8");
+          const barIdx = buf.indexOf(0x7c, 4); // "|" after the prefix
+          const headerLen = Number(buf.subarray(4, barIdx).toString("utf8"));
+          const header = JSON.parse(
+            buf.subarray(barIdx + 1, barIdx + 1 + headerLen).toString("utf8"),
+          ) as Record<string, unknown>;
+          const body = buf.subarray(barIdx + 1 + headerLen).toString("utf8");
+          delete header.s;
+          const json = JSON.stringify(header);
+          return `${value.slice(0, 4)}${Buffer.byteLength(json)}|${json}${body}`;
+        };
+
+        it("costs the payload cap for an offloaded body", async () => {
+          const { tieredBlobs } = makeTiered();
+          const encoded = await encodeJobEnvelope({
+            jobData: { __jobName: "spanReceived", bulk: "z".repeat(64 * 1024) },
+            tieredBlobs,
+            projectId: PROJECT,
+          });
+
+          const legacy = withoutRecordedSize(encoded);
+
+          // A stored-length reading would call a 64 KiB payload ~200 bytes.
+          expect(Buffer.byteLength(legacy)).toBeLessThan(1024);
+          expect(readJobPayloadBytes(legacy)).toBe(MAX_BLOB_BYTES);
+        });
+
+        it("costs the payload cap for a compressed inline body", async () => {
+          const { tieredBlobs } = makeTiered();
+          const encoded = await encodeJobEnvelope({
+            jobData: { __jobName: "tiny", bulk: "z".repeat(3 * 1024) },
+            tieredBlobs,
+            projectId: PROJECT,
+          });
+
+          const legacy = withoutRecordedSize(encoded);
+
+          expect(readJobPayloadBytes(legacy)).toBe(MAX_BLOB_BYTES);
+        });
+
+        it("keeps the stored length for a plain inline body", async () => {
+          const { tieredBlobs } = makeTiered();
+          const encoded = await encodeJobEnvelope({
+            jobData: { __jobName: "tiny", value: 1 },
+            tieredBlobs,
+            projectId: PROJECT,
+          });
+
+          const legacy = withoutRecordedSize(encoded);
+
+          expect(readJobPayloadBytes(legacy)).toBe(Buffer.byteLength(legacy));
+        });
+      });
     });
 
     describe("when a small payload is encoded", () => {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -511,7 +511,14 @@ describe("jobEnvelope", () => {
         // budget down. `1e999` is the one that matters: it is valid JSON, parses
         // to Infinity, and would reach the Lua drain as an unparseable ARGV.
         // Written as raw header text because JSON.stringify cannot emit these.
-        const SIZES = ["1e999", "0.1", "-1", '"4096"', "null"];
+        const SIZES = [
+          "1e999",
+          "9007199254740992",
+          "0.1",
+          "-1",
+          '"4096"',
+          "null",
+        ];
 
         it.each(
           SIZES,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5297,7 +5297,7 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       // closes, in the window with the deepest backlog.
       describe("given a pre-`s` envelope whose body was compressed or offloaded", () => {
         /** Every body encoding whose stored length is a fraction of its payload. */
-        const ENCODINGS = ["redis", "s3", "ref", "gz"];
+        const ENCODINGS = ["redis", "s3", "ref", "gz"] as const;
 
         const sizelessEnvelope = (encoding: string) => {
           const header = JSON.stringify({
@@ -5335,9 +5335,8 @@ describe("GroupStagingScripts.drainGroupReady", () => {
             initialBytes: 0,
           });
 
-          // Unknown payload: no sibling is coalesced, and none is dropped —
-          // the dispatched job processes alone and these stay staged for their
-          // own later dispatch.
+          // Unknown payload: nothing is coalesced and nothing is dropped —
+          // both jobs stay staged for their own later dispatch.
           expect(drained).toEqual([]);
           expect(await inspectGroupJobs("group-a")).toEqual([
             "j1",
@@ -5345,6 +5344,29 @@ describe("GroupStagingScripts.drainGroupReady", () => {
             "j2",
             "200",
           ]);
+          expect(await inspectTotalPending()).toBe("2");
+        });
+
+        // cjson decodes `1e999` to a Lua infinity, which `s >= 0` alone lets
+        // through and which no arithmetic downstream survives sensibly.
+        it.each([
+          "1e999",
+          "0.1",
+          "-1",
+          '"4096"',
+        ])("ignores a recorded size of %s, costing the cap", async (s) => {
+          const header = `{"v":2,"e":"redis","s":${s}}`;
+          await stageTwo(`GQ2|${Buffer.byteLength(header)}|${header}`);
+
+          const drained = await scripts.drainGroupReady({
+            groupId: "group-a",
+            nowMs: 10_000,
+            maxJobs: 10,
+            maxBytes: 4 * 1024 * 1024,
+            initialBytes: 0,
+          });
+
+          expect(drained).toEqual([]);
           expect(await inspectTotalPending()).toBe("2");
         });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5296,6 +5296,9 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       // the ~150-byte reference there would reinstate the exact blindness `s`
       // closes, in the window with the deepest backlog.
       describe("given a pre-`s` envelope whose body was compressed or offloaded", () => {
+        /** Every body encoding whose stored length is a fraction of its payload. */
+        const ENCODINGS = ["redis", "s3", "ref", "gz"];
+
         const sizelessEnvelope = (encoding: string) => {
           const header = JSON.stringify({
             v: 2,
@@ -5306,47 +5309,7 @@ describe("GroupStagingScripts.drainGroupReady", () => {
           return `GQ2|${Buffer.byteLength(header)}|${header}`;
         };
 
-        it.each(["redis", "s3", "ref", "gz"])(
-          "costs the payload cap rather than the stored length (e=%s)",
-          async (encoding) => {
-            const value = sizelessEnvelope(encoding);
-            expect(Buffer.byteLength(value)).toBeLessThan(300);
-
-            for (const [index, dispatchAfterMs] of [100, 200].entries()) {
-              await scripts.stage(
-                makeJob({
-                  stagedJobId: `j${index + 1}`,
-                  dispatchAfterMs,
-                  jobDataJson: value,
-                }),
-              );
-            }
-
-            // A budget that a stored-length reading would clear many times over.
-            const drained = await scripts.drainGroupReady({
-              groupId: "group-a",
-              nowMs: 10_000,
-              maxJobs: 10,
-              maxBytes: 4 * 1024 * 1024,
-              initialBytes: 0,
-            });
-
-            // Unknown payload: no sibling is coalesced, and none is dropped —
-            // the dispatched job processes alone and these stay staged for
-            // their own later dispatch.
-            expect(drained).toEqual([]);
-            expect(await inspectGroupJobs("group-a")).toEqual([
-              "j1",
-              "100",
-              "j2",
-              "200",
-            ]);
-            expect(await inspectTotalPending()).toBe("2");
-          },
-        );
-
-        it("still ignores the byte bound entirely when maxBytes is zero", async () => {
-          const value = sizelessEnvelope("redis");
+        async function stageTwo(value: string) {
           for (const [index, dispatchAfterMs] of [100, 200].entries()) {
             await scripts.stage(
               makeJob({
@@ -5356,6 +5319,37 @@ describe("GroupStagingScripts.drainGroupReady", () => {
               }),
             );
           }
+        }
+
+        it.each(ENCODINGS)("costs the payload cap (e=%s)", async (encoding) => {
+          const value = sizelessEnvelope(encoding);
+          expect(Buffer.byteLength(value)).toBeLessThan(300);
+          await stageTwo(value);
+
+          // A budget that a stored-length reading would clear many times over.
+          const drained = await scripts.drainGroupReady({
+            groupId: "group-a",
+            nowMs: 10_000,
+            maxJobs: 10,
+            maxBytes: 4 * 1024 * 1024,
+            initialBytes: 0,
+          });
+
+          // Unknown payload: no sibling is coalesced, and none is dropped —
+          // the dispatched job processes alone and these stay staged for their
+          // own later dispatch.
+          expect(drained).toEqual([]);
+          expect(await inspectGroupJobs("group-a")).toEqual([
+            "j1",
+            "100",
+            "j2",
+            "200",
+          ]);
+          expect(await inspectTotalPending()).toBe("2");
+        });
+
+        it("still ignores the byte bound entirely when maxBytes is zero", async () => {
+          await stageTwo(sizelessEnvelope("redis"));
 
           const drained = await scripts.drainGroupReady({
             groupId: "group-a",

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5202,6 +5202,94 @@ describe("GroupStagingScripts.drainGroupReady", () => {
 
       expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2", "j3"]);
     });
+
+    // The case the stored-length budget was blind to: a body over the inline
+    // ceiling lives in the blob store, so the staged value is a ~100-byte
+    // reference no matter how large the payload is. Without the header's
+    // recorded size a 256-wide drain of megabyte payloads sails through a 4 MiB
+    // budget.
+    describe("when the bodies were offloaded to the blob store", () => {
+      /** A GQ2 envelope whose body is a blob reference, declaring `s` bytes of payload. */
+      const offloadedEnvelope = (payloadBytes: number) => {
+        const header = JSON.stringify({
+          v: 2,
+          e: "redis",
+          ref: { tier: "redis", projectId: "project-a", hash: "abc123" },
+          h: "holder-1",
+          s: payloadBytes,
+        });
+        return `GQ2|${Buffer.byteLength(header)}|${header}`;
+      };
+
+      async function stageThreeOffloadedJobs(payloadBytes: number) {
+        for (const [index, dispatchAfterMs] of [100, 200, 300].entries()) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `j${index + 1}`,
+              dispatchAfterMs,
+              jobDataJson: offloadedEnvelope(payloadBytes),
+            }),
+          );
+        }
+      }
+
+      it("budgets on the declared payload size, not the reference's stored length", async () => {
+        await stageThreeOffloadedJobs(1024 * 1024);
+
+        // Every staged value is a few hundred bytes; every payload is 1 MiB.
+        const drained = await scripts.drainGroupReady({
+          groupId: "group-a",
+          nowMs: 10_000,
+          maxJobs: 10,
+          maxBytes: 2 * 1024 * 1024,
+          initialBytes: 0,
+        });
+
+        expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2"]);
+        expect(await inspectGroupJobs("group-a")).toEqual(["j3", "300"]);
+      });
+
+      it("drains no siblings when one declared payload already fills the budget", async () => {
+        await stageThreeOffloadedJobs(4 * 1024 * 1024);
+
+        const drained = await scripts.drainGroupReady({
+          groupId: "group-a",
+          nowMs: 10_000,
+          maxJobs: 10,
+          maxBytes: 4 * 1024 * 1024,
+          initialBytes: 4 * 1024 * 1024,
+        });
+
+        expect(drained).toEqual([]);
+        expect(await inspectTotalPending()).toBe("3");
+      });
+
+      it("falls back to the stored length for an envelope that declares no size", async () => {
+        // Pre-`s` envelopes are still in flight during a rollout. They keep the
+        // old behaviour — bounded by count — rather than being read as zero-cost.
+        const header = JSON.stringify({ v: 2, e: "j" });
+        const value = `GQ2|${Buffer.byteLength(header)}|${header}{"p":"${"x".repeat(60)}"}`;
+        for (const [index, dispatchAfterMs] of [100, 200].entries()) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `j${index + 1}`,
+              dispatchAfterMs,
+              jobDataJson: value,
+            }),
+          );
+        }
+
+        const drained = await scripts.drainGroupReady({
+          groupId: "group-a",
+          nowMs: 10_000,
+          maxJobs: 10,
+          maxBytes: Buffer.byteLength(value) + 1,
+          initialBytes: 0,
+        });
+
+        expect(drained.map((d) => d.stagedJobId)).toEqual(["j1"]);
+      });
+    });
   });
 });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5264,9 +5264,10 @@ describe("GroupStagingScripts.drainGroupReady", () => {
         expect(await inspectTotalPending()).toBe("3");
       });
 
-      it("falls back to the stored length for an envelope that declares no size", async () => {
-        // Pre-`s` envelopes are still in flight during a rollout. They keep the
-        // old behaviour — bounded by count — rather than being read as zero-cost.
+      it("falls back to the stored length for a plain inline envelope that declares no size", async () => {
+        // Pre-`s` envelopes are still in flight during a rollout. An inline,
+        // uncompressed body IS its stored length, so it keeps the old
+        // behaviour rather than being read as zero-cost.
         const header = JSON.stringify({ v: 2, e: "j" });
         const value = `GQ2|${Buffer.byteLength(header)}|${header}{"p":"${"x".repeat(60)}"}`;
         for (const [index, dispatchAfterMs] of [100, 200].entries()) {
@@ -5288,6 +5289,84 @@ describe("GroupStagingScripts.drainGroupReady", () => {
         });
 
         expect(drained.map((d) => d.stagedJobId)).toEqual(["j1"]);
+      });
+
+      // The rollout window this fix is really about: an old worker stages an
+      // offloaded envelope with no `s` while a new worker drains it. Reading
+      // the ~150-byte reference there would reinstate the exact blindness `s`
+      // closes, in the window with the deepest backlog.
+      describe("given a pre-`s` envelope whose body was compressed or offloaded", () => {
+        const sizelessEnvelope = (encoding: string) => {
+          const header = JSON.stringify({
+            v: 2,
+            e: encoding,
+            ref: { tier: "redis", projectId: "project-a", hash: "abc123" },
+            h: "holder-1",
+          });
+          return `GQ2|${Buffer.byteLength(header)}|${header}`;
+        };
+
+        it.each(["redis", "s3", "ref", "gz"])(
+          "costs the payload cap rather than the stored length (e=%s)",
+          async (encoding) => {
+            const value = sizelessEnvelope(encoding);
+            expect(Buffer.byteLength(value)).toBeLessThan(300);
+
+            for (const [index, dispatchAfterMs] of [100, 200].entries()) {
+              await scripts.stage(
+                makeJob({
+                  stagedJobId: `j${index + 1}`,
+                  dispatchAfterMs,
+                  jobDataJson: value,
+                }),
+              );
+            }
+
+            // A budget that a stored-length reading would clear many times over.
+            const drained = await scripts.drainGroupReady({
+              groupId: "group-a",
+              nowMs: 10_000,
+              maxJobs: 10,
+              maxBytes: 4 * 1024 * 1024,
+              initialBytes: 0,
+            });
+
+            // Unknown payload: no sibling is coalesced, and none is dropped —
+            // the dispatched job processes alone and these stay staged for
+            // their own later dispatch.
+            expect(drained).toEqual([]);
+            expect(await inspectGroupJobs("group-a")).toEqual([
+              "j1",
+              "100",
+              "j2",
+              "200",
+            ]);
+            expect(await inspectTotalPending()).toBe("2");
+          },
+        );
+
+        it("still ignores the byte bound entirely when maxBytes is zero", async () => {
+          const value = sizelessEnvelope("redis");
+          for (const [index, dispatchAfterMs] of [100, 200].entries()) {
+            await scripts.stage(
+              makeJob({
+                stagedJobId: `j${index + 1}`,
+                dispatchAfterMs,
+                jobDataJson: value,
+              }),
+            );
+          }
+
+          const drained = await scripts.drainGroupReady({
+            groupId: "group-a",
+            nowMs: 10_000,
+            maxJobs: 10,
+            maxBytes: 0,
+            initialBytes: 0,
+          });
+
+          expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2"]);
+        });
       });
     });
   });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5347,14 +5347,21 @@ describe("GroupStagingScripts.drainGroupReady", () => {
           expect(await inspectTotalPending()).toBe("2");
         });
 
-        // cjson decodes `1e999` to a Lua infinity, which `s >= 0` alone lets
-        // through and which no arithmetic downstream survives sensibly.
-        it.each([
+        // The same set the TS twin rejects, asserted here so the two ends of
+        // one budget cannot drift: cjson decodes `1e999` to a Lua infinity, and
+        // `2^53` is the first integer outside JS's safe range, so accepting it
+        // here would have meant the two helpers disagreeing on one value.
+        const INVALID_SIZES = [
           "1e999",
+          "9007199254740992",
           "0.1",
           "-1",
           '"4096"',
-        ])("ignores a recorded size of %s, costing the cap", async (s) => {
+        ];
+
+        it.each(
+          INVALID_SIZES,
+        )("ignores a size of %s, costing the cap", async (s) => {
           const header = `{"v":2,"e":"redis","s":${s}}`;
           await stageTwo(`GQ2|${Buffer.byteLength(header)}|${header}`);
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5157,6 +5157,27 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       expect(await inspectTotalPending()).toBe("1");
     });
 
+    // The boundary itself. The drain's condition is `(accumulated + size) >
+    // maxBytes`, so a job landing EXACTLY on the budget is admitted, not
+    // rejected. Nothing else pins that: the overflow test above only proves
+    // 300 > 250 stops, which a `>=` would satisfy too.
+    it("admits a job that lands exactly on the budget", async () => {
+      await stageThreeSizedJobs();
+
+      // 0 + 100 = 100, 100 + 100 = 200 — exactly maxBytes, admitted.
+      // Third would be 300 > 200, so it stays staged.
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 10,
+        maxBytes: 200,
+        initialBytes: 0,
+      });
+
+      expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2"]);
+      expect(await inspectGroupJobs("group-a")).toEqual(["j3", "300"]);
+    });
+
     it("counts initialBytes (the dispatched job's own size) toward the budget", async () => {
       await stageThreeSizedJobs();
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -56,6 +56,7 @@ import {
   PayloadTooLargeError,
   readEnvelopeDescriptor,
   readJobAttempt,
+  readJobPayloadBytes,
   readJobRoutingMeta,
   withJobAttempt,
 } from "./jobEnvelope";
@@ -924,12 +925,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     if (maxBatch > 1 && this.processBatch) {
       // Byte bound (ADR-066 pillar 2): the drain also stops before a job that
       // would push the batch past maxBytes, counting the dispatched job's own
-      // stored size as the starting point. Whichever of the count/byte bound
+      // payload size as the starting point. Whichever of the count/byte bound
       // binds first wins; an oversized dispatched job (initialBytes already at
       // or over the budget) drains no siblings and processes on its own.
+      //
+      // Payload size, not `jobDataJson.length`: an offloaded body leaves a small
+      // reference in the stored value, so measuring the value would let 256
+      // megabyte-sized records through a 4 MiB budget untouched.
       const maxBytes =
         this.coalesceMaxBytes?.(payload) ?? DEFAULT_COALESCE_MAX_BYTES;
-      const initialBytes = Buffer.byteLength(jobDataJson);
+      const initialBytes = readJobPayloadBytes(jobDataJson);
       try {
         drainedSiblings = await this.scripts.drainGroupReady({
           groupId,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -762,7 +762,12 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
  *
  * Three cases, only one of which is a plain measurement:
  *
- * 1. `s` present — the payload size the encoder recorded. Exact.
+ * 1. `s` present and a non-negative safe integer — the payload size the encoder
+ *    recorded. Exact. Anything else in that field (fractional, `Infinity`,
+ *    `NaN`, negative) is not a byte count and is not trusted: a forged or
+ *    corrupt header must not be able to talk the budget down, and `Infinity`
+ *    would reach the Lua drain as an unparseable ARGV. Those fall through to
+ *    the encoding rule below, so an offloaded body still costs the cap.
  * 2. No `s`, body inline and uncompressed (`e:"j"`), or legacy bare JSON — the
  *    stored length IS the payload. Exact enough.
  * 3. No `s`, body compressed or offloaded (`e` of `gz`/`ref`/`redis`/`s3`, or
@@ -793,8 +798,10 @@ export function readJobPayloadBytes(value: string): number {
   try {
     if (isEnvelope(value)) {
       const { header } = splitEnvelope(value);
-      if (typeof header.s === "number" && header.s >= 0) return header.s;
-      // Pre-`s` envelope: only a plain inline body is worth its stored length.
+      if (Number.isSafeInteger(header.s) && (header.s as number) >= 0) {
+        return header.s as number;
+      }
+      // No usable `s`: only a plain inline body is worth its stored length.
       if (header.e !== "j") return MAX_BLOB_BYTES;
     }
   } catch {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -768,6 +768,12 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
  *
  * Never throws: a value this cannot read is worth its stored length, not an
  * exception on the drain path.
+ *
+ * Has a Lua twin: `gqPayloadSize` in `scripts.ts` reads the same `s` field with
+ * the same fallback, because the drain spends the byte budget inside Redis
+ * while this sets its starting point. An envelope-format change — new prefix,
+ * renamed header field, different length-prefix encoding — has to land in both
+ * or the two ends of one budget silently disagree.
  */
 export function readJobPayloadBytes(value: string): number {
   try {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -210,6 +210,23 @@ export interface EnvelopeHeader {
   ref?: BlobRef;
   /** GQ2 per-stage lease holder identity for this staged occupancy. */
   h?: string;
+  /**
+   * Serialized payload size in bytes, BEFORE compression and before any offload
+   * to the blob store — the size the payload has once it is back in a worker's
+   * hands (ADR-066 pillar 2).
+   *
+   * It exists because the stored value's own length answers a different
+   * question. A body over {@link INLINE_CEILING_BYTES} leaves only a reference
+   * behind, and a body over {@link COMPRESSION_THRESHOLD_BYTES} is stored
+   * compressed, so `#value` can be two or three orders of magnitude under the
+   * bytes a coalesced batch will actually hold in memory and append downstream.
+   * The drain's byte budget reads this field, so its bound survives offload.
+   *
+   * In the header, never the body: the body is content-addressed and hashing it
+   * with a size field would be harmless but redundant, while the header is what
+   * both the Lua drain and the ops dashboard can read without blob I/O.
+   */
+  s?: number;
   /** Routing fields read by the Lua dispatcher and ops dashboard WITHOUT parsing the body. */
   p?: string;
   t?: string;
@@ -533,6 +550,10 @@ export async function encodeJobEnvelope({
     });
     const payloadBytes = bytes.length;
     assertPayloadWithinCap(payloadBytes, { projectId, queueName, logger });
+    // Recorded on every envelope, not just offloaded ones: an inline body over
+    // COMPRESSION_THRESHOLD_BYTES is stored compressed, so `#value` understates
+    // it too. See EnvelopeHeader.s.
+    header.s = payloadBytes;
 
     if (payloadBytes > INLINE_CEILING_BYTES) {
       const compression = writeCompression();
@@ -593,6 +614,7 @@ export async function encodeJobEnvelope({
     );
   }
   const header = routingHeader(jobData, 1);
+  header.s = jsonBytes;
   if (blobs && jsonBytes > BLOB_OFFLOAD_THRESHOLD_BYTES) {
     const id = randomUUID();
     await blobs.put({ id, data: await compress(json, writeCompression()) });
@@ -731,6 +753,32 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
   } catch {
     return { pipelineName: null, jobType: null, jobName: null };
   }
+}
+
+/**
+ * How many bytes this job costs a coalesced batch: the header's recorded
+ * payload size when the value carries one, the stored length otherwise.
+ *
+ * The fallback is the honest answer for the values that have no `s` — legacy
+ * bare JSON, and envelopes written before this field existed — because for them
+ * the stored length IS the payload, modulo inline compression. It is also the
+ * conservative direction only for uncompressed values; a pre-`s` envelope with a
+ * blob body still under-reports. Those drain under the count bound alone, same
+ * as before, and age out as the fleet cycles.
+ *
+ * Never throws: a value this cannot read is worth its stored length, not an
+ * exception on the drain path.
+ */
+export function readJobPayloadBytes(value: string): number {
+  try {
+    if (isEnvelope(value)) {
+      const { header } = splitEnvelope(value);
+      if (typeof header.s === "number" && header.s >= 0) return header.s;
+    }
+  } catch {
+    // Fall through: an unreadable envelope still occupies its stored bytes.
+  }
+  return Buffer.byteLength(value, "utf8");
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -757,29 +757,45 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
 
 /**
  * How many bytes this job costs a coalesced batch: the header's recorded
- * payload size when the value carries one, the stored length otherwise.
+ * payload size when the value carries one, and for the values that carry none,
+ * whichever reading cannot let the batch overshoot.
  *
- * The fallback is the honest answer for the values that have no `s` — legacy
- * bare JSON, and envelopes written before this field existed — because for them
- * the stored length IS the payload, modulo inline compression. It is also the
- * conservative direction only for uncompressed values; a pre-`s` envelope with a
- * blob body still under-reports. Those drain under the count bound alone, same
- * as before, and age out as the fleet cycles.
+ * Three cases, only one of which is a plain measurement:
  *
- * Never throws: a value this cannot read is worth its stored length, not an
- * exception on the drain path.
+ * 1. `s` present — the payload size the encoder recorded. Exact.
+ * 2. No `s`, body inline and uncompressed (`e:"j"`), or legacy bare JSON — the
+ *    stored length IS the payload. Exact enough.
+ * 3. No `s`, body compressed or offloaded (`e` of `gz`/`ref`/`redis`/`s3`, or
+ *    absent) — the stored length is a fraction of the payload and there is
+ *    nothing in the value that says by how much. Worth {@link MAX_BLOB_BYTES}:
+ *    an unreadable payload is treated as the largest payload we accept.
  *
- * Has a Lua twin: `gqPayloadSize` in `scripts.ts` reads the same `s` field with
- * the same fallback, because the drain spends the byte budget inside Redis
- * while this sets its starting point. An envelope-format change — new prefix,
- * renamed header field, different length-prefix encoding — has to land in both
- * or the two ends of one budget silently disagree.
+ * Case 3 exists for the length of a rolling deploy: old workers keep staging
+ * pre-`s` envelopes while new ones drain them, and a deep backlog is exactly
+ * where it does not age out promptly — which is also exactly where the byte
+ * bound is load-bearing. Reading the stored length there would reinstate the
+ * defect this field was added to close, for the window with the most jobs
+ * queued. Costing the cap instead makes such a job drain alone (any sane
+ * `coalesceMaxBytes` is far under 50 MiB), so the rollout loses coalescing on
+ * those jobs rather than losing the bound. Coalescing is an optimization; the
+ * bound is what keeps a worker from assembling a batch it cannot hold.
+ *
+ * Never throws: a value this cannot parse at all is worth its stored length,
+ * not an exception on the drain path.
+ *
+ * Has a Lua twin: `gqPayloadSize` in `scripts.ts` makes the same three
+ * decisions, because the drain spends the byte budget inside Redis while this
+ * sets its starting point. An envelope-format change — new prefix, renamed
+ * header field, different length-prefix encoding — has to land in both or the
+ * two ends of one budget silently disagree.
  */
 export function readJobPayloadBytes(value: string): number {
   try {
     if (isEnvelope(value)) {
       const { header } = splitEnvelope(value);
       if (typeof header.s === "number" && header.s >= 0) return header.s;
+      // Pre-`s` envelope: only a plain inline body is worth its stored length.
+      if (header.e !== "j") return MAX_BLOB_BYTES;
     }
   } catch {
     // Fall through: an unreadable envelope still occupies its stored bytes.

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -446,10 +446,13 @@ local function gqPayloadSize(value)
         local ok, header = pcall(cjson.decode, string.sub(value, barIdx + 1, barIdx + headerLen))
         if ok and type(header) == "table" then
           local s = header["s"]
-          -- Finite non-negative integer or it is not a byte count. NaN fails
-          -- the >= 0 test; math.floor(inf) == inf, so infinity needs the
-          -- explicit math.huge bound.
-          if type(s) == "number" and s >= 0 and s < math.huge and s == math.floor(s) then
+          -- Non-negative integer within JS's safe-integer range, which is what
+          -- the TS twin's Number.isSafeInteger admits — the same set, or the
+          -- two ends of one budget disagree on a value. NaN fails the >= 0
+          -- test, and the upper bound is what rejects infinity: cjson decodes
+          -- 1e999 to inf, and math.floor(inf) == inf would pass an integer
+          -- check on its own.
+          if type(s) == "number" and s >= 0 and s <= ${Number.MAX_SAFE_INTEGER} and s == math.floor(s) then
             return s
           end
           if header["e"] ~= "j" then

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -414,6 +414,33 @@ local function gqRoutingMeta(jobDataJson)
 end
 `;
 
+// What a staged job will weigh once a worker holds it, which is NOT its stored
+// length: a body over the inline ceiling lives in the blob store and leaves a
+// ~200-byte reference behind, and a body over the compression threshold is
+// stored compressed. The encoder records the pre-compression, pre-offload
+// payload size in the envelope header (`s`), so the drain's byte budget can be
+// about the batch a worker will actually assemble rather than about Redis
+// occupancy. Mirrors the TS `readJobPayloadBytes`, including the fallback:
+// legacy bare JSON and pre-`s` envelopes are worth their stored length.
+const PAYLOAD_SIZE_HELPER_LUA = `
+local function gqPayloadSize(value)
+  local prefix = string.sub(value, 1, 4)
+  if prefix == "GQ1|" or prefix == "GQ2|" then
+    local barIdx = string.find(value, "|", 5, true)
+    if barIdx then
+      local headerLen = tonumber(string.sub(value, 5, barIdx - 1))
+      if headerLen and headerLen > 0 then
+        local ok, header = pcall(cjson.decode, string.sub(value, barIdx + 1, barIdx + headerLen))
+        if ok and type(header) == "table" and type(header["s"]) == "number" and header["s"] >= 0 then
+          return header["s"]
+        end
+      end
+    end
+  end
+  return #value
+end
+`;
+
 // Lua side of the GQ2 blob-lease lifecycle for staging. A genuine stage takes
 // its lease in the same eval as the staged value becomes visible. A squash
 // transfers the displaced lease atomically with that replacement. Releases
@@ -1118,16 +1145,21 @@ return results
  *     coalesced batch stays inside the downstream append/flush budget. A job
  *     too large to fit is LEFT in staging (it becomes its own later dispatch),
  *     never dropped. maxBytes <= 0 disables the byte bound (count bound only,
- *     the pre-ADR-066 behaviour). Sizes are the stored envelope's `#value`,
- *     which is the append-shaped quantity — for the small inline appends this
- *     targets it equals the payload size.
+ *     the pre-ADR-066 behaviour). Sizes are the envelope header's recorded
+ *     payload size (`s`), falling back to the stored `#value` for values that
+ *     carry none — see `gqPayloadSize`. `#value` alone is NOT the append-shaped
+ *     quantity: a compressed or offloaded body stores a fraction of what the
+ *     batch then holds in memory, which let a 256-wide batch of megabyte
+ *     payloads pass a 4 MiB budget untouched.
  *
  * Mirrors the per-job bookkeeping DISPATCH does for the jobs it removes:
  * ZREM from the jobs zset, HDEL the job data, and DECR total-pending. It does
  * NOT mark anything active and does NOT re-score ready — the caller's active
  * job remains the one that frees the group on COMPLETE.
  */
-const DRAIN_GROUP_LUA = `
+const DRAIN_GROUP_LUA =
+  PAYLOAD_SIZE_HELPER_LUA +
+  `
 local jobsKey         = KEYS[1]
 local dataKey         = KEYS[2]
 local totalPendingKey = KEYS[3]
@@ -1157,7 +1189,12 @@ while i < #entries do
   local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
   local size = 0
   if jobDataJson then
-    size = #jobDataJson
+    -- Only pay the header parse when the budget can actually bind.
+    if maxBytes > 0 then
+      size = gqPayloadSize(jobDataJson)
+    else
+      size = #jobDataJson
+    end
   end
 
   -- Byte bound: stop before the first job that would overflow the budget.

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -445,8 +445,12 @@ local function gqPayloadSize(value)
       if headerLen and headerLen > 0 then
         local ok, header = pcall(cjson.decode, string.sub(value, barIdx + 1, barIdx + headerLen))
         if ok and type(header) == "table" then
-          if type(header["s"]) == "number" and header["s"] >= 0 then
-            return header["s"]
+          local s = header["s"]
+          -- Finite non-negative integer or it is not a byte count. NaN fails
+          -- the >= 0 test; math.floor(inf) == inf, so infinity needs the
+          -- explicit math.huge bound.
+          if type(s) == "number" and s >= 0 and s < math.huge and s == math.floor(s) then
+            return s
           end
           if header["e"] ~= "j" then
             return ${MAX_BLOB_BYTES}

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -5,6 +5,7 @@ import {
   BLOB_LEASE_SET_TTL_SECONDS,
   BLOB_LEASE_TTL_SECONDS,
   LEGACY_HOLDER_LEASE_GUARD,
+  MAX_BLOB_BYTES,
 } from "./blobConstants";
 import { GQ_BLOB_GRACE_LUA } from "./blobGraceLua";
 import { CachedLuaScript } from "./cachedLuaScript";
@@ -420,11 +421,20 @@ end
 // stored compressed. The encoder records the pre-compression, pre-offload
 // payload size in the envelope header (`s`), so the drain's byte budget can be
 // about the batch a worker will actually assemble rather than about Redis
-// occupancy. Mirrors the TS `readJobPayloadBytes` in `jobEnvelope.ts`,
-// including the fallback: legacy bare JSON and pre-`s` envelopes are worth
-// their stored length. The two are one budget read from two ends, so an
-// envelope-format change — new prefix, renamed header field, different
-// length-prefix encoding — has to land in both or they silently disagree.
+// occupancy.
+//
+// A value with no `s` gets the reading that cannot let the batch overshoot,
+// not simply its stored length: legacy bare JSON and a plain inline body
+// (`e:"j"`) ARE their stored length, but a pre-`s` compressed or offloaded body
+// is a fraction of one and the value does not say by how much. Those are worth
+// the payload cap, so they drain alone for the length of a rolling deploy
+// rather than reinstating the very blindness `s` closes — in the window where
+// the most jobs are queued. See the TS twin `readJobPayloadBytes` in
+// `jobEnvelope.ts` for the full reasoning.
+//
+// The two are one budget read from two ends, so an envelope-format change —
+// new prefix, renamed header field, different length-prefix encoding — has to
+// land in both or they silently disagree.
 const PAYLOAD_SIZE_HELPER_LUA = `
 local function gqPayloadSize(value)
   local prefix = string.sub(value, 1, 4)
@@ -434,8 +444,13 @@ local function gqPayloadSize(value)
       local headerLen = tonumber(string.sub(value, 5, barIdx - 1))
       if headerLen and headerLen > 0 then
         local ok, header = pcall(cjson.decode, string.sub(value, barIdx + 1, barIdx + headerLen))
-        if ok and type(header) == "table" and type(header["s"]) == "number" and header["s"] >= 0 then
-          return header["s"]
+        if ok and type(header) == "table" then
+          if type(header["s"]) == "number" and header["s"] >= 0 then
+            return header["s"]
+          end
+          if header["e"] ~= "j" then
+            return ${MAX_BLOB_BYTES}
+          end
         end
       end
     end

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -420,8 +420,11 @@ end
 // stored compressed. The encoder records the pre-compression, pre-offload
 // payload size in the envelope header (`s`), so the drain's byte budget can be
 // about the batch a worker will actually assemble rather than about Redis
-// occupancy. Mirrors the TS `readJobPayloadBytes`, including the fallback:
-// legacy bare JSON and pre-`s` envelopes are worth their stored length.
+// occupancy. Mirrors the TS `readJobPayloadBytes` in `jobEnvelope.ts`,
+// including the fallback: legacy bare JSON and pre-`s` envelopes are worth
+// their stored length. The two are one budget read from two ends, so an
+// envelope-format change — new prefix, renamed header field, different
+// length-prefix encoding — has to land in both or they silently disagree.
 const PAYLOAD_SIZE_HELPER_LUA = `
 local function gqPayloadSize(value)
   local prefix = string.sub(value, 1, 4)

--- a/platform/app/src/server/event-sourcing/queues/queue.types.ts
+++ b/platform/app/src/server/event-sourcing/queues/queue.types.ts
@@ -156,6 +156,10 @@ export interface EventSourcedQueueDefinition<
    * own later dispatch. Returns undefined to fall back to the GroupQueue default
    * ({@link DEFAULT_COALESCE_MAX_BYTES}). Only consulted when `coalesceMaxBatch`
    * enables coalescing.
+   *
+   * The budget is spent in payload bytes — the size a worker's batch actually
+   * holds — not in the bytes the job occupies in Redis, which for a compressed
+   * or blob-offloaded body is a small fraction of it.
    */
   coalesceMaxBytes?: (payload: Payload) => number | undefined;
 

--- a/specs/event-sourcing/payload-cost.feature
+++ b/specs/event-sourcing/payload-cost.feature
@@ -158,9 +158,10 @@ Feature: Payload cost governs the scheduling plane
 
   # --- Phases 2-4: the remaining ADR-069 invariants ---
 
-  @planned
-  # Not yet implemented as of 2026-07-28 — ADR-069 phase 2: offloaded payloads
-  # stage as small stubs, and byte budgets count the stub, not the payload.
+  @integration
+  # ADR-069 phase 2, shipped: the encoder records the pre-compression,
+  # pre-offload payload size on the envelope header, and the coalescing drain
+  # spends its byte budget against that rather than the stored value's length.
   Scenario: an offloaded payload's reference advertises its true cost
     Given a job whose payload is offloaded to blob storage
     When the job is staged


### PR DESCRIPTION
## For humans

When our background workers get backed up, they bundle queued items together and write them in one go instead of one at a time. There is a size limit on that bundle so a worker never tries to assemble something huge in memory.

That limit was being measured against the wrong thing. Large items are not kept in the queue itself — they are stored off to the side and the queue only holds a small pointer to them. The limit was measuring the pointer, not the item. So a bundle of 256 large items looked tiny, sailed past the limit, and the protection did nothing precisely when a backlog of large items made it matter.

This measures the real size. Nothing changes for small items, which is nearly everything today; it closes the door before the first big customer walks through it.

## What changed

- The queue's message header now records the payload's size **before** compression and **before** it is offloaded to the blob store (`EnvelopeHeader.s`).
- The drain's byte budget — both the starting point in TypeScript and the per-candidate size in Lua — spends against that recorded size instead of the stored value's length.
- A recorded size is trusted only when it is a finite non-negative integer. `1e999` is valid JSON and parses to `Infinity`, which a bare `>= 0` check accepts and which would reach the Lua drain as an unparseable ARGV; fractional and string values under-report quietly. Anything else falls through to the rule below.
- Values with no usable recorded size get the reading that cannot let the batch overshoot, not simply their stored length:
  - legacy bare JSON and a plain inline body (`e:"j"`) **are** their stored length, so they keep the old behaviour exactly;
  - a compressed or offloaded body (`gz`/`ref`/`redis`/`s3`, or a header naming no encoding) is a fraction of its payload with nothing in the value saying by how much, so it costs `MAX_BLOB_BYTES` — an unreadable payload is worth the largest payload we accept.

No migration, no rollout ordering.

The fix is in the one path every coalescing consumer drains through, so it covers the command producers and the map/fold projections together.

## Why the cap, and not the stored length, for pre-`s` values

This is the rollout window, and it is the whole point. During a rolling deploy old workers keep staging pre-`s` envelopes while new workers drain them, and a deep backlog — the condition the byte bound exists for — does not age out promptly. Reading a pre-`s` blob reference as its ~200 stored bytes would reinstate the exact blindness `s` was added to close, for the window with the most jobs queued.

Any sane `coalesceMaxBytes` is far below 50 MiB, so a pre-`s` offloaded job drains alone. The rollout loses coalescing on those jobs rather than losing the bound: coalescing is an optimization, the bound is what keeps a worker from assembling a batch it cannot hold.

## Why it wasn't caught

The byte bound was correct for uncompressed, inline payloads, which is what the existing tests staged. The blindness only appears once a body crosses the 4 KiB inline ceiling — the case with the most to lose.

## Tests

- `groupQueue.gq2.integration.test.ts` — end-to-end regression: a burst of six offloaded 8 KiB payloads against a 20 KiB budget folds into batches of exactly two. **Verified to fail on `main`** (the whole burst folded into one batch). Asserted exactly, not as an upper bound, so a regression that stopped coalescing altogether fails it too.
- `scripts.integration.test.ts` — Lua-level byte math for offloaded values, a budget already filled by one payload, the plain-inline no-`s` fallback, the rollout case (a pre-`s` envelope for each of `redis`/`s3`/`ref`/`gz` coalesces nothing and drops nothing), the invalid-`s` cases (`1e999`/`0.1`/`-1`/`"4096"`), and `maxBytes: 0` still disabling the bound entirely.
- `jobEnvelope.unit.test.ts` — the recorded size survives offload and inline compression; a pre-`s` envelope costs the cap when its body was compressed or offloaded and its stored length when it was plain inline; a recorded size that is not a byte count is ignored; legacy and corrupt values fall back to stored length.

Full suites green: 183 unit + 318 integration in `groupQueue`.

## Notes

Follow-up to the review on langwatch/langwatch#6462, which is unaffected — this is the underlying accounting defect that predates it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue batching so byte limits accurately reflect full decoded payloads, including compressed and offloaded jobs.
  * Prevented oversized payloads from bypassing configured limits when only a small storage reference is present.
  * Added safe size fallbacks for legacy or malformed queue entries.
  * Ensured offloaded payload batches are fully resolved and each job is delivered exactly once.

* **Tests**
  * Added coverage for payload sizing, byte-budget enforcement, offloaded data, compression, and legacy formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Tracked by langwatch/langwatch#6484 (merge card). Related: langwatch/langwatch-saas#896 (bisect a failing batch — the recovery layer this prevention layer pairs with).
