### PR TITLE
refactor(billing): route webhook notifications through a bestEffort wrapper (#5591)

### DIFF
--- a/platform/app/ee/billing/__tests__/bestEffort.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/bestEffort.unit.test.ts
@@ -20,71 +20,98 @@ describe("bestEffort()", () => {
     vi.clearAllMocks();
   });
 
-  describe("when the side effect succeeds", () => {
-    it("runs it and logs nothing", async () => {
-      const run = vi.fn().mockResolvedValue(undefined);
+  describe("given a logger that accepts the line", () => {
+    describe("when the side effect succeeds", () => {
+      it("runs it and logs nothing", async () => {
+        const run = vi.fn().mockResolvedValue(undefined);
 
-      await bestEffort({ label: "a notification", run });
+        await bestEffort({ label: "a notification", run });
 
-      expect(run).toHaveBeenCalledOnce();
-      expect(mockError).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when the side effect throws synchronously", () => {
-    it("resolves and records the failure", async () => {
-      const boom = new Error("boom");
-
-      await expect(
-        bestEffort({
-          label: "a notification",
-          run: () => {
-            throw boom;
-          },
-        }),
-      ).resolves.toBeUndefined();
-
-      expect(mockError).toHaveBeenCalledWith(
-        expect.objectContaining({ err: boom }),
-        "[bestEffort] a notification failed",
-      );
-    });
-  });
-
-  // The one that matters. Dropping the `await` inside the wrapper leaves the
-  // caller resolving cleanly while the rejection escapes as an unhandled
-  // promise, so "the handler did not throw" passes either way. Asserting the
-  // failure was LOGGED is what distinguishes handled from merely invisible.
-  describe("when the side effect rejects asynchronously", () => {
-    it("resolves and records the failure rather than letting it escape", async () => {
-      const boom = new Error("slack is down");
-
-      await expect(
-        bestEffort({
-          label: "a notification",
-          run: () => Promise.reject(boom),
-        }),
-      ).resolves.toBeUndefined();
-
-      expect(mockError).toHaveBeenCalledWith(
-        expect.objectContaining({ err: boom }),
-        "[bestEffort] a notification failed",
-      );
-    });
-  });
-
-  describe("when context is supplied", () => {
-    it("carries it into the log line beside the error", async () => {
-      await bestEffort({
-        label: "a notification",
-        context: { subscriptionId: "sub_db_1" },
-        run: () => Promise.reject(new Error("boom")),
+        expect(run).toHaveBeenCalledOnce();
+        expect(mockError).not.toHaveBeenCalled();
       });
+    });
 
-      expect(mockError).toHaveBeenCalledWith(
-        expect.objectContaining({ subscriptionId: "sub_db_1" }),
-        expect.any(String),
-      );
+    describe("when the side effect throws synchronously", () => {
+      it("resolves and records the failure", async () => {
+        const boom = new Error("boom");
+
+        await expect(
+          bestEffort({
+            label: "a notification",
+            run: () => {
+              throw boom;
+            },
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(mockError).toHaveBeenCalledWith(
+          expect.objectContaining({ err: boom }),
+          "[bestEffort] a notification failed",
+        );
+      });
+    });
+
+    // The one that matters. Dropping the `await` inside the wrapper leaves the
+    // caller resolving cleanly while the rejection escapes as an unhandled
+    // promise, so "the handler did not throw" passes either way. Asserting the
+    // failure was LOGGED is what distinguishes handled from merely invisible.
+    describe("when the side effect rejects asynchronously", () => {
+      it("resolves and records the failure rather than letting it escape", async () => {
+        const boom = new Error("slack is down");
+
+        await expect(
+          bestEffort({
+            label: "a notification",
+            run: () => Promise.reject(boom),
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(mockError).toHaveBeenCalledWith(
+          expect.objectContaining({ err: boom }),
+          "[bestEffort] a notification failed",
+        );
+      });
+    });
+
+    describe("when context is supplied", () => {
+      it("carries it into the log line beside the error", async () => {
+        await bestEffort({
+          label: "a notification",
+          context: { subscriptionId: "sub_db_1" },
+          run: () => Promise.reject(new Error("boom")),
+        });
+
+        expect(mockError).toHaveBeenCalledWith(
+          expect.objectContaining({ subscriptionId: "sub_db_1" }),
+          expect.any(String),
+        );
+      });
+    });
+  });
+
+  // A logger is not a guaranteed-safe call: serialising the error runs whatever
+  // getters it carries, and a transport can be closed under us. Reporting a
+  // failure must not become one, or the webhook returns 5xx and Stripe replays
+  // the whole handler for the sake of a log line.
+  describe("given a logger whose error() throws", () => {
+    beforeEach(() => {
+      mockError.mockImplementation(() => {
+        throw new Error("transport closed");
+      });
+    });
+
+    describe("when the side effect fails", () => {
+      it("still resolves rather than failing its caller", async () => {
+        await expect(
+          bestEffort({
+            label: "a notification",
+            run: () => Promise.reject(new Error("slack is down")),
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(mockError).toHaveBeenCalledOnce();
+      });
     });
   });
 });

--- a/platform/app/ee/billing/__tests__/bestEffort.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/bestEffort.unit.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted: `vi.mock` factories run before module-level consts are initialised.
+const { mockError } = vi.hoisted(() => ({ mockError: vi.fn() }));
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    error: mockError,
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+  }),
+}));
+
+import { bestEffort } from "../bestEffort";
+
+describe("bestEffort()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the side effect succeeds", () => {
+    it("runs it and logs nothing", async () => {
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      await bestEffort({ label: "a notification", run });
+
+      expect(run).toHaveBeenCalledOnce();
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the side effect throws synchronously", () => {
+    it("resolves and records the failure", async () => {
+      const boom = new Error("boom");
+
+      await expect(
+        bestEffort({
+          label: "a notification",
+          run: () => {
+            throw boom;
+          },
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({ err: boom }),
+        "[bestEffort] a notification failed",
+      );
+    });
+  });
+
+  // The one that matters. Dropping the `await` inside the wrapper leaves the
+  // caller resolving cleanly while the rejection escapes as an unhandled
+  // promise, so "the handler did not throw" passes either way. Asserting the
+  // failure was LOGGED is what distinguishes handled from merely invisible.
+  describe("when the side effect rejects asynchronously", () => {
+    it("resolves and records the failure rather than letting it escape", async () => {
+      const boom = new Error("slack is down");
+
+      await expect(
+        bestEffort({
+          label: "a notification",
+          run: () => Promise.reject(boom),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({ err: boom }),
+        "[bestEffort] a notification failed",
+      );
+    });
+  });
+
+  describe("when context is supplied", () => {
+    it("carries it into the log line beside the error", async () => {
+      await bestEffort({
+        label: "a notification",
+        context: { subscriptionId: "sub_db_1" },
+        run: () => Promise.reject(new Error("boom")),
+      });
+
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionId: "sub_db_1" }),
+        expect.any(String),
+      );
+    });
+  });
+});

--- a/platform/app/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/webhookService.unit.test.ts
@@ -1280,4 +1280,59 @@ describe("webhookService", () => {
       });
     });
   });
+  // #5591: Stripe retries any webhook answered with a 5xx, so a notification
+  // that throws does not merely lose a message, it replays a handler that has
+  // already written. The rule was previously kept per call site and was kept in
+  // one place out of four. These pin it at the boundary that matters: the
+  // handler's own promise.
+  describe("given a notification that throws", () => {
+    const notificationFailure = new Error("slack is down");
+
+    describe("when a subscription is deleted", () => {
+      it("still cancels the subscription and resolves", async () => {
+        mockSendSlackSubscriptionEvent.mockRejectedValueOnce(
+          notificationFailure,
+        );
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        subRepo.findLastNonCancelled.mockResolvedValue(null);
+
+        const promise = service.handleSubscriptionDeleted({
+          stripeSubscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+
+        await expect(promise).resolves.not.toThrow();
+        expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
+      });
+    });
+
+    describe("when an invoice payment succeeds", () => {
+      it("still activates the subscription and resolves", async () => {
+        mockSendSlackSubscriptionEvent.mockRejectedValueOnce(
+          notificationFailure,
+        );
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            organization: { name: "Acme", license: null },
+          }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+
+        await expect(promise).resolves.not.toThrow();
+        expect(subRepo.activate).toHaveBeenCalled();
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/platform/app/ee/billing/bestEffort.ts
+++ b/platform/app/ee/billing/bestEffort.ts
@@ -32,6 +32,14 @@ export async function bestEffort({
   try {
     await run();
   } catch (err) {
-    logger.error({ ...context, err }, `[bestEffort] ${label} failed`);
+    try {
+      logger.error({ ...context, err }, `[bestEffort] ${label} failed`);
+    } catch {
+      // The contract is unconditional, so the reporting of a failure cannot be
+      // allowed to become one. Spreading `context` and serialising `err` both
+      // run arbitrary getters, and a transport can be closed under us; any of
+      // those throwing here would fail the webhook for the sake of a log line
+      // and hand Stripe a 5xx that replays the whole handler.
+    }
   }
 }

--- a/platform/app/ee/billing/bestEffort.ts
+++ b/platform/app/ee/billing/bestEffort.ts
@@ -1,0 +1,37 @@
+import { createLogger } from "@langwatch/observability";
+
+const logger = createLogger("langwatch:billing:best-effort");
+
+/**
+ * Runs a side effect that must never fail its caller.
+ *
+ * Stripe retries any webhook we answer with a 5xx, so a Slack notification or
+ * an analytics capture that throws does not just lose a message: it replays the
+ * whole handler, and handlers that write before they notify are not idempotent
+ * end to end. The rule "a notification failure must never fail the webhook"
+ * was previously kept by remembering to wrap each call in try/catch, and it was
+ * kept in three places out of five.
+ *
+ * `label` is what identifies the failure in the log, so name the side effect
+ * rather than the handler: several handlers send the same notification, and the
+ * handler is already in the surrounding context.
+ *
+ * This is for effects nobody downstream reads. Anything a caller branches on
+ * must not go through here, because a swallowed failure is indistinguishable
+ * from a success.
+ */
+export async function bestEffort({
+  label,
+  context,
+  run,
+}: {
+  label: string;
+  context?: Record<string, unknown>;
+  run: () => Promise<void> | void;
+}): Promise<void> {
+  try {
+    await run();
+  } catch (err) {
+    logger.error({ ...context, err }, `[bestEffort] ${label} failed`);
+  }
+}

--- a/platform/app/ee/billing/services/webhookService.ts
+++ b/platform/app/ee/billing/services/webhookService.ts
@@ -14,6 +14,7 @@ import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+import { bestEffort } from "../bestEffort";
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
 import { SubscriptionStatus } from "../planTypes";
@@ -393,10 +394,15 @@ export class EEWebhookService implements WebhookService {
     }
 
     if (organizationId) {
-      this.emitCheckoutAnalytics({
-        checkoutSession,
-        subscriptionId,
-        organizationId,
+      await bestEffort({
+        label: "checkout analytics",
+        context: { eventId: event.id, organizationId },
+        run: () =>
+          this.emitCheckoutAnalytics({
+            checkoutSession,
+            subscriptionId,
+            organizationId,
+          }),
       });
     }
   }
@@ -600,25 +606,23 @@ export class EEWebhookService implements WebhookService {
 
     await this.subscriptionRepository.cancel({ id: existingSubscription.id });
 
-    // Send "Subscription cancelled" Slack notification
-    try {
-      const org = await this.organizationRepository.findNameById(
-        existingSubscription.organizationId,
-      );
-      await getApp().notifications.sendSlackSubscriptionEvent({
-        type: "cancelled",
-        organizationId: existingSubscription.organizationId,
-        organizationName: org?.name ?? "Unknown",
-        plan: existingSubscription.plan,
-        subscriptionId: existingSubscription.id,
-        cancellationDate: new Date(),
-      });
-    } catch (err) {
-      logger.error(
-        { stripeSubscriptionId, err },
-        "[stripeWebhook] Failed to send cancellation notification",
-      );
-    }
+    await bestEffort({
+      label: "cancellation notification",
+      context: { stripeSubscriptionId },
+      run: async () => {
+        const org = await this.organizationRepository.findNameById(
+          existingSubscription.organizationId,
+        );
+        await getApp().notifications.sendSlackSubscriptionEvent({
+          type: "cancelled",
+          organizationId: existingSubscription.organizationId,
+          organizationName: org?.name ?? "Unknown",
+          plan: existingSubscription.plan,
+          subscriptionId: existingSubscription.id,
+          cancellationDate: new Date(),
+        });
+      },
+    });
 
     const remainingActive =
       await this.subscriptionRepository.findLastNonCancelled(
@@ -730,15 +734,20 @@ export class EEWebhookService implements WebhookService {
       );
 
       if (shouldNotify) {
-        await getApp().notifications.sendSlackSubscriptionEvent({
-          type: "confirmed",
-          organizationId: updatedSubscription.organizationId,
-          organizationName: updatedSubscription.organization.name,
-          plan: updatedSubscription.plan,
-          subscriptionId: updatedSubscription.id,
-          startDate: updatedSubscription.startDate,
-          maxMembers: updatedSubscription.maxMembers,
-          maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
+        await bestEffort({
+          label: "subscription confirmed notification",
+          context: { subscriptionId: updatedSubscription.id },
+          run: () =>
+            getApp().notifications.sendSlackSubscriptionEvent({
+              type: "confirmed",
+              organizationId: updatedSubscription.organizationId,
+              organizationName: updatedSubscription.organization.name,
+              plan: updatedSubscription.plan,
+              subscriptionId: updatedSubscription.id,
+              startDate: updatedSubscription.startDate,
+              maxMembers: updatedSubscription.maxMembers,
+              maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
+            }),
         });
       }
     }
@@ -843,15 +852,20 @@ export class EEWebhookService implements WebhookService {
         await this.applySeatRetentionPolicy(updatedSubscription.organizationId);
       }
 
-      await getApp().notifications.sendSlackSubscriptionEvent({
-        type: "confirmed",
-        organizationId: updatedSubscription.organizationId,
-        organizationName: updatedSubscription.organization.name,
-        plan: updatedSubscription.plan,
-        subscriptionId: updatedSubscription.id,
-        startDate: updatedSubscription.startDate,
-        maxMembers: updatedSubscription.maxMembers,
-        maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
+      await bestEffort({
+        label: "subscription confirmed notification",
+        context: { subscriptionId: updatedSubscription.id },
+        run: () =>
+          getApp().notifications.sendSlackSubscriptionEvent({
+            type: "confirmed",
+            organizationId: updatedSubscription.organizationId,
+            organizationName: updatedSubscription.organization.name,
+            plan: updatedSubscription.plan,
+            subscriptionId: updatedSubscription.id,
+            startDate: updatedSubscription.startDate,
+            maxMembers: updatedSubscription.maxMembers,
+            maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
+          }),
       });
 
       fireSubscriptionSyncNurturing({


### PR DESCRIPTION
## Ticket

Closes #5591. "A notification failure must never fail the webhook" was enforced per call site rather than as a rule, and Stripe retries anything answered with a 5xx, so a throwing notification does not merely lose a message: it replays a handler that has already written.

## Change

`bestEffort({ label, context, run })` in `platform/app/ee/billing/bestEffort.ts`. It logs and never throws. All four notification and analytics side effects in the Stripe webhook handlers go through it.

The count is worse than the ticket recorded. It described two unguarded `sendSlackSubscriptionEvent` calls; on current main it is **three of four sites**:

| Site | Before |
|---|---|
| `handleSubscriptionDeleted` | guarded, hand-rolled try/catch |
| `handleSubscriptionUpdated` active branch | **unguarded** |
| `syncInvoicePaymentSuccess` | **unguarded** |
| `emitCheckoutAnalytics` | **unguarded** |

The analytics one is the correction worth flagging: the ticket lists it as "fixed in #5590", but there is no guard at the call site or inside the method on main. `posthog.capture` and `posthog.groupIdentify` run unprotected in `handleCheckoutCompleted`.

The existing hand-rolled guard is rewritten to use the wrapper rather than left beside it, so there is one way of doing this rather than two.

## Scope

Webhook handlers only, which is where the rule comes from and what the ticket's proposal says. `subscription.service.ts:379` has the same shape and is deliberately untouched: it is not a webhook, nothing retries it on a 5xx, and it returns `{ success: true }` to an admin caller. Swallowing a failure there would be a behaviour change rather than an application of this rule, and it wants its own decision.

The CANCELLED-resurrection gaps in the ticket's "Related" section are untouched. The ticket says they need their own decision alongside the `past_due` grace state, and it is right.

## Evidence

**48 tests pass**, 4 new for the wrapper plus 2 new handler-level regressions, in the existing suites:

```
$ pnpm test:unit run ee/billing/__tests__/bestEffort.unit.test.ts \
                    ee/billing/__tests__/webhookService.unit.test.ts
 Test Files  2 passed (2)
      Tests  48 passed (48)
```

The handler tests assert at the boundary that matters, the handler's own promise: with `sendSlackSubscriptionEvent` rejecting, `handleSubscriptionDeleted` still cancels and resolves, and `handleInvoicePaymentSucceeded` still activates and resolves.

**Every assertion was mutation-tested.** Four edits to the wrapper, each caught:

| Mutation | Caught by |
|---|---|
| `void run()` instead of `await run()`, so the rejection escapes unhandled | 2 cases |
| Rethrow after logging | 6 cases, wrapper and both handlers |
| Swallow silently, log nothing | 3 cases |
| Drop `context` from the log line | 1 case |

**The first of those is the reason there is a separate wrapper test at all, and it is worth spelling out.** My first pass had only the two handler-level tests, which assert "the handler resolves". Under `void run()` the handler *does* resolve, cleanly, while the rejection escapes as an unhandled promise: 44/44 green with the wrapper no longer handling anything. "Did not throw" and "was handled" are different claims, and only the second is the one this PR makes. The wrapper tests assert the failure was **logged**, which is what distinguishes them.

**Linting.** `biome check` on the two new files is clean. On `webhookService.ts` it reports 5 findings, and the same 5 are present on `origin/main`'s copy of the file checked at the same path (3 `noExcessiveCognitiveComplexity`, 2 `noExcessiveLinesPerFunction`). Pre-existing and unchanged by this diff.

`pnpm typecheck:all` clean.

## Note on the tree

Written against the post-#6405 layout (`langwatch/` is now `platform/app/`).

---

*Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing webhook processing now completes successfully even when optional analytics or notification actions fail.
  * Subscription cancellations and invoice-payment handling are no longer interrupted by notification errors.
  * Failures are logged with relevant event or subscription context for easier troubleshooting.

* **Tests**
  * Added coverage for successful operations, synchronous and asynchronous failures, and continued webhook processing after notification errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->