### PR TITLE
perf(metrics): fold a rollup chunk's reads instead of one seek per point

### DIFF
--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -270,6 +270,9 @@ describe("given a cumulative series long enough to span several rollup buckets",
   // is a counter reset, so the fold's dependency on each sample's predecessor
   // is live rather than incidental.
   const values = [10, 15, 18, 26, 31, 4, 9, 14, 22, 27, 33, 40];
+  // Shared, because the read-counting block below compares its own rollups
+  // against this series rather than writing a second copy of them.
+  const chunkSeriesId = "d".repeat(64);
 
   function samples(seriesId: string): CanonicalMetricDataPoint[] {
     return values.map((value, index) =>
@@ -291,7 +294,6 @@ describe("given a cumulative series long enough to span several rollup buckets",
     // Both series use the same timestamps, so the fixture derives the same
     // point ids for both. That is deliberate: a point id is only unique within
     // its series, and the chunk path reads many series in one query.
-    const chunkSeriesId = "d".repeat(64);
     const perPointSeriesId = "e".repeat(64);
 
     beforeAll(async () => {
@@ -351,9 +353,10 @@ describe("given a cumulative series long enough to span several rollup buckets",
     });
 
     it("still produces the same rollups as the uncounted chunk", async () => {
-      expect(await readRollups(countedSeriesId)).toEqual(
-        await readRollups("d".repeat(64)),
-      );
+      const counted = await readRollups(countedSeriesId);
+
+      expect(counted).toHaveLength(4);
+      expect(counted).toEqual(await readRollups(chunkSeriesId));
     });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -4,15 +4,18 @@
  *
  * Runs the canonical metric repository's real INSERT/SELECT SQL against
  * ClickHouse (migration 00049). The rollup unit tests exercise the pure fold;
- * the immediateNeighbors / pointsForBuckets queries and the rollup INSERT they
- * feed are only ever mocked. This file is what proves:
+ * the successor / affected-bucket seek queries and the rollup INSERT they feed
+ * are only ever mocked. This file is what proves:
  * - ensureDataPoints lands raw points plus their usage-estimate ledger rows;
  * - recomputeAffectedRollupsMany converts a cumulative monotonic sum series
  *   spanning two 30s buckets into per-bucket deltas using rows it fetched back
  *   from ClickHouse, not the in-memory chunk;
  * - a late point ensured between existing samples converges the affected
  *   buckets on re-recompute (ReplacingMergeTree(UpdatedAt), read via FINAL —
- *   the dedup pattern migration 00049 mandates for metric_time_rollups).
+ *   the dedup pattern migration 00049 mandates for metric_time_rollups);
+ * - folding a chunk in one pass lands on exactly the rollups the per-point
+ *   path produces, using a number of reads set by the affected buckets rather
+ *   than by how many points the chunk carries.
  *
  * Fixtures come from the shared metric-point builder the rollup unit tests
  * use, so expectations here mirror rollupScalar.unit.test.ts semantics: the
@@ -258,6 +261,99 @@ describe("given a cumulative monotonic sum series spanning two rollup buckets", 
           sourcePointCount: 1,
         },
       ]);
+    });
+  });
+});
+
+describe("given a cumulative series long enough to span several rollup buckets", () => {
+  // Twelve samples every ten seconds cover four 30s buckets, and the drop to 4
+  // is a counter reset, so the fold's dependency on each sample's predecessor
+  // is live rather than incidental.
+  const values = [10, 15, 18, 26, 31, 4, 9, 14, 22, 27, 33, 40];
+
+  function samples(seriesId: string): CanonicalMetricDataPoint[] {
+    return values.map((value, index) =>
+      point({
+        tenantId,
+        organizationId,
+        seriesId,
+        timeUnixMs: bucket0 + index * 10_000,
+        metricKind: "sum",
+        aggregationTemporality: "cumulative",
+        isMonotonic: true,
+        valueDouble: value,
+        acceptedAt,
+      }),
+    );
+  }
+
+  describe("when one series folds as a chunk and an identical one folds a point at a time", () => {
+    // Both series use the same timestamps, so the fixture derives the same
+    // point ids for both. That is deliberate: a point id is only unique within
+    // its series, and the chunk path reads many series in one query.
+    const chunkSeriesId = "d".repeat(64);
+    const perPointSeriesId = "e".repeat(64);
+
+    beforeAll(async () => {
+      await repo.recomputeAffectedRollupsMany({
+        points: samples(chunkSeriesId),
+      });
+      // Reverse order on purpose: every sample is late relative to the one
+      // before it, which is the arrival pattern a chunk collapses.
+      for (const single of [...samples(perPointSeriesId)].reverse()) {
+        await repo.recomputeAffectedRollups({ point: single });
+      }
+    }, 60_000);
+
+    it("folds the chunk to exactly the rollups the per-point path produces", async () => {
+      const chunked = await readRollups(chunkSeriesId);
+      const perPoint = await readRollups(perPointSeriesId);
+
+      expect(chunked).toEqual(perPoint);
+      expect(chunked).toHaveLength(4);
+    });
+
+    it("counts every sample exactly once across the buckets", async () => {
+      const chunked = await readRollups(chunkSeriesId);
+
+      expect(
+        chunked.reduce((total, row) => total + row.sourcePointCount, 0),
+      ).toBe(values.length);
+    });
+  });
+
+  describe("when the chunk is folded through a client that counts its reads", () => {
+    const countedSeriesId = "f".repeat(64);
+    let reads: number;
+
+    beforeAll(async () => {
+      reads = 0;
+      const counting = {
+        query: async (args: Parameters<ClickHouseClient["query"]>[0]) => {
+          reads += 1;
+          return await ch.query(args);
+        },
+        insert: async (args: Parameters<ClickHouseClient["insert"]>[0]) =>
+          await ch.insert(args),
+      } as unknown as ClickHouseClient;
+
+      await new MetricDataPointClickHouseRepository({
+        resolveClient: async () => counting,
+        resolveOrganizationClient: async () => counting,
+      }).recomputeAffectedRollupsMany({ points: samples(countedSeriesId) });
+    }, 60_000);
+
+    it("reads once for the successors and once for the affected buckets", async () => {
+      // The seek budget folds all twelve successor seeks into one statement
+      // and every affected bucket into a second. Reading per point would make
+      // this grow with the chunk instead.
+      expect(reads).toBe(2);
+    });
+
+    it("still produces the same rollups as the uncounted chunk", async () => {
+      expect(await readRollups(countedSeriesId)).toEqual(
+        await readRollups("d".repeat(64)),
+      );
     });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -298,6 +298,11 @@ describe("MetricDataPointClickHouseRepository", () => {
       await repository.recomputeAffectedRollupsMany({ points: chunkOf(2) });
 
       const successorSeeks = query.mock.calls[0]![0].query;
+      // The bound is what encodes "successor" — an ascending order with a `<`
+      // bound would still read backwards, so pin the direction of both.
+      expect(successorSeeks).toContain(
+        "metric_data_points.TimeUnixMs > {time0:DateTime64(3)}",
+      );
       expect(successorSeeks).toContain(
         "ORDER BY metric_data_points.TimeUnixMs",
       );

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -243,7 +243,9 @@ describe("MetricDataPointClickHouseRepository", () => {
     }
 
     function reader() {
-      const query = vi.fn(async () => ({ json: async () => [] }));
+      const query = vi.fn<
+        (args: { query: string }) => Promise<{ json: () => Promise<unknown[]> }>
+      >(async () => ({ json: async () => [] }));
       const insert = vi.fn(async () => {});
       return { query, client: { query, insert } as never };
     }
@@ -295,8 +297,10 @@ describe("MetricDataPointClickHouseRepository", () => {
 
       await repository.recomputeAffectedRollupsMany({ points: chunkOf(2) });
 
-      const successorSeeks = query.mock.calls[0]![0].query as string;
-      expect(successorSeeks).toContain("ORDER BY metric_data_points.TimeUnixMs");
+      const successorSeeks = query.mock.calls[0]![0].query;
+      expect(successorSeeks).toContain(
+        "ORDER BY metric_data_points.TimeUnixMs",
+      );
       expect(successorSeeks).not.toContain("DESC");
     });
   });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { METRIC_ROLLUP_INTERVAL_MS } from "~/server/event-sourcing/pipelines/metric-processing/schemas/constants";
 import type { CanonicalMetricDataPoint } from "~/server/event-sourcing/pipelines/metric-processing/schemas/metricDataPoint";
 import { MetricDataPointClickHouseRepository } from "../metric-data-point.clickhouse.repository";
 
@@ -219,5 +220,84 @@ describe("MetricDataPointClickHouseRepository", () => {
         projectedEventEquivalentUsage: 3,
       },
     ]);
+  });
+
+  describe("when a coalesced chunk is folded into rollups", () => {
+    // A bucket-aligned base keeps every generated point inside one 30s bucket,
+    // so the affected-bucket read stays at a single seek and the successor
+    // seeks are the only thing the chunk size moves.
+    const base =
+      Math.floor(1_700_000_000_000 / METRIC_ROLLUP_INTERVAL_MS) *
+      METRIC_ROLLUP_INTERVAL_MS;
+
+    function chunkOf(count: number): CanonicalMetricDataPoint[] {
+      return Array.from({ length: count }, (_, index) => {
+        const timeUnixMs = base + index;
+        return {
+          ...dataPoint(),
+          pointId: String(index).padStart(64, "0"),
+          timeUnixMs,
+          timeUnixNano: String(BigInt(timeUnixMs) * 1_000_000n),
+        };
+      });
+    }
+
+    function reader() {
+      const query = vi.fn(async () => ({ json: async () => [] }));
+      const insert = vi.fn(async () => {});
+      return { query, client: { query, insert } as never };
+    }
+
+    it("reads once for the successors and once for the affected bucket", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(12) });
+
+      expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the reads flat as the chunk grows within the seek budget", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(64) });
+
+      expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it("splits the successor seeks once the chunk outgrows the budget", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      // 130 points need three statements of successor seeks; the single
+      // affected bucket still needs one. Reading per point would be 131.
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(130) });
+
+      expect(query).toHaveBeenCalledTimes(4);
+    });
+
+    it("asks for each point's own successor rather than its predecessor", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(2) });
+
+      const successorSeeks = query.mock.calls[0]![0].query as string;
+      expect(successorSeeks).toContain("ORDER BY metric_data_points.TimeUnixMs");
+      expect(successorSeeks).not.toContain("DESC");
+    });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -249,7 +249,8 @@ export class MetricDataPointClickHouseRepository
 
     const authoritative = await this.pointsForAffectedBuckets({
       affectedBySeries,
-      bySeries,
+      tenantId: points[0]!.tenantId,
+      organizationId: points[0]!.organizationId,
     });
 
     const rows: MetricRollupRow[] = [];
@@ -424,10 +425,12 @@ export class MetricDataPointClickHouseRepository
    */
   private async pointsForAffectedBuckets({
     affectedBySeries,
-    bySeries,
+    tenantId,
+    organizationId,
   }: {
     affectedBySeries: ReadonlyMap<string, ReadonlySet<number>>;
-    bySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+    tenantId: string;
+    organizationId: string;
   }): Promise<Map<string, CanonicalMetricDataPoint[]>> {
     const seeks = [...affectedBySeries].flatMap(([seriesId, buckets]) =>
       [...buckets]
@@ -437,8 +440,7 @@ export class MetricDataPointClickHouseRepository
     const found = new Map<string, CanonicalMetricDataPoint[]>();
     if (seeks.length === 0) return found;
 
-    const anyPoint = [...bySeries.values()][0]![0]!;
-    const client = await this.resolveClient(anyPoint.tenantId);
+    const client = await this.resolveClient(tenantId);
     // A bucket's predecessor may itself sit in an earlier affected bucket, so
     // the ranges overlap by design; the fold needs each point exactly once.
     // Identity is (series, point) because one query now spans many series, and
@@ -448,7 +450,7 @@ export class MetricDataPointClickHouseRepository
     // Each seek contributes two statements, so half the budget keeps a single
     // query's statement count at the same ceiling the successor seeks use.
     for (const chunk of chunked(seeks, Math.floor(SEEKS_PER_QUERY / 2))) {
-      const params: Record<string, unknown> = { tenantId: anyPoint.tenantId };
+      const params: Record<string, unknown> = { tenantId };
       const selects = chunk.flatMap(({ seriesId, start }, index) => {
         params[`series${index}`] = seriesId;
         params[`from${index}`] = new Date(start);
@@ -475,7 +477,7 @@ export class MetricDataPointClickHouseRepository
       for (const row of await result.json<RawMetricRow>()) {
         unique.set(
           `${row.SeriesId}\u0000${row.PointId}`,
-          fromRaw({ row, organizationId: anyPoint.organizationId }),
+          fromRaw({ row, organizationId }),
         );
       }
     }

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -474,7 +474,7 @@ export class MetricDataPointClickHouseRepository
       });
       for (const row of await result.json<RawMetricRow>()) {
         unique.set(
-          `${row.SeriesId} ${row.PointId}`,
+          `${row.SeriesId}\u0000${row.PointId}`,
           fromRaw({ row, organizationId: anyPoint.organizationId }),
         );
       }

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -37,6 +37,33 @@ const logger = createLogger(
 
 const INSERT_SETTINGS = { async_insert: 1, wait_for_async_insert: 1 } as const;
 
+/**
+ * How many index seeks one rollup query may fold together. High enough that a
+ * full coalesced chunk costs a handful of round trips instead of hundreds, low
+ * enough that no single statement grows unbounded with the chunk.
+ */
+const SEEKS_PER_QUERY = 64;
+
+function chunked<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function groupBySeries(
+  points: readonly CanonicalMetricDataPoint[],
+): Map<string, CanonicalMetricDataPoint[]> {
+  const bySeries = new Map<string, CanonicalMetricDataPoint[]>();
+  for (const point of points) {
+    const existing = bySeries.get(point.seriesId);
+    if (existing) existing.push(point);
+    else bySeries.set(point.seriesId, [point]);
+  }
+  return bySeries;
+}
+
 export class MetricDataPointClickHouseRepository
   implements MetricDataPointRepository
 {
@@ -156,10 +183,16 @@ export class MetricDataPointClickHouseRepository
   }
 
   /**
-   * Recomputes a chunk's rollups per series rather than per point: the
-   * authoritative fetch and the row write are what cost round trips, and every
-   * point of a series shares them. Ensuring the raw points up front also makes
-   * the result independent of the order the chunk happens to arrive in.
+   * Recomputes a chunk's rollups with a fixed number of reads rather than one
+   * per point. Both reads a rollup needs — the successor that decides which
+   * buckets moved, and the authoritative points inside them — are index seeks,
+   * so the round trip, not the scan, is what a chunk pays for. Folding every
+   * seek in the chunk into a handful of statements makes the cost track the
+   * number of affected buckets instead of the number of points.
+   *
+   * Ensuring the raw points up front also makes the result independent of the
+   * order the chunk happens to arrive in: every decision below is taken
+   * against stored rows, never against the chunk's own sequence.
    */
   async recomputeAffectedRollupsMany({
     points,
@@ -170,17 +203,46 @@ export class MetricDataPointClickHouseRepository
     // raw-before-derived invariant true even if this projection wins the race.
     await this.ensureDataPoints({ points, retentionDays });
 
-    const bySeries = new Map<string, CanonicalMetricDataPoint[]>();
-    for (const point of points) {
-      bySeries.set(point.seriesId, [
-        ...(bySeries.get(point.seriesId) ?? []),
-        point,
-      ]);
+    const bySeries = groupBySeries(points);
+    const successorsBySeries = groupBySeries(await this.successorsOf(points));
+
+    const affectedBySeries = new Map<string, Set<number>>();
+    for (const [seriesId, seriesPoints] of bySeries) {
+      // A chunk point's true successor is the smallest stored point after it.
+      // Every chunk point is stored by now, and the seek returned the smallest
+      // stored point after each one, so the successor is somewhere in this
+      // union and no stored point can sit between the two. Taking the minimum
+      // of the union therefore lands on exactly the row a per-point neighbour
+      // query would have returned.
+      const candidates = [
+        ...seriesPoints,
+        ...(successorsBySeries.get(seriesId) ?? []),
+      ];
+      const affected = new Set<number>();
+      for (const point of seriesPoints) {
+        for (const bucket of affectedRollupBuckets({
+          points: candidates,
+          insertedPoint: point,
+        })) {
+          affected.add(bucket);
+        }
+      }
+      if (affected.size > 0) affectedBySeries.set(seriesId, affected);
     }
 
+    const authoritative = await this.pointsForAffectedBuckets({
+      affectedBySeries,
+      bySeries,
+    });
+
     const rows: MetricRollupRow[] = [];
-    for (const seriesPoints of bySeries.values()) {
-      rows.push(...(await this.rollupRowsForSeries(seriesPoints)));
+    for (const [seriesId, affected] of affectedBySeries) {
+      rows.push(
+        ...buildMetricRollups({
+          points: authoritative.get(seriesId) ?? [],
+          affectedBuckets: affected,
+        }),
+      );
     }
     if (rows.length === 0) return;
 
@@ -190,26 +252,6 @@ export class MetricDataPointClickHouseRepository
       values: rows.map((row) => rollupRow({ row, retentionDays })),
       format: "JSONEachRow",
       clickhouse_settings: INSERT_SETTINGS,
-    });
-  }
-
-  private async rollupRowsForSeries(
-    points: CanonicalMetricDataPoint[],
-  ): Promise<MetricRollupRow[]> {
-    const affected = new Set<number>();
-    for (const point of points) {
-      const neighbors = await this.immediateNeighbors(point);
-      for (const bucket of affectedRollupBuckets({
-        points: neighbors,
-        insertedPoint: point,
-      })) {
-        affected.add(bucket);
-      }
-    }
-    const authoritative = await this.pointsForBuckets(points[0]!, affected);
-    return buildMetricRollups({
-      points: authoritative,
-      affectedBuckets: affected,
     });
   }
 
@@ -308,94 +350,124 @@ export class MetricDataPointClickHouseRepository
     });
   }
 
-  private async immediateNeighbors(
-    point: CanonicalMetricDataPoint,
+  /**
+   * The stored point immediately after each of `points` within its own series.
+   * That successor is the only neighbour able to pull a second bucket into the
+   * affected set, so it is the only one worth a read — an earlier revision also
+   * fetched each point's predecessor and then discarded it.
+   *
+   * ORDER BY leads with TimeUnixMs to match the table's sort key
+   * (TenantId, SeriesId, TimeUnixMs, TimeUnixNano, PointId). TimeUnixMs is
+   * derived from TimeUnixNano, so the row order is unchanged — but
+   * optimize_read_in_order is syntactic and cannot infer that, so ordering on
+   * TimeUnixNano alone made ClickHouse materialise and sort every point in
+   * the series (each carrying a ZSTD CanonicalPayload) to return one row.
+   * TimeUnixMs is table-qualified throughout: RAW_SELECT aliases
+   * toUnixTimestamp64Milli(...) AS TimeUnixMs, and a bare TimeUnixMs
+   * resolves to that alias (epoch millis), never matching a DateTime64
+   * bound — the same pitfall log-record-storage documents.
+   */
+  private async successorsOf(
+    points: CanonicalMetricDataPoint[],
   ): Promise<CanonicalMetricDataPoint[]> {
-    const client = await this.resolveClient(point.tenantId);
-    // ORDER BY leads with TimeUnixMs to match the table's sort key
-    // (TenantId, SeriesId, TimeUnixMs, TimeUnixNano, PointId). TimeUnixMs is
-    // derived from TimeUnixNano, so the row order is unchanged — but
-    // optimize_read_in_order is syntactic and cannot infer that, so ordering on
-    // TimeUnixNano alone made ClickHouse materialise and sort every point in
-    // the series (each carrying a ZSTD CanonicalPayload) to return one row.
-    // TimeUnixMs is table-qualified throughout: RAW_SELECT aliases
-    // toUnixTimestamp64Milli(...) AS TimeUnixMs, and a bare TimeUnixMs
-    // resolves to that alias (epoch millis), never matching a DateTime64
-    // bound — the same pitfall log-record-storage documents.
-    const result = await client.query({
-      query: `
-        (SELECT ${RAW_SELECT}
-         FROM metric_data_points FINAL
-         WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-           AND (metric_data_points.TimeUnixMs < {time:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time:DateTime64(3)} AND (TimeUnixNano < {timeNano:UInt64} OR (TimeUnixNano = {timeNano:UInt64} AND PointId < {pointId:String}))))
-         ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)
-        UNION ALL
-        (SELECT ${RAW_SELECT}
-         FROM metric_data_points FINAL
-         WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-           AND (metric_data_points.TimeUnixMs > {time:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time:DateTime64(3)} AND (TimeUnixNano > {timeNano:UInt64} OR (TimeUnixNano = {timeNano:UInt64} AND PointId >= {pointId:String}))))
-         ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC LIMIT 2)
-      `,
-      query_params: {
-        tenantId: point.tenantId,
-        seriesId: point.seriesId,
-        time: new Date(point.timeUnixMs),
-        timeNano: point.timeUnixNano,
-        pointId: point.pointId,
-      },
-      format: "JSONEachRow",
-    });
-    return (await result.json<RawMetricRow>()).map((row) =>
-      fromRaw({ row, organizationId: point.organizationId }),
-    );
+    const tenantId = points[0]!.tenantId;
+    const client = await this.resolveClient(tenantId);
+    const found: CanonicalMetricDataPoint[] = [];
+
+    for (const chunk of chunked(points, SEEKS_PER_QUERY)) {
+      const params: Record<string, unknown> = { tenantId };
+      const selects = chunk.map((point, index) => {
+        params[`series${index}`] = point.seriesId;
+        params[`time${index}`] = new Date(point.timeUnixMs);
+        params[`nano${index}`] = point.timeUnixNano;
+        params[`point${index}`] = point.pointId;
+        return `(SELECT ${RAW_SELECT}
+          FROM metric_data_points FINAL
+          WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+            AND (metric_data_points.TimeUnixMs > {time${index}:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time${index}:DateTime64(3)} AND (TimeUnixNano > {nano${index}:UInt64} OR (TimeUnixNano = {nano${index}:UInt64} AND PointId > {point${index}:String}))))
+          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC LIMIT 1)`;
+      });
+      const result = await client.query({
+        query: selects.join("\n UNION ALL\n"),
+        query_params: params,
+        format: "JSONEachRow",
+      });
+      for (const row of await result.json<RawMetricRow>()) {
+        found.push(fromRaw({ row, organizationId: points[0]!.organizationId }));
+      }
+    }
+    return found;
   }
 
   /**
    * Every point in the affected buckets, each preceded by the sample the fold
-   * differences it against. Buckets are fetched as their own narrow ranges
-   * rather than one span: a late point and a distant next sample would
-   * otherwise scan every partition between them only to discard the rows.
+   * differences it against, grouped by series. Buckets are fetched as their own
+   * narrow ranges rather than one span: a late point and a distant next sample
+   * would otherwise scan every partition between them only to discard the rows.
    */
-  private async pointsForBuckets(
-    point: CanonicalMetricDataPoint,
-    buckets: ReadonlySet<number>,
-  ): Promise<CanonicalMetricDataPoint[]> {
-    const starts = [...buckets].sort((a, b) => a - b);
-    if (starts.length === 0) return [];
-    const params: Record<string, unknown> = {
-      tenantId: point.tenantId,
-      seriesId: point.seriesId,
-    };
-    const selects = starts.flatMap((start, index) => {
-      params[`from${index}`] = new Date(start);
-      params[`to${index}`] = new Date(start + METRIC_ROLLUP_INTERVAL_MS);
-      return [
-        `(SELECT ${RAW_SELECT}
-          FROM metric_data_points FINAL
-          WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-            AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
-          ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
-        `(SELECT ${RAW_SELECT}
-          FROM metric_data_points FINAL
-          WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-            AND metric_data_points.TimeUnixMs >= {from${index}:DateTime64(3)}
-            AND metric_data_points.TimeUnixMs < {to${index}:DateTime64(3)}
-          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC)`,
-      ];
-    });
-    const client = await this.resolveClient(point.tenantId);
-    const result = await client.query({
-      query: selects.join("\n UNION ALL\n"),
-      query_params: params,
-      format: "JSONEachRow",
-    });
+  private async pointsForAffectedBuckets({
+    affectedBySeries,
+    bySeries,
+  }: {
+    affectedBySeries: ReadonlyMap<string, ReadonlySet<number>>;
+    bySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+  }): Promise<Map<string, CanonicalMetricDataPoint[]>> {
+    const seeks = [...affectedBySeries].flatMap(([seriesId, buckets]) =>
+      [...buckets]
+        .sort((a, b) => a - b)
+        .map((start) => ({ seriesId, start }) as const),
+    );
+    const found = new Map<string, CanonicalMetricDataPoint[]>();
+    if (seeks.length === 0) return found;
+
+    const anyPoint = [...bySeries.values()][0]![0]!;
+    const client = await this.resolveClient(anyPoint.tenantId);
     // A bucket's predecessor may itself sit in an earlier affected bucket, so
     // the ranges overlap by design; the fold needs each point exactly once.
+    // Identity is (series, point) because one query now spans many series, and
+    // a point id is only ever unique within its own.
     const unique = new Map<string, CanonicalMetricDataPoint>();
-    for (const row of await result.json<RawMetricRow>()) {
-      const parsed = fromRaw({ row, organizationId: point.organizationId });
-      unique.set(parsed.pointId, parsed);
+
+    // Each seek contributes two statements, so half the budget keeps a single
+    // query's statement count at the same ceiling the successor seeks use.
+    for (const chunk of chunked(seeks, Math.floor(SEEKS_PER_QUERY / 2))) {
+      const params: Record<string, unknown> = { tenantId: anyPoint.tenantId };
+      const selects = chunk.flatMap(({ seriesId, start }, index) => {
+        params[`series${index}`] = seriesId;
+        params[`from${index}`] = new Date(start);
+        params[`to${index}`] = new Date(start + METRIC_ROLLUP_INTERVAL_MS);
+        return [
+          `(SELECT ${RAW_SELECT}
+            FROM metric_data_points FINAL
+            WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+              AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
+            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
+          `(SELECT ${RAW_SELECT}
+            FROM metric_data_points FINAL
+            WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+              AND metric_data_points.TimeUnixMs >= {from${index}:DateTime64(3)}
+              AND metric_data_points.TimeUnixMs < {to${index}:DateTime64(3)}
+            ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC)`,
+        ];
+      });
+      const result = await client.query({
+        query: selects.join("\n UNION ALL\n"),
+        query_params: params,
+        format: "JSONEachRow",
+      });
+      for (const row of await result.json<RawMetricRow>()) {
+        unique.set(
+          `${row.SeriesId} ${row.PointId}`,
+          fromRaw({ row, organizationId: anyPoint.organizationId }),
+        );
+      }
     }
-    return [...unique.values()];
+
+    for (const point of unique.values()) {
+      const existing = found.get(point.seriesId);
+      if (existing) existing.push(point);
+      else found.set(point.seriesId, [point]);
+    }
+    return found;
   }
 }

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -64,6 +64,44 @@ function groupBySeries(
   return bySeries;
 }
 
+/**
+ * Which rollup buckets a chunk moved, per series, decided without another read.
+ *
+ * A chunk point's true successor is the smallest stored point after it. Every
+ * chunk point is already stored by the time this runs, and the seek returned
+ * the smallest stored point after each one, so the true successor is somewhere
+ * in the union of the two and no stored point can sit between them. Taking the
+ * minimum of that union — which is all `affectedRollupBuckets` does — therefore
+ * lands on exactly the row a per-point neighbour query would have returned,
+ * whatever order the chunk arrived in.
+ */
+function affectedBucketsBySeries({
+  bySeries,
+  successorsBySeries,
+}: {
+  bySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+  successorsBySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+}): Map<string, Set<number>> {
+  const affectedBySeries = new Map<string, Set<number>>();
+  for (const [seriesId, seriesPoints] of bySeries) {
+    const candidates = [
+      ...seriesPoints,
+      ...(successorsBySeries.get(seriesId) ?? []),
+    ];
+    const affected = new Set<number>();
+    for (const point of seriesPoints) {
+      for (const bucket of affectedRollupBuckets({
+        points: candidates,
+        insertedPoint: point,
+      })) {
+        affected.add(bucket);
+      }
+    }
+    if (affected.size > 0) affectedBySeries.set(seriesId, affected);
+  }
+  return affectedBySeries;
+}
+
 export class MetricDataPointClickHouseRepository
   implements MetricDataPointRepository
 {
@@ -204,31 +242,10 @@ export class MetricDataPointClickHouseRepository
     await this.ensureDataPoints({ points, retentionDays });
 
     const bySeries = groupBySeries(points);
-    const successorsBySeries = groupBySeries(await this.successorsOf(points));
-
-    const affectedBySeries = new Map<string, Set<number>>();
-    for (const [seriesId, seriesPoints] of bySeries) {
-      // A chunk point's true successor is the smallest stored point after it.
-      // Every chunk point is stored by now, and the seek returned the smallest
-      // stored point after each one, so the successor is somewhere in this
-      // union and no stored point can sit between the two. Taking the minimum
-      // of the union therefore lands on exactly the row a per-point neighbour
-      // query would have returned.
-      const candidates = [
-        ...seriesPoints,
-        ...(successorsBySeries.get(seriesId) ?? []),
-      ];
-      const affected = new Set<number>();
-      for (const point of seriesPoints) {
-        for (const bucket of affectedRollupBuckets({
-          points: candidates,
-          insertedPoint: point,
-        })) {
-          affected.add(bucket);
-        }
-      }
-      if (affected.size > 0) affectedBySeries.set(seriesId, affected);
-    }
+    const affectedBySeries = affectedBucketsBySeries({
+      bySeries,
+      successorsBySeries: groupBySeries(await this.successorsOf(points)),
+    });
 
     const authoritative = await this.pointsForAffectedBuckets({
       affectedBySeries,


### PR DESCRIPTION
## For humans

Metrics arrive constantly, and for every incoming data point we keep a set of
30-second summaries up to date so charts load fast. Those summaries were already
being written efficiently — a whole batch of points produced one write. But
deciding *what* to write still asked the database a separate question about
every single point, one after another, and waited for each answer before asking
the next. A batch of 256 points meant 257 sequential round trips to produce one
write.

This asks the same questions in two goes instead of hundreds. The cost of
handling a batch now depends on how many time buckets it touched, not on how
many points it carried, so bursts of metrics drain much faster.

Nothing about the resulting summaries changes. There is a test that folds one
batch of points in one pass, folds an identical batch one point at a time in
reverse order, and asserts the two produce byte-identical summaries.

## What this changes

`metricTimeRollup` was flagged as the last un-batched heavy map projection. It
turned out **not** to be un-batched: #6462 already gave it `coalesceMaxBatch`,
and `MetricTimeRollupAppendStore.bulkAppend` already collapses a chunk into one
`metric_time_rollups` INSERT. The queue and write sides were done.

The read side was not. `recomputeAffectedRollupsMany` looped over the chunk
awaiting `immediateNeighbors(point)` once per point, then one affected-bucket
query per series — so a coalesced chunk of N points across S series cost
`N + S` sequential ClickHouse round trips to produce a single insert. The
coalescing bought the write path and left the read path exactly as it was.

Both reads are index seeks, so the round trip is the cost, not the scan. This
folds them:

- **One statement carries up to `SEEKS_PER_QUERY` (64) successor seeks** across
  every series in the chunk, replacing the per-point neighbour query.
- **A second carries the affected buckets** the same way, now spanning series
  rather than one at a time.
- Both chunk their seek lists, so no single statement grows without bound as the
  chunk does.

The predecessor was also dead weight. `affectedRollupBuckets` takes the smallest
point *after* the inserted one and ignores everything else, so the backward half
of the old neighbour query was fetched and discarded on every point. It is gone.

## Why the fold is exact

`ensureDataPoints` already ran before any of this, which is what makes it work:

1. Every chunk point is stored before the seeks run.
2. Each seek returns the smallest stored point after one chunk point.
3. So a chunk point's true successor is always in the union of *the chunk* and
   *the seek results*, and no stored point can sit between the two.
4. Taking the minimum of that union — all `affectedRollupBuckets` does — lands on
   exactly the row a per-point query would have returned, **whatever order the
   chunk arrived in**.

One latent hazard fixed along the way: the affected-bucket dedup keyed on
`PointId` alone. That was safe when a query covered one series; now that one
query spans many, identity is `(SeriesId, PointId)`. The separator joining the
two is written as a `\u0000` escape rather than a raw NUL byte — the raw
spelling made git classify the file as binary, which would have left it
unreviewable on GitHub for every future diff.

## Proof, not argument

Every new test fails on `origin/main`'s implementation — verified by checking the
old file back out and re-running:

| Test | New | Old |
|---|---|---|
| 12-point chunk, reads | 2 | 13 |
| 64-point chunk, reads | 2 | 65 |
| 130-point chunk, reads | 4 | 131 |
| successor seek is forward-bounded and has no `DESC` | passes | fails |

The order-independence proof is an integration test against real ClickHouse: one
series folded as a chunk, an identical series folded a point at a time **in
reverse order**, asserting `toEqual`. Twelve cumulative samples over four buckets
with a counter reset in the middle, so the fold's predecessor dependency is live
rather than incidental. A read-counting client pins the chunk to two reads.

## Gates

- `pnpm typecheck:all` clean
- `pnpm test:unit run src/server/event-sourcing src/server/app-layer/metrics` — 261 files, 7657 passed
- integration suite — 8/8 against native ClickHouse
- `biome ci` clean on changed files

## Follow-up, not in this PR

`subscriber/pm` is the other heavy family, and the `pm` is **process manager**,
not project metadata — `pm:${definition.config.name}` in `processRuntime.ts`,
covering `pm:triggerSettlement`, `pm:langyConversation` and five others.
#6460/#6463 did **not** touch it: those were trace-pipeline reactor changes under
a different group-key prefix. Process-manager subscribers register with no
`options` at all, so they fall back to the default per-aggregate lane with no
dedup, no delay and no coalescing — strictly one job, one Postgres read/write
transaction per event, and a `revisionConflict` retry when a hot aggregate fans
in. Worth a follow-up, but dedup-with-replace is **not** safe there: process
managers are state machines that must see every event, so it needs true batching
(evolve over N envelopes in one transaction), not squashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved metric rollup recalculation by processing points in batches, reducing database reads.
  * Enhanced handling of cumulative series, including counter resets and affected time buckets.
  * Ensured recalculated rollups remain consistent with point-by-point processing.

* **Bug Fixes**
  * Improved successor-based data retrieval and deduplication during rollup updates.
  * Added safeguards for larger recalculation chunks while maintaining bounded read behavior.

* **Tests**
  * Expanded coverage for multi-bucket rollups, query ordering, read counts, and cumulative-series scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
