### PR TITLE
fix(packages): declare the deps the root workspace members import at runtime

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,13 +23,11 @@
 	"license": "MIT",
 	"dependencies": {
 		"@langwatch/handled-error": "workspace:*",
-		"@langwatch/observability": "workspace:*"
-	},
-	"peerDependencies": {
-		"@opentelemetry/api": "^1.9.0",
-		"hono": "^4.12.25",
-		"hono-openapi": "^0.4.0",
-		"zod": "^3.23.0"
+		"@langwatch/observability": "workspace:*",
+		"@opentelemetry/api": "^1.9.1",
+		"hono": "^4.12.27",
+		"hono-openapi": "^0.4.8",
+		"zod": "^3.25.76"
 	},
 	"devDependencies": {
 		"@types/node": "^26.0.1",

--- a/packages/automations/package.json
+++ b/packages/automations/package.json
@@ -28,16 +28,13 @@
 	"dependencies": {
 		"liquidjs": "^10.27.1",
 		"marked": "^18.0.5",
-		"sanitize-html": "^2.17.5"
-	},
-	"peerDependencies": {
-		"zod": "^3.25.0"
+		"sanitize-html": "^2.17.5",
+		"zod": "^3.25.76"
 	},
 	"devDependencies": {
 		"@types/node": "^26.0.1",
 		"@types/sanitize-html": "^2.16.0",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.9",
-		"zod": "^3.25.76"
+		"vitest": "^4.1.9"
 	}
 }

--- a/packages/handled-error/package.json
+++ b/packages/handled-error/package.json
@@ -20,11 +20,10 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.1"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.9.1",
     "typescript": "^5.9.2",
     "vitest": "^4.1.9"
   }

--- a/packages/langy/package.json
+++ b/packages/langy/package.json
@@ -2,7 +2,7 @@
   "name": "@langwatch/langy",
   "version": "0.1.0",
   "private": true,
-  "description": "Langy's shared contract: the CARD vocabulary (every kind of card the panel can draw, the closed derived-safe allowlist a model may write, the CLI verb registry, digest and handled-error), the inline ```langy-card channel, and the conversation-projection contract (event payload schemas, the pure turn fold, the turn-phase machine, the event cursor) — imported by the LangWatch server pipeline, the browser panel and the CLI so a turn renders identically everywhere (ADR-059, ADR-060).",
+  "description": "Langy's shared contract: the CARD vocabulary (every kind of card the panel can draw, the closed derived-safe allowlist a model may write, the CLI verb registry, digest and handled-error), the inline ```langy-card channel, and the conversation-projection contract (event payload schemas, the pure turn fold, the turn-phase machine, the event cursor) \u2014 imported by the LangWatch server pipeline, the browser panel and the CLI so a turn renders identically everywhere (ADR-059, ADR-060).",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -29,12 +29,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "peerDependencies": {
-    "zod": ">=3.25.0 <5"
+  "dependencies": {
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "typescript": "^5.9.2",
-    "vitest": "^4.1.9",
-    "zod": "^3.25.76"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -26,16 +26,13 @@
 	],
 	"license": "MIT",
 	"dependencies": {
+		"@opentelemetry/api": "^1.9.1",
 		"pino": "^10.3.1",
 		"pino-opentelemetry-transport": "^3.0.0",
 		"pino-pretty": "^13.1.3",
 		"superjson": "^2.2.6"
 	},
-	"peerDependencies": {
-		"@opentelemetry/api": "^1.9.0"
-	},
 	"devDependencies": {
-		"@opentelemetry/api": "^1.9.1",
 		"@types/node": "^26.0.1",
 		"esbuild": "^0.28.1",
 		"typescript": "^6.0.3",

--- a/packages/react-rum/package.json
+++ b/packages/react-rum/package.json
@@ -22,17 +22,17 @@
 		"react"
 	],
 	"license": "MIT",
-	"peerDependencies": {
-		"@opentelemetry/api": "^1.9.0",
-		"@opentelemetry/core": "^2.0.0",
+	"dependencies": {
+		"@opentelemetry/api": "^1.9.1",
+		"@opentelemetry/core": "2.9.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
 		"@opentelemetry/instrumentation": "^0.219.0",
-		"@opentelemetry/instrumentation-document-load": "*",
+		"@opentelemetry/instrumentation-document-load": "^0.65.0",
 		"@opentelemetry/instrumentation-fetch": "^0.219.0",
-		"@opentelemetry/resources": "^2.0.0",
-		"@opentelemetry/sdk-trace-base": "^2.0.0",
-		"@opentelemetry/sdk-trace-web": "^2.0.0",
-		"@opentelemetry/semantic-conventions": "^1.36.0"
+		"@opentelemetry/resources": "^2.8.0",
+		"@opentelemetry/sdk-trace-base": "2.8.0",
+		"@opentelemetry/sdk-trace-web": "2.8.0",
+		"@opentelemetry/semantic-conventions": "^1.41.1"
 	},
 	"devDependencies": {
 		"@types/node": "^26.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,16 +185,16 @@ importers:
         specifier: workspace:*
         version: link:../observability
       '@opentelemetry/api':
-        specifier: ^1.9.0
+        specifier: ^1.9.1
         version: 1.9.1
       hono:
-        specifier: ^4.12.25
+        specifier: ^4.12.27
         version: 4.12.27
       hono-openapi:
-        specifier: ^0.4.0
+        specifier: ^0.4.8
         version: 0.4.8(@hono/zod-validator@0.4.3(hono@4.12.27)(zod@3.25.76))(@sinclair/typebox@0.34.52)(hono@4.12.27)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@types/node':
@@ -218,6 +218,9 @@ importers:
       sanitize-html:
         specifier: ^2.17.5
         version: 2.17.5
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^26.0.1
@@ -231,15 +234,13 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.2(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
 
   packages/handled-error:
-    devDependencies:
+    dependencies:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+    devDependencies:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -248,6 +249,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@5.9.3))(vite@8.1.2(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/langy:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.9.2
@@ -255,12 +260,12 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@5.9.3))(vite@8.1.2(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
 
   packages/observability:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -274,9 +279,6 @@ importers:
         specifier: ^2.2.6
         version: 2.2.6
     devDependencies:
-      '@opentelemetry/api':
-        specifier: ^1.9.1
-        version: 1.9.1
       '@types/node':
         specifier: ^26.0.1
         version: 26.1.1
@@ -293,10 +295,10 @@ importers:
   packages/react-rum:
     dependencies:
       '@opentelemetry/api':
-        specifier: ^1.9.0
+        specifier: ^1.9.1
         version: 1.9.1
       '@opentelemetry/core':
-        specifier: ^2.0.0
+        specifier: 2.9.0
         version: 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.219.0
@@ -305,22 +307,22 @@ importers:
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-document-load':
-        specifier: '*'
+        specifier: ^0.65.0
         version: 0.65.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-fetch':
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
-        specifier: ^2.0.0
+        specifier: ^2.8.0
         version: 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
-        specifier: ^2.0.0
+        specifier: 2.8.0
         version: 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web':
-        specifier: ^2.0.0
+        specifier: 2.8.0
         version: 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.36.0
+        specifier: ^1.41.1
         version: 1.43.0
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## What breaks without this

The saas `langwatch-app` image crashes on **every container start**, in `clickhouse:migrate`:

```
Cannot find module '@opentelemetry/api'
requireStack: [ '/app/langwatch/packages/handled-error/src/handled-error.ts', … ]
```

Found by booting the image built from langwatch-saas#828 rather than trusting a green build.

## Why

`packages/handled-error` imports `@opentelemetry/api` at runtime but declared it only as a **peer + dev** dependency.

That worked while `packages/` lived inside the app — Node walked up from the real path into `platform/app/node_modules`, which carries otel. **ADR-076 moved `packages/` to the workspace root**, so the walk now ends at the workspace-root `node_modules`, which holds the virtual store and nothing hoisted. CI's prod steps then remove the devDependency that was the only thing satisfying the peer:

```
pnpm install --frozen-lockfile --prod --filter "@langwatch/web..." --ignore-scripts
pnpm prune --prod --ignore-scripts
```

Result: **6 of 9 members ship with no `node_modules` at all** (api, handled-error, langy, redaction, server, ssrf).

## The change

Every one of these packages is `private: true`, so `peerDependencies` bought nothing — there is no external consumer to satisfy, only our own app, and resolution can no longer reach it. A module imported at runtime is a dependency, so that is how it is declared now.

| package | moved to `dependencies` |
|---|---|
| `handled-error` | `@opentelemetry/api` |
| `api` | `@opentelemetry/api`, `hono`, `hono-openapi`, `zod` |
| `automations` | `zod` |
| `langy` | `zod` |
| `observability` | `@opentelemetry/api` |
| `react-rum` | the 10 otel packages its entrypoint pulls |

Prod still ships **no dev `node_modules`** — these are real dependencies, so `--prod` keeps them and `prune --prod` still strips dev.

## Single-copy safety

Specifiers are the **app's**, not the old peer ranges. `langy`'s peer was `>=3.25.0 <5`; as a dependency that is free to resolve zod 4 while the app stays on 3, giving two zods and breaking every `instanceof` across the boundary.

Verified after the change that every member still resolves **otel 1.9.1, zod 3.25.76, core 2.9.0** — unchanged from before.

## Testing

- All 9 workspace packages green: 1019 tests, exit 0.
- Lockfile diff confined to the 6 touched importers.
- Re-boot of the rebuilt image tracked in langwatch-saas#828.

## Note

**No CI check could have caught this.** `build-and-push-artifacts` builds and pushes the image; it never runs it. A boot smoke test is the follow-up on the saas side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved installation reliability by ensuring required runtime functionality is available automatically.
  * Standardized package setup across observability, validation, tracing, and sanitization capabilities.
  * Aligned component version requirements to improve compatibility.
  * Simplified setup by removing redundant configuration and reducing manual installation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->