### PR TITLE
feat(clickhouse): a shared client package for pooling, logging and retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "packages/server/dist/",
     "packages/api/",
     "packages/automations/",
+    "packages/clickhouse-client/",
     "packages/handled-error/",
     "packages/langy/",
     "packages/observability/",

--- a/packages/clickhouse-client/package.json
+++ b/packages/clickhouse-client/package.json
@@ -2,7 +2,7 @@
   "name": "@langwatch/clickhouse-client",
   "version": "0.1.0",
   "private": true,
-  "description": "The shared ClickHouse client contract: fleet-aware connection-pool sizing, the vendor logging policy, transient-failure classification and backoff. Pure and dependency-light so every construction site agrees on the same rules.",
+  "description": "The shared ClickHouse client contract: fail-closed tenant routing and scope guarding, bounded concurrency with shedding, retries and backoff, tracing and vendor logging policy, and fleet-aware connection-pool sizing - composed as middleware over one query function type.",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/clickhouse-client/package.json
+++ b/packages/clickhouse-client/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@langwatch/clickhouse-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The shared ClickHouse client contract: fleet-aware connection-pool sizing, the vendor logging policy, transient-failure classification and backoff. Pure and dependency-light so every construction site agrees on the same rules.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -1,0 +1,42 @@
+export {
+  DEFAULT_CLIENTS_PER_PROCESS,
+  DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+  deriveFleetPoolCeiling,
+  FALLBACK_POOL_SIZE,
+  FLEET_SAFETY_FACTOR,
+  MAX_POOL_SIZE,
+  MIN_POOL_SIZE,
+  poolSizingFromEnv,
+  resolvePoolSize,
+} from "./pool";
+export type {
+  PoolSizeSource,
+  PoolSizingDecision,
+  PoolSizingInput,
+} from "./pool";
+
+export {
+  decideVendorLog,
+  emitVendorLog,
+  VENDOR_CAUSE_FIELD,
+} from "./logging";
+export type {
+  EmittedLevel,
+  VendorLogDecision,
+  VendorLogLevel,
+  VendorLogRecord,
+  VendorLogSink,
+} from "./logging";
+
+export {
+  isTransientClickHouseError,
+  jitteredBackoffMs,
+  RETRY_CAUSE_FIELD,
+  retryNoticeLevel,
+  TRANSIENT_HTTP_STATUSES,
+  TRANSIENT_NETWORK_CODES,
+} from "./resilience";
+export type {
+  BackoffInput,
+  TransientClassificationOptions,
+} from "./resilience";

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -63,7 +63,6 @@ export {
 export type { RetryNotice, RetryOptions } from "./retry";
 export { retry } from "./retry";
 export type {
-  Clock,
   RoutingTable,
   TenantDirectory,
   TenantRoute,
@@ -75,7 +74,6 @@ export {
   DuplicateRouteError,
   PRIVATE_ROUTE_ENV_PREFIX,
   parseRoutingTable,
-  systemClock,
   UnknownTenantError,
 } from "./tenancy";
 export type { TenantGuardOptions, TenantScopeViolation } from "./tenantGuard";

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -1,3 +1,31 @@
+export type {
+  DecideVendorLogInput,
+  EmittedLevel,
+  EmitVendorLogInput,
+  VendorLogDecision,
+  VendorLogLevel,
+  VendorLogRecord,
+  VendorLogSink,
+} from "./logging";
+export {
+  decideVendorLog,
+  emitVendorLog,
+  VENDOR_CAUSE_FIELD,
+} from "./logging";
+export type {
+  AbortSignalLike,
+  QueryExecutor,
+  QueryKind,
+  QueryMiddleware,
+  QueryRequest,
+  QueryResult,
+} from "./pipeline";
+export { compose } from "./pipeline";
+export type {
+  PoolSizeSource,
+  PoolSizingDecision,
+  PoolSizingInput,
+} from "./pool";
 export {
   DEFAULT_CLIENTS_PER_PROCESS,
   DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
@@ -10,26 +38,20 @@ export {
   resolvePoolSize,
 } from "./pool";
 export type {
-  PoolSizeSource,
-  PoolSizingDecision,
-  PoolSizingInput,
-} from "./pool";
-
+  ConcurrencyLimiter,
+  ConcurrencyLimiterOptions,
+  LimiterStats,
+} from "./rateLimit";
 export {
-  decideVendorLog,
-  emitVendorLog,
-  VENDOR_CAUSE_FIELD,
-} from "./logging";
+  AcquireAbortedError,
+  createConcurrencyLimiter,
+  QueueFullError,
+  rateLimit,
+} from "./rateLimit";
 export type {
-  DecideVendorLogInput,
-  EmitVendorLogInput,
-  EmittedLevel,
-  VendorLogDecision,
-  VendorLogLevel,
-  VendorLogRecord,
-  VendorLogSink,
-} from "./logging";
-
+  BackoffInput,
+  TransientClassificationInput,
+} from "./resilience";
 export {
   isTransientClickHouseError,
   jitteredBackoffMs,
@@ -38,7 +60,30 @@ export {
   TRANSIENT_HTTP_STATUSES,
   TRANSIENT_NETWORK_CODES,
 } from "./resilience";
+export type { RetryNotice, RetryOptions } from "./retry";
+export { retry } from "./retry";
 export type {
-  BackoffInput,
-  TransientClassificationInput,
-} from "./resilience";
+  Clock,
+  RoutingTable,
+  TenantDirectory,
+  TenantRoute,
+  TenantRouter,
+  TenantRouterOptions,
+} from "./tenancy";
+export {
+  createTenantRouter,
+  DuplicateRouteError,
+  PRIVATE_ROUTE_ENV_PREFIX,
+  parseRoutingTable,
+  systemClock,
+  UnknownTenantError,
+} from "./tenancy";
+export type { TenantGuardOptions, TenantScopeViolation } from "./tenantGuard";
+export { checkTenantScope, TenantScopeError, tenantGuard } from "./tenantGuard";
+export type {
+  QueryOutcome,
+  SpanPort,
+  TraceOptions,
+  TracerPort,
+} from "./tracing";
+export { SPAN_ATTRIBUTES, trace } from "./tracing";

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -60,8 +60,13 @@ export {
   TRANSIENT_HTTP_STATUSES,
   TRANSIENT_NETWORK_CODES,
 } from "./resilience";
-export type { RetryNotice, RetryOptions } from "./retry";
-export { retry } from "./retry";
+export type {
+  RetryAttemptNotice,
+  RetryNotice,
+  RetryOptions,
+  RunWithRetryOptions,
+} from "./retry";
+export { retry, runWithRetry } from "./retry";
 export type {
   RoutingTable,
   TenantDirectory,

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -84,9 +84,10 @@ export {
 export type { TenantGuardOptions, TenantScopeViolation } from "./tenantGuard";
 export { checkTenantScope, TenantScopeError, tenantGuard } from "./tenantGuard";
 export type {
+  QueryErrorDescriptor,
   QueryOutcome,
   SpanPort,
   TraceOptions,
   TracerPort,
 } from "./tracing";
-export { SPAN_ATTRIBUTES, trace } from "./tracing";
+export { describeQueryError, SPAN_ATTRIBUTES, trace } from "./tracing";

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -21,6 +21,8 @@ export {
   VENDOR_CAUSE_FIELD,
 } from "./logging";
 export type {
+  DecideVendorLogInput,
+  EmitVendorLogInput,
   EmittedLevel,
   VendorLogDecision,
   VendorLogLevel,
@@ -38,5 +40,5 @@ export {
 } from "./resilience";
 export type {
   BackoffInput,
-  TransientClassificationOptions,
+  TransientClassificationInput,
 } from "./resilience";

--- a/packages/clickhouse-client/src/logging.test.ts
+++ b/packages/clickhouse-client/src/logging.test.ts
@@ -22,95 +22,120 @@ const makeSink = (): VendorLogSink & {
 
 describe("decideVendorLog", () => {
   describe("given the vendor reports an error", () => {
-    it("drops the record", () => {
-      expect(decideVendorLog("error", record)).toBeNull();
-    });
+    describe("when decided", () => {
+      it("drops the record", () => {
+        expect(decideVendorLog({ level: "error", record })).toBeNull();
+      });
 
-    it("drops it even when no cause is attached", () => {
-      expect(decideVendorLog("error", { message: "boom" })).toBeNull();
+      it("drops it even when no cause is attached", () => {
+        expect(
+          decideVendorLog({ level: "error", record: { message: "boom" } }),
+        ).toBeNull();
+      });
     });
   });
 
   describe("given the vendor reports a warning", () => {
-    it("keeps it at warn", () => {
-      expect(decideVendorLog("warn", record)?.level).toBe("warn");
-    });
+    describe("when decided", () => {
+      it("keeps it at warn", () => {
+        expect(decideVendorLog({ level: "warn", record })?.level).toBe(
+          "warn",
+        );
+      });
 
-    it("attaches the cause away from the `error` field", () => {
-      const decision = decideVendorLog("warn", record);
+      it("attaches the cause away from the `error` field", () => {
+        const decision = decideVendorLog({ level: "warn", record });
 
-      // Loki derives detected_level from an `error` field, so a cause parked
-      // there reads as an error whatever level was chosen.
-      expect(decision?.fields).not.toHaveProperty("error");
-      expect(decision?.fields[VENDOR_CAUSE_FIELD]).toBe(record.err);
-    });
+        // Loki derives detected_level from an `error` field, so a cause
+        // parked there reads as an error whatever level was chosen.
+        expect(decision?.fields).not.toHaveProperty("error");
+        expect(decision?.fields[VENDOR_CAUSE_FIELD]).toBe(record.err);
+      });
 
-    it("keeps the vendor's own args and module", () => {
-      const decision = decideVendorLog("warn", record);
+      it("keeps the vendor's own args and module", () => {
+        const decision = decideVendorLog({ level: "warn", record });
 
-      expect(decision?.fields.url).toBe("http://ch:8123");
-      expect(decision?.fields.module).toBe("Connection");
-    });
+        expect(decision?.fields.url).toBe("http://ch:8123");
+        expect(decision?.fields.module).toBe("Connection");
+      });
 
-    it("carries the message through unchanged", () => {
-      expect(decideVendorLog("warn", record)?.message).toBe(record.message);
-    });
+      it("carries the message through unchanged", () => {
+        expect(decideVendorLog({ level: "warn", record })?.message).toBe(
+          record.message,
+        );
+      });
 
-    it("omits the cause field when there is no cause", () => {
-      const decision = decideVendorLog("warn", { message: "no cause" });
+      it("omits the cause field when there is no cause", () => {
+        const decision = decideVendorLog({
+          level: "warn",
+          record: { message: "no cause" },
+        });
 
-      expect(decision?.fields).not.toHaveProperty(VENDOR_CAUSE_FIELD);
+        expect(decision?.fields).not.toHaveProperty(VENDOR_CAUSE_FIELD);
+      });
     });
   });
 
   describe("given the vendor reports below warning", () => {
-    it("keeps info on its own level", () => {
-      expect(decideVendorLog("info", record)?.level).toBe("info");
-    });
+    describe("when decided", () => {
+      it("keeps info on its own level", () => {
+        expect(decideVendorLog({ level: "info", record })?.level).toBe(
+          "info",
+        );
+      });
 
-    it("keeps debug on its own level", () => {
-      expect(decideVendorLog("debug", record)?.level).toBe("debug");
-    });
+      it("keeps debug on its own level", () => {
+        expect(decideVendorLog({ level: "debug", record })?.level).toBe(
+          "debug",
+        );
+      });
 
-    it("folds trace into debug", () => {
-      expect(decideVendorLog("trace", record)?.level).toBe("debug");
+      it("folds trace into debug", () => {
+        expect(decideVendorLog({ level: "trace", record })?.level).toBe(
+          "debug",
+        );
+      });
     });
   });
 });
 
 describe("emitVendorLog", () => {
   describe("given the vendor reports an error", () => {
-    it("emits nothing at any level", () => {
-      const sink = makeSink();
+    describe("when emitted", () => {
+      it("emits nothing at any level", () => {
+        const sink = makeSink();
 
-      const emitted = emitVendorLog(sink, "error", record);
+        const emitted = emitVendorLog({ sink, level: "error", record });
 
-      expect(emitted).toBe(false);
-      expect(sink.debug).not.toHaveBeenCalled();
-      expect(sink.info).not.toHaveBeenCalled();
-      expect(sink.warn).not.toHaveBeenCalled();
+        expect(emitted).toBe(false);
+        expect(sink.debug).not.toHaveBeenCalled();
+        expect(sink.info).not.toHaveBeenCalled();
+        expect(sink.warn).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe("given the vendor reports a warning", () => {
-    it("emits once on the warn channel", () => {
-      const sink = makeSink();
+    describe("when emitted", () => {
+      it("emits once on the warn channel", () => {
+        const sink = makeSink();
 
-      const emitted = emitVendorLog(sink, "warn", record);
+        const emitted = emitVendorLog({ sink, level: "warn", record });
 
-      expect(emitted).toBe(true);
-      expect(sink.warn).toHaveBeenCalledTimes(1);
-    });
+        expect(emitted).toBe(true);
+        expect(sink.warn).toHaveBeenCalledTimes(1);
+      });
 
-    it("passes the fields and message the policy decided", () => {
-      const sink = makeSink();
+      it("passes the fields and message the policy decided", () => {
+        const sink = makeSink();
 
-      emitVendorLog(sink, "warn", record);
+        emitVendorLog({ sink, level: "warn", record });
 
-      expect(sink.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ [VENDOR_CAUSE_FIELD]: record.err }),
-        record.message,
-      );
+        expect(sink.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ [VENDOR_CAUSE_FIELD]: record.err }),
+          record.message,
+        );
+      });
     });
   });
 });

--- a/packages/clickhouse-client/src/logging.test.ts
+++ b/packages/clickhouse-client/src/logging.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  decideVendorLog,
+  emitVendorLog,
+  VENDOR_CAUSE_FIELD,
+  type VendorLogRecord,
+  type VendorLogSink,
+} from "./logging";
+
+const record: VendorLogRecord = {
+  module: "Connection",
+  message: "Insert: HTTP request error.",
+  args: { url: "http://ch:8123" },
+  err: new Error("socket hang up"),
+};
+
+const makeSink = (): VendorLogSink & {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+} => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() });
+
+describe("decideVendorLog", () => {
+  describe("given the vendor reports an error", () => {
+    it("drops the record", () => {
+      expect(decideVendorLog("error", record)).toBeNull();
+    });
+
+    it("drops it even when no cause is attached", () => {
+      expect(decideVendorLog("error", { message: "boom" })).toBeNull();
+    });
+  });
+
+  describe("given the vendor reports a warning", () => {
+    it("keeps it at warn", () => {
+      expect(decideVendorLog("warn", record)?.level).toBe("warn");
+    });
+
+    it("attaches the cause away from the `error` field", () => {
+      const decision = decideVendorLog("warn", record);
+
+      // Loki derives detected_level from an `error` field, so a cause parked
+      // there reads as an error whatever level was chosen.
+      expect(decision?.fields).not.toHaveProperty("error");
+      expect(decision?.fields[VENDOR_CAUSE_FIELD]).toBe(record.err);
+    });
+
+    it("keeps the vendor's own args and module", () => {
+      const decision = decideVendorLog("warn", record);
+
+      expect(decision?.fields.url).toBe("http://ch:8123");
+      expect(decision?.fields.module).toBe("Connection");
+    });
+
+    it("carries the message through unchanged", () => {
+      expect(decideVendorLog("warn", record)?.message).toBe(record.message);
+    });
+
+    it("omits the cause field when there is no cause", () => {
+      const decision = decideVendorLog("warn", { message: "no cause" });
+
+      expect(decision?.fields).not.toHaveProperty(VENDOR_CAUSE_FIELD);
+    });
+  });
+
+  describe("given the vendor reports below warning", () => {
+    it("keeps info on its own level", () => {
+      expect(decideVendorLog("info", record)?.level).toBe("info");
+    });
+
+    it("keeps debug on its own level", () => {
+      expect(decideVendorLog("debug", record)?.level).toBe("debug");
+    });
+
+    it("folds trace into debug", () => {
+      expect(decideVendorLog("trace", record)?.level).toBe("debug");
+    });
+  });
+});
+
+describe("emitVendorLog", () => {
+  describe("given the vendor reports an error", () => {
+    it("emits nothing at any level", () => {
+      const sink = makeSink();
+
+      const emitted = emitVendorLog(sink, "error", record);
+
+      expect(emitted).toBe(false);
+      expect(sink.debug).not.toHaveBeenCalled();
+      expect(sink.info).not.toHaveBeenCalled();
+      expect(sink.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the vendor reports a warning", () => {
+    it("emits once on the warn channel", () => {
+      const sink = makeSink();
+
+      const emitted = emitVendorLog(sink, "warn", record);
+
+      expect(emitted).toBe(true);
+      expect(sink.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes the fields and message the policy decided", () => {
+      const sink = makeSink();
+
+      emitVendorLog(sink, "warn", record);
+
+      expect(sink.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ [VENDOR_CAUSE_FIELD]: record.err }),
+        record.message,
+      );
+    });
+  });
+});

--- a/packages/clickhouse-client/src/logging.test.ts
+++ b/packages/clickhouse-client/src/logging.test.ts
@@ -38,9 +38,7 @@ describe("decideVendorLog", () => {
   describe("given the vendor reports a warning", () => {
     describe("when decided", () => {
       it("keeps it at warn", () => {
-        expect(decideVendorLog({ level: "warn", record })?.level).toBe(
-          "warn",
-        );
+        expect(decideVendorLog({ level: "warn", record })?.level).toBe("warn");
       });
 
       it("attaches the cause away from the `error` field", () => {
@@ -79,9 +77,7 @@ describe("decideVendorLog", () => {
   describe("given the vendor reports below warning", () => {
     describe("when decided", () => {
       it("keeps info on its own level", () => {
-        expect(decideVendorLog({ level: "info", record })?.level).toBe(
-          "info",
-        );
+        expect(decideVendorLog({ level: "info", record })?.level).toBe("info");
       });
 
       it("keeps debug on its own level", () => {

--- a/packages/clickhouse-client/src/logging.ts
+++ b/packages/clickhouse-client/src/logging.ts
@@ -40,16 +40,21 @@ export interface VendorLogDecision {
   fields: Record<string, unknown>;
 }
 
+export interface DecideVendorLogInput {
+  level: VendorLogLevel;
+  record: VendorLogRecord;
+}
+
 /**
  * Decide how a vendor record should be emitted, or `null` to drop it.
  *
  * Pure, so the policy is testable without a logger and identical in every
  * process that adopts it.
  */
-export function decideVendorLog(
-  level: VendorLogLevel,
-  record: VendorLogRecord,
-): VendorLogDecision | null {
+export function decideVendorLog({
+  level,
+  record,
+}: DecideVendorLogInput): VendorLogDecision | null {
   if (level === "error") return null;
 
   const fields: Record<string, unknown> = { ...(record.args ?? {}) };
@@ -70,17 +75,23 @@ export interface VendorLogSink {
   warn: (fields: Record<string, unknown>, message: string) => void;
 }
 
+export interface EmitVendorLogInput {
+  sink: VendorLogSink;
+  level: VendorLogLevel;
+  record: VendorLogRecord;
+}
+
 /**
  * Apply {@link decideVendorLog} to a sink. Returns whether anything was
  * emitted, which is what lets a caller assert the drop without reaching into
  * the sink.
  */
-export function emitVendorLog(
-  sink: VendorLogSink,
-  level: VendorLogLevel,
-  record: VendorLogRecord,
-): boolean {
-  const decision = decideVendorLog(level, record);
+export function emitVendorLog({
+  sink,
+  level,
+  record,
+}: EmitVendorLogInput): boolean {
+  const decision = decideVendorLog({ level, record });
   if (decision === null) return false;
   sink[decision.level](decision.fields, decision.message);
   return true;

--- a/packages/clickhouse-client/src/logging.ts
+++ b/packages/clickhouse-client/src/logging.ts
@@ -58,6 +58,9 @@ export function decideVendorLog({
   if (level === "error") return null;
 
   const fields: Record<string, unknown> = { ...(record.args ?? {}) };
+  // The vendor owns `args`, so it could carry an `error` key of its own and
+  // silently defeat the rule this module exists for.
+  delete fields.error;
   if (record.module !== undefined) fields.module = record.module;
   if (record.err !== undefined) fields[VENDOR_CAUSE_FIELD] = record.err;
 

--- a/packages/clickhouse-client/src/logging.ts
+++ b/packages/clickhouse-client/src/logging.ts
@@ -1,0 +1,87 @@
+/**
+ * What to do with the vendor client's own log records.
+ *
+ * `@clickhouse/client` logs an error for every failed HTTP attempt and cannot
+ * know whether the caller then retried and succeeded, so those records carry no
+ * verdict. Routed to our error level they made recovered work indistinguishable
+ * from real failure and were roughly half of one service's error volume.
+ *
+ * Two rules come out of that, and they are the whole of this module:
+ *
+ *  1. Drop the vendor's `error`. A call under the retry wrapper is reported by
+ *     the wrapper, which knows the outcome, and an unwrapped call throws, which
+ *     surfaces at the request boundary with a stack. The exception is the
+ *     signal; the vendor record is an echo with the verdict missing.
+ *
+ *  2. Never attach the cause under a field named `error`. Loki derives
+ *     `detected_level` from the presence of that field, so an `error` key
+ *     promotes a record to error regardless of the level chosen here - which is
+ *     how successful retries came to be counted as failures.
+ */
+
+export type VendorLogLevel = "trace" | "debug" | "info" | "warn" | "error";
+
+/** The shape `@clickhouse/client` hands its logger, narrowed to what is used. */
+export interface VendorLogRecord {
+  module?: string | undefined;
+  message: string;
+  args?: Record<string, unknown> | undefined;
+  err?: Error | undefined;
+}
+
+/** Where the cause is attached. Deliberately not `error`; see rule 2 above. */
+export const VENDOR_CAUSE_FIELD = "clientError";
+
+export type EmittedLevel = "debug" | "info" | "warn";
+
+export interface VendorLogDecision {
+  level: EmittedLevel;
+  message: string;
+  fields: Record<string, unknown>;
+}
+
+/**
+ * Decide how a vendor record should be emitted, or `null` to drop it.
+ *
+ * Pure, so the policy is testable without a logger and identical in every
+ * process that adopts it.
+ */
+export function decideVendorLog(
+  level: VendorLogLevel,
+  record: VendorLogRecord,
+): VendorLogDecision | null {
+  if (level === "error") return null;
+
+  const fields: Record<string, unknown> = { ...(record.args ?? {}) };
+  if (record.module !== undefined) fields.module = record.module;
+  if (record.err !== undefined) fields[VENDOR_CAUSE_FIELD] = record.err;
+
+  return {
+    level: level === "trace" ? "debug" : level,
+    message: record.message,
+    fields,
+  };
+}
+
+/** The subset of a structured logger this policy needs. */
+export interface VendorLogSink {
+  debug: (fields: Record<string, unknown>, message: string) => void;
+  info: (fields: Record<string, unknown>, message: string) => void;
+  warn: (fields: Record<string, unknown>, message: string) => void;
+}
+
+/**
+ * Apply {@link decideVendorLog} to a sink. Returns whether anything was
+ * emitted, which is what lets a caller assert the drop without reaching into
+ * the sink.
+ */
+export function emitVendorLog(
+  sink: VendorLogSink,
+  level: VendorLogLevel,
+  record: VendorLogRecord,
+): boolean {
+  const decision = decideVendorLog(level, record);
+  if (decision === null) return false;
+  sink[decision.level](decision.fields, decision.message);
+  return true;
+}

--- a/packages/clickhouse-client/src/pipeline.test.ts
+++ b/packages/clickhouse-client/src/pipeline.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { compose, type QueryExecutor, type QueryMiddleware } from "./pipeline";
+import { createConcurrencyLimiter, rateLimit } from "./rateLimit";
+import { retry } from "./retry";
+
+const driver: QueryExecutor = async () => ({ rows: [] });
+
+const marking =
+  (order: string[], name: string): QueryMiddleware =>
+  (next) =>
+  async (request) => {
+    order.push(`${name}:before`);
+    const result = await next(request);
+    order.push(`${name}:after`);
+    return result;
+  };
+
+const request = { tenantId: "project_1", sql: "SELECT 1" };
+
+describe("compose", () => {
+  describe("given several middleware", () => {
+    it("applies them left to right, so the first entry is outermost", () => {
+      const order: string[] = [];
+
+      void compose([marking(order, "a"), marking(order, "b")])(driver)(request);
+
+      expect(order).toEqual(["a:before", "b:before"]);
+    });
+
+    it("unwinds in reverse", async () => {
+      const order: string[] = [];
+
+      await compose([marking(order, "a"), marking(order, "b")])(driver)(
+        request,
+      );
+
+      expect(order).toEqual(["a:before", "b:before", "b:after", "a:after"]);
+    });
+  });
+
+  describe("given no middleware", () => {
+    it("composes to the identity so an empty pipeline needs no special case", async () => {
+      const executor = vi.fn(driver);
+
+      await compose([])(executor)(request);
+
+      expect(executor).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("the limiter and retry together", () => {
+  describe("given the limiter is composed outside retry", () => {
+    it("holds one slot for the whole statement, retries included", async () => {
+      // The ordering that matters. Inside-out, a retrying statement releases
+      // its slot and rejoins the queue behind fresh work, which is how a small
+      // overload becomes a persistent one.
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+      const seen: number[] = [];
+      let attempts = 0;
+
+      const flaky: QueryExecutor = async () => {
+        seen.push(limiter.stats().inFlight);
+        attempts += 1;
+        if (attempts < 3) {
+          throw Object.assign(new Error("socket"), { code: "ECONNRESET" });
+        }
+        return { rows: [] };
+      };
+
+      await compose([
+        rateLimit({ limiter }),
+        retry({ maxAttempts: 5, sleep: async () => undefined }),
+      ])(flaky)(request);
+
+      expect(attempts).toBe(3);
+      // One slot, held throughout - never released and re-acquired.
+      expect(seen).toEqual([1, 1, 1]);
+      expect(limiter.stats()).toEqual({ inFlight: 0, queued: 0 });
+    });
+  });
+});

--- a/packages/clickhouse-client/src/pipeline.ts
+++ b/packages/clickhouse-client/src/pipeline.ts
@@ -72,11 +72,13 @@ export interface QueryRequest {
 export interface QueryResult<Row> {
   rows: Row[];
   /** Whatever the driver knows about the execution. All fields optional. */
-  stats?: {
-    rowsRead?: number | undefined;
-    bytesRead?: number | undefined;
-    durationMs?: number | undefined;
-  };
+  stats?:
+    | {
+        rowsRead?: number | undefined;
+        bytesRead?: number | undefined;
+        durationMs?: number | undefined;
+      }
+    | undefined;
 }
 
 /** The one function type every layer of this package speaks. */

--- a/packages/clickhouse-client/src/pipeline.ts
+++ b/packages/clickhouse-client/src/pipeline.ts
@@ -1,0 +1,102 @@
+/**
+ * The composition core.
+ *
+ * Everything this package does to a query - tenant checks, rate limiting,
+ * retries, tracing, logging - is a middleware over one function type. There is
+ * no base class and nothing to extend: behaviour is added by wrapping, and the
+ * order of the wrapping is the order of the behaviour, visible at the call site
+ * rather than buried in an inheritance chain.
+ *
+ *     const execute = compose([
+ *       tenantGuard({ ... }),   // outermost: refuse before spending anything
+ *       trace({ ... }),
+ *       rateLimit({ ... }),     // hold the slot across retries, not per attempt
+ *       retry({ ... }),
+ *     ])(driver);
+ *
+ * A middleware may inspect the request, refuse it, alter it, call `next` zero,
+ * one or many times, and inspect or replace the result. That is the whole
+ * contract, and it is why retry (calls `next` many times) and rate limiting
+ * (calls it once, holding a slot) compose without knowing about each other.
+ */
+
+/** Whether a statement reads or writes, which several policies branch on. */
+export type QueryKind = "read" | "write";
+
+/**
+ * The part of `AbortSignal` this package uses, declared structurally.
+ *
+ * A real `AbortSignal` satisfies it. Declaring it here rather than reaching for
+ * the DOM or Node lib is what keeps the package buildable without `@types/node`
+ * and usable from any host.
+ */
+export interface AbortSignalLike {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+export interface QueryRequest {
+  /**
+   * The tenant this statement belongs to. Required, and not optional by
+   * oversight: no other identifier in this schema is unique across tenants, so
+   * a request that cannot name its tenant cannot be routed or audited safely.
+   */
+  tenantId: string;
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+  /** The primary table, used for metrics and span attributes. */
+  table?: string | undefined;
+  kind?: QueryKind | undefined;
+  /** Per-query ClickHouse settings, e.g. a `max_memory_usage` cap. */
+  settings?: Record<string, string> | undefined;
+  /** Cooperative cancellation. Middleware should stop retrying when aborted. */
+  signal?: AbortSignalLike | undefined;
+  /**
+   * Declares a statement that genuinely has no tenant predicate - DDL, a
+   * `system.*` read, a migration, a cross-tenant maintenance sweep.
+   *
+   * The tenant guard refuses anything untenanted unless this is set, and it is
+   * a written reason rather than a boolean on purpose: it has to be typed out
+   * by a person, it shows up in review as an added string, and it is recorded
+   * on the span so an audit can list every unscoped statement the system ran
+   * and why. A boolean would be set to `true` and forgotten.
+   */
+  unscoped?: { reason: string } | undefined;
+}
+
+export interface QueryResult<Row> {
+  rows: Row[];
+  /** Whatever the driver knows about the execution. All fields optional. */
+  stats?: {
+    rowsRead?: number | undefined;
+    bytesRead?: number | undefined;
+    durationMs?: number | undefined;
+  };
+}
+
+/** The one function type every layer of this package speaks. */
+export type QueryExecutor = <Row>(
+  request: QueryRequest,
+) => Promise<QueryResult<Row>>;
+
+/** Wraps an executor to add one behaviour. */
+export type QueryMiddleware = (next: QueryExecutor) => QueryExecutor;
+
+/**
+ * Compose middleware into a single wrapper, applied left to right: the first
+ * entry is the outermost layer and sees the request first.
+ *
+ * An empty list composes to the identity, so a caller can build a pipeline from
+ * a filtered array without special-casing the empty case.
+ */
+export function compose(
+  middleware: readonly QueryMiddleware[],
+): QueryMiddleware {
+  return (executor) =>
+    middleware.reduceRight((next, wrap) => wrap(next), executor);
+}

--- a/packages/clickhouse-client/src/pool.test.ts
+++ b/packages/clickhouse-client/src/pool.test.ts
@@ -10,214 +10,268 @@ import {
 
 describe("deriveFleetPoolCeiling", () => {
   describe("given the fleet size is unknown", () => {
-    it.each([
-      ["undefined replicas", undefined],
-      ["zero replicas", 0],
-      ["negative replicas", -3],
-      ["a non-finite replica count", Number.NaN],
-    ])("cannot derive a ceiling from %s", (_label, replicas) => {
-      expect(deriveFleetPoolCeiling({ replicas })).toBeNull();
+    describe("when a ceiling is derived", () => {
+      it.each([
+        ["undefined replicas", undefined],
+        ["zero replicas", 0],
+        ["negative replicas", -3],
+        ["a non-finite replica count", Number.NaN],
+      ])("cannot derive a ceiling from %s", (_label, replicas) => {
+        expect(deriveFleetPoolCeiling({ replicas })).toBeNull();
+      });
+    });
+  });
+
+  describe("given a fractional fleet description", () => {
+    describe("when a ceiling is derived", () => {
+      it("cannot derive a ceiling from fractional replicas", () => {
+        expect(deriveFleetPoolCeiling({ replicas: 2.5 })).toBeNull();
+      });
+
+      it("falls back to the default client count rather than accept a fraction", () => {
+        // A fractional clientsPerProcess must not inflate the derived
+        // ceiling - it previously did, since floor((300*0.7)/(10*0.5)) = 42
+        // is *more* permissive than any real client count would allow.
+        const withFraction = deriveFleetPoolCeiling({
+          replicas: 10,
+          clientsPerProcess: 0.5,
+        });
+        const withDefault = deriveFleetPoolCeiling({ replicas: 10 });
+
+        expect(withFraction).toBe(withDefault);
+      });
     });
   });
 
   describe("given the fleet size is known", () => {
-    it("keeps every pool on every pod inside the server's budget", () => {
-      const replicas = 10;
-      const clientsPerProcess = 2;
+    describe("when a ceiling is derived", () => {
+      it("keeps every pool on every pod inside the server's budget", () => {
+        const replicas = 10;
+        const clientsPerProcess = 2;
 
-      const ceiling = deriveFleetPoolCeiling({ replicas, clientsPerProcess });
+        const ceiling = deriveFleetPoolCeiling({ replicas, clientsPerProcess });
 
-      expect(ceiling).toBe(10);
-      expect(ceiling! * replicas * clientsPerProcess).toBeLessThanOrEqual(
-        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
-      );
-    });
+        expect(ceiling).toBe(10);
+        expect(ceiling! * replicas * clientsPerProcess).toBeLessThanOrEqual(
+          DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+        );
+      });
 
-    it("grows with the server's budget", () => {
-      expect(
-        deriveFleetPoolCeiling({
+      it("grows with the server's budget", () => {
+        expect(
+          deriveFleetPoolCeiling({
+            replicas: 10,
+            serverMaxConcurrentQueries: 1000,
+          }),
+        ).toBe(35);
+      });
+
+      it("gives a process holding one client twice the pool", () => {
+        const two = deriveFleetPoolCeiling({
           replicas: 10,
-          serverMaxConcurrentQueries: 1000,
-        }),
-      ).toBe(35);
-    });
-
-    it("gives a process holding one client twice the pool", () => {
-      const two = deriveFleetPoolCeiling({
-        replicas: 10,
-        clientsPerProcess: 2,
-      });
-      const one = deriveFleetPoolCeiling({
-        replicas: 10,
-        clientsPerProcess: 1,
-      });
-
-      expect(one).toBe(21);
-      expect(one!).toBeGreaterThan(two!);
-    });
-
-    it("shrinks as the fleet grows", () => {
-      const small = deriveFleetPoolCeiling({ replicas: 4 })!;
-      const large = deriveFleetPoolCeiling({ replicas: 40 })!;
-
-      expect(large).toBeLessThan(small);
-    });
-
-    it("never derives below a single usable connection", () => {
-      expect(deriveFleetPoolCeiling({ replicas: 100_000 })).toBe(1);
-    });
-
-    it("never derives above the hard cap", () => {
-      expect(
-        deriveFleetPoolCeiling({
-          replicas: 1,
+          clientsPerProcess: 2,
+        });
+        const one = deriveFleetPoolCeiling({
+          replicas: 10,
           clientsPerProcess: 1,
-          serverMaxConcurrentQueries: 10_000_000,
-        }),
-      ).toBe(MAX_POOL_SIZE);
-    });
+        });
 
-    it("reproduces the sizing that broke production", () => {
-      // 10 worker pods x 2 clients x a fixed 64 against a 300-query ceiling.
-      const fixedDefault = 64;
-      const ceiling = deriveFleetPoolCeiling({ replicas: 10 })!;
+        expect(one).toBe(21);
+        expect(one!).toBeGreaterThan(two!);
+      });
 
-      expect(fixedDefault * 10 * 2).toBeGreaterThan(
-        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
-      );
-      expect(ceiling).toBeLessThan(fixedDefault);
+      it("shrinks as the fleet grows", () => {
+        const small = deriveFleetPoolCeiling({ replicas: 4 })!;
+        const large = deriveFleetPoolCeiling({ replicas: 40 })!;
+
+        expect(large).toBeLessThan(small);
+      });
+
+      it("never derives below a single usable connection", () => {
+        expect(deriveFleetPoolCeiling({ replicas: 100_000 })).toBe(1);
+      });
+
+      it("never derives above the hard cap", () => {
+        expect(
+          deriveFleetPoolCeiling({
+            replicas: 1,
+            clientsPerProcess: 1,
+            serverMaxConcurrentQueries: 10_000_000,
+          }),
+        ).toBe(MAX_POOL_SIZE);
+      });
+
+      it("reproduces the sizing that broke production", () => {
+        // 10 worker pods x 2 clients x a fixed 64 against a 300-query ceiling.
+        const fixedDefault = 64;
+        const ceiling = deriveFleetPoolCeiling({ replicas: 10 })!;
+
+        expect(fixedDefault * 10 * 2).toBeGreaterThan(
+          DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+        );
+        expect(ceiling).toBeLessThan(fixedDefault);
+      });
     });
   });
 });
 
 describe("resolvePoolSize", () => {
   describe("given no inputs at all", () => {
-    it("falls back rather than guessing a fleet size", () => {
-      const decision = resolvePoolSize();
+    describe("when the size is resolved", () => {
+      it("falls back rather than guessing a fleet size", () => {
+        const decision = resolvePoolSize();
 
-      expect(decision.size).toBe(FALLBACK_POOL_SIZE);
-      expect(decision.source).toBe("fallback");
-      expect(decision.derivedCeiling).toBeNull();
-      expect(decision.exceedsBudget).toBe(false);
+        expect(decision.size).toBe(FALLBACK_POOL_SIZE);
+        expect(decision.source).toBe("fallback");
+        expect(decision.derivedCeiling).toBeNull();
+        expect(decision.exceedsBudget).toBe(false);
+      });
     });
   });
 
   describe("given the fleet size is known", () => {
-    it("derives the size", () => {
-      const decision = resolvePoolSize({ replicas: 10 });
+    describe("when the size is resolved", () => {
+      it("derives the size", () => {
+        const decision = resolvePoolSize({ replicas: 10 });
 
-      expect(decision).toMatchObject({
-        size: 10,
-        source: "derived",
-        derivedCeiling: 10,
-        exceedsBudget: false,
+        expect(decision).toMatchObject({
+          size: 10,
+          source: "derived",
+          derivedCeiling: 10,
+          exceedsBudget: false,
+        });
+      });
+    });
+  });
+
+  describe("given a fleet so large the budget cannot afford one connection", () => {
+    describe("when the size is resolved", () => {
+      it("still reports the budget as exceeded", () => {
+        // 151 replicas x 2 clients x the floored minimum of 1 is 302
+        // connections against the default 300-query ceiling - the floor that
+        // keeps the *ceiling* at a usable 1 must not also hide that the real
+        // budget is already gone.
+        const decision = resolvePoolSize({ replicas: 151 });
+
+        expect(decision.size).toBe(1);
+        expect(decision.exceedsBudget).toBe(true);
       });
     });
   });
 
   describe("given an operator override", () => {
-    it("wins over the derived size", () => {
-      const decision = resolvePoolSize({ override: 40, replicas: 10 });
+    describe("when the size is resolved", () => {
+      it("wins over the derived size", () => {
+        const decision = resolvePoolSize({ override: 40, replicas: 10 });
 
-      expect(decision.size).toBe(40);
-      expect(decision.source).toBe("override");
+        expect(decision.size).toBe(40);
+        expect(decision.source).toBe("override");
+      });
+
+      it("reports a conflict with the fleet budget instead of hiding it", () => {
+        const decision = resolvePoolSize({ override: 40, replicas: 10 });
+
+        expect(decision.exceedsBudget).toBe(true);
+        expect(decision.derivedCeiling).toBe(10);
+      });
+
+      it("raises no conflict when it fits the budget", () => {
+        const decision = resolvePoolSize({ override: 8, replicas: 10 });
+
+        expect(decision.exceedsBudget).toBe(false);
+      });
+
+      it("still reports the ceiling when nothing conflicts", () => {
+        expect(
+          resolvePoolSize({ override: 8, replicas: 10 }).derivedCeiling,
+        ).toBe(10);
+      });
     });
 
-    it("reports a conflict with the fleet budget instead of hiding it", () => {
-      const decision = resolvePoolSize({ override: 40, replicas: 10 });
+    describe("when the override is unusable", () => {
+      it.each([
+        ["zero", 0],
+        ["negative", -5],
+        ["fractional", 2.5],
+        ["above the hard cap", 5000],
+        ["not a number", Number.NaN],
+      ])("ignores an unusable override (%s)", (_label, override) => {
+        const decision = resolvePoolSize({ override });
 
-      expect(decision.exceedsBudget).toBe(true);
-      expect(decision.derivedCeiling).toBe(10);
-    });
+        expect(decision.size).toBe(FALLBACK_POOL_SIZE);
+        expect(decision.rejectedOverride).toBe(override);
+      });
 
-    it("raises no conflict when it fits the budget", () => {
-      const decision = resolvePoolSize({ override: 8, replicas: 10 });
+      it("falls through to the derived size when it is unusable", () => {
+        const decision = resolvePoolSize({ override: 0, replicas: 10 });
 
-      expect(decision.exceedsBudget).toBe(false);
-    });
-
-    it("still reports the ceiling when nothing conflicts", () => {
-      expect(resolvePoolSize({ override: 8, replicas: 10 }).derivedCeiling).toBe(
-        10,
-      );
-    });
-
-    it.each([
-      ["zero", 0],
-      ["negative", -5],
-      ["fractional", 2.5],
-      ["above the hard cap", 5000],
-      ["not a number", Number.NaN],
-    ])("ignores an unusable override (%s)", (_label, override) => {
-      const decision = resolvePoolSize({ override });
-
-      expect(decision.size).toBe(FALLBACK_POOL_SIZE);
-      expect(decision.rejectedOverride).toBe(override);
-    });
-
-    it("falls through to the derived size when it is unusable", () => {
-      const decision = resolvePoolSize({ override: 0, replicas: 10 });
-
-      expect(decision.size).toBe(10);
-      expect(decision.source).toBe("derived");
-      expect(decision.rejectedOverride).toBe(0);
+        expect(decision.size).toBe(10);
+        expect(decision.source).toBe("derived");
+        expect(decision.rejectedOverride).toBe(0);
+      });
     });
   });
 });
 
 describe("poolSizingFromEnv", () => {
   describe("given an empty environment", () => {
-    it("supplies nothing rather than inventing defaults", () => {
-      expect(poolSizingFromEnv({})).toEqual({
-        override: undefined,
-        replicas: undefined,
-        serverMaxConcurrentQueries: undefined,
-        clientsPerProcess: undefined,
+    describe("when the inputs are read", () => {
+      it("supplies nothing rather than inventing defaults", () => {
+        expect(poolSizingFromEnv({})).toEqual({
+          override: undefined,
+          replicas: undefined,
+          serverMaxConcurrentQueries: undefined,
+          clientsPerProcess: undefined,
+        });
       });
-    });
 
-    it("treats an empty string as unset", () => {
-      expect(poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "" }).replicas)
-        .toBeUndefined();
+      it("treats an empty string as unset", () => {
+        expect(poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "" }).replicas)
+          .toBeUndefined();
+      });
     });
   });
 
   describe("given a populated environment", () => {
-    it("reads every knob", () => {
-      expect(
-        poolSizingFromEnv({
-          CLICKHOUSE_MAX_OPEN_CONNECTIONS: "40",
-          CLICKHOUSE_CLIENT_REPLICAS: "10",
-          CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES: "500",
-          CLICKHOUSE_CLIENTS_PER_PROCESS: "1",
-        }),
-      ).toEqual({
-        override: 40,
-        replicas: 10,
-        serverMaxConcurrentQueries: 500,
-        clientsPerProcess: 1,
-      });
-    });
-
-    it("surfaces a non-numeric value as NaN so the resolver rejects it", () => {
-      const input = poolSizingFromEnv({
-        CLICKHOUSE_MAX_OPEN_CONNECTIONS: "lots",
+    describe("when the inputs are read", () => {
+      it("reads every knob", () => {
+        expect(
+          poolSizingFromEnv({
+            CLICKHOUSE_MAX_OPEN_CONNECTIONS: "40",
+            CLICKHOUSE_CLIENT_REPLICAS: "10",
+            CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES: "500",
+            CLICKHOUSE_CLIENTS_PER_PROCESS: "1",
+          }),
+        ).toEqual({
+          override: 40,
+          replicas: 10,
+          serverMaxConcurrentQueries: 500,
+          clientsPerProcess: 1,
+        });
       });
 
-      expect(input.override).toBeNaN();
-      expect(resolvePoolSize(input).size).toBe(FALLBACK_POOL_SIZE);
+      it("surfaces a non-numeric value as NaN so the resolver rejects it", () => {
+        const input = poolSizingFromEnv({
+          CLICKHOUSE_MAX_OPEN_CONNECTIONS: "lots",
+        });
+
+        expect(input.override).toBeNaN();
+        expect(resolvePoolSize(input).size).toBe(FALLBACK_POOL_SIZE);
+      });
     });
   });
 
   describe("given the environment describes the production fleet", () => {
-    it("resolves a size that fits the server's budget", () => {
-      const decision = resolvePoolSize(
-        poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "10" }),
-      );
+    describe("when the size is resolved", () => {
+      it("resolves a size that fits the server's budget", () => {
+        const decision = resolvePoolSize(
+          poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "10" }),
+        );
 
-      expect(decision.size * 10 * 2).toBeLessThanOrEqual(
-        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
-      );
+        expect(decision.size * 10 * 2).toBeLessThanOrEqual(
+          DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+        );
+      });
     });
   });
 });

--- a/packages/clickhouse-client/src/pool.test.ts
+++ b/packages/clickhouse-client/src/pool.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+  deriveFleetPoolCeiling,
+  FALLBACK_POOL_SIZE,
+  MAX_POOL_SIZE,
+  poolSizingFromEnv,
+  resolvePoolSize,
+} from "./pool";
+
+describe("deriveFleetPoolCeiling", () => {
+  describe("given the fleet size is unknown", () => {
+    it.each([
+      ["undefined replicas", undefined],
+      ["zero replicas", 0],
+      ["negative replicas", -3],
+      ["a non-finite replica count", Number.NaN],
+    ])("cannot derive a ceiling from %s", (_label, replicas) => {
+      expect(deriveFleetPoolCeiling({ replicas })).toBeNull();
+    });
+  });
+
+  describe("given the fleet size is known", () => {
+    it("keeps every pool on every pod inside the server's budget", () => {
+      const replicas = 10;
+      const clientsPerProcess = 2;
+
+      const ceiling = deriveFleetPoolCeiling({ replicas, clientsPerProcess });
+
+      expect(ceiling).toBe(10);
+      expect(ceiling! * replicas * clientsPerProcess).toBeLessThanOrEqual(
+        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+      );
+    });
+
+    it("grows with the server's budget", () => {
+      expect(
+        deriveFleetPoolCeiling({
+          replicas: 10,
+          serverMaxConcurrentQueries: 1000,
+        }),
+      ).toBe(35);
+    });
+
+    it("gives a process holding one client twice the pool", () => {
+      const two = deriveFleetPoolCeiling({
+        replicas: 10,
+        clientsPerProcess: 2,
+      });
+      const one = deriveFleetPoolCeiling({
+        replicas: 10,
+        clientsPerProcess: 1,
+      });
+
+      expect(one).toBe(21);
+      expect(one!).toBeGreaterThan(two!);
+    });
+
+    it("shrinks as the fleet grows", () => {
+      const small = deriveFleetPoolCeiling({ replicas: 4 })!;
+      const large = deriveFleetPoolCeiling({ replicas: 40 })!;
+
+      expect(large).toBeLessThan(small);
+    });
+
+    it("never derives below a single usable connection", () => {
+      expect(deriveFleetPoolCeiling({ replicas: 100_000 })).toBe(1);
+    });
+
+    it("never derives above the hard cap", () => {
+      expect(
+        deriveFleetPoolCeiling({
+          replicas: 1,
+          clientsPerProcess: 1,
+          serverMaxConcurrentQueries: 10_000_000,
+        }),
+      ).toBe(MAX_POOL_SIZE);
+    });
+
+    it("reproduces the sizing that broke production", () => {
+      // 10 worker pods x 2 clients x a fixed 64 against a 300-query ceiling.
+      const fixedDefault = 64;
+      const ceiling = deriveFleetPoolCeiling({ replicas: 10 })!;
+
+      expect(fixedDefault * 10 * 2).toBeGreaterThan(
+        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+      );
+      expect(ceiling).toBeLessThan(fixedDefault);
+    });
+  });
+});
+
+describe("resolvePoolSize", () => {
+  describe("given no inputs at all", () => {
+    it("falls back rather than guessing a fleet size", () => {
+      const decision = resolvePoolSize();
+
+      expect(decision.size).toBe(FALLBACK_POOL_SIZE);
+      expect(decision.source).toBe("fallback");
+      expect(decision.derivedCeiling).toBeNull();
+      expect(decision.exceedsBudget).toBe(false);
+    });
+  });
+
+  describe("given the fleet size is known", () => {
+    it("derives the size", () => {
+      const decision = resolvePoolSize({ replicas: 10 });
+
+      expect(decision).toMatchObject({
+        size: 10,
+        source: "derived",
+        derivedCeiling: 10,
+        exceedsBudget: false,
+      });
+    });
+  });
+
+  describe("given an operator override", () => {
+    it("wins over the derived size", () => {
+      const decision = resolvePoolSize({ override: 40, replicas: 10 });
+
+      expect(decision.size).toBe(40);
+      expect(decision.source).toBe("override");
+    });
+
+    it("reports a conflict with the fleet budget instead of hiding it", () => {
+      const decision = resolvePoolSize({ override: 40, replicas: 10 });
+
+      expect(decision.exceedsBudget).toBe(true);
+      expect(decision.derivedCeiling).toBe(10);
+    });
+
+    it("raises no conflict when it fits the budget", () => {
+      const decision = resolvePoolSize({ override: 8, replicas: 10 });
+
+      expect(decision.exceedsBudget).toBe(false);
+    });
+
+    it("still reports the ceiling when nothing conflicts", () => {
+      expect(resolvePoolSize({ override: 8, replicas: 10 }).derivedCeiling).toBe(
+        10,
+      );
+    });
+
+    it.each([
+      ["zero", 0],
+      ["negative", -5],
+      ["fractional", 2.5],
+      ["above the hard cap", 5000],
+      ["not a number", Number.NaN],
+    ])("ignores an unusable override (%s)", (_label, override) => {
+      const decision = resolvePoolSize({ override });
+
+      expect(decision.size).toBe(FALLBACK_POOL_SIZE);
+      expect(decision.rejectedOverride).toBe(override);
+    });
+
+    it("falls through to the derived size when it is unusable", () => {
+      const decision = resolvePoolSize({ override: 0, replicas: 10 });
+
+      expect(decision.size).toBe(10);
+      expect(decision.source).toBe("derived");
+      expect(decision.rejectedOverride).toBe(0);
+    });
+  });
+});
+
+describe("poolSizingFromEnv", () => {
+  describe("given an empty environment", () => {
+    it("supplies nothing rather than inventing defaults", () => {
+      expect(poolSizingFromEnv({})).toEqual({
+        override: undefined,
+        replicas: undefined,
+        serverMaxConcurrentQueries: undefined,
+        clientsPerProcess: undefined,
+      });
+    });
+
+    it("treats an empty string as unset", () => {
+      expect(poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "" }).replicas)
+        .toBeUndefined();
+    });
+  });
+
+  describe("given a populated environment", () => {
+    it("reads every knob", () => {
+      expect(
+        poolSizingFromEnv({
+          CLICKHOUSE_MAX_OPEN_CONNECTIONS: "40",
+          CLICKHOUSE_CLIENT_REPLICAS: "10",
+          CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES: "500",
+          CLICKHOUSE_CLIENTS_PER_PROCESS: "1",
+        }),
+      ).toEqual({
+        override: 40,
+        replicas: 10,
+        serverMaxConcurrentQueries: 500,
+        clientsPerProcess: 1,
+      });
+    });
+
+    it("surfaces a non-numeric value as NaN so the resolver rejects it", () => {
+      const input = poolSizingFromEnv({
+        CLICKHOUSE_MAX_OPEN_CONNECTIONS: "lots",
+      });
+
+      expect(input.override).toBeNaN();
+      expect(resolvePoolSize(input).size).toBe(FALLBACK_POOL_SIZE);
+    });
+  });
+
+  describe("given the environment describes the production fleet", () => {
+    it("resolves a size that fits the server's budget", () => {
+      const decision = resolvePoolSize(
+        poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "10" }),
+      );
+
+      expect(decision.size * 10 * 2).toBeLessThanOrEqual(
+        DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+      );
+    });
+  });
+});

--- a/packages/clickhouse-client/src/pool.test.ts
+++ b/packages/clickhouse-client/src/pool.test.ts
@@ -226,8 +226,9 @@ describe("poolSizingFromEnv", () => {
       });
 
       it("treats an empty string as unset", () => {
-        expect(poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "" }).replicas)
-          .toBeUndefined();
+        expect(
+          poolSizingFromEnv({ CLICKHOUSE_CLIENT_REPLICAS: "" }).replicas,
+        ).toBeUndefined();
       });
     });
   });

--- a/packages/clickhouse-client/src/pool.ts
+++ b/packages/clickhouse-client/src/pool.ts
@@ -1,0 +1,182 @@
+/**
+ * Connection-pool sizing.
+ *
+ * A pool is per client INSTANCE, and a process that constructs two clients
+ * opens two pools. The server's budget has to cover every pool on every pod, so
+ * the only safe way to pick a size is from the server's own
+ * `max_concurrent_queries` divided by the fleet - never a fixed number chosen
+ * against an assumed replica count.
+ *
+ * On 2026-07-31 a fixed default of 64, reasoned about as "4 pods x 1 client",
+ * met a fleet of 10 worker pods and 3 app pods each holding 2 clients. The
+ * server rejected ~37k queries with TOO_MANY_SIMULTANEOUS_QUERIES, and the
+ * retry path drove every rejection straight back into the same wall.
+ *
+ * Nothing here reads `process.env`: the caller passes the numbers in, so the
+ * rules are the same in every process and testable without mocking the
+ * environment.
+ */
+
+/** ClickHouse's own `max_concurrent_queries` when the deployment says nothing. */
+export const DEFAULT_SERVER_MAX_CONCURRENT_QUERIES = 300;
+
+/**
+ * Headroom left for everything the derivation cannot see: ad-hoc queries, ops
+ * tooling, migrations, and the burst a retry storm adds on top of steady state.
+ */
+export const FLEET_SAFETY_FACTOR = 0.7;
+
+/** Both the raw client and the app-layer factory build one, each with a pool. */
+export const DEFAULT_CLIENTS_PER_PROCESS = 2;
+
+/**
+ * Used only when the fleet size is unknown, which is the case for any process
+ * that has not been told its replica count. Preserves the historical value so
+ * adopting this package changes nothing until the deployment opts in.
+ */
+export const FALLBACK_POOL_SIZE = 64;
+
+/** A typo must not be able to melt the server or re-choke the client. */
+export const MIN_POOL_SIZE = 1;
+export const MAX_POOL_SIZE = 1024;
+
+export interface PoolSizingInput {
+  /** Operator override. Wins whenever it is a usable integer. */
+  override?: number | undefined;
+  /** Replicas of this deployment. Unknown or zero disables derivation. */
+  replicas?: number | undefined;
+  /** The server's `max_concurrent_queries`. */
+  serverMaxConcurrentQueries?: number | undefined;
+  /** Client instances this process constructs. */
+  clientsPerProcess?: number | undefined;
+}
+
+export type PoolSizeSource = "override" | "derived" | "fallback";
+
+export interface PoolSizingDecision {
+  size: number;
+  source: PoolSizeSource;
+  /**
+   * What the fleet budget would have allowed, when it is knowable. Present
+   * even for an override so the caller can report a conflict rather than
+   * discovering it as rejected queries.
+   */
+  derivedCeiling: number | null;
+  /**
+   * Set when the resolved size lets the fleet exceed the server's budget. The
+   * caller decides whether that is a warning or a refusal to boot; this module
+   * only states the fact.
+   */
+  exceedsBudget: boolean;
+  /** Set when an override was supplied but was not a usable integer. */
+  rejectedOverride: number | undefined;
+}
+
+function isUsableInteger(value: number | undefined): value is number {
+  return (
+    value !== undefined &&
+    Number.isInteger(value) &&
+    value >= MIN_POOL_SIZE &&
+    value <= MAX_POOL_SIZE
+  );
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+/**
+ * The largest per-client pool that keeps every pool on every pod inside the
+ * server's budget. Null when the fleet size is unknown, because a pod cannot
+ * infer how many siblings it has.
+ */
+export function deriveFleetPoolCeiling(input: PoolSizingInput): number | null {
+  const replicas = input.replicas;
+  if (replicas === undefined || !Number.isFinite(replicas) || replicas <= 0) {
+    return null;
+  }
+
+  const serverMax = positiveOr(
+    input.serverMaxConcurrentQueries,
+    DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+  );
+  const clients = positiveOr(
+    input.clientsPerProcess,
+    DEFAULT_CLIENTS_PER_PROCESS,
+  );
+
+  const derived = Math.floor(
+    (serverMax * FLEET_SAFETY_FACTOR) / (replicas * clients),
+  );
+  return Math.min(MAX_POOL_SIZE, Math.max(MIN_POOL_SIZE, derived));
+}
+
+/**
+ * Resolve the pool size and say where it came from. Returns a decision rather
+ * than a number so the caller owns the reporting, and so a conflict between an
+ * override and the fleet budget is visible instead of silent.
+ */
+export function resolvePoolSize(
+  input: PoolSizingInput = {},
+): PoolSizingDecision {
+  const derivedCeiling = deriveFleetPoolCeiling(input);
+
+  if (input.override !== undefined && isUsableInteger(input.override)) {
+    return {
+      size: input.override,
+      source: "override",
+      derivedCeiling,
+      exceedsBudget:
+        derivedCeiling !== null && input.override > derivedCeiling,
+      rejectedOverride: undefined,
+    };
+  }
+
+  const rejectedOverride =
+    input.override !== undefined && !isUsableInteger(input.override)
+      ? input.override
+      : undefined;
+
+  if (derivedCeiling !== null) {
+    return {
+      size: derivedCeiling,
+      source: "derived",
+      derivedCeiling,
+      exceedsBudget: false,
+      rejectedOverride,
+    };
+  }
+
+  return {
+    size: FALLBACK_POOL_SIZE,
+    source: "fallback",
+    derivedCeiling: null,
+    exceedsBudget: false,
+    rejectedOverride,
+  };
+}
+
+/**
+ * Parse the sizing inputs out of an environment bag. Kept separate from
+ * {@link resolvePoolSize} so the rules stay testable without touching
+ * `process.env`, and so a non-Node host can supply the numbers another way.
+ */
+export function poolSizingFromEnv(
+  env: Record<string, string | undefined>,
+): PoolSizingInput {
+  const int = (name: string): number | undefined => {
+    const raw = env[name];
+    if (raw === undefined || raw === "") return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : Number.NaN;
+  };
+
+  return {
+    override: int("CLICKHOUSE_MAX_OPEN_CONNECTIONS"),
+    replicas: int("CLICKHOUSE_CLIENT_REPLICAS"),
+    serverMaxConcurrentQueries: int("CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES"),
+    clientsPerProcess: int("CLICKHOUSE_CLIENTS_PER_PROCESS"),
+  };
+}

--- a/packages/clickhouse-client/src/pool.ts
+++ b/packages/clickhouse-client/src/pool.ts
@@ -81,10 +81,42 @@ function isUsableInteger(value: number | undefined): value is number {
   );
 }
 
-function positiveOr(value: number | undefined, fallback: number): number {
-  return value !== undefined && Number.isFinite(value) && value > 0
+/**
+ * A fractional replica or client count cannot exist, and treating it as one
+ * anyway (e.g. `clientsPerProcess: 0.5`) inflates the derived ceiling instead
+ * of shrinking it - the opposite of what the safety factor is for. Anything
+ * that is not a positive integer falls back to the default.
+ */
+function positiveIntegerOr(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isInteger(value) && value > 0
     ? value
     : fallback;
+}
+
+/**
+ * The unclamped ceiling: how many connections per pod the server's budget
+ * actually allows, before the "never below one usable connection" floor is
+ * applied. Callers that only need the reportable ceiling want
+ * {@link deriveFleetPoolCeiling}; this is for detecting the case the floor
+ * would otherwise hide - a fleet so large that even a single connection per
+ * pod exceeds the budget.
+ */
+function rawFleetPoolCeiling(input: PoolSizingInput): number | null {
+  const replicas = input.replicas;
+  if (replicas === undefined || !Number.isInteger(replicas) || replicas <= 0) {
+    return null;
+  }
+
+  const serverMax = positiveIntegerOr(
+    input.serverMaxConcurrentQueries,
+    DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
+  );
+  const clients = positiveIntegerOr(
+    input.clientsPerProcess,
+    DEFAULT_CLIENTS_PER_PROCESS,
+  );
+
+  return Math.floor((serverMax * FLEET_SAFETY_FACTOR) / (replicas * clients));
 }
 
 /**
@@ -93,24 +125,9 @@ function positiveOr(value: number | undefined, fallback: number): number {
  * infer how many siblings it has.
  */
 export function deriveFleetPoolCeiling(input: PoolSizingInput): number | null {
-  const replicas = input.replicas;
-  if (replicas === undefined || !Number.isFinite(replicas) || replicas <= 0) {
-    return null;
-  }
-
-  const serverMax = positiveOr(
-    input.serverMaxConcurrentQueries,
-    DEFAULT_SERVER_MAX_CONCURRENT_QUERIES,
-  );
-  const clients = positiveOr(
-    input.clientsPerProcess,
-    DEFAULT_CLIENTS_PER_PROCESS,
-  );
-
-  const derived = Math.floor(
-    (serverMax * FLEET_SAFETY_FACTOR) / (replicas * clients),
-  );
-  return Math.min(MAX_POOL_SIZE, Math.max(MIN_POOL_SIZE, derived));
+  const raw = rawFleetPoolCeiling(input);
+  if (raw === null) return null;
+  return Math.min(MAX_POOL_SIZE, Math.max(MIN_POOL_SIZE, raw));
 }
 
 /**
@@ -121,7 +138,14 @@ export function deriveFleetPoolCeiling(input: PoolSizingInput): number | null {
 export function resolvePoolSize(
   input: PoolSizingInput = {},
 ): PoolSizingDecision {
-  const derivedCeiling = deriveFleetPoolCeiling(input);
+  const raw = rawFleetPoolCeiling(input);
+  const derivedCeiling =
+    raw === null ? null : Math.min(MAX_POOL_SIZE, Math.max(MIN_POOL_SIZE, raw));
+  // A raw ceiling below one means the fleet's budget cannot afford even a
+  // single connection per pod - `deriveFleetPoolCeiling` floors that to 1 for
+  // display, but a resolved size of 1 still exceeds the real budget, so the
+  // floor must not also silence the warning.
+  const infeasible = raw !== null && raw < MIN_POOL_SIZE;
 
   if (input.override !== undefined && isUsableInteger(input.override)) {
     return {
@@ -129,7 +153,8 @@ export function resolvePoolSize(
       source: "override",
       derivedCeiling,
       exceedsBudget:
-        derivedCeiling !== null && input.override > derivedCeiling,
+        infeasible ||
+        (derivedCeiling !== null && input.override > derivedCeiling),
       rejectedOverride: undefined,
     };
   }
@@ -144,7 +169,7 @@ export function resolvePoolSize(
       size: derivedCeiling,
       source: "derived",
       derivedCeiling,
-      exceedsBudget: false,
+      exceedsBudget: infeasible,
       rejectedOverride,
     };
   }

--- a/packages/clickhouse-client/src/pool.ts
+++ b/packages/clickhouse-client/src/pool.ts
@@ -87,7 +87,10 @@ function isUsableInteger(value: number | undefined): value is number {
  * of shrinking it - the opposite of what the safety factor is for. Anything
  * that is not a positive integer falls back to the default.
  */
-function positiveIntegerOr(value: number | undefined, fallback: number): number {
+function positiveIntegerOr(
+  value: number | undefined,
+  fallback: number,
+): number {
   return value !== undefined && Number.isInteger(value) && value > 0
     ? value
     : fallback;

--- a/packages/clickhouse-client/src/rateLimit.test.ts
+++ b/packages/clickhouse-client/src/rateLimit.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AcquireAbortedError,
+  createConcurrencyLimiter,
+  QueueFullError,
+  rateLimit,
+} from "./rateLimit";
+
+/** A task whose completion the test controls. */
+const deferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("createConcurrencyLimiter", () => {
+  describe("given an invalid limit", () => {
+    it.each([0, -1, 2.5])("refuses to be built with %s", (maxConcurrent) => {
+      expect(() => createConcurrencyLimiter({ maxConcurrent })).toThrow(
+        RangeError,
+      );
+    });
+  });
+
+  describe("given more work than the limit allows", () => {
+    it("runs only up to the limit at once", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 2 });
+      const gates = [deferred(), deferred(), deferred()];
+      const started = [false, false, false];
+
+      gates.forEach((gate, i) => {
+        void limiter.run(async () => {
+          started[i] = true;
+          await gate.promise;
+        });
+      });
+      await Promise.resolve();
+
+      expect(started).toEqual([true, true, false]);
+      expect(limiter.stats()).toEqual({ inFlight: 2, queued: 1 });
+    });
+
+    it("admits the next waiter when a slot frees", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+      const first = deferred();
+      let secondStarted = false;
+
+      void limiter.run(() => first.promise);
+      const second = limiter.run(async () => {
+        secondStarted = true;
+      });
+      await Promise.resolve();
+      expect(secondStarted).toBe(false);
+
+      first.resolve();
+      await second;
+
+      expect(secondStarted).toBe(true);
+    });
+  });
+
+  describe("given a task that fails", () => {
+    it("still releases the slot", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+
+      await expect(
+        limiter.run(async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(limiter.stats().inFlight).toBe(0);
+      await expect(limiter.run(async () => "ok")).resolves.toBe("ok");
+    });
+  });
+
+  describe("given the wait queue is full", () => {
+    it("sheds immediately rather than queueing without bound", async () => {
+      // An unbounded queue does not prevent overload, it hides it: the server
+      // stays inside its limit while latency and memory climb.
+      const limiter = createConcurrencyLimiter({
+        maxConcurrent: 1,
+        maxQueued: 1,
+      });
+      const gate = deferred();
+
+      void limiter.run(() => gate.promise);
+      void limiter.run(() => gate.promise);
+
+      await expect(limiter.run(async () => "third")).rejects.toBeInstanceOf(
+        QueueFullError,
+      );
+      gate.resolve();
+    });
+  });
+
+  describe("given a caller that aborts while waiting", () => {
+    it("gives up its place instead of occupying the queue", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+      const gate = deferred();
+      const controller = new AbortController();
+
+      void limiter.run(() => gate.promise);
+      const waiting = limiter.run(async () => "never", controller.signal);
+      await Promise.resolve();
+      expect(limiter.stats().queued).toBe(1);
+
+      controller.abort();
+
+      await expect(waiting).rejects.toBeInstanceOf(AcquireAbortedError);
+      expect(limiter.stats().queued).toBe(0);
+      gate.resolve();
+    });
+
+    it("refuses an already-aborted caller without taking a slot", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        limiter.run(async () => "never", controller.signal),
+      ).rejects.toBeInstanceOf(AcquireAbortedError);
+      expect(limiter.stats().inFlight).toBe(0);
+    });
+  });
+});
+
+describe("rateLimit middleware", () => {
+  describe("given a statement", () => {
+    it("runs it through the limiter", async () => {
+      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+      const next = vi.fn(async () => ({ rows: [1] }));
+
+      const result = await rateLimit({ limiter })(next as never)({
+        tenantId: "project_1",
+        sql: "SELECT 1",
+      });
+
+      expect(result.rows).toEqual([1]);
+      expect(limiter.stats().inFlight).toBe(0);
+    });
+  });
+});

--- a/packages/clickhouse-client/src/rateLimit.test.ts
+++ b/packages/clickhouse-client/src/rateLimit.test.ts
@@ -18,130 +18,184 @@ const deferred = () => {
 };
 
 describe("createConcurrencyLimiter", () => {
-  describe("given an invalid limit", () => {
-    it.each([0, -1, 2.5])("refuses to be built with %s", (maxConcurrent) => {
-      expect(() => createConcurrencyLimiter({ maxConcurrent })).toThrow(
-        RangeError,
-      );
+  describe("given an invalid concurrency limit", () => {
+    describe("when the limiter is built", () => {
+      it.each([0, -1, 2.5])("refuses to be built with %s", (maxConcurrent) => {
+        expect(() => createConcurrencyLimiter({ maxConcurrent })).toThrow(
+          RangeError,
+        );
+      });
+    });
+  });
+
+  describe("given an invalid queue bound", () => {
+    describe("when the limiter is built", () => {
+      it.each([
+        -1,
+        2.5,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+      ])("refuses to be built with %s", (maxQueued) => {
+        // `waiting.length >= NaN` is false forever, so an unvalidated NaN
+        // unbounds the queue and removes the only thing this module is for.
+        expect(() =>
+          createConcurrencyLimiter({ maxConcurrent: 1, maxQueued }),
+        ).toThrow(RangeError);
+      });
+    });
+  });
+
+  describe("given a queue bound of zero", () => {
+    describe("when the slots are all taken", () => {
+      it("sheds without waiting, which is a real configuration", async () => {
+        // Zero is the boundary between valid and invalid, and it means
+        // something deliberate: never queue, refuse the moment the slots go.
+        const limiter = createConcurrencyLimiter({
+          maxConcurrent: 1,
+          maxQueued: 0,
+        });
+        const gate = deferred();
+
+        void limiter.run(() => gate.promise);
+
+        await expect(limiter.run(async () => "second")).rejects.toBeInstanceOf(
+          QueueFullError,
+        );
+        gate.resolve();
+      });
     });
   });
 
   describe("given more work than the limit allows", () => {
-    it("runs only up to the limit at once", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 2 });
-      const gates = [deferred(), deferred(), deferred()];
-      const started = [false, false, false];
+    describe("when the tasks are submitted", () => {
+      it("runs only up to the limit at once", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 2 });
+        const gates = [deferred(), deferred(), deferred()];
+        const started = [false, false, false];
 
-      gates.forEach((gate, i) => {
-        void limiter.run(async () => {
-          started[i] = true;
-          await gate.promise;
+        gates.forEach((gate, i) => {
+          void limiter.run(async () => {
+            started[i] = true;
+            await gate.promise;
+          });
         });
-      });
-      await Promise.resolve();
+        await Promise.resolve();
 
-      expect(started).toEqual([true, true, false]);
-      expect(limiter.stats()).toEqual({ inFlight: 2, queued: 1 });
+        expect(started).toEqual([true, true, false]);
+        expect(limiter.stats()).toEqual({ inFlight: 2, queued: 1 });
+      });
     });
 
-    it("admits the next waiter when a slot frees", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
-      const first = deferred();
-      let secondStarted = false;
+    describe("when a slot frees", () => {
+      it("admits the next waiter", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+        const first = deferred();
+        let secondStarted = false;
 
-      void limiter.run(() => first.promise);
-      const second = limiter.run(async () => {
-        secondStarted = true;
+        void limiter.run(() => first.promise);
+        const second = limiter.run(async () => {
+          secondStarted = true;
+        });
+        await Promise.resolve();
+        expect(secondStarted).toBe(false);
+
+        first.resolve();
+        await second;
+
+        expect(secondStarted).toBe(true);
       });
-      await Promise.resolve();
-      expect(secondStarted).toBe(false);
-
-      first.resolve();
-      await second;
-
-      expect(secondStarted).toBe(true);
     });
   });
 
   describe("given a task that fails", () => {
-    it("still releases the slot", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+    describe("when the failure propagates", () => {
+      it("still releases the slot", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
 
-      await expect(
-        limiter.run(async () => {
-          throw new Error("boom");
-        }),
-      ).rejects.toThrow("boom");
+        await expect(
+          limiter.run(async () => {
+            throw new Error("boom");
+          }),
+        ).rejects.toThrow("boom");
 
-      expect(limiter.stats().inFlight).toBe(0);
-      await expect(limiter.run(async () => "ok")).resolves.toBe("ok");
+        expect(limiter.stats().inFlight).toBe(0);
+        await expect(limiter.run(async () => "ok")).resolves.toBe("ok");
+      });
     });
   });
 
   describe("given the wait queue is full", () => {
-    it("sheds immediately rather than queueing without bound", async () => {
-      // An unbounded queue does not prevent overload, it hides it: the server
-      // stays inside its limit while latency and memory climb.
-      const limiter = createConcurrencyLimiter({
-        maxConcurrent: 1,
-        maxQueued: 1,
+    describe("when another caller arrives", () => {
+      it("sheds immediately rather than queueing without bound", async () => {
+        // An unbounded queue does not prevent overload, it hides it: the
+        // server stays inside its limit while latency and memory climb.
+        const limiter = createConcurrencyLimiter({
+          maxConcurrent: 1,
+          maxQueued: 1,
+        });
+        const gate = deferred();
+
+        void limiter.run(() => gate.promise);
+        void limiter.run(() => gate.promise);
+
+        await expect(limiter.run(async () => "third")).rejects.toBeInstanceOf(
+          QueueFullError,
+        );
+        gate.resolve();
       });
-      const gate = deferred();
-
-      void limiter.run(() => gate.promise);
-      void limiter.run(() => gate.promise);
-
-      await expect(limiter.run(async () => "third")).rejects.toBeInstanceOf(
-        QueueFullError,
-      );
-      gate.resolve();
     });
   });
 
-  describe("given a caller that aborts while waiting", () => {
-    it("gives up its place instead of occupying the queue", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
-      const gate = deferred();
-      const controller = new AbortController();
+  describe("given a caller that aborts", () => {
+    describe("when it aborts while waiting", () => {
+      it("gives up its place instead of occupying the queue", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+        const gate = deferred();
+        const controller = new AbortController();
 
-      void limiter.run(() => gate.promise);
-      const waiting = limiter.run(async () => "never", controller.signal);
-      await Promise.resolve();
-      expect(limiter.stats().queued).toBe(1);
+        void limiter.run(() => gate.promise);
+        const waiting = limiter.run(async () => "never", controller.signal);
+        await Promise.resolve();
+        expect(limiter.stats().queued).toBe(1);
 
-      controller.abort();
+        controller.abort();
 
-      await expect(waiting).rejects.toBeInstanceOf(AcquireAbortedError);
-      expect(limiter.stats().queued).toBe(0);
-      gate.resolve();
+        await expect(waiting).rejects.toBeInstanceOf(AcquireAbortedError);
+        expect(limiter.stats().queued).toBe(0);
+        gate.resolve();
+      });
     });
 
-    it("refuses an already-aborted caller without taking a slot", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
-      const controller = new AbortController();
-      controller.abort();
+    describe("when it has already aborted before arriving", () => {
+      it("refuses it without taking a slot", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+        const controller = new AbortController();
+        controller.abort();
 
-      await expect(
-        limiter.run(async () => "never", controller.signal),
-      ).rejects.toBeInstanceOf(AcquireAbortedError);
-      expect(limiter.stats().inFlight).toBe(0);
+        await expect(
+          limiter.run(async () => "never", controller.signal),
+        ).rejects.toBeInstanceOf(AcquireAbortedError);
+        expect(limiter.stats().inFlight).toBe(0);
+      });
     });
   });
 });
 
 describe("rateLimit middleware", () => {
   describe("given a statement", () => {
-    it("runs it through the limiter", async () => {
-      const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
-      const next = vi.fn(async () => ({ rows: [1] }));
+    describe("when it is executed", () => {
+      it("runs it through the limiter", async () => {
+        const limiter = createConcurrencyLimiter({ maxConcurrent: 1 });
+        const next = vi.fn(async () => ({ rows: [1] }));
 
-      const result = await rateLimit({ limiter })(next as never)({
-        tenantId: "project_1",
-        sql: "SELECT 1",
+        const result = await rateLimit({ limiter })(next as never)({
+          tenantId: "project_1",
+          sql: "SELECT 1",
+        });
+
+        expect(result.rows).toEqual([1]);
+        expect(limiter.stats().inFlight).toBe(0);
       });
-
-      expect(result.rows).toEqual([1]);
-      expect(limiter.stats().inFlight).toBe(0);
     });
   });
 });

--- a/packages/clickhouse-client/src/rateLimit.ts
+++ b/packages/clickhouse-client/src/rateLimit.ts
@@ -68,6 +68,12 @@ export function createConcurrencyLimiter({
   if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
     throw new RangeError("maxConcurrent must be a positive integer");
   }
+  // Zero is a real setting - never queue, shed the moment the slots are gone.
+  // A non-integer is not: `waiting.length >= NaN` is false forever, which
+  // unbounds the queue and quietly removes the only thing this module is for.
+  if (!Number.isInteger(maxQueued) || maxQueued < 0) {
+    throw new RangeError("maxQueued must be a non-negative integer");
+  }
 
   let inFlight = 0;
   const waiting: { release: () => void; abort: (error: Error) => void }[] = [];

--- a/packages/clickhouse-client/src/rateLimit.ts
+++ b/packages/clickhouse-client/src/rateLimit.ts
@@ -1,0 +1,141 @@
+/**
+ * Bounded concurrency, with shedding.
+ *
+ * Pool sizing bounds how many sockets a process may open. It does not bound how
+ * many statements the process will try to run: work arrives from a queue whose
+ * concurrency is set somewhere else entirely, and on a bad day every lane wants
+ * the server at once. That is the shape of the 2026-07-31 incident - the server
+ * hit `max_concurrent_queries`, rejected, the rejections were classified as
+ * transient, and the retries went back into the same wall.
+ *
+ * Two rules follow, and they are the reason this exists as a separate layer
+ * rather than a flag on the retry policy:
+ *
+ *  - A slot is held across retries, not taken per attempt. Compose this
+ *    *outside* retry. Inside, a retrying statement releases its slot, joins the
+ *    back of the queue, and competes with fresh work, which is how a queue
+ *    turns a small overload into a persistent one.
+ *
+ *  - The waiting queue is bounded and sheds when full. An unbounded wait queue
+ *    does not prevent overload, it hides it: the server stays inside its limit
+ *    while memory grows and latency climbs until something upstream times out.
+ *    Refusing immediately is worse for one caller and much better for the rest.
+ */
+
+import type { AbortSignalLike, QueryMiddleware } from "./pipeline";
+
+/** Raised when the wait queue is full. Shed load rather than grow it. */
+export class QueueFullError extends Error {
+  constructor(public readonly maxQueued: number) {
+    super(
+      `ClickHouse concurrency queue is full (${maxQueued} waiting). Shedding rather than queueing further.`,
+    );
+    this.name = "QueueFullError";
+  }
+}
+
+/** Raised when a caller's signal aborts while it is still waiting for a slot. */
+export class AcquireAbortedError extends Error {
+  constructor() {
+    super("Aborted while waiting for a ClickHouse concurrency slot.");
+    this.name = "AcquireAbortedError";
+  }
+}
+
+export interface ConcurrencyLimiterOptions {
+  /** Statements allowed to be in flight at once. */
+  maxConcurrent: number;
+  /** Callers allowed to wait. Beyond this, `run` rejects immediately. */
+  maxQueued?: number | undefined;
+}
+
+export interface LimiterStats {
+  inFlight: number;
+  queued: number;
+}
+
+export interface ConcurrencyLimiter {
+  run<T>(task: () => Promise<T>, signal?: AbortSignalLike): Promise<T>;
+  stats(): LimiterStats;
+}
+
+const DEFAULT_MAX_QUEUED = 1_000;
+
+export function createConcurrencyLimiter({
+  maxConcurrent,
+  maxQueued = DEFAULT_MAX_QUEUED,
+}: ConcurrencyLimiterOptions): ConcurrencyLimiter {
+  if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
+    throw new RangeError("maxConcurrent must be a positive integer");
+  }
+
+  let inFlight = 0;
+  const waiting: { release: () => void; abort: (error: Error) => void }[] = [];
+
+  const pump = (): void => {
+    if (inFlight >= maxConcurrent) return;
+    const next = waiting.shift();
+    if (next === undefined) return;
+    inFlight += 1;
+    next.release();
+  };
+
+  const acquire = (signal?: AbortSignalLike): Promise<void> => {
+    if (signal?.aborted === true) {
+      return Promise.reject(new AcquireAbortedError());
+    }
+    if (inFlight < maxConcurrent) {
+      inFlight += 1;
+      return Promise.resolve();
+    }
+    if (waiting.length >= maxQueued) {
+      return Promise.reject(new QueueFullError(maxQueued));
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const entry = {
+        release: () => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        abort: (error: Error) => reject(error),
+      };
+      const onAbort = () => {
+        const index = waiting.indexOf(entry);
+        // Already released: the task is starting, so the abort is the task's
+        // problem now, not the queue's.
+        if (index === -1) return;
+        waiting.splice(index, 1);
+        entry.abort(new AcquireAbortedError());
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      waiting.push(entry);
+    });
+  };
+
+  return {
+    async run(task, signal) {
+      await acquire(signal);
+      try {
+        return await task();
+      } finally {
+        inFlight -= 1;
+        pump();
+      }
+    },
+    stats: () => ({ inFlight, queued: waiting.length }),
+  };
+}
+
+/**
+ * Middleware form. Compose outside retry so a slot is held for the whole
+ * statement, retries included.
+ */
+export function rateLimit({
+  limiter,
+}: {
+  limiter: ConcurrencyLimiter;
+}): QueryMiddleware {
+  return (next) => (request) =>
+    limiter.run(() => next(request), request.signal);
+}

--- a/packages/clickhouse-client/src/resilience.test.ts
+++ b/packages/clickhouse-client/src/resilience.test.ts
@@ -5,82 +5,117 @@ import {
   retryNoticeLevel,
 } from "./resilience";
 
-const withCode = (message: string, code: string): Error =>
-  Object.assign(new Error(message), { code });
+const withCode = ({
+  message,
+  code,
+}: {
+  message: string;
+  code: string;
+}): Error => Object.assign(new Error(message), { code });
 
-const withStatus = (message: string, status: number): Error =>
-  Object.assign(new Error(message), { statusCode: status });
+const withStatus = ({
+  message,
+  status,
+}: {
+  message: string;
+  status: number;
+}): Error => Object.assign(new Error(message), { statusCode: status });
 
 describe("isTransientClickHouseError", () => {
   describe("given something that is not an error", () => {
-    it.each([
-      ["a string", "ECONNRESET"],
-      ["null", null],
-      ["undefined", undefined],
-      ["a plain object", { code: "ECONNRESET" }],
-    ])("treats %s as permanent", (_label, value) => {
-      expect(isTransientClickHouseError(value)).toBe(false);
+    describe("when classified", () => {
+      it.each([
+        ["a string", "ECONNRESET"],
+        ["null", null],
+        ["undefined", undefined],
+        ["a plain object", { code: "ECONNRESET" }],
+      ])("treats %s as permanent", (_label, value) => {
+        expect(isTransientClickHouseError({ error: value })).toBe(false);
+      });
     });
   });
 
   describe("given a socket-level failure", () => {
-    it.each(["ECONNRESET", "EPIPE", "ETIMEDOUT", "EAI_AGAIN"])(
-      "retries %s",
-      (code) => {
-        expect(isTransientClickHouseError(withCode("socket", code))).toBe(true);
-      },
-    );
-
-    it("does not retry an unrecognised code", () => {
-      expect(isTransientClickHouseError(withCode("nope", "EACCES"))).toBe(
-        false,
+    describe("when the code is a known transient one", () => {
+      it.each(["ECONNRESET", "EPIPE", "ETIMEDOUT", "EAI_AGAIN"])(
+        "retries %s",
+        (code) => {
+          expect(
+            isTransientClickHouseError({ error: withCode({ message: "socket", code }) }),
+          ).toBe(true);
+        },
       );
+    });
+
+    describe("when the code is not recognised", () => {
+      it("does not retry", () => {
+        expect(
+          isTransientClickHouseError({
+            error: withCode({ message: "nope", code: "EACCES" }),
+          }),
+        ).toBe(false);
+      });
     });
   });
 
   describe("given an HTTP status", () => {
-    it.each([429, 502, 503])("retries %s", (status) => {
-      expect(isTransientClickHouseError(withStatus("busy", status))).toBe(true);
+    describe("when the status means busy", () => {
+      it.each([429, 502, 503])("retries %s", (status) => {
+        expect(
+          isTransientClickHouseError({ error: withStatus({ message: "busy", status }) }),
+        ).toBe(true);
+      });
     });
 
-    it.each([400, 401, 404, 500])("does not retry %s", (status) => {
-      expect(isTransientClickHouseError(withStatus("nope", status))).toBe(
-        false,
-      );
+    describe("when the status means permanent rejection", () => {
+      it.each([400, 401, 404, 500])("does not retry %s", (status) => {
+        expect(
+          isTransientClickHouseError({ error: withStatus({ message: "nope", status }) }),
+        ).toBe(false);
+      });
     });
   });
 
   describe("given a timeout", () => {
-    it("retries on the message alone", () => {
-      expect(isTransientClickHouseError(new Error("Timeout error."))).toBe(
-        true,
-      );
+    describe("when only the message says so", () => {
+      it("retries on the message alone", () => {
+        expect(
+          isTransientClickHouseError({ error: new Error("Timeout error.") }),
+        ).toBe(true);
+      });
     });
   });
 
   describe("given caller-supplied transient fragments", () => {
-    it("retries a message that contains one", () => {
-      const error = new Error("Code: 202. Too many simultaneous queries.");
+    describe("when the message contains one", () => {
+      it("retries", () => {
+        const error = new Error("Code: 202. Too many simultaneous queries.");
 
-      expect(
-        isTransientClickHouseError(error, {
-          transientMessageFragments: ["Too many simultaneous queries"],
-        }),
-      ).toBe(true);
+        expect(
+          isTransientClickHouseError({
+            error,
+            transientMessageFragments: ["Too many simultaneous queries"],
+          }),
+        ).toBe(true);
+      });
     });
 
-    it("does not retry it when the caller supplies no fragments", () => {
-      const error = new Error("Code: 202. Too many simultaneous queries.");
+    describe("when the caller supplies no fragments", () => {
+      it("does not retry", () => {
+        const error = new Error("Code: 202. Too many simultaneous queries.");
 
-      expect(isTransientClickHouseError(error)).toBe(false);
+        expect(isTransientClickHouseError({ error })).toBe(false);
+      });
     });
   });
 
   describe("given a query the server will never accept", () => {
-    it("fails fast rather than spending the budget", () => {
-      const syntaxError = new Error("Code: 62. DB::Exception: Syntax error");
+    describe("when the failure is a syntax error", () => {
+      it("fails fast rather than spending the budget", () => {
+        const syntaxError = new Error("Code: 62. DB::Exception: Syntax error");
 
-      expect(isTransientClickHouseError(syntaxError)).toBe(false);
+        expect(isTransientClickHouseError({ error: syntaxError })).toBe(false);
+      });
     });
   });
 });
@@ -89,48 +124,62 @@ describe("jitteredBackoffMs", () => {
   const base = { baseDelayMs: 500, maxDelayMs: 600_000, random: () => 0 };
 
   describe("given no jitter", () => {
-    it("doubles with each attempt", () => {
-      expect(jitteredBackoffMs({ ...base, attempt: 0 })).toBe(500);
-      expect(jitteredBackoffMs({ ...base, attempt: 1 })).toBe(1000);
-      expect(jitteredBackoffMs({ ...base, attempt: 2 })).toBe(2000);
+    describe("when the attempt increases", () => {
+      it("doubles with each attempt", () => {
+        expect(jitteredBackoffMs({ ...base, attempt: 0 })).toBe(500);
+        expect(jitteredBackoffMs({ ...base, attempt: 1 })).toBe(1000);
+        expect(jitteredBackoffMs({ ...base, attempt: 2 })).toBe(2000);
+      });
     });
   });
 
   describe("given full jitter", () => {
-    it("adds at most one base delay", () => {
-      expect(jitteredBackoffMs({ ...base, attempt: 0, random: () => 1 })).toBe(
-        1000,
-      );
+    describe("when the random source always returns 1", () => {
+      it("adds at most one base delay", () => {
+        expect(
+          jitteredBackoffMs({ ...base, attempt: 0, random: () => 1 }),
+        ).toBe(1000);
+      });
     });
   });
 
-  describe("given enough attempts to overflow", () => {
-    it("clamps to the maximum", () => {
-      expect(jitteredBackoffMs({ ...base, attempt: 40 })).toBe(600_000);
-    });
+  describe("given an attempt whose exponential delay exceeds the maximum", () => {
+    describe("when the delay is computed", () => {
+      it("clamps to the maximum", () => {
+        expect(jitteredBackoffMs({ ...base, attempt: 40 })).toBe(600_000);
+      });
 
-    it("never exceeds the maximum whatever the jitter", () => {
-      for (let attempt = 0; attempt < 30; attempt++) {
-        const delay = jitteredBackoffMs({ ...base, attempt, random: () => 1 });
-        expect(delay).toBeLessThanOrEqual(600_000);
-      }
+      it("never exceeds the maximum whatever the jitter", () => {
+        for (let attempt = 0; attempt < 30; attempt++) {
+          const delay = jitteredBackoffMs({
+            ...base,
+            attempt,
+            random: () => 1,
+          });
+          expect(delay).toBeLessThanOrEqual(600_000);
+        }
+      });
     });
   });
 });
 
 describe("retryNoticeLevel", () => {
   describe("given the first attempt", () => {
-    it("warns once", () => {
-      expect(retryNoticeLevel(0)).toBe("warn");
+    describe("when the level is chosen", () => {
+      it("warns once", () => {
+        expect(retryNoticeLevel(0)).toBe("warn");
+      });
     });
   });
 
   describe("given a later attempt", () => {
-    it("stays quiet so one failure is not counted many times", () => {
-      // A 25-attempt budget previously produced 25 warn records per failure.
-      const levels = Array.from({ length: 25 }, (_, i) => retryNoticeLevel(i));
+    describe("when the level is chosen", () => {
+      it("stays quiet so one failure is not counted many times", () => {
+        // A 25-attempt budget previously produced 25 warn records per failure.
+        const levels = Array.from({ length: 25 }, (_, i) => retryNoticeLevel(i));
 
-      expect(levels.filter((l) => l === "warn")).toHaveLength(1);
+        expect(levels.filter((l) => l === "warn")).toHaveLength(1);
+      });
     });
   });
 });

--- a/packages/clickhouse-client/src/resilience.test.ts
+++ b/packages/clickhouse-client/src/resilience.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTransientClickHouseError,
+  jitteredBackoffMs,
+  retryNoticeLevel,
+} from "./resilience";
+
+const withCode = (message: string, code: string): Error =>
+  Object.assign(new Error(message), { code });
+
+const withStatus = (message: string, status: number): Error =>
+  Object.assign(new Error(message), { statusCode: status });
+
+describe("isTransientClickHouseError", () => {
+  describe("given something that is not an error", () => {
+    it.each([
+      ["a string", "ECONNRESET"],
+      ["null", null],
+      ["undefined", undefined],
+      ["a plain object", { code: "ECONNRESET" }],
+    ])("treats %s as permanent", (_label, value) => {
+      expect(isTransientClickHouseError(value)).toBe(false);
+    });
+  });
+
+  describe("given a socket-level failure", () => {
+    it.each(["ECONNRESET", "EPIPE", "ETIMEDOUT", "EAI_AGAIN"])(
+      "retries %s",
+      (code) => {
+        expect(isTransientClickHouseError(withCode("socket", code))).toBe(true);
+      },
+    );
+
+    it("does not retry an unrecognised code", () => {
+      expect(isTransientClickHouseError(withCode("nope", "EACCES"))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given an HTTP status", () => {
+    it.each([429, 502, 503])("retries %s", (status) => {
+      expect(isTransientClickHouseError(withStatus("busy", status))).toBe(true);
+    });
+
+    it.each([400, 401, 404, 500])("does not retry %s", (status) => {
+      expect(isTransientClickHouseError(withStatus("nope", status))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given a timeout", () => {
+    it("retries on the message alone", () => {
+      expect(isTransientClickHouseError(new Error("Timeout error."))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("given caller-supplied transient fragments", () => {
+    it("retries a message that contains one", () => {
+      const error = new Error("Code: 202. Too many simultaneous queries.");
+
+      expect(
+        isTransientClickHouseError(error, {
+          transientMessageFragments: ["Too many simultaneous queries"],
+        }),
+      ).toBe(true);
+    });
+
+    it("does not retry it when the caller supplies no fragments", () => {
+      const error = new Error("Code: 202. Too many simultaneous queries.");
+
+      expect(isTransientClickHouseError(error)).toBe(false);
+    });
+  });
+
+  describe("given a query the server will never accept", () => {
+    it("fails fast rather than spending the budget", () => {
+      const syntaxError = new Error("Code: 62. DB::Exception: Syntax error");
+
+      expect(isTransientClickHouseError(syntaxError)).toBe(false);
+    });
+  });
+});
+
+describe("jitteredBackoffMs", () => {
+  const base = { baseDelayMs: 500, maxDelayMs: 600_000, random: () => 0 };
+
+  describe("given no jitter", () => {
+    it("doubles with each attempt", () => {
+      expect(jitteredBackoffMs({ ...base, attempt: 0 })).toBe(500);
+      expect(jitteredBackoffMs({ ...base, attempt: 1 })).toBe(1000);
+      expect(jitteredBackoffMs({ ...base, attempt: 2 })).toBe(2000);
+    });
+  });
+
+  describe("given full jitter", () => {
+    it("adds at most one base delay", () => {
+      expect(jitteredBackoffMs({ ...base, attempt: 0, random: () => 1 })).toBe(
+        1000,
+      );
+    });
+  });
+
+  describe("given enough attempts to overflow", () => {
+    it("clamps to the maximum", () => {
+      expect(jitteredBackoffMs({ ...base, attempt: 40 })).toBe(600_000);
+    });
+
+    it("never exceeds the maximum whatever the jitter", () => {
+      for (let attempt = 0; attempt < 30; attempt++) {
+        const delay = jitteredBackoffMs({ ...base, attempt, random: () => 1 });
+        expect(delay).toBeLessThanOrEqual(600_000);
+      }
+    });
+  });
+});
+
+describe("retryNoticeLevel", () => {
+  describe("given the first attempt", () => {
+    it("warns once", () => {
+      expect(retryNoticeLevel(0)).toBe("warn");
+    });
+  });
+
+  describe("given a later attempt", () => {
+    it("stays quiet so one failure is not counted many times", () => {
+      // A 25-attempt budget previously produced 25 warn records per failure.
+      const levels = Array.from({ length: 25 }, (_, i) => retryNoticeLevel(i));
+
+      expect(levels.filter((l) => l === "warn")).toHaveLength(1);
+    });
+  });
+});

--- a/packages/clickhouse-client/src/resilience.test.ts
+++ b/packages/clickhouse-client/src/resilience.test.ts
@@ -37,14 +37,18 @@ describe("isTransientClickHouseError", () => {
 
   describe("given a socket-level failure", () => {
     describe("when the code is a known transient one", () => {
-      it.each(["ECONNRESET", "EPIPE", "ETIMEDOUT", "EAI_AGAIN"])(
-        "retries %s",
-        (code) => {
-          expect(
-            isTransientClickHouseError({ error: withCode({ message: "socket", code }) }),
-          ).toBe(true);
-        },
-      );
+      it.each([
+        "ECONNRESET",
+        "EPIPE",
+        "ETIMEDOUT",
+        "EAI_AGAIN",
+      ])("retries %s", (code) => {
+        expect(
+          isTransientClickHouseError({
+            error: withCode({ message: "socket", code }),
+          }),
+        ).toBe(true);
+      });
     });
 
     describe("when the code is not recognised", () => {
@@ -62,7 +66,9 @@ describe("isTransientClickHouseError", () => {
     describe("when the status means busy", () => {
       it.each([429, 502, 503])("retries %s", (status) => {
         expect(
-          isTransientClickHouseError({ error: withStatus({ message: "busy", status }) }),
+          isTransientClickHouseError({
+            error: withStatus({ message: "busy", status }),
+          }),
         ).toBe(true);
       });
     });
@@ -70,7 +76,9 @@ describe("isTransientClickHouseError", () => {
     describe("when the status means permanent rejection", () => {
       it.each([400, 401, 404, 500])("does not retry %s", (status) => {
         expect(
-          isTransientClickHouseError({ error: withStatus({ message: "nope", status }) }),
+          isTransientClickHouseError({
+            error: withStatus({ message: "nope", status }),
+          }),
         ).toBe(false);
       });
     });
@@ -176,7 +184,9 @@ describe("retryNoticeLevel", () => {
     describe("when the level is chosen", () => {
       it("stays quiet so one failure is not counted many times", () => {
         // A 25-attempt budget previously produced 25 warn records per failure.
-        const levels = Array.from({ length: 25 }, (_, i) => retryNoticeLevel(i));
+        const levels = Array.from({ length: 25 }, (_, i) =>
+          retryNoticeLevel(i),
+        );
 
         expect(levels.filter((l) => l === "warn")).toHaveLength(1);
       });

--- a/packages/clickhouse-client/src/resilience.ts
+++ b/packages/clickhouse-client/src/resilience.ts
@@ -1,0 +1,106 @@
+/**
+ * Transient-failure classification and backoff.
+ *
+ * Two things live here that were previously decided inline at the retry site.
+ *
+ * Classification is a policy, not a detail: whether a failure is worth
+ * retrying has to match the outer queue's classifier, or the two layers
+ * disagree and a permanent failure burns a 25-attempt budget. The caller
+ * supplies the shared message fragments rather than this package owning a
+ * second copy of the list.
+ *
+ * Backoff takes an injectable `random` so a test can pin the jitter. That is
+ * the only reason it is a parameter.
+ */
+
+/** Socket-level codes worth another attempt. */
+export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+]);
+
+/** Statuses the server uses for "busy, come back". */
+export const TRANSIENT_HTTP_STATUSES: ReadonlySet<number> = new Set([
+  429, 502, 503,
+]);
+
+export interface TransientClassificationOptions {
+  /**
+   * Message fragments that mark a ClickHouse-side transient condition, owned by
+   * the caller so this package cannot drift from the queue's classifier.
+   */
+  transientMessageFragments?: readonly string[];
+}
+
+function statusOf(error: object): number | undefined {
+  const withStatus = error as { statusCode?: number; status?: number };
+  return withStatus.statusCode ?? withStatus.status;
+}
+
+/**
+ * Whether a failure is worth another attempt.
+ *
+ * Deliberately conservative: anything unrecognised is permanent. Retrying a
+ * permanent failure costs the full budget and, when the failure is a server
+ * overload the retries themselves caused, makes the overload worse.
+ */
+export function isTransientClickHouseError(
+  error: unknown,
+  options: TransientClassificationOptions = {},
+): boolean {
+  if (!(error instanceof Error)) return false;
+
+  if (/timeout/i.test(error.message)) return true;
+
+  for (const fragment of options.transientMessageFragments ?? []) {
+    if (error.message.includes(fragment)) return true;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string" && TRANSIENT_NETWORK_CODES.has(code)) {
+    return true;
+  }
+
+  const status = statusOf(error);
+  return status !== undefined && TRANSIENT_HTTP_STATUSES.has(status);
+}
+
+export interface BackoffInput {
+  /** Zero-based. */
+  attempt: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Injectable for deterministic tests. Defaults to `Math.random`. */
+  random?: () => number;
+}
+
+/** Exponential with full-base jitter, clamped to `maxDelayMs`. */
+export function jitteredBackoffMs({
+  attempt,
+  baseDelayMs,
+  maxDelayMs,
+  random = Math.random,
+}: BackoffInput): number {
+  const exponential = baseDelayMs * 2 ** attempt;
+  const jitter = random() * baseDelayMs;
+  return Math.min(exponential + jitter, maxDelayMs);
+}
+
+/**
+ * The level a retry notice should be emitted at.
+ *
+ * Only the first attempt is worth a warn. A slow endpoint produces one notice
+ * per retry, so a 25-attempt budget turned a single failure into 25 records
+ * that each read as a separate failure.
+ */
+export function retryNoticeLevel(attempt: number): "warn" | "debug" {
+  return attempt === 0 ? "warn" : "debug";
+}
+
+/** Where a retry notice attaches its cause. Never `error`; see ./logging.ts. */
+export const RETRY_CAUSE_FIELD = "retryError";

--- a/packages/clickhouse-client/src/resilience.ts
+++ b/packages/clickhouse-client/src/resilience.ts
@@ -29,7 +29,8 @@ export const TRANSIENT_HTTP_STATUSES: ReadonlySet<number> = new Set([
   429, 502, 503,
 ]);
 
-export interface TransientClassificationOptions {
+export interface TransientClassificationInput {
+  error: unknown;
   /**
    * Message fragments that mark a ClickHouse-side transient condition, owned by
    * the caller so this package cannot drift from the queue's classifier.
@@ -49,15 +50,15 @@ function statusOf(error: object): number | undefined {
  * permanent failure costs the full budget and, when the failure is a server
  * overload the retries themselves caused, makes the overload worse.
  */
-export function isTransientClickHouseError(
-  error: unknown,
-  options: TransientClassificationOptions = {},
-): boolean {
+export function isTransientClickHouseError({
+  error,
+  transientMessageFragments = [],
+}: TransientClassificationInput): boolean {
   if (!(error instanceof Error)) return false;
 
   if (/timeout/i.test(error.message)) return true;
 
-  for (const fragment of options.transientMessageFragments ?? []) {
+  for (const fragment of transientMessageFragments) {
     if (error.message.includes(fragment)) return true;
   }
 

--- a/packages/clickhouse-client/src/retry.test.ts
+++ b/packages/clickhouse-client/src/retry.test.ts
@@ -25,151 +25,229 @@ const fakeSleep = () => {
 
 describe("runWithRetry", () => {
   describe("given a degenerate attempt budget", () => {
-    it.each([
-      0, -1, 2.5,
-    ])("refuses %s rather than throwing an undefined", async (maxAttempts) => {
-      // The loop would never run and `throw lastError` would throw
-      // `undefined` - no message, no stack, and every instanceof handler
-      // upstream misses it.
-      await expect(
-        runWithRetry(async () => "ok", { maxAttempts }),
-      ).rejects.toBeInstanceOf(RangeError);
+    describe("when the operation is run", () => {
+      it.each([
+        0, -1, 2.5,
+      ])("refuses %s rather than throwing an undefined", async (maxAttempts) => {
+        // The loop would never run and `throw lastError` would throw
+        // `undefined` - no message, no stack, and every instanceof handler
+        // upstream misses it.
+        await expect(
+          runWithRetry(async () => "ok", { maxAttempts }),
+        ).rejects.toBeInstanceOf(RangeError);
+      });
     });
   });
 });
 
 describe("retry", () => {
   describe("given a transient failure that then succeeds", () => {
-    it("returns the eventual result", async () => {
-      const { sleep } = fakeSleep();
-      const next = vi
-        .fn()
-        .mockRejectedValueOnce(transient())
-        .mockResolvedValue({ rows: ["ok"] });
+    describe("when the statement is executed", () => {
+      it("returns the eventual result", async () => {
+        const { sleep } = fakeSleep();
+        const next = vi
+          .fn()
+          .mockRejectedValueOnce(transient())
+          .mockResolvedValue({ rows: ["ok"] });
 
-      const result = await retry({ sleep, random: () => 0 })(next as never)(
-        request,
-      );
+        const result = await retry({ sleep, random: () => 0 })(next as never)(
+          request,
+        );
 
-      expect(result.rows).toEqual(["ok"]);
-      expect(next).toHaveBeenCalledTimes(2);
+        expect(result.rows).toEqual(["ok"]);
+        expect(next).toHaveBeenCalledTimes(2);
+      });
     });
   });
 
   describe("given a permanent failure", () => {
-    it("fails on the first attempt instead of spending the budget", async () => {
-      // Retrying a syntax error costs the full budget and, when the failure is
-      // an overload the retries caused, makes the overload worse.
-      const { sleep } = fakeSleep();
-      const next = vi.fn().mockRejectedValue(permanent());
+    describe("when the statement is executed", () => {
+      it("fails on the first attempt instead of spending the budget", async () => {
+        // Retrying a syntax error costs the full budget and, when the failure
+        // is an overload the retries caused, makes the overload worse.
+        const { sleep } = fakeSleep();
+        const next = vi.fn().mockRejectedValue(permanent());
 
-      await expect(retry({ sleep })(next as never)(request)).rejects.toThrow(
-        /Syntax error/,
-      );
-      expect(next).toHaveBeenCalledTimes(1);
+        await expect(retry({ sleep })(next as never)(request)).rejects.toThrow(
+          /Syntax error/,
+        );
+        expect(next).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
   describe("given a failure that never clears", () => {
-    it("stops at the attempt budget", async () => {
-      const { sleep } = fakeSleep();
-      const next = vi.fn().mockRejectedValue(transient());
+    describe("when the attempt budget runs out", () => {
+      it("stops at the attempt budget", async () => {
+        const { sleep } = fakeSleep();
+        const next = vi.fn().mockRejectedValue(transient());
 
-      await expect(
-        retry({ maxAttempts: 3, sleep })(next as never)(request),
-      ).rejects.toThrow("socket");
-      expect(next).toHaveBeenCalledTimes(3);
-    });
+        await expect(
+          retry({ maxAttempts: 3, sleep })(next as never)(request),
+        ).rejects.toThrow("socket");
+        expect(next).toHaveBeenCalledTimes(3);
+      });
 
-    it("backs off exponentially between attempts", async () => {
-      const { delays, sleep } = fakeSleep();
-      const next = vi.fn().mockRejectedValue(transient());
+      it("backs off exponentially between attempts", async () => {
+        const { delays, sleep } = fakeSleep();
+        const next = vi.fn().mockRejectedValue(transient());
 
-      await expect(
-        retry({
-          maxAttempts: 4,
-          baseDelayMs: 100,
-          maxDelayMs: 10_000,
-          sleep,
-          random: () => 0,
-        })(next as never)(request),
-      ).rejects.toThrow();
+        await expect(
+          retry({
+            maxAttempts: 4,
+            baseDelayMs: 100,
+            maxDelayMs: 10_000,
+            sleep,
+            random: () => 0,
+          })(next as never)(request),
+        ).rejects.toThrow();
 
-      expect(delays).toEqual([100, 200, 400]);
+        expect(delays).toEqual([100, 200, 400]);
+      });
     });
   });
 
   describe("given the caller has aborted", () => {
-    it("stops retrying, because nobody is waiting for the answer", async () => {
-      const { sleep } = fakeSleep();
-      const controller = new AbortController();
-      const next = vi.fn().mockImplementation(() => {
-        controller.abort();
-        return Promise.reject(transient());
-      });
+    describe("when the abort lands during the attempt", () => {
+      it("stops retrying, because nobody is waiting for the answer", async () => {
+        const { sleep } = fakeSleep();
+        const controller = new AbortController();
+        const next = vi.fn().mockImplementation(() => {
+          controller.abort();
+          return Promise.reject(transient());
+        });
 
-      await expect(
-        retry({ maxAttempts: 5, sleep })(next as never)({
-          ...request,
-          signal: controller.signal,
-        }),
-      ).rejects.toThrow("socket");
-      expect(next).toHaveBeenCalledTimes(1);
+        await expect(
+          retry({ maxAttempts: 5, sleep })(next as never)({
+            ...request,
+            signal: controller.signal,
+          }),
+        ).rejects.toThrow("socket");
+        expect(next).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the abort lands during the backoff", () => {
+      it("does not start another attempt after the wait", async () => {
+        // A backoff can be tens of seconds. Checking only before the sleep
+        // means a caller that gave up during it still pays for one more
+        // attempt, against a server that is usually already struggling.
+        const controller = new AbortController();
+        const next = vi.fn().mockRejectedValue(transient());
+        const sleep = async () => {
+          controller.abort();
+        };
+
+        await expect(
+          retry({ maxAttempts: 5, sleep })(next as never)({
+            ...request,
+            signal: controller.signal,
+          }),
+        ).rejects.toThrow("socket");
+        expect(next).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
   describe("given retries happen", () => {
-    it("warns once and stays quiet after", async () => {
-      // A 25-attempt budget previously produced 25 warnings for one failure.
-      const { sleep } = fakeSleep();
-      const notices: string[] = [];
-      const next = vi.fn().mockRejectedValue(transient());
+    describe("when the failure repeats", () => {
+      it("warns once and stays quiet after", async () => {
+        // A 25-attempt budget previously produced 25 warnings for one failure.
+        const { sleep } = fakeSleep();
+        const notices: string[] = [];
+        const next = vi.fn().mockRejectedValue(transient());
 
-      await expect(
-        retry({
-          maxAttempts: 5,
-          sleep,
-          onRetry: (notice) => notices.push(notice.level),
-        })(next as never)(request),
-      ).rejects.toThrow();
+        await expect(
+          retry({
+            maxAttempts: 5,
+            sleep,
+            onRetry: (notice) => notices.push(notice.level),
+          })(next as never)(request),
+        ).rejects.toThrow();
 
-      expect(notices.filter((level) => level === "warn")).toHaveLength(1);
-      expect(notices).toHaveLength(4);
+        expect(notices.filter((level) => level === "warn")).toHaveLength(1);
+        expect(notices).toHaveLength(4);
+      });
+
+      it("reports the statement's tenant on every notice", async () => {
+        const { sleep } = fakeSleep();
+        const onRetry = vi.fn();
+        const next = vi.fn().mockRejectedValue(transient());
+
+        await expect(
+          retry({ maxAttempts: 2, sleep, onRetry })(next as never)(request),
+        ).rejects.toThrow();
+
+        expect(onRetry).toHaveBeenCalledWith(
+          expect.objectContaining({
+            request: expect.objectContaining({ tenantId: "project_1" }),
+          }),
+        );
+      });
     });
 
-    it("reports the statement's tenant on every notice", async () => {
-      const { sleep } = fakeSleep();
-      const onRetry = vi.fn();
-      const next = vi.fn().mockRejectedValue(transient());
+    describe("when the retry notice itself throws", () => {
+      it("still reports the ClickHouse failure, not the logging one", async () => {
+        // `onRetry` is host code on the query's own path. Unguarded, a broken
+        // logger replaces the error the caller needs to diagnose with one
+        // about the logger.
+        const { sleep } = fakeSleep();
+        const next = vi.fn().mockRejectedValue(transient());
 
-      await expect(
-        retry({ maxAttempts: 2, sleep, onRetry })(next as never)(request),
-      ).rejects.toThrow();
+        await expect(
+          retry({
+            maxAttempts: 3,
+            sleep,
+            onRetry: () => {
+              throw new Error("the metrics registry is misconfigured");
+            },
+          })(next as never)(request),
+        ).rejects.toThrow("socket");
+      });
 
-      expect(onRetry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          request: expect.objectContaining({ tenantId: "project_1" }),
-        }),
-      );
+      it("still spends the remaining attempts", async () => {
+        const { sleep } = fakeSleep();
+        const next = vi.fn().mockRejectedValue(transient());
+
+        await expect(
+          retry({
+            maxAttempts: 3,
+            sleep,
+            onRetry: () => {
+              throw new Error("the metrics registry is misconfigured");
+            },
+          })(next as never)(request),
+        ).rejects.toThrow();
+
+        expect(next).toHaveBeenCalledTimes(3);
+      });
     });
   });
 
   describe("given a caller-supplied transient fragment", () => {
-    it("retries a ClickHouse overload the classifier would otherwise reject", async () => {
-      const { sleep } = fakeSleep();
-      const next = vi
-        .fn()
-        .mockRejectedValueOnce(
-          new Error("Code: 202. Too many simultaneous queries."),
-        )
-        .mockResolvedValue({ rows: [] });
+    describe("when a ClickHouse overload is returned", () => {
+      it("retries an overload the classifier would otherwise reject", async () => {
+        // Retrying this is only safe because the caller opts in per pipeline
+        // and composes `rateLimit` outside `retry`: the slot is held across
+        // attempts, so a retried overload waits in the limiter rather than
+        // going straight back at the server. That ordering is what stops this
+        // becoming the 2026-07-31 loop, where rejections were classified as
+        // transient and the retries went back into the same wall.
+        const { sleep } = fakeSleep();
+        const next = vi
+          .fn()
+          .mockRejectedValueOnce(
+            new Error("Code: 202. Too many simultaneous queries."),
+          )
+          .mockResolvedValue({ rows: [] });
 
-      await retry({
-        sleep,
-        transientMessageFragments: ["Too many simultaneous queries"],
-      })(next as never)(request);
+        await retry({
+          sleep,
+          transientMessageFragments: ["Too many simultaneous queries"],
+        })(next as never)(request);
 
-      expect(next).toHaveBeenCalledTimes(2);
+        expect(next).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/packages/clickhouse-client/src/retry.test.ts
+++ b/packages/clickhouse-client/src/retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { QueryRequest } from "./pipeline";
-import { retry } from "./retry";
+import { retry, runWithRetry } from "./retry";
 
 const request: QueryRequest = {
   tenantId: "project_1",
@@ -22,6 +22,21 @@ const fakeSleep = () => {
     },
   };
 };
+
+describe("runWithRetry", () => {
+  describe("given a degenerate attempt budget", () => {
+    it.each([
+      0, -1, 2.5,
+    ])("refuses %s rather than throwing an undefined", async (maxAttempts) => {
+      // The loop would never run and `throw lastError` would throw
+      // `undefined` - no message, no stack, and every instanceof handler
+      // upstream misses it.
+      await expect(
+        runWithRetry(async () => "ok", { maxAttempts }),
+      ).rejects.toBeInstanceOf(RangeError);
+    });
+  });
+});
 
 describe("retry", () => {
   describe("given a transient failure that then succeeds", () => {

--- a/packages/clickhouse-client/src/retry.test.ts
+++ b/packages/clickhouse-client/src/retry.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryRequest } from "./pipeline";
+import { retry } from "./retry";
+
+const request: QueryRequest = {
+  tenantId: "project_1",
+  sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+  params: { tenantId: "project_1" },
+};
+
+const transient = () =>
+  Object.assign(new Error("socket"), { code: "ECONNRESET" });
+const permanent = () => new Error("Code: 62. DB::Exception: Syntax error");
+
+/** Never actually waits, and records what the delays would have been. */
+const fakeSleep = () => {
+  const delays: number[] = [];
+  return {
+    delays,
+    sleep: async (ms: number) => {
+      delays.push(ms);
+    },
+  };
+};
+
+describe("retry", () => {
+  describe("given a transient failure that then succeeds", () => {
+    it("returns the eventual result", async () => {
+      const { sleep } = fakeSleep();
+      const next = vi
+        .fn()
+        .mockRejectedValueOnce(transient())
+        .mockResolvedValue({ rows: ["ok"] });
+
+      const result = await retry({ sleep, random: () => 0 })(next as never)(
+        request,
+      );
+
+      expect(result.rows).toEqual(["ok"]);
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("given a permanent failure", () => {
+    it("fails on the first attempt instead of spending the budget", async () => {
+      // Retrying a syntax error costs the full budget and, when the failure is
+      // an overload the retries caused, makes the overload worse.
+      const { sleep } = fakeSleep();
+      const next = vi.fn().mockRejectedValue(permanent());
+
+      await expect(retry({ sleep })(next as never)(request)).rejects.toThrow(
+        /Syntax error/,
+      );
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a failure that never clears", () => {
+    it("stops at the attempt budget", async () => {
+      const { sleep } = fakeSleep();
+      const next = vi.fn().mockRejectedValue(transient());
+
+      await expect(
+        retry({ maxAttempts: 3, sleep })(next as never)(request),
+      ).rejects.toThrow("socket");
+      expect(next).toHaveBeenCalledTimes(3);
+    });
+
+    it("backs off exponentially between attempts", async () => {
+      const { delays, sleep } = fakeSleep();
+      const next = vi.fn().mockRejectedValue(transient());
+
+      await expect(
+        retry({
+          maxAttempts: 4,
+          baseDelayMs: 100,
+          maxDelayMs: 10_000,
+          sleep,
+          random: () => 0,
+        })(next as never)(request),
+      ).rejects.toThrow();
+
+      expect(delays).toEqual([100, 200, 400]);
+    });
+  });
+
+  describe("given the caller has aborted", () => {
+    it("stops retrying, because nobody is waiting for the answer", async () => {
+      const { sleep } = fakeSleep();
+      const controller = new AbortController();
+      const next = vi.fn().mockImplementation(() => {
+        controller.abort();
+        return Promise.reject(transient());
+      });
+
+      await expect(
+        retry({ maxAttempts: 5, sleep })(next as never)({
+          ...request,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow("socket");
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given retries happen", () => {
+    it("warns once and stays quiet after", async () => {
+      // A 25-attempt budget previously produced 25 warnings for one failure.
+      const { sleep } = fakeSleep();
+      const notices: string[] = [];
+      const next = vi.fn().mockRejectedValue(transient());
+
+      await expect(
+        retry({
+          maxAttempts: 5,
+          sleep,
+          onRetry: (notice) => notices.push(notice.level),
+        })(next as never)(request),
+      ).rejects.toThrow();
+
+      expect(notices.filter((level) => level === "warn")).toHaveLength(1);
+      expect(notices).toHaveLength(4);
+    });
+
+    it("reports the statement's tenant on every notice", async () => {
+      const { sleep } = fakeSleep();
+      const onRetry = vi.fn();
+      const next = vi.fn().mockRejectedValue(transient());
+
+      await expect(
+        retry({ maxAttempts: 2, sleep, onRetry })(next as never)(request),
+      ).rejects.toThrow();
+
+      expect(onRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({ tenantId: "project_1" }),
+        }),
+      );
+    });
+  });
+
+  describe("given a caller-supplied transient fragment", () => {
+    it("retries a ClickHouse overload the classifier would otherwise reject", async () => {
+      const { sleep } = fakeSleep();
+      const next = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error("Code: 202. Too many simultaneous queries."),
+        )
+        .mockResolvedValue({ rows: [] });
+
+      await retry({
+        sleep,
+        transientMessageFragments: ["Too many simultaneous queries"],
+      })(next as never)(request);
+
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/clickhouse-client/src/retry.ts
+++ b/packages/clickhouse-client/src/retry.ts
@@ -129,14 +129,31 @@ export async function runWithRetry<T>(
         maxDelayMs,
         ...(random === undefined ? {} : { random }),
       });
-      onRetry?.({
-        attempt,
-        maxAttempts,
-        delayMs,
-        error,
-        level: retryNoticeLevel(attempt),
-      });
+      // Guarded because `onRetry` is host code - a logger, a counter - and it
+      // runs inside the catch. An exception from it would propagate in place of
+      // `error`, so the caller would be handed a logging failure and never
+      // learn which ClickHouse error actually happened, and the remaining
+      // attempts would be cancelled by the reporting of the failure rather than
+      // the failure. Observability must not change what it observes.
+      try {
+        onRetry?.({
+          attempt,
+          maxAttempts,
+          delayMs,
+          error,
+          level: retryNoticeLevel(attempt),
+        });
+      } catch {
+        // Deliberately swallowed. There is nowhere better to put it: the only
+        // channel for reporting it is the thing that just threw.
+      }
+
       await sleep(delayMs);
+
+      // Checked again after the wait, not only before it. A backoff can be
+      // tens of seconds, and a caller that gave up during it is not waiting for
+      // the answer any more, so another attempt is pure load.
+      if (isAborted?.() === true) throw error;
     }
   }
 

--- a/packages/clickhouse-client/src/retry.ts
+++ b/packages/clickhouse-client/src/retry.ts
@@ -57,54 +57,96 @@ const realSleep = (ms: number): Promise<void> =>
     ).setTimeout(resolve, ms);
   });
 
-export function retry({
-  maxAttempts = DEFAULT_MAX_ATTEMPTS,
-  baseDelayMs = DEFAULT_BASE_DELAY_MS,
-  maxDelayMs = DEFAULT_MAX_DELAY_MS,
-  transientMessageFragments,
-  sleep = realSleep,
-  random,
-  onRetry,
-}: RetryOptions = {}): QueryMiddleware {
-  return (next) =>
-    async <Row>(request: QueryRequest) => {
-      let lastError: unknown;
+/** What {@link runWithRetry} reports on each retry. No request: it is generic. */
+export interface RetryAttemptNotice {
+  /** Zero-based. */
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  error: unknown;
+  /** `warn` for the first attempt, `debug` after: one failure, one warning. */
+  level: "warn" | "debug";
+}
 
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        try {
-          return await next<Row>(request);
-        } catch (error) {
-          lastError = error;
+export interface RunWithRetryOptions
+  extends Omit<RetryOptions, "onRetry" | "transientMessageFragments"> {
+  transientMessageFragments?: readonly string[] | undefined;
+  onRetry?: ((notice: RetryAttemptNotice) => void) | undefined;
+  /** Stop retrying once this reports true. Nobody is waiting any more. */
+  isAborted?: (() => boolean) | undefined;
+}
 
-          const isLastAttempt = attempt === maxAttempts - 1;
-          const transient = isTransientClickHouseError({
-            error,
-            transientMessageFragments,
-          });
-          // An aborted caller is not waiting for the answer any more, so
-          // spending the rest of the budget only adds load.
-          if (!transient || isLastAttempt || request.signal?.aborted === true) {
-            throw error;
-          }
+/**
+ * Retry any operation under this package's policy.
+ *
+ * The loop lives here rather than in the middleware so a caller that is not
+ * yet on the pipeline - the app's `ResilientClickHouseClient`, which wraps the
+ * vendor client's own `query`/`insert` - can share one implementation instead
+ * of keeping a second copy that drifts.
+ */
+export async function runWithRetry<T>(
+  fn: () => Promise<T>,
+  {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    transientMessageFragments,
+    sleep = realSleep,
+    random,
+    onRetry,
+    isAborted,
+  }: RunWithRetryOptions = {},
+): Promise<T> {
+  let lastError: unknown;
 
-          const delayMs = jitteredBackoffMs({
-            attempt,
-            baseDelayMs,
-            maxDelayMs,
-            ...(random === undefined ? {} : { random }),
-          });
-          onRetry?.({
-            request,
-            attempt,
-            maxAttempts,
-            delayMs,
-            error,
-            level: retryNoticeLevel(attempt),
-          });
-          await sleep(delayMs);
-        }
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      const isLastAttempt = attempt === maxAttempts - 1;
+      const transient = isTransientClickHouseError({
+        error,
+        transientMessageFragments,
+      });
+      // An aborted caller is not waiting for the answer any more, so spending
+      // the rest of the budget only adds load.
+      if (!transient || isLastAttempt || isAborted?.() === true) {
+        throw error;
       }
 
-      throw lastError;
-    };
+      const delayMs = jitteredBackoffMs({
+        attempt,
+        baseDelayMs,
+        maxDelayMs,
+        ...(random === undefined ? {} : { random }),
+      });
+      onRetry?.({
+        attempt,
+        maxAttempts,
+        delayMs,
+        error,
+        level: retryNoticeLevel(attempt),
+      });
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError;
+}
+
+export function retry({
+  onRetry,
+  ...options
+}: RetryOptions = {}): QueryMiddleware {
+  return (next) =>
+    <Row>(request: QueryRequest) =>
+      runWithRetry(() => next<Row>(request), {
+        ...options,
+        isAborted: () => request.signal?.aborted === true,
+        ...(onRetry === undefined
+          ? {}
+          : { onRetry: (notice) => onRetry({ ...notice, request }) }),
+      });
 }

--- a/packages/clickhouse-client/src/retry.ts
+++ b/packages/clickhouse-client/src/retry.ts
@@ -97,6 +97,13 @@ export async function runWithRetry<T>(
     isAborted,
   }: RunWithRetryOptions = {},
 ): Promise<T> {
+  // Without this, `maxAttempts: 0` never enters the loop and throws the
+  // uninitialised `lastError` - an `undefined` with no message and no stack,
+  // which every instanceof-based handler upstream misses.
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError("maxAttempts must be a positive integer");
+  }
+
   let lastError: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/packages/clickhouse-client/src/retry.ts
+++ b/packages/clickhouse-client/src/retry.ts
@@ -1,0 +1,110 @@
+/**
+ * Retry middleware.
+ *
+ * Composes the policies in ./resilience.ts rather than restating them, so the
+ * classifier this uses is the same one the outer job queue uses and the two
+ * cannot drift into disagreeing about what "transient" means.
+ *
+ * Compose this *inside* the rate limiter, so a retrying statement keeps its
+ * slot instead of rejoining the queue behind fresh work.
+ */
+
+import type { QueryMiddleware, QueryRequest } from "./pipeline";
+import {
+  isTransientClickHouseError,
+  jitteredBackoffMs,
+  retryNoticeLevel,
+} from "./resilience";
+
+export interface RetryNotice {
+  request: QueryRequest;
+  /** Zero-based. */
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  error: unknown;
+  /** `warn` for the first attempt, `debug` after: one failure, one warning. */
+  level: "warn" | "debug";
+}
+
+export interface RetryOptions {
+  /** Total attempts including the first. */
+  maxAttempts?: number | undefined;
+  baseDelayMs?: number | undefined;
+  maxDelayMs?: number | undefined;
+  /** Owned by the caller so this cannot drift from the queue's classifier. */
+  transientMessageFragments?: readonly string[] | undefined;
+  /** Injectable for deterministic tests. */
+  sleep?: ((ms: number) => Promise<void>) | undefined;
+  random?: (() => number) | undefined;
+  onRetry?: ((notice: RetryNotice) => void) | undefined;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+
+/**
+ * Reached through `globalThis` so the package needs neither the Node nor the
+ * DOM lib to build. Every host that can run a query has a timer.
+ */
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    (
+      globalThis as unknown as {
+        setTimeout: (fn: () => void, ms: number) => unknown;
+      }
+    ).setTimeout(resolve, ms);
+  });
+
+export function retry({
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  transientMessageFragments,
+  sleep = realSleep,
+  random,
+  onRetry,
+}: RetryOptions = {}): QueryMiddleware {
+  return (next) =>
+    async <Row>(request: QueryRequest) => {
+      let lastError: unknown;
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          return await next<Row>(request);
+        } catch (error) {
+          lastError = error;
+
+          const isLastAttempt = attempt === maxAttempts - 1;
+          const transient = isTransientClickHouseError({
+            error,
+            transientMessageFragments,
+          });
+          // An aborted caller is not waiting for the answer any more, so
+          // spending the rest of the budget only adds load.
+          if (!transient || isLastAttempt || request.signal?.aborted === true) {
+            throw error;
+          }
+
+          const delayMs = jitteredBackoffMs({
+            attempt,
+            baseDelayMs,
+            maxDelayMs,
+            ...(random === undefined ? {} : { random }),
+          });
+          onRetry?.({
+            request,
+            attempt,
+            maxAttempts,
+            delayMs,
+            error,
+            level: retryNoticeLevel(attempt),
+          });
+          await sleep(delayMs);
+        }
+      }
+
+      throw lastError;
+    };
+}

--- a/packages/clickhouse-client/src/tenancy.test.ts
+++ b/packages/clickhouse-client/src/tenancy.test.ts
@@ -138,55 +138,44 @@ describe("createTenantRouter", () => {
     });
   });
 
-  describe("given a tenant that moves organisation", () => {
-    it("stops using the old organisation once the entry expires", async () => {
-      // The bug this replaces cached forever, so a moved project kept reading
-      // its previous organisation's ClickHouse until the process restarted.
-      let organizationId = "org_old";
-      let now = 0;
+  describe("given the same tenant resolved many times", () => {
+    it("asks the directory once, because the mapping cannot change", async () => {
+      // A project belongs to a team and a team to an organisation, and neither
+      // link is reassignable, so a resolved answer is final. There is nothing
+      // for an expiry to protect against; the bound below covers memory.
+      const organizationForTenant = vi.fn(async () => "org_1");
       const router = createTenantRouter({
-        table: tableOf({
-          org_old: "http://old:8123",
-          org_new: "http://new:8123",
-        }),
-        directory: { organizationForTenant: async () => organizationId },
-        cacheTtlMs: 1_000,
-        clock: { now: () => now },
+        table: tableOf({ org_1: "http://acme:8123" }),
+        directory: { organizationForTenant },
       });
 
-      await expect(router.route("project_1")).resolves.toMatchObject({
-        organizationId: "org_old",
-      });
+      for (let i = 0; i < 50; i++) {
+        await expect(router.route("project_1")).resolves.toMatchObject({
+          organizationId: "org_1",
+        });
+      }
 
-      organizationId = "org_new";
-      now = 1_001;
-
-      await expect(router.route("project_1")).resolves.toMatchObject({
-        organizationId: "org_new",
-        url: "http://new:8123",
-      });
+      expect(organizationForTenant).toHaveBeenCalledTimes(1);
     });
+  });
 
-    it("can be corrected immediately by invalidating the tenant", async () => {
-      let organizationId = "org_old";
+  describe("given a tenant that does not exist yet", () => {
+    it("does not cache the failure, so it routes once it is created", async () => {
+      let known = false;
       const router = createTenantRouter({
-        table: tableOf({
-          org_old: "http://old:8123",
-          org_new: "http://new:8123",
-        }),
-        directory: { organizationForTenant: async () => organizationId },
+        table: tableOf({}),
+        directory: {
+          organizationForTenant: async () => (known ? "org_1" : null),
+        },
       });
 
-      await expect(router.route("project_1")).resolves.toMatchObject({
-        organizationId: "org_old",
-      });
+      await expect(router.route("project_new")).rejects.toBeInstanceOf(
+        UnknownTenantError,
+      );
+      known = true;
 
-      organizationId = "org_new";
-      router.invalidate("project_1");
-
-      await expect(router.route("project_1")).resolves.toMatchObject({
-        organizationId: "org_new",
-        url: "http://new:8123",
+      await expect(router.route("project_new")).resolves.toEqual({
+        kind: "shared",
       });
     });
   });

--- a/packages/clickhouse-client/src/tenancy.test.ts
+++ b/packages/clickhouse-client/src/tenancy.test.ts
@@ -14,206 +14,259 @@ const directoryOf = (mapping: Record<string, string>): TenantDirectory => ({
 const tableOf = (routes: Record<string, string>) => ({
   routes: new Map(Object.entries(routes)),
   skipped: [],
+  ambiguous: [],
 });
 
 describe("parseRoutingTable", () => {
   describe("given well-formed entries", () => {
-    it("keys the route by the organisation id, ignoring the human label", () => {
-      const table = parseRoutingTable({
-        CLICKHOUSE_URL__acme__org_1: "http://acme:8123",
-        UNRELATED: "x",
+    describe("when the table is parsed", () => {
+      it("keys the route by the organisation id, ignoring the human label", () => {
+        const table = parseRoutingTable({
+          CLICKHOUSE_URL__acme__org_1: "http://acme:8123",
+          UNRELATED: "x",
+        });
+
+        expect(table.routes.get("org_1")).toBe("http://acme:8123");
+        expect(table.routes.size).toBe(1);
       });
 
-      expect(table.routes.get("org_1")).toBe("http://acme:8123");
-      expect(table.routes.size).toBe(1);
-    });
+      it("tolerates a label containing the separator", () => {
+        const table = parseRoutingTable({
+          CLICKHOUSE_URL__acme__eu__org_1: "http://acme:8123",
+        });
 
-    it("tolerates a label containing the separator", () => {
-      const table = parseRoutingTable({
-        CLICKHOUSE_URL__acme__eu__org_1: "http://acme:8123",
+        expect(table.routes.get("org_1")).toBe("http://acme:8123");
       });
-
-      expect(table.routes.get("org_1")).toBe("http://acme:8123");
     });
   });
 
   describe("given unusable entries", () => {
-    it.each([
-      ["an empty value", { CLICKHOUSE_URL__acme__org_1: "" }],
-      ["a whitespace value", { CLICKHOUSE_URL__acme__org_1: "   " }],
-      ["no organisation id", { CLICKHOUSE_URL__: "http://x:8123" }],
-    ])("skips %s rather than routing on it", (_label, env) => {
-      const table = parseRoutingTable(env);
+    describe("when the table is parsed", () => {
+      it.each([
+        ["an empty value", { CLICKHOUSE_URL__acme__org_1: "" }],
+        ["a whitespace value", { CLICKHOUSE_URL__acme__org_1: "   " }],
+        ["no organisation id", { CLICKHOUSE_URL__: "http://x:8123" }],
+      ])("skips %s rather than routing on it", (_label, env) => {
+        const table = parseRoutingTable(env);
 
-      expect(table.routes.size).toBe(0);
-      expect(table.skipped).toHaveLength(1);
-    });
-
-    it("collects every problem instead of dying on the first", () => {
-      const table = parseRoutingTable({
-        CLICKHOUSE_URL__a__org_1: "",
-        CLICKHOUSE_URL__b__org_2: "  ",
+        expect(table.routes.size).toBe(0);
+        expect(table.skipped).toHaveLength(1);
       });
 
-      expect(table.skipped).toHaveLength(2);
+      it("collects every problem instead of dying on the first", () => {
+        const table = parseRoutingTable({
+          CLICKHOUSE_URL__a__org_1: "",
+          CLICKHOUSE_URL__b__org_2: "  ",
+        });
+
+        expect(table.skipped).toHaveLength(2);
+      });
     });
   });
 
   describe("given an organisation id that contains the separator", () => {
-    it("reports the split as a guess rather than making it silently", () => {
-      // Guessing wrong is a fail-open: the intended organisation gets no route,
-      // so every one of its tenants falls through to the shared instance.
-      const table = parseRoutingTable({
-        CLICKHOUSE_URL__acme__organization__x1: "http://acme:8123",
-      });
+    describe("when the name cannot be split unambiguously", () => {
+      it("reports the split as a guess rather than making it silently", () => {
+        // Guessing wrong is a fail-open: the intended organisation gets no
+        // route, so every one of its tenants falls through to the shared
+        // instance.
+        const table = parseRoutingTable({
+          CLICKHOUSE_URL__acme__organization__x1: "http://acme:8123",
+        });
 
-      expect(table.ambiguous).toEqual([
-        {
-          envVar: "CLICKHOUSE_URL__acme__organization__x1",
-          organizationId: "x1",
-        },
-      ]);
+        expect(table.ambiguous).toEqual([
+          {
+            envVar: "CLICKHOUSE_URL__acme__organization__x1",
+            organizationId: "x1",
+          },
+        ]);
+      });
     });
 
-    it("does not flag an unambiguous single-separator name", () => {
-      expect(
-        parseRoutingTable({ CLICKHOUSE_URL__org_1: "http://x:8123" }).ambiguous,
-      ).toEqual([]);
+    describe("when the name has a single separator", () => {
+      it("does not flag it", () => {
+        expect(
+          parseRoutingTable({ CLICKHOUSE_URL__org_1: "http://x:8123" })
+            .ambiguous,
+        ).toEqual([]);
+      });
     });
   });
 
   describe("given two routes for one organisation", () => {
-    it("refuses to guess which instance holds their data", () => {
-      expect(() =>
-        parseRoutingTable({
-          CLICKHOUSE_URL__acme__org_1: "http://one:8123",
-          CLICKHOUSE_URL__acme_eu__org_1: "http://two:8123",
-        }),
-      ).toThrow(DuplicateRouteError);
+    describe("when the table is parsed", () => {
+      it("refuses to guess which instance holds their data", () => {
+        expect(() =>
+          parseRoutingTable({
+            CLICKHOUSE_URL__acme__org_1: "http://one:8123",
+            CLICKHOUSE_URL__acme_eu__org_1: "http://two:8123",
+          }),
+        ).toThrow(DuplicateRouteError);
+      });
     });
   });
 });
 
 describe("createTenantRouter", () => {
-  describe("given a tenant in an organisation with no private instance", () => {
-    it("routes to the shared instance", async () => {
-      const router = createTenantRouter({
-        table: tableOf({}),
-        directory: directoryOf({ project_1: "org_1" }),
+  describe("given an invalid cache bound", () => {
+    describe("when the router is built", () => {
+      it.each([
+        0,
+        -1,
+        2.5,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+      ])("refuses to be built with %s", (maxCacheEntries) => {
+        // `cache.size >= NaN` and `>= Infinity` are both false forever, so an
+        // unvalidated value removes the bound and lets a long-lived worker
+        // grow the map for the life of the process.
+        expect(() =>
+          createTenantRouter({
+            table: tableOf({}),
+            directory: directoryOf({}),
+            maxCacheEntries,
+          }),
+        ).toThrow(RangeError);
       });
+    });
+  });
 
-      await expect(router.route("project_1")).resolves.toEqual({
-        kind: "shared",
+  describe("given a tenant in an organisation with no private instance", () => {
+    describe("when it is routed", () => {
+      it("routes to the shared instance", async () => {
+        const router = createTenantRouter({
+          table: tableOf({}),
+          directory: directoryOf({ project_1: "org_1" }),
+        });
+
+        await expect(router.route("project_1")).resolves.toEqual({
+          kind: "shared",
+        });
       });
     });
   });
 
   describe("given a tenant in an organisation with a private instance", () => {
-    it("routes to that instance", async () => {
-      const router = createTenantRouter({
-        table: tableOf({ org_1: "http://acme:8123" }),
-        directory: directoryOf({ project_1: "org_1" }),
-      });
+    describe("when it is routed", () => {
+      it("routes to that instance", async () => {
+        const router = createTenantRouter({
+          table: tableOf({ org_1: "http://acme:8123" }),
+          directory: directoryOf({ project_1: "org_1" }),
+        });
 
-      await expect(router.route("project_1")).resolves.toEqual({
-        kind: "private",
-        organizationId: "org_1",
-        url: "http://acme:8123",
+        await expect(router.route("project_1")).resolves.toEqual({
+          kind: "private",
+          organizationId: "org_1",
+          url: "http://acme:8123",
+        });
       });
     });
   });
 
   describe("given a tenant the directory does not know", () => {
-    it("fails closed rather than falling back to shared", async () => {
-      // Falling back would run the statement against the shared instance,
-      // which succeeds and returns plausible rows belonging to someone else.
-      const router = createTenantRouter({
-        table: tableOf({}),
-        directory: directoryOf({}),
-      });
+    describe("when it is routed", () => {
+      it("fails closed rather than falling back to shared", async () => {
+        // Falling back would run the statement against the shared instance,
+        // which succeeds and returns plausible rows belonging to someone else.
+        const router = createTenantRouter({
+          table: tableOf({}),
+          directory: directoryOf({}),
+        });
 
-      await expect(router.route("project_unknown")).rejects.toBeInstanceOf(
-        UnknownTenantError,
-      );
+        await expect(router.route("project_unknown")).rejects.toBeInstanceOf(
+          UnknownTenantError,
+        );
+      });
     });
 
-    it("fails closed on an empty tenant id without asking the directory", async () => {
-      const directory = { organizationForTenant: vi.fn() };
-      const router = createTenantRouter({ table: tableOf({}), directory });
+    describe("when the tenant id is empty", () => {
+      it("fails closed without asking the directory", async () => {
+        const directory = { organizationForTenant: vi.fn() };
+        const router = createTenantRouter({ table: tableOf({}), directory });
 
-      await expect(router.route("")).rejects.toBeInstanceOf(UnknownTenantError);
-      expect(directory.organizationForTenant).not.toHaveBeenCalled();
+        await expect(router.route("")).rejects.toBeInstanceOf(
+          UnknownTenantError,
+        );
+        expect(directory.organizationForTenant).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe("given repeated lookups for the same tenant", () => {
-    it("asks the directory once while the answer is fresh", async () => {
-      const organizationForTenant = vi.fn(async () => "org_1");
-      const router = createTenantRouter({
-        table: tableOf({}),
-        directory: { organizationForTenant },
-      });
-
-      await router.route("project_1");
-      await router.route("project_1");
-
-      expect(organizationForTenant).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("given the same tenant resolved many times", () => {
-    it("asks the directory once, because the mapping cannot change", async () => {
-      // A project belongs to a team and a team to an organisation, and neither
-      // link is reassignable, so a resolved answer is final. There is nothing
-      // for an expiry to protect against; the bound below covers memory.
-      const organizationForTenant = vi.fn(async () => "org_1");
-      const router = createTenantRouter({
-        table: tableOf({ org_1: "http://acme:8123" }),
-        directory: { organizationForTenant },
-      });
-
-      for (let i = 0; i < 50; i++) {
-        await expect(router.route("project_1")).resolves.toMatchObject({
-          organizationId: "org_1",
+    describe("when it is routed twice", () => {
+      it("asks the directory once while the answer is fresh", async () => {
+        const organizationForTenant = vi.fn(async () => "org_1");
+        const router = createTenantRouter({
+          table: tableOf({}),
+          directory: { organizationForTenant },
         });
-      }
 
-      expect(organizationForTenant).toHaveBeenCalledTimes(1);
+        await router.route("project_1");
+        await router.route("project_1");
+
+        expect(organizationForTenant).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when it is routed many times", () => {
+      it("asks the directory once, because the mapping cannot change", async () => {
+        // A project belongs to a team and a team to an organisation, and
+        // neither link is reassignable, so a resolved answer is final. There is
+        // nothing for an expiry to protect against; the bound below covers
+        // memory.
+        const organizationForTenant = vi.fn(async () => "org_1");
+        const router = createTenantRouter({
+          table: tableOf({ org_1: "http://acme:8123" }),
+          directory: { organizationForTenant },
+        });
+
+        for (let i = 0; i < 50; i++) {
+          await expect(router.route("project_1")).resolves.toMatchObject({
+            organizationId: "org_1",
+          });
+        }
+
+        expect(organizationForTenant).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
   describe("given a tenant that does not exist yet", () => {
-    it("does not cache the failure, so it routes once it is created", async () => {
-      let known = false;
-      const router = createTenantRouter({
-        table: tableOf({}),
-        directory: {
-          organizationForTenant: async () => (known ? "org_1" : null),
-        },
-      });
+    describe("when it is created between two lookups", () => {
+      it("does not cache the failure, so it routes once it is created", async () => {
+        let known = false;
+        const router = createTenantRouter({
+          table: tableOf({}),
+          directory: {
+            organizationForTenant: async () => (known ? "org_1" : null),
+          },
+        });
 
-      await expect(router.route("project_new")).rejects.toBeInstanceOf(
-        UnknownTenantError,
-      );
-      known = true;
+        await expect(router.route("project_new")).rejects.toBeInstanceOf(
+          UnknownTenantError,
+        );
+        known = true;
 
-      await expect(router.route("project_new")).resolves.toEqual({
-        kind: "shared",
+        await expect(router.route("project_new")).resolves.toEqual({
+          kind: "shared",
+        });
       });
     });
   });
 
   describe("given more tenants than the cache bound", () => {
-    it("stays bounded instead of growing for the life of the process", async () => {
-      const router = createTenantRouter({
-        table: tableOf({}),
-        directory: { organizationForTenant: async () => "org_1" },
-        maxCacheEntries: 3,
+    describe("when they are all routed", () => {
+      it("stays bounded instead of growing for the life of the process", async () => {
+        const router = createTenantRouter({
+          table: tableOf({}),
+          directory: { organizationForTenant: async () => "org_1" },
+          maxCacheEntries: 3,
+        });
+
+        for (let i = 0; i < 10; i++) await router.route(`project_${i}`);
+
+        expect(router.size()).toBeLessThanOrEqual(3);
       });
-
-      for (let i = 0; i < 10; i++) await router.route(`project_${i}`);
-
-      expect(router.size()).toBeLessThanOrEqual(3);
     });
   });
 });

--- a/packages/clickhouse-client/src/tenancy.test.ts
+++ b/packages/clickhouse-client/src/tenancy.test.ts
@@ -59,6 +59,29 @@ describe("parseRoutingTable", () => {
     });
   });
 
+  describe("given an organisation id that contains the separator", () => {
+    it("reports the split as a guess rather than making it silently", () => {
+      // Guessing wrong is a fail-open: the intended organisation gets no route,
+      // so every one of its tenants falls through to the shared instance.
+      const table = parseRoutingTable({
+        CLICKHOUSE_URL__acme__organization__x1: "http://acme:8123",
+      });
+
+      expect(table.ambiguous).toEqual([
+        {
+          envVar: "CLICKHOUSE_URL__acme__organization__x1",
+          organizationId: "x1",
+        },
+      ]);
+    });
+
+    it("does not flag an unambiguous single-separator name", () => {
+      expect(
+        parseRoutingTable({ CLICKHOUSE_URL__org_1: "http://x:8123" }).ambiguous,
+      ).toEqual([]);
+    });
+  });
+
   describe("given two routes for one organisation", () => {
     it("refuses to guess which instance holds their data", () => {
       expect(() =>

--- a/packages/clickhouse-client/src/tenancy.test.ts
+++ b/packages/clickhouse-client/src/tenancy.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTenantRouter,
+  DuplicateRouteError,
+  parseRoutingTable,
+  type TenantDirectory,
+  UnknownTenantError,
+} from "./tenancy";
+
+const directoryOf = (mapping: Record<string, string>): TenantDirectory => ({
+  organizationForTenant: async (tenantId) => mapping[tenantId] ?? null,
+});
+
+const tableOf = (routes: Record<string, string>) => ({
+  routes: new Map(Object.entries(routes)),
+  skipped: [],
+});
+
+describe("parseRoutingTable", () => {
+  describe("given well-formed entries", () => {
+    it("keys the route by the organisation id, ignoring the human label", () => {
+      const table = parseRoutingTable({
+        CLICKHOUSE_URL__acme__org_1: "http://acme:8123",
+        UNRELATED: "x",
+      });
+
+      expect(table.routes.get("org_1")).toBe("http://acme:8123");
+      expect(table.routes.size).toBe(1);
+    });
+
+    it("tolerates a label containing the separator", () => {
+      const table = parseRoutingTable({
+        CLICKHOUSE_URL__acme__eu__org_1: "http://acme:8123",
+      });
+
+      expect(table.routes.get("org_1")).toBe("http://acme:8123");
+    });
+  });
+
+  describe("given unusable entries", () => {
+    it.each([
+      ["an empty value", { CLICKHOUSE_URL__acme__org_1: "" }],
+      ["a whitespace value", { CLICKHOUSE_URL__acme__org_1: "   " }],
+      ["no organisation id", { CLICKHOUSE_URL__: "http://x:8123" }],
+    ])("skips %s rather than routing on it", (_label, env) => {
+      const table = parseRoutingTable(env);
+
+      expect(table.routes.size).toBe(0);
+      expect(table.skipped).toHaveLength(1);
+    });
+
+    it("collects every problem instead of dying on the first", () => {
+      const table = parseRoutingTable({
+        CLICKHOUSE_URL__a__org_1: "",
+        CLICKHOUSE_URL__b__org_2: "  ",
+      });
+
+      expect(table.skipped).toHaveLength(2);
+    });
+  });
+
+  describe("given two routes for one organisation", () => {
+    it("refuses to guess which instance holds their data", () => {
+      expect(() =>
+        parseRoutingTable({
+          CLICKHOUSE_URL__acme__org_1: "http://one:8123",
+          CLICKHOUSE_URL__acme_eu__org_1: "http://two:8123",
+        }),
+      ).toThrow(DuplicateRouteError);
+    });
+  });
+});
+
+describe("createTenantRouter", () => {
+  describe("given a tenant in an organisation with no private instance", () => {
+    it("routes to the shared instance", async () => {
+      const router = createTenantRouter({
+        table: tableOf({}),
+        directory: directoryOf({ project_1: "org_1" }),
+      });
+
+      await expect(router.route("project_1")).resolves.toEqual({
+        kind: "shared",
+      });
+    });
+  });
+
+  describe("given a tenant in an organisation with a private instance", () => {
+    it("routes to that instance", async () => {
+      const router = createTenantRouter({
+        table: tableOf({ org_1: "http://acme:8123" }),
+        directory: directoryOf({ project_1: "org_1" }),
+      });
+
+      await expect(router.route("project_1")).resolves.toEqual({
+        kind: "private",
+        organizationId: "org_1",
+        url: "http://acme:8123",
+      });
+    });
+  });
+
+  describe("given a tenant the directory does not know", () => {
+    it("fails closed rather than falling back to shared", async () => {
+      // Falling back would run the statement against the shared instance,
+      // which succeeds and returns plausible rows belonging to someone else.
+      const router = createTenantRouter({
+        table: tableOf({}),
+        directory: directoryOf({}),
+      });
+
+      await expect(router.route("project_unknown")).rejects.toBeInstanceOf(
+        UnknownTenantError,
+      );
+    });
+
+    it("fails closed on an empty tenant id without asking the directory", async () => {
+      const directory = { organizationForTenant: vi.fn() };
+      const router = createTenantRouter({ table: tableOf({}), directory });
+
+      await expect(router.route("")).rejects.toBeInstanceOf(UnknownTenantError);
+      expect(directory.organizationForTenant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given repeated lookups for the same tenant", () => {
+    it("asks the directory once while the answer is fresh", async () => {
+      const organizationForTenant = vi.fn(async () => "org_1");
+      const router = createTenantRouter({
+        table: tableOf({}),
+        directory: { organizationForTenant },
+      });
+
+      await router.route("project_1");
+      await router.route("project_1");
+
+      expect(organizationForTenant).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a tenant that moves organisation", () => {
+    it("stops using the old organisation once the entry expires", async () => {
+      // The bug this replaces cached forever, so a moved project kept reading
+      // its previous organisation's ClickHouse until the process restarted.
+      let organizationId = "org_old";
+      let now = 0;
+      const router = createTenantRouter({
+        table: tableOf({
+          org_old: "http://old:8123",
+          org_new: "http://new:8123",
+        }),
+        directory: { organizationForTenant: async () => organizationId },
+        cacheTtlMs: 1_000,
+        clock: { now: () => now },
+      });
+
+      await expect(router.route("project_1")).resolves.toMatchObject({
+        organizationId: "org_old",
+      });
+
+      organizationId = "org_new";
+      now = 1_001;
+
+      await expect(router.route("project_1")).resolves.toMatchObject({
+        organizationId: "org_new",
+        url: "http://new:8123",
+      });
+    });
+
+    it("can be corrected immediately by invalidating the tenant", async () => {
+      let organizationId = "org_old";
+      const router = createTenantRouter({
+        table: tableOf({
+          org_old: "http://old:8123",
+          org_new: "http://new:8123",
+        }),
+        directory: { organizationForTenant: async () => organizationId },
+      });
+
+      await expect(router.route("project_1")).resolves.toMatchObject({
+        organizationId: "org_old",
+      });
+
+      organizationId = "org_new";
+      router.invalidate("project_1");
+
+      await expect(router.route("project_1")).resolves.toMatchObject({
+        organizationId: "org_new",
+        url: "http://new:8123",
+      });
+    });
+  });
+
+  describe("given more tenants than the cache bound", () => {
+    it("stays bounded instead of growing for the life of the process", async () => {
+      const router = createTenantRouter({
+        table: tableOf({}),
+        directory: { organizationForTenant: async () => "org_1" },
+        maxCacheEntries: 3,
+      });
+
+      for (let i = 0; i < 10; i++) await router.route(`project_${i}`);
+
+      expect(router.size()).toBeLessThanOrEqual(3);
+    });
+  });
+});

--- a/packages/clickhouse-client/src/tenancy.ts
+++ b/packages/clickhouse-client/src/tenancy.ts
@@ -1,0 +1,201 @@
+/**
+ * Tenant routing, fail-closed.
+ *
+ * Some organisations are served by their own ClickHouse instance rather than
+ * the shared one. Getting that wrong in either direction is a data-leak class
+ * of bug, not a performance one: routing tenant A's read at tenant B's server
+ * returns B's rows, and routing a private tenant's write at the shared server
+ * puts their data somewhere they did not agree to.
+ *
+ * So every decision here is explicit and every unknown is an error. There is no
+ * "fall back to shared and hope" path, because the shared instance is exactly
+ * where a mistake is least visible - the query succeeds and returns plausible
+ * rows.
+ *
+ * The lookup from tenant to organisation is cached, and the cache is bounded
+ * and expiring. An unbounded cache that is never invalidated grows without
+ * limit and, worse, pins a tenant to whichever organisation it had the first
+ * time it was seen: move a project between organisations and it keeps reading
+ * the old organisation's data until the process restarts.
+ */
+
+/** Where a tenant's statements should be sent. */
+export type TenantRoute =
+  | { kind: "shared" }
+  | { kind: "private"; organizationId: string; url: string };
+
+/** Raised when a tenant cannot be resolved. Never fall back on this. */
+export class UnknownTenantError extends Error {
+  constructor(public readonly tenantId: string) {
+    super(
+      `Cannot route ClickHouse statement: tenant "${tenantId}" has no known organisation. ` +
+        "Refusing to fall back to the shared instance, which would read or write another tenant's data.",
+    );
+    this.name = "UnknownTenantError";
+  }
+}
+
+/** Raised when two env vars claim the same organisation. */
+export class DuplicateRouteError extends Error {
+  constructor(organizationId: string, first: string, second: string) {
+    super(
+      `Two ClickHouse routes are configured for organisation "${organizationId}" ("${first}" and "${second}"). ` +
+        "Refusing to guess which instance holds their data.",
+    );
+    this.name = "DuplicateRouteError";
+  }
+}
+
+/** `CLICKHOUSE_URL__<label>__<organizationId>=<url>`; the label is for humans. */
+export const PRIVATE_ROUTE_ENV_PREFIX = "CLICKHOUSE_URL__";
+
+export interface RoutingTable {
+  /** organizationId -> connection url. */
+  readonly routes: ReadonlyMap<string, string>;
+  /** Env vars that were present but unusable, for the caller to report. */
+  readonly skipped: readonly { envVar: string; reason: string }[];
+}
+
+/**
+ * Parse the routing table out of an environment bag.
+ *
+ * Pure and total: it never throws for a malformed entry, it collects those in
+ * `skipped` so a caller can log them all at once rather than dying on the first
+ * one at module load. The single exception is a duplicate organisation, which
+ * is ambiguous rather than merely malformed - there is no safe way to pick.
+ */
+export function parseRoutingTable(
+  env: Record<string, string | undefined>,
+): RoutingTable {
+  const routes = new Map<string, string>();
+  const source = new Map<string, string>();
+  const skipped: { envVar: string; reason: string }[] = [];
+
+  for (const [envVar, value] of Object.entries(env)) {
+    if (!envVar.startsWith(PRIVATE_ROUTE_ENV_PREFIX)) continue;
+
+    if (value === undefined || value.trim() === "") {
+      skipped.push({ envVar, reason: "empty value" });
+      continue;
+    }
+
+    const suffix = envVar.slice(PRIVATE_ROUTE_ENV_PREFIX.length);
+    const separator = suffix.lastIndexOf("__");
+    const organizationId =
+      separator >= 0 ? suffix.slice(separator + 2) : suffix;
+
+    if (organizationId === "") {
+      skipped.push({ envVar, reason: "no organization id in the name" });
+      continue;
+    }
+
+    const existing = source.get(organizationId);
+    if (existing !== undefined) {
+      throw new DuplicateRouteError(organizationId, existing, envVar);
+    }
+
+    routes.set(organizationId, value.trim());
+    source.set(organizationId, envVar);
+  }
+
+  return { routes, skipped };
+}
+
+/** Resolves a tenant to its organisation. Backed by the control-plane database. */
+export interface TenantDirectory {
+  /** Null means "no such tenant", which is an error, never a shared fallback. */
+  organizationForTenant(tenantId: string): Promise<string | null>;
+}
+
+export interface Clock {
+  now(): number;
+}
+
+export const systemClock: Clock = { now: () => Date.now() };
+
+export interface TenantRouterOptions {
+  table: RoutingTable;
+  directory: TenantDirectory;
+  /**
+   * How long a tenant->organisation answer may be reused. Bounded because the
+   * mapping can change: a project can move organisation, and a stale answer
+   * routes it at the wrong instance for as long as it is kept.
+   */
+  cacheTtlMs?: number | undefined;
+  /** Bounds memory. The least-recently-resolved entry is dropped past this. */
+  maxCacheEntries?: number | undefined;
+  clock?: Clock | undefined;
+}
+
+export interface TenantRouter {
+  route(tenantId: string): Promise<TenantRoute>;
+  /** Drop a cached mapping. Call when a tenant's organisation changes. */
+  invalidate(tenantId: string): void;
+  invalidateAll(): void;
+  /** Entries currently cached; exposed so a caller can meter the bound. */
+  size(): number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_MAX_CACHE_ENTRIES = 10_000;
+
+export function createTenantRouter({
+  table,
+  directory,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  maxCacheEntries = DEFAULT_MAX_CACHE_ENTRIES,
+  clock = systemClock,
+}: TenantRouterOptions): TenantRouter {
+  const cache = new Map<
+    string,
+    { organizationId: string; expiresAt: number }
+  >();
+
+  const remember = (tenantId: string, organizationId: string): void => {
+    // Map preserves insertion order, so the first key is the oldest write.
+    if (cache.size >= maxCacheEntries) {
+      const oldest = cache.keys().next();
+      if (!oldest.done) cache.delete(oldest.value);
+    }
+    cache.set(tenantId, {
+      organizationId,
+      expiresAt: clock.now() + cacheTtlMs,
+    });
+  };
+
+  const organizationFor = async (tenantId: string): Promise<string> => {
+    const cached = cache.get(tenantId);
+    if (cached !== undefined && cached.expiresAt > clock.now()) {
+      return cached.organizationId;
+    }
+    if (cached !== undefined) cache.delete(tenantId);
+
+    const resolved = await directory.organizationForTenant(tenantId);
+    if (resolved === null || resolved === "") {
+      throw new UnknownTenantError(tenantId);
+    }
+    remember(tenantId, resolved);
+    return resolved;
+  };
+
+  return {
+    async route(tenantId) {
+      if (tenantId === "") throw new UnknownTenantError(tenantId);
+
+      const organizationId = await organizationFor(tenantId);
+      const url = table.routes.get(organizationId);
+      return url === undefined
+        ? { kind: "shared" }
+        : { kind: "private", organizationId, url };
+    },
+    invalidate(tenantId) {
+      cache.delete(tenantId);
+    },
+    invalidateAll() {
+      cache.clear();
+    },
+    size() {
+      return cache.size;
+    },
+  };
+}

--- a/packages/clickhouse-client/src/tenancy.ts
+++ b/packages/clickhouse-client/src/tenancy.ts
@@ -37,7 +37,15 @@ export class UnknownTenantError extends Error {
 
 /** Raised when two env vars claim the same organisation. */
 export class DuplicateRouteError extends Error {
-  constructor(organizationId: string, first: string, second: string) {
+  constructor({
+    organizationId,
+    first,
+    second,
+  }: {
+    organizationId: string;
+    first: string;
+    second: string;
+  }) {
     super(
       `Two ClickHouse routes are configured for organisation "${organizationId}" ("${first}" and "${second}"). ` +
         "Refusing to guess which instance holds their data.",
@@ -112,7 +120,11 @@ export function parseRoutingTable(
 
     const existing = source.get(organizationId);
     if (existing !== undefined) {
-      throw new DuplicateRouteError(organizationId, existing, envVar);
+      throw new DuplicateRouteError({
+        organizationId,
+        first: existing,
+        second: envVar,
+      });
     }
 
     routes.set(organizationId, value.trim());
@@ -162,9 +174,22 @@ export function createTenantRouter({
   directory,
   maxCacheEntries = DEFAULT_MAX_CACHE_ENTRIES,
 }: TenantRouterOptions): TenantRouter {
+  // `NaN` and `Infinity` both make `cache.size >= maxCacheEntries` false
+  // forever, which removes the bound this option exists to impose and lets a
+  // long-lived worker grow the map for the life of the process.
+  if (!Number.isInteger(maxCacheEntries) || maxCacheEntries < 1) {
+    throw new RangeError("maxCacheEntries must be a positive integer");
+  }
+
   const cache = new Map<string, string>();
 
-  const remember = (tenantId: string, organizationId: string): void => {
+  const remember = ({
+    tenantId,
+    organizationId,
+  }: {
+    tenantId: string;
+    organizationId: string;
+  }): void => {
     // Map preserves insertion order, so the first key is the oldest write.
     if (cache.size >= maxCacheEntries) {
       const oldest = cache.keys().next();
@@ -184,7 +209,7 @@ export function createTenantRouter({
       // would make a newly created project unroutable until eviction.
       throw new UnknownTenantError(tenantId);
     }
-    remember(tenantId, resolved);
+    remember({ tenantId, organizationId: resolved });
     return resolved;
   };
 

--- a/packages/clickhouse-client/src/tenancy.ts
+++ b/packages/clickhouse-client/src/tenancy.ts
@@ -12,11 +12,11 @@
  * where a mistake is least visible - the query succeeds and returns plausible
  * rows.
  *
- * The lookup from tenant to organisation is cached, and the cache is bounded
- * and expiring. An unbounded cache that is never invalidated grows without
- * limit and, worse, pins a tenant to whichever organisation it had the first
- * time it was seen: move a project between organisations and it keeps reading
- * the old organisation's data until the process restarts.
+ * The lookup from tenant to organisation is cached and the cache is bounded.
+ * It does not expire, and that is deliberate rather than an omission: a
+ * project belongs to a team and a team to an organisation, and neither link is
+ * reassignable, so the answer is fixed once it is known. The bound exists for
+ * memory alone, since a long-lived worker sees a great many tenants.
  */
 
 /** Where a tenant's statements should be sent. */
@@ -107,49 +107,41 @@ export interface TenantDirectory {
   organizationForTenant(tenantId: string): Promise<string | null>;
 }
 
-export interface Clock {
-  now(): number;
-}
-
-export const systemClock: Clock = { now: () => Date.now() };
-
 export interface TenantRouterOptions {
   table: RoutingTable;
   directory: TenantDirectory;
   /**
-   * How long a tenant->organisation answer may be reused. Bounded because the
-   * mapping can change: a project can move organisation, and a stale answer
-   * routes it at the wrong instance for as long as it is kept.
+   * Bounds memory. The oldest entry is dropped past this.
+   *
+   * This is the only reason the cache evicts. A tenant's organisation is fixed
+   * at creation - a project belongs to a team, a team to an organisation, and
+   * nothing reassigns either - so a cached answer cannot go stale and there is
+   * no expiry to get right. What remains is a long-lived worker that sees many
+   * tenants, which without a bound grows this map for the life of the process.
    */
-  cacheTtlMs?: number | undefined;
-  /** Bounds memory. The least-recently-resolved entry is dropped past this. */
   maxCacheEntries?: number | undefined;
-  clock?: Clock | undefined;
 }
 
 export interface TenantRouter {
   route(tenantId: string): Promise<TenantRoute>;
-  /** Drop a cached mapping. Call when a tenant's organisation changes. */
-  invalidate(tenantId: string): void;
+  /**
+   * Drop every cached mapping. Nothing in normal operation needs this - the
+   * mapping is immutable - but it keeps a test deterministic and gives an
+   * operator a way to clear state after a directory misconfiguration.
+   */
   invalidateAll(): void;
   /** Entries currently cached; exposed so a caller can meter the bound. */
   size(): number;
 }
 
-const DEFAULT_CACHE_TTL_MS = 60_000;
 const DEFAULT_MAX_CACHE_ENTRIES = 10_000;
 
 export function createTenantRouter({
   table,
   directory,
-  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
   maxCacheEntries = DEFAULT_MAX_CACHE_ENTRIES,
-  clock = systemClock,
 }: TenantRouterOptions): TenantRouter {
-  const cache = new Map<
-    string,
-    { organizationId: string; expiresAt: number }
-  >();
+  const cache = new Map<string, string>();
 
   const remember = (tenantId: string, organizationId: string): void => {
     // Map preserves insertion order, so the first key is the oldest write.
@@ -157,21 +149,18 @@ export function createTenantRouter({
       const oldest = cache.keys().next();
       if (!oldest.done) cache.delete(oldest.value);
     }
-    cache.set(tenantId, {
-      organizationId,
-      expiresAt: clock.now() + cacheTtlMs,
-    });
+    cache.set(tenantId, organizationId);
   };
 
   const organizationFor = async (tenantId: string): Promise<string> => {
     const cached = cache.get(tenantId);
-    if (cached !== undefined && cached.expiresAt > clock.now()) {
-      return cached.organizationId;
-    }
-    if (cached !== undefined) cache.delete(tenantId);
+    if (cached !== undefined) return cached;
 
     const resolved = await directory.organizationForTenant(tenantId);
     if (resolved === null || resolved === "") {
+      // Deliberately not cached. A tenant that does not exist yet is a
+      // different thing from one that never will, and caching the negative
+      // would make a newly created project unroutable until eviction.
       throw new UnknownTenantError(tenantId);
     }
     remember(tenantId, resolved);
@@ -187,9 +176,6 @@ export function createTenantRouter({
       return url === undefined
         ? { kind: "shared" }
         : { kind: "private", organizationId, url };
-    },
-    invalidate(tenantId) {
-      cache.delete(tenantId);
     },
     invalidateAll() {
       cache.clear();

--- a/packages/clickhouse-client/src/tenancy.ts
+++ b/packages/clickhouse-client/src/tenancy.ts
@@ -54,6 +54,14 @@ export interface RoutingTable {
   readonly routes: ReadonlyMap<string, string>;
   /** Env vars that were present but unusable, for the caller to report. */
   readonly skipped: readonly { envVar: string; reason: string }[];
+  /**
+   * Env vars whose `<label>__<organizationId>` split was a guess, because the
+   * part before the last separator contains one too. The route was still
+   * created from the guess, but the caller should surface these loudly: if the
+   * guess is wrong the intended organisation has no route at all and its
+   * tenants fall through to the shared instance.
+   */
+  readonly ambiguous: readonly { envVar: string; organizationId: string }[];
 }
 
 /**
@@ -70,6 +78,7 @@ export function parseRoutingTable(
   const routes = new Map<string, string>();
   const source = new Map<string, string>();
   const skipped: { envVar: string; reason: string }[] = [];
+  const ambiguous: { envVar: string; organizationId: string }[] = [];
 
   for (const [envVar, value] of Object.entries(env)) {
     if (!envVar.startsWith(PRIVATE_ROUTE_ENV_PREFIX)) continue;
@@ -89,6 +98,18 @@ export function parseRoutingTable(
       continue;
     }
 
+    // `<label>__<organizationId>` cannot be split unambiguously when either
+    // half may itself contain the separator, and taking the last one is a
+    // guess. Guessing wrong is not a parse error, it is a silent fail-open:
+    // the intended organisation gets no route, so every one of its tenants
+    // falls through to the shared instance and reads and writes there.
+    //
+    // Nothing here can tell which split was meant, so say so and let the
+    // operator disambiguate rather than discovering it as misplaced data.
+    if (suffix.slice(0, Math.max(separator, 0)).includes("__")) {
+      ambiguous.push({ envVar, organizationId });
+    }
+
     const existing = source.get(organizationId);
     if (existing !== undefined) {
       throw new DuplicateRouteError(organizationId, existing, envVar);
@@ -98,7 +119,7 @@ export function parseRoutingTable(
     source.set(organizationId, envVar);
   }
 
-  return { routes, skipped };
+  return { routes, skipped, ambiguous };
 }
 
 /** Resolves a tenant to its organisation. Backed by the control-plane database. */

--- a/packages/clickhouse-client/src/tenantGuard.test.ts
+++ b/packages/clickhouse-client/src/tenantGuard.test.ts
@@ -15,202 +15,289 @@ const request = (overrides: Partial<QueryRequest> = {}): QueryRequest => ({
 
 describe("checkTenantScope", () => {
   describe("given a properly scoped statement", () => {
-    it.each([
-      [
-        "a bare predicate",
-        "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
-      ],
-      [
-        "an aliased predicate",
-        "SELECT 1 FROM stored_spans AS t WHERE t.TenantId = {tenantId:String}",
-      ],
-      [
-        "a predicate inside parentheses",
-        "SELECT 1 FROM t WHERE (TenantId = {tenantId:String}) AND x = 1",
-      ],
-      [
-        "an unusually named parameter",
-        "SELECT 1 FROM t WHERE TenantId = {scope_id:String}",
-      ],
-    ])("accepts %s", (_label, sql) => {
-      const param = /\{\s*(\w+)\s*:/.exec(sql)?.[1] as string;
+    describe("when the statement is checked", () => {
+      it.each([
+        [
+          "a bare predicate",
+          "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+        ],
+        [
+          "an aliased predicate",
+          "SELECT 1 FROM stored_spans AS t WHERE t.TenantId = {tenantId:String}",
+        ],
+        [
+          "a predicate inside parentheses",
+          "SELECT 1 FROM t WHERE (TenantId = {tenantId:String}) AND x = 1",
+        ],
+        [
+          "an unusually named parameter",
+          "SELECT 1 FROM t WHERE TenantId = {scope_id:String}",
+        ],
+      ])("accepts %s", (_label, sql) => {
+        const param = /\{\s*(\w+)\s*:/.exec(sql)?.[1] as string;
 
-      expect(
-        checkTenantScope({
-          sql,
-          params: { [param]: TENANT },
-          tenantId: TENANT,
-        }),
-      ).toBeNull();
+        expect(
+          checkTenantScope({
+            sql,
+            params: { [param]: TENANT },
+            tenantId: TENANT,
+          }),
+        ).toBeNull();
+      });
     });
   });
 
   describe("given a statement with no tenant predicate", () => {
-    it("reports the omission", () => {
-      // The dangerous case: TraceId is not unique across tenants, so this
-      // returns another customer's spans and looks entirely healthy doing it.
-      const violation = checkTenantScope({
-        sql: "SELECT SpanId FROM stored_spans WHERE TraceId = {traceId:String}",
-        params: { traceId: "trace_1" },
-        tenantId: TENANT,
-      });
+    describe("when the statement is checked", () => {
+      it("reports the omission", () => {
+        // The dangerous case: TraceId is not unique across tenants, so this
+        // returns another customer's spans and looks entirely healthy doing it.
+        const violation = checkTenantScope({
+          sql: "SELECT SpanId FROM stored_spans WHERE TraceId = {traceId:String}",
+          params: { traceId: "trace_1" },
+          tenantId: TENANT,
+        });
 
-      expect(violation).toEqual({ kind: "missing-predicate" });
+        expect(violation).toEqual({ kind: "missing-predicate" });
+      });
     });
   });
 
   describe("given a statement that inlines the tenant", () => {
-    it.each([
-      ["single quotes", "SELECT 1 FROM t WHERE TenantId = 'project_abc'"],
-      ["double quotes", 'SELECT 1 FROM t WHERE TenantId = "project_abc"'],
-    ])("refuses %s even when the value is correct", (_label, sql) => {
-      expect(checkTenantScope({ sql, tenantId: TENANT })).toEqual({
-        kind: "literal-predicate",
+    describe("when the inlined value is the correct tenant", () => {
+      it.each([
+        ["single quotes", "SELECT 1 FROM t WHERE TenantId = 'project_abc'"],
+        ["double quotes", 'SELECT 1 FROM t WHERE TenantId = "project_abc"'],
+      ])("still refuses %s", (_label, sql) => {
+        expect(checkTenantScope({ sql, tenantId: TENANT })).toEqual({
+          kind: "literal-predicate",
+        });
       });
     });
   });
 
   describe("given a bound predicate whose parameter is absent", () => {
-    it("reports the missing parameter", () => {
-      expect(
-        checkTenantScope({
-          sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
-          params: {},
-          tenantId: TENANT,
-        }),
-      ).toEqual({ kind: "missing-param", param: "tenantId" });
+    describe("when the statement is checked", () => {
+      it("reports the missing parameter", () => {
+        expect(
+          checkTenantScope({
+            sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+            params: {},
+            tenantId: TENANT,
+          }),
+        ).toEqual({ kind: "missing-param", param: "tenantId" });
+      });
     });
   });
 
   describe("given a bound predicate for a different tenant", () => {
-    it("refuses the mismatch rather than trusting the statement", () => {
-      const violation = checkTenantScope({
-        sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
-        params: { tenantId: "project_someone_else" },
-        tenantId: TENANT,
-      });
+    describe("when the statement is checked", () => {
+      it("refuses the mismatch rather than trusting the statement", () => {
+        const violation = checkTenantScope({
+          sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+          params: { tenantId: "project_someone_else" },
+          tenantId: TENANT,
+        });
 
-      expect(violation).toMatchObject({
-        kind: "param-mismatch",
-        expected: TENANT,
-        actual: "project_someone_else",
+        expect(violation).toMatchObject({
+          kind: "param-mismatch",
+          expected: TENANT,
+          actual: "project_someone_else",
+        });
       });
     });
   });
 
   describe("given a commented-out predicate", () => {
-    it.each([
-      ["a line comment", "SELECT 1 FROM t -- WHERE TenantId = {t:String}"],
-      ["a block comment", "/* TenantId = {t:String} */ SELECT 1 FROM t"],
-    ])("refuses %s, which is the case the guard exists for", (_label, sql) => {
-      expect(
-        checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
-      ).toEqual({ kind: "missing-predicate" });
+    describe("when the statement is checked", () => {
+      it.each([
+        ["a line comment", "SELECT 1 FROM t -- WHERE TenantId = {t:String}"],
+        ["a block comment", "/* TenantId = {t:String} */ SELECT 1 FROM t"],
+      ])("refuses %s, which is the case the guard exists for", (_label, sql) => {
+        expect(
+          checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+        ).toEqual({ kind: "missing-predicate" });
+      });
+    });
+  });
+
+  describe("given a disjunction that can weaken the predicate", () => {
+    describe("when the OR sits at or above the predicate's depth", () => {
+      it.each([
+        [
+          "a trailing OR",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} OR Status = 'x'",
+        ],
+        [
+          "an OR outside the predicate's brackets",
+          "SELECT 1 FROM t WHERE (TenantId = {t:String}) OR Status = 'x'",
+        ],
+        [
+          "precedence confusion, which is how this reaches production",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} AND A = 1 OR B = 2",
+        ],
+        [
+          "an OR in the outer query above a scoped subquery",
+          "SELECT * FROM (SELECT Id FROM t WHERE TenantId = {t:String}) WHERE a = 1 OR b = 2",
+        ],
+      ])("refuses %s", (_label, sql) => {
+        expect(
+          checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+        ).toEqual({ kind: "weakening-disjunction" });
+      });
+    });
+
+    describe("when the OR is bracketed beneath the predicate", () => {
+      it.each([
+        [
+          "a bracketed disjunction",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} AND (A = 1 OR B = 2)",
+        ],
+        [
+          "an OR inside a string literal",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} AND Name = 'a OR b'",
+        ],
+        [
+          "ORDER BY, which merely starts with the letters",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} ORDER BY OccurredAt",
+        ],
+      ])("accepts %s, because it cannot weaken the scoping", (_label, sql) => {
+        expect(
+          checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+        ).toBeNull();
+      });
     });
   });
 
   describe("given a statement the text check cannot see through", () => {
-    // Accepted limits, kept executable so they stay documented rather than
-    // becoming folklore. One match anywhere satisfies the whole statement, and
-    // closing these needs a parser. See the module docblock.
-    it.each([
-      [
-        "a disjunction that returns every tenant",
-        "SELECT 1 FROM t WHERE TenantId = {t:String} OR Status = 'x'",
-      ],
-      [
-        "a UNION whose second arm is unscoped",
-        "SELECT 1 FROM t WHERE TenantId = {t:String} UNION ALL SELECT 1 FROM t",
-      ],
-      [
-        "a JOIN with only one side scoped",
-        "SELECT 1 FROM a JOIN b ON a.Id = b.Id WHERE a.TenantId = {t:String}",
-      ],
-      [
-        "a scoped subquery beneath an unscoped outer query",
-        "SELECT * FROM (SELECT Id FROM t WHERE TenantId = {t:String}) UNION ALL SELECT Id FROM t",
-      ],
-    ])("still accepts %s", (_label, sql) => {
-      expect(
-        checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
-      ).toBeNull();
+    describe("when the statement is checked", () => {
+      // Accepted limits, kept executable so they stay documented rather than
+      // becoming folklore. One match anywhere satisfies the whole statement,
+      // and closing these needs a parser. See the module docblock.
+      it.each([
+        [
+          "a UNION whose second arm is unscoped",
+          "SELECT 1 FROM t WHERE TenantId = {t:String} UNION ALL SELECT 1 FROM t",
+        ],
+        [
+          "a JOIN with only one side scoped",
+          "SELECT 1 FROM a JOIN b ON a.Id = b.Id WHERE a.TenantId = {t:String}",
+        ],
+        [
+          "a scoped subquery beneath an unscoped outer query",
+          "SELECT * FROM (SELECT Id FROM t WHERE TenantId = {t:String}) UNION ALL SELECT Id FROM t",
+        ],
+      ])("still accepts %s", (_label, sql) => {
+        expect(
+          checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+        ).toBeNull();
+      });
+    });
+  });
+
+  describe("given a statement built to make comment stripping backtrack", () => {
+    describe("when the statement is checked", () => {
+      it("still answers promptly", () => {
+        // The previous `/\/\*[\s\S]*?\*\//` rescanned to the end of the input
+        // from every unterminated `/*`, so this input took time quadratic in
+        // its length. Once is enough to catch a regression: unbounded, this
+        // does not finish.
+        const hostile = `SELECT 1 FROM t WHERE TenantId = {t:String} ${"a/*".repeat(40_000)}`;
+        const startedAt = performance.now();
+
+        checkTenantScope({
+          sql: hostile,
+          params: { t: TENANT },
+          tenantId: TENANT,
+        });
+
+        expect(performance.now() - startedAt).toBeLessThan(1_000);
+      });
     });
   });
 
   describe("given a multi-tenant IN predicate", () => {
-    it("does not accept it as scoping", () => {
-      // `IN` spans tenants by construction. If that is genuinely wanted it has
-      // to be declared unscoped, not smuggled past the check.
-      expect(
-        checkTenantScope({
-          sql: "SELECT 1 FROM t WHERE TenantId IN ({tenantIds:Array(String)})",
-          params: { tenantIds: [TENANT] },
-          tenantId: TENANT,
-        }),
-      ).toEqual({ kind: "missing-predicate" });
+    describe("when the statement is checked", () => {
+      it("does not accept it as scoping", () => {
+        // `IN` spans tenants by construction. If that is genuinely wanted it
+        // has to be declared unscoped, not smuggled past the check.
+        expect(
+          checkTenantScope({
+            sql: "SELECT 1 FROM t WHERE TenantId IN ({tenantIds:Array(String)})",
+            params: { tenantIds: [TENANT] },
+            tenantId: TENANT,
+          }),
+        ).toEqual({ kind: "missing-predicate" });
+      });
     });
   });
 });
 
 describe("tenantGuard", () => {
   describe("given a scoped statement", () => {
-    it("passes it through", async () => {
-      const next = vi.fn(passthrough);
+    describe("when it is executed", () => {
+      it("passes it through", async () => {
+        const next = vi.fn(passthrough);
 
-      await tenantGuard()(next)(request());
+        await tenantGuard()(next)(request());
 
-      expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
   describe("given an unscoped statement", () => {
-    it("refuses before the statement runs", async () => {
-      const next = vi.fn(passthrough);
-      const execute = tenantGuard()(next);
+    describe("when it is executed", () => {
+      it("refuses before the statement runs", async () => {
+        const next = vi.fn(passthrough);
+        const execute = tenantGuard()(next);
 
-      await expect(
-        execute(request({ sql: "SELECT 1 FROM t", params: {} })),
-      ).rejects.toBeInstanceOf(TenantScopeError);
-      expect(next).not.toHaveBeenCalled();
-    });
+        await expect(
+          execute(request({ sql: "SELECT 1 FROM t", params: {} })),
+        ).rejects.toBeInstanceOf(TenantScopeError);
+        expect(next).not.toHaveBeenCalled();
+      });
 
-    it("explains how to fix it", async () => {
-      const execute = tenantGuard()(passthrough);
+      it("explains how to fix it", async () => {
+        const execute = tenantGuard()(passthrough);
 
-      await expect(
-        execute(request({ sql: "SELECT 1 FROM t", params: {} })),
-      ).rejects.toThrow(/TenantId = \{param:String\}/);
+        await expect(
+          execute(request({ sql: "SELECT 1 FROM t", params: {} })),
+        ).rejects.toThrow(/TenantId = \{param:String\}/);
+      });
     });
   });
 
   describe("given a statement declared unscoped", () => {
-    it("allows it", async () => {
-      const next = vi.fn(passthrough);
-      const execute = tenantGuard()(next);
+    describe("when it is executed", () => {
+      it("allows it", async () => {
+        const next = vi.fn(passthrough);
+        const execute = tenantGuard()(next);
 
-      await execute(
-        request({
+        await execute(
+          request({
+            sql: "SELECT count() FROM system.parts",
+            params: {},
+            unscoped: { reason: "operational part-count check" },
+          }),
+        );
+
+        expect(next).toHaveBeenCalledTimes(1);
+      });
+
+      it("reports it so the exemptions can be audited", async () => {
+        const onUnscoped = vi.fn();
+        const execute = tenantGuard({ onUnscoped })(passthrough);
+        const unscoped = request({
           sql: "SELECT count() FROM system.parts",
           params: {},
           unscoped: { reason: "operational part-count check" },
-        }),
-      );
+        });
 
-      expect(next).toHaveBeenCalledTimes(1);
-    });
+        await execute(unscoped);
 
-    it("reports it so the exemptions can be audited", async () => {
-      const onUnscoped = vi.fn();
-      const execute = tenantGuard({ onUnscoped })(passthrough);
-      const unscoped = request({
-        sql: "SELECT count() FROM system.parts",
-        params: {},
-        unscoped: { reason: "operational part-count check" },
+        expect(onUnscoped).toHaveBeenCalledWith(unscoped);
       });
-
-      await execute(unscoped);
-
-      expect(onUnscoped).toHaveBeenCalledWith(unscoped);
     });
   });
 });

--- a/packages/clickhouse-client/src/tenantGuard.test.ts
+++ b/packages/clickhouse-client/src/tenantGuard.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryExecutor, QueryRequest } from "./pipeline";
+import { checkTenantScope, TenantScopeError, tenantGuard } from "./tenantGuard";
+
+const TENANT = "project_abc";
+
+const passthrough: QueryExecutor = async () => ({ rows: [] });
+
+const request = (overrides: Partial<QueryRequest> = {}): QueryRequest => ({
+  tenantId: TENANT,
+  sql: "SELECT SpanId FROM stored_spans WHERE TenantId = {tenantId:String}",
+  params: { tenantId: TENANT },
+  ...overrides,
+});
+
+describe("checkTenantScope", () => {
+  describe("given a properly scoped statement", () => {
+    it.each([
+      [
+        "a bare predicate",
+        "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+      ],
+      [
+        "an aliased predicate",
+        "SELECT 1 FROM stored_spans AS t WHERE t.TenantId = {tenantId:String}",
+      ],
+      [
+        "a predicate inside parentheses",
+        "SELECT 1 FROM t WHERE (TenantId = {tenantId:String}) AND x = 1",
+      ],
+      [
+        "an unusually named parameter",
+        "SELECT 1 FROM t WHERE TenantId = {scope_id:String}",
+      ],
+    ])("accepts %s", (_label, sql) => {
+      const param = /\{\s*(\w+)\s*:/.exec(sql)?.[1] as string;
+
+      expect(
+        checkTenantScope({
+          sql,
+          params: { [param]: TENANT },
+          tenantId: TENANT,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("given a statement with no tenant predicate", () => {
+    it("reports the omission", () => {
+      // The dangerous case: TraceId is not unique across tenants, so this
+      // returns another customer's spans and looks entirely healthy doing it.
+      const violation = checkTenantScope({
+        sql: "SELECT SpanId FROM stored_spans WHERE TraceId = {traceId:String}",
+        params: { traceId: "trace_1" },
+        tenantId: TENANT,
+      });
+
+      expect(violation).toEqual({ kind: "missing-predicate" });
+    });
+  });
+
+  describe("given a statement that inlines the tenant", () => {
+    it.each([
+      ["single quotes", "SELECT 1 FROM t WHERE TenantId = 'project_abc'"],
+      ["double quotes", 'SELECT 1 FROM t WHERE TenantId = "project_abc"'],
+    ])("refuses %s even when the value is correct", (_label, sql) => {
+      expect(checkTenantScope({ sql, tenantId: TENANT })).toEqual({
+        kind: "literal-predicate",
+      });
+    });
+  });
+
+  describe("given a bound predicate whose parameter is absent", () => {
+    it("reports the missing parameter", () => {
+      expect(
+        checkTenantScope({
+          sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+          params: {},
+          tenantId: TENANT,
+        }),
+      ).toEqual({ kind: "missing-param", param: "tenantId" });
+    });
+  });
+
+  describe("given a bound predicate for a different tenant", () => {
+    it("refuses the mismatch rather than trusting the statement", () => {
+      const violation = checkTenantScope({
+        sql: "SELECT 1 FROM t WHERE TenantId = {tenantId:String}",
+        params: { tenantId: "project_someone_else" },
+        tenantId: TENANT,
+      });
+
+      expect(violation).toMatchObject({
+        kind: "param-mismatch",
+        expected: TENANT,
+        actual: "project_someone_else",
+      });
+    });
+  });
+
+  describe("given a multi-tenant IN predicate", () => {
+    it("does not accept it as scoping", () => {
+      // `IN` spans tenants by construction. If that is genuinely wanted it has
+      // to be declared unscoped, not smuggled past the check.
+      expect(
+        checkTenantScope({
+          sql: "SELECT 1 FROM t WHERE TenantId IN ({tenantIds:Array(String)})",
+          params: { tenantIds: [TENANT] },
+          tenantId: TENANT,
+        }),
+      ).toEqual({ kind: "missing-predicate" });
+    });
+  });
+});
+
+describe("tenantGuard", () => {
+  describe("given a scoped statement", () => {
+    it("passes it through", async () => {
+      const next = vi.fn(passthrough);
+
+      await tenantGuard()(next)(request());
+
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given an unscoped statement", () => {
+    it("refuses before the statement runs", async () => {
+      const next = vi.fn(passthrough);
+      const execute = tenantGuard()(next);
+
+      await expect(
+        execute(request({ sql: "SELECT 1 FROM t", params: {} })),
+      ).rejects.toBeInstanceOf(TenantScopeError);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("explains how to fix it", async () => {
+      const execute = tenantGuard()(passthrough);
+
+      await expect(
+        execute(request({ sql: "SELECT 1 FROM t", params: {} })),
+      ).rejects.toThrow(/TenantId = \{param:String\}/);
+    });
+  });
+
+  describe("given a statement declared unscoped", () => {
+    it("allows it", async () => {
+      const next = vi.fn(passthrough);
+      const execute = tenantGuard()(next);
+
+      await execute(
+        request({
+          sql: "SELECT count() FROM system.parts",
+          params: {},
+          unscoped: { reason: "operational part-count check" },
+        }),
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports it so the exemptions can be audited", async () => {
+      const onUnscoped = vi.fn();
+      const execute = tenantGuard({ onUnscoped })(passthrough);
+      const unscoped = request({
+        sql: "SELECT count() FROM system.parts",
+        params: {},
+        unscoped: { reason: "operational part-count check" },
+      });
+
+      await execute(unscoped);
+
+      expect(onUnscoped).toHaveBeenCalledWith(unscoped);
+    });
+  });
+});

--- a/packages/clickhouse-client/src/tenantGuard.test.ts
+++ b/packages/clickhouse-client/src/tenantGuard.test.ts
@@ -98,6 +98,45 @@ describe("checkTenantScope", () => {
     });
   });
 
+  describe("given a commented-out predicate", () => {
+    it.each([
+      ["a line comment", "SELECT 1 FROM t -- WHERE TenantId = {t:String}"],
+      ["a block comment", "/* TenantId = {t:String} */ SELECT 1 FROM t"],
+    ])("refuses %s, which is the case the guard exists for", (_label, sql) => {
+      expect(
+        checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+      ).toEqual({ kind: "missing-predicate" });
+    });
+  });
+
+  describe("given a statement the text check cannot see through", () => {
+    // Accepted limits, kept executable so they stay documented rather than
+    // becoming folklore. One match anywhere satisfies the whole statement, and
+    // closing these needs a parser. See the module docblock.
+    it.each([
+      [
+        "a disjunction that returns every tenant",
+        "SELECT 1 FROM t WHERE TenantId = {t:String} OR Status = 'x'",
+      ],
+      [
+        "a UNION whose second arm is unscoped",
+        "SELECT 1 FROM t WHERE TenantId = {t:String} UNION ALL SELECT 1 FROM t",
+      ],
+      [
+        "a JOIN with only one side scoped",
+        "SELECT 1 FROM a JOIN b ON a.Id = b.Id WHERE a.TenantId = {t:String}",
+      ],
+      [
+        "a scoped subquery beneath an unscoped outer query",
+        "SELECT * FROM (SELECT Id FROM t WHERE TenantId = {t:String}) UNION ALL SELECT Id FROM t",
+      ],
+    ])("still accepts %s", (_label, sql) => {
+      expect(
+        checkTenantScope({ sql, params: { t: TENANT }, tenantId: TENANT }),
+      ).toBeNull();
+    });
+  });
+
   describe("given a multi-tenant IN predicate", () => {
     it("does not accept it as scoping", () => {
       // `IN` spans tenants by construction. If that is genuinely wanted it has

--- a/packages/clickhouse-client/src/tenantGuard.ts
+++ b/packages/clickhouse-client/src/tenantGuard.ts
@@ -13,13 +13,19 @@
  * normal query and forgetting a WHERE clause. Real isolation is enforced by the
  * routing in ./tenancy.ts and by the credentials the server was given.
  *
+ * A disjunction is refused rather than merely noted. `WHERE TenantId = {t} OR
+ * Status = 'x'` contains the predicate and still returns every tenant's rows,
+ * and it is not an exotic statement - it is what operator precedence produces
+ * when somebody writes `WHERE TenantId = {t} AND A OR B` meaning `AND (A OR
+ * B)`. Any `OR` at or above the predicate's parenthesis depth can weaken it, so
+ * that is the rule: an `OR` nested deeper is inside a group and harmless, one
+ * at the same depth or shallower is refused. Putting brackets round the
+ * disjunction both satisfies the guard and fixes the query.
+ *
  * Known and accepted limits, each pinned by a test in ./tenantGuard.test.ts so
  * they stay documented rather than becoming folklore. One match anywhere in the
- * statement satisfies the whole statement, so all of these pass:
+ * statement satisfies the whole statement, so these still pass:
  *
- *   - a disjunction: `WHERE TenantId = {t:String} OR Status = 'x'` matches, and
- *     returns every tenant's rows. This is the one a regex cannot see, and the
- *     reason this check is a backstop rather than the isolation mechanism.
  *   - a UNION whose second arm is unscoped.
  *   - a JOIN where only one side is scoped.
  *   - a scoped subquery or CTE beneath an unscoped outer query.
@@ -38,6 +44,7 @@ import type { QueryMiddleware, QueryRequest } from "./pipeline";
 export type TenantScopeViolation =
   | { kind: "missing-predicate" }
   | { kind: "literal-predicate" }
+  | { kind: "weakening-disjunction" }
   | { kind: "missing-param"; param: string }
   | {
       kind: "param-mismatch";
@@ -61,14 +68,133 @@ const LITERAL_TENANT_PREDICATE =
  * driver, a server, or a pipeline.
  */
 /**
- * Removes `--` line comments and block comments before matching.
+ * Blanks out comment bodies and string-literal bodies, keeping every other
+ * character at its original index.
  *
- * Without this the guard misses the case it most exists for: someone debugging
- * comments the WHERE clause out, and the statement then reads every tenant's
- * rows while still visibly "containing" the predicate.
+ * Comments have to go before matching or the guard misses the case it most
+ * exists for: someone debugging comments the WHERE clause out, and the
+ * statement then reads every tenant's rows while still visibly "containing" the
+ * predicate. String bodies go too, so that a literal containing `OR`, `--` or
+ * `/*` cannot steer any of the checks below.
+ *
+ * Written as one pass rather than a pair of replaces because the obvious
+ * `/\/\*[\s\S]*?\*\//` backtracks: against a long run of unterminated `/*` each
+ * start position rescans to the end of the input, which is quadratic in the
+ * length of the statement and reachable from any caller that builds SQL from
+ * input it did not write. Here every character is visited once.
+ *
+ * Length is preserved so the returned indices still address the original text.
  */
-function withoutComments(sql: string): string {
-  return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+function maskNonCode(sql: string): string {
+  const out = [...sql];
+
+  const blank = (from: number, to: number): void => {
+    for (let i = from; i < to && i < out.length; i++) {
+      if (out[i] !== "\n") out[i] = " ";
+    }
+  };
+
+  let cursor = 0;
+  while (cursor < sql.length) {
+    const pair = sql.slice(cursor, cursor + 2);
+
+    if (pair === "/*") {
+      const close = sql.indexOf("*/", cursor + 2);
+      const end = close === -1 ? sql.length : close + 2;
+      blank(cursor, end);
+      cursor = end;
+      continue;
+    }
+
+    if (pair === "--") {
+      const newline = sql.indexOf("\n", cursor);
+      const end = newline === -1 ? sql.length : newline;
+      blank(cursor, end);
+      cursor = end;
+      continue;
+    }
+
+    const quote = sql[cursor];
+    if (quote === "'" || quote === '"' || quote === "`") {
+      let scan = cursor + 1;
+      while (scan < sql.length) {
+        if (sql[scan] === "\\") {
+          scan += 2;
+          continue;
+        }
+        if (sql[scan] === quote) {
+          // A doubled quote is an escaped quote, not the end of the literal.
+          if (sql[scan + 1] === quote) {
+            scan += 2;
+            continue;
+          }
+          break;
+        }
+        scan += 1;
+      }
+      // The delimiters stay, so `TenantId = 'x'` is still recognisably a
+      // literal predicate rather than becoming a bare `TenantId =`.
+      blank(cursor + 1, Math.min(scan, sql.length));
+      cursor = Math.min(scan + 1, sql.length);
+      continue;
+    }
+
+    cursor += 1;
+  }
+
+  return out.join("");
+}
+
+const isWordCharacter = (character: string | undefined): boolean =>
+  character !== undefined && /[A-Za-z0-9_]/.test(character);
+
+/**
+ * Reports an `OR` that can disjoin the tenant predicate away.
+ *
+ * Depth is the test. An `OR` nested inside a bracketed group cannot weaken a
+ * predicate outside it, so only one at the predicate's own depth or shallower
+ * counts. That accepts `TenantId = {t} AND (a OR b)` and refuses both
+ * `TenantId = {t} OR a` and `(TenantId = {t}) OR a`.
+ *
+ * One pass, so this cannot become the quadratic thing `maskNonCode` just
+ * stopped being.
+ */
+function hasWeakeningDisjunction({
+  masked,
+  predicateIndex,
+}: {
+  masked: string;
+  predicateIndex: number;
+}): boolean {
+  const disjunctionDepths: number[] = [];
+  let depth = 0;
+  let predicateDepth = 0;
+
+  for (let i = 0; i < masked.length; i++) {
+    if (i === predicateIndex) predicateDepth = depth;
+
+    const character = masked[i];
+    if (character === "(") {
+      depth += 1;
+      continue;
+    }
+    if (character === ")") {
+      depth -= 1;
+      continue;
+    }
+
+    // `\bOR\b` by hand, so `ORDER BY` and a column called `colour` are not ORs.
+    if (
+      (character === "o" || character === "O") &&
+      (masked[i + 1] === "r" || masked[i + 1] === "R") &&
+      !isWordCharacter(masked[i - 1]) &&
+      !isWordCharacter(masked[i + 2])
+    ) {
+      disjunctionDepths.push(depth);
+    }
+  }
+
+  return disjunctionDepths.some((each) => each <= predicateDepth);
 }
 
 export function checkTenantScope({
@@ -80,13 +206,19 @@ export function checkTenantScope({
   params?: Record<string, unknown> | undefined;
   tenantId: string;
 }): TenantScopeViolation | null {
-  const statement = withoutComments(sql);
+  const statement = maskNonCode(sql);
   const bound = BOUND_TENANT_PREDICATE.exec(statement);
 
   if (bound === null) {
     return LITERAL_TENANT_PREDICATE.test(statement)
       ? { kind: "literal-predicate" }
       : { kind: "missing-predicate" };
+  }
+
+  if (
+    hasWeakeningDisjunction({ masked: statement, predicateIndex: bound.index })
+  ) {
+    return { kind: "weakening-disjunction" };
   }
 
   const param = bound[1] as string;
@@ -120,6 +252,8 @@ function describe(violation: TenantScopeViolation): string {
       return "Statement has no `TenantId = {param:String}` predicate. No other id in this schema is unique across tenants, so this would read another tenant's rows. Add the predicate, or declare `unscoped: { reason }` if the statement genuinely spans tenants.";
     case "literal-predicate":
       return "Statement inlines the tenant as a literal instead of binding a parameter. Bind it, so it can be checked against the caller's tenant and cannot be built by concatenation.";
+    case "weakening-disjunction":
+      return "Statement has an `OR` that can disjoin the tenant predicate away, which would return every tenant's rows. Bracket the disjunction so it cannot weaken the tenant scoping, or declare `unscoped: { reason }` if the statement genuinely spans tenants.";
     case "missing-param":
       return `Statement binds tenant parameter "${violation.param}" but no such parameter was supplied.`;
     case "param-mismatch":

--- a/packages/clickhouse-client/src/tenantGuard.ts
+++ b/packages/clickhouse-client/src/tenantGuard.ts
@@ -1,0 +1,136 @@
+/**
+ * Refuses a statement that is not scoped to exactly one tenant.
+ *
+ * In this schema no identifier other than `TenantId` is unique across tenants -
+ * a TraceId, a RunId or a SpanId can collide between customers - so a read that
+ * omits the tenant predicate does not merely return too much, it returns
+ * somebody else's rows. The failure is silent: the query succeeds, the shape is
+ * right, and nothing looks wrong until a customer reports seeing data that is
+ * not theirs.
+ *
+ * This is a guard against omission, not a security boundary. It matches on the
+ * statement text, so a determined caller can defeat it (a predicate hidden in a
+ * string literal, an unusual alias). That is fine: the thing it has to stop is
+ * a normal engineer writing a normal query and forgetting a WHERE clause, and
+ * for that a text check is exactly enough. Real isolation is enforced by the
+ * routing in ./tenancy.ts and by the credentials the server was given.
+ *
+ * The predicate must bind a parameter rather than inline a literal. An inlined
+ * tenant is a string built by concatenation somewhere, which is the shape that
+ * eventually becomes an injection, and it cannot be checked against the tenant
+ * the caller claims to be acting for.
+ */
+
+import type { QueryMiddleware, QueryRequest } from "./pipeline";
+
+export type TenantScopeViolation =
+  | { kind: "missing-predicate" }
+  | { kind: "literal-predicate" }
+  | { kind: "missing-param"; param: string }
+  | {
+      kind: "param-mismatch";
+      param: string;
+      expected: string;
+      actual: unknown;
+    };
+
+/** `TenantId = {someName:String}`, allowing an optional table alias. */
+const BOUND_TENANT_PREDICATE =
+  /(?:^|[\s.(])TenantId\s*=\s*\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/i;
+
+/** `TenantId = 'literal'` or `= "literal"`, which is never acceptable. */
+const LITERAL_TENANT_PREDICATE =
+  /(?:^|[\s.(])TenantId\s*=\s*(?:'[^']*'|"[^"]*")/i;
+
+/**
+ * Returns the reason a statement is not tenant-scoped, or null when it is.
+ *
+ * Pure, so the rule can be exercised over a table of statements without a
+ * driver, a server, or a pipeline.
+ */
+export function checkTenantScope({
+  sql,
+  params,
+  tenantId,
+}: {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+  tenantId: string;
+}): TenantScopeViolation | null {
+  const bound = BOUND_TENANT_PREDICATE.exec(sql);
+
+  if (bound === null) {
+    return LITERAL_TENANT_PREDICATE.test(sql)
+      ? { kind: "literal-predicate" }
+      : { kind: "missing-predicate" };
+  }
+
+  const param = bound[1] as string;
+  const supplied = params?.[param];
+
+  if (supplied === undefined) return { kind: "missing-param", param };
+  if (supplied !== tenantId) {
+    return {
+      kind: "param-mismatch",
+      param,
+      expected: tenantId,
+      actual: supplied,
+    };
+  }
+  return null;
+}
+
+export class TenantScopeError extends Error {
+  constructor(
+    public readonly violation: TenantScopeViolation,
+    public readonly tenantId: string,
+  ) {
+    super(`${describe(violation)} (tenant "${tenantId}")`);
+    this.name = "TenantScopeError";
+  }
+}
+
+function describe(violation: TenantScopeViolation): string {
+  switch (violation.kind) {
+    case "missing-predicate":
+      return "Statement has no `TenantId = {param:String}` predicate. No other id in this schema is unique across tenants, so this would read another tenant's rows. Add the predicate, or declare `unscoped: { reason }` if the statement genuinely spans tenants.";
+    case "literal-predicate":
+      return "Statement inlines the tenant as a literal instead of binding a parameter. Bind it, so it can be checked against the caller's tenant and cannot be built by concatenation.";
+    case "missing-param":
+      return `Statement binds tenant parameter "${violation.param}" but no such parameter was supplied.`;
+    case "param-mismatch":
+      return `Statement binds tenant parameter "${violation.param}" to a different tenant than the request claims.`;
+  }
+}
+
+export interface TenantGuardOptions {
+  /** Called for each declared-unscoped statement, so they can be audited. */
+  onUnscoped?: ((request: QueryRequest) => void) | undefined;
+}
+
+/**
+ * Middleware form. Place it outermost: refusing costs nothing, and it should
+ * happen before a rate-limit slot or a retry budget is spent on a statement
+ * that must not run.
+ */
+export function tenantGuard({
+  onUnscoped,
+}: TenantGuardOptions = {}): QueryMiddleware {
+  return (next) => async (request) => {
+    if (request.unscoped !== undefined) {
+      onUnscoped?.(request);
+      return next(request);
+    }
+
+    const violation = checkTenantScope({
+      sql: request.sql,
+      params: request.params,
+      tenantId: request.tenantId,
+    });
+    if (violation !== null) {
+      throw new TenantScopeError(violation, request.tenantId);
+    }
+
+    return next(request);
+  };
+}

--- a/packages/clickhouse-client/src/tenantGuard.ts
+++ b/packages/clickhouse-client/src/tenantGuard.ts
@@ -9,11 +9,23 @@
  * not theirs.
  *
  * This is a guard against omission, not a security boundary. It matches on the
- * statement text, so a determined caller can defeat it (a predicate hidden in a
- * string literal, an unusual alias). That is fine: the thing it has to stop is
- * a normal engineer writing a normal query and forgetting a WHERE clause, and
- * for that a text check is exactly enough. Real isolation is enforced by the
+ * statement text, so the thing it has to stop is a normal engineer writing a
+ * normal query and forgetting a WHERE clause. Real isolation is enforced by the
  * routing in ./tenancy.ts and by the credentials the server was given.
+ *
+ * Known and accepted limits, each pinned by a test in ./tenantGuard.test.ts so
+ * they stay documented rather than becoming folklore. One match anywhere in the
+ * statement satisfies the whole statement, so all of these pass:
+ *
+ *   - a disjunction: `WHERE TenantId = {t:String} OR Status = 'x'` matches, and
+ *     returns every tenant's rows. This is the one a regex cannot see, and the
+ *     reason this check is a backstop rather than the isolation mechanism.
+ *   - a UNION whose second arm is unscoped.
+ *   - a JOIN where only one side is scoped.
+ *   - a scoped subquery or CTE beneath an unscoped outer query.
+ *
+ * Closing these needs a parser. If that day comes, the shape of this function
+ * does not have to change - only `checkTenantScope`'s internals.
  *
  * The predicate must bind a parameter rather than inline a literal. An inlined
  * tenant is a string built by concatenation somewhere, which is the shape that
@@ -48,6 +60,17 @@ const LITERAL_TENANT_PREDICATE =
  * Pure, so the rule can be exercised over a table of statements without a
  * driver, a server, or a pipeline.
  */
+/**
+ * Removes `--` line comments and block comments before matching.
+ *
+ * Without this the guard misses the case it most exists for: someone debugging
+ * comments the WHERE clause out, and the statement then reads every tenant's
+ * rows while still visibly "containing" the predicate.
+ */
+function withoutComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+}
+
 export function checkTenantScope({
   sql,
   params,
@@ -57,10 +80,11 @@ export function checkTenantScope({
   params?: Record<string, unknown> | undefined;
   tenantId: string;
 }): TenantScopeViolation | null {
-  const bound = BOUND_TENANT_PREDICATE.exec(sql);
+  const statement = withoutComments(sql);
+  const bound = BOUND_TENANT_PREDICATE.exec(statement);
 
   if (bound === null) {
-    return LITERAL_TENANT_PREDICATE.test(sql)
+    return LITERAL_TENANT_PREDICATE.test(statement)
       ? { kind: "literal-predicate" }
       : { kind: "missing-predicate" };
   }

--- a/packages/clickhouse-client/src/tracing.test.ts
+++ b/packages/clickhouse-client/src/tracing.test.ts
@@ -38,134 +38,236 @@ const request: QueryRequest = {
 
 describe("trace", () => {
   describe("given a statement that succeeds", () => {
-    it("records the tenant, table and operation", async () => {
-      const { tracer, attributes } = recordingTracer();
+    describe("when the span is recorded", () => {
+      it("records the tenant, table and operation", async () => {
+        const { tracer, attributes } = recordingTracer();
 
-      await trace({ tracer })(async () => ({ rows: [1, 2] }))(request);
+        await trace({ tracer })(async () => ({ rows: [1, 2] }))(request);
 
-      expect(attributes[SPAN_ATTRIBUTES.system]).toBe("clickhouse");
-      expect(attributes[SPAN_ATTRIBUTES.tenant]).toBe("project_1");
-      expect(attributes[SPAN_ATTRIBUTES.table]).toBe("stored_spans");
-      expect(attributes[SPAN_ATTRIBUTES.operation]).toBe("read");
-    });
+        expect(attributes[SPAN_ATTRIBUTES.system]).toBe("clickhouse");
+        expect(attributes[SPAN_ATTRIBUTES.tenant]).toBe("project_1");
+        expect(attributes[SPAN_ATTRIBUTES.table]).toBe("stored_spans");
+        expect(attributes[SPAN_ATTRIBUTES.operation]).toBe("read");
+      });
 
-    it("records how much came back", async () => {
-      const { tracer, attributes } = recordingTracer();
+      it("records how much came back", async () => {
+        const { tracer, attributes } = recordingTracer();
 
-      await trace({ tracer })(async () => ({
-        rows: [1, 2],
-        stats: { bytesRead: 4096 },
-      }))(request);
+        await trace({ tracer })(async () => ({
+          rows: [1, 2],
+          stats: { bytesRead: 4096 },
+        }))(request);
 
-      expect(attributes[SPAN_ATTRIBUTES.rows]).toBe(2);
-      expect(attributes[SPAN_ATTRIBUTES.bytesRead]).toBe(4096);
-    });
+        expect(attributes[SPAN_ATTRIBUTES.rows]).toBe(2);
+        expect(attributes[SPAN_ATTRIBUTES.bytesRead]).toBe(4096);
+      });
 
-    it("never puts the statement or its parameters on the span", async () => {
-      // Spans leave the process. Neither the SQL nor the bound values have
-      // been through redaction, and a span backend is not a place customer
-      // content is allowed to reach.
-      const { tracer, attributes } = recordingTracer();
+      it("never puts the statement or its parameters on the span", async () => {
+        // Spans leave the process. Neither the SQL nor the bound values have
+        // been through redaction, and a span backend is not a place customer
+        // content is allowed to reach.
+        const { tracer, attributes } = recordingTracer();
 
-      await trace({ tracer })(async () => ({ rows: [] }))(request);
+        await trace({ tracer })(async () => ({ rows: [] }))(request);
 
-      const recorded = JSON.stringify(attributes);
-      expect(recorded).not.toContain("SELECT");
-      expect(recorded).not.toContain("ops@example.com");
-      expect(recorded).not.toContain("sk-live-1234");
+        const recorded = JSON.stringify(attributes);
+        expect(recorded).not.toContain("SELECT");
+        expect(recorded).not.toContain("ops@example.com");
+        expect(recorded).not.toContain("sk-live-1234");
+      });
     });
   });
 
   describe("given a statement declared unscoped", () => {
-    it("records the stated reason so exemptions can be audited", async () => {
-      const { tracer, attributes } = recordingTracer();
+    describe("when the span is recorded", () => {
+      it("records the stated reason so exemptions can be audited", async () => {
+        const { tracer, attributes } = recordingTracer();
 
-      await trace({ tracer })(async () => ({ rows: [] }))({
-        ...request,
-        unscoped: { reason: "operational part-count check" },
+        await trace({ tracer })(async () => ({ rows: [] }))({
+          ...request,
+          unscoped: { reason: "operational part-count check" },
+        });
+
+        expect(attributes[SPAN_ATTRIBUTES.unscopedReason]).toBe(
+          "operational part-count check",
+        );
       });
-
-      expect(attributes[SPAN_ATTRIBUTES.unscopedReason]).toBe(
-        "operational part-count check",
-      );
     });
   });
 
   describe("given a statement that fails", () => {
-    it("records the failure class and rethrows the original", async () => {
-      const { tracer, errors } = recordingTracer();
-      const failure = Object.assign(new Error("boom"), { code: "ECONNRESET" });
+    describe("when the failure is recorded", () => {
+      it("records the failure class and rethrows the original", async () => {
+        const { tracer, errors } = recordingTracer();
+        const failure = Object.assign(new Error("boom"), {
+          code: "ECONNRESET",
+        });
 
-      await expect(
-        trace({ tracer })(async () => {
-          throw failure;
-        })(request),
-      ).rejects.toThrow("boom");
+        await expect(
+          trace({ tracer })(async () => {
+            throw failure;
+          })(request),
+        ).rejects.toThrow("boom");
 
-      expect(errors).toEqual([{ name: "Error", code: "ECONNRESET" }]);
-    });
+        expect(errors).toEqual([{ name: "Error", code: "ECONNRESET" }]);
+      });
 
-    it("never lets the failing statement reach the span", async () => {
-      // ClickHouse embeds the statement in its own error message, so recording
-      // the raw error would re-open the no-SQL rule on the failure path - the
-      // path nobody inspects until an incident.
-      const { tracer, errors } = recordingTracer();
+      it("never lets the failing statement reach the span", async () => {
+        // ClickHouse embeds the statement in its own error message, so
+        // recording the raw error would re-open the no-SQL rule on the failure
+        // path - the path nobody inspects until an incident.
+        const { tracer, errors } = recordingTracer();
 
-      await expect(
-        trace({ tracer })(async () => {
-          throw new Error(
-            "Code: 62. DB::Exception: Syntax error (in query: SELECT Email FROM t WHERE Email = 'ops@example.com')",
-          );
-        })(request),
-      ).rejects.toThrow();
+        await expect(
+          trace({ tracer })(async () => {
+            throw new Error(
+              "Code: 62. DB::Exception: Syntax error (in query: SELECT Email FROM t WHERE Email = 'ops@example.com')",
+            );
+          })(request),
+        ).rejects.toThrow();
 
-      const recorded = JSON.stringify(errors);
-      expect(recorded).not.toContain("SELECT");
-      expect(recorded).not.toContain("ops@example.com");
-    });
+        const recorded = JSON.stringify(errors);
+        expect(recorded).not.toContain("SELECT");
+        expect(recorded).not.toContain("ops@example.com");
+      });
 
-    it("still ends the span", async () => {
-      const { tracer, ended } = recordingTracer();
+      it("still ends the span", async () => {
+        const { tracer, ended } = recordingTracer();
 
-      await expect(
-        trace({ tracer })(async () => {
-          throw new Error("boom");
-        })(request),
-      ).rejects.toThrow();
+        await expect(
+          trace({ tracer })(async () => {
+            throw new Error("boom");
+          })(request),
+        ).rejects.toThrow();
 
-      expect(ended()).toBe(1);
+        expect(ended()).toBe(1);
+      });
     });
   });
 
   describe("given a completion hook", () => {
-    it("reports the duration on success", async () => {
-      const { tracer } = recordingTracer();
-      const onComplete = vi.fn();
-      let clock = 1000;
+    describe("when the statement completes", () => {
+      it("reports the duration on success", async () => {
+        const { tracer } = recordingTracer();
+        const onComplete = vi.fn();
+        let clock = 1000;
 
-      await trace({ tracer, onComplete, now: () => clock })(async () => {
-        clock = 1075;
-        return { rows: [] };
-      })(request);
+        await trace({ tracer, onComplete, now: () => clock })(async () => {
+          clock = 1075;
+          return { rows: [] };
+        })(request);
 
-      expect(onComplete).toHaveBeenCalledWith(
-        expect.objectContaining({ durationMs: 75, rowCount: 0 }),
-      );
+        expect(onComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ durationMs: 75, rowCount: 0 }),
+        );
+      });
+
+      it("reports the failure too, so error rates are countable", async () => {
+        const { tracer } = recordingTracer();
+        const onComplete = vi.fn();
+
+        await expect(
+          trace({ tracer, onComplete })(async () => {
+            throw new Error("boom");
+          })(request),
+        ).rejects.toThrow();
+
+        expect(onComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ error: expect.any(Error) }),
+        );
+      });
+    });
+  });
+
+  describe("given host observability that is itself broken", () => {
+    // Every one of these runs on the query's own path. A misconfigured span
+    // exporter is a reporting problem, and it must not be able to fail a query
+    // that ClickHouse answered perfectly well, nor replace a real ClickHouse
+    // error with a telemetry one.
+    const exploding = new Error("the span exporter is misconfigured");
+
+    describe("when the tracer cannot start a span", () => {
+      it("still returns the rows", async () => {
+        const tracer: TracerPort = {
+          startSpan: () => {
+            throw exploding;
+          },
+        };
+
+        await expect(
+          trace({ tracer })(async () => ({ rows: [1] }))(request),
+        ).resolves.toEqual({ rows: [1] });
+      });
     });
 
-    it("reports the failure too, so error rates are countable", async () => {
-      const { tracer } = recordingTracer();
-      const onComplete = vi.fn();
+    describe("when the span throws while being written", () => {
+      it("still returns the rows", async () => {
+        const tracer: TracerPort = {
+          startSpan: () => ({
+            setAttribute: () => {
+              throw exploding;
+            },
+            recordError: () => {
+              throw exploding;
+            },
+            end: () => {
+              throw exploding;
+            },
+          }),
+        };
 
-      await expect(
-        trace({ tracer, onComplete })(async () => {
-          throw new Error("boom");
-        })(request),
-      ).rejects.toThrow();
+        await expect(
+          trace({ tracer })(async () => ({ rows: [1] }))(request),
+        ).resolves.toEqual({ rows: [1] });
+      });
 
-      expect(onComplete).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.any(Error) }),
-      );
+      it("still reports the ClickHouse failure, not the span one", async () => {
+        const tracer: TracerPort = {
+          startSpan: () => ({
+            setAttribute: () => undefined,
+            recordError: () => {
+              throw exploding;
+            },
+            end: () => undefined,
+          }),
+        };
+
+        await expect(
+          trace({ tracer })(async () => {
+            throw new Error("Code: 241. Memory limit exceeded");
+          })(request),
+        ).rejects.toThrow(/Memory limit exceeded/);
+      });
+    });
+
+    describe("when the completion hook throws", () => {
+      it("still returns the rows", async () => {
+        const { tracer } = recordingTracer();
+
+        await expect(
+          trace({
+            tracer,
+            onComplete: () => {
+              throw exploding;
+            },
+          })(async () => ({ rows: [1] }))(request),
+        ).resolves.toEqual({ rows: [1] });
+      });
+
+      it("still reports the ClickHouse failure, not the counter one", async () => {
+        const { tracer } = recordingTracer();
+
+        await expect(
+          trace({
+            tracer,
+            onComplete: () => {
+              throw exploding;
+            },
+          })(async () => {
+            throw new Error("Code: 241. Memory limit exceeded");
+          })(request),
+        ).rejects.toThrow(/Memory limit exceeded/);
+      });
     });
   });
 });

--- a/packages/clickhouse-client/src/tracing.test.ts
+++ b/packages/clickhouse-client/src/tracing.test.ts
@@ -92,9 +92,9 @@ describe("trace", () => {
   });
 
   describe("given a statement that fails", () => {
-    it("records the error and rethrows it", async () => {
+    it("records the failure class and rethrows the original", async () => {
       const { tracer, errors } = recordingTracer();
-      const failure = new Error("boom");
+      const failure = Object.assign(new Error("boom"), { code: "ECONNRESET" });
 
       await expect(
         trace({ tracer })(async () => {
@@ -102,7 +102,26 @@ describe("trace", () => {
         })(request),
       ).rejects.toThrow("boom");
 
-      expect(errors).toEqual([failure]);
+      expect(errors).toEqual([{ name: "Error", code: "ECONNRESET" }]);
+    });
+
+    it("never lets the failing statement reach the span", async () => {
+      // ClickHouse embeds the statement in its own error message, so recording
+      // the raw error would re-open the no-SQL rule on the failure path - the
+      // path nobody inspects until an incident.
+      const { tracer, errors } = recordingTracer();
+
+      await expect(
+        trace({ tracer })(async () => {
+          throw new Error(
+            "Code: 62. DB::Exception: Syntax error (in query: SELECT Email FROM t WHERE Email = 'ops@example.com')",
+          );
+        })(request),
+      ).rejects.toThrow();
+
+      const recorded = JSON.stringify(errors);
+      expect(recorded).not.toContain("SELECT");
+      expect(recorded).not.toContain("ops@example.com");
     });
 
     it("still ends the span", async () => {

--- a/packages/clickhouse-client/src/tracing.test.ts
+++ b/packages/clickhouse-client/src/tracing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryRequest } from "./pipeline";
+import {
+  SPAN_ATTRIBUTES,
+  type SpanPort,
+  type TracerPort,
+  trace,
+} from "./tracing";
+
+const recordingTracer = () => {
+  const attributes: Record<string, string | number | boolean> = {};
+  const errors: unknown[] = [];
+  let ended = 0;
+
+  const span: SpanPort = {
+    setAttribute: (key, value) => {
+      attributes[key] = value;
+    },
+    recordError: (error) => {
+      errors.push(error);
+    },
+    end: () => {
+      ended += 1;
+    },
+  };
+
+  const tracer: TracerPort = { startSpan: () => span };
+  return { tracer, attributes, errors, ended: () => ended };
+};
+
+const request: QueryRequest = {
+  tenantId: "project_1",
+  sql: "SELECT SpanId FROM stored_spans WHERE TenantId = {tenantId:String} AND Email = 'ops@example.com'",
+  params: { tenantId: "project_1", secret: "sk-live-1234" },
+  table: "stored_spans",
+  kind: "read",
+};
+
+describe("trace", () => {
+  describe("given a statement that succeeds", () => {
+    it("records the tenant, table and operation", async () => {
+      const { tracer, attributes } = recordingTracer();
+
+      await trace({ tracer })(async () => ({ rows: [1, 2] }))(request);
+
+      expect(attributes[SPAN_ATTRIBUTES.system]).toBe("clickhouse");
+      expect(attributes[SPAN_ATTRIBUTES.tenant]).toBe("project_1");
+      expect(attributes[SPAN_ATTRIBUTES.table]).toBe("stored_spans");
+      expect(attributes[SPAN_ATTRIBUTES.operation]).toBe("read");
+    });
+
+    it("records how much came back", async () => {
+      const { tracer, attributes } = recordingTracer();
+
+      await trace({ tracer })(async () => ({
+        rows: [1, 2],
+        stats: { bytesRead: 4096 },
+      }))(request);
+
+      expect(attributes[SPAN_ATTRIBUTES.rows]).toBe(2);
+      expect(attributes[SPAN_ATTRIBUTES.bytesRead]).toBe(4096);
+    });
+
+    it("never puts the statement or its parameters on the span", async () => {
+      // Spans leave the process. Neither the SQL nor the bound values have
+      // been through redaction, and a span backend is not a place customer
+      // content is allowed to reach.
+      const { tracer, attributes } = recordingTracer();
+
+      await trace({ tracer })(async () => ({ rows: [] }))(request);
+
+      const recorded = JSON.stringify(attributes);
+      expect(recorded).not.toContain("SELECT");
+      expect(recorded).not.toContain("ops@example.com");
+      expect(recorded).not.toContain("sk-live-1234");
+    });
+  });
+
+  describe("given a statement declared unscoped", () => {
+    it("records the stated reason so exemptions can be audited", async () => {
+      const { tracer, attributes } = recordingTracer();
+
+      await trace({ tracer })(async () => ({ rows: [] }))({
+        ...request,
+        unscoped: { reason: "operational part-count check" },
+      });
+
+      expect(attributes[SPAN_ATTRIBUTES.unscopedReason]).toBe(
+        "operational part-count check",
+      );
+    });
+  });
+
+  describe("given a statement that fails", () => {
+    it("records the error and rethrows it", async () => {
+      const { tracer, errors } = recordingTracer();
+      const failure = new Error("boom");
+
+      await expect(
+        trace({ tracer })(async () => {
+          throw failure;
+        })(request),
+      ).rejects.toThrow("boom");
+
+      expect(errors).toEqual([failure]);
+    });
+
+    it("still ends the span", async () => {
+      const { tracer, ended } = recordingTracer();
+
+      await expect(
+        trace({ tracer })(async () => {
+          throw new Error("boom");
+        })(request),
+      ).rejects.toThrow();
+
+      expect(ended()).toBe(1);
+    });
+  });
+
+  describe("given a completion hook", () => {
+    it("reports the duration on success", async () => {
+      const { tracer } = recordingTracer();
+      const onComplete = vi.fn();
+      let clock = 1000;
+
+      await trace({ tracer, onComplete, now: () => clock })(async () => {
+        clock = 1075;
+        return { rows: [] };
+      })(request);
+
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ durationMs: 75, rowCount: 0 }),
+      );
+    });
+
+    it("reports the failure too, so error rates are countable", async () => {
+      const { tracer } = recordingTracer();
+      const onComplete = vi.fn();
+
+      await expect(
+        trace({ tracer, onComplete })(async () => {
+          throw new Error("boom");
+        })(request),
+      ).rejects.toThrow();
+
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+    });
+  });
+});

--- a/packages/clickhouse-client/src/tracing.ts
+++ b/packages/clickhouse-client/src/tracing.ts
@@ -17,10 +17,44 @@
 
 import type { QueryMiddleware, QueryRequest, QueryResult } from "./pipeline";
 
+/**
+ * A failure, reduced to what is safe to ship.
+ *
+ * Deliberately not the error itself. A ClickHouse server error embeds the
+ * failing statement in its message ("...(in query: SELECT ...)"), so handing
+ * the raw error to a span backend re-opens the very hole the no-SQL rule above
+ * closes - and does it on the failure path, where nobody looks until later.
+ * The class and the server's error code are enough to group and alert on.
+ */
+export interface QueryErrorDescriptor {
+  name: string;
+  code?: string | undefined;
+  status?: number | undefined;
+}
+
 export interface SpanPort {
   setAttribute(key: string, value: string | number | boolean): void;
-  recordError(error: unknown): void;
+  recordError(error: QueryErrorDescriptor): void;
   end(): void;
+}
+
+/** Strips a failure down to {@link QueryErrorDescriptor}. Never the message. */
+export function describeQueryError(error: unknown): QueryErrorDescriptor {
+  if (typeof error !== "object" || error === null) {
+    return { name: typeof error };
+  }
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    statusCode?: unknown;
+    status?: unknown;
+  };
+  const status = candidate.statusCode ?? candidate.status;
+  return {
+    name: typeof candidate.name === "string" ? candidate.name : "Error",
+    ...(typeof candidate.code === "string" ? { code: candidate.code } : {}),
+    ...(typeof status === "number" ? { status } : {}),
+  };
 }
 
 export interface TracerPort {
@@ -93,7 +127,7 @@ export function trace({
         });
         return result;
       } catch (error) {
-        span.recordError(error);
+        span.recordError(describeQueryError(error));
         onComplete?.({ request, durationMs: now() - startedAt, error });
         throw error;
       } finally {

--- a/packages/clickhouse-client/src/tracing.ts
+++ b/packages/clickhouse-client/src/tracing.ts
@@ -88,6 +88,25 @@ export const SPAN_ATTRIBUTES = {
   bytesRead: "db.response.read_bytes",
 } as const;
 
+/**
+ * Runs host observability code without letting it change the outcome.
+ *
+ * Everything this middleware calls - the tracer, the span, the completion
+ * counter - is supplied by the host and runs on the query's own path. An
+ * exception from any of it would surface to the caller as though the query had
+ * failed, or would replace a real ClickHouse error with a telemetry one. A
+ * span exporter that is misconfigured is a reporting problem; it must not
+ * become an outage.
+ */
+function quietly(report: () => void): void {
+  try {
+    report();
+  } catch {
+    // Deliberately swallowed. The only channel for reporting a telemetry
+    // failure is the telemetry that just failed.
+  }
+}
+
 export function trace({
   tracer,
   spanName = "clickhouse.query",
@@ -96,42 +115,55 @@ export function trace({
 }: TraceOptions): QueryMiddleware {
   return (next) =>
     async <Row>(request: QueryRequest): Promise<QueryResult<Row>> => {
-      const span = tracer.startSpan(spanName);
+      let span: SpanPort | undefined;
+      quietly(() => {
+        span = tracer.startSpan(spanName);
+      });
       const startedAt = now();
 
-      span.setAttribute(SPAN_ATTRIBUTES.system, "clickhouse");
-      span.setAttribute(SPAN_ATTRIBUTES.tenant, request.tenantId);
-      span.setAttribute(SPAN_ATTRIBUTES.operation, request.kind ?? "read");
-      if (request.table !== undefined) {
-        span.setAttribute(SPAN_ATTRIBUTES.table, request.table);
-      }
-      // Recorded so an audit can enumerate every statement that opted out of
-      // the tenant predicate, and why, without reading the code.
-      if (request.unscoped !== undefined) {
-        span.setAttribute(
-          SPAN_ATTRIBUTES.unscopedReason,
-          request.unscoped.reason,
-        );
-      }
+      quietly(() => {
+        if (span === undefined) return;
+        span.setAttribute(SPAN_ATTRIBUTES.system, "clickhouse");
+        span.setAttribute(SPAN_ATTRIBUTES.tenant, request.tenantId);
+        span.setAttribute(SPAN_ATTRIBUTES.operation, request.kind ?? "read");
+        if (request.table !== undefined) {
+          span.setAttribute(SPAN_ATTRIBUTES.table, request.table);
+        }
+        // Recorded so an audit can enumerate every statement that opted out of
+        // the tenant predicate, and why, without reading the code.
+        if (request.unscoped !== undefined) {
+          span.setAttribute(
+            SPAN_ATTRIBUTES.unscopedReason,
+            request.unscoped.reason,
+          );
+        }
+      });
 
       try {
         const result = await next<Row>(request);
-        span.setAttribute(SPAN_ATTRIBUTES.rows, result.rows.length);
-        if (result.stats?.bytesRead !== undefined) {
-          span.setAttribute(SPAN_ATTRIBUTES.bytesRead, result.stats.bytesRead);
-        }
-        onComplete?.({
-          request,
-          durationMs: now() - startedAt,
-          rowCount: result.rows.length,
+        quietly(() => {
+          span?.setAttribute(SPAN_ATTRIBUTES.rows, result.rows.length);
+          if (result.stats?.bytesRead !== undefined) {
+            span?.setAttribute(
+              SPAN_ATTRIBUTES.bytesRead,
+              result.stats.bytesRead,
+            );
+          }
+          onComplete?.({
+            request,
+            durationMs: now() - startedAt,
+            rowCount: result.rows.length,
+          });
         });
         return result;
       } catch (error) {
-        span.recordError(describeQueryError(error));
-        onComplete?.({ request, durationMs: now() - startedAt, error });
+        quietly(() => {
+          span?.recordError(describeQueryError(error));
+          onComplete?.({ request, durationMs: now() - startedAt, error });
+        });
         throw error;
       } finally {
-        span.end();
+        quietly(() => span?.end());
       }
     };
 }

--- a/packages/clickhouse-client/src/tracing.ts
+++ b/packages/clickhouse-client/src/tracing.ts
@@ -1,0 +1,103 @@
+/**
+ * Span and metric emission for a statement.
+ *
+ * Written against narrow ports rather than OpenTelemetry directly. The package
+ * stays dependency-free, the host wires its own tracer, and a test asserts on a
+ * recorded array instead of standing up an SDK.
+ *
+ * What is deliberately NOT recorded: the statement text and its parameters.
+ * A span is shipped to whatever backend the host configured, and neither the
+ * SQL nor the bound values have been through redaction - parameters carry ids,
+ * and a hand-written statement can carry literals. This package already learned
+ * that lesson at a different boundary, where unparsed request bodies reached a
+ * third-party processor because nobody asked what was in them. The table name,
+ * the tenant and the shape of the result are enough to find a slow or failing
+ * query; the text of it belongs in the code, where it already is.
+ */
+
+import type { QueryMiddleware, QueryRequest, QueryResult } from "./pipeline";
+
+export interface SpanPort {
+  setAttribute(key: string, value: string | number | boolean): void;
+  recordError(error: unknown): void;
+  end(): void;
+}
+
+export interface TracerPort {
+  startSpan(name: string): SpanPort;
+}
+
+export interface QueryOutcome {
+  request: QueryRequest;
+  durationMs: number;
+  error?: unknown;
+  rowCount?: number | undefined;
+}
+
+export interface TraceOptions {
+  tracer: TracerPort;
+  /** Defaults to `clickhouse.query`. */
+  spanName?: string | undefined;
+  /** Called on every completion, success or failure. For counters. */
+  onComplete?: ((outcome: QueryOutcome) => void) | undefined;
+  /** Injectable so a test can assert an exact duration. */
+  now?: (() => number) | undefined;
+}
+
+export const SPAN_ATTRIBUTES = {
+  system: "db.system",
+  table: "db.sql.table",
+  operation: "db.operation",
+  tenant: "langwatch.tenant_id",
+  unscopedReason: "langwatch.unscoped_reason",
+  rows: "db.response.returned_rows",
+  bytesRead: "db.response.read_bytes",
+} as const;
+
+export function trace({
+  tracer,
+  spanName = "clickhouse.query",
+  onComplete,
+  now = () => Date.now(),
+}: TraceOptions): QueryMiddleware {
+  return (next) =>
+    async <Row>(request: QueryRequest): Promise<QueryResult<Row>> => {
+      const span = tracer.startSpan(spanName);
+      const startedAt = now();
+
+      span.setAttribute(SPAN_ATTRIBUTES.system, "clickhouse");
+      span.setAttribute(SPAN_ATTRIBUTES.tenant, request.tenantId);
+      span.setAttribute(SPAN_ATTRIBUTES.operation, request.kind ?? "read");
+      if (request.table !== undefined) {
+        span.setAttribute(SPAN_ATTRIBUTES.table, request.table);
+      }
+      // Recorded so an audit can enumerate every statement that opted out of
+      // the tenant predicate, and why, without reading the code.
+      if (request.unscoped !== undefined) {
+        span.setAttribute(
+          SPAN_ATTRIBUTES.unscopedReason,
+          request.unscoped.reason,
+        );
+      }
+
+      try {
+        const result = await next<Row>(request);
+        span.setAttribute(SPAN_ATTRIBUTES.rows, result.rows.length);
+        if (result.stats?.bytesRead !== undefined) {
+          span.setAttribute(SPAN_ATTRIBUTES.bytesRead, result.stats.bytesRead);
+        }
+        onComplete?.({
+          request,
+          durationMs: now() - startedAt,
+          rowCount: result.rows.length,
+        });
+        return result;
+      } catch (error) {
+        span.recordError(error);
+        onComplete?.({ request, durationMs: now() - startedAt, error });
+        throw error;
+      } finally {
+        span.end();
+      }
+    };
+}

--- a/packages/clickhouse-client/tsconfig.json
+++ b/packages/clickhouse-client/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["es2020"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"],
+  // Tests run via vitest (`pnpm test`), which provides the `vitest` module and
+  // its types at runtime; the declaration build must not require them.
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/clickhouse-client/tsconfig.json
+++ b/packages/clickhouse-client/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "incremental": true,
-    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo/clickhouse-client.tsbuildinfo",
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "./dist",
@@ -16,7 +16,7 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts"],
-  // Tests run via vitest (`pnpm test`), which provides the `vitest` module and
-  // its types at runtime; the declaration build must not require them.
+  // Exclude Vitest tests from the source typecheck and declaration build;
+  // Vitest is a test-only dependency.
   "exclude": ["src/**/*.test.ts"]
 }

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -87,6 +87,7 @@
     "@google-cloud/dlp": "^6.7.0",
     "@hono/node-server": "^2.0.6",
     "@langwatch/automations": "workspace:*",
+    "@langwatch/clickhouse-client": "workspace:*",
     "@langwatch/handled-error": "workspace:*",
     "@langwatch/ksuid": "^2.0.2",
     "@langwatch/langy": "workspace:*",

--- a/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
@@ -48,16 +48,17 @@ describe("createResilientClickHouseClient()", () => {
     mockLogger.fatal.mockReset();
   });
 
-  describe("when insert fails with transient error then succeeds", () => {
-    /** @scenario Transient insert errors are retried with exponential backoff */
-    it("retries and returns the result", async () => {
+  describe("when insert fails with transient error", () => {
+    /** @scenario Insert failures are not retried by the client */
+    it("attempts it exactly once and raises for the queue to retry", async () => {
+      // Every insert comes from a queued job that retries the whole job, so a
+      // retry here multiplies attempts rather than adding resilience. These
+      // are also async inserts with deduplication off, so a failure raised
+      // after the server buffered the batch can still flush - retrying then
+      // writes the rows twice.
       const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
-      const result = { executed: true };
       const mock = makeMockClient({
-        insert: vi
-          .fn()
-          .mockRejectedValueOnce(transientError)
-          .mockResolvedValueOnce(result),
+        insert: vi.fn().mockRejectedValue(transientError),
       });
       const client = createResilientClickHouseClient({
         client: mock,
@@ -65,24 +66,15 @@ describe("createResilientClickHouseClient()", () => {
         baseDelayMs: 1,
       });
 
-      const actual = await client.insert({
-        table: "test",
-        values: [],
-        format: "JSONEachRow",
-      });
-
-      expect(actual).toBe(result);
-      expect(mock.insert).toHaveBeenCalledTimes(2);
+      await expect(
+        client.insert({ table: "test", values: [], format: "JSONEachRow" }),
+      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      expect(mock.insert).toHaveBeenCalledTimes(1);
     });
 
-    it("logs a retry warning with structured metadata", async () => {
-      const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
-      const result = { executed: true };
+    it("emits no retry warning, because there is no retry", async () => {
       const mock = makeMockClient({
-        insert: vi
-          .fn()
-          .mockRejectedValueOnce(transientError)
-          .mockResolvedValueOnce(result),
+        insert: vi.fn().mockRejectedValue(new Error("MEMORY_LIMIT_EXCEEDED")),
       });
       const client = createResilientClickHouseClient({
         client: mock,
@@ -90,18 +82,12 @@ describe("createResilientClickHouseClient()", () => {
         baseDelayMs: 1,
       });
 
-      await client.insert({
-        table: "test",
-        values: [],
-        format: "JSONEachRow",
-      });
+      await expect(
+        client.insert({ table: "test", values: [], format: "JSONEachRow" }),
+      ).rejects.toThrow();
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          source: "clickhouse",
-          operation: "insert",
-          attempt: 1,
-        }),
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ operation: "insert" }),
         expect.any(String),
       );
     });
@@ -127,11 +113,11 @@ describe("createResilientClickHouseClient()", () => {
     });
   });
 
-  describe("when all retries are exhausted", () => {
+  describe("when a read exhausts its retries", () => {
     it("calls maxRetries+1 times then throws the final error", async () => {
       const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
       const mock = makeMockClient({
-        insert: vi.fn().mockRejectedValue(transientError),
+        query: vi.fn().mockRejectedValue(transientError),
       });
       const client = createResilientClickHouseClient({
         client: mock,
@@ -140,9 +126,9 @@ describe("createResilientClickHouseClient()", () => {
       });
 
       await expect(
-        client.insert({ table: "test", values: [], format: "JSONEachRow" }),
-      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
-      expect(mock.insert).toHaveBeenCalledTimes(3);
+        client.query({ query: "SELECT 1" } as any),
+      ).rejects.toThrow();
+      expect(mock.query).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -339,15 +325,15 @@ describe("createResilientClickHouseClient()", () => {
     });
   });
 
-  describe("when logging throws during insert retry", () => {
+  describe("when logging throws during a read retry", () => {
     it("still retries and succeeds", async () => {
       const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
-      const result = { executed: true };
+      const queryResult = { data: [] };
       const mock = makeMockClient({
-        insert: vi
+        query: vi
           .fn()
           .mockRejectedValueOnce(transientError)
-          .mockResolvedValueOnce(result),
+          .mockResolvedValueOnce(queryResult),
       });
       mockLogger.warn.mockImplementation(() => {
         throw new Error("pino transport crashed");
@@ -359,14 +345,9 @@ describe("createResilientClickHouseClient()", () => {
         baseDelayMs: 1,
       });
 
-      const actual = await client.insert({
-        table: "test",
-        values: [],
-        format: "JSONEachRow",
-      });
+      await client.query({ query: "SELECT 1" } as any);
 
-      expect(actual).toBe(result);
-      expect(mock.insert).toHaveBeenCalledTimes(2);
+      expect(mock.query).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/platform/app/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
@@ -175,11 +175,46 @@ describe("createResilientClickHouseClient()", () => {
     ] as const;
 
     for (const { label, message } of transientCases) {
-      it(`retries the insert for ${label}`, async () => {
-        const insert = vi
+      it(`retries the read for ${label}`, async () => {
+        const query = vi
           .fn()
           .mockRejectedValueOnce(new Error(message))
-          .mockResolvedValueOnce(undefined);
+          .mockResolvedValueOnce({ response_headers: {} });
+        const client = {
+          query,
+          insert: vi.fn(),
+        } as unknown as ClickHouseClient;
+
+        const wrapper = createResilientClickHouseClient({
+          client,
+          maxRetries: 2,
+          baseDelayMs: 1,
+          maxDelayMs: 1,
+        });
+
+        await wrapper.query({ query: "SELECT 1" } as any);
+
+        expect(query).toHaveBeenCalledTimes(2);
+        expect(mockIncrementQueryCount).toHaveBeenCalledWith(
+          "SELECT",
+          "success",
+        );
+      });
+    }
+
+    describe("when an insert hits the same transient failure", () => {
+      it("does not retry it, because the queue already will", async () => {
+        // Every insert is issued from a queued job that retries the whole job,
+        // so a retry here multiplies attempts rather than adding resilience -
+        // and these are async inserts with deduplication off, so a failure
+        // raised after the server buffered the batch can duplicate rows.
+        const insert = vi
+          .fn()
+          .mockRejectedValue(
+            new Error(
+              "Code: 202. DB::Exception: Too many simultaneous queries.",
+            ),
+          );
         const client = {
           query: vi.fn(),
           insert,
@@ -192,14 +227,13 @@ describe("createResilientClickHouseClient()", () => {
           maxDelayMs: 1,
         });
 
-        await wrapper.insert({ table: "events", values: [] } as any);
+        await expect(
+          wrapper.insert({ table: "events", values: [] } as any),
+        ).rejects.toThrow(/Too many simultaneous queries/);
 
-        expect(insert).toHaveBeenCalledTimes(2);
-        expect(mockIncrementQueryCount).toHaveBeenCalledWith(
-          "INSERT",
-          "success",
-        );
+        expect(insert).toHaveBeenCalledTimes(1);
+        expect(mockIncrementQueryCount).toHaveBeenCalledWith("INSERT", "error");
       });
-    }
+    });
   });
 });

--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -1,8 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import {
-  RETRY_CAUSE_FIELD,
-  retryNoticeLevel,
-} from "@langwatch/clickhouse-client";
+import { RETRY_CAUSE_FIELD, runWithRetry } from "@langwatch/clickhouse-client";
 import { createLogger } from "@langwatch/observability";
 import {
   incrementClickHouseQueryCount,
@@ -10,10 +7,7 @@ import {
 } from "~/server/clickhouse/metrics";
 import { CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS } from "~/server/event-sourcing/services/errorHandling";
 import { detectColdScan } from "./cold-scan-detector";
-import {
-  TRANSIENT_NETWORK_CODES,
-  translateClickHouseQueryError,
-} from "./translate-query-error";
+import { translateClickHouseQueryError } from "./translate-query-error";
 import { queryWindowed } from "./windowed-read";
 
 /**
@@ -30,55 +24,14 @@ const logger = createLogger("langwatch:clickhouse:resilient");
 const queryLogger = createLogger("langwatch:clickhouse:query");
 
 /**
- * Reuses the canonical transient-message list from
- * event-sourcing/services/errorHandling.ts so the inline insert retry
- * loop catches the exact same set of cluster-recovery cases (ZK
- * reconnect, replica shutdown, KILL during graceful shutdown, overload)
- * as the outer group-queue retry classifier. Importing instead of
- * duplicating keeps the two layers in lock-step forever.
- */
-function isTransientError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-
-  const message = error.message;
-  if (/timeout/i.test(message)) return true;
-  for (const fragment of CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS) {
-    if (message.includes(fragment)) return true;
-  }
-
-  const code = (error as NodeJS.ErrnoException).code;
-  if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
-
-  const status =
-    (error as { statusCode?: number }).statusCode ??
-    (error as { status?: number }).status;
-  if (status === 429 || status === 502 || status === 503) return true;
-
-  return false;
-}
-
-function jitteredBackoff({
-  attempt,
-  baseDelayMs,
-  maxDelayMs,
-}: {
-  attempt: number;
-  baseDelayMs: number;
-  maxDelayMs: number;
-}): number {
-  const exponential = baseDelayMs * 2 ** attempt;
-  const jitter = Math.random() * baseDelayMs;
-  return Math.min(exponential + jitter, maxDelayMs);
-}
-
-/**
- * Runs an operation against ClickHouse, retrying transient failures with
- * jittered backoff. Both reads and writes use this: a read rejected with
- * "Too many simultaneous queries" (or any other transient overload /
- * cluster-recovery condition) frees up within moments, and reads are
- * idempotent, so retrying rides through the spike instead of surfacing a
- * 500 to the user. Non-transient errors (e.g. a query syntax error) fail
- * fast on the first attempt.
+ * The whole retry policy - classification, backoff, how loudly to report an
+ * attempt - lives in @langwatch/clickhouse-client, so every ClickHouse caller
+ * in the repo answers to one implementation rather than a copy per layer.
+ *
+ * The transient-message list is still passed in from
+ * event-sourcing/services/errorHandling.ts rather than owned by the package,
+ * which keeps this layer and the outer group-queue classifier reading the same
+ * list forever.
  */
 async function withTransientRetry<T>(
   fn: () => Promise<T>,
@@ -94,32 +47,21 @@ async function withTransientRetry<T>(
     maxDelayMs: number;
   },
 ): Promise<T> {
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-
-      if (!isTransientError(error) || attempt === maxRetries) {
-        throw error;
-      }
-
-      const delay = jitteredBackoff({ attempt, baseDelayMs, maxDelayMs });
-
+  return runWithRetry(fn, {
+    // maxRetries counts retries after the first try; runWithRetry counts tries.
+    maxAttempts: maxRetries + 1,
+    baseDelayMs,
+    maxDelayMs,
+    transientMessageFragments: CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS,
+    onRetry: ({ attempt, maxAttempts, delayMs, error, level }) => {
       try {
-        // Only the first attempt warns, and the cause never rides under
-        // `error`. Both rules live in @langwatch/clickhouse-client: a 25-attempt
-        // budget otherwise turned one failure into 25 records, each of which
-        // Loki promoted to error because of the field name.
-        logger[retryNoticeLevel(attempt)](
+        logger[level](
           {
             source: "clickhouse",
             operation,
             attempt: attempt + 1,
-            maxRetries,
-            delayMs: Math.round(delay),
+            maxRetries: maxAttempts - 1,
+            delayMs: Math.round(delayMs),
             [RETRY_CAUSE_FIELD]: error,
           },
           `Transient ClickHouse ${operation} error, retrying`,
@@ -130,12 +72,8 @@ async function withTransientRetry<T>(
           `Failed to log transient ${operation} retry`,
         );
       }
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-    }
-  }
-
-  throw lastError;
+    },
+  });
 }
 
 function safeQueryMeta(params: unknown): {

--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -321,7 +321,32 @@ function guardInbandException<
 }
 
 /**
- * Wraps a ClickHouseClient with structured logging and insert retry.
+ * Wraps a ClickHouseClient with structured logging, error translation, and
+ * retry on reads only.
+ *
+ * Reads retry here because they are idempotent and nothing above them will do
+ * it: a transient overload would otherwise surface as a failed page.
+ *
+ * Writes deliberately do not. Every insert in this system is issued from a job
+ * on the group queue, which retries the whole job on its own backoff, so a
+ * client-side retry does not add resilience - it multiplies attempts. The two
+ * layers compounded: 4 attempts here inside up to 25 there, so one insert could
+ * be tried ~100 times against a server that was rejecting precisely because it
+ * was overloaded.
+ *
+ * It was also the unsafe half. These are async inserts
+ * (`async_insert` + `wait_for_async_insert`, see ~/server/clickhouse/queryDefaults)
+ * and `async_insert_deduplicate` is not set anywhere, so it takes ClickHouse's
+ * default of off. A failure raised after the server has accepted the batch into
+ * its buffer - `Query was cancelled`, or the memory limit hit while executing
+ * `WaitForAsyncInsert`, which between them were most of the insert retries in
+ * production - can still flush. Retrying then writes the rows twice.
+ * ReplacingMergeTree collapses that for the tables keyed to collapse it; the
+ * rollup and analytics tables just double-count.
+ *
+ * If insert retries are ever wanted back, make them idempotent first: set
+ * `async_insert_deduplicate`, or pass a deterministic `insert_deduplication_token`
+ * per batch.
  */
 export function createResilientClickHouseClient({
   client,
@@ -370,12 +395,8 @@ export function createResilientClickHouseClient({
       "unknown";
     const start = performance.now();
     try {
-      const result = await withTransientRetry(() => client.insert(params), {
-        operation: "insert",
-        maxRetries,
-        baseDelayMs,
-        maxDelayMs,
-      });
+      // Deliberately NOT retried here. See the note on this function.
+      const result = await client.insert(params);
       const durationMs = performance.now() - start;
       logSuccess({ operation: "insert", durationMs, params });
       observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);

--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -1,4 +1,8 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  RETRY_CAUSE_FIELD,
+  retryNoticeLevel,
+} from "@langwatch/clickhouse-client";
 import { createLogger } from "@langwatch/observability";
 import {
   incrementClickHouseQueryCount,
@@ -105,14 +109,18 @@ async function withTransientRetry<T>(
       const delay = jitteredBackoff({ attempt, baseDelayMs, maxDelayMs });
 
       try {
-        logger.warn(
+        // Only the first attempt warns, and the cause never rides under
+        // `error`. Both rules live in @langwatch/clickhouse-client: a 25-attempt
+        // budget otherwise turned one failure into 25 records, each of which
+        // Loki promoted to error because of the field name.
+        logger[retryNoticeLevel(attempt)](
           {
             source: "clickhouse",
             operation,
             attempt: attempt + 1,
             maxRetries,
             delayMs: Math.round(delay),
-            error,
+            [RETRY_CAUSE_FIELD]: error,
           },
           `Transient ClickHouse ${operation} error, retrying`,
         );

--- a/platform/app/src/server/clickhouse/clickhouseLogger.ts
+++ b/platform/app/src/server/clickhouse/clickhouseLogger.ts
@@ -4,6 +4,7 @@ import type {
   LogParams,
   WarnLogParams,
 } from "@clickhouse/client";
+import { emitVendorLog } from "@langwatch/clickhouse-client";
 import { createLogger } from "@langwatch/observability";
 
 const logger = createLogger("langwatch:clickhouse");
@@ -13,29 +14,36 @@ const logger = createLogger("langwatch:clickhouse");
  * share the same console format as the rest of the app (and the Go services)
  * instead of the client's own `[ts][ERROR][@clickhouse/client][module]` lines.
  *
+ * What reaches the log, and what is dropped, is decided by
+ * `@langwatch/clickhouse-client` so every ClickHouse construction site in the
+ * repo answers to the same policy. The short version: the vendor's `error` is
+ * dropped, because the client cannot know whether the caller retried and
+ * succeeded, and no cause is ever attached under a field named `error`,
+ * because that is what Loki reads to decide a record's level.
+ *
  * The client instantiates this with `new ()` (see its `log.LoggerClass`
  * option), so it must have a zero-arg constructor — it borrows the module
  * singleton above. The client gates which levels reach us via `log.level`
  * (defaults to WARN), so `trace`/`debug`/`info` rarely fire in practice.
  */
 export class ClickHouseLogger implements Logger {
-  trace({ module, message, args }: LogParams): void {
-    logger.debug({ module, ...args }, message);
+  trace(params: LogParams): void {
+    emitVendorLog(logger, "trace", params);
   }
 
-  debug({ module, message, args }: LogParams): void {
-    logger.debug({ module, ...args }, message);
+  debug(params: LogParams): void {
+    emitVendorLog(logger, "debug", params);
   }
 
-  info({ module, message, args }: LogParams): void {
-    logger.info({ module, ...args }, message);
+  info(params: LogParams): void {
+    emitVendorLog(logger, "info", params);
   }
 
-  warn({ module, message, args, err }: WarnLogParams): void {
-    logger.warn({ module, ...args, error: err }, message);
+  warn(params: WarnLogParams): void {
+    emitVendorLog(logger, "warn", params);
   }
 
-  error({ module, message, args, err }: ErrorLogParams): void {
-    logger.error({ module, ...args, error: err }, message);
+  error(params: ErrorLogParams): void {
+    emitVendorLog(logger, "error", params);
   }
 }

--- a/platform/app/src/server/clickhouse/clickhouseLogger.ts
+++ b/platform/app/src/server/clickhouse/clickhouseLogger.ts
@@ -28,22 +28,22 @@ const logger = createLogger("langwatch:clickhouse");
  */
 export class ClickHouseLogger implements Logger {
   trace(params: LogParams): void {
-    emitVendorLog(logger, "trace", params);
+    emitVendorLog({ sink: logger, level: "trace", record: params });
   }
 
   debug(params: LogParams): void {
-    emitVendorLog(logger, "debug", params);
+    emitVendorLog({ sink: logger, level: "debug", record: params });
   }
 
   info(params: LogParams): void {
-    emitVendorLog(logger, "info", params);
+    emitVendorLog({ sink: logger, level: "info", record: params });
   }
 
   warn(params: WarnLogParams): void {
-    emitVendorLog(logger, "warn", params);
+    emitVendorLog({ sink: logger, level: "warn", record: params });
   }
 
   error(params: ErrorLogParams): void {
-    emitVendorLog(logger, "error", params);
+    emitVendorLog({ sink: logger, level: "error", record: params });
   }
 }

--- a/platform/app/src/server/clickhouse/connectionPool.ts
+++ b/platform/app/src/server/clickhouse/connectionPool.ts
@@ -1,50 +1,51 @@
+import {
+  poolSizingFromEnv,
+  resolvePoolSize,
+} from "@langwatch/clickhouse-client";
 import { createLogger } from "@langwatch/observability";
 
 const logger = createLogger("langwatch:clickhouse:connection-pool");
 
 /**
- * Default HTTP connection pool size per ClickHouse client INSTANCE — each
- * `createClient` call (`~/server/clickhouse/client.ts` and
- * `~/server/app-layer/clients/clickhouse.factory.ts`) gets its own pool, so a
- * process holding both can open up to 2x this value. The server budget must
- * therefore sum every client pool across every pod.
+ * Resolve the ClickHouse client pool size for this process.
  *
- * Sizing note: the historical value of 25 predated the event-sourcing dispatch
- * concurrency (GLOBAL_QUEUE_CONCURRENCY=256 in production) and became the
- * system bottleneck: with 4 worker pods the server showed exactly 4 x 25 = 100
- * open connections pinned at cap while sitting at a third of its
- * `max_concurrent_queries` (300) and answering in ~55ms — workers measured
- * multi-second latency for those same queries, all of it client-side queueing
- * for a pooled socket.
+ * The rules live in `@langwatch/clickhouse-client` so every construction site
+ * agrees on them; this function only supplies the environment and reports what
+ * was decided.
  *
- * 64 keeps a 4-pod worker fleet driving one hot client each (256 potential
- * concurrent queries) within the server's 300-query ceiling. Deployments with
- * more replicas, both clients hot, or a different server budget tune
- * CLICKHOUSE_MAX_OPEN_CONNECTIONS instead of editing code.
- */
-const DEFAULT_MAX_OPEN_CONNECTIONS = 64;
-
-/** Hard bounds so a typo'd env value cannot melt the server or re-choke the client. */
-const MIN_POOL = 1;
-const MAX_POOL = 1024;
-
-/**
- * Resolve the ClickHouse client pool size from
- * `CLICKHOUSE_MAX_OPEN_CONNECTIONS`, falling back to the default when unset
- * or invalid. Shared by every ClickHouse client construction site so the
- * knob stays one env var.
+ * A pool is per client INSTANCE, and a process constructing both the raw client
+ * (`~/server/clickhouse/client.ts`) and the app-layer factory
+ * (`~/server/app-layer/clients/clickhouse.factory.ts`) opens two of them, so
+ * the server's budget has to cover every pool on every pod. Set
+ * `CLICKHOUSE_CLIENT_REPLICAS` from the downward API and the size is derived
+ * from that budget. Without it a pod cannot know how many siblings it has, so
+ * the historical fixed default stands.
  */
 export function getClickHouseMaxOpenConnections(): number {
-  const raw = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
-  if (raw === undefined || raw === "") return DEFAULT_MAX_OPEN_CONNECTIONS;
+  const decision = resolvePoolSize(poolSizingFromEnv(process.env));
 
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < MIN_POOL || parsed > MAX_POOL) {
+  if (decision.rejectedOverride !== undefined) {
     logger.warn(
-      { raw, default: DEFAULT_MAX_OPEN_CONNECTIONS },
-      "Invalid CLICKHOUSE_MAX_OPEN_CONNECTIONS; using default",
+      // The raw string, not the parsed value: a non-numeric setting parses to
+      // NaN, which serialises as null and tells the reader nothing.
+      {
+        raw: process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
+        using: decision.size,
+        source: decision.source,
+      },
+      "Invalid CLICKHOUSE_MAX_OPEN_CONNECTIONS; using resolved default",
     );
-    return DEFAULT_MAX_OPEN_CONNECTIONS;
   }
-  return parsed;
+
+  if (decision.exceedsBudget) {
+    logger.warn(
+      {
+        configured: decision.size,
+        derivedCeiling: decision.derivedCeiling,
+      },
+      "CLICKHOUSE_MAX_OPEN_CONNECTIONS lets this fleet exceed the server's concurrent-query budget",
+    );
+  }
+
+  return decision.size;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,15 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.2(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/clickhouse-client:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@5.9.3))(vite@8.1.2(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/handled-error:
     dependencies:
       '@opentelemetry/api':
@@ -461,6 +470,9 @@ importers:
       '@langwatch/automations':
         specifier: workspace:*
         version: link:../../packages/automations
+      '@langwatch/clickhouse-client':
+        specifier: workspace:*
+        version: link:../../packages/clickhouse-client
       '@langwatch/handled-error':
         specifier: workspace:*
         version: link:../../packages/handled-error

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -36,17 +36,25 @@ Feature: Structured Logging for ClickHouse Queries
   # ---------------------------------------------------------------------------
   # Retry behavior
   #
-  # Both reads and inserts retry transient ClickHouse failures (overload,
-  # connection, cluster-recovery). Read-side retry behavior lives in
-  # clickhouse-concurrency-resilience.feature; the insert scenarios stay here
-  # next to the logging they emit.
+  # Reads retry transient ClickHouse failures (overload, connection,
+  # cluster-recovery); that behaviour lives in
+  # clickhouse-concurrency-resilience.feature. Inserts do not retry here, and
+  # the scenarios for that stay in this file next to the logging they emit.
+  #
+  # Inserts are only ever issued from a queued job, which retries the whole job
+  # on its own backoff, so retrying again at the client multiplies attempts
+  # rather than adding resilience. It is also the unsafe half: these are async
+  # inserts with deduplication left at ClickHouse's default of off, so a failure
+  # raised after the server has buffered the batch can still flush, and a retry
+  # writes the rows twice.
   # ---------------------------------------------------------------------------
 
   @unit @regression
-  Scenario: Transient insert errors are retried with exponential backoff
+  Scenario: Insert failures are not retried by the client
+    Given every insert is issued from a job the queue will retry
     When an insert fails with a transient error
-    Then the insert is retried up to the configured maximum
-    And each retry uses jittered exponential backoff
+    Then the insert is attempted exactly once
+    And the failure is raised to the caller for the queue to retry
 
   @unit @regression
   Scenario: Non-transient insert errors fail immediately


### PR DESCRIPTION
A new `@langwatch/clickhouse-client` package, and the app wired to it.

The client rules were being decided independently at each construction site, and several of them were wrong in production on their own terms. Putting them in one place is the point; the behaviour changes fall out of it.

Independent of #6602 - branched from `main`, no overlapping files.

## Pool sizing derives from the server's budget

The default was a fixed 64, reasoned about in a comment as "a 4-pod worker fleet driving one hot client each, 256 potential concurrent queries, inside the server's 300-query ceiling".

Both halves of that were wrong. The fleet is **10 worker pods and 3 app pods at rest, autoscaling to 20 and 5**, and a process constructing both the raw client and the app-layer factory opens **two** pools, which the same comment says out loud two paragraphs earlier. So the real ceiling was 13 x 2 x 64 = 1,664 at rest and 3,200 at full scale, against a server that admits 300.

On 2026-07-31 that produced about 37,000 `TOO_MANY_SIMULTANEOUS_QUERIES` rejections in two hours, and the retry path drove every rejection straight back into the same wall.

The 300 is the **per-server** `max_concurrent_queries`, not the cluster total across the three replicas. Query load does not spread evenly - clickhouse-0 is the node that grazed the old 200 ceiling and rejected live ingest on 07-21 - so a budget assuming perfect balance would license three times what the hot node can actually admit.

`resolvePoolSize` now derives the size from `max_concurrent_queries` divided by the fleet, with a safety factor for everything the derivation cannot see (ad-hoc queries, ops tooling, and the burst a retry storm adds). It returns a decision - the size, where it came from, and whether an override conflicts with the budget - so a conflict is reported rather than discovered later as rejected queries.

**This changes nothing until a deployment opts in.** A pod cannot know how many siblings it has, so without `CLICKHOUSE_CLIENT_REPLICAS` the old fixed default stands.

The infra side is **langwatch-saas#913**, which computes the fleet numbers from the HPA maximums and the ClickHouse settings rather than writing them down again. It also fixes something this PR surfaced: the app pods never received the 07-31 mitigation at all. The workers were capped at 20 that day; the app kept the default of 64 across two pools, which was the larger remaining share of the oversubscription and the quieter one, since the workers are what shows up in the rejection logs.

It deliberately does **not** raise `max_concurrent_queries`. That went 200 to 300 on 07-21 and its own comment records why it is near the end of the road: admission is no longer the binding constraint, `max_server_memory_usage` is, so more admitted queries converts these rejections into `MEMORY_LIMIT_EXCEEDED`.

The cheapest real headroom is here rather than on the server. The x2 is self-inflicted - the raw client and the app-layer factory open separate pools to the same place. Sharing one halves the fleet's socket demand and doubles the derived ceiling at no cost. Not in this PR, but it should come before anyone reaches for the server's limits.

## Inserts are no longer retried by the client

Reads are idempotent and still retry. Writes did too, and that was wrong twice over.

It was redundant. Every insert is issued from a queued job the queue already retries up to 25 times, so a client budget of 4 nested inside it reached roughly a hundred attempts against a server that was rejecting *because* it was overloaded. Production bore this out: **14,442 insert retries against 1,789 query retries over two days**, so 89% of all retry traffic was writes that were going to be retried anyway.

It was also unsafe. `async_insert: 1` with `wait_for_async_insert: 1` and `async_insert_deduplicate` unset (ClickHouse defaults it off) means a failure raised after the server has already buffered the batch can still flush. Retrying then writes the rows twice. ReplacingMergeTree hides that on the tables keyed to collapse it; the rollup and analytics tables just double-count.

The prerequisite for ever putting this back - `insert_deduplication_token`, or turning on `async_insert_deduplicate` - is recorded at the function rather than left to be rediscovered. `specs/analytics/clickhouse-structured-logging-alerting.feature` mandated the old behaviour, so the scenario is rewritten and rebound rather than quietly unbound.

## The vendor client's error log is dropped

`@clickhouse/client` logs an error for every failed HTTP attempt and cannot know whether the caller then retried and succeeded. Those records carried no verdict, and they were roughly half of the worker's error volume, all of it recovered work.

Nothing is lost. A call under the retry wrapper is reported by the wrapper, which knows the outcome, and an unwrapped call throws and surfaces at the request boundary with a stack. The exception is the signal; this was an echo of it with the verdict missing.

## No cause rides under a field called `error`

Loki derives `detected_level` from the presence of an `error` field, so a `logger.warn` carrying `{ error }` reads as an error regardless of the level chosen. That is why successful retries were being counted as failures and why the worker's error rate looked several times its real size.

Both the vendor adapter and the retry notice now use dedicated field names. The retry notice also warns only on the **first** attempt, since a 25-attempt budget was turning one failure into 25 records that each read as a separate failure.

## Shape of the package

Pure, dependency-free, and it reads no environment of its own. Callers pass the numbers in and get a decision back, which is what makes the rules testable without mocking a process and identical wherever they are applied.

Everything composes as middleware over one function type, `(request) => Promise<QueryResult<Row>>`. No inheritance, and each layer is usable on its own.

```
src/pipeline.ts    the one function type, and compose()
src/tenancy.ts     fail-closed routing: parseRoutingTable, createTenantRouter
src/tenantGuard.ts refuses a statement that is not scoped to one tenant
src/rateLimit.ts   bounded concurrency that sheds rather than queues forever
src/retry.ts       runWithRetry, and the middleware form
src/resilience.ts  transient classification, jittered backoff, notice level
src/tracing.ts     spans and counters, carrying no SQL and no parameters
src/logging.ts     what to emit for a vendor record, or nothing
src/pool.ts        sizing: deriveFleetPoolCeiling, resolvePoolSize
```

Ordering is load-bearing in two places, and both are written down at the modules. `rateLimit` composes **outside** `retry`, so a retrying statement holds its slot instead of rejoining the queue behind fresh work - inside, it turns a small overload into a persistent one. `tenantGuard` goes outermost, because refusing costs nothing and should happen before a slot or a retry budget is spent on a statement that must not run.

Transient classification takes the caller's message fragments rather than owning a second copy of the list, so it cannot drift from the outer queue's classifier. Backoff takes an injectable `random` so a test can pin the jitter.

Tracing deliberately records neither the statement nor its parameters. Spans leave the process, neither has been through redaction, and ClickHouse embeds the failing statement in its own error message - so failures are reduced to a class and a server code rather than handed over whole.

## Wired, and not yet wired

`connectionPool.ts`, `clickhouseLogger.ts` and `resilient-client.ts` consume the package today. `compose`, `tenantGuard`, `createTenantRouter`, `rateLimit` and `trace` have **no consumers yet** - they are the contract the migration moves onto, and adopting them is a wide, mechanical change per repository that belongs in its own PR.

## Test plan

- [x] `cd packages/clickhouse-client && pnpm test` - 167 pass
- [x] `cd packages/clickhouse-client && pnpm typecheck` - clean
- [x] `pnpm test:unit run src/server/clickhouse src/server/app-layer/clients` - 209 pass
- [x] With `CLICKHOUSE_CLIENT_REPLICAS` unset the resolved pool is still 64
- [x] With it set to 10 the resolved pool is 10, and 10 x 10 x 2 stays inside 300
- [x] An override above the fleet ceiling is honoured and logs the conflict
- [x] A vendor error record emits nothing at any level
- [x] A failing insert is attempted exactly once and emits no retry warning
- [x] A statement whose tenant predicate can be disjoined away is refused
- [x] A tracer or counter that throws cannot fail the query it observes

## Review follow-ups

Two rounds. The first caught fractional `replicas`/`clientsPerProcess` inflating the derived ceiling, and `resolvePoolSize` hardcoding `exceedsBudget: false` so a fleet large enough to floor the raw ceiling below 1 reported no conflict.

The second round found two that matter:

- **The tenant guard accepted `WHERE TenantId = {t:String} OR Status = 'x'`**, which contains the predicate and returns every tenant's rows. I had this documented as an accepted limit of a text check, and the justification was weak: `AND A OR B` meaning `AND (A OR B)` is ordinary precedence confusion, not an exotic statement. Now refused by bracket depth - an `OR` at or above the predicate's depth weakens it, one nested deeper cannot.
- **Comment stripping was quadratic.** `/\/\*[\s\S]*?\*\//` rescans to the end of the input from every unterminated `/*`, reachable from any caller building SQL from input it did not write (CodeQL flagged it as a high-severity alert). Replaced with a single-pass scanner that also masks string bodies, so a literal containing `OR` or `--` cannot steer the checks either.

Also: host observability could fail a query it only observes (a throwing `onRetry`, tracer or completion hook), retry checked the abort signal before the backoff but not after, and `maxQueued`/`maxCacheEntries` went unvalidated where `NaN` silently removed both bounds. Plus named-parameter style, the `tsBuildInfoFile` path, and nested `describe("when ...")` blocks throughout.

## Not in here

Moving the whole client - construction, windowed reads, metrics - into the package, and migrating the repositories onto the pipeline. Both are wide import refactors and worth doing separately, on top of this. What is here is the part where the rules were actually wrong.

---

Root `package.json`'s `files[]` didn't list the new package, which the ADR-076 workspace-invariants test catches - fixed in the first follow-up commit so the npm tarball actually ships it.
