### PR TITLE
fix: seven production defects found in a five-day error review

### DIFF
--- a/platform/app/src/app/api/middleware/trace-limit.ts
+++ b/platform/app/src/app/api/middleware/trace-limit.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@langwatch/observability";
 import type { MiddlewareHandler } from "hono";
 import { getApp } from "~/server/app-layer/app";
+import { PlanLimitExceededError } from "~/server/app-layer/usage/errors";
 import { prisma } from "~/server/db";
 
 const logger = createLogger("langwatch:api:middleware:trace-limit");
@@ -49,7 +50,11 @@ export const blockTraceUsageExceededMiddleware: MiddlewareHandler = async (
       "Project has reached plan limit",
     );
 
-    return c.json({ error: "ERR_PLAN_LIMIT", message: result.message }, 429);
+    throw new PlanLimitExceededError(result.message, {
+      currentMonthMessagesCount: result.count,
+      maxMessagesPerMonth: result.maxMessagesPerMonth,
+      activePlanName: result.planName,
+    });
   }
 
   await next();

--- a/platform/app/src/components/run-via-api/__tests__/runSnippets.unit.test.ts
+++ b/platform/app/src/components/run-via-api/__tests__/runSnippets.unit.test.ts
@@ -169,6 +169,11 @@ describe("buildRunSnippet", () => {
       expect(snippet).toContain("giving up");
     });
 
+    it("gives up on any other non-200 status instead of parsing it as the run body", () => {
+      const snippet = shell();
+      expect(snippet).toContain('if [ "$CODE" != "200" ]');
+    });
+
     it("breaks on every terminal status the API can report", () => {
       expect(shell()).toContain(
         'case "$STATUS" in completed|failed|stopped|interrupted) break;; esac',

--- a/platform/app/src/components/run-via-api/__tests__/runSnippets.unit.test.ts
+++ b/platform/app/src/components/run-via-api/__tests__/runSnippets.unit.test.ts
@@ -149,6 +149,37 @@ describe("buildRunSnippet", () => {
     });
   });
 
+  describe("when the shell snippet polls for the run to finish", () => {
+    const shell = () =>
+      buildRunSnippet({
+        ...baseInput,
+        dataSource: "attached",
+        lang: "shell",
+      });
+
+    it("bounds the poll loop instead of looping forever", () => {
+      expect(shell()).not.toContain("while true");
+      expect(shell()).toContain("MAX_ATTEMPTS");
+    });
+
+    it("gives up on a 404 rather than polling a run that cannot appear", () => {
+      const snippet = shell();
+      expect(snippet).toContain("%{http_code}");
+      expect(snippet).toContain('if [ "$CODE" = "404" ]');
+      expect(snippet).toContain("giving up");
+    });
+
+    it("breaks on every terminal status the API can report", () => {
+      expect(shell()).toContain(
+        'case "$STATUS" in completed|failed|stopped|interrupted) break;; esac',
+      );
+    });
+
+    it("does not advertise an events stream the API does not serve", () => {
+      expect(shell()).not.toContain("/events");
+    });
+  });
+
   describe("given the experiment kind", () => {
     it("calls the experiment SDK entry points", () => {
       const input = { ...baseInput, kind: "experiment" as const };

--- a/platform/app/src/components/run-via-api/runSnippets.ts
+++ b/platform/app/src/components/run-via-api/runSnippets.ts
@@ -290,21 +290,35 @@ RUN=$(curl -s -X POST "${startUrl}" \\
 RUN_ID=$(echo "$RUN" | jq -r '.runId // .run_id')
 echo "Started run: $RUN_ID"
 
-# 2. Poll until it finishes (completed | failed | stopped)
-while true; do
-  STATUS=$(curl -s "${baseUrl}/api/experiments/runs/$RUN_ID" \\
-    -H "X-Auth-Token: \${LANGWATCH_API_KEY}" | jq -r '.status')
+# 2. Poll until it finishes (completed | failed | stopped | interrupted).
+#    Branch on the HTTP status, not the body: a 404 carries no .status, so
+#    matching the body alone spins forever once a run expires (runs stay
+#    readable for 24h) or was never recorded.
+ATTEMPTS=0
+MAX_ATTEMPTS=1800
+while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
+  RESPONSE=$(curl -s -w '\\n%{http_code}' "${baseUrl}/api/experiments/runs/$RUN_ID" \\
+    -H "X-Auth-Token: \${LANGWATCH_API_KEY}")
+  CODE=$(printf '%s' "$RESPONSE" | tail -n1)
+  if [ "$CODE" = "404" ]; then
+    echo "run $RUN_ID not found (expired, or never recorded); giving up"
+    exit 1
+  fi
+  STATUS=$(printf '%s' "$RESPONSE" | sed '$d' | jq -r '.status')
   echo "status: $STATUS"
-  case "$STATUS" in completed|failed|stopped) break;; esac
+  case "$STATUS" in completed|failed|stopped|interrupted) break;; esac
+  ATTEMPTS=$((ATTEMPTS + 1))
   sleep 2
 done
 
+if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+  echo "gave up waiting for $RUN_ID after $MAX_ATTEMPTS polls"
+  exit 1
+fi
+
 # 3. Fetch the per-row results
 curl -s "${baseUrl}/api/experiments/runs/$RUN_ID/results" \\
-  -H "X-Auth-Token: \${LANGWATCH_API_KEY}" | jq
-
-# Alternative: stream live progress instead of polling by listening to the
-# Server-Sent Events stream at GET /api/experiments/runs/$RUN_ID/events.`;
+  -H "X-Auth-Token: \${LANGWATCH_API_KEY}" | jq`;
 }
 
 /**

--- a/platform/app/src/components/run-via-api/runSnippets.ts
+++ b/platform/app/src/components/run-via-api/runSnippets.ts
@@ -291,9 +291,9 @@ RUN_ID=$(echo "$RUN" | jq -r '.runId // .run_id')
 echo "Started run: $RUN_ID"
 
 # 2. Poll until it finishes (completed | failed | stopped | interrupted).
-#    Branch on the HTTP status, not the body: a 404 carries no .status, so
-#    matching the body alone spins forever once a run expires (runs stay
-#    readable for 24h) or was never recorded.
+#    Branch on the HTTP status, not the body: a non-200 response (404, an
+#    auth failure, a 5xx) carries no .status, so matching the body alone
+#    spins on it for the full hour instead of failing fast.
 ATTEMPTS=0
 MAX_ATTEMPTS=1800
 while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
@@ -302,6 +302,10 @@ while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
   CODE=$(printf '%s' "$RESPONSE" | tail -n1)
   if [ "$CODE" = "404" ]; then
     echo "run $RUN_ID not found (expired, or never recorded); giving up"
+    exit 1
+  fi
+  if [ "$CODE" != "200" ]; then
+    echo "could not read run $RUN_ID (HTTP $CODE); giving up"
     exit 1
   fi
   STATUS=$(printf '%s' "$RESPONSE" | sed '$d' | jq -r '.status')

--- a/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -7,7 +7,22 @@ import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 import { USAGE_UNKNOWN } from "../../../traces/usage-count";
 import type { OrganizationService } from "../../organizations/organization.service";
 import type { PlanResolver } from "../../subscription/plan-provider";
-import { UsageService } from "../usage.service";
+import { type UsageLimitResult, UsageService } from "../usage.service";
+
+/**
+ * Narrows a UsageLimitResult to its exceeded branch. An `expect().toBe(true)`
+ * here would assert but not narrow the discriminated union for callers, and
+ * biome's noMisplacedAssertion rejects an `expect()` outside an `it()` body
+ * anyway, so this throws instead - still fails the test loudly if the
+ * invariant doesn't hold.
+ */
+function assertExceeded(
+  result: UsageLimitResult,
+): asserts result is Extract<UsageLimitResult, { exceeded: true }> {
+  if (!result.exceeded) {
+    throw new Error("expected checkLimit() to report exceeded: true");
+  }
+}
 
 const ENTERPRISE_LICENSE_PLAN: PlanInfo = {
   ...FREE_PLAN,
@@ -177,7 +192,7 @@ describe("UsageService", () => {
         ]);
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
       });
     });
 
@@ -200,7 +215,7 @@ describe("UsageService", () => {
       it("returns message with Free prefix, events unit, and SaaS upgrade URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "upgrade your plan at https://app.langwatch.ai/settings/subscription",
@@ -228,7 +243,7 @@ describe("UsageService", () => {
       it("returns message with Free prefix, events unit, and self-hosted license URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "buy a license at https://my-langwatch.example.com/settings/license",
@@ -255,7 +270,7 @@ describe("UsageService", () => {
       it("returns message with Monthly prefix, traces unit, and SaaS upgrade URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain(
           "Monthly limit of 10000 traces reached",
         );
@@ -285,7 +300,7 @@ describe("UsageService", () => {
       it("returns message with Monthly prefix, traces unit, and self-hosted license URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain(
           "Monthly limit of 10000 traces reached",
         );
@@ -314,7 +329,7 @@ describe("UsageService", () => {
       it("returns exceeded: true with count and plan details", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.count).toBe(1000);
         expect(result.maxMessagesPerMonth).toBe(1000);
         expect(result.planName).toBe("Free");
@@ -348,7 +363,7 @@ describe("UsageService", () => {
 
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.maxMessagesPerMonth).toBe(1000);
         // "Monthly"/"events" only come from firstPlan (free: false, license
         // override with usageUnit "events"); laterPlan would render "Free"/"traces".

--- a/platform/app/src/server/app-layer/usage/errors.ts
+++ b/platform/app/src/server/app-layer/usage/errors.ts
@@ -1,0 +1,35 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * The project has spent its plan's monthly event allowance.
+ *
+ * 402 rather than 429 on purpose. The OTel SDKs, and most HTTP clients with a
+ * retry policy, treat 429 as transient and re-post the same batch until their
+ * elapsed-time budget runs out. A plan limit is terminal for that payload, so a
+ * retryable status turns one rejection into an unbounded loop against a
+ * customer who cannot succeed until they upgrade.
+ *
+ * The code stays `ERR_PLAN_LIMIT`: it is the discriminant SDKs and the AI
+ * gateway already match on, and the serialised body puts it in the same `error`
+ * field the hand-rolled response used.
+ */
+export class PlanLimitExceededError extends HandledError {
+  declare readonly code: "ERR_PLAN_LIMIT";
+
+  constructor(
+    message: string,
+    meta: {
+      currentMonthMessagesCount?: number;
+      maxMessagesPerMonth?: number;
+      activePlanName?: string;
+    } = {},
+  ) {
+    super("ERR_PLAN_LIMIT", message, {
+      meta,
+      httpStatus: 402,
+      fault: "customer",
+      tips: ["Upgrade the plan to raise the monthly event allowance."],
+    });
+    this.name = "PlanLimitExceededError";
+  }
+}

--- a/platform/app/src/server/app-layer/usage/usage.service.ts
+++ b/platform/app/src/server/app-layer/usage/usage.service.ts
@@ -25,13 +25,15 @@ import {
 
 const CACHE_TTL_MS = 30_000; // 30 seconds
 
-export interface UsageLimitResult {
-  exceeded: boolean;
-  message?: string;
-  count?: number;
-  maxMessagesPerMonth?: number;
-  planName?: string;
-}
+export type UsageLimitResult =
+  | { exceeded: false }
+  | {
+      exceeded: true;
+      message: string;
+      count: number;
+      maxMessagesPerMonth: number;
+      planName: string;
+    };
 
 /**
  * App-layer usage service.

--- a/platform/app/src/server/data-privacy/__tests__/dataPrivacyPolicy.cache.unit.test.ts
+++ b/platform/app/src/server/data-privacy/__tests__/dataPrivacyPolicy.cache.unit.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cacheGet = vi.fn();
+const cacheSet = vi.fn();
+const cacheDelete = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../utils/ttlCache", () => ({
+  TtlCache: class {
+    get = cacheGet;
+    set = cacheSet;
+    delete = cacheDelete;
+  },
+}));
+
+const { DataPrivacyPolicyCache } = await import("../dataPrivacyPolicy.cache");
+
+/**
+ * Old and new pods share this Redis cache across a rolling deploy, so a cached
+ * blob can predate any field added since. These cover the read-back of such a
+ * blob, which is what dropped span processing in production on 2026-07-31.
+ */
+describe("DataPrivacyPolicyCache", () => {
+  const repository = {
+    getProjectScopeFacts: vi.fn(),
+    findForProjectChain: vi.fn(),
+  };
+
+  const buildCache = () => new DataPrivacyPolicyCache(repository as never);
+
+  const fullPolicy = {
+    categories: { input: {}, output: {}, system: {}, tools: {} },
+    pii: { level: "custom", entities: ["EMAIL"], exceptPatterns: ["ops@"] },
+    secrets: { enabled: true, customPatterns: ["sk-"] },
+    customAttributes: [{ pattern: "x" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository.getProjectScopeFacts.mockResolvedValue(null);
+  });
+
+  describe("given a cached policy written by the current version", () => {
+    it("returns the collections untouched", async () => {
+      cacheGet.mockResolvedValue(structuredClone(fullPolicy));
+
+      const resolved = await buildCache().resolve("project_1");
+
+      expect(resolved?.pii.exceptPatterns).toEqual(["ops@"]);
+      expect(resolved?.pii.entities).toEqual(["EMAIL"]);
+      expect(resolved?.secrets.customPatterns).toEqual(["sk-"]);
+      expect(resolved?.customAttributes).toHaveLength(1);
+      expect(repository.getProjectScopeFacts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a cached policy written before a collection field existed", () => {
+    it("defaults every missing collection so callers can walk them", async () => {
+      cacheGet.mockResolvedValue({
+        categories: { input: {}, output: {}, system: {}, tools: {} },
+        pii: { level: "strict" },
+        secrets: { enabled: false },
+      });
+
+      const resolved = await buildCache().resolve("project_1");
+
+      expect(resolved?.pii.exceptPatterns).toEqual([]);
+      expect(resolved?.pii.entities).toEqual([]);
+      expect(resolved?.secrets.customPatterns).toEqual([]);
+      expect(resolved?.customAttributes).toEqual([]);
+    });
+
+    it("keeps the fields the old writer did set", async () => {
+      cacheGet.mockResolvedValue({
+        categories: { input: {}, output: {}, system: {}, tools: {} },
+        pii: { level: "strict" },
+        secrets: { enabled: false },
+      });
+
+      const resolved = await buildCache().resolve("project_1");
+
+      expect(resolved?.pii.level).toBe("strict");
+      expect(resolved?.secrets.enabled).toBe(false);
+    });
+
+    it("does not re-walk the scope cascade for a defaultable blob", async () => {
+      cacheGet.mockResolvedValue({
+        categories: { input: {}, output: {}, system: {}, tools: {} },
+        pii: { level: "strict" },
+        secrets: { enabled: false },
+      });
+
+      await buildCache().resolve("project_1");
+
+      expect(repository.getProjectScopeFacts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a cached blob too old to default", () => {
+    it.each([
+      ["categories", { pii: { level: "strict" }, secrets: { enabled: false } }],
+      ["pii", { categories: {}, secrets: { enabled: false } }],
+      ["secrets", { categories: {}, pii: { level: "strict" } }],
+    ])("treats a blob missing %s as a miss and recomputes", async (_, blob) => {
+      cacheGet.mockResolvedValue(blob);
+
+      const resolved = await buildCache().resolve("project_1");
+
+      expect(repository.getProjectScopeFacts).toHaveBeenCalledWith({
+        projectId: "project_1",
+      });
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe("given a cached null", () => {
+    it("passes it through without recomputing", async () => {
+      cacheGet.mockResolvedValue(null);
+
+      const resolved = await buildCache().resolve("project_1");
+
+      expect(resolved).toBeNull();
+      expect(repository.getProjectScopeFacts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no cached entry", () => {
+    it("resolves from the repository and caches the result", async () => {
+      cacheGet.mockResolvedValue(undefined);
+
+      await buildCache().resolve("project_1");
+
+      expect(repository.getProjectScopeFacts).toHaveBeenCalled();
+      expect(cacheSet).toHaveBeenCalledWith("project_1", null);
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/dataPrivacyPolicy.cache.ts
+++ b/platform/app/src/server/data-privacy/dataPrivacyPolicy.cache.ts
@@ -14,6 +14,37 @@ import { resolveDataPrivacy } from "./resolveDataPrivacy";
  * TTL layer on top. A `null` value means the project has no resolvable scope
  * context (no org anchor); the service maps that to the platform default.
  */
+/** Sentinel for a cached blob too old to read; the caller recomputes. */
+const UNREADABLE = Symbol("unreadable");
+
+/**
+ * Old and new pods share this Redis cache for the whole of a rolling deploy,
+ * so a blob can predate any field added since the writer last shipped. The
+ * deserialised value is cast to a type it may not satisfy, which is why every
+ * collection is defaulted here rather than at the ~20 call sites that walk it.
+ * A blob missing `categories` is beyond defaulting, so it reads as a miss.
+ */
+function reviveCached(
+  cached: ResolvedDataPrivacy | null,
+): ResolvedDataPrivacy | null | typeof UNREADABLE {
+  if (cached === null) return null;
+  if (!cached.categories || !cached.pii || !cached.secrets) return UNREADABLE;
+
+  return {
+    ...cached,
+    pii: {
+      ...cached.pii,
+      entities: cached.pii.entities ?? [],
+      exceptPatterns: cached.pii.exceptPatterns ?? [],
+    },
+    secrets: {
+      ...cached.secrets,
+      customPatterns: cached.secrets.customPatterns ?? [],
+    },
+    customAttributes: cached.customAttributes ?? [],
+  };
+}
+
 export class DataPrivacyPolicyCache {
   private readonly cache: TtlCache<ResolvedDataPrivacy | null>;
 
@@ -23,7 +54,10 @@ export class DataPrivacyPolicyCache {
 
   async resolve(projectId: string): Promise<ResolvedDataPrivacy | null> {
     const cached = await this.cache.get(projectId);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      const revived = reviveCached(cached);
+      if (revived !== UNREADABLE) return revived;
+    }
 
     const resolved = await this.loadResolved(projectId);
     await this.cache.set(projectId, resolved);

--- a/platform/app/src/server/otel/errors.ts
+++ b/platform/app/src/server/otel/errors.ts
@@ -1,13 +1,17 @@
 import { HandledError } from "@langwatch/handled-error";
 
 /**
- * A compressed OTLP body expanded past what we are willing to hold.
+ * An OTLP body passed the number of bytes we are willing to hold, either on the
+ * wire or after decompression.
  *
- * `bodyLimit` only ever sees the compressed bytes, so a request that is well
- * inside the advertised 10 MiB can still decompress to hundreds of megabytes,
- * or to gigabytes at Node's own default. That is a decompression bomb: cheap
- * to send, expensive to receive, and it exhausts the process before anything
- * downstream gets a chance to reject it.
+ * Both stages need a bound and neither can express the other. `bodyLimit` only
+ * ever sees the compressed bytes, so a request well inside the advertised
+ * 10 MiB still decompresses to hundreds of megabytes, or to gigabytes at Node's
+ * own default. That is a decompression bomb: cheap to send, expensive to
+ * receive, and it exhausts the process before anything downstream gets a chance
+ * to reject it. An uncompressed body has no such ratio, but it is read whole
+ * before any of this, so a route without a wire limit is exposed to the plain
+ * version of the same attack.
  *
  * 413 rather than 400, because the request is well-formed. The sender's
  * remedy is a smaller batch, which is a thing OTLP exporters are already
@@ -16,18 +20,24 @@ import { HandledError } from "@langwatch/handled-error";
 export class OtlpBodyTooLargeError extends HandledError {
   declare readonly code: "ERR_PAYLOAD_TOO_LARGE";
 
+  /**
+   * `encoding` is the `Content-Encoding` the body arrived under, or null when
+   * the limit was hit reading the wire bytes rather than expanding them.
+   */
   constructor({
-    maxDecompressedBytes,
+    maxBytes,
     encoding,
   }: {
-    maxDecompressedBytes: number;
-    encoding: string;
+    maxBytes: number;
+    encoding: string | null;
   }) {
     super(
       "ERR_PAYLOAD_TOO_LARGE",
-      `Decompressed request body exceeds the ${maxDecompressedBytes} byte limit.`,
+      encoding === null
+        ? `Request body exceeds the ${maxBytes} byte limit.`
+        : `Decompressed request body exceeds the ${maxBytes} byte limit.`,
       {
-        meta: { maxDecompressedBytes, encoding },
+        meta: { maxBytes, encoding },
         httpStatus: 413,
         fault: "customer",
         tips: [

--- a/platform/app/src/server/otel/errors.ts
+++ b/platform/app/src/server/otel/errors.ts
@@ -1,0 +1,40 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * A compressed OTLP body expanded past what we are willing to hold.
+ *
+ * `bodyLimit` only ever sees the compressed bytes, so a request that is well
+ * inside the advertised 10 MiB can still decompress to hundreds of megabytes,
+ * or to gigabytes at Node's own default. That is a decompression bomb: cheap
+ * to send, expensive to receive, and it exhausts the process before anything
+ * downstream gets a chance to reject it.
+ *
+ * 413 rather than 400, because the request is well-formed. The sender's
+ * remedy is a smaller batch, which is a thing OTLP exporters are already
+ * configured to do.
+ */
+export class OtlpBodyTooLargeError extends HandledError {
+  declare readonly code: "ERR_PAYLOAD_TOO_LARGE";
+
+  constructor({
+    maxDecompressedBytes,
+    encoding,
+  }: {
+    maxDecompressedBytes: number;
+    encoding: string;
+  }) {
+    super(
+      "ERR_PAYLOAD_TOO_LARGE",
+      `Decompressed request body exceeds the ${maxDecompressedBytes} byte limit.`,
+      {
+        meta: { maxDecompressedBytes, encoding },
+        httpStatus: 413,
+        fault: "customer",
+        tips: [
+          "Send smaller batches, by lowering the exporter's max batch size or shortening its export interval.",
+        ],
+      },
+    );
+    this.name = "OtlpBodyTooLargeError";
+  }
+}

--- a/platform/app/src/server/otel/parseOtlpBody.test.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from "vitest";
 
 import { OtlpBodyTooLargeError } from "./errors";
 import {
-  OTLP_MAX_DECOMPRESSED_BYTES,
+  OTLP_MAX_BODY_BYTES,
   parseOtlpLogs,
   parseOtlpMetrics,
   parseOtlpTraces,
@@ -189,7 +189,7 @@ describe("readOtlpBody", () => {
     const bomb = (bytes: number) => gzipSync(Buffer.alloc(bytes, 0));
 
     it("refuses it rather than holding the expanded body", async () => {
-      const compressed = bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024);
+      const compressed = bomb(OTLP_MAX_BODY_BYTES + 1024);
       const req = makeRequest(compressed, { "content-encoding": "gzip" });
 
       await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
@@ -198,7 +198,7 @@ describe("readOtlpBody", () => {
     });
 
     it("asks the sender for smaller batches with a 413", async () => {
-      const compressed = bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024);
+      const compressed = bomb(OTLP_MAX_BODY_BYTES + 1024);
       const req = makeRequest(compressed, { "content-encoding": "gzip" });
 
       await expect(readOtlpBody(req)).rejects.toMatchObject({
@@ -210,8 +210,8 @@ describe("readOtlpBody", () => {
     it("costs a fraction of the wire budget to send", async () => {
       // Worth stating as a number: this is why the compressed limit alone was
       // never a defence.
-      expect(bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024).byteLength).toBeLessThan(
-        OTLP_MAX_DECOMPRESSED_BYTES / 100,
+      expect(bomb(OTLP_MAX_BODY_BYTES + 1024).byteLength).toBeLessThan(
+        OTLP_MAX_BODY_BYTES / 100,
       );
     });
 
@@ -220,7 +220,7 @@ describe("readOtlpBody", () => {
       "deflate",
       "br",
     ])("applies the cap to %s as well", async (encoding) => {
-      const payload = Buffer.alloc(OTLP_MAX_DECOMPRESSED_BYTES + 1024, 0);
+      const payload = Buffer.alloc(OTLP_MAX_BODY_BYTES + 1024, 0);
       const compressed =
         encoding === "gzip"
           ? gzipSync(payload)
@@ -235,7 +235,7 @@ describe("readOtlpBody", () => {
     });
 
     it("still accepts a body that sits just under the cap", async () => {
-      const payload = Buffer.alloc(OTLP_MAX_DECOMPRESSED_BYTES - 1024, 0);
+      const payload = Buffer.alloc(OTLP_MAX_BODY_BYTES - 1024, 0);
       const req = makeRequest(gzipSync(payload), {
         "content-encoding": "gzip",
       });
@@ -244,6 +244,52 @@ describe("readOtlpBody", () => {
         "byteLength",
         payload.byteLength,
       );
+    });
+  });
+
+  describe("when an uncompressed body is larger than the cap", () => {
+    // The decompressed cap never sees this one: an identity body skips zlib
+    // altogether. The governance ingest routes carry no `bodyLimit` either, so
+    // without a bound here their only limit is the memory of the process.
+    it("refuses it rather than reading the whole body", async () => {
+      const req = makeRequest(Buffer.alloc(OTLP_MAX_BODY_BYTES + 1024, 0), {
+        "content-type": "application/x-protobuf",
+      });
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpBodyTooLargeError,
+      );
+    });
+
+    it("asks the sender for smaller batches with a 413", async () => {
+      const req = makeRequest(Buffer.alloc(OTLP_MAX_BODY_BYTES + 1024, 0), {
+        "content-encoding": "identity",
+      });
+
+      await expect(readOtlpBody(req)).rejects.toMatchObject({
+        code: "ERR_PAYLOAD_TOO_LARGE",
+        httpStatus: 413,
+      });
+    });
+
+    it("still accepts an uncompressed body just under the cap", async () => {
+      const payload = Buffer.alloc(OTLP_MAX_BODY_BYTES - 1024, 0);
+      const req = makeRequest(payload, {
+        "content-type": "application/x-protobuf",
+      });
+
+      await expect(readOtlpBody(req)).resolves.toHaveProperty(
+        "byteLength",
+        payload.byteLength,
+      );
+    });
+  });
+
+  describe("when the request carries no body at all", () => {
+    it("reads as empty rather than throwing", async () => {
+      const req = new Request("http://localhost/test", { method: "POST" });
+
+      await expect(readOtlpBody(req)).resolves.toHaveProperty("byteLength", 0);
     });
   });
 });

--- a/platform/app/src/server/otel/parseOtlpBody.test.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.test.ts
@@ -18,7 +18,9 @@ import { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
 import { describe, expect, it } from "vitest";
 
+import { OtlpBodyTooLargeError } from "./errors";
 import {
+  OTLP_MAX_DECOMPRESSED_BYTES,
   parseOtlpLogs,
   parseOtlpMetrics,
   parseOtlpTraces,
@@ -176,6 +178,71 @@ describe("readOtlpBody", () => {
       });
       await expect(readOtlpBody(req)).rejects.toThrow(
         /Unsupported Content-Encoding/,
+      );
+    });
+  });
+
+  describe("when a small body decompresses to an enormous one", () => {
+    // The compressed cap the routes advertise cannot see this: `bodyLimit`
+    // weighs the bytes on the wire and the sender picks the ratio, so a
+    // request comfortably inside 10 MiB expands past it in memory.
+    const bomb = (bytes: number) => gzipSync(Buffer.alloc(bytes, 0));
+
+    it("refuses it rather than holding the expanded body", async () => {
+      const compressed = bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024);
+      const req = makeRequest(compressed, { "content-encoding": "gzip" });
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpBodyTooLargeError,
+      );
+    });
+
+    it("asks the sender for smaller batches with a 413", async () => {
+      const compressed = bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024);
+      const req = makeRequest(compressed, { "content-encoding": "gzip" });
+
+      await expect(readOtlpBody(req)).rejects.toMatchObject({
+        code: "ERR_PAYLOAD_TOO_LARGE",
+        httpStatus: 413,
+      });
+    });
+
+    it("costs a fraction of the wire budget to send", async () => {
+      // Worth stating as a number: this is why the compressed limit alone was
+      // never a defence.
+      expect(bomb(OTLP_MAX_DECOMPRESSED_BYTES + 1024).byteLength).toBeLessThan(
+        OTLP_MAX_DECOMPRESSED_BYTES / 100,
+      );
+    });
+
+    it.each([
+      "gzip",
+      "deflate",
+      "br",
+    ])("applies the cap to %s as well", async (encoding) => {
+      const payload = Buffer.alloc(OTLP_MAX_DECOMPRESSED_BYTES + 1024, 0);
+      const compressed =
+        encoding === "gzip"
+          ? gzipSync(payload)
+          : encoding === "deflate"
+            ? deflateSync(payload)
+            : brotliCompressSync(payload);
+      const req = makeRequest(compressed, { "content-encoding": encoding });
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpBodyTooLargeError,
+      );
+    });
+
+    it("still accepts a body that sits just under the cap", async () => {
+      const payload = Buffer.alloc(OTLP_MAX_DECOMPRESSED_BYTES - 1024, 0);
+      const req = makeRequest(gzipSync(payload), {
+        "content-encoding": "gzip",
+      });
+
+      await expect(readOtlpBody(req)).resolves.toHaveProperty(
+        "byteLength",
+        payload.byteLength,
       );
     });
   });

--- a/platform/app/src/server/otel/parseOtlpBody.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.ts
@@ -53,17 +53,25 @@ function toArrayBuffer(buf: Buffer): ArrayBuffer {
 }
 
 /**
- * The most we will hold after decompressing, matching the compressed cap the
- * OTLP routes advertise.
+ * The most we will read off the wire, and the most we will hold after
+ * decompressing.
  *
- * The cap lives here rather than at each route because the compressed limit
- * cannot express it: `bodyLimit` weighs the bytes on the wire, and the ratio
- * between those and the bytes in memory is chosen by the sender. A 10 MiB gzip
- * of repetitive protobuf expands by orders of magnitude, so without this the
- * advertised limit is one any holder of an ingest key can walk straight past,
- * and the governance ingest routes have no compressed limit at all.
+ * One number covers both because they bound the same thing — the bytes this
+ * process ends up holding for one request — and neither stage can express the
+ * other. `bodyLimit` weighs the bytes on the wire, and the ratio between those
+ * and the bytes in memory is chosen by the sender: a 10 MiB gzip of repetitive
+ * protobuf expands by orders of magnitude. An uncompressed body has no such
+ * ratio, but it is read whole before any of that, so a route with no wire limit
+ * is exposed to the plain version of the same attack.
+ *
+ * Both caps live here rather than at each route because the routes do not agree
+ * on middleware: the OTLP handler routes carry `bodyLimit`, and the governance
+ * ingest routes carry none at all, which made them the more exposed of the two
+ * receivers. Applying the bound in the one function both receivers share means
+ * neither can be left out, and each still answers in its own contract — the
+ * OTLP routes with a 413, the ingest routes with their existing ack-and-hint.
  */
-export const OTLP_MAX_DECOMPRESSED_BYTES = 10 * 1024 * 1024;
+export const OTLP_MAX_BODY_BYTES = 10 * 1024 * 1024;
 
 /**
  * Node reports the cap as a RangeError with this code rather than anything
@@ -78,45 +86,96 @@ function isOutputLimitExceeded(error: unknown): boolean {
   );
 }
 
-/**
- * Read the request body, decompressing per `Content-Encoding`.
- *
- * Throws on unsupported encodings, and on a body that expands past
- * {@link OTLP_MAX_DECOMPRESSED_BYTES} — the caller decides how to respond.
- * The limit is enforced by zlib itself, so an oversized body stops being
- * written the moment it crosses the line rather than being buffered whole and
- * measured afterwards, which would concede exactly the memory being defended.
- */
-const DECOMPRESSORS: Record<
-  string,
-  (buf: Buffer, opts: { maxOutputLength: number }) => Promise<Buffer>
-> = {
+type Decompressor = (
+  buf: Buffer,
+  opts: { maxOutputLength: number },
+) => Promise<Buffer>;
+
+const DECOMPRESSORS = {
   gzip: gunzipAsync,
   deflate: inflateAsync,
   br: brotliDecompressAsync,
-};
+} as const satisfies Record<string, Decompressor>;
 
+type SupportedEncoding = keyof typeof DECOMPRESSORS;
+
+function isSupportedEncoding(encoding: string): encoding is SupportedEncoding {
+  return encoding in DECOMPRESSORS;
+}
+
+/**
+ * Read the wire body, refusing it the moment it passes
+ * {@link OTLP_MAX_BODY_BYTES}.
+ *
+ * Consuming the stream by hand rather than calling `req.arrayBuffer()` is the
+ * point: `arrayBuffer()` buffers the whole body and only then hands it over, so
+ * measuring afterwards would concede exactly the memory being defended.
+ */
+async function readWireBody(req: Request): Promise<Buffer> {
+  const stream = req.body;
+  if (!stream) return Buffer.alloc(0);
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let held = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      held += value.byteLength;
+      if (held > OTLP_MAX_BODY_BYTES) {
+        await reader.cancel();
+        throw new OtlpBodyTooLargeError({
+          maxBytes: OTLP_MAX_BODY_BYTES,
+          encoding: null,
+        });
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Read the request body, decompressing per `Content-Encoding`.
+ *
+ * Throws on unsupported encodings, and on a body that passes
+ * {@link OTLP_MAX_BODY_BYTES} either on the wire or on expanding — the caller
+ * decides how to respond. Decompression is bounded by zlib itself, so an
+ * oversized body stops being written the moment it crosses the line.
+ */
 export async function readOtlpBody(req: Request): Promise<ArrayBuffer> {
-  const raw = await req.arrayBuffer();
   const encoding = req.headers.get("content-encoding");
 
-  if (!encoding || encoding === "identity") return raw;
+  if (!encoding || encoding === "identity") {
+    return toArrayBuffer(await readWireBody(req));
+  }
 
-  const decompress = DECOMPRESSORS[encoding];
-  if (decompress === undefined) {
+  // Settled before the body is read, so a request we are going to refuse
+  // outright does not get to spend the read budget first.
+  if (!isSupportedEncoding(encoding)) {
     throw new Error(`Unsupported Content-Encoding: ${encoding}`);
   }
 
+  // Widened to the shared signature deliberately: the three entries differ in
+  // their options type (ZlibOptions vs BrotliOptions), so calling the indexed
+  // union directly is not something TypeScript will resolve.
+  const decompress: Decompressor = DECOMPRESSORS[encoding];
+  const raw = await readWireBody(req);
+
   try {
     return toArrayBuffer(
-      await decompress(Buffer.from(raw), {
-        maxOutputLength: OTLP_MAX_DECOMPRESSED_BYTES,
-      }),
+      await decompress(raw, { maxOutputLength: OTLP_MAX_BODY_BYTES }),
     );
   } catch (error) {
     if (isOutputLimitExceeded(error)) {
       throw new OtlpBodyTooLargeError({
-        maxDecompressedBytes: OTLP_MAX_DECOMPRESSED_BYTES,
+        maxBytes: OTLP_MAX_BODY_BYTES,
         encoding,
       });
     }

--- a/platform/app/src/server/otel/parseOtlpBody.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.ts
@@ -35,6 +35,7 @@ import type {
   IExportTraceServiceRequest,
 } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
+import { OtlpBodyTooLargeError } from "./errors";
 
 const gunzipAsync = promisify(gunzip);
 const inflateAsync = promisify(inflate);
@@ -52,24 +53,75 @@ function toArrayBuffer(buf: Buffer): ArrayBuffer {
 }
 
 /**
- * Read the request body, decompressing per `Content-Encoding`.
- * Throws on unsupported encodings — the caller decides how to respond.
+ * The most we will hold after decompressing, matching the compressed cap the
+ * OTLP routes advertise.
+ *
+ * The cap lives here rather than at each route because the compressed limit
+ * cannot express it: `bodyLimit` weighs the bytes on the wire, and the ratio
+ * between those and the bytes in memory is chosen by the sender. A 10 MiB gzip
+ * of repetitive protobuf expands by orders of magnitude, so without this the
+ * advertised limit is one any holder of an ingest key can walk straight past,
+ * and the governance ingest routes have no compressed limit at all.
  */
+export const OTLP_MAX_DECOMPRESSED_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Node reports the cap as a RangeError with this code rather than anything
+ * zlib-specific, and it is the only signal distinguishing "too big" from a
+ * genuinely corrupt stream.
+ */
+function isOutputLimitExceeded(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "ERR_BUFFER_TOO_LARGE"
+  );
+}
+
+/**
+ * Read the request body, decompressing per `Content-Encoding`.
+ *
+ * Throws on unsupported encodings, and on a body that expands past
+ * {@link OTLP_MAX_DECOMPRESSED_BYTES} — the caller decides how to respond.
+ * The limit is enforced by zlib itself, so an oversized body stops being
+ * written the moment it crosses the line rather than being buffered whole and
+ * measured afterwards, which would concede exactly the memory being defended.
+ */
+const DECOMPRESSORS: Record<
+  string,
+  (buf: Buffer, opts: { maxOutputLength: number }) => Promise<Buffer>
+> = {
+  gzip: gunzipAsync,
+  deflate: inflateAsync,
+  br: brotliDecompressAsync,
+};
+
 export async function readOtlpBody(req: Request): Promise<ArrayBuffer> {
   const raw = await req.arrayBuffer();
   const encoding = req.headers.get("content-encoding");
 
   if (!encoding || encoding === "identity") return raw;
-  if (encoding === "gzip") {
-    return toArrayBuffer(await gunzipAsync(Buffer.from(raw)));
+
+  const decompress = DECOMPRESSORS[encoding];
+  if (decompress === undefined) {
+    throw new Error(`Unsupported Content-Encoding: ${encoding}`);
   }
-  if (encoding === "deflate") {
-    return toArrayBuffer(await inflateAsync(Buffer.from(raw)));
+
+  try {
+    return toArrayBuffer(
+      await decompress(Buffer.from(raw), {
+        maxOutputLength: OTLP_MAX_DECOMPRESSED_BYTES,
+      }),
+    );
+  } catch (error) {
+    if (isOutputLimitExceeded(error)) {
+      throw new OtlpBodyTooLargeError({
+        maxDecompressedBytes: OTLP_MAX_DECOMPRESSED_BYTES,
+        encoding,
+      });
+    }
+    throw error;
   }
-  if (encoding === "br") {
-    return toArrayBuffer(await brotliDecompressAsync(Buffer.from(raw)));
-  }
-  throw new Error(`Unsupported Content-Encoding: ${encoding}`);
 }
 
 export type OtlpParseResult<T> =

--- a/platform/app/src/server/routes/__tests__/collector.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector.unit.test.ts
@@ -305,6 +305,33 @@ describe("POST /api/collector", () => {
     });
   });
 
+  describe("given a body that is valid json but not an object", () => {
+    // `typeof null` is "object" and so is an array, so both walk past a bare
+    // typeof check and reach `"metadata" in body`, which throws on null. That
+    // turns a caller's mistake into a 500 in the platform's error stream, which
+    // is the same class of noise the warn-level change above removes.
+    describe("when the body is json null", () => {
+      it("answers 400 rather than throwing", async () => {
+        const res = await postCollector(null);
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({
+          message: "Invalid body, expecting json",
+        });
+        expect(mockIngestNormalizedSpan).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the body is a json array", () => {
+      it("answers 400", async () => {
+        const res = await postCollector([{ trace_id: "trace-1" }]);
+
+        expect(res.status).toBe(400);
+        expect(mockIngestNormalizedSpan).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("given multiple evaluations where one dispatch fails", () => {
     describe("when the first reportEvaluation throws", () => {
       it("continues dispatching the rest and reports the failure count", async () => {

--- a/platform/app/src/server/routes/__tests__/collector.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector.unit.test.ts
@@ -193,6 +193,36 @@ describe("POST /api/collector", () => {
     });
   });
 
+  describe("given a project over its plan limit", () => {
+    describe("when the payload is dispatched", () => {
+      it("rejects the batch with 402 and the plan-limit metadata", async () => {
+        mockCheckLimit.mockResolvedValue({
+          exceeded: true,
+          message: "monthly limit reached",
+          planName: "free",
+          count: 10,
+          maxMessagesPerMonth: 10,
+        });
+
+        const res = await postCollector({
+          trace_id: "trace-1",
+          spans: [makeSpan(1)],
+        });
+
+        expect(res.status).toBe(402);
+        const body = await res.json();
+        expect(body).toMatchObject({
+          error: "ERR_PLAN_LIMIT",
+          message: "monthly limit reached",
+          currentMonthMessagesCount: 10,
+          maxMessagesPerMonth: 10,
+          activePlanName: "free",
+        });
+        expect(mockIngestNormalizedSpan).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("given more than 200 spans", () => {
     describe("when the payload is dispatched", () => {
       it("returns 429 before ingesting anything", async () => {

--- a/platform/app/src/server/routes/__tests__/otel.logs.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.logs.unit.test.ts
@@ -177,7 +177,7 @@ describe("POST /api/otel/v1/logs", () => {
 
       const response = await postLogs();
 
-      expect(response.status).toBe(429);
+      expect(response.status).toBe(402);
       expect(mockHandleLogs).not.toHaveBeenCalled();
     });
   });

--- a/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
@@ -123,8 +123,13 @@ describe("POST /api/otel/v1/metrics", () => {
     const response = await postMetrics();
 
     expect(response.status).toBe(402);
-    expect(await response.json()).toEqual({
-      message: "ERR_PLAN_LIMIT: monthly limit reached",
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: "ERR_PLAN_LIMIT",
+      message: "monthly limit reached",
+      currentMonthMessagesCount: 10,
+      maxMessagesPerMonth: 10,
+      activePlanName: "free",
     });
     expect(mockHandleMetrics).not.toHaveBeenCalled();
   });

--- a/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
@@ -122,7 +122,7 @@ describe("POST /api/otel/v1/metrics", () => {
 
     const response = await postMetrics();
 
-    expect(response.status).toBe(429);
+    expect(response.status).toBe(402);
     expect(await response.json()).toEqual({
       message: "ERR_PLAN_LIMIT: monthly limit reached",
     });

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -94,8 +94,12 @@ secured
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 
-      if (typeof body !== "object") {
-        logger.warn("collector request body is not json");
+      // `typeof null` is "object" and an array is one too, so both walk past a
+      // bare typeof check and reach `"metadata" in body` below — which throws on
+      // null. That is the same customer mistake as the two guards above, so it
+      // belongs on the same 400 rather than in the error stream as a 500.
+      if (body === null || Array.isArray(body) || typeof body !== "object") {
+        logger.warn("collector request body is not a json object");
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -75,9 +75,13 @@ secured
         );
       }
 
+      // warn, not error: a malformed body is the caller's mistake and we answer
+      // it with a 400. These three sites return rather than throw, so they never
+      // reach the boundary that would classify them as customer fault, and at
+      // error level they were about a fifth of this service's error stream.
       const contentType = c.req.header("content-type");
       if (!contentType?.includes("application/json")) {
-        logger.error("collector request body is not json");
+        logger.warn("collector request body is not json");
 
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
@@ -86,12 +90,12 @@ secured
       try {
         body = await c.req.json();
       } catch {
-        logger.error("collector request body is not valid json");
+        logger.warn("collector request body is not valid json");
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 
       if (typeof body !== "object") {
-        logger.error("collector request body is not json");
+        logger.warn("collector request body is not json");
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -169,11 +169,14 @@ secured
             "Project has reached plan limit",
           );
 
+          // 402, not 429: OTel SDKs and most HTTP clients retry a 429, and a
+          // plan limit is terminal for that payload, so a retryable status
+          // turns one rejection into an unbounded loop.
           return c.json(
             {
               message: `ERR_PLAN_LIMIT: ${limitResult.message}`,
             },
-            429,
+            402,
           );
         }
       } catch (error) {

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -17,6 +17,8 @@ import {
 import { TokenResolver } from "../api-key/token-resolver";
 import { getApp } from "../app-layer/app";
 import { SPAN_MAX_PAST_MS } from "../app-layer/traces/trace-request-collection.service";
+import { PlanLimitExceededError } from "../app-layer/usage/errors";
+import type { UsageLimitResult } from "../app-layer/usage/usage.service";
 import { prisma } from "../db";
 import { evaluationNameAutoslug } from "../tracer/collector/evaluationNameAutoslug";
 import { maybeAddIdsToContextList } from "../tracer/collector/rag";
@@ -139,46 +141,15 @@ secured
         "collector request being processed",
       );
 
+      // The lookup is wrapped in try/catch on its own — on failure we log and
+      // let the request through (same behaviour as before). The thrown limit
+      // error below lives outside that try block so it is never mistaken for
+      // a lookup failure.
+      let limitResult: UsageLimitResult;
       try {
-        const limitResult = await getApp().usage.checkLimit({
+        limitResult = await getApp().usage.checkLimit({
           teamId: project.teamId,
         });
-
-        if (limitResult.exceeded) {
-          try {
-            const activePlan = await getApp().planProvider.getActivePlan({
-              organizationId: project.team.organizationId,
-            });
-            await getApp().usageLimits.notifyPlanLimitReached({
-              organizationId: project.team.organizationId,
-              planName: activePlan.name ?? "free",
-            });
-          } catch (error) {
-            logger.error(
-              { error, projectId: project.id },
-              "Error sending plan limit notification",
-            );
-          }
-          logger.info(
-            {
-              projectId: project.id,
-              currentMonthMessagesCount: limitResult.count,
-              activePlanName: limitResult.planName,
-              maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
-            },
-            "Project has reached plan limit",
-          );
-
-          // 402, not 429: OTel SDKs and most HTTP clients retry a 429, and a
-          // plan limit is terminal for that payload, so a retryable status
-          // turns one rejection into an unbounded loop.
-          return c.json(
-            {
-              message: `ERR_PLAN_LIMIT: ${limitResult.message}`,
-            },
-            402,
-          );
-        }
       } catch (error) {
         logger.error(
           { error, projectId: project.id },
@@ -186,6 +157,42 @@ secured
         );
         captureException(new Error("Error checking trace limit"), {
           extra: { projectId: project.id, error },
+        });
+        limitResult = { exceeded: false };
+      }
+
+      if (limitResult.exceeded) {
+        try {
+          const activePlan = await getApp().planProvider.getActivePlan({
+            organizationId: project.team.organizationId,
+          });
+          await getApp().usageLimits.notifyPlanLimitReached({
+            organizationId: project.team.organizationId,
+            planName: activePlan.name ?? "free",
+          });
+        } catch (error) {
+          logger.error(
+            { error, projectId: project.id },
+            "Error sending plan limit notification",
+          );
+        }
+        logger.info(
+          {
+            projectId: project.id,
+            currentMonthMessagesCount: limitResult.count,
+            activePlanName: limitResult.planName,
+            maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
+          },
+          "Project has reached plan limit",
+        );
+
+        // 402, not 429: OTel SDKs and most HTTP clients retry a 429, and a
+        // plan limit is terminal for that payload, so a retryable status
+        // turns one rejection into an unbounded loop.
+        throw new PlanLimitExceededError(limitResult.message, {
+          currentMonthMessagesCount: limitResult.count,
+          maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
+          activePlanName: limitResult.planName,
         });
       }
 

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -36,6 +36,7 @@ import type { UsageLimitResult } from "~/server/app-layer/usage/usage.service";
 import { prisma } from "~/server/db";
 import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
+  OTLP_MAX_BODY_BYTES,
   parseOtlpLogs,
   parseOtlpMetrics,
   parseOtlpTraces,
@@ -50,9 +51,6 @@ const traceRequestType = (root as any).opentelemetry.proto.collector.trace.v1
 const loggerTraces = createLogger("langwatch:otel:v1:traces");
 const loggerLogs = createLogger("langwatch:otel:v1:logs");
 const loggerMetrics = createLogger("langwatch:otel:v1:metrics");
-
-/** Matches the collector route, which has always been capped. */
-const OTLP_MAX_BODY_BYTES = 10 * 1024 * 1024;
 
 /**
  * A rejected OTLP body is unparsed, so it has not been through PII redaction.

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -31,6 +31,8 @@ import {
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
 import { getApp } from "~/server/app-layer/app";
+import { PlanLimitExceededError } from "~/server/app-layer/usage/errors";
+import type { UsageLimitResult } from "~/server/app-layer/usage/usage.service";
 import { prisma } from "~/server/db";
 import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
@@ -182,65 +184,23 @@ async function authenticate(
 }
 
 /**
- * Checks usage limits for the project and returns a 402 result if exceeded.
- * Logs `Project has reached plan limit` with `customerTraceIds` so a
- * customer-supplied trace_id can be matched to the rejection. The check
+ * Checks usage limits for the project and throws PlanLimitExceededError (402)
+ * if exceeded. Logs `Project has reached plan limit` with `customerTraceIds`
+ * so a customer-supplied trace_id can be matched to the rejection. The lookup
  * itself is wrapped in try/catch — on lookup failure we log and let the
- * request through (same behaviour as before).
+ * request through (same behaviour as before); the thrown limit error lives
+ * outside that try block so it is never mistaken for a lookup failure.
  */
 async function enforcePlanLimit(
   project: { id: string; teamId: string; team: { organizationId: string } },
   customerTraceIds: string[],
   logger: ReturnType<typeof createLogger>,
-) {
+): Promise<void> {
+  let limitResult: UsageLimitResult;
   try {
-    const limitResult = await getApp().usage.checkLimit({
+    limitResult = await getApp().usage.checkLimit({
       teamId: project.teamId,
     });
-
-    if (!limitResult.exceeded) return null;
-
-    try {
-      const activePlan = await getApp().planProvider.getActivePlan({
-        organizationId: project.team.organizationId,
-      });
-      getApp()
-        .usageLimits.notifyPlanLimitReached({
-          organizationId: project.team.organizationId,
-          planName: activePlan.name ?? "free",
-        })
-        .catch((error: unknown) => {
-          logger.error(
-            { error, projectId: project.id },
-            "Error sending plan limit notification",
-          );
-        });
-    } catch (error) {
-      logger.error(
-        { error, projectId: project.id },
-        "Error getting active plan information",
-      );
-    }
-
-    logger.info(
-      {
-        projectId: project.id,
-        currentMonthMessagesCount: limitResult.count,
-        activePlanName: limitResult.planName,
-        maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
-        customerTraceIds,
-      },
-      "Project has reached plan limit",
-    );
-
-    // 402, not 429: the OTel SDKs treat 429 as retryable and will re-post the
-    // same batch until their elapsed-time budget runs out. A plan limit is
-    // terminal for that payload, so a retryable status turns one rejection
-    // into an unbounded loop against a customer who cannot succeed.
-    return {
-      error: `ERR_PLAN_LIMIT: ${limitResult.message}`,
-      status: 402 as const,
-    };
   } catch (error) {
     logger.error(
       { error, projectId: project.id, customerTraceIds },
@@ -249,8 +209,53 @@ async function enforcePlanLimit(
     captureException(error as Error, {
       extra: { projectId: project.id },
     });
-    return null;
+    return;
   }
+
+  if (!limitResult.exceeded) return;
+
+  try {
+    const activePlan = await getApp().planProvider.getActivePlan({
+      organizationId: project.team.organizationId,
+    });
+    getApp()
+      .usageLimits.notifyPlanLimitReached({
+        organizationId: project.team.organizationId,
+        planName: activePlan.name ?? "free",
+      })
+      .catch((error: unknown) => {
+        logger.error(
+          { error, projectId: project.id },
+          "Error sending plan limit notification",
+        );
+      });
+  } catch (error) {
+    logger.error(
+      { error, projectId: project.id },
+      "Error getting active plan information",
+    );
+  }
+
+  logger.info(
+    {
+      projectId: project.id,
+      currentMonthMessagesCount: limitResult.count,
+      activePlanName: limitResult.planName,
+      maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
+      customerTraceIds,
+    },
+    "Project has reached plan limit",
+  );
+
+  // 402, not 429: the OTel SDKs treat 429 as retryable and will re-post the
+  // same batch until their elapsed-time budget runs out. A plan limit is
+  // terminal for that payload, so a retryable status turns one rejection
+  // into an unbounded loop against a customer who cannot succeed.
+  throw new PlanLimitExceededError(limitResult.message, {
+    currentMonthMessagesCount: limitResult.count,
+    maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
+    activePlanName: limitResult.planName,
+  });
 }
 
 /**
@@ -455,21 +460,7 @@ secured
           );
         }
 
-        const limitFailure = await enforcePlanLimit(
-          project,
-          customerTraceIds,
-          loggerTraces,
-        );
-        if (limitFailure) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: limitFailure.error,
-          });
-          return c.json(
-            { message: limitFailure.error },
-            { status: limitFailure.status },
-          );
-        }
+        await enforcePlanLimit(project, customerTraceIds, loggerTraces);
 
         const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
 
@@ -561,17 +552,7 @@ secured
         const { project, resolved } = authResult;
         span.setAttribute("langwatch.project.id", project.id);
 
-        const limitFailure = await enforcePlanLimit(project, [], loggerLogs);
-        if (limitFailure) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: limitFailure.error,
-          });
-          return c.json(
-            { message: limitFailure.error },
-            { status: limitFailure.status },
-          );
-        }
+        await enforcePlanLimit(project, [], loggerLogs);
 
         const body = await readOtlpBody(c.req.raw);
         const parsed = parseOtlpLogs(body, c.req.header("content-type"));
@@ -665,17 +646,7 @@ secured
         const { project, resolved } = authResult;
         span.setAttribute("langwatch.project.id", project.id);
 
-        const limitFailure = await enforcePlanLimit(project, [], loggerMetrics);
-        if (limitFailure) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: limitFailure.error,
-          });
-          return c.json(
-            { message: limitFailure.error },
-            { status: limitFailure.status },
-          );
-        }
+        await enforcePlanLimit(project, [], loggerMetrics);
 
         const body = await readOtlpBody(c.req.raw);
         const parsed = parseOtlpMetrics(body, c.req.header("content-type"));

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -20,6 +20,7 @@ import { createLogger } from "@langwatch/observability";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
+import { bodyLimit } from "hono/body-limit";
 import { getLangWatchTracer } from "langwatch";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import {
@@ -47,6 +48,19 @@ const traceRequestType = (root as any).opentelemetry.proto.collector.trace.v1
 const loggerTraces = createLogger("langwatch:otel:v1:traces");
 const loggerLogs = createLogger("langwatch:otel:v1:logs");
 const loggerMetrics = createLogger("langwatch:otel:v1:metrics");
+
+/** Matches the collector route, which has always been capped. */
+const OTLP_MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+/**
+ * A rejected OTLP body is unparsed, so it has not been through PII redaction.
+ * Only its length may be recorded: the bytes themselves carry prompts,
+ * completions and host identifiers, and neither the log sink nor PostHog is a
+ * place customer content is allowed to reach.
+ */
+function bodyForensics(body: ArrayBuffer | Uint8Array) {
+  return { bodyBytes: body.byteLength };
+}
 
 const AUTH_REASON = "OTLP ingestion API key resolved in-handler";
 
@@ -168,7 +182,7 @@ async function authenticate(
 }
 
 /**
- * Checks usage limits for the project and returns a 429 result if exceeded.
+ * Checks usage limits for the project and returns a 402 result if exceeded.
  * Logs `Project has reached plan limit` with `customerTraceIds` so a
  * customer-supplied trace_id can be matched to the rejection. The check
  * itself is wrapped in try/catch — on lookup failure we log and let the
@@ -219,9 +233,13 @@ async function enforcePlanLimit(
       "Project has reached plan limit",
     );
 
+    // 402, not 429: the OTel SDKs treat 429 as retryable and will re-post the
+    // same batch until their elapsed-time budget runs out. A plan limit is
+    // terminal for that payload, so a retryable status turns one rejection
+    // into an unbounded loop against a customer who cannot succeed.
     return {
       error: `ERR_PLAN_LIMIT: ${limitResult.message}`,
-      status: 429 as const,
+      status: 402 as const,
     };
   } catch (error) {
     logger.error(
@@ -399,321 +417,328 @@ export function peekCustomerTraceIds(
 
 // ── POST /traces ─────────────────────────────────────────────────────
 
-secured.access(otelIngestAuth).post("/traces", async (c) => {
-  const tracer = getLangWatchTracer("langwatch.otel.traces");
+secured
+  .access(otelIngestAuth)
+  .post("/traces", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+    const tracer = getLangWatchTracer("langwatch.otel.traces");
 
-  return tracer.withActiveSpan(
-    "TracesV1.handleTracesRequest",
-    { kind: SpanKind.SERVER },
-    async (span) => {
-      // Auth first — 401s/permission failures should not pay body decompression
-      // cost, and body content is irrelevant when we don't know who's calling.
-      const authResult = await authenticate(c, loggerTraces);
+    return tracer.withActiveSpan(
+      "TracesV1.handleTracesRequest",
+      { kind: SpanKind.SERVER },
+      async (span) => {
+        // Auth first — 401s/permission failures should not pay body decompression
+        // cost, and body content is irrelevant when we don't know who's calling.
+        const authResult = await authenticate(c, loggerTraces);
 
-      if ("error" in authResult) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: authResult.error,
+        if ("error" in authResult) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: authResult.error,
+          });
+          return c.json(authResult.body, { status: authResult.status });
+        }
+
+        const { project, resolved } = authResult;
+        span.setAttribute("langwatch.project.id", project.id);
+
+        const body = await readOtlpBody(c.req.raw);
+        const contentType = c.req.header("content-type");
+
+        // Best-effort. If the body can't be peeked (malformed, unsupported
+        // shape, etc.), customerTraceIds stays empty — the projectId is still
+        // logged on every subsequent failure for correlation.
+        const customerTraceIds = peekCustomerTraceIds(body, contentType);
+        if (customerTraceIds.length > 0) {
+          span.setAttribute(
+            "langwatch.otel.customer_trace_ids",
+            customerTraceIds.join(","),
+          );
+        }
+
+        const limitFailure = await enforcePlanLimit(
+          project,
+          customerTraceIds,
+          loggerTraces,
+        );
+        if (limitFailure) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: limitFailure.error,
+          });
+          return c.json(
+            { message: limitFailure.error },
+            { status: limitFailure.status },
+          );
+        }
+
+        const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
+
+        if (body.byteLength === 0) {
+          loggerTraces.debug(
+            { projectId: project.id },
+            "Received empty trace request, ignoring",
+          );
+          return c.json({
+            message: "No traces to process",
+            partialSuccess: emptyPartialSuccess,
+          });
+        }
+
+        const parsed = parseOtlpTraces(body, contentType);
+        if (!parsed.ok) {
+          loggerTraces.error(
+            {
+              error: parsed.error,
+              projectId: project.id,
+              customerTraceIds,
+              ...bodyForensics(body),
+            },
+            "error parsing traces",
+          );
+          captureException(new Error(parsed.error), {
+            extra: {
+              projectId: project.id,
+              customerTraceIds,
+            },
+          });
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "Failed to parse traces",
+          });
+          return c.json({ error: "Failed to parse traces" }, { status: 400 });
+        }
+        const traceRequest = parsed.request;
+
+        // Body successfully parsed — mark the API key as used
+        if (resolved.type === "apiKey") {
+          tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
+        }
+
+        await applyReceiverProvenanceToTraces({
+          request: traceRequest,
+          resolved,
         });
-        return c.json(authResult.body, { status: authResult.status });
-      }
 
-      const { project, resolved } = authResult;
-      span.setAttribute("langwatch.project.id", project.id);
+        const collectionResult =
+          await getApp().traces.collection.handleOtlpTraceRequest(
+            project.id,
+            traceRequest,
+            DEFAULT_PII_REDACTION_LEVEL,
+          );
 
-      const body = await readOtlpBody(c.req.raw);
-      const contentType = c.req.header("content-type");
-
-      // Best-effort. If the body can't be peeked (malformed, unsupported
-      // shape, etc.), customerTraceIds stays empty — the projectId is still
-      // logged on every subsequent failure for correlation.
-      const customerTraceIds = peekCustomerTraceIds(body, contentType);
-      if (customerTraceIds.length > 0) {
-        span.setAttribute(
-          "langwatch.otel.customer_trace_ids",
-          customerTraceIds.join(","),
-        );
-      }
-
-      const limitFailure = await enforcePlanLimit(
-        project,
-        customerTraceIds,
-        loggerTraces,
-      );
-      if (limitFailure) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: limitFailure.error,
-        });
-        return c.json(
-          { message: limitFailure.error },
-          { status: limitFailure.status },
-        );
-      }
-
-      const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
-
-      if (body.byteLength === 0) {
-        loggerTraces.debug(
-          { projectId: project.id },
-          "Received empty trace request, ignoring",
-        );
         return c.json({
-          message: "No traces to process",
-          partialSuccess: emptyPartialSuccess,
-        });
-      }
-
-      const parsed = parseOtlpTraces(body, contentType);
-      if (!parsed.ok) {
-        loggerTraces.error(
-          {
-            error: parsed.error,
-            projectId: project.id,
-            customerTraceIds,
-            traceRequest: Buffer.from(body).toString("base64"),
-          },
-          "error parsing traces",
-        );
-        captureException(new Error(parsed.error), {
-          extra: {
-            projectId: project.id,
-            customerTraceIds,
-            traceRequest: Buffer.from(body).toString("base64"),
+          message: "Trace received successfully.",
+          partialSuccess: {
+            rejectedSpans: collectionResult?.rejectedSpans ?? 0,
+            errorMessage: collectionResult?.errorMessage ?? "",
           },
         });
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: "Failed to parse traces",
-        });
-        return c.json({ error: "Failed to parse traces" }, { status: 400 });
-      }
-      const traceRequest = parsed.request;
-
-      // Body successfully parsed — mark the API key as used
-      if (resolved.type === "apiKey") {
-        tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
-      }
-
-      await applyReceiverProvenanceToTraces({
-        request: traceRequest,
-        resolved,
-      });
-
-      const collectionResult =
-        await getApp().traces.collection.handleOtlpTraceRequest(
-          project.id,
-          traceRequest,
-          DEFAULT_PII_REDACTION_LEVEL,
-        );
-
-      return c.json({
-        message: "Trace received successfully.",
-        partialSuccess: {
-          rejectedSpans: collectionResult?.rejectedSpans ?? 0,
-          errorMessage: collectionResult?.errorMessage ?? "",
-        },
-      });
-    },
-  );
-});
+      },
+    );
+  });
 
 // ── POST /logs ───────────────────────────────────────────────────────
 
-secured.access(otelIngestAuth).post("/logs", async (c) => {
-  const tracer = getLangWatchTracer("langwatch.otel.logs");
+secured
+  .access(otelIngestAuth)
+  .post("/logs", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+    const tracer = getLangWatchTracer("langwatch.otel.logs");
 
-  return tracer.withActiveSpan(
-    "[POST] /api/otel/v1/logs",
-    { kind: SpanKind.SERVER },
-    async (span) => {
-      const authResult = await authenticate(c, loggerLogs);
+    return tracer.withActiveSpan(
+      "[POST] /api/otel/v1/logs",
+      { kind: SpanKind.SERVER },
+      async (span) => {
+        const authResult = await authenticate(c, loggerLogs);
 
-      if ("error" in authResult) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: authResult.error,
+        if ("error" in authResult) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: authResult.error,
+          });
+          return c.json(authResult.body, { status: authResult.status });
+        }
+
+        const { project, resolved } = authResult;
+        span.setAttribute("langwatch.project.id", project.id);
+
+        const limitFailure = await enforcePlanLimit(project, [], loggerLogs);
+        if (limitFailure) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: limitFailure.error,
+          });
+          return c.json(
+            { message: limitFailure.error },
+            { status: limitFailure.status },
+          );
+        }
+
+        const body = await readOtlpBody(c.req.raw);
+        const parsed = parseOtlpLogs(body, c.req.header("content-type"));
+        if (!parsed.ok) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "Failed to parse logs",
+          });
+          span.recordException(new Error(parsed.error));
+          loggerLogs.error(
+            {
+              error: parsed.error,
+              projectId: project.id,
+              ...bodyForensics(body),
+            },
+            "error parsing logs",
+          );
+          captureException(new Error(parsed.error), {
+            extra: {
+              projectId: project.id,
+            },
+          });
+          return c.json({ error: "Failed to parse logs" }, { status: 400 });
+        }
+        const logRequest = parsed.request;
+
+        // Body successfully parsed — mark the API key as used
+        if (resolved.type === "apiKey") {
+          tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
+        }
+
+        await applyReceiverProvenanceToLogs({
+          request: logRequest,
+          resolved,
         });
-        return c.json(authResult.body, { status: authResult.status });
-      }
 
-      const { project, resolved } = authResult;
-      span.setAttribute("langwatch.project.id", project.id);
-
-      const limitFailure = await enforcePlanLimit(project, [], loggerLogs);
-      if (limitFailure) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: limitFailure.error,
-        });
-        return c.json(
-          { message: limitFailure.error },
-          { status: limitFailure.status },
-        );
-      }
-
-      const body = await readOtlpBody(c.req.raw);
-      const parsed = parseOtlpLogs(body, c.req.header("content-type"));
-      if (!parsed.ok) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: "Failed to parse logs",
-        });
-        span.recordException(new Error(parsed.error));
-        loggerLogs.error(
+        const result = await getApp().traces.logCollection.handleOtlpLogRequest(
           {
-            error: parsed.error,
-            projectId: project.id,
-            logRequest: Buffer.from(body).toString("base64"),
+            tenantId: project.id,
+            organizationId: project.team.organizationId,
+            logRequest,
+            piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
           },
-          "error parsing logs",
         );
-        captureException(new Error(parsed.error), {
-          extra: {
-            projectId: project.id,
-            logRequest: Buffer.from(body).toString("base64"),
-          },
-        });
-        return c.json({ error: "Failed to parse logs" }, { status: 400 });
-      }
-      const logRequest = parsed.request;
 
-      // Body successfully parsed — mark the API key as used
-      if (resolved.type === "apiKey") {
-        tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
-      }
+        // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
+        // with `partialSuccess` as a permanent rejection the client must not
+        // re-send, so answering that here would turn a queue blip into fleet-wide
+        // data loss. 503 is in OTLP's retryable set.
+        if (result.outcome === "unavailable") {
+          return c.json({ error: result.errorMessage }, { status: 503 });
+        }
 
-      await applyReceiverProvenanceToLogs({
-        request: logRequest,
-        resolved,
-      });
-
-      const result = await getApp().traces.logCollection.handleOtlpLogRequest({
-        tenantId: project.id,
-        organizationId: project.team.organizationId,
-        logRequest,
-        piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
-      });
-
-      // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
-      // with `partialSuccess` as a permanent rejection the client must not
-      // re-send, so answering that here would turn a queue blip into fleet-wide
-      // data loss. 503 is in OTLP's retryable set.
-      if (result.outcome === "unavailable") {
-        return c.json({ error: result.errorMessage }, { status: 503 });
-      }
-
-      return c.json(
-        result.rejectedLogRecords > 0
-          ? {
-              partialSuccess: {
-                rejectedLogRecords: result.rejectedLogRecords,
-                ...(result.errorMessage
-                  ? { errorMessage: result.errorMessage }
-                  : {}),
-              },
-            }
-          : {},
-      );
-    },
-  );
-});
+        return c.json(
+          result.rejectedLogRecords > 0
+            ? {
+                partialSuccess: {
+                  rejectedLogRecords: result.rejectedLogRecords,
+                  ...(result.errorMessage
+                    ? { errorMessage: result.errorMessage }
+                    : {}),
+                },
+              }
+            : {},
+        );
+      },
+    );
+  });
 
 // ── POST /metrics ────────────────────────────────────────────────────
 
-secured.access(otelIngestAuth).post("/metrics", async (c) => {
-  const tracer = getLangWatchTracer("langwatch.otel.metrics");
+secured
+  .access(otelIngestAuth)
+  .post("/metrics", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+    const tracer = getLangWatchTracer("langwatch.otel.metrics");
 
-  return tracer.withActiveSpan(
-    "[POST] /api/otel/v1/metrics",
-    { kind: SpanKind.SERVER },
-    async (span) => {
-      const authResult = await authenticate(c, loggerMetrics);
+    return tracer.withActiveSpan(
+      "[POST] /api/otel/v1/metrics",
+      { kind: SpanKind.SERVER },
+      async (span) => {
+        const authResult = await authenticate(c, loggerMetrics);
 
-      if ("error" in authResult) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: authResult.error,
+        if ("error" in authResult) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: authResult.error,
+          });
+          return c.json(authResult.body, { status: authResult.status });
+        }
+
+        const { project, resolved } = authResult;
+        span.setAttribute("langwatch.project.id", project.id);
+
+        const limitFailure = await enforcePlanLimit(project, [], loggerMetrics);
+        if (limitFailure) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: limitFailure.error,
+          });
+          return c.json(
+            { message: limitFailure.error },
+            { status: limitFailure.status },
+          );
+        }
+
+        const body = await readOtlpBody(c.req.raw);
+        const parsed = parseOtlpMetrics(body, c.req.header("content-type"));
+        if (!parsed.ok) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "Failed to parse metrics",
+          });
+          span.recordException(new Error(parsed.error));
+          loggerMetrics.error(
+            {
+              error: parsed.error,
+              projectId: project.id,
+              ...bodyForensics(body),
+            },
+            "error parsing metrics",
+          );
+          captureException(new Error(parsed.error), {
+            extra: {
+              projectId: project.id,
+            },
+          });
+          return c.json({ error: "Failed to parse metrics" }, { status: 400 });
+        }
+        const metricsRequest = parsed.request;
+
+        applyReceiverProvenanceToMetrics({
+          request: metricsRequest,
+          resolved,
         });
-        return c.json(authResult.body, { status: authResult.status });
-      }
 
-      const { project, resolved } = authResult;
-      span.setAttribute("langwatch.project.id", project.id);
+        // Body successfully parsed — mark the API key as used
+        if (resolved.type === "apiKey") {
+          tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
+        }
 
-      const limitFailure = await enforcePlanLimit(project, [], loggerMetrics);
-      if (limitFailure) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: limitFailure.error,
-        });
-        return c.json(
-          { message: limitFailure.error },
-          { status: limitFailure.status },
-        );
-      }
+        const result =
+          await getApp().traces.metricCollection.handleOtlpMetricRequest({
+            tenantId: project.id,
+            organizationId: project.team.organizationId,
+            metricRequest: metricsRequest,
+            piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
+          });
 
-      const body = await readOtlpBody(c.req.raw);
-      const parsed = parseOtlpMetrics(body, c.req.header("content-type"));
-      if (!parsed.ok) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: "Failed to parse metrics",
-        });
-        span.recordException(new Error(parsed.error));
-        loggerMetrics.error(
-          {
-            error: parsed.error,
-            projectId: project.id,
-            metricsRequest: Buffer.from(body).toString("base64"),
+        // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
+        // with `partialSuccess` as a permanent rejection the client must not
+        // re-send, so answering that here would turn a queue blip into fleet-wide
+        // data loss. 503 is in OTLP's retryable set.
+        if (result.outcome === "unavailable") {
+          return c.json({ error: result.errorMessage }, { status: 503 });
+        }
+
+        if (result.rejectedDataPoints === 0) return c.json({});
+        return c.json({
+          partialSuccess: {
+            rejectedDataPoints: result.rejectedDataPoints,
+            ...(result.errorMessage
+              ? { errorMessage: result.errorMessage }
+              : {}),
           },
-          "error parsing metrics",
-        );
-        captureException(new Error(parsed.error), {
-          extra: {
-            projectId: project.id,
-            metricsRequest: Buffer.from(body).toString("base64"),
-          },
         });
-        return c.json({ error: "Failed to parse metrics" }, { status: 400 });
-      }
-      const metricsRequest = parsed.request;
-
-      applyReceiverProvenanceToMetrics({
-        request: metricsRequest,
-        resolved,
-      });
-
-      // Body successfully parsed — mark the API key as used
-      if (resolved.type === "apiKey") {
-        tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
-      }
-
-      const result =
-        await getApp().traces.metricCollection.handleOtlpMetricRequest({
-          tenantId: project.id,
-          organizationId: project.team.organizationId,
-          metricRequest: metricsRequest,
-          piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
-        });
-
-      // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
-      // with `partialSuccess` as a permanent rejection the client must not
-      // re-send, so answering that here would turn a queue blip into fleet-wide
-      // data loss. 503 is in OTLP's retryable set.
-      if (result.outcome === "unavailable") {
-        return c.json({ error: result.errorMessage }, { status: 503 });
-      }
-
-      if (result.rejectedDataPoints === 0) return c.json({});
-      return c.json({
-        partialSuccess: {
-          rejectedDataPoints: result.rejectedDataPoints,
-          ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
-        },
-      });
-    },
-  );
-});
+      },
+    );
+  });
 
 export const app = secured.hono;

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -191,11 +191,15 @@ async function authenticate(
  * request through (same behaviour as before); the thrown limit error lives
  * outside that try block so it is never mistaken for a lookup failure.
  */
-async function enforcePlanLimit(
-  project: { id: string; teamId: string; team: { organizationId: string } },
-  customerTraceIds: string[],
-  logger: ReturnType<typeof createLogger>,
-): Promise<void> {
+async function enforcePlanLimit({
+  project,
+  customerTraceIds,
+  logger,
+}: {
+  project: { id: string; teamId: string; team: { organizationId: string } };
+  customerTraceIds: string[];
+  logger: ReturnType<typeof createLogger>;
+}): Promise<void> {
   let limitResult: UsageLimitResult;
   try {
     limitResult = await getApp().usage.checkLimit({
@@ -460,7 +464,11 @@ secured
           );
         }
 
-        await enforcePlanLimit(project, customerTraceIds, loggerTraces);
+        await enforcePlanLimit({
+          project,
+          customerTraceIds,
+          logger: loggerTraces,
+        });
 
         const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
 
@@ -552,7 +560,11 @@ secured
         const { project, resolved } = authResult;
         span.setAttribute("langwatch.project.id", project.id);
 
-        await enforcePlanLimit(project, [], loggerLogs);
+        await enforcePlanLimit({
+          project,
+          customerTraceIds: [],
+          logger: loggerLogs,
+        });
 
         const body = await readOtlpBody(c.req.raw);
         const parsed = parseOtlpLogs(body, c.req.header("content-type"));
@@ -646,7 +658,11 @@ secured
         const { project, resolved } = authResult;
         span.setAttribute("langwatch.project.id", project.id);
 
-        await enforcePlanLimit(project, [], loggerMetrics);
+        await enforcePlanLimit({
+          project,
+          customerTraceIds: [],
+          logger: loggerMetrics,
+        });
 
         const body = await readOtlpBody(c.req.raw);
         const parsed = parseOtlpMetrics(body, c.req.header("content-type"));

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -975,6 +975,20 @@ describe("ClickHouseTraceService", () => {
         expect(traces).toHaveLength(1);
         expect(traces[0]!.spans).toHaveLength(1);
         expect(traces[0]!.spans[0]!.span_id).toBe("span-1");
+
+        // The span read is the heavy one: uncapped, a trace whose summaries
+        // carry no usable OccurredAt scans every partition and gets stopped by
+        // the server's OvercommitTracker, which picks its victim across the
+        // whole cluster, so one bad read degrades unrelated queries.
+        //
+        // Pinning the cap to this specific call is the point. A cap that is
+        // merely present somewhere, or that drifts onto the summary query,
+        // reads as protection while protecting nothing.
+        const spanQuery = mockClickHouseQuery.mock.calls[4]?.[0];
+        expect(spanQuery.query).toContain("FROM stored_spans");
+        expect(spanQuery.clickhouse_settings).toHaveProperty(
+          "max_memory_usage",
+        );
       });
     });
   });

--- a/platform/app/src/server/traces/clickhouse-trace.service.ts
+++ b/platform/app/src/server/traces/clickhouse-trace.service.ts
@@ -136,6 +136,29 @@ const DISTINCT_FIELD_NAMES_LIMIT = 10_000;
  * actually reaches this many spans is logged as a potential truncation.
  */
 const MAX_SPANS_PER_TRACE = 10_000;
+
+/**
+ * Caps the joined span read's own memory instead of letting it draw on the
+ * server's total budget.
+ *
+ * This read selects every heavy column (`SpanAttributes`, `ResourceAttributes`,
+ * `Events.Attributes`, `Links.*`), and its `fallback: "none"` window means a
+ * page of traces whose summaries carry no usable `OccurredAt` scans every
+ * partition, cold S3 tiers included. Uncapped, the pathological tail was
+ * stopped by the server's OvercommitTracker, which picks a victim across the
+ * whole cluster - so one bad trace read degraded unrelated queries.
+ *
+ * With an explicit cap the offending read fails on its own and surfaces as a
+ * query error on that request. Mirrors the single-trace read path in
+ * `app-layer/traces/repositories/span-storage.clickhouse.repository.ts`.
+ *
+ * The durable fix is upstream: anchor `OccurredAt` on trace_summaries so the
+ * window is never null (#6306 did this for trace_analytics only).
+ */
+const JOINED_SPAN_READ_SETTINGS = {
+  // ClickHouse settings are string-typed over the wire.
+  max_memory_usage: String(2 * 1024 * 1024 * 1024), // 2 GiB
+} as const;
 /** Per-trace cap on projected events (events are a small subset of spans). */
 const MAX_EVENTS_PER_TRACE = 1_000;
 /** Bounds the bounded events stored_spans scan to the page's occurrence weeks. */
@@ -2979,6 +3002,7 @@ export class ClickHouseTraceService {
                   traceIds: batchTraceIds,
                   ...(window?.params ?? {}),
                 },
+                clickhouse_settings: JOINED_SPAN_READ_SETTINGS,
                 format: "JSONEachRow",
               });
               return (await spansResult.json()) as SpanRow[];


### PR DESCRIPTION
Seven fixes found by reading five days of production errors. They are independent, so they are separate commits and can be reviewed one at a time. #6603 was stacked on this branch and has since merged into it, so its two changes are described here too.

None of them is the headline defect it first looked like, and the commit messages say so where the first read was wrong.

### Cached privacy policy loses collections across a rolling deploy

Old and new pods share the Redis policy cache for the whole of a rollout, so a cached blob can predate any field added since the writer last shipped. #6324 added `pii.exceptPatterns` and read `.length` on it unguarded, so upgraded pods deserialised an old blob and threw on a field the type promises is always there. 2,244 spans hit it on 2026-07-31.

No data was lost. Span processing fails closed on a redaction error, and the queue's 25-attempt budget rides out a deploy comfortably, so they landed on retry. What it cost was ingest latency and a retry storm.

Defaulted at the cache boundary rather than at the ~20 call sites that walk the shape, because every one of them is exposed to the same skew, and a deserialised blob is cast to a type it may predate no matter which site reads it. A blob missing `categories`, `pii` or `secrets` is past defaulting, so it reads as a miss and the cascade recomputes.

### OTLP parse failures shipped unredacted bodies to Loki and PostHog

The three ingest routes dumped the whole request body as base64 twice on a parse failure, once into the log record and once into `captureException`, with no size cap on either and no `bodyLimit` on the routes.

That body has not been parsed, so it has not been through PII redaction. The bytes carry prompt and completion attributes, hostnames and OS usernames, and one misconfigured client pushed roughly 219MB of them into Loki over three days with a matching copy into PostHog, which is a third-party processor.

Only the length survives now. The routes also pick up the 10MB cap the collector route has always had.

### A 10 MiB body could still cost gigabytes of memory

Follow-on from the cap above, and the reason a compressed limit is not a limit. `bodyLimit` weighs the bytes on the wire, and the sender picks the ratio between those and the bytes we end up holding. A request comfortably inside 10 MiB expands to hundreds of megabytes, or to gigabytes at Node zlib's own default, and exhausts the process before anything downstream gets a chance to reject it. Cheap to send, expensive to receive, and available to any holder of an ingest key.

The bound goes in the shared `readOtlpBody` rather than at each route, because the compressed limit cannot express it and because the governance ingest routes have no compressed limit at all. They were the more exposed of the two receivers.

zlib enforces it via `maxOutputLength`, so an oversized body stops being written the moment it crosses the line. Buffering it whole and measuring afterwards would concede exactly the memory being defended. `/api/otel/v1` answers 413; the governance ingest routes keep their existing ack-and-hint contract for receive failures and get the memory bound regardless.

**Amended after review.** The first pass bounded only the half of the problem that needs compression. An identity-encoded body skips zlib entirely, and `readOtlpBody` then read it whole with `arrayBuffer()` before anything could object, so on the three governance ingest routes, the ones with no `bodyLimit`, the only limit on an uncompressed body was the memory of the process. The wire read is bounded in the same place and by the same number now, consuming the stream by hand rather than measuring a body that is already held. `OTLP_MAX_BODY_BYTES` moved next to the reader and `otel.ts` imports it, so the cap the middleware advertises and the cap the reader enforces cannot drift apart.

### Plan limits answered 429, so OTel clients retried them forever

429 sits in the OTel SDKs' retryable set, so an exporter that hits a plan limit re-posts the same batch until its elapsed-time budget runs out. A plan limit is terminal for that payload. One free-tier project spent five days retrying a quota rejection every ~30s against a control plane that could never accept it.

402 is outside every SDK's retryable set, so this holds for any OTLP client rather than only ours. The `ERR_PLAN_LIMIT` discriminant is unchanged, which is what the SDKs and the AI gateway match on.

The middleware and the OTLP ingest routes (`otel.ts`, `collector.ts`) now throw a typed `PlanLimitExceededError` instead of hand-rolling the response, so the boundary classifies it as customer fault and logs it at warn. The serialised body is a superset of the old one: same `error` and `message`, plus the counts and a tip. (The OTLP routes previously had no `error` field at all, just `ERR_PLAN_LIMIT:` folded into the `message` string. CodeRabbit caught the inconsistency with the middleware and it is fixed here too.)

**This is a wire-contract change.** Worth a second opinion on whether anything downstream branches on 429 before this lands.

### The Run via API snippet polled forever

The shell snippet behind the Run via API button polled `while true` and matched on `.status` parsed from the body. A 404 carries no `.status`, so jq returned null, no case matched, and the loop ran on. Runs stay readable for 24h and SDK-logged runs never write run-state at all, so 404 is permanent for whole populations of run ids.

57 distinct runs were polled about 361 times each over five days, from a snippet we hand customers, running in their CI.

Now branches on the HTTP status, caps at 1800 polls (an hour at 2s), and breaks on `interrupted` alongside the other terminal states. Also drops the trailing note advertising an events stream, because there is no `/api/experiments/runs/:runId/events` route.

### A malformed collector body is not a platform error

From #6603. The three body-validation sites in the collector route answer a 400 and `return` rather than throwing, so they never reach the boundary that classifies a customer fault as `warn`. Logged at `error`, they were roughly a fifth of the app's real error stream, and every one of them is a caller sending the wrong content-type or invalid JSON.

The HTTP response is unchanged. This is a level change only.

**Amended after review.** One of those three guards did not hold. `typeof null` is `"object"`, so a body of literal `null` passed the object check and reached `"metadata" in body` further down, which throws on it. The caller's mistake became a TypeError and a 500, which is the thing this section exists to remove. An array passed the same check. Both take the 400 that was always intended now.

### The joined span read caps its own memory

From #6603. `fetchTracesWithSpansJoined` selects every heavy column (`SpanAttributes`, `ResourceAttributes`, `Events.Attributes`, `Links.*`), and its window falls back to `"none"` when a page's summaries carry no usable `OccurredAt`, at which point both time filters collapse to empty strings and it scans every partition, cold S3 tiers included.

Uncapped, the pathological tail was stopped by ClickHouse's OvercommitTracker, which picks its victim across the whole server. So one bad trace read degraded queries that had nothing to do with it. A per-query `max_memory_usage` fails the offending read on its own request instead, which is what the single-trace read path in `span-storage.clickhouse.repository.ts` already does.

**This is containment, not a cure.** The window goes null because `trace_summaries` rows land on an `OccurredAt` sentinel. #6306 anchored `trace_analytics` against exactly this and left `trace_summaries` alone. That port is the real fix and is not in this PR.

## Test plan

- [ ] `pnpm test:unit run src/server/data-privacy src/app/api/middleware src/components/run-via-api` - 162 pass
- [ ] `pnpm test:unit run src/server/otel` - 29 pass
- [ ] `pnpm test:unit run src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts` - 41 pass
- [ ] `pnpm test:unit run src/server/routes/__tests__/collector.unit.test.ts` - 13 pass
- [ ] `pnpm test:unit run src/server/app-layer/usage/__tests__/usage.service.unit.test.ts` - 24 pass
- [ ] `pnpm test:unit run src/server/routes` - 7 failures remain in `trpc-empty-body` and `hono-bridge-streaming`, both of which fail on clean main
- [ ] A cached policy written before `exceptPatterns` existed resolves with `[]` rather than throwing
- [ ] A cached blob missing `categories` recomputes instead of being patched up
- [ ] An OTLP body that fails to parse logs a length and nothing else
- [ ] A gzip body that expands past 10 MiB is refused with a 413 rather than held
- [ ] An uncompressed body past 10 MiB is refused before it has been read whole, on the governance ingest routes as well as `/api/otel/v1`
- [ ] A project over its plan limit gets 402 with `error: ERR_PLAN_LIMIT`, logged at warn
- [ ] The generated shell snippet exits on a 404 instead of looping
- [ ] A collector request with the wrong content-type still answers 400, now logged at warn
- [ ] A collector request whose body is json `null` answers 400 rather than throwing
- [ ] A trace detail load on a trace whose summary has no `OccurredAt` fails that request rather than the server's other queries

## Notes for the reviewer

The 402 change is the one with blast radius outside this repo. Everything else is contained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plan-limit errors now provide structured details and return HTTP 402 responses.
  - OTLP ingestion rejects decompressed payloads exceeding 10 MiB with a clear error.
  - Requests exceeding 10 MiB are consistently limited across traces, logs, and metrics.
- **Bug Fixes**
  - API-run shell snippets now use bounded polling, handle failures and missing runs, and stop on interruption or timeout.
  - Cached privacy policies are validated and safely refreshed when outdated or incomplete.
  - Large span queries are protected against excessive memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->