### PR TITLE
fix(monitors): require an evaluator to create an online evaluation; CLI --settings lands under config.settings

### DIFF
--- a/langwatch/src/app/api/evaluators/__tests__/evaluators-api.integration.test.ts
+++ b/langwatch/src/app/api/evaluators/__tests__/evaluators-api.integration.test.ts
@@ -146,6 +146,22 @@ describe("Evaluators API", () => {
         });
       });
 
+      /** @scenario Updating settings replaces config.settings and preserves evaluatorType */
+      it("keeps the canonical config shape on a settings-only update", async () => {
+        const res = await helpers.api.put(`/api/evaluators/${evaluator.id}`, {
+          config: {
+            settings: { model: "openai/gpt-5-mini", prompt: "Judge it" },
+          },
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.config).toEqual({
+          evaluatorType: "langevals/exact_match",
+          settings: { model: "openai/gpt-5-mini", prompt: "Judge it" },
+        });
+      });
+
       it("rejects changing evaluatorType", async () => {
         const res = await helpers.api.put(`/api/evaluators/${evaluator.id}`, {
           config: {

--- a/langwatch/src/app/api/evaluators/__tests__/evaluators-api.integration.test.ts
+++ b/langwatch/src/app/api/evaluators/__tests__/evaluators-api.integration.test.ts
@@ -146,7 +146,7 @@ describe("Evaluators API", () => {
         });
       });
 
-      /** @scenario Updating settings replaces config.settings and preserves evaluatorType */
+      /** @scenario Updated settings take effect and the evaluator type is unchanged */
       it("keeps the canonical config shape on a settings-only update", async () => {
         const res = await helpers.api.put(`/api/evaluators/${evaluator.id}`, {
           config: {

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -6,6 +6,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
+import { MonitorEvaluatorRequiredError } from "~/server/app-layer/monitors/errors";
 import { prisma } from "~/server/db";
 import { monitorMappingsSchema } from "~/server/tracer/tracesMapping";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
@@ -219,20 +220,25 @@ secured.access(requires("evaluations:manage")).post(
     const body = c.req.valid("json");
     logger.info({ projectId: project.id }, "Creating monitor");
 
-    if (body.evaluatorId) {
-      const evaluator = await prisma.evaluator.findFirst({
-        where: {
-          id: body.evaluatorId,
-          projectId: project.id,
-          archivedAt: null,
-        },
-      });
-      if (!evaluator) {
-        return c.json(
-          { error: "Evaluator not found or does not belong to this project" },
-          404,
-        );
-      }
+    // A monitor without an evaluator sits enabled but evaluates nothing —
+    // the edit drawer shows an empty evaluator selection and no evaluation
+    // ever runs off it. Reject at the boundary instead of creating it broken.
+    if (!body.evaluatorId) {
+      throw new MonitorEvaluatorRequiredError();
+    }
+
+    const evaluator = await prisma.evaluator.findFirst({
+      where: {
+        id: body.evaluatorId,
+        projectId: project.id,
+        archivedAt: null,
+      },
+    });
+    if (!evaluator) {
+      return c.json(
+        { error: "Evaluator not found or does not belong to this project" },
+        404,
+      );
     }
 
     const slug = `${slugify(body.name)}-${nanoid(5)}`;
@@ -249,7 +255,7 @@ secured.access(requires("evaluations:manage")).post(
         mappings: (body.mappings ?? null) as Prisma.InputJsonValue,
         sample: body.sample,
         enabled: true,
-        evaluatorId: body.evaluatorId ?? null,
+        evaluatorId: body.evaluatorId,
         level: body.level,
         threadIdleTimeout: body.threadIdleTimeout ?? null,
       },
@@ -304,6 +310,13 @@ secured.access(requires("evaluations:update")).patch(
 
     if (!existing) {
       return c.json({ error: "Monitor not found" }, 404);
+    }
+
+    // Stripping the evaluator would leave the monitor unable to evaluate
+    // anything — legacy monitors without one keep working as long as the
+    // update leaves `evaluatorId` untouched.
+    if (body.evaluatorId === null) {
+      throw new MonitorEvaluatorRequiredError();
     }
 
     if (body.evaluatorId) {

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -6,6 +6,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
+import { EvaluatorNotFoundError } from "~/server/app-layer/evaluations/errors";
 import { MonitorEvaluatorRequiredError } from "~/server/app-layer/monitors/errors";
 import { prisma } from "~/server/db";
 import { monitorMappingsSchema } from "~/server/tracer/tracesMapping";
@@ -51,7 +52,7 @@ const createMonitorSchema = z.object({
   parameters: z.record(z.unknown()).default({}),
   mappings: monitorMappingsSchema,
   sample: z.number().min(0).max(1).default(1.0),
-  evaluatorId: z.string().optional(),
+  evaluatorId: z.string().min(1).optional(),
   level: z.enum(["trace", "thread"]).default("trace"),
   threadIdleTimeout: z.number().int().positive().nullable().optional(),
 });
@@ -65,7 +66,7 @@ const updateMonitorSchema = z.object({
   parameters: z.record(z.unknown()).optional(),
   mappings: monitorMappingsSchema,
   sample: z.number().min(0).max(1).optional(),
-  evaluatorId: z.string().nullable().optional(),
+  evaluatorId: z.string().min(1).nullable().optional(),
   level: z.enum(["trace", "thread"]).optional(),
   threadIdleTimeout: z.number().int().positive().nullable().optional(),
 });
@@ -235,10 +236,7 @@ secured.access(requires("evaluations:manage")).post(
       },
     });
     if (!evaluator) {
-      return c.json(
-        { error: "Evaluator not found or does not belong to this project" },
-        404,
-      );
+      throw new EvaluatorNotFoundError(body.evaluatorId);
     }
 
     const slug = `${slugify(body.name)}-${nanoid(5)}`;
@@ -328,10 +326,7 @@ secured.access(requires("evaluations:update")).patch(
         },
       });
       if (!evaluator) {
-        return c.json(
-          { error: "Evaluator not found or does not belong to this project" },
-          404,
-        );
+        throw new EvaluatorNotFoundError(body.evaluatorId);
       }
     }
 

--- a/langwatch/src/app/api/monitors/__tests__/monitors-api.integration.test.ts
+++ b/langwatch/src/app/api/monitors/__tests__/monitors-api.integration.test.ts
@@ -1,0 +1,193 @@
+import type { Evaluator, Organization, Project, Team } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { app } from "../[[...route]]/app";
+
+describe("Monitors API", () => {
+  let testApiKey: string;
+  let testProjectId: string;
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let testProject: Project;
+  let evaluator: Evaluator;
+
+  const createAuthHeaders = () => ({
+    "X-Auth-Token": testApiKey,
+    "Content-Type": "application/json",
+  });
+
+  const post = (path: string, body: unknown) =>
+    app.request(path, {
+      method: "POST",
+      headers: createAuthHeaders(),
+      body: JSON.stringify(body),
+    });
+
+  const patch = (path: string, body: unknown) =>
+    app.request(path, {
+      method: "PATCH",
+      headers: createAuthHeaders(),
+      body: JSON.stringify(body),
+    });
+
+  const createBody = (overrides: Record<string, unknown> = {}) => ({
+    name: "Toxicity Monitor",
+    checkType: "langevals/llm_boolean",
+    parameters: { model: "openai/gpt-5-mini" },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    testOrganization = await prisma.organization.create({
+      data: { name: "Test Organization", slug: `test-org-${nanoid()}` },
+    });
+
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${nanoid()}`,
+        organizationId: testOrganization.id,
+      },
+    });
+
+    testProject = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: nanoid() }),
+        teamId: testTeam.id,
+        personalFeatures: {},
+      },
+    });
+
+    testApiKey = testProject.apiKey;
+    testProjectId = testProject.id;
+
+    evaluator = await prisma.evaluator.create({
+      data: {
+        id: `evaluator_${nanoid()}`,
+        projectId: testProjectId,
+        name: "LLM Boolean Judge",
+        slug: `llm-boolean-${nanoid()}`,
+        type: "evaluator",
+        config: {
+          evaluatorType: "langevals/llm_boolean",
+          settings: {},
+        },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupTestRows(prisma, [
+      ["monitor", { projectId: testProjectId }],
+      ["evaluator", { projectId: testProjectId }],
+    ]);
+    await prisma.project.delete({ where: { id: testProjectId } });
+    await prisma.team.delete({ where: { id: testTeam.id } });
+    await prisma.organization.delete({ where: { id: testOrganization.id } });
+  });
+
+  describe("POST /api/monitors", () => {
+    describe("when no evaluator id is provided", () => {
+      /** @scenario Creating a monitor without an evaluator is rejected */
+      it("rejects the create with monitor_evaluator_required", async () => {
+        const res = await post("/api/monitors", createBody());
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe("monitor_evaluator_required");
+        expect((body.tips as string[]).join("\n")).toContain(
+          "langwatch evaluator create",
+        );
+
+        const created = await prisma.monitor.findFirst({
+          where: { projectId: testProjectId },
+        });
+        expect(created).toBeNull();
+      });
+    });
+
+    describe("when a valid evaluator id is provided", () => {
+      /** @scenario Creating a monitor with an evaluator succeeds */
+      it("creates the monitor with the evaluator attached", async () => {
+        const res = await post(
+          "/api/monitors",
+          createBody({ evaluatorId: evaluator.id }),
+        );
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.evaluatorId).toBe(evaluator.id);
+      });
+    });
+
+    describe("when the evaluator does not exist", () => {
+      /** @scenario Creating a monitor with an unknown evaluator is rejected */
+      it("rejects the create as not found", async () => {
+        const res = await post(
+          "/api/monitors",
+          createBody({ evaluatorId: "evaluator_nonexistent" }),
+        );
+
+        expect(res.status).toBe(404);
+      });
+    });
+  });
+
+  describe("PATCH /api/monitors/:id", () => {
+    describe("when setting the evaluator to null", () => {
+      /** @scenario Removing the evaluator from a monitor is rejected */
+      it("rejects the update and keeps the evaluator", async () => {
+        const createRes = await post(
+          "/api/monitors",
+          createBody({ evaluatorId: evaluator.id }),
+        );
+        const monitor = await createRes.json();
+
+        const res = await patch(`/api/monitors/${monitor.id}`, {
+          evaluatorId: null,
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe("monitor_evaluator_required");
+
+        const persisted = await prisma.monitor.findFirst({
+          where: { id: monitor.id, projectId: testProjectId },
+        });
+        expect(persisted?.evaluatorId).toBe(evaluator.id);
+      });
+    });
+
+    describe("when a legacy monitor has no evaluator", () => {
+      /** @scenario Updating other fields of a legacy monitor without an evaluator still works */
+      it("updates the name without touching the evaluator", async () => {
+        const legacy = await prisma.monitor.create({
+          data: {
+            id: `check_${nanoid()}`,
+            projectId: testProjectId,
+            name: "Legacy Check",
+            slug: `legacy-check-${nanoid()}`,
+            checkType: "langevals/llm_boolean",
+            preconditions: [],
+            parameters: { model: "openai/gpt-5-mini" },
+            sample: 1,
+            enabled: true,
+            executionMode: "ON_MESSAGE",
+          },
+        });
+
+        const res = await patch(`/api/monitors/${legacy.id}`, {
+          name: "Legacy Check Renamed",
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.name).toBe("Legacy Check Renamed");
+        expect(body.evaluatorId).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/app/api/monitors/__tests__/monitors-api.integration.test.ts
+++ b/langwatch/src/app/api/monitors/__tests__/monitors-api.integration.test.ts
@@ -89,7 +89,7 @@ describe("Monitors API", () => {
     await prisma.organization.delete({ where: { id: testOrganization.id } });
   });
 
-  describe("POST /api/monitors", () => {
+  describe("when creating a monitor", () => {
     describe("when no evaluator id is provided", () => {
       /** @scenario Creating a monitor without an evaluator is rejected */
       it("rejects the create with monitor_evaluator_required", async () => {
@@ -136,7 +136,7 @@ describe("Monitors API", () => {
     });
   });
 
-  describe("PATCH /api/monitors/:id", () => {
+  describe("when updating a monitor", () => {
     describe("when setting the evaluator to null", () => {
       /** @scenario Removing the evaluator from a monitor is rejected */
       it("rejects the update and keeps the evaluator", async () => {

--- a/langwatch/src/features/errors/logic/codes.ts
+++ b/langwatch/src/features/errors/logic/codes.ts
@@ -124,6 +124,7 @@ export const APP_ERROR_CODES = [
   "model_provider_not_found",
   "model_provider_scope_forbidden",
   "model_provider_scopes_required",
+  "monitor_evaluator_required",
   "no_admin_configured",
   // Also a Go code, with copy already written under the shared/transport
   // heading — `ee/admin/routes/admin.ts` raises it to hide the admin surface

--- a/langwatch/src/features/errors/logic/presentation.ts
+++ b/langwatch/src/features/errors/logic/presentation.ts
@@ -196,6 +196,11 @@ const presentations = {
 
   // ---- evaluations & experiments ----
   evaluation_not_found: { title: "Evaluation not found" },
+  monitor_evaluator_required: {
+    title: "This evaluation needs an evaluator",
+    describe: () =>
+      "Pick an existing evaluator or create one first, then attach it to the evaluation.",
+  },
   evaluator_not_found: { title: "Evaluator not found" },
   evaluator_config_error: {
     title: "This evaluator isn't configured correctly",

--- a/langwatch/src/server/api/routers/__tests__/monitors-evaluator.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/monitors-evaluator.integration.test.ts
@@ -84,19 +84,22 @@ describe("Monitor-Evaluator Integration", () => {
       expect(result.evaluatorId).toBe(testEvaluatorId);
     });
 
-    it("creates a monitor without evaluatorId (legacy mode)", async () => {
-      const result = await caller.monitors.create({
-        projectId,
-        name: "Legacy Monitor",
-        checkType: "langevals/exact_match",
-        preconditions: [],
-        settings: { caseSensitive: true },
-        sample: 0.5,
-        executionMode: EvaluationExecutionMode.ON_MESSAGE,
+    /** @scenario Creating a monitor without an evaluator is rejected */
+    it("rejects creating a monitor without evaluatorId", async () => {
+      await expect(
+        caller.monitors.create({
+          projectId,
+          name: "Monitor Without Evaluator",
+          checkType: "langevals/exact_match",
+          preconditions: [],
+          settings: { caseSensitive: true },
+          sample: 0.5,
+          executionMode: EvaluationExecutionMode.ON_MESSAGE,
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        cause: expect.objectContaining({ code: "monitor_evaluator_required" }),
       });
-
-      expect(result.id).toMatch(/^monitor_/);
-      expect(result.evaluatorId).toBeNull();
     });
 
     it("throws error when evaluatorId does not exist", async () => {
@@ -149,16 +152,22 @@ describe("Monitor-Evaluator Integration", () => {
   });
 
   describe("update with evaluatorId", () => {
-    it("links an existing monitor to an evaluator", async () => {
-      // Create a monitor without evaluatorId
-      const created = await caller.monitors.create({
-        projectId,
-        name: "Monitor To Be Linked",
-        checkType: "langevals/exact_match",
-        preconditions: [],
-        settings: { caseSensitive: false },
-        sample: 1.0,
-        executionMode: EvaluationExecutionMode.ON_MESSAGE,
+    it("links an existing legacy monitor to an evaluator", async () => {
+      // Legacy monitors predate evaluators — seed one directly, the create
+      // path no longer allows creating a monitor without an evaluator.
+      const created = await prisma.monitor.create({
+        data: {
+          id: `check_${Date.now()}`,
+          projectId,
+          name: "Monitor To Be Linked",
+          slug: `monitor-to-be-linked-${Date.now()}`,
+          checkType: "langevals/exact_match",
+          preconditions: [],
+          parameters: { caseSensitive: false },
+          sample: 1.0,
+          enabled: true,
+          executionMode: EvaluationExecutionMode.ON_MESSAGE,
+        },
       });
 
       expect(created.evaluatorId).toBeNull();
@@ -180,7 +189,8 @@ describe("Monitor-Evaluator Integration", () => {
       expect(updated.evaluatorId).toBe(testEvaluatorId);
     });
 
-    it("unlinks a monitor from an evaluator by setting null", async () => {
+    /** @scenario Removing the evaluator from a monitor is rejected */
+    it("rejects unlinking a monitor from its evaluator", async () => {
       // Create a monitor with evaluatorId
       const created = await caller.monitors.create({
         projectId,
@@ -195,21 +205,23 @@ describe("Monitor-Evaluator Integration", () => {
 
       expect(created.evaluatorId).toBe(testEvaluatorId);
 
-      // Update to unlink
-      const updated = await caller.monitors.update({
-        id: created.id,
-        projectId,
-        name: "Monitor To Be Unlinked",
-        checkType: "langevals/exact_match",
-        preconditions: [],
-        settings: { caseSensitive: false },
-        mappings: {},
-        sample: 1.0,
-        executionMode: EvaluationExecutionMode.ON_MESSAGE,
-        evaluatorId: null,
+      await expect(
+        caller.monitors.update({
+          id: created.id,
+          projectId,
+          name: "Monitor To Be Unlinked",
+          checkType: "langevals/exact_match",
+          preconditions: [],
+          settings: { caseSensitive: false },
+          mappings: {},
+          sample: 1.0,
+          executionMode: EvaluationExecutionMode.ON_MESSAGE,
+          evaluatorId: null,
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        cause: expect.objectContaining({ code: "monitor_evaluator_required" }),
       });
-
-      expect(updated.evaluatorId).toBeNull();
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/monitors.copy.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/monitors.copy.integration.test.ts
@@ -83,15 +83,22 @@ describe("monitors.copy", () => {
   describe("given a monitor with inline settings and no linked evaluator", () => {
     describe("when it is replicated to the target project", () => {
       it("recreates a disabled monitor with the same config and leaves the source alone", async () => {
-        const source = await caller.monitors.create({
-          projectId: sourceProjectId,
-          name: "Inline Monitor",
-          checkType: "custom/test",
-          preconditions: [],
-          settings: { foo: "bar" },
-          sample: 0.5,
-          executionMode: "ON_MESSAGE",
-          level: "trace",
+        // Legacy monitors predate evaluators — seed one directly, the create
+        // path no longer allows creating a monitor without an evaluator.
+        const source = await prisma.monitor.create({
+          data: {
+            id: `check_inline_${Date.now()}`,
+            projectId: sourceProjectId,
+            name: "Inline Monitor",
+            slug: `inline-monitor-${Date.now()}`,
+            checkType: "custom/test",
+            preconditions: [],
+            parameters: { foo: "bar" },
+            sample: 0.5,
+            enabled: true,
+            executionMode: "ON_MESSAGE",
+            level: "trace",
+          },
         });
 
         const replica = await caller.monitors.copy({
@@ -213,14 +220,21 @@ describe("monitors.copy", () => {
   describe("given a name that already exists in the target project", () => {
     describe("when a monitor with that name is replicated", () => {
       it("de-duplicates the replicated monitor name", async () => {
-        const source = await caller.monitors.create({
-          projectId: sourceProjectId,
-          name: "Dup Monitor",
-          checkType: "custom/test",
-          preconditions: [],
-          settings: {},
-          sample: 1,
-          executionMode: "ON_MESSAGE",
+        // Seeded directly: the create path requires an evaluator, and this
+        // test only cares about name de-duplication on copy.
+        const source = await prisma.monitor.create({
+          data: {
+            id: `check_dup_${Date.now()}`,
+            projectId: sourceProjectId,
+            name: "Dup Monitor",
+            slug: `dup-monitor-${Date.now()}`,
+            checkType: "custom/test",
+            preconditions: [],
+            parameters: {},
+            sample: 1,
+            enabled: true,
+            executionMode: "ON_MESSAGE",
+          },
         });
 
         const first = await caller.monitors.copy({

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { customAlphabet } from "nanoid";
 import { ZodError, z } from "zod";
 import { getApp } from "~/server/app-layer";
+import { MonitorEvaluatorRequiredError } from "~/server/app-layer/monitors/errors";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
 import {
@@ -202,17 +203,20 @@ export const monitorsRouter = createTRPCRouter({
       } = input;
       const prisma = ctx.prisma;
 
-      // Validate evaluator exists and belongs to project if provided
-      if (evaluatorId) {
-        const evaluator = await prisma.evaluator.findFirst({
-          where: { id: evaluatorId, projectId, archivedAt: null },
+      // A monitor without an evaluator sits enabled but evaluates nothing —
+      // reject at the boundary instead of creating it broken.
+      if (!evaluatorId) {
+        throw new MonitorEvaluatorRequiredError();
+      }
+
+      const evaluator = await prisma.evaluator.findFirst({
+        where: { id: evaluatorId, projectId, archivedAt: null },
+      });
+      if (!evaluator) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Evaluator not found or does not belong to this project",
         });
-        if (!evaluator) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Evaluator not found or does not belong to this project",
-          });
-        }
       }
 
       validateCheckSettings(checkType, parameters);
@@ -388,6 +392,13 @@ export const monitorsRouter = createTRPCRouter({
       } = input;
       const prisma = ctx.prisma;
       const slug = slugify(name, { lower: true, strict: true });
+
+      // Stripping the evaluator would leave the monitor unable to evaluate
+      // anything — legacy monitors without one keep working as long as the
+      // update leaves `evaluatorId` untouched.
+      if (evaluatorId === null) {
+        throw new MonitorEvaluatorRequiredError();
+      }
 
       // Validate evaluator exists and belongs to project if provided
       if (evaluatorId) {

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -181,7 +181,7 @@ export const monitorsRouter = createTRPCRouter({
           EvaluationExecutionMode.AS_GUARDRAIL,
           EvaluationExecutionMode.MANUALLY,
         ]),
-        evaluatorId: z.string().optional(),
+        evaluatorId: z.string().min(1).optional(),
         level: z.enum(["trace", "thread"]).optional(), // Evaluation level: trace or thread
         threadIdleTimeout: z.number().int().positive().nullable().optional(), // Seconds to wait after last message before evaluating thread
       }),
@@ -368,7 +368,7 @@ export const monitorsRouter = createTRPCRouter({
           EvaluationExecutionMode.AS_GUARDRAIL,
           EvaluationExecutionMode.MANUALLY,
         ]),
-        evaluatorId: z.string().nullable().optional(),
+        evaluatorId: z.string().min(1).nullable().optional(),
         level: z.enum(["trace", "thread"]).optional(), // Evaluation level: trace or thread
         threadIdleTimeout: z.number().int().positive().nullable().optional(), // Seconds to wait after last message before evaluating thread
       }),

--- a/langwatch/src/server/app-layer/error-remediation.ts
+++ b/langwatch/src/server/app-layer/error-remediation.ts
@@ -164,6 +164,13 @@ const registry = {
     tips: ["Check the evaluator type against the list of available evaluators"],
     docsPath: "/evaluations/evaluators/list",
   },
+  monitor_evaluator_required: {
+    tips: [
+      "Create an evaluator first: langwatch evaluator create <name> --type <type>, then pass its id via evaluatorId",
+      "Or pick an existing one: langwatch evaluator list",
+    ],
+    docsPath: "/evaluations/evaluators/list",
+  },
 
   // ---- langy ----
   langy_conversation_not_found: {

--- a/langwatch/src/server/app-layer/monitors/errors.ts
+++ b/langwatch/src/server/app-layer/monitors/errors.ts
@@ -1,0 +1,29 @@
+import { HandledError } from "@langwatch/handled-error";
+
+import { remediation } from "../error-remediation";
+
+/**
+ * A monitor (online evaluation) cannot exist without an evaluator: it would
+ * sit enabled but evaluate nothing, and the app's edit drawer would show an
+ * empty evaluator selection. Raised when a create omits `evaluatorId` or an
+ * update sets it to null. Monitors that predate evaluators keep running off
+ * their stored parameters, so updates that leave `evaluatorId` untouched are
+ * not gated.
+ */
+export class MonitorEvaluatorRequiredError extends HandledError {
+  declare readonly code: "monitor_evaluator_required";
+
+  constructor(options: { reasons?: readonly Error[] } = {}) {
+    super(
+      "monitor_evaluator_required",
+      "An evaluator is required to create an online evaluation",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        ...remediation("monitor_evaluator_required"),
+        ...options,
+      },
+    );
+    this.name = "MonitorEvaluatorRequiredError";
+  }
+}

--- a/specs/evaluators/evaluator-update-settings.feature
+++ b/specs/evaluators/evaluator-update-settings.feature
@@ -1,24 +1,23 @@
 @integration
-Feature: Updating evaluator settings keeps the canonical config shape
+Feature: Updating evaluator settings takes effect
   As an agent or developer updating an evaluator's settings through the API or CLI
-  I want the settings to land under config.settings with the evaluator type preserved
-  So that the update actually takes effect instead of leaving stale settings behind
+  I want the new settings to actually take effect on the evaluator
+  So that the next evaluation runs with what I configured instead of stale defaults
 
   # The failure this spec pins: `langwatch evaluator update <id> --settings
-  # '<json>'` sent the parsed JSON as the whole `config` object, so the model,
-  # prompt and other keys were merged at the TOP level of config while
-  # config.settings kept the old defaults. The monitor kept evaluating with the
-  # stale settings and the update silently did nothing effective. Found while
-  # dogfooding with a customer project.
+  # '<json>'` sent the parsed JSON in a shape the server merged as dead data,
+  # so the evaluator kept running with its old settings and the update
+  # silently did nothing effective. Found while dogfooding with a customer
+  # project.
 
-  Scenario: Updating settings replaces config.settings and preserves evaluatorType
+  Scenario: Updated settings take effect and the evaluator type is unchanged
     Given an evaluator with settings exists
-    When I update the evaluator with new settings under config.settings
-    Then config.evaluatorType is unchanged
-    And config.settings equals the new settings
-    And no settings keys appear at the top level of config
+    When I update the evaluator's settings
+    Then the evaluator runs with the new settings
+    And the evaluator's type is unchanged
+    And none of the old settings linger
 
   @unit
-  Scenario: The CLI sends --settings under config.settings
+  Scenario: Settings updated through the CLI take effect
     When I run "langwatch evaluator update" with --settings JSON
-    Then the update request body nests the parsed JSON under config.settings
+    Then the evaluator's stored settings become the provided JSON

--- a/specs/evaluators/evaluator-update-settings.feature
+++ b/specs/evaluators/evaluator-update-settings.feature
@@ -1,0 +1,24 @@
+@integration
+Feature: Updating evaluator settings keeps the canonical config shape
+  As an agent or developer updating an evaluator's settings through the API or CLI
+  I want the settings to land under config.settings with the evaluator type preserved
+  So that the update actually takes effect instead of leaving stale settings behind
+
+  # The failure this spec pins: `langwatch evaluator update <id> --settings
+  # '<json>'` sent the parsed JSON as the whole `config` object, so the model,
+  # prompt and other keys were merged at the TOP level of config while
+  # config.settings kept the old defaults. The monitor kept evaluating with the
+  # stale settings and the update silently did nothing effective. Found while
+  # dogfooding with a customer project.
+
+  Scenario: Updating settings replaces config.settings and preserves evaluatorType
+    Given an evaluator with settings exists
+    When I update the evaluator with new settings under config.settings
+    Then config.evaluatorType is unchanged
+    And config.settings equals the new settings
+    And no settings keys appear at the top level of config
+
+  @unit
+  Scenario: The CLI sends --settings under config.settings
+    When I run "langwatch evaluator update" with --settings JSON
+    Then the update request body nests the parsed JSON under config.settings

--- a/specs/monitors/monitor-requires-evaluator.feature
+++ b/specs/monitors/monitor-requires-evaluator.feature
@@ -1,0 +1,48 @@
+@integration
+Feature: Creating a monitor requires an evaluator
+  As an agent or developer creating an online-evaluation monitor through the API or CLI
+  I want a monitor created without an evaluator to be rejected with an actionable error
+  So that I never end up with a monitor that silently evaluates nothing
+
+  # The failure this spec pins: `langwatch monitor create "X" --check-type
+  # langevals/llm_boolean` with no --evaluator-id created a monitor with
+  # evaluatorId null. The app's Edit Online Evaluation drawer then showed an
+  # empty "Select Evaluator" and the monitor could not evaluate anything.
+  # Found while dogfooding with a customer project.
+  #
+  # Monitors that predate evaluators (legacy check_* rows) keep running off
+  # their stored parameters, so existing rows are untouched: only creating a
+  # new evaluator-less monitor, or stripping the evaluator from an existing
+  # one, is gated.
+
+  Scenario: Creating a monitor without an evaluator is rejected
+    When I create a monitor without an evaluator id
+    Then the request fails with code "monitor_evaluator_required"
+    And the failure tells me to create or pick an evaluator first
+
+  Scenario: Creating a monitor with an evaluator succeeds
+    Given an evaluator exists in the project
+    When I create a monitor referencing that evaluator
+    Then the monitor is created with that evaluator attached
+
+  Scenario: Creating a monitor with an unknown evaluator is rejected
+    When I create a monitor referencing an evaluator that does not exist
+    Then the request fails as not found
+
+  Scenario: Removing the evaluator from a monitor is rejected
+    Given a monitor with an evaluator exists
+    When I update the monitor setting its evaluator to null
+    Then the request fails with code "monitor_evaluator_required"
+    And the monitor keeps its evaluator
+
+  Scenario: Updating other fields of a legacy monitor without an evaluator still works
+    Given a legacy monitor without an evaluator exists
+    When I update the monitor's name without touching the evaluator
+    Then the update succeeds
+
+  @unit
+  Scenario: The CLI refuses to create a monitor without --evaluator-id
+    When I run "langwatch monitor create" without --evaluator-id
+    Then the command fails before calling the API
+    And the error tells me to create an evaluator with "langwatch evaluator create" and pass --evaluator-id
+    And the error tells me I can find existing evaluators with "langwatch evaluator list"

--- a/typescript-sdk/src/cli/commands/__tests__/cli-error-propagation-commands.integration.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/cli-error-propagation-commands.integration.test.ts
@@ -209,6 +209,8 @@ describe("CLI error propagation across commands", () => {
           "m1",
           "--check-type",
           "not-a-real-type",
+          "--evaluator-id",
+          "evaluator_123",
         ],
         testDir,
       );

--- a/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
@@ -30,6 +30,7 @@ import { listEvaluatorsCommand } from "../list";
 import { getEvaluatorCommand } from "../get";
 import { createEvaluatorCommand } from "../create";
 import { deleteEvaluatorCommand } from "../delete";
+import { updateEvaluatorCommand } from "../update";
 import { applyOutputContext, resolveOutputOptions } from "../../../utils/output";
 
 class ProcessExitError extends Error {
@@ -452,5 +453,53 @@ describe("listEvaluatorsCommand() failure shape under machine formats", () => {
     await expect(listEvaluatorsCommand()).rejects.toThrow(ProcessExitError);
 
     expect(() => JSON.parse(printedStdout())).toThrow();
+  });
+});
+
+describe("updateEvaluatorCommand()", () => {
+  let mockGet: ReturnType<typeof vi.fn>;
+  let mockUpdate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet = vi.fn();
+    mockUpdate = vi.fn();
+    vi.mocked(EvaluatorsApiService).mockImplementation(function () { return ({
+      getAll: vi.fn(),
+      get: mockGet,
+      create: vi.fn(),
+      update: mockUpdate,
+      delete: vi.fn(),
+    }) as unknown as EvaluatorsApiService; });
+    vi.spyOn(console, "log").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+    mockProcessExit();
+  });
+
+  describe("when --settings JSON is provided", () => {
+    /** @scenario The CLI sends --settings under config.settings */
+    it("nests the parsed settings under config.settings", async () => {
+      mockGet.mockResolvedValue(makeEvaluator());
+      mockUpdate.mockResolvedValue(makeEvaluator());
+
+      await updateEvaluatorCommand("test-evaluator", {
+        settings: JSON.stringify({ model: "openai/gpt-5-mini", prompt: "Judge it" }),
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith("evaluator_abc123", {
+        config: {
+          settings: { model: "openai/gpt-5-mini", prompt: "Judge it" },
+        },
+      });
+    });
+
+    it("exits when the settings are not valid JSON", async () => {
+      mockGet.mockResolvedValue(makeEvaluator());
+
+      await expect(
+        updateEvaluatorCommand("test-evaluator", { settings: "{not json" }),
+      ).rejects.toThrow(ProcessExitError);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
@@ -477,7 +477,7 @@ describe("updateEvaluatorCommand()", () => {
   });
 
   describe("when --settings JSON is provided", () => {
-    /** @scenario The CLI sends --settings under config.settings */
+    /** @scenario Settings updated through the CLI take effect */
     it("nests the parsed settings under config.settings", async () => {
       mockGet.mockResolvedValue(makeEvaluator());
       mockUpdate.mockResolvedValue(makeEvaluator());

--- a/typescript-sdk/src/cli/commands/evaluators/update.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/update.ts
@@ -42,7 +42,13 @@ export const updateEvaluatorCommand = async (
     const body: UpdateEvaluatorBody = {};
     if (options.name !== undefined) body.name = options.name;
     if (options.settings !== undefined) {
-      body.config = JSON.parse(options.settings) as Record<string, unknown>;
+      // The canonical config shape is { evaluatorType, settings }: the parsed
+      // JSON must land under config.settings, not at the top level of config,
+      // or the server merges it as dead top-level keys while config.settings
+      // keeps the old values and the update silently does nothing effective.
+      body.config = {
+        settings: JSON.parse(options.settings) as Record<string, unknown>,
+      };
     }
 
     updated = await service.update(evaluatorId, body);

--- a/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
@@ -183,6 +183,8 @@ describe("createMonitorCommand()", () => {
 
       expect(mockFetch).not.toHaveBeenCalled();
       const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      // The stable machine contract is the code; the prose is supplementary.
+      expect(output).toContain("validation_error");
       expect(output).toContain("--evaluator-id is required");
       expect(output).toContain("langwatch evaluator create");
       expect(output).toContain("langwatch evaluator list");

--- a/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
@@ -146,10 +146,13 @@ describe("createMonitorCommand()", () => {
   it("creates a monitor", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => makeMonitor(),
+      json: async () => makeMonitor({ evaluatorId: "eval_abc" }),
     });
 
-    await createMonitorCommand("Toxicity Check", { checkType: "ragas/toxicity" });
+    await createMonitorCommand("Toxicity Check", {
+      checkType: "ragas/toxicity",
+      evaluatorId: "eval_abc",
+    });
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/monitors"),
       expect.objectContaining({
@@ -161,8 +164,29 @@ describe("createMonitorCommand()", () => {
 
   it("rejects invalid execution mode", async () => {
     await expect(
-      createMonitorCommand("Test", { checkType: "ragas/toxicity", executionMode: "INVALID" })
+      createMonitorCommand("Test", {
+        checkType: "ragas/toxicity",
+        evaluatorId: "eval_abc",
+        executionMode: "INVALID",
+      })
     ).rejects.toThrow(ProcessExitError);
+  });
+
+  describe("when --evaluator-id is missing", () => {
+    /** @scenario The CLI refuses to create a monitor without --evaluator-id */
+    it("fails before calling the API and points at evaluator create and list", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(noop);
+
+      await expect(
+        createMonitorCommand("Test", { checkType: "ragas/toxicity" })
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(output).toContain("--evaluator-id is required");
+      expect(output).toContain("langwatch evaluator create");
+      expect(output).toContain("langwatch evaluator list");
+    });
   });
 });
 

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -26,6 +26,19 @@ export const createMonitorCommand = async (
 ): Promise<CommandResult | void> => {
   await resolveCredentials();
 
+  // A monitor without an evaluator would be created broken: it sits enabled
+  // but evaluates nothing. Fail before calling the API with the way out.
+  if (!options.evaluatorId) {
+    reportCommandError({
+      error: commandValidationError(
+        "--evaluator-id is required: a monitor runs a saved evaluator.\n" +
+          "  Create one first: langwatch evaluator create <name> --type <type>\n" +
+          "  Or pick an existing one: langwatch evaluator list",
+      ),
+    });
+    process.exit(1);
+  }
+
   const validModes = ["ON_MESSAGE", "AS_GUARDRAIL", "MANUALLY"];
   if (options.executionMode && !validModes.includes(options.executionMode)) {
     reportCommandError({

--- a/typescript-sdk/src/cli/program.ts
+++ b/typescript-sdk/src/cli/program.ts
@@ -2397,7 +2397,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
       .requiredOption("--check-type <type>", "Evaluator check type (e.g. ragas/toxicity, custom/my-eval)")
       .option("--execution-mode <mode>", "Execution mode: ON_MESSAGE (default), AS_GUARDRAIL, MANUALLY", "ON_MESSAGE")
       .option("--sample <rate>", "Sampling rate 0.0-1.0 (default: 1.0)")
-      .option("--evaluator-id <id>", "Link to a saved evaluator")
+      .option("--evaluator-id <id>", "Saved evaluator to run (required; see `langwatch evaluator list`)")
       .option("--level <level>", "Evaluation level: trace (default) or thread")
       .option("--parameters <json>", "Evaluator settings as JSON")
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),


### PR DESCRIPTION
Two bugs found while dogfooding against production with a customer project, both in the monitor/evaluator surface.

## 1. Creating a monitor without an evaluator silently succeeded

`langwatch monitor create "X" --check-type langevals/llm_boolean --level thread --parameters '{...}'` (no `--evaluator-id`) created a monitor with `evaluatorId: null`. The Edit Online Evaluation drawer then showed an empty "Select Evaluator" and the monitor could not evaluate anything. The UI create path always attaches an evaluator, so the REST and tRPC boundaries now enforce the same invariant.

Guard behavior:

- `POST /api/monitors` and `monitors.create` (tRPC) reject a missing `evaluatorId` with a `HandledError` code `monitor_evaluator_required` (400, fault customer), with tips pointing at `langwatch evaluator create` / `langwatch evaluator list` and a presentation registry entry for the UI.
- `PATCH /api/monitors/:id` and `monitors.update` reject `evaluatorId: null`, so an existing monitor cannot be stripped of its evaluator.
- Legacy evaluator-less monitors (old `check_*` rows) keep working: execution falls back to their stored parameters, updates that leave `evaluatorId` untouched still succeed, and `monitors.copy` still replicates them. Only creating a new broken monitor, or breaking an existing one, is gated.
- The CLI fails before calling the API with actionable copy:

```
Error: --evaluator-id is required: a monitor runs a saved evaluator.
  Create one first: langwatch evaluator create <name> --type <type>
  Or pick an existing one: langwatch evaluator list
```

## 2. `langwatch evaluator update --settings` merged settings at the top level of config

The CLI sent the parsed `--settings` JSON as the whole `config` object, so `model`, `prompt`, etc. landed as dead top-level keys while `config.settings` kept the old defaults, and the update silently did nothing effective. The CLI now nests the JSON under `config.settings`; the server's shallow merge preserves the canonical `{evaluatorType, settings}` shape.

## QA (real CLI against a local server)

```
$ langwatch monitor create "Dogfood Boolean Monitor" --check-type langevals/llm_boolean --level thread --parameters '{...}'
Error: --evaluator-id is required: a monitor runs a saved evaluator. ...   (exit 1, no API call)

$ langwatch evaluator create "Dogfood Judge" --type langevals/llm_boolean
Created evaluator "Dogfood Judge"

$ langwatch monitor create "Dogfood Boolean Monitor" --check-type langevals/llm_boolean --level thread --evaluator-id evaluator_8eXL...
Monitor created with evaluatorId attached

$ langwatch evaluator update evaluator_8eXL... --settings '{"model":"openai/gpt-5-mini","prompt":"...","max_tokens":4096}'
$ langwatch evaluator get evaluator_8eXL... -f json
"config": { "settings": { "model": "openai/gpt-5-mini", ... }, "evaluatorType": "langevals/llm_boolean" }
```

The CLI-created monitor rendering correctly in the Edit Online Evaluation drawer (this exact drawer showed an empty evaluator before the fix):

![Edit Online Evaluation drawer with evaluator attached](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6478/monitors/drawer-monitor-with-evaluator.png)

## Tests

- `specs/monitors/monitor-requires-evaluator.feature` and `specs/evaluators/evaluator-update-settings.feature`, all scenarios bound (`check-feature-parity` green)
- REST integration tests: `src/app/api/monitors/__tests__/monitors-api.integration.test.ts` (new), settings-shape regression in `evaluators-api.integration.test.ts`
- tRPC integration tests updated: create/unlink now rejected, legacy monitors seeded directly
- CLI unit tests: missing `--evaluator-id` fails pre-flight with the actionable copy; `--settings` nests under `config.settings`

https://claude.ai/code/session_01WKLMWcBwMSbzAL77N9i3sx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitors now require a valid, active evaluator when created.
  * Removing an evaluator is prevented, while legacy monitors remain supported.
  * CLI guidance explains how to select or create an evaluator.
  * Evaluator settings updates preserve evaluator type and replace settings correctly.

* **Bug Fixes**
  * Added clear validation for missing, unknown, archived, or removed evaluators.
  * Invalid evaluator settings JSON is rejected before submission.

* **Tests**
  * Expanded coverage for monitor validation and evaluator settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->