### PR TITLE
perf(metrics): re-land the rollup chunk read folding, with a decodable failure

### DIFF
--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -4,15 +4,18 @@
  *
  * Runs the canonical metric repository's real INSERT/SELECT SQL against
  * ClickHouse (migration 00049). The rollup unit tests exercise the pure fold;
- * the immediateNeighbors / pointsForBuckets queries and the rollup INSERT they
- * feed are only ever mocked. This file is what proves:
+ * the successor / affected-bucket seek queries and the rollup INSERT they feed
+ * are only ever mocked. This file is what proves:
  * - ensureDataPoints lands raw points plus their usage-estimate ledger rows;
  * - recomputeAffectedRollupsMany converts a cumulative monotonic sum series
  *   spanning two 30s buckets into per-bucket deltas using rows it fetched back
  *   from ClickHouse, not the in-memory chunk;
  * - a late point ensured between existing samples converges the affected
  *   buckets on re-recompute (ReplacingMergeTree(UpdatedAt), read via FINAL —
- *   the dedup pattern migration 00049 mandates for metric_time_rollups).
+ *   the dedup pattern migration 00049 mandates for metric_time_rollups);
+ * - folding a chunk in one pass lands on exactly the rollups the per-point
+ *   path produces, using a number of reads set by the affected buckets rather
+ *   than by how many points the chunk carries.
  *
  * Fixtures come from the shared metric-point builder the rollup unit tests
  * use, so expectations here mirror rollupScalar.unit.test.ts semantics: the
@@ -258,6 +261,102 @@ describe("given a cumulative monotonic sum series spanning two rollup buckets", 
           sourcePointCount: 1,
         },
       ]);
+    });
+  });
+});
+
+describe("given a cumulative series long enough to span several rollup buckets", () => {
+  // Twelve samples every ten seconds cover four 30s buckets, and the drop to 4
+  // is a counter reset, so the fold's dependency on each sample's predecessor
+  // is live rather than incidental.
+  const values = [10, 15, 18, 26, 31, 4, 9, 14, 22, 27, 33, 40];
+  // Shared, because the read-counting block below compares its own rollups
+  // against this series rather than writing a second copy of them.
+  const chunkSeriesId = "d".repeat(64);
+
+  function samples(seriesId: string): CanonicalMetricDataPoint[] {
+    return values.map((value, index) =>
+      point({
+        tenantId,
+        organizationId,
+        seriesId,
+        timeUnixMs: bucket0 + index * 10_000,
+        metricKind: "sum",
+        aggregationTemporality: "cumulative",
+        isMonotonic: true,
+        valueDouble: value,
+        acceptedAt,
+      }),
+    );
+  }
+
+  describe("when one series folds as a chunk and an identical one folds a point at a time", () => {
+    // Both series use the same timestamps, so the fixture derives the same
+    // point ids for both. That is deliberate: a point id is only unique within
+    // its series, and the chunk path reads many series in one query.
+    const perPointSeriesId = "e".repeat(64);
+
+    beforeAll(async () => {
+      await repo.recomputeAffectedRollupsMany({
+        points: samples(chunkSeriesId),
+      });
+      // Reverse order on purpose: every sample is late relative to the one
+      // before it, which is the arrival pattern a chunk collapses.
+      for (const single of [...samples(perPointSeriesId)].reverse()) {
+        await repo.recomputeAffectedRollups({ point: single });
+      }
+    }, 60_000);
+
+    it("folds the chunk to exactly the rollups the per-point path produces", async () => {
+      const chunked = await readRollups(chunkSeriesId);
+      const perPoint = await readRollups(perPointSeriesId);
+
+      expect(chunked).toEqual(perPoint);
+      expect(chunked).toHaveLength(4);
+    });
+
+    it("counts every sample exactly once across the buckets", async () => {
+      const chunked = await readRollups(chunkSeriesId);
+
+      expect(
+        chunked.reduce((total, row) => total + row.sourcePointCount, 0),
+      ).toBe(values.length);
+    });
+  });
+
+  describe("when the chunk is folded through a client that counts its reads", () => {
+    const countedSeriesId = "f".repeat(64);
+    let reads: number;
+
+    beforeAll(async () => {
+      reads = 0;
+      const counting = {
+        query: async (args: Parameters<ClickHouseClient["query"]>[0]) => {
+          reads += 1;
+          return await ch.query(args);
+        },
+        insert: async (args: Parameters<ClickHouseClient["insert"]>[0]) =>
+          await ch.insert(args),
+      } as unknown as ClickHouseClient;
+
+      await new MetricDataPointClickHouseRepository({
+        resolveClient: async () => counting,
+        resolveOrganizationClient: async () => counting,
+      }).recomputeAffectedRollupsMany({ points: samples(countedSeriesId) });
+    }, 60_000);
+
+    it("reads once for the successors and once for the affected buckets", async () => {
+      // The seek budget folds all twelve successor seeks into one statement
+      // and every affected bucket into a second. Reading per point would make
+      // this grow with the chunk instead.
+      expect(reads).toBe(2);
+    });
+
+    it("still produces the same rollups as the uncounted chunk", async () => {
+      const counted = await readRollups(countedSeriesId);
+
+      expect(counted).toHaveLength(4);
+      expect(counted).toEqual(await readRollups(chunkSeriesId));
     });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -271,7 +271,9 @@ describe("given a cumulative series long enough to span several rollup buckets",
   // is live rather than incidental.
   const values = [10, 15, 18, 26, 31, 4, 9, 14, 22, 27, 33, 40];
   // Shared, because the read-counting block below compares its own rollups
-  // against this series rather than writing a second copy of them.
+  // against this series rather than writing a second copy of them. Seeded in
+  // THIS describe's beforeAll so a filtered run of either child block still
+  // finds the rollups it compares against.
   const chunkSeriesId = "d".repeat(64);
 
   function samples(seriesId: string): CanonicalMetricDataPoint[] {
@@ -290,6 +292,12 @@ describe("given a cumulative series long enough to span several rollup buckets",
     );
   }
 
+  beforeAll(async () => {
+    await repo.recomputeAffectedRollupsMany({
+      points: samples(chunkSeriesId),
+    });
+  }, 60_000);
+
   describe("when one series folds as a chunk and an identical one folds a point at a time", () => {
     // Both series use the same timestamps, so the fixture derives the same
     // point ids for both. That is deliberate: a point id is only unique within
@@ -297,9 +305,6 @@ describe("given a cumulative series long enough to span several rollup buckets",
     const perPointSeriesId = "e".repeat(64);
 
     beforeAll(async () => {
-      await repo.recomputeAffectedRollupsMany({
-        points: samples(chunkSeriesId),
-      });
       // Reverse order on purpose: every sample is late relative to the one
       // before it, which is the arrival pattern a chunk collapses.
       for (const single of [...samples(perPointSeriesId)].reverse()) {

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -304,9 +304,8 @@ describe("MetricDataPointClickHouseRepository", () => {
         "metric_data_points.TimeUnixMs > {time0:DateTime64(3)}",
       );
       expect(successorSeeks).toContain(
-        "ORDER BY metric_data_points.TimeUnixMs",
+        "ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC",
       );
-      expect(successorSeeks).not.toContain("DESC");
     });
   });
 

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -339,7 +339,7 @@ describe("MetricDataPointClickHouseRepository", () => {
       };
     }
 
-    it("names the missing column instead of dereferencing it", async () => {
+    it("names the missing column, the series and the point instead of dereferencing it", async () => {
       const query = vi.fn(async () => ({
         json: async () => [rowMissingBucketCounts()],
       }));
@@ -349,28 +349,20 @@ describe("MetricDataPointClickHouseRepository", () => {
         resolveOrganizationClient: async () => client,
       });
 
+      const point = dataPoint();
+      // One rejection, three identifiers: the column that was absent, and the
+      // series + point that locate the untrustworthy row. That is the whole
+      // contract this guard exists for — a bare undefined-property error named
+      // none of them.
       await expect(
         repository.recomputeAffectedRollupsMany({
-          points: [{ ...dataPoint(), timeUnixMs: base }],
+          points: [{ ...point, timeUnixMs: base }],
         }),
-      ).rejects.toThrow(/missing the BucketCounts column/);
-    });
-
-    it("does not surface the bare undefined-property failure", async () => {
-      const query = vi.fn(async () => ({
-        json: async () => [rowMissingBucketCounts()],
-      }));
-      const client = { query, insert: vi.fn(async () => {}) } as never;
-      const repository = new MetricDataPointClickHouseRepository({
-        resolveClient: async () => client,
-        resolveOrganizationClient: async () => client,
-      });
-
-      await expect(
-        repository.recomputeAffectedRollupsMany({
-          points: [{ ...dataPoint(), timeUnixMs: base }],
-        }),
-      ).rejects.not.toThrow(/Cannot read properties of undefined/);
+      ).rejects.toThrow(
+        new RegExp(
+          `missing the BucketCounts column \\(series ${point.seriesId}, point ${point.pointId}\\)`,
+        ),
+      );
     });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { METRIC_ROLLUP_INTERVAL_MS } from "~/server/event-sourcing/pipelines/metric-processing/schemas/constants";
 import type { CanonicalMetricDataPoint } from "~/server/event-sourcing/pipelines/metric-processing/schemas/metricDataPoint";
 import { MetricDataPointClickHouseRepository } from "../metric-data-point.clickhouse.repository";
 
@@ -219,5 +220,157 @@ describe("MetricDataPointClickHouseRepository", () => {
         projectedEventEquivalentUsage: 3,
       },
     ]);
+  });
+
+  describe("when a coalesced chunk is folded into rollups", () => {
+    // A bucket-aligned base keeps every generated point inside one 30s bucket,
+    // so the affected-bucket read stays at a single seek and the successor
+    // seeks are the only thing the chunk size moves.
+    const base =
+      Math.floor(1_700_000_000_000 / METRIC_ROLLUP_INTERVAL_MS) *
+      METRIC_ROLLUP_INTERVAL_MS;
+
+    function chunkOf(count: number): CanonicalMetricDataPoint[] {
+      return Array.from({ length: count }, (_, index) => {
+        const timeUnixMs = base + index;
+        return {
+          ...dataPoint(),
+          pointId: String(index).padStart(64, "0"),
+          timeUnixMs,
+          timeUnixNano: String(BigInt(timeUnixMs) * 1_000_000n),
+        };
+      });
+    }
+
+    function reader() {
+      const query = vi.fn<
+        (args: { query: string }) => Promise<{ json: () => Promise<unknown[]> }>
+      >(async () => ({ json: async () => [] }));
+      const insert = vi.fn(async () => {});
+      return { query, client: { query, insert } as never };
+    }
+
+    it("reads once for the successors and once for the affected bucket", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(12) });
+
+      expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the reads flat as the chunk grows within the seek budget", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(64) });
+
+      expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it("splits the successor seeks once the chunk outgrows the budget", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      // 130 points need three statements of successor seeks; the single
+      // affected bucket still needs one. Reading per point would be 131.
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(130) });
+
+      expect(query).toHaveBeenCalledTimes(4);
+    });
+
+    it("asks for each point's own successor rather than its predecessor", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(2) });
+
+      const successorSeeks = query.mock.calls[0]![0].query;
+      // The bound is what encodes "successor" — an ascending order with a `<`
+      // bound would still read backwards, so pin the direction of both.
+      expect(successorSeeks).toContain(
+        "metric_data_points.TimeUnixMs > {time0:DateTime64(3)}",
+      );
+      expect(successorSeeks).toContain(
+        "ORDER BY metric_data_points.TimeUnixMs",
+      );
+      expect(successorSeeks).not.toContain("DESC");
+    });
+  });
+
+  describe("when a folded read answers with a row it cannot decode", () => {
+    const base =
+      Math.floor(1_700_000_000_000 / METRIC_ROLLUP_INTERVAL_MS) *
+      METRIC_ROLLUP_INTERVAL_MS;
+
+    /**
+     * The shape the rollup lane actually failed on in production: a row that
+     * parses as JSON and carries its identifiers, but is missing one of the
+     * `Array(UInt64)` count columns the decoder dereferences unguarded. The
+     * decoder used to walk straight into `undefined.map`, and the queue logs
+     * only an error's message — so the incident produced no column, no series
+     * and no query to work from.
+     */
+    function rowMissingBucketCounts() {
+      const point = dataPoint();
+      return {
+        TenantId: point.tenantId,
+        PointId: point.pointId,
+        SeriesId: point.seriesId,
+        TimeUnixMs: base,
+        TimeUnixNano: String(BigInt(base) * 1_000_000n),
+        StartTimeUnixNano: "1",
+        MetricKind: "gauge",
+        AggregationTemporality: "unspecified",
+        PositiveBucketCounts: [],
+        NegativeBucketCounts: [],
+      };
+    }
+
+    it("names the missing column instead of dereferencing it", async () => {
+      const query = vi.fn(async () => ({
+        json: async () => [rowMissingBucketCounts()],
+      }));
+      const client = { query, insert: vi.fn(async () => {}) } as never;
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await expect(
+        repository.recomputeAffectedRollupsMany({
+          points: [{ ...dataPoint(), timeUnixMs: base }],
+        }),
+      ).rejects.toThrow(/missing the BucketCounts column/);
+    });
+
+    it("does not surface the bare undefined-property failure", async () => {
+      const query = vi.fn(async () => ({
+        json: async () => [rowMissingBucketCounts()],
+      }));
+      const client = { query, insert: vi.fn(async () => {}) } as never;
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await expect(
+        repository.recomputeAffectedRollupsMany({
+          points: [{ ...dataPoint(), timeUnixMs: base }],
+        }),
+      ).rejects.not.toThrow(/Cannot read properties of undefined/);
+    });
   });
 });

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -37,6 +37,71 @@ const logger = createLogger(
 
 const INSERT_SETTINGS = { async_insert: 1, wait_for_async_insert: 1 } as const;
 
+/**
+ * How many index seeks one rollup query may fold together. High enough that a
+ * full coalesced chunk costs a handful of round trips instead of hundreds, low
+ * enough that no single statement grows unbounded with the chunk.
+ */
+const SEEKS_PER_QUERY = 64;
+
+function chunked<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function groupBySeries(
+  points: readonly CanonicalMetricDataPoint[],
+): Map<string, CanonicalMetricDataPoint[]> {
+  const bySeries = new Map<string, CanonicalMetricDataPoint[]>();
+  for (const point of points) {
+    const existing = bySeries.get(point.seriesId);
+    if (existing) existing.push(point);
+    else bySeries.set(point.seriesId, [point]);
+  }
+  return bySeries;
+}
+
+/**
+ * Which rollup buckets a chunk moved, per series, decided without another read.
+ *
+ * A chunk point's true successor is the smallest stored point after it. Every
+ * chunk point is already stored by the time this runs, and the seek returned
+ * the smallest stored point after each one, so the true successor is somewhere
+ * in the union of the two and no stored point can sit between them. Taking the
+ * minimum of that union — which is all `affectedRollupBuckets` does — therefore
+ * lands on exactly the row a per-point neighbour query would have returned,
+ * whatever order the chunk arrived in.
+ */
+function affectedBucketsBySeries({
+  bySeries,
+  successorsBySeries,
+}: {
+  bySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+  successorsBySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+}): Map<string, Set<number>> {
+  const affectedBySeries = new Map<string, Set<number>>();
+  for (const [seriesId, seriesPoints] of bySeries) {
+    const candidates = [
+      ...seriesPoints,
+      ...(successorsBySeries.get(seriesId) ?? []),
+    ];
+    const affected = new Set<number>();
+    for (const point of seriesPoints) {
+      for (const bucket of affectedRollupBuckets({
+        points: candidates,
+        insertedPoint: point,
+      })) {
+        affected.add(bucket);
+      }
+    }
+    if (affected.size > 0) affectedBySeries.set(seriesId, affected);
+  }
+  return affectedBySeries;
+}
+
 export class MetricDataPointClickHouseRepository
   implements MetricDataPointRepository
 {
@@ -156,10 +221,16 @@ export class MetricDataPointClickHouseRepository
   }
 
   /**
-   * Recomputes a chunk's rollups per series rather than per point: the
-   * authoritative fetch and the row write are what cost round trips, and every
-   * point of a series shares them. Ensuring the raw points up front also makes
-   * the result independent of the order the chunk happens to arrive in.
+   * Recomputes a chunk's rollups with a fixed number of reads rather than one
+   * per point. Both reads a rollup needs — the successor that decides which
+   * buckets moved, and the authoritative points inside them — are index seeks,
+   * so the round trip, not the scan, is what a chunk pays for. Folding every
+   * seek in the chunk into a handful of statements makes the cost track the
+   * number of affected buckets instead of the number of points.
+   *
+   * Ensuring the raw points up front also makes the result independent of the
+   * order the chunk happens to arrive in: every decision below is taken
+   * against stored rows, never against the chunk's own sequence.
    */
   async recomputeAffectedRollupsMany({
     points,
@@ -170,17 +241,26 @@ export class MetricDataPointClickHouseRepository
     // raw-before-derived invariant true even if this projection wins the race.
     await this.ensureDataPoints({ points, retentionDays });
 
-    const bySeries = new Map<string, CanonicalMetricDataPoint[]>();
-    for (const point of points) {
-      bySeries.set(point.seriesId, [
-        ...(bySeries.get(point.seriesId) ?? []),
-        point,
-      ]);
-    }
+    const bySeries = groupBySeries(points);
+    const affectedBySeries = affectedBucketsBySeries({
+      bySeries,
+      successorsBySeries: groupBySeries(await this.successorsOf(points)),
+    });
+
+    const authoritative = await this.pointsForAffectedBuckets({
+      affectedBySeries,
+      tenantId: points[0]!.tenantId,
+      organizationId: points[0]!.organizationId,
+    });
 
     const rows: MetricRollupRow[] = [];
-    for (const seriesPoints of bySeries.values()) {
-      rows.push(...(await this.rollupRowsForSeries(seriesPoints)));
+    for (const [seriesId, affected] of affectedBySeries) {
+      rows.push(
+        ...buildMetricRollups({
+          points: authoritative.get(seriesId) ?? [],
+          affectedBuckets: affected,
+        }),
+      );
     }
     if (rows.length === 0) return;
 
@@ -190,26 +270,6 @@ export class MetricDataPointClickHouseRepository
       values: rows.map((row) => rollupRow({ row, retentionDays })),
       format: "JSONEachRow",
       clickhouse_settings: INSERT_SETTINGS,
-    });
-  }
-
-  private async rollupRowsForSeries(
-    points: CanonicalMetricDataPoint[],
-  ): Promise<MetricRollupRow[]> {
-    const affected = new Set<number>();
-    for (const point of points) {
-      const neighbors = await this.immediateNeighbors(point);
-      for (const bucket of affectedRollupBuckets({
-        points: neighbors,
-        insertedPoint: point,
-      })) {
-        affected.add(bucket);
-      }
-    }
-    const authoritative = await this.pointsForBuckets(points[0]!, affected);
-    return buildMetricRollups({
-      points: authoritative,
-      affectedBuckets: affected,
     });
   }
 
@@ -308,94 +368,125 @@ export class MetricDataPointClickHouseRepository
     });
   }
 
-  private async immediateNeighbors(
-    point: CanonicalMetricDataPoint,
+  /**
+   * The stored point immediately after each of `points` within its own series.
+   * That successor is the only neighbour able to pull a second bucket into the
+   * affected set, so it is the only one worth a read — an earlier revision also
+   * fetched each point's predecessor and then discarded it.
+   *
+   * ORDER BY leads with TimeUnixMs to match the table's sort key
+   * (TenantId, SeriesId, TimeUnixMs, TimeUnixNano, PointId). TimeUnixMs is
+   * derived from TimeUnixNano, so the row order is unchanged — but
+   * optimize_read_in_order is syntactic and cannot infer that, so ordering on
+   * TimeUnixNano alone made ClickHouse materialise and sort every point in
+   * the series (each carrying a ZSTD CanonicalPayload) to return one row.
+   * TimeUnixMs is table-qualified throughout: RAW_SELECT aliases
+   * toUnixTimestamp64Milli(...) AS TimeUnixMs, and a bare TimeUnixMs
+   * resolves to that alias (epoch millis), never matching a DateTime64
+   * bound — the same pitfall log-record-storage documents.
+   */
+  private async successorsOf(
+    points: CanonicalMetricDataPoint[],
   ): Promise<CanonicalMetricDataPoint[]> {
-    const client = await this.resolveClient(point.tenantId);
-    // ORDER BY leads with TimeUnixMs to match the table's sort key
-    // (TenantId, SeriesId, TimeUnixMs, TimeUnixNano, PointId). TimeUnixMs is
-    // derived from TimeUnixNano, so the row order is unchanged — but
-    // optimize_read_in_order is syntactic and cannot infer that, so ordering on
-    // TimeUnixNano alone made ClickHouse materialise and sort every point in
-    // the series (each carrying a ZSTD CanonicalPayload) to return one row.
-    // TimeUnixMs is table-qualified throughout: RAW_SELECT aliases
-    // toUnixTimestamp64Milli(...) AS TimeUnixMs, and a bare TimeUnixMs
-    // resolves to that alias (epoch millis), never matching a DateTime64
-    // bound — the same pitfall log-record-storage documents.
-    const result = await client.query({
-      query: `
-        (SELECT ${RAW_SELECT}
-         FROM metric_data_points FINAL
-         WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-           AND (metric_data_points.TimeUnixMs < {time:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time:DateTime64(3)} AND (TimeUnixNano < {timeNano:UInt64} OR (TimeUnixNano = {timeNano:UInt64} AND PointId < {pointId:String}))))
-         ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)
-        UNION ALL
-        (SELECT ${RAW_SELECT}
-         FROM metric_data_points FINAL
-         WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-           AND (metric_data_points.TimeUnixMs > {time:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time:DateTime64(3)} AND (TimeUnixNano > {timeNano:UInt64} OR (TimeUnixNano = {timeNano:UInt64} AND PointId >= {pointId:String}))))
-         ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC LIMIT 2)
-      `,
-      query_params: {
-        tenantId: point.tenantId,
-        seriesId: point.seriesId,
-        time: new Date(point.timeUnixMs),
-        timeNano: point.timeUnixNano,
-        pointId: point.pointId,
-      },
-      format: "JSONEachRow",
-    });
-    return (await result.json<RawMetricRow>()).map((row) =>
-      fromRaw({ row, organizationId: point.organizationId }),
-    );
+    const tenantId = points[0]!.tenantId;
+    const client = await this.resolveClient(tenantId);
+    const found: CanonicalMetricDataPoint[] = [];
+
+    for (const chunk of chunked(points, SEEKS_PER_QUERY)) {
+      const params: Record<string, unknown> = { tenantId };
+      const selects = chunk.map((point, index) => {
+        params[`series${index}`] = point.seriesId;
+        params[`time${index}`] = new Date(point.timeUnixMs);
+        params[`nano${index}`] = point.timeUnixNano;
+        params[`point${index}`] = point.pointId;
+        return `(SELECT ${RAW_SELECT}
+          FROM metric_data_points FINAL
+          WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+            AND (metric_data_points.TimeUnixMs > {time${index}:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time${index}:DateTime64(3)} AND (TimeUnixNano > {nano${index}:UInt64} OR (TimeUnixNano = {nano${index}:UInt64} AND PointId > {point${index}:String}))))
+          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC LIMIT 1)`;
+      });
+      const result = await client.query({
+        query: selects.join("\n UNION ALL\n"),
+        query_params: params,
+        format: "JSONEachRow",
+      });
+      for (const row of await result.json<RawMetricRow>()) {
+        found.push(fromRaw({ row, organizationId: points[0]!.organizationId }));
+      }
+    }
+    return found;
   }
 
   /**
    * Every point in the affected buckets, each preceded by the sample the fold
-   * differences it against. Buckets are fetched as their own narrow ranges
-   * rather than one span: a late point and a distant next sample would
-   * otherwise scan every partition between them only to discard the rows.
+   * differences it against, grouped by series. Buckets are fetched as their own
+   * narrow ranges rather than one span: a late point and a distant next sample
+   * would otherwise scan every partition between them only to discard the rows.
    */
-  private async pointsForBuckets(
-    point: CanonicalMetricDataPoint,
-    buckets: ReadonlySet<number>,
-  ): Promise<CanonicalMetricDataPoint[]> {
-    const starts = [...buckets].sort((a, b) => a - b);
-    if (starts.length === 0) return [];
-    const params: Record<string, unknown> = {
-      tenantId: point.tenantId,
-      seriesId: point.seriesId,
-    };
-    const selects = starts.flatMap((start, index) => {
-      params[`from${index}`] = new Date(start);
-      params[`to${index}`] = new Date(start + METRIC_ROLLUP_INTERVAL_MS);
-      return [
-        `(SELECT ${RAW_SELECT}
-          FROM metric_data_points FINAL
-          WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-            AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
-          ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
-        `(SELECT ${RAW_SELECT}
-          FROM metric_data_points FINAL
-          WHERE TenantId = {tenantId:String} AND SeriesId = {seriesId:String}
-            AND metric_data_points.TimeUnixMs >= {from${index}:DateTime64(3)}
-            AND metric_data_points.TimeUnixMs < {to${index}:DateTime64(3)}
-          ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC)`,
-      ];
-    });
-    const client = await this.resolveClient(point.tenantId);
-    const result = await client.query({
-      query: selects.join("\n UNION ALL\n"),
-      query_params: params,
-      format: "JSONEachRow",
-    });
+  private async pointsForAffectedBuckets({
+    affectedBySeries,
+    tenantId,
+    organizationId,
+  }: {
+    affectedBySeries: ReadonlyMap<string, ReadonlySet<number>>;
+    tenantId: string;
+    organizationId: string;
+  }): Promise<Map<string, CanonicalMetricDataPoint[]>> {
+    const seeks = [...affectedBySeries].flatMap(([seriesId, buckets]) =>
+      [...buckets]
+        .sort((a, b) => a - b)
+        .map((start) => ({ seriesId, start }) as const),
+    );
+    const found = new Map<string, CanonicalMetricDataPoint[]>();
+    if (seeks.length === 0) return found;
+
+    const client = await this.resolveClient(tenantId);
     // A bucket's predecessor may itself sit in an earlier affected bucket, so
     // the ranges overlap by design; the fold needs each point exactly once.
+    // Identity is (series, point) because one query now spans many series, and
+    // a point id is only ever unique within its own.
     const unique = new Map<string, CanonicalMetricDataPoint>();
-    for (const row of await result.json<RawMetricRow>()) {
-      const parsed = fromRaw({ row, organizationId: point.organizationId });
-      unique.set(parsed.pointId, parsed);
+
+    // Each seek contributes two statements, so half the budget keeps a single
+    // query's statement count at the same ceiling the successor seeks use.
+    for (const chunk of chunked(seeks, Math.floor(SEEKS_PER_QUERY / 2))) {
+      const params: Record<string, unknown> = { tenantId };
+      const selects = chunk.flatMap(({ seriesId, start }, index) => {
+        params[`series${index}`] = seriesId;
+        params[`from${index}`] = new Date(start);
+        params[`to${index}`] = new Date(start + METRIC_ROLLUP_INTERVAL_MS);
+        return [
+          `(SELECT ${RAW_SELECT}
+            FROM metric_data_points FINAL
+            WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+              AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
+            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
+          `(SELECT ${RAW_SELECT}
+            FROM metric_data_points FINAL
+            WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
+              AND metric_data_points.TimeUnixMs >= {from${index}:DateTime64(3)}
+              AND metric_data_points.TimeUnixMs < {to${index}:DateTime64(3)}
+            ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC)`,
+        ];
+      });
+      const result = await client.query({
+        query: selects.join("\n UNION ALL\n"),
+        query_params: params,
+        format: "JSONEachRow",
+      });
+      for (const row of await result.json<RawMetricRow>()) {
+        unique.set(
+          `${row.SeriesId}\u0000${row.PointId}`,
+          fromRaw({ row, organizationId }),
+        );
+      }
     }
-    return [...unique.values()];
+
+    for (const point of unique.values()) {
+      const existing = found.get(point.seriesId);
+      if (existing) existing.push(point);
+      else found.set(point.seriesId, [point]);
+    }
+    return found;
   }
 }

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -5,6 +5,7 @@ import {
   affectedRollupBuckets,
   buildMetricRollups,
 } from "~/server/event-sourcing/pipelines/metric-processing/rollup";
+import { comparePoints } from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
 import { METRIC_ROLLUP_INTERVAL_MS } from "~/server/event-sourcing/pipelines/metric-processing/schemas/constants";
 import type {
   CanonicalMetricDataPoint,
@@ -84,14 +85,26 @@ function affectedBucketsBySeries({
 }): Map<string, Set<number>> {
   const affectedBySeries = new Map<string, Set<number>>();
   for (const [seriesId, seriesPoints] of bySeries) {
+    // Sorted once so each point's successor is a binary search, not a rescan
+    // of every candidate — the per-point scan made a single hot series cost
+    // O(N²) per chunk. `affectedRollupBuckets` stays the sole owner of the
+    // bucket semantics; it just receives the one candidate that can matter.
     const candidates = [
       ...seriesPoints,
       ...(successorsBySeries.get(seriesId) ?? []),
-    ];
+    ].sort(comparePoints);
     const affected = new Set<number>();
     for (const point of seriesPoints) {
+      let lo = 0;
+      let hi = candidates.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (comparePoints(candidates[mid]!, point) > 0) hi = mid;
+        else lo = mid + 1;
+      }
+      const successor = candidates[lo];
       for (const bucket of affectedRollupBuckets({
-        points: candidates,
+        points: successor ? [successor] : [],
         insertedPoint: point,
       })) {
         affected.add(bucket);

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -93,26 +93,48 @@ function affectedBucketsBySeries({
       ...seriesPoints,
       ...(successorsBySeries.get(seriesId) ?? []),
     ].sort(comparePoints);
-    const affected = new Set<number>();
-    for (const point of seriesPoints) {
-      let lo = 0;
-      let hi = candidates.length;
-      while (lo < hi) {
-        const mid = (lo + hi) >>> 1;
-        if (comparePoints(candidates[mid]!, point) > 0) hi = mid;
-        else lo = mid + 1;
-      }
-      const successor = candidates[lo];
-      for (const bucket of affectedRollupBuckets({
-        points: successor ? [successor] : [],
-        insertedPoint: point,
-      })) {
-        affected.add(bucket);
-      }
-    }
+    const affected = affectedBucketsForSeries({ seriesPoints, candidates });
     if (affected.size > 0) affectedBySeries.set(seriesId, affected);
   }
   return affectedBySeries;
+}
+
+function affectedBucketsForSeries({
+  seriesPoints,
+  candidates,
+}: {
+  seriesPoints: readonly CanonicalMetricDataPoint[];
+  candidates: readonly CanonicalMetricDataPoint[];
+}): Set<number> {
+  const affected = new Set<number>();
+  for (const point of seriesPoints) {
+    const successor = successorIn({ sorted: candidates, point });
+    for (const bucket of affectedRollupBuckets({
+      points: successor ? [successor] : [],
+      insertedPoint: point,
+    })) {
+      affected.add(bucket);
+    }
+  }
+  return affected;
+}
+
+/** The first point ordering strictly after `point`, from a sorted array. */
+function successorIn({
+  sorted,
+  point,
+}: {
+  sorted: readonly CanonicalMetricDataPoint[];
+  point: CanonicalMetricDataPoint;
+}): CanonicalMetricDataPoint | undefined {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (comparePoints(sorted[mid]!, point) > 0) hi = mid;
+    else lo = mid + 1;
+  }
+  return sorted[lo];
 }
 
 export class MetricDataPointClickHouseRepository

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -264,6 +264,7 @@ export class MetricDataPointClickHouseRepository
       affectedBySeries,
       tenantId: points[0]!.tenantId,
       organizationId: points[0]!.organizationId,
+      retentionDays,
     });
 
     const rows: MetricRollupRow[] = [];
@@ -435,15 +436,23 @@ export class MetricDataPointClickHouseRepository
    * differences it against, grouped by series. Buckets are fetched as their own
    * narrow ranges rather than one span: a late point and a distant next sample
    * would otherwise scan every partition between them only to discard the rows.
+   *
+   * The predecessor seek is bounded below by the series' retention window: a
+   * predecessor older than that is expired (or about to be), and the fold
+   * already treats an absent predecessor as a reset/gap. Without the bound a
+   * sparse series pays a reverse scan across every partition — including
+   * S3-tiered cold storage — hunting for a row that no longer matters.
    */
   private async pointsForAffectedBuckets({
     affectedBySeries,
     tenantId,
     organizationId,
+    retentionDays,
   }: {
     affectedBySeries: ReadonlyMap<string, ReadonlySet<number>>;
     tenantId: string;
     organizationId: string;
+    retentionDays: number;
   }): Promise<Map<string, CanonicalMetricDataPoint[]>> {
     const seeks = [...affectedBySeries].flatMap(([seriesId, buckets]) =>
       [...buckets]
@@ -468,11 +477,15 @@ export class MetricDataPointClickHouseRepository
         params[`series${index}`] = seriesId;
         params[`from${index}`] = new Date(start);
         params[`to${index}`] = new Date(start + METRIC_ROLLUP_INTERVAL_MS);
+        params[`cutoff${index}`] = new Date(
+          start - retentionDays * 24 * 60 * 60 * 1000,
+        );
         return [
           `(SELECT ${RAW_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
               AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
+              AND metric_data_points.TimeUnixMs >= {cutoff${index}:DateTime64(3)}
             ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
           `(SELECT ${RAW_SELECT}
             FROM metric_data_points FINAL

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
@@ -257,8 +257,12 @@ function countsColumn({
 }): string[] {
   const counts = row[column];
   if (!Array.isArray(counts)) {
+    const problem =
+      counts === undefined
+        ? `is missing the ${column} column`
+        : `carries a non-array ${typeof counts} in the ${column} column`;
     throw new Error(
-      `metric_data_points row is missing the ${column} column (series ${row.SeriesId ?? "unknown"}, point ${row.PointId ?? "unknown"}); a read returned a row this decoder cannot trust`,
+      `metric_data_points row ${problem} (series ${row.SeriesId ?? "unknown"}, point ${row.PointId ?? "unknown"}); a read returned a row this decoder cannot trust`,
     );
   }
   return counts.map(String);

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
@@ -235,6 +235,35 @@ export function rollupRow({
   };
 }
 
+/**
+ * One of the three `Array(UInt64)` count columns, refusing to decode a row that
+ * does not carry it.
+ *
+ * These are the only fields `fromRaw` dereferences without a null check, so a
+ * row arriving without them used to surface as a bare
+ * `Cannot read properties of undefined (reading 'map')` — no column, no series,
+ * no query, and a stack the queue drops in favour of the message alone. Naming
+ * the column and the row turns the next occurrence into evidence instead of a
+ * guess. It stays a plain `Error`: nothing here is customer-actionable, so it
+ * degrades to a generic failure with a trace id at the boundary and the queue
+ * retries it on the normal backoff (dev/docs/best_practices/error-handling.md).
+ */
+function countsColumn({
+  row,
+  column,
+}: {
+  row: RawMetricRow;
+  column: "BucketCounts" | "PositiveBucketCounts" | "NegativeBucketCounts";
+}): string[] {
+  const counts = row[column];
+  if (!Array.isArray(counts)) {
+    throw new Error(
+      `metric_data_points row is missing the ${column} column (series ${row.SeriesId ?? "unknown"}, point ${row.PointId ?? "unknown"}); a read returned a row this decoder cannot trust`,
+    );
+  }
+  return counts.map(String);
+}
+
 export function fromRaw({
   row,
   organizationId,
@@ -277,14 +306,14 @@ export function fromRaw({
     min: row.Min,
     max: row.Max,
     explicitBounds: row.ExplicitBounds,
-    bucketCounts: row.BucketCounts.map(String),
+    bucketCounts: countsColumn({ row, column: "BucketCounts" }),
     exponentialScale: row.ExponentialScale,
     exponentialZeroThreshold: row.ExponentialZeroThreshold,
     zeroCount: row.ZeroCount === null ? null : String(row.ZeroCount),
     positiveOffset: row.PositiveOffset,
-    positiveBucketCounts: row.PositiveBucketCounts.map(String),
+    positiveBucketCounts: countsColumn({ row, column: "PositiveBucketCounts" }),
     negativeOffset: row.NegativeOffset,
-    negativeBucketCounts: row.NegativeBucketCounts.map(String),
+    negativeBucketCounts: countsColumn({ row, column: "NegativeBucketCounts" }),
     summaryQuantilesJson: row.SummaryQuantilesJson,
     canonicalPayload: row.CanonicalPayload,
     canonicalSizeBytes: Number(row._size_bytes),

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
@@ -191,5 +191,54 @@ describe.skipIf(!hasTestcontainers)(
         });
       });
     });
+
+    describe("given the failure-streak breaker quarantines a group", () => {
+      describe("when the stored blocked record is written", () => {
+        it("persists the handler's stack, not the quarantine wrapper's", async () => {
+          const previous =
+            process.env.LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD;
+          process.env.LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD = "1";
+          try {
+            function streakingHandlerForStackAssertion(): never {
+              throw new Error("recurring handler failure");
+            }
+            // Threshold is read at construction, so the env var must be set
+            // before createQueue.
+            const queue = createQueue(async () => {
+              streakingHandlerForStackAssertion();
+            });
+            const name = (queue as unknown as { queueName: string }).queueName;
+            await queue.waitUntilReady();
+
+            await queue.send({ id: "job-1", groupId: "g1" });
+
+            // First failure re-stages with backoff (streak 1); the second
+            // crosses the threshold and quarantines the group.
+            await vi.waitFor(
+              async () => {
+                expect(await redis.sismember(`${name}:gq:blocked`, "g1")).toBe(
+                  1,
+                );
+              },
+              { timeout: 10_000, interval: 100 },
+            );
+
+            const stored = await redis.hgetall(`${name}:gq:group:g1:error`);
+            expect(stored.message).toContain("Poison guard");
+            // The wrapper explains WHY the group blocked; the persisted stack
+            // must still name the handler's throwing line — that is the whole
+            // diagnostic value of the record.
+            expect(stored.stack).toContain("streakingHandlerForStackAssertion");
+          } finally {
+            if (previous === undefined) {
+              delete process.env.LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD;
+            } else {
+              process.env.LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD =
+                previous;
+            }
+          }
+        });
+      });
+    });
   },
 );

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
@@ -104,9 +104,7 @@ describe.skipIf(!hasTestcontainers)(
       spy: ReturnType<typeof vi.spyOn>,
       message: string,
     ): Record<string, unknown> | undefined {
-      const call = spy.mock.calls.find(
-        (c: unknown[]) => c[1] === message,
-      );
+      const call = spy.mock.calls.find((c: unknown[]) => c[1] === message);
       return call?.[0] as Record<string, unknown> | undefined;
     }
 
@@ -127,7 +125,10 @@ describe.skipIf(!hasTestcontainers)(
           await vi.waitFor(
             () => {
               expect(
-                loggedObjectFor(warnSpy, "Job attempt failed, re-staged with backoff"),
+                loggedObjectFor(
+                  warnSpy,
+                  "Job attempt failed, re-staged with backoff",
+                ),
               ).toBeDefined();
             },
             { timeout: 5000, interval: 50 },

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
@@ -1,0 +1,194 @@
+import type { Redis } from "ioredis";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../../__tests__/integration/testContainers";
+import { ValidationError } from "../../../services/errorHandling";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+
+// Skip when running without testcontainers (unit-only test runs)
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+type TestPayload = {
+  id: string;
+  groupId: string;
+};
+
+function createQueueDefinition(
+  overrides: Partial<EventSourcedQueueDefinition<TestPayload>> & {
+    process: (payload: TestPayload) => Promise<void>;
+  },
+): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gqfaillog/${crypto.randomUUID().slice(0, 8)}}`,
+    groupKey: (p) => p.groupId,
+    ...overrides,
+  };
+}
+
+/**
+ * A handler crash observed only as `error.message` is undiagnosable: the
+ * message names no file and no line, and the queue is the only place that
+ * ever sees the throw. These tests pin that every failure-path log record
+ * carries the full Error object — the logger's `error` serializer emits
+ * the stack from it — so a production crash can be traced to its call site
+ * without a rollback-and-guess cycle.
+ */
+describe.skipIf(!hasTestcontainers)(
+  "GroupQueueProcessor - failure logging",
+  () => {
+    let redis: Redis;
+    let queues: GroupQueueProcessor<TestPayload>[];
+
+    beforeAll(async () => {
+      await startTestContainers();
+      redis = getTestRedisConnection()!;
+    });
+
+    beforeEach(() => {
+      queues = [];
+    });
+
+    afterEach(async () => {
+      await Promise.all(queues.map((q) => q.close().catch(() => {})));
+      // Scoped to this suite's own namespace, never flushdb().
+      const keys = await redis.keys("{test/gqfaillog/*");
+      if (keys.length > 0) await redis.del(...keys);
+    });
+
+    afterAll(async () => {
+      await stopTestContainers();
+    });
+
+    function createQueue(
+      processFn: (payload: TestPayload) => Promise<void>,
+    ): GroupQueueProcessor<TestPayload> {
+      const definition = createQueueDefinition({ process: processFn });
+      const queue = new GroupQueueProcessor<TestPayload>(definition, redis);
+      queues.push(queue);
+      return queue;
+    }
+
+    /** The logger is a private field; the spy sees the raw log object before
+     *  pino serializes it, which is exactly the contract under test: the
+     *  Error INSTANCE must reach the logger, not a pre-flattened string. */
+    function spyOnLogger(
+      queue: GroupQueueProcessor<TestPayload>,
+      level: "warn" | "error",
+    ) {
+      const logger = (queue as unknown as { logger: Record<string, unknown> })
+        .logger;
+      return vi.spyOn(logger as never, level as never) as ReturnType<
+        typeof vi.spyOn
+      >;
+    }
+
+    function loggedObjectFor(
+      spy: ReturnType<typeof vi.spyOn>,
+      message: string,
+    ): Record<string, unknown> | undefined {
+      const call = spy.mock.calls.find(
+        (c: unknown[]) => c[1] === message,
+      );
+      return call?.[0] as Record<string, unknown> | undefined;
+    }
+
+    describe("given a handler that throws a retryable error", () => {
+      describe("when the job attempt fails and is re-staged", () => {
+        it("logs the full Error so the stack survives to the log record", async () => {
+          function explodingHandlerForStackAssertion(): never {
+            throw new Error("Cannot read properties of undefined");
+          }
+          const queue = createQueue(async () => {
+            explodingHandlerForStackAssertion();
+          });
+          const warnSpy = spyOnLogger(queue, "warn");
+          await queue.waitUntilReady();
+
+          await queue.send({ id: "job-1", groupId: "g1" });
+
+          await vi.waitFor(
+            () => {
+              expect(
+                loggedObjectFor(warnSpy, "Job attempt failed, re-staged with backoff"),
+              ).toBeDefined();
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          const logged = loggedObjectFor(
+            warnSpy,
+            "Job attempt failed, re-staged with backoff",
+          )!;
+          expect(logged.error).toBeInstanceOf(Error);
+          const stack = (logged.error as Error).stack ?? "";
+          expect(stack).toContain("explodingHandlerForStackAssertion");
+        });
+      });
+    });
+
+    describe("given a handler that throws a non-retryable error", () => {
+      describe("when the job skips retries and the group is blocked", () => {
+        it("logs the full Error on both the non-retryable and blocked records", async () => {
+          function invalidPayloadHandlerForStackAssertion(): never {
+            throw new ValidationError("bad payload", "field");
+          }
+          const queue = createQueue(async () => {
+            invalidPayloadHandlerForStackAssertion();
+          });
+          const errorSpy = spyOnLogger(queue, "error");
+          await queue.waitUntilReady();
+
+          await queue.send({ id: "job-1", groupId: "g1" });
+
+          await vi.waitFor(
+            () => {
+              expect(
+                loggedObjectFor(
+                  errorSpy,
+                  "Group blocked after exhausted retries, job re-staged",
+                ),
+              ).toBeDefined();
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          const nonRetryable = loggedObjectFor(
+            errorSpy,
+            "Job failed with non-retryable error, skipping retries",
+          )!;
+          expect(nonRetryable.error).toBeInstanceOf(Error);
+          expect((nonRetryable.error as Error).stack ?? "").toContain(
+            "invalidPayloadHandlerForStackAssertion",
+          );
+
+          const blocked = loggedObjectFor(
+            errorSpy,
+            "Group blocked after exhausted retries, job re-staged",
+          )!;
+          expect(blocked.error).toBeInstanceOf(Error);
+          expect((blocked.error as Error).stack ?? "").toContain(
+            "invalidPayloadHandlerForStackAssertion",
+          );
+        });
+      });
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1305,7 +1305,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                       stagedJobId,
                       failStreak,
                       threshold: this.quarantineFailStreakThreshold,
-                      error: error.message,
+                      error,
                     },
                     "Group quarantined after a run of failures with no success; blocking it to protect the shared queue",
                   );
@@ -1466,7 +1466,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     attempt,
                     maxAttempts: JOB_RETRY_CONFIG.maxAttempts,
                     backoffMs,
-                    error: error.message,
+                    // The whole Error, not `error.message`: the serializer emits
+                    // the stack, and for a handler crash the stack IS the
+                    // diagnosis — a bare "undefined is not a function" names no
+                    // file and no line, and the queue is the only place that
+                    // ever sees the throw.
+                    error,
                   },
                   "Job attempt failed, re-staged with backoff",
                 );
@@ -1483,7 +1488,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                       stagedJobId,
                       attempt,
                       errorCategory: category,
-                      error: error.message,
+                      error,
                     },
                     "Job failed with non-retryable error, skipping retries",
                   );
@@ -1811,7 +1816,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         groupId,
         stagedJobId,
         restagedAs: newStagedJobId,
-        error: lastError?.message,
+        error: lastError,
       },
       "Group blocked after exhausted retries, job re-staged",
     );
@@ -1959,9 +1964,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         envelopeVersion: descriptor.version,
         blobId: descriptor.blobId,
         bodyPreserved,
+        // Redacted text, not the raw Error: drop errors can quote storage
+        // URIs, and the stack's first line repeats the message — so both go
+        // through the same redaction.
         err: redactStorageUrisInText(
           err instanceof Error ? err.message : String(err),
         ),
+        errStack:
+          err instanceof Error && err.stack
+            ? redactStorageUrisInText(err.stack)
+            : undefined,
       },
       message,
     );
@@ -2250,7 +2262,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       this.logger.error(
         {
           queueName: this.queueName,
-          error: error instanceof Error ? error.message : String(error),
+          error,
           queueIdle: this.processingQueue.idle(),
           dispatcherActive: this.dispatcher != null,
         },

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1290,8 +1290,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   // Carried into handleExhaustedRetries as the group's stored
                   // error so /ops shows WHY it was blocked (a run of failures),
                   // not just the last job's error.
+                  // The handler error rides along as `cause` so the blocked
+                  // record can persist the throwing location — the quarantine
+                  // wrapper's own stack starts in queue control flow and names
+                  // nothing an investigator can use.
                   quarantineError = new Error(
                     `Poison guard: group quarantined after ${failStreak} consecutive failures (threshold ${this.quarantineFailStreakThreshold}) with no success. Last error: ${error.message}. Inspect the staged jobs, then unblock the group.`,
+                    { cause: error },
                   );
                   gqGroupsPoisonParkedTotal.inc({
                     queue_name: this.queueName,
@@ -1797,6 +1802,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       groupId,
     });
 
+    // The quarantine breaker wraps the handler error to explain WHY the group
+    // is blocked; the wrapper's stack is queue control flow. The persisted
+    // stack must be the handler's — that is the only place the throwing
+    // location survives once the job stops retrying.
+    const handlerError =
+      lastError?.cause instanceof Error ? lastError.cause : lastError;
+
     // Atomically: block the group, re-stage the job, update ready score, store error
     await this.scripts.restageAndBlock({
       groupId,
@@ -1804,7 +1816,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       score,
       jobDataJson,
       errorMessage: lastError?.message,
-      errorStack: lastError?.stack,
+      errorStack: handlerError?.stack,
     });
 
     gqGroupsBlockedTotal.inc(routingLabels);
@@ -1817,6 +1829,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         stagedJobId,
         restagedAs: newStagedJobId,
         error: lastError,
+        // Explicit rather than relying on the serializer to walk the cause
+        // chain: when the quarantine breaker wrapped the handler error, this
+        // is the stack that names the throwing line.
+        handlerStack:
+          handlerError === lastError ? undefined : handlerError?.stack,
       },
       "Group blocked after exhausted retries, job re-staged",
     );


### PR DESCRIPTION
## For humans

A while back we made the metric rollups cheaper: instead of asking the database a separate question for every single data point in a batch, we bundled those questions into a handful of larger ones. Shortly after it went live, one customer's rollup jobs started failing with a completely opaque message — `Cannot read properties of undefined (reading 'map')`. No file, no line, no clue which piece of data was involved. We assumed the optimization was at fault and rolled it back.

**It wasn't.** The rollback shipped, and the same failures kept happening without the optimization present. So we were chasing the wrong change, and the real trigger is still out there.

This PR does three things. It brings the optimization back, since it has now been shown not to be the culprit. It fixes the code that turns a database row into an object, which assumed three columns were always present and crashed opaquely when one wasn't — now it refuses the row and says exactly which column was missing and which row it came from. And it fixes the deeper blind spot that made the wrong rollback possible in the first place: when any queued job crashes, the queue now records **where** it crashed (the full stack trace), not just the error's one-line message. The next crash — this one or any other — arrives as evidence instead of a guess.

## What changed

- Re-applies #6481: the rollup chunk's successor seeks and affected-bucket reads are folded into a bounded number of batched statements instead of one round trip per point.
- `fromRaw` (`metric-data-point.rows.ts`) no longer dereferences `BucketCounts`, `PositiveBucketCounts` or `NegativeBucketCounts` unguarded. A row missing one is rejected with an error naming the column, the series and the point.
- Keeps every test from #6481, plus two regression tests that drive the repository with a read answering the deployed row shape.
- Closes #6488: every failure-path log in the group queue (`groupQueue.ts`) now passes the full `Error` object — the logger's serializer emits the stack — instead of `error.message`. Covers the retry, non-retryable, quarantine, exhausted-retries and shutdown paths. The unreadable-payload drop path keeps its storage-URI redaction and gains a redacted stack alongside the redacted message.
- Two integration tests drive a real queue with a crashing handler and assert the stack — naming the throwing function — survives to the log record on both the retry and the blocked-group paths.

## Why the failure was undiagnosable

The decoder had exactly three unguarded `.map` dereferences, and they were the only ones on the rollup read path. A read that answered with a row lacking one of those columns produced the bare undefined-property error seen in the logs. Because the group queue persists an error's `message` but not its `stack`, that message was the entire diagnostic record — which is why a rollback happened without a root cause, and why the rollback targeted the wrong change.

The guard is deliberately a plain `Error`, not a `HandledError`: the cause is not customer-actionable, so it degrades to a generic failure plus a trace id at the boundary and the queue retries it on its normal backoff. Dressing it up as handled would leak internals and promise the caller an action it does not have.

## Root cause status

**The optimization is not the cause.** The revert (#6485) reached the workers on fresh pods, and the same crash still fires on the reverted image, in the same single project and the same `map/metricTimeRollup` lane, with the optimization absent.

Two corrections to the original incident narrative:

- It was never "every metricTimeRollup batch". The failures are one poison job per shard, retrying on a 10-minute backoff — which is why they arrive in evenly spaced bursts and appear to stop and restart on their own.
- They also quieted *before* the revert reached the workers, so the revert was never what stopped them.

Ruled out, each with evidence rather than reasoning:

- **The resilient client does not swallow failures.** `resilient-client.ts:309` throws a translated error on every path; it never returns undefined.
- **Database memory pressure throws cleanly.** Verified against a real ClickHouse: a query rejected by a memory cap raises a `ClickHouseError`, never partial rows.
- **A read that dies mid-stream also throws cleanly.** Verified the same way with rows already on the wire. The client raises rather than returning a truncated result.
- **The folded query shape is sound.** Verified against a real ClickHouse across many series per chunk, chunks larger than the seek budget, and all five metric kinds.
- **The data is clean at every layer.** The queued payloads decode with every array field well-formed; the stored rows carry complete bucket arrays with no degenerate rows anywhere in the tenant; and the repository's own `SELECT` returns all its columns with the arrays present and correctly typed.
- **The fold itself does not crash on the failing input.** Replaying the exact batch that fails in the live system — through the real decoder and the real rollup builder, against real stored data — completes without error.

So the hypothesis that "the batched read's failure path returned no result and the code assumed rows" does not hold: those failure paths all raise, and the inputs are not malformed. The trigger is still unidentified and is not in the code this PR touches.

The reason it stayed unidentified is the subject of #6488: the group queue records a failed job's `error` **message** but not its `stack`, and emits no ERROR-level line for the lane. That message was the entire diagnostic record available.

## Risk

This is a **diagnostic, not a cure**, and it is worth being plain about that.

Re-landing the optimization is safe on the evidence: it demonstrably is not what crashes the lane, since the lane crashes identically without it. What this PR buys is that the next occurrence names the column, the series and the point instead of producing a bare undefined-property error — which is exactly what was missing when this incident was first triaged and mis-attributed.

The underlying trigger is still loose — but the stack capture ships in this PR. Once deployed, the failing job's next retry logs the exact file and line, which ends the hunt.

## Gates

- `pnpm typecheck:all` — clean
- `pnpm test:unit run` on the metric paths — 57 passed
- Repository integration tests against a real ClickHouse — 8 passed
- `biome ci` on changed files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved metric rollup processing with faster, more efficient reads.
  * Added predictable query limits during rollup recomputation.

* **Bug Fixes**
  * Improved cumulative metric accuracy across multiple time buckets, including counter resets.
  * Added clearer errors when histogram data is incomplete or invalid.
  * Enhanced failure logs with complete error details and available stack traces.

* **Tests**
  * Expanded coverage for rollups, cumulative metrics, query limits, and queue failure logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

