### PR TITLE
refactor(ci): extract the boxd ssh-agent step into a composite action (#5300)

### DIFF
--- a/.github/actions/boxd-ssh-agent/action.yml
+++ b/.github/actions/boxd-ssh-agent/action.yml
@@ -1,0 +1,44 @@
+# Starts an ssh-agent holding the boxd CI key. Extracted from four verbatim
+# copies of the same block across preview-up, preview-down, refresh-staging
+# and reaper in boxd-pr-preview.yml (#5300).
+#
+# The caller MUST check out the repo first, or neither this action nor the
+# script it runs is on disk. None of the four boxd jobs checked anything out
+# before this, so they take a sparse checkout of `.github` rather than the
+# whole monorepo.
+#
+# The shell lives in .github/scripts/start-boxd-ssh-agent.sh rather than inline
+# here, because a composite action's `run:` block cannot be executed by a test.
+# .github/scripts/__tests__/start-boxd-ssh-agent.test.sh drives that file
+# directly, which is what makes this extraction verifiable rather than just
+# shorter.
+#
+# Usage:
+#   - uses: actions/checkout@...
+#     with:
+#       sparse-checkout: .github
+#   - uses: ./.github/actions/boxd-ssh-agent
+#     with:
+#       ssh-key: ${{ secrets.BOXD_SSH_KEY }}
+#       skipped-steps: preview VM steps
+name: boxd-ssh-agent
+description: Start an ssh-agent holding the boxd CI key, or set BOXD_SKIP when no key is configured.
+inputs:
+  ssh-key:
+    description: Private key for the boxd host. Empty means skip the VM steps rather than fail the job.
+    required: false
+    default: ""
+  skipped-steps:
+    description: What the warning names as skipped when no key is configured, e.g. "preview VM steps".
+    required: false
+    default: preview VM steps
+
+runs:
+  using: composite
+  steps:
+    - name: Start ssh-agent with CI key
+      shell: bash
+      env:
+        BOXD_SSH_KEY: ${{ inputs.ssh-key }}
+        SKIPPED_STEPS: ${{ inputs.skipped-steps }}
+      run: bash "$GITHUB_WORKSPACE/.github/scripts/start-boxd-ssh-agent.sh"

--- a/.github/scripts/__tests__/start-boxd-ssh-agent.test.sh
+++ b/.github/scripts/__tests__/start-boxd-ssh-agent.test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Unit tests for start-boxd-ssh-agent.sh
+#
+# Runs the real script, not a copy: the point of extracting the four duplicated
+# blocks into one file is that one file can be driven, and a test that re-states
+# the logic would pass just as happily if the script inverted.
+#
+# HOME is redirected to a temp tree so ~/.ssh is never the real one, and
+# ssh-keyscan is shimmed on PATH so nothing reaches the network. ssh-agent and
+# ssh-add are real: whether the key actually loads is the behaviour under test,
+# and a shimmed ssh-add would assert nothing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$SCRIPTS_DIR/start-boxd-ssh-agent.sh"
+
+PASS=0
+FAIL=0
+
+if [ ! -f "$SCRIPT" ] || [ ! -r "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT is missing or not readable"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$desc (exit $actual)"
+  else
+    fail "$desc: expected exit $expected, got $actual"
+  fi
+}
+
+assert_contains() {
+  local file="$1" needle="$2" desc="$3"
+  if grep -qF -- "$needle" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc: '$needle' not found in $file:"
+    sed 's/^/      /' "$file"
+  fi
+}
+
+assert_absent() {
+  local file="$1" needle="$2" desc="$3"
+  if grep -qF -- "$needle" "$file"; then
+    fail "$desc: '$needle' unexpectedly present in $file"
+  else
+    pass "$desc"
+  fi
+}
+
+# A sandbox per case: its own HOME, its own GITHUB_ENV, and a bin dir holding
+# the ssh-keyscan shim. Echoes the sandbox path.
+setup_sandbox() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  mkdir -p "$tmpdir/home" "$tmpdir/bin"
+  : > "$tmpdir/github_env"
+
+  cat > "$tmpdir/bin/ssh-keyscan" <<'SHIM'
+#!/usr/bin/env bash
+# Stands in for a real key scan of the boxd host. Emits a plausible known_hosts
+# line so the script's redirect has something to write, and never dials out.
+echo "boxd.sh ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIStubKeyForTestsOnly"
+SHIM
+  chmod +x "$tmpdir/bin/ssh-keyscan"
+
+  echo "$tmpdir"
+}
+
+# Kills the agent the script started, if it started one, so cases do not leak
+# daemons into the runner.
+teardown_sandbox() {
+  local tmpdir="$1"
+  local agent_pid
+  agent_pid="$(sed -n 's/^SSH_AGENT_PID=//p' "$tmpdir/github_env" | tail -1)"
+  if [ -n "$agent_pid" ]; then
+    kill "$agent_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+
+# Runs the script with the sandbox in place. Extra env comes in as NAME=VALUE
+# arguments. Stdout and stderr land in $tmpdir/output.
+run_script() {
+  local tmpdir="$1"
+  shift
+  set +e
+  env -i \
+    PATH="$tmpdir/bin:/usr/bin:/bin" \
+    HOME="$tmpdir/home" \
+    GITHUB_ENV="$tmpdir/github_env" \
+    "$@" \
+    bash "$SCRIPT" > "$tmpdir/output" 2>&1
+  local code=$?
+  set -e
+  return $code
+}
+
+# ---------------------------------------------------------------------------
+# Case a: no key at all, the fork / unconfigured-secret path.
+# Degrading here is deliberate, so the assertion is that it degrades AND says
+# so, not merely that it exits 0.
+# ---------------------------------------------------------------------------
+
+run_case_a() {
+  local tmpdir exit_code
+  tmpdir="$(setup_sandbox)"
+
+  exit_code=0
+  run_script "$tmpdir" SKIPPED_STEPS="preview VM steps" || exit_code=$?
+
+  assert_exit 0 "$exit_code" "case a: no BOXD_SSH_KEY → exit 0"
+  assert_contains "$tmpdir/github_env" "BOXD_SKIP=true" \
+    "case a: no key → BOXD_SKIP=true so later steps opt out"
+  assert_contains "$tmpdir/output" \
+    "::warning::BOXD_SSH_KEY is not configured; preview VM steps skipped" \
+    "case a: no key → warning names what was skipped"
+  assert_absent "$tmpdir/github_env" "SSH_AUTH_SOCK=" \
+    "case a: no key → no agent socket exported"
+
+  teardown_sandbox "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Case b: the secret exists but is empty. GitHub hands an unset secret through
+# as an empty string, so this is the shape the fork case actually arrives in.
+# ---------------------------------------------------------------------------
+
+run_case_b() {
+  local tmpdir exit_code
+  tmpdir="$(setup_sandbox)"
+
+  exit_code=0
+  run_script "$tmpdir" BOXD_SSH_KEY="" SKIPPED_STEPS="orphan reaper steps" || exit_code=$?
+
+  assert_exit 0 "$exit_code" "case b: empty BOXD_SSH_KEY → exit 0"
+  assert_contains "$tmpdir/github_env" "BOXD_SKIP=true" \
+    "case b: empty key → BOXD_SKIP=true"
+  assert_contains "$tmpdir/output" \
+    "::warning::BOXD_SSH_KEY is not configured; orphan reaper steps skipped" \
+    "case b: the caller's label reaches the warning, not a hardcoded one"
+
+  teardown_sandbox "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Case c: a usable key. The four copies disagreed about SSH_AGENT_PID, so both
+# exports are asserted, and the key is checked to be really in the agent rather
+# than the agent merely having started.
+# ---------------------------------------------------------------------------
+
+run_case_c() {
+  local tmpdir exit_code key
+  tmpdir="$(setup_sandbox)"
+  key="$tmpdir/id_ed25519"
+  ssh-keygen -q -t ed25519 -N "" -C "start-boxd-ssh-agent-test" -f "$key"
+
+  exit_code=0
+  run_script "$tmpdir" BOXD_SSH_KEY="$(cat "$key")" || exit_code=$?
+
+  assert_exit 0 "$exit_code" "case c: usable key → exit 0"
+  assert_absent "$tmpdir/github_env" "BOXD_SKIP=true" \
+    "case c: usable key → does not set BOXD_SKIP"
+  assert_contains "$tmpdir/github_env" "SSH_AUTH_SOCK=" \
+    "case c: usable key → exports the agent socket"
+  assert_contains "$tmpdir/github_env" "SSH_AGENT_PID=" \
+    "case c: usable key → exports the agent pid so later steps can kill it"
+  assert_contains "$tmpdir/home/.ssh/known_hosts" "boxd.sh" \
+    "case c: usable key → the boxd host lands in known_hosts"
+
+  local sock
+  sock="$(sed -n 's/^SSH_AUTH_SOCK=//p' "$tmpdir/github_env" | tail -1)"
+  if SSH_AUTH_SOCK="$sock" ssh-add -l 2>/dev/null | grep -q "start-boxd-ssh-agent-test"; then
+    pass "case c: usable key → the key is loaded into the running agent"
+  else
+    fail "case c: agent started but the key is not in it"
+  fi
+
+  teardown_sandbox "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Case d: a key that is present but not a key. This is a broken secret, not a
+# missing one, and it must fail the job. Degrading here would report "no
+# preview configured" for as long as the secret stayed corrupt.
+# ---------------------------------------------------------------------------
+
+run_case_d() {
+  local tmpdir exit_code
+  tmpdir="$(setup_sandbox)"
+
+  exit_code=0
+  run_script "$tmpdir" BOXD_SSH_KEY="not actually a private key" || exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    pass "case d: unusable key → non-zero exit (exit $exit_code)"
+  else
+    fail "case d: unusable key exited 0, so a corrupt secret would pass silently"
+  fi
+  assert_absent "$tmpdir/github_env" "BOXD_SKIP=true" \
+    "case d: unusable key → not reported as an absent key"
+
+  teardown_sandbox "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Case e: no SKIPPED_STEPS supplied. The composite action defaults it, but the
+# script is what runs, so it carries its own default rather than emitting
+# "; skipped" with a hole in the middle.
+# ---------------------------------------------------------------------------
+
+run_case_e() {
+  local tmpdir exit_code
+  tmpdir="$(setup_sandbox)"
+
+  exit_code=0
+  run_script "$tmpdir" || exit_code=$?
+
+  assert_exit 0 "$exit_code" "case e: no SKIPPED_STEPS → exit 0"
+  assert_contains "$tmpdir/output" \
+    "::warning::BOXD_SSH_KEY is not configured; preview VM steps skipped" \
+    "case e: no SKIPPED_STEPS → falls back to a complete sentence"
+
+  teardown_sandbox "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Run all cases
+# ---------------------------------------------------------------------------
+
+run_case_a
+run_case_b
+run_case_c
+run_case_d
+run_case_e
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/start-boxd-ssh-agent.sh
+++ b/.github/scripts/start-boxd-ssh-agent.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Starts an ssh-agent holding the boxd CI key for the preview-VM jobs in
+# boxd-pr-preview.yml. Extracted from four verbatim copies of the same block
+# (#5300), and kept as a script rather than inline composite-action shell so
+# __tests__/start-boxd-ssh-agent.test.sh can drive the real thing instead of a
+# copy of it.
+#
+# A missing key is not a failure. Forks and secret-less environments are
+# expected, so the run degrades: BOXD_SKIP=true goes into the environment and
+# every later step opts out through `if: env.BOXD_SKIP != 'true'`. A key that
+# is present but unusable IS a failure, because that is a broken secret rather
+# than an absent one, and skipping quietly would read as "no preview
+# configured" forever.
+#
+# Env in:
+#   BOXD_SSH_KEY   private key for the boxd host; empty or unset means skip
+#   SKIPPED_STEPS  what the warning names as skipped, e.g. "preview VM steps"
+#   BOXD_SSH_HOST  host to add to known_hosts (default boxd.sh)
+#   GITHUB_ENV     set by the runner; the file later steps read their env from
+set -euo pipefail
+
+skipped_steps="${SKIPPED_STEPS:-preview VM steps}"
+boxd_host="${BOXD_SSH_HOST:-boxd.sh}"
+
+if [ -z "${BOXD_SSH_KEY:-}" ]; then
+  echo "BOXD_SKIP=true" >> "$GITHUB_ENV"
+  echo "::warning::BOXD_SSH_KEY is not configured; ${skipped_steps} skipped"
+  exit 0
+fi
+
+mkdir -p ~/.ssh
+ssh-keyscan -T 10 "$boxd_host" >> ~/.ssh/known_hosts 2>/dev/null
+
+eval "$(ssh-agent -s)"
+echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+# preview-up exported the pid and the other three did not, so on those the
+# agent outlived the job with nothing able to name it. Exporting it everywhere
+# is the drift the four copies were hiding.
+echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+
+printf '%s\n' "$BOXD_SSH_KEY" | ssh-add -

--- a/.github/workflows/boxd-pr-preview.yml
+++ b/.github/workflows/boxd-pr-preview.yml
@@ -36,26 +36,22 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # The ssh-agent step below is a local action, so it has to be on disk
+      # first. Sparse: nothing else in this job reads the tree.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          sparse-checkout: .github
+
       - name: Install boxd CLI
         run: |
           curl -fsSL https://boxd.sh/downloads/cli/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Start ssh-agent with CI key
-        env:
-          BOXD_SSH_KEY: ${{ secrets.BOXD_SSH_KEY }}
-        run: |
-          if [ -z "$BOXD_SSH_KEY" ]; then
-            echo "BOXD_SKIP=true" >> "$GITHUB_ENV"
-            echo "::warning::BOXD_SSH_KEY is not configured; preview VM steps skipped"
-            exit 0
-          fi
-          mkdir -p ~/.ssh
-          ssh-keyscan -T 10 boxd.sh >> ~/.ssh/known_hosts 2>/dev/null
-          eval "$(ssh-agent -s)"
-          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
-          printf '%s\n' "$BOXD_SSH_KEY" | ssh-add -
+      - uses: ./.github/actions/boxd-ssh-agent
+        with:
+          ssh-key: ${{ secrets.BOXD_SSH_KEY }}
+          skipped-steps: preview VM steps
 
       - name: FIFO-evict oldest pr<N> if over soft cap
         if: env.BOXD_SKIP != 'true'
@@ -180,25 +176,22 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # The ssh-agent step below is a local action, so it has to be on disk
+      # first. Sparse: nothing else in this job reads the tree.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          sparse-checkout: .github
+
       - name: Install boxd CLI
         run: |
           curl -fsSL https://boxd.sh/downloads/cli/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Start ssh-agent with CI key
-        env:
-          BOXD_SSH_KEY: ${{ secrets.BOXD_SSH_KEY }}
-        run: |
-          if [ -z "$BOXD_SSH_KEY" ]; then
-            echo "BOXD_SKIP=true" >> "$GITHUB_ENV"
-            echo "::warning::BOXD_SSH_KEY is not configured; preview VM steps skipped"
-            exit 0
-          fi
-          mkdir -p ~/.ssh
-          ssh-keyscan -T 10 boxd.sh >> ~/.ssh/known_hosts 2>/dev/null
-          eval "$(ssh-agent -s)"
-          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          printf '%s\n' "$BOXD_SSH_KEY" | ssh-add -
+      - uses: ./.github/actions/boxd-ssh-agent
+        with:
+          ssh-key: ${{ secrets.BOXD_SSH_KEY }}
+          skipped-steps: preview VM steps
 
       - name: Destroy pr<N>
         if: env.BOXD_SKIP != 'true'
@@ -228,25 +221,22 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      # The ssh-agent step below is a local action, so it has to be on disk
+      # first. Sparse: nothing else in this job reads the tree.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          sparse-checkout: .github
+
       - name: Install boxd CLI
         run: |
           curl -fsSL https://boxd.sh/downloads/cli/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Start ssh-agent with CI key
-        env:
-          BOXD_SSH_KEY: ${{ secrets.BOXD_SSH_KEY }}
-        run: |
-          if [ -z "$BOXD_SSH_KEY" ]; then
-            echo "BOXD_SKIP=true" >> "$GITHUB_ENV"
-            echo "::warning::BOXD_SSH_KEY is not configured; staging refresh steps skipped"
-            exit 0
-          fi
-          mkdir -p ~/.ssh
-          ssh-keyscan -T 10 boxd.sh >> ~/.ssh/known_hosts 2>/dev/null
-          eval "$(ssh-agent -s)"
-          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          printf '%s\n' "$BOXD_SSH_KEY" | ssh-add -
+      - uses: ./.github/actions/boxd-ssh-agent
+        with:
+          ssh-key: ${{ secrets.BOXD_SSH_KEY }}
+          skipped-steps: staging refresh steps
 
       # Soft refresh: git reset --hard origin/main + compose up --build on the running staging VM.
       # "Dirty staging" risk is bounded by the no-human-access policy; full destroy/recreate is future work (see TODO below).
@@ -288,25 +278,22 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
+      # The ssh-agent step below is a local action, so it has to be on disk
+      # first. Sparse: nothing else in this job reads the tree.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          sparse-checkout: .github
+
       - name: Install boxd CLI
         run: |
           curl -fsSL https://boxd.sh/downloads/cli/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Start ssh-agent with CI key
-        env:
-          BOXD_SSH_KEY: ${{ secrets.BOXD_SSH_KEY }}
-        run: |
-          if [ -z "$BOXD_SSH_KEY" ]; then
-            echo "BOXD_SKIP=true" >> "$GITHUB_ENV"
-            echo "::warning::BOXD_SSH_KEY is not configured; orphan reaper steps skipped"
-            exit 0
-          fi
-          mkdir -p ~/.ssh
-          ssh-keyscan -T 10 boxd.sh >> ~/.ssh/known_hosts 2>/dev/null
-          eval "$(ssh-agent -s)"
-          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          printf '%s\n' "$BOXD_SSH_KEY" | ssh-add -
+      - uses: ./.github/actions/boxd-ssh-agent
+        with:
+          ssh-key: ${{ secrets.BOXD_SSH_KEY }}
+          skipped-steps: orphan reaper steps
 
       - name: Reap pr<N> VMs whose PRs are CLOSED or MERGED
         if: env.BOXD_SKIP != 'true'

--- a/.github/workflows/boxd-pr-preview.yml
+++ b/.github/workflows/boxd-pr-preview.yml
@@ -34,10 +34,14 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
+      # Job-level permissions replace the workflow-level block rather than
+      # merging with it, so `contents: read` has to be restated here for the
+      # checkout below.
+      contents: read
       pull-requests: write
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
-      # first. Sparse: nothing else in this job reads the tree.
+      # first. Sparse because `.github` is all of the tree it needs.
       #
       # persist-credentials: false because nothing here talks to git after the
       # checkout, and the default would leave the workflow token in
@@ -179,10 +183,14 @@ jobs:
       && github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:
+      # Job-level permissions replace the workflow-level block rather than
+      # merging with it, so `contents: read` has to be restated here for the
+      # checkout below.
+      contents: read
       pull-requests: write
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
-      # first. Sparse: nothing else in this job reads the tree.
+      # first. Sparse because `.github` is all of the tree it needs.
       #
       # persist-credentials: false because nothing here talks to git after the
       # checkout, and the default would leave the workflow token in
@@ -232,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
-      # first. Sparse: nothing else in this job reads the tree.
+      # first. Sparse because `.github` is all of the tree it needs.
       #
       # persist-credentials: false because nothing here talks to git after the
       # checkout, and the default would leave the workflow token in
@@ -294,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
-      # first. Sparse: nothing else in this job reads the tree.
+      # first. Sparse because `.github` is all of the tree it needs.
       #
       # persist-credentials: false because nothing here talks to git after the
       # checkout, and the default would leave the workflow token in

--- a/.github/workflows/boxd-pr-preview.yml
+++ b/.github/workflows/boxd-pr-preview.yml
@@ -38,10 +38,15 @@ jobs:
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
       # first. Sparse: nothing else in this job reads the tree.
+      #
+      # persist-credentials: false because nothing here talks to git after the
+      # checkout, and the default would leave the workflow token in
+      # .git/config for the `curl | sh` installer that runs next.
       - name: Check out .github
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           sparse-checkout: .github
+          persist-credentials: false
 
       - name: Install boxd CLI
         run: |
@@ -178,10 +183,15 @@ jobs:
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
       # first. Sparse: nothing else in this job reads the tree.
+      #
+      # persist-credentials: false because nothing here talks to git after the
+      # checkout, and the default would leave the workflow token in
+      # .git/config for the `curl | sh` installer that runs next.
       - name: Check out .github
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           sparse-checkout: .github
+          persist-credentials: false
 
       - name: Install boxd CLI
         run: |
@@ -223,10 +233,15 @@ jobs:
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
       # first. Sparse: nothing else in this job reads the tree.
+      #
+      # persist-credentials: false because nothing here talks to git after the
+      # checkout, and the default would leave the workflow token in
+      # .git/config for the `curl | sh` installer that runs next.
       - name: Check out .github
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           sparse-checkout: .github
+          persist-credentials: false
 
       - name: Install boxd CLI
         run: |
@@ -280,10 +295,15 @@ jobs:
     steps:
       # The ssh-agent step below is a local action, so it has to be on disk
       # first. Sparse: nothing else in this job reads the tree.
+      #
+      # persist-credentials: false because nothing here talks to git after the
+      # checkout, and the default would leave the workflow token in
+      # .git/config for the `curl | sh` installer that runs next.
       - name: Check out .github
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           sparse-checkout: .github
+          persist-credentials: false
 
       - name: Install boxd CLI
         run: |

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -108,6 +108,10 @@ jobs:
               - '.github/workflows/langwatch-app-ci.yml'
               - '.github/.release-please-manifest.json'
               - '.github/scripts/**'
+              # Composite actions are covered by ci-scripts-test through the
+              # scripts they call, so an edit that only touches an action.yml
+              # has to reach the gate too.
+              - '.github/actions/**'
             # The parity scanner binds @scenario annotations from test files
             # across many roots, not just specs/ and platform/app/. This list MUST
             # cover every root the scanner reads (DEFAULT_TEST_ROOTS,
@@ -882,6 +886,9 @@ jobs:
 
       - name: Test start-clickhouse-with-storage-policy.sh
         run: bash .github/scripts/__tests__/start-clickhouse-with-storage-policy.test.sh
+
+      - name: Test start-boxd-ssh-agent.sh
+        run: bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
 
   ci-self-test:
     needs: changes


### PR DESCRIPTION
## Ticket

Closes #5300. The "Start ssh-agent with CI key" step is duplicated verbatim across four jobs in `boxd-pr-preview.yml` (`preview-up`, `preview-down`, `refresh-staging`, `reaper`), ~48 lines. Flagged on PR #3772 as "Non-blocking (Decide / New Issue)" and never filed until this ticket.

## Change

`.github/actions/boxd-ssh-agent/action.yml`, a composite action with two inputs: `ssh-key` and `skipped-steps` (the only thing the four copies actually varied, in the warning text).

The shell body lives in `.github/scripts/start-boxd-ssh-agent.sh`, not inline in the action. A composite action's `run:` block cannot be executed by anything but a workflow run, so inlining it would have made the extraction shorter but no more verifiable. As a script it is driven directly by `.github/scripts/__tests__/start-boxd-ssh-agent.test.sh`, which is the same shape the repo already uses for `extract-failures.sh` and `start-clickhouse-with-storage-policy.sh`.

Two things worth flagging, because neither is purely subtractive:

**The four copies had already drifted.** Only `preview-up` exported `SSH_AGENT_PID`. On the other three the agent started and outlived the job with nothing able to name it, so no later step could kill it. The action exports it in all four. Nothing reads `SSH_AGENT_PID` today, so this is inert in behaviour and consistent in intent.

**Each job now takes a sparse checkout of `.github`.** A local action has to be on disk before it can be used, and none of the four jobs checked anything out. `sparse-checkout: .github` buys the action and its script rather than the whole monorepo. This is the real cost of the extraction: 48 duplicated lines traded for four sparse checkouts. GitHub Actions offers no other way to share a step, so it is that or the duplication.

`.github/actions/**` joins the `relevant` filter in `langwatch-app-ci.yml`. Without it, a later edit confined to `action.yml` would merge without the script test that covers it ever running, which is the same failure mode the `feature-parity` filter comment right below it was written about.

## Evidence

**The extraction is behaviour-preserving.** The four replaced blocks were compared to the script line by line. The only differences are the two the action parameterises (the warning label) and normalises (the `SSH_AGENT_PID` export, above).

**17 assertions over 5 cases, against the real script, no copies:**

```
$ bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
PASS: case a: no BOXD_SSH_KEY → exit 0 (exit 0)
PASS: case a: no key → BOXD_SKIP=true so later steps opt out
PASS: case a: no key → warning names what was skipped
PASS: case a: no key → no agent socket exported
PASS: case b: empty BOXD_SSH_KEY → exit 0 (exit 0)
PASS: case b: empty key → BOXD_SKIP=true
PASS: case b: the caller's label reaches the warning, not a hardcoded one
PASS: case c: usable key → exit 0 (exit 0)
PASS: case c: usable key → does not set BOXD_SKIP
PASS: case c: usable key → exports the agent socket
PASS: case c: usable key → exports the agent pid so later steps can kill it
PASS: case c: usable key → the boxd host lands in known_hosts
PASS: case c: usable key → the key is loaded into the running agent
PASS: case d: unusable key → non-zero exit (exit 1)
PASS: case d: unusable key → not reported as an absent key
PASS: case e: no SKIPPED_STEPS → exit 0 (exit 0)
PASS: case e: no SKIPPED_STEPS → falls back to a complete sentence

Results: 17 passed, 0 failed
```

`ssh-keyscan` is shimmed on `PATH` so nothing dials out and `HOME` is a temp tree, but `ssh-agent` and `ssh-add` are real: whether the key actually loads is the behaviour under test, and a shimmed `ssh-add` would assert nothing. Case c reads the socket back out of the written `GITHUB_ENV` and checks the key is in the agent by comment.

**Every assertion was mutation-tested.** Four edits to the script, each caught:

| Mutation | Caught by |
|---|---|
| Drop the `SSH_AGENT_PID` export (back to the pre-existing drift) | case c, 16/1 |
| `exit 1` instead of `exit 0` on a missing key | cases a, b, e, 14/3 |
| Hardcode the warning label instead of using the input | case b, 16/1 |
| `ssh-add - \|\| true`, swallowing a corrupt secret | case d, 16/1 |

Case d is the one worth keeping: a key that is present but unusable is a broken secret, not an absent one, and must fail the job. Degrading there would report "no preview configured" for as long as the secret stayed corrupt.

**Linting.** `shellcheck` clean on both new scripts. `actionlint` reports nothing new on either workflow; the three shellcheck findings it surfaces in `langwatch-app-ci.yml` are pre-existing and identical on `origin/main` (3 before, 3 after, at lines 664/759/816, none of them near this diff).

## Not covered

The boxd jobs only run on `pull_request` against this repo, on a schedule, or on `workflow_dispatch`, so this PR's own CI does not exercise them end to end. The script test is what stands in for that. The first real proof is the next preview-VM run on main.

---

*Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined preview environment setup with reusable SSH-agent automation.
  * Preview jobs now handle missing or invalid SSH credentials consistently, with clear skip behavior when credentials are unavailable.
  * SSH host registration and environment configuration are handled automatically for supported preview workflows.
  * CI more reliably detects changes to workflow actions.

* **Tests**
  * Added comprehensive coverage for SSH setup, credential validation, environment configuration, host registration, cleanup, and failure scenarios.
  * CI now runs these checks automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->