### PR TITLE
fix(event-sourcing): bisect a failing coalesced batch instead of retrying it whole

### DIFF
--- a/platform/app/src/server/event-sourcing/__tests__/runtime/eventSourcing.deliveryForwarding.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/runtime/eventSourcing.deliveryForwarding.unit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The shared queue's wrappers must forward the delivery to the registry entry.
+ *
+ * Dropping it is silent and catastrophic in slow motion: every entry downstream
+ * forwards `delivery.attempt` as `deliveryAttempt`, the fold executor keys its
+ * applied-id merge on it, and the queue passes it in — so this wrapper is the
+ * single point where losing the argument pins every delivery at attempt 1 and
+ * disables retry dedup for the whole system (#6578). The fold idempotency suite
+ * cannot catch that, because its harness wires its own queue definition and
+ * forwards the delivery itself. This test pins the wrapper.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventSourcing } from "../../eventSourcing";
+import type { EventSourcedQueueDefinition } from "../../queues";
+
+const captured: {
+  definition?: EventSourcedQueueDefinition<Record<string, unknown>>;
+} = {};
+
+vi.mock("../../queues/groupQueue/groupQueue", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../queues/groupQueue/groupQueue")>();
+  class CapturingGroupQueueProcessor {
+    constructor(definition: EventSourcedQueueDefinition<any>) {
+      captured.definition = definition;
+    }
+    async waitUntilReady() {}
+    async close() {}
+    async send() {}
+    async sendBatch() {}
+  }
+  return { ...actual, GroupQueueProcessor: CapturingGroupQueueProcessor };
+});
+
+const ROUTING = {
+  __pipelineName: "test_pipeline",
+  __jobType: "subscriber",
+  __jobName: "testJob",
+} as const;
+
+function createWithEntry() {
+  // A truthy redis makes EventSourcing take the GroupQueueProcessor branch,
+  // which the mock above captures instead of connecting anywhere. The runtime
+  // initializes lazily, so touch the getter to force queue creation.
+  const eventSourcing = new EventSourcing({ redis: {} as never });
+  void eventSourcing.globalQueue;
+  const entry = {
+    process: vi.fn().mockResolvedValue(undefined),
+    processBatch: vi.fn().mockResolvedValue(undefined),
+  };
+  (
+    eventSourcing as unknown as {
+      _globalJobRegistry: Map<string, typeof entry>;
+    }
+  )._globalJobRegistry.set(
+    `${ROUTING.__pipelineName}:${ROUTING.__jobType}:${ROUTING.__jobName}`,
+    entry,
+  );
+  return { eventSourcing, entry };
+}
+
+describe("the shared queue's handler wrappers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the queue delivers a single job with a delivery", () => {
+    it("forwards the delivery to the entry", async () => {
+      const { eventSourcing, entry } = createWithEntry();
+
+      await captured.definition!.process(
+        { ...ROUTING, value: "a" },
+        { attempt: 3 },
+      );
+
+      expect(entry.process).toHaveBeenCalledWith(
+        { value: "a" },
+        { attempt: 3 },
+      );
+      await eventSourcing.close();
+    });
+  });
+
+  describe("when the queue delivers a coalesced batch with a delivery", () => {
+    it("forwards the delivery — including the continuation flag — to the entry", async () => {
+      const { eventSourcing, entry } = createWithEntry();
+
+      await captured.definition!.processBatch!(
+        [
+          { ...ROUTING, value: "a" },
+          { ...ROUTING, value: "b" },
+        ],
+        { attempt: 2, continuation: true },
+      );
+
+      expect(entry.processBatch).toHaveBeenCalledWith(
+        [{ value: "a" }, { value: "b" }],
+        { attempt: 2, continuation: true },
+      );
+      await eventSourcing.close();
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/__tests__/runtime/eventSourcing.deliveryForwarding.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/runtime/eventSourcing.deliveryForwarding.unit.test.ts
@@ -90,12 +90,12 @@ describe("the shared queue's handler wrappers", () => {
           { ...ROUTING, value: "a" },
           { ...ROUTING, value: "b" },
         ],
-        { attempt: 2, continuation: true },
+        { attempt: 2, isContinuation: true },
       );
 
       expect(entry.processBatch).toHaveBeenCalledWith(
         [{ value: "a" }, { value: "b" }],
-        { attempt: 2, continuation: true },
+        { attempt: 2, isContinuation: true },
       );
       await eventSourcing.close();
     });

--- a/platform/app/src/server/event-sourcing/eventSourcing.ts
+++ b/platform/app/src/server/event-sourcing/eventSourcing.ts
@@ -28,7 +28,7 @@ import { createBillingMeterDispatchReactor } from "./projections/global/billingM
 import { orgBillableEventsMeterProjection } from "./projections/global/orgBillableEventsMeter.mapProjection";
 import { ProjectionRegistry } from "./projections/projectionRegistry";
 import { RedisReplayMarkerChecker } from "./projections/replayMarkerCheck";
-import type { EventSourcedQueueProcessor } from "./queues";
+import type { EventSourcedQueueProcessor, JobDelivery } from "./queues";
 import { GroupQueueProcessor } from "./queues/groupQueue/groupQueue";
 import { gqJobsUnroutableTotal } from "./queues/groupQueue/metrics";
 import { EventSourcedQueueProcessorMemory } from "./queues/memory";
@@ -557,7 +557,10 @@ export class EventSourcing {
         if (!result.entry.spanAttributes) return {};
         return result.entry.spanAttributes(result.clean);
       },
-      process: async (payload: Record<string, unknown>) => {
+      process: async (
+        payload: Record<string, unknown>,
+        delivery?: JobDelivery,
+      ) => {
         if (isLegacyOutboxPayload(payload)) {
           dropLegacyOutboxPayload(payload);
           return;
@@ -566,7 +569,12 @@ export class EventSourcing {
         if (!result) {
           this.rejectUnroutableJob(payload, queueName);
         }
-        await result.entry.process(result.clean);
+        // Forward the delivery. Dropping it here silently pinned
+        // `deliveryAttempt` at 1 for every registry entry, which disabled the
+        // fold store's merge-on-retry applied-id handling in the running
+        // system (#6578) — the entries forward it, this wrapper was the only
+        // point of loss.
+        await result.entry.process(result.clean, delivery);
       },
       coalesceMaxBatch: (payload: Record<string, unknown>) => {
         const result = this.lookupEntry(payload);
@@ -581,7 +589,10 @@ export class EventSourcing {
         const result = this.lookupEntry(payload);
         return result?.entry.coalesceMaxBytes;
       },
-      processBatch: async (payloads: Record<string, unknown>[]) => {
+      processBatch: async (
+        payloads: Record<string, unknown>[],
+        delivery?: JobDelivery,
+      ) => {
         if (payloads.length === 0) return;
         // A coalesced batch is always one group → one registry entry. Resolve
         // every payload and guard against a mixed/unknown batch (should never
@@ -606,11 +617,15 @@ export class EventSourcing {
             if (!result) {
               this.rejectUnroutableJob(survivors[index]!, queueName);
             }
-            await result.entry.process(result.clean);
+            await result.entry.process(result.clean, delivery);
           }
           return;
         }
-        await first.entry.processBatch!(resolved.map((r) => r!.clean));
+        // Forward the delivery — see the `process` wrapper above (#6578).
+        await first.entry.processBatch!(
+          resolved.map((r) => r!.clean),
+          delivery,
+        );
       },
     };
 

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.appliedSetEviction.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.appliedSetEviction.unit.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../domain/types";
+import {
+  createMockFoldProjectionDefinition,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import type { FoldProjectionStore } from "../foldProjection.types";
+import { FoldProjectionExecutor } from "../foldProjectionExecutor";
+import type { ProjectionStoreContext } from "../projectionStoreContext";
+
+/**
+ * A commit must record every id it RECOGNISED, not only the ids it folded
+ * fresh (#6578).
+ *
+ * The applied-event-id set answers one question: "has this aggregate already
+ * absorbed this event?" An id that arrives in a batch and is correctly dropped
+ * as already-applied is still an id the committed state absorbs — so dropping
+ * it from the set on the way out is a lie the next delivery believes.
+ *
+ * A first-attempt commit replaces the set (bounded garbage collection), so
+ * recording only the fresh ids EVICTS any redelivered id that rode along.
+ * Whoever sees that id next treats it as new and folds it a second time.
+ * Batch coalescing and bisection both make an already-applied id riding along
+ * with fresh ones ordinary rather than exotic.
+ */
+describe("FoldProjectionExecutor applied-set eviction", () => {
+  const tenantId = createTestTenantId();
+
+  interface FoldState {
+    ids: string[];
+    LastEventOccurredAt: number;
+  }
+
+  const init = (): FoldState => ({ ids: [], LastEventOccurredAt: 0 });
+
+  function makeEvent(id: string, createdAt: number): Event {
+    return createTestEvent(
+      TEST_CONSTANTS.AGGREGATE_ID,
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      tenantId,
+      undefined,
+      createdAt,
+      undefined,
+      {},
+      id,
+    );
+  }
+
+  function durableStore({
+    state,
+    appliedEventIds,
+  }: {
+    state: FoldState | null;
+    appliedEventIds: string[];
+  }): {
+    store: FoldProjectionStore<FoldState>;
+    storeFn: ReturnType<typeof vi.fn>;
+  } {
+    const storeFn = vi.fn().mockResolvedValue(undefined);
+    const store: FoldProjectionStore<FoldState> = {
+      get: vi.fn().mockResolvedValue(state),
+      getWithApplied: vi.fn().mockResolvedValue({ state, appliedEventIds }),
+      store: storeFn,
+    };
+    return { store, storeFn };
+  }
+
+  const appendingApply = () =>
+    vi.fn(
+      (state: FoldState, event: Event): FoldState => ({
+        ids: [...state.ids, event.id],
+        LastEventOccurredAt: Math.max(
+          state.LastEventOccurredAt,
+          event.occurredAt ?? 0,
+        ),
+      }),
+    );
+
+  const committedAppliedIds = (storeFn: ReturnType<typeof vi.fn>): string[] =>
+    ((storeFn.mock.calls[0]?.[1] as ProjectionStoreContext | undefined)
+      ?.appliedEventIds ?? []) as string[];
+
+  let executor: FoldProjectionExecutor;
+
+  beforeEach(() => {
+    executor = new FoldProjectionExecutor();
+  });
+
+  describe("given a batch carrying one already-applied event and three new ones", () => {
+    describe("when it commits on a first attempt", () => {
+      it("keeps the already-applied id in the set instead of evicting it", async () => {
+        const events = ["c0", "c1", "c2", "c3"].map((id, index) =>
+          makeEvent(id, 1000 + index),
+        );
+        const { store, storeFn } = durableStore({
+          state: { ids: ["c0"], LastEventOccurredAt: 1000 },
+          appliedEventIds: ["c0"],
+        });
+        const fold = createMockFoldProjectionDefinition("eviction", {
+          store,
+          init,
+          apply: appendingApply(),
+        });
+
+        await executor.executeBatch(fold, events, {
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          tenantId,
+        });
+
+        // c0 was correctly not re-folded — but the state it is folded into is
+        // the one being committed, so the set must still vouch for it. Drop it
+        // and the next delivery carrying c0 folds it twice.
+        expect([...committedAppliedIds(storeFn)].sort()).toEqual([
+          "c0",
+          "c1",
+          "c2",
+          "c3",
+        ]);
+      });
+    });
+  });
+
+  describe("given a single already-applied event redelivered alongside nothing", () => {
+    describe("when the batch is entirely redelivery", () => {
+      it("does not store at all, so nothing can be evicted", async () => {
+        const events = ["c0", "c1"].map((id, index) =>
+          makeEvent(id, 1000 + index),
+        );
+        const { store, storeFn } = durableStore({
+          state: { ids: ["c0", "c1"], LastEventOccurredAt: 1001 },
+          appliedEventIds: ["c0", "c1"],
+        });
+        const fold = createMockFoldProjectionDefinition("eviction-noop", {
+          store,
+          init,
+          apply: appendingApply(),
+        });
+
+        await executor.executeBatch(fold, events, {
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          tenantId,
+        });
+
+        expect(storeFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a fresh delivery with nothing previously applied", () => {
+    describe("when it commits", () => {
+      it("records exactly the delivered ids, keeping the set bounded", async () => {
+        const events = ["a", "b"].map((id, index) =>
+          makeEvent(id, 1000 + index),
+        );
+        const { store, storeFn } = durableStore({
+          state: null,
+          appliedEventIds: [],
+        });
+        const fold = createMockFoldProjectionDefinition("eviction-fresh", {
+          store,
+          init,
+          apply: appendingApply(),
+        });
+
+        await executor.executeBatch(fold, events, {
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          tenantId,
+        });
+
+        // The replace-on-fresh-delivery garbage collection still holds: the
+        // set is this delivery's ids, not an ever-growing history.
+        expect([...committedAppliedIds(storeFn)].sort()).toEqual(["a", "b"]);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.continuationForwarding.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.continuationForwarding.unit.test.ts
@@ -29,7 +29,7 @@ import { ProjectionRouter } from "../projectionRouter";
 
 describe("continuation forwarding", () => {
   describe("when the queue manager's registry entry receives a batch delivery", () => {
-    it("stamps deliveryAttempt and deliveryContinuation on the read context", async () => {
+    it("stamps deliveryAttempt and isDeliveryContinuation on the read context", async () => {
       const registry = new Map<
         string,
         {
@@ -63,12 +63,12 @@ describe("continuation forwarding", () => {
         TEST_CONSTANTS.AGGREGATE_TYPE,
         createTestTenantId(),
       );
-      const delivery: JobDelivery = { attempt: 2, continuation: true };
+      const delivery: JobDelivery = { attempt: 2, isContinuation: true };
       await entry.processBatch!([event], delivery);
 
       expect(seenContexts[0]).toMatchObject({
         deliveryAttempt: 2,
-        deliveryContinuation: true,
+        isDeliveryContinuation: true,
       });
     });
   });
@@ -131,7 +131,7 @@ describe("continuation forwarding", () => {
       // Continuation: the commit must carry the loaded ids AND the new ones.
       await onEventBatch("continuation-fold", makeEvents(["new-1", "new-2"]), {
         tenantId,
-        deliveryContinuation: true,
+        isDeliveryContinuation: true,
       });
       expect(stored[0]?.appliedEventIds).toEqual(
         expect.arrayContaining(["prev-1", "prev-2", "new-1", "new-2"]),

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.continuationForwarding.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.continuationForwarding.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The continuation flag must survive every link of the runtime chain, because
+ * any single link dropping it silently re-enables the double-apply it exists
+ * to prevent (#6578): a bisected sub-batch's fold commit would REPLACE the
+ * applied-event-id set instead of extending it, and the redelivery after a
+ * failed later sub-batch re-applies the committed prefix.
+ *
+ * The links, each pinned separately (a chain test through the full runtime
+ * would boot pipelines this unit lane cannot):
+ * - shared-queue wrapper → registry entry: eventSourcing.deliveryForwarding
+ * - registry entry → read context: THIS FILE (queue manager)
+ * - read context → executor commit: THIS FILE (projection router)
+ * - executor commit semantics + real store: foldRedeliveryIdempotency
+ *   (integration, drives the real GroupQueue bisection end to end)
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "../../domain/types";
+import type { JobDelivery } from "../../queues";
+import {
+  createMockFoldProjectionDefinition,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import { QueueManager } from "../../services/queues/queueManager";
+import type { FoldProjectionStore } from "../foldProjection.types";
+import { ProjectionRouter } from "../projectionRouter";
+
+describe("continuation forwarding", () => {
+  describe("when the queue manager's registry entry receives a batch delivery", () => {
+    it("stamps deliveryAttempt and deliveryContinuation on the read context", async () => {
+      const registry = new Map<
+        string,
+        {
+          processBatch?: (
+            events: Event[],
+            delivery?: JobDelivery,
+          ) => Promise<void>;
+        }
+      >();
+      const queueManager = new QueueManager<Event>({
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+        pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+        globalQueue: {} as never,
+        globalJobRegistry: registry as never,
+      });
+
+      const seenContexts: Record<string, unknown>[] = [];
+      queueManager.initializeProjectionQueues(
+        {
+          myFold: { name: "myFold", coalesceMaxBatch: 10 },
+        },
+        async () => {},
+        async (_name, _events, context) => {
+          seenContexts.push(context as unknown as Record<string, unknown>);
+        },
+      );
+
+      const entry = [...registry.values()][0]!;
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestTenantId(),
+      );
+      const delivery: JobDelivery = { attempt: 2, continuation: true };
+      await entry.processBatch!([event], delivery);
+
+      expect(seenContexts[0]).toMatchObject({
+        deliveryAttempt: 2,
+        deliveryContinuation: true,
+      });
+    });
+  });
+
+  describe("when the router's batch callback receives a continuation context", () => {
+    it("commits with the applied set extended rather than replaced", async () => {
+      const queueManager = createMockQueueManager();
+      const initializeSpy =
+        queueManager.initializeProjectionQueues as ReturnType<typeof vi.fn>;
+
+      const router = new ProjectionRouter(
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        TEST_CONSTANTS.PIPELINE_NAME,
+        queueManager,
+      );
+
+      const stored: { appliedEventIds?: readonly string[] }[] = [];
+      const store: FoldProjectionStore<{ count: number }> = {
+        store: vi.fn(async (_state, context) => {
+          stored.push({ appliedEventIds: context.appliedEventIds });
+        }),
+        get: vi.fn(async () => ({ count: 1 })),
+        getWithApplied: vi.fn(async () => ({
+          state: { count: 1 },
+          appliedEventIds: ["prev-1", "prev-2"],
+        })),
+      };
+      const fold = createMockFoldProjectionDefinition("continuation-fold", {
+        store,
+        eventTypes: [],
+        init: () => ({ count: 0 }),
+        apply: (state: { count: number }) => ({ count: state.count + 1 }),
+      });
+      router.registerFoldProjection(fold);
+      router.initializeFoldQueues();
+
+      // The batch callback the router handed the queue manager — the exact
+      // function the runtime invokes for a coalesced fold batch.
+      const onEventBatch = initializeSpy.mock.calls[0]![2] as (
+        name: string,
+        events: Event[],
+        context: Record<string, unknown>,
+      ) => Promise<void>;
+
+      const tenantId = createTestTenantId();
+      const makeEvents = (ids: string[]) =>
+        ids.map((id, index) => {
+          const event = createTestEvent(
+            TEST_CONSTANTS.AGGREGATE_ID,
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+          );
+          return {
+            ...event,
+            id,
+            occurredAt: TEST_CONSTANTS.BASE_TIMESTAMP + index,
+          } as Event;
+        });
+
+      // Continuation: the commit must carry the loaded ids AND the new ones.
+      await onEventBatch("continuation-fold", makeEvents(["new-1", "new-2"]), {
+        tenantId,
+        deliveryContinuation: true,
+      });
+      expect(stored[0]?.appliedEventIds).toEqual(
+        expect.arrayContaining(["prev-1", "prev-2", "new-1", "new-2"]),
+      );
+
+      // Fresh delivery: the commit replaces — the bounded-set garbage
+      // collection this chain must NOT break.
+      await onEventBatch("continuation-fold", makeEvents(["new-3", "new-4"]), {
+        tenantId,
+      });
+      expect(stored[1]?.appliedEventIds).toEqual(["new-3", "new-4"]);
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
@@ -273,7 +273,7 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
         {
           ...context,
           deliveryAttempt: delivery?.attempt,
-          deliveryContinuation: delivery?.continuation,
+          isDeliveryContinuation: delivery?.isContinuation,
         },
       );
       if (failuresLeft > 0) {
@@ -822,7 +822,7 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
         // The mechanism, not just the outcome: the leaf that committed after
         // the first successful leaf carried the continuation flag.
         expect(
-          deliveries.some((delivery) => delivery.continuation === true),
+          deliveries.some((delivery) => delivery.isContinuation === true),
         ).toBe(true);
       }, 40_000);
     });

--- a/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
@@ -728,7 +728,7 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
 
     describe("given a retry chain that has not yet acked", () => {
       it("accumulates across attempts so nothing in the chain is forgotten", async () => {
-        const { queue, readAppliedIds, applied } = createFoldQueue({
+        const { queue, readAppliedIds } = createFoldQueue({
           keyPrefix: "it_lifecycle_chain",
           failures: 2,
           coalesce: 10,
@@ -744,17 +744,22 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
           });
         }
 
+        // Wait on the condition being asserted, not on a proxy for it. Counting
+        // handler applications used to be a sound barrier because a failing
+        // batch retried whole, so the chain's events could only ever land
+        // together. A failing batch is now bisected, so they can land in
+        // separate sub-batches within one attempt — and a count of 2 no longer
+        // means the third has been applied. Polling the set itself is immune to
+        // however the queue chooses to divide the work, and still fails within
+        // the timeout if accumulation is genuinely broken, which is the point
+        // of the test.
         await vi.waitFor(
-          () => expect(applied.length).toBeGreaterThanOrEqual(2),
-          {
-            timeout: 20_000,
-            interval: 50,
+          async () => {
+            expect(await readAppliedIds()).toEqual(
+              expect.arrayContaining(["chain-0", "chain-1", "chain-2"]),
+            );
           },
-        );
-
-        const ids = await readAppliedIds();
-        expect(ids).toEqual(
-          expect.arrayContaining(["chain-0", "chain-1", "chain-2"]),
+          { timeout: 20_000, interval: 50 },
         );
       }, 40_000);
     });

--- a/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
@@ -43,7 +43,10 @@ import {
 import { createTenantId } from "../../../domain/tenantId";
 import type { Event } from "../../../domain/types";
 import { GroupQueueProcessor } from "../../../queues/groupQueue/groupQueue";
-import type { EventSourcedQueueDefinition } from "../../../queues/queue.types";
+import type {
+  EventSourcedQueueDefinition,
+  JobDelivery,
+} from "../../../queues/queue.types";
 import { createMockFoldProjectionDefinition } from "../../../services/__tests__/testHelpers";
 import type { FoldProjectionStore } from "../../foldProjection.types";
 import { FoldProjectionExecutor } from "../../foldProjectionExecutor";
@@ -140,6 +143,29 @@ function toEvent(
   } as unknown as Event;
 }
 
+/**
+ * Pre-fold rejector for the bisection scenario: fails any batch carrying the
+ * poison id while failures remain, and records every delivery it sees.
+ * Module-level so the test body stays within the complexity gate.
+ */
+function makePoisonRejector({
+  poisonId,
+  poison,
+  deliveries,
+}: {
+  poisonId: string;
+  poison: { failuresLeft: number };
+  deliveries: JobDelivery[];
+}) {
+  return (jobs: FoldJob[], delivery?: JobDelivery) => {
+    if (delivery) deliveries.push(delivery);
+    const poisoned = jobs.some((job) => job.eventId === poisonId);
+    if (!poisoned || poison.failuresLeft <= 0) return;
+    poison.failuresLeft--;
+    throw new Error("unprocessable while the poison id is present");
+  };
+}
+
 describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
   let redis: Redis;
   const queues: GroupQueueProcessor<FoldJob>[] = [];
@@ -184,6 +210,7 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
     aggregateId = AGGREGATE,
     tenantId = TENANT,
     durableFactory = createDurableStore,
+    rejectBefore,
   }: {
     keyPrefix: string;
     failFirstBatch?: boolean;
@@ -193,6 +220,13 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
     aggregateId?: string;
     tenantId?: ReturnType<typeof createTenantId>;
     durableFactory?: DurableStoreFactory;
+    /**
+     * Pre-fold failure: called before the fold runs; a throw models a batch
+     * the handler cannot process at all (nothing stored). This is the shape
+     * bisection splits on — unlike `failures`, which models the post-store
+     * redelivery window.
+     */
+    rejectBefore?: (jobs: FoldJob[], delivery?: JobDelivery) => void;
   }) {
     const durable = durableFactory();
     const cached = new RedisCachedFoldStore<CounterState>(
@@ -230,15 +264,17 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
       ? Number.POSITIVE_INFINITY
       : (failures ?? (failFirstBatch ? 1 : 0));
 
-    const runBatch = async (
-      jobs: FoldJob[],
-      delivery?: { attempt: number },
-    ) => {
+    const runBatch = async (jobs: FoldJob[], delivery?: JobDelivery) => {
+      rejectBefore?.(jobs, delivery);
       applied.push(jobs.map((job) => job.eventId));
       await executor.executeBatch(
         fold,
         jobs.map((job) => toEvent(job, aggregateId, tenantId)),
-        { ...context, deliveryAttempt: delivery?.attempt },
+        {
+          ...context,
+          deliveryAttempt: delivery?.attempt,
+          deliveryContinuation: delivery?.continuation,
+        },
       );
       if (failuresLeft > 0) {
         failuresLeft--;
@@ -724,6 +760,71 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
         const ids = await readAppliedIds();
         expect(ids).toEqual(["batch3-e0"]);
       }, 60_000);
+    });
+
+    describe("given a bisected batch whose later sub-batch fails", () => {
+      /**
+       * The #6578 scenario: the whole batch fails pre-fold, bisection commits
+       * two prefix leaves as SEPARATE fold writes within the same locked
+       * dispatch, the final singleton fails, and the queue redelivers. Without
+       * the continuation flag the second leaf's commit REPLACES the applied
+       * set, erasing the first leaf's ids, and the retry double-applies them —
+       * final count 6, not 4. This drives the real GroupQueue bisection, the
+       * real executor, and the real cached store end to end.
+       */
+      it("extends the applied set across leaves so the retry folds each event exactly once", async () => {
+        // root, [c2,c3], [c3] — the fourth c3-carrying delivery passes.
+        const poison = { failuresLeft: 3 };
+        const deliveries: JobDelivery[] = [];
+        const { queue, durable, order, applied } = createFoldQueue({
+          keyPrefix: "it_bisect_chain",
+          coalesce: 10,
+          rejectBefore: makePoisonRejector({
+            poisonId: "c3",
+            poison,
+            deliveries,
+          }),
+        });
+        await queue.waitUntilReady();
+
+        // Future-dated so all four are STAGED before any becomes due — staging
+        // races the dispatcher, and a root batch that only coalesces a subset
+        // never exercises the multi-event leaf this scenario is about.
+        const base = Date.now() + 750;
+        await queue.sendBatch(
+          ["c0", "c1", "c2", "c3"].map((eventId, index) => ({
+            eventId,
+            groupId: AGGREGATE,
+            occurredAt: base + index,
+          })),
+        );
+
+        // Dispatch 1 walks: [c0..c3] fails → [c0,c1] commits (replace) →
+        // [c2,c3] fails → [c2] commits (continuation → merge) → [c3] fails →
+        // redelivery. Attempt 2 folds ONLY what the applied set does not
+        // already hold.
+        await vi.waitFor(() => expect(durable.committed()?.count).toBe(4), {
+          timeout: 20_000,
+          interval: 50,
+        });
+
+        // The descent this scenario depends on actually happened: the root
+        // coalesced all four, and the committing prefix leaf carried MORE than
+        // one event (a single-event leaf takes the single-event executor path
+        // and cannot reproduce the replace-vs-extend hazard).
+        expect(applied[0]).toEqual(["c0", "c1"]);
+
+        // Every event folded exactly once across the whole story — the
+        // assertion that fails (count 6, duplicates for c0/c1) if a leaf
+        // commit replaces the applied set instead of extending it.
+        expect([...order].sort()).toEqual(["c0", "c1", "c2", "c3"]);
+
+        // The mechanism, not just the outcome: the leaf that committed after
+        // the first successful leaf carried the continuation flag.
+        expect(
+          deliveries.some((delivery) => delivery.continuation === true),
+        ).toBe(true);
+      }, 40_000);
     });
 
     describe("given a retry chain that has not yet acked", () => {

--- a/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -270,11 +270,11 @@ export class FoldProjectionExecutor {
   private appliedIdsForCommit({
     context,
     loadedAppliedIds,
-    freshIds,
+    deliveredIds,
   }: {
     context: ProjectionStoreContext;
     loadedAppliedIds: readonly string[];
-    freshIds: readonly string[];
+    deliveredIds: readonly string[];
   }): string[] {
     // Replace ONLY on the first commit of a fresh delivery — that is the
     // garbage collection that keeps the applied set bounded at one delivery's
@@ -288,8 +288,11 @@ export class FoldProjectionExecutor {
     //   would double-apply the committed prefix (#6578).
     const isRetry = (context.deliveryAttempt ?? 1) > 1;
     return isRetry || context.isDeliveryContinuation
-      ? mergeAppliedEventIds({ previous: loadedAppliedIds, applied: freshIds })
-      : [...freshIds];
+      ? mergeAppliedEventIds({
+          previous: loadedAppliedIds,
+          applied: deliveredIds,
+        })
+      : [...deliveredIds];
   }
 
   /**
@@ -412,7 +415,7 @@ export class FoldProjectionExecutor {
             this.appliedIdsForCommit({
               context,
               loadedAppliedIds: appliedEventIds,
-              freshIds: [event.id],
+              deliveredIds: [event.id],
             }),
           ),
         );
@@ -491,7 +494,7 @@ export class FoldProjectionExecutor {
         this.appliedIdsForCommit({
           context,
           loadedAppliedIds: appliedEventIds,
-          freshIds: [event.id],
+          deliveredIds: [event.id],
         }),
       ),
     );
@@ -586,7 +589,7 @@ export class FoldProjectionExecutor {
             this.appliedIdsForCommit({
               context,
               loadedAppliedIds: appliedEventIds,
-              freshIds: ordered.map((event) => event.id),
+              deliveredIds: ordered.map((event) => event.id),
             }),
           ),
         );
@@ -664,7 +667,12 @@ export class FoldProjectionExecutor {
         this.appliedIdsForCommit({
           context,
           loadedAppliedIds: appliedEventIds,
-          freshIds: fresh.map((event) => event.id),
+          // `ordered`, not `fresh`: an id dropped as already-applied is still
+          // an id the state being committed absorbs, so the set must keep
+          // vouching for it. Recording only the freshly-folded ids EVICTS a
+          // redelivered id that rode along, and whoever sees it next folds it
+          // a second time (#6578).
+          deliveredIds: ordered.map((event) => event.id),
         }),
       ),
     );

--- a/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -287,7 +287,7 @@ export class FoldProjectionExecutor {
     //   the rest of the chain, so a redelivery after a failed later sub-batch
     //   would double-apply the committed prefix (#6578).
     const isRetry = (context.deliveryAttempt ?? 1) > 1;
-    return isRetry || context.deliveryContinuation
+    return isRetry || context.isDeliveryContinuation
       ? mergeAppliedEventIds({ previous: loadedAppliedIds, applied: freshIds })
       : [...freshIds];
   }

--- a/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -276,7 +276,18 @@ export class FoldProjectionExecutor {
     loadedAppliedIds: readonly string[];
     freshIds: readonly string[];
   }): string[] {
-    return (context.deliveryAttempt ?? 1) > 1
+    // Replace ONLY on the first commit of a fresh delivery — that is the
+    // garbage collection that keeps the applied set bounded at one delivery's
+    // ids instead of growing forever. Everything else extends:
+    // - a retry (attempt > 1) must keep what earlier attempts recorded, or the
+    //   redelivery re-applies it;
+    // - a continuation (a later sub-batch of the same locked dispatch, from
+    //   batch bisection) must keep what the earlier sub-batches recorded — each
+    //   commit only carries its own sub-batch's ids, and replacing would erase
+    //   the rest of the chain, so a redelivery after a failed later sub-batch
+    //   would double-apply the committed prefix (#6578).
+    const isRetry = (context.deliveryAttempt ?? 1) > 1;
+    return isRetry || context.deliveryContinuation
       ? mergeAppliedEventIds({ previous: loadedAppliedIds, applied: freshIds })
       : [...freshIds];
   }

--- a/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
@@ -668,8 +668,8 @@ export class ProjectionRouter<
           // fold commit must extend the applied-id set, not replace it
           // (#6578). Dropping this here silently re-enables the double-apply
           // this chain exists to prevent.
-          ...(context.deliveryContinuation !== undefined
-            ? { deliveryContinuation: context.deliveryContinuation }
+          ...(context.isDeliveryContinuation !== undefined
+            ? { isDeliveryContinuation: context.isDeliveryContinuation }
             : {}),
         });
       },
@@ -1822,7 +1822,7 @@ export class ProjectionRouter<
           event: first,
           key,
           deliveryAttempt: context.deliveryAttempt,
-          deliveryContinuation: context.deliveryContinuation,
+          isDeliveryContinuation: context.isDeliveryContinuation,
         });
 
         const foldState = await withMetrics({
@@ -2290,12 +2290,12 @@ export class ProjectionRouter<
     event,
     key,
     deliveryAttempt,
-    deliveryContinuation,
+    isDeliveryContinuation,
   }: {
     event: EventType;
     key?: string;
     deliveryAttempt?: number;
-    deliveryContinuation?: boolean;
+    isDeliveryContinuation?: boolean;
   }): Promise<ProjectionStoreContext> {
     const retentionPolicy = await this.resolveRetention(event.tenantId);
     return {
@@ -2303,7 +2303,9 @@ export class ProjectionRouter<
       tenantId: event.tenantId,
       ...(key !== undefined ? { key } : {}),
       ...(deliveryAttempt !== undefined ? { deliveryAttempt } : {}),
-      ...(deliveryContinuation !== undefined ? { deliveryContinuation } : {}),
+      ...(isDeliveryContinuation !== undefined
+        ? { isDeliveryContinuation }
+        : {}),
       retentionPolicy,
     };
   }

--- a/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
@@ -664,6 +664,13 @@ export class ProjectionRouter<
           ...(context.deliveryAttempt !== undefined
             ? { deliveryAttempt: context.deliveryAttempt }
             : {}),
+          // A bisected sub-batch after the first commit of its dispatch: the
+          // fold commit must extend the applied-id set, not replace it
+          // (#6578). Dropping this here silently re-enables the double-apply
+          // this chain exists to prevent.
+          ...(context.deliveryContinuation !== undefined
+            ? { deliveryContinuation: context.deliveryContinuation }
+            : {}),
         });
       },
     );
@@ -702,7 +709,7 @@ export class ProjectionRouter<
               if (decision === "skip") return;
             }
 
-            const context = await this.buildStoreContext(event);
+            const context = await this.buildStoreContext({ event });
             const record = await withMetrics({
               fn: () => this.mapExecutor.execute(mapProj, event, context),
               onComplete: (ms) => {
@@ -755,7 +762,9 @@ export class ProjectionRouter<
             }
             if (toApply.length === 0) return;
 
-            const firstContext = await this.buildStoreContext(toApply[0]!);
+            const firstContext = await this.buildStoreContext({
+              event: toApply[0]!,
+            });
             const contexts = toApply.map((event) => ({
               ...firstContext,
               aggregateId: String(event.aggregateId),
@@ -1168,7 +1177,7 @@ export class ProjectionRouter<
               if (decision === "skip") continue;
             }
 
-            const storeContext = await this.buildStoreContext(event);
+            const storeContext = await this.buildStoreContext({ event });
             const record = await withMetrics({
               fn: () => this.mapExecutor.execute(mapProj, event, storeContext),
               onComplete: (ms) => {
@@ -1504,11 +1513,11 @@ export class ProjectionRouter<
         if (toApply.length === 0) return;
 
         const key = projection.key ? projection.key(toApply[0]!) : undefined;
-        const storeContext = await this.buildStoreContext(
-          toApply[0]!,
+        const storeContext = await this.buildStoreContext({
+          event: toApply[0]!,
           key,
-          context.deliveryAttempt,
-        );
+          deliveryAttempt: context.deliveryAttempt,
+        });
         await withMetrics({
           fn: () =>
             this.stateProjectionExecutor.execute({
@@ -1619,11 +1628,11 @@ export class ProjectionRouter<
         }
 
         const key = fold.key ? fold.key(event) : undefined;
-        const storeContext = await this.buildStoreContext(
+        const storeContext = await this.buildStoreContext({
           event,
           key,
-          context.deliveryAttempt,
-        );
+          deliveryAttempt: context.deliveryAttempt,
+        });
 
         const foldState = await withMetrics({
           fn: () => this.foldExecutor.execute(fold, event, storeContext),
@@ -1809,11 +1818,12 @@ export class ProjectionRouter<
 
         const first = toApply[0]!;
         const key = fold.key ? fold.key(first) : undefined;
-        const storeContext = await this.buildStoreContext(
-          first,
+        const storeContext = await this.buildStoreContext({
+          event: first,
           key,
-          context.deliveryAttempt,
-        );
+          deliveryAttempt: context.deliveryAttempt,
+          deliveryContinuation: context.deliveryContinuation,
+        });
 
         const foldState = await withMetrics({
           fn: () => this.foldExecutor.executeBatch(fold, toApply, storeContext),
@@ -2276,17 +2286,24 @@ export class ProjectionRouter<
    * Centralising it ensures every store sees the same shape — and any new
    * context field (e.g. process role, trace correlation) lands in one place.
    */
-  private async buildStoreContext(
-    event: EventType,
-    key?: string,
-    deliveryAttempt?: number,
-  ): Promise<ProjectionStoreContext> {
+  private async buildStoreContext({
+    event,
+    key,
+    deliveryAttempt,
+    deliveryContinuation,
+  }: {
+    event: EventType;
+    key?: string;
+    deliveryAttempt?: number;
+    deliveryContinuation?: boolean;
+  }): Promise<ProjectionStoreContext> {
     const retentionPolicy = await this.resolveRetention(event.tenantId);
     return {
       aggregateId: String(event.aggregateId),
       tenantId: event.tenantId,
       ...(key !== undefined ? { key } : {}),
       ...(deliveryAttempt !== undefined ? { deliveryAttempt } : {}),
+      ...(deliveryContinuation !== undefined ? { deliveryContinuation } : {}),
       retentionPolicy,
     };
   }

--- a/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
@@ -102,5 +102,5 @@ export interface ProjectionStoreContext {
    * dispatch whose earlier sub-batch already committed (batch bisection). The
    * applied-event-id set must be extended, not replaced (#6578).
    */
-  deliveryContinuation?: boolean;
+  isDeliveryContinuation?: boolean;
 }

--- a/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
@@ -97,4 +97,10 @@ export interface ProjectionStoreContext {
    * or a later attempt re-applies the batch the first attempt already folded.
    */
   deliveryAttempt?: number;
+  /**
+   * True when this commit belongs to a later sub-batch of the same locked
+   * dispatch whose earlier sub-batch already committed (batch bisection). The
+   * applied-event-id set must be extended, not replaced (#6578).
+   */
+  deliveryContinuation?: boolean;
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -864,6 +864,175 @@ describe.skipIf(!hasTestcontainers)(
         });
       });
 
+      describe("when one payload in a coalesced batch is unprocessable", () => {
+        it("commits every payload ahead of it and narrows the failure to it alone", async () => {
+          // Payloads AFTER the offender deliberately do not commit here: the
+          // fold derives fields from arrival order, so applying j6 while j5 is
+          // unresolved would leave a silent gap. Bisection's job is to stop
+          // losing the payloads BEFORE the offender and to name it — not to
+          // step over it. Letting later work past requires deciding what to do
+          // about that gap, which is the side-lining decision (#6482).
+          const POISON = "j5";
+          const attempted: TestPayload[][] = [];
+          const processedIds = new Set<string>();
+
+          const queue = createQueue(
+            async (p) => {
+              // The isolate ends up here only if it is ever dispatched alone;
+              // healthy singles land here too once a half narrows to one.
+              if (p.id === POISON) throw new Error("unprocessable payload");
+              processedIds.add(p.id);
+            },
+            {
+              processBatch: async (ps) => {
+                const batch = ps as TestPayload[];
+                attempted.push(batch);
+                // Fails for any batch containing the poison payload — including
+                // the batch of exactly one, which is what makes it attributable.
+                if (batch.some((p) => p.id === POISON)) {
+                  throw new Error("unprocessable payload");
+                }
+                for (const p of batch) processedIds.add(p.id);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 8 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
+          );
+
+          // j0..j4 commit despite sharing a batch with the offender. Without
+          // bisection the whole batch fails together and NONE of them apply —
+          // that is the regression this pins.
+          await vi.waitFor(
+            () => {
+              expect([...processedIds].sort()).toEqual([
+                "j0",
+                "j1",
+                "j2",
+                "j3",
+                "j4",
+              ]);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+          expect(processedIds.has(POISON)).toBe(false);
+
+          // The split actually narrowed to the offender rather than retrying
+          // the batch whole: some attempt isolated it on its own.
+          const isolated = attempted.filter(
+            (b) => b.length === 1 && b[0]?.id === POISON,
+          );
+          expect(isolated.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("keeps each half in arrival order while splitting", async () => {
+          const POISON = "j6";
+          const attempted: TestPayload[][] = [];
+
+          const queue = createQueue(
+            async (p) => {
+              if (p.id === POISON) throw new Error("unprocessable payload");
+            },
+            {
+              processBatch: async (ps) => {
+                const batch = ps as TestPayload[];
+                attempted.push(batch);
+                if (batch.some((p) => p.id === POISON)) {
+                  throw new Error("unprocessable payload");
+                }
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 8 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(
+                attempted.some((b) => b.length === 1 && b[0]?.id === POISON),
+              ).toBe(true);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // The ordering invariant: a fold derives fields from arrival order, so
+          // every sub-batch a split produces must still be ascending and
+          // contiguous — never a reshuffle or an interleave.
+          for (const batch of attempted) {
+            const values = batch.map((p) => Number(p.value));
+            expect(values).toEqual([...values].sort((a, b) => a - b));
+            for (let i = 1; i < values.length; i++) {
+              expect(values[i]! - values[i - 1]!).toBe(1);
+            }
+          }
+        });
+      });
+
+      describe("when a coalesced batch fails only because it is too large", () => {
+        it("halves it until it fits and commits every payload once", async () => {
+          const MAX_WORKABLE = 2;
+          const seen: string[] = [];
+
+          const queue = createQueue(
+            async (p) => {
+              seen.push(p.id);
+            },
+            {
+              processBatch: async (ps) => {
+                const batch = ps as TestPayload[];
+                // Models a size-driven downstream limit (a query that exceeds
+                // its memory budget): nothing is wrong with any individual
+                // payload, the batch is simply too big for one pass.
+                if (batch.length > MAX_WORKABLE) {
+                  throw new Error("batch exceeded the downstream budget");
+                }
+                for (const p of batch) seen.push(p.id);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 8 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(new Set(seen).size).toBe(8);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // Converged by construction rather than by a retry happening to
+          // re-assemble a smaller batch — and without re-applying a payload
+          // that already succeeded inside this dispatch.
+          expect(seen.length).toBe(8);
+        });
+      });
+
       describe("when coalescing is disabled (maxBatch 1)", () => {
         /** @scenario 'Coalescing is a no-op when disabled' */
         it("processes each event individually and never calls processBatch", async () => {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -908,11 +908,15 @@ describe.skipIf(!hasTestcontainers)(
           );
           await queue.waitUntilReady();
 
+          // Future-dated so all eight are staged before any is due — staging
+          // races the dispatcher, and a partial root softens the exact descent
+          // this test asserts.
+          const dueAt = Date.now() + 2500;
           await queue.sendBatch(
             Array.from({ length: 8 }, (_, i) => ({
               id: `j${i}`,
               groupId: "group-a",
-              value: String(i),
+              value: String((dueAt + i) / 1000),
             })),
           );
 
@@ -976,11 +980,15 @@ describe.skipIf(!hasTestcontainers)(
           );
           await queue.waitUntilReady();
 
+          // Future-dated so all eight are staged before any is due — staging
+          // races the dispatcher, and a partial root softens the exact descent
+          // this test asserts.
+          const dueAt = Date.now() + 2500;
           await queue.sendBatch(
             Array.from({ length: 8 }, (_, i) => ({
               id: `j${i}`,
               groupId: "group-a",
-              value: String(i),
+              value: String((dueAt + i) / 1000),
             })),
           );
 
@@ -997,10 +1005,13 @@ describe.skipIf(!hasTestcontainers)(
           // every sub-batch a split produces must still be ascending and
           // contiguous — never a reshuffle or an interleave.
           for (const batch of attempted) {
-            const values = batch.map((p) => Number(p.value));
-            expect(values).toEqual([...values].sort((a, b) => a - b));
-            for (let i = 1; i < values.length; i++) {
-              expect(values[i]! - values[i - 1]!).toBe(1);
+            // Contiguity in the ORIGINAL arrival sequence: ids are j0..j7, so
+            // a sub-batch must be a run of consecutive indices — a reshuffle
+            // or an interleave breaks either the ordering or the step.
+            const indices = batch.map((p) => Number(p.id.slice(1)));
+            expect(indices).toEqual([...indices].sort((a, b) => a - b));
+            for (let i = 1; i < indices.length; i++) {
+              expect(indices[i]! - indices[i - 1]!).toBe(1);
             }
           }
         });
@@ -1044,11 +1055,15 @@ describe.skipIf(!hasTestcontainers)(
           );
           await queue.waitUntilReady();
 
+          // Future-dated so all eight are staged before any is due — staging
+          // races the dispatcher, and a partial root softens the exact descent
+          // this test asserts.
+          const dueAt = Date.now() + 2500;
           await queue.sendBatch(
             Array.from({ length: 8 }, (_, i) => ({
               id: `j${i}`,
               groupId: "group-a",
-              value: String(i),
+              value: String((dueAt + i) / 1000),
             })),
           );
 
@@ -1095,11 +1110,15 @@ describe.skipIf(!hasTestcontainers)(
           });
           await queue.waitUntilReady();
 
+          // Future-dated so all eight are staged before any is due — staging
+          // races the dispatcher, and a partial root softens the exact descent
+          // this test asserts.
+          const dueAt = Date.now() + 2500;
           await queue.sendBatch(
             Array.from({ length: 8 }, (_, i) => ({
               id: `j${i}`,
               groupId: "group-a",
-              value: String(i),
+              value: String((dueAt + i) / 1000),
             })),
           );
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -15,6 +15,7 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "../../../__tests__/integration/testContainers";
+import { ConfigurationError } from "../../../services/errorHandling";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
 import { GroupQueueProcessor } from "../groupQueue";
 
@@ -881,8 +882,9 @@ describe.skipIf(!hasTestcontainers)(
 
           const queue = createQueue(
             async (p) => {
-              // The isolate ends up here only if it is ever dispatched alone;
-              // healthy singles land here too once a half narrows to one.
+              // Only reached when the queue dispatches a job with no siblings
+              // to coalesce. A split that narrows to one payload still goes
+              // through processBatch with a one-element batch, never here.
               if (p.id === POISON) throw new Error("unprocessable payload");
               committed.push(p.id);
             },
@@ -911,7 +913,7 @@ describe.skipIf(!hasTestcontainers)(
             })),
           );
 
-          const HEALTHY_PREFIX = ["j0", "j1", "j2", "j3", "j4"];
+          const HEALTHY_PREFIX = ["j0", "j1", "j2", "j3", "j4"] as const;
 
           // j0..j4 commit despite sharing a batch with the offender. Without
           // bisection the whole batch fails together and NONE of them apply —
@@ -1006,6 +1008,10 @@ describe.skipIf(!hasTestcontainers)(
           const MAX_WORKABLE = 2;
           const seen: string[] = [];
 
+          const sizes: number[] = [];
+          let inFlight = 0;
+          let maxConcurrent = 0;
+
           const queue = createQueue(
             async (p) => {
               seen.push(p.id);
@@ -1013,6 +1019,14 @@ describe.skipIf(!hasTestcontainers)(
             {
               processBatch: async (ps) => {
                 const batch = ps as TestPayload[];
+                sizes.push(batch.length);
+                inFlight += 1;
+                maxConcurrent = Math.max(maxConcurrent, inFlight);
+                // Yield so a concurrent sibling call would overlap here and be
+                // caught by maxConcurrent, rather than being hidden by a
+                // handler that never awaits.
+                await new Promise((resolve) => setTimeout(resolve, 5));
+                inFlight -= 1;
                 // Models a size-driven downstream limit (a query that exceeds
                 // its memory budget): nothing is wrong with any individual
                 // payload, the batch is simply too big for one pass.
@@ -1046,6 +1060,57 @@ describe.skipIf(!hasTestcontainers)(
           // re-assemble a smaller batch — and without re-applying a payload
           // that already succeeded inside this dispatch.
           expect(seen.length).toBe(8);
+
+          // The exact descent, which a "sizes are non-increasing" assertion
+          // would not pin: 8 fails, its left half 4 fails, that half's two 2s
+          // succeed, then the right 4 fails and its two 2s succeed. Any
+          // concurrency between halves, or a fallback to one-at-a-time instead
+          // of halving, produces a different sequence.
+          expect(sizes).toEqual([8, 4, 2, 2, 4, 2, 2]);
+
+          // Sequential, not merely ordered: no batch ever started while
+          // another was still running.
+          expect(maxConcurrent).toBe(1);
+        });
+      });
+
+      describe("when a coalesced batch fails non-retryably", () => {
+        it("fails fast without splitting", async () => {
+          const attempts: number[] = [];
+
+          const queue = createQueue(async () => {}, {
+            processBatch: async (ps) => {
+              attempts.push(ps.length);
+              // CRITICAL category — `isRetryableJobError` is false for this, so
+              // the batch must not be split: it would fail identically at every
+              // size, and bisecting only multiplies work before the same
+              // verdict.
+              throw new ConfigurationError("test-handler", "not retryable");
+            },
+            coalesceMaxBatch: () => 50,
+            score: (p) => Number(p.value) * 1000,
+          });
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 8 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(attempts.length).toBeGreaterThan(0);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // Give any split a chance to appear before asserting none did.
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          expect(attempts.every((n) => n === attempts[0])).toBe(true);
+          expect(Math.min(...attempts)).toBeGreaterThan(1);
         });
       });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -17,7 +17,10 @@ import {
 } from "../../../__tests__/integration/testContainers";
 import { ConfigurationError } from "../../../services/errorHandling";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
-import { GroupQueueProcessor } from "../groupQueue";
+import {
+  GroupQueueProcessor,
+  MAX_BISECTION_SPLITS_PER_DISPATCH,
+} from "../groupQueue";
 
 async function foreignSiblingsRestagedCount(
   queueName: string,
@@ -1111,6 +1114,73 @@ describe.skipIf(!hasTestcontainers)(
           await new Promise((resolve) => setTimeout(resolve, 500));
           expect(attempts.every((n) => n === attempts[0])).toBe(true);
           expect(Math.min(...attempts)).toBeGreaterThan(1);
+        });
+      });
+
+      describe("when a batch degrades toward singletons", () => {
+        // Driven through the bisector directly rather than via staged dispatch:
+        // how large a root the drain assembles varies with staging timing, and
+        // this contract — bounded work per locked attempt — must hold for any
+        // shape, so the test pins it on the worst one deterministically.
+        it("stops splitting at the budget and rethrows to the retry path", async () => {
+          const sizes: number[] = [];
+          const queue = createQueue(async () => {}, {
+            processBatch: async (ps) => {
+              sizes.push(ps.length);
+              // Only singletons fit: without a budget this walks the entire
+              // tree — 127 calls for 64 payloads — inside one locked attempt.
+              if (ps.length > 1) {
+                throw new Error("only singletons fit");
+              }
+            },
+            coalesceMaxBatch: () => 64,
+          });
+          await queue.waitUntilReady();
+
+          const entries = Array.from({ length: 64 }, (_, i) => ({
+            payload: { id: `j${i}`, groupId: "group-a", value: String(i) },
+            stagedJobId: `job-${i}`,
+          }));
+          const span = {
+            addEvent: () => {},
+            setAttribute: () => {},
+          } as never;
+
+          await expect(
+            (
+              queue as unknown as {
+                processBatchBisecting: (args: {
+                  entries: typeof entries;
+                  attempt: number;
+                  routingLabels: Record<string, string>;
+                  span: never;
+                }) => Promise<void>;
+              }
+            ).processBatchBisecting({
+              entries,
+              attempt: 1,
+              routingLabels: {
+                queue_name: "q",
+                pipeline_name: "p",
+                job_type: "t",
+                job_name: "n",
+              },
+              span,
+            }),
+          ).rejects.toThrow("only singletons fit");
+
+          // Splits are the calls that failed with more than one payload; the
+          // budget caps them at MAX_BISECTION_SPLITS_PER_DISPATCH. Total calls
+          // stay far below the 127-call full walk that completing without a
+          // budget would require — and the throw above is the yield itself:
+          // the dispatch fails to the normal restage/backoff machinery instead
+          // of finishing the walk under the group lock.
+          const splits = sizes.filter((n) => n > 1).length;
+          expect(splits).toBeLessThanOrEqual(
+            MAX_BISECTION_SPLITS_PER_DISPATCH + 1,
+          );
+          expect(sizes.length).toBeLessThan(80);
+          expect(sizes.length).toBeGreaterThan(5);
         });
       });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -874,14 +874,17 @@ describe.skipIf(!hasTestcontainers)(
           // about that gap, which is the side-lining decision (#6482).
           const POISON = "j5";
           const attempted: TestPayload[][] = [];
-          const processedIds = new Set<string>();
+          // An ARRAY, not a set: a set cannot tell "committed once" from
+          // "committed twice", and the second is the thing worth watching when
+          // a dispatch applies part of a batch before failing.
+          const committed: string[] = [];
 
           const queue = createQueue(
             async (p) => {
               // The isolate ends up here only if it is ever dispatched alone;
               // healthy singles land here too once a half narrows to one.
               if (p.id === POISON) throw new Error("unprocessable payload");
-              processedIds.add(p.id);
+              committed.push(p.id);
             },
             {
               processBatch: async (ps) => {
@@ -892,7 +895,7 @@ describe.skipIf(!hasTestcontainers)(
                 if (batch.some((p) => p.id === POISON)) {
                   throw new Error("unprocessable payload");
                 }
-                for (const p of batch) processedIds.add(p.id);
+                for (const p of batch) committed.push(p.id);
               },
               coalesceMaxBatch: () => 50,
               score: (p) => Number(p.value) * 1000,
@@ -908,22 +911,35 @@ describe.skipIf(!hasTestcontainers)(
             })),
           );
 
+          const HEALTHY_PREFIX = ["j0", "j1", "j2", "j3", "j4"];
+
           // j0..j4 commit despite sharing a batch with the offender. Without
           // bisection the whole batch fails together and NONE of them apply —
           // that is the regression this pins.
           await vi.waitFor(
             () => {
-              expect([...processedIds].sort()).toEqual([
-                "j0",
-                "j1",
-                "j2",
-                "j3",
-                "j4",
-              ]);
+              expect([...new Set(committed)].sort()).toEqual(HEALTHY_PREFIX);
             },
             { timeout: 30000, interval: 50 },
           );
-          expect(processedIds.has(POISON)).toBe(false);
+          expect(committed).not.toContain(POISON);
+
+          // No payload is applied more often than its peers. The prefix always
+          // commits as a unit, so equal counts hold however many times the
+          // group is redelivered — while a payload applied one extra time (the
+          // failure a set-based assertion cannot see) breaks equality.
+          //
+          // Scope note: this pins that BISECTION does not re-run a payload it
+          // already committed within a dispatch. Redelivery across dispatches
+          // is at-least-once by design and is made safe by the fold store's
+          // applied-event-id set, which has its own suite
+          // (projections/foldCache/__tests__/foldRedeliveryIdempotency) — this
+          // handler is a mock with no such guard, so asserting it here would
+          // test the mock rather than the queue.
+          const counts = HEALTHY_PREFIX.map(
+            (id) => committed.filter((c) => c === id).length,
+          );
+          expect(new Set(counts).size).toBe(1);
 
           // The split actually narrowed to the offender rather than retrying
           // the batch whole: some attempt isolated it on its own.

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -16,11 +16,12 @@ import {
   stopTestContainers,
 } from "../../../__tests__/integration/testContainers";
 import { ConfigurationError } from "../../../services/errorHandling";
-import type { EventSourcedQueueDefinition } from "../../queue.types";
-import {
-  GroupQueueProcessor,
-  MAX_BISECTION_SPLITS_PER_DISPATCH,
-} from "../groupQueue";
+import type {
+  EventSourcedQueueDefinition,
+  JobDelivery,
+} from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+import { DEFAULT_BISECTION_SPLITS_PER_DISPATCH } from "../scripts";
 
 async function foreignSiblingsRestagedCount(
   queueName: string,
@@ -1136,6 +1137,115 @@ describe.skipIf(!hasTestcontainers)(
         });
       });
 
+      describe("when the split budget is set to zero", () => {
+        it("never splits, restoring the pre-bisection behaviour", async () => {
+          // The kill switch: an operator can disable bisection through the
+          // environment rather than waiting on a deploy.
+          vi.stubEnv("LANGWATCH_GQ_BISECTION_SPLIT_BUDGET", "0");
+          const sizes: number[] = [];
+          const queue = createQueue(async () => {}, {
+            processBatch: async (ps) => {
+              sizes.push(ps.length);
+              throw new Error("retryable");
+            },
+            coalesceMaxBatch: () => 8,
+          });
+          await queue.waitUntilReady();
+
+          const entries = Array.from({ length: 4 }, (_, i) => ({
+            payload: { id: `j${i}`, groupId: "group-a", value: String(i) },
+            stagedJobId: `job-${i}`,
+          }));
+
+          await expect(
+            (
+              queue as unknown as {
+                processBatchBisecting: (args: {
+                  entries: typeof entries;
+                  attempt: number;
+                  routingLabels: Record<string, string>;
+                  span: never;
+                }) => Promise<void>;
+              }
+            ).processBatchBisecting({
+              entries,
+              attempt: 1,
+              routingLabels: {
+                queue_name: "q",
+                pipeline_name: "p",
+                job_type: "t",
+                job_name: "n",
+              },
+              span: { addEvent: () => {}, setAttribute: () => {} } as never,
+            }),
+          ).rejects.toThrow("retryable");
+
+          // One call, the whole batch, no descent.
+          expect(sizes).toEqual([4]);
+          vi.unstubAllEnvs();
+        });
+      });
+
+      describe("when the root of a bisected batch commits and then fails", () => {
+        // Driven through the bisector directly: this is about which delivery
+        // flags the descent emits, and staged dispatch adds timing noise that
+        // has nothing to do with the contract.
+        it("marks the sub-batches as continuations so their commits extend rather than replace", async () => {
+          const deliveries: (JobDelivery | undefined)[] = [];
+          let rootFailed = false;
+
+          const queue = createQueue(async () => {}, {
+            processBatch: async (ps, delivery) => {
+              deliveries.push(delivery);
+              // The post-store window: the handler COMMITS and only then
+              // throws (a reactor failing after the fold stored). The commit
+              // is the part that matters — a later sub-batch that replaces
+              // the applied set erases what this call recorded.
+              if (!rootFailed && ps.length > 1) {
+                rootFailed = true;
+                throw new Error("reactor failed after the fold was stored");
+              }
+            },
+            coalesceMaxBatch: () => 8,
+          });
+          await queue.waitUntilReady();
+
+          const entries = Array.from({ length: 4 }, (_, i) => ({
+            payload: { id: `j${i}`, groupId: "group-a", value: String(i) },
+            stagedJobId: `job-${i}`,
+          }));
+
+          await (
+            queue as unknown as {
+              processBatchBisecting: (args: {
+                entries: typeof entries;
+                attempt: number;
+                routingLabels: Record<string, string>;
+                span: never;
+              }) => Promise<void>;
+            }
+          ).processBatchBisecting({
+            entries,
+            attempt: 1,
+            routingLabels: {
+              queue_name: "q",
+              pipeline_name: "p",
+              job_type: "t",
+              job_name: "n",
+            },
+            span: { addEvent: () => {}, setAttribute: () => {} } as never,
+          });
+
+          // The root is a fresh delivery; every call the split produces after
+          // it must be a continuation, because the root already wrote.
+          expect(deliveries[0]?.isContinuation).toBeUndefined();
+          expect(deliveries.length).toBeGreaterThan(1);
+          expect(
+            deliveries.slice(1).every((d) => d?.isContinuation === true),
+          ).toBe(true);
+        });
+      });
+
       describe("when a batch degrades toward singletons", () => {
         // Driven through the bisector directly rather than via staged dispatch:
         // how large a root the drain assembles varies with staging timing, and
@@ -1189,14 +1299,14 @@ describe.skipIf(!hasTestcontainers)(
           ).rejects.toThrow("only singletons fit");
 
           // Splits are the calls that failed with more than one payload; the
-          // budget caps them at MAX_BISECTION_SPLITS_PER_DISPATCH. Total calls
+          // budget caps them at DEFAULT_BISECTION_SPLITS_PER_DISPATCH. Total calls
           // stay far below the 127-call full walk that completing without a
           // budget would require — and the throw above is the yield itself:
           // the dispatch fails to the normal restage/backoff machinery instead
           // of finishing the walk under the group lock.
           const splits = sizes.filter((n) => n > 1).length;
           expect(splits).toBeLessThanOrEqual(
-            MAX_BISECTION_SPLITS_PER_DISPATCH + 1,
+            DEFAULT_BISECTION_SPLITS_PER_DISPATCH + 1,
           );
           expect(sizes.length).toBeLessThan(80);
           expect(sizes.length).toBeGreaterThan(5);

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -99,6 +99,24 @@ import {
 import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
 
 /**
+ * Splits one dispatch may perform before bisection gives up and lets the
+ * normal retry/backoff path take over. Sized to cover every useful descent
+ * (isolating one poison payload in a 256 batch costs 8 splits; converging to
+ * sub-batches of 8 costs 31) while cutting off the pathological
+ * singleton-degradation walk (~2N calls) that would otherwise run under the
+ * group lock for the whole tree.
+ */
+export const MAX_BISECTION_SPLITS_PER_DISPATCH = 32;
+
+/** Mutable state shared across one dispatch's bisection descent. */
+interface BisectionDispatchState {
+  /** True once any sub-batch of this dispatch committed successfully. */
+  committed: boolean;
+  /** Splits performed so far — compared against the budget above. */
+  splits: number;
+}
+
+/**
  * How long the group's retry-chain counter survives without a refresh.
  *
  * It is re-set on every retry, so it only has to outlive ONE backoff — but it
@@ -1809,13 +1827,24 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * explicit decision about the gap, which is the side-lining work in #6482.
    *
    * Re-running a payload that already applied is safe — fold redelivery is
-   * idempotent via the store's applied-event-id set (#6016) — which is what
-   * makes a partially-applied batch a recoverable state rather than a
-   * double-count. Bisection therefore does not widen the known residual there
-   * (a lost cache can still double-count), it only reaches it by a new route.
+   * idempotent via the store's applied-event-id set (#6016) — but ONLY because
+   * every sub-batch call after the first successful commit carries
+   * `delivery.continuation`, which tells the fold commit to EXTEND that set
+   * rather than replace it. Without the flag, each sub-batch commit would erase
+   * the ids the earlier sub-batches recorded, and a retry after a failed later
+   * sub-batch would re-apply the committed prefix (#6578).
    *
    * Non-retryable failures are NOT split: they will fail identically at every
    * size, so bisecting one only multiplies the work before the same verdict.
+   *
+   * Work within one locked attempt is BOUNDED. Splitting happens while this
+   * job holds the group's active key (heartbeat-renewed), so an unbounded
+   * descent — a handler that only accepts singletons turns a full batch into
+   * ~2N sequential calls — would hold the group lock and a worker slot for the
+   * whole walk instead of yielding to retry/backoff. After
+   * MAX_BISECTION_SPLITS_PER_DISPATCH splits the current failure propagates
+   * un-split: committed prefixes stay committed, the failed remainder re-stages
+   * through the normal failure path, and backoff takes over.
    */
   private async processBatchBisecting({
     entries,
@@ -1823,6 +1852,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     routingLabels,
     span,
     narrowed = false,
+    dispatch = { committed: false, splits: 0 },
   }: {
     /**
      * Payloads paired with the staged job each came from, so a failure that
@@ -1837,6 +1867,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     span: Span;
     /** True in a recursive call — i.e. this batch is the product of a split. */
     narrowed?: boolean;
+    /**
+     * State shared across the whole descent of ONE dispatch, deliberately
+     * mutable: `committed` flips once the first sub-batch commits (every later
+     * call is a continuation and must carry the flag — see JobDelivery), and
+     * `splits` is the call budget that bounds work under the group lock.
+     */
+    dispatch?: BisectionDispatchState;
   }): Promise<void> {
     if (!this.processBatch) {
       throw new Error("processBatchBisecting called without a batch handler");
@@ -1845,8 +1882,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     try {
       await this.processBatch(
         entries.map((entry) => entry.payload),
-        { attempt },
+        { attempt, ...(dispatch.committed ? { continuation: true } : {}) },
       );
+      dispatch.committed = true;
     } catch (err) {
       await this.splitFailedBatch({
         entries,
@@ -1854,6 +1892,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         routingLabels,
         span,
         narrowed,
+        dispatch,
         err,
       });
     }
@@ -1873,6 +1912,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     routingLabels,
     span,
     narrowed,
+    dispatch,
     err,
   }: {
     entries: { payload: Payload; stagedJobId: string }[];
@@ -1880,6 +1920,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     routingLabels: Record<string, string>;
     span: Span;
     narrowed: boolean;
+    dispatch: BisectionDispatchState;
     err: unknown;
   }): Promise<void> {
     // Fails the same way at every size, so splitting only multiplies the work
@@ -1899,6 +1940,34 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       });
       throw err;
     }
+
+    // Call budget: splitting runs under the group's heartbeat-renewed active
+    // key, so a batch degrading toward singletons must not walk the whole tree
+    // (~2N sequential handler calls for N payloads) inside one locked attempt.
+    // Past the budget the failure propagates un-split: committed prefixes stay
+    // committed, the remainder re-stages via the normal failure path, and
+    // exponential backoff takes over. The budget comfortably covers the useful
+    // descents — isolating one poison payload in a 256 batch costs 8 splits,
+    // converging to sub-batches of 8 costs 31 — and cuts off only the
+    // pathological walk where backoff is the right behaviour anyway.
+    if (dispatch.splits >= MAX_BISECTION_SPLITS_PER_DISPATCH) {
+      this.logger.warn(
+        {
+          queueName: this.queueName,
+          batchSize: entries.length,
+          splits: dispatch.splits,
+          attempt,
+          error: err instanceof Error ? err : new Error(String(err)),
+        },
+        "Bisection split budget exhausted; failing the remainder to the normal retry path",
+      );
+      span.addEvent("queue.batch_bisection_budget_exhausted", {
+        "queue.batch_size": entries.length,
+        "queue.batch_splits": dispatch.splits,
+      });
+      throw err;
+    }
+    dispatch.splits += 1;
 
     const mid = Math.ceil(entries.length / 2);
     gqBatchBisectionsTotal.inc(routingLabels);
@@ -1924,6 +1993,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       routingLabels,
       span,
       narrowed: true,
+      dispatch,
     });
     await this.processBatchBisecting({
       entries: entries.slice(mid),
@@ -1931,6 +2001,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       routingLabels,
       span,
       narrowed: true,
+      dispatch,
     });
   }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -990,6 +990,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // per-job path below is unchanged.
     const maxBatch = this.coalesceMaxBatch?.(payload) ?? 1;
     let batchPayloads: Payload[] | null = null;
+    // Staged-job id per batch member, index-aligned with batchPayloads, so a
+    // bisected failure can name the payload it narrowed to.
+    let batchJobIds: string[] = [];
     let drainedSiblings: DrainedJob[] = [];
     if (maxBatch > 1 && this.processBatch) {
       // Byte bound (ADR-066 pillar 2): the drain also stops before a job that
@@ -1075,6 +1078,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           drainedSiblings = liveSiblings;
           if (siblingPayloads.length > 0) {
             batchPayloads = [payload, ...siblingPayloads];
+            batchJobIds = [
+              stagedJobId,
+              ...liveSiblings.map((sibling) => sibling.stagedJobId),
+            ];
           }
         } catch (err) {
           if (err instanceof TransientBlobStoreError) {
@@ -1236,7 +1243,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     batchPayloads.length,
                   );
                   await this.processBatchBisecting({
-                    payloads: batchPayloads,
+                    entries: batchPayloads.map((batchPayload, index) => ({
+                      payload: batchPayload,
+                      stagedJobId: batchJobIds[index] ?? stagedJobId,
+                    })),
                     attempt,
                     routingLabels,
                     span,
@@ -1808,61 +1818,152 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * size, so bisecting one only multiplies the work before the same verdict.
    */
   private async processBatchBisecting({
-    payloads,
+    entries,
     attempt,
     routingLabels,
     span,
+    narrowed = false,
   }: {
-    payloads: Payload[];
+    /**
+     * Payloads paired with the staged job each came from, so a failure that
+     * narrows to one payload can name it. Carrying the id is the whole reason
+     * bisection is worth more than a retry: without it the throw is anonymous
+     * and the terminal record anchors to the DISPATCHED job, which for a failing
+     * drained sibling is the wrong job entirely.
+     */
+    entries: { payload: Payload; stagedJobId: string }[];
     attempt: number;
     routingLabels: Record<string, string>;
     span: Span;
+    /** True in a recursive call — i.e. this batch is the product of a split. */
+    narrowed?: boolean;
   }): Promise<void> {
     if (!this.processBatch) {
       throw new Error("processBatchBisecting called without a batch handler");
     }
 
     try {
-      await this.processBatch(payloads, { attempt });
-      return;
-    } catch (err) {
-      // A single payload is already the smallest attributable unit, and a
-      // non-retryable error fails the same way at every size.
-      if (payloads.length <= 1 || !isRetryableJobError(err)) {
-        throw err;
-      }
-
-      const mid = Math.ceil(payloads.length / 2);
-      gqBatchBisectionsTotal.inc(routingLabels);
-      span.addEvent("queue.batch_bisected", {
-        "queue.batch_size": payloads.length,
-        "queue.batch_split_at": mid,
-      });
-      this.logger.warn(
-        {
-          queueName: this.queueName,
-          batchSize: payloads.length,
-          splitAt: mid,
-          attempt,
-          error: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Coalesced batch failed; splitting in half and retrying each half in order",
+      await this.processBatch(
+        entries.map((entry) => entry.payload),
+        { attempt },
       );
-
-      // Sequential and contiguous — see the ordering note above.
-      await this.processBatchBisecting({
-        payloads: payloads.slice(0, mid),
+    } catch (err) {
+      await this.splitFailedBatch({
+        entries,
         attempt,
         routingLabels,
         span,
-      });
-      await this.processBatchBisecting({
-        payloads: payloads.slice(mid),
-        attempt,
-        routingLabels,
-        span,
+        narrowed,
+        err,
       });
     }
+  }
+
+  /**
+   * The failure half of {@link processBatchBisecting}: decide whether this
+   * batch can usefully be made smaller, and if so run both halves in order.
+   *
+   * Split out so each half of the decision stays readable on its own — the
+   * happy path is one call, and everything about *why* a failure does or does
+   * not warrant a split lives here.
+   */
+  private async splitFailedBatch({
+    entries,
+    attempt,
+    routingLabels,
+    span,
+    narrowed,
+    err,
+  }: {
+    entries: { payload: Payload; stagedJobId: string }[];
+    attempt: number;
+    routingLabels: Record<string, string>;
+    span: Span;
+    narrowed: boolean;
+    err: unknown;
+  }): Promise<void> {
+    // Fails the same way at every size, so splitting only multiplies the work
+    // before reaching the identical verdict.
+    if (!isRetryableJobError(err)) {
+      throw err;
+    }
+
+    if (entries.length <= 1) {
+      // Smallest attributable unit — report it, then let the existing retry
+      // and quarantine path take over.
+      this.reportBisectedIsolate({
+        entry: narrowed ? entries[0] : undefined,
+        attempt,
+        span,
+        err,
+      });
+      throw err;
+    }
+
+    const mid = Math.ceil(entries.length / 2);
+    gqBatchBisectionsTotal.inc(routingLabels);
+    span.addEvent("queue.batch_bisected", {
+      "queue.batch_size": entries.length,
+      "queue.batch_split_at": mid,
+    });
+    this.logger.warn(
+      {
+        queueName: this.queueName,
+        batchSize: entries.length,
+        splitAt: mid,
+        attempt,
+        error: err instanceof Error ? err : new Error(String(err)),
+      },
+      "Coalesced batch failed; splitting in half and retrying each half in order",
+    );
+
+    // Sequential and contiguous — see the ordering note on the caller.
+    await this.processBatchBisecting({
+      entries: entries.slice(0, mid),
+      attempt,
+      routingLabels,
+      span,
+      narrowed: true,
+    });
+    await this.processBatchBisecting({
+      entries: entries.slice(mid),
+      attempt,
+      routingLabels,
+      span,
+      narrowed: true,
+    });
+  }
+
+  /**
+   * Names the payload a bisection narrowed to, so the offender is attributable
+   * rather than "something in that batch".
+   *
+   * `entry` is undefined when the failing batch of one was never split — an
+   * un-split single is just a job that failed, and reporting it as an isolate
+   * would send an investigator hunting for a bisection that never happened.
+   */
+  private reportBisectedIsolate({
+    entry,
+    attempt,
+    span,
+    err,
+  }: {
+    entry: { payload: Payload; stagedJobId: string } | undefined;
+    attempt: number;
+    span: Span;
+    err: unknown;
+  }): void {
+    if (!entry) return;
+    this.logger.error(
+      {
+        queueName: this.queueName,
+        offendingStagedJobId: entry.stagedJobId,
+        attempt,
+        error: err instanceof Error ? err : new Error(String(err)),
+      },
+      "Coalesced batch narrowed to a single failing payload; this staged job is the offender",
+    );
+    span.setAttribute("queue.batch_offending_job_id", entry.stagedJobId);
   }
 
   private async restageDrainedSiblings(

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -6,6 +6,7 @@ import { createLogger } from "@langwatch/observability";
 import {
   context as otelContext,
   ROOT_CONTEXT,
+  type Span,
   SpanKind,
   TraceFlags,
   trace,
@@ -62,6 +63,7 @@ import {
 } from "./jobEnvelope";
 import { legacyStagedJobAttempt } from "./legacyStagedJobAttempt";
 import {
+  gqBatchBisectionsTotal,
   gqForeignSiblingsRestagedTotal,
   gqGroupAttemptReadFailuresTotal,
   gqGroupsBlockedTotal,
@@ -1233,7 +1235,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     "queue.coalesced_batch_size",
                     batchPayloads.length,
                   );
-                  await this.processBatch(batchPayloads, { attempt });
+                  await this.processBatchBisecting({
+                    payloads: batchPayloads,
+                    attempt,
+                    routingLabels,
+                    span,
+                  });
                 } else {
                   await this.process(payload, { attempt });
                 }
@@ -1760,6 +1767,101 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       await this.redisConnection.del(this.groupAttemptKey(groupId));
     } catch {
       // The TTL reclaims it.
+    }
+  }
+
+  /**
+   * Runs a coalesced batch, halving it on a retryable failure until it either
+   * succeeds or the failure is attributable to a single payload.
+   *
+   * Why this exists: a coalesced batch is all-or-nothing, so without bisection
+   * ONE unprocessable payload fails the whole batch, and the retry re-drains
+   * the same siblings into the same batch — the poison payload takes up to
+   * `coalesceMaxBatch - 1` healthy payloads down with it on every attempt until
+   * the group blocks. Recovery from a *size*-driven failure (a batch too heavy
+   * for a downstream query's memory budget) was equally undirected: it only
+   * succeeded if the retry happened to re-assemble a lighter set.
+   *
+   * One split handles both, because both are "this set of payloads fails but a
+   * smaller set might not": a too-heavy batch halves until it fits, and a
+   * poison payload halves until it is alone, at which point the throw is
+   * attributable to it and the existing retry / quarantine path takes over.
+   *
+   * Ordering is preserved: the halves are CONTIGUOUS and awaited in sequence,
+   * never concurrently, because a fold derives fields from arrival order (the
+   * same invariant that makes splitting a group across lanes unsafe).
+   *
+   * That invariant also sets the limit of what this can do. A throw propagates
+   * immediately, so payloads AFTER the offender are not attempted — stepping
+   * over it would apply them across a gap the fold cannot see, producing wrong
+   * values silently. So bisection recovers everything BEFORE the offender and
+   * names it; it does not rescue what queued behind it. Doing that needs an
+   * explicit decision about the gap, which is the side-lining work in #6482.
+   *
+   * Re-running a payload that already applied is safe — fold redelivery is
+   * idempotent via the store's applied-event-id set (#6016) — which is what
+   * makes a partially-applied batch a recoverable state rather than a
+   * double-count. Bisection therefore does not widen the known residual there
+   * (a lost cache can still double-count), it only reaches it by a new route.
+   *
+   * Non-retryable failures are NOT split: they will fail identically at every
+   * size, so bisecting one only multiplies the work before the same verdict.
+   */
+  private async processBatchBisecting({
+    payloads,
+    attempt,
+    routingLabels,
+    span,
+  }: {
+    payloads: Payload[];
+    attempt: number;
+    routingLabels: Record<string, string>;
+    span: Span;
+  }): Promise<void> {
+    if (!this.processBatch) {
+      throw new Error("processBatchBisecting called without a batch handler");
+    }
+
+    try {
+      await this.processBatch(payloads, { attempt });
+      return;
+    } catch (err) {
+      // A single payload is already the smallest attributable unit, and a
+      // non-retryable error fails the same way at every size.
+      if (payloads.length <= 1 || !isRetryableJobError(err)) {
+        throw err;
+      }
+
+      const mid = Math.ceil(payloads.length / 2);
+      gqBatchBisectionsTotal.inc(routingLabels);
+      span.addEvent("queue.batch_bisected", {
+        "queue.batch_size": payloads.length,
+        "queue.batch_split_at": mid,
+      });
+      this.logger.warn(
+        {
+          queueName: this.queueName,
+          batchSize: payloads.length,
+          splitAt: mid,
+          attempt,
+          error: err instanceof Error ? err : new Error(String(err)),
+        },
+        "Coalesced batch failed; splitting in half and retrying each half in order",
+      );
+
+      // Sequential and contiguous — see the ordering note above.
+      await this.processBatchBisecting({
+        payloads: payloads.slice(0, mid),
+        attempt,
+        routingLabels,
+        span,
+      });
+      await this.processBatchBisecting({
+        payloads: payloads.slice(mid),
+        attempt,
+        routingLabels,
+        span,
+      });
     }
   }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -93,20 +93,11 @@ import {
   type DispatchResult,
   type DrainedJob,
   GroupStagingScripts,
+  readBisectionSplitBudget,
   readClaimStrikeThreshold,
   readGroupQuarantineThreshold,
 } from "./scripts";
 import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
-
-/**
- * Splits one dispatch may perform before bisection gives up and lets the
- * normal retry/backoff path take over. Sized to cover every useful descent
- * (isolating one poison payload in a 256 batch costs 8 splits; converging to
- * sub-batches of 8 costs 31) while cutting off the pathological
- * singleton-degradation walk (~2N calls) that would otherwise run under the
- * group lock for the whole tree.
- */
-export const MAX_BISECTION_SPLITS_PER_DISPATCH = 32;
 
 /** Mutable state shared across one dispatch's bisection descent. */
 interface BisectionDispatchState {
@@ -324,6 +315,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    */
   private readonly quarantineFailStreakThreshold =
     readGroupQuarantineThreshold();
+
+  /**
+   * Splits allowed per dispatch before bisection yields to retry/backoff. Read
+   * once at construction; 0 disables bisection outright, which restores the
+   * pre-bisection behaviour without a deploy. See
+   * {@link readBisectionSplitBudget}.
+   */
+  private readonly bisectionSplitBudget = readBisectionSplitBudget();
 
   private shutdownRequested = false;
   /** Tracks in-flight jobs for active count metrics. */
@@ -1009,7 +1008,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const maxBatch = this.coalesceMaxBatch?.(payload) ?? 1;
     let batchPayloads: Payload[] | null = null;
     // Staged-job id per batch member, index-aligned with batchPayloads, so a
-    // bisected failure can name the payload it isNarrowed to.
+    // bisected failure can name the payload it narrowed to.
     let batchJobIds: string[] = [];
     let drainedSiblings: DrainedJob[] = [];
     if (maxBatch > 1 && this.processBatch) {
@@ -1842,7 +1841,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * descent — a handler that only accepts singletons turns a full batch into
    * ~2N sequential calls — would hold the group lock and a worker slot for the
    * whole walk instead of yielding to retry/backoff. After
-   * MAX_BISECTION_SPLITS_PER_DISPATCH splits the current failure propagates
+   * the split budget is spent the current failure propagates
    * un-split: committed prefixes stay committed, the failed remainder re-stages
    * through the normal failure path, and backoff takes over.
    */
@@ -1879,13 +1878,27 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       throw new Error("processBatchBisecting called without a batch handler");
     }
 
+    let failure: { err: unknown } | undefined;
     try {
       await this.processBatch(
         entries.map((entry) => entry.payload),
         { attempt, ...(dispatch.hasCommitted ? { isContinuation: true } : {}) },
       );
-      dispatch.hasCommitted = true;
     } catch (err) {
+      failure = { err };
+    }
+
+    // Set on BOTH outcomes, and before the split recurses. The flag means "an
+    // earlier call in this descent MAY have written", which is what a later
+    // commit needs to know — a handler that stored and then threw (a reactor
+    // failing after the fold committed) has written just as surely as one that
+    // returned. Treating that as a fresh delivery lets the next sub-batch's
+    // commit REPLACE the applied set the failed call recorded (#6578). The
+    // flag only ever turns a replace into a merge, so over-setting it is the
+    // safe direction and under-setting it is what double-applies.
+    dispatch.hasCommitted = true;
+
+    if (failure) {
       await this.splitFailedBatch({
         entries,
         attempt,
@@ -1893,7 +1906,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         span,
         isNarrowed,
         dispatch,
-        err,
+        err: failure.err,
       });
     }
   }
@@ -1950,7 +1963,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // descents — isolating one poison payload in a 256 batch costs 8 splits,
     // converging to sub-batches of 8 costs 31 — and cuts off only the
     // pathological walk where backoff is the right behaviour anyway.
-    if (dispatch.splits >= MAX_BISECTION_SPLITS_PER_DISPATCH) {
+    if (dispatch.splits >= this.bisectionSplitBudget) {
       this.logger.warn(
         {
           queueName: this.queueName,
@@ -2006,7 +2019,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
-   * Names the payload a bisection isNarrowed to, so the offender is attributable
+   * Names the payload a bisection narrowed to, so the offender is attributable
    * rather than "something in that batch".
    *
    * `entry` is undefined when the failing batch of one was never split — an
@@ -2032,7 +2045,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         attempt,
         error: err instanceof Error ? err : new Error(String(err)),
       },
-      "Coalesced batch isNarrowed to a single failing payload; this staged job is the offender",
+      "Coalesced batch narrowed to a single failing payload; this staged job is the offender",
     );
     span.setAttribute("queue.batch_offending_job_id", entry.stagedJobId);
   }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -111,7 +111,7 @@ export const MAX_BISECTION_SPLITS_PER_DISPATCH = 32;
 /** Mutable state shared across one dispatch's bisection descent. */
 interface BisectionDispatchState {
   /** True once any sub-batch of this dispatch committed successfully. */
-  committed: boolean;
+  hasCommitted: boolean;
   /** Splits performed so far — compared against the budget above. */
   splits: number;
 }
@@ -1009,7 +1009,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const maxBatch = this.coalesceMaxBatch?.(payload) ?? 1;
     let batchPayloads: Payload[] | null = null;
     // Staged-job id per batch member, index-aligned with batchPayloads, so a
-    // bisected failure can name the payload it narrowed to.
+    // bisected failure can name the payload it isNarrowed to.
     let batchJobIds: string[] = [];
     let drainedSiblings: DrainedJob[] = [];
     if (maxBatch > 1 && this.processBatch) {
@@ -1829,7 +1829,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * Re-running a payload that already applied is safe — fold redelivery is
    * idempotent via the store's applied-event-id set (#6016) — but ONLY because
    * every sub-batch call after the first successful commit carries
-   * `delivery.continuation`, which tells the fold commit to EXTEND that set
+   * `delivery.isContinuation`, which tells the fold commit to EXTEND that set
    * rather than replace it. Without the flag, each sub-batch commit would erase
    * the ids the earlier sub-batches recorded, and a retry after a failed later
    * sub-batch would re-apply the committed prefix (#6578).
@@ -1851,8 +1851,8 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     attempt,
     routingLabels,
     span,
-    narrowed = false,
-    dispatch = { committed: false, splits: 0 },
+    isNarrowed = false,
+    dispatch = { hasCommitted: false, splits: 0 },
   }: {
     /**
      * Payloads paired with the staged job each came from, so a failure that
@@ -1866,10 +1866,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     routingLabels: Record<string, string>;
     span: Span;
     /** True in a recursive call — i.e. this batch is the product of a split. */
-    narrowed?: boolean;
+    isNarrowed?: boolean;
     /**
      * State shared across the whole descent of ONE dispatch, deliberately
-     * mutable: `committed` flips once the first sub-batch commits (every later
+     * mutable: `hasCommitted` flips once the first sub-batch commits (every later
      * call is a continuation and must carry the flag — see JobDelivery), and
      * `splits` is the call budget that bounds work under the group lock.
      */
@@ -1882,16 +1882,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     try {
       await this.processBatch(
         entries.map((entry) => entry.payload),
-        { attempt, ...(dispatch.committed ? { continuation: true } : {}) },
+        { attempt, ...(dispatch.hasCommitted ? { isContinuation: true } : {}) },
       );
-      dispatch.committed = true;
+      dispatch.hasCommitted = true;
     } catch (err) {
       await this.splitFailedBatch({
         entries,
         attempt,
         routingLabels,
         span,
-        narrowed,
+        isNarrowed,
         dispatch,
         err,
       });
@@ -1911,7 +1911,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     attempt,
     routingLabels,
     span,
-    narrowed,
+    isNarrowed,
     dispatch,
     err,
   }: {
@@ -1919,7 +1919,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     attempt: number;
     routingLabels: Record<string, string>;
     span: Span;
-    narrowed: boolean;
+    isNarrowed: boolean;
     dispatch: BisectionDispatchState;
     err: unknown;
   }): Promise<void> {
@@ -1933,7 +1933,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       // Smallest attributable unit — report it, then let the existing retry
       // and quarantine path take over.
       this.reportBisectedIsolate({
-        entry: narrowed ? entries[0] : undefined,
+        entry: isNarrowed ? entries[0] : undefined,
         attempt,
         span,
         err,
@@ -1992,7 +1992,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       attempt,
       routingLabels,
       span,
-      narrowed: true,
+      isNarrowed: true,
       dispatch,
     });
     await this.processBatchBisecting({
@@ -2000,13 +2000,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       attempt,
       routingLabels,
       span,
-      narrowed: true,
+      isNarrowed: true,
       dispatch,
     });
   }
 
   /**
-   * Names the payload a bisection narrowed to, so the offender is attributable
+   * Names the payload a bisection isNarrowed to, so the offender is attributable
    * rather than "something in that batch".
    *
    * `entry` is undefined when the failing batch of one was never split — an
@@ -2032,7 +2032,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         attempt,
         error: err instanceof Error ? err : new Error(String(err)),
       },
-      "Coalesced batch narrowed to a single failing payload; this staged job is the offender",
+      "Coalesced batch isNarrowed to a single failing payload; this staged job is the offender",
     );
     span.setAttribute("queue.batch_offending_job_id", entry.stagedJobId);
   }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -418,9 +418,16 @@ export const gqForeignSiblingsRestagedTotal = new Counter({
  * A coalesced batch failed retryably and was split in half to isolate the
  * cause.
  *
- * Counts SPLITS, not batches: isolating one poison payload out of a full batch
- * costs `log2(batchSize)` increments, so a single stubborn payload shows up as
- * a burst rather than a single event. Read it as a rate, not a total.
+ * Increments ONCE PER SPLIT, not once per batch, so one failing batch produces
+ * a burst rather than a single event. Read it as a rate, not a total, and do
+ * not infer a batch count from it — how many splits a batch costs depends on
+ * why it failed:
+ * - a single unprocessable payload costs one split per level of the descent to
+ *   it, so roughly `log2(batchSize)` — but the exact count moves with the
+ *   payload's position (a batch of 5 costs 2 or 3, not 2.32).
+ * - a batch that fails purely on size keeps splitting until every part fits, so
+ *   the cost is driven by how far the working size is below the batch bound and
+ *   approaches `batchSize - 1` in the worst case, far above `log2(batchSize)`.
  *
  * A steady non-zero rate is the signal worth acting on, and it means one of two
  * things — both real:
@@ -435,6 +442,6 @@ export const gqForeignSiblingsRestagedTotal = new Counter({
  */
 export const gqBatchBisectionsTotal = new Counter({
   name: "gq_batch_bisections_total",
-  help: "Retryable coalesced-batch failures that were split in half to isolate the cause — counts splits, so isolating one payload costs log2(batchSize)",
+  help: "Retryable coalesced-batch failures that were split in half to isolate the cause — increments once per split, so one failing batch costs several",
   labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -40,6 +40,7 @@ const metricNames = [
   // ADR-066 pillar 2 mixed-command isolation
   "gq_foreign_siblings_restaged_total",
   "gq_jobs_unroutable_total",
+  "gq_batch_bisections_total",
 ] as const;
 
 for (const name of metricNames) {
@@ -411,4 +412,29 @@ export const gqForeignSiblingsRestagedTotal = new Counter({
   name: "gq_foreign_siblings_restaged_total",
   help: "Drained siblings restaged untouched because their __jobName differed from the dispatched job (ADR-066 mixed-command isolation) — excludes the batch-failure restage paths",
   labelNames: ["queue_name"] as const,
+});
+
+/**
+ * A coalesced batch failed retryably and was split in half to isolate the
+ * cause.
+ *
+ * Counts SPLITS, not batches: isolating one poison payload out of a full batch
+ * costs `log2(batchSize)` increments, so a single stubborn payload shows up as
+ * a burst rather than a single event. Read it as a rate, not a total.
+ *
+ * A steady non-zero rate is the signal worth acting on, and it means one of two
+ * things — both real:
+ * - the batch bound is too generous for what the handler can process in one
+ *   pass (size-driven; the fix is a tighter budget, not more bisection), or
+ * - a payload in this pipeline is persistently unprocessable (poison; bisection
+ *   is containing the blast radius but something still needs to look at it).
+ *
+ * Zero means batches either succeed whole or fail non-retryably. Correlate with
+ * `gq_jobs_retried_total` to tell "we recovered inside the dispatch" from "we
+ * gave the whole batch back to the queue".
+ */
+export const gqBatchBisectionsTotal = new Counter({
+  name: "gq_batch_bisections_total",
+  help: "Retryable coalesced-batch failures that were split in half to isolate the cause — counts splits, so isolating one payload costs log2(batchSize)",
+  labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1718,6 +1718,32 @@ export const DEFAULT_GROUP_QUARANTINE_THRESHOLD = 500;
 export const GROUP_QUARANTINE_TTL_SECONDS = 15 * 60;
 
 /**
+ * Splits one dispatch may perform before bisection gives up and hands the
+ * remainder to the normal retry/backoff path.
+ *
+ * Sized to cover every useful descent (isolating one unprocessable payload in a
+ * 256 batch costs 8 splits; converging to sub-batches of 8 costs 31) while
+ * cutting off the pathological singleton-degradation walk (~2N calls) that
+ * would otherwise run under the group lock for the whole tree.
+ */
+export const DEFAULT_BISECTION_SPLITS_PER_DISPATCH = 32;
+
+/**
+ * Read the bisection split budget from the environment. Mirrors
+ * {@link readGroupQuarantineThreshold}:
+ *   - unset / empty / non-numeric / negative → DEFAULT_BISECTION_SPLITS_PER_DISPATCH
+ *   - "0" → 0 (explicit kill switch — a failing batch is never split, which is
+ *     exactly the pre-bisection behaviour, recoverable without a deploy)
+ *   - positive integer → that integer
+ */
+export function readBisectionSplitBudget(): number {
+  return readNonNegativeIntEnv({
+    name: "LANGWATCH_GQ_BISECTION_SPLIT_BUDGET",
+    fallback: DEFAULT_BISECTION_SPLITS_PER_DISPATCH,
+  });
+}
+
+/**
  * Read the group-quarantine failure-streak threshold from the environment.
  * Mirrors {@link readClaimStrikeThreshold}:
  *   - unset / empty / non-numeric / negative → DEFAULT_GROUP_QUARANTINE_THRESHOLD

--- a/platform/app/src/server/event-sourcing/queues/queue.types.ts
+++ b/platform/app/src/server/event-sourcing/queues/queue.types.ts
@@ -99,6 +99,16 @@ export type DeduplicationStrategy<Payload> =
  */
 export interface JobDelivery {
   attempt: number;
+  /**
+   * True when this handler call is a later sub-batch of the SAME locked
+   * dispatch, after an earlier sub-batch of this delivery already committed
+   * (set by the GroupQueue's batch bisection). Delivery-scoped state written by
+   * the handler — the fold store's applied-event-id set — must be EXTENDED on a
+   * continuation, never replaced: each commit in the chain only carries its own
+   * sub-batch's ids, and replacing would erase the ids the earlier commits
+   * recorded, letting a retry re-apply them (#6578).
+   */
+  continuation?: boolean;
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/queues/queue.types.ts
+++ b/platform/app/src/server/event-sourcing/queues/queue.types.ts
@@ -108,7 +108,7 @@ export interface JobDelivery {
    * sub-batch's ids, and replacing would erase the ids the earlier commits
    * recorded, letting a retry re-apply them (#6578).
    */
-  continuation?: boolean;
+  isContinuation?: boolean;
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
@@ -489,7 +489,7 @@ export class QueueManager<EventType extends Event = Event> {
                 await onEventBatch(projectionName, events, {
                   tenantId: events[0]?.tenantId,
                   deliveryAttempt: delivery?.attempt,
-                  deliveryContinuation: delivery?.continuation,
+                  isDeliveryContinuation: delivery?.isContinuation,
                 });
               }
             : undefined,

--- a/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
@@ -489,6 +489,7 @@ export class QueueManager<EventType extends Event = Event> {
                 await onEventBatch(projectionName, events, {
                   tenantId: events[0]?.tenantId,
                   deliveryAttempt: delivery?.attempt,
+                  deliveryContinuation: delivery?.continuation,
                 });
               }
             : undefined,

--- a/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
+++ b/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
@@ -59,7 +59,7 @@ export interface EventStoreReadContext<_EventType extends Event = Event> {
    * commit must EXTEND the applied-event-id set rather than replace it, or the
    * earlier sub-batches' ids are erased and a retry re-applies them (#6578).
    */
-  deliveryContinuation?: boolean;
+  isDeliveryContinuation?: boolean;
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
+++ b/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
@@ -53,6 +53,13 @@ export interface EventStoreReadContext<_EventType extends Event = Event> {
    * outside the queue, e.g. during replay.
    */
   deliveryAttempt?: number;
+  /**
+   * True when this call is a later sub-batch of the same locked dispatch and an
+   * earlier sub-batch already committed (GroupQueue batch bisection). A fold
+   * commit must EXTEND the applied-event-id set rather than replace it, or the
+   * earlier sub-batches' ids are erased and a retry re-applies them (#6578).
+   */
+  deliveryContinuation?: boolean;
 }
 
 /**


### PR DESCRIPTION
## For humans

When the queue gets backed up it bundles many queued records together and processes them in one pass. Today that bundle is all-or-nothing: if a single record in it cannot be processed, the entire bundle fails, nothing in it is saved, and the retry rebuilds the same bundle with the same bad record inside. One bad record could take up to 255 healthy ones down with it, over and over, until the whole lane stopped and someone unblocked it by hand.

Now, when a bundle fails, we split it in half and try each half — repeating until either it works or the problem is narrowed down to the single record causing it. Everything ahead of that record is saved instead of thrown away, and we learn exactly which record is at fault instead of only knowing "something in these 256 failed".

## Why

Closes langwatch/langwatch-saas#896.

A coalesced batch writes its fold state once, at the end, so any throw discards the work for every payload in it. `restageDrainedSiblings` then puts the siblings back and the next dispatch re-drains them into a batch of the same maximum size — so nothing narrows and nothing is identified. Two consequences:

- **One unprocessable payload holds the rest hostage.** With a cap of 256, a single permanently-failing payload prevents 255 healthy ones from ever committing, on every attempt, until the group blocks.
- **Recovery from a size-driven failure was luck.** A batch too heavy for a downstream query's memory budget only succeeded if the retry happened to re-assemble a lighter set of payloads. Same cap, different contents.

## What changed

On a **retryable** batch failure the dispatch now splits the batch into two contiguous halves and runs them in sequence, recursing until the batch either fits or the failure is attributable to a single payload. One mechanism covers both failure classes above, because both are "this set of payloads fails but a smaller set might not".

Batch members travel as `{ payload, stagedJobId }` pairs, so narrowing to a single failing payload can **name** it — logged as `offendingStagedJobId` and stamped on the span as `queue.batch_offending_job_id`. Without that the throw is anonymous and the terminal record anchors to the dispatched job, which for a failing drained sibling is the wrong job entirely. Only a batch a split actually produced is reported as an isolate; an un-split batch of one is just a job that failed.

Adds `gq_batch_bisections_total`, labelled like the other queue counters.

## How it works

**Ordering is preserved, and it is the constraint that shapes the design.** Halves are contiguous and awaited sequentially, never concurrently, because a fold derives fields from arrival order — the same invariant that makes splitting a group across lanes unsafe.

**That invariant also bounds what this can do.** A throw propagates immediately, so payloads *after* the offender are not attempted. Stepping over it would apply later payloads across a gap the fold cannot see, producing wrong values silently. So bisection recovers everything *before* the offender and names it; it does not rescue what queued behind it. Doing that needs an explicit decision about the gap, which is the side-lining work in langwatch/langwatch#6482.

**Partial application is safe — and making it so surfaced a deeper bug (#6578).** Review found that partial commits were NOT safe as first shipped: a fold commit replaces the applied-event-id set on a fresh delivery (deliberate garbage collection assuming one save per delivery), so each bisection leaf erased the previous leaves' ids and a retry re-applied the committed prefix. Worse, the shared queue's wrappers dropped the delivery argument entirely, so the merge-on-retry branch never ran in the deployed system at all. Both are fixed here: the wrappers forward the delivery, `JobDelivery` carries a `continuation` flag set by the bisector after the first successful commit of a dispatch, and the commit rule becomes replace-on-first-save / merge-on-continuation-and-retry. The flag's path (wrapper → queue manager → router → store context → executor) is pinned link-by-link by mutation-checked tests, plus an end-to-end scenario that fails with the double-count (6 instead of 4) without the fix.

**Non-retryable failures are not split.** They fail identically at every size, so bisecting one only multiplies work before reaching the same verdict.

**Work per locked attempt is bounded.** A batch degrading toward singletons would walk the entire tree (~2N sequential handler calls) while the heartbeat renews the group lock. After `MAX_BISECTION_SPLITS_PER_DISPATCH` (32) splits the failure propagates un-split: committed prefixes stay committed, the remainder re-stages, and backoff takes over. Every useful descent fits under the budget (poison isolation in 256 costs 8 splits; converging to sub-batches of 8 costs 31).

Cost is extra handler calls on the failure path only; the success path is unchanged. How many depends on why the batch failed — a single unprocessable payload costs one split per level of the descent to it (roughly `log2(batchSize)`, varying with the payload's position), while a batch failing purely on size keeps splitting until every part fits and approaches `batchSize - 1`:

| case | batch | splits |
|---|---|---|
| one unprocessable payload | 5 | 2 or 3, by position |
| size-capped at 1 | 8 | 7 |
| size-capped at 16 | 256 | 15 |

## Test plan

Three integration tests added to the existing `group coalescing` suite in `groupQueue.integration.test.ts`, driving the real `GroupQueueProcessor` against real Redis:

1. **One unprocessable payload** — asserts every payload ahead of the offender commits (`j0..j4`), the offender never commits, and some attempt isolated it alone. Also asserts the prefix's per-payload commit counts stay equal, so a payload applied one extra time fails the test. Fails without the change: nothing commits at all.
2. **Ordering under splitting** — asserts every sub-batch a split produces is still ascending *and* contiguous, so no split can reshuffle or interleave the fold order.
3. **Size-driven failure** — a handler that rejects any batch over a workable size; asserts all 8 payloads commit exactly once, converging by construction rather than by a lucky re-assembly. Also pins the exact descent (`[8, 4, 2, 2, 4, 2, 2]`) and that no two batches ever overlap, which sorted-and-contiguous alone would not prove.
4. **Non-retryable failure** — a CRITICAL-category error is never split: every attempt is the same size, and that size is greater than one.

Verified locally:

- `groupQueue.integration.test.ts` — 25 passed
- `groupQueue.poisonGuard.integration.test.ts` — 15 passed (no regression in the neighbouring retry/quarantine path); 40 passed across both files
- `pnpm typecheck` and `pnpm typecheck:tests` — both clean
- CI's exact lint gate (`biome-new-violations.sh` against the merge base) — `no new Biome violations`

## Anything surprising?

**The first version of test 1 was wrong, and the failure was informative.** It expected all 7 healthy payloads out of 8 to commit; only 5 did. That is correct behaviour, not a bug — the payloads *after* the offender are deliberately not attempted, for the ordering reason above. Worth knowing when reviewing: this PR does not make a poison payload harmless, it makes it *cheap and attributable*. The lane still blocks on it eventually, via the existing 25-attempt path.

**This is the recovery layer, not the prevention layer.** langwatch/langwatch#6473 (byte-accurate batch budget) is the layer that stops most size-driven failures happening at all; the two compose and neither replaces the other.

**Deliberately not here:** re-anchoring the terminal blocked record to the offending payload rather than the dispatched job. The offender's identity is now in the log and on the span, but changing which job an ops surface attributes a block to is a behavioural change to that contract and belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of coalesced batches when individual payloads fail.
  * Isolates problematic payloads while preserving order and committing healthy items.
  * Splits oversized batches sequentially without duplicate processing.
  * Preserves event-processing state across retries and continuation batches.
  * Retains existing handling for non-retryable failures and split-limit exhaustion.

* **Monitoring**
  * Added metrics and tracing for batch-splitting activity and isolated failed items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Review surfaced langwatch/langwatch#6578 (applied-id watermark replaced on first-attempt commits + delivery attempt dropped at the shared queue wrapper). Both fixes landed in this PR, along with the split budget from the same review.

