### PR TITLE
fix(sdk): @opentelemetry/api is a runtime import, so declare it as a dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,6 +1075,9 @@ importers:
       '@ai-sdk/openai':
         specifier: '>=2.0.0 <5.0.0'
         version: 3.0.79(zod@4.4.3)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@opentelemetry/api-logs':
         specifier: 0.205.0
         version: 0.205.0
@@ -1105,6 +1108,9 @@ importers:
       '@opentelemetry/sdk-metrics':
         specifier: ^2.0.1
         version: 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.219.0
+        version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.0.1
         version: 2.8.0(@opentelemetry/api@1.9.1)
@@ -1160,12 +1166,6 @@ importers:
       '@langwatch/langy':
         specifier: workspace:*
         version: link:../../packages/langy
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.1
-      '@opentelemetry/sdk-node':
-        specifier: 0.219.0
-        version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node':
         specifier: ^2.0.1
         version: 2.8.0(@opentelemetry/api@1.9.1)

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -73,9 +73,9 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@langchain/core": ">=0.3.68 <0.4.0",
-    "@langwatch/langy": "workspace:*",
     "@langchain/langgraph": ">=0.4.0 <1.0.0",
     "@langchain/openai": ">=0.6.0 <1.0.0",
+    "@langwatch/langy": "workspace:*",
     "@opentelemetry/sdk-node": "0.219.0",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
     "@opentelemetry/sdk-trace-web": ">=2.0.1",
@@ -101,10 +101,10 @@
     "typescript-eslint": "^8.38.0",
     "vitest": "^4.1.0",
     "vitest-mock-extended": "^4.0.0",
-    "yaml": "^2.8.1",
-    "@opentelemetry/api": "^1.9.0"
+    "yaml": "^2.8.1"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "0.205.0",
     "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
@@ -113,6 +113,7 @@
     "@opentelemetry/resources": "^2.0.1",
     "@opentelemetry/sdk-logs": "0.205.0",
     "@opentelemetry/sdk-metrics": "^2.0.1",
+    "@opentelemetry/sdk-node": "^0.219.0",
     "@opentelemetry/sdk-trace-base": "^2.0.1",
     "@opentelemetry/semantic-conventions": "^1.36.0",
     "chalk": "^5.6.2",
@@ -128,14 +129,12 @@
     "zod": "^4.0.14"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0",
     "@ai-sdk/openai": ">=2.0.0 <5.0.0",
     "@langchain/core": ">=0.3.0 <2.0.0",
     "@langchain/langgraph": ">=0.4.0 <2.0.0",
     "@langchain/openai": ">=0.6.0 <2.0.0",
     "@opentelemetry/context-async-hooks": "^2.1.0",
     "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
-    "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
     "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
     "langchain": ">=0.3.0 <2.0.0"
   },
@@ -156,9 +155,6 @@
       "optional": true
     },
     "@opentelemetry/context-zone": {
-      "optional": true
-    },
-    "@opentelemetry/sdk-node": {
       "optional": true
     },
     "@opentelemetry/sdk-trace-web": {


### PR DESCRIPTION
Follow-up to #6548, found by booting the rebuilt image rather than trusting the green build again.

## The failure moved, it did not go away

#6548 fixed `packages/*`. The image built from it still crash-loops on `clickhouse:migrate`, which runs at every container start:

```
Cannot find package '@opentelemetry/api'
imported from /app/langwatch/sdks/typescript/dist/chunk-OGRLVYP5.mjs
```

Same shape as `handled-error`: the SDK imports `@opentelemetry/api` from its built `dist`, but declared it **peer + dev only**. The prod install drops the devDependency that satisfied the peer, and nothing is left to resolve.

Consumed from npm this never shows — the SDK sits in the consumer's `node_modules` and resolution reaches their copy. As a workspace member under ADR-076 it resolves from `sdks/typescript`, and the walk up ends at the workspace root, which carries the virtual store and nothing hoisted.

## Why a dependency rather than a peer

This one is published, so the contract change deserves justifying:

- `@opentelemetry/core`, `@opentelemetry/api-logs` and both exporters are **already plain `dependencies`** here. `api` was the lone outlier, and `core` depends on it anyway.
- `@opentelemetry/api` is explicitly built for duplication — it resolves through a global registry, so a consumer with their own copy still lands on one implementation.

Range is unchanged (`^1.9.0`), so no consumer's resolution moves.

## Verification

The image's own resolver, run inside the image, importing every workspace member the app depends on:

| before | after |
|---|---|
| 8 × `@langwatch/*` ok, **`langwatch` FAILED** | all 9 ok |

- SDK unit tests: **2152 pass**. The 2 failures (`feature-map-drift`, `commandCatalog`) reproduce on main untouched — pre-existing, not from this.
- Lockfile confined to the two importer entries this changes; `--frozen-lockfile` accepts it.

## Lockfile drift, deliberately not included

A full re-resolve also rewrites parts of `snapshots:` — `@ai-sdk/provider-utils` under `@ai-sdk/openai`'s zod 4 variant drops to the zod 3 one (two zod majors in one subtree), and `@langchain/core`'s transitive `openai` goes **4.104.0 → 6.45.0**. That is latent drift in main's lockfile which surfaces whenever those subtrees are re-resolved. Worth fixing; not worth doing silently inside a one-line dependency change.

## Companion

langwatch-saas#828's import guard filtered on `@langwatch/*`, which is exactly why it went green on a broken image — the SDK is named `langwatch`. Being widened there to detect workspace members by resolved path instead of by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure required telemetry support is available at runtime.
  * Improved the reliability of telemetry-related functionality when using the TypeScript SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->