### PR TITLE
ci: build ECR images for arm64 only

### DIFF
--- a/.github/workflows/publish-docker-ecr.yml
+++ b/.github/workflows/publish-docker-ecr.yml
@@ -12,6 +12,15 @@ name: publish-docker-ecr
 #   - Different tag policy. This workflow NEVER pushes `:latest`. The SaaS
 #     pipeline still owns that tag on these repositories, and racing it would
 #     silently repoint production.
+#   - Different architecture set. arm64 only. Every consumer of these images is
+#     Graviton: the EKS node groups are AL2023_ARM_64_STANDARD on m8g, and every
+#     Lambda is `architectures = ["arm64"]`. Building amd64 here doubled the
+#     matrix to produce a manifest nothing ever pulled. Docker Hub still ships
+#     both arches for the community — that flow is untouched.
+#
+# If a consumer of these ECR images is ever added on x86, restore the amd64 rows
+# in the build table and add `-amd64` back to SOURCES in create-manifest. Both
+# carry a pointer to this note.
 #
 # The tags written here, and only these:
 #   - `git-<short-sha>`   always
@@ -221,18 +230,17 @@ jobs:
           # The full build table. `image` doubles as the ECR repository name and
           # as the key of the path filter above, so the two cannot drift.
           #
-          # Runner labels mirror publish-docker-app.yml: the app's arm64 build
-          # needs the 32GB larger runner for the pnpm/vite bundle, everything
-          # else fits on the standard hosted arm runner.
+          # arm64 only — see the header. Docker Hub still ships both arches for
+          # the community; this registry serves one all-Graviton consumer.
+          #
+          # Runner labels mirror publish-docker-app.yml: the app's build needs
+          # the 32GB larger runner for the pnpm/vite bundle, everything else
+          # fits on the standard hosted arm runner.
           ALL=$(cat <<'JSON'
           [
-            {"image":"langwatch-app",         "dockerfile":"infra/docker/Dockerfile",              "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
             {"image":"langwatch-app",         "dockerfile":"infra/docker/Dockerfile",              "arch":"arm64","platform":"linux/arm64/v8","runner":"arm64-runner-32gb"},
-            {"image":"langwatch-nlp-service", "dockerfile":"infra/docker/Dockerfile.langwatch_nlp","arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
             {"image":"langwatch-nlp-service", "dockerfile":"infra/docker/Dockerfile.langwatch_nlp","arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"},
-            {"image":"langwatch-langevals",   "dockerfile":"infra/docker/Dockerfile.langevals",    "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
             {"image":"langwatch-langevals",   "dockerfile":"infra/docker/Dockerfile.langevals",    "arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"},
-            {"image":"langwatch-gateway",     "dockerfile":"infra/docker/Dockerfile.go_service",   "arch":"amd64","platform":"linux/amd64",   "runner":"ubuntu-latest"},
             {"image":"langwatch-gateway",     "dockerfile":"infra/docker/Dockerfile.go_service",   "arch":"arm64","platform":"linux/arm64/v8","runner":"ubuntu-24.04-arm"}
           ]
           JSON
@@ -396,18 +404,21 @@ jobs:
           set -euo pipefail
 
           if printf '%s' "${BUILT}" | jq -e --arg i "${IMAGE}" 'index($i)' >/dev/null; then
-            # Rebuilt this run: assemble the index from the per-arch tags.
-            SOURCES=("${REPO}:${IMAGE_TAG}-amd64" "${REPO}:${IMAGE_TAG}-arm64")
+            # Rebuilt this run: wrap the per-arch tag in an index. Single-source
+            # `imagetools create` still writes a proper image index, so the
+            # consumer-facing tag has the same shape whether the image was
+            # rebuilt this run or re-tagged below.
+            SOURCES=("${REPO}:${IMAGE_TAG}-arm64")
           else
             # Not rebuilt: point this commit's tag at the index already published
             # for the last commit that did change this image. `imagetools create`
             # from a single index copies it, so this writes a manifest and moves
             # no layers.
             #
-            # Newest first, bare `git-<sha>` only — the per-arch `-amd64` /
-            # `-arm64` tags are pushed just before their index and are not
-            # multi-arch, so matching one here would publish a single-arch image
-            # under a tag consumers expect to be multi-arch.
+            # Newest first, bare `git-<sha>` only. The `-arm64` tag is pushed
+            # just before its index and is a bare manifest rather than an index;
+            # matching one here would hand consumers a different media type than
+            # the tag normally carries.
             # The lookup and the match are separate statements on purpose. With
             # both in one pipeline, the `|| true` that keeps a no-match from
             # tripping `set -e` also swallows a failed `describe-images` — and


### PR DESCRIPTION
Follow-up to #6610. Drops the amd64 half of the ECR build matrix.

## Why

Every consumer of these ECR images runs on Graviton — verified in `langwatch-saas/infrastructure`:

| Consumer | Evidence |
|---|---|
| EKS node groups | `ami_type = "AL2023_ARM_64_STANDARD"`, `instance_types = ["m8g.4xlarge"]` |
| EKS module default | same AMI type, `m8g.2xlarge` — so backbase and DR inherit it |
| Private-instance nodes | `m8g.large` |
| NLP Lambda | `architectures = ["arm64"]` |
| Evaluator Lambdas | `architectures = ["arm64"]` |

There is no x86 consumer of this registry. The amd64 rows were building four images every run to contribute manifest entries nothing has ever pulled.

**Docker Hub is untouched.** `publish-docker-app.yml` still publishes both arches, which is where multi-arch actually matters — the community runs LangWatch on whatever they have. This registry serves one private, all-arm64 deployment.

## What changes

- Build table goes from 8 rows to 4. The four `ubuntu-latest` runners go with it.
- `create-manifest` assembles from `:${IMAGE_TAG}-arm64` alone.

`create-manifest` still runs, and still wraps the per-arch tag in an index rather than pushing the bare manifest. That's deliberate: the consumer-facing tag keeps the same media type whether an image was rebuilt this run or re-tagged from a previous one, so nothing downstream has to care which path it took. It also preserves the property #6610 was built around — every image gets this commit's tag every run, so a single `git-<sha>` can be pinned across the whole deployment.

## Reversibility

Both the build table and the `SOURCES` line carry a pointer to a header note explaining what to restore if an x86 consumer ever appears. It's two edits.

## Verification

- `actionlint` (with shellcheck) clean
- Build table extracted and validated with `jq`: 4 entries, all four images present, `arches: ["arm64"]`, runners `arm64-runner-32gb` + `ubuntu-24.04-arm`
- No remaining `amd64` references outside the explanatory comments

As with #6610, the ECR push itself can't be exercised from a PR — the OIDC trust policy admits only `refs/heads/main` and `refs/tags/langwatch@v*`. First real proof is the merge to main.

> **Note:** `ARTIFACTS_ECR_OIDC_ROLE_ARN` still isn't set on this repo, so the post-#6610 run failed at assume-role. That's unrelated to this PR and needs setting either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Docker images published to ECR target arm64 Graviton consumers.

* **Chores**
  * Updated image publishing to build and publish arm64 images only.
  * Ensured manifests use the rebuilt arm64 image or retain the latest existing image when unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->