### PR TITLE
fix: add overflowX="auto" to settings tables for horizontal scroll on narrow viewports (Fixes #6174)

### DIFF
--- a/langwatch/src/components/settings/TeamForm.tsx
+++ b/langwatch/src/components/settings/TeamForm.tsx
@@ -220,7 +220,7 @@ export const TeamForm = ({
           )}
         </HStack>
         <Card.Root width="full" overflow="hidden">
-          <Card.Body paddingY={0} paddingX={0}>
+          <Card.Body paddingY={0} paddingX={0} overflowX="auto">
             <Table.Root variant="line" width="full">
               <Table.Header>
                 <Table.Row>
@@ -381,7 +381,7 @@ export const TeamForm = ({
           <>
             <TeamFormProjects team={team} />
             <Card.Root width="full" overflow="hidden">
-              <Card.Body paddingY={0} paddingX={0}>
+              <Card.Body paddingY={0} paddingX={0} overflowX="auto">
                 <Table.Root variant="line" width="full" size="md">
                   <Table.Header>
                     <Table.Row>

--- a/langwatch/src/components/settings/governance/IngestionTemplatesEditor.tsx
+++ b/langwatch/src/components/settings/governance/IngestionTemplatesEditor.tsx
@@ -133,6 +133,7 @@ export function IngestionTemplatesEditor({
           borderColor="border.muted"
           borderRadius="md"
           overflow="hidden"
+          overflowX="auto"
         >
           <Table.Root size="sm">
             <Table.Header backgroundColor="bg.subtle">

--- a/langwatch/src/components/ui/ListTable.tsx
+++ b/langwatch/src/components/ui/ListTable.tsx
@@ -25,6 +25,7 @@ export function ListTable({
       borderColor="border.emphasized"
       borderRadius="md"
       overflow="hidden"
+      overflowX="auto"
     >
       <Table.Root
         variant="line"

--- a/langwatch/src/pages/settings/data-privacy.tsx
+++ b/langwatch/src/pages/settings/data-privacy.tsx
@@ -331,7 +331,7 @@ export function DataPrivacyPage({ projectId }: { projectId: string }) {
         ) : (
           snapshot && (
             <Card.Root width="full" overflow="hidden">
-              <Card.Body paddingX={0} paddingY={0}>
+              <Card.Body paddingX={0} paddingY={0} overflowX="auto">
                 <Table.Root variant="line" size="md" width="full">
                   <Table.Header>
                     <Table.Row>

--- a/langwatch/src/pages/settings/gateway/budgets.tsx
+++ b/langwatch/src/pages/settings/gateway/budgets.tsx
@@ -163,7 +163,7 @@ function BudgetsPage() {
                 </Alert.Root>
               )}
               <Card.Root width="full" overflow="hidden">
-                <Card.Body paddingY={0} paddingX={0}>
+                <Card.Body paddingY={0} paddingX={0} overflowX="auto">
                   <Table.Root variant="line" size="md" width="full">
                     <Table.Header>
                       <Table.Row>

--- a/langwatch/src/pages/settings/gateway/cache-rules.tsx
+++ b/langwatch/src/pages/settings/gateway/cache-rules.tsx
@@ -170,7 +170,7 @@ function CacheRulesPage() {
             </EmptyState.Root>
           ) : (
             <Card.Root width="full" overflow="hidden">
-              <Card.Body paddingY={0} paddingX={0}>
+              <Card.Body paddingY={0} paddingX={0} overflowX="auto">
                 <Table.Root variant="line" size="md" width="full">
                   <Table.Header>
                     <Table.Row>

--- a/langwatch/src/pages/settings/gateway/virtual-keys.tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys.tsx
@@ -299,7 +299,7 @@ function VirtualKeysPage() {
                 </Card.Root>
               ) : (
                 <Card.Root width="full" overflow="hidden">
-                  <Card.Body paddingY={0} paddingX={0}>
+                  <Card.Body paddingY={0} paddingX={0} overflowX="auto">
                     <Table.Root variant="line" size="md" width="full">
                       <Table.Header>
                         <Table.Row>


### PR DESCRIPTION
## Summary

Fixes #6174 — Settings and AI Gateway tables are clipped on narrow viewports instead of scrolling.

### Root cause

Several `Card.Body` and `Box` wrappers set `overflow="hidden"` without providing a horizontal scroll container, so tables wider than the card are simply cut off. No scrollbar appears, and the last columns (including row action menus) become unreachable.

### Changes

**Shared component fix:**
- `langwatch/src/components/ui/ListTable.tsx` — Added `overflowX="auto"` so the default list table wrapper scrolls horizontally when content overflows.

**Surface fixes (7 files):**
- `langwatch/src/pages/settings/gateway/budgets.tsx` — Budgets list table
- `langwatch/src/pages/settings/gateway/virtual-keys.tsx` — Virtual Keys list table
- `langwatch/src/pages/settings/gateway/cache-rules.tsx` — Cache Rules list table
- `langwatch/src/pages/settings/data-privacy.tsx` — Data Privacy rules table
- `langwatch/src/components/settings/TeamForm.tsx` — Team members and projects tables
- `langwatch/src/components/settings/governance/IngestionTemplatesEditor.tsx` — Ingestion templates table

Each surface now has `overflowX="auto"` on the container, matching the existing pattern from Members, Groups, and 11 other settings tables that were already fixed in #4538 and #4658.

### Notes

This is a pure contribution — no bounty was involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added horizontal scrolling to settings tables, including members, projects, governance templates, privacy rules, budgets, cache rules, and virtual keys.
  - Improved usability of wide tables on smaller screens without changing existing layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->