### PR TITLE
perf(event-sourcing): coalesce coding-agent session contributions

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/__tests__/contributionCoalescing.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/__tests__/contributionCoalescing.unit.test.ts
@@ -1,0 +1,295 @@
+/**
+ * ADR-066 pillar 2 for the coding-agent contributions.
+ *
+ * Every contribution is keyed on its session, so one session is one queue group
+ * and a long run drains its transcript one tiny insert at a time. Coalescing
+ * folds the group's queued contributions into a single multi-row append.
+ *
+ * The property that makes this safe — and that sharding the session key would
+ * destroy — is that coalescing does not reorder. A logs-only agent's model calls
+ * fold through `foldModelCall`, which derives its cache-rebuild comparison, its
+ * final request id and its stop reason from the ORDER the calls arrive in, so
+ * these tests pin the order through the batch and out the other side.
+ *
+ * See specs/coding-agent/session-aggregate.feature and
+ * specs/event-sourcing/producer-append-coalescing.feature.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import { processCommandBatch } from "../../../services/commands/commandDispatcher";
+import { ContributeLogFactsCommand } from "../commands/contributeLogFactsCommand";
+import { createCodingAgentProcessingPipeline } from "../pipeline";
+import type { ContributeLogFactsCommandData } from "../schemas/commands";
+import {
+  CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+  CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+} from "../schemas/constants";
+import {
+  applyLogToCodingAgentSession,
+  createInitCodingAgentSession,
+} from "../services/coding-agent-session.derivation";
+
+vi.mock("../../../utils/killSwitch", () => ({
+  isComponentDisabled: vi.fn().mockResolvedValue(false),
+}));
+
+import { isComponentDisabled } from "../../../utils/killSwitch";
+
+const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
+
+const TENANT_ID = "tenant-coding-agent-coalescing";
+const SESSION_ID = "session-abc";
+/** Cowork is the registry's logs-only agent, so its model calls fold from logs. */
+const LOGS_ONLY_AGENT = "claude_cowork";
+
+function buildPipeline() {
+  const store = {} as never;
+  return createCodingAgentProcessingPipeline({
+    codingAgentSessionStore: store,
+    codingAgentTraceSessionAppendStore: store,
+    sessionMetricSeriesAppendStore: store,
+  });
+}
+
+function commandNamed(name: string) {
+  return buildPipeline().commands.find((candidate) => candidate.name === name);
+}
+
+/** One api_request log contribution — the shape that folds as a model call. */
+function modelCallPayload({
+  index,
+  contextTokens,
+  stopReason,
+}: {
+  index: number;
+  contextTokens: number;
+  stopReason?: string;
+}): ContributeLogFactsCommandData {
+  return {
+    tenantId: TENANT_ID,
+    sessionId: SESSION_ID,
+    sessionKeySource: "provider",
+    agent: LOGS_ONLY_AGENT,
+    occurredAt: 1_700_000_000_000 + index,
+    recordId: `record-${index}`,
+    traceId: null,
+    spanId: null,
+    timeUnixMs: 1_700_000_000_000 + index,
+    severityNumber: 9,
+    providerKind: "generic",
+    scopeName: null,
+    facts: {
+      "event.name": "api_request",
+      request_id: `req-${index}`,
+      cache_read_tokens: contextTokens,
+      cache_creation_tokens: 0,
+      ...(stopReason ? { stop_reason: stopReason } : {}),
+    },
+  } as ContributeLogFactsCommandData;
+}
+
+function batchParamsFor({
+  payloads,
+  storeEventsFn,
+}: {
+  payloads: ContributeLogFactsCommandData[];
+  storeEventsFn: (events: Event[], context: unknown) => Promise<void>;
+}) {
+  return {
+    payloads: payloads as unknown as Record<string, unknown>[],
+    commandType: CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+    commandSchema: ContributeLogFactsCommand.schema,
+    handler: new ContributeLogFactsCommand(),
+    getAggregateId: ContributeLogFactsCommand.getAggregateId,
+    storeEventsFn: storeEventsFn as never,
+    aggregateType: "coding_agent_session" as const,
+    commandName: "contributeLogFacts",
+    pipelineName: "coding_agent_processing",
+  };
+}
+
+/** Fold a batch's events through the log derivation, in the order given. */
+function foldInOrder(events: Event[]) {
+  let state = createInitCodingAgentSession();
+  for (const event of events) {
+    const data = event.data as ContributeLogFactsCommandData;
+    state = applyLogToCodingAgentSession({
+      state,
+      attributes: data.facts,
+      agent: data.agent,
+      occurredAtMs: data.timeUnixMs,
+    });
+  }
+  return state;
+}
+
+describe("coding-agent contribution append coalescing", () => {
+  beforeEach(() => {
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("given the coding-agent pipeline is defined", () => {
+    describe("when its contribution commands are registered", () => {
+      /** @scenario "a busy session's contributions are written together" */
+      it("gives every contribution command an append-coalescing bound", () => {
+        for (const name of [
+          "contributeSpanFacts",
+          "contributeLogFacts",
+          "contributeMetricFacts",
+        ]) {
+          expect(commandNamed(name)?.options?.coalesceMaxBatch).toBe(
+            CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+          );
+        }
+      });
+
+      // Sharding would give one session parallel lanes at the cost of its
+      // order; the fold's model-call chain cannot take that. The test below
+      // this one is why.
+      it("leaves the session key unsharded so one session stays one ordered lane", () => {
+        expect(
+          commandNamed("contributeLogFacts")?.options?.getGroupKey,
+        ).toBeUndefined();
+      });
+    });
+  });
+
+  // The executable reason the lane above must stay ordered. If this ever stops
+  // holding, sharding the session key becomes an option; while it holds, it is
+  // not one.
+  describe("given the same model calls folded in two different orders", () => {
+    describe("when the session is assembled from each", () => {
+      it("reports a different final request and context chain", () => {
+        const calls = [
+          modelCallPayload({ index: 0, contextTokens: 1_000 }),
+          modelCallPayload({ index: 1, contextTokens: 5_000 }),
+          modelCallPayload({ index: 2, contextTokens: 9_000 }),
+        ].map((payload) => ({ data: payload }) as Event);
+
+        const inOrder = foldInOrder(calls);
+        const reordered = foldInOrder([...calls].reverse());
+
+        expect(inOrder.finalRequestId).toBe("req-2");
+        expect(reordered.finalRequestId).toBe("req-0");
+        expect(inOrder.previousCallContextTokens).toBe(9_000);
+        expect(reordered.previousCallContextTokens).toBe(1_000);
+      });
+    });
+  });
+
+  describe("given a session with several queued contributions", () => {
+    describe("when the coalesced batch is processed", () => {
+      /** @scenario "a busy session's contributions are written together" */
+      it("appends them as one insert rather than one per contribution", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2, 3].map((index) =>
+          modelCallPayload({ index, contextTokens: 1_000 }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        const [events, context] = storeEventsFn.mock.calls[0]!;
+        expect(events as Event[]).toHaveLength(payloads.length);
+        expect(context).toEqual({ tenantId: TENANT_ID });
+      });
+
+      /** @scenario "writing contributions together keeps the session's order" */
+      it("keeps the contributions in the order the agent produced them", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2, 3].map((index) =>
+          modelCallPayload({ index, contextTokens: 1_000 }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect(
+          (events as Event[]).map((event) => event.idempotencyKey),
+        ).toEqual(
+          payloads.map((payload) => `${TENANT_ID}:${payload.recordId}`),
+        );
+        expect(
+          new Set((events as Event[]).map((event) => event.aggregateId)),
+        ).toEqual(new Set([SESSION_ID]));
+      });
+
+      /** @scenario 'an agent that reports only logs keeps its model-call sequence' */
+      it("folds the batch to the same session a per-contribution write would", async () => {
+        const payloads = [
+          modelCallPayload({ index: 0, contextTokens: 1_000 }),
+          modelCallPayload({ index: 1, contextTokens: 5_000 }),
+          modelCallPayload({
+            index: 2,
+            contextTokens: 9_000,
+            stopReason: "max_tokens",
+          }),
+        ];
+
+        const batched = vi.fn().mockResolvedValue(undefined);
+        await processCommandBatch(
+          batchParamsFor({ payloads, storeEventsFn: batched }),
+        );
+        const [batchedEvents] = batched.mock.calls[0]!;
+
+        // The same payloads written one at a time, as the un-coalesced path did.
+        const oneAtATime: Event[] = [];
+        for (const payload of payloads) {
+          const single = vi.fn().mockResolvedValue(undefined);
+          await processCommandBatch(
+            batchParamsFor({ payloads: [payload], storeEventsFn: single }),
+          );
+          oneAtATime.push(...(single.mock.calls[0]![0] as Event[]));
+        }
+
+        expect(foldInOrder(batchedEvents as Event[])).toEqual(
+          foldInOrder(oneAtATime),
+        );
+      });
+
+      /** @scenario 'an agent that reports only logs keeps its model-call sequence' */
+      it("takes the final request and stop reason from the last call in the batch", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [
+          modelCallPayload({ index: 0, contextTokens: 1_000 }),
+          modelCallPayload({ index: 1, contextTokens: 5_000 }),
+          modelCallPayload({
+            index: 2,
+            contextTokens: 9_000,
+            stopReason: "max_tokens",
+          }),
+        ];
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+        const [events] = storeEventsFn.mock.calls[0]!;
+        const session = foldInOrder(events as Event[]);
+
+        expect(session.modelCalls).toBe(3);
+        expect(session.finalRequestId).toBe("req-2");
+        expect(session.stopReason).toBe("max_tokens");
+        expect(session.truncated).toBe(true);
+        // The chain the next call is compared against: the LAST call's context.
+        expect(session.previousCallContextTokens).toBe(9_000);
+      });
+    });
+
+    describe("when the command is killed for the tenant", () => {
+      it("appends nothing for the whole batch", async () => {
+        mockedIsComponentDisabled.mockResolvedValue(true);
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const payloads = [0, 1, 2].map((index) =>
+          modelCallPayload({ index, contextTokens: 1_000 }),
+        );
+
+        await processCommandBatch(batchParamsFor({ payloads, storeEventsFn }));
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/pipeline.ts
@@ -16,6 +16,7 @@ import {
   SessionMetricSeriesMapProjection,
   type SessionMetricSeriesRecord,
 } from "./projections/sessionMetricSeries.mapProjection";
+import { CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH } from "./schemas/constants";
 import type { CodingAgentProcessingEvent } from "./schemas/events";
 
 export interface CodingAgentProcessingPipelineDeps {
@@ -53,29 +54,49 @@ export interface CodingAgentProcessingPipelineDeps {
 export function createCodingAgentProcessingPipeline(
   deps: CodingAgentProcessingPipelineDeps,
 ) {
-  return definePipeline<CodingAgentProcessingEvent>()
-    .withName("coding_agent_processing")
-    .withAggregateType("coding_agent_session")
-    .withFoldProjection(
-      "codingAgentSession",
-      new CodingAgentSessionFoldProjection({
-        store: deps.codingAgentSessionStore,
-      }),
-    )
-    .withMapProjection(
-      "codingAgentTraceSessions",
-      new CodingAgentTraceSessionsMapProjection({
-        store: deps.codingAgentTraceSessionAppendStore,
-      }),
-    )
-    .withMapProjection(
-      "sessionMetricSeries",
-      new SessionMetricSeriesMapProjection({
-        store: deps.sessionMetricSeriesAppendStore,
-      }),
-    )
-    .withCommand("contributeSpanFacts", ContributeSpanFactsCommand)
-    .withCommand("contributeLogFacts", ContributeLogFactsCommand)
-    .withCommand("contributeMetricFacts", ContributeMetricFactsCommand)
-    .build();
+  return (
+    definePipeline<CodingAgentProcessingEvent>()
+      .withName("coding_agent_processing")
+      .withAggregateType("coding_agent_session")
+      .withFoldProjection(
+        "codingAgentSession",
+        new CodingAgentSessionFoldProjection({
+          store: deps.codingAgentSessionStore,
+        }),
+      )
+      .withMapProjection(
+        "codingAgentTraceSessions",
+        new CodingAgentTraceSessionsMapProjection({
+          store: deps.codingAgentTraceSessionAppendStore,
+        }),
+      )
+      .withMapProjection(
+        "sessionMetricSeries",
+        new SessionMetricSeriesMapProjection({
+          store: deps.sessionMetricSeriesAppendStore,
+        }),
+      )
+      // ADR-066 pillar 2: every contribution is keyed on its session, so one
+      // session is one queue group and a long run drains its transcript one tiny
+      // insert at a time. Fold the group's queued contributions into a single
+      // multi-row append instead.
+      //
+      // Safe to fold, and safe ONLY as a fold — coalescing preserves the group's
+      // order (the drain takes the head in score order and the batch is handled,
+      // appended and dispatched in that order), which this pipeline needs.
+      // Sharding the session key would not preserve it; see the note above
+      // `CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH` and the derivation's
+      // model-call chain. Each handler derives its event from its own command
+      // alone and never reads back a same-batch append.
+      .withCommand("contributeSpanFacts", ContributeSpanFactsCommand, {
+        coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+      })
+      .withCommand("contributeLogFacts", ContributeLogFactsCommand, {
+        coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+      })
+      .withCommand("contributeMetricFacts", ContributeMetricFactsCommand, {
+        coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+      })
+      .build()
+  );
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/constants.ts
@@ -25,11 +25,11 @@ export const CODING_AGENT_PROCESSING_EVENT_TYPES = [
 ] as const;
 
 export const CONTRIBUTE_SPAN_FACTS_COMMAND_TYPE =
-  "lw.obs.coding_agent_session.contribute_span_facts";
+  "lw.obs.coding_agent_session.contribute_span_facts" as const;
 export const CONTRIBUTE_LOG_FACTS_COMMAND_TYPE =
-  "lw.obs.coding_agent_session.contribute_log_facts";
+  "lw.obs.coding_agent_session.contribute_log_facts" as const;
 export const CONTRIBUTE_METRIC_FACTS_COMMAND_TYPE =
-  "lw.obs.coding_agent_session.contribute_metric_facts";
+  "lw.obs.coding_agent_session.contribute_metric_facts" as const;
 
 export const CODING_AGENT_PROCESSING_COMMAND_TYPES = [
   CONTRIBUTE_SPAN_FACTS_COMMAND_TYPE,
@@ -53,3 +53,36 @@ export const CODING_AGENT_PROCESSING_COMMAND_TYPES = [
  * does not apply.
  */
 export const CODING_AGENT_MAP_COALESCE_MAX_BATCH = 256;
+
+/**
+ * Append-coalescing bound for the three contribution commands (ADR-066 pillar 2).
+ *
+ * Every contribution is keyed on its SESSION, so one session is one queue group
+ * and a long agent run parks its whole transcript behind a single lane that
+ * drains one job — one tiny event_log insert — per dispatch. Folding the group's
+ * queued contributions into a single multi-row append is what takes that lane
+ * off the per-item write path.
+ *
+ * 256 matches the sibling record commands
+ * (`LOG_COMMAND_COALESCE_MAX_BATCH`, `METRIC_COMMAND_COALESCE_MAX_BATCH`) and
+ * this pipeline's own map ceiling: a contribution carries lifted scalar facts,
+ * the same payload class, and the drain's byte budget backs the count up.
+ * `CODING_AGENT_SESSION_COALESCE_MAX_BATCH` (128) is deliberately NOT the
+ * reference — that bound exists because the session fold persists its
+ * applied-event-id watermark into its row, which is a constraint on the fold
+ * stage, not on this append.
+ *
+ * Why the session key is NOT sharded, though sharding is what would give one
+ * session parallel lanes: a session's contributions are not interchangeable.
+ * `foldModelCall` derives three things from the ORDER model calls arrive in —
+ * `previousCallContextTokens`, which the next call is compared against to decide
+ * whether it rebuilt its cache; `finalRequestId`, which is last-call-wins; and
+ * `stopReason`/`truncated`, which are only the last call's. A logs-only agent's
+ * API_REQUEST records fold through exactly that path, so spreading one session's
+ * log contributions across shards would systematically reorder them and corrupt
+ * all three. The fold's `refoldOnOutOfOrder: false` is not permission to
+ * reorder: it accepts the occasional late event folding in place, which is very
+ * different from introducing reordering by design. Coalescing needs none of
+ * that — it changes how many contributions share an insert, never their order.
+ */
+export const CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH = 256;

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -107,3 +107,22 @@ Feature: Coding-agent sessions
     When the session is read
     Then the version that folded the most telemetry is returned
     And reading it again returns that same version
+
+  # A busy session can queue its whole transcript faster than it is written.
+  # Writing those contributions together is what keeps up, but the session's
+  # story is told in order — so the grouping must not reorder it.
+  Scenario: a busy session's contributions are written together
+    Given a session queueing telemetry faster than it is written
+    When its waiting contributions are written
+    Then they are written as one batch
+    And not one write per contribution
+
+  Scenario: writing contributions together keeps the session's order
+    Given several of a session's contributions written together
+    When the session is assembled from them
+    Then they apply in the order the agent produced them
+
+  Scenario: an agent that reports only logs keeps its model-call sequence
+    Given an agent whose model calls are reported as logs rather than spans
+    When a run of its model calls is written together
+    Then the session's context growth, final request and stop reason match the last call in that run


### PR DESCRIPTION
## For humans

A coding-agent session — one long agent run — sends a stream of telemetry, and each piece was being saved to the database on its own. Because everything from one session queues up in a single line, a long run's telemetry had to be saved one item at a time, in order, while the rest of the system had nothing to do. Now the items waiting in that line are saved together, in one go.

What this deliberately does **not** do is split a session's line into several parallel lines. That would be the other obvious way to go faster, and it would quietly get the answers wrong — a session's story is told in order, and some of what we report about it only makes sense in that order. The details are below.

## What changed

All three contribution commands (`contributeSpanFacts`, `contributeLogFacts`, `contributeMetricFacts`) now declare `coalesceMaxBatch`. They all key their queue group on the session, so they all have the same shape and the same problem; fixing only the loudest one would have left the next pile waiting.

A plain count bound is enough here — no resolver. These payloads carry lifted scalar facts and nothing is spooled, so the drain's byte budget weighs them honestly, unlike the span case that needed a per-payload bound.

## Why the session key is not sharded

Sharding is the other half of the throughput story and it was explicitly on the table. It is not safe here, and the reason is specific rather than precautionary.

`foldModelCall` derives three things from the **order** model calls arrive in:

- `previousCallContextTokens` — the running value the *next* call is compared against to decide whether it rebuilt its prompt cache. A strict sequential chain.
- `finalRequestId` — last-call-wins.
- `stopReason` / `truncated` — deliberately only the last call's, because every earlier call stops on `tool_use` by definition.

For a logs-only agent, `CLAUDE.EVENT.API_REQUEST` folds through exactly that path — the log record *is* the model call. So spreading one session's log contributions across shards would systematically reorder them and corrupt all three fields.

The fold's `refoldOnOutOfOrder: false` is not a licence to reorder. It accepts an occasional late event folding in place; that is a different proposition from designing reordering in.

This is asserted, not just argued: a test folds the same three model calls in two orders and shows the session changes (`finalRequestId` moves from the last call to the first, and the context chain from the last call's size to the first's). If that ever stops holding, sharding becomes an option — and the test will say so.

Coalescing needs none of that latitude. The drain takes the group head in score order and the batch is handled, appended, and dispatched in that order, so the group's order is preserved exactly.

## Safety

- **Statelessness** — all three handlers are pure payload-to-event, with no read-back of a same-batch append.
- **Ordering** — preserved, and pinned by a test that folds a batch and the same payloads written one at a time and asserts the resulting session is identical.
- **Kill switch** — checked per payload inside the batch loop, unchanged.
- **Idempotency** — each contribution keeps its own key, so a batch retry neither duplicates nor drops.
- **Group keys** — untouched. Sessions keep the group they already had.

## Also in this change

The three command-type constants were missing the `as const` every sibling pipeline's constants carry. Without it they widened to `string` and silently dropped out of the `CommandType` union — a latent typing hole that surfaced as soon as a test tried to pass one where the union was expected. One word each; no behaviour change.

## Known limitation

Coalescing applies to newly staged jobs. Groups already staged keep their existing job ids and drain at the old rate. This is a forward fix, not a backlog rewrite.

Worth recording for whoever picks up the next one: the un-coalesced-producer warning did **not** fire for these commands, even after it was widened to cover explicit group keys. They set no group key at all — they fall back to the aggregate id, which for this pipeline is the session. The warning cannot tell a coarse aggregate (a session, a trace — many items each) from a fine one (a single evaluation id — one item, where coalescing would be pointless), so making it fire on every aggregate-keyed command would be noise rather than signal. Left alone deliberately; the judgement stays with whoever registers the command.

## Specs

Three scenarios added to `specs/coding-agent/session-aggregate.feature` (which is `@unit` at feature level, so they inherit the binding tag), each bound by a `@scenario` annotation. `check-feature-parity.ts` reports 21/21 bound for that file.

## Tests

- New `contributionCoalescing.unit.test.ts`: every contribution command carries the bound; the session key stays unsharded; a batch becomes one insert; contributions keep the agent's order; a batch folds to the identical session that per-contribution writes produce; the final request and stop reason come from the last call in the batch; the kill switch still suppresses the whole batch; and the order-sensitivity proof that justifies not sharding.
- `pnpm test:unit run src/server/event-sourcing`: 257 files, 7606 tests passing.
- `pnpm typecheck` and `pnpm typecheck:tests` clean; `biome check` clean on the files this touches.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved processing of coding-agent telemetry by efficiently coalescing contribution events into batches.
  - Supports larger event batches while maintaining reliable session processing.

- **Data Integrity**
  - Preserves contribution order during session assembly.
  - Ensures aggregated model-call details reflect the latest available context, request information, and stop reason.

- **Reliability**
  - Added comprehensive validation for batched and individual event processing, including disabled-command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->