### PR TITLE
fix(datasets): stop the dataset list counting every tenant's entries

### DIFF
--- a/platform/app/prisma/migrations/20260804120000_dataset_record_project_dataset_index/migration.sql
+++ b/platform/app/prisma/migrations/20260804120000_dataset_record_project_dataset_index/migration.sql
@@ -1,0 +1,24 @@
+-- Composite index for the per-project dataset entry counts.
+--
+-- The dataset lists count entries with
+-- `WHERE "projectId" = $1 AND "datasetId" IN (...) GROUP BY "datasetId"`.
+-- With only the two single-column indexes available, the planner has to
+-- combine them with a BitmapAnd, and its row estimate collapses whenever a
+-- single project owns most of the table (projectId and datasetId are almost
+-- perfectly correlated there) — so it gives up and sequentially scans the
+-- whole table. Measured on production data, that mis-plan costs 13s for the
+-- largest project.
+--
+-- The composite serves the same predicate as one index-only scan, never
+-- touching the heap: 3.5ms for a typical project, 165ms for the largest,
+-- on a faithful 2.58M-row reproduction of the production distribution.
+-- It also serves the project-scoped record reads on the dataset editor page.
+--
+-- LOCKING NOTE: plain `CREATE INDEX` takes a SHARE lock on "DatasetRecord" —
+-- concurrent reads keep working, writes (uploads, appends, row edits) block
+-- until the build finishes. The build reads the heap once: ~2.8s on a 2.58M-row
+-- reproduction, so expect single-digit seconds against production. Dataset
+-- writes are low-frequency and this runs during deploy, so the brief write
+-- pause is acceptable. `CREATE INDEX CONCURRENTLY` would avoid it entirely but
+-- cannot run inside a transaction, which the Prisma migration setup requires.
+CREATE INDEX "DatasetRecord_projectId_datasetId_idx" ON "DatasetRecord"("projectId", "datasetId");

--- a/platform/app/prisma/migrations/20260804120000_dataset_record_project_dataset_index/migration.sql
+++ b/platform/app/prisma/migrations/20260804120000_dataset_record_project_dataset_index/migration.sql
@@ -22,3 +22,6 @@
 -- pause is acceptable. `CREATE INDEX CONCURRENTLY` would avoid it entirely but
 -- cannot run inside a transaction, which the Prisma migration setup requires.
 CREATE INDEX "DatasetRecord_projectId_datasetId_idx" ON "DatasetRecord"("projectId", "datasetId");
+
+-- Down (manual rollback):
+-- DROP INDEX "DatasetRecord_projectId_datasetId_idx";

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -677,6 +677,11 @@ model DatasetRecord {
   @@index([datasetId])
   @@index([projectId])
   @@index([createdAt])
+  // Serves the per-project entry counts the dataset lists render, and the
+  // project-scoped record reads on the editor page, as an index-only scan.
+  // Without it the planner has to combine the two single-column indexes and
+  // falls back to a sequential scan once a project's rows dominate the table.
+  @@index([projectId, datasetId])
 }
 
 model Dashboard {

--- a/platform/app/src/components/AddDatasetRecordDrawer.tsx
+++ b/platform/app/src/components/AddDatasetRecordDrawer.tsx
@@ -294,6 +294,7 @@ export function AddDatasetRecordDrawerV2(props: AddDatasetDrawerProps) {
           <form onSubmit={handleSubmit(onSubmit)}>
             <VStack paddingX={6}>
               <DatasetSelector
+                isLoading={datasets.isLoading}
                 datasets={datasets.data}
                 localStorageDatasetId={datasetId}
                 errors={errors}

--- a/platform/app/src/components/AddDatasetRecordDrawer.tsx
+++ b/platform/app/src/components/AddDatasetRecordDrawer.tsx
@@ -295,6 +295,7 @@ export function AddDatasetRecordDrawerV2(props: AddDatasetDrawerProps) {
             <VStack paddingX={6}>
               <DatasetSelector
                 isLoading={datasets.isLoading}
+                isError={datasets.isError}
                 datasets={datasets.data}
                 localStorageDatasetId={datasetId}
                 errors={errors}

--- a/platform/app/src/components/datasets/DatasetSelector.tsx
+++ b/platform/app/src/components/datasets/DatasetSelector.tsx
@@ -17,6 +17,54 @@ import type {
 import { HorizontalFormControl } from "../HorizontalFormControl";
 import { Select } from "../ui/select";
 
+/**
+ * What the picker has to show. An empty dropdown renders identically whether
+ * the list is still coming, genuinely empty, or failed to arrive, so the three
+ * are kept apart here rather than collapsing into "no items": a slow project
+ * reads as having no datasets, and a failed request reads as the same, which
+ * is the one thing we know is false.
+ */
+type PickerState = "loading" | "unavailable" | "empty" | "ready";
+
+const pickerStateOf = ({
+  datasets,
+  isLoading,
+  isError,
+}: {
+  datasets: Dataset[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}): PickerState => {
+  if (isLoading) return "loading";
+  if (isError || datasets === undefined) return "unavailable";
+  if (datasets.length === 0) return "empty";
+  return "ready";
+};
+
+const PLACEHOLDER: Record<Exclude<PickerState, "loading">, string> = {
+  unavailable: "Could not load datasets",
+  empty: "No datasets yet",
+  ready: "Select Dataset",
+};
+
+function LoadingDatasets() {
+  return (
+    <HStack
+      height="40px"
+      paddingX={3}
+      gap={2}
+      borderWidth="1px"
+      borderRadius="md"
+      color="fg.muted"
+      role="status"
+      aria-label="Loading datasets"
+    >
+      <Spinner size="xs" />
+      <Text textStyle="sm">Loading datasets...</Text>
+    </HStack>
+  );
+}
+
 interface DatasetSelectorProps<T extends { datasetId: string }> {
   datasets: Dataset[] | undefined;
   localStorageDatasetId: string;
@@ -37,6 +85,8 @@ export function DatasetSelector<T extends { datasetId: string }>({
   isLoading = false,
   isError = false,
 }: DatasetSelectorProps<T>) {
+  const state = pickerStateOf({ datasets, isLoading, isError });
+
   const datasetCollection = createListCollection({
     items:
       datasets?.map((dataset) => ({
@@ -53,41 +103,19 @@ export function DatasetSelector<T extends { datasetId: string }>({
     setSelectedValue(localStorageDatasetId ? [localStorageDatasetId] : []);
   }, [localStorageDatasetId]);
 
-  // An empty dropdown looks exactly like a project with no datasets, so while
-  // the list is in flight the trigger says so outright rather than inviting a
-  // click that would open nothing. A failed request leaves no datasets either,
-  // and telling someone they have none when we simply could not ask is worse
-  // than saying nothing worked — so only a list that actually arrived empty
-  // counts as empty.
-  const hasLoaded = !isLoading && !isError && datasets !== undefined;
-  const isEmpty = hasLoaded && datasetCollection.items.length === 0;
-  const isUnavailable = isError || (!isLoading && datasets === undefined);
-
   return (
     <HorizontalFormControl
       label="Dataset"
       helper="Add to an existing dataset or create a new one"
       invalid={!!errors.datasetId}
     >
-      {isLoading ? (
-        <HStack
-          height="40px"
-          paddingX={3}
-          gap={2}
-          borderWidth="1px"
-          borderRadius="md"
-          color="fg.muted"
-          role="status"
-          aria-label="Loading datasets"
-        >
-          <Spinner size="xs" />
-          <Text textStyle="sm">Loading datasets...</Text>
-        </HStack>
+      {state === "loading" ? (
+        <LoadingDatasets />
       ) : (
         <Select.Root
           collection={datasetCollection}
           value={selectedValue}
-          disabled={isEmpty || isUnavailable}
+          disabled={state !== "ready"}
           onValueChange={(e) => {
             const value = e.value[0] ?? "";
             setSelectedValue(e.value);
@@ -95,15 +123,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
           }}
         >
           <Select.Trigger>
-            <Select.ValueText
-              placeholder={
-                isUnavailable
-                  ? "Could not load datasets"
-                  : isEmpty
-                    ? "No datasets yet"
-                    : "Select Dataset"
-              }
-            />
+            <Select.ValueText placeholder={PLACEHOLDER[state]} />
           </Select.Trigger>
           <Select.Content portalled={false}>
             {datasetCollection.items.map((dataset) => (

--- a/platform/app/src/components/datasets/DatasetSelector.tsx
+++ b/platform/app/src/components/datasets/DatasetSelector.tsx
@@ -24,6 +24,7 @@ interface DatasetSelectorProps<T extends { datasetId: string }> {
   setValue: UseFormSetValue<T>;
   onCreateNew: () => void;
   isLoading?: boolean;
+  isError?: boolean;
   register?: never;
 }
 
@@ -34,6 +35,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
   setValue,
   onCreateNew,
   isLoading = false,
+  isError = false,
 }: DatasetSelectorProps<T>) {
   const datasetCollection = createListCollection({
     items:
@@ -53,8 +55,13 @@ export function DatasetSelector<T extends { datasetId: string }>({
 
   // An empty dropdown looks exactly like a project with no datasets, so while
   // the list is in flight the trigger says so outright rather than inviting a
-  // click that would open nothing.
-  const isEmpty = !isLoading && datasetCollection.items.length === 0;
+  // click that would open nothing. A failed request leaves no datasets either,
+  // and telling someone they have none when we simply could not ask is worse
+  // than saying nothing worked — so only a list that actually arrived empty
+  // counts as empty.
+  const hasLoaded = !isLoading && !isError && datasets !== undefined;
+  const isEmpty = hasLoaded && datasetCollection.items.length === 0;
+  const isUnavailable = isError || (!isLoading && datasets === undefined);
 
   return (
     <HorizontalFormControl
@@ -70,7 +77,8 @@ export function DatasetSelector<T extends { datasetId: string }>({
           borderWidth="1px"
           borderRadius="md"
           color="fg.muted"
-          aria-live="polite"
+          role="status"
+          aria-label="Loading datasets"
         >
           <Spinner size="xs" />
           <Text textStyle="sm">Loading datasets...</Text>
@@ -79,7 +87,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
         <Select.Root
           collection={datasetCollection}
           value={selectedValue}
-          disabled={isEmpty}
+          disabled={isEmpty || isUnavailable}
           onValueChange={(e) => {
             const value = e.value[0] ?? "";
             setSelectedValue(e.value);
@@ -88,7 +96,13 @@ export function DatasetSelector<T extends { datasetId: string }>({
         >
           <Select.Trigger>
             <Select.ValueText
-              placeholder={isEmpty ? "No datasets yet" : "Select Dataset"}
+              placeholder={
+                isUnavailable
+                  ? "Could not load datasets"
+                  : isEmpty
+                    ? "No datasets yet"
+                    : "Select Dataset"
+              }
             />
           </Select.Trigger>
           <Select.Content portalled={false}>

--- a/platform/app/src/components/datasets/DatasetSelector.tsx
+++ b/platform/app/src/components/datasets/DatasetSelector.tsx
@@ -1,4 +1,9 @@
-import { Button, createListCollection, Field } from "@chakra-ui/react";
+import {
+  Button,
+  createListCollection,
+  Field,
+  Skeleton,
+} from "@chakra-ui/react";
 import type { Dataset } from "@prisma/client";
 import { type ReactNode, useEffect, useState } from "react";
 import type {
@@ -16,6 +21,7 @@ interface DatasetSelectorProps<T extends { datasetId: string }> {
   errors: FieldErrors<T>;
   setValue: UseFormSetValue<T>;
   onCreateNew: () => void;
+  isLoading?: boolean;
   register?: never;
 }
 
@@ -25,6 +31,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
   errors,
   setValue,
   onCreateNew,
+  isLoading = false,
 }: DatasetSelectorProps<T>) {
   const datasetCollection = createListCollection({
     items:
@@ -42,32 +49,48 @@ export function DatasetSelector<T extends { datasetId: string }>({
     setSelectedValue(localStorageDatasetId ? [localStorageDatasetId] : []);
   }, [localStorageDatasetId]);
 
+  // An empty dropdown looks exactly like a project with no datasets, so while
+  // the list is in flight the trigger is replaced by a skeleton rather than
+  // inviting a click that would open nothing.
+  const isEmpty = !isLoading && datasetCollection.items.length === 0;
+
   return (
     <HorizontalFormControl
       label="Dataset"
       helper="Add to an existing dataset or create a new one"
       invalid={!!errors.datasetId}
     >
-      <Select.Root
-        collection={datasetCollection}
-        value={selectedValue}
-        onValueChange={(e) => {
-          const value = e.value[0] ?? "";
-          setSelectedValue(e.value);
-          setValue("datasetId" as Path<T>, value as PathValue<T, Path<T>>);
-        }}
-      >
-        <Select.Trigger>
-          <Select.ValueText placeholder="Select Dataset" />
-        </Select.Trigger>
-        <Select.Content portalled={false}>
-          {datasetCollection.items.map((dataset) => (
-            <Select.Item key={dataset.value} item={dataset}>
-              {dataset.label}
-            </Select.Item>
-          ))}
-        </Select.Content>
-      </Select.Root>
+      {isLoading ? (
+        <Skeleton
+          height="40px"
+          borderRadius="md"
+          aria-label="Loading datasets"
+        />
+      ) : (
+        <Select.Root
+          collection={datasetCollection}
+          value={selectedValue}
+          disabled={isEmpty}
+          onValueChange={(e) => {
+            const value = e.value[0] ?? "";
+            setSelectedValue(e.value);
+            setValue("datasetId" as Path<T>, value as PathValue<T, Path<T>>);
+          }}
+        >
+          <Select.Trigger>
+            <Select.ValueText
+              placeholder={isEmpty ? "No datasets yet" : "Select Dataset"}
+            />
+          </Select.Trigger>
+          <Select.Content portalled={false}>
+            {datasetCollection.items.map((dataset) => (
+              <Select.Item key={dataset.value} item={dataset}>
+                {dataset.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      )}
       {errors.datasetId && (
         <Field.ErrorText>
           {errors.datasetId.message as ReactNode}

--- a/platform/app/src/components/datasets/DatasetSelector.tsx
+++ b/platform/app/src/components/datasets/DatasetSelector.tsx
@@ -2,7 +2,9 @@ import {
   Button,
   createListCollection,
   Field,
-  Skeleton,
+  HStack,
+  Spinner,
+  Text,
 } from "@chakra-ui/react";
 import type { Dataset } from "@prisma/client";
 import { type ReactNode, useEffect, useState } from "react";
@@ -50,8 +52,8 @@ export function DatasetSelector<T extends { datasetId: string }>({
   }, [localStorageDatasetId]);
 
   // An empty dropdown looks exactly like a project with no datasets, so while
-  // the list is in flight the trigger is replaced by a skeleton rather than
-  // inviting a click that would open nothing.
+  // the list is in flight the trigger says so outright rather than inviting a
+  // click that would open nothing.
   const isEmpty = !isLoading && datasetCollection.items.length === 0;
 
   return (
@@ -61,11 +63,18 @@ export function DatasetSelector<T extends { datasetId: string }>({
       invalid={!!errors.datasetId}
     >
       {isLoading ? (
-        <Skeleton
+        <HStack
           height="40px"
+          paddingX={3}
+          gap={2}
+          borderWidth="1px"
           borderRadius="md"
-          aria-label="Loading datasets"
-        />
+          color="fg.muted"
+          aria-live="polite"
+        >
+          <Spinner size="xs" />
+          <Text textStyle="sm">Loading datasets...</Text>
+        </HStack>
       ) : (
         <Select.Root
           collection={datasetCollection}

--- a/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
+++ b/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
@@ -4,19 +4,21 @@
  * Renders the real dataset picker used by the "Add to Dataset" drawer and the
  * automations trigger editor.
  *
- * The behaviour being pinned is the difference between "still loading" and
- * "nothing here". An empty dropdown renders identically in both cases, so a
- * slow project looked like a project with no datasets at all.
+ * The behaviour being pinned is what the picker says when it has nothing to
+ * show. An empty dropdown renders identically whether the list is still
+ * loading, genuinely empty, or failed to arrive - so a slow project looked
+ * like a project with no datasets at all.
  *
  * Spec: specs/datasets/add-to-dataset-picker.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import type { Dataset } from "@prisma/client";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DatasetSelector } from "../DatasetSelector";
 
-const buildDataset = (name: string, id: string): Dataset =>
+const buildDataset = ({ name, id }: { name: string; id: string }): Dataset =>
   ({
     id,
     name,
@@ -40,21 +42,23 @@ const buildDataset = (name: string, id: string): Dataset =>
     chunkOffsets: null,
   }) as unknown as Dataset;
 
-const renderSelector = (
-  props: Partial<Parameters<typeof DatasetSelector>[0]> = {},
-) =>
-  render(
-    <ChakraProvider value={defaultSystem}>
-      <DatasetSelector
-        datasets={undefined}
-        localStorageDatasetId=""
-        errors={{}}
-        setValue={vi.fn()}
-        onCreateNew={vi.fn()}
-        {...props}
-      />
-    </ChakraProvider>,
-  );
+type SelectorProps = Parameters<typeof DatasetSelector>[0];
+
+const selector = (props: Partial<SelectorProps> = {}) => (
+  <ChakraProvider value={defaultSystem}>
+    <DatasetSelector
+      datasets={undefined}
+      localStorageDatasetId=""
+      errors={{}}
+      setValue={vi.fn()}
+      onCreateNew={vi.fn()}
+      {...props}
+    />
+  </ChakraProvider>
+);
+
+const renderSelector = (props: Partial<SelectorProps> = {}) =>
+  render(selector(props));
 
 afterEach(cleanup);
 
@@ -62,12 +66,41 @@ describe("DatasetSelector", () => {
   describe("given the project's datasets have not finished loading", () => {
     describe("when the picker renders", () => {
       /** @scenario "The dataset dropdown says it is loading" */
-      it("shows that it is loading instead of an empty dropdown", () => {
+      it("announces that it is loading instead of showing an empty dropdown", () => {
         renderSelector({ datasets: undefined, isLoading: true });
 
+        expect(
+          screen.getByRole("status", { name: "Loading datasets" }),
+        ).toBeInTheDocument();
         expect(screen.getByText("Loading datasets...")).toBeInTheDocument();
         expect(screen.queryByText("Select Dataset")).not.toBeInTheDocument();
         expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the datasets then arrive", () => {
+      /** @scenario "The datasets appear once they arrive" */
+      it("swaps the loading state for a usable dropdown", () => {
+        const { rerender } = renderSelector({
+          datasets: undefined,
+          isLoading: true,
+        });
+
+        expect(screen.getByRole("status")).toBeInTheDocument();
+
+        rerender(
+          selector({
+            datasets: [
+              buildDataset({ name: "offline evals", id: "dataset-1" }),
+            ],
+            isLoading: false,
+          }),
+        );
+
+        expect(screen.queryByRole("status")).toBeNull();
+        expect(screen.queryByText("Loading datasets...")).toBeNull();
+        expect(screen.getByText("Select Dataset")).toBeInTheDocument();
+        expect(screen.getByRole("combobox")).not.toBeDisabled();
       });
     });
   });
@@ -75,14 +108,50 @@ describe("DatasetSelector", () => {
   describe("given the project has no datasets", () => {
     describe("when the picker renders", () => {
       /** @scenario "A project with no datasets is told so, not left blank" */
-      it("says there are none yet and still offers to create one", () => {
+      it("says there are none yet, and does not invite a click into nothing", () => {
         renderSelector({ datasets: [], isLoading: false });
 
         expect(screen.getByText("No datasets yet")).toBeInTheDocument();
         expect(screen.queryByText("Loading datasets...")).toBeNull();
-        expect(
-          screen.getByRole("button", { name: "+ Create New" }),
-        ).toBeInTheDocument();
+        expect(screen.getByRole("combobox")).toBeDisabled();
+      });
+    });
+
+    describe("when I choose to create one", () => {
+      /** @scenario "I can still create a dataset from the drawer" */
+      it("hands off to the creation flow", async () => {
+        const user = userEvent.setup();
+        const onCreateNew = vi.fn();
+        renderSelector({ datasets: [], isLoading: false, onCreateNew });
+
+        await user.click(screen.getByRole("button", { name: "+ Create New" }));
+
+        expect(onCreateNew).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("given the request for the datasets failed", () => {
+    describe("when the picker renders", () => {
+      /** @scenario "A failed request is not reported as an empty project" */
+      it("says they could not be loaded, not that there are none", () => {
+        renderSelector({
+          datasets: undefined,
+          isLoading: false,
+          isError: true,
+        });
+
+        expect(screen.getByText("Could not load datasets")).toBeInTheDocument();
+        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
+        expect(screen.getByRole("combobox")).toBeDisabled();
+      });
+
+      /** @scenario "A failed request is not reported as an empty project" */
+      it("does the same when the caller reports no failure but sends no list", () => {
+        renderSelector({ datasets: undefined, isLoading: false });
+
+        expect(screen.getByText("Could not load datasets")).toBeInTheDocument();
+        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
       });
     });
   });
@@ -91,24 +160,11 @@ describe("DatasetSelector", () => {
   // dataset's presence in the dropdown is asserted through the value the
   // trigger resolves for it rather than by opening the list.
   describe("given the datasets have arrived", () => {
-    describe("when the picker renders", () => {
+    describe("when one is already selected", () => {
       /** @scenario "The datasets appear once they arrive" */
-      it("stops saying it is loading and offers a usable dropdown", () => {
+      it("resolves that dataset's name from the list", () => {
         renderSelector({
-          datasets: [buildDataset("offline evals", "dataset-1")],
-          isLoading: false,
-        });
-
-        expect(screen.queryByText("Loading datasets...")).toBeNull();
-        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
-        expect(screen.getByText("Select Dataset")).toBeInTheDocument();
-        expect(screen.getByRole("combobox")).not.toBeDisabled();
-      });
-
-      /** @scenario "The datasets appear once they arrive" */
-      it("resolves a dataset's name once it is in the list", () => {
-        renderSelector({
-          datasets: [buildDataset("offline evals", "dataset-1")],
+          datasets: [buildDataset({ name: "offline evals", id: "dataset-1" })],
           isLoading: false,
           localStorageDatasetId: "dataset-1",
         });

--- a/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
+++ b/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Renders the real dataset picker used by the "Add to Dataset" drawer and the
+ * automations trigger editor.
+ *
+ * The behaviour being pinned is the difference between "still loading" and
+ * "nothing here". An empty dropdown renders identically in both cases, so a
+ * slow project looked like a project with no datasets at all.
+ *
+ * Spec: specs/datasets/add-to-dataset-picker.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { Dataset } from "@prisma/client";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DatasetSelector } from "../DatasetSelector";
+
+const buildDataset = (name: string, id: string): Dataset =>
+  ({
+    id,
+    name,
+    slug: id,
+    projectId: "test-project-id",
+    columnTypes: [],
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    archivedAt: null,
+    mapping: null,
+    useS3: false,
+    s3RecordCount: null,
+    contentLayout: "s3_jsonl",
+    status: "ready",
+    statusError: null,
+    stagingKey: null,
+    uploadFilename: null,
+    rowCount: 10,
+    sizeBytes: null,
+    chunkCount: 1,
+    chunkOffsets: null,
+  }) as unknown as Dataset;
+
+const renderSelector = (
+  props: Partial<Parameters<typeof DatasetSelector>[0]> = {},
+) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <DatasetSelector
+        datasets={undefined}
+        localStorageDatasetId=""
+        errors={{}}
+        setValue={vi.fn()}
+        onCreateNew={vi.fn()}
+        {...props}
+      />
+    </ChakraProvider>,
+  );
+
+afterEach(cleanup);
+
+describe("DatasetSelector", () => {
+  describe("given the project's datasets have not finished loading", () => {
+    describe("when the picker renders", () => {
+      /** @scenario "The dataset dropdown says it is loading" */
+      it("shows that it is loading instead of an empty dropdown", () => {
+        renderSelector({ datasets: undefined, isLoading: true });
+
+        expect(screen.getByLabelText("Loading datasets")).toBeInTheDocument();
+        expect(screen.queryByText("Select Dataset")).not.toBeInTheDocument();
+        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the project has no datasets", () => {
+    describe("when the picker renders", () => {
+      /** @scenario "A project with no datasets is told so, not left blank" */
+      it("says there are none yet and still offers to create one", () => {
+        renderSelector({ datasets: [], isLoading: false });
+
+        expect(screen.getByText("No datasets yet")).toBeInTheDocument();
+        expect(screen.queryByLabelText("Loading datasets")).toBeNull();
+        expect(
+          screen.getByRole("button", { name: "+ Create New" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // Ark UI's Select does not mount its portaled options under jsdom, so a
+  // dataset's presence in the dropdown is asserted through the value the
+  // trigger resolves for it rather than by opening the list.
+  describe("given the datasets have arrived", () => {
+    describe("when the picker renders", () => {
+      /** @scenario "The datasets appear once they arrive" */
+      it("stops saying it is loading and offers a usable dropdown", () => {
+        renderSelector({
+          datasets: [buildDataset("offline evals", "dataset-1")],
+          isLoading: false,
+        });
+
+        expect(screen.queryByLabelText("Loading datasets")).toBeNull();
+        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
+        expect(screen.getByText("Select Dataset")).toBeInTheDocument();
+        expect(screen.getByRole("combobox")).not.toBeDisabled();
+      });
+
+      /** @scenario "The datasets appear once they arrive" */
+      it("resolves a dataset's name once it is in the list", () => {
+        renderSelector({
+          datasets: [buildDataset("offline evals", "dataset-1")],
+          isLoading: false,
+          localStorageDatasetId: "dataset-1",
+        });
+
+        expect(screen.getByRole("combobox")).toHaveTextContent("offline evals");
+      });
+    });
+  });
+});

--- a/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
+++ b/platform/app/src/components/datasets/__tests__/DatasetSelector.integration.test.tsx
@@ -65,7 +65,7 @@ describe("DatasetSelector", () => {
       it("shows that it is loading instead of an empty dropdown", () => {
         renderSelector({ datasets: undefined, isLoading: true });
 
-        expect(screen.getByLabelText("Loading datasets")).toBeInTheDocument();
+        expect(screen.getByText("Loading datasets...")).toBeInTheDocument();
         expect(screen.queryByText("Select Dataset")).not.toBeInTheDocument();
         expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
       });
@@ -79,7 +79,7 @@ describe("DatasetSelector", () => {
         renderSelector({ datasets: [], isLoading: false });
 
         expect(screen.getByText("No datasets yet")).toBeInTheDocument();
-        expect(screen.queryByLabelText("Loading datasets")).toBeNull();
+        expect(screen.queryByText("Loading datasets...")).toBeNull();
         expect(
           screen.getByRole("button", { name: "+ Create New" }),
         ).toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("DatasetSelector", () => {
           isLoading: false,
         });
 
-        expect(screen.queryByLabelText("Loading datasets")).toBeNull();
+        expect(screen.queryByText("Loading datasets...")).toBeNull();
         expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
         expect(screen.getByText("Select Dataset")).toBeInTheDocument();
         expect(screen.getByRole("combobox")).not.toBeDisabled();

--- a/platform/app/src/features/automations/providers/dataset/client.tsx
+++ b/platform/app/src/features/automations/providers/dataset/client.tsx
@@ -172,6 +172,7 @@ function DatasetConfigForm({
       <DatasetSelector
         datasets={datasets.data}
         isLoading={datasets.isLoading}
+        isError={datasets.isError}
         localStorageDatasetId={slice.datasetId}
         errors={{}}
         setValue={(_field: string, value: string) => selectDataset(value)}

--- a/platform/app/src/features/automations/providers/dataset/client.tsx
+++ b/platform/app/src/features/automations/providers/dataset/client.tsx
@@ -171,6 +171,7 @@ function DatasetConfigForm({
     <VStack align="stretch" gap={3}>
       <DatasetSelector
         datasets={datasets.data}
+        isLoading={datasets.isLoading}
         localStorageDatasetId={slice.datasetId}
         errors={{}}
         setValue={(_field: string, value: string) => selectDataset(value)}

--- a/platform/app/src/pages/__tests__/datasets-list-loading.integration.test.tsx
+++ b/platform/app/src/pages/__tests__/datasets-list-loading.integration.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for the datasets list page while its data is in flight.
+ *
+ * The list is the surface a customer lands on first, and the query behind it
+ * can take a moment on a large project. It has to read as "loading", never as
+ * "you have no datasets" — an empty-state flash sends people off to create a
+ * dataset they already have.
+ *
+ * Spec: specs/datasets/datasets-list-page.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { datasetsQueryRef } = vi.hoisted(() => ({
+  datasetsQueryRef: {
+    current: { data: undefined as unknown, isLoading: true },
+  },
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: {}, push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    organizations: [{ id: "org-1", name: "Test Org" }],
+    project: { id: "proj-1", slug: "test-project" },
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: () => ({ isLiteMember: false }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    drawerOpen: () => false,
+  }),
+  getComplexProps: () => ({}),
+}));
+
+vi.mock("~/hooks/useDeleteDatasetConfirmation", () => ({
+  useDeleteDatasetConfirmation: () => ({
+    openDeleteDialog: vi.fn(),
+    DeleteDialog: () => null,
+  }),
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard:
+    () =>
+    <P extends object>(Component: (props: P) => ReactNode) =>
+    (props: P) =>
+      Component(props),
+}));
+
+vi.mock("../../components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/SetupWithAgentButton", () => ({
+  SetupWithAgentButton: () => null,
+}));
+
+vi.mock("~/features/langy/components/LangyContextTarget", () => ({
+  LangyContextTarget: ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../../components/AddOrEditDatasetDrawer", () => ({
+  AddOrEditDatasetDrawer: () => null,
+}));
+
+vi.mock("../../components/datasets/bulkUpload/BulkUploadDrawer", () => ({
+  BulkUploadDrawer: () => null,
+}));
+
+vi.mock("../../components/datasets/CopyDatasetDialog", () => ({
+  CopyDatasetDialog: () => null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({ dataset: { getAll: { invalidate: vi.fn() } } }),
+    dataset: {
+      getAll: { useQuery: () => datasetsQueryRef.current },
+      deleteById: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+const DatasetsPage = (await import("../[project]/datasets")).default;
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <DatasetsPage />
+    </ChakraProvider>,
+  );
+
+afterEach(cleanup);
+
+describe("datasets list page", () => {
+  describe("given my datasets are still being fetched", () => {
+    describe("when the page renders", () => {
+      /** @scenario "The list loads while I wait, and tells me it is loading" */
+      it("shows loading placeholders instead of the empty-project message", () => {
+        datasetsQueryRef.current = { data: undefined, isLoading: true };
+
+        const { container } = renderPage();
+
+        expect(
+          container.querySelectorAll("[class*='chakra-skeleton']").length,
+        ).toBeGreaterThan(0);
+        expect(screen.queryByText("No datasets yet")).not.toBeInTheDocument();
+        // The table's own scaffolding is up, so the page does not jump when the
+        // rows land.
+        expect(screen.getByText("Entries")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the project genuinely has no datasets", () => {
+    describe("when the page renders", () => {
+      it("shows the empty-project message", () => {
+        datasetsQueryRef.current = { data: [], isLoading: false };
+
+        renderPage();
+
+        expect(screen.getByText("No datasets yet")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/__tests__/dataset.getAll.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/dataset.getAll.integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration coverage for `dataset.getAll` — the query behind the datasets
+ * list page, the "Add to Dataset" picker, the command bar and the automations
+ * pages — running end to end against the real Postgres.
+ *
+ * This pins the wiring the helper tests cannot see: that the router returns the
+ * `_count.datasetRecords` shape its consumers render, with the right number for
+ * each storage layout, and that another project's entries never contribute.
+ *
+ * Spec: specs/datasets/datasets-list-page.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { datasetDisplayRecordCount } from "~/server/datasets/record-count";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { getTestUser } from "../../../../utils/testUtils";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+
+const PROJECT_ID = "test-project-id";
+
+describe("dataset.getAll", () => {
+  let caller: ReturnType<typeof appRouter.createCaller>;
+  const ns = nanoid(8);
+  const datasetIds: string[] = [];
+  let otherProjectId: string;
+
+  const seedDataset = async ({
+    projectId,
+    name,
+    contentLayout = "postgres",
+    useS3 = false,
+    rowCount,
+    s3RecordCount,
+    records = 0,
+  }: {
+    projectId: string;
+    name: string;
+    contentLayout?: string;
+    useS3?: boolean;
+    rowCount?: number;
+    s3RecordCount?: number;
+    records?: number;
+  }) => {
+    const dataset = await prisma.dataset.create({
+      data: {
+        id: `dataset_${ns}_${nanoid(6)}`,
+        name,
+        slug: `${ns}-${nanoid(6)}`,
+        projectId,
+        columnTypes: [],
+        contentLayout,
+        useS3,
+        rowCount,
+        s3RecordCount,
+      },
+    });
+    datasetIds.push(dataset.id);
+
+    if (records > 0) {
+      await prisma.datasetRecord.createMany({
+        data: Array.from({ length: records }, (_, i) => ({
+          id: `record_${ns}_${nanoid(6)}`,
+          datasetId: dataset.id,
+          projectId,
+          entry: { input: `row ${i}` },
+        })),
+      });
+    }
+
+    return dataset;
+  };
+
+  beforeAll(async () => {
+    const user = await getTestUser();
+    caller = appRouter.createCaller(
+      createInnerTRPCContext({
+        session: { user: { id: user.id }, expires: "1" },
+      }),
+    );
+
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { id: PROJECT_ID },
+    });
+    const otherProject = await prisma.project.create({
+      data: {
+        id: `project_other_${ns}`,
+        name: "Neighbouring project",
+        slug: `other-${ns}`,
+        teamId: project.teamId,
+        apiKey: `test-api-key-${ns}`,
+        language: "python",
+        framework: "openai",
+        personalFeatures: {},
+      },
+    });
+    otherProjectId = otherProject.id;
+
+    // A neighbouring tenant with entries in the same table. Its rows must never
+    // reach this project's counts.
+    await seedDataset({
+      projectId: otherProjectId,
+      name: "neighbour dataset",
+      records: 25,
+    });
+  });
+
+  afterAll(async () => {
+    // `test-project-id` is shared with every other integration suite, so each
+    // entry stays pinned to the ids this suite created as well as the two
+    // projects it touched — the tenancy guard requires the projectId besides.
+    const projectIds = [PROJECT_ID, otherProjectId];
+    await cleanupTestRows(prisma, [
+      [
+        "datasetRecord",
+        { datasetId: { in: datasetIds }, projectId: { in: projectIds } },
+      ],
+      ["dataset", { id: { in: datasetIds }, projectId: { in: projectIds } }],
+      ["project", { id: otherProjectId }],
+    ]);
+  });
+
+  describe("given datasets across every storage layout, and a neighbouring project with entries", () => {
+    describe("when listing my project's datasets", () => {
+      /** @scenario "Entry counts are right whichever storage a dataset uses" */
+      it("gives each dataset its own count and ignores the neighbour's entries", async () => {
+        const inTable = await seedDataset({
+          projectId: PROJECT_ID,
+          name: `${ns} entries table`,
+          records: 6,
+        });
+        const chunked = await seedDataset({
+          projectId: PROJECT_ID,
+          name: `${ns} object storage`,
+          contentLayout: "s3_jsonl",
+          rowCount: 4_200,
+        });
+        const legacyBlob = await seedDataset({
+          projectId: PROJECT_ID,
+          name: `${ns} legacy blob`,
+          useS3: true,
+          s3RecordCount: 31,
+        });
+
+        const listed = await caller.dataset.getAll({ projectId: PROJECT_ID });
+        const byId = new Map(listed.map((dataset) => [dataset.id, dataset]));
+
+        expect(datasetDisplayRecordCount(byId.get(inTable.id)!)).toBe(6);
+        expect(datasetDisplayRecordCount(byId.get(chunked.id)!)).toBe(4_200);
+        expect(datasetDisplayRecordCount(byId.get(legacyBlob.id)!)).toBe(31);
+
+        // The neighbouring project's dataset is not in my list at all, and its
+        // 25 entries have not inflated any row here.
+        expect(
+          listed.some((dataset) => dataset.name === "neighbour dataset"),
+        ).toBe(false);
+      });
+
+      /** @scenario "Listing never counts another project's entries" */
+      it("reports zero for an empty dataset rather than the neighbour's total", async () => {
+        const empty = await seedDataset({
+          projectId: PROJECT_ID,
+          name: `${ns} empty`,
+        });
+
+        const listed = await caller.dataset.getAll({ projectId: PROJECT_ID });
+        const found = listed.find((dataset) => dataset.id === empty.id)!;
+
+        expect(found._count.datasetRecords).toBe(0);
+        expect(datasetDisplayRecordCount(found)).toBe(0);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/dataset.ts
+++ b/platform/app/src/server/api/routers/dataset.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { slugify } from "~/utils/slugify";
 import { DatasetService } from "../../datasets/dataset.service";
+import { attachDatasetRecordCounts } from "../../datasets/dataset-record-counts";
 import { datasetErrorHandler } from "../../datasets/middleware";
 import {
   datasetColumnsSchema,
@@ -98,14 +99,13 @@ export const datasetRouter = createTRPCRouter({
       const { projectId } = input;
       const prisma = ctx.prisma;
 
-      const datasets = await prisma.dataset.findMany({
-        where: { projectId, archivedAt: null },
-        orderBy: { createdAt: "desc" },
-        include: {
-          _count: {
-            select: { datasetRecords: true },
-          },
-        },
+      const datasets = await attachDatasetRecordCounts({
+        prisma,
+        projectId,
+        datasets: await prisma.dataset.findMany({
+          where: { projectId, archivedAt: null },
+          orderBy: { createdAt: "desc" },
+        }),
       });
 
       return datasets.map((dataset) => ({

--- a/platform/app/src/server/datasets/__tests__/dataset-record-counts.integration.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-record-counts.integration.test.ts
@@ -1,0 +1,243 @@
+import { PrismaClient } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { attachDatasetRecordCounts } from "../dataset-record-counts";
+import { datasetDisplayRecordCount } from "../record-count";
+
+/**
+ * Integration coverage for how dataset lists count entries, against a real
+ * Postgres.
+ *
+ * The behaviour under test is not just "the number is right" — it is *what the
+ * database is asked to read to produce it*. Prisma's relation-count `include`
+ * returns correct numbers while aggregating the whole `DatasetRecord` table
+ * across every tenant, so a correctness-only test passes on the slow path and
+ * the fast path alike. These tests therefore capture the SQL actually issued
+ * and assert on its shape, which is the only thing that distinguishes them.
+ *
+ * Spec: specs/datasets/datasets-list-page.feature
+ */
+describe("dataset entry counts (integration)", () => {
+  const ns = nanoid();
+  let queryLoggingPrisma: PrismaClient;
+
+  // Two tenants: `project` is the one whose list we render, `otherProject`
+  // stands in for the rest of the platform's data.
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+  let otherProjectId: string;
+
+  const captured: string[] = [];
+  const recordQueries = () =>
+    captured.filter((sql) => sql.includes('"DatasetRecord"'));
+
+  const createDataset = async ({
+    project,
+    name,
+    contentLayout = "postgres",
+    useS3 = false,
+    rowCount,
+    s3RecordCount,
+    records = 0,
+  }: {
+    project: string;
+    name: string;
+    contentLayout?: string;
+    useS3?: boolean;
+    rowCount?: number;
+    s3RecordCount?: number;
+    records?: number;
+  }) => {
+    const dataset = await prisma.dataset.create({
+      data: {
+        id: `dataset_${nanoid()}`,
+        name,
+        slug: `${name}-${nanoid()}`,
+        projectId: project,
+        columnTypes: [],
+        contentLayout,
+        useS3,
+        rowCount,
+        s3RecordCount,
+      },
+    });
+
+    if (records > 0) {
+      await prisma.datasetRecord.createMany({
+        data: Array.from({ length: records }, (_, i) => ({
+          id: `record_${nanoid()}`,
+          datasetId: dataset.id,
+          projectId: project,
+          entry: { input: `row ${i}` },
+        })),
+      });
+    }
+
+    return dataset;
+  };
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Count Org", slug: `count-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: "Count Team",
+        slug: `count-team-${ns}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const project = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: `count-${ns}` }),
+        teamId,
+        personalFeatures: {},
+      },
+    });
+    projectId = project.id;
+
+    const otherProject = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: `count-other-${ns}` }),
+        teamId,
+        personalFeatures: {},
+      },
+    });
+    otherProjectId = otherProject.id;
+
+    // The rest of the platform's data. If counting is not tenant-scoped, this
+    // is what a customer's list ends up paying for.
+    await createDataset({
+      project: otherProjectId,
+      name: "someone elses dataset",
+      records: 40,
+    });
+
+    queryLoggingPrisma = new PrismaClient({
+      log: [{ emit: "event", level: "query" }],
+    });
+    queryLoggingPrisma.$on("query" as never, (event: { query: string }) => {
+      captured.push(event.query);
+    });
+  });
+
+  afterAll(async () => {
+    await queryLoggingPrisma?.$disconnect();
+    await cleanupTestRows(prisma, [
+      ["datasetRecord", { projectId: { in: [projectId, otherProjectId] } }],
+      ["dataset", { projectId: { in: [projectId, otherProjectId] } }],
+      ["project", { id: { in: [projectId, otherProjectId] } }],
+      ["team", { id: teamId }],
+      ["organization", { id: organizationId }],
+    ]);
+  });
+
+  const countFor = async (datasets: { id: string }[]) => {
+    captured.length = 0;
+    return await attachDatasetRecordCounts({
+      prisma: queryLoggingPrisma,
+      projectId,
+      datasets: datasets as Parameters<
+        typeof attachDatasetRecordCounts
+      >[0]["datasets"],
+    });
+  };
+
+  describe("given another project holds far more dataset entries than mine", () => {
+    describe("when counting my project's datasets", () => {
+      /** @scenario "Listing never counts another project's entries" */
+      it("reads only my own project's entries", async () => {
+        const mine = await createDataset({
+          project: projectId,
+          name: "mine",
+          records: 3,
+        });
+
+        const counted = await countFor([mine]);
+
+        expect(counted[0]!._count.datasetRecords).toBe(3);
+
+        // The count must be constrained to this project. A query that reads
+        // `DatasetRecord` without a projectId predicate is reading every
+        // tenant's rows, whatever number it ends up returning.
+        const queries = recordQueries();
+        expect(queries).toHaveLength(1);
+        expect(queries[0]).toContain('"projectId"');
+        expect(queries[0]).not.toMatch(/WHERE\s+1=1/i);
+      });
+    });
+  });
+
+  describe("given every dataset in my project is stored in object storage", () => {
+    describe("when counting them", () => {
+      /** @scenario "Datasets kept in object storage report their count without reading entries" */
+      it("reports the stored count without querying the entries table", async () => {
+        const chunked = await createDataset({
+          project: projectId,
+          name: "chunked",
+          contentLayout: "s3_jsonl",
+          rowCount: 5_000,
+        });
+        const legacyBlob = await createDataset({
+          project: projectId,
+          name: "legacy blob",
+          useS3: true,
+          s3RecordCount: 77,
+        });
+
+        const counted = await countFor([chunked, legacyBlob]);
+
+        expect(recordQueries()).toHaveLength(0);
+        expect(
+          counted.map((dataset) => datasetDisplayRecordCount(dataset)),
+        ).toEqual([5_000, 77]);
+      });
+    });
+  });
+
+  describe("given my project mixes entries-table datasets with object-storage ones", () => {
+    describe("when counting them", () => {
+      /** @scenario "Entry counts are right whichever storage a dataset uses" */
+      it("gives every dataset its own entry count", async () => {
+        const inTable = await createDataset({
+          project: projectId,
+          name: "in table",
+          records: 4,
+        });
+        const alsoInTable = await createDataset({
+          project: projectId,
+          name: "also in table",
+          records: 9,
+        });
+        const empty = await createDataset({
+          project: projectId,
+          name: "empty",
+          records: 0,
+        });
+        const chunked = await createDataset({
+          project: projectId,
+          name: "chunked mixed",
+          contentLayout: "s3_jsonl",
+          rowCount: 12_345,
+        });
+
+        const counted = await countFor([inTable, alsoInTable, empty, chunked]);
+
+        expect(
+          counted.map((dataset) => datasetDisplayRecordCount(dataset)),
+        ).toEqual([4, 9, 0, 12_345]);
+
+        // One round trip for the whole page, not one per dataset.
+        expect(recordQueries()).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/datasets/dataset-record-counts.ts
+++ b/platform/app/src/server/datasets/dataset-record-counts.ts
@@ -1,0 +1,66 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+/**
+ * Attaches the `_count.datasetRecords` shape that dataset lists render, without
+ * Prisma's relation-count `include`.
+ *
+ * Prisma compiles `include: { _count: { select: { datasetRecords: true } } }`
+ * into a subquery with no tenancy predicate at all:
+ *
+ *   LEFT JOIN (SELECT "datasetId", COUNT(*) FROM "DatasetRecord"
+ *              WHERE 1=1 GROUP BY "datasetId") ...
+ *
+ * so every dataset list aggregates the whole `DatasetRecord` table across every
+ * tenant, and the cost of one customer's list grows with all the others' data.
+ *
+ * Counting here instead keeps the read inside the project and inside the
+ * datasets that actually store rows in that table: `s3_jsonl` and legacy
+ * `useS3` datasets keep their content in object storage, so their row count is
+ * already a column on `Dataset` and their `DatasetRecord` count is a
+ * guaranteed zero that nobody reads (see `datasetDisplayRecordCount`). A
+ * project fully on object storage issues no count query at all.
+ */
+
+type CountableDataset = {
+  id: string;
+  contentLayout?: string | null;
+  useS3?: boolean | null;
+};
+
+/**
+ * Whether a dataset's entries still live in the `DatasetRecord` table. Mirrors
+ * the fallback branch of `datasetDisplayRecordCount` — the two must agree, or
+ * a dataset gets counted and then has its count discarded, or vice versa.
+ */
+const storesRowsInRecordsTable = (dataset: CountableDataset): boolean =>
+  dataset.contentLayout !== "s3_jsonl" && !dataset.useS3;
+
+export const attachDatasetRecordCounts = async <T extends CountableDataset>({
+  prisma,
+  projectId,
+  datasets,
+}: {
+  prisma: PrismaClient | Prisma.TransactionClient;
+  projectId: string;
+  datasets: T[];
+}): Promise<Array<T & { _count: { datasetRecords: number } }>> => {
+  const datasetIds = datasets.filter(storesRowsInRecordsTable).map((d) => d.id);
+
+  const grouped =
+    datasetIds.length > 0
+      ? await prisma.datasetRecord.groupBy({
+          by: ["datasetId"],
+          where: { projectId, datasetId: { in: datasetIds } },
+          _count: { _all: true },
+        })
+      : [];
+
+  const countByDatasetId = new Map(
+    grouped.map((row) => [row.datasetId, row._count._all]),
+  );
+
+  return datasets.map((dataset) => ({
+    ...dataset,
+    _count: { datasetRecords: countByDatasetId.get(dataset.id) ?? 0 },
+  }));
+};

--- a/platform/app/src/server/datasets/dataset.repository.ts
+++ b/platform/app/src/server/datasets/dataset.repository.ts
@@ -1,5 +1,7 @@
 import type { Dataset, Prisma, PrismaClient } from "@prisma/client";
 
+import { attachDatasetRecordCounts } from "./dataset-record-counts";
+
 /**
  * Input types derived from Prisma for type safety
  */
@@ -354,16 +356,21 @@ export class DatasetRepository {
   }> {
     const where = { projectId: input.projectId, archivedAt: null };
 
-    const [datasets, total] = await Promise.all([
+    const [page, total] = await Promise.all([
       this.prisma.dataset.findMany({
         where,
         orderBy: { createdAt: "desc" },
-        include: { _count: { select: { datasetRecords: true } } },
         skip: input.skip,
         take: input.take,
       }),
       this.prisma.dataset.count({ where }),
     ]);
+
+    const datasets = await attachDatasetRecordCounts({
+      prisma: this.prisma,
+      projectId: input.projectId,
+      datasets: page,
+    });
 
     return { datasets, total };
   }

--- a/specs/datasets/add-to-dataset-picker.feature
+++ b/specs/datasets/add-to-dataset-picker.feature
@@ -39,3 +39,21 @@ Feature: Picking the target dataset when adding traces to a dataset
     And the datasets finish loading
     Then "offline evals" is offered in the dataset dropdown
     And the dropdown no longer says it is loading
+
+  # ============================================================================
+  # When the list cannot be fetched
+  # ============================================================================
+
+  @integration
+  Scenario: A failed request is not reported as an empty project
+    Given the request for my project's datasets fails
+    When I open the "Add to Dataset" drawer
+    Then the dataset dropdown tells me the datasets could not be loaded
+    And it does not tell me I have no datasets
+
+  @integration
+  Scenario: I can still create a dataset from the drawer
+    Given my project has no datasets
+    When I open the "Add to Dataset" drawer
+    And I choose to create a new dataset
+    Then the dataset creation form opens

--- a/specs/datasets/add-to-dataset-picker.feature
+++ b/specs/datasets/add-to-dataset-picker.feature
@@ -1,0 +1,41 @@
+Feature: Picking the target dataset when adding traces to a dataset
+  As a user adding traces to a dataset
+  I want the dataset picker to tell me what it is doing
+  So that I never mistake a slow load for having no datasets at all
+
+  # Context: the "Add to Dataset" drawer opens with a dataset dropdown that is
+  # populated by a request. While that request is in flight the dropdown used to
+  # render as an ordinary empty select, which reads exactly like "this project
+  # has no datasets" - so users clicked it, saw nothing, and assumed the feature
+  # was broken. A customer reported this on a project where the request took
+  # several seconds. The dropdown must distinguish "still loading" from "empty".
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+
+  # ============================================================================
+  # Loading feedback
+  # ============================================================================
+
+  @integration
+  Scenario: The dataset dropdown says it is loading
+    Given my project's datasets have not finished loading
+    When I open the "Add to Dataset" drawer
+    Then the dataset dropdown tells me it is loading
+    And it does not offer me an empty list to choose from
+
+  @integration
+  Scenario: A project with no datasets is told so, not left blank
+    Given my project has no datasets
+    When I open the "Add to Dataset" drawer
+    Then the dataset dropdown tells me there are no datasets yet
+    And I can create one from the drawer
+
+  @integration
+  Scenario: The datasets appear once they arrive
+    Given my project has a dataset named "offline evals"
+    When I open the "Add to Dataset" drawer
+    And the datasets finish loading
+    Then "offline evals" is offered in the dataset dropdown
+    And the dropdown no longer says it is loading

--- a/specs/datasets/datasets-list-page.feature
+++ b/specs/datasets/datasets-list-page.feature
@@ -41,6 +41,43 @@ Feature: Datasets list page
     Then I am taken into the upload flow to add files
 
   # ============================================================================
+  # The list stays fast as the platform grows
+  # ============================================================================
+  #
+  # Entry counts come from three places depending on where a dataset's content
+  # lives: the records table for the original layout, and a stored count column
+  # for datasets kept in object storage (ADR-032). Counting must never depend on
+  # how much data other projects hold - a customer's list should load at the
+  # same speed whether the platform serves one project or ten thousand.
+
+  @integration
+  Scenario: Listing never counts another project's entries
+    Given another project holds far more dataset entries than mine
+    When I open my datasets page
+    Then the entry counts I see cover only my own project's datasets
+    And no other project's entries are read to produce them
+
+  @integration
+  Scenario: Datasets kept in object storage report their count without reading entries
+    Given every dataset in my project is stored in object storage
+    When I open my datasets page
+    Then each row shows the stored entry count
+    And the entries table is not queried at all
+
+  @integration
+  Scenario: Entry counts are right whichever storage a dataset uses
+    Given my project mixes datasets stored in the entries table with datasets stored in object storage
+    When I open my datasets page
+    Then every row shows that dataset's own entry count
+
+  @integration
+  Scenario: The list loads while I wait, and tells me it is loading
+    Given my datasets are still being fetched
+    When I open my datasets page
+    Then I see that the list is loading
+    And I am not shown an empty-project message
+
+  # ============================================================================
   # Creating
   # ============================================================================
 

--- a/specs/datasets/datasets-list-page.feature
+++ b/specs/datasets/datasets-list-page.feature
@@ -45,10 +45,11 @@ Feature: Datasets list page
   # ============================================================================
   #
   # Entry counts come from three places depending on where a dataset's content
-  # lives: the records table for the original layout, and a stored count column
-  # for datasets kept in object storage (ADR-032). Counting must never depend on
-  # how much data other projects hold - a customer's list should load at the
-  # same speed whether the platform serves one project or ten thousand.
+  # lives: the records table for the original layout, a stored row count for
+  # datasets kept as chunks in object storage (ADR-032), and a separate stored
+  # count for the older single-file object-storage layout. Counting must never
+  # depend on how much data other projects hold - a customer's list should load
+  # at the same speed whether the platform serves one project or ten thousand.
 
   @integration
   Scenario: Listing never counts another project's entries


### PR DESCRIPTION
## The report

> when you click Add to dataset, the select there is super slow to load in some customers in prod, and there is no feedback indicating the loading. also datasets list page is super slow. is it because of s3?

It is not S3. S3 is never touched on either path.

![the reported bug](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/01-before-empty-select-no-feedback.png)

*Today, on a slow project: an ordinary dropdown with nothing behind it. Indistinguishable from a project that has no datasets.*

## What it actually is

Both surfaces call `dataset.getAll`, which counted entries with Prisma's relation-count `include`. Prisma compiles that into a subquery with **no tenancy predicate at all**:

```sql
LEFT JOIN (SELECT "datasetId", COUNT(*) AS "_aggr_count_datasetRecords"
           FROM "DatasetRecord"
           WHERE 1=1                                  -- <- no projectId
           GROUP BY "datasetId") AS aggr_selection_0 ...
WHERE "Dataset"."projectId" = $1 AND "Dataset"."archivedAt" IS NULL
```

That is the literal SQL, captured from the Prisma client. Every dataset list aggregates the **entire `DatasetRecord` table, across every tenant**, so the cost of one customer's list grows with everybody else's data.

`EXPLAIN (ANALYZE, BUFFERS)` against production:

```
Parallel Seq Scan on "DatasetRecord"
  (actual time=0.499..3995.079 rows=861394 loops=3)
  Buffers: shared hit=808 read=147348
  I/O Timings: shared read=11203.659
Execution Time: 4359.918 ms
```

4.36 seconds, 2.58M rows, 3.2 GB, 147k blocks off disk, on **every** open. Seven surfaces call this query: the datasets page, the "Add to Dataset" drawer, the dataset picker, the command bar, the automations page and its trigger editor, and the Langy hydrator.

The sharpest illustration is a production project that owns exactly **one** dataset, stored in object storage, with **zero** rows in `DatasetRecord`:

```
Parallel Seq Scan on "DatasetRecord" (actual time=0.211..12960.983 rows=861422 loops=3)
Execution Time: 13758.595 ms
```

13.7 seconds to count entries for a dataset that has none in that table, and the number is then discarded. Since [ADR-032](dev/docs/adr/032-datasets-s3-jsonl.md), rows live in chunked JSONL and the count sits on the dataset row (`rowCount`); `datasetDisplayRecordCount` throws the scanned figure away. Object storage made this worse, not better.

(A project with *no* datasets at all is spared: the join short-circuits when the outer side is empty.)

## The fix

**Count inside the tenant, and only where rows actually are.** `attachDatasetRecordCounts` replaces the relation `include` with a `groupBy` scoped to the project and to the datasets that still store rows in that table. A project fully on object storage issues no count query at all.

**A composite index so the planner cannot get it wrong.** `projectId` alone is not enough. Where a project's rows dominate the table, the two single-column indexes have to be combined with a `BitmapAnd`, the estimate collapses (`rows=9` vs `578695` actual) and Postgres falls back to a sequential scan. Measured on production, scoping without the index costs **13s** on that project, and a correlated-subquery shape costs **30s**. `@@index([projectId, datasetId])` serves the predicate as one index-only scan that never touches the heap. It also serves the project-scoped record reads on the editor page. The index is 18 MB.

**Loading feedback.** The picker now says what it is doing, and distinguishes "loading" from "you have none".

| loading | project with no datasets | request failed |
|---|---|---|
| ![loading](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/02-after-loading-light.png) | ![empty](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/04-project-with-no-datasets.png) | ![failed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/07-request-failed.png) |

![dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/03-after-loading-dark.png)

Review turned up a third state worth separating. A failed request also leaves no datasets, and the old code let that fall into the empty branch: a customer whose request errored was told "No datasets yet", which is the one message that is actively wrong there. Only a list that actually arrived counts as empty now.

## Numbers

Measured on a local reproduction of the production distribution: 2,579,321 rows (production's exact count), one project holding 1.74M of them across 3 datasets.

| | before | after |
|---|---|---|
| typical project (107 datasets, 42k entries) | 251 ms | **3.5 ms** |
| largest project (3 datasets, 1.74M entries) | 176 ms | **165 ms** |
| project fully on object storage | full-table scan | **no query** |

Production plans for the new query shape, same projects as the baseline above:

| project | current `_count` | scoped + index-only |
|---|---|---|
| 107 datasets / 42k entries | 4359 ms | 34 ms |
| 128 datasets / 11k entries | ~4300 ms | 56 ms |

Local absolute times are far below production for the same plans, because production RDS is paying cold I/O (11.2s of `shared read` in the trace above) while a laptop serves everything from page cache. What carries over is structural, and it is the point: other tenants' data is no longer read, and the heap is no longer touched.

## Migration

`CREATE INDEX` on `DatasetRecord` takes a SHARE lock: reads keep working, writes (uploads, appends, row edits) pause until it finishes. The build reads the heap once, 2.8s on the 2.58M-row reproduction, so expect single-digit seconds against production. Dataset writes are low-frequency and this runs during deploy. `CONCURRENTLY` would avoid the pause but cannot run inside a transaction, which the Prisma migration setup requires (same conclusion as `20260426150000_drop_redundant_audit_log_org_index`).

## Specs

- `specs/datasets/datasets-list-page.feature` gains a section on counting staying inside the project, storage-backed datasets not reading the entries table, counts being right across all three layouts, and the list reading as loading rather than empty.
- `specs/datasets/add-to-dataset-picker.feature` is new and covers the picker's loading / empty / loaded states.

## Tests

Nothing covered the dataset lists' three storage layouts against a real database before.

- `dataset-record-counts.integration.test.ts` captures the SQL actually issued and asserts on its shape. That is the only thing separating the fast path from the slow one, since both return correct numbers.
- `dataset.getAll.integration.test.ts` runs the tRPC procedure end to end with a neighbouring tenant seeded alongside.
- `DatasetSelector.integration.test.tsx` and `datasets-list-loading.integration.test.tsx` render the real component trees for the loading, empty and loaded states.

## QA

Driven in a real browser against a database seeded to production's shape (1.5M entries in a neighbouring tenant, 60 datasets in the customer's project split across both storage layouts), measuring the same flow before and after in the same environment.

- `dataset.getAll` end to end: **57 ms → 14 ms** on that data.
- Counts correct for both layouts: object-storage datasets report `rowCount`, entries-table datasets report their own count.
- The full add flow still works, and the count moves: added a trace to "Offline evals 1" and watched the list go **200 → 201**.
- Loading, empty, failed and populated states checked in light and dark. The failure state was verified by forcing the request to 500 and waiting out React Query's retries.
- The REST list (`GET /api/dataset`, the other caller of the changed repository method) checked against the database: counts match ground truth for both layouts, and the neighbouring tenant's datasets never appear.

![full flow](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/drawer/06-full-add-flow.png)

![datasets list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6559/list/01-datasets-list.png)

## Swept for the same bug elsewhere

Prisma's relation `_count` is unscoped everywhere it is used, so I checked every other call site against production table sizes. Only one other is worth anything, and it is two orders of magnitude smaller than this one:

| call site | related table | cross-tenant aggregate |
|---|---|---|
| `dataset.getAll` (this PR) | `DatasetRecord` — 2.58M rows / 3.2 GB | **4359 ms** |
| `llm-config.repository.ts` `copiedPrompts` | `LlmPromptConfig` — 190k rows / 61 MB | 81 ms (143 ms total) |
| `group`, `dashboard.graphs`, `agent.copiedAgents`, `evaluator.copiedEvaluators` | 12 – 2k rows | negligible |

`workflows.ts` builds its `_count` by hand and `batchRecord.ts` already scopes its `groupBy` on `projectId`; neither is affected.

The prompts one is the same bug and the same one-line shape, left out of this PR only to keep it to the reported surface — it is a 81 ms tax on a list nobody has complained about, against a 4.4 s one on two that people have. Worth doing next, in its own change with its own prompt-list coverage.