### PR TITLE
ci: publish container images to artifacts ECR via OIDC

### DIFF
--- a/.github/workflows/publish-docker-ecr.yml
+++ b/.github/workflows/publish-docker-ecr.yml
@@ -84,10 +84,40 @@ jobs:
           IS_RELEASE="false"
           IMAGE_TAG="git-${SHORT_HASH}"
 
+          # Both branches below turn external input into a Docker tag. Reject a
+          # malformed one here, where the run has cost nothing, rather than at
+          # the manifest step after eight images have already been pushed.
+          #
+          # `case` rather than `grep -E '^…$'`: grep matches line by line, so a
+          # value whose FIRST line is well formed passes even when the rest is
+          # not — and a newline is the input that matters most here, because the
+          # `key=value` writes below are line-oriented and a second line would
+          # define further step outputs. A shell glob matches the whole string,
+          # newlines included.
+          assert_docker_tag() {
+            case "$2" in
+              "") echo "::error::$1 is empty"; exit 1 ;;
+              *[!A-Za-z0-9._-]* | [!A-Za-z0-9_]*)
+                echo "::error::$1 must match ^[A-Za-z0-9_][A-Za-z0-9._-]*$"; exit 1 ;;
+            esac
+            if [ "${#2}" -gt 128 ]; then
+              echo "::error::$1 is longer than the 128 characters a Docker tag allows"; exit 1
+            fi
+          }
+
           if [ "${EVENT_NAME}" = "release" ]; then
+            # The gate on this job accepts any `langwatch@` tag, including one
+            # without the `v`. The prefix strip below would then leave VERSION as
+            # the whole ref, and `@` is not a legal tag character.
+            case "${GITHUB_REF}" in
+              refs/tags/langwatch@v*) ;;
+              *) echo "::error::release ref ${GITHUB_REF} is not a langwatch@v* tag"; exit 1 ;;
+            esac
             VERSION="${GITHUB_REF#refs/tags/langwatch@v}"
+            assert_docker_tag "release version" "${VERSION}"
             IS_RELEASE="true"
           elif [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${INPUT_IMAGE_TAG}" ]; then
+            assert_docker_tag "image_tag" "${INPUT_IMAGE_TAG}"
             IMAGE_TAG="${INPUT_IMAGE_TAG}"
           fi
 
@@ -105,12 +135,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: meta
     outputs:
-      # A JSON `include:` list, one entry per (image, arch) still worth building,
-      # and the matching list of image names. These are matrices rather than four
-      # booleans because `jobs.<job_id>.if` cannot read the `matrix` context, so a
+      # A JSON `include:` list, one entry per (image, arch) worth rebuilding, and
+      # the matching list of image names. A matrix rather than four booleans
+      # because `jobs.<job_id>.if` cannot read the `matrix` context, so a
       # per-image gate has to be applied before the matrix is expanded.
+      #
+      # `built` is NOT the set of images that get a tag this run — every image
+      # gets one, see create-manifest. It is only the set that needs rebuilding.
       build-matrix: ${{ steps.select.outputs.build-matrix }}
-      images: ${{ steps.select.outputs.images }}
+      built: ${{ steps.select.outputs.built }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -202,7 +235,7 @@ jobs:
           )
 
           if [ "${IS_PUSH}" = "true" ]; then
-            IMAGES=$(jq -cn \
+            BUILT=$(jq -cn \
               --arg app "${LANGWATCH_APP}" \
               --arg nlp "${LANGWATCH_NLP_SERVICE}" \
               --arg evals "${LANGWATCH_LANGEVALS}" \
@@ -213,18 +246,18 @@ jobs:
                  "langwatch-gateway": $gateway}
                 | to_entries[] | select(.value == "true") | .key]')
           else
-            IMAGES=$(printf '%s' "${ALL}" | jq -c '[.[].image] | unique')
+            BUILT=$(printf '%s' "${ALL}" | jq -c '[.[].image] | unique')
           fi
 
-          MATRIX=$(printf '%s' "${ALL}" | jq -c --argjson images "${IMAGES}" \
-            '[.[] | select(.image as $i | $images | index($i))]')
-
-          echo "images=${IMAGES}" >> "$GITHUB_OUTPUT"
-          echo "build-matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          MATRIX=$(printf '%s' "${ALL}" | jq -c --argjson built "${BUILT}" \
+            '[.[] | select(.image as $i | $built | index($i))]')
 
           {
-            echo "Images selected: ${IMAGES}"
-          } >> "$GITHUB_STEP_SUMMARY"
+            echo "built=${BUILT}"
+            echo "build-matrix=${MATRIX}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Images to rebuild: ${BUILT}" >> "$GITHUB_STEP_SUMMARY"
 
   build-and-push:
     needs: [meta, changes]
@@ -294,9 +327,23 @@ jobs:
           tags: |
             ${{ steps.ecr.outputs.registry }}/${{ matrix.image }}:${{ needs.meta.outputs.image_tag }}-${{ matrix.arch }}
 
+  # EVERY image gets this commit's tag, including the ones the path filter
+  # skipped. The point of the whole workflow is that SaaS can pin one `git-<sha>`
+  # across the whole deployment; if a docs-plus-gateway commit published
+  # `langwatch-gateway:git-abc` and nothing else, that pin would fail to resolve
+  # for the other three. A skipped image is re-tagged from the manifest it
+  # already has, which costs a manifest PUT and no build.
+  #
+  # `!cancelled()` because build-and-push reports `skipped` when nothing needed
+  # rebuilding, and this job still has four tags to write in that case. It brings
+  # the implicit "all needs succeeded" check with it, hence the explicit results.
   create-manifest:
     needs: [meta, changes, build-and-push]
-    if: needs.changes.outputs.images != '[]'
+    if: >-
+      ${{ !cancelled()
+          && needs.meta.result == 'success'
+          && needs.changes.result == 'success'
+          && needs.build-and-push.result != 'failure' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -304,7 +351,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(needs.changes.outputs.images) }}
+        image:
+          - langwatch-app
+          - langwatch-nlp-service
+          - langwatch-langevals
+          - langwatch-gateway
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -329,24 +380,50 @@ jobs:
 
       # No `:latest` here, on purpose — see the header. The SaaS pipeline owns
       # that tag on these repositories.
-      - name: Create multi-arch manifest
+      - name: Publish this commit's tag
         env:
           IMAGE: ${{ matrix.image }}
           REPO: ${{ steps.ecr.outputs.registry }}/${{ matrix.image }}
+          BUILT: ${{ needs.changes.outputs.built }}
           IMAGE_TAG: ${{ needs.meta.outputs.image_tag }}
           IS_RELEASE: ${{ needs.meta.outputs.is_release }}
           VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -euo pipefail
-          docker buildx imagetools create -t "${REPO}:${IMAGE_TAG}" \
-            "${REPO}:${IMAGE_TAG}-amd64" \
-            "${REPO}:${IMAGE_TAG}-arm64"
+
+          if printf '%s' "${BUILT}" | jq -e --arg i "${IMAGE}" 'index($i)' >/dev/null; then
+            # Rebuilt this run: assemble the index from the per-arch tags.
+            SOURCES=("${REPO}:${IMAGE_TAG}-amd64" "${REPO}:${IMAGE_TAG}-arm64")
+          else
+            # Not rebuilt: point this commit's tag at the index already published
+            # for the last commit that did change this image. `imagetools create`
+            # from a single index copies it, so this writes a manifest and moves
+            # no layers.
+            #
+            # Newest first, bare `git-<sha>` only — the per-arch `-amd64` /
+            # `-arm64` tags are pushed just before their index and are not
+            # multi-arch, so matching one here would publish a single-arch image
+            # under a tag consumers expect to be multi-arch.
+            PREVIOUS=$(aws ecr describe-images --repository-name "${IMAGE}" \
+              --query 'reverse(sort_by(imageDetails, &imagePushedAt))[].imageTags[]' \
+              --output text \
+              | tr '\t' '\n' | grep -E '^git-[0-9a-f]+$' | head -n 1 || true)
+
+            if [ -z "${PREVIOUS}" ]; then
+              # Expected until every image has been published once. A dispatch
+              # run builds all four and seeds them.
+              echo "::warning::${IMAGE} has no previous git-* manifest to re-tag as ${IMAGE_TAG}; run this workflow via workflow_dispatch to seed it"
+              exit 0
+            fi
+            echo "Re-tagging ${IMAGE} ${PREVIOUS} -> ${IMAGE_TAG} (unchanged by this commit)"
+            SOURCES=("${REPO}:${PREVIOUS}")
+          fi
+
+          docker buildx imagetools create -t "${REPO}:${IMAGE_TAG}" "${SOURCES[@]}"
 
           TAGS="${IMAGE_TAG}"
           if [ "${IS_RELEASE}" = "true" ]; then
-            docker buildx imagetools create -t "${REPO}:${VERSION}" \
-              "${REPO}:${IMAGE_TAG}-amd64" \
-              "${REPO}:${IMAGE_TAG}-arm64"
+            docker buildx imagetools create -t "${REPO}:${VERSION}" "${SOURCES[@]}"
             TAGS="${TAGS}, ${VERSION}"
           fi
 

--- a/.github/workflows/publish-docker-ecr.yml
+++ b/.github/workflows/publish-docker-ecr.yml
@@ -1,0 +1,353 @@
+name: publish-docker-ecr
+
+# Mirrors the Docker Hub publish flow (publish-docker-app.yml) into the LangWatch
+# shared "artifacts" AWS account ECR, so the private SaaS deployment can pin an
+# OSS-built `git-<sha>` image instead of rebuilding this same source itself.
+#
+# Why a second workflow rather than extra steps in publish-docker-app.yml:
+#   - Different trigger surface. ECR also publishes on every merge to main, so
+#     SaaS always has a `git-<sha>` to pin. Docker Hub stays release/dispatch-only.
+#   - Different auth. GitHub OIDC role assumption into the artifacts account —
+#     no long-lived AWS keys in this public repository.
+#   - Different tag policy. This workflow NEVER pushes `:latest`. The SaaS
+#     pipeline still owns that tag on these repositories, and racing it would
+#     silently repoint production.
+#
+# The tags written here, and only these:
+#   - `git-<short-sha>`   always
+#   - `<version>`         additionally, on a `langwatch@v*` release
+#   - `<image_tag>`       instead of `git-<short-sha>`, on a manual dispatch
+#                         that supplies one
+#
+# The OIDC role (`langwatch-oss-ecr-push`, langwatch/langwatch-saas#486) trusts
+# exactly two subjects: `refs/heads/main` and `refs/tags/langwatch@v*`. There is
+# deliberately no `pull_request` trigger — a PR-ref assume-role is denied by that
+# trust policy, so a PR-triggered run could only ever fail. End-to-end
+# verification happens on the first merge to main.
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Custom image tag (default: git-<short-sha>)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# Never cancel in flight. A superseded run may already have pushed some of the
+# per-arch layers, and every commit that lands on main needs its own `git-<sha>`
+# published rather than being voided by the commit after it — the same rule
+# code-scanners.yml and langwatch-app-ci.yml apply to main.
+concurrency:
+  group: publish-docker-ecr-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    # Same release gate as publish-docker-app.yml. This repository cuts releases
+    # under several tag prefixes (sdk-python@, mcp@, ...) and only `langwatch@v*`
+    # describes these images — it is also the only tag shape the OIDC trust
+    # policy accepts.
+    if: >-
+      github.event_name != 'release'
+      || startsWith(github.event.release.tag_name, 'langwatch@')
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      version: ${{ steps.meta.outputs.version }}
+      is_release: ${{ steps.meta.outputs.is_release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve tags
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          SHORT_HASH=$(git rev-parse --short HEAD)
+
+          VERSION=""
+          IS_RELEASE="false"
+          IMAGE_TAG="git-${SHORT_HASH}"
+
+          if [ "${EVENT_NAME}" = "release" ]; then
+            VERSION="${GITHUB_REF#refs/tags/langwatch@v}"
+            IS_RELEASE="true"
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${INPUT_IMAGE_TAG}" ]; then
+            IMAGE_TAG="${INPUT_IMAGE_TAG}"
+          fi
+
+          {
+            echo "image_tag=${IMAGE_TAG}"
+            echo "is_release=${IS_RELEASE}"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+  # On push:[main], skip the images a commit cannot have affected so a docs-only
+  # merge does not pay for four multi-arch builds. Release and dispatch always
+  # build everything — those are the runs someone is waiting on a complete set
+  # from.
+  changes:
+    runs-on: ubuntu-latest
+    needs: meta
+    outputs:
+      # A JSON `include:` list, one entry per (image, arch) still worth building,
+      # and the matching list of image names. These are matrices rather than four
+      # booleans because `jobs.<job_id>.if` cannot read the `matrix` context, so a
+      # per-image gate has to be applied before the matrix is expanded.
+      build-matrix: ${{ steps.select.outputs.build-matrix }}
+      images: ${{ steps.select.outputs.images }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+          # Nothing here reads working-tree content: dorny/paths-filter diffs two
+          # commits out of the object store, and the rest of this job is jq.
+          sparse-checkout: .github
+
+      # NO NEGATION PATTERNS — dorny ORs a filter's patterns, so a lone `!x`
+      # matches everything. See specs/ci/path-filters.feature.
+      #
+      # Each list mirrors the COPY lines of the corresponding Dockerfile, plus
+      # this workflow itself so a change to the build definition republishes
+      # every image it describes.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        if: github.event_name == 'push'
+        id: filter
+        with:
+          filters: |
+            langwatch-app:
+              - 'infra/docker/Dockerfile'
+              - 'infra/docker/Dockerfile.langyagent'
+              - 'platform/app/**'
+              - 'packages/**'
+              - 'mcp/typescript/**'
+              - 'sdks/typescript/**'
+              - 'skills/**'
+              - 'services/langevals/ts-integration/evaluators.generated.ts'
+              - 'tests/agentic-e2e/package.json'
+              - 'feature-map.json'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - '.github/workflows/publish-docker-ecr.yml'
+            langwatch-nlp-service:
+              - 'infra/docker/Dockerfile.langwatch_nlp'
+              - 'cmd/**'
+              - 'pkg/**'
+              - 'services/**'
+              - 'sdks/go/**'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/publish-docker-ecr.yml'
+            langwatch-langevals:
+              - 'infra/docker/Dockerfile.langevals'
+              - 'services/langevals/**'
+              - '.github/workflows/publish-docker-ecr.yml'
+            langwatch-gateway:
+              - 'infra/docker/Dockerfile.go_service'
+              - 'cmd/**'
+              - 'pkg/**'
+              - 'services/**'
+              - 'sdks/go/**'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/publish-docker-ecr.yml'
+
+      - name: Select the images to build
+        id: select
+        env:
+          IS_PUSH: ${{ github.event_name == 'push' }}
+          LANGWATCH_APP: ${{ steps.filter.outputs.langwatch-app }}
+          LANGWATCH_NLP_SERVICE: ${{ steps.filter.outputs.langwatch-nlp-service }}
+          LANGWATCH_LANGEVALS: ${{ steps.filter.outputs.langwatch-langevals }}
+          LANGWATCH_GATEWAY: ${{ steps.filter.outputs.langwatch-gateway }}
+        run: |
+          set -euo pipefail
+
+          # The full build table. `image` doubles as the ECR repository name and
+          # as the key of the path filter above, so the two cannot drift.
+          #
+          # Runner labels mirror publish-docker-app.yml: the app's arm64 build
+          # needs the 32GB larger runner for the pnpm/vite bundle, everything
+          # else fits on the standard hosted arm runner.
+          ALL=$(cat <<'JSON'
+          [
+            {"image":"langwatch-app",         "dockerfile":"infra/docker/Dockerfile",              "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
+            {"image":"langwatch-app",         "dockerfile":"infra/docker/Dockerfile",              "arch":"arm64","platform":"linux/arm64/v8","runner":"arm64-runner-32gb"},
+            {"image":"langwatch-nlp-service", "dockerfile":"infra/docker/Dockerfile.langwatch_nlp","arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
+            {"image":"langwatch-nlp-service", "dockerfile":"infra/docker/Dockerfile.langwatch_nlp","arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"},
+            {"image":"langwatch-langevals",   "dockerfile":"infra/docker/Dockerfile.langevals",    "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
+            {"image":"langwatch-langevals",   "dockerfile":"infra/docker/Dockerfile.langevals",    "arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"},
+            {"image":"langwatch-gateway",     "dockerfile":"infra/docker/Dockerfile.go_service",   "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
+            {"image":"langwatch-gateway",     "dockerfile":"infra/docker/Dockerfile.go_service",   "arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"}
+          ]
+          JSON
+          )
+
+          if [ "${IS_PUSH}" = "true" ]; then
+            IMAGES=$(jq -cn \
+              --arg app "${LANGWATCH_APP}" \
+              --arg nlp "${LANGWATCH_NLP_SERVICE}" \
+              --arg evals "${LANGWATCH_LANGEVALS}" \
+              --arg gateway "${LANGWATCH_GATEWAY}" \
+              '[{"langwatch-app": $app,
+                 "langwatch-nlp-service": $nlp,
+                 "langwatch-langevals": $evals,
+                 "langwatch-gateway": $gateway}
+                | to_entries[] | select(.value == "true") | .key]')
+          else
+            IMAGES=$(printf '%s' "${ALL}" | jq -c '[.[].image] | unique')
+          fi
+
+          MATRIX=$(printf '%s' "${ALL}" | jq -c --argjson images "${IMAGES}" \
+            '[.[] | select(.image as $i | $images | index($i))]')
+
+          echo "images=${IMAGES}" >> "$GITHUB_OUTPUT"
+          echo "build-matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "Images selected: ${IMAGES}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-and-push:
+    needs: [meta, changes]
+    # An empty `include:` is a workflow startup error, so the "nothing changed"
+    # case has to be caught here rather than by the matrix.
+    if: needs.changes.outputs.build-matrix != '[]'
+    permissions:
+      contents: read
+      id-token: write # OIDC assume-role into the artifacts account
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.changes.outputs.build-matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.ARTIFACTS_ECR_OIDC_ROLE_ARN }}
+          role-session-name: publish-docker-ecr-${{ github.run_id }}
+
+      # The AWS CLI rather than aws-actions/amazon-ecr-login: every `uses:` in
+      # this repository is a first-party action or an already-approved pin, and
+      # an unapproved third-party reference fails the run at startup (see the
+      # note in code-scanners.yml). The CLI ships on the hosted runner images.
+      #
+      # The registry host is derived from the role ARN so the AWS account id
+      # stays in a secret rather than being written into this public file.
+      - name: Log in to Amazon ECR
+        id: ecr
+        env:
+          ROLE_ARN: ${{ secrets.ARTIFACTS_ECR_OIDC_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(printf '%s' "${ROLE_ARN}" | cut -d: -f5)"
+          echo "::add-mask::${ACCOUNT_ID}"
+          REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+          aws ecr get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${REGISTRY}"
+
+      - name: Build and push ${{ matrix.image }} (${{ matrix.arch }})
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: ${{ matrix.platform }}
+          # Keep each per-arch push a plain manifest. With provenance on, buildx
+          # pushes an index carrying an attestation manifest, and the multi-arch
+          # index assembled below would then nest indexes — which several ECR
+          # consumers (Lambda in particular) refuse to run.
+          provenance: false
+          cache-from: type=gha,scope=ecr-${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ecr-${{ matrix.image }}-${{ matrix.arch }}
+          tags: |
+            ${{ steps.ecr.outputs.registry }}/${{ matrix.image }}:${{ needs.meta.outputs.image_tag }}-${{ matrix.arch }}
+
+  create-manifest:
+    needs: [meta, changes, build-and-push]
+    if: needs.changes.outputs.images != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC assume-role into the artifacts account
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.ARTIFACTS_ECR_OIDC_ROLE_ARN }}
+          role-session-name: publish-docker-ecr-manifest-${{ github.run_id }}
+
+      # See the note on the same step in build-and-push above.
+      - name: Log in to Amazon ECR
+        id: ecr
+        env:
+          ROLE_ARN: ${{ secrets.ARTIFACTS_ECR_OIDC_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(printf '%s' "${ROLE_ARN}" | cut -d: -f5)"
+          echo "::add-mask::${ACCOUNT_ID}"
+          REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+          aws ecr get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${REGISTRY}"
+
+      # No `:latest` here, on purpose — see the header. The SaaS pipeline owns
+      # that tag on these repositories.
+      - name: Create multi-arch manifest
+        env:
+          IMAGE: ${{ matrix.image }}
+          REPO: ${{ steps.ecr.outputs.registry }}/${{ matrix.image }}
+          IMAGE_TAG: ${{ needs.meta.outputs.image_tag }}
+          IS_RELEASE: ${{ needs.meta.outputs.is_release }}
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create -t "${REPO}:${IMAGE_TAG}" \
+            "${REPO}:${IMAGE_TAG}-amd64" \
+            "${REPO}:${IMAGE_TAG}-arm64"
+
+          TAGS="${IMAGE_TAG}"
+          if [ "${IS_RELEASE}" = "true" ]; then
+            docker buildx imagetools create -t "${REPO}:${VERSION}" \
+              "${REPO}:${IMAGE_TAG}-amd64" \
+              "${REPO}:${IMAGE_TAG}-arm64"
+            TAGS="${TAGS}, ${VERSION}"
+          fi
+
+          echo "Published \`${IMAGE}\` to ECR with tags: ${TAGS}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docker-ecr.yml
+++ b/.github/workflows/publish-docker-ecr.yml
@@ -97,6 +97,10 @@ jobs:
           assert_docker_tag() {
             case "$2" in
               "") echo "::error::$1 is empty"; exit 1 ;;
+              # The one tag this workflow must never write. Nothing else here
+              # can produce it — but a dispatcher can type it into the input
+              # box, and a `langwatch@vlatest` tag would reach the same place.
+              latest) echo "::error::$1 must not be 'latest'; the SaaS pipeline owns that tag"; exit 1 ;;
               *[!A-Za-z0-9._-]* | [!A-Za-z0-9_]*)
                 echo "::error::$1 must match ^[A-Za-z0-9_][A-Za-z0-9._-]*$"; exit 1 ;;
             esac
@@ -404,10 +408,16 @@ jobs:
             # `-arm64` tags are pushed just before their index and are not
             # multi-arch, so matching one here would publish a single-arch image
             # under a tag consumers expect to be multi-arch.
-            PREVIOUS=$(aws ecr describe-images --repository-name "${IMAGE}" \
+            # The lookup and the match are separate statements on purpose. With
+            # both in one pipeline, the `|| true` that keeps a no-match from
+            # tripping `set -e` also swallows a failed `describe-images` — and
+            # the job would then report success having written no tag at all.
+            # awk exits 0 on no match, so only a genuine AWS failure stops here.
+            CANDIDATES=$(aws ecr describe-images --repository-name "${IMAGE}" \
               --query 'reverse(sort_by(imageDetails, &imagePushedAt))[].imageTags[]' \
-              --output text \
-              | tr '\t' '\n' | grep -E '^git-[0-9a-f]+$' | head -n 1 || true)
+              --output text)
+            PREVIOUS=$(printf '%s' "${CANDIDATES}" | tr '\t' '\n' \
+              | awk '/^git-[0-9a-f]+$/ { print; exit }')
 
             if [ -z "${PREVIOUS}" ]; then
               # Expected until every image has been published once. A dispatch


### PR DESCRIPTION
## Why

The OSS build already produces every container image the LangWatch SaaS deployment runs, but SaaS could not consume them: they only landed on Docker Hub, so the private pipeline rebuilt the same source from a git submodule. Two builds of one tree, and a permanent opportunity for them to disagree.

This publishes the same images to the LangWatch shared **artifacts** AWS account ECR as well, so SaaS can pin an OSS-built `git-<sha>` instead of rebuilding.

Supersedes #3709. That PR was closed because its stated dependency — langwatch/langwatch-saas#486, which creates the `langwatch-oss-ecr-push` IAM role and the GitHub OIDC provider — had not landed. **It merged on 2026-05-05, so the role exists now.** #3709's branch was deleted and could not be reopened, and its tree was 7 months stale anyway (see "What changed" for the paths that moved).

## What changed

One new file: `.github/workflows/publish-docker-ecr.yml`. Nothing else is touched — in particular `publish-docker-app.yml` is left exactly as it is, and keeps its own triggers, credentials and `:latest`.

- **Triggers:** `release: [published]` (gated to `langwatch@v*` tags), `push: [main]`, and `workflow_dispatch` with an optional `image_tag`.
- **Images:** multi-arch (amd64 + arm64) for `langwatch-app`, `langwatch-nlp-service`, `langwatch-langevals`, `langwatch-gateway`.
- **Auth:** GitHub OIDC assume-role into `langwatch-oss-ecr-push`. No long-lived AWS keys in this public repository.
- **Path filters** skip *rebuilding* images a `push: [main]` commit cannot have affected; release and dispatch always rebuild everything. Every image still gets this commit's tag — see below.

### Every `git-<sha>` resolves for every image

The point of the workflow is that SaaS can pin **one** `git-<sha>` across the whole deployment. Path filtering on its own breaks that: a commit touching only `platform/app/**` would publish `langwatch-app:git-abc` and nothing else, and a uniform pin would fail to resolve for the other three repositories.

So the filter gates the *build*, not the *tag*. `create-manifest` runs for all four images on every run: an image that was rebuilt gets its index assembled from the per-arch tags just pushed, and an image that was not gets this commit's tag pointed at the index it already has (`imagetools create` from a single index writes a manifest and moves no layers). Cost of a skipped image is one manifest PUT.

Until an image has been published at least once there is nothing to re-tag; that case logs a `::warning::` rather than failing, and a `workflow_dispatch` run rebuilds all four and seeds them. Doing that dispatch right after the first merge is the cleanest bootstrap.

### Tag policy

| Event | Tags written |
|---|---|
| push to `main` | `git-<short-sha>` |
| `langwatch@v*` release | `git-<short-sha>` **and** `<version>` |
| `workflow_dispatch` | `git-<short-sha>`, or the supplied `image_tag` |

**Never `:latest`.** The SaaS pipeline still owns `:latest` on these ECR repositories; racing it would silently repoint production. That is stated in the workflow header and in a comment on the manifest step so it does not get "helpfully" added later.

## How it works

Same shape as `publish-docker-app.yml`: a per-arch build matrix pushes `…:<tag>-amd64` / `…:<tag>-arm64`, then a `create-manifest` job assembles the multi-arch index with `docker buildx imagetools create`. Runner labels are copied from that workflow too — the app's arm64 build gets `arm64-runner-32gb` for the pnpm/vite bundle, everything else uses `ubuntu-24.04-arm`.

Two places where it deliberately differs:

- **ECR login uses the AWS CLI, not `aws-actions/amazon-ecr-login`.** Every `uses:` in this repository is a first-party action or an already-approved pin, and an unapproved third-party reference fails the run at startup (the lesson recorded in `code-scanners.yml`). `aws-actions/configure-aws-credentials` is already approved and in use in `embedded-binaries-publish.yml`; the ECR token is then fetched with `aws ecr get-login-password`, which needs no new approval.
- **The build matrix is emitted as JSON by the `changes` job** rather than written statically with a per-entry `if:`. `jobs.<job_id>.if` cannot read the `matrix` context, so a per-image gate has to be applied *before* the matrix expands, or the gated jobs still claim a runner. Same `fromJSON(needs.changes.outputs.…)` pattern `langwatch-app-ci.yml` uses for its test shards.

`provenance: false` on the per-arch builds keeps each push a plain manifest; with provenance on, buildx pushes an index carrying an attestation manifest and the multi-arch index assembled afterwards would nest indexes, which several ECR consumers (Lambda in particular) refuse to run.

### Paths corrected versus #3709

The repository was restructured by ADR-076 (#6405) after that PR was written, so every path in it was wrong. Cross-checked against the current `publish-docker-app.yml` and the current Dockerfiles:

| #3709 | Now |
|---|---|
| `Dockerfile` | `infra/docker/Dockerfile` |
| `Dockerfile.langwatch_nlp` | `infra/docker/Dockerfile.langwatch_nlp` |
| `Dockerfile.langevals` | `infra/docker/Dockerfile.langevals` |
| `Dockerfile.go_service` | `infra/docker/Dockerfile.go_service` |
| filter `langwatch/**` | `platform/app/**` |
| filter `python-sdk/**` | `sdks/python/**` (no longer an input to any of these images) |
| filter `typescript-sdk/package.json` | `sdks/typescript/**` |
| filter `mcp-server/**` | `mcp/typescript/**` |
| filter `langevals/**` | `services/langevals/**` |

`langwatch-nlp-lambda` is **dropped**: `Dockerfile.langwatch_nlp.lambda` was deleted in #4653 ("remove the python langwatch_nlp service, nlpgo is the only engine"), so this repository no longer builds that image at all. The ECR repository and the IAM grant for it still exist and are simply unused by this workflow.

`langyagent` is **not** included: `publish-docker-app.yml` builds it for Docker Hub, but there is no `langwatch-langyagent` ECR repository and the IAM policy does not grant push to one. Adding it needs a terraform change first.

The path filters now mirror the `COPY` lines of each Dockerfile, including the root workspace files (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`, `.npmrc`) that a dependency bump touches and nothing else — the case `langwatch-app-ci.yml` documents as the common one, not the odd one.

## Test plan

- `actionlint` (with shellcheck) is clean on the new file; the rest of the repository's pre-existing findings are unchanged.
- `node --experimental-strip-types .github/scripts/guard-pull-request-target.ts` passes — this workflow does not use `pull_request_target`, so it is outside the guard's scope, but the guard was run to confirm nothing regressed.
- The three non-trivial shell steps were extracted from the YAML after a parse round-trip and executed locally:
  - **tag resolution** across all event shapes (release → `git-<sha>` + `1.42.0`; dispatch with `image_tag` → that tag; dispatch without → `git-<sha>`; push → `git-<sha>`), plus every rejection: a `langwatch@1.2.3` tag without the `v`, an `image_tag` with a leading `-`, an `image_tag` containing a newline, and `latest` arriving by either route (`image_tag=latest` or a `langwatch@vlatest` tag);
  - **matrix selection** for release/dispatch (all four images), for a push touching one image (that image's two arches only), and for a push touching none (`[]`, which the job-level `if` catches before an empty `include:` becomes a startup error);
  - **tag publication** with `docker` and `aws` stubbed: rebuilt (assembles from per-arch tags), not rebuilt (re-tags the previous index, correctly preferring the bare `git-<sha>` over the `-amd64` / `-arm64` siblings), not rebuilt with nothing published yet (warns, exit 0), release (writes the version tag from the same sources), and a stubbed `AccessDeniedException` from `describe-images` (fails the job rather than reporting success with no tag written).
- No path-filter negation patterns, per `specs/ci/path-filters.feature`. No `pull_request` trigger, so no `-unmodified` stub is required.

**End-to-end verification is only possible on the first merge to `main`.** The OIDC trust policy accepts exactly `repo:langwatch/langwatch:ref:refs/heads/main` and `repo:langwatch/langwatch:ref:refs/tags/langwatch@v*`; an assume-role from a PR ref is denied by design. Adding a `pull_request` trigger to "prove it works" would produce a guaranteed red check and nothing else, so this PR does not do that. What CI can prove here is that the workflow lints, parses, and satisfies the repository's workflow gates — the push to ECR itself is proven by the first merge.

## Anything surprising?

**Prerequisite — a repository secret must exist before the first merge to `main`:**

- `ARTIFACTS_ECR_OIDC_ROLE_ARN` — the ARN of the `langwatch-oss-ecr-push` role in the artifacts account (`arn:aws:iam::<artifacts-account-id>:role/langwatch-oss-ecr-push`). The value is deliberately **not** in this diff: this is a public repository, and the registry hostname is derived from the ARN at run time (with the account id masked) so the account id never appears in the file. Without the secret the first run fails at assume-role, having pushed nothing.

The region (`eu-central-1`) is in the workflow as plain text — it already is in `embedded-binaries-publish.yml`, and it is not sensitive.

**Follow-ups for the infra side, not blockers:**

1. **ECR lifecycle retention.** Those repositories keep the 100 most recent images. A rebuilt image adds three entries (two per-arch manifests plus the index); a re-tagged one adds none, because the tag lands on an image that is already there. So the pressure is roughly 30 merges of retained history for whichever image changes most often — after which an older `git-<sha>` that SaaS is still pinned to can be expired. Either raise `countNumber`, or scope the rule so `git-`-prefixed tags are retained longer.
2. **Temp-tag cleanup.** `publish-docker-app.yml` deletes its `<hash>-<arch>` tags from Docker Hub once the manifest exists. The equivalent is not done here because the IAM policy grants no `ecr:BatchDeleteImage`. Adding that action to the role would let this workflow clean up after itself and would roughly halve the retention pressure in (1).
3. Whether SaaS should now stop building these images from the submodule is out of scope for this PR — this only makes the images available.

## Deployment Impact

None for self-hosted or BYOC operators. No chart values, no environment variables, no image contents change: this workflow publishes copies of images that are already built today to an additional registry that only the LangWatch-managed SaaS deployment pulls from. Docker Hub publishing, which is what self-hosted installs consume, is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publication of container images for releases, main-branch updates, and manual runs.
  * Published images support AMD64 and ARM64 platforms.
  * Release-specific and commit-based image tags improve version tracking.
  * Multi-platform image manifests are available for supported images.

* **Improvements**
  * Unchanged images can be reused without rebuilding.
  * Images are published securely to the container registry.
  * The `latest` tag is no longer published automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->