### PR TITLE
fix(aigateway): derive the control-plane URL in dev instead of silently defaulting, and unbreak the docs-metrics contract test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,16 @@ setup-hooks:
 # launching the gateway, but a flat `. .env` would clobber it back to
 # the hardcoded default and the gateway would hit a dead control-plane
 # port (every VK call → 401 invalid_api_key).
+#
+# For a standalone run (no pnpm dev in the ancestry, so nothing pre-derived
+# LW_GATEWAY_BASE_URL) dev/scripts/lib/derive-gateway-base-url.sh derives it
+# from PORT the same way start.sh does, once .env has had its say. Without
+# this, a bare `make service svc=aigateway` on a non-default-PORT worktree
+# silently falls through to services/aigateway/config.go's compatibility
+# default (http://localhost:5560), correct only for a single worktree on
+# the default port, and wrong everywhere else with no error anywhere: the
+# gateway still proxies LLM traffic and returns 200, it just ships spend,
+# budget and auth traffic to whichever control plane that port belongs to.
 DEV_ENV_FILE ?= platform/app/.env
 service:
 	@test -n "$(svc)" || (echo "usage: make service svc=<name>" && exit 1)
@@ -117,6 +127,7 @@ service:
 			&& set -a && . $(DEV_ENV_FILE) && set +a \
 			|| echo "$(DEV_ENV_FILE) not found — using process environment"; } && \
 		eval "$$_snap" && \
+		. dev/scripts/lib/derive-gateway-base-url.sh && derive_gateway_base_url && \
 		export LOG_FORMAT=pretty && \
 		exec go run ./cmd/service $(svc)
 
@@ -129,6 +140,7 @@ service-watch:
 	@_snap=$$(export -p) && \
 		set -a && . $(DEV_ENV_FILE) && set +a && \
 		eval "$$_snap" && \
+		. dev/scripts/lib/derive-gateway-base-url.sh && derive_gateway_base_url && \
 		export LOG_FORMAT=pretty && \
 		air --build.cmd "go build -o ./tmp/$(svc) ./cmd/service" \
 			--build.bin "./tmp/$(svc) $(svc)" \

--- a/dev/scripts/lib/derive-gateway-base-url.sh
+++ b/dev/scripts/lib/derive-gateway-base-url.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Derive LW_GATEWAY_BASE_URL from PORT when it is not already set, so a
+# standalone `make service svc=aigateway` / `make service-watch
+# svc=aigateway` targets THIS worktree's control plane instead of silently
+# falling back to services/aigateway/config.go's compatibility default
+# (http://localhost:5560), which is only correct for a single worktree on
+# the default port.
+#
+# Mirrors platform/app/scripts/start.sh's own derivation exactly: PORT + 1000
+# is the API port `pnpm dev` binds its Hono backend to, so a gateway started
+# either way ends up pointed at the same place. An explicit
+# LW_GATEWAY_BASE_URL, whether inherited from the calling shell or set in
+# platform/app/.env, always wins; this only fills the gap when nothing set
+# it at all.
+#
+# Usage from the Makefile, after platform/app/.env is sourced:
+#
+#   . dev/scripts/lib/derive-gateway-base-url.sh
+#   derive_gateway_base_url
+
+derive_gateway_base_url() {
+  if [ -n "${LW_GATEWAY_BASE_URL:-}" ]; then
+    return 0
+  fi
+
+  local app_port="${PORT:-5560}"
+  local api_port=$((app_port + 1000))
+  export LW_GATEWAY_BASE_URL="http://localhost:${api_port}"
+  echo "  ✓ LW_GATEWAY_BASE_URL derived from PORT=${app_port} -> ${LW_GATEWAY_BASE_URL}"
+}

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -289,10 +289,13 @@ LW_GATEWAY_PUBLIC_URL=http://localhost:5563
 # OS temp dir.
 LW_GATEWAY_SPEND_ENABLED=1
 
-# Base URL the Go gateway reaches the control-plane at. Defaults to
-# localhost:5560 which matches `pnpm dev`. Override for split-deploy
-# topologies (e.g. gateway in a separate pod from the app).
-LW_GATEWAY_BASE_URL=http://localhost:5560
+# Base URL the Go gateway reaches the control-plane at. `pnpm dev` and
+# `make service svc=aigateway` / `make service-watch svc=aigateway` derive
+# this from PORT automatically (PORT + 1000, the same port the API backend
+# binds to), so it only needs to be set here for a split-deploy topology
+# (e.g. gateway in a separate pod from the app) or to pin a value the
+# derivation would get wrong.
+# LW_GATEWAY_BASE_URL=http://localhost:5560
 
 # AI Gateway auth-cache stale-while-error knobs (Go gateway only).
 # When the control plane is briefly unreachable, the gateway extends the

--- a/platform/app/scripts/__tests__/check-gateway-control-plane.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-gateway-control-plane.unit.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the pure decision logic behind
+ * scripts/check-gateway-control-plane.ts: given what this worktree expects
+ * and what a reused AI Gateway process actually reports on its
+ * GET /debug/control-plane endpoint, decide whether to warn and what to
+ * say. The probe (fetch, timeout, JSON parsing) is deliberately not under
+ * test here, only the comparison and the resulting message.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { evaluateGatewayReuse } from "../check-gateway-control-plane";
+
+describe("evaluateGatewayReuse", () => {
+  describe("when the reused gateway reports the control plane this worktree expects", () => {
+    /** @scenario "a reused gateway pointed at the right control plane raises no warning" */
+    it("raises no warning", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "ok", controlPlaneBaseUrl: "http://localhost:7580" },
+      });
+
+      expect(result).toEqual({ verdict: "ok", warning: null });
+    });
+
+    it("treats a trailing slash as the same URL", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "ok", controlPlaneBaseUrl: "http://localhost:7580/" },
+      });
+
+      expect(result.verdict).toBe("ok");
+      expect(result.warning).toBeNull();
+    });
+  });
+
+  describe("when the reused gateway reports a different control plane", () => {
+    /** @scenario "a reused gateway pointed at a different control plane raises a loud, actionable warning" */
+    it("raises a multi-line warning naming both the expected and the actual URL", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "ok", controlPlaneBaseUrl: "http://localhost:5560" },
+      });
+
+      expect(result.verdict).toBe("mismatch");
+      expect(result.warning).toContain("http://localhost:7580");
+      expect(result.warning).toContain("http://localhost:5560");
+      expect(result.warning?.split("\n").length).toBeGreaterThan(3);
+    });
+
+    it("states how to fix it", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "ok", controlPlaneBaseUrl: "http://localhost:5560" },
+      });
+
+      expect(result.warning).toMatch(/fix/i);
+      expect(result.warning).toContain("5563");
+    });
+  });
+
+  describe("when the reused gateway's control-plane target cannot be verified", () => {
+    /** @scenario "a reused gateway whose control-plane target cannot be verified is treated as suspect, not silently trusted" */
+    it("raises a warning saying the target could not be verified", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "unreachable", reason: "fetch failed: ECONNREFUSED" },
+      });
+
+      expect(result.verdict).toBe("unverifiable");
+      expect(result.warning).toContain("ECONNREFUSED");
+      expect(result.warning).toContain("http://localhost:7580");
+    });
+
+    it("does not report ok", () => {
+      const result = evaluateGatewayReuse({
+        expectedControlPlaneUrl: "http://localhost:7580",
+        gatewayPort: 5563,
+        probe: { kind: "unreachable", reason: "timed out" },
+      });
+
+      expect(result.verdict).not.toBe("ok");
+      expect(result.warning).not.toBeNull();
+    });
+  });
+});

--- a/platform/app/scripts/__tests__/derive-gateway-base-url.unit.test.ts
+++ b/platform/app/scripts/__tests__/derive-gateway-base-url.unit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for dev/scripts/lib/derive-gateway-base-url.sh, sourced the same way
+ * `make service` / `make service-watch` source it: after platform/app/.env,
+ * so an explicit LW_GATEWAY_BASE_URL (inherited from the shell, or set in
+ * .env) always wins over the derived one. Mirrors the PORT + 1000 rule
+ * platform/app/scripts/start.sh already uses for `pnpm dev` (the API port
+ * Vite proxies to), so a gateway started either way targets the same place.
+ *
+ * The helper is bash; we drive it by sourcing it from `bash -s` and reading
+ * the resulting env, the same technique as sanitize-dev-env.unit.test.ts.
+ */
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const HELPER = path.join(
+  REPO_ROOT,
+  "dev/scripts/lib/derive-gateway-base-url.sh",
+);
+
+function runHelper(env: Record<string, string | undefined>): {
+  stdout: string;
+  gatewayBaseUrl: string;
+  exitCode: number;
+} {
+  const exports = Object.entries(env)
+    .map(([k, v]) =>
+      v === undefined
+        ? `unset ${k}`
+        : `export ${k}='${v.replace(/'/g, "'\\''")}'`,
+    )
+    .join("\n");
+  const script = `
+set -e
+${exports}
+. "${HELPER}"
+derive_gateway_base_url
+echo "__LW_GATEWAY_BASE_URL=\${LW_GATEWAY_BASE_URL:-}"
+`;
+  let stdout = "";
+  let exitCode = 0;
+  try {
+    stdout = execSync("bash -s", {
+      encoding: "utf8",
+      input: script,
+      stdio: ["pipe", "pipe", "pipe"],
+      // Isolate the subprocess env. The helper reads PORT / LW_GATEWAY_BASE_URL,
+      // so any of those present on the parent process (e.g. loaded from the
+      // developer's platform/app/.env) would leak in and make assertions
+      // depend on the local machine. Start from a bare PATH and let each
+      // test's own export/unset lines be the single source of truth.
+      env: { PATH: process.env.PATH ?? "" },
+    });
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout ?? "") + (err.stderr ?? "");
+  }
+  const gatewayBaseUrl = stdout.match(/__LW_GATEWAY_BASE_URL=(.*)/)?.[1] ?? "";
+  return { stdout, gatewayBaseUrl, exitCode };
+}
+
+describe("derive-gateway-base-url.sh", () => {
+  describe("when LW_GATEWAY_BASE_URL is unset and PORT is a non-default worktree port", () => {
+    /** @scenario "make service derives the control-plane URL from PORT when it is unset" */
+    it("derives LW_GATEWAY_BASE_URL as PORT + 1000", () => {
+      const r = runHelper({ PORT: "6580", LW_GATEWAY_BASE_URL: undefined });
+      expect(r.exitCode).toBe(0);
+      expect(r.gatewayBaseUrl).toBe("http://localhost:7580");
+    });
+
+    it("prints what it derived", () => {
+      const r = runHelper({ PORT: "6580", LW_GATEWAY_BASE_URL: undefined });
+      expect(r.stdout).toMatch(/derived from PORT=6580/);
+      expect(r.stdout).toMatch(/http:\/\/localhost:7580/);
+    });
+  });
+
+  describe("when LW_GATEWAY_BASE_URL is already set", () => {
+    /** @scenario "make service leaves an explicit control-plane URL untouched" */
+    it("leaves the explicit value unchanged, ignoring PORT", () => {
+      const r = runHelper({
+        PORT: "6580",
+        LW_GATEWAY_BASE_URL: "http://elsewhere.internal:9000",
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.gatewayBaseUrl).toBe("http://elsewhere.internal:9000");
+    });
+
+    it("does not print a derivation line", () => {
+      const r = runHelper({
+        PORT: "6580",
+        LW_GATEWAY_BASE_URL: "http://elsewhere.internal:9000",
+      });
+      expect(r.stdout).not.toMatch(/derived from PORT/);
+    });
+  });
+
+  describe("when neither PORT nor LW_GATEWAY_BASE_URL is set", () => {
+    /** @scenario "make service falls back to the default port pairing when PORT is unset too" */
+    it("derives the single-worktree default control-plane URL", () => {
+      const r = runHelper({ PORT: undefined, LW_GATEWAY_BASE_URL: undefined });
+      expect(r.exitCode).toBe(0);
+      expect(r.gatewayBaseUrl).toBe("http://localhost:6560");
+    });
+  });
+});

--- a/platform/app/scripts/check-gateway-control-plane.ts
+++ b/platform/app/scripts/check-gateway-control-plane.ts
@@ -1,0 +1,149 @@
+/**
+ * Verifies that an already-running AI Gateway process, the one `pnpm dev`
+ * (scripts/start.sh) is about to reuse because its derived gateway port is
+ * already listening, is actually pointed at THIS worktree's control plane
+ * rather than another worktree's or a stale process left over from an
+ * earlier run.
+ *
+ * A gateway proxies LLM traffic and answers every request 200 regardless of
+ * which control plane it ships spend, budget and auth traffic to, so a
+ * wrong target produces no error anywhere. This script asks the gateway
+ * directly, via its GET /debug/control-plane endpoint
+ * (services/aigateway/adapters/httpapi/debug_control_plane.go), and prints
+ * a loud warning when the answer does not match what this worktree expects,
+ * or when the gateway cannot be asked at all (an older build that predates
+ * the endpoint is the common case for a mismatch this check cannot name
+ * precisely).
+ *
+ * Usage: tsx check-gateway-control-plane.ts <gatewayPort> <expectedControlPlaneUrl>
+ */
+
+export type GatewayReuseVerdict = "ok" | "mismatch" | "unverifiable";
+
+export type ControlPlaneProbe =
+  | { kind: "ok"; controlPlaneBaseUrl: string }
+  | { kind: "unreachable"; reason: string };
+
+export interface EvaluateGatewayReuseInput {
+  /** This worktree's own expected control-plane URL, already derived from PORT by start.sh. */
+  expectedControlPlaneUrl: string;
+  /** The port the already-running gateway process is listening on. */
+  gatewayPort: number;
+  probe: ControlPlaneProbe;
+}
+
+export interface EvaluateGatewayReuseResult {
+  verdict: GatewayReuseVerdict;
+  /** Multi-line, unmissable banner. Null only when the verdict is "ok". */
+  warning: string | null;
+}
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function warningBanner(lines: string[]): string {
+  const rule = "!".repeat(78);
+  return ["", rule, ...lines.map((line) => `! ${line}`), rule, ""].join("\n");
+}
+
+export function evaluateGatewayReuse({
+  expectedControlPlaneUrl,
+  gatewayPort,
+  probe,
+}: EvaluateGatewayReuseInput): EvaluateGatewayReuseResult {
+  if (probe.kind === "unreachable") {
+    return {
+      verdict: "unverifiable",
+      warning: warningBanner([
+        `AI Gateway on :${gatewayPort} is being reused, but it did not answer`,
+        "GET /debug/control-plane, so its control-plane target cannot be verified.",
+        `Reason: ${probe.reason}`,
+        "This usually means the running process predates this check (an older",
+        "build from another worktree). It may be silently shipping spend, budget",
+        "and auth traffic somewhere other than this worktree's control plane.",
+        `Expected control plane: ${expectedControlPlaneUrl}`,
+        `Fix: stop whatever is holding :${gatewayPort} and let pnpm dev start its`,
+        "own gateway, or rebuild the other worktree's gateway and retry.",
+      ]),
+    };
+  }
+
+  if (
+    normalizeUrl(probe.controlPlaneBaseUrl) ===
+    normalizeUrl(expectedControlPlaneUrl)
+  ) {
+    return { verdict: "ok", warning: null };
+  }
+
+  return {
+    verdict: "mismatch",
+    warning: warningBanner([
+      `AI Gateway on :${gatewayPort} is being reused, but it is shipping spend,`,
+      "budget and auth traffic to a DIFFERENT control plane than this worktree:",
+      `  this worktree expects   : ${expectedControlPlaneUrl}`,
+      `  the running gateway targets: ${probe.controlPlaneBaseUrl}`,
+      "Every request still returns 200 while budgets, spend and auth silently",
+      "apply to the wrong project.",
+      `Fix: stop whatever is holding :${gatewayPort} and let pnpm dev start its`,
+      "own gateway, or set LW_GATEWAY_BASE_URL explicitly before starting it.",
+    ]),
+  };
+}
+
+async function probeControlPlane(
+  gatewayPort: number,
+): Promise<ControlPlaneProbe> {
+  try {
+    const response = await fetch(
+      `http://localhost:${gatewayPort}/debug/control-plane`,
+      {
+        signal: AbortSignal.timeout(1500),
+      },
+    );
+    if (!response.ok) {
+      return { kind: "unreachable", reason: `HTTP ${response.status}` };
+    }
+    const body = (await response.json()) as { control_plane_base_url?: string };
+    if (!body.control_plane_base_url) {
+      return {
+        kind: "unreachable",
+        reason: "response had no control_plane_base_url",
+      };
+    }
+    return { kind: "ok", controlPlaneBaseUrl: body.control_plane_base_url };
+  } catch (error) {
+    return {
+      kind: "unreachable",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function main() {
+  const gatewayPort = Number(process.argv[2]);
+  const expectedControlPlaneUrl = process.argv[3];
+  if (!gatewayPort || !expectedControlPlaneUrl) {
+    console.error(
+      "usage: check-gateway-control-plane.ts <gatewayPort> <expectedControlPlaneUrl>",
+    );
+    // Never block pnpm dev startup over a usage error in this guard.
+    return;
+  }
+
+  const probe = await probeControlPlane(gatewayPort);
+  const { warning } = evaluateGatewayReuse({
+    expectedControlPlaneUrl,
+    gatewayPort,
+    probe,
+  });
+  if (warning) {
+    console.error(warning);
+  }
+}
+
+const isMainModule =
+  process.argv[1] != null && import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  void main();
+}

--- a/platform/app/scripts/start.sh
+++ b/platform/app/scripts/start.sh
@@ -146,6 +146,15 @@ if [[ "$NODE_ENV" = "development" && "$LANGWATCH_SKIP_AIGATEWAY" != "1" ]]; then
     echo "  ! aigateway: skipped (Go toolchain not in PATH); run \`make service svc=aigateway\` manually"
   elif lsof -i ":$_GATEWAY_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     echo "  ✓ aigateway: already running on :$_GATEWAY_PORT, reusing"
+    # A reused gateway ships ITS OWN spend, budget and auth traffic to
+    # whatever control plane it was started with, which is not necessarily
+    # this worktree's, the process could belong to another worktree or be
+    # a stale leftover, and nothing about a proxying, 200-returning gateway
+    # reveals that on its own. Ask it directly (scripts/check-gateway-
+    # control-plane.ts, backed by GET /debug/control-plane) and warn loudly
+    # on any mismatch, or when it cannot be asked at all. Never blocks
+    # startup: the check has its own short timeout and always exits 0.
+    tsx "$(dirname "$0")/check-gateway-control-plane.ts" "$_GATEWAY_PORT" "$LW_GATEWAY_BASE_URL"
   else
     START_GATEWAY_COMMAND="make -C ../.. service svc=aigateway"
     echo "  ✓ aigateway: auto-start on :$_GATEWAY_PORT"

--- a/services/aigateway/adapters/gatewaymetrics/docs_contract_test.go
+++ b/services/aigateway/adapters/gatewaymetrics/docs_contract_test.go
@@ -78,7 +78,13 @@ var notMetrics = map[string]string{
 	// `error.code` values on the REST error envelope. They share the
 	// `gateway_` prefix with the metrics because they name the same
 	// subsystem, but they are values inside a JSON body, not series.
-	"gateway_scope_org_mismatch": "REST error code",
+	"gateway_scope_org_mismatch":          "REST error code",
+	"gateway_budget_cycle_anchor_invalid": "REST error code",
+
+	// SDK facade names. The python SDK exposes each resource as a
+	// snake_case attribute, so a documented call reads as a
+	// `gateway_`-prefixed token without naming a series.
+	"gateway_budgets": "python SDK facade name",
 }
 
 // plannedMetrics are names the docs explicitly describe as not yet

--- a/services/aigateway/adapters/httpapi/debug_control_plane.go
+++ b/services/aigateway/adapters/httpapi/debug_control_plane.go
@@ -1,0 +1,30 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// debugControlPlaneResponse is the body of GET /debug/control-plane.
+type debugControlPlaneResponse struct {
+	ControlPlaneBaseURL string `json:"control_plane_base_url"`
+}
+
+// debugControlPlaneHandler serves GET /debug/control-plane: the resolved
+// control-plane base URL this gateway process ships spend, budget and auth
+// traffic to. Unauthenticated and kept off the public ingress the same way
+// as /healthz, /readyz and /metrics: charts/gateway/templates/ingress.yaml
+// allowlists only /v1 and the exact /health path, so this route is never
+// reachable from outside the cluster regardless of auth.
+//
+// Exists for dev tooling, not operators: a worktree's `pnpm dev` calls this
+// before trusting an already-running gateway process on a shared port, so
+// a stale or foreign gateway can be told apart from this worktree's own
+// instead of silently reused.
+func debugControlPlaneHandler(controlPlaneBaseURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(debugControlPlaneResponse{ControlPlaneBaseURL: controlPlaneBaseURL})
+	}
+}

--- a/services/aigateway/adapters/httpapi/debug_control_plane_test.go
+++ b/services/aigateway/adapters/httpapi/debug_control_plane_test.go
@@ -1,0 +1,39 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+)
+
+// @scenario "the gateway exposes its resolved control-plane target on an unauthenticated debug endpoint"
+func TestDebugControlPlaneEndpoint_ReportsResolvedURL(t *testing.T) {
+	reg := health.New("test")
+	reg.MarkStarted()
+	router := NewRouter(RouterDeps{
+		App:                 app.New(),
+		Logger:              zap.NewNop(),
+		Health:              reg,
+		ControlPlaneBaseURL: "http://localhost:7580",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/control-plane", nil)
+	req.Header.Set("Authorization", "") // no credential of any kind
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "the endpoint must not require auth")
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var body debugControlPlaneResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, "http://localhost:7580", body.ControlPlaneBaseURL)
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -73,6 +73,13 @@ type RouterDeps struct {
 	// answer 503: a gateway that cannot observe its control plane must not
 	// report itself healthy to a public status page.
 	Status StatusReporter
+	// ControlPlaneBaseURL is the resolved control-plane target this
+	// gateway process ships spend, budget and auth traffic to. Surfaced
+	// read-only on GET /debug/control-plane so dev tooling can tell a
+	// stale or foreign gateway apart from this worktree's own before
+	// reusing an already-bound port (specs/setup/
+	// aigateway-control-plane-target.feature).
+	ControlPlaneBaseURL string
 }
 
 // NewRouter creates the chi router with all gateway routes mounted.
@@ -115,6 +122,13 @@ func NewRouter(deps RouterDeps) http.Handler {
 	if deps.Metrics != nil {
 		r.Handle("/metrics", deps.Metrics.Handler())
 	}
+
+	// Unauthenticated and kept off the public ingress the same way as the
+	// probes and /metrics above (charts/gateway/templates/ingress.yaml
+	// allowlists only /v1 and the exact /health path). Reveals nothing but
+	// a URL: dev tooling polls it to verify an already-running gateway
+	// before trusting it on a reused port.
+	r.Get("/debug/control-plane", debugControlPlaneHandler(deps.ControlPlaneBaseURL))
 
 	r.Route("/v1", func(v1 chi.Router) {
 		v1.Use(AuthMiddleware(deps.App.Auth()))

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -77,6 +77,16 @@ type ControlPlaneConfig struct {
 	InternalSecret string `env:"INTERNAL_SECRET"     validate:"required"`
 	JWTSecret      string `env:"JWT_SECRET"          validate:"required"`
 	JWTSecretPrev  string `env:"JWT_SECRET_PREVIOUS"`
+	// BaseURLExplicit distinguishes an operator-provided BaseURL from the
+	// compatibility default (see defaultConfig). Not populated by Hydrate
+	// (no env tag): LoadConfig sets it directly from the same env vars
+	// BaseURL itself can come from, canonical or legacy, so a value that
+	// happens to match the default still counts as explicit. Serve logs a
+	// warning at boot when this is false, naming the resolved URL: every
+	// spend, budget and auth call this gateway makes depends on it pointing
+	// at the right control plane, and a wrong one fails silently (every
+	// request still answers 200, nothing errors anywhere).
+	BaseURLExplicit bool
 }
 
 // AuthCacheConfig governs the resolver's stale-while-error behavior. The
@@ -179,6 +189,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return Config{}, err
 	}
 	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
+	cfg.ControlPlane.BaseURLExplicit = os.Getenv("LW_GATEWAY_BASE_URL") != "" || os.Getenv("GATEWAY_CONTROL_PLANE_URL") != ""
 	applyLegacyEnvAliases(&cfg)
 	if err := validateHostedEgressSecurity(cfg); err != nil {
 		return Config{}, err

--- a/services/aigateway/config_test.go
+++ b/services/aigateway/config_test.go
@@ -229,6 +229,63 @@ func TestLoadConfig_RefusesConflictingOTelEndpointNames(t *testing.T) {
 	}
 }
 
+// Whether ControlPlane.BaseURL came from an operator or from the
+// compatibility default decides whether Serve logs a boot warning at start.
+// Both the canonical and the legacy control-plane env var count as
+// explicit; an unset gateway falls back to the compatibility default while
+// reporting that it did. Three dedicated tests rather than a table so each
+// binds unambiguously to its own scenario.
+
+// @scenario "the gateway reports the control-plane URL as not explicitly configured when it was defaulted"
+func TestLoadConfig_ControlPlaneBaseURLNotExplicitByDefault(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("LW_GATEWAY_INTERNAL_SECRET", "internal-1")
+	t.Setenv("LW_GATEWAY_JWT_SECRET", "jwt-1")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ControlPlane.BaseURLExplicit {
+		t.Error("ControlPlane.BaseURLExplicit = true, want false when neither LW_GATEWAY_BASE_URL nor the legacy var is set")
+	}
+	if cfg.ControlPlane.BaseURL != "http://localhost:5560" {
+		t.Errorf("ControlPlane.BaseURL = %q, want the compatibility default", cfg.ControlPlane.BaseURL)
+	}
+}
+
+// @scenario "the gateway reports the control-plane URL as explicitly configured when LW_GATEWAY_BASE_URL is set"
+func TestLoadConfig_ControlPlaneBaseURLExplicitCanonical(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("LW_GATEWAY_BASE_URL", "http://localhost:7580")
+	t.Setenv("LW_GATEWAY_INTERNAL_SECRET", "internal-1")
+	t.Setenv("LW_GATEWAY_JWT_SECRET", "jwt-1")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.ControlPlane.BaseURLExplicit {
+		t.Error("ControlPlane.BaseURLExplicit = false, want true when LW_GATEWAY_BASE_URL is set")
+	}
+}
+
+// @scenario "the gateway reports the control-plane URL as explicitly configured when the legacy control-plane URL variable is set"
+func TestLoadConfig_ControlPlaneBaseURLExplicitLegacy(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("GATEWAY_CONTROL_PLANE_URL", "http://legacy.example.com")
+	t.Setenv("LW_GATEWAY_INTERNAL_SECRET", "internal-1")
+	t.Setenv("LW_GATEWAY_JWT_SECRET", "jwt-1")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.ControlPlane.BaseURLExplicit {
+		t.Error("ControlPlane.BaseURLExplicit = false, want true when the legacy GATEWAY_CONTROL_PLANE_URL is set")
+	}
+}
+
 // clearGatewayEnv unsets every env var the alias layer or Hydrate inspects,
 // so each test starts from a clean slate. t.Setenv handles per-test scope on
 // what we explicitly set; this clears the bleed-through from the harness env.

--- a/services/aigateway/serve.go
+++ b/services/aigateway/serve.go
@@ -20,6 +20,12 @@ import (
 // until shutdown signal.
 func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) error {
 	deps.Logger.Info("aigateway_starting", zap.String("addr", cfg.Server.Addr))
+	if !cfg.ControlPlane.BaseURLExplicit {
+		deps.Logger.Warn("aigateway_control_plane_base_url_not_explicit",
+			zap.String("control_plane_base_url", cfg.ControlPlane.BaseURL),
+			zap.String("fix", "set LW_GATEWAY_BASE_URL explicitly, see platform/app/.env.example"),
+		)
+	}
 
 	ottlSrv, err := ottlserver.New(deps.Logger)
 	if err != nil {
@@ -47,6 +53,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		MaxRequestBodyBytes:   cfg.Server.MaxRequestBodyBytes,
 		HeartbeatInterval:     time.Duration(cfg.NonStreamingHeartbeatIntervalSeconds) * time.Second,
 		Status:                statusMon,
+		ControlPlaneBaseURL:   cfg.ControlPlane.BaseURL,
 	})
 
 	srv := &http.Server{Handler: handler, Addr: cfg.Server.Addr, ReadHeaderTimeout: 10 * time.Second}

--- a/specs/setup/aigateway-control-plane-target.feature
+++ b/specs/setup/aigateway-control-plane-target.feature
@@ -1,0 +1,112 @@
+Feature: AI Gateway control-plane target cannot silently default to the wrong worktree
+  As a developer running several LangWatch worktrees at once
+  I want the AI Gateway to always know which control plane is actually mine
+  So that spend, budget and auth traffic can never silently apply to a different worktree
+
+  # The gateway (services/aigateway) ships spend-emitter batches, budget
+  # checks and auth resolution to a "control plane" URL. Getting that URL
+  # wrong is invisible at the gateway's own hot path: LLM traffic keeps
+  # proxying fine and every request still returns 200, because the wrong
+  # control plane answers just as happily as the right one. Only the
+  # spend, budget and auth side effects land somewhere else, silently.
+  #
+  # `pnpm dev` (platform/app/scripts/start.sh) derives this URL from the
+  # app's own PORT before it starts a gateway itself, so a freshly-started
+  # gateway is always correct. That path is proven, existing behavior and
+  # is not what this feature covers.
+  #
+  # Two gaps remained:
+  #
+  #   - A standalone `make service svc=aigateway` / `make service-watch
+  #     svc=aigateway` derived nothing: an unset LW_GATEWAY_BASE_URL fell
+  #     straight through to services/aigateway/config.go's compatibility
+  #     default, which is only correct for a single worktree on the
+  #     default port.
+  #   - When `pnpm dev` finds its derived gateway port already listening,
+  #     it reuses that process without ever asking where ITS spend, budget
+  #     and auth traffic actually goes, so a stale or foreign gateway
+  #     sitting on that port gets trusted blind.
+  #
+  # Closing them: `make service` / `make service-watch` now derive the
+  # control-plane URL the same way start.sh does
+  # (dev/scripts/lib/derive-gateway-base-url.sh), the gateway tracks and
+  # logs whether its control-plane URL was explicitly configured or fell
+  # back to the compatibility default, and it exposes the resolved target
+  # on an unauthenticated debug endpoint so dev tooling can verify a
+  # reused process before trusting it, warning loudly on any mismatch or
+  # on a process too old to answer at all.
+
+  # --- Standalone `make service` / `make service-watch` ---
+
+  @unit
+  Scenario: make service derives the control-plane URL from PORT when it is unset
+    Given a worktree whose app runs on a non-default PORT
+    And LW_GATEWAY_BASE_URL is not set anywhere
+    When "make service svc=aigateway" resolves its environment
+    Then it derives LW_GATEWAY_BASE_URL from that PORT, matching the API port pnpm dev would use
+    And it prints what it derived
+
+  @unit
+  Scenario: make service leaves an explicit control-plane URL untouched
+    Given LW_GATEWAY_BASE_URL is already set, whether inherited from the shell or from platform/app/.env
+    When "make service svc=aigateway" resolves its environment
+    Then the explicit value is used unchanged
+
+  @unit
+  Scenario: make service falls back to the default port pairing when PORT is unset too
+    Given neither PORT nor LW_GATEWAY_BASE_URL is set
+    When "make service svc=aigateway" resolves its environment
+    Then it derives the same control-plane URL as the single-worktree default case
+
+  # --- The gateway's own awareness of how it was configured ---
+
+  @unit
+  Scenario: the gateway reports the control-plane URL as not explicitly configured when it was defaulted
+    Given the gateway boots with no LW_GATEWAY_BASE_URL and no legacy control-plane URL variable set
+    When it loads its configuration
+    Then it reports the control-plane URL as not explicitly configured
+    And a deployment that boots this way logs a warning naming the URL spend will actually ship to
+
+  @unit
+  Scenario: the gateway reports the control-plane URL as explicitly configured when LW_GATEWAY_BASE_URL is set
+    Given the gateway boots with LW_GATEWAY_BASE_URL set
+    When it loads its configuration
+    Then it reports the control-plane URL as explicitly configured
+
+  @unit
+  Scenario: the gateway reports the control-plane URL as explicitly configured when the legacy control-plane URL variable is set
+    Given the gateway boots with only the legacy control-plane URL variable set
+    When it loads its configuration
+    Then it reports the control-plane URL as explicitly configured
+
+  # --- Verifying a reused gateway before trusting it ---
+
+  @unit
+  Scenario: the gateway exposes its resolved control-plane target on an unauthenticated debug endpoint
+    Given a running gateway with a resolved control-plane URL
+    When something requests its control-plane debug endpoint
+    Then it reports that exact URL
+    And the endpoint requires no credential, matching the k8s probes and the metrics endpoint
+
+  @unit
+  Scenario: a reused gateway pointed at the right control plane raises no warning
+    Given pnpm dev finds a gateway already listening on the port it would have started its own on
+    And that gateway's debug endpoint reports the same control-plane URL this worktree expects
+    When pnpm dev evaluates whether to trust the reused gateway
+    Then it raises no warning
+
+  @unit
+  Scenario: a reused gateway pointed at a different control plane raises a loud, actionable warning
+    Given pnpm dev finds a gateway already listening on the port it would have started its own on
+    And that gateway's debug endpoint reports a control-plane URL different from what this worktree expects
+    When pnpm dev evaluates whether to trust the reused gateway
+    Then it raises a multi-line warning naming both the expected and the actual control-plane URL
+    And the warning states how to fix it
+
+  @unit
+  Scenario: a reused gateway whose control-plane target cannot be verified is treated as suspect, not silently trusted
+    Given pnpm dev finds a gateway already listening on the port it would have started its own on
+    And that gateway's debug endpoint cannot be reached, for instance because it predates this check
+    When pnpm dev evaluates whether to trust the reused gateway
+    Then it raises a warning saying the control-plane target could not be verified
+    And it does not claim the reused gateway is safe


### PR DESCRIPTION
Two AI Gateway correctness fixes found while dogfooding the billing flow after #6511 merged.

## 1. Main's Go suite is red, from #6511's docs sweep

`TestDocumentedMetricsAreRegistered` treats every `gateway_`-prefixed token in `docs/` and `charts/` as a Prometheus series and asserts a collector registers it. #6511 documented two tokens that are not metrics: the error code `gateway_budget_cycle_anchor_invalid` and the python SDK facade name `gateway_budgets`. Both now sit in the test's existing `notMetrics` list, beside the REST error code already there.

This did not show up as a red check on main because `go-services` is path-filtered: #6511 changed docs, not Go, so the docs-vs-code contract test never ran on that merge. It fails for the next person to touch Go, which is how it surfaced. Worth a separate look: a contract test whose inputs are docs is gated on Go paths changing, so a docs-only PR can break it invisibly. Not fixed here.

## 2. The gateway could ship spend to another worktree's control plane, silently

The gateway reports spend, budget and auth traffic to a control-plane URL. When that URL is wrong nothing fails visibly: LLM traffic keeps proxying and every request still returns 200, because the wrong control plane answers just as happily as the right one. Only the side effects land somewhere else.

`pnpm dev` was never at risk: `platform/app/scripts/start.sh` already derives `LW_GATEWAY_BASE_URL` from `PORT` before starting its own gateway. Two paths were:

- **A standalone `make service svc=aigateway` derived nothing** and fell through to the Go compatibility default of `localhost:5560`, correct only for a single worktree on the default port. `make service` and `make service-watch` now derive the same way `start.sh` does, when nothing else set it.
- **`pnpm dev` reused an already-listening gateway without asking where it reports.** It now verifies the running process before trusting it, via a new unauthenticated `GET /debug/control-plane` that returns only the resolved URL, and warns loudly on a mismatch or when the target cannot be verified (an older gateway predating the endpoint). It never blocks startup.

Defense in depth: the gateway now tracks whether its control-plane URL was explicit or defaulted, and logs a warning at boot naming the exact URL when it was defaulted. Confirmed this cannot fire in a chart-deployed pod: `charts/gateway/templates/configmap.yaml` always renders a non-empty value, and the helm-render CI test refuses to render when the app runs on a non-default port without an explicit override.

The Go default is deliberately left alone rather than made to derive from `PORT`: that would import a TS-side port convention into Go, and in a hosted environment with an unrelated `PORT` set, a plausible-but-wrong guess is worse than a default that fails identically everywhere.

## Verification

`specs/setup/aigateway-control-plane-target.feature`, 10 scenarios, all bound.

- `go test ./services/aigateway/...` pass (red before fix 1)
- `golangci-lint` both CI steps, 0 issues
- `pnpm test:unit` 11/11 on the two new suites
- `pnpm check:feature-parity` pass
- `pnpm typecheck` and `typecheck:tests` pass
- biome 2.5.1 clean on the three new TS files

The derivation helper is sourced by whatever shell `make` uses, so it was checked under both `/bin/sh` and `dash`.

## Deployment Impact

None. Every change is dev tooling, a test-only exclusion list, or an unauthenticated debug endpoint that is not exposed through the chart's ingress, which allowlists only the configured path plus an exact `/health` match. The new boot warning cannot fire in a chart-deployed pod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development services now automatically determine the gateway control-plane URL from the configured port when no explicit URL is provided.
  - Added a diagnostic endpoint to show the gateway’s active control-plane target.
  - Reused development gateways now warn when they point to a different or unreachable control plane.

- **Bug Fixes**
  - Reduced the risk of requests, authentication, and budget activity being routed to the wrong development project.

- **Documentation**
  - Updated environment configuration guidance for automatic and explicit control-plane URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->