### PR TITLE
fix(clickhouse): in-band exceptions surfaced as errors; rollup reads slimmed under the memory cap

### DIFF
--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
@@ -1,0 +1,164 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockObserveQueryDuration = vi.fn();
+const mockIncrementQueryCount = vi.fn();
+
+vi.mock("~/server/clickhouse/metrics", () => ({
+  observeClickHouseQueryDuration: (...args: unknown[]) =>
+    mockObserveQueryDuration(...args),
+  incrementClickHouseQueryCount: (...args: unknown[]) =>
+    mockIncrementQueryCount(...args),
+}));
+
+// Must import after mock setup
+import { createResilientClickHouseClient } from "../resilient-client";
+
+/**
+ * ClickHouse streams over HTTP: an error after the first flushed row cannot
+ * change the 200 status, so the server appends `{"exception": "..."}` to the
+ * output instead. Left unread, that line reaches a decoder as a "row" with
+ * none of the selected columns. These tests pin both halves of the guard —
+ * such a line is surfaced as a thrown error carrying the real ClickHouse
+ * message, and a legitimate result whose sole column happens to be named
+ * `exception` is passed through untouched.
+ */
+describe("createResilientClickHouseClient()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function clientAnswering(rows: unknown[]): ClickHouseClient {
+    return {
+      query: vi.fn().mockResolvedValue({
+        response_headers: {},
+        json: vi.fn().mockResolvedValue(rows),
+      }),
+      insert: vi.fn(),
+    } as unknown as ClickHouseClient;
+  }
+
+  describe("when a streamed response carries an in-band exception row", () => {
+    it("throws through the translator so the incident shape lands as a typed error", async () => {
+      const exceptionText =
+        "Code: 241. DB::Exception: Query memory limit exceeded: would use 9.99 GiB, maximum: 9.50 GiB: While executing ReplacingSorted. (MEMORY_LIMIT_EXCEEDED)";
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering([
+          { SeriesId: "s1", BucketCounts: [] },
+          { exception: exceptionText },
+        ]),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+
+      // Assert on code, not message prose — the code is the stable contract.
+      await expect(result.json()).rejects.toMatchObject({
+        code: "query_memory_exceeded",
+      });
+    });
+
+    it("throws a plain error carrying the ClickHouse text for untranslated codes", async () => {
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering([
+          { exception: "Code: 999. DB::Exception: some future failure" },
+        ]),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+
+      await expect(result.json()).rejects.toThrow(
+        /Code: 999\. DB::Exception: some future failure/,
+      );
+    });
+
+    it("throws for exception subclasses that print their own class name", async () => {
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering([
+          {
+            exception:
+              "Code: 210. DB::NetException: Connection reset by peer. (NETWORK_ERROR)",
+          },
+        ]),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+
+      await expect(result.json()).rejects.toThrow(/DB::NetException/);
+    });
+
+    it("records a dedicated in-band outcome without double-counting", async () => {
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering([
+          { exception: "Code: 241. DB::Exception: memory" },
+        ]),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+      // Transport-level success is recorded when the query resolves — a
+      // caller may stream() or never consume, so that cannot be deferred.
+      expect(mockIncrementQueryCount).toHaveBeenCalledWith("SELECT", "success");
+      expect(mockObserveQueryDuration).toHaveBeenCalledTimes(1);
+
+      await expect(result.json()).rejects.toThrow();
+
+      // The failure lands under its own outcome, never as a second terminal
+      // outcome for the same query, and the latency histogram is not
+      // sampled twice.
+      expect(mockIncrementQueryCount).toHaveBeenCalledWith(
+        "SELECT",
+        "inband_error",
+      );
+      expect(mockIncrementQueryCount).not.toHaveBeenCalledWith(
+        "SELECT",
+        "error",
+      );
+      expect(mockObserveQueryDuration).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when a legitimate single-column result is named exception", () => {
+    it("returns the rows untouched", async () => {
+      // Sole key, but no ClickHouse error signature — this is data, not the
+      // server's exception line, and rejecting it would break the query.
+      const rows = [{ exception: "healthy" }, { exception: "degraded" }];
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering(rows),
+      });
+
+      const result = await wrapper.query({
+        query: "SELECT status AS exception FROM checks",
+      } as never);
+
+      await expect(result.json()).resolves.toEqual(rows);
+    });
+  });
+
+  describe("when a legitimate row merely has a column named exception", () => {
+    it("returns the rows untouched", async () => {
+      const rows = [
+        { exception: "a real column value", other: 1 },
+        { exception: "another", other: 2 },
+      ];
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering(rows),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+
+      await expect(result.json()).resolves.toEqual(rows);
+    });
+  });
+
+  describe("when the response has no exception row", () => {
+    it("returns the rows untouched", async () => {
+      const rows = [{ a: 1 }, { a: 2 }];
+      const wrapper = createResilientClickHouseClient({
+        client: clientAnswering(rows),
+      });
+
+      const result = await wrapper.query({ query: "SELECT 1" } as never);
+
+      await expect(result.json()).resolves.toEqual(rows);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
@@ -66,9 +66,13 @@ describe("createResilientClickHouseClient()", () => {
 
       const result = await wrapper.query({ query: "SELECT 1" } as never);
 
-      await expect(result.json()).rejects.toThrow(
-        /Code: 999\. DB::Exception: some future failure/,
-      );
+      // Code first — the message is supplementary coverage.
+      await expect(result.json()).rejects.toMatchObject({
+        code: "999",
+        message: expect.stringContaining(
+          "Code: 999. DB::Exception: some future failure",
+        ),
+      });
     });
 
     it("throws for exception subclasses that print their own class name", async () => {

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-inband-exception.unit.test.ts
@@ -11,7 +11,9 @@ vi.mock("~/server/clickhouse/metrics", () => ({
     mockIncrementQueryCount(...args),
 }));
 
-// Must import after mock setup
+// Vitest hoists vi.mock above static imports, so this import receives the
+// mocked metrics module regardless of ordering; kept below the factory for
+// readability only.
 import { createResilientClickHouseClient } from "../resilient-client";
 
 /**

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -309,7 +309,13 @@ function inbandExceptionOf(row: unknown): string | undefined {
   return CLICKHOUSE_EXCEPTION_SIGNATURE.test(exception) ? exception : undefined;
 }
 
-function inbandExceptionError(message: string, durationMs: number): unknown {
+function inbandExceptionError({
+  message,
+  durationMs,
+}: {
+  message: string;
+  durationMs: number;
+}): unknown {
   const error = new Error(message);
   const code = /Code:\s*(\d+)/.exec(message)?.[1];
   if (code) (error as { code?: string }).code = code;
@@ -334,7 +340,15 @@ function inbandExceptionError(message: string, durationMs: number): unknown {
  */
 function guardInbandException<
   T extends { json?: (...args: never[]) => unknown },
->(result: T, startMs: number, params: unknown): T {
+>({
+  result,
+  startMs,
+  params,
+}: {
+  result: T;
+  startMs: number;
+  params: unknown;
+}): T {
   if (typeof result?.json !== "function") return result;
   const queryType = extractQueryType(params);
   const originalJson = result.json.bind(result);
@@ -344,7 +358,7 @@ function guardInbandException<
       const exception = inbandExceptionOf(row);
       if (exception !== undefined) {
         const durationMs = performance.now() - startMs;
-        const error = inbandExceptionError(exception, durationMs);
+        const error = inbandExceptionError({ message: exception, durationMs });
         logFailure({ operation: "query", error, durationMs, params });
         // Dedicated outcome, and no second duration sample: the transport
         // outcome (success + one histogram observation) was already
@@ -389,7 +403,7 @@ export function createResilientClickHouseClient({
       logSuccess({ operation: "query", durationMs, params });
       observeClickHouseQueryDuration(queryType, table, durationMs / 1000);
       incrementClickHouseQueryCount(queryType, "success");
-      return guardInbandException(result, start, params);
+      return guardInbandException({ result, startMs: start, params });
     } catch (error) {
       const durationMs = performance.now() - start;
       logFailure({ operation: "query", error, durationMs, params });

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -267,6 +267,100 @@ function logSuccess({
 }
 
 /**
+ * ClickHouse streams results over HTTP. Once rows have been flushed, a
+ * failure can no longer change the 200 status code, so the server writes the
+ * error INTO the output as a final `{"exception": "..."}` line
+ * (`http_write_exception_in_output_format`, on by default). The transport
+ * never throws, the line parses as JSON, and without this guard it reaches
+ * the caller as a "row" with none of the selected columns — which surfaces
+ * as a property access on a missing column deep in a decoder, pointing every
+ * investigation away from ClickHouse. (Observed live: a
+ * MEMORY_LIMIT_EXCEEDED mid-`FINAL` arriving as a data row.)
+ *
+ * The guard wraps `json()` and throws the real ClickHouse error through the
+ * same translator the catch path uses.
+ */
+
+/**
+ * The server-side exception prefix, e.g.
+ * `Code: 241. DB::Exception: Memory limit ... (MEMORY_LIMIT_EXCEEDED)`.
+ * The class name is deliberately loose: the thrown type prints its own name
+ * (`DB::NetException`, `DB::ErrnoException`, `Coordination::Exception`) and
+ * every one of them means the query died. Missing one is the expensive
+ * direction — it puts an error row back in front of a decoder.
+ */
+const CLICKHOUSE_EXCEPTION_SIGNATURE = /^Code: \d+\. (\w+::)?\w*Exception:/;
+
+/**
+ * A row is the server's exception line only when both hold: `exception` is
+ * its sole key, and the value carries the ClickHouse error signature. The
+ * sole-key test alone would reject a legitimate one-column result such as
+ * `SELECT status AS exception`. A value that reproduces the full signature is
+ * an accepted residual false positive — the stream offers nothing else to
+ * tell it apart from the real thing.
+ */
+function inbandExceptionOf(row: unknown): string | undefined {
+  if (row === null || typeof row !== "object" || Array.isArray(row)) {
+    return undefined;
+  }
+  if (Object.keys(row).length !== 1) return undefined;
+  const exception = (row as { exception?: unknown }).exception;
+  if (typeof exception !== "string") return undefined;
+  return CLICKHOUSE_EXCEPTION_SIGNATURE.test(exception) ? exception : undefined;
+}
+
+function inbandExceptionError(message: string, durationMs: number): unknown {
+  const error = new Error(message);
+  const code = /Code:\s*(\d+)/.exec(message)?.[1];
+  if (code) (error as { code?: string }).code = code;
+  return translateClickHouseQueryError(error, durationMs);
+}
+
+/**
+ * Outcome accounting is two-phase for streamed results. The transport-level
+ * "success" is recorded when the query resolves — that cannot be deferred
+ * to consumption, because a caller may stream() or never read the body at
+ * all. When consumption then surfaces an in-band exception, the failure is
+ * recorded HERE (failure log + error counter), so dashboards alerting on
+ * errors see it. The earlier success increment is left standing and
+ * documents itself as "the server accepted and started answering"; an
+ * in-band failure therefore shows up as one success + one error for the
+ * same query, never as silence.
+ *
+ * No transport-level retry happens for in-band exceptions: the body has
+ * been consumed, and the classes that arrive in-band (memory limit, server
+ * timeout) are not transient. Callers that need a retry get it from their
+ * own layer — the job queue re-runs the whole unit of work.
+ */
+function guardInbandException<
+  T extends { json?: (...args: never[]) => unknown },
+>(result: T, startMs: number, params: unknown): T {
+  if (typeof result?.json !== "function") return result;
+  const queryType = extractQueryType(params);
+  const originalJson = result.json.bind(result);
+  result.json = (async (...args: never[]) => {
+    const rows = (await originalJson(...args)) as unknown;
+    for (const row of Array.isArray(rows) ? rows : [rows]) {
+      const exception = inbandExceptionOf(row);
+      if (exception !== undefined) {
+        const durationMs = performance.now() - startMs;
+        const error = inbandExceptionError(exception, durationMs);
+        logFailure({ operation: "query", error, durationMs, params });
+        // Dedicated outcome, and no second duration sample: the transport
+        // outcome (success + one histogram observation) was already
+        // recorded when the query resolved. Counting this as "error" too
+        // would put one query under both terminal outcomes and corrupt
+        // the success/error ratio.
+        incrementClickHouseQueryCount(queryType, "inband_error");
+        throw error;
+      }
+    }
+    return rows;
+  }) as T["json"];
+  return result;
+}
+
+/**
  * Wraps a ClickHouseClient with structured logging and insert retry.
  */
 export function createResilientClickHouseClient({
@@ -295,7 +389,7 @@ export function createResilientClickHouseClient({
       logSuccess({ operation: "query", durationMs, params });
       observeClickHouseQueryDuration(queryType, table, durationMs / 1000);
       incrementClickHouseQueryCount(queryType, "success");
-      return result;
+      return guardInbandException(result, start, params);
     } catch (error) {
       const durationMs = performance.now() - start;
       logFailure({ operation: "query", error, durationMs, params });

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -307,6 +307,29 @@ describe("MetricDataPointClickHouseRepository", () => {
         "ORDER BY metric_data_points.TimeUnixMs ASC, TimeUnixNano ASC, PointId ASC",
       );
     });
+
+    it("never fetches the payload column on either read", async () => {
+      const { query, client } = reader();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: chunkOf(2) });
+
+      // The fold never reads CanonicalPayload, and it is the one
+      // megabyte-scale column: fetching it through FINAL across the folded
+      // seek branches can push a single query past the server's per-query
+      // memory cap (MEMORY_LIMIT_EXCEEDED in ReplacingSorted). Both reads
+      // must stay payload-free.
+      const successorSeeks = query.mock.calls[0]![0].query;
+      const bucketReads = query.mock.calls[1]![0].query;
+      expect(successorSeeks).not.toContain("CanonicalPayload");
+      expect(bucketReads).not.toContain("CanonicalPayload");
+      // The seek stays minimal: sequence fields only.
+      expect(successorSeeks).not.toContain("ResourceAttributesJson");
+      expect(bucketReads).toContain("BucketCounts");
+    });
   });
 
   describe("when a folded read answers with a row it cannot decode", () => {
@@ -315,12 +338,12 @@ describe("MetricDataPointClickHouseRepository", () => {
       METRIC_ROLLUP_INTERVAL_MS;
 
     /**
-     * The shape the rollup lane actually failed on in production: a row that
-     * parses as JSON and carries its identifiers, but is missing one of the
-     * `Array(UInt64)` count columns the decoder dereferences unguarded. The
-     * decoder used to walk straight into `undefined.map`, and the queue logs
-     * only an error's message — so the incident produced no column, no series
-     * and no query to work from.
+     * The shape the rollup lane actually failed on: a row that parses as JSON
+     * and carries its identifiers, but is missing one of the `Array(UInt64)`
+     * count columns the decoder dereferences unguarded. Walking straight into
+     * `undefined.map` costs the whole diagnosis — the queue logs an error's
+     * message and nothing else, so the failure names no column, no series and
+     * no query.
      */
     function rowMissingBucketCounts() {
       const point = dataPoint();

--- a/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -330,6 +330,92 @@ describe("MetricDataPointClickHouseRepository", () => {
       expect(successorSeeks).not.toContain("ResourceAttributesJson");
       expect(bucketReads).toContain("BucketCounts");
     });
+
+    it("folds rows that arrive without the payload column all the way to a rollup write", async () => {
+      // Runtime counterpart to the SQL-text assertions above: the mock
+      // REJECTS any read that asks for the payload column and answers with
+      // rows that omit it, so this executes fromSeekRow and the
+      // payload-free fromRaw end to end instead of only inspecting strings.
+      const point = { ...dataPoint(), timeUnixMs: base + 1_000 };
+      const seekRow = {
+        SeriesId: point.seriesId,
+        PointId: "f".repeat(64),
+        TimeUnixMs: base + 2_000,
+        TimeUnixNano: String(BigInt(base + 2_000) * 1_000_000n),
+        MetricKind: "gauge",
+        AggregationTemporality: "unspecified",
+      };
+      const authoritativeRow = {
+        TenantId: point.tenantId,
+        PointId: point.pointId,
+        SeriesId: point.seriesId,
+        ResourceSchemaUrl: "",
+        ResourceAttributesJson: "[]",
+        ResourceAttributeKeys: [],
+        ScopeSchemaUrl: "",
+        ScopeName: "scope",
+        ScopeVersion: "",
+        ScopeAttributesJson: "[]",
+        ScopeAttributeKeys: [],
+        MetricName: "requests",
+        MetricDescription: "",
+        MetricUnit: "1",
+        MetricKind: "gauge",
+        AggregationTemporality: "unspecified",
+        IsMonotonic: null,
+        PointAttributesJson: "[]",
+        PointAttributeKeys: [],
+        StartTimeUnixNano: "0",
+        TimeUnixNano: point.timeUnixNano,
+        TimeUnixMs: point.timeUnixMs,
+        Flags: 0,
+        ValueType: "double",
+        ValueInt: null,
+        ValueDouble: 1.5,
+        Count: null,
+        Sum: null,
+        Min: null,
+        Max: null,
+        ExplicitBounds: [],
+        BucketCounts: [],
+        ExponentialScale: null,
+        ExponentialZeroThreshold: null,
+        ZeroCount: null,
+        PositiveOffset: null,
+        PositiveBucketCounts: [],
+        NegativeOffset: null,
+        NegativeBucketCounts: [],
+        SummaryQuantilesJson: "[]",
+        _size_bytes: 23,
+        OccurredAt: point.timeUnixMs,
+        AcceptedAt: point.timeUnixMs,
+      };
+      const query = vi.fn<
+        (args: { query: string }) => Promise<{ json: () => Promise<unknown[]> }>
+      >(async ({ query: sql }) => {
+        if (sql.includes("CanonicalPayload")) {
+          throw new Error("read selected the payload column");
+        }
+        return sql.includes("{from0:")
+          ? { json: async () => [authoritativeRow] }
+          : { json: async () => [seekRow] };
+      });
+      const insert = vi.fn<
+        (args: { table: string; values: unknown[] }) => Promise<void>
+      >(async () => {});
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => ({ query, insert }) as never,
+        resolveOrganizationClient: async () => ({ query, insert }) as never,
+      });
+
+      await repository.recomputeAffectedRollupsMany({ points: [point] });
+
+      const rollupInsert = insert.mock.calls.find(
+        (call) => call[0].table === "metric_time_rollups",
+      );
+      expect(rollupInsert).toBeDefined();
+      expect(rollupInsert![0].values.length).toBeGreaterThan(0);
+    });
   });
 
   describe("when a folded read answers with a row it cannot decode", () => {

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -5,7 +5,10 @@ import {
   affectedRollupBuckets,
   buildMetricRollups,
 } from "~/server/event-sourcing/pipelines/metric-processing/rollup";
-import { comparePoints } from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
+import {
+  comparePoints,
+  type MetricSequencePoint,
+} from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
 import { METRIC_ROLLUP_INTERVAL_MS } from "~/server/event-sourcing/pipelines/metric-processing/schemas/constants";
 import type {
   CanonicalMetricDataPoint,
@@ -21,11 +24,14 @@ import type {
   SeriesTotalByPointAttribute,
 } from "./metric-data-point.repository";
 import {
+  AUTHORITATIVE_SELECT,
   fromRaw,
-  RAW_SELECT,
+  fromSeekRow,
   type RawMetricRow,
   rawRow,
   rollupRow,
+  SEEK_SELECT,
+  type SeekMetricRow,
   seriesRow,
   usageEstimateRow,
   validatePoint,
@@ -53,10 +59,10 @@ function chunked<T>(items: readonly T[], size: number): T[][] {
   return chunks;
 }
 
-function groupBySeries(
-  points: readonly CanonicalMetricDataPoint[],
-): Map<string, CanonicalMetricDataPoint[]> {
-  const bySeries = new Map<string, CanonicalMetricDataPoint[]>();
+function groupBySeries<T extends { seriesId: string }>(
+  points: readonly T[],
+): Map<string, T[]> {
+  const bySeries = new Map<string, T[]>();
   for (const point of points) {
     const existing = bySeries.get(point.seriesId);
     if (existing) existing.push(point);
@@ -81,7 +87,7 @@ function affectedBucketsBySeries({
   successorsBySeries,
 }: {
   bySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
-  successorsBySeries: ReadonlyMap<string, CanonicalMetricDataPoint[]>;
+  successorsBySeries: ReadonlyMap<string, MetricSequencePoint[]>;
 }): Map<string, Set<number>> {
   const affectedBySeries = new Map<string, Set<number>>();
   for (const [seriesId, seriesPoints] of bySeries) {
@@ -89,7 +95,7 @@ function affectedBucketsBySeries({
     // of every candidate — the per-point scan made a single hot series cost
     // O(N²) per chunk. `affectedRollupBuckets` stays the sole owner of the
     // bucket semantics; it just receives the one candidate that can matter.
-    const candidates = [
+    const candidates: MetricSequencePoint[] = [
       ...seriesPoints,
       ...(successorsBySeries.get(seriesId) ?? []),
     ].sort(comparePoints);
@@ -104,7 +110,7 @@ function affectedBucketsForSeries({
   candidates,
 }: {
   seriesPoints: readonly CanonicalMetricDataPoint[];
-  candidates: readonly CanonicalMetricDataPoint[];
+  candidates: readonly MetricSequencePoint[];
 }): Set<number> {
   const affected = new Set<number>();
   for (const point of seriesPoints) {
@@ -124,9 +130,9 @@ function successorIn({
   sorted,
   point,
 }: {
-  sorted: readonly CanonicalMetricDataPoint[];
-  point: CanonicalMetricDataPoint;
-}): CanonicalMetricDataPoint | undefined {
+  sorted: readonly MetricSequencePoint[];
+  point: MetricSequencePoint;
+}): MetricSequencePoint | undefined {
   let lo = 0;
   let hi = sorted.length;
   while (lo < hi) {
@@ -416,17 +422,17 @@ export class MetricDataPointClickHouseRepository
    * optimize_read_in_order is syntactic and cannot infer that, so ordering on
    * TimeUnixNano alone made ClickHouse materialise and sort every point in
    * the series (each carrying a ZSTD CanonicalPayload) to return one row.
-   * TimeUnixMs is table-qualified throughout: RAW_SELECT aliases
+   * TimeUnixMs is table-qualified throughout: SEEK_SELECT aliases
    * toUnixTimestamp64Milli(...) AS TimeUnixMs, and a bare TimeUnixMs
    * resolves to that alias (epoch millis), never matching a DateTime64
    * bound — the same pitfall log-record-storage documents.
    */
   private async successorsOf(
     points: CanonicalMetricDataPoint[],
-  ): Promise<CanonicalMetricDataPoint[]> {
+  ): Promise<MetricSequencePoint[]> {
     const tenantId = points[0]!.tenantId;
     const client = await this.resolveClient(tenantId);
-    const found: CanonicalMetricDataPoint[] = [];
+    const found: MetricSequencePoint[] = [];
 
     for (const chunk of chunked(points, SEEKS_PER_QUERY)) {
       const params: Record<string, unknown> = { tenantId };
@@ -435,7 +441,12 @@ export class MetricDataPointClickHouseRepository
         params[`time${index}`] = new Date(point.timeUnixMs);
         params[`nano${index}`] = point.timeUnixNano;
         params[`point${index}`] = point.pointId;
-        return `(SELECT ${RAW_SELECT}
+        // SEEK_SELECT, never the full row: each branch runs FINAL over its
+        // series, and materialising the megabyte-scale payload column across
+        // SEEKS_PER_QUERY branches is what pushed one query past the server's
+        // per-query memory cap (MEMORY_LIMIT_EXCEEDED in ReplacingSorted).
+        // The seek only exists to order points and locate buckets.
+        return `(SELECT ${SEEK_SELECT}
           FROM metric_data_points FINAL
           WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
             AND (metric_data_points.TimeUnixMs > {time${index}:DateTime64(3)} OR (metric_data_points.TimeUnixMs = {time${index}:DateTime64(3)} AND (TimeUnixNano > {nano${index}:UInt64} OR (TimeUnixNano = {nano${index}:UInt64} AND PointId > {point${index}:String}))))
@@ -446,8 +457,8 @@ export class MetricDataPointClickHouseRepository
         query_params: params,
         format: "JSONEachRow",
       });
-      for (const row of await result.json<RawMetricRow>()) {
-        found.push(fromRaw({ row, organizationId: points[0]!.organizationId }));
+      for (const row of await result.json<SeekMetricRow>()) {
+        found.push(fromSeekRow(row));
       }
     }
     return found;
@@ -502,14 +513,17 @@ export class MetricDataPointClickHouseRepository
         params[`cutoff${index}`] = new Date(
           start - retentionDays * 24 * 60 * 60 * 1000,
         );
+        // AUTHORITATIVE_SELECT: everything the fold reads, without the
+        // payload column — the fold never touches it, and it is the column
+        // that made these FINAL reads memory-heavy.
         return [
-          `(SELECT ${RAW_SELECT}
+          `(SELECT ${AUTHORITATIVE_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
               AND metric_data_points.TimeUnixMs < {from${index}:DateTime64(3)}
               AND metric_data_points.TimeUnixMs >= {cutoff${index}:DateTime64(3)}
             ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
-          `(SELECT ${RAW_SELECT}
+          `(SELECT ${AUTHORITATIVE_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
               AND metric_data_points.TimeUnixMs >= {from${index}:DateTime64(3)}
@@ -522,7 +536,9 @@ export class MetricDataPointClickHouseRepository
         query_params: params,
         format: "JSONEachRow",
       });
-      for (const row of await result.json<RawMetricRow>()) {
+      for (const row of await result.json<
+        Omit<RawMetricRow, "CanonicalPayload">
+      >()) {
         unique.set(
           `${row.SeriesId}\u0000${row.PointId}`,
           fromRaw({ row, organizationId }),

--- a/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
+++ b/langwatch/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
@@ -1,3 +1,4 @@
+import type { MetricSequencePoint } from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
 import type {
   AggregationTemporality,
   CanonicalMetricDataPoint,
@@ -252,7 +253,14 @@ function countsColumn({
   row,
   column,
 }: {
-  row: RawMetricRow;
+  row: Pick<
+    RawMetricRow,
+    | "SeriesId"
+    | "PointId"
+    | "BucketCounts"
+    | "PositiveBucketCounts"
+    | "NegativeBucketCounts"
+  >;
   column: "BucketCounts" | "PositiveBucketCounts" | "NegativeBucketCounts";
 }): string[] {
   const counts = row[column];
@@ -268,11 +276,59 @@ function countsColumn({
   return counts.map(String);
 }
 
+/**
+ * The columns the rollup fold actually reads. Identical to {@link RAW_SELECT}
+ * minus CanonicalPayload: the fold never touches the payload, and it is the
+ * one megabyte-scale column, so fetching it through `FINAL` was what pushed
+ * the folded seek queries past the server's per-query memory cap
+ * (MEMORY_LIMIT_EXCEEDED while executing ReplacingSorted).
+ */
+export const AUTHORITATIVE_SELECT = RAW_SELECT.replace(
+  "SummaryQuantilesJson, CanonicalPayload, _size_bytes,",
+  "SummaryQuantilesJson, _size_bytes,",
+);
+
+/**
+ * The columns a successor seek needs: just enough to order points
+ * (TimeUnixNano, PointId), locate their buckets (TimeUnixMs) and decide
+ * predecessor dependency (MetricKind, AggregationTemporality). Everything else
+ * — attributes, values, buckets, payload — is dead weight the seek used to
+ * materialise through `FINAL` for every one of its folded branches.
+ */
+export const SEEK_SELECT = `
+  SeriesId, PointId,
+  toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs, TimeUnixNano,
+  MetricKind, AggregationTemporality
+`;
+
+export interface SeekMetricRow {
+  SeriesId: string;
+  PointId: string;
+  TimeUnixMs: string | number;
+  TimeUnixNano: string;
+  MetricKind: MetricKind;
+  AggregationTemporality: AggregationTemporality;
+}
+
+export function fromSeekRow(row: SeekMetricRow): MetricSequencePoint {
+  return {
+    seriesId: row.SeriesId,
+    pointId: row.PointId,
+    timeUnixMs: Number(row.TimeUnixMs),
+    timeUnixNano: String(row.TimeUnixNano),
+    metricKind: row.MetricKind,
+    aggregationTemporality: row.AggregationTemporality,
+  };
+}
+
 export function fromRaw({
   row,
   organizationId,
 }: {
-  row: RawMetricRow;
+  // CanonicalPayload is optional on purpose: the authoritative bucket reads
+  // deliberately do not select it (see AUTHORITATIVE_SELECT), and the fold
+  // never reads the decoded field.
+  row: Omit<RawMetricRow, "CanonicalPayload"> & { CanonicalPayload?: string };
   organizationId: string;
 }): CanonicalMetricDataPoint {
   return {
@@ -319,7 +375,7 @@ export function fromRaw({
     negativeOffset: row.NegativeOffset,
     negativeBucketCounts: countsColumn({ row, column: "NegativeBucketCounts" }),
     summaryQuantilesJson: row.SummaryQuantilesJson,
-    canonicalPayload: row.CanonicalPayload,
+    canonicalPayload: row.CanonicalPayload ?? "",
     canonicalSizeBytes: Number(row._size_bytes),
     occurredAt: Number(row.OccurredAt),
     acceptedAt: Number(row.AcceptedAt),

--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -36,7 +36,11 @@ const clickhouseQueryTotal = new Counter({
 
 export const incrementClickHouseQueryCount = (
   queryType: "SELECT" | "INSERT" | "OTHER",
-  status: "success" | "error",
+  // "inband_error": the transport succeeded (already counted as "success")
+  // but the streamed body carried a ClickHouse exception row. A dedicated
+  // outcome keeps success/error ratios honest — the same query is never
+  // counted under both terminal outcomes.
+  status: "success" | "error" | "inband_error",
 ) => clickhouseQueryTotal.labels(queryType, status).inc();
 
 // Counter for windowed reads: the partition-pruning-window-with-fallback read

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/rollup.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/rollup.ts
@@ -2,7 +2,12 @@ import { buildHistogramRow } from "./rollup/explicitHistogram";
 import { buildExponentialHistogramRow } from "./rollup/exponentialHistogram";
 import { type BucketEntry, baseRow } from "./rollup/row";
 import { buildGaugeRow, buildSumRow } from "./rollup/scalar";
-import { comparePoints, floorBucket, usesPredecessor } from "./rollup/sequence";
+import {
+  comparePoints,
+  floorBucket,
+  type MetricSequencePoint,
+  usesPredecessor,
+} from "./rollup/sequence";
 import { buildSummaryRow } from "./rollup/summary";
 import type {
   CanonicalMetricDataPoint,
@@ -63,8 +68,8 @@ export function affectedRollupBuckets({
   points,
   insertedPoint,
 }: {
-  points: CanonicalMetricDataPoint[];
-  insertedPoint: CanonicalMetricDataPoint;
+  points: MetricSequencePoint[];
+  insertedPoint: MetricSequencePoint;
 }): Set<number> {
   const affected = new Set([floorBucket(insertedPoint.timeUnixMs)]);
   const next = [...points]

--- a/langwatch/src/server/event-sourcing/pipelines/metric-processing/rollup/sequence.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/metric-processing/rollup/sequence.ts
@@ -26,10 +26,26 @@ export function floorBucket(timeUnixMs: number): number {
   );
 }
 
+/**
+ * The fields sequence decisions actually read. Successor seeks fetch only
+ * these — never the megabyte-scale payload columns — so the type names the
+ * contract: anything with these fields can participate in ordering and
+ * predecessor-dependency checks.
+ */
+export type MetricSequencePoint = Pick<
+  CanonicalMetricDataPoint,
+  | "seriesId"
+  | "pointId"
+  | "timeUnixMs"
+  | "timeUnixNano"
+  | "metricKind"
+  | "aggregationTemporality"
+>;
+
 /** Mirrors the ClickHouse ORDER BY, which collates PointId by bytes. */
 export function comparePoints(
-  left: CanonicalMetricDataPoint,
-  right: CanonicalMetricDataPoint,
+  left: MetricSequencePoint,
+  right: MetricSequencePoint,
 ): number {
   const leftNano = bigint(left.timeUnixNano);
   const rightNano = bigint(right.timeUnixNano);
@@ -66,7 +82,7 @@ export function startsNewSequence(
  * carry no temporality field yet are always cumulative, so temporality alone
  * cannot answer this.
  */
-export function usesPredecessor(point: CanonicalMetricDataPoint): boolean {
+export function usesPredecessor(point: MetricSequencePoint): boolean {
   return (
     point.metricKind === "summary" ||
     point.aggregationTemporality === "cumulative"


### PR DESCRIPTION
## For humans

The chart-aggregation lanes were crashing with an error that made no sense — a database row missing columns that always exist. The stack capture from #6487 plus reproducing it live finally explained it: the query was running out of memory on the database server, and because the server had already started streaming the response, it could not fail the request — so it wrote the error **into** the response as a line of JSON. Our client read that line as data, and everything downstream blamed the wrong layer, through one wrong rollback.

This fixes both halves: the client now recognizes those in-band error lines and throws the real database error, and the aggregation queries stop fetching a megabyte-sized column they never read — which is what was blowing the memory limit in the first place.

## Root cause (reproduced, not inferred)

Running the exact deployed successor-seek query for a wedged live batch returned a first tranche of rows and then, mid-stream on an accepted response:

```
{"exception": "Code: 241. DB::Exception: Query memory limit exceeded: would use <multiple GiB> … maximum: <per-query cap>: While executing ReplacingSorted."}
```

The seek selected the full row — including the megabyte-scale `CanonicalPayload` column — through `FINAL` across 64 folded branches. The revert of #6481 did not stop the crashes because the per-point path crossed the same cap once the data got fat enough.

## What changed

- **Resilient client**: `json()` results are scanned for the exact exception-row shape (`exception` as sole key); on match the real ClickHouse error is thrown through the existing translator (typed `query_memory_exceeded` for code 241), and the failure is recorded in the failure log + error metric at discovery. Transport-level success accounting stays at query resolution — a caller may stream or never consume, so it cannot be deferred; an in-band failure shows as one success + one error, never as silence.
- **Rollup reads**: the successor seek now selects only the six sequence columns (`SEEK_SELECT`); the affected-bucket reads drop `CanonicalPayload` (`AUTHORITATIVE_SELECT`) — the fold never reads it. Verified against the same wedged batch: the query that died just past the per-query memory cap now returns the full batch cleanly in a response measured in kilobytes.
- New types keep the contract honest: `MetricSequencePoint` names exactly what ordering and predecessor checks read.

## Verification

- Reproduced before/after against live data (read-only): OOM with full select, clean with slim select.
- 43 unit tests on the client + metric paths, 8 repository integration tests against real ClickHouse — green.
- `pnpm typecheck:all` clean; CI's exact Biome merge-base gate: no new violations.

Closes the trigger hunt in #6489.

https://claude.ai/code/session_012RMGtzjs68KfFgpmynqd5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ClickHouse errors returned within streamed query results, including clearer error translation and failure reporting.
  * Preserved legitimate data rows containing an `exception` field.
  * Improved metric rollup processing by reducing unnecessary data reads during recomputation.
* **Tests**
  * Added coverage for streamed ClickHouse exceptions, metrics, normal rows, and efficient rollup queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
