### PR TITLE
fix(ops): queue dashboard retry counts + retry-pinned backlog visibility

### DIFF
--- a/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
@@ -22,10 +22,10 @@ class FakeRedis {
 
   private static flat(
     entries: Array<{ member: string; score: number }>,
-    withScores: boolean,
+    shouldIncludeScores: boolean,
   ): string[] {
     return entries.flatMap((e) =>
-      withScores ? [e.member, String(e.score)] : [e.member],
+      shouldIncludeScores ? [e.member, String(e.score)] : [e.member],
     );
   }
 
@@ -143,115 +143,135 @@ function stageGroup({
   redis,
   groupId,
   readyScore,
+  headJobScore,
   headJobId,
 }: {
   redis: FakeRedis;
   groupId: string;
   readyScore: number;
+  headJobScore: number;
   headJobId: string;
 }): void {
   const ready = redis.zsets.get(`${PREFIX}ready`) ?? [];
   ready.push({ member: groupId, score: readyScore });
   redis.zsets.set(`${PREFIX}ready`, ready);
   redis.zsets.set(`${PREFIX}group:${groupId}:jobs`, [
-    { member: headJobId, score: readyScore },
+    { member: headJobId, score: headJobScore },
   ]);
 }
 
-async function scan(redis: FakeRedis, topN: number) {
+async function scan({ redis, topN }: { redis: FakeRedis; topN: number }) {
   const repo = new QueueRedisRepository(redis as unknown as Redis);
   const queues = await repo.scanQueues({ queueNames: [QUEUE_NAME], topN });
   return queues[0]!;
 }
 
 describe("QueueRedisRepository.scanQueues — group summary", () => {
-  describe("when the ready zset holds more groups than the scan limit", () => {
-    it("samples both ends, so the most-eligible and most-deferred groups are listed", async () => {
-      const redis = new FakeRedis();
-      const now = Date.now();
-      // Ascending eligibility: oldest-due first, most-deferred last.
-      stageGroup({
-        redis,
-        groupId: "group-eligible-old",
-        readyScore: now - 86_400_000,
-        headJobId: "job-a",
-      });
-      stageGroup({
-        redis,
-        groupId: "group-mid-1",
-        readyScore: now - 5_000,
-        headJobId: "job-b",
-      });
-      stageGroup({
-        redis,
-        groupId: "group-mid-2",
-        readyScore: now - 1_000,
-        headJobId: "job-c",
-      });
-      stageGroup({
-        redis,
-        groupId: "group-deferred",
-        readyScore: now + 300_000,
-        headJobId: "job-d",
-      });
+  describe("given more ready groups than the scan limit", () => {
+    describe("when the queue is scanned", () => {
+      it("samples both ends, so the most-eligible and most-deferred groups are listed", async () => {
+        const redis = new FakeRedis();
+        const now = Date.now();
+        // Ascending eligibility: oldest-due first, most-deferred last.
+        stageGroup({
+          redis,
+          groupId: "group-eligible-old",
+          readyScore: now - 86_400_000,
+          headJobScore: now - 86_400_000,
+          headJobId: "job-a",
+        });
+        stageGroup({
+          redis,
+          groupId: "group-mid-1",
+          readyScore: now - 5_000,
+          headJobScore: now - 5_000,
+          headJobId: "job-b",
+        });
+        stageGroup({
+          redis,
+          groupId: "group-mid-2",
+          readyScore: now - 1_000,
+          headJobScore: now - 1_000,
+          headJobId: "job-c",
+        });
+        // Deferred group models a group whose ready score sits far in the
+        // future (retry backoff / delayed stage) while its head job's
+        // ORIGINAL due time (preserved across retries) is already overdue.
+        stageGroup({
+          redis,
+          groupId: "group-deferred",
+          readyScore: now + 300_000,
+          headJobScore: now - 60_000,
+          headJobId: "job-d",
+        });
 
-      const queue = await scan(redis, 1);
+        const queue = await scan({ redis, topN: 1 });
 
-      const listed = queue.groups.map((g) => g.groupId);
-      expect(listed).toContain("group-eligible-old");
-      expect(listed).toContain("group-deferred");
+        const listed = queue.groups.map((g) => g.groupId);
+        expect(listed).toContain("group-eligible-old");
+        expect(listed).toContain("group-deferred");
+      });
     });
   });
 
-  describe("when the head job has retried since ADR-080", () => {
-    it("reads the retry count from the group's attempt key, not the job id", async () => {
-      const redis = new FakeRedis();
-      stageGroup({
-        redis,
-        groupId: "group-retrying",
-        readyScore: Date.now() + 60_000,
-        headJobId: "evt-plain-id",
+  describe("given a head job that retried since ADR-080", () => {
+    describe("when the queue is scanned", () => {
+      it("reads the retry count from the group's attempt key, not the job id", async () => {
+        const redis = new FakeRedis();
+        stageGroup({
+          redis,
+          groupId: "group-retrying",
+          readyScore: Date.now() + 60_000,
+          headJobScore: Date.now() + 60_000,
+          headJobId: "evt-plain-id",
+        });
+        redis.strings.set(`${PREFIX}group:group-retrying:attempt`, "4");
+
+        const queue = await scan({ redis, topN: 10 });
+
+        const group = queue.groups.find((g) => g.groupId === "group-retrying");
+        expect(group?.retryCount).toBe(4);
       });
-      redis.strings.set(`${PREFIX}group:group-retrying:attempt`, "4");
-
-      const queue = await scan(redis, 10);
-
-      const group = queue.groups.find((g) => g.groupId === "group-retrying");
-      expect(group?.retryCount).toBe(4);
     });
   });
 
-  describe("when only a pre-ADR-080 job id marker exists", () => {
-    it("falls back to the legacy /r/<n> id parse", async () => {
-      const redis = new FakeRedis();
-      stageGroup({
-        redis,
-        groupId: "group-legacy",
-        readyScore: Date.now(),
-        headJobId: "evt-1/r/2",
+  describe("given only a pre-ADR-080 job id marker", () => {
+    describe("when the queue is scanned", () => {
+      it("falls back to the legacy /r/<n> id parse", async () => {
+        const redis = new FakeRedis();
+        stageGroup({
+          redis,
+          groupId: "group-legacy",
+          readyScore: Date.now(),
+          headJobScore: Date.now(),
+          headJobId: "evt-1/r/2",
+        });
+
+        const queue = await scan({ redis, topN: 10 });
+
+        const group = queue.groups.find((g) => g.groupId === "group-legacy");
+        expect(group?.retryCount).toBe(2);
       });
-
-      const queue = await scan(redis, 10);
-
-      const group = queue.groups.find((g) => g.groupId === "group-legacy");
-      expect(group?.retryCount).toBe(2);
     });
   });
 
-  describe("when the head job has never been retried", () => {
-    it("reports no retry count", async () => {
-      const redis = new FakeRedis();
-      stageGroup({
-        redis,
-        groupId: "group-fresh",
-        readyScore: Date.now(),
-        headJobId: "evt-fresh",
+  describe("given a head job that never retried", () => {
+    describe("when the queue is scanned", () => {
+      it("reports no retry count", async () => {
+        const redis = new FakeRedis();
+        stageGroup({
+          redis,
+          groupId: "group-fresh",
+          readyScore: Date.now(),
+          headJobScore: Date.now(),
+          headJobId: "evt-fresh",
+        });
+
+        const queue = await scan({ redis, topN: 10 });
+
+        const group = queue.groups.find((g) => g.groupId === "group-fresh");
+        expect(group?.retryCount).toBeNull();
       });
-
-      const queue = await scan(redis, 10);
-
-      const group = queue.groups.find((g) => g.groupId === "group-fresh");
-      expect(group?.retryCount).toBeNull();
     });
   });
 });

--- a/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
@@ -65,6 +65,7 @@ class FakeRedis {
     return Object.fromEntries(this.hashes.get(key) ?? []);
   }
 
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional zrange signature
   async zrange(
     key: string,
     start: number,
@@ -79,6 +80,7 @@ class FakeRedis {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional zrevrange signature
   async zrevrange(
     key: string,
     start: number,
@@ -104,6 +106,7 @@ class FakeRedis {
         commands.push(() => this.get(key));
         return chain;
       },
+      // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional zrange signature
       zrange: (key: string, start: number, stop: number, ws?: string) => {
         commands.push(() => this.zrange(key, start, stop, ws));
         return chain;
@@ -136,12 +139,17 @@ class FakeRedis {
   }
 }
 
-function stageGroup(
-  redis: FakeRedis,
-  groupId: string,
-  readyScore: number,
-  headJobId: string,
-): void {
+function stageGroup({
+  redis,
+  groupId,
+  readyScore,
+  headJobId,
+}: {
+  redis: FakeRedis;
+  groupId: string;
+  readyScore: number;
+  headJobId: string;
+}): void {
   const ready = redis.zsets.get(`${PREFIX}ready`) ?? [];
   ready.push({ member: groupId, score: readyScore });
   redis.zsets.set(`${PREFIX}ready`, ready);
@@ -162,10 +170,30 @@ describe("QueueRedisRepository.scanQueues — group summary", () => {
       const redis = new FakeRedis();
       const now = Date.now();
       // Ascending eligibility: oldest-due first, most-deferred last.
-      stageGroup(redis, "group-eligible-old", now - 86_400_000, "job-a");
-      stageGroup(redis, "group-mid-1", now - 5_000, "job-b");
-      stageGroup(redis, "group-mid-2", now - 1_000, "job-c");
-      stageGroup(redis, "group-deferred", now + 300_000, "job-d");
+      stageGroup({
+        redis,
+        groupId: "group-eligible-old",
+        readyScore: now - 86_400_000,
+        headJobId: "job-a",
+      });
+      stageGroup({
+        redis,
+        groupId: "group-mid-1",
+        readyScore: now - 5_000,
+        headJobId: "job-b",
+      });
+      stageGroup({
+        redis,
+        groupId: "group-mid-2",
+        readyScore: now - 1_000,
+        headJobId: "job-c",
+      });
+      stageGroup({
+        redis,
+        groupId: "group-deferred",
+        readyScore: now + 300_000,
+        headJobId: "job-d",
+      });
 
       const queue = await scan(redis, 1);
 
@@ -178,7 +206,12 @@ describe("QueueRedisRepository.scanQueues — group summary", () => {
   describe("when the head job has retried since ADR-080", () => {
     it("reads the retry count from the group's attempt key, not the job id", async () => {
       const redis = new FakeRedis();
-      stageGroup(redis, "group-retrying", Date.now() + 60_000, "evt-plain-id");
+      stageGroup({
+        redis,
+        groupId: "group-retrying",
+        readyScore: Date.now() + 60_000,
+        headJobId: "evt-plain-id",
+      });
       redis.strings.set(`${PREFIX}group:group-retrying:attempt`, "4");
 
       const queue = await scan(redis, 10);
@@ -191,7 +224,12 @@ describe("QueueRedisRepository.scanQueues — group summary", () => {
   describe("when only a pre-ADR-080 job id marker exists", () => {
     it("falls back to the legacy /r/<n> id parse", async () => {
       const redis = new FakeRedis();
-      stageGroup(redis, "group-legacy", Date.now(), "evt-1/r/2");
+      stageGroup({
+        redis,
+        groupId: "group-legacy",
+        readyScore: Date.now(),
+        headJobId: "evt-1/r/2",
+      });
 
       const queue = await scan(redis, 10);
 
@@ -203,7 +241,12 @@ describe("QueueRedisRepository.scanQueues — group summary", () => {
   describe("when the head job has never been retried", () => {
     it("reports no retry count", async () => {
       const redis = new FakeRedis();
-      stageGroup(redis, "group-fresh", Date.now(), "evt-fresh");
+      stageGroup({
+        redis,
+        groupId: "group-fresh",
+        readyScore: Date.now(),
+        headJobId: "evt-fresh",
+      });
 
       const queue = await scan(redis, 10);
 

--- a/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.scan-groups.unit.test.ts
@@ -1,0 +1,214 @@
+import type { Redis } from "ioredis";
+import { describe, expect, it } from "vitest";
+import { QueueRedisRepository } from "../queue.redis.repository";
+
+const QUEUE_NAME = "test-queue";
+const PREFIX = `${QUEUE_NAME}:gq:`;
+
+/**
+ * Minimal in-memory stand-in for the Redis commands a group scan issues.
+ * Zsets are held sorted ascending by score, mirroring Redis ordering, so
+ * zrange/zrevrange return genuinely opposite ends.
+ */
+class FakeRedis {
+  readonly strings = new Map<string, string>();
+  readonly zsets = new Map<string, Array<{ member: string; score: number }>>();
+  readonly sets = new Map<string, string[]>();
+  readonly hashes = new Map<string, Map<string, string>>();
+
+  private sorted(key: string) {
+    return [...(this.zsets.get(key) ?? [])].sort((a, b) => a.score - b.score);
+  }
+
+  private static flat(
+    entries: Array<{ member: string; score: number }>,
+    withScores: boolean,
+  ): string[] {
+    return entries.flatMap((e) =>
+      withScores ? [e.member, String(e.score)] : [e.member],
+    );
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.zsets.get(key)?.length ?? 0;
+  }
+
+  async scard(key: string): Promise<number> {
+    return this.sets.get(key)?.length ?? 0;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    return this.sets.get(key) ?? [];
+  }
+
+  async srandmember(key: string, count: number): Promise<string[]> {
+    return (this.sets.get(key) ?? []).slice(0, count);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async ttl(_key: string): Promise<number> {
+    return -2;
+  }
+
+  async sismember(key: string, member: string): Promise<number> {
+    return (this.sets.get(key) ?? []).includes(member) ? 1 : 0;
+  }
+
+  async hget(key: string, field: string): Promise<string | null> {
+    return this.hashes.get(key)?.get(field) ?? null;
+  }
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.hashes.get(key) ?? []);
+  }
+
+  async zrange(
+    key: string,
+    start: number,
+    stop: number,
+    withScores?: string,
+  ): Promise<string[]> {
+    const entries = this.sorted(key);
+    const end = stop === -1 ? entries.length - 1 : stop;
+    return FakeRedis.flat(
+      entries.slice(start, end + 1),
+      withScores === "WITHSCORES",
+    );
+  }
+
+  async zrevrange(
+    key: string,
+    start: number,
+    stop: number,
+    withScores?: string,
+  ): Promise<string[]> {
+    const entries = this.sorted(key).reverse();
+    const end = stop === -1 ? entries.length - 1 : stop;
+    return FakeRedis.flat(
+      entries.slice(start, end + 1),
+      withScores === "WITHSCORES",
+    );
+  }
+
+  pipeline() {
+    const commands: Array<() => Promise<unknown>> = [];
+    const chain = {
+      zcard: (key: string) => {
+        commands.push(() => this.zcard(key));
+        return chain;
+      },
+      get: (key: string) => {
+        commands.push(() => this.get(key));
+        return chain;
+      },
+      zrange: (key: string, start: number, stop: number, ws?: string) => {
+        commands.push(() => this.zrange(key, start, stop, ws));
+        return chain;
+      },
+      sismember: (key: string, member: string) => {
+        commands.push(() => this.sismember(key, member));
+        return chain;
+      },
+      ttl: (key: string) => {
+        commands.push(() => this.ttl(key));
+        return chain;
+      },
+      hget: (key: string, field: string) => {
+        commands.push(() => this.hget(key, field));
+        return chain;
+      },
+      hgetall: (key: string) => {
+        commands.push(() => this.hgetall(key));
+        return chain;
+      },
+      exec: async () => {
+        const results: Array<[null, unknown]> = [];
+        for (const run of commands) {
+          results.push([null, await run()]);
+        }
+        return results;
+      },
+    };
+    return chain;
+  }
+}
+
+function stageGroup(
+  redis: FakeRedis,
+  groupId: string,
+  readyScore: number,
+  headJobId: string,
+): void {
+  const ready = redis.zsets.get(`${PREFIX}ready`) ?? [];
+  ready.push({ member: groupId, score: readyScore });
+  redis.zsets.set(`${PREFIX}ready`, ready);
+  redis.zsets.set(`${PREFIX}group:${groupId}:jobs`, [
+    { member: headJobId, score: readyScore },
+  ]);
+}
+
+async function scan(redis: FakeRedis, topN: number) {
+  const repo = new QueueRedisRepository(redis as unknown as Redis);
+  const queues = await repo.scanQueues({ queueNames: [QUEUE_NAME], topN });
+  return queues[0]!;
+}
+
+describe("QueueRedisRepository.scanQueues — group summary", () => {
+  describe("when the ready zset holds more groups than the scan limit", () => {
+    it("samples both ends, so the most-eligible and most-deferred groups are listed", async () => {
+      const redis = new FakeRedis();
+      const now = Date.now();
+      // Ascending eligibility: oldest-due first, most-deferred last.
+      stageGroup(redis, "group-eligible-old", now - 86_400_000, "job-a");
+      stageGroup(redis, "group-mid-1", now - 5_000, "job-b");
+      stageGroup(redis, "group-mid-2", now - 1_000, "job-c");
+      stageGroup(redis, "group-deferred", now + 300_000, "job-d");
+
+      const queue = await scan(redis, 1);
+
+      const listed = queue.groups.map((g) => g.groupId);
+      expect(listed).toContain("group-eligible-old");
+      expect(listed).toContain("group-deferred");
+    });
+  });
+
+  describe("when the head job has retried since ADR-080", () => {
+    it("reads the retry count from the group's attempt key, not the job id", async () => {
+      const redis = new FakeRedis();
+      stageGroup(redis, "group-retrying", Date.now() + 60_000, "evt-plain-id");
+      redis.strings.set(`${PREFIX}group:group-retrying:attempt`, "4");
+
+      const queue = await scan(redis, 10);
+
+      const group = queue.groups.find((g) => g.groupId === "group-retrying");
+      expect(group?.retryCount).toBe(4);
+    });
+  });
+
+  describe("when only a pre-ADR-080 job id marker exists", () => {
+    it("falls back to the legacy /r/<n> id parse", async () => {
+      const redis = new FakeRedis();
+      stageGroup(redis, "group-legacy", Date.now(), "evt-1/r/2");
+
+      const queue = await scan(redis, 10);
+
+      const group = queue.groups.find((g) => g.groupId === "group-legacy");
+      expect(group?.retryCount).toBe(2);
+    });
+  });
+
+  describe("when the head job has never been retried", () => {
+    it("reports no retry count", async () => {
+      const redis = new FakeRedis();
+      stageGroup(redis, "group-fresh", Date.now(), "evt-fresh");
+
+      const queue = await scan(redis, 10);
+
+      const group = queue.groups.find((g) => g.groupId === "group-fresh");
+      expect(group?.retryCount).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -417,10 +417,13 @@ function stripHashTag(name: string): string {
  * legacy id parse stays as the last-resort fallback for jobs staged before an
  * ADR-080 deploy.
  */
-function resolveRetryCount(
-  attemptRaw: string | null,
-  jobId: string | null,
-): number | null {
+function resolveRetryCount({
+  attemptRaw,
+  jobId,
+}: {
+  attemptRaw: string | null;
+  jobId: string | null;
+}): number | null {
   const attempt = attemptRaw === null ? Number.NaN : parseInt(attemptRaw, 10);
   if (Number.isInteger(attempt) && attempt > 0) return attempt;
   if (!jobId) return null;
@@ -691,7 +694,10 @@ export class QueueRedisRepository implements QueueRepository {
         errorTimestamp: errorInfo?.timestamp
           ? parseFloat(errorInfo.timestamp)
           : null,
-        retryCount: resolveRetryCount(attemptRaw, firstJobIds[i]!.jobId),
+        retryCount: resolveRetryCount({
+          attemptRaw,
+          jobId: firstJobIds[i]!.jobId,
+        }),
         activeKeyTtlSec: activeKeyTtlSec > 0 ? activeKeyTtlSec : null,
         processingDurationMs: null,
       });

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -11,6 +11,7 @@ import {
   decodeJobEnvelope,
   readJobRoutingMeta,
 } from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
+import { legacyStagedJobAttempt } from "~/server/event-sourcing/queues/groupQueue/legacyStagedJobAttempt";
 import { RedisJobBlobStore } from "~/server/event-sourcing/queues/groupQueue/redisJobBlobStore";
 import {
   GROUP_QUEUE_REGISTRY_KEY,
@@ -407,12 +408,24 @@ function stripHashTag(name: string): string {
   return name;
 }
 
-function parseRetryCount(id: string | null): number | null {
-  if (!id) return null;
-  const match = id.match(/\/r\/(\d+)$/);
-  if (!match) return null;
-  const n = parseInt(match[1]!, 10);
-  return n < 1000 ? n : null;
+/**
+ * The head job's retry count, ADR-080 first: the group's retry chain lives in
+ * the `group:{id}:attempt` key (TTL'd past the max backoff), written on every
+ * restage. The `/r/<n>` job-id suffix stopped being written at ADR-080, so
+ * parsing only the id read "—" for every retrying group — during the
+ * 2026-08-05 backup it made day-old retry loops look never-attempted. The
+ * legacy id parse stays as the last-resort fallback for jobs staged before an
+ * ADR-080 deploy.
+ */
+function resolveRetryCount(
+  attemptRaw: string | null,
+  jobId: string | null,
+): number | null {
+  const attempt = attemptRaw === null ? Number.NaN : parseInt(attemptRaw, 10);
+  if (Number.isInteger(attempt) && attempt > 0) return attempt;
+  if (!jobId) return null;
+  const legacy = legacyStagedJobAttempt(jobId);
+  return legacy > 0 ? legacy : null;
 }
 
 // ── Repository Implementation ────────────────────────────────────────
@@ -494,11 +507,20 @@ export class QueueRedisRepository implements QueueRepository {
     const totalPendingKey = `${prefix}stats:total-pending`;
     const parkedTenantsKey = `${prefix}parked-tenants`;
 
+    // Sample BOTH ends of the ready zset. The zset is scored by dispatch
+    // eligibility, so its ends hold the two distinct stuck-group classes: the
+    // high end is the most-deferred groups (in-flight, retry backoff — where a
+    // failing group hides between attempts), the low end is the most-eligible
+    // ones (an old due head the dispatcher is starving). A single-ended
+    // ZREVRANGE sampled only the deferred end, so an aged eligible backlog past
+    // `limit` never appeared in the dashboard at all. When the zset fits in
+    // `limit` the two ranges coincide and dedup makes this identical to before.
     const [
       readyCount,
       blockedCount,
       dlqCount,
       topReadyMembers,
+      bottomReadyMembers,
       totalPendingRaw,
       parkedTenants,
     ] = await Promise.all([
@@ -506,6 +528,7 @@ export class QueueRedisRepository implements QueueRepository {
       this.redis.scard(blockedKey),
       this.redis.scard(dlqKey),
       this.redis.zrevrange(readyKey, offset, offset + limit - 1, "WITHSCORES"),
+      this.redis.zrange(readyKey, offset, offset + limit - 1, "WITHSCORES"),
       this.redis.get(totalPendingKey),
       this.redis.smembers(parkedTenantsKey),
     ]);
@@ -528,11 +551,14 @@ export class QueueRedisRepository implements QueueRepository {
 
     const groupIds: string[] = [];
     const readyScores = new Map<string, number>();
-    for (let i = 0; i < topReadyMembers.length; i += 2) {
-      const groupId = topReadyMembers[i]!;
-      const score = parseFloat(topReadyMembers[i + 1]!);
-      groupIds.push(groupId);
-      readyScores.set(groupId, score);
+    for (const members of [topReadyMembers, bottomReadyMembers]) {
+      for (let i = 0; i < members.length; i += 2) {
+        const groupId = members[i]!;
+        if (readyScores.has(groupId)) continue;
+        const score = parseFloat(members[i + 1]!);
+        groupIds.push(groupId);
+        readyScores.set(groupId, score);
+      }
     }
 
     const blockedMembers =
@@ -549,7 +575,7 @@ export class QueueRedisRepository implements QueueRepository {
 
     const allGroupIds = [...groupIds, ...blockedGroupIds];
 
-    const CMDS_PER_GROUP = 6;
+    const CMDS_PER_GROUP = 7;
     const pipeline = this.redis.pipeline();
     for (const groupId of allGroupIds) {
       const jobsKey = `${prefix}group:${groupId}:jobs`;
@@ -560,6 +586,7 @@ export class QueueRedisRepository implements QueueRepository {
       pipeline.zrange(jobsKey, -1, -1, "WITHSCORES");
       pipeline.sismember(blockedKey, groupId);
       pipeline.ttl(`${prefix}group:${groupId}:active`);
+      pipeline.get(`${prefix}group:${groupId}:attempt`);
     }
 
     const pipelineResults = await pipeline.exec();
@@ -621,6 +648,7 @@ export class QueueRedisRepository implements QueueRepository {
       const isBlocked = (pipelineResults?.[base + 4]?.[1] as number) === 1;
       const activeKeyTtlSec =
         (pipelineResults?.[base + 5]?.[1] as number) ?? -2;
+      const attemptRaw = (pipelineResults?.[base + 6]?.[1] as string) ?? null;
 
       const oldestJobMs =
         oldestArr.length >= 2 ? parseFloat(oldestArr[1]!) : null;
@@ -663,7 +691,7 @@ export class QueueRedisRepository implements QueueRepository {
         errorTimestamp: errorInfo?.timestamp
           ? parseFloat(errorInfo.timestamp)
           : null,
-        retryCount: parseRetryCount(firstJobIds[i]!.jobId),
+        retryCount: resolveRetryCount(attemptRaw, firstJobIds[i]!.jobId),
         activeKeyTtlSec: activeKeyTtlSec > 0 ? activeKeyTtlSec : null,
         processingDurationMs: null,
       });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
@@ -62,6 +62,13 @@ describe("GroupQueue metrics", () => {
       expect(metric).toBeDefined();
     });
 
+    it("registers gq_oldest_backlog_age_milliseconds gauge", () => {
+      const metric = register.getSingleMetric(
+        "gq_oldest_backlog_age_milliseconds",
+      );
+      expect(metric).toBeDefined();
+    });
+
     it("registers gq_blocked_groups gauge", () => {
       const metric = register.getSingleMetric("gq_blocked_groups");
       expect(metric).toBeDefined();

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -1,7 +1,7 @@
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 import { register } from "prom-client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   gqOldestBacklogAgeMilliseconds,
   gqOldestPendingAgeMilliseconds,
@@ -123,21 +123,24 @@ async function readGauge(): Promise<number | undefined> {
 describe("GroupQueueMetricsCollector — oldest pending age", () => {
   beforeEach(() => {
     register.resetMetrics();
+    // Freeze the clock so scores seeded relative to "now" keep their
+    // eligible/deferred classification no matter how slowly the test runs,
+    // and ages assert exactly instead of through tolerance windows.
+    vi.useFakeTimers({ now: Date.now() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("reports the age of the oldest eligible-waiting group", async () => {
-    // Seeded relative to Date.now() at test setup; the collector reads
-    // Date.now() again at call time, so assert with a tolerance window
-    // rather than an exact millisecond match.
     const redis = makeRedis({
       readyZset: [{ member: "group-abc", score: Date.now() - 5_000 }],
     });
 
     await runCollect(redis);
 
-    const age = await readGauge();
-    expect(age).toBeGreaterThanOrEqual(5_000);
-    expect(age).toBeLessThan(15_000);
+    expect(await readGauge()).toBe(5_000);
 
     // The query must exclude the unblock sentinel (score 1) via an exclusive
     // lower bound, cap at "now", and read only the single oldest member.
@@ -146,8 +149,7 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
     const args = redis.zrangebyscore.mock.calls[0]!;
     expect(args[0]).toBe(`${PREFIX}ready`);
     expect(args[1]).toBe("(1");
-    expect(typeof args[2]).toBe("number");
-    expect(Number(args[2])).toBeGreaterThan(Date.now() - 5_000);
+    expect(args[2]).toBe(Date.now());
     expect(args).toContain("WITHSCORES");
     expect(args.slice(-3)).toEqual(["LIMIT", 0, 1]);
   });
@@ -180,6 +182,14 @@ async function readBacklogGauge(): Promise<number | undefined> {
 describe("GroupQueueMetricsCollector — oldest backlog age", () => {
   beforeEach(() => {
     register.resetMetrics();
+    // Frozen clock: a score of now+5s must stay DEFERRED through the whole
+    // test, however slowly CI runs it — otherwise the group turns eligible,
+    // the deferred sample skips its head job, and the assertion flakes.
+    vi.useFakeTimers({ now: Date.now() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe("when a group is pinned in retry backoff (deferred ready score, day-old head job)", () => {
@@ -203,9 +213,7 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
       await runCollect(redis);
 
       expect(await readGauge()).toBe(0);
-      const backlogAge = await readBacklogGauge();
-      expect(backlogAge).toBeGreaterThanOrEqual(60_000);
-      expect(backlogAge).toBeLessThan(70_000);
+      expect(await readBacklogGauge()).toBe(60_000);
     });
   });
 
@@ -237,9 +245,7 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
 
       await runCollect(redis);
 
-      const backlogAge = await readBacklogGauge();
-      expect(backlogAge).toBeGreaterThanOrEqual(5_000);
-      expect(backlogAge).toBeLessThan(15_000);
+      expect(await readBacklogGauge()).toBe(5_000);
     });
   });
 
@@ -276,9 +282,7 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
 
         await runCollect(redis);
 
-        const backlogAge = await readBacklogGauge();
-        expect(backlogAge).toBeGreaterThanOrEqual(86_400_000);
-        expect(backlogAge).toBeLessThan(86_400_000 + 60_000);
+        expect(await readBacklogGauge()).toBe(86_400_000);
       });
     });
   });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -12,18 +12,55 @@ import type { GroupStagingScripts } from "../scripts";
 const QUEUE = "test-queue";
 const PREFIX = "gq:test:";
 
-type ZRangeByScore = (...args: unknown[]) => Promise<string[]>;
+type ReadyEntry = { member: string; score: number };
 
 /**
- * Minimal Redis stub exposing only the reads collect() performs. The backlog
- * gauge samples deferred groups via zrevrange and reads each group's head job
- * through a pipeline of zrange calls; `headJobScores` maps a group's jobs key
- * to the [member, score] pair its zrange returns.
+ * Real zrangebyscore semantics over an in-memory ready zset: exclusive "(x"
+ * lower bound, a numeric or "+inf" upper bound, LIMIT offset/count, ascending
+ * by score, and WITHSCORES flattening. The collector issues two shapes of
+ * this call per collect (the eligible probe and the deferred-backlog sample),
+ * so one model backs both instead of a bespoke per-test stub.
+ */
+function zrangebyscoreModel({
+  entries,
+  min,
+  max,
+  rest,
+}: {
+  entries: ReadyEntry[];
+  min: string | number;
+  max: string | number;
+  rest: unknown[];
+}): string[] {
+  const minStr = String(min);
+  const exclusive = minStr.startsWith("(");
+  const minVal = Number(exclusive ? minStr.slice(1) : minStr);
+  const maxVal = max === "+inf" ? Infinity : Number(max);
+
+  const withScores = rest.includes("WITHSCORES");
+  const limitIdx = rest.indexOf("LIMIT");
+  const offset = limitIdx >= 0 ? Number(rest[limitIdx + 1]) : 0;
+  const count = limitIdx >= 0 ? Number(rest[limitIdx + 2]) : Infinity;
+
+  return [...entries]
+    .filter(
+      (e) =>
+        (exclusive ? e.score > minVal : e.score >= minVal) && e.score <= maxVal,
+    )
+    .sort((a, b) => a.score - b.score)
+    .slice(offset, offset + count)
+    .flatMap((e) => (withScores ? [e.member, String(e.score)] : [e.member]));
+}
+
+/**
+ * Minimal Redis stub exposing only the reads collect() performs. `readyZset`
+ * backs both zrangebyscore calls (the eligible probe and the deferred-backlog
+ * sample) through the real model above; `headJobScores` maps a group's jobs
+ * key to the [member, score] pair its pipelined zrange returns.
  */
 function makeRedis(
-  zrangebyscore: ZRangeByScore,
   opts: {
-    deferredGroups?: string[];
+    readyZset?: ReadyEntry[];
     headJobScores?: Record<string, string[]>;
   } = {},
 ) {
@@ -31,8 +68,14 @@ function makeRedis(
     zcard: vi.fn(async () => 0),
     scard: vi.fn(async () => 0),
     smembers: vi.fn(async () => [] as string[]),
-    zrangebyscore: vi.fn(zrangebyscore),
-    zrevrange: vi.fn(async () => opts.deferredGroups ?? []),
+    zrangebyscore: vi.fn(async (...args: unknown[]) =>
+      zrangebyscoreModel({
+        entries: opts.readyZset ?? [],
+        min: args[1] as string | number,
+        max: args[2] as string | number,
+        rest: args.slice(3),
+      }),
+    ),
     pipeline: vi.fn(() => {
       const cmds: string[] = [];
       const chain = {
@@ -47,7 +90,6 @@ function makeRedis(
     }),
   } as unknown as (IORedis | Cluster) & {
     zrangebyscore: ReturnType<typeof vi.fn>;
-    zrevrange: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -81,20 +123,24 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
   });
 
   it("reports the age of the oldest eligible-waiting group", async () => {
-    // Stub returns a group whose ready score is (query max) - 5000, so the
-    // computed age is exactly 5000ms regardless of wall-clock timing.
-    const redis = makeRedis(async (...args) => {
-      const max = Number(args[2]);
-      return ["group-abc", String(max - 5000)];
+    // Seeded relative to Date.now() at test setup; the collector reads
+    // Date.now() again at call time, so assert with a tolerance window
+    // rather than an exact millisecond match.
+    const redis = makeRedis({
+      readyZset: [{ member: "group-abc", score: Date.now() - 5_000 }],
     });
 
     await runCollect(redis);
 
-    expect(await readGauge()).toBe(5000);
+    const age = await readGauge();
+    expect(age).toBeGreaterThanOrEqual(5_000);
+    expect(age).toBeLessThan(15_000);
 
     // The query must exclude the unblock sentinel (score 1) via an exclusive
     // lower bound, cap at "now", and read only the single oldest member.
-    const args = redis.zrangebyscore.mock.calls.at(-1)!;
+    // This is the FIRST zrangebyscore call (the eligible probe); the second
+    // is the deferred-backlog sample.
+    const args = redis.zrangebyscore.mock.calls[0]!;
     expect(args[0]).toBe(`${PREFIX}ready`);
     expect(args[1]).toBe("(1");
     expect(typeof args[2]).toBe("number");
@@ -104,15 +150,18 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
   });
 
   it("reports 0 when no group is eligible (empty / all in-flight / just unblocked)", async () => {
-    const redis = makeRedis(async () => []);
+    // A just-unblocked group carries the sentinel score (1), which the
+    // exclusive "(1" lower bound must drop rather than surface as eligible.
+    const redis = makeRedis({
+      readyZset: [{ member: "just-unblocked", score: 1 }],
+    });
     await runCollect(redis);
     expect(await readGauge()).toBe(0);
   });
 
   it("never emits a negative age (clock skew / future score)", async () => {
-    const redis = makeRedis(async (...args) => {
-      const max = Number(args[2]);
-      return ["group-future", String(max + 1000)];
+    const redis = makeRedis({
+      readyZset: [{ member: "group-future", score: Date.now() + 1_000 }],
     });
     await runCollect(redis);
     const age = await readGauge();
@@ -133,10 +182,13 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
   describe("when a group is pinned in retry backoff (deferred ready score, day-old head job)", () => {
     it("reports the head job's age even though the eligible gauge reads 0", async () => {
       // Nothing eligible: the group's ready score was rewritten to now+backoff
-      // by the last failed attempt, so the eligible scan sees an empty queue.
+      // by the last failed attempt (a real backoff, not the full incident
+      // delay), so the eligible scan sees an empty queue.
       const headDueMs = Date.now() - 60_000;
-      const redis = makeRedis(async () => [], {
-        deferredGroups: ["tenant/sub/trace:abc"],
+      const redis = makeRedis({
+        readyZset: [
+          { member: "tenant/sub/trace:abc", score: Date.now() + 5_000 },
+        ],
         headJobScores: {
           [`${PREFIX}group:tenant/sub/trace:abc:jobs`]: [
             "job-1",
@@ -156,8 +208,10 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
 
   describe("when a deferred group's head job is scheduled in the future", () => {
     it("does not count it as backlog", async () => {
-      const redis = makeRedis(async () => [], {
-        deferredGroups: ["tenant/sub/trace:delayed"],
+      const redis = makeRedis({
+        readyZset: [
+          { member: "tenant/sub/trace:delayed", score: Date.now() + 5_000 },
+        ],
         headJobScores: {
           [`${PREFIX}group:tenant/sub/trace:delayed:jobs`]: [
             "job-1",
@@ -174,14 +228,53 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
 
   describe("when only an eligible group is waiting", () => {
     it("folds the eligible head into the backlog age", async () => {
-      const redis = makeRedis(async (...args) => {
-        const max = Number(args[2]);
-        return ["group-abc", String(max - 5000)];
+      const redis = makeRedis({
+        readyZset: [{ member: "group-abc", score: Date.now() - 5_000 }],
       });
 
       await runCollect(redis);
 
-      expect(await readBacklogGauge()).toBe(5000);
+      const backlogAge = await readBacklogGauge();
+      expect(backlogAge).toBeGreaterThanOrEqual(5_000);
+      expect(backlogAge).toBeLessThan(15_000);
+    });
+  });
+
+  describe("when 50 long-delayed groups outnumber a single day-old retry-backoff group", () => {
+    it("still surfaces the retry-backoff group's age (regression: nearest-first sampling)", async () => {
+      // Regression for the 2026-08-05 incident this gauge exists to catch:
+      // fifty monitor-timer groups scored hours out must NOT displace a
+      // retry-backoff group (scored only seconds out) from the sample. Under
+      // the old zrevrange(0, 49) sampling — largest scores first — the 50
+      // far-future groups would fill the sample and this test fails; the
+      // nearest-first zrangebyscore sampling ranks the backoff group first.
+      const now = Date.now();
+      const readyZset: ReadyEntry[] = [];
+      const headJobScores: Record<string, string[]> = {};
+
+      for (let i = 0; i < 50; i++) {
+        const groupId = `tenant/sub/trace:long-delayed-${i}`;
+        readyZset.push({ member: groupId, score: now + 3_600_000 });
+        headJobScores[`${PREFIX}group:${groupId}:jobs`] = [
+          "job-future",
+          String(now + 3_600_000),
+        ];
+      }
+
+      const backoffGroupId = "tenant/sub/trace:day-old-backoff";
+      readyZset.push({ member: backoffGroupId, score: now + 5_000 });
+      headJobScores[`${PREFIX}group:${backoffGroupId}:jobs`] = [
+        "job-1",
+        String(now - 86_400_000),
+      ];
+
+      const redis = makeRedis({ readyZset, headJobScores });
+
+      await runCollect(redis);
+
+      const backlogAge = await readBacklogGauge();
+      expect(backlogAge).toBeGreaterThanOrEqual(86_400_000);
+      expect(backlogAge).toBeLessThan(86_400_000 + 60_000);
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -2,7 +2,10 @@ import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 import { register } from "prom-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { gqOldestPendingAgeMilliseconds } from "../metrics";
+import {
+  gqOldestBacklogAgeMilliseconds,
+  gqOldestPendingAgeMilliseconds,
+} from "../metrics";
 import { GroupQueueMetricsCollector } from "../metricsCollector";
 import type { GroupStagingScripts } from "../scripts";
 
@@ -11,15 +14,40 @@ const PREFIX = "gq:test:";
 
 type ZRangeByScore = (...args: unknown[]) => Promise<string[]>;
 
-/** Minimal Redis stub exposing only the reads collect() performs. */
-function makeRedis(zrangebyscore: ZRangeByScore) {
+/**
+ * Minimal Redis stub exposing only the reads collect() performs. The backlog
+ * gauge samples deferred groups via zrevrange and reads each group's head job
+ * through a pipeline of zrange calls; `headJobScores` maps a group's jobs key
+ * to the [member, score] pair its zrange returns.
+ */
+function makeRedis(
+  zrangebyscore: ZRangeByScore,
+  opts: {
+    deferredGroups?: string[];
+    headJobScores?: Record<string, string[]>;
+  } = {},
+) {
   return {
     zcard: vi.fn(async () => 0),
     scard: vi.fn(async () => 0),
     smembers: vi.fn(async () => [] as string[]),
     zrangebyscore: vi.fn(zrangebyscore),
+    zrevrange: vi.fn(async () => opts.deferredGroups ?? []),
+    pipeline: vi.fn(() => {
+      const cmds: string[] = [];
+      const chain = {
+        zrange: (key: string) => {
+          cmds.push(key);
+          return chain;
+        },
+        exec: async () =>
+          cmds.map((key) => [null, opts.headJobScores?.[key] ?? []]),
+      };
+      return chain;
+    }),
   } as unknown as (IORedis | Cluster) & {
     zrangebyscore: ReturnType<typeof vi.fn>;
+    zrevrange: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -89,5 +117,71 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
     await runCollect(redis);
     const age = await readGauge();
     expect(age).toBeGreaterThanOrEqual(0);
+  });
+});
+
+async function readBacklogGauge(): Promise<number | undefined> {
+  const m = await gqOldestBacklogAgeMilliseconds.get();
+  return m.values.find((v) => v.labels.queue_name === QUEUE)?.value;
+}
+
+describe("GroupQueueMetricsCollector — oldest backlog age", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+  });
+
+  describe("when a group is pinned in retry backoff (deferred ready score, day-old head job)", () => {
+    it("reports the head job's age even though the eligible gauge reads 0", async () => {
+      // Nothing eligible: the group's ready score was rewritten to now+backoff
+      // by the last failed attempt, so the eligible scan sees an empty queue.
+      const headDueMs = Date.now() - 60_000;
+      const redis = makeRedis(async () => [], {
+        deferredGroups: ["tenant/sub/trace:abc"],
+        headJobScores: {
+          [`${PREFIX}group:tenant/sub/trace:abc:jobs`]: [
+            "job-1",
+            String(headDueMs),
+          ],
+        },
+      });
+
+      await runCollect(redis);
+
+      expect(await readGauge()).toBe(0);
+      const backlogAge = await readBacklogGauge();
+      expect(backlogAge).toBeGreaterThanOrEqual(60_000);
+      expect(backlogAge).toBeLessThan(70_000);
+    });
+  });
+
+  describe("when a deferred group's head job is scheduled in the future", () => {
+    it("does not count it as backlog", async () => {
+      const redis = makeRedis(async () => [], {
+        deferredGroups: ["tenant/sub/trace:delayed"],
+        headJobScores: {
+          [`${PREFIX}group:tenant/sub/trace:delayed:jobs`]: [
+            "job-1",
+            String(Date.now() + 3_600_000),
+          ],
+        },
+      });
+
+      await runCollect(redis);
+
+      expect(await readBacklogGauge()).toBe(0);
+    });
+  });
+
+  describe("when only an eligible group is waiting", () => {
+    it("folds the eligible head into the backlog age", async () => {
+      const redis = makeRedis(async (...args) => {
+        const max = Number(args[2]);
+        return ["group-abc", String(max - 5000)];
+      });
+
+      await runCollect(redis);
+
+      expect(await readBacklogGauge()).toBe(5000);
+    });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -33,11 +33,11 @@ function zrangebyscoreModel({
   rest: unknown[];
 }): string[] {
   const minStr = String(min);
-  const exclusive = minStr.startsWith("(");
-  const minVal = Number(exclusive ? minStr.slice(1) : minStr);
+  const isExclusive = minStr.startsWith("(");
+  const minVal = Number(isExclusive ? minStr.slice(1) : minStr);
   const maxVal = max === "+inf" ? Infinity : Number(max);
 
-  const withScores = rest.includes("WITHSCORES");
+  const shouldIncludeScores = rest.includes("WITHSCORES");
   const limitIdx = rest.indexOf("LIMIT");
   const offset = limitIdx >= 0 ? Number(rest[limitIdx + 1]) : 0;
   const count = limitIdx >= 0 ? Number(rest[limitIdx + 2]) : Infinity;
@@ -45,11 +45,14 @@ function zrangebyscoreModel({
   return [...entries]
     .filter(
       (e) =>
-        (exclusive ? e.score > minVal : e.score >= minVal) && e.score <= maxVal,
+        (isExclusive ? e.score > minVal : e.score >= minVal) &&
+        e.score <= maxVal,
     )
     .sort((a, b) => a.score - b.score)
     .slice(offset, offset + count)
-    .flatMap((e) => (withScores ? [e.member, String(e.score)] : [e.member]));
+    .flatMap((e) =>
+      shouldIncludeScores ? [e.member, String(e.score)] : [e.member],
+    );
 }
 
 /**
@@ -240,41 +243,43 @@ describe("GroupQueueMetricsCollector — oldest backlog age", () => {
     });
   });
 
-  describe("when 50 long-delayed groups outnumber a single day-old retry-backoff group", () => {
-    it("still surfaces the retry-backoff group's age (regression: nearest-first sampling)", async () => {
-      // Regression for the 2026-08-05 incident this gauge exists to catch:
-      // fifty monitor-timer groups scored hours out must NOT displace a
-      // retry-backoff group (scored only seconds out) from the sample. Under
-      // the old zrevrange(0, 49) sampling — largest scores first — the 50
-      // far-future groups would fill the sample and this test fails; the
-      // nearest-first zrangebyscore sampling ranks the backoff group first.
-      const now = Date.now();
-      const readyZset: ReadyEntry[] = [];
-      const headJobScores: Record<string, string[]> = {};
+  describe("given 50 long-delayed groups and a single day-old retry-backoff group", () => {
+    describe("when metrics are collected", () => {
+      it("still surfaces the retry-backoff group's age (regression: nearest-first sampling)", async () => {
+        // Regression for the 2026-08-05 incident this gauge exists to catch:
+        // fifty monitor-timer groups scored hours out must NOT displace a
+        // retry-backoff group (scored only seconds out) from the sample. Under
+        // the old zrevrange(0, 49) sampling — largest scores first — the 50
+        // far-future groups would fill the sample and this test fails; the
+        // nearest-first zrangebyscore sampling ranks the backoff group first.
+        const now = Date.now();
+        const readyZset: ReadyEntry[] = [];
+        const headJobScores: Record<string, string[]> = {};
 
-      for (let i = 0; i < 50; i++) {
-        const groupId = `tenant/sub/trace:long-delayed-${i}`;
-        readyZset.push({ member: groupId, score: now + 3_600_000 });
-        headJobScores[`${PREFIX}group:${groupId}:jobs`] = [
-          "job-future",
-          String(now + 3_600_000),
+        for (let i = 0; i < 50; i++) {
+          const groupId = `tenant/sub/trace:long-delayed-${i}`;
+          readyZset.push({ member: groupId, score: now + 3_600_000 });
+          headJobScores[`${PREFIX}group:${groupId}:jobs`] = [
+            "job-future",
+            String(now + 3_600_000),
+          ];
+        }
+
+        const backoffGroupId = "tenant/sub/trace:day-old-backoff";
+        readyZset.push({ member: backoffGroupId, score: now + 5_000 });
+        headJobScores[`${PREFIX}group:${backoffGroupId}:jobs`] = [
+          "job-1",
+          String(now - 86_400_000),
         ];
-      }
 
-      const backoffGroupId = "tenant/sub/trace:day-old-backoff";
-      readyZset.push({ member: backoffGroupId, score: now + 5_000 });
-      headJobScores[`${PREFIX}group:${backoffGroupId}:jobs`] = [
-        "job-1",
-        String(now - 86_400_000),
-      ];
+        const redis = makeRedis({ readyZset, headJobScores });
 
-      const redis = makeRedis({ readyZset, headJobScores });
+        await runCollect(redis);
 
-      await runCollect(redis);
-
-      const backlogAge = await readBacklogGauge();
-      expect(backlogAge).toBeGreaterThanOrEqual(86_400_000);
-      expect(backlogAge).toBeLessThan(86_400_000 + 60_000);
+        const backlogAge = await readBacklogGauge();
+        expect(backlogAge).toBeGreaterThanOrEqual(86_400_000);
+        expect(backlogAge).toBeLessThan(86_400_000 + 60_000);
+      });
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -190,6 +190,21 @@ export const gqOldestPendingAgeMilliseconds = new Gauge({
   labelNames: ["queue_name"] as const,
 });
 
+/**
+ * Backlog age the eligible-waiting gauge is structurally blind to. A group
+ * pinned in retry backoff has its ready score REWRITTEN to now+backoff on every
+ * failed attempt, so `gq_oldest_pending_age_milliseconds` (which clocks off the
+ * ready score) reads seconds even while the group's head job has been due for a
+ * day. This gauge clocks off the per-group jobs zset instead, whose scores are
+ * preserved across retries/blocks/parks, sampling the most-deferred ready
+ * groups — exactly where retry-pinned and in-flight groups live.
+ */
+export const gqOldestBacklogAgeMilliseconds = new Gauge({
+  name: "gq_oldest_backlog_age_milliseconds",
+  help: "Age of the oldest due job across sampled groups regardless of dispatch eligibility (catches groups pinned in retry backoff)",
+  labelNames: ["queue_name"] as const,
+});
+
 // --- Blob lifecycle observability (ADR-030 hardening + review 2026-06-24) ---
 
 /** A stored blob exceeded the decode cap — possible tamper / zip-bomb. Distinct from a missing blob. */

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -22,6 +22,7 @@ const metricNames = [
   "gq_retry_backoff_milliseconds",
   "gq_job_duration_milliseconds",
   "gq_oldest_pending_age_milliseconds",
+  "gq_oldest_backlog_age_milliseconds",
   // ADR-030 hardening + review 2026-06-24
   "gq_blob_reclaim_s3_failures_total",
   "gq_blob_decode_cap_exceeded_total",

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -114,99 +114,7 @@ export class GroupQueueMetricsCollector {
         this.params.activeJobCountFn(),
       );
 
-      // Oldest eligible-waiting age. A group's readyKey score is its
-      // dispatch-eligibility time, and every not-yet-dispatchable state is
-      // future-scored:
-      //   - genuinely eligible & waiting     → score <= now   (counted)
-      //   - in-flight (re-scored to activeUntil), backoff-pending retry,
-      //     and not-yet-due delayed stage    → score > now    (excluded)
-      // So the oldest eligible-waiting group is simply the smallest score in
-      // (sentinel, now]. STAGE writes the score with ZADD LT (keep-if-smaller)
-      // and COMPLETE rewrites it to the next remaining job, so the readyKey
-      // score already tracks the group's oldest still-pending job.
-      //
-      // This replaces the previous "min dispatchAfterMs over the first 10 ready
-      // groups" scan, which had two independent defects:
-      //   1. Sampling bias — zrange(readyKey, 0, 9) returns the 10 MOST
-      //      dispatch-eligible groups, not the oldest, so a real backlog sitting
-      //      past index 10 was never inspected and the gauge under-reported.
-      //   2. Wrong clock origin — it read the per-group jobs zset, whose scores
-      //      are PRESERVED across a block/park, so a just-unblocked group
-      //      reported its entire blocked duration as backlog age (0 -> hours in
-      //      one tick).
-      //
-      // Exclude the unblock sentinel: UNBLOCK_LUA (app-layer/ops/repositories/
-      // queue.redis.repository.ts) re-adds a group to ready with the constant
-      // score 1 (epoch 1ms) to force prompt dispatch — not a real eligibility
-      // time, so a just-unblocked group must not read as ~56 years. The
-      // exclusive `(1` lower bound drops it; any real timestamp is far larger.
-      //
-      // Known residual: unpark restores a group's preserved (pre-park) ready
-      // score, so a long-parked group briefly over-reports on unpark until it is
-      // dispatched (one scan cycle). Closing that needs an unpark re-score
-      // decision (queue-fairness change), tracked separately.
-      const nowMs = Date.now();
-      const oldestEligible = await this.params.redisConnection.zrangebyscore(
-        readyKey,
-        `(${READY_UNBLOCK_SENTINEL_SCORE}`,
-        nowMs,
-        "WITHSCORES",
-        "LIMIT",
-        0,
-        1,
-      );
-      const age =
-        oldestEligible.length >= 2
-          ? Math.max(0, nowMs - Number(oldestEligible[1]))
-          : 0;
-      gqOldestPendingAgeMilliseconds.set(
-        { queue_name: this.params.queueName },
-        age,
-      );
-
-      // Backlog age regardless of eligibility. The gauge above is structurally
-      // blind to a group pinned in retry backoff: every failed attempt rewrites
-      // the group's ready score to now+backoff, so it is either future-scored
-      // (excluded) or freshly re-scored (reads as seconds old) — a head job due
-      // for a day never surfaces (2026-08-05 incident: day-old
-      // codingAgentSpanFactsDispatch backlogs under a ~2.5s gauge). The
-      // per-group jobs zset keeps the job's ORIGINAL due time across retries,
-      // so clock off that instead, sampling the deferred end of ready where
-      // retry-pinned groups live, and folding in the eligible head so an old
-      // eligible group past the sample bound still registers.
-      let oldestDueMs: number | null =
-        oldestEligible.length >= 2 ? Number(oldestEligible[1]) : null;
-      const deferredGroups = await this.params.redisConnection.zrevrange(
-        readyKey,
-        0,
-        OLDEST_BACKLOG_SAMPLE_GROUPS - 1,
-      );
-      if (deferredGroups.length > 0) {
-        const headPipeline = this.params.redisConnection.pipeline();
-        for (const groupId of deferredGroups) {
-          headPipeline.zrange(
-            `${keyPrefix}group:${groupId}:jobs`,
-            0,
-            0,
-            "WITHSCORES",
-          );
-        }
-        const headResults = (await headPipeline.exec()) ?? [];
-        for (const [err, value] of headResults) {
-          if (err) continue;
-          const arr = value as string[];
-          if (arr.length < 2) continue;
-          const dueMs = Number(arr[1]);
-          // Only DUE jobs are backlog: a head legitimately scheduled in the
-          // future (delayed stage, monitor timers hours out) is not late work.
-          if (!Number.isFinite(dueMs) || dueMs > nowMs) continue;
-          if (oldestDueMs === null || dueMs < oldestDueMs) oldestDueMs = dueMs;
-        }
-      }
-      gqOldestBacklogAgeMilliseconds.set(
-        { queue_name: this.params.queueName },
-        oldestDueMs === null ? 0 : Math.max(0, nowMs - oldestDueMs),
-      );
+      await this.collectOldestAges(readyKey, keyPrefix);
     } catch (error) {
       this.params.logger.debug(
         {
@@ -217,4 +125,116 @@ export class GroupQueueMetricsCollector {
       );
     }
   }
+
+  /**
+   * The two age gauges, from opposite clock origins.
+   *
+   * Oldest eligible-waiting age. A group's readyKey score is its
+   * dispatch-eligibility time, and every not-yet-dispatchable state is
+   * future-scored:
+   *   - genuinely eligible & waiting     → score <= now   (counted)
+   *   - in-flight (re-scored to activeUntil), backoff-pending retry,
+   *     and not-yet-due delayed stage    → score > now    (excluded)
+   * So the oldest eligible-waiting group is simply the smallest score in
+   * (sentinel, now]. STAGE writes the score with ZADD LT (keep-if-smaller)
+   * and COMPLETE rewrites it to the next remaining job, so the readyKey
+   * score already tracks the group's oldest still-pending job.
+   *
+   * This replaces the previous "min dispatchAfterMs over the first 10 ready
+   * groups" scan, which had two independent defects:
+   *   1. Sampling bias — zrange(readyKey, 0, 9) returns the 10 MOST
+   *      dispatch-eligible groups, not the oldest, so a real backlog sitting
+   *      past index 10 was never inspected and the gauge under-reported.
+   *   2. Wrong clock origin — it read the per-group jobs zset, whose scores
+   *      are PRESERVED across a block/park, so a just-unblocked group
+   *      reported its entire blocked duration as backlog age (0 -> hours in
+   *      one tick).
+   *
+   * Exclude the unblock sentinel: UNBLOCK_LUA (app-layer/ops/repositories/
+   * queue.redis.repository.ts) re-adds a group to ready with the constant
+   * score 1 (epoch 1ms) to force prompt dispatch — not a real eligibility
+   * time, so a just-unblocked group must not read as ~56 years. The
+   * exclusive `(1` lower bound drops it; any real timestamp is far larger.
+   *
+   * Known residual: unpark restores a group's preserved (pre-park) ready
+   * score, so a long-parked group briefly over-reports on unpark until it is
+   * dispatched (one scan cycle). Closing that needs an unpark re-score
+   * decision (queue-fairness change), tracked separately.
+   *
+   * Backlog age regardless of eligibility. The eligible gauge is structurally
+   * blind to a group pinned in retry backoff: every failed attempt rewrites
+   * the group's ready score to now+backoff, so it is either future-scored
+   * (excluded) or freshly re-scored (reads as seconds old) — a head job due
+   * for a day never surfaces (2026-08-05 incident: day-old
+   * codingAgentSpanFactsDispatch backlogs under a ~2.5s gauge). The
+   * per-group jobs zset keeps the job's ORIGINAL due time across retries,
+   * so clock off that instead, sampling the deferred end of ready where
+   * retry-pinned groups live, and folding in the eligible head so an old
+   * eligible group past the sample bound still registers.
+   */
+  private async collectOldestAges(
+    readyKey: string,
+    keyPrefix: string,
+  ): Promise<void> {
+    const nowMs = Date.now();
+    const oldestEligible = await this.params.redisConnection.zrangebyscore(
+      readyKey,
+      `(${READY_UNBLOCK_SENTINEL_SCORE}`,
+      nowMs,
+      "WITHSCORES",
+      "LIMIT",
+      0,
+      1,
+    );
+    const eligibleDueMs =
+      oldestEligible.length >= 2 ? Number(oldestEligible[1]) : null;
+    gqOldestPendingAgeMilliseconds.set(
+      { queue_name: this.params.queueName },
+      eligibleDueMs === null ? 0 : Math.max(0, nowMs - eligibleDueMs),
+    );
+
+    let oldestDueMs = eligibleDueMs;
+    const deferredGroups = await this.params.redisConnection.zrevrange(
+      readyKey,
+      0,
+      OLDEST_BACKLOG_SAMPLE_GROUPS - 1,
+    );
+    if (deferredGroups.length > 0) {
+      const headPipeline = this.params.redisConnection.pipeline();
+      for (const groupId of deferredGroups) {
+        headPipeline.zrange(
+          `${keyPrefix}group:${groupId}:jobs`,
+          0,
+          0,
+          "WITHSCORES",
+        );
+      }
+      const headResults = (await headPipeline.exec()) ?? [];
+      oldestDueMs = minDueMs(oldestDueMs, headResults, nowMs);
+    }
+    gqOldestBacklogAgeMilliseconds.set(
+      { queue_name: this.params.queueName },
+      oldestDueMs === null ? 0 : Math.max(0, nowMs - oldestDueMs),
+    );
+  }
+}
+
+/**
+ * Folds the sampled head-job [member, score] replies into the running oldest
+ * due time. Only DUE jobs are backlog: a head legitimately scheduled in the
+ * future (delayed stage, monitor timers hours out) is not late work.
+ */
+function minDueMs(
+  seed: number | null,
+  headResults: Array<[unknown, unknown]>,
+  nowMs: number,
+): number | null {
+  let oldest = seed;
+  for (const [err, value] of headResults) {
+    const arr = err ? [] : (value as string[]);
+    const dueMs = arr.length >= 2 ? Number(arr[1]) : Number.NaN;
+    const isDue = Number.isFinite(dueMs) && dueMs <= nowMs;
+    if (isDue && (oldest === null || dueMs < oldest)) oldest = dueMs;
+  }
+  return oldest;
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -7,6 +7,7 @@ import {
   gqBlockedGroups,
   gqFastqActive,
   gqFastqPending,
+  gqOldestBacklogAgeMilliseconds,
   gqOldestPendingAgeMilliseconds,
   gqParkedGroups,
   gqPendingGroups,
@@ -20,6 +21,16 @@ import type { DispatchResult, GroupStagingScripts } from "./scripts";
  * oldest-pending-age gauge excludes it — see the computation in collect().
  */
 const READY_UNBLOCK_SENTINEL_SCORE = 1;
+
+/**
+ * How many of the most-deferred ready groups the backlog-age gauge samples per
+ * collect. Retry-pinned groups sit at the deferred END of the ready zset (their
+ * score is now+backoff, larger than any eligible group's), so a small sample
+ * from that end catches them; in-flight groups sampled alongside contribute
+ * nothing because their head job is not due. Bounded so a collect cycle stays
+ * O(sample) pipeline commands whatever the backlog size.
+ */
+const OLDEST_BACKLOG_SAMPLE_GROUPS = 50;
 
 /**
  * Periodically collects metrics from the group queue processing and staging layers.
@@ -151,6 +162,50 @@ export class GroupQueueMetricsCollector {
       gqOldestPendingAgeMilliseconds.set(
         { queue_name: this.params.queueName },
         age,
+      );
+
+      // Backlog age regardless of eligibility. The gauge above is structurally
+      // blind to a group pinned in retry backoff: every failed attempt rewrites
+      // the group's ready score to now+backoff, so it is either future-scored
+      // (excluded) or freshly re-scored (reads as seconds old) — a head job due
+      // for a day never surfaces (2026-08-05 incident: day-old
+      // codingAgentSpanFactsDispatch backlogs under a ~2.5s gauge). The
+      // per-group jobs zset keeps the job's ORIGINAL due time across retries,
+      // so clock off that instead, sampling the deferred end of ready where
+      // retry-pinned groups live, and folding in the eligible head so an old
+      // eligible group past the sample bound still registers.
+      let oldestDueMs: number | null =
+        oldestEligible.length >= 2 ? Number(oldestEligible[1]) : null;
+      const deferredGroups = await this.params.redisConnection.zrevrange(
+        readyKey,
+        0,
+        OLDEST_BACKLOG_SAMPLE_GROUPS - 1,
+      );
+      if (deferredGroups.length > 0) {
+        const headPipeline = this.params.redisConnection.pipeline();
+        for (const groupId of deferredGroups) {
+          headPipeline.zrange(
+            `${keyPrefix}group:${groupId}:jobs`,
+            0,
+            0,
+            "WITHSCORES",
+          );
+        }
+        const headResults = (await headPipeline.exec()) ?? [];
+        for (const [err, value] of headResults) {
+          if (err) continue;
+          const arr = value as string[];
+          if (arr.length < 2) continue;
+          const dueMs = Number(arr[1]);
+          // Only DUE jobs are backlog: a head legitimately scheduled in the
+          // future (delayed stage, monitor timers hours out) is not late work.
+          if (!Number.isFinite(dueMs) || dueMs > nowMs) continue;
+          if (oldestDueMs === null || dueMs < oldestDueMs) oldestDueMs = dueMs;
+        }
+      }
+      gqOldestBacklogAgeMilliseconds.set(
+        { queue_name: this.params.queueName },
+        oldestDueMs === null ? 0 : Math.max(0, nowMs - oldestDueMs),
       );
     } catch (error) {
       this.params.logger.debug(

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -23,12 +23,14 @@ import type { DispatchResult, GroupStagingScripts } from "./scripts";
 const READY_UNBLOCK_SENTINEL_SCORE = 1;
 
 /**
- * How many of the most-deferred ready groups the backlog-age gauge samples per
- * collect. Retry-pinned groups sit at the deferred END of the ready zset (their
- * score is now+backoff, larger than any eligible group's), so a small sample
- * from that end catches them; in-flight groups sampled alongside contribute
- * nothing because their head job is not due. Bounded so a collect cycle stays
- * O(sample) pipeline commands whatever the backlog size.
+ * How many of the soonest-future-scored ("nearest deferred") ready groups the
+ * backlog-age gauge samples per collect. Retry-pinned groups' scores sit
+ * within maxBackoffMs (600s) of now, so an ascending scan from just-past-now
+ * finds them first; long-delayed groups (monitor timers, hours out) rank far
+ * later in that same scan and can no longer displace them, unlike a sample
+ * taken from the opposite (largest-score) end. In-flight groups sampled
+ * alongside contribute nothing because their head job is not due. Bounded so
+ * a collect cycle stays O(sample) pipeline commands whatever the backlog size.
  */
 const OLDEST_BACKLOG_SAMPLE_GROUPS = 50;
 
@@ -114,7 +116,7 @@ export class GroupQueueMetricsCollector {
         this.params.activeJobCountFn(),
       );
 
-      await this.collectOldestAges(readyKey, keyPrefix);
+      await this.collectOldestAges({ readyKey, keyPrefix });
     } catch (error) {
       this.params.logger.debug(
         {
@@ -167,15 +169,20 @@ export class GroupQueueMetricsCollector {
    * (excluded) or freshly re-scored (reads as seconds old) — a head job due
    * for a day never surfaces (2026-08-05 incident: day-old
    * codingAgentSpanFactsDispatch backlogs under a ~2.5s gauge). The
-   * per-group jobs zset keeps the job's ORIGINAL due time across retries,
-   * so clock off that instead, sampling the deferred end of ready where
-   * retry-pinned groups live, and folding in the eligible head so an old
-   * eligible group past the sample bound still registers.
+   * per-group jobs zset keeps the job's ORIGINAL due time across retries, so
+   * clock off that instead, sampling the soonest-future-scored ("nearest
+   * deferred") groups of ready — where retry-pinned groups live, their scores
+   * within maxBackoffMs of now — while long-delayed groups (hours out) rank
+   * far later and can no longer displace them, and folding in the eligible
+   * head so an old eligible group past the sample bound still registers.
    */
-  private async collectOldestAges(
-    readyKey: string,
-    keyPrefix: string,
-  ): Promise<void> {
+  private async collectOldestAges({
+    readyKey,
+    keyPrefix,
+  }: {
+    readyKey: string;
+    keyPrefix: string;
+  }): Promise<void> {
     const nowMs = Date.now();
     const oldestEligible = await this.params.redisConnection.zrangebyscore(
       readyKey,
@@ -194,10 +201,13 @@ export class GroupQueueMetricsCollector {
     );
 
     let oldestDueMs = eligibleDueMs;
-    const deferredGroups = await this.params.redisConnection.zrevrange(
+    const deferredGroups = await this.params.redisConnection.zrangebyscore(
       readyKey,
+      `(${nowMs}`,
+      "+inf",
+      "LIMIT",
       0,
-      OLDEST_BACKLOG_SAMPLE_GROUPS - 1,
+      OLDEST_BACKLOG_SAMPLE_GROUPS,
     );
     if (deferredGroups.length > 0) {
       const headPipeline = this.params.redisConnection.pipeline();


### PR DESCRIPTION
## What

Two observability fixes from today's trace_processing backup investigation, where day-old `codingAgentSpanFactsDispatch` retry loops were effectively invisible to the tooling:

1. **Retry column read "—" for every retrying group.** `parseRetryCount` parsed the legacy `/r/<n>` job-id suffix, which ADR-080 stopped writing when attempts moved to the `group:{id}:attempt` key. The scan now pipelines a `GET` of that key per group and keeps the id parse only as the pre-ADR-080 fallback (reusing `legacyStagedJobAttempt` instead of a duplicate regex). `getGroupDetail` reuses the same scan, so the drawer inherits the fix.

2. **Aged backlogs invisible to sampling and to the health gauge.**
   - The groups table sampled only `ZREVRANGE` on the ready zset (the most-deferred end); an aged *eligible* backlog past the limit never appeared. The scan now samples both ends and dedups — identical to before when the zset fits within the limit.
   - `gq_oldest_pending_age_milliseconds` clocks off the group ready score, which every failed attempt rewrites to now+backoff, so retry-pinned day-old backlogs read as ~2.5s. Added `gq_oldest_backlog_age_milliseconds`, clocked off the per-group jobs zset (scores preserved across retries): it samples the 50 soonest-eligible deferred groups (`ZRANGEBYSCORE` ascending from just-past-now — where retry-backoff scores live, so far-future long-delayed groups can't displace them) and folds in the eligible head. Future-scheduled heads (delayed stages, monitor timers) are excluded — only due work counts as backlog. The new gauge is in the metrics module's hot-reload removal list, so double module evaluation doesn't throw.

## Tests

- `queue.redis.repository.scan-groups.unit.test.ts` (new): attempt-key retry counts, legacy fallback, null for fresh heads, and both-ends sampling; fixtures stage head-job time independently of dispatch eligibility.
- `metricsCollector.unit.test.ts`: backlog gauge reports a retry-pinned group's head-job age while the eligible gauge reads 0; future-scheduled heads excluded; eligible head folded in; regression test with 50 far-future groups plus one overdue retry-backoff group (fails under the old largest-score sampling).
- `metrics.unit.test.ts`: registration of the new gauge.

`pnpm test:unit run src/server/app-layer/ops src/server/event-sourcing/queues/groupQueue` — 31 files, 308 tests green. Biome clean on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metric showing the age of the oldest due job in the queue backlog.
* **Bug Fixes**
  * Improved queue group retry-count reporting, including support for older queued jobs.
  * Enhanced queue scanning to consider groups from both ends of the ready queue.
  * Improved backlog-age calculations by excluding future-scheduled and invalid jobs.
* **Tests**
  * Expanded coverage for queue scanning, retry counts, metric registration, and deferred-group backlog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
