### PR TITLE
fix(members): a personal workspace no longer blocks moving someone to a Lite Member seat

### DIFF
--- a/platform/app/ee/governance/services/personalWorkspace.service.ts
+++ b/platform/app/ee/governance/services/personalWorkspace.service.ts
@@ -122,6 +122,14 @@ export class PersonalWorkspaceService {
         return { ...existing, created: false };
       }
 
+      const reactivated = await this.reactivateInTx(tx, {
+        userId,
+        organizationId,
+      });
+      if (reactivated) {
+        return { ...reactivated, created: false };
+      }
+
       // Use the user's display name if available, otherwise their local
       // email part (jane@acme.com → "jane"), otherwise a fallback. Slug
       // gets a nanoid suffix to avoid global slug collisions across orgs.
@@ -201,6 +209,84 @@ export class PersonalWorkspaceService {
         created: true,
       };
     });
+  }
+
+  /**
+   * Brings back the workspace a removed membership archived, if there is one.
+   *
+   * The slot is one personal team per (organization, owner) and the partial
+   * unique index enforcing it covers archived rows, while every lookup filters
+   * `archivedAt: null`. So an archived workspace is invisible and yet still holds
+   * the slot: creating a replacement raises P2002 and there is no way back.
+   * Reactivating is the only correct answer, and it is also the kinder one,
+   * because the person gets their own history back rather than an empty room.
+   *
+   * Runs inside `tryCreate`'s transaction, between the live lookup and the
+   * create, so the ordering is: use it, revive it, or make it.
+   *
+   * The owner's ADMIN binding is recreated rather than assumed: removing the
+   * membership deleted every role binding they had in the organization, this one
+   * included, so a revived workspace without it would be one they cannot open.
+   */
+  private async reactivateInTx(
+    tx: TxClient,
+    { userId, organizationId }: { userId: string; organizationId: string },
+  ): Promise<Omit<PersonalWorkspace, "created"> | null> {
+    const archived = await tx.team.findFirst({
+      where: {
+        organizationId,
+        ownerUserId: userId,
+        isPersonal: true,
+        archivedAt: { not: null },
+      },
+      select: {
+        id: true,
+        projects: {
+          where: { isPersonal: true },
+          select: { id: true },
+          take: 1,
+        },
+      },
+    });
+
+    // A team without its project is the broken shape `ensure()` cannot resolve,
+    // and reviving half of it would only hide that. Leave it to raise P2002 on
+    // the create below, which is loud and recoverable by hand, rather than hand
+    // back a workspace with nowhere to put anything.
+    if (!archived || archived.projects.length === 0) return null;
+
+    await tx.team.update({
+      where: { id: archived.id },
+      data: { archivedAt: null },
+    });
+    await tx.project.updateMany({
+      where: { teamId: archived.id, isPersonal: true },
+      data: { archivedAt: null },
+    });
+
+    const existingBinding = await tx.roleBinding.findFirst({
+      where: {
+        organizationId,
+        userId,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: archived.id,
+      },
+      select: { id: true },
+    });
+    if (!existingBinding) {
+      await tx.roleBinding.create({
+        data: {
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId,
+          userId,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: archived.id,
+        },
+      });
+    }
+
+    return await this.findInTx(tx, { userId, organizationId });
   }
 
   /**

--- a/platform/app/src/components/me/PersonalWorkspaceViewOnlyNotice.tsx
+++ b/platform/app/src/components/me/PersonalWorkspaceViewOnlyNotice.tsx
@@ -1,0 +1,47 @@
+import { Box, HStack, Text } from "@chakra-ui/react";
+import { Eye } from "lucide-react";
+
+import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
+
+/**
+ * Why a Lite Member's own workspace does not keep anything they add to it.
+ *
+ * A member's organization role caps what any of their role bindings can do
+ * (`resolveBindingPermission` in `server/api/rbac.ts`), and that includes the
+ * admin binding on the workspace provisioned for them. So reads work, writes do
+ * not, and the workspace itself is left alone: it is still theirs, and it starts
+ * taking writes again the moment they have full access.
+ *
+ * Saying so is the whole point of this. Without it the page looks broken rather
+ * than restricted, because everything renders and only the save fails.
+ *
+ * Spec: specs/ai-gateway/governance/personal-workspace-integrity.feature
+ */
+export function PersonalWorkspaceViewOnlyNotice() {
+  const { isLiteMember } = useLiteMemberGuard();
+
+  if (!isLiteMember) return null;
+
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor="border"
+      borderRadius="lg"
+      bg="bg.subtle"
+      paddingY={3}
+      paddingX={4}
+      data-testid="personal-workspace-view-only-notice"
+    >
+      <HStack gap={3} align="start">
+        <Box color="fg.muted" paddingTop={0.5}>
+          <Eye size={16} />
+        </Box>
+        <Text fontSize="sm" color="fg.muted">
+          Your organization gives you view-only access, so you can read your
+          workspace but not add to it. Ask an organization admin if you need to
+          change something here.
+        </Text>
+      </HStack>
+    </Box>
+  );
+}

--- a/platform/app/src/components/me/__tests__/PersonalWorkspaceViewOnlyNotice.integration.test.tsx
+++ b/platform/app/src/components/me/__tests__/PersonalWorkspaceViewOnlyNotice.integration.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Why a Lite Member's own workspace keeps nothing they add.
+ *
+ * Their organization role caps what any of their role bindings can do, the admin
+ * binding on their own workspace included, so reads work and writes do not. The
+ * page renders in full either way and only the save fails, which reads as broken
+ * rather than restricted unless the workspace says so itself.
+ *
+ * Spec: specs/ai-gateway/governance/personal-workspace-integrity.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { OrganizationUserRole } from "@prisma/client";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrganizationRole } = vi.hoisted(() => ({
+  mockOrganizationRole: {
+    current: null as OrganizationUserRole | null,
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organizationRole: mockOrganizationRole.current,
+  }),
+}));
+
+import { PersonalWorkspaceViewOnlyNotice } from "../PersonalWorkspaceViewOnlyNotice";
+
+const renderNotice = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <PersonalWorkspaceViewOnlyNotice />
+    </ChakraProvider>,
+  );
+
+describe("given a member opening their own personal workspace", () => {
+  afterEach(() => {
+    cleanup();
+    mockOrganizationRole.current = null;
+  });
+
+  describe("when their organization has them on a Lite Member seat", () => {
+    /** @scenario A Lite Member is told why their own workspace takes nothing */
+    it("tells them their access is view-only and who can change that", () => {
+      mockOrganizationRole.current = OrganizationUserRole.EXTERNAL;
+
+      renderNotice();
+
+      const notice = screen.getByTestId(
+        "personal-workspace-view-only-notice",
+      ).textContent;
+      expect(notice).toContain("view-only access");
+      expect(notice).toContain("organization admin");
+    });
+
+    /** @scenario A Lite Member is told why their own workspace takes nothing */
+    it("says nothing about how the restriction is implemented", () => {
+      mockOrganizationRole.current = OrganizationUserRole.EXTERNAL;
+
+      renderNotice();
+
+      // Copy says what it means for the reader, never our vocabulary for it:
+      // "EXTERNAL", "role binding" and "permission" are all ours, not theirs.
+      const notice = screen.getByTestId(
+        "personal-workspace-view-only-notice",
+      ).textContent;
+      expect(notice).not.toMatch(/EXTERNAL|binding|permission|RBAC/i);
+    });
+  });
+
+  describe.each([
+    OrganizationUserRole.MEMBER,
+    OrganizationUserRole.ADMIN,
+  ])("when they hold full access as %s", (role) => {
+    /** @scenario A Lite Member is told why their own workspace takes nothing */
+    it("says nothing at all", () => {
+      mockOrganizationRole.current = role;
+
+      const { container } = renderNotice();
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/platform/app/src/components/settings/MemberDetailDialog.tsx
+++ b/platform/app/src/components/settings/MemberDetailDialog.tsx
@@ -134,6 +134,10 @@ export function MemberDetailDialog({
         queryClient.roleBinding.listForOrg.invalidate(),
         queryClient.organization.getOrganizationWithMembersAndTheirTeams.invalidate(),
         queryClient.organization.getAll.invalidate(),
+        // An org role change moves the member between full and Lite Member
+        // seats, so the seat counts an admin is reconciling against changed
+        // with this save.
+        queryClient.limits.getUsage.invalidate(),
       ]);
       toaster.create({ title: "Member updated", type: "success" });
       onClose();

--- a/platform/app/src/components/settings/MemberSeatUsage.tsx
+++ b/platform/app/src/components/settings/MemberSeatUsage.tsx
@@ -1,0 +1,54 @@
+import { SimpleGrid } from "@chakra-ui/react";
+
+import type { PlanInfo } from "../../../ee/licensing/planInfo";
+import { LIMIT_TYPE_DISPLAY_LABELS } from "../../server/license-enforcement/constants";
+import { api } from "../../utils/api";
+import { ResourceLimitRow } from "../license/ResourceLimitRow";
+
+/**
+ * Where the organization stands on each kind of seat, on the page where seats
+ * are decided.
+ *
+ * The two decisions the member list offers, moving somebody to a Lite Member
+ * seat and disabling them, are each refused once the matching allowance runs
+ * out. Without this an admin reconciling down to their plan learns the
+ * allowances one refusal at a time, having already picked the person and clicked
+ * save. Same counts and the same row component as the usage page, so the two
+ * never disagree.
+ *
+ * Spec: specs/licensing/seat-reconciliation.feature
+ */
+export function MemberSeatUsage({
+  organizationId,
+  activePlan,
+}: {
+  organizationId: string;
+  activePlan: PlanInfo;
+}) {
+  const usage = api.limits.getUsage.useQuery(
+    { organizationId },
+    { refetchOnWindowFocus: false },
+  );
+
+  if (!usage.data) return null;
+
+  return (
+    <SimpleGrid
+      columns={{ base: 1, md: 2 }}
+      gap={3}
+      width="full"
+      maxWidth="2xl"
+    >
+      <ResourceLimitRow
+        label={LIMIT_TYPE_DISPLAY_LABELS.members}
+        current={usage.data.membersCount}
+        max={activePlan.maxMembers}
+      />
+      <ResourceLimitRow
+        label={LIMIT_TYPE_DISPLAY_LABELS.membersLite}
+        current={usage.data.membersLiteCount}
+        max={activePlan.maxMembersLite}
+      />
+    </SimpleGrid>
+  );
+}

--- a/platform/app/src/components/settings/__tests__/MemberSeatUsage.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/MemberSeatUsage.integration.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The seat counts on the member list.
+ *
+ * An admin reconciling an organization down to its plan decides person by
+ * person, and the two decisions available to them, moving somebody to a Lite
+ * Member seat and disabling them, are each refused once the matching allowance
+ * runs out. Reading the allowance off a refusal means learning it after picking
+ * the person and clicking save, so both counts belong on the page where the
+ * picking happens.
+ *
+ * Spec: specs/licensing/seat-reconciliation.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockUsageData } = vi.hoisted(() => ({
+  mockUsageData: {
+    current: null as { membersCount: number; membersLiteCount: number } | null,
+  },
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    limits: {
+      getUsage: {
+        useQuery: () => ({ data: mockUsageData.current }),
+      },
+    },
+  },
+}));
+
+import { MemberSeatUsage } from "../MemberSeatUsage";
+
+const planWith = ({
+  maxMembers,
+  maxMembersLite,
+}: {
+  maxMembers: number;
+  maxMembersLite: number;
+}) => ({ maxMembers, maxMembersLite }) as any;
+
+const renderSeatUsage = (plan: {
+  maxMembers: number;
+  maxMembersLite: number;
+}) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <MemberSeatUsage organizationId="org_1" activePlan={planWith(plan)} />
+    </ChakraProvider>,
+  );
+
+describe("given an organization with a seat allowance of each kind", () => {
+  afterEach(() => {
+    cleanup();
+    mockUsageData.current = null;
+  });
+
+  describe("when an admin opens the member list", () => {
+    /** @scenario The member list shows how many seats of each kind are in use */
+    it("shows the full member seats in use against what the plan covers", () => {
+      mockUsageData.current = { membersCount: 12, membersLiteCount: 1 };
+
+      renderSeatUsage({ maxMembers: 15, maxMembersLite: 3 });
+
+      expect(screen.getByText("Team Members")).toBeInTheDocument();
+      expect(screen.getByText("12")).toBeInTheDocument();
+      expect(screen.getByText("/ 15")).toBeInTheDocument();
+    });
+
+    /** @scenario The member list shows how many seats of each kind are in use */
+    it("shows the Lite Member seats the same way", () => {
+      mockUsageData.current = { membersCount: 12, membersLiteCount: 1 };
+
+      renderSeatUsage({ maxMembers: 15, maxMembersLite: 3 });
+
+      expect(screen.getByText("Lite Members")).toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(screen.getByText("/ 3")).toBeInTheDocument();
+    });
+
+    /** @scenario The member list shows how many seats of each kind are in use */
+    it("says unlimited rather than a number nobody can read", () => {
+      // Self-hosted with no license resolves to MAX_SAFE_INTEGER, and printing
+      // 9,007,199,254,740,991 seats would be worse than saying nothing.
+      mockUsageData.current = { membersCount: 40, membersLiteCount: 0 };
+
+      renderSeatUsage({
+        maxMembers: Number.MAX_SAFE_INTEGER,
+        maxMembersLite: Number.MAX_SAFE_INTEGER,
+      });
+
+      expect(screen.getAllByText("/ Unlimited").length).toBe(2);
+    });
+  });
+
+  describe("when the counts have not arrived yet", () => {
+    it("renders nothing rather than a zero it does not know", () => {
+      const { container } = renderSeatUsage({
+        maxMembers: 15,
+        maxMembersLite: 3,
+      });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/platform/app/src/components/upgrade-modal/LimitContent.tsx
+++ b/platform/app/src/components/upgrade-modal/LimitContent.tsx
@@ -8,6 +8,16 @@ import type { UpgradeModalVariant } from "../../stores/upgradeModalStore";
 import { trackEvent } from "../../utils/tracking";
 import { Dialog } from "../ui/dialog";
 
+/**
+ * Seat allowances are the two limits an admin runs into while doing the
+ * opposite of upgrading: working down the member list to fit the plan they
+ * already have. Upgrading is still an answer, so the button stays, but on its
+ * own it is the one answer they came here to avoid, and disabling a membership
+ * is the reversible move that actually returns a seat.
+ * See specs/licensing/seat-reconciliation.feature.
+ */
+const SEAT_LIMIT_TYPES = new Set(["members", "membersLite"]);
+
 function LimitContentBody({
   variant,
 }: {
@@ -30,6 +40,12 @@ function LimitContentBody({
           <Text>
             You've reached the limit of {LIMIT_TYPE_LABELS[variant.limitType]}{" "}
             on your current plan.
+          </Text>
+        )}
+        {SEAT_LIMIT_TYPES.has(variant.limitType) && (
+          <Text color="gray.500">
+            To free a seat instead, disable a membership from the members page.
+            That is reversible, and it keeps their role and everything they did.
           </Text>
         )}
       </VStack>

--- a/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
+++ b/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
@@ -99,6 +99,50 @@ describe("explainHandledError", () => {
     });
   });
 
+  describe("when a seat allowance is what ran out", () => {
+    /** @scenario Running out of Lite Member seats names that allowance */
+    it("names which seats ran out and the reversible way to free one", () => {
+      const { description } = explainHandledError(
+        shape({
+          code: "resource_limit_exceeded",
+          httpStatus: 403,
+          meta: { limitType: "membersLite", current: 3, max: 3 },
+        }),
+      );
+
+      // An admin reaching this is reconciling down to their plan, so "upgrade"
+      // on its own is the one answer they came here to avoid.
+      expect(description).toContain("Lite Member seats");
+      expect(description).toContain("disable a membership");
+      expect(description).toContain("reversible");
+    });
+
+    /** @scenario Running out of Lite Member seats names that allowance */
+    it("names the full member seats when those are the ones in use", () => {
+      const { description } = explainHandledError(
+        shape({
+          code: "resource_limit_exceeded",
+          httpStatus: 403,
+          meta: { limitType: "members", current: 15, max: 15 },
+        }),
+      );
+
+      expect(description).toContain("full member seats");
+    });
+
+    it("keeps the generic plan-limit line for every other allowance", () => {
+      const { description } = explainHandledError(
+        shape({
+          code: "resource_limit_exceeded",
+          httpStatus: 403,
+          meta: { limitType: "messagesPerMonth" },
+        }),
+      );
+
+      expect(description).toBe("Upgrade your plan to raise it.");
+    });
+  });
+
   describe("given a code the registry has never seen", () => {
     /**
      * The fallback used to be `FAULT_TITLES[fault]`, which is a guess dressed

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -142,6 +142,7 @@ export const APP_ERROR_CODES = [
   "notification_delivery_error",
   "organization_not_found",
   "organization_not_found_for_team",
+  "personal_workspace_not_managed_here",
   "project_not_found",
   "project_permission_denied",
   "prompt_not_found",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -61,6 +61,16 @@ const str = (
 };
 
 /**
+ * The two plan allowances an admin meets while reconciling seats, in words that
+ * read inside a sentence. Not taken from the license-enforcement labels, which
+ * are column headings ("Team Members") and land badly mid-sentence.
+ */
+const SEAT_LIMIT_LABELS: Record<string, string> = {
+  members: "full member seats",
+  membersLite: "Lite Member seats",
+};
+
+/**
  * Whether any code in the error's reason chain (depth-first, nested included)
  * is one of `codes`.
  *
@@ -554,6 +564,20 @@ const presentations = {
     title: "Your account doesn't include this",
     describe: () => "Ask an admin on your team to upgrade your access.",
   },
+  personal_workspace_not_managed_here: {
+    // Whoever reads this was managing somebody's access, so the answer has to
+    // say why there is nothing to manage here rather than restate the rule. An
+    // admin changing a seat needs to know the seat is elsewhere and that they
+    // do not have to touch this to change it.
+    title: "That workspace belongs to one person",
+    describe: (error) => {
+      const ownerName = str(error, "ownerName", "");
+      const workspace = ownerName
+        ? `"${ownerName}" is that member's own workspace`
+        : "A personal workspace belongs to one member";
+      return `${workspace}, so its access isn't managed from here. Their organization role already decides what they can do in it. To work together, use a shared team.`;
+    },
+  },
   already_organization_member: {
     // An invite form takes several addresses at once, so the address has to be
     // in the sentence — "one of these is already a member" is not an answer.
@@ -596,7 +620,17 @@ const presentations = {
   },
   resource_limit_exceeded: {
     title: "You've hit a plan limit",
-    describe: () => "Upgrade your plan to raise it.",
+    // Names the allowance and where it stands, because "a plan limit" leaves
+    // the reader to guess which of several they just met. The seat allowances
+    // get the reversible alternative too: an admin who hits one is usually
+    // working down to their plan, and "upgrade" is the answer they came here to
+    // avoid. Most seat refusals arrive as the upgrade modal rather than a toast,
+    // and it says the same thing.
+    describe: (error) => {
+      const label = SEAT_LIMIT_LABELS[str(error, "limitType", "")];
+      if (!label) return "Upgrade your plan to raise it.";
+      return `Your plan's ${label} are all in use. Upgrade to raise the allowance, or disable a membership from the members page to free one, which is reversible.`;
+    },
   },
   // Browser-telemetry ingest (ADR-058). These answer the RUM endpoint rather
   // than a screen, so the reader is usually an engineer with the network tab

--- a/platform/app/src/features/onboarding/utils/welcome-redirect.ts
+++ b/platform/app/src/features/onboarding/utils/welcome-redirect.ts
@@ -2,9 +2,9 @@
  * Pure decision for the welcome screen's mount effect: does this user need
  * onboarding, or where do they go instead? (ADR-038 v6)
  *
- * - An intent-set org is onboarded, period: never show the create-org form
- *   again (it would mint a duplicate org) — send home and let the resolver
- *   pick /me, the project, or /settings.
+ * - Belonging to an organization is what "already onboarded" means: never show
+ *   the create-org form to a member of one (it would mint a duplicate org) —
+ *   send them home and let the resolver pick /me, the project, or /settings.
  * - Personal-workspace teams never count as onboarded projects and are
  *   never a redirect target.
  */
@@ -34,16 +34,25 @@ export function resolveWelcomeRedirect({
       sharedTeams(org).some((t) => t.projects.length > 0),
     ) ?? false;
 
-  const hasIntentSetOrg =
-    organizations?.some((org) => org.primaryIntent != null) ?? false;
+  // Membership is the test, not `primaryIntent`. That field is null for every
+  // organization created before ADR-038 and for every one created outside
+  // onboarding, so a member invited into such an organization was shown "let's
+  // kick off by creating your organization" with no way past it except making a
+  // second organization nobody wanted. An organization with no shared project
+  // yet is still an organization they belong to; where they land from here is
+  // the home resolver's job.
+  const belongsToAnOrganization = (organizations?.length ?? 0) > 0;
 
-  if (!hasAnyProject && hasIntentSetOrg) return { kind: "home" };
-  if (!hasAnyProject) return { kind: "onboard" };
+  if (!hasAnyProject) {
+    return belongsToAnOrganization ? { kind: "home" } : { kind: "onboard" };
+  }
 
   const slug =
     currentProjectSlug ??
     organizations?.flatMap((o) => sharedTeams(o)).flatMap((t) => t.projects)[0]
       ?.slug;
 
-  return slug ? { kind: "project", slug } : { kind: "onboard" };
+  // Only reachable with a shared project in hand, so with an organization too:
+  // whatever happens to the slug, onboarding is not the answer.
+  return slug ? { kind: "project", slug } : { kind: "home" };
 }

--- a/platform/app/src/features/onboarding/utils/welcome-redirect.unit.test.ts
+++ b/platform/app/src/features/onboarding/utils/welcome-redirect.unit.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { resolveWelcomeRedirect } from "./welcome-redirect";
 
 /**
- * ADR-038 v6: the welcome screen's redirect decision. An intent-set org is
- * onboarded, period — re-showing the create-org form would mint a duplicate
- * organization. Personal workspaces never count as projects.
+ * ADR-038 v6: the welcome screen's redirect decision. Belonging to an
+ * organization means onboarded, period — re-showing the create-org form would
+ * mint a duplicate organization. Personal workspaces never count as projects.
  *
  * Spec: specs/features/onboarding/intent-fork.feature
  */
@@ -91,10 +91,40 @@ describe("resolveWelcomeRedirect", () => {
   });
 
   describe("when a legacy org has no project at all", () => {
-    it("onboards, exactly as before the fork", () => {
+    // The invited-member trap. `primaryIntent` is null for every organization
+    // created before ADR-038, so reading onboardedness off it sent a member who
+    // had just accepted an invitation to "let's kick off by creating your
+    // organization", with nothing on that screen to do but create a second
+    // organization nobody wanted.
+    /** @scenario An invited member of an organization with no shared project goes home */
+    it("sends the member home rather than offering to create another organization", () => {
       expect(
         resolveWelcomeRedirect({
           organizations: [org(null, [{ isPersonal: false, projects: [] }])],
+          currentProjectSlug: null,
+        }),
+      ).toEqual({ kind: "home" });
+    });
+
+    /** @scenario A member whose only team is their own workspace goes home */
+    it("sends them home when their only team is their own workspace", () => {
+      expect(
+        resolveWelcomeRedirect({
+          organizations: [
+            org(null, [
+              { isPersonal: true, projects: [{ slug: "personal-abc" }] },
+            ]),
+          ],
+          currentProjectSlug: null,
+        }),
+      ).toEqual({ kind: "home" });
+    });
+
+    /** @scenario Someone who belongs to no organization is still onboarded */
+    it("still onboards a member of nothing at all", () => {
+      expect(
+        resolveWelcomeRedirect({
+          organizations: undefined,
           currentProjectSlug: null,
         }),
       ).toEqual({ kind: "onboard" });

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -493,18 +493,32 @@ export const useOrganizationTeamProject = (
       org.teams.filter((team) => team.projects.length > 0),
     );
 
+    // Onboarding is for people who belong to no organization. It is the page
+    // that creates one, so offering it to a member only ever produces a second
+    // organization nobody asked for, and `pages/index.tsx` already draws the
+    // line here.
+    if (organizations.data.length === 0) {
+      void router.push(`/onboarding/welcome${returnTo}`);
+      return;
+    }
+
     // ADR-038 v6: an intent-set org is onboarded, period. Governance orgs
     // deliberately have no project (users live on /me, data flows through
     // personal workspaces); an LLMOps org that postponed project creation
-    // recovers via /settings. Never bounce either into onboarding — the
-    // welcome screen would offer to create a duplicate org — or to another
-    // org's project.
+    // recovers via /settings. Never redirect either to another org's project.
     if (organization?.primaryIntent) {
       return;
     }
 
+    // A member with nothing to be redirected *to* stays put, and the home
+    // resolver in `pages/index.tsx` picks their destination. This used to bounce
+    // to onboarding, which is how a member invited into an organization with no
+    // shared project ended up at "let's kick off by creating your organization".
+    // Note `teamsWithProjectsOnAnyOrg` counts personal workspaces, so a member
+    // who has only their own workspace reaches here rather than the branch
+    // below, which is deliberate: a personal workspace is never a project-home
+    // target (ADR-038 v6).
     if (!organization || !teamsWithProjectsOnAnyOrg.length) {
-      void router.push(`/onboarding/welcome${returnTo}`);
       return;
     }
 

--- a/platform/app/src/pages/me/index.tsx
+++ b/platform/app/src/pages/me/index.tsx
@@ -20,6 +20,7 @@ import {
   PERSONAL_AI_TOOLS_ANCHOR,
   PERSONAL_TRACE_INGEST_ANCHOR,
 } from "~/components/me/PersonalTracesEmptyState";
+import { PersonalWorkspaceViewOnlyNotice } from "~/components/me/PersonalWorkspaceViewOnlyNotice";
 import { spentSubline } from "~/components/me/spentSubline";
 import { TraceIngestSection } from "~/components/me/TraceIngestSection";
 import { usePersonalContext } from "~/components/me/usePersonalContext";
@@ -86,6 +87,8 @@ function MyUsagePage() {
       </Head>
 
       <VStack align="stretch" gap={6} width="full">
+        <PersonalWorkspaceViewOnlyNotice />
+
         <VStack
           id={PERSONAL_AI_TOOLS_ANCHOR}
           align="stretch"

--- a/platform/app/src/pages/settings/members.tsx
+++ b/platform/app/src/pages/settings/members.tsx
@@ -32,6 +32,7 @@ import { InvitesTable } from "../../components/members/InvitesTable";
 import SettingsLayout from "../../components/SettingsLayout";
 import { DepartmentPicker } from "../../components/settings/DepartmentPicker";
 import { MemberDetailDialog } from "../../components/settings/MemberDetailDialog";
+import { MemberSeatUsage } from "../../components/settings/MemberSeatUsage";
 import { useDepartmentColumn } from "../../components/settings/useDepartmentColumn";
 import { Dialog } from "../../components/ui/dialog";
 import { Menu } from "../../components/ui/menu";
@@ -314,6 +315,12 @@ function MembersList({
             </HStack>
           )}
         </HStack>
+        {hasOrganizationManagePermission && (
+          <MemberSeatUsage
+            organizationId={organization.id}
+            activePlan={activePlan}
+          />
+        )}
         <Card.Root width="full" overflow="hidden">
           {/*
             Card wraps the table in overflowX="auto" so the row never

--- a/platform/app/src/pages/settings/members.tsx
+++ b/platform/app/src/pages/settings/members.tsx
@@ -187,6 +187,7 @@ function MembersList({
                 },
               });
             });
+          void queryClient.limits.getUsage.invalidate();
           void queryClient.licenseEnforcement.checkLimit.invalidate();
         },
         onError: () => {
@@ -214,6 +215,7 @@ function MembersList({
             tags: { organizationId: organization.id },
           });
         });
+      void queryClient.limits.getUsage.invalidate();
       void queryClient.licenseEnforcement.checkLimit.invalidate();
     },
   });

--- a/platform/app/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -34,7 +34,6 @@ import {
 import { PromptTagRepository } from "~/server/prompt-config/repositories/prompt-tag.repository";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { prisma } from "../../../db";
-import { LICENSE_LIMIT_ERRORS } from "../../../license-enforcement/license-limit-guard";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 import {
@@ -239,7 +238,10 @@ describe("organization member role plan limit enforcement", () => {
           }),
         ).rejects.toMatchObject({
           code: "FORBIDDEN",
-          message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
+          cause: {
+            code: "resource_limit_exceeded",
+            meta: { limitType: "membersLite" },
+          },
         });
       });
 
@@ -326,7 +328,10 @@ describe("organization member role plan limit enforcement", () => {
           }),
         ).rejects.toMatchObject({
           code: "FORBIDDEN",
-          message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
+          cause: {
+            code: "resource_limit_exceeded",
+            meta: { limitType: "membersLite" },
+          },
         });
       });
 

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
@@ -54,9 +54,13 @@ import { PersonalWorkspaceService } from "../../../../../ee/governance/services/
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { cleanupTestRows } from "../../../../test-utils/cleanupTestRows";
 import { globalForApp, resetApp } from "../../../app-layer/app";
+import { OrganizationService } from "../../../app-layer/organizations/organization.service";
+import { PrismaOrganizationRepository } from "../../../app-layer/organizations/repositories/organization.prisma.repository";
 import { createTestApp } from "../../../app-layer/presets";
 import { PlanProviderService } from "../../../app-layer/subscription/plan-provider";
 import { prisma } from "../../../db";
+import { PromptTagRepository } from "../../../prompt-config/repositories/prompt-tag.repository";
+import { hasProjectPermission } from "../../rbac";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 
@@ -71,6 +75,8 @@ const colleagueEmail = `${ns}-colleague@example.com`;
 let organizationId: string;
 let ownerUserId: string;
 let colleagueUserId: string;
+/** Set by the seat-decision block; read by the shared teardown. */
+let seatUserIdForCleanup: string | undefined;
 let sharedTeamId: string;
 let sharedProjectId: string;
 let personalTeamId: string;
@@ -560,12 +566,30 @@ function takingTheOwnersAccessToTheirWorkspaceAway() {
       }),
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
-      message: expect.stringContaining("exactly one member"),
+      // The code, not the sentence: the sentence is copy, and it is the code
+      // the client keys the refusal's copy off once this crosses the wire.
+      cause: { code: "personal_workspace_not_managed_here" },
     });
 
     await expect(ownerBindingsOnPersonalTeam()).resolves.toEqual([
       { userId: ownerUserId, role: TeamUserRole.ADMIN },
     ]);
+  });
+
+  /** @scenario Refusing a change to a personal workspace says whose workspace it is */
+  it("names the workspace so an admin knows whose it is", async () => {
+    const error = await callerAsOwner()
+      .organization.updateTeamMemberRole({
+        teamId: personalTeamId,
+        userId: ownerUserId,
+        role: TeamUserRole.VIEWER,
+      })
+      .catch((e) => e);
+
+    expect(error.cause).toMatchObject({
+      code: "personal_workspace_not_managed_here",
+      meta: { ownerName: personalTeamName },
+    });
   });
 
   /** @scenario Taking the owner's access to their own workspace away is refused */
@@ -716,6 +740,262 @@ function archivingThePersonalTeam() {
   });
 }
 
+/**
+ * The seat decision, which is the one thing here that has to *succeed*.
+ *
+ * Every other block in this suite proves a refusal. This one proves the
+ * refusals stay out of the way of an organization-level decision about a person:
+ * an admin working down the member list to fit their plan moves somebody to a
+ * Lite Member seat, and the workspace provisioned for that member has no say in
+ * it. It used to: the downgrade swept the personal team into its
+ * everything-becomes-Viewer correction, tripped the last-admin guard on a team
+ * whose only admin is its owner, and rolled the whole transaction back, so the
+ * organization role never changed either.
+ *
+ * A separate member from the rest of the fixture, because this block changes
+ * their role and reads it back.
+ */
+function movingAMemberWithAPersonalWorkspaceToALiteSeat() {
+  const seatUserEmail = `${ns}-seat@example.com`;
+  let seatUserId: string;
+  let seatPersonalTeamId: string;
+  let seatPersonalProjectId: string;
+
+  const rbacCtxForSeatUser = () => ({
+    prisma,
+    session: {
+      user: { id: seatUserId, name: "Seat User", email: seatUserEmail },
+      expires: "1",
+    } as any,
+  });
+
+  const orgRoleOfSeatUser = async () =>
+    (
+      await prisma.organizationUser.findUniqueOrThrow({
+        where: {
+          userId_organizationId: { userId: seatUserId, organizationId },
+        },
+        select: { role: true },
+      })
+    ).role;
+
+  const teamBindingRoles = async (teamId: string) =>
+    (
+      await prisma.roleBinding.findMany({
+        where: {
+          organizationId,
+          userId: seatUserId,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: teamId,
+        },
+        select: { role: true },
+      })
+    ).map((binding) => binding.role);
+
+  const setSeatUserOrganizationRole = (role: OrganizationUserRole) =>
+    callerAsOwner().organization.updateMemberRole({
+      organizationId,
+      userId: seatUserId,
+      role,
+    });
+
+  beforeAll(async () => {
+    const seatUser = await prisma.user.create({
+      data: { name: "Seat User", email: seatUserEmail },
+    });
+    seatUserId = seatUser.id;
+    seatUserIdForCleanup = seatUser.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: seatUserId,
+        organizationId,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    // Admin of the team the organization shares, which is the binding the
+    // downgrade is supposed to correct. The fixture owner is an admin of it too,
+    // so correcting this one does not strand the team without an admin.
+    await prisma.roleBinding.create({
+      data: {
+        userId: seatUserId,
+        organizationId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: sharedTeamId,
+      },
+    });
+
+    const workspace = await workspaceService.ensure({
+      userId: seatUserId,
+      organizationId,
+      displayName: "Seat User",
+      displayEmail: seatUserEmail,
+    });
+    seatPersonalTeamId = workspace.team.id;
+    seatPersonalProjectId = workspace.project.id;
+  });
+
+  // A plan with Lite Member seats to give away. FREE_PLAN allows none, so
+  // without this the downgrade is refused for the allowance rather than for
+  // anything this block is about.
+  //
+  // With a REAL organization service against the test database, because
+  // `createTestApp` defaults to a NullOrganizationRepository that resolves
+  // without writing: every assertion here is about what the role change left
+  // behind, and a mutation that quietly no-opped would satisfy all of them.
+  beforeEach(async () => {
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue({
+          ...FREE_PLAN,
+          overrideAddingLimitations: false,
+          maxMembers: 100,
+          maxMembersLite: 100,
+        }),
+      }),
+      organizations: new OrganizationService(
+        new PrismaOrganizationRepository(prisma),
+        new PromptTagRepository(prisma),
+      ),
+      usageLimits: {
+        notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    await setSeatUserOrganizationRole(OrganizationUserRole.MEMBER).catch(
+      () => {},
+    );
+  });
+
+  /** @scenario Moving a member who has a personal workspace to Lite Member succeeds */
+  it("changes the organization role", async () => {
+    await expect(
+      setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL),
+    ).resolves.toMatchObject({ success: true });
+
+    await expect(orgRoleOfSeatUser()).resolves.toBe(
+      OrganizationUserRole.EXTERNAL,
+    );
+  });
+
+  /** @scenario Moving a member who has a personal workspace to Lite Member succeeds */
+  it("corrects their role on the shared team to viewer", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+
+    await expect(teamBindingRoles(sharedTeamId)).resolves.toEqual([
+      TeamUserRole.VIEWER,
+    ]);
+  });
+
+  /** @scenario Moving a member who has a personal workspace to Lite Member succeeds */
+  it("leaves them the admin of their own workspace", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+
+    await expect(teamBindingRoles(seatPersonalTeamId)).resolves.toEqual([
+      TeamUserRole.ADMIN,
+    ]);
+  });
+
+  /** @scenario Moving a member who has a personal workspace to Lite Member succeeds */
+  it("leaves the workspace where their next login finds it", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+
+    await expect(
+      workspaceService.ensure({
+        userId: seatUserId,
+        organizationId,
+        displayName: "Seat User",
+        displayEmail: seatUserEmail,
+      }),
+    ).resolves.toMatchObject({
+      created: false,
+      team: { id: seatPersonalTeamId },
+      project: { id: seatPersonalProjectId },
+    });
+  });
+
+  // Why leaving that admin binding alone is safe, and the assertion the whole
+  // design rests on. A member's organization role caps what any non-custom
+  // binding of theirs can do (`resolveBindingPermission`), so the cap does the
+  // restricting and the binding is free to stay what it is. Nothing asserted
+  // this before, and `rbac.ts` names retiring that cap as future work.
+
+  /** @scenario A Lite Member reads their own personal workspace but cannot write to it */
+  it("still lets them read their own workspace", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+
+    await expect(
+      hasProjectPermission(
+        rbacCtxForSeatUser(),
+        seatPersonalProjectId,
+        "datasets:view",
+      ),
+    ).resolves.toBe(true);
+  });
+
+  /** @scenario A Lite Member reads their own personal workspace but cannot write to it */
+  it("stops them writing to it, admin binding and all", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+
+    await expect(
+      hasProjectPermission(
+        rbacCtxForSeatUser(),
+        seatPersonalProjectId,
+        "datasets:create",
+      ),
+    ).resolves.toBe(false);
+  });
+
+  /** @scenario Giving a Lite Member their full access back restores writing in their own workspace */
+  it("lets them write again once they are a member, with nothing to repair", async () => {
+    await setSeatUserOrganizationRole(OrganizationUserRole.EXTERNAL);
+    await setSeatUserOrganizationRole(OrganizationUserRole.MEMBER);
+
+    await expect(
+      hasProjectPermission(
+        rbacCtxForSeatUser(),
+        seatPersonalProjectId,
+        "datasets:create",
+      ),
+    ).resolves.toBe(true);
+  });
+
+  /** @scenario A personal workspace is not listed among the access an admin manages */
+  it("keeps the workspace out of the access an admin is shown for them", async () => {
+    const bindings = await callerAsOwner().roleBinding.listForUser({
+      organizationId,
+      userId: seatUserId,
+    });
+
+    expect(bindings.map((binding) => binding.scopeId)).not.toContain(
+      seatPersonalTeamId,
+    );
+    // The shared team is still there: this hides what cannot be managed, not
+    // everything about the member.
+    expect(bindings.map((binding) => binding.scopeId)).toContain(sharedTeamId);
+  });
+
+  /** @scenario A personal workspace is not listed among the access an admin manages */
+  it("keeps every member's workspace out of the organization-wide list", async () => {
+    const bindings = await callerAsOwner().roleBinding.listForOrg({
+      organizationId,
+    });
+
+    expect(bindings.map((binding) => binding.scopeId)).not.toContain(
+      seatPersonalTeamId,
+    );
+    expect(bindings.map((binding) => binding.scopeId)).not.toContain(
+      personalTeamId,
+    );
+  });
+}
+
 function archivingASharedTeam() {
   it("archives it, because only personal teams are held back", async () => {
     const disposable = await prisma.team.create({
@@ -744,7 +1024,7 @@ describe("given a personal workspace beside a shared team in one organization", 
   afterAll(async () => {
     await deleteFixture({
       organizationId,
-      userIds: [ownerUserId, colleagueUserId],
+      userIds: [ownerUserId, colleagueUserId, seatUserIdForCleanup],
     });
   });
 
@@ -786,6 +1066,12 @@ describe("given a personal workspace beside a shared team in one organization", 
   describe(
     "when the owner archives the personal team",
     archivingThePersonalTeam,
+  );
+
+  // The one decision that has to go through rather than be refused.
+  describe(
+    "when an admin moves a member who has a personal workspace to a Lite Member seat",
+    movingAMemberWithAPersonalWorkspaceToALiteSeat,
   );
 
   // Runs last: it archives a team, which moves the team count the assertions

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
@@ -866,11 +866,27 @@ function movingAMemberWithAPersonalWorkspaceToALiteSeat() {
     });
   });
 
+  // Put the seat user back the way `beforeAll` left them, by writing the rows
+  // rather than replaying the router: teardown that depends on the app a test
+  // wired up restores nothing once the app is reset, and swallowing that is how
+  // it goes unnoticed. The shared-team binding goes back to ADMIN too, or the
+  // next test's assertion that the cascade corrected it to VIEWER would hold
+  // whether or not the cascade ran.
   afterEach(async () => {
     await resetApp();
-    await setSeatUserOrganizationRole(OrganizationUserRole.MEMBER).catch(
-      () => {},
-    );
+    await prisma.organizationUser.update({
+      where: { userId_organizationId: { userId: seatUserId, organizationId } },
+      data: { role: OrganizationUserRole.MEMBER },
+    });
+    await prisma.roleBinding.updateMany({
+      where: {
+        organizationId,
+        userId: seatUserId,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: sharedTeamId,
+      },
+      data: { role: TeamUserRole.ADMIN },
+    });
   });
 
   /** @scenario Moving a member who has a personal workspace to Lite Member succeeds */

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * @vitest-environment node
+ *
+ * When a personal workspace goes, and what happens if its owner comes back.
+ *
+ * Refusing to archive a personal workspace directly is only defensible because
+ * there is one moment when it does go, and `PERSONAL_TEAM_ARCHIVE_REFUSAL` names
+ * it: these workspaces "disappear with the member's access to the organization".
+ * Nothing made that true. Removing a membership took the `OrganizationUser` row
+ * and every role binding with it and left the team and project behind, owned by
+ * somebody who is no longer a member and still holding their one slot per
+ * (organization, owner).
+ *
+ * Which is why the two halves are tested together. Archiving alone would brick
+ * the slot: the partial unique index enforcing it covers archived rows, while
+ * every lookup filters `archivedAt: null`, so a re-invited member's provisioning
+ * would find nothing and then fail to create a replacement. `ensure()` has to
+ * recognise its own archived workspace and revive it, binding included, because
+ * removing the membership deleted the one that made it reachable.
+ *
+ * Requires: PostgreSQL database (Prisma)
+ */
+
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PersonalWorkspaceService } from "../../../../../ee/governance/services/personalWorkspace.service";
+import { cleanupTestRows } from "../../../../test-utils/cleanupTestRows";
+import { globalForApp, resetApp } from "../../../app-layer/app";
+import { OrganizationService } from "../../../app-layer/organizations/organization.service";
+import { PrismaOrganizationRepository } from "../../../app-layer/organizations/repositories/organization.prisma.repository";
+import { createTestApp } from "../../../app-layer/presets";
+import { prisma } from "../../../db";
+import { PromptTagRepository } from "../../../prompt-config/repositories/prompt-tag.repository";
+import { hasProjectPermission } from "../../rbac";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+
+vi.mock("@ee/audit-log/auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+const ns = `pw-lifecycle-${nanoid(8)}`;
+const adminEmail = `${ns}-admin@example.com`;
+const leaverEmail = `${ns}-leaver@example.com`;
+
+let organizationId: string;
+let adminUserId: string;
+let leaverUserId: string;
+let workspaceService: PersonalWorkspaceService;
+let personalTeamId: string;
+let personalProjectId: string;
+
+const callerAsAdmin = () =>
+  appRouter.createCaller(
+    createInnerTRPCContext({
+      session: {
+        user: { id: adminUserId, name: "Org Admin", email: adminEmail },
+        expires: "1",
+      } as any,
+    }),
+  );
+
+const ensureLeaverWorkspace = () =>
+  workspaceService.ensure({
+    userId: leaverUserId,
+    organizationId,
+    displayName: "Leaver",
+    displayEmail: leaverEmail,
+  });
+
+const workspaceRows = () =>
+  prisma.team.findUnique({
+    where: { id: personalTeamId },
+    select: {
+      archivedAt: true,
+      projects: { select: { id: true, archivedAt: true } },
+    },
+  });
+
+describe("given a member with a personal workspace in an organization", () => {
+  beforeAll(async () => {
+    const admin = await prisma.user.create({
+      data: { name: "Org Admin", email: adminEmail },
+    });
+    adminUserId = admin.id;
+    const leaver = await prisma.user.create({
+      data: { name: "Leaver", email: leaverEmail },
+    });
+    leaverUserId = leaver.id;
+
+    const organization = await prisma.organization.create({
+      data: { name: `ACME ${ns}`, slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: adminUserId,
+        organizationId,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+    await prisma.organizationUser.create({
+      data: {
+        userId: leaverUserId,
+        organizationId,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        userId: adminUserId,
+        organizationId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organizationId,
+      },
+    });
+
+    workspaceService = new PersonalWorkspaceService(prisma);
+    const workspace = await ensureLeaverWorkspace();
+    personalTeamId = workspace.team.id;
+    personalProjectId = workspace.project.id;
+
+    // A real organization service against the test database: `createTestApp`
+    // defaults to a NullOrganizationRepository that resolves without writing,
+    // and every assertion below is about what the removal left behind.
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      organizations: new OrganizationService(
+        new PrismaOrganizationRepository(prisma),
+        new PromptTagRepository(prisma),
+      ),
+    });
+  });
+
+  afterAll(async () => {
+    await resetApp();
+    await prisma.project.deleteMany({ where: { teamId: personalTeamId } });
+    await cleanupTestRows(prisma, [
+      ["teamUser", { teamId: personalTeamId }],
+      ["roleBinding", { organizationId }],
+      ["organizationUser", { organizationId }],
+      ["team", { organizationId }],
+      ["organization", { id: organizationId }],
+    ]);
+    const created = [adminUserId, leaverUserId].filter(Boolean);
+    if (created.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: created } } });
+    }
+  });
+
+  describe("when an admin removes that member from the organization", () => {
+    beforeAll(async () => {
+      await callerAsAdmin().organization.deleteMember({
+        organizationId,
+        userId: leaverUserId,
+      });
+    });
+
+    /** @scenario Removing a member takes their personal workspace with them */
+    it("archives the workspace team", async () => {
+      await expect(workspaceRows()).resolves.toMatchObject({
+        archivedAt: expect.any(Date),
+      });
+    });
+
+    /** @scenario Removing a member takes their personal workspace with them */
+    it("archives its project with it", async () => {
+      const rows = await workspaceRows();
+      expect(rows?.projects).toEqual([
+        { id: personalProjectId, archivedAt: expect.any(Date) },
+      ]);
+    });
+
+    /** @scenario Removing a member takes their personal workspace with them */
+    it("leaves nothing an admin still has to clean up", async () => {
+      // The whole point of archiving here: no live personal workspace remains in
+      // the organization for a user who is no longer in it.
+      await expect(
+        prisma.team.findFirst({
+          where: {
+            organizationId,
+            ownerUserId: leaverUserId,
+            isPersonal: true,
+            archivedAt: null,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    describe("and that member joins the organization again", () => {
+      beforeAll(async () => {
+        await prisma.organizationUser.create({
+          data: {
+            userId: leaverUserId,
+            organizationId,
+            role: OrganizationUserRole.MEMBER,
+          },
+        });
+      });
+
+      /** @scenario Inviting a removed member back gives them their workspace again */
+      it("hands back the same workspace rather than a new one", async () => {
+        // Not merely "a workspace exists": the same team and project ids, which
+        // is the difference between reviving the slot and having quietly
+        // sidestepped the uniqueness that made this hard.
+        await expect(ensureLeaverWorkspace()).resolves.toMatchObject({
+          created: false,
+          team: { id: personalTeamId },
+          project: { id: personalProjectId },
+        });
+      });
+
+      /** @scenario Inviting a removed member back gives them their workspace again */
+      it("gives them back the access to reach it", async () => {
+        await ensureLeaverWorkspace();
+
+        // Removing the membership deleted the owner's admin binding along with
+        // every other one, so a revival that only cleared `archivedAt` would
+        // hand back a workspace they cannot open.
+        await expect(
+          hasProjectPermission(
+            {
+              prisma,
+              session: {
+                user: {
+                  id: leaverUserId,
+                  name: "Leaver",
+                  email: leaverEmail,
+                },
+                expires: "1",
+              } as any,
+            },
+            personalProjectId,
+            "datasets:create",
+          ),
+        ).resolves.toBe(true);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
@@ -194,7 +194,7 @@ describe("given a member with a personal workspace in an organization", () => {
       ).resolves.toBeNull();
     });
 
-    describe("and that member joins the organization again", () => {
+    describe("when that member joins the organization again", () => {
       beforeAll(async () => {
         await prisma.organizationUser.create({
           data: {

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-lifecycle.integration.test.ts
@@ -141,8 +141,8 @@ describe("given a member with a personal workspace in an organization", () => {
 
   afterAll(async () => {
     await resetApp();
-    await prisma.project.deleteMany({ where: { teamId: personalTeamId } });
     await cleanupTestRows(prisma, [
+      ["project", { teamId: personalTeamId }],
       ["teamUser", { teamId: personalTeamId }],
       ["roleBinding", { organizationId }],
       ["organizationUser", { organizationId }],

--- a/platform/app/src/server/api/routers/group.ts
+++ b/platform/app/src/server/api/routers/group.ts
@@ -297,7 +297,10 @@ export const groupRouter = createTRPCRouter({
         });
 
         if (input.bindings?.length) {
-          await assertNoPersonalTeamScope(tx, input.bindings);
+          await assertNoPersonalTeamScope({
+            client: tx,
+            scopes: input.bindings,
+          });
           await tx.roleBinding.createMany({
             data: input.bindings.map((b) => ({
               id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
@@ -355,9 +358,10 @@ export const groupRouter = createTRPCRouter({
         scopeType: input.scopeType,
         scopeId: input.scopeId,
       });
-      await assertNoPersonalTeamScope(ctx.prisma, [
-        { scopeType: input.scopeType, scopeId: input.scopeId },
-      ]);
+      await assertNoPersonalTeamScope({
+        client: ctx.prisma,
+        scopes: [{ scopeType: input.scopeType, scopeId: input.scopeId }],
+      });
 
       if (input.role === TeamUserRole.CUSTOM && input.customRoleId) {
         const roleService = new RoleService(ctx.prisma);
@@ -404,7 +408,10 @@ export const groupRouter = createTRPCRouter({
           message: "Binding not found",
         });
       }
-      await assertNoPersonalTeamScope(ctx.prisma, [binding]);
+      await assertNoPersonalTeamScope({
+        client: ctx.prisma,
+        scopes: [binding],
+      });
       await ctx.prisma.roleBinding.delete({ where: { id: input.bindingId } });
       return { success: true };
     }),

--- a/platform/app/src/server/api/routers/organization.ts
+++ b/platform/app/src/server/api/routers/organization.ts
@@ -18,7 +18,10 @@ import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/re
 import { createLicenseEnforcementService } from "~/server/license-enforcement";
 import { trackServerEvent } from "~/server/posthog";
 import { RoleService } from "~/server/role/role.service";
-import { assertNoPersonalTeamScope } from "~/server/role-bindings/personal-team-scope";
+import {
+  assertNoPersonalTeamScope,
+  findSharedTeamIds,
+} from "~/server/role-bindings/personal-team-scope";
 import { signUpDataSchema } from "~/server/schemas/sign-up-data.schema";
 import { decrypt } from "~/utils/encryption";
 import {
@@ -1482,12 +1485,27 @@ export const organizationRouter = createTRPCRouter({
         });
       }
 
-      // Get current member's custom role permissions (if any) for license change detection
-      const organizationTeams = await prisma.team.findMany({
-        where: { organizationId: input.organizationId },
-        select: { id: true },
+      // A caller who names a personal workspace outright is told so. Without
+      // this the shared-teams-only set below would answer "that team is not in
+      // the organization", which is both wrong and no help. No UI sends these
+      // updates today; the procedure accepts them, so it has to answer them.
+      await assertNoPersonalTeamScope(
+        prisma,
+        (input.teamRoleUpdates ?? []).map((update) => ({
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: update.teamId,
+        })),
+      );
+
+      // Only the teams the organization shares. A seat decision is about the
+      // person, so it applies to the teams they work in with other people and
+      // leaves the workspace that is only theirs alone. Including it would ask
+      // the organization to demote a team's last admin, which is refused, and
+      // the whole role change would go down with the refusal.
+      const organizationTeamIds = await findSharedTeamIds({
+        client: prisma,
+        organizationId: input.organizationId,
       });
-      const organizationTeamIds = organizationTeams.map((team) => team.id);
 
       const currentTeamBindings = await prisma.roleBinding.findMany({
         where: {

--- a/platform/app/src/server/api/routers/organization.ts
+++ b/platform/app/src/server/api/routers/organization.ts
@@ -1327,9 +1327,12 @@ export const organizationRouter = createTRPCRouter({
     .use(checkTeamPermission("organization:manage"))
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
-      await assertNoPersonalTeamScope(prisma, [
-        { scopeType: RoleBindingScopeType.TEAM, scopeId: input.teamId },
-      ]);
+      await assertNoPersonalTeamScope({
+        client: prisma,
+        scopes: [
+          { scopeType: RoleBindingScopeType.TEAM, scopeId: input.teamId },
+        ],
+      });
       const inputIsCustomRole = isCustomRole(input.role);
 
       if (inputIsCustomRole && input.customRoleId) {
@@ -1489,13 +1492,13 @@ export const organizationRouter = createTRPCRouter({
       // this the shared-teams-only set below would answer "that team is not in
       // the organization", which is both wrong and no help. No UI sends these
       // updates today; the procedure accepts them, so it has to answer them.
-      await assertNoPersonalTeamScope(
-        prisma,
-        (input.teamRoleUpdates ?? []).map((update) => ({
+      await assertNoPersonalTeamScope({
+        client: prisma,
+        scopes: (input.teamRoleUpdates ?? []).map((update) => ({
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: update.teamId,
         })),
-      );
+      });
 
       // Only the teams the organization shares. A seat decision is about the
       // person, so it applies to the teams they work in with other people and

--- a/platform/app/src/server/app-layer/groups/group.service.ts
+++ b/platform/app/src/server/app-layer/groups/group.service.ts
@@ -6,10 +6,7 @@ import type {
   RoleBindingScopeType,
   TeamUserRole,
 } from "@prisma/client";
-import {
-  PERSONAL_TEAM_MEMBERSHIP_REFUSAL,
-  PersonalTeamProtectedError,
-} from "~/server/app-layer/teams/team.service";
+import { PersonalWorkspaceNotManagedHereError } from "~/server/app-layer/teams/team.service";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
 import type {
@@ -50,12 +47,16 @@ export class GroupRestService {
    * A personal team holds exactly its owner, which is why plan limits exempt
    * it. A group binding would make it multi-member by proxy while it still
    * counts as nobody's, so group bindings never point at one.
+   *
+   * Handed on as a handled error so the REST boundary answers 403 with a code.
+   * It used to be a plain `Error`, which `handleGroupError` had nowhere to put,
+   * so a caller naming a personal scope was told the server had fallen over.
    */
   private async assertNoPersonalTeamScope(
     scopes: Array<{ scopeType: RoleBindingScopeType; scopeId: string }>,
   ): Promise<void> {
     if (await this.repo.anyScopeIsPersonalTeam(scopes)) {
-      throw new PersonalTeamProtectedError(PERSONAL_TEAM_MEMBERSHIP_REFUSAL);
+      throw new PersonalWorkspaceNotManagedHereError();
     }
   }
 

--- a/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -260,7 +260,7 @@ export class PrismaGroupRepository implements GroupRepository {
   ): Promise<boolean> {
     // One definition of "this scope reaches a personal workspace", shared with
     // the role-binding paths.
-    return scopesTouchPersonalTeam(this.prisma, scopes);
+    return scopesTouchPersonalTeam({ client: this.prisma, scopes });
   }
 
   async validateScopeInOrganization({

--- a/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -12,6 +12,7 @@ import {
   TeamUserRole,
 } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
+import { findSharedTeamIds } from "~/server/role-bindings/personal-team-scope";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { encrypt } from "~/utils/encryption";
 import {
@@ -490,6 +491,23 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
     });
   }
 
+  /**
+   * Removes a membership, and the personal workspace that came with it.
+   *
+   * `PERSONAL_TEAM_ARCHIVE_REFUSAL` is the sentence an admin gets when they try
+   * to archive a personal workspace directly, and it tells them these
+   * workspaces "disappear with the member's access to the organization". That
+   * was not true: the membership and its role bindings went, and the personal
+   * team and project stayed behind owned by somebody who is no longer a member,
+   * still holding their one slot per (organization, owner). So the refusal
+   * pointed at a cleanup that never happened, and an admin asking how to get
+   * rid of one had no answer at all.
+   *
+   * Archived, not deleted, for the same reason every other project is: the work
+   * is still the work. `PersonalWorkspaceService.ensure()` reactivates this
+   * exact pair if the person is invited back, which is what keeps archiving here
+   * from bricking that slot.
+   */
   async deleteMember(input: DeleteMemberInput): Promise<void> {
     const { organizationId, userId } = input;
 
@@ -504,6 +522,28 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
       });
       await tx.roleBinding.deleteMany({
         where: { organizationId, userId },
+      });
+
+      const archivedAt = new Date();
+      const personalTeams = await tx.team.findMany({
+        where: {
+          organizationId,
+          ownerUserId: userId,
+          isPersonal: true,
+          archivedAt: null,
+        },
+        select: { id: true },
+      });
+      if (personalTeams.length === 0) return;
+
+      const personalTeamIds = personalTeams.map((team) => team.id);
+      await tx.project.updateMany({
+        where: { teamId: { in: personalTeamIds }, archivedAt: null },
+        data: { archivedAt },
+      });
+      await tx.team.updateMany({
+        where: { id: { in: personalTeamIds } },
+        data: { archivedAt },
       });
     });
   }
@@ -634,11 +674,15 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
         });
       }
 
-      const organizationTeams = await tx.team.findMany({
-        where: { organizationId },
-        select: { id: true },
+      // Shared teams only, matching what the router resolved before it computed
+      // the effective updates. The personal workspace each member gets to
+      // themselves has one admin, its owner, so a downgrade that reached it
+      // would trip the last-admin guard below and roll this transaction back,
+      // taking the organization role change with it.
+      const organizationTeamIds = await findSharedTeamIds({
+        client: tx,
+        organizationId,
       });
-      const organizationTeamIds = organizationTeams.map((team) => team.id);
 
       const currentMemberships = await tx.roleBinding.findMany({
         where: {

--- a/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -537,8 +537,18 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
       if (personalTeams.length === 0) return;
 
       const personalTeamIds = personalTeams.map((team) => team.id);
+      // `isPersonal` on the same terms the reactivation reads it, so the two
+      // sides move the same rows. A personal team holds nothing else today
+      // (creating a project in one, or moving one into it, is refused), and the
+      // flag mirrors the team's, so this narrows nothing away; it keeps the pair
+      // symmetric if that ever slips, since archiving what the revival would
+      // not return is the failure with no way back.
       await tx.project.updateMany({
-        where: { teamId: { in: personalTeamIds }, archivedAt: null },
+        where: {
+          teamId: { in: personalTeamIds },
+          isPersonal: true,
+          archivedAt: null,
+        },
         data: { archivedAt },
       });
       await tx.team.updateMany({

--- a/platform/app/src/server/app-layer/teams/team.service.ts
+++ b/platform/app/src/server/app-layer/teams/team.service.ts
@@ -1,3 +1,4 @@
+import { HandledError } from "@langwatch/handled-error";
 import type { Team } from "@prisma/client";
 import { nanoid } from "nanoid";
 import { slugify } from "~/utils/slugify";
@@ -14,6 +15,7 @@ export class TeamSlugConflictError extends Error {
   name = "TeamSlugConflictError" as const;
 }
 
+/** Raised when something would archive a personal team. */
 export class PersonalTeamProtectedError extends Error {
   name = "PersonalTeamProtectedError" as const;
 }
@@ -25,6 +27,45 @@ export const PERSONAL_TEAM_ARCHIVE_REFUSAL =
 /** The refusal a personal team gives to anything that would change who is on it. */
 export const PERSONAL_TEAM_MEMBERSHIP_REFUSAL =
   "Personal workspace teams have exactly one member: their owner. Create a shared team to collaborate with others.";
+
+/**
+ * Something tried to change who reaches a personal workspace.
+ *
+ * Handled rather than a plain `Error` because the cause is known exactly and
+ * the caller has somewhere to go: the workspace belongs to one member, their
+ * organization role already decides what they can do inside it, and a shared
+ * team is where collaboration goes. An administrator reaching this was usually
+ * managing a seat, and the old raw refusal read as an internal invariant with
+ * no bearing on the seat they were trying to change.
+ *
+ * `ownerName` is in `meta` because a client renders it: "this is Robin's own
+ * workspace" is an answer, whereas "a personal workspace" leaves the admin
+ * looking for which one. It is the team name the owner sees, which the
+ * organization's admins can already read on the member list.
+ *
+ * Consolidates three shapes this same refusal used to take, one per entry
+ * point: a bare `TRPCError`, a `PersonalTeamProtectedError`, and a
+ * `ValidationError` whose `validation_error` code and 422 both misreported it.
+ * The REST team API keeps its own 403 with the sentence in the body, because
+ * there the message *is* the documented contract
+ * (`specs/teams/teams-rest-api.feature`).
+ */
+export class PersonalWorkspaceNotManagedHereError extends HandledError {
+  declare readonly code: "personal_workspace_not_managed_here";
+
+  constructor(ownerName?: string | null) {
+    super(
+      "personal_workspace_not_managed_here",
+      PERSONAL_TEAM_MEMBERSHIP_REFUSAL,
+      {
+        meta: ownerName ? { ownerName } : {},
+        httpStatus: 403,
+        fault: "customer",
+      },
+    );
+    this.name = "PersonalWorkspaceNotManagedHereError";
+  }
+}
 
 export class TeamRestService {
   constructor(readonly repo: TeamRepository) {}

--- a/platform/app/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
+++ b/platform/app/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
@@ -1,13 +1,12 @@
-import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EXPIRED_LICENSE_KEY } from "../../../../ee/licensing/__tests__/fixtures/testLicenses";
 import { floorAtOssBaseline } from "../../../../ee/licensing/ossBaselineFloor";
 import { mapToPlanInfo } from "../../../../ee/licensing/planMapping";
 import { parseLicenseKey } from "../../../../ee/licensing/validation";
+import { LimitExceededError } from "../errors";
 import type { ILicenseEnforcementRepository } from "../license-enforcement.repository";
 import {
   assertMemberTypeLimitNotExceeded,
-  LICENSE_LIMIT_ERRORS,
   type MemberTypeLimits,
 } from "../license-limit-guard";
 
@@ -165,10 +164,13 @@ describe("assertMemberTypeLimitNotExceeded", () => {
         limits,
       ).catch((e) => e);
 
+      // The allowance travels as `meta` under a stable code, which is what lets
+      // the client name which seats ran out. Asserting the code rather than the
+      // sentence: the sentence is copy.
       expect(error).toMatchObject({
-        code: "FORBIDDEN",
-        message: LICENSE_LIMIT_ERRORS.FULL_MEMBER_LIMIT,
-        cause: {
+        code: "resource_limit_exceeded",
+        httpStatus: 403,
+        meta: {
           limitType: "members",
           current: 5,
           max: 5,
@@ -206,7 +208,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
           mockRepo,
           limits,
         ),
-      ).rejects.toThrow(TRPCError);
+      ).rejects.toThrow(LimitExceededError);
     });
   });
 
@@ -253,9 +255,9 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       ).catch((e) => e);
 
       expect(error).toMatchObject({
-        code: "FORBIDDEN",
-        message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
-        cause: {
+        code: "resource_limit_exceeded",
+        httpStatus: 403,
+        meta: {
           limitType: "membersLite",
           current: 10,
           max: 10,
@@ -293,7 +295,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
           mockRepo,
           limits,
         ),
-      ).rejects.toThrow(TRPCError);
+      ).rejects.toThrow(LimitExceededError);
     });
   });
 
@@ -317,8 +319,8 @@ describe("assertMemberTypeLimitNotExceeded", () => {
           plan,
         ),
       ).rejects.toMatchObject({
-        code: "FORBIDDEN",
-        message: LICENSE_LIMIT_ERRORS.FULL_MEMBER_LIMIT,
+        code: "resource_limit_exceeded",
+        meta: { limitType: "members" },
       });
     });
 

--- a/platform/app/src/server/license-enforcement/license-limit-guard.ts
+++ b/platform/app/src/server/license-enforcement/license-limit-guard.ts
@@ -1,12 +1,17 @@
-import { TRPCError } from "@trpc/server";
 import { getApp } from "~/server/app-layer/app";
 import { captureException } from "~/utils/posthogErrorCapture";
+import { LimitExceededError } from "./errors";
 import type { ILicenseEnforcementRepository } from "./license-enforcement.repository";
 import type { RoleChangeType } from "./member-classification";
 
 /**
  * Error messages for license limit violations.
  * Consistent wording using "Lite Member" (not "External").
+ *
+ * Server copy and log lines only. What a customer reads comes from the
+ * `resource_limit_exceeded` entry in the client presentation registry, keyed off
+ * the code {@link LimitExceededError} carries, with the allowance itself read
+ * from its `meta`.
  */
 export const LICENSE_LIMIT_ERRORS = {
   FULL_MEMBER_LIMIT: "Cannot complete action: full member limit reached",
@@ -24,10 +29,15 @@ export interface MemberTypeLimits {
 
 /**
  * Asserts that a role change doesn't exceed license limits.
- * Throws TRPCError with FORBIDDEN code if limits would be exceeded.
  * Sends a fire-and-forget Slack notification to ops before throwing.
  *
- * @throws TRPCError with code FORBIDDEN if limit exceeded
+ * The refusal is a {@link LimitExceededError}, so the allowance that ran out
+ * travels as `meta` under a stable code and the client can name it. It used to
+ * be a bare `TRPCError` whose whole answer was the sentence "Cannot complete
+ * action", which is the least useful thing to tell an admin working down a
+ * member list one seat at a time.
+ *
+ * @throws LimitExceededError if the limit would be exceeded
  */
 export async function assertMemberTypeLimitNotExceeded(
   changeType: RoleChangeType,
@@ -52,15 +62,7 @@ export async function assertMemberTypeLimitNotExceeded(
         })
         .catch(captureException);
 
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: LICENSE_LIMIT_ERRORS.FULL_MEMBER_LIMIT,
-        cause: {
-          limitType: "members",
-          current: memberCount,
-          max: limits.maxMembers,
-        },
-      });
+      throw new LimitExceededError("members", memberCount, limits.maxMembers);
     }
   }
 
@@ -76,15 +78,11 @@ export async function assertMemberTypeLimitNotExceeded(
         })
         .catch(captureException);
 
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: LICENSE_LIMIT_ERRORS.MEMBER_LITE_LIMIT,
-        cause: {
-          limitType: "membersLite",
-          current: liteCount,
-          max: limits.maxMembersLite,
-        },
-      });
+      throw new LimitExceededError(
+        "membersLite",
+        liteCount,
+        limits.maxMembersLite,
+      );
     }
   }
 }

--- a/platform/app/src/server/role-bindings/personal-team-scope.ts
+++ b/platform/app/src/server/role-bindings/personal-team-scope.ts
@@ -3,18 +3,93 @@ import {
   type PrismaClient,
   RoleBindingScopeType,
 } from "@prisma/client";
-import { TRPCError } from "@trpc/server";
 
-import {
-  PERSONAL_TEAM_MEMBERSHIP_REFUSAL,
-  PersonalTeamProtectedError,
-} from "~/server/app-layer/teams/team.service";
+import { PersonalWorkspaceNotManagedHereError } from "~/server/app-layer/teams/team.service";
 
 type Client = PrismaClient | Prisma.TransactionClient;
 
 export interface RoleBindingScope {
   scopeType: RoleBindingScopeType;
   scopeId: string;
+}
+
+/**
+ * The teams an organization actually shares, which is every team except the
+ * personal workspace each member gets to themselves.
+ *
+ * The counterpart to the refusal below, and here beside it so the two sides of
+ * the same invariant cannot drift. Anything deciding what an organization-wide
+ * change applies to asks for this rather than for `team.findMany` by
+ * organization: a personal workspace has exactly one admin, its owner, so
+ * sweeping it into such a change asks the organization to demote a team's last
+ * admin, which is refused, and the refusal takes the whole change down with it.
+ */
+export async function findSharedTeamIds({
+  client,
+  organizationId,
+}: {
+  client: Client;
+  organizationId: string;
+}): Promise<string[]> {
+  const teams = await client.team.findMany({
+    where: { organizationId, isPersonal: false },
+    select: { id: true },
+  });
+  return teams.map((team) => team.id);
+}
+
+/**
+ * The personal team a set of scopes reaches, by the name its owner sees, or
+ * null when they reach only shared ground.
+ *
+ * Both TEAM and PROJECT scopes are resolved, since a binding on the personal
+ * project reaches the same private space as one on the personal team, so naming
+ * the project rather than the team cannot be the way around the refusal.
+ */
+export async function findPersonalTeamInScopes(
+  client: Client,
+  scopes: RoleBindingScope[],
+): Promise<{ name: string } | null> {
+  const idsOfType = (scopeType: RoleBindingScopeType) => [
+    ...new Set(
+      scopes
+        .filter((scope) => scope.scopeType === scopeType)
+        .map((scope) => scope.scopeId),
+    ),
+  ];
+
+  const teamIds = idsOfType(RoleBindingScopeType.TEAM);
+  if (teamIds.length > 0) {
+    const personalTeam = await client.team.findFirst({
+      where: { id: { in: teamIds }, isPersonal: true },
+      select: { name: true },
+    });
+    if (personalTeam) return personalTeam;
+  }
+
+  // A project-scoped binding on the personal project reaches the same private
+  // space the team-scoped one does, so naming the project rather than the team
+  // cannot be the way around this.
+  const projectIds = idsOfType(RoleBindingScopeType.PROJECT);
+  if (projectIds.length > 0) {
+    const personalProject = await client.project.findFirst({
+      where: {
+        id: { in: projectIds },
+        OR: [{ isPersonal: true }, { team: { isPersonal: true } }],
+      },
+      select: { team: { select: { name: true } } },
+    });
+    if (personalProject) return personalProject.team;
+  }
+
+  return null;
+}
+
+export async function scopesTouchPersonalTeam(
+  client: Client,
+  scopes: RoleBindingScope[],
+): Promise<boolean> {
+  return (await findPersonalTeamInScopes(client, scopes)) !== null;
 }
 
 /**
@@ -36,70 +111,23 @@ export interface RoleBindingScope {
  *
  * Pass every scope a write touches, creates and deletes alike: removing the
  * owner's binding is as much a membership change as adding someone else's.
- * Both TEAM and PROJECT scopes are resolved, since a binding on the personal
- * project reaches the same private space as one on the personal team.
+ *
+ * Refuses with a handled error, which every boundary reads: tRPC maps its 403
+ * to FORBIDDEN and puts the code on the wire for the client to key its copy
+ * off, and the app layer hands it on as it is. One shape for one refusal, so no
+ * caller has to know which entry point it arrived through.
+ *
+ * A seat change is not supposed to reach here at all. It asks
+ * {@link findSharedTeamIds} which teams it applies to, so the personal
+ * workspace is never in the set, and this stays what it was built to be: the
+ * line an attempt to *share* a personal workspace runs into.
  */
-export async function scopesTouchPersonalTeam(
-  client: Client,
-  scopes: RoleBindingScope[],
-): Promise<boolean> {
-  const idsOfType = (scopeType: RoleBindingScopeType) => [
-    ...new Set(
-      scopes
-        .filter((scope) => scope.scopeType === scopeType)
-        .map((scope) => scope.scopeId),
-    ),
-  ];
-
-  const teamIds = idsOfType(RoleBindingScopeType.TEAM);
-  if (teamIds.length > 0) {
-    const personalTeam = await client.team.findFirst({
-      where: { id: { in: teamIds }, isPersonal: true },
-      select: { id: true },
-    });
-    if (personalTeam) return true;
-  }
-
-  // A project-scoped binding on the personal project reaches the same private
-  // space the team-scoped one does, so naming the project rather than the team
-  // cannot be the way around this.
-  const projectIds = idsOfType(RoleBindingScopeType.PROJECT);
-  if (projectIds.length > 0) {
-    const personalProject = await client.project.findFirst({
-      where: {
-        id: { in: projectIds },
-        OR: [{ isPersonal: true }, { team: { isPersonal: true } }],
-      },
-      select: { id: true },
-    });
-    if (personalProject) return true;
-  }
-
-  return false;
-}
-
-/** tRPC entry points: refuses with FORBIDDEN. */
 export async function assertNoPersonalTeamScope(
   client: Client,
   scopes: RoleBindingScope[],
 ): Promise<void> {
-  if (await scopesTouchPersonalTeam(client, scopes)) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: PERSONAL_TEAM_MEMBERSHIP_REFUSAL,
-    });
-  }
-}
-
-/**
- * App-layer and REST entry points, which map their own domain errors to HTTP
- * status codes and must not be handed a tRPC error.
- */
-export async function assertNoPersonalTeamScopeInService(
-  client: Client,
-  scopes: RoleBindingScope[],
-): Promise<void> {
-  if (await scopesTouchPersonalTeam(client, scopes)) {
-    throw new PersonalTeamProtectedError(PERSONAL_TEAM_MEMBERSHIP_REFUSAL);
+  const personalTeam = await findPersonalTeamInScopes(client, scopes);
+  if (personalTeam) {
+    throw new PersonalWorkspaceNotManagedHereError(personalTeam.name);
   }
 }

--- a/platform/app/src/server/role-bindings/personal-team-scope.ts
+++ b/platform/app/src/server/role-bindings/personal-team-scope.ts
@@ -46,10 +46,13 @@ export async function findSharedTeamIds({
  * project reaches the same private space as one on the personal team, so naming
  * the project rather than the team cannot be the way around the refusal.
  */
-export async function findPersonalTeamInScopes(
-  client: Client,
-  scopes: RoleBindingScope[],
-): Promise<{ name: string } | null> {
+export async function findPersonalTeamInScopes({
+  client,
+  scopes,
+}: {
+  client: Client;
+  scopes: RoleBindingScope[];
+}): Promise<{ name: string } | null> {
   const idsOfType = (scopeType: RoleBindingScopeType) => [
     ...new Set(
       scopes
@@ -85,11 +88,14 @@ export async function findPersonalTeamInScopes(
   return null;
 }
 
-export async function scopesTouchPersonalTeam(
-  client: Client,
-  scopes: RoleBindingScope[],
-): Promise<boolean> {
-  return (await findPersonalTeamInScopes(client, scopes)) !== null;
+export async function scopesTouchPersonalTeam({
+  client,
+  scopes,
+}: {
+  client: Client;
+  scopes: RoleBindingScope[];
+}): Promise<boolean> {
+  return (await findPersonalTeamInScopes({ client, scopes })) !== null;
 }
 
 /**
@@ -122,11 +128,14 @@ export async function scopesTouchPersonalTeam(
  * workspace is never in the set, and this stays what it was built to be: the
  * line an attempt to *share* a personal workspace runs into.
  */
-export async function assertNoPersonalTeamScope(
-  client: Client,
-  scopes: RoleBindingScope[],
-): Promise<void> {
-  const personalTeam = await findPersonalTeamInScopes(client, scopes);
+export async function assertNoPersonalTeamScope({
+  client,
+  scopes,
+}: {
+  client: Client;
+  scopes: RoleBindingScope[];
+}): Promise<void> {
+  const personalTeam = await findPersonalTeamInScopes({ client, scopes });
   if (personalTeam) {
     throw new PersonalWorkspaceNotManagedHereError(personalTeam.name);
   }

--- a/platform/app/src/server/role-bindings/role-binding.service.ts
+++ b/platform/app/src/server/role-bindings/role-binding.service.ts
@@ -78,6 +78,83 @@ export class RoleBindingService {
     }
   }
 
+  /**
+   * The display name of every scope these bindings name, and which of those
+   * scopes are somebody's personal workspace.
+   *
+   * A personal workspace is not access an administrator granted or can take
+   * away: it is provisioned with the member, holds only them, and every write
+   * against it is refused (see `assertNoPersonalTeamScope`). So the two lists
+   * an administrator manages access from leave it out, rather than putting a
+   * row on the members page for every member of the organization with a control
+   * behind it that cannot succeed. What a member may do inside their own
+   * workspace follows from their organization role, which those pages already
+   * show. `getMyAccessBreakdown` is a member reading their own access rather
+   * than a management surface, so it keeps listing it.
+   *
+   * Scope lookups stay filtered by organization as defense in depth against a
+   * stray binding whose scopeId points outside it (historical data, failed
+   * migrations), even though the bindings are already filtered by it.
+   */
+  private async resolveScopes(
+    bindings: Array<{ scopeType: RoleBindingScopeType; scopeId: string }>,
+    organizationId: string,
+  ): Promise<{
+    scopeNames: Map<string, string>;
+    personalScopeIds: Set<string>;
+  }> {
+    const idsOfType = (scopeType: RoleBindingScopeType) =>
+      bindings.filter((b) => b.scopeType === scopeType).map((b) => b.scopeId);
+
+    const orgIds = idsOfType(RoleBindingScopeType.ORGANIZATION);
+    const teamIds = idsOfType(RoleBindingScopeType.TEAM);
+    const projectIds = idsOfType(RoleBindingScopeType.PROJECT);
+
+    const [orgs, teams, projects] = await Promise.all([
+      orgIds.length > 0
+        ? this.prisma.organization.findMany({
+            where: { id: { in: orgIds } },
+            select: { id: true, name: true },
+          })
+        : [],
+      teamIds.length > 0
+        ? this.prisma.team.findMany({
+            where: { id: { in: teamIds }, organizationId },
+            select: { id: true, name: true, isPersonal: true },
+          })
+        : [],
+      projectIds.length > 0
+        ? this.prisma.project.findMany({
+            where: { id: { in: projectIds }, team: { organizationId } },
+            select: {
+              id: true,
+              name: true,
+              isPersonal: true,
+              team: { select: { isPersonal: true } },
+            },
+          })
+        : [],
+    ]);
+
+    const scopeNames = new Map<string, string>();
+    for (const o of orgs) scopeNames.set(o.id, o.name);
+    for (const t of teams) scopeNames.set(t.id, t.name);
+    for (const p of projects) scopeNames.set(p.id, p.name);
+
+    // Either flag is enough to hide a project. The two are meant to agree, and
+    // a reader that insisted on both would offer a half-migrated row as
+    // manageable access, which is the one answer that is wrong either way.
+    const personalScopeIds = new Set<string>();
+    for (const t of teams) {
+      if (t.isPersonal) personalScopeIds.add(t.id);
+    }
+    for (const p of projects) {
+      if (p.isPersonal || p.team.isPersonal) personalScopeIds.add(p.id);
+    }
+
+    return { scopeNames, personalScopeIds };
+  }
+
   async listForUser({
     organizationId,
     userId,
@@ -93,53 +170,24 @@ export class RoleBindingService {
       orderBy: { createdAt: "asc" },
     });
 
-    const orgIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.ORGANIZATION)
-      .map((b) => b.scopeId);
-    const teamIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.TEAM)
-      .map((b) => b.scopeId);
-    const projectIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.PROJECT)
-      .map((b) => b.scopeId);
+    const { scopeNames, personalScopeIds } = await this.resolveScopes(
+      bindings,
+      organizationId,
+    );
 
-    const [orgs, teams, projects] = await Promise.all([
-      orgIds.length > 0
-        ? this.prisma.organization.findMany({
-            where: { id: { in: orgIds } },
-            select: { id: true, name: true },
-          })
-        : [],
-      teamIds.length > 0
-        ? this.prisma.team.findMany({
-            where: { id: { in: teamIds }, organizationId },
-            select: { id: true, name: true },
-          })
-        : [],
-      projectIds.length > 0
-        ? this.prisma.project.findMany({
-            where: { id: { in: projectIds }, team: { organizationId } },
-            select: { id: true, name: true },
-          })
-        : [],
-    ]);
-
-    const scopeNames = new Map<string, string>();
-    for (const o of orgs) scopeNames.set(o.id, o.name);
-    for (const t of teams) scopeNames.set(t.id, t.name);
-    for (const p of projects) scopeNames.set(p.id, p.name);
-
-    return bindings.map((b) => ({
-      id: b.id,
-      userId: b.userId,
-      role: b.role,
-      customRoleId: b.customRoleId,
-      customRoleName: b.customRole?.name ?? null,
-      scopeType: b.scopeType,
-      scopeId: b.scopeId,
-      scopeName: scopeNames.get(b.scopeId) ?? null,
-      createdAt: b.createdAt,
-    }));
+    return bindings
+      .filter((b) => !personalScopeIds.has(b.scopeId))
+      .map((b) => ({
+        id: b.id,
+        userId: b.userId,
+        role: b.role,
+        customRoleId: b.customRoleId,
+        customRoleName: b.customRole?.name ?? null,
+        scopeType: b.scopeType,
+        scopeId: b.scopeId,
+        scopeName: scopeNames.get(b.scopeId) ?? null,
+        createdAt: b.createdAt,
+      }));
   }
 
   async listForOrg({ organizationId }: { organizationId: string }) {
@@ -163,46 +211,13 @@ export class RoleBindingService {
       orderBy: { createdAt: "asc" },
     });
 
-    const orgIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.ORGANIZATION)
-      .map((b) => b.scopeId);
-    const teamIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.TEAM)
-      .map((b) => b.scopeId);
-    const projectIds = bindings
-      .filter((b) => b.scopeType === RoleBindingScopeType.PROJECT)
-      .map((b) => b.scopeId);
+    const { scopeNames, personalScopeIds } = await this.resolveScopes(
+      bindings,
+      organizationId,
+    );
+    const manageable = bindings.filter((b) => !personalScopeIds.has(b.scopeId));
 
-    // Keep scope-name lookups symmetric with listForUser and defense-in-depth
-    // against any stray binding whose scopeId points outside the org (historical
-    // data, failed migrations). Bindings are already filtered by organizationId.
-    const [orgs, teams, projects] = await Promise.all([
-      orgIds.length > 0
-        ? this.prisma.organization.findMany({
-            where: { id: { in: orgIds } },
-            select: { id: true, name: true },
-          })
-        : [],
-      teamIds.length > 0
-        ? this.prisma.team.findMany({
-            where: { id: { in: teamIds }, organizationId },
-            select: { id: true, name: true },
-          })
-        : [],
-      projectIds.length > 0
-        ? this.prisma.project.findMany({
-            where: { id: { in: projectIds }, team: { organizationId } },
-            select: { id: true, name: true },
-          })
-        : [],
-    ]);
-
-    const scopeNames = new Map<string, string>();
-    for (const o of orgs) scopeNames.set(o.id, o.name);
-    for (const t of teams) scopeNames.set(t.id, t.name);
-    for (const p of projects) scopeNames.set(p.id, p.name);
-
-    const groupIds = bindings
+    const groupIds = manageable
       .filter((b) => b.groupId != null)
       .map((b) => b.groupId!);
     const groupMemberships =
@@ -222,7 +237,7 @@ export class RoleBindingService {
       membersByGroup.get(m.groupId)!.push(m.userId);
     }
 
-    return bindings.map((b) => ({
+    return manageable.map((b) => ({
       id: b.id,
       userId: b.userId,
       userName: b.user?.name ?? null,

--- a/platform/app/src/server/role-bindings/role-binding.service.ts
+++ b/platform/app/src/server/role-bindings/role-binding.service.ts
@@ -16,6 +16,47 @@ import type { RoleService } from "~/server/role/role.service";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { assertNoPersonalTeamScope } from "./personal-team-scope";
 
+type ScopeRows = {
+  orgs: Array<{ id: string; name: string }>;
+  teams: Array<{ id: string; name: string; isPersonal: boolean }>;
+  projects: Array<{
+    id: string;
+    name: string;
+    isPersonal: boolean;
+    team: { isPersonal: boolean };
+  }>;
+};
+
+/**
+ * The scope rows as the two list surfaces need them: a name per scope, and the
+ * set of scopes that are somebody's personal workspace.
+ *
+ * Either flag is enough to call a project personal. The two are meant to agree,
+ * and a reader that insisted on both would offer a half-migrated row as
+ * manageable access, which is the one answer that is wrong either way.
+ */
+function foldScopeRows({ orgs, teams, projects }: ScopeRows): {
+  scopeNames: Map<string, string>;
+  personalScopeIds: Set<string>;
+} {
+  const scopeNames = new Map<string, string>();
+  for (const scope of [...orgs, ...teams, ...projects]) {
+    scopeNames.set(scope.id, scope.name);
+  }
+
+  const personalScopeIds = new Set<string>();
+  for (const team of teams) {
+    if (team.isPersonal) personalScopeIds.add(team.id);
+  }
+  for (const project of projects) {
+    if (project.isPersonal || project.team.isPersonal) {
+      personalScopeIds.add(project.id);
+    }
+  }
+
+  return { scopeNames, personalScopeIds };
+}
+
 export class RoleBindingService {
   constructor(
     // TODO: complex queries (listForUser, listForOrg, etc.) should be moved to the repository
@@ -96,13 +137,29 @@ export class RoleBindingService {
    * stray binding whose scopeId points outside it (historical data, failed
    * migrations), even though the bindings are already filtered by it.
    */
-  private async resolveScopes(
-    bindings: Array<{ scopeType: RoleBindingScopeType; scopeId: string }>,
-    organizationId: string,
-  ): Promise<{
+  private async resolveScopes({
+    bindings,
+    organizationId,
+  }: {
+    bindings: Array<{ scopeType: RoleBindingScopeType; scopeId: string }>;
+    organizationId: string;
+  }): Promise<{
     scopeNames: Map<string, string>;
     personalScopeIds: Set<string>;
   }> {
+    return foldScopeRows(
+      await this.findScopeRows({ bindings, organizationId }),
+    );
+  }
+
+  /** The scoped rows these bindings point at, one query per scope type. */
+  private async findScopeRows({
+    bindings,
+    organizationId,
+  }: {
+    bindings: Array<{ scopeType: RoleBindingScopeType; scopeId: string }>;
+    organizationId: string;
+  }): Promise<ScopeRows> {
     const idsOfType = (scopeType: RoleBindingScopeType) =>
       bindings.filter((b) => b.scopeType === scopeType).map((b) => b.scopeId);
 
@@ -136,23 +193,7 @@ export class RoleBindingService {
         : [],
     ]);
 
-    const scopeNames = new Map<string, string>();
-    for (const o of orgs) scopeNames.set(o.id, o.name);
-    for (const t of teams) scopeNames.set(t.id, t.name);
-    for (const p of projects) scopeNames.set(p.id, p.name);
-
-    // Either flag is enough to hide a project. The two are meant to agree, and
-    // a reader that insisted on both would offer a half-migrated row as
-    // manageable access, which is the one answer that is wrong either way.
-    const personalScopeIds = new Set<string>();
-    for (const t of teams) {
-      if (t.isPersonal) personalScopeIds.add(t.id);
-    }
-    for (const p of projects) {
-      if (p.isPersonal || p.team.isPersonal) personalScopeIds.add(p.id);
-    }
-
-    return { scopeNames, personalScopeIds };
+    return { orgs, teams, projects };
   }
 
   async listForUser({
@@ -170,10 +211,10 @@ export class RoleBindingService {
       orderBy: { createdAt: "asc" },
     });
 
-    const { scopeNames, personalScopeIds } = await this.resolveScopes(
+    const { scopeNames, personalScopeIds } = await this.resolveScopes({
       bindings,
       organizationId,
-    );
+    });
 
     return bindings
       .filter((b) => !personalScopeIds.has(b.scopeId))
@@ -211,10 +252,10 @@ export class RoleBindingService {
       orderBy: { createdAt: "asc" },
     });
 
-    const { scopeNames, personalScopeIds } = await this.resolveScopes(
+    const { scopeNames, personalScopeIds } = await this.resolveScopes({
       bindings,
       organizationId,
-    );
+    });
     const manageable = bindings.filter((b) => !personalScopeIds.has(b.scopeId));
 
     const groupIds = manageable
@@ -444,7 +485,10 @@ export class RoleBindingService {
     }
 
     await this.repo.validateScopeInOrg({ organizationId, scopeType, scopeId });
-    await assertNoPersonalTeamScope(this.prisma, [{ scopeType, scopeId }]);
+    await assertNoPersonalTeamScope({
+      client: this.prisma,
+      scopes: [{ scopeType, scopeId }],
+    });
     await this.validatePrincipalInOrganization({
       organizationId,
       userId,
@@ -487,7 +531,7 @@ export class RoleBindingService {
     if (!binding) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Binding not found" });
     }
-    await assertNoPersonalTeamScope(this.prisma, [binding]);
+    await assertNoPersonalTeamScope({ client: this.prisma, scopes: [binding] });
     await this.validateCustomRolesAssignable({
       organizationId,
       bindings: [{ role, customRoleId }],
@@ -515,7 +559,7 @@ export class RoleBindingService {
     if (!binding) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Binding not found" });
     }
-    await assertNoPersonalTeamScope(this.prisma, [binding]);
+    await assertNoPersonalTeamScope({ client: this.prisma, scopes: [binding] });
     await this.prisma.roleBinding.delete({ where: { id: bindingId } });
     return { success: true };
   }
@@ -551,7 +595,10 @@ export class RoleBindingService {
         scopeId: b.scopeId,
       });
     }
-    await assertNoPersonalTeamScope(this.prisma, bindingsToCreate);
+    await assertNoPersonalTeamScope({
+      client: this.prisma,
+      scopes: bindingsToCreate,
+    });
     await this.validateCustomRolesAssignable({
       organizationId,
       bindings: bindingsToCreate,
@@ -569,7 +616,7 @@ export class RoleBindingService {
             message: "One or more bindings not found",
           });
         }
-        await assertNoPersonalTeamScope(tx, existing);
+        await assertNoPersonalTeamScope({ client: tx, scopes: existing });
         await tx.roleBinding.deleteMany({
           where: { id: { in: bindingIdsToDelete }, organizationId },
         });
@@ -629,7 +676,10 @@ export class RoleBindingService {
         scopeId: b.scopeId,
       });
     }
-    await assertNoPersonalTeamScope(this.prisma, bindingsToCreate);
+    await assertNoPersonalTeamScope({
+      client: this.prisma,
+      scopes: bindingsToCreate,
+    });
     await this.validateCustomRolesAssignable({
       organizationId,
       bindings: bindingsToCreate,
@@ -672,7 +722,7 @@ export class RoleBindingService {
             message: "One or more bindings not found",
           });
         }
-        await assertNoPersonalTeamScope(tx, existing);
+        await assertNoPersonalTeamScope({ client: tx, scopes: existing });
         await tx.roleBinding.deleteMany({
           where: { id: { in: bindingIdsToDelete }, organizationId, groupId },
         });

--- a/platform/app/src/server/role/role.service.ts
+++ b/platform/app/src/server/role/role.service.ts
@@ -142,18 +142,20 @@ export class RoleService {
       throw new UserNotTeamMemberError();
     }
 
-    await assertNoPersonalTeamScope(this.prisma, [
-      { scopeType: RoleBindingScopeType.TEAM, scopeId: teamId },
-    ]);
+    await assertNoPersonalTeamScope({
+      client: this.prisma,
+      scopes: [{ scopeType: RoleBindingScopeType.TEAM, scopeId: teamId }],
+    });
     await this.repository.assignToUser(userId, teamId, customRoleId);
 
     return { success: true };
   }
 
   async removeRoleFromUser(userId: string, teamId: string) {
-    await assertNoPersonalTeamScope(this.prisma, [
-      { scopeType: RoleBindingScopeType.TEAM, scopeId: teamId },
-    ]);
+    await assertNoPersonalTeamScope({
+      client: this.prisma,
+      scopes: [{ scopeType: RoleBindingScopeType.TEAM, scopeId: teamId }],
+    });
     await this.repository.removeFromUser(userId, teamId);
     return { success: true };
   }

--- a/platform/app/src/server/teams/team.service.ts
+++ b/platform/app/src/server/teams/team.service.ts
@@ -10,7 +10,7 @@ import type {
   RoleBindingRepository,
   TeamScopedMemberBinding,
 } from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
-import { PERSONAL_TEAM_MEMBERSHIP_REFUSAL } from "~/server/app-layer/teams/team.service";
+import { PersonalWorkspaceNotManagedHereError } from "~/server/app-layer/teams/team.service";
 
 // When a user holds multiple bindings on one team, the most privileged is the
 // one the settings page displays (and the binding team.update edits).
@@ -623,7 +623,7 @@ export class TeamService {
         // projection below stops protecting them the moment a group binding
         // exists on the team, so the invariant is stated here directly.
         if (team.isPersonal) {
-          throw new ValidationError(PERSONAL_TEAM_MEMBERSHIP_REFUSAL);
+          throw new PersonalWorkspaceNotManagedHereError(team.name);
         }
 
         // Compute the effective set of admin userIds — direct user ADMIN

--- a/platform/app/src/utils/__tests__/memberRoleConstraints.unit.test.ts
+++ b/platform/app/src/utils/__tests__/memberRoleConstraints.unit.test.ts
@@ -143,7 +143,7 @@ describe("memberRoleConstraints", () => {
     describe("when organization role is Lite Member", () => {
       /** @scenario Switching from Member to Lite Member auto-corrects team role to Viewer */
       /** @scenario Switching from Admin to Lite Member auto-corrects team role to Viewer */
-      /** @scenario Saving a Lite Member update enforces Viewer team role in every team */
+      /** @scenario Saving a Lite Member update enforces Viewer team role in every shared team */
       it("forces Admin to Viewer", () => {
         expect(
           getAutoCorrectedTeamRoleForOrganizationRole({

--- a/specs/ai-gateway/governance/personal-workspace-integrity.feature
+++ b/specs/ai-gateway/governance/personal-workspace-integrity.feature
@@ -115,3 +115,97 @@ Feature: A personal workspace stays one person's
     Given the organization has 1 personal team
     When I rename the personal team
     Then the team is renamed successfully
+
+  # ============================================================================
+  # A seat decision is never blocked by a personal workspace
+  # ============================================================================
+  #
+  # A personal workspace is not one of the organization's teams. It is
+  # provisioned for every member rather than chosen by anyone, and its owner is
+  # its only admin. So the correction that drops a downgraded member to Viewer
+  # covers the shared teams they work in and leaves the workspace that is only
+  # theirs alone: sweeping it in would ask the organization to remove the last
+  # admin of a team, which is refused, and the refusal used to take the seat
+  # change down with it.
+  #
+  # Leaving the workspace alone costs nothing, because a person's organization
+  # role already decides what they can do inside it. A view-only member reads
+  # their workspace and writes nothing, holding the same admin role on it they
+  # always did, which is why nothing has to be rebuilt when they get their full
+  # access back.
+
+  @integration
+  Scenario: Moving a member who has a personal workspace to Lite Member succeeds
+    Given another member of the organization who has a personal workspace
+    And that member is an admin of a shared team
+    When I change that member's organization role to Lite Member
+    Then the member's organization role is Lite Member
+    And their role on the shared team is Viewer
+    And they are still the admin of their own personal workspace
+
+  @integration
+  Scenario: A Lite Member reads their own personal workspace but cannot write to it
+    Given a Lite Member of the organization who has a personal workspace
+    Then they can read their personal workspace
+    But they cannot write to it
+
+  @integration
+  Scenario: Giving a Lite Member their full access back restores writing in their own workspace
+    Given a Lite Member of the organization who has a personal workspace
+    When I change that member's organization role to Member
+    Then they can write to their personal workspace again
+
+  # Read-only and unexplained is indistinguishable from broken: the page renders
+  # in full and only the save fails, so the workspace has to say why itself.
+
+  @integration
+  Scenario: A Lite Member is told why their own workspace takes nothing
+    Given a Lite Member of the organization who has a personal workspace
+    When they open their workspace
+    Then they are told their organization gives them view-only access
+    And a member with full access is told nothing
+
+  @integration
+  Scenario: A personal workspace is not listed among the access an admin manages
+    Given another member of the organization who has a personal workspace
+    When I list the access that member holds in the organization
+    Then their personal workspace is not among it
+
+  # An admin who still finds a way to aim a role change at a personal workspace
+  # gets told which workspace, because "a personal workspace" leaves them looking
+  # for the one they hit among as many as the organization has members.
+
+  @integration
+  Scenario: Refusing a change to a personal workspace says whose workspace it is
+    Given the organization has 1 personal team
+    When I change the owner's role on their personal workspace
+    Then the refusal names the workspace as that member's own
+
+  # ============================================================================
+  # A workspace goes when the access it came with goes
+  # ============================================================================
+  #
+  # Refusing to archive a personal workspace is only defensible because there is
+  # a moment when it does go: when the member stops being a member. That was the
+  # promise the refusal made and the one thing nothing did, so a workspace
+  # outlived its owner's membership, kept its one slot per (organization, owner),
+  # and no admin had any way to be rid of it.
+  #
+  # Archived rather than deleted, like every other project. Which means the slot
+  # is still taken, so provisioning has to recognise its own archived workspace
+  # and revive it, or inviting the same person back would fail on the uniqueness
+  # of a slot nothing can see.
+
+  @integration
+  Scenario: Removing a member takes their personal workspace with them
+    Given another member of the organization who has a personal workspace
+    When I remove that member from the organization
+    Then their personal workspace is archived
+    And its project is archived with it
+
+  @integration
+  Scenario: Inviting a removed member back gives them their workspace again
+    Given a member whose personal workspace was archived when they were removed
+    When that member joins the organization again
+    Then they get the same workspace back rather than a new one
+    And they can reach it

--- a/specs/features/onboarding/intent-fork.feature
+++ b/specs/features/onboarding/intent-fork.feature
@@ -98,6 +98,41 @@ Feature: Onboarding forks on declared intent — Agent Governance vs LLMOps
       When onboarding completes
       Then an organization, a team, and a default project exist for the user
 
+  # ============================================================================
+  # Onboarding is only ever offered to someone who belongs to nothing
+  # ============================================================================
+
+  Rule: a member of an organization is never asked to create one
+
+    # Onboarding is the page that creates an organization, so offering it to
+    # somebody who already belongs to one can only produce a second organization
+    # nobody wanted. Whether they are onboarded used to be read off the
+    # organization's primary intent, which is null for every organization created
+    # before this fork and every one created outside onboarding. So a member who
+    # had just accepted an invitation into such an organization was shown "let's
+    # kick off by creating your organization", and the screen offered nothing else
+    # to do. Reported by a customer whose invited colleague could not escape it.
+
+    @unit
+    Scenario: An invited member of an organization with no shared project goes home
+      Given the user belongs to an organization with no primary intent
+      And that organization has no project in a shared team
+      When the welcome screen decides where they go
+      Then they are sent home rather than into organization creation
+
+    @unit
+    Scenario: A member whose only team is their own workspace goes home
+      Given the user belongs to an organization with no primary intent
+      And their only team there is their personal workspace
+      When the welcome screen decides where they go
+      Then they are sent home rather than into organization creation
+
+    @unit
+    Scenario: Someone who belongs to no organization is still onboarded
+      Given the user belongs to no organization
+      When the welcome screen decides where they go
+      Then they are sent to organization creation
+
   Rule: the governance track provisions the signer's personal workspace
 
     # Coding-agent usage lands in a personal workspace, so /me is empty until

--- a/specs/licensing/seat-reconciliation.feature
+++ b/specs/licensing/seat-reconciliation.feature
@@ -89,3 +89,28 @@ Feature: Reconciling an organization down to its licensed seats
     Given the organization has as many members as its license covers
     When an admin opens the license page
     Then no seat warning is shown
+
+  # ============================================================================
+  # Choosing who keeps a seat, without guessing
+  # ============================================================================
+  #
+  # Reconciling means walking the member list and deciding person by person, and
+  # the two decisions available there are moving someone to a Lite Member seat
+  # and disabling them outright. Each has its own allowance and each is refused
+  # once that allowance runs out, so an admin who cannot see the allowances
+  # learns them one refusal at a time. The member list carries the same seat
+  # counts the license page does, and a refusal names the allowance that ran out
+  # rather than reporting that the action could not be completed.
+
+  @integration
+  Scenario: The member list shows how many seats of each kind are in use
+    When an admin opens the member list
+    Then the full member seats in use are shown against what the license covers
+    And the Lite Member seats in use are shown the same way
+
+  @integration
+  Scenario: Running out of Lite Member seats names that allowance
+    Given the organization has every Lite Member seat in use
+    When an admin moves another member to a Lite Member seat
+    Then the request is refused for exceeding the Lite Member seats
+    And the refusal offers disabling a membership as the reversible alternative

--- a/specs/members/member-role-team-restrictions.feature
+++ b/specs/members/member-role-team-restrictions.feature
@@ -177,14 +177,22 @@ Feature: Member Role Team Restrictions
     Then the change should remain pending
     And the persisted organization role should stay "Member" until I click "Save"
 
+  # The correction reaches the teams the organization shares, not the workspace
+  # each member gets to themselves. That workspace has a single admin, its
+  # owner, so including it would ask the organization to remove a team's last
+  # admin and the whole save would be refused. See
+  # specs/ai-gateway/governance/personal-workspace-integrity.feature for the
+  # scenarios that hold that line.
+
   @integration @unimplemented
-  Scenario: Saving a Lite Member update enforces Viewer team role in every team
+  Scenario: Saving a Lite Member update enforces Viewer team role in every shared team
     Given I am editing a member with organization role "Member"
     And the member has team roles "Admin" and "Member"
     When I change the organization role to "Lite Member"
     And I click "Save"
     Then the member should be saved as "Lite Member"
-    And all of the member team roles should be "Viewer"
+    And all of the member shared team roles should be "Viewer"
+    And their own personal workspace should be untouched
 
   @integration @unimplemented
   Scenario: API rejects non-Viewer team role assignments for Lite Members


### PR DESCRIPTION
## The report

A customer admin was reducing their organization to fit their subscription: move a
few full members down to Lite Member, keep the seats they pay for. Two of those
members had a personal workspace, and the downgrade was refused. Trying the other
route, setting the member to Viewer on that workspace, hit a different refusal
about personal workspaces holding exactly one member. They asked us to either fix
the flow or delete the workspaces.

Every member of every organization is provisioned a personal workspace on
invite-accept, first login and `/me` load, so this was not an edge case: any admin
moving any member to a Lite Member seat hit it.

## What was actually broken

Two failure paths, one cause.

**The seat change.** `organization.updateMemberRole` loaded every team in the
organization with no `isPersonal` filter, in the router and again inside the
repository transaction. `computeEffectiveTeamRoleUpdates` then rewrote every
non-Viewer membership to Viewer, personal team included. A personal workspace's
only admin is its owner, so the loop hit the last-admin guard and threw. The whole
transaction rolled back, which is why the organization role never changed either.

**The per-team change.** `assertNoPersonalTeamScope` refuses any role-binding write
naming a personal workspace, which is correct, and surfaced its internal invariant
sentence verbatim.

**Why the admin was offered a control that cannot work.** The role-binding lists
did not filter personal scopes, so the members table, the member dialog and
`/settings/role-bindings` each rendered an unremovable `ADMIN on <name>'s
Workspace` row per member.

## The fix

A personal workspace is not one of the organization's teams. The member surfaces
now treat it that way, which is the rule the repo already applies in three other
places (`useWorkspaceData.ts:113`, `rbac.ts:1191`, `organization.ts:509`).

- `findSharedTeamIds` is the set a seat decision applies to, and it lives beside
  the refusal it is the counterpart to so the two cannot drift. Both the router
  and the repository resolve through it.
- The two lists an admin manages access from drop personal scopes. Every write
  against one is refused by design, so listing them offered an action that could
  never succeed.
- The refusal is now a `HandledError` with a stable code, customer-facing copy and
  the workspace name in `meta`. That consolidates three shapes the same refusal
  took depending on entry point, including a `ValidationError` whose
  `validation_error` code and 422 both misreported it, and a plain `Error` that
  reached the groups REST boundary as a **500**.

**No new permission logic, and nobody loses admin of their own workspace.** A
member's organization role already caps what any of their non-custom bindings can
do (`resolveBindingPermission`, `rbac.ts:933`), so a Lite Member reads their own
workspace and writes nothing while the owner binding stays exactly as it was.
Getting their full access back restores writes immediately with nothing to repair.
That cap had no test covering a personal workspace; it has one now, because this
design leans on it and `rbac.ts:1141` names retiring it as future work.

## Same journey, two steps further

Once the block is gone, an admin working down the member list hits the next wall
blind: `full-to-lite` is refused once the Lite allowance runs out, `maxMembersLite`
defaults to 1, and the members page showed no seat counts at all.

- The member list now shows full and Lite seats in use against the plan, reusing
  the usage page's `ResourceLimitRow`, and refreshes them after every action that
  moves one: removing a member, disabling one, or changing their seat type. A
  count that lags the action it reports is worse than no count on a page whose
  whole purpose is reconciling against it.
- Both seat refusals name which allowance ran out and offer disabling a
  membership, which is reversible, as the way to free a seat. An admin who hits
  one is reducing, so "upgrade" on its own is the answer they came here to avoid.

## How the unwanted workspaces got there

- An invited member of an organization with no project in a shared team was shown
  "let's kick off by creating your organization", with nothing else on the screen
  to do. Onboardedness was read off `primaryIntent`, which is null for every
  organization created before ADR-038 and every one created outside onboarding.
  Belonging to an organization is the test now, matching what `pages/index.tsx`
  already does.
- Removing a membership deleted the `OrganizationUser` and its role bindings and
  left the personal team and project behind, owned by a non-member and still
  holding their one slot per (organization, owner), while
  `PERSONAL_TEAM_ARCHIVE_REFUSAL` told admins these workspaces disappear with the
  member's access. They now do. Archived rather than deleted, so provisioning
  revives its own archived workspace and inviting the person back returns the same
  one, binding included, instead of failing on a slot nothing can see.

That is also the honest answer to "can you delete these personal workspaces":
remove the member and the workspace goes with their access.

## What it looks like

Personal workspaces gone from the Access column, both seat counts on the page:

![members page](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/lite-member-personal-workspace/01-members-seats-and-access.png)

The downgrade that used to fail, with the shared team corrected to Viewer:

![after downgrade](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/lite-member-personal-workspace/02-after-lite-downgrade.png)

Seat counts move, which is the whole point of a reduction pass:

![seats after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/lite-member-personal-workspace/04-seats-after-reduction.png)

What the downgraded member sees on their own workspace. `/me` keeps working,
including the AI tools portal Lite Members are meant to reach:

![me notice](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/lite-member-personal-workspace/03-me-view-only-notice.png)

## Specs and tests

Specs first, all bound (`check-feature-parity` passes):

- `specs/ai-gateway/governance/personal-workspace-integrity.feature` gains the
  seat decision that has to succeed, the read-only guarantee, the restore, the
  hidden-from-management rule, the named refusal, and the removal lifecycle.
- `specs/licensing/seat-reconciliation.feature` gains the seat counts and the
  named allowance.
- `specs/features/onboarding/intent-fork.feature` gains the rule that a member is
  never asked to create an organization.
- `specs/members/member-role-team-restrictions.feature` had a scenario stating the
  correction covers "every team", which this makes false; it says shared team now.

The seat-decision block in `personal-workspace-invariants.integration.test.ts` is
the only one in that suite proving a mutation *succeeds*, driven through the real
tRPC router against a real organization service, with the read-only cap checked
through the real resolver. `personal-workspace-lifecycle.integration.test.ts`
covers archive-on-removal and revive-on-return together, because archiving alone
would brick the slot.

## Verified

- `pnpm typecheck:all`, `pnpm lint`, `check-feature-parity` clean.
- Unit and the affected integration suites pass; the two flakes seen under load
  (`ssrfProtection`, `hono-bridge-streaming`) pass in isolation and are unrelated.
- Browser QA against `pnpm dev` end to end, as both the admin and the downgraded
  member, with the resulting Postgres rows checked: organization role `EXTERNAL`,
  shared team `VIEWER`, personal workspace still `ADMIN` and unarchived.

## Deliberately unchanged

Personal virtual keys stay open to Lite Members. Consuming org-published AI tools
through a personal key against a personal budget is the governance use case from
ADR-038, and the spend is metered, so it is not a seat loophole. Retiring
`EXTERNAL` as a permission gate is left alone: that refactor has to answer this
same question and should not ride along here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lite Members receive view-only messaging for personal workspaces while retaining ownership and read access.
  * Organization settings show full and Lite Member seat usage against plan limits.
  * Limit messages explain how disabling memberships can free seats without removing roles or activity.
* **Bug Fixes**
  * Personal workspaces are archived when members leave and restored when they rejoin.
  * Organization role changes no longer affect personal workspaces.
  * Onboarding and redirects correctly handle existing organization members.
* **Documentation**
  * Added coverage for workspace lifecycle, access restrictions, seat limits, and onboarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->