### PR TITLE
fix(tokenizer): tiktoken's JSON imports need an import attribute under the bundle

### DIFF
--- a/platform/app/scripts/build-server.mjs
+++ b/platform/app/scripts/build-server.mjs
@@ -230,24 +230,29 @@ for (const { name, entry } of ENTRIES) {
       }
       files.add(input);
     }
-  }
-  // Dynamic imports of JSON from an external package. These survive into the
-  // bundle verbatim, so Node resolves them through the ESM loader, which
-  // rejects JSON without an import attribute (ERR_IMPORT_ATTRIBUTE_MISSING).
-  // tsx absorbs the missing attribute, so this only ever breaks in production,
-  // and it breaks quietly wherever the caller catches and degrades — the
-  // tokenizer skipped tokenization entirely for exactly this reason.
-  for (const input of scannedSources) {
-    if (!/\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(input)) continue;
-    const source = readFileSync(path.join(APP, input), "utf8");
+    // Dynamic imports of JSON from an external package. These survive into the
+    // bundle verbatim, so Node resolves them through the ESM loader, which
+    // rejects JSON without an import attribute (ERR_IMPORT_ATTRIBUTE_MISSING).
+    // tsx absorbs the missing attribute, so this only ever breaks in
+    // production, and it breaks quietly wherever the caller catches and
+    // degrades — the tokenizer skipped tokenization entirely for exactly this
+    // reason.
     for (const m of source.matchAll(
       /import\s*\(\s*(["'])([^"'\n]+\.json)\1\s*([,)])/g,
     )) {
       const spec = m[2] ?? "";
       // Relative JSON is bundled in, so the loader never sees it.
       if (/^(\.|\/|~\/|@app\/|@ee\/)/.test(spec)) continue;
-      // A closing paren right after the specifier means no attribute argument.
-      if (m[3] !== ")") continue;
+      // Only a literal `with: { type: "json" }` second argument satisfies the
+      // loader. Anything else still throws at runtime: `{}`, an options
+      // variable the scan can't see into, or `assert` (removed in Node 22).
+      if (
+        m[3] === "," &&
+        /^\s*\{\s*with\s*:\s*\{\s*type\s*:\s*(["'])json\1/.test(
+          source.slice((m.index ?? 0) + m[0].length),
+        )
+      )
+        continue;
       let files = jsonImportsWithoutAttribute.get(spec);
       if (!files) {
         files = new Set();
@@ -282,7 +287,7 @@ if (undeclared.size > 0) {
 }
 for (const [spec, files] of jsonImportsWithoutAttribute) {
   console.error(
-    `  error: dynamic import of "${spec}" in ${[...files].join(", ")} has no import attribute — Node's ESM loader rejects JSON without one (ERR_IMPORT_ATTRIBUTE_MISSING). Write: import("${spec}", { with: { type: "json" } })`,
+    `  error: dynamic import of "${spec}" in ${[...files].join(", ")} lacks a literal \`with: { type: "json" }\` import attribute — Node's ESM loader rejects JSON without it (ERR_IMPORT_ATTRIBUTE_MISSING). Write: import("${spec}", { with: { type: "json" } })`,
   );
 }
 if (

--- a/platform/app/scripts/build-server.mjs
+++ b/platform/app/scripts/build-server.mjs
@@ -158,6 +158,8 @@ const undeclared = new Map();
 const scannedSources = new Set();
 /** @type {Map<string, Set<string>>} specifier -> source files that bare-import it */
 const unlistedSideEffectImports = new Map();
+/** @type {Map<string, Set<string>>} specifier -> files importing JSON with no attribute */
+const jsonImportsWithoutAttribute = new Map();
 
 for (const { name, entry } of ENTRIES) {
   const result = await build({
@@ -229,6 +231,31 @@ for (const { name, entry } of ENTRIES) {
       files.add(input);
     }
   }
+  // Dynamic imports of JSON from an external package. These survive into the
+  // bundle verbatim, so Node resolves them through the ESM loader, which
+  // rejects JSON without an import attribute (ERR_IMPORT_ATTRIBUTE_MISSING).
+  // tsx absorbs the missing attribute, so this only ever breaks in production,
+  // and it breaks quietly wherever the caller catches and degrades — the
+  // tokenizer skipped tokenization entirely for exactly this reason.
+  for (const input of scannedSources) {
+    if (!/\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(input)) continue;
+    const source = readFileSync(path.join(APP, input), "utf8");
+    for (const m of source.matchAll(
+      /import\s*\(\s*(["'])([^"'\n]+\.json)\1\s*([,)])/g,
+    )) {
+      const spec = m[2] ?? "";
+      // Relative JSON is bundled in, so the loader never sees it.
+      if (/^(\.|\/|~\/|@app\/|@ee\/)/.test(spec)) continue;
+      // A closing paren right after the specifier means no attribute argument.
+      if (m[3] !== ")") continue;
+      let files = jsonImportsWithoutAttribute.get(spec);
+      if (!files) {
+        files = new Set();
+        jsonImportsWithoutAttribute.set(spec, files);
+      }
+      files.add(input);
+    }
+  }
   if (emitMeta) {
     writeFileSync(
       path.join(OUT_DIR, `${name}.meta.json`),
@@ -253,7 +280,16 @@ if (undeclared.size > 0) {
     "  The bundles resolve external requires from node_modules at runtime; a --prod install only ships `dependencies`. Declare the packages above in platform/app/package.json dependencies.",
   );
 }
-if (undeclared.size > 0 || unlistedSideEffectImports.size > 0) {
+for (const [spec, files] of jsonImportsWithoutAttribute) {
+  console.error(
+    `  error: dynamic import of "${spec}" in ${[...files].join(", ")} has no import attribute — Node's ESM loader rejects JSON without one (ERR_IMPORT_ATTRIBUTE_MISSING). Write: import("${spec}", { with: { type: "json" } })`,
+  );
+}
+if (
+  undeclared.size > 0 ||
+  unlistedSideEffectImports.size > 0 ||
+  jsonImportsWithoutAttribute.size > 0
+) {
   process.exit(1);
 }
 

--- a/platform/app/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
+++ b/platform/app/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
@@ -58,7 +58,16 @@ export class TiktokenClient implements TokenizerClient {
 
   private async resolveEncoding(model: string): Promise<string> {
     try {
-      const models = (await import("tiktoken/model_to_encoding.json")) as {
+      // The `with` attribute is required, not decorative: production runs the
+      // esbuild bundle, where tiktoken stays external, so this survives as a
+      // real dynamic import and Node resolves it through the ESM loader, which
+      // rejects JSON without it (ERR_IMPORT_ATTRIBUTE_MISSING). tsx used to
+      // absorb that, which is why it only broke once the bundles shipped — and
+      // it broke quietly, because the catch below falls back to a default
+      // encoding rather than failing.
+      const models = (await import("tiktoken/model_to_encoding.json", {
+        with: { type: "json" },
+      })) as {
         default: Record<string, string>;
       };
       if (model in models.default) return models.default[model]!;
@@ -74,7 +83,10 @@ export class TiktokenClient implements TokenizerClient {
     try {
       const { Tiktoken } = await import("tiktoken/lite");
       const { load } = await import("tiktoken/load");
-      const registry = (await import("tiktoken/registry.json")) as {
+      // See resolveEncoding: JSON needs the import attribute under the bundle.
+      const registry = (await import("tiktoken/registry.json", {
+        with: { type: "json" },
+      })) as {
         default: Record<string, unknown>;
       };
 


### PR DESCRIPTION
Production stopped counting tokens after #6557. The worker logs this once per encoder load:

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module
".../tiktoken@1.0.22/node_modules/tiktoken/registry.json"
needs an import attribute of "type: json"
msg: "tiktoken could not be loaded, skipping tokenization"
```

## Cause

`tiktoken` is external to the bundle, so

```ts
await import("tiktoken/registry.json")
```

survives into the output verbatim. Node resolves it through the **ESM loader**, which rejects JSON without `with { type: "json" }`. `tsx` absorbed the missing attribute, which is why this only appeared once the bundles reached production — the source has been written this way for a long time.

## Why it was silent

Both call sites catch:

- `loadEncoder` logs the warning above and returns `undefined`, so **token counts became `undefined`** rather than raising.
- `resolveEncoding` swallows it entirely and returns the `o200k_base` default, so **encoding selection was wrong for every model**, not merely missing. That one logs nothing at all.

## Reproduced, not inferred

Ran the three import forms inside the image pulled from ECR:

```
BARE import      : FAIL ERR_IMPORT_ATTRIBUTE_MISSING   ← what shipped
WITH attribute   : OK, keys = 6
require()        : OK, keys = 6
tiktoken/lite    : OK                                   ← module imports fine
```

Only the JSON subpaths are affected; `tiktoken/lite` and `tiktoken/load` resolve normally.

## The guard

`build-server.mjs` now fails the build on a dynamic import of JSON from an external package with no import attribute, alongside the existing bare-side-effect-import scan:

```
error: dynamic import of "tiktoken/registry.json" in
src/server/app-layer/clients/tokenizer/tiktoken.client.ts has no import
attribute — Node's ESM loader rejects JSON without one
(ERR_IMPORT_ATTRIBUTE_MISSING). Write:
import("tiktoken/registry.json", { with: { type: "json" } })
```

**A unit test cannot catch this class.** Under vitest the bare import resolves, so a test would pass on exactly the code that breaks in production. The guard has to live where the bundle is produced. Verified by mutation: removing the attribute again fails the build with the message above; restoring it builds clean.

Relative JSON imports are skipped by the scan — those get bundled in, so the loader never sees them.

## Checks

- `pnpm run build:server` clean; attribute confirmed in the emitted bundle as `import("tiktoken/registry.json", { with: { type: "json" } })`.
- Tokenizer unit tests 9/9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server builds failing at runtime when dynamically loading external JSON files.
  * Added clearer build errors identifying JSON imports that need the required import attribute.
  * Updated tokenizer metadata loading to work correctly in bundled ESM environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->