### PR TITLE
fix(auth): recover sign-up when the account already exists, ship NEXTAUTH_URL to every helm process

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -597,6 +597,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: BASE_HOST
   value: {{ .Values.app.http.baseHost | default "http://localhost:5560" }}
 
+{{/* The address this installation answers on, and the one BetterAuth measures
+     every callback, redirect and same-origin check against. Shared rather than
+     app-only: the auth module is imported wherever the app code is, so a
+     workers or cronjob process without it boots into
+     "[better-auth] Base URL could not be determined" and builds its links off
+     nothing. Same value everywhere, so no process can disagree with another
+     about what this installation is called. */}}
+- name: NEXTAUTH_URL
+  value: {{ .Values.app.http.publicUrl | default .Values.app.http.baseHost | default "http://localhost:5560" }}
+
 - name: SKIP_ENV_VALIDATION
   value: {{ .Values.app.features.skipEnvValidation | default false | quote }}
 {{- if .Values.app.features.disableStrictPiiRedaction }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -133,8 +133,8 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: {{ .Values.app.otel.serviceName | default "langwatch-app" | quote }}
 
-            - name: NEXTAUTH_URL
-              value: {{ .Values.app.http.publicUrl | default .Values.app.http.baseHost | default "http://localhost:5560" }}
+            {{/* NEXTAUTH_URL comes from langwatch.sharedEnv: every process
+                 needs the same answer for what this installation is called. */}}
             - name: NEXTAUTH_URL_INTERNAL
               value: "http://localhost:{{ .Values.app.service.port | default 5560 }}"
 

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -438,13 +438,21 @@ test_auth_base_url() {
 
   # One key per container: a duplicate would leave which value wins up to
   # manifest order rather than to this chart.
-  local app_render app_count
+  local app_render app_count workers_render workers_count
   app_render=$(tmpl_only "templates/app/deployment.yaml" --set autogen.enabled=true)
   app_count=$(count_matches "$app_render" "name: NEXTAUTH_URL$")
   if [ "$app_count" = "1" ]; then
     pass "app declares NEXTAUTH_URL exactly once"
   else
     fail "app declares NEXTAUTH_URL exactly once: found $app_count"
+  fi
+
+  workers_render=$(tmpl_only "templates/workers/deployment.yaml" --set autogen.enabled=true)
+  workers_count=$(count_matches "$workers_render" "name: NEXTAUTH_URL$")
+  if [ "$workers_count" = "1" ]; then
+    pass "workers declare NEXTAUTH_URL exactly once"
+  else
+    fail "workers declare NEXTAUTH_URL exactly once: found $workers_count"
   fi
 
   # Falls back to baseHost when only that is set, so an install that never
@@ -457,6 +465,17 @@ test_auth_base_url() {
     | grep -A1 "name: NEXTAUTH_URL$")
   assert_contains "NEXTAUTH_URL falls back to baseHost" \
     "$fallback" "https://internal.example.com"
+
+  # And with both values blanked, the template's own literal default answers,
+  # so a bare install still boots with a coherent (if local) address.
+  local default_fallback
+  default_fallback=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true \
+    --set "app.http.publicUrl=" \
+    --set "app.http.baseHost=" \
+    | grep -A1 "name: NEXTAUTH_URL$")
+  assert_contains "NEXTAUTH_URL falls back to the localhost default" \
+    "$default_fallback" "http://localhost:5560"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -407,6 +407,59 @@ test_langwatch_endpoint() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: NEXTAUTH_URL reaches every process running the app image. It used to be
+# set on the app Deployment only, so the workers pod booted into
+# "[better-auth] Base URL could not be determined" and had no address to build
+# callbacks and redirects from.
+# ─────────────────────────────────────────────────────────────────────────────
+test_auth_base_url() {
+  sep; info "Suite: NEXTAUTH_URL on every app-image workload"
+
+  local public_url="https://langwatch.example.com"
+
+  # Assert on the NEXTAUTH_URL line itself: the whole render carries BASE_HOST
+  # with the same value, so a bare grep for the URL would pass with the env var
+  # missing entirely.
+  local app_url workers_url
+  app_url=$(tmpl_only "templates/app/deployment.yaml" \
+    --set autogen.enabled=true \
+    --set "app.http.publicUrl=${public_url}" \
+    | grep -A1 "name: NEXTAUTH_URL$")
+  assert_contains "app sets NEXTAUTH_URL" "$app_url" "name: NEXTAUTH_URL"
+  assert_contains "app NEXTAUTH_URL is the public URL" "$app_url" "$public_url"
+
+  workers_url=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true \
+    --set "app.http.publicUrl=${public_url}" \
+    | grep -A1 "name: NEXTAUTH_URL$")
+  assert_contains "workers set NEXTAUTH_URL" "$workers_url" "name: NEXTAUTH_URL"
+  assert_contains "workers NEXTAUTH_URL is the public URL" \
+    "$workers_url" "$public_url"
+
+  # One key per container: a duplicate would leave which value wins up to
+  # manifest order rather than to this chart.
+  local app_render app_count
+  app_render=$(tmpl_only "templates/app/deployment.yaml" --set autogen.enabled=true)
+  app_count=$(count_matches "$app_render" "name: NEXTAUTH_URL$")
+  if [ "$app_count" = "1" ]; then
+    pass "app declares NEXTAUTH_URL exactly once"
+  else
+    fail "app declares NEXTAUTH_URL exactly once: found $app_count"
+  fi
+
+  # Falls back to baseHost when only that is set, so an install that never
+  # names a separate public URL still agrees with itself.
+  local fallback
+  fallback=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true \
+    --set "app.http.publicUrl=" \
+    --set "app.http.baseHost=https://internal.example.com" \
+    | grep -A1 "name: NEXTAUTH_URL$")
+  assert_contains "NEXTAUTH_URL falls back to baseHost" \
+    "$fallback" "https://internal.example.com"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: backup metrics gate — CLICKHOUSE_BACKUP_METRICS_ENABLED must follow the
 # backup config so the "Backup Reporting Absent" signal cannot silently drift
 # from whether backups actually run (PR #5814).
@@ -1216,6 +1269,7 @@ main() {
   test_access_nodeport
   test_access_ingress
   test_langwatch_endpoint
+  test_auth_base_url
   test_backup_metrics_gate
   test_size_overlays
   test_component_toggles

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -53,6 +53,7 @@ export const APP_ERROR_CODES = [
   "dataset_not_ready",
   "dataset_stale_columns",
   "dspy_step_not_found",
+  "email_already_registered",
   "evaluation_not_found",
   "evaluator_config_error",
   "evaluator_execution_error",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -271,6 +271,17 @@ const presentations = {
     describe: () =>
       "It may have been removed along with its run. Reload to see the current steps.",
   },
+  email_already_registered: {
+    // Reached from the sign-up screen, and the reader there is usually looking
+    // at their own account: either a previous sign-up created it and could not
+    // sign them in, or they were a member before and an invite asked them to
+    // create an account they already have. The screen retries the sign-in for
+    // them first, so by the time this copy renders the password they typed was
+    // not the account's, which leaves exactly two moves worth naming.
+    title: "That email already has an account",
+    describe: () =>
+      "Sign in with it, or reset the password if you don't have it.",
+  },
   prompt_not_found: {
     title: "Prompt not found",
     describe: () => "It may have been deleted. Reload to see the current list.",

--- a/platform/app/src/pages/auth/__tests__/signup-recovers-stranded-account.integration.test.tsx
+++ b/platform/app/src/pages/auth/__tests__/signup-recovers-stranded-account.integration.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Sign-up never dead-ends someone on their own account.
+ *
+ * Creating an account is two calls and only the first is durable: one writes
+ * the User row and its password, the second exchanges them for a session. A
+ * customer reported people hitting an unexplained error on sign-up and, on
+ * every retry after it, "User already exists": an account they could not see,
+ * sign into, or be found on the members list through, because the failed second
+ * leg left them with no session and no organization.
+ *
+ * Rendered rather than unit-tested against the submit handler: the whole defect
+ * was that the screen turned a recoverable state into a wall, so the assertions
+ * are about what the screen does next.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sessionRef, publicEnvRef, searchParamsRef, registerRef, signInMock } =
+  vi.hoisted(() => ({
+    sessionRef: { current: { data: null as unknown } },
+    publicEnvRef: {
+      current: { NEXTAUTH_PROVIDER: "email" as string | undefined },
+    },
+    searchParamsRef: { current: new URLSearchParams("") },
+    registerRef: {
+      current: {
+        mutateAsync: vi.fn(() => Promise.resolve({ id: "user_1" })),
+        error: null as unknown,
+        isLoading: false,
+      },
+    },
+    signInMock: vi.fn(),
+  }));
+
+vi.mock("~/utils/auth-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/auth-client")>();
+  return {
+    ...actual,
+    signIn: signInMock,
+    useSession: () => sessionRef.current,
+  };
+});
+
+vi.mock("~/utils/compat/next-navigation", () => ({
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: publicEnvRef.current }),
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    user: { register: { useMutation: () => registerRef.current } },
+  },
+}));
+
+import SignUp from "../signup";
+
+/**
+ * What a tRPC rejection carrying a handled error looks like on the wire: the
+ * payload nests under `data.error` and the message IS the code slug (#5984),
+ * which is exactly why the screen must read the payload rather than the
+ * message.
+ */
+const alreadyRegistered = () =>
+  Object.assign(new Error("email_already_registered"), {
+    data: {
+      error: {
+        code: "email_already_registered",
+        meta: {},
+        httpStatus: 409,
+        fault: "customer",
+        reasons: [],
+      },
+    },
+  });
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <SignUp />
+    </ChakraProvider>,
+  );
+
+const fillAndSubmit = (container: HTMLElement) => {
+  const set = (name: string, value: string) => {
+    const input = container.querySelector<HTMLInputElement>(`[name="${name}"]`);
+    if (!input) throw new Error(`no field named ${name}`);
+    fireEvent.change(input, { target: { value } });
+  };
+  set("name", "Returning Colleague");
+  set("email", "returning@example.com");
+  set("password", "SuperSecret123!");
+  set("confirmPassword", "SuperSecret123!");
+
+  const form = container.querySelector("form");
+  if (!form) throw new Error("no form");
+  fireEvent.submit(form);
+};
+
+describe("SignUp when the email already has an account", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRef.current = { data: null };
+    publicEnvRef.current = { NEXTAUTH_PROVIDER: "email" };
+    searchParamsRef.current = new URLSearchParams("");
+    registerRef.current = {
+      mutateAsync: vi.fn(() => Promise.resolve({ id: "user_1" })),
+      error: null,
+      isLoading: false,
+    };
+  });
+
+  afterEach(() => cleanup());
+
+  describe("when the password is the one on the account", () => {
+    /** @scenario "Submitting the same details again signs me in" */
+    it("signs them in with the credentials they just typed", async () => {
+      const rejection = alreadyRegistered();
+      registerRef.current.mutateAsync = vi.fn(() => Promise.reject(rejection));
+      registerRef.current.error = rejection;
+      signInMock.mockResolvedValue({ ok: true });
+      searchParamsRef.current = new URLSearchParams(
+        "callbackUrl=%2Finvite%2Faccept%3FinviteCode%3Dabc",
+      );
+
+      const { container } = renderPage();
+      fillAndSubmit(container);
+
+      await waitFor(() => expect(signInMock).toHaveBeenCalled());
+      expect(signInMock).toHaveBeenCalledWith("credentials", {
+        email: "returning@example.com",
+        password: "SuperSecret123!",
+        callbackUrl: "/invite/accept?inviteCode=abc",
+      });
+    });
+  });
+
+  describe("when the password is not the one on the account", () => {
+    /** @scenario "An email that belongs to an account I cannot open points at the way in" */
+    it("names the account and offers signing in or resetting the password", async () => {
+      const rejection = alreadyRegistered();
+      registerRef.current.mutateAsync = vi.fn(() => Promise.reject(rejection));
+      registerRef.current.error = rejection;
+      signInMock.mockResolvedValue({
+        ok: false,
+        code: "INVALID_EMAIL_OR_PASSWORD",
+        error: "Invalid email or password",
+        status: 401,
+      });
+
+      const { container } = renderPage();
+      fillAndSubmit(container);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/that email already has an account/i),
+        ).toBeTruthy();
+      });
+      expect(screen.getByText(/^sign in$/i)).toBeTruthy();
+      expect(screen.getByText(/reset your password/i)).toBeTruthy();
+      // The code slug is the wire message for a handled error, so putting it on
+      // screen is the failure mode this registry exists to prevent.
+      expect(screen.queryByText(/email_already_registered/)).toBeNull();
+    });
+  });
+
+  describe("when recovery fails for a reason of its own", () => {
+    /**
+     * A rate limit is not "wrong password", and answering it with the
+     * already-registered copy would send someone to reset a password that was
+     * never the problem.
+     */
+    /** @scenario "A rate-limited recovery says to wait, not to reset the password" */
+    it("says to wait rather than pointing at the password", async () => {
+      const rejection = alreadyRegistered();
+      registerRef.current.mutateAsync = vi.fn(() => Promise.reject(rejection));
+      registerRef.current.error = rejection;
+      signInMock.mockResolvedValue({ ok: false, status: 429 });
+
+      const { container } = renderPage();
+      fillAndSubmit(container);
+
+      await waitFor(() => {
+        expect(screen.getByText(/too many attempts/i)).toBeTruthy();
+      });
+      expect(screen.queryByText(/reset your password/i)).toBeNull();
+    });
+  });
+
+  describe("when the account was created but the sign-in leg fails", () => {
+    /**
+     * The original strand: the durable half succeeded, the session half did
+     * not, and on the customer's version the screen answered with a fixed
+     * "Failed to sign up" toast. The honest sentence is that the account
+     * exists and signing in is the way forward.
+     */
+    /** @scenario "A sign-up whose second leg fails still says what happened" */
+    it("says the account was created rather than that sign-up failed", async () => {
+      signInMock.mockResolvedValue({
+        ok: false,
+        error: "SOME_UNMAPPED_IDENTIFIER",
+        status: 400,
+      });
+
+      const { container } = renderPage();
+      fillAndSubmit(container);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText(/your account was created/i).length,
+        ).toBeGreaterThan(0);
+      });
+      expect(screen.queryByText(/failed to sign up/i)).toBeNull();
+      expect(screen.queryByText(/SOME_UNMAPPED_IDENTIFIER/)).toBeNull();
+    });
+  });
+
+  describe("when the refusal is anything else", () => {
+    it("does not attempt a sign-in", async () => {
+      const rejection = Object.assign(new Error("validation_error"), {
+        data: {
+          error: {
+            code: "validation_error",
+            meta: {},
+            httpStatus: 400,
+            fault: "customer",
+            reasons: [],
+          },
+        },
+      });
+      registerRef.current.mutateAsync = vi.fn(() => Promise.reject(rejection));
+      registerRef.current.error = rejection;
+
+      const { container } = renderPage();
+      fillAndSubmit(container);
+
+      await waitFor(() =>
+        expect(registerRef.current.mutateAsync).toHaveBeenCalled(),
+      );
+      expect(signInMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/pages/auth/authFailureMessage.ts
+++ b/platform/app/src/pages/auth/authFailureMessage.ts
@@ -25,14 +25,26 @@ const normalize = (value: string | undefined): string =>
     .replace(/[\s-]+/g, "_");
 
 /**
+ * Every identifier the auth layer uses for "those are not the credentials for
+ * this account". `user_not_found` belongs in here on purpose: telling a
+ * stranger which addresses have accounts is an enumeration oracle, so it must
+ * be indistinguishable from a wrong password everywhere this set is read.
+ */
+const CREDENTIAL_REJECTION_KEYS = new Set([
+  "invalid_email_or_password",
+  "credentialssignin",
+  "user_not_found",
+]);
+
+/**
  * The auth layer's way of saying "those are not the credentials for this
  * account", as opposed to a rate limit, an address mismatch, or our side
  * falling over, each of which needs its own wording.
  *
  * The sign-up screen branches on this: it retries the sign-in with whatever the
  * customer typed, and a credential rejection is the one outcome that means the
- * address belongs to an account they cannot open. Lives beside the mapping
- * above so the set of identifiers meaning this has exactly one definition.
+ * address belongs to an account they cannot open. Reads the same set the
+ * wording below does, so the two answers cannot drift.
  */
 export const isCredentialRejection = ({
   code,
@@ -40,14 +52,8 @@ export const isCredentialRejection = ({
 }: {
   code?: string;
   message?: string;
-}): boolean => {
-  const key = normalize(code) || normalize(message);
-  return (
-    key === "invalid_email_or_password" ||
-    key === "credentialssignin" ||
-    key === "user_not_found"
-  );
-};
+}): boolean =>
+  CREDENTIAL_REJECTION_KEYS.has(normalize(code) || normalize(message));
 
 export const authFailureMessage = ({
   code,
@@ -63,13 +69,11 @@ export const authFailureMessage = ({
 }): string => {
   const key = normalize(code) || normalize(message);
 
+  if (CREDENTIAL_REJECTION_KEYS.has(key)) {
+    return "Invalid email or password.";
+  }
+
   switch (key) {
-    // `user_not_found` gets the same wording on purpose: telling a stranger
-    // which addresses have accounts is an enumeration oracle.
-    case "invalid_email_or_password":
-    case "credentialssignin":
-    case "user_not_found":
-      return "Invalid email or password.";
     case "invalid_origin":
       // Naming the concept ("origin", "trusted origins") would only help
       // someone who already knows the answer. The address bar is the thing

--- a/platform/app/src/pages/auth/authFailureMessage.ts
+++ b/platform/app/src/pages/auth/authFailureMessage.ts
@@ -24,6 +24,31 @@ const normalize = (value: string | undefined): string =>
     .toLowerCase()
     .replace(/[\s-]+/g, "_");
 
+/**
+ * The auth layer's way of saying "those are not the credentials for this
+ * account", as opposed to a rate limit, an address mismatch, or our side
+ * falling over, each of which needs its own wording.
+ *
+ * The sign-up screen branches on this: it retries the sign-in with whatever the
+ * customer typed, and a credential rejection is the one outcome that means the
+ * address belongs to an account they cannot open. Lives beside the mapping
+ * above so the set of identifiers meaning this has exactly one definition.
+ */
+export const isCredentialRejection = ({
+  code,
+  message,
+}: {
+  code?: string;
+  message?: string;
+}): boolean => {
+  const key = normalize(code) || normalize(message);
+  return (
+    key === "invalid_email_or_password" ||
+    key === "credentialssignin" ||
+    key === "user_not_found"
+  );
+};
+
 export const authFailureMessage = ({
   code,
   message,

--- a/platform/app/src/pages/auth/authFailureMessage.ts
+++ b/platform/app/src/pages/auth/authFailureMessage.ts
@@ -55,6 +55,36 @@ export const isCredentialRejection = ({
 }): boolean =>
   CREDENTIAL_REJECTION_KEYS.has(normalize(code) || normalize(message));
 
+/** The wording for each identifier worth naming beyond a credential rejection. */
+const KEYED_MESSAGES: Record<string, string> = {
+  // Naming the concept ("origin", "trusted origins") would only help someone
+  // who already knows the answer. The address bar is the thing this reader can
+  // actually look at.
+  invalid_origin:
+    "LangWatch is set up for a different web address than the one you are using. Check the address and try again.",
+  user_already_exists:
+    "An account with that email already exists. Try signing in instead.",
+  email_not_verified: "Verify your email address before signing in.",
+};
+
+/**
+ * Failures named by their status class rather than an identifier: a rate limit
+ * and a server-side fault each get their own sentence, everything else falls
+ * through to the message-or-fallback handling.
+ */
+const statusClassMessage = (
+  status: number | undefined,
+  key: string,
+): string | null => {
+  if (status === 429 || key.includes("too_many")) {
+    return "Too many attempts. Wait a minute and try again.";
+  }
+  if (status !== undefined && status >= 500) {
+    return "Something went wrong on our side. Try again in a moment.";
+  }
+  return null;
+};
+
 export const authFailureMessage = ({
   code,
   message,
@@ -72,24 +102,9 @@ export const authFailureMessage = ({
   if (CREDENTIAL_REJECTION_KEYS.has(key)) {
     return "Invalid email or password.";
   }
-
-  switch (key) {
-    case "invalid_origin":
-      // Naming the concept ("origin", "trusted origins") would only help
-      // someone who already knows the answer. The address bar is the thing
-      // this reader can actually look at.
-      return "LangWatch is set up for a different web address than the one you are using. Check the address and try again.";
-    case "user_already_exists":
-      return "An account with that email already exists. Try signing in instead.";
-    case "email_not_verified":
-      return "Verify your email address before signing in.";
-  }
-
-  if (status === 429 || key.includes("too_many")) {
-    return "Too many attempts. Wait a minute and try again.";
-  }
-  if (status !== undefined && status >= 500) {
-    return "Something went wrong on our side. Try again in a moment.";
+  const keyed = KEYED_MESSAGES[key] ?? statusClassMessage(status, key);
+  if (keyed) {
+    return keyed;
   }
 
   // An unmapped message can still be a real sentence worth showing ("Password

--- a/platform/app/src/pages/auth/signup.tsx
+++ b/platform/app/src/pages/auth/signup.tsx
@@ -279,8 +279,9 @@ function SignUpForm() {
               {/* Shown only once the sign-in this screen ran on the customer's
                   behalf came back with the wrong password for an account that
                   does exist. The copy above names the situation; these are the
-                  two ways out of it, and they carry the callback so the invite
-                  they were following survives the detour. */}
+                  two ways out of it. The sign-in link carries the callback so
+                  the invite they were following survives the detour; the reset
+                  flow returns through the emailed link instead. */}
               {showRecoveryLinks ? (
                 <HStack width="full" gap={4}>
                   <Link href={signInHref} textDecoration="underline">

--- a/platform/app/src/pages/auth/signup.tsx
+++ b/platform/app/src/pages/auth/signup.tsx
@@ -13,7 +13,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { HandledErrorAlert } from "~/features/errors";
+import { HandledErrorAlert, readHandledError } from "~/features/errors";
 import { signIn, useSession } from "~/utils/auth-client";
 import { useSearchParams } from "~/utils/compat/next-navigation";
 import { HorizontalFormControl } from "../../components/HorizontalFormControl";
@@ -22,7 +22,10 @@ import { Link } from "../../components/ui/link";
 import { toaster } from "../../components/ui/toaster";
 import { usePublicEnv } from "../../hooks/usePublicEnv";
 import { api } from "../../utils/api";
-import { authFailureMessage } from "./authFailureMessage";
+import {
+  authFailureMessage,
+  isCredentialRejection,
+} from "./authFailureMessage";
 
 /**
  * Wording for a sign-in failure this screen can't name. The account has
@@ -31,6 +34,14 @@ import { authFailureMessage } from "./authFailureMessage";
  */
 const SIGN_UP_FALLBACK =
   "Your account was created — sign in with your new details.";
+
+/**
+ * The same wording for the other direction: the address already had an account
+ * and the sign-in this screen ran on the customer's behalf failed for a reason
+ * it can't name. Saying the account "was created" there would be a lie.
+ */
+const RECOVERY_FALLBACK =
+  "That email already has an account. Sign in with it instead.";
 
 export default function SignUp() {
   const { data: session } = useSession();
@@ -64,6 +75,11 @@ export default function SignUp() {
 function SignUpForm() {
   const query = useSearchParams();
   const callbackUrl = query?.get("callbackUrl") ?? undefined;
+  // Where this screen sends someone who turns out to already have an account.
+  // Keeps the callback so an invite they were following survives the detour.
+  const signInHref = `/auth/signin${
+    callbackUrl ? `?callbackUrl=${encodeURIComponent(callbackUrl)}` : ""
+  }`;
 
   const schema = z
     .object({
@@ -88,17 +104,34 @@ function SignUpForm() {
   const register = api.user.register.useMutation();
   const [signInLoading, setSignInLoading] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showRecoveryLinks, setShowRecoveryLinks] = useState(false);
 
   const onSubmit = async (values: z.infer<typeof schema>) => {
     setSubmitError(null);
+    setShowRecoveryLinks(false);
 
+    // Whether this submit created the account, or found one already there.
+    // The two legs below read differently depending on the answer, because a
+    // sign-in failure means "your new account is waiting for you" in the first
+    // case and "this is not your account's password" in the second.
+    let accountWasJustCreated = true;
     try {
       await register.mutateAsync(values);
-    } catch {
-      // `register.error` renders in the alert below, through the code registry,
-      // carrying the reason the server actually gave ("that email is already
-      // registered"). A toast here would only cover that with a vaguer line.
-      return;
+    } catch (error) {
+      // An address that already has an account is not a wall, it is almost
+      // always the customer's own: sign-up writes the account and its password
+      // in one call and exchanges them for a session in another, so a failure
+      // in the second leaves an account nobody ever mentions and every retry
+      // lands here. It is also where someone who was a member before and got
+      // invited back arrives, because an invite asks them to create an account
+      // they already have. Carry on into the sign-in leg with the credentials
+      // they just typed rather than dead-ending them on their own account.
+      if (readHandledError(error)?.code !== "email_already_registered") {
+        // Every other refusal renders in the alert below, through the code
+        // registry. A toast here would only cover it with a vaguer line.
+        return;
+      }
+      accountWasJustCreated = false;
     }
 
     // The account exists from here on, so this leg fails on its own terms —
@@ -118,12 +151,30 @@ function SignUpForm() {
       });
 
       if (response?.error ?? (response?.status && response.status >= 400)) {
-        message = authFailureMessage({
-          code: response.code,
-          message: response.error,
-          status: response.status,
-          fallback: SIGN_UP_FALLBACK,
-        });
+        // Recovering an existing account and the password was not its
+        // password: the honest answer is the one the server already gave,
+        // that address has an account, plus the two ways into it. Leave
+        // `submitError` unset so the registry copy for
+        // `email_already_registered` renders instead of being masked by a
+        // sign-in sentence that would read as though the account were new.
+        if (
+          !accountWasJustCreated &&
+          isCredentialRejection({
+            code: response.code,
+            message: response.error,
+          })
+        ) {
+          setShowRecoveryLinks(true);
+        } else {
+          message = authFailureMessage({
+            code: response.code,
+            message: response.error,
+            status: response.status,
+            fallback: accountWasJustCreated
+              ? SIGN_UP_FALLBACK
+              : RECOVERY_FALLBACK,
+          });
+        }
       }
     } catch (error) {
       // A thrown exception is not the auth layer answering — it is the fetch
@@ -134,7 +185,9 @@ function SignUpForm() {
       // so nothing here is shown: the caught error goes to the console for
       // whoever is debugging, and the customer reads the fallback.
       console.error("sign-in after sign-up threw", error);
-      message = authFailureMessage({ fallback: SIGN_UP_FALLBACK });
+      message = authFailureMessage({
+        fallback: accountWasJustCreated ? SIGN_UP_FALLBACK : RECOVERY_FALLBACK,
+      });
     } finally {
       setSignInLoading(false);
     }
@@ -223,15 +276,23 @@ function SignUpForm() {
                   fallbackTitle="Couldn't create your account"
                 />
               ) : null}
+              {/* Shown only once the sign-in this screen ran on the customer's
+                  behalf came back with the wrong password for an account that
+                  does exist. The copy above names the situation; these are the
+                  two ways out of it, and they carry the callback so the invite
+                  they were following survives the detour. */}
+              {showRecoveryLinks ? (
+                <HStack width="full" gap={4}>
+                  <Link href={signInHref} textDecoration="underline">
+                    Sign in
+                  </Link>
+                  <Link href="/auth/forgot-password" textDecoration="underline">
+                    Reset your password
+                  </Link>
+                </HStack>
+              ) : null}
               <HStack width="full" paddingTop={4}>
-                <Link
-                  href={`/auth/signin${
-                    callbackUrl
-                      ? `?callbackUrl=${encodeURIComponent(callbackUrl)}`
-                      : ""
-                  }`}
-                  textDecoration="underline"
-                >
+                <Link href={signInHref} textDecoration="underline">
                   Already have an account?
                 </Link>
                 <Spacer />

--- a/platform/app/src/server/api/routers/__tests__/user.register.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/user.register.unit.test.ts
@@ -120,13 +120,16 @@ describe("userRouter.register()", () => {
     it("does not track signed_up", async () => {
       userFindUniqueMock.mockResolvedValue({ id: "user-1" });
 
+      // The refusal is the handled email_already_registered error (the signup
+      // screen keys its recovery flow off this code), surfaced through tRPC
+      // with the CONFLICT transport code its 409 maps to.
       await expect(
         createCaller().register({
           name: "Alice",
           email: "a@x.com",
           password: "supersecret",
         }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      ).rejects.toMatchObject({ code: "CONFLICT" });
 
       expect(mockTrackServerEvent).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/api/routers/__tests__/user.register.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/user.register.unit.test.ts
@@ -64,13 +64,13 @@ vi.mock("../../rbac", async (importOriginal) => {
 });
 
 describe("userRouter.register()", () => {
-  let userFindUniqueMock: ReturnType<typeof vi.fn>;
+  let userFindFirstMock: ReturnType<typeof vi.fn>;
   let userCreateMock: ReturnType<typeof vi.fn>;
   let accountCreateMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    userFindUniqueMock = vi.fn().mockResolvedValue(null);
+    userFindFirstMock = vi.fn().mockResolvedValue(null);
     userCreateMock = vi
       .fn()
       .mockResolvedValue({ id: "user-1", name: "Alice", email: "a@x.com" });
@@ -83,7 +83,7 @@ describe("userRouter.register()", () => {
   const createCaller = () => {
     const ctx = createInnerTRPCContext({ session: null });
     const prismaMock = {
-      user: { findUnique: userFindUniqueMock, create: userCreateMock },
+      user: { findFirst: userFindFirstMock, create: userCreateMock },
       account: { create: accountCreateMock },
       $transaction: vi.fn(
         async (cb: (tx: unknown) => unknown) =>
@@ -115,10 +115,50 @@ describe("userRouter.register()", () => {
     });
   });
 
+  describe("when the email is typed with capital letters", () => {
+    /**
+     * Sign-in goes through BetterAuth, which lowercases the address on every
+     * lookup, so an account stored as typed is one sign-in can never find:
+     * the customer is locked out with "User already exists" forever.
+     */
+    /** @scenario "A capitalised email creates an account sign-in can find" */
+    it("stores the lowercased address", async () => {
+      await createCaller().register({
+        name: "Joel",
+        email: "Joel.During@example.com",
+        password: "supersecret",
+      });
+
+      expect(userCreateMock).toHaveBeenCalledWith({
+        data: { name: "Joel", email: "joel.during@example.com" },
+      });
+    });
+
+    /** @scenario "A capitalised email creates an account sign-in can find" */
+    it("finds an existing account regardless of its stored casing", async () => {
+      userFindFirstMock.mockResolvedValue({ id: "user-1" });
+
+      await expect(
+        createCaller().register({
+          name: "Joel",
+          email: "Joel.During@example.com",
+          password: "supersecret",
+        }),
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      expect(userFindFirstMock).toHaveBeenCalledWith({
+        where: {
+          email: { equals: "joel.during@example.com", mode: "insensitive" },
+        },
+      });
+      expect(userCreateMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when the user already exists", () => {
     /** @scenario A rejected registration tracks no PostHog signed_up milestone */
     it("does not track signed_up", async () => {
-      userFindUniqueMock.mockResolvedValue({ id: "user-1" });
+      userFindFirstMock.mockResolvedValue({ id: "user-1" });
 
       // The refusal is the handled email_already_registered error (the signup
       // screen keys its recovery flow off this code), surfaced through tRPC

--- a/platform/app/src/server/api/routers/user.ts
+++ b/platform/app/src/server/api/routers/user.ts
@@ -28,6 +28,7 @@ import { trackServerEvent } from "~/server/posthog";
 import { rateLimit } from "~/server/rateLimit";
 import { AvatarRateLimitedError } from "~/server/user-avatar/avatar";
 import { UserAvatarService } from "~/server/user-avatar/avatar.service";
+import { EmailAlreadyRegisteredError } from "~/server/users/errors";
 import { UserService } from "~/server/users/user.service";
 import { getClientIp } from "~/utils/getClientIp";
 import { isAdmin as checkIsAdmin } from "../../../../ee/admin/isAdmin";
@@ -135,10 +136,7 @@ export const userRouter = createTRPCRouter({
       });
 
       if (user) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "User already exists",
-        });
+        throw new EmailAlreadyRegisteredError();
       }
 
       const hashedPassword = await hash(password, 10);

--- a/platform/app/src/server/api/routers/user.ts
+++ b/platform/app/src/server/api/routers/user.ts
@@ -98,7 +98,14 @@ export const userRouter = createTRPCRouter({
     )
     .use(skipPermissionCheck)
     .mutation(async ({ ctx, input }) => {
-      const { name, email, password } = input;
+      const { name, password } = input;
+      // BetterAuth lowercases the email on every one of its lookups and
+      // writes, and sign-in goes through BetterAuth. An account stored as
+      // typed, capitals and all, is therefore one that sign-in can never find
+      // again, no matter the password. Store the shape sign-in will search
+      // for. Customer report: onboarding signups that autocapitalised the
+      // address were permanently locked out with "User already exists".
+      const email = input.email.toLowerCase();
 
       // Keyed off the RESOLVED provider, not the raw env: on an SSO-capable
       // deployment with no genuine license the platform gate coerces the
@@ -129,9 +136,12 @@ export const userRouter = createTRPCRouter({
         });
       }
 
-      const user = await ctx.prisma.user.findUnique({
+      // Case-insensitive on purpose: rows written before the lowercasing
+      // above (or seeded by other means) may carry capitals, and minting a
+      // case-twin beside one would leave two Users answering for one human.
+      const user = await ctx.prisma.user.findFirst({
         where: {
-          email,
+          email: { equals: email, mode: "insensitive" },
         },
       });
 

--- a/platform/app/src/server/better-auth/__tests__/helm-auth-base-url.unit.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/helm-auth-base-url.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment node
+ *
+ * The chart hands NEXTAUTH_URL to every process running the app image.
+ *
+ * File-content assertions against the real chart templates on disk, in the
+ * same spirit as evaluations/__tests__/helm-langevals-memory.unit.test.ts: the
+ * regression this guards is textual (the env entry lived on the app Deployment
+ * only, so the workers pod booted into "[better-auth] Base URL could not be
+ * determined"), so reading the templates is the direct check. What the chart
+ * actually renders, value precedence and the once-per-container guarantee, is
+ * asserted by rendering in charts/langwatch/tests/e2e-overlays.sh
+ * (test_auth_base_url), which chart CI runs on every change under charts/.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Repo root containing both `platform/app/` and `charts/`. `process.cwd()` is
+// the platform/app/ package dir when vitest runs, so two levels up lands on the
+// repo root reliably across worktrees and CI.
+const REPO_ROOT = path.resolve(process.cwd(), "..", "..");
+
+const read = (relativePath: string): string =>
+  readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+
+const HELPERS = "charts/langwatch/templates/_helpers.tpl";
+const APP_DEPLOYMENT = "charts/langwatch/templates/app/deployment.yaml";
+const WORKERS_DEPLOYMENT = "charts/langwatch/templates/workers/deployment.yaml";
+
+/** The sharedEnv template block, from its define to the next define. */
+const sharedEnvBlock = (): string => {
+  const helpers = read(HELPERS);
+  const start = helpers.indexOf('{{- define "langwatch.sharedEnv" }}');
+  if (start === -1) {
+    throw new Error(`no langwatch.sharedEnv define in ${HELPERS}`);
+  }
+  const end = helpers.indexOf("{{- define ", start + 1);
+  return helpers.slice(start, end === -1 ? undefined : end);
+};
+
+describe("helm chart auth base URL", () => {
+  describe("when a pod other than the app runs the app image", () => {
+    /** @scenario "The workers pod is told the public address" */
+    it("carries NEXTAUTH_URL through sharedEnv into the workers container", () => {
+      expect(sharedEnvBlock()).toContain("- name: NEXTAUTH_URL");
+      expect(read(WORKERS_DEPLOYMENT)).toContain(
+        'include "langwatch.sharedEnv"',
+      );
+      expect(read(APP_DEPLOYMENT)).toContain('include "langwatch.sharedEnv"');
+    });
+  });
+
+  describe("when the install names no separate public URL", () => {
+    /** @scenario "An install that only names an internal address still agrees with itself" */
+    it("falls back from publicUrl to baseHost on the shared entry", () => {
+      const entry = sharedEnvBlock()
+        .split("- name: NEXTAUTH_URL")[1]!
+        .split("- name:")[0]!;
+      expect(entry).toContain(".Values.app.http.publicUrl");
+      expect(entry).toContain(".Values.app.http.baseHost");
+    });
+  });
+
+  describe("when the app deployment renders", () => {
+    /** @scenario "The address is declared once per container" */
+    it("declares no NEXTAUTH_URL of its own beside the shared entry", () => {
+      // NEXTAUTH_URL_INTERNAL is a different key and stays app-only; the
+      // negative lookahead keeps it out of this match.
+      expect(read(APP_DEPLOYMENT)).not.toMatch(/- name: NEXTAUTH_URL(?!_)/);
+    });
+  });
+});

--- a/platform/app/src/server/users/__tests__/errors.unit.test.ts
+++ b/platform/app/src/server/users/__tests__/errors.unit.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The already-registered refusal is a contract between the register mutation
+ * and the sign-up screen: the screen keys its whole recovery flow off the code,
+ * and the registry supplies the words a customer reads. Assert on `code`, never
+ * on message prose; the wire message IS the code slug since #5984.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveErrorCopy } from "~/features/errors";
+import { EmailAlreadyRegisteredError } from "../errors";
+
+describe("EmailAlreadyRegisteredError", () => {
+  describe("when the server refuses a sign-up for an email that has an account", () => {
+    /** @scenario "The refusal carries a code the screen can act on" */
+    it("carries the email_already_registered code and customer-read wording", () => {
+      const error = new EmailAlreadyRegisteredError();
+
+      expect(error.code).toBe("email_already_registered");
+      expect(error.httpStatus).toBe(409);
+      expect(error.fault).toBe("customer");
+
+      // The words a customer actually reads come from the code-keyed registry,
+      // resolved from the serialized shape the way the client would.
+      const copy = resolveErrorCopy({
+        error: { data: { error: error.serialize() } },
+      });
+      expect(copy.title.toLowerCase()).toContain("already has an account");
+      expect(copy.description.toLowerCase()).toContain("sign in");
+      expect(copy.description.toLowerCase()).toContain("reset");
+    });
+  });
+});

--- a/platform/app/src/server/users/errors.ts
+++ b/platform/app/src/server/users/errors.ts
@@ -1,0 +1,31 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * The address being signed up already has a LangWatch account.
+ *
+ * Handled rather than generic because the screen has a real move to offer:
+ * this is almost never a stranger's address, it is the person's own account.
+ * Sign-up is two calls, one writes the User row and its password, the second
+ * exchanges them for a session, and only the first is durable, so a failure in
+ * the second leaves an account nobody mentions. Every retry lands here. It is
+ * also where someone who was a member before, was removed, and got invited back
+ * ends up, because an invite asks them to create an account they already have.
+ *
+ * The wording deliberately confirms the address is registered. Sign-up cannot
+ * avoid saying so, the alternative is silently refusing to create an account
+ * and explaining nothing, and the sign-in retry the client runs off this code
+ * is bounded by the same rate limit as the sign-in screen, so it hands a guesser
+ * nothing the sign-in form does not already.
+ */
+export class EmailAlreadyRegisteredError extends HandledError {
+  declare readonly code: "email_already_registered";
+
+  constructor() {
+    super(
+      "email_already_registered",
+      "An account with this email already exists",
+      { httpStatus: 409, fault: "customer" },
+    );
+    this.name = "EmailAlreadyRegisteredError";
+  }
+}

--- a/specs/auth/signup-does-not-strand-an-account.feature
+++ b/specs/auth/signup-does-not-strand-an-account.feature
@@ -1,0 +1,61 @@
+Feature: Signing up never strands an account
+  As someone joining a colleague's LangWatch
+  I want a sign-up that half-succeeded to still let me in
+  So that I am not locked out of an account I cannot see, sign into, or report
+
+  # Creating an account is two server calls: one writes the User row and its
+  # password, the second exchanges those credentials for a session. Only the
+  # first one is durable. When the second fails (a rate limit, an installation
+  # set up for another address, a blip) the account exists and the person is
+  # told nothing they can act on. Every retry then hits "that email is already
+  # registered", which reads as a wall rather than as the door it actually is:
+  # their own account, with the password they just chose. Meanwhile they hold no
+  # organization membership, so the admin inviting them cannot find them on the
+  # members list either, and neither side can move.
+  #
+  # The account is not the problem. Dead-ending on it is.
+
+  Background:
+    Given a credentials installation
+    And I am on the sign-up screen
+
+  @integration
+  Scenario: A sign-up whose second leg fails still says what happened
+    Given creating my account succeeds
+    But signing me in afterwards fails for a reason the screen has no wording for
+    Then the screen tells me the account was created and to sign in
+    And the screen never replaces that with a fixed "failed to sign up" line
+
+  @integration
+  Scenario: Submitting the same details again signs me in
+    Given my previous attempt created my account and failed to sign me in
+    When I fill the form in again with the same email and password
+    Then I am signed in and continue to where I was heading
+    And I am not told the email is already registered
+
+  # An invite lands a signed-out visitor on the sign-in screen. Someone who was
+  # a member before (removed, then invited back) still has their account, and
+  # reaches for "Sign up" because that is what the invite asked them to do.
+  @integration
+  Scenario: An email that belongs to an account I cannot open points at the way in
+    Given an account already exists for that email
+    When I fill the form in with a password that is not its password
+    Then the screen tells me an account with that email already exists
+    And the screen offers me signing in and resetting my password
+    And the screen never shows an internal error code
+
+  # The recovery sign-in rides the same endpoint and rate limit as the sign-in
+  # screen, so a refusal there is not a password problem and must not be
+  # answered as one. Guessing is not cheaper through this door.
+  @integration
+  Scenario: A rate-limited recovery says to wait, not to reset the password
+    Given an account already exists for that email
+    When the sign-in attempt is refused for too many attempts
+    Then the screen tells me to wait before trying again
+    And the screen does not send me to reset my password
+
+  @unit
+  Scenario: The refusal carries a code the screen can act on
+    When the server refuses a sign-up because the email is already registered
+    Then it answers with the "email_already_registered" code
+    And the code carries the wording a customer reads

--- a/specs/auth/signup-does-not-strand-an-account.feature
+++ b/specs/auth/signup-does-not-strand-an-account.feature
@@ -59,3 +59,12 @@ Feature: Signing up never strands an account
     When the server refuses a sign-up because the email is already registered
     Then it answers with the "email_already_registered" code
     And the code carries the wording a customer reads
+
+  # Sign-in lowercases the address on every lookup, so an account stored as
+  # typed, capitals and all, is one that sign-in can never find, no matter the
+  # password. Autocapitalised addresses locked people out this way.
+  @unit
+  Scenario: A capitalised email creates an account sign-in can find
+    When I sign up with "Joel.During@example.com"
+    Then the account is stored with the lowercased address
+    And a later sign-up for any casing of that address says it is already registered

--- a/specs/setup/helm-auth-base-url.feature
+++ b/specs/setup/helm-auth-base-url.feature
@@ -1,0 +1,39 @@
+Feature: Every process knows the address this installation answers on
+  As someone running LangWatch on Kubernetes
+  I want each pod to agree on the installation's public address
+  So that callbacks, redirects and sign-in checks are measured against one answer
+
+  # The chart set NEXTAUTH_URL on the app Deployment only. The workers pod runs
+  # the same image, so it imports the same auth module, and booted straight into
+  # "[better-auth] Base URL could not be determined. Please set a valid base
+  # URL": a warning a self-hoster reasonably reads as the cause of whatever
+  # else is going wrong that day, and which leaves anything the worker builds
+  # off that address pointing at nothing.
+  #
+  # Bound twice, on purpose: the @unit tests below read the chart templates as
+  # text (the regression was textual, the env entry lived on the app Deployment
+  # only), and charts/langwatch/tests/e2e-overlays.sh (test_auth_base_url)
+  # renders the chart in chart CI to assert value precedence and the
+  # once-per-container guarantee on the actual manifests.
+
+  Background:
+    Given the LangWatch chart with the workers component enabled
+
+  @unit
+  Scenario: The workers pod is told the public address
+    When I install with a public URL for the app
+    Then the workers container carries that address as its auth base URL
+    And the app container carries the same address
+
+  @unit
+  Scenario: An install that only names an internal address still agrees with itself
+    When I install with a base host and no separate public URL
+    Then every container falls back to the base host
+    And no container is left without an address
+
+  # Two entries for one key leaves which value wins up to manifest ordering
+  # rather than to the chart.
+  @unit
+  Scenario: The address is declared once per container
+    When I render the app deployment
+    Then the auth base URL appears exactly once


### PR DESCRIPTION
## What

A self-hosted customer onboarding new team members reported two symptoms:

1. People signing up hit an unexplained error, and every retry after it says "User already exists". The admin then cannot find the person on the members list to fix anything.
2. The workers pod logs `[better-auth] Base URL could not be determined. Please set a valid base URL` on boot.

Both trace back to the same corner: sign-up is two server calls, and the auth base URL was only configured on one deployment.

## Why the strand happens

`user.register` (tRPC) durably writes the User row and its password. The screen then exchanges those credentials for a session through `POST /api/auth/sign-in/email`. Only the first call is durable: when the second fails (an origin mismatch because NEXTAUTH_URL does not match the address in the browser, a rate limit, a blip), the person now owns an account nobody ever mentions, with no session and no organization membership. Every retry hits "User already exists", which reads as a wall. The members admin panel cannot see them either, because there is no OrganizationUser row to list. Someone who was a member before, was removed, and got invited back lands in the same spot: the invite asks them to create an account they already have.

## Changes

**Sign-up recovers instead of dead-ending** (`platform/app/src/pages/auth/signup.tsx`, `user.register`):

- The register mutation now refuses a taken email with a handled `email_already_registered` error (409, customer fault) instead of a bare TRPCError string.
- On that code, the screen carries on into the sign-in leg with the credentials just typed. For the stranded person and for the re-invited member who knows their password, the retry simply signs them in and the callback URL keeps the invite flow going.
- When the password is not the account's, the screen says the account exists and offers the two ways in: sign in (callback preserved) and reset your password. The registry copy renders; no code slug reaches the screen.
- A rate-limited recovery says to wait, and does not point at the password. Recovery rides the same `/sign-in/email` endpoint and rate limit as the sign-in screen, so this hands account enumeration nothing the sign-in form does not already answer.

**Every helm process gets NEXTAUTH_URL** (`charts/langwatch`):

- `NEXTAUTH_URL` moves from the app Deployment into `langwatch.sharedEnv`, so workers (and anything else running the app image) boot with the same answer for what the installation is called. This removes the `[better-auth] Base URL could not be determined` warning and the guessing it invites during an incident.
- Same value precedence as before: `app.http.publicUrl`, then `app.http.baseHost`, then the localhost default. Verified once per container.

## Specs and tests

- `specs/auth/signup-does-not-strand-an-account.feature`: 5/5 scenarios bound (`signup-recovers-stranded-account.integration.test.tsx`, `users/__tests__/errors.unit.test.ts`).
- `specs/setup/helm-auth-base-url.feature`: 3/3 scenarios bound (`better-auth/__tests__/helm-auth-base-url.unit.test.ts` reads the templates; `charts/langwatch/tests/e2e-overlays.sh` `test_auth_base_url` renders the chart in chart CI and asserts precedence, workers coverage and once-per-container).
- Existing signup field-error tests still pass; typecheck and typecheck:tests clean; biome clean on touched files.

## Deployment Impact

- Env vars: no new variables. `NEXTAUTH_URL` is now also set on the workers container (and any pod including `langwatch.sharedEnv`), with the exact same value and precedence the app container already used: `app.http.publicUrl`, then `app.http.baseHost`, then `http://localhost:5560`.
- Helm values: none added, removed, or renamed.
- Vanilla `helm install` with no overrides: renders the same manifests as before plus one extra env entry (`NEXTAUTH_URL: http://localhost:5560`) on the workers container; app container output is unchanged (the entry moves from the deployment template into sharedEnv). No restarts beyond the normal rollout, no data migrations.
- Installs that set `NEXTAUTH_URL` through `workers.extraEnvs` should drop that override after upgrading; `extraEnvs` renders after sharedEnv, so keeping it means a duplicate key where the last entry wins, which is the same value anyway in the usual case.
- BYOC dataplane: unaffected. The gateway chart and dataplane components do not consume `langwatch.sharedEnv`.

## Notes for self-hosted operators

The "Model provider not found" save failure the same customer saw is a different bug, already fixed: editing an Organization-scoped provider from a project used to resolve only PROJECT-scoped rows and 404 (fixed by #4992 in 3.5.0, hardened in #6010/#6186). On 3.4.x the workaround is to delete the org-scoped provider and recreate it scoped to the project. Upgrading also picks up the origin-gate diagnostic log (#6143) which turns a silent sign-in 403 into a log line naming the expected and received origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-up recovery when an email already has an account.
  * Added clear guidance to sign in or reset the password.
  * Improved handling of invalid credentials, rate limits, and partial registration failures.
  * Configured authentication URLs consistently across app and worker deployments, with reliable fallbacks.

* **Tests**
  * Added coverage for sign-up recovery scenarios and authentication URL configuration.
  * Added validation for customer-facing existing-account errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->