### PR TITLE
fix(sdk): normalize the configured endpoint so a trailing slash stops 404ing

### DIFF
--- a/mcp-server/src/__tests__/config.unit.test.ts
+++ b/mcp-server/src/__tests__/config.unit.test.ts
@@ -64,6 +64,11 @@ describe("config", () => {
       expect(getConfig().endpoint).toBe("https://cli.example.com");
     });
 
+    it("trims whitespace around a CLI endpoint", () => {
+      initConfig({ endpoint: "  https://cli.example.com///  " });
+      expect(getConfig().endpoint).toBe("https://cli.example.com");
+    });
+
     it("strips repeated slashes from the env var", () => {
       process.env.LANGWATCH_ENDPOINT = "http://localhost:5560///";
       initConfig({});

--- a/mcp-server/src/__tests__/config.unit.test.ts
+++ b/mcp-server/src/__tests__/config.unit.test.ts
@@ -58,6 +58,34 @@ describe("config", () => {
     });
   });
 
+  describe("when the endpoint carries a trailing slash", () => {
+    it("strips it from a CLI endpoint", () => {
+      initConfig({ endpoint: "https://cli.example.com/" });
+      expect(getConfig().endpoint).toBe("https://cli.example.com");
+    });
+
+    it("strips repeated slashes from the env var", () => {
+      process.env.LANGWATCH_ENDPOINT = "http://localhost:5560///";
+      initConfig({});
+      expect(getConfig().endpoint).toBe("http://localhost:5560");
+    });
+
+    it("keeps the built request path free of a double slash", () => {
+      initConfig({ endpoint: "https://app.langwatch.ai/" });
+      expect(`${getConfig().endpoint}/api/bug-reports`).toBe(
+        "https://app.langwatch.ai/api/bug-reports",
+      );
+    });
+  });
+
+  describe("when the endpoint is blank", () => {
+    it("falls back to the default rather than an empty base url", () => {
+      process.env.LANGWATCH_ENDPOINT = "   ";
+      initConfig({});
+      expect(getConfig().endpoint).toBe("https://app.langwatch.ai");
+    });
+  });
+
   describe("when no args or env vars are provided", () => {
     it("defaults endpoint to https://app.langwatch.ai", () => {
       initConfig({});

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -49,13 +49,28 @@ function getGlobalState(): McpGlobalState {
   };
 }
 
+/**
+ * Trim surrounding whitespace and drop any trailing slashes.
+ *
+ * Request URLs are built as `${endpoint}/api/...`, so an endpoint written as
+ * `https://app.langwatch.ai/` would produce a double slash the router does not
+ * match, and the caller gets an opaque 404 with nothing pointing at the
+ * endpoint as the cause.
+ */
+function normalizeEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+  let end = trimmed.length;
+  while (end > 0 && trimmed[end - 1] === "/") end--;
+  return trimmed.slice(0, end);
+}
+
 export function initConfig(args: { apiKey?: string; endpoint?: string }): void {
   const state = getGlobalState();
   state.globalConfig = {
     apiKey: args.apiKey || process.env.LANGWATCH_API_KEY,
     endpoint:
-      args.endpoint ||
-      process.env.LANGWATCH_ENDPOINT ||
+      normalizeEndpoint(args.endpoint ?? "") ||
+      normalizeEndpoint(process.env.LANGWATCH_ENDPOINT ?? "") ||
       "https://app.langwatch.ai",
     projectId: process.env.LANGWATCH_PROJECT_ID,
   };

--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Sequence, ClassVar
 from langwatch.__version__ import __version__
 from langwatch.attributes import AttributeKey
 from langwatch.domain import BaseAttributes, SpanProcessingExcludeRule
-from langwatch.state import get_instance
+from langwatch.state import DEFAULT_ENDPOINT, get_instance, normalize_endpoint
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
@@ -232,7 +232,7 @@ class Client(LangWatchClientProtocol):
             Client._project_id = os.getenv("LANGWATCH_PROJECT_ID")
 
         if endpoint_url is not None:
-            Client._endpoint_url = endpoint_url
+            Client._endpoint_url = normalize_endpoint(endpoint_url)
         else:
             # Always re-read LANGWATCH_ENDPOINT from env on every setup()
             # call. The previous "pin once on first init" behavior caused
@@ -243,11 +243,11 @@ class Client(LangWatchClientProtocol):
             # callback 401 against the cloud API. Re-reading per-call costs
             # one os.getenv lookup; the explicit endpoint_url path above
             # still wins.
-            env_endpoint = os.getenv("LANGWATCH_ENDPOINT")
+            env_endpoint = normalize_endpoint(os.getenv("LANGWATCH_ENDPOINT") or "")
             if env_endpoint:
                 Client._endpoint_url = env_endpoint
             elif not Client._endpoint_url:
-                Client._endpoint_url = "https://app.langwatch.ai"
+                Client._endpoint_url = DEFAULT_ENDPOINT
 
         if debug is not None:
             Client._debug = debug

--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -232,7 +232,7 @@ class Client(LangWatchClientProtocol):
             Client._project_id = os.getenv("LANGWATCH_PROJECT_ID")
 
         if endpoint_url is not None:
-            Client._endpoint_url = normalize_endpoint(endpoint_url)
+            Client._endpoint_url = normalize_endpoint(endpoint_url) or DEFAULT_ENDPOINT
         else:
             # Always re-read LANGWATCH_ENDPOINT from env on every setup()
             # call. The previous "pin once on first init" behavior caused

--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -147,8 +147,18 @@ class Client(LangWatchClientProtocol):
                 ):
                     self.__shutdown_tracer_provider()
                     self.__setup_tracer_provider()
-            if endpoint_url is not None and endpoint_url != Client._endpoint_url:
-                Client._endpoint_url = endpoint_url
+            # Normalized before the comparison, so reconfiguring with the same
+            # endpoint written differently ("https://host/" for "https://host")
+            # is recognized as unchanged and does not restart the exporter.
+            # A value that normalizes to nothing is treated as not supplied
+            # rather than as the cloud default: this instance already has an
+            # endpoint, and silently moving a self-hosted client to the cloud
+            # is worse than ignoring a blank argument.
+            normalized_endpoint = (
+                normalize_endpoint(endpoint_url) if endpoint_url is not None else None
+            )
+            if normalized_endpoint and normalized_endpoint != Client._endpoint_url:
+                Client._endpoint_url = normalized_endpoint
                 if (
                     not Client._skip_open_telemetry_setup
                     and not Client._disable_sending

--- a/python-sdk/src/langwatch/state.py
+++ b/python-sdk/src/langwatch/state.py
@@ -4,6 +4,8 @@ import os
 from typing import Optional
 from .types import LangWatchClientProtocol
 
+DEFAULT_ENDPOINT = "https://app.langwatch.ai"
+
 # Singleton instance of the client
 __instance: Optional[LangWatchClientProtocol] = None
 
@@ -16,11 +18,23 @@ def set_instance(client: LangWatchClientProtocol) -> None:
     global __instance
     __instance = client
 
+def normalize_endpoint(endpoint: str) -> str:
+    """Trim surrounding whitespace and drop any trailing slashes.
+
+    Request URLs are built by appending paths that already carry a leading
+    slash, so an endpoint written as ``https://app.langwatch.ai/`` would
+    produce ``https://app.langwatch.ai//api/experiment/init``. The router does
+    not match that, and the caller gets an opaque 404 with nothing pointing at
+    the endpoint as the cause.
+    """
+    return endpoint.strip().rstrip("/")
+
+
 def get_endpoint() -> str:
     """Get the current endpoint URL of the LangWatch client."""
     if __instance is None:
-        return os.getenv("LANGWATCH_ENDPOINT") or "https://app.langwatch.ai"
-    return __instance.endpoint_url
+        return normalize_endpoint(os.getenv("LANGWATCH_ENDPOINT") or "") or DEFAULT_ENDPOINT
+    return normalize_endpoint(__instance.endpoint_url) or DEFAULT_ENDPOINT
 
 def get_api_key() -> str:
     """Get the current API key of the LangWatch client."""

--- a/python-sdk/tests/test_endpoint_normalization.py
+++ b/python-sdk/tests/test_endpoint_normalization.py
@@ -76,6 +76,46 @@ class TestClientSetup:
         finally:
             Client.reset_for_testing()
 
+    def test_an_equivalent_spelling_does_not_restart_the_exporter(self) -> None:
+        """Normalizing before the comparison makes the reconfiguration a no-op."""
+        Client.reset_for_testing()
+        with (
+            patch.object(Client, "_Client__setup_tracer_provider") as setup,
+            patch.object(Client, "_Client__shutdown_tracer_provider") as shutdown,
+        ):
+            try:
+                Client(api_key="test-key", endpoint_url="https://host.example.com")
+                setup.reset_mock()
+                shutdown.reset_mock()
+
+                reconfigured = Client(endpoint_url="  https://host.example.com///  ")
+
+                setup.assert_not_called()
+                shutdown.assert_not_called()
+                assert reconfigured.endpoint_url == "https://host.example.com"
+            finally:
+                Client.reset_for_testing()
+
+    def test_a_genuinely_different_endpoint_still_restarts_the_exporter(self) -> None:
+        """The no-restart assertion above would be vacuous without this."""
+        Client.reset_for_testing()
+        with (
+            patch.object(Client, "_Client__setup_tracer_provider") as setup,
+            patch.object(Client, "_Client__shutdown_tracer_provider") as shutdown,
+        ):
+            try:
+                Client(api_key="test-key", endpoint_url="https://host.example.com")
+                setup.reset_mock()
+                shutdown.reset_mock()
+
+                reconfigured = Client(endpoint_url="https://other.example.com/")
+
+                assert reconfigured.endpoint_url == "https://other.example.com"
+                setup.assert_called_once()
+                shutdown.assert_called_once()
+            finally:
+                Client.reset_for_testing()
+
     def test_keeps_the_endpoint_when_reconfigured_with_a_blank_value(self) -> None:
         """A blank argument must not move a self-hosted client to the cloud."""
         Client.reset_for_testing()

--- a/python-sdk/tests/test_endpoint_normalization.py
+++ b/python-sdk/tests/test_endpoint_normalization.py
@@ -63,6 +63,33 @@ class TestClientSetup:
         finally:
             Client.reset_for_testing()
 
+    def test_normalizes_when_reconfiguring_an_existing_instance(self) -> None:
+        Client.reset_for_testing()
+        try:
+            Client(
+                api_key="test-key",
+                endpoint_url="https://first.example.com",
+                skip_open_telemetry_setup=True,
+            )
+            reconfigured = Client(endpoint_url="  https://second.example.com///  ")
+            assert reconfigured.endpoint_url == "https://second.example.com"
+        finally:
+            Client.reset_for_testing()
+
+    def test_keeps_the_endpoint_when_reconfigured_with_a_blank_value(self) -> None:
+        """A blank argument must not move a self-hosted client to the cloud."""
+        Client.reset_for_testing()
+        try:
+            Client(
+                api_key="test-key",
+                endpoint_url="https://self.hosted.example.com",
+                skip_open_telemetry_setup=True,
+            )
+            reconfigured = Client(endpoint_url="   ")
+            assert reconfigured.endpoint_url == "https://self.hosted.example.com"
+        finally:
+            Client.reset_for_testing()
+
     def test_stores_the_endpoint_without_its_trailing_slash(self) -> None:
         Client.reset_for_testing()
         try:

--- a/python-sdk/tests/test_endpoint_normalization.py
+++ b/python-sdk/tests/test_endpoint_normalization.py
@@ -1,0 +1,54 @@
+"""A trailing slash on the endpoint must not reach the URL builders.
+
+Request URLs are built as ``f"{get_endpoint()}/api/experiment/init"``, so an
+endpoint written as ``https://app.langwatch.ai/`` produced a double slash the
+router does not match, and the caller saw an opaque 404.
+"""
+
+from unittest.mock import patch
+
+import langwatch
+from langwatch.client import Client
+from langwatch.state import DEFAULT_ENDPOINT, get_endpoint, normalize_endpoint
+
+
+class TestNormalizeEndpoint:
+    def test_strips_a_trailing_slash(self) -> None:
+        assert normalize_endpoint("https://app.langwatch.ai/") == "https://app.langwatch.ai"
+
+    def test_strips_repeated_trailing_slashes(self) -> None:
+        assert normalize_endpoint("http://localhost:5560///") == "http://localhost:5560"
+
+    def test_trims_surrounding_whitespace(self) -> None:
+        assert normalize_endpoint("  https://app.langwatch.ai/  ") == "https://app.langwatch.ai"
+
+    def test_leaves_a_clean_endpoint_untouched(self) -> None:
+        assert normalize_endpoint("https://app.langwatch.ai") == "https://app.langwatch.ai"
+
+
+class TestGetEndpointWithoutAClient:
+    def test_strips_the_trailing_slash_from_the_environment(self) -> None:
+        with patch.dict("os.environ", {"LANGWATCH_ENDPOINT": "https://app.langwatch.ai/"}):
+            assert get_endpoint() == "https://app.langwatch.ai"
+
+    def test_falls_back_to_the_default_when_the_environment_is_blank(self) -> None:
+        with patch.dict("os.environ", {"LANGWATCH_ENDPOINT": "   "}):
+            assert get_endpoint() == DEFAULT_ENDPOINT
+
+
+class TestClientSetup:
+    def test_stores_the_endpoint_without_its_trailing_slash(self) -> None:
+        Client.reset_for_testing()
+        try:
+            client = Client(
+                api_key="test-key",
+                endpoint_url="https://app.langwatch.ai/",
+                skip_open_telemetry_setup=True,
+            )
+            assert client.endpoint_url == "https://app.langwatch.ai"
+            assert langwatch.get_endpoint() == "https://app.langwatch.ai"
+            assert f"{langwatch.get_endpoint()}/api/experiment/init" == (
+                "https://app.langwatch.ai/api/experiment/init"
+            )
+        finally:
+            Client.reset_for_testing()

--- a/python-sdk/tests/test_endpoint_normalization.py
+++ b/python-sdk/tests/test_endpoint_normalization.py
@@ -37,6 +37,32 @@ class TestGetEndpointWithoutAClient:
 
 
 class TestClientSetup:
+    def test_falls_back_to_the_default_when_the_explicit_endpoint_is_blank(self) -> None:
+        Client.reset_for_testing()
+        try:
+            client = Client(
+                api_key="test-key",
+                endpoint_url="   ",
+                skip_open_telemetry_setup=True,
+            )
+            assert client.endpoint_url == DEFAULT_ENDPOINT
+        finally:
+            Client.reset_for_testing()
+
+    def test_falls_back_to_the_default_when_the_explicit_endpoint_is_only_slashes(
+        self,
+    ) -> None:
+        Client.reset_for_testing()
+        try:
+            client = Client(
+                api_key="test-key",
+                endpoint_url="///",
+                skip_open_telemetry_setup=True,
+            )
+            assert client.endpoint_url == DEFAULT_ENDPOINT
+        finally:
+            Client.reset_for_testing()
+
     def test_stores_the_endpoint_without_its_trailing_slash(self) -> None:
         Client.reset_for_testing()
         try:

--- a/specs/typescript-sdk/endpoint-resolution.feature
+++ b/specs/typescript-sdk/endpoint-resolution.feature
@@ -1,0 +1,41 @@
+Feature: TypeScript SDK endpoint resolution
+  As a developer pointing the SDK at LangWatch cloud or a self-hosted instance
+  I want the configured endpoint accepted in the shapes people actually write it
+  So that a trailing slash or a blank value never turns into an unexplained 404
+
+  Background:
+    Given the SDK builds request URLs by appending paths that carry a leading slash
+
+  @unit
+  Scenario: A trailing slash on the configured endpoint still reaches the API
+    Given a LangWatch client configured with endpoint "https://app.langwatch.ai/"
+    When I initialize an experiment
+    Then the request goes to "https://app.langwatch.ai/api/experiment/init"
+    And the path contains no double slash
+
+  @unit
+  Scenario: A trailing slash in the environment endpoint is normalized
+    Given LANGWATCH_ENDPOINT is set to "https://app.langwatch.ai/"
+    And no endpoint is passed to the client
+    When I initialize an experiment
+    Then the request goes to "https://app.langwatch.ai/api/experiment/init"
+
+  @unit
+  Scenario: Repeated trailing slashes are normalized
+    Given a LangWatch client configured with endpoint "http://localhost:5560///"
+    When I initialize an experiment
+    Then the request goes to "http://localhost:5560/api/experiment/init"
+
+  @unit
+  Scenario: A blank environment endpoint falls back to the cloud default
+    Given LANGWATCH_ENDPOINT is set to an empty value
+    And no endpoint is passed to the client
+    When the endpoint is resolved
+    Then the resolved endpoint is the cloud default
+
+  @unit
+  Scenario: An explicitly configured endpoint wins over the environment
+    Given LANGWATCH_ENDPOINT is set to "https://env.langwatch.test/"
+    And a LangWatch client configured with endpoint "https://explicit.langwatch.test/"
+    When the endpoint is resolved
+    Then the resolved endpoint is "https://explicit.langwatch.test"

--- a/typescript-sdk/src/cli/__tests__/index-boot.unit.test.ts
+++ b/typescript-sdk/src/cli/__tests__/index-boot.unit.test.ts
@@ -189,6 +189,11 @@ describe("the CLI boot module graph", () => {
         // few lines over node:async_hooks (no third-party deps), so its boot
         // cost is negligible; it belongs here deliberately.
         "internal/credentialContext.ts",
+        // The endpoint normalizer shared with the client SDK, so the CLI and an
+        // embedded SDK agree on what a configured endpoint means. Two pure
+        // string functions over internal/constants.ts, which is already at
+        // boot; it adds no transitive dependency.
+        "internal/endpoint.ts",
         "internal/runtime.ts",
       ]);
     });

--- a/typescript-sdk/src/cli/utils/governance/__tests__/resolveEndpoint.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/resolveEndpoint.unit.test.ts
@@ -138,6 +138,35 @@ describe("resolveControlPlaneEndpoint — 4-source priority", () => {
     });
   });
 
+  describe("when a source holds only whitespace", () => {
+    it("skips a blank flag and falls through to the environment", () => {
+      process.env.LANGWATCH_ENDPOINT = "https://env.example.com";
+      const result = resolveControlPlaneEndpoint({ flag: "   " });
+      expect(result.url).toBe("https://env.example.com");
+      expect(result.source).toBe("env");
+    });
+
+    it("skips a blank persisted url and falls through to the default", () => {
+      delete process.env.LANGWATCH_ENDPOINT;
+      const result = resolveControlPlaneEndpoint({
+        cfg: cfgFixture({ control_plane_url: "   " }),
+      });
+      expect(result.url).toBe("https://app.langwatch.ai");
+      expect(result.source).toBe("default");
+    });
+  });
+
+  describe("when a source carries a trailing slash", () => {
+    it("strips it", () => {
+      delete process.env.LANGWATCH_ENDPOINT;
+      const result = resolveControlPlaneEndpoint({
+        flag: "https://self.hosted.example.com///",
+      });
+      expect(result.url).toBe("https://self.hosted.example.com");
+      expect(result.source).toBe("flag");
+    });
+  });
+
   describe("resolveControlPlaneUrl convenience", () => {
     /** @scenario every CLI command resolves the endpoint via the same single function */
     it("returns just the URL string", () => {

--- a/typescript-sdk/src/cli/utils/governance/__tests__/resolveEndpoint.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/resolveEndpoint.unit.test.ts
@@ -156,6 +156,31 @@ describe("resolveControlPlaneEndpoint — 4-source priority", () => {
     });
   });
 
+  describe("when a source holds only slashes", () => {
+    it("skips a slash-only flag rather than resolving to an empty url", () => {
+      process.env.LANGWATCH_ENDPOINT = "https://env.example.com";
+      const result = resolveControlPlaneEndpoint({ flag: "///" });
+      expect(result.url).toBe("https://env.example.com");
+      expect(result.source).toBe("env");
+    });
+
+    it("skips a slash-only env var rather than resolving to an empty url", () => {
+      process.env.LANGWATCH_ENDPOINT = "/";
+      const result = resolveControlPlaneEndpoint({});
+      expect(result.url).toBe("https://app.langwatch.ai");
+      expect(result.source).toBe("default");
+    });
+
+    it("skips a slash-only persisted url rather than resolving to an empty url", () => {
+      delete process.env.LANGWATCH_ENDPOINT;
+      const result = resolveControlPlaneEndpoint({
+        cfg: cfgFixture({ control_plane_url: "//" }),
+      });
+      expect(result.url).toBe("https://app.langwatch.ai");
+      expect(result.source).toBe("default");
+    });
+  });
+
   describe("when a source carries a trailing slash", () => {
     it("strips it", () => {
       delete process.env.LANGWATCH_ENDPOINT;

--- a/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
+++ b/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
@@ -42,11 +42,14 @@ export interface ResolvedEndpoint {
 export function resolveControlPlaneEndpoint(
   opts: ResolveEndpointOptions = {},
 ): ResolvedEndpoint {
-  if (opts.flag) {
+  // Every source is checked for content, not truthiness: a whitespace-only
+  // value normalizes to the empty string, and returning that as the resolved
+  // URL is worse than falling through to the next source.
+  if (opts.flag?.trim()) {
     return { url: normalizeEndpoint(opts.flag), source: "flag" };
   }
   const env = process.env.LANGWATCH_ENDPOINT;
-  if (env && env.trim() !== "") {
+  if (env?.trim()) {
     return { url: normalizeEndpoint(env), source: "env" };
   }
   // Reading the config involves disk I/O; only do it if we need to.
@@ -64,7 +67,7 @@ export function resolveControlPlaneEndpoint(
   // explicit `langwatch config set endpoint <url>`. If it differs from
   // the hardcoded default, treat it as a user choice.
   const persisted = cfg?.control_plane_url;
-  if (persisted && persisted !== DEFAULT_ENDPOINT) {
+  if (persisted?.trim() && persisted !== DEFAULT_ENDPOINT) {
     return { url: normalizeEndpoint(persisted), source: "config" };
   }
   return { url: normalizeEndpoint(DEFAULT_ENDPOINT), source: "default" };

--- a/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
+++ b/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
@@ -42,15 +42,17 @@ export interface ResolvedEndpoint {
 export function resolveControlPlaneEndpoint(
   opts: ResolveEndpointOptions = {},
 ): ResolvedEndpoint {
-  // Every source is checked for content, not truthiness: a whitespace-only
-  // value normalizes to the empty string, and returning that as the resolved
-  // URL is worse than falling through to the next source.
-  if (opts.flag?.trim()) {
-    return { url: normalizeEndpoint(opts.flag), source: "flag" };
+  // Each source is judged on what it normalizes to, not on truthiness: both a
+  // whitespace-only value and a slash-only one reduce to the empty string, and
+  // returning that as the resolved URL is worse than falling through to the
+  // next source.
+  const flag = normalizeEndpoint(opts.flag ?? "");
+  if (flag) {
+    return { url: flag, source: "flag" };
   }
-  const env = process.env.LANGWATCH_ENDPOINT;
-  if (env?.trim()) {
-    return { url: normalizeEndpoint(env), source: "env" };
+  const env = normalizeEndpoint(process.env.LANGWATCH_ENDPOINT ?? "");
+  if (env) {
+    return { url: env, source: "env" };
   }
   // Reading the config involves disk I/O; only do it if we need to.
   // Callers that already have a cfg in scope can pass it in to skip.
@@ -66,9 +68,9 @@ export function resolveControlPlaneEndpoint(
   // `langwatch login --device` (snapshot of env at save time) OR by an
   // explicit `langwatch config set endpoint <url>`. If it differs from
   // the hardcoded default, treat it as a user choice.
-  const persisted = cfg?.control_plane_url;
-  if (persisted?.trim() && persisted !== DEFAULT_ENDPOINT) {
-    return { url: normalizeEndpoint(persisted), source: "config" };
+  const persisted = normalizeEndpoint(cfg?.control_plane_url ?? "");
+  if (persisted && persisted !== DEFAULT_ENDPOINT) {
+    return { url: persisted, source: "config" };
   }
   return { url: normalizeEndpoint(DEFAULT_ENDPOINT), source: "default" };
 }

--- a/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
+++ b/typescript-sdk/src/cli/utils/governance/resolveEndpoint.ts
@@ -16,6 +16,7 @@
  */
 
 import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { normalizeEndpoint } from "@/internal/endpoint";
 import { loadConfig } from "./config";
 
 export interface ResolveEndpointOptions {
@@ -42,11 +43,11 @@ export function resolveControlPlaneEndpoint(
   opts: ResolveEndpointOptions = {},
 ): ResolvedEndpoint {
   if (opts.flag) {
-    return { url: stripTrailingSlash(opts.flag), source: "flag" };
+    return { url: normalizeEndpoint(opts.flag), source: "flag" };
   }
   const env = process.env.LANGWATCH_ENDPOINT;
   if (env && env.trim() !== "") {
-    return { url: stripTrailingSlash(env), source: "env" };
+    return { url: normalizeEndpoint(env), source: "env" };
   }
   // Reading the config involves disk I/O; only do it if we need to.
   // Callers that already have a cfg in scope can pass it in to skip.
@@ -64,9 +65,9 @@ export function resolveControlPlaneEndpoint(
   // the hardcoded default, treat it as a user choice.
   const persisted = cfg?.control_plane_url;
   if (persisted && persisted !== DEFAULT_ENDPOINT) {
-    return { url: stripTrailingSlash(persisted), source: "config" };
+    return { url: normalizeEndpoint(persisted), source: "config" };
   }
-  return { url: stripTrailingSlash(DEFAULT_ENDPOINT), source: "default" };
+  return { url: normalizeEndpoint(DEFAULT_ENDPOINT), source: "default" };
 }
 
 /**
@@ -78,8 +79,4 @@ export function resolveControlPlaneUrl(
   opts: ResolveEndpointOptions = {},
 ): string {
   return resolveControlPlaneEndpoint(opts).url;
-}
-
-function stripTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, "");
 }

--- a/typescript-sdk/src/client-sdk/index.ts
+++ b/typescript-sdk/src/client-sdk/index.ts
@@ -81,7 +81,7 @@ import { type InternalConfig } from "./types";
 import { createLangWatchApiClient, type LangwatchApiClient } from "../internal/api/client";
 import { type Logger, NoOpLogger } from "../logger";
 import { TracesFacade } from "./services/traces/facade";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export interface LangWatchConstructorOptions {
   apiKey?: string;
@@ -150,7 +150,7 @@ export class LangWatch {
 
   constructor(options: LangWatchConstructorOptions = {}) {
     const apiKey = options.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
-    const endpoint = options.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    const endpoint = resolveEndpoint(options.endpoint);
 
     this.config = this.#createInternalConfig({
       apiKey,

--- a/typescript-sdk/src/client-sdk/services/api-keys/api-keys-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/api-keys/api-keys-api.service.ts
@@ -1,7 +1,7 @@
 import { scopedApiKey } from "@/internal/credentialContext";
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export interface RoleBinding {
   id: string;
@@ -59,7 +59,7 @@ export class ApiKeysApiService {
   private readonly apiKey: string;
 
   constructor(config?: { endpoint?: string; apiKey?: string }) {
-    this.endpoint = (config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
   }
 

--- a/typescript-sdk/src/client-sdk/services/datasets/dataset.service.ts
+++ b/typescript-sdk/src/client-sdk/services/datasets/dataset.service.ts
@@ -25,6 +25,7 @@ import { createTracingProxy } from "@/client-sdk/tracing/create-tracing-proxy";
 import { tracer } from "./tracing";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 type DatasetServiceConfig = {
   langwatchApiClient: LangwatchApiClient;
@@ -46,7 +47,7 @@ export class DatasetService {
   private readonly config: DatasetServiceConfig;
 
   constructor(config: DatasetServiceConfig) {
-    this.config = config;
+    this.config = { ...config, endpoint: resolveEndpoint(config.endpoint) };
 
     /**
      * Wraps the service in a tracing proxy that automatically creates
@@ -411,7 +412,7 @@ export class DatasetService {
     slugOrId?: string,
   ): Promise<T> {
     const { endpoint, apiKey } = this.config;
-    const url = `${endpoint.replace(/\/$/, "")}${path}`;
+    const url = `${endpoint}${path}`;
 
     const response = await fetch(url, {
       method: "POST",

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-endpoint.unit.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-endpoint.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { LangWatch } from "@/client-sdk";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const initResponse = (): Response =>
+  new Response(
+    JSON.stringify({ slug: "trailing-slash-eval", path: "/acme/experiments/trailing-slash-eval" }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+
+const fetchedUrl = (): string => {
+  const request = mockFetch.mock.calls[0]![0];
+  return request instanceof Request ? request.url : String(request);
+};
+
+/**
+ * A trailing slash on the endpoint used to append onto paths that already carry
+ * their own leading slash, producing `//api/experiment/init`. The router does
+ * not match that, so the SDK surfaced the server's opaque `{"error":"Not
+ * Found"}` with nothing pointing at the endpoint as the cause.
+ */
+describe("Experiment.init endpoint handling", () => {
+  const previousApiKey = process.env.LANGWATCH_API_KEY;
+  const previousEndpoint = process.env.LANGWATCH_ENDPOINT;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(initResponse());
+    // Left unset so ensureSetup() stays a no-op; the key is passed explicitly.
+    delete process.env.LANGWATCH_API_KEY;
+    delete process.env.LANGWATCH_ENDPOINT;
+  });
+
+  afterEach(() => {
+    if (previousApiKey === undefined) delete process.env.LANGWATCH_API_KEY;
+    else process.env.LANGWATCH_API_KEY = previousApiKey;
+    if (previousEndpoint === undefined) delete process.env.LANGWATCH_ENDPOINT;
+    else process.env.LANGWATCH_ENDPOINT = previousEndpoint;
+  });
+
+  describe("given an endpoint configured with a trailing slash", () => {
+    describe("when an experiment is initialized", () => {
+      /** @scenario A trailing slash on the configured endpoint still reaches the API */
+      it("requests the init path without a double slash", async () => {
+        const langwatch = new LangWatch({
+          apiKey: "sk-lw-test",
+          endpoint: "https://app.langwatch.ai/",
+        });
+
+        await langwatch.experiments.init("trailing-slash-eval");
+
+        expect(fetchedUrl()).toBe("https://app.langwatch.ai/api/experiment/init");
+        expect(new URL(fetchedUrl()).pathname).toBe("/api/experiment/init");
+      });
+    });
+  });
+
+  describe("given repeated trailing slashes on a self-hosted endpoint", () => {
+    describe("when an experiment is initialized", () => {
+      /** @scenario Repeated trailing slashes are normalized */
+      it("collapses them to a single path separator", async () => {
+        const langwatch = new LangWatch({
+          apiKey: "sk-lw-test",
+          endpoint: "http://localhost:5560///",
+        });
+
+        await langwatch.experiments.init("trailing-slash-eval");
+
+        expect(fetchedUrl()).toBe("http://localhost:5560/api/experiment/init");
+      });
+    });
+  });
+
+  describe("given LANGWATCH_ENDPOINT carries the trailing slash", () => {
+    describe("when an experiment is initialized without an explicit endpoint", () => {
+      /** @scenario A trailing slash in the environment endpoint is normalized */
+      it("requests the init path without a double slash", async () => {
+        process.env.LANGWATCH_ENDPOINT = "https://app.langwatch.ai/";
+
+        const langwatch = new LangWatch({ apiKey: "sk-lw-test" });
+
+        await langwatch.experiments.init("trailing-slash-eval");
+
+        expect(fetchedUrl()).toBe("https://app.langwatch.ai/api/experiment/init");
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -16,6 +16,7 @@ import type { LangWatchSpan } from "@/observability-sdk/span/types";
 import type { LangwatchApiClient } from "@/internal/api/client";
 import type { Logger } from "@/logger";
 import { ensureSetup } from "@/observability-sdk/setup/node";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { generateHumanReadableId } from "./humanReadableId";
 import {
   ExperimentInitError,
@@ -138,7 +139,7 @@ export class Experiment {
     this.experimentSlug = name;
     this.runId = options.runId ?? generateHumanReadableId();
     this.apiClient = options.apiClient;
-    this.endpoint = options.endpoint;
+    this.endpoint = resolveEndpoint(options.endpoint);
     this.apiKey = options.apiKey;
     this.logger = options.logger;
     this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
@@ -202,7 +203,7 @@ export class Experiment {
       (this as { experimentSlug: string }).experimentSlug = data.slug;
 
       const encodedRunId = encodeURIComponent(this.runId);
-      this.runUrl = `${this.endpoint.replace(/\/$/, "")}${data.path}?runId=${encodedRunId}`;
+      this.runUrl = `${this.endpoint}${data.path}?runId=${encodedRunId}`;
       console.log(`Follow results at: ${this.runUrl}`);
 
       this.initialized = true;

--- a/typescript-sdk/src/client-sdk/services/gateway-budgets/gateway-budgets-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/gateway-budgets/gateway-budgets-api.service.ts
@@ -5,7 +5,7 @@ import {
 } from "@/client-sdk/services/_shared/collect-cursor-pages";
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export type BudgetScopeKind =
   | "organization"
@@ -130,7 +130,7 @@ export class GatewayBudgetsApiService {
   private readonly projectId: string | undefined;
 
   constructor(config?: { endpoint?: string; apiKey?: string; projectId?: string }) {
-    this.endpoint = (config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
     this.projectId = config?.projectId ?? process.env.LANGWATCH_PROJECT_ID;
   }

--- a/typescript-sdk/src/client-sdk/services/model-defaults/model-defaults-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/model-defaults/model-defaults-api.service.ts
@@ -1,5 +1,5 @@
 import { scopedApiKey } from "@/internal/credentialContext";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
@@ -67,8 +67,7 @@ export class ModelDefaultsApiService {
 
   constructor(config?: { apiKey?: string; endpoint?: string }) {
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
-    this.endpoint =
-      config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    this.endpoint = resolveEndpoint(config?.endpoint);
   }
 
   private async request<T>(

--- a/typescript-sdk/src/client-sdk/services/monitors/monitors-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/monitors/monitors-api.service.ts
@@ -1,5 +1,5 @@
 import { scopedApiKey } from "@/internal/credentialContext";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
@@ -65,7 +65,7 @@ export class MonitorsApiService {
 
   constructor(config?: { apiKey?: string; endpoint?: string }) {
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
-    this.endpoint = config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    this.endpoint = resolveEndpoint(config?.endpoint);
   }
 
   private async request<T>(path: string, options?: RequestInit): Promise<T> {

--- a/typescript-sdk/src/client-sdk/services/projects/projects-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/projects/projects-api.service.ts
@@ -1,7 +1,7 @@
 import { scopedApiKey } from "@/internal/credentialContext";
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export interface Project {
   id: string;
@@ -67,7 +67,7 @@ export class ProjectsApiService {
   private readonly apiKey: string;
 
   constructor(config?: { endpoint?: string; apiKey?: string }) {
-    this.endpoint = (config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
   }
 

--- a/typescript-sdk/src/client-sdk/services/secrets/secrets-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/secrets/secrets-api.service.ts
@@ -1,5 +1,5 @@
 import { scopedApiKey } from "@/internal/credentialContext";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
@@ -34,7 +34,7 @@ export class SecretsApiService {
 
   constructor(config?: { apiKey?: string; endpoint?: string }) {
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
-    this.endpoint = config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    this.endpoint = resolveEndpoint(config?.endpoint);
   }
 
   private async request<T>(path: string, options?: RequestInit): Promise<T> {

--- a/typescript-sdk/src/client-sdk/services/spend-events/spend-events-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/spend-events/spend-events-api.service.ts
@@ -1,6 +1,6 @@
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export interface SpendEvent {
   id: string;
@@ -143,11 +143,7 @@ export class SpendEventsApiService {
   private readonly apiKey: string;
 
   constructor(config?: { endpoint?: string; apiKey?: string }) {
-    this.endpoint = (
-      config?.endpoint ??
-      process.env.LANGWATCH_ENDPOINT ??
-      DEFAULT_ENDPOINT
-    ).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? process.env.LANGWATCH_API_KEY ?? "";
   }
 

--- a/typescript-sdk/src/client-sdk/services/virtual-keys/virtual-keys-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/virtual-keys/virtual-keys-api.service.ts
@@ -5,7 +5,7 @@ import {
 } from "@/client-sdk/services/_shared/collect-cursor-pages";
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export type VirtualKeyScopeType = "organization" | "team" | "project";
 
@@ -134,7 +134,7 @@ export class VirtualKeysApiService {
   private readonly projectId: string | undefined;
 
   constructor(config?: { endpoint?: string; apiKey?: string; projectId?: string }) {
-    this.endpoint = (config?.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
     this.projectId = config?.projectId ?? process.env.LANGWATCH_PROJECT_ID;
   }

--- a/typescript-sdk/src/client-sdk/services/webhooks/webhooks-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/webhooks/webhooks-api.service.ts
@@ -1,6 +1,6 @@
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export interface WebhookEndpointSummary {
   id: string;
@@ -95,11 +95,7 @@ export class WebhooksApiService {
   private readonly apiKey: string;
 
   constructor(config?: { endpoint?: string; apiKey?: string }) {
-    this.endpoint = (
-      config?.endpoint ??
-      process.env.LANGWATCH_ENDPOINT ??
-      DEFAULT_ENDPOINT
-    ).replace(/\/+$/, "");
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.apiKey = config?.apiKey ?? process.env.LANGWATCH_API_KEY ?? "";
   }
 

--- a/typescript-sdk/src/client-sdk/services/workflows/workflows-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/workflows/workflows-api.service.ts
@@ -70,8 +70,13 @@ export class WorkflowsApiService {
   constructor(
     config?: Pick<InternalConfig, "langwatchApiClient"> & { endpoint?: string },
   ) {
-    this.apiClient = config?.langwatchApiClient ?? createLangWatchApiClient();
+    // The run URLs this service rebases and the requests it issues have to
+    // name the same host, so a caller that supplies only an endpoint gets a
+    // client built on that endpoint rather than on the environment.
     this.endpoint = resolveEndpoint(config?.endpoint);
+    this.apiClient =
+      config?.langwatchApiClient ??
+      createLangWatchApiClient(undefined, this.endpoint);
     this.experimentsApiService = new ExperimentsApiService({
       langwatchApiClient: this.apiClient,
     });

--- a/typescript-sdk/src/client-sdk/services/workflows/workflows-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/workflows/workflows-api.service.ts
@@ -19,6 +19,7 @@ import type {
   RunWithResultsOptions,
   ExperimentRunWithResults,
 } from "@/client-sdk/services/experiments/platformTypes";
+import { resolveEndpoint } from "@/internal/endpoint";
 
 export type WorkflowResponse = NonNullable<
   paths["/api/workflows"]["get"]["responses"]["200"]["content"]["application/json"]
@@ -70,10 +71,7 @@ export class WorkflowsApiService {
     config?: Pick<InternalConfig, "langwatchApiClient"> & { endpoint?: string },
   ) {
     this.apiClient = config?.langwatchApiClient ?? createLangWatchApiClient();
-    this.endpoint =
-      config?.endpoint ??
-      process.env.LANGWATCH_ENDPOINT ??
-      "https://app.langwatch.ai";
+    this.endpoint = resolveEndpoint(config?.endpoint);
     this.experimentsApiService = new ExperimentsApiService({
       langwatchApiClient: this.apiClient,
     });

--- a/typescript-sdk/src/internal/__tests__/endpoint.unit.test.ts
+++ b/typescript-sdk/src/internal/__tests__/endpoint.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DEFAULT_ENDPOINT } from "../constants";
+import { normalizeEndpoint, resolveEndpoint } from "../endpoint";
+
+describe("resolveEndpoint", () => {
+  const previousEndpoint = process.env.LANGWATCH_ENDPOINT;
+
+  beforeEach(() => {
+    delete process.env.LANGWATCH_ENDPOINT;
+  });
+
+  afterEach(() => {
+    if (previousEndpoint === undefined) delete process.env.LANGWATCH_ENDPOINT;
+    else process.env.LANGWATCH_ENDPOINT = previousEndpoint;
+  });
+
+  describe("given an explicit endpoint", () => {
+    describe("when it carries a trailing slash", () => {
+      it("strips the slash", () => {
+        expect(resolveEndpoint("https://app.langwatch.ai/")).toBe(
+          "https://app.langwatch.ai",
+        );
+      });
+    });
+
+    describe("when it carries repeated trailing slashes", () => {
+      it("strips all of them", () => {
+        expect(resolveEndpoint("http://localhost:5560///")).toBe(
+          "http://localhost:5560",
+        );
+      });
+    });
+
+    describe("when the environment also sets an endpoint", () => {
+      /** @scenario An explicitly configured endpoint wins over the environment */
+      it("prefers the explicit value", () => {
+        process.env.LANGWATCH_ENDPOINT = "https://env.langwatch.test/";
+
+        expect(resolveEndpoint("https://explicit.langwatch.test/")).toBe(
+          "https://explicit.langwatch.test",
+        );
+      });
+    });
+
+    describe("when it is blank", () => {
+      it("falls through to the environment", () => {
+        process.env.LANGWATCH_ENDPOINT = "https://env.langwatch.test";
+
+        expect(resolveEndpoint("   ")).toBe("https://env.langwatch.test");
+      });
+    });
+  });
+
+  describe("given no explicit endpoint", () => {
+    describe("when LANGWATCH_ENDPOINT carries a trailing slash", () => {
+      it("strips the slash", () => {
+        process.env.LANGWATCH_ENDPOINT = "https://app.langwatch.ai/";
+
+        expect(resolveEndpoint()).toBe("https://app.langwatch.ai");
+      });
+    });
+
+    describe("when LANGWATCH_ENDPOINT is empty", () => {
+      /** @scenario A blank environment endpoint falls back to the cloud default */
+      it("falls back to the cloud default", () => {
+        process.env.LANGWATCH_ENDPOINT = "";
+
+        expect(resolveEndpoint()).toBe(DEFAULT_ENDPOINT);
+      });
+    });
+
+    describe("when LANGWATCH_ENDPOINT is unset", () => {
+      it("falls back to the cloud default", () => {
+        expect(resolveEndpoint()).toBe(DEFAULT_ENDPOINT);
+      });
+    });
+  });
+});
+
+describe("normalizeEndpoint", () => {
+  describe("when the value has surrounding whitespace", () => {
+    it("trims it", () => {
+      expect(normalizeEndpoint("  https://app.langwatch.ai/  ")).toBe(
+        "https://app.langwatch.ai",
+      );
+    });
+  });
+
+  describe("when the value has no trailing slash", () => {
+    it("leaves it untouched", () => {
+      expect(normalizeEndpoint("https://app.langwatch.ai")).toBe(
+        "https://app.langwatch.ai",
+      );
+    });
+  });
+});

--- a/typescript-sdk/src/internal/api/client.ts
+++ b/typescript-sdk/src/internal/api/client.ts
@@ -7,7 +7,7 @@ import {
   LANGWATCH_SDK_RUNTIME,
   LANGWATCH_SDK_VERSION,
 } from "../constants";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { scopedApiKey } from "@/internal/credentialContext";
 import { buildAuthHeaders } from "./auth";
 import { handledErrorFrom } from "./errors";
@@ -79,11 +79,11 @@ export const createLangWatchApiClient = (
   // requests can't read each other's credential. A plain SDK embed sets no
   // scope and falls back to the environment unchanged.
   apiKey: string = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "",
-  endpoint: string = process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT,
+  endpoint?: string,
   projectId: string | undefined = process.env.LANGWATCH_PROJECT_ID,
 ) => {
   const client = openApiCreateClient<paths>({
-    baseUrl: endpoint,
+    baseUrl: resolveEndpoint(endpoint),
     headers: {
       ...buildAuthHeaders({ apiKey, projectId }),
       "content-type": "application/json",

--- a/typescript-sdk/src/internal/endpoint.ts
+++ b/typescript-sdk/src/internal/endpoint.ts
@@ -1,0 +1,34 @@
+/**
+ * Single place where a configured LangWatch endpoint becomes a usable base URL.
+ *
+ * Most services build request URLs by concatenation — `${endpoint}/api/...` —
+ * and every path already carries its own leading slash. A trailing slash on the
+ * endpoint therefore yields `https://app.langwatch.ai//api/experiment/init`,
+ * which the router does not match, and the caller gets an opaque
+ * `{"error":"Not Found"}` with nothing pointing at the real cause. Normalizing
+ * at the point of resolution keeps every call site free of that concern.
+ */
+
+import { DEFAULT_ENDPOINT } from "./constants";
+
+const isSet = (value: string | null | undefined): value is string =>
+  typeof value === "string" && value.trim() !== "";
+
+/** Trim surrounding whitespace and drop any trailing slashes. */
+export const normalizeEndpoint = (endpoint: string): string =>
+  endpoint.trim().replace(/\/+$/, "");
+
+/**
+ * Resolve the endpoint from an explicit value, then `LANGWATCH_ENDPOINT`, then
+ * the cloud default. Blank values are treated as unset so that an empty
+ * `LANGWATCH_ENDPOINT=` in a `.env` falls through to the default rather than
+ * producing relative request URLs.
+ */
+export const resolveEndpoint = (endpoint?: string | null): string => {
+  for (const candidate of [endpoint, process.env.LANGWATCH_ENDPOINT]) {
+    if (!isSet(candidate)) continue;
+    const normalized = normalizeEndpoint(candidate);
+    if (normalized !== "") return normalized;
+  }
+  return normalizeEndpoint(DEFAULT_ENDPOINT);
+};

--- a/typescript-sdk/src/internal/endpoint.ts
+++ b/typescript-sdk/src/internal/endpoint.ts
@@ -14,9 +14,21 @@ import { DEFAULT_ENDPOINT } from "./constants";
 const isSet = (value: string | null | undefined): value is string =>
   typeof value === "string" && value.trim() !== "";
 
-/** Trim surrounding whitespace and drop any trailing slashes. */
-export const normalizeEndpoint = (endpoint: string): string =>
-  endpoint.trim().replace(/\/+$/, "");
+/**
+ * Trim surrounding whitespace and drop any trailing slashes.
+ *
+ * Scanned rather than matched with `/\/+$/`: a repeated character class bound
+ * to an anchor backtracks from every start index, which is quadratic on a
+ * string of many slashes. The endpoint is configuration rather than attacker
+ * input, but a linear scan costs nothing and leaves no such edge to reason
+ * about.
+ */
+export const normalizeEndpoint = (endpoint: string): string => {
+  const trimmed = endpoint.trim();
+  let end = trimmed.length;
+  while (end > 0 && trimmed[end - 1] === "/") end--;
+  return trimmed.slice(0, end);
+};
 
 /**
  * Resolve the endpoint from an explicit value, then `LANGWATCH_ENDPOINT`, then

--- a/typescript-sdk/src/observability-sdk/setup/node/setup.ts
+++ b/typescript-sdk/src/observability-sdk/setup/node/setup.ts
@@ -14,7 +14,7 @@ import { LangWatchLogsExporter, LangWatchTraceExporter } from "../../exporters";
 import { ConsoleLogger, type Logger } from "../../../logger";
 import { initializeObservabilitySdkConfig } from "../../config";
 import { setLangWatchLoggerProvider } from "../../logger";
-import { DEFAULT_ENDPOINT } from "@/internal/constants";
+import { resolveEndpoint } from "@/internal/endpoint";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 
 // Helper functions
@@ -31,7 +31,7 @@ const getLangWatchConfig = (options: SetupObservabilityOptions) => {
   return {
     disabled: isDisabled,
     apiKey: isDisabled ? void 0 : (config.apiKey ?? process.env.LANGWATCH_API_KEY),
-    endpoint: isDisabled ? void 0 : (config.endpoint ?? process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT),
+    endpoint: isDisabled ? void 0 : resolveEndpoint(config.endpoint),
     processorType: config.processorType ?? 'batch'
   };
 };


### PR DESCRIPTION
## What

`new LangWatch({ endpoint: "https://app.langwatch.ai/" })` used to fail every request with an opaque 404:

```
ExperimentInitError: Failed to initialize experiment: {"error":"Not Found"}
```

Both SDKs build request URLs by concatenation, and every path already carries its own leading slash, so a trailing slash on the endpoint produced `https://app.langwatch.ai//api/experiment/init`. The router does not match a double slash, and `{"error":"Not Found"}` is what the app returns for any unmatched `/api/*` path, so nothing in the error pointed at the endpoint as the cause.

Whether a trailing slash worked at all depended on which service you happened to call. In the TypeScript SDK, `api-keys`, `virtual-keys`, `gateway-budgets`, `projects`, `webhooks` and `spend-events` each stripped it inline; `experiments`, `datasets`, `evaluations`, `secrets`, `monitors`, `model-defaults`, `workflows` and the shared OpenAPI client did not. The Python SDK and the MCP server stripped it nowhere.

## How

**TypeScript.** A single `resolveEndpoint()` in `internal/endpoint.ts` owns the decision: explicit value, then `LANGWATCH_ENDPOINT`, then the cloud default, trimmed and stripped of trailing slashes. Every resolution site calls it, including the `LangWatch` constructor that feeds the facades, and `Experiment` and `DatasetService` normalize at construction so direct instantiations are covered too. The six inline `.replace(/\/+$/, "")` copies and the CLI's private `stripTrailingSlash` are gone.

**Python.** `normalize_endpoint()` guards both `get_endpoint()` branches and the two places `Client.setup` stores the URL.

**MCP server.** `initConfig` normalizes the CLI flag and the env var before storing them.

The Go SDK needs no equivalent change: it joins with `url.JoinPath`, which collapses the separator itself.

Blank values now count as unset in both, so an empty `LANGWATCH_ENDPOINT=` in a `.env` falls through to the cloud default instead of producing relative request URLs.

`WorkflowsApiService` also had `https://app.langwatch.ai` hardcoded rather than reading `DEFAULT_ENDPOINT`; it goes through the same resolver now.

## Also fixed along the way

- `resolveControlPlaneEndpoint` accepted a whitespace-only `--endpoint` flag or persisted `control_plane_url` and returned an empty URL. All three sources check for content and fall through when blank.
- `WorkflowsApiService` resolved its endpoint but still built its fallback API client from the environment, so a caller supplying only an endpoint issued requests to one host and emitted run URLs for another.
- The normalizer scans backwards rather than matching `/\/+$/`. That pattern backtracks from every start index and goes quadratic on a run of slashes (CodeQL `js/polynomial-redos`). An endpoint is configuration rather than attacker input, but the linear form costs nothing.

## Boot graph

`internal/endpoint.ts` joins the pinned CLI boot graph. It is two pure string functions over `internal/constants.ts`, which is already at boot, so it adds no transitive dependency and no measurable cold-start cost.

## Testing

- `specs/typescript-sdk/endpoint-resolution.feature`, 5 scenarios, 5/5 bound (`check:feature-parity` passes).
- `experiment-endpoint.unit.test.ts` runs the real `experiments.init()` path with a trailing-slash endpoint and asserts the fetched URL. Reverted against the unfixed resolver it fails with `expected 'https://app.langwatch.ai//api/experiment/init'`, so it reproduces the bug rather than just describing it.
- `endpoint.unit.test.ts` and `test_endpoint_normalization.py` cover precedence, repeated slashes, whitespace and the blank-env fallback in each SDK.
- TypeScript SDK: 2151 tests across 157 files pass, `tsc --noEmit` and `eslint` clean. Python SDK: 399 tests pass. MCP server: 442 unit tests pass and `tsgo --noEmit` is clean.

Dogfooded against production with the built SDK. All four shapes now reach the API and create the experiment:

```
OK   "https://app.langwatch.ai/"      -> slug "endpoint-normalization-check"
OK   "https://app.langwatch.ai///"    -> slug "endpoint-normalization-check"
OK   "https://app.langwatch.ai"       -> slug "endpoint-normalization-check"
OK   "  https://app.langwatch.ai/  "  -> slug "endpoint-normalization-check"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint handling across SDKs and the MCP server.
  * Removed trailing, repeated, and surrounding whitespace from configured endpoints to prevent malformed request URLs.
  * Blank endpoint values now fall back correctly to environment settings or the default cloud endpoint.
  * Explicitly configured endpoints take precedence over environment-based values.

* **Tests**
  * Added coverage for normalization, fallback behavior, precedence, and request URL construction across supported SDKs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->