### PR TITLE
ci: cut the wasted runner minutes out of checkout, the dependency scanners and the vite cache

### DIFF
--- a/.github/workflows/clickhouse-serverless.yml
+++ b/.github/workflows/clickhouse-serverless.yml
@@ -27,6 +27,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/code-scanners.yml
+++ b/.github/workflows/code-scanners.yml
@@ -44,6 +44,55 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Gate for the two DEPENDENCY scanners only. gitleaks, trufflehog and
+  # semgrep stay ungated on purpose: a credential or an injection can arrive
+  # in any file type, including the ones a language filter would exclude, so
+  # a secret/SAST scanner that only runs on "relevant" paths is a scanner
+  # with a documented blind spot. govulncheck and pip-audit have no such
+  # property — they read a manifest, so on a PR that touches no Go and no
+  # Python manifest they can only report what the last run already reported.
+  #
+  # Non-PR events force both filters true, the same rule
+  # .github/actions/detect-changes and go-services.yaml already use. That
+  # keeps the weekly cron (where the report-only scanners are actually
+  # actioned), merge_group, push and workflow_dispatch running everything.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ github.event_name != 'pull_request' || steps.filter.outputs.go }}
+      python: ${{ github.event_name != 'pull_request' || steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+          # dorny/paths-filter reads the PR diff from the API; nothing here
+          # touches the working tree.
+          sparse-checkout: .github
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          # NO NEGATION PATTERNS — dorny ORs a filter's patterns, so a lone
+          # `!x` matches everything. See specs/ci/path-filters.feature.
+          filters: |
+            # `**/*.go` is a superset of what govulncheck walks
+            # (./services/... ./pkg/... ./cmd/... ./tools/...), which is what
+            # keeps this filter correct when a new Go root appears.
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'go.work'
+              - 'go.work.sum'
+              - '.github/workflows/code-scanners.yml'
+            # pip-audit reads requirements files and the two audited
+            # pyprojects; `**/pyproject.toml` is deliberately wider than the
+            # two it audits today so a newly audited manifest is covered.
+            python:
+              - '**/requirements*.txt'
+              - '**/pyproject.toml'
+              - '.github/workflows/code-scanners.yml'
+
   secrets:
     name: secrets (gitleaks + trufflehog)
     runs-on: ubuntu-latest
@@ -168,6 +217,8 @@ jobs:
 
   go-advisories:
     name: govulncheck (blocking)
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -200,6 +251,8 @@ jobs:
 
   python-advisories:
     name: pip-audit (report-only)
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -23,6 +23,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -30,6 +30,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -36,6 +36,12 @@ jobs:
       heavy: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       # Only `pull_request` has a base to diff against. Every other event
       # (push, merge_group, workflow_dispatch) forces the filter true, so the
       # aggregator below always has a concrete result to require. See

--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -27,6 +27,12 @@ jobs:
       langyagent: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.langyagent }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         if: github.event_name != 'workflow_dispatch'
         id: filter

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -28,6 +28,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -85,6 +85,12 @@ jobs:
       coverage: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -837,15 +837,25 @@ jobs:
           path: platform/app/node_modules/.prisma
           key: ${{ runner.os }}-prisma-${{ hashFiles('platform/app/prisma/schema.prisma') }}
 
-      # Cache Vite build artifacts
+      # Cache Vite build artifacts.
+      #
+      # The key deliberately does NOT hash platform/app/src/**. It used to,
+      # which made the primary key change on every commit: the cache was
+      # therefore never a hit, and every run still wrote a fresh multi-MB
+      # entry, churning the repository's 10GB cache quota for a cache that
+      # could not be read. Hashing that tree also costs real time on its own.
+      #
+      # What is cached here is Vite's dependency pre-bundle, which is keyed by
+      # the dependency set, not by app source — and Vite re-optimizes on its
+      # own when its internal hash moves. So the key tracks the lockfile and
+      # the Vite config, and nothing else.
       - name: Cache Vite
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             platform/app/node_modules/.vite
-          key: ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('platform/app/src/**/*', 'platform/app/vite.config.ts') }}
+          key: ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml', 'platform/app/vite.config.ts') }}
           restore-keys: |
-            ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-vite-
 
       # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux

--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -30,6 +30,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -27,6 +27,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/no-committed-screenshots.yml
+++ b/.github/workflows/no-committed-screenshots.yml
@@ -34,6 +34,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
+          # The check reads the diff, never a file's contents: the only thing
+          # it needs materialised is the script below, which lives under
+          # .github/. History still comes down in full (fetch-depth: 0) so the
+          # base-branch diff resolves — sparse-checkout narrows the working
+          # tree, not the object graph.
+          sparse-checkout: .github
 
       - name: Fetch base branch
         env:

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -27,6 +27,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -30,6 +30,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -32,6 +32,12 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: ./.github/actions/detect-changes
         id: detect
         with:

--- a/.github/workflows/ssrf-conformance.yaml
+++ b/.github/workflows/ssrf-conformance.yaml
@@ -37,6 +37,12 @@ jobs:
       ssrf: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.ssrf }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The gate reads no working-tree content: on pull_request events
+          # dorny/paths-filter takes the changed-file list from the API, and
+          # every file this job needs on disk lives under .github/. Checking
+          # out the rest of the tree is pure runner time.
+          sparse-checkout: .github
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         if: github.event_name != 'workflow_dispatch'
         id: filter

--- a/specs/ci/path-filters.feature
+++ b/specs/ci/path-filters.feature
@@ -55,6 +55,28 @@ Feature: CI path filters skip unnecessary workflows on non-code changes
     Then all workflows run regardless of which files changed
 
   # ============================================================================
+  # Dependency scanners are path-gated, secret and SAST scanners are not
+  # ============================================================================
+
+  Scenario: A PR with no Go changes does not run the Go advisory scanner
+    When a PR changes no Go source and no Go module manifest
+    Then govulncheck does not run
+    And gitleaks, trufflehog and semgrep still run
+
+  Scenario: A PR with no Python manifest changes does not run the Python advisory scanner
+    When a PR changes no requirements file and no pyproject
+    Then pip-audit does not run
+    And gitleaks, trufflehog and semgrep still run
+
+  Scenario: The scheduled scan runs every scanner
+    When the weekly code-scanners cron fires
+    Then govulncheck and pip-audit both run regardless of which files changed
+
+  Scenario: A merge queue entry runs every scanner
+    When a change enters the merge queue
+    Then govulncheck and pip-audit both run regardless of which files changed
+
+  # ============================================================================
   # Safety invariants
   # ============================================================================
 


### PR DESCRIPTION
## Why

A measured audit of the workflows found a large, boring slice of runner time that buys nothing:

- a docs-only PR burns ~66 runner-minutes, of which ~50 is waste
- a full app PR push burns ~156 runner-min in `langwatch-app-ci`, plus ~22 of default-setup CodeQL
- across the 40 jobs of one app PR SHA, `actions/checkout` steps alone total ~36 runner-min — 23% of the run
- median `langwatch-app-ci` wall clock is ~19 minutes

This picks off the three changes that are pure waste removal: nothing here changes what a green PR certifies, and no required check is touched.

## What changed

**1. Gate jobs check out `.github` only (~15 runner-min/PR).** Fifteen jobs — the fourteen `changes` gates plus `no-committed-screenshots` — checked out the whole repository and then read one file from it. On `pull_request` events `dorny/paths-filter` takes the changed-file list from the API, so no gate touches the working tree at all beyond the local composite action under `.github/`.

**2. `govulncheck` and `pip-audit` are path-gated (~8 runner-min per non-Go/non-Python PR).** Both read a manifest, so on a PR that touches no Go and no Python manifest they can only report what the previous run already reported. gitleaks, trufflehog and semgrep stay ungated: a credential or an injection can arrive in any file type, so path-gating a secret or SAST scanner buys minutes in exchange for a blind spot.

**3. The vite cache key stops changing every commit.** The `build` job keyed its Vite cache on `hashFiles('platform/app/src/**/*', ...)`. That moves with every commit, so the primary key could never hit — while every run still wrote a fresh multi-MB entry, churning the repository's 10GB cache quota for a cache nothing could read. Hashing that tree also costs time on its own. The key now tracks `pnpm-lock.yaml` and `vite.config.ts`; `restore-keys` covers the rest.

## How it works

`sparse-checkout` narrows the working tree, not the object graph. That matters for `no-committed-screenshots`, which keeps `fetch-depth: 0` and still resolves its base-branch diff — and it gets a second, larger win, because `actions/checkout` switches to `--filter=blob:none` when `sparse-checkout` is set, so its full-history clone stops pulling blobs it never reads.

The scanner gate reuses the force-on-non-PR rule that `.github/actions/detect-changes`, `go-services.yaml` and `ssrf-conformance.yaml` already use, rather than inventing a mechanism: every non-`pull_request` event forces both filters true. The weekly cron — which is where the report-only scanner is actually actioned — plus `merge_group`, `push` and `workflow_dispatch` therefore keep running everything.

## Test plan

- Every edited workflow parses (`ruby -ryaml`).
- `actionlint` over the whole workflow directory reports nothing new; the shellcheck warnings it prints are pre-existing and in untouched steps.
- Each edited job re-read end to end against the question "does every later step still have the files it needs". The gate jobs have exactly two steps, checkout and the filter, and the filter's only on-disk input is `.github/actions/detect-changes/action.yml`. `no-committed-screenshots` runs `.github/scripts/check-added-images.sh`, which does `git diff --name-only --diff-filter=A` and string-matches the paths — it never opens a file.
- Gating confirmed safe against branch protection AND the ruleset: required contexts are `validate title` plus the `*-complete` aggregators. `code-scanners` has no aggregator and none of its jobs is required, so a skipped `govulncheck` / `pip-audit` cannot leave a PR waiting on a check that never arrives.
- Spec scenarios added to `specs/ci/path-filters.feature` for the new gating, including the "cron and merge queue still run everything" invariant.

## Anything surprising?

**Deliberately skipped: removing `node-pty` from `onlyBuiltDependencies`.** The audit recommended this to kill a recurring `gyp_main.py: Permission denied` install flake. It is unsafe. `mcp/typescript/tests/scenario-openai.test.ts` imports `node-pty` at module scope; the test body is `it.skipIf(isCI)`, but vitest still loads the module during collection, and `mcp-javascript-ci` really does run `pnpm run test` in that package — so skipping the native build fails that lane at collection time. The honest fixes are to make that import lazy (the repo bans inline `import()` outside the CLI startup path, so this needs thought) or to exclude that one file from the CI vitest run. Neither belongs in a mechanical speed PR.

Also skipped: dropping the unused `node-pty` devDependency from `skills/package.json`. Nothing under `skills/` imports it, so the removal is correct — but it needs a lockfile regeneration, `skills-publish.yml` already installs with `--ignore-scripts`, and `node-pty` stays in `onlyBuiltDependencies` for `mcp/typescript` regardless. Real cleanup, ~zero CI minutes, so it should ride its own PR.

**Deliberately skipped: `migration-order`.** It runs `go run ./cmd/migrationorder`, which needs the Go module and the migration trees materialised. Left alone.

Follow-ups, both out of scope here:

- **GitHub's default-setup CodeQL is the single biggest remaining win, ~22 runner-min/PR.** It is a repo-settings change, not a code change. The advanced `codeql.yml` in this repo already covers js-ts and python with draft-skip and path gating, so the default setup is duplicating work that is already gated.
- **Extending the affected-tests mode beyond drafts.** That trades what a PR's green certifies, so it needs an ADR and a sign-off rather than a quiet workflow edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CI workflows now use lightweight checkouts for faster change detection.
  * Dependency vulnerability scans run only when relevant Go or Python files change.
  * Build caching is more consistent and clearly documents when cached results are refreshed.
* **Documentation**
  * Added coverage for scanner behavior across pull requests, scheduled runs, and merge queue checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->