### PR TITLE
docs(build): the saas image prunes devDependencies too, so drop the exception

### DIFF
--- a/platform/app/scripts/run-task.sh
+++ b/platform/app/scripts/run-task.sh
@@ -3,14 +3,11 @@ set -euo pipefail
 
 # One `task` entry point for both worlds, keyed on whether tsx is installed — NOT
 # on NODE_ENV. Migrations (clickhouse:migrate / prisma:migrate) run through here
-# in CI with NODE_ENV=test and no bundle built, AND in the OSS image where
-# `pnpm install --prod` pruned tsx and build:server produced dist/server/task.cjs.
+# in CI with NODE_ENV=test and no bundle built, and in the production images,
+# which prune devDependencies away and run build:server's dist/server/task.cjs.
 # Either branch is a supported way to run a task, so both must keep working:
-# the app server itself always runs the bundle on plain node (see start.sh),
-# but a task may run from source. An image that ships devDependencies — the
-# saas one does, because pnpm's prune cannot scope to a single workspace member
-# — therefore takes the tsx branch in production, by design. Do not delete the
-# node branch: the OSS image has no tsx and depends on it.
+# tsx from source where it is installed (dev, CI, e2e), the bundle where it is
+# not. Do not delete the node branch — production has no tsx and depends on it.
 if command -v tsx >/dev/null 2>&1; then
   # Regenerate the registry so a task just added to src/tasks/ runs without a
   # separate build, and so tsx has tasks.generated.ts to import (it is gitignored).


### PR DESCRIPTION
Follow-up to #6557. One comment, no behaviour change.

`run-task.sh` picks its branch on whether `tsx` is installed, and the comment explained the two worlds it serves. It carried an exception that has since stopped being true:

> An image that ships devDependencies — the saas one does, because pnpm's prune cannot scope to a single workspace member — therefore takes the tsx branch in production, by design.

That was accurate when #6557 landed. [langwatch-saas#886](https://github.com/langwatch/langwatch-saas/pull/886) has since given the saas image the same filtered `--prod` install plus `pnpm prune --prod` the OSS Dockerfile uses, so **neither** production image carries `tsx` and both run tasks from `dist/server/task.cjs`. Leaving the exception in place would tell the next reader that a tsx-in-production path is expected and supported, which would make the `node` branch look optional.

Verified against the built image pulled from ECR rather than inferred:

- `node_modules/.bin/tsx` is absent.
- A task run in the image produces `at runAsync (/app/langwatch/platform/app/src/task.ts:28:13)` — the `node` branch, resolved through the bundle's source map.

The instruction not to delete the `node` branch stays, since that is the branch production now always takes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for running tasks in environments with or without `tsx`.
  * Removed outdated references to image-specific and app-server execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->