### PR TITLE
fix: contain two error-volume and blast-radius problems

### DIFF
--- a/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -7,7 +7,22 @@ import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 import { USAGE_UNKNOWN } from "../../../traces/usage-count";
 import type { OrganizationService } from "../../organizations/organization.service";
 import type { PlanResolver } from "../../subscription/plan-provider";
-import { UsageService } from "../usage.service";
+import { type UsageLimitResult, UsageService } from "../usage.service";
+
+/**
+ * Narrows a UsageLimitResult to its exceeded branch. An `expect().toBe(true)`
+ * here would assert but not narrow the discriminated union for callers, and
+ * biome's noMisplacedAssertion rejects an `expect()` outside an `it()` body
+ * anyway, so this throws instead - still fails the test loudly if the
+ * invariant doesn't hold.
+ */
+function assertExceeded(
+  result: UsageLimitResult,
+): asserts result is Extract<UsageLimitResult, { exceeded: true }> {
+  if (!result.exceeded) {
+    throw new Error("expected checkLimit() to report exceeded: true");
+  }
+}
 
 const ENTERPRISE_LICENSE_PLAN: PlanInfo = {
   ...FREE_PLAN,
@@ -177,7 +192,7 @@ describe("UsageService", () => {
         ]);
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
       });
     });
 
@@ -200,7 +215,7 @@ describe("UsageService", () => {
       it("returns message with Free prefix, events unit, and SaaS upgrade URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "upgrade your plan at https://app.langwatch.ai/settings/subscription",
@@ -228,7 +243,7 @@ describe("UsageService", () => {
       it("returns message with Free prefix, events unit, and self-hosted license URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "buy a license at https://my-langwatch.example.com/settings/license",
@@ -255,7 +270,7 @@ describe("UsageService", () => {
       it("returns message with Monthly prefix, traces unit, and SaaS upgrade URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain(
           "Monthly limit of 10000 traces reached",
         );
@@ -285,7 +300,7 @@ describe("UsageService", () => {
       it("returns message with Monthly prefix, traces unit, and self-hosted license URL", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.message).toContain(
           "Monthly limit of 10000 traces reached",
         );
@@ -314,7 +329,7 @@ describe("UsageService", () => {
       it("returns exceeded: true with count and plan details", async () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.count).toBe(1000);
         expect(result.maxMessagesPerMonth).toBe(1000);
         expect(result.planName).toBe("Free");
@@ -348,7 +363,7 @@ describe("UsageService", () => {
 
         const result = await service.checkLimit({ teamId: "team-123" });
 
-        expect(result.exceeded).toBe(true);
+        assertExceeded(result);
         expect(result.maxMessagesPerMonth).toBe(1000);
         // "Monthly"/"events" only come from firstPlan (free: false, license
         // override with usageUnit "events"); laterPlan would render "Free"/"traces".

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -75,9 +75,13 @@ secured
         );
       }
 
+      // warn, not error: a malformed body is the caller's mistake and we answer
+      // it with a 400. These three sites return rather than throw, so they never
+      // reach the boundary that would classify them as customer fault, and at
+      // error level they were about a fifth of this service's error stream.
       const contentType = c.req.header("content-type");
       if (!contentType?.includes("application/json")) {
-        logger.error("collector request body is not json");
+        logger.warn("collector request body is not json");
 
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
@@ -86,12 +90,12 @@ secured
       try {
         body = await c.req.json();
       } catch {
-        logger.error("collector request body is not valid json");
+        logger.warn("collector request body is not valid json");
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 
       if (typeof body !== "object") {
-        logger.error("collector request body is not json");
+        logger.warn("collector request body is not json");
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 

--- a/platform/app/src/server/traces/clickhouse-trace.service.ts
+++ b/platform/app/src/server/traces/clickhouse-trace.service.ts
@@ -136,6 +136,29 @@ const DISTINCT_FIELD_NAMES_LIMIT = 10_000;
  * actually reaches this many spans is logged as a potential truncation.
  */
 const MAX_SPANS_PER_TRACE = 10_000;
+
+/**
+ * Caps the joined span read's own memory instead of letting it draw on the
+ * server's total budget.
+ *
+ * This read selects every heavy column (`SpanAttributes`, `ResourceAttributes`,
+ * `Events.Attributes`, `Links.*`), and its `fallback: "none"` window means a
+ * page of traces whose summaries carry no usable `OccurredAt` scans every
+ * partition, cold S3 tiers included. Uncapped, the pathological tail was
+ * stopped by the server's OvercommitTracker, which picks a victim across the
+ * whole cluster - so one bad trace read degraded unrelated queries.
+ *
+ * With an explicit cap the offending read fails on its own and surfaces as a
+ * query error on that request. Mirrors the single-trace read path in
+ * `app-layer/traces/repositories/span-storage.clickhouse.repository.ts`.
+ *
+ * The durable fix is upstream: anchor `OccurredAt` on trace_summaries so the
+ * window is never null (#6306 did this for trace_analytics only).
+ */
+const JOINED_SPAN_READ_SETTINGS = {
+  // ClickHouse settings are string-typed over the wire.
+  max_memory_usage: String(2 * 1024 * 1024 * 1024), // 2 GiB
+} as const;
 /** Per-trace cap on projected events (events are a small subset of spans). */
 const MAX_EVENTS_PER_TRACE = 1_000;
 /** Bounds the bounded events stored_spans scan to the page's occurrence weeks. */
@@ -2979,6 +3002,7 @@ export class ClickHouseTraceService {
                   traceIds: batchTraceIds,
                   ...(window?.params ?? {}),
                 },
+                clickhouse_settings: JOINED_SPAN_READ_SETTINGS,
                 format: "JSONEachRow",
               });
               return (await spansResult.json()) as SpanRow[];


### PR DESCRIPTION
Round two from the same five-day production error review as #6602. Stacked on it, so review that one first.

Two changes, both about blast radius rather than new behaviour.

### A malformed collector body is not a platform error

The three body-validation sites in the collector route answer a 400 and `return` rather than throwing, so they never reach the boundary that classifies a customer fault as `warn`. Logged at `error`, they were roughly a fifth of the app's real error stream, and every one of them is a caller sending the wrong content-type or invalid JSON.

The HTTP response is unchanged. This is a level change only.

### The joined span read caps its own memory

`fetchTracesWithSpansJoined` selects every heavy column (`SpanAttributes`, `ResourceAttributes`, `Events.Attributes`, `Links.*`), and its window falls back to `"none"` when a page's summaries carry no usable `OccurredAt` - at which point both time filters collapse to empty strings and it scans every partition, cold S3 tiers included.

Uncapped, the pathological tail was stopped by ClickHouse's OvercommitTracker, which picks its victim across the whole server. So one bad trace read degraded queries that had nothing to do with it. A per-query `max_memory_usage` fails the offending read on its own request instead, which is what the single-trace read path in `span-storage.clickhouse.repository.ts` already does.

**This is containment, not a cure.** The window goes null because `trace_summaries` rows land on an `OccurredAt` sentinel. #6306 anchored `trace_analytics` against exactly this and left `trace_summaries` alone. That port is the real fix and is not in this PR.

### Unrelated: a rebase-inherited typecheck break

Rebasing onto #6602 pulled in the `UsageLimitResult` discriminated union from that PR. Its own test file still read `.message`/`.count`/`.maxMessagesPerMonth`/`.planName` right after `expect(result.exceeded).toBe(true)` - a real runtime check, but one that doesn't narrow the type for `tsgo`, so typecheck failed on the `{ exceeded: false }` branch. Fixed with a type-narrowing `assertExceeded()` helper in `usage.service.unit.test.ts`; no behaviour change.

## What is deliberately not here

The ClickHouse client work - connection-pool sizing, the retry wrapper's logging, and the vendor client's error log - is coming as its own PR building a proper `@langwatch/clickhouse-client` package, rather than being scattered across three files here.

## Test plan

- [ ] `pnpm test:unit run src/server/routes/__tests__/collector.unit.test.ts` - 11 pass
- [ ] `pnpm test:unit run src/server/app-layer/usage/__tests__/usage.service.unit.test.ts` - 24 pass
- [ ] A collector request with the wrong content-type still answers 400, now logged at warn
- [ ] A trace detail load on a trace whose summary has no `OccurredAt` fails that request rather than the server's other queries

Refs #6602
