### PR TITLE
fix(ci): render the prerelease smoke check with autogen enabled

### DIFF
--- a/.github/workflows/prerelease-charts-oci.yml
+++ b/.github/workflows/prerelease-charts-oci.yml
@@ -164,8 +164,14 @@ jobs:
             # Never sign something that cannot install. Without this, a template
             # error merged to main still produces a cryptographically valid
             # signature over a broken chart.
+            #
+            # autogen.enabled=true matches every entry of the chart CI matrix
+            # in langwatch-chart.yml: clickhouse-serverless and the langwatch
+            # umbrella refuse to render at all without credentials config, and
+            # autogen is how a throwaway render satisfies that gate. Charts
+            # without an autogen gate ignore the value.
             helm lint "$chart_dir" >/dev/null
-            helm template smoke "$chart_dir" >/dev/null
+            helm template smoke "$chart_dir" --set autogen.enabled=true >/dev/null
             # --app-version deliberately NOT set: clickhouse-serverless declares
             # appVersion "25.10.2.65" (the actual ClickHouse release), and
             # overwriting it with a git sha both destroys that and claims a


### PR DESCRIPTION
The `prerelease-charts-oci` workflow — the per-merge OCI channel that lets a cluster track `main` without waiting for a tagged release — has **never published**. All 11 runs failed the same way: the pre-sign smoke check runs a bare `helm template`, and both `clickhouse-serverless` and the `langwatch` umbrella refuse to render without credentials configuration, by design:

```
Error: execution error at (clickhouse-serverless/templates/NOTES.txt:1:4): clickhouse-serverless: no credentials Secret configured. Either set autogen.enabled=true ... OR pre-create a Secret ...
```

The loop dies on the first chart alphabetically, so nothing was ever pushed to `ghcr.io/langwatch/charts`.

## Fix

Pass `--set autogen.enabled=true` to the smoke render — the same flag every entry of the chart CI matrix in `langwatch-chart.yml` passes, for the same reason. Charts without an autogen gate (`gateway`, `langyagent`) ignore the value; no chart ships a `values.schema.json` that would reject it.

## Verification

Replicated the workflow's package loop locally against `main` for all four charts: `helm dependency build`, `helm lint`, `helm template --set autogen.enabled=true`, and `helm package` with a prerelease version string all succeed. Without the flag, `clickhouse-serverless` and `langwatch` fail exactly as in CI.

Merging this self-triggers the workflow (its own path is in the `paths` filter), so the first successful publish should appear immediately. One follow-up after that: the first push creates the `charts/*` GHCR packages **private** by default — they need flipping to public (or consumers need a pull secret) before anything anonymous can pull them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart smoke-rendering for charts that require autogenerated credentials configuration.
  * Helm lint behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->