### PR TITLE
fix(event-sourcing): floor the group queue's ready score so the age gauge cannot report 56 years

### DIFF
--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -29,6 +29,15 @@ async function foreignSiblingsRestagedCount(
   );
 }
 
+async function readyScoreImplausibleCount(queueName: string): Promise<number> {
+  const metric = await register
+    .getSingleMetric("gq_ready_score_implausible_total")
+    ?.get();
+  return (
+    metric?.values.find((v) => v.labels.queue_name === queueName)?.value ?? 0
+  );
+}
+
 // Skip when running without testcontainers (unit-only test runs)
 const hasTestcontainers = !!(
   process.env.TEST_CLICKHOUSE_URL ||
@@ -166,7 +175,7 @@ describe.skipIf(!hasTestcontainers)(
          * the staged score back out of the group's own jobs zset.
          */
         /** @scenario "a job staged with an unusable score dispatches behind one that occurred earlier" */
-        it("stages it at the current time and dispatches it behind an genuinely older job", async () => {
+        it("stages it at the current time and dispatches it behind a genuinely older job", async () => {
           const processedOrder: string[] = [];
           let releaseBlocker: (() => void) | undefined;
           const blockerHeld = new Promise<void>((resolve) => {
@@ -227,6 +236,11 @@ describe.skipIf(!hasTestcontainers)(
           // Rescored to now, so it sorts BEHIND the job that really did occur a
           // minute ago. Staged at 0 it would have led the group for ever.
           expect(processedOrder).toEqual(["blocker", "older", "broken"]);
+
+          // Exactly one: the counter reports PRODUCERS, so only the supplied
+          // score the queue refused registers. The two accepted scores do not,
+          // and neither would a re-stage - see `restageScore`.
+          expect(await readyScoreImplausibleCount(queueName)).toBe(1);
         });
       });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -43,6 +43,17 @@ type TestPayload = {
   value: string;
 };
 
+/**
+ * Ready scores are validated against the staging clock now (`resolveReadyScore`),
+ * so a bare ordinal like `value * 1000` is rejected as "not a timestamp" and
+ * replaced with the staging time - which would silently turn every ordering
+ * assertion below into an assertion about arrival order. Anchor the ordinal to a
+ * real, recent timestamp instead: same relative order, and it exercises the
+ * shape a production score function actually returns.
+ */
+const SCORE_BASE_MS = Date.now() - 60 * 60 * 1000;
+const orderedScore = (n: number): number => SCORE_BASE_MS + n * 1000;
+
 function createQueueDefinition(
   overrides: Partial<EventSourcedQueueDefinition<TestPayload>> & {
     process: (payload: TestPayload) => Promise<void>;
@@ -140,6 +151,82 @@ describe.skipIf(!hasTestcontainers)(
             // timeout and charging the delay to whichever test runs next.
             releaseFirst?.();
           }
+        });
+      });
+
+      describe("when a producer's score function returns a value that is not a timestamp", () => {
+        /**
+         * The end-to-end version of the 2026-07-31 / 2026-08-03 defect, and the
+         * one assertion the unit tests cannot make: that what is WRITTEN to
+         * Redis is the resolved score, and that the resolved score takes its
+         * place in the real dispatch order.
+         *
+         * A test that recomputes the expected score in the test body would keep
+         * passing if `send` stopped calling the guard altogether. This one reads
+         * the staged score back out of the group's own jobs zset.
+         */
+        /** @scenario "a job staged with an unusable score dispatches behind one that occurred earlier" */
+        it("stages it at the current time and dispatches it behind an genuinely older job", async () => {
+          const processedOrder: string[] = [];
+          let releaseBlocker: (() => void) | undefined;
+          const blockerHeld = new Promise<void>((resolve) => {
+            releaseBlocker = resolve;
+          });
+
+          const queueName = `{test/gqmain/${crypto.randomUUID().slice(0, 8)}}`;
+          const scores: Record<string, number> = {
+            blocker: SCORE_BASE_MS,
+            older: Date.now() - 60_000,
+            broken: 0,
+          };
+          const queue = createQueue(
+            async (p) => {
+              if (p.id === "blocker") await blockerHeld;
+              processedOrder.push(p.id);
+            },
+            { name: queueName, score: (p) => scores[p.id] ?? 0 },
+          );
+          await queue.waitUntilReady();
+
+          // The blocker is staged first and carries the lowest score, so it
+          // leads the group and holds it while the two jobs behind it stay
+          // staged long enough to read their scores back out of Redis.
+          await queue.send({ id: "blocker", groupId: "g", value: "b" });
+
+          const stagedAtLeast = Date.now();
+          await queue.send({ id: "broken", groupId: "g", value: "x" });
+          await queue.send({ id: "older", groupId: "g", value: "y" });
+
+          try {
+            const jobsKey = `${queueName}:gq:group:g:jobs`;
+            await vi.waitFor(
+              async () => {
+                expect(await redis.zcard(jobsKey)).toBeGreaterThanOrEqual(2);
+              },
+              { timeout: 5000, interval: 50 },
+            );
+
+            // The broken score reached Redis as a real timestamp, not as 0.
+            const staged = await redis.zrange(jobsKey, 0, -1, "WITHSCORES");
+            const brokenScore = Number(
+              staged[staged.findIndex((m) => m.includes("broken")) + 1],
+            );
+            expect(brokenScore).toBeGreaterThanOrEqual(stagedAtLeast);
+            expect(brokenScore).toBeLessThanOrEqual(Date.now() + 1000);
+          } finally {
+            releaseBlocker?.();
+          }
+
+          await vi.waitFor(
+            () => {
+              expect(processedOrder).toHaveLength(3);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // Rescored to now, so it sorts BEHIND the job that really did occur a
+          // minute ago. Staged at 0 it would have led the group for ever.
+          expect(processedOrder).toEqual(["blocker", "older", "broken"]);
         });
       });
 
@@ -662,7 +749,7 @@ describe.skipIf(!hasTestcontainers)(
                 batches.push(ps as TestPayload[]);
               },
               coalesceMaxBatch: () => 50,
-              score: (p) => Number(p.value) * 1000,
+              score: (p) => orderedScore(Number(p.value)),
             },
           );
           await queue.waitUntilReady();
@@ -698,7 +785,7 @@ describe.skipIf(!hasTestcontainers)(
               if (ps.length > largest.length) largest = ps as TestPayload[];
             },
             coalesceMaxBatch: () => 50,
-            score: (p) => Number(p.value) * 1000,
+            score: (p) => orderedScore(Number(p.value)),
           });
           await queue.waitUntilReady();
 
@@ -733,7 +820,7 @@ describe.skipIf(!hasTestcontainers)(
                 batches.push(ps as TestPayload[]);
               },
               coalesceMaxBatch: () => 3,
-              score: (p) => Number(p.value) * 1000,
+              score: (p) => orderedScore(Number(p.value)),
             },
           );
           await queue.waitUntilReady();
@@ -777,7 +864,7 @@ describe.skipIf(!hasTestcontainers)(
                 batches.push(ps as TestPayload[]);
               },
               coalesceMaxBatch: () => 1,
-              score: (p) => Number(p.value) * 1000,
+              score: (p) => orderedScore(Number(p.value)),
             },
           );
           await queue.waitUntilReady();
@@ -818,7 +905,7 @@ describe.skipIf(!hasTestcontainers)(
                 for (const p of ps) succeeded.push(p as TestPayload);
               },
               coalesceMaxBatch: () => 50,
-              score: (p) => Number(p.value) * 1000,
+              score: (p) => orderedScore(Number(p.value)),
             },
           );
           await queue.waitUntilReady();
@@ -867,7 +954,7 @@ describe.skipIf(!hasTestcontainers)(
               },
               coalesceMaxBatch: () => 50,
               coalesceMaxBytes: () => 1500,
-              score: (p) => Number((p.id as string).slice(1)),
+              score: (p) => orderedScore(Number((p.id as string).slice(1))),
             },
           );
           await queue.waitUntilReady();
@@ -921,7 +1008,7 @@ describe.skipIf(!hasTestcontainers)(
               // Smaller than any single job's stored size, so every dispatch's
               // own initialBytes already exceeds the budget.
               coalesceMaxBytes: () => 50,
-              score: (p) => Number((p.id as string).slice(1)),
+              score: (p) => orderedScore(Number((p.id as string).slice(1))),
             },
           );
           await queue.waitUntilReady();
@@ -964,7 +1051,7 @@ describe.skipIf(!hasTestcontainers)(
                 batches.push(ps as TestPayload[]);
               },
               coalesceMaxBatch: () => 50,
-              score: (p) => Number((p.id as string).slice(1)),
+              score: (p) => orderedScore(Number((p.id as string).slice(1))),
             },
           );
           await queue.waitUntilReady();

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   gqOldestBacklogAgeMilliseconds,
   gqOldestPendingAgeMilliseconds,
+  gqReadyScoreImplausibleTotal,
 } from "../metrics";
 import { GroupQueueMetricsCollector } from "../metricsCollector";
+import { MIN_PLAUSIBLE_EPOCH_MS } from "../readyScore";
 import type { GroupStagingScripts } from "../scripts";
 
 const QUEUE = "test-queue";
@@ -34,8 +36,16 @@ function zrangebyscoreModel({
 }): string[] {
   const minStr = String(min);
   const isExclusive = minStr.startsWith("(");
-  const minVal = Number(isExclusive ? minStr.slice(1) : minStr);
-  const maxVal = max === "+inf" ? Infinity : Number(max);
+  const minVal =
+    minStr === "-inf"
+      ? -Infinity
+      : Number(isExclusive ? minStr.slice(1) : minStr);
+  const maxStr = String(max);
+  const isMaxExclusive = maxStr.startsWith("(");
+  const maxVal =
+    maxStr === "+inf"
+      ? Infinity
+      : Number(isMaxExclusive ? maxStr.slice(1) : maxStr);
 
   const shouldIncludeScores = rest.includes("WITHSCORES");
   const limitIdx = rest.indexOf("LIMIT");
@@ -46,7 +56,7 @@ function zrangebyscoreModel({
     .filter(
       (e) =>
         (isExclusive ? e.score > minVal : e.score >= minVal) &&
-        e.score <= maxVal,
+        (isMaxExclusive ? e.score < maxVal : e.score <= maxVal),
     )
     .sort((a, b) => a.score - b.score)
     .slice(offset, offset + count)
@@ -78,6 +88,17 @@ function makeRedis(
         max: args[2] as string | number,
         rest: args.slice(3),
       }),
+    ),
+    // ZCOUNT over the same bounds the range model understands, so the
+    // implausible-score band is counted by the same semantics it is read by.
+    zcount: vi.fn(
+      async (_key: string, min: string | number, max: string | number) =>
+        zrangebyscoreModel({
+          entries: opts.readyZset ?? [],
+          min,
+          max,
+          rest: [],
+        }).length,
     ),
     pipeline: vi.fn(() => {
       const cmds: string[] = [];
@@ -142,26 +163,31 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
 
     expect(await readGauge()).toBe(5_000);
 
-    // The query must exclude the unblock sentinel (score 1) via an exclusive
-    // lower bound, cap at "now", and read only the single oldest member.
-    // This is the FIRST zrangebyscore call (the eligible probe); the second
-    // is the deferred-backlog sample.
+    // The query must start at the plausible-epoch floor (which drops the
+    // unblock sentinel and every mis-scored row alike), cap at "now", and read
+    // only the single oldest member. This is the FIRST zrangebyscore call (the
+    // eligible probe); the second is the deferred-backlog sample.
     const args = redis.zrangebyscore.mock.calls[0]!;
     expect(args[0]).toBe(`${PREFIX}ready`);
-    expect(args[1]).toBe("(1");
+    expect(args[1]).toBe(MIN_PLAUSIBLE_EPOCH_MS);
     expect(args[2]).toBe(Date.now());
     expect(args).toContain("WITHSCORES");
     expect(args.slice(-3)).toEqual(["LIMIT", 0, 1]);
   });
 
+  /**
+   * A just-unblocked group carries the sentinel score (1), which the
+   * plausible-epoch floor drops rather than surface as eligible. The sentinel
+   * is deliberate, so it must not be counted as corruption either.
+   */
+  /** @scenario "the unblock sentinel is not counted as an implausible score" */
   it("reports 0 when no group is eligible (empty / all in-flight / just unblocked)", async () => {
-    // A just-unblocked group carries the sentinel score (1), which the
-    // exclusive "(1" lower bound must drop rather than surface as eligible.
     const redis = makeRedis({
       readyZset: [{ member: "just-unblocked", score: 1 }],
     });
     await runCollect(redis);
     expect(await readGauge()).toBe(0);
+    expect(await readImplausibleCounter()).toBeUndefined();
   });
 
   it("never emits a negative age (clock skew / future score)", async () => {
@@ -171,6 +197,106 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
     await runCollect(redis);
     const age = await readGauge();
     expect(age).toBeGreaterThanOrEqual(0);
+  });
+});
+
+async function readImplausibleCounter(): Promise<number | undefined> {
+  const m = await gqReadyScoreImplausibleTotal.get();
+  return m.values.find((v) => v.labels.queue_name === QUEUE)?.value;
+}
+
+describe("GroupQueueMetricsCollector - implausible ready scores", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+    vi.useFakeTimers({ now: Date.now() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("given a group staged a few seconds after the Unix epoch", () => {
+    /**
+     * Regression for the 2026-07-31 / 2026-08-03 spurious alert fires: a score
+     * of ~2 to 57,000 made the gauge read `now - ~0`, i.e. about 56 years, and
+     * the Events Backed Up rule divides that by 1000 and fires. The floor makes
+     * the gauge structurally unable to report it.
+     */
+    /** @scenario "the oldest-pending-age gauge skips a score from just after the Unix epoch" */
+    it("does not report its age, and probes from the plausible-epoch floor", async () => {
+      const redis = makeRedis({
+        readyZset: [{ member: "mis-scored", score: 57_000 }],
+      });
+
+      await runCollect(redis);
+
+      expect(await readGauge()).toBe(0);
+      expect(await readBacklogGauge()).toBe(0);
+      expect(redis.zrangebyscore.mock.calls[0]![1]).toBe(
+        MIN_PLAUSIBLE_EPOCH_MS,
+      );
+    });
+
+    /** @scenario "an implausible ready score raises a counter instead of being swallowed" */
+    it("raises the implausible-ready-score counter rather than skipping in silence", async () => {
+      const redis = makeRedis({
+        readyZset: [
+          { member: "mis-scored", score: 57_000 },
+          { member: "also-mis-scored", score: 0 },
+          { member: "just-unblocked", score: 1 },
+          { member: "healthy", score: Date.now() - 5_000 },
+        ],
+      });
+
+      await runCollect(redis);
+
+      // Both mis-scored rows, and only those: the deliberate unblock sentinel
+      // is subtracted back out and the healthy group is above the floor.
+      expect(await readImplausibleCounter()).toBe(2);
+      // The healthy group still drives the gauge, undisturbed by its neighbours.
+      expect(await readGauge()).toBe(5_000);
+    });
+
+    it("keeps counting for as long as the mis-scored row stays in the queue", async () => {
+      const redis = makeRedis({
+        readyZset: [{ member: "mis-scored", score: 57_000 }],
+      });
+
+      await runCollect(redis);
+      await runCollect(redis);
+
+      expect(await readImplausibleCounter()).toBe(2);
+    });
+  });
+
+  describe("given a sampled group whose head job score is not a timestamp", () => {
+    it("drops the head from the backlog age and counts it", async () => {
+      const redis = makeRedis({
+        readyZset: [
+          { member: "tenant/sub/trace:abc", score: Date.now() + 5_000 },
+        ],
+        headJobScores: {
+          [`${PREFIX}group:tenant/sub/trace:abc:jobs`]: ["job-1", "0"],
+        },
+      });
+
+      await runCollect(redis);
+
+      expect(await readBacklogGauge()).toBe(0);
+      expect(await readImplausibleCounter()).toBe(1);
+    });
+  });
+
+  describe("given every ready group carries a real timestamp", () => {
+    it("leaves the counter untouched", async () => {
+      const redis = makeRedis({
+        readyZset: [{ member: "healthy", score: Date.now() - 1_000 }],
+      });
+
+      await runCollect(redis);
+
+      expect(await readImplausibleCounter()).toBeUndefined();
+    });
   });
 });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   gqOldestBacklogAgeMilliseconds,
   gqOldestPendingAgeMilliseconds,
-  gqReadyScoreImplausibleTotal,
 } from "../metrics";
 import { GroupQueueMetricsCollector } from "../metricsCollector";
 import { MIN_PLAUSIBLE_EPOCH_MS } from "../readyScore";
@@ -89,17 +88,6 @@ function makeRedis(
         rest: args.slice(3),
       }),
     ),
-    // ZCOUNT over the same bounds the range model understands, so the
-    // implausible-score band is counted by the same semantics it is read by.
-    zcount: vi.fn(
-      async (_key: string, min: string | number, max: string | number) =>
-        zrangebyscoreModel({
-          entries: opts.readyZset ?? [],
-          min,
-          max,
-          rest: [],
-        }).length,
-    ),
     pipeline: vi.fn(() => {
       const cmds: string[] = [];
       const chain = {
@@ -177,17 +165,15 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
 
   /**
    * A just-unblocked group carries the sentinel score (1), which the
-   * plausible-epoch floor drops rather than surface as eligible. The sentinel
-   * is deliberate, so it must not be counted as corruption either.
+   * plausible-epoch floor drops rather than surface as eligible.
    */
-  /** @scenario "the unblock sentinel is not counted as an implausible score" */
+  /** @scenario "the unblock sentinel is not read as an age" */
   it("reports 0 when no group is eligible (empty / all in-flight / just unblocked)", async () => {
     const redis = makeRedis({
       readyZset: [{ member: "just-unblocked", score: 1 }],
     });
     await runCollect(redis);
     expect(await readGauge()).toBe(0);
-    expect(await readImplausibleCounter()).toBeUndefined();
   });
 
   it("never emits a negative age (clock skew / future score)", async () => {
@@ -200,12 +186,7 @@ describe("GroupQueueMetricsCollector — oldest pending age", () => {
   });
 });
 
-async function readImplausibleCounter(): Promise<number | undefined> {
-  const m = await gqReadyScoreImplausibleTotal.get();
-  return m.values.find((v) => v.labels.queue_name === QUEUE)?.value;
-}
-
-describe("GroupQueueMetricsCollector - implausible ready scores", () => {
+describe("GroupQueueMetricsCollector - scores that are not timestamps", () => {
   beforeEach(() => {
     register.resetMetrics();
     vi.useFakeTimers({ now: Date.now() });
@@ -237,8 +218,7 @@ describe("GroupQueueMetricsCollector - implausible ready scores", () => {
       );
     });
 
-    /** @scenario "an implausible ready score raises a counter instead of being swallowed" */
-    it("raises the implausible-ready-score counter rather than skipping in silence", async () => {
+    it("leaves a healthy neighbour driving the gauge", async () => {
       const redis = makeRedis({
         readyZset: [
           { member: "mis-scored", score: 57_000 },
@@ -250,27 +230,18 @@ describe("GroupQueueMetricsCollector - implausible ready scores", () => {
 
       await runCollect(redis);
 
-      // Both mis-scored rows, and only those: the deliberate unblock sentinel
-      // is subtracted back out and the healthy group is above the floor.
-      expect(await readImplausibleCounter()).toBe(2);
-      // The healthy group still drives the gauge, undisturbed by its neighbours.
       expect(await readGauge()).toBe(5_000);
-    });
-
-    it("keeps counting for as long as the mis-scored row stays in the queue", async () => {
-      const redis = makeRedis({
-        readyZset: [{ member: "mis-scored", score: 57_000 }],
-      });
-
-      await runCollect(redis);
-      await runCollect(redis);
-
-      expect(await readImplausibleCounter()).toBe(2);
     });
   });
 
   describe("given a sampled group whose head job score is not a timestamp", () => {
-    it("drops the head from the backlog age and counts it", async () => {
+    /**
+     * A genuine backlog IS arbitrarily far in the past, so the gauge applies
+     * only the absolute bound, never the staging-time skew bounds - otherwise
+     * it would hide the very backlog it exists to report.
+     */
+    /** @scenario "the backlog gauge drops a head job score that is not a timestamp" */
+    it("drops the head from the backlog age", async () => {
       const redis = makeRedis({
         readyZset: [
           { member: "tenant/sub/trace:abc", score: Date.now() + 5_000 },
@@ -283,19 +254,23 @@ describe("GroupQueueMetricsCollector - implausible ready scores", () => {
       await runCollect(redis);
 
       expect(await readBacklogGauge()).toBe(0);
-      expect(await readImplausibleCounter()).toBe(1);
     });
-  });
 
-  describe("given every ready group carries a real timestamp", () => {
-    it("leaves the counter untouched", async () => {
+    it("still reports a genuinely old head job, however far past it is", async () => {
+      const veryOld = Date.now() - 30 * 24 * 60 * 60 * 1000;
       const redis = makeRedis({
-        readyZset: [{ member: "healthy", score: Date.now() - 1_000 }],
+        readyZset: [{ member: "tenant/sub/trace:old", score: Date.now() + 1 }],
+        headJobScores: {
+          [`${PREFIX}group:tenant/sub/trace:old:jobs`]: [
+            "job-1",
+            String(veryOld),
+          ],
+        },
       });
 
       await runCollect(redis);
 
-      expect(await readImplausibleCounter()).toBeUndefined();
+      expect(await readBacklogGauge()).toBe(30 * 24 * 60 * 60 * 1000);
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isPlausibleReadyScore,
+  MIN_PLAUSIBLE_EPOCH_MS,
+  resolveReadyScore,
+} from "../readyScore";
+
+const NOW = 1_786_000_000_000; // 2026-08-05T...Z, comfortably above the floor.
+
+describe("resolveReadyScore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("given a score function that cannot produce an occurrence time", () => {
+    /**
+     * The production defect: `??` passes 0, so a job staged at the epoch and
+     * `gq_oldest_pending_age_milliseconds` read `now - 0`, about 56 years.
+     */
+    /** @scenario "a score that is not a plausible timestamp falls back to the current time" */
+    it.each([
+      ["zero", 0],
+      ["not a number", Number.NaN],
+      ["absent", undefined],
+      ["null", null],
+      ["negative", -1],
+      ["the unblock sentinel", 1],
+      ["epoch seconds rather than milliseconds", 1_786_000_000],
+      ["infinite", Number.POSITIVE_INFINITY],
+      ["a Date rather than a number", new Date(NOW)],
+      ["a numeric string", String(NOW)],
+    ])("falls back to the current time when the score is %s", (_label, score) => {
+      expect(resolveReadyScore({ score })).toBe(NOW);
+    });
+
+    it("falls back to the shared clock reading when one is supplied", () => {
+      const shared = NOW - 5_000;
+
+      expect(resolveReadyScore({ score: 0, nowMs: shared })).toBe(shared);
+    });
+  });
+
+  describe("given a score function that returns a real timestamp", () => {
+    /** @scenario "a plausible timestamp is staged unchanged" */
+    it("passes the timestamp through untouched", () => {
+      const occurredAt = NOW - 90_000;
+
+      expect(resolveReadyScore({ score: occurredAt })).toBe(occurredAt);
+    });
+
+    it("accepts a score sitting exactly on the plausible-epoch floor", () => {
+      expect(resolveReadyScore({ score: MIN_PLAUSIBLE_EPOCH_MS })).toBe(
+        MIN_PLAUSIBLE_EPOCH_MS,
+      );
+    });
+
+    it("accepts a future score, which is how deferred and in-flight groups are marked", () => {
+      const future = NOW + 600_000;
+
+      expect(resolveReadyScore({ score: future })).toBe(future);
+    });
+  });
+
+  describe("given a batch whose scores are all unusable", () => {
+    /** @scenario "a batch that falls back keeps its arrival order" */
+    it("gives every payload the same fallback so the per-index tiebreak orders them", () => {
+      const sharedNow = NOW;
+      const payloads = [0, Number.NaN, undefined];
+
+      const scores = payloads.map((score, index) => {
+        const resolved = resolveReadyScore({ score, nowMs: sharedNow });
+        return resolved + index;
+      });
+
+      expect(scores).toEqual([sharedNow, sharedNow + 1, sharedNow + 2]);
+    });
+  });
+});
+
+describe("isPlausibleReadyScore", () => {
+  describe("when the value is one millisecond below the floor", () => {
+    it("rejects it", () => {
+      expect(isPlausibleReadyScore(MIN_PLAUSIBLE_EPOCH_MS - 1)).toBe(false);
+    });
+  });
+
+  describe("when the value is on the floor", () => {
+    it("accepts it", () => {
+      expect(isPlausibleReadyScore(MIN_PLAUSIBLE_EPOCH_MS)).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
@@ -44,7 +44,7 @@ describe("resolveReadyScore", () => {
     ])("falls back to the staging time when the score is %s", (_label, score) => {
       expect(resolveReadyScore({ score })).toEqual({
         score: NOW,
-        rejected: true,
+        isRejected: true,
       });
     });
 
@@ -53,7 +53,7 @@ describe("resolveReadyScore", () => {
 
       expect(resolveReadyScore({ score: 0, nowMs: shared })).toEqual({
         score: shared,
-        rejected: true,
+        isRejected: true,
       });
     });
   });
@@ -72,7 +72,7 @@ describe("resolveReadyScore", () => {
     ])("scores at the staging time and does not report %s", (_label, score) => {
       expect(resolveReadyScore({ score })).toEqual({
         score: NOW,
-        rejected: false,
+        isRejected: false,
       });
     });
   });
@@ -84,7 +84,7 @@ describe("resolveReadyScore", () => {
 
       expect(resolveReadyScore({ score: occurredAt })).toEqual({
         score: occurredAt,
-        rejected: false,
+        isRejected: false,
       });
     });
 
@@ -94,7 +94,10 @@ describe("resolveReadyScore", () => {
       ["late but inside the past bound", NOW - 6 * 60 * 60 * 1000],
       ["a little ahead, as an unsynchronised client emits", NOW + 30_000],
     ])("accepts a score %s", (_label, score) => {
-      expect(resolveReadyScore({ score })).toEqual({ score, rejected: false });
+      expect(resolveReadyScore({ score })).toEqual({
+        score,
+        isRejected: false,
+      });
     });
   });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/readyScore.unit.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  isPlausibleReadyScore,
+  fallbackReadyScore,
+  isUsableReadyScore,
+  MAX_SCORE_FUTURE_SKEW_MS,
+  MAX_SCORE_PAST_SKEW_MS,
   MIN_PLAUSIBLE_EPOCH_MS,
   resolveReadyScore,
 } from "../readyScore";
 
-const NOW = 1_786_000_000_000; // 2026-08-05T...Z, comfortably above the floor.
+const NOW = 1_786_000_000_000; // 2026-08-05, comfortably above the backstop.
 
 describe("resolveReadyScore", () => {
   beforeEach(() => {
@@ -16,81 +19,131 @@ describe("resolveReadyScore", () => {
     vi.useRealTimers();
   });
 
-  describe("given a score function that cannot produce an occurrence time", () => {
+  describe("given a score the queue cannot use as an eligibility time", () => {
     /**
-     * The production defect: `??` passes 0, so a job staged at the epoch and
-     * `gq_oldest_pending_age_milliseconds` read `now - 0`, about 56 years.
+     * The production defect and its two-sided sibling. `??` passed 0, so a job
+     * staged at the epoch and the age gauge read `now - 0`, about 56 years. A
+     * fixed floor alone would not catch the rest of this table: a
+     * customer-supplied OTLP timestamp is unbounded in BOTH directions, and
+     * 2021-01-01 clears any floor while still reading as years of backlog.
      */
-    /** @scenario "a score that is not a plausible timestamp falls back to the current time" */
+    /** @scenario "a score outside the allowed skew around now falls back to the staging time" */
     it.each([
       ["zero", 0],
       ["not a number", Number.NaN],
-      ["absent", undefined],
-      ["null", null],
       ["negative", -1],
       ["the unblock sentinel", 1],
       ["epoch seconds rather than milliseconds", 1_786_000_000],
       ["infinite", Number.POSITIVE_INFINITY],
       ["a Date rather than a number", new Date(NOW)],
       ["a numeric string", String(NOW)],
-    ])("falls back to the current time when the score is %s", (_label, score) => {
-      expect(resolveReadyScore({ score })).toBe(NOW);
+      ["a customer timestamp years in the past", Date.UTC(2021, 0, 1)],
+      ["a customer clock years in the future", Date.UTC(2030, 0, 1)],
+      ["just beyond the past skew", NOW - MAX_SCORE_PAST_SKEW_MS - 1],
+      ["just beyond the future skew", NOW + MAX_SCORE_FUTURE_SKEW_MS + 1],
+    ])("falls back to the staging time when the score is %s", (_label, score) => {
+      expect(resolveReadyScore({ score })).toEqual({
+        score: NOW,
+        rejected: true,
+      });
     });
 
     it("falls back to the shared clock reading when one is supplied", () => {
       const shared = NOW - 5_000;
 
-      expect(resolveReadyScore({ score: 0, nowMs: shared })).toBe(shared);
+      expect(resolveReadyScore({ score: 0, nowMs: shared })).toEqual({
+        score: shared,
+        rejected: true,
+      });
     });
   });
 
-  describe("given a score function that returns a real timestamp", () => {
+  describe("given a score the producer never supplied", () => {
+    /**
+     * Absent is not a defect. `deferredOriginResolution` and `datasetNormalize`
+     * carry no occurrence time by design, so scoring them at staging time is
+     * the intended default - and reporting every one of them as a broken
+     * producer would bury the signal the counter exists to carry.
+     */
+    /** @scenario "a payload with no occurrence time is scored at the staging time without being reported" */
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+    ])("scores at the staging time and does not report %s", (_label, score) => {
+      expect(resolveReadyScore({ score })).toEqual({
+        score: NOW,
+        rejected: false,
+      });
+    });
+  });
+
+  describe("given a score the queue can use", () => {
     /** @scenario "a plausible timestamp is staged unchanged" */
     it("passes the timestamp through untouched", () => {
       const occurredAt = NOW - 90_000;
 
-      expect(resolveReadyScore({ score: occurredAt })).toBe(occurredAt);
+      expect(resolveReadyScore({ score: occurredAt })).toEqual({
+        score: occurredAt,
+        rejected: false,
+      });
     });
 
-    it("accepts a score sitting exactly on the plausible-epoch floor", () => {
-      expect(resolveReadyScore({ score: MIN_PLAUSIBLE_EPOCH_MS })).toBe(
-        MIN_PLAUSIBLE_EPOCH_MS,
-      );
-    });
-
-    it("accepts a future score, which is how deferred and in-flight groups are marked", () => {
-      const future = NOW + 600_000;
-
-      expect(resolveReadyScore({ score: future })).toBe(future);
+    it.each([
+      ["exactly on the past skew bound", NOW - MAX_SCORE_PAST_SKEW_MS],
+      ["exactly on the future skew bound", NOW + MAX_SCORE_FUTURE_SKEW_MS],
+      ["late but inside the past bound", NOW - 6 * 60 * 60 * 1000],
+      ["a little ahead, as an unsynchronised client emits", NOW + 30_000],
+    ])("accepts a score %s", (_label, score) => {
+      expect(resolveReadyScore({ score })).toEqual({ score, rejected: false });
     });
   });
 
   describe("given a batch whose scores are all unusable", () => {
     /** @scenario "a batch that falls back keeps its arrival order" */
-    it("gives every payload the same fallback so the per-index tiebreak orders them", () => {
-      const sharedNow = NOW;
-      const payloads = [0, Number.NaN, undefined];
+    it("gives every payload the same fallback against one shared clock", () => {
+      const resolved = [0, Number.NaN, Date.UTC(2021, 0, 1)].map(
+        (score) => resolveReadyScore({ score, nowMs: NOW }).score,
+      );
 
-      const scores = payloads.map((score, index) => {
-        const resolved = resolveReadyScore({ score, nowMs: sharedNow });
-        return resolved + index;
-      });
-
-      expect(scores).toEqual([sharedNow, sharedNow + 1, sharedNow + 2]);
+      expect(resolved).toEqual([NOW, NOW, NOW]);
     });
   });
 });
 
-describe("isPlausibleReadyScore", () => {
-  describe("when the value is one millisecond below the floor", () => {
-    it("rejects it", () => {
-      expect(isPlausibleReadyScore(MIN_PLAUSIBLE_EPOCH_MS - 1)).toBe(false);
+describe("isUsableReadyScore", () => {
+  describe("when the score sits one millisecond outside a bound", () => {
+    it.each([
+      ["past", NOW - MAX_SCORE_PAST_SKEW_MS - 1],
+      ["future", NOW + MAX_SCORE_FUTURE_SKEW_MS + 1],
+    ])("rejects it on the %s side", (_side, score) => {
+      expect(isUsableReadyScore(score, NOW)).toBe(false);
     });
   });
 
-  describe("when the value is on the floor", () => {
-    it("accepts it", () => {
-      expect(isPlausibleReadyScore(MIN_PLAUSIBLE_EPOCH_MS)).toBe(true);
+  describe("when the clock it is judged against moves", () => {
+    it("re-judges the same score against the new reading", () => {
+      const score = NOW - MAX_SCORE_PAST_SKEW_MS;
+
+      expect(isUsableReadyScore(score, NOW)).toBe(true);
+      expect(isUsableReadyScore(score, NOW + 1)).toBe(false);
     });
+  });
+});
+
+describe("fallbackReadyScore", () => {
+  /**
+   * The terminal step is checked, not trusted. A worker that boots before its
+   * NTP sync reads `Date.now()` in 1970, and every score it staged would then
+   * be "plausible" relative to that clock - the one case the relative bounds
+   * structurally cannot catch.
+   */
+  /** @scenario "a fallback taken from an unsynchronised clock is itself bounded" */
+  it("pins a pre-NTP clock reading to the backstop", () => {
+    expect(fallbackReadyScore(57_000)).toBe(MIN_PLAUSIBLE_EPOCH_MS);
+    expect(fallbackReadyScore(0)).toBe(MIN_PLAUSIBLE_EPOCH_MS);
+  });
+
+  it("returns a real clock reading unchanged", () => {
+    expect(fallbackReadyScore(NOW)).toBe(NOW);
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -76,12 +76,17 @@ import {
   gqJobsNonRetryableTotal,
   gqJobsRetriedTotal,
   gqJobsStagedTotal,
+  gqReadyScoreImplausibleTotal,
   gqRetryAttempt,
   gqRetryBackoffMilliseconds,
   gqRetryEncodeFailuresTotal,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
-import { isPlausibleReadyScore, resolveReadyScore } from "./readyScore";
+import {
+  fallbackReadyScore,
+  isPlausibleReadyScore,
+  resolveReadyScore,
+} from "./readyScore";
 import {
   type DispatchResult,
   type DrainedJob,
@@ -460,6 +465,50 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
+   * Resolves a ready score and reports what it had to refuse.
+   *
+   * Every path that writes a ready score goes through here, so the counter is
+   * raised at the one moment the information exists. Counting it later, by
+   * scanning the ready set for out-of-range scores, cannot work: by then the
+   * bad value has already been replaced by this function and the scan finds
+   * nothing while the broken producer carries on.
+   *
+   * `delay` is deliberately NOT part of this. Deferral is a queue decision
+   * added to the resolved score by the caller; only the producer's own claim
+   * about when the work occurred is judged here.
+   */
+  private resolveScore(rawScore: unknown, nowMs: number = Date.now()): number {
+    const { score, rejected } = resolveReadyScore({ score: rawScore, nowMs });
+    if (rejected) {
+      gqReadyScoreImplausibleTotal.inc({ queue_name: this.queueName });
+    }
+    return score;
+  }
+
+  /**
+   * Ready score for a job the queue is putting BACK - an exhausted retry, a
+   * poison park, a drained sibling after a failed batch.
+   *
+   * Only the absolute check applies, not the two-sided one. The score was
+   * already judged against the producer's clock when the job was first staged,
+   * and re-judging it against a later clock would rewrite a legitimately old
+   * job (a long retry chain, a batch exported a day late) for no reason. What
+   * is still worth catching is a value that is not a timestamp at all, i.e. a
+   * row staged before this guard existed.
+   *
+   * All three re-stage paths share this so they cannot disagree. They used to:
+   * the exhausted-retry path re-scored an unusable value while drained siblings
+   * kept theirs verbatim, so one failure could move the failed job to now and
+   * leave its siblings at 0 - and on unblock the siblings dispatched ahead of
+   * the job they were drained behind.
+   */
+  private restageScore(originalScore: unknown): number {
+    if (isPlausibleReadyScore(originalScore)) return originalScore;
+    gqReadyScoreImplausibleTotal.inc({ queue_name: this.queueName });
+    return fallbackReadyScore();
+  }
+
+  /**
    * Stages a job into the group queue's Redis staging layer.
    */
   async send(
@@ -486,7 +535,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const stagedJobId = this.generateStagedJobId(payload);
     // Not `?? Date.now()`: a score function returning 0 or NaN (a payload with
     // no usable occurrence time) survives `??` and stages the job at the epoch.
-    const score = resolveReadyScore({ score: this.score?.(payload) });
+    const score = this.resolveScore(this.score?.(payload));
     const dispatchAfterMs = score + (delay ?? 0);
 
     // Get dedup config
@@ -618,11 +667,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         const groupId = this.groupKey(payload);
         const stagedJobId = this.generateStagedJobId(payload);
         // Same guard as send(); `now` is shared so a batch that falls back
-        // keeps its FIFO order.
-        const score = resolveReadyScore({
-          score: this.score?.(payload),
-          nowMs: now,
-        });
+        // keeps its FIFO order, and so every payload is judged against one
+        // clock reading rather than drifting across the batch.
+        const score = this.resolveScore(this.score?.(payload), now);
         // Add index to ensure FIFO order within the batch even if timestamps are identical
         const dispatchAfterMs = score + (delay ?? 0) + index;
 
@@ -1713,7 +1760,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         await this.scripts.stage({
           stagedJobId: sibling.stagedJobId,
           groupId,
-          dispatchAfterMs: sibling.originalScore,
+          // Guarded like every other re-stage. Unvalidated, a legacy row at 0
+          // was rewritten at 0 on every batch failure and never healed, and
+          // because the exhausted-retry path DID re-score, one failure could
+          // leave the siblings ordered ahead of the job they were drained
+          // behind.
+          dispatchAfterMs: this.restageScore(sibling.originalScore),
           dedupId: "",
           dedupTtlMs: 0,
           jobDataJson: sibling.jobDataJson,
@@ -1803,9 +1855,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // where it belongs in the queue - unless that score is not a usable
     // timestamp, in which case re-staging it would park the group at the epoch
     // for as long as it stays blocked.
-    const score = isPlausibleReadyScore(originalScore)
-      ? originalScore
-      : resolveReadyScore({ score: this.score?.(payload) });
+    const score = this.restageScore(originalScore);
 
     // Re-stage under the id the job was dispatched under (ADR-080), so the
     // staged job an operator inspects is named by the id its producer knows.
@@ -2036,7 +2086,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }): Promise<void> {
     // Same reasoning as handleExhaustedRetries: keep the original score when it
     // is a real timestamp, otherwise the parked group reads as decades old.
-    const score = resolveReadyScore({ score: originalScore });
+    const score = this.restageScore(originalScore);
     await this.scripts.restageAndBlock({
       groupId,
       // Parked under the id it was dispatched under (ADR-080). This used to

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -478,8 +478,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * about when the work occurred is judged here.
    */
   private resolveScore(rawScore: unknown, nowMs: number = Date.now()): number {
-    const { score, rejected } = resolveReadyScore({ score: rawScore, nowMs });
-    if (rejected) {
+    const { score, isRejected } = resolveReadyScore({
+      score: rawScore,
+      nowMs,
+    });
+    if (isRejected) {
       gqReadyScoreImplausibleTotal.inc({ queue_name: this.queueName });
     }
     return score;
@@ -501,11 +504,20 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * kept theirs verbatim, so one failure could move the failed job to now and
    * leave its siblings at 0 - and on unblock the siblings dispatched ahead of
    * the job they were drained behind.
+   *
+   * Deliberately does NOT raise `gq_ready_score_implausible_total`, which
+   * counts producers, not us. `originalScore` is always a value this queue
+   * wrote and then read back out of Redis, and staging already required it to
+   * clear MIN_PLAUSIBLE_EPOCH_MS - an ABSOLUTE floor, so a score that cleared
+   * it once clears it for ever. This check can therefore only ever fire for a
+   * row staged before the guard existed, or one corrupted in Redis. Neither is
+   * a broken score function, and counting them here would dilute the one
+   * signal that is with our own bookkeeping.
    */
   private restageScore(originalScore: unknown): number {
-    if (isPlausibleReadyScore(originalScore)) return originalScore;
-    gqReadyScoreImplausibleTotal.inc({ queue_name: this.queueName });
-    return fallbackReadyScore();
+    return isPlausibleReadyScore(originalScore)
+      ? originalScore
+      : fallbackReadyScore();
   }
 
   /**

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -81,6 +81,7 @@ import {
   gqRetryEncodeFailuresTotal,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
+import { isPlausibleReadyScore, resolveReadyScore } from "./readyScore";
 import {
   type DispatchResult,
   type DrainedJob,
@@ -483,7 +484,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     const groupId = this.groupKey(payload);
     const stagedJobId = this.generateStagedJobId(payload);
-    const score = this.score?.(payload) ?? Date.now();
+    // Not `?? Date.now()`: a score function returning 0 or NaN (a payload with
+    // no usable occurrence time) survives `??` and stages the job at the epoch.
+    const score = resolveReadyScore({ score: this.score?.(payload) });
     const dispatchAfterMs = score + (delay ?? 0);
 
     // Get dedup config
@@ -614,7 +617,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       payloads.map(async (payload, index) => {
         const groupId = this.groupKey(payload);
         const stagedJobId = this.generateStagedJobId(payload);
-        const score = this.score?.(payload) ?? now;
+        // Same guard as send(); `now` is shared so a batch that falls back
+        // keeps its FIFO order.
+        const score = resolveReadyScore({
+          score: this.score?.(payload),
+          nowMs: now,
+        });
         // Add index to ensure FIFO order within the batch even if timestamps are identical
         const dispatchAfterMs = score + (delay ?? 0) + index;
 
@@ -1791,10 +1799,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     contextMetadata: JobContextMetadata | undefined;
     routingLabels: Record<string, string>;
   }): Promise<void> {
-    const score =
-      typeof originalScore === "number"
-        ? originalScore
-        : (this.score?.(payload) ?? Date.now());
+    // The re-staged job keeps its original ready score so an operator sees it
+    // where it belongs in the queue - unless that score is not a usable
+    // timestamp, in which case re-staging it would park the group at the epoch
+    // for as long as it stays blocked.
+    const score = isPlausibleReadyScore(originalScore)
+      ? originalScore
+      : resolveReadyScore({ score: this.score?.(payload) });
 
     // Re-stage under the id the job was dispatched under (ADR-080), so the
     // staged job an operator inspects is named by the id its producer knows.
@@ -2023,8 +2034,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     reason: "claim_strikes" | "oversized_payload";
     errorMessage: string;
   }): Promise<void> {
-    const score =
-      typeof originalScore === "number" ? originalScore : Date.now();
+    // Same reasoning as handleExhaustedRetries: keep the original score when it
+    // is a real timestamp, otherwise the parked group reads as decades old.
+    const score = resolveReadyScore({ score: originalScore });
     await this.scripts.restageAndBlock({
       groupId,
       // Parked under the id it was dispatched under (ADR-080). This used to

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -23,6 +23,7 @@ const metricNames = [
   "gq_job_duration_milliseconds",
   "gq_oldest_pending_age_milliseconds",
   "gq_oldest_backlog_age_milliseconds",
+  "gq_ready_score_implausible_total",
   // ADR-030 hardening + review 2026-06-24
   "gq_blob_reclaim_s3_failures_total",
   "gq_blob_decode_cap_exceeded_total",
@@ -203,6 +204,23 @@ export const gqOldestPendingAgeMilliseconds = new Gauge({
 export const gqOldestBacklogAgeMilliseconds = new Gauge({
   name: "gq_oldest_backlog_age_milliseconds",
   help: "Age of the oldest due job across sampled groups regardless of dispatch eligibility (catches groups pinned in retry backoff)",
+  labelNames: ["queue_name"] as const,
+});
+
+/**
+ * Ready rows the age probe refused to read as a timestamp.
+ *
+ * A ready score below MIN_PLAUSIBLE_EPOCH_MS cannot be an occurrence time, so
+ * the gauges skip it rather than report `now - 0` as decades of backlog. The
+ * skip is the right call for the gauge and the wrong thing to do silently: a
+ * score that low means a producer staged a job with a broken score, which also
+ * puts that job ahead of every real one in the dispatch order. Counted once per
+ * collect cycle per offending row, so `increase(...[5m]) > 0` means "a queue is
+ * carrying implausibly-scored work right now", not "N jobs were mis-scored".
+ */
+export const gqReadyScoreImplausibleTotal = new Counter({
+  name: "gq_ready_score_implausible_total",
+  help: "Ready rows skipped by the age probes for a score below the plausible-epoch floor, counted once per collect cycle each",
   labelNames: ["queue_name"] as const,
 });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -208,19 +208,22 @@ export const gqOldestBacklogAgeMilliseconds = new Gauge({
 });
 
 /**
- * Ready rows the age probe refused to read as a timestamp.
+ * Jobs whose producer supplied a ready score the queue refused.
  *
- * A ready score below MIN_PLAUSIBLE_EPOCH_MS cannot be an occurrence time, so
- * the gauges skip it rather than report `now - 0` as decades of backlog. The
- * skip is the right call for the gauge and the wrong thing to do silently: a
- * score that low means a producer staged a job with a broken score, which also
- * puts that job ahead of every real one in the dispatch order. Counted once per
- * collect cycle per offending row, so `increase(...[5m]) > 0` means "a queue is
- * carrying implausibly-scored work right now", not "N jobs were mis-scored".
+ * Raised at the staging fallback, once per job, the moment the value is
+ * rejected - not by scanning the ready set afterwards. That ordering is the
+ * whole point: the guard replaces the bad score before it is written, so a scan
+ * would find nothing and report zero for ever while the broken producer carried
+ * on. This is a true monotonic count of events, so `rate()` and `increase()`
+ * mean what they usually mean.
+ *
+ * Only a value the producer actually supplied counts. A payload with no
+ * occurrence time at all (`deferredOriginResolution` and friends) is scored at
+ * staging time by design, and is not a defect to report.
  */
 export const gqReadyScoreImplausibleTotal = new Counter({
   name: "gq_ready_score_implausible_total",
-  help: "Ready rows skipped by the age probes for a score below the plausible-epoch floor, counted once per collect cycle each",
+  help: "Jobs staged with a producer score the queue rejected (not a timestamp, or outside the allowed skew around now) and replaced with the staging time",
   labelNames: ["queue_name"] as const,
 });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -11,23 +11,9 @@ import {
   gqOldestPendingAgeMilliseconds,
   gqParkedGroups,
   gqPendingGroups,
-  gqReadyScoreImplausibleTotal,
 } from "./metrics";
 import { isPlausibleReadyScore, MIN_PLAUSIBLE_EPOCH_MS } from "./readyScore";
 import type { DispatchResult, GroupStagingScripts } from "./scripts";
-
-/**
- * Ready-score written by UNBLOCK_LUA (app-layer/ops/repositories/
- * queue.redis.repository.ts) to force a just-unblocked group to dispatch
- * promptly. It is a sentinel (epoch 1ms), not a real eligibility time, so the
- * oldest-pending-age gauge excludes it — see the computation in collect().
- *
- * It sits below MIN_PLAUSIBLE_EPOCH_MS, so the floor the gauges now apply
- * already drops it. The constant survives as the lower edge of the band the
- * implausible-score counter watches: a sentinel is deliberate, a score of 0 or
- * 57,000 is a producer bug, and only the second should raise a signal.
- */
-const READY_UNBLOCK_SENTINEL_SCORE = 1;
 
 /**
  * How many of the soonest-future-scored ("nearest deferred") ready groups the
@@ -46,13 +32,6 @@ const OLDEST_BACKLOG_SAMPLE_GROUPS = 50;
  */
 export class GroupQueueMetricsCollector {
   private interval: ReturnType<typeof setInterval> | null = null;
-  /**
-   * Implausible rows seen last cycle. Only the transition from none to some is
-   * logged: the counter carries the ongoing signal, and an implausibly-scored
-   * group can sit in ready for days, which at collect cadence would be a warn
-   * line every few seconds for as long as it stays.
-   */
-  private lastImplausibleRows = 0;
 
   constructor(
     private readonly params: {
@@ -169,14 +148,20 @@ export class GroupQueueMetricsCollector {
    * Exclude every score that cannot be a timestamp, not just the sentinel.
    * UNBLOCK_LUA (app-layer/ops/repositories/queue.redis.repository.ts) re-adds
    * a group to ready with the constant score 1 (epoch 1ms) to force prompt
-   * dispatch, and a producer whose score function returns 0 or NaN used to
+   * dispatch, and a producer whose score function returned 0 or NaN used to
    * stage at the epoch too (`?? 0` in queueManager, `??` in GroupQueue.send:
    * neither catches 0). Both read as ~56 years of age. The lower bound is
-   * therefore MIN_PLAUSIBLE_EPOCH_MS rather than `(1`, which makes the gauge
-   * structurally incapable of reporting an age that predates the queue,
-   * whatever a producer writes. Rows dropped for an implausible (rather than
-   * sentinel) score raise gq_ready_score_implausible_total, because a silent
-   * skip would leave a mis-scored producer invisible.
+   * therefore MIN_PLAUSIBLE_EPOCH_MS rather than `(1`, which drops the sentinel
+   * and every non-timestamp alike.
+   *
+   * This is the ABSOLUTE bound only, deliberately - not the two-sided one
+   * `resolveReadyScore` applies at staging. A genuine backlog IS arbitrarily
+   * far in the past, and reporting it is this gauge's entire job, so "old" must
+   * stay reportable while "not a timestamp" is skipped. Staging now bounds what
+   * can be written, so what this catches is rows staged before that guard
+   * existed; they are not counted here, because by the time a row is read back
+   * the producer that wrote it is no longer identifiable. The counter is raised
+   * at the staging fallback instead.
    *
    * Known residual: unpark restores a group's preserved (pre-park) ready
    * score, so a long-parked group briefly over-reports on unpark until it is
@@ -220,7 +205,7 @@ export class GroupQueueMetricsCollector {
       eligibleDueMs === null ? 0 : Math.max(0, nowMs - eligibleDueMs),
     );
 
-    const backlog = await this.foldDeferredHeads({
+    const oldestDueMs = await this.foldDeferredHeads({
       readyKey,
       keyPrefix,
       nowMs,
@@ -228,13 +213,8 @@ export class GroupQueueMetricsCollector {
     });
     gqOldestBacklogAgeMilliseconds.set(
       { queue_name: this.params.queueName },
-      backlog.oldest === null ? 0 : Math.max(0, nowMs - backlog.oldest),
+      oldestDueMs === null ? 0 : Math.max(0, nowMs - oldestDueMs),
     );
-
-    await this.reportImplausibleScores({
-      readyKey,
-      headRows: backlog.implausible,
-    });
   }
 
   /**
@@ -252,7 +232,7 @@ export class GroupQueueMetricsCollector {
     keyPrefix: string;
     nowMs: number;
     seed: number | null;
-  }): Promise<{ oldest: number | null; implausible: number }> {
+  }): Promise<number | null> {
     const deferredGroups = await this.params.redisConnection.zrangebyscore(
       readyKey,
       `(${nowMs}`,
@@ -261,7 +241,7 @@ export class GroupQueueMetricsCollector {
       0,
       OLDEST_BACKLOG_SAMPLE_GROUPS,
     );
-    if (deferredGroups.length === 0) return { oldest: seed, implausible: 0 };
+    if (deferredGroups.length === 0) return seed;
 
     const headPipeline = this.params.redisConnection.pipeline();
     for (const groupId of deferredGroups) {
@@ -275,54 +255,6 @@ export class GroupQueueMetricsCollector {
     const headResults = (await headPipeline.exec()) ?? [];
     return minDueMs(seed, headResults, nowMs);
   }
-
-  /**
-   * Counts the ready rows the age probes refused to read as a timestamp, and
-   * raises the counter that makes those refusals visible.
-   *
-   * The unblock sentinel is a deliberate score, so subtract it back out;
-   * anything else under the floor is a producer writing something that is not
-   * an occurrence time. The sentinel count only runs when something was found
-   * under the floor, so the healthy steady state pays for one ZCOUNT over an
-   * empty range.
-   */
-  private async reportImplausibleScores({
-    readyKey,
-    headRows,
-  }: {
-    readyKey: string;
-    headRows: number;
-  }): Promise<void> {
-    const belowFloorRows = await this.params.redisConnection.zcount(
-      readyKey,
-      "-inf",
-      `(${MIN_PLAUSIBLE_EPOCH_MS}`,
-    );
-    const sentinelRows =
-      belowFloorRows === 0
-        ? 0
-        : await this.params.redisConnection.zcount(
-            readyKey,
-            READY_UNBLOCK_SENTINEL_SCORE,
-            READY_UNBLOCK_SENTINEL_SCORE,
-          );
-    const implausibleRows =
-      Math.max(0, belowFloorRows - sentinelRows) + headRows;
-
-    if (implausibleRows > 0) {
-      gqReadyScoreImplausibleTotal.inc(
-        { queue_name: this.params.queueName },
-        implausibleRows,
-      );
-    }
-    if (implausibleRows > 0 && this.lastImplausibleRows === 0) {
-      this.params.logger.warn(
-        { queueName: this.params.queueName, implausibleRows },
-        "Queue holds jobs scored below the plausible-epoch floor - a producer's score function is returning a value that is not an occurrence time, which also ranks those jobs ahead of every real one",
-      );
-    }
-    this.lastImplausibleRows = implausibleRows;
-  }
 }
 
 /**
@@ -331,29 +263,22 @@ export class GroupQueueMetricsCollector {
  * future (delayed stage, monitor timers hours out) is not late work.
  *
  * A head score below the plausible-epoch floor is dropped for the same reason
- * the eligible probe drops one - `nowMs - 0` is not an age - and reported back
- * so the caller can count it. An absent or unreadable head is not implausible,
- * just nothing to fold.
+ * the eligible probe drops one: `nowMs - 0` is not an age. It is not counted
+ * here - the counter is raised at staging, where the value still exists and the
+ * producer is still identifiable.
  */
 function minDueMs(
   seed: number | null,
   headResults: Array<[unknown, unknown]>,
   nowMs: number,
-): { oldest: number | null; implausible: number } {
-  const heads = headResults
+): number | null {
+  return headResults
     .map(([err, value]) => (err ? [] : (value as string[])))
     .filter((arr) => arr.length >= 2)
-    .map((arr) => Number(arr[1]));
-
-  const oldest = heads
+    .map((arr) => Number(arr[1]))
     .filter((dueMs) => isPlausibleReadyScore(dueMs) && dueMs <= nowMs)
     .reduce<number | null>(
       (acc, dueMs) => (acc === null || dueMs < acc ? dueMs : acc),
       seed,
     );
-
-  return {
-    oldest,
-    implausible: heads.filter((dueMs) => !isPlausibleReadyScore(dueMs)).length,
-  };
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -11,7 +11,9 @@ import {
   gqOldestPendingAgeMilliseconds,
   gqParkedGroups,
   gqPendingGroups,
+  gqReadyScoreImplausibleTotal,
 } from "./metrics";
+import { isPlausibleReadyScore, MIN_PLAUSIBLE_EPOCH_MS } from "./readyScore";
 import type { DispatchResult, GroupStagingScripts } from "./scripts";
 
 /**
@@ -19,6 +21,11 @@ import type { DispatchResult, GroupStagingScripts } from "./scripts";
  * queue.redis.repository.ts) to force a just-unblocked group to dispatch
  * promptly. It is a sentinel (epoch 1ms), not a real eligibility time, so the
  * oldest-pending-age gauge excludes it — see the computation in collect().
+ *
+ * It sits below MIN_PLAUSIBLE_EPOCH_MS, so the floor the gauges now apply
+ * already drops it. The constant survives as the lower edge of the band the
+ * implausible-score counter watches: a sentinel is deliberate, a score of 0 or
+ * 57,000 is a producer bug, and only the second should raise a signal.
  */
 const READY_UNBLOCK_SENTINEL_SCORE = 1;
 
@@ -39,6 +46,13 @@ const OLDEST_BACKLOG_SAMPLE_GROUPS = 50;
  */
 export class GroupQueueMetricsCollector {
   private interval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Implausible rows seen last cycle. Only the transition from none to some is
+   * logged: the counter carries the ongoing signal, and an implausibly-scored
+   * group can sit in ready for days, which at collect cadence would be a warn
+   * line every few seconds for as long as it stays.
+   */
+  private lastImplausibleRows = 0;
 
   constructor(
     private readonly params: {
@@ -152,11 +166,17 @@ export class GroupQueueMetricsCollector {
    *      reported its entire blocked duration as backlog age (0 -> hours in
    *      one tick).
    *
-   * Exclude the unblock sentinel: UNBLOCK_LUA (app-layer/ops/repositories/
-   * queue.redis.repository.ts) re-adds a group to ready with the constant
-   * score 1 (epoch 1ms) to force prompt dispatch — not a real eligibility
-   * time, so a just-unblocked group must not read as ~56 years. The
-   * exclusive `(1` lower bound drops it; any real timestamp is far larger.
+   * Exclude every score that cannot be a timestamp, not just the sentinel.
+   * UNBLOCK_LUA (app-layer/ops/repositories/queue.redis.repository.ts) re-adds
+   * a group to ready with the constant score 1 (epoch 1ms) to force prompt
+   * dispatch, and a producer whose score function returns 0 or NaN used to
+   * stage at the epoch too (`?? 0` in queueManager, `??` in GroupQueue.send:
+   * neither catches 0). Both read as ~56 years of age. The lower bound is
+   * therefore MIN_PLAUSIBLE_EPOCH_MS rather than `(1`, which makes the gauge
+   * structurally incapable of reporting an age that predates the queue,
+   * whatever a producer writes. Rows dropped for an implausible (rather than
+   * sentinel) score raise gq_ready_score_implausible_total, because a silent
+   * skip would leave a mis-scored producer invisible.
    *
    * Known residual: unpark restores a group's preserved (pre-park) ready
    * score, so a long-parked group briefly over-reports on unpark until it is
@@ -186,7 +206,7 @@ export class GroupQueueMetricsCollector {
     const nowMs = Date.now();
     const oldestEligible = await this.params.redisConnection.zrangebyscore(
       readyKey,
-      `(${READY_UNBLOCK_SENTINEL_SCORE}`,
+      MIN_PLAUSIBLE_EPOCH_MS,
       nowMs,
       "WITHSCORES",
       "LIMIT",
@@ -200,7 +220,39 @@ export class GroupQueueMetricsCollector {
       eligibleDueMs === null ? 0 : Math.max(0, nowMs - eligibleDueMs),
     );
 
-    let oldestDueMs = eligibleDueMs;
+    const backlog = await this.foldDeferredHeads({
+      readyKey,
+      keyPrefix,
+      nowMs,
+      seed: eligibleDueMs,
+    });
+    gqOldestBacklogAgeMilliseconds.set(
+      { queue_name: this.params.queueName },
+      backlog.oldest === null ? 0 : Math.max(0, nowMs - backlog.oldest),
+    );
+
+    await this.reportImplausibleScores({
+      readyKey,
+      headRows: backlog.implausible,
+    });
+  }
+
+  /**
+   * Samples the nearest-deferred ready groups and folds their head-job scores
+   * into the oldest due time, seeded with the eligible head so an old eligible
+   * group past the sample bound still registers.
+   */
+  private async foldDeferredHeads({
+    readyKey,
+    keyPrefix,
+    nowMs,
+    seed,
+  }: {
+    readyKey: string;
+    keyPrefix: string;
+    nowMs: number;
+    seed: number | null;
+  }): Promise<{ oldest: number | null; implausible: number }> {
     const deferredGroups = await this.params.redisConnection.zrangebyscore(
       readyKey,
       `(${nowMs}`,
@@ -209,23 +261,67 @@ export class GroupQueueMetricsCollector {
       0,
       OLDEST_BACKLOG_SAMPLE_GROUPS,
     );
-    if (deferredGroups.length > 0) {
-      const headPipeline = this.params.redisConnection.pipeline();
-      for (const groupId of deferredGroups) {
-        headPipeline.zrange(
-          `${keyPrefix}group:${groupId}:jobs`,
-          0,
-          0,
-          "WITHSCORES",
-        );
-      }
-      const headResults = (await headPipeline.exec()) ?? [];
-      oldestDueMs = minDueMs(oldestDueMs, headResults, nowMs);
+    if (deferredGroups.length === 0) return { oldest: seed, implausible: 0 };
+
+    const headPipeline = this.params.redisConnection.pipeline();
+    for (const groupId of deferredGroups) {
+      headPipeline.zrange(
+        `${keyPrefix}group:${groupId}:jobs`,
+        0,
+        0,
+        "WITHSCORES",
+      );
     }
-    gqOldestBacklogAgeMilliseconds.set(
-      { queue_name: this.params.queueName },
-      oldestDueMs === null ? 0 : Math.max(0, nowMs - oldestDueMs),
+    const headResults = (await headPipeline.exec()) ?? [];
+    return minDueMs(seed, headResults, nowMs);
+  }
+
+  /**
+   * Counts the ready rows the age probes refused to read as a timestamp, and
+   * raises the counter that makes those refusals visible.
+   *
+   * The unblock sentinel is a deliberate score, so subtract it back out;
+   * anything else under the floor is a producer writing something that is not
+   * an occurrence time. The sentinel count only runs when something was found
+   * under the floor, so the healthy steady state pays for one ZCOUNT over an
+   * empty range.
+   */
+  private async reportImplausibleScores({
+    readyKey,
+    headRows,
+  }: {
+    readyKey: string;
+    headRows: number;
+  }): Promise<void> {
+    const belowFloorRows = await this.params.redisConnection.zcount(
+      readyKey,
+      "-inf",
+      `(${MIN_PLAUSIBLE_EPOCH_MS}`,
     );
+    const sentinelRows =
+      belowFloorRows === 0
+        ? 0
+        : await this.params.redisConnection.zcount(
+            readyKey,
+            READY_UNBLOCK_SENTINEL_SCORE,
+            READY_UNBLOCK_SENTINEL_SCORE,
+          );
+    const implausibleRows =
+      Math.max(0, belowFloorRows - sentinelRows) + headRows;
+
+    if (implausibleRows > 0) {
+      gqReadyScoreImplausibleTotal.inc(
+        { queue_name: this.params.queueName },
+        implausibleRows,
+      );
+    }
+    if (implausibleRows > 0 && this.lastImplausibleRows === 0) {
+      this.params.logger.warn(
+        { queueName: this.params.queueName, implausibleRows },
+        "Queue holds jobs scored below the plausible-epoch floor - a producer's score function is returning a value that is not an occurrence time, which also ranks those jobs ahead of every real one",
+      );
+    }
+    this.lastImplausibleRows = implausibleRows;
   }
 }
 
@@ -233,18 +329,31 @@ export class GroupQueueMetricsCollector {
  * Folds the sampled head-job [member, score] replies into the running oldest
  * due time. Only DUE jobs are backlog: a head legitimately scheduled in the
  * future (delayed stage, monitor timers hours out) is not late work.
+ *
+ * A head score below the plausible-epoch floor is dropped for the same reason
+ * the eligible probe drops one - `nowMs - 0` is not an age - and reported back
+ * so the caller can count it. An absent or unreadable head is not implausible,
+ * just nothing to fold.
  */
 function minDueMs(
   seed: number | null,
   headResults: Array<[unknown, unknown]>,
   nowMs: number,
-): number | null {
-  let oldest = seed;
-  for (const [err, value] of headResults) {
-    const arr = err ? [] : (value as string[]);
-    const dueMs = arr.length >= 2 ? Number(arr[1]) : Number.NaN;
-    const isDue = Number.isFinite(dueMs) && dueMs <= nowMs;
-    if (isDue && (oldest === null || dueMs < oldest)) oldest = dueMs;
-  }
-  return oldest;
+): { oldest: number | null; implausible: number } {
+  const heads = headResults
+    .map(([err, value]) => (err ? [] : (value as string[])))
+    .filter((arr) => arr.length >= 2)
+    .map((arr) => Number(arr[1]));
+
+  const oldest = heads
+    .filter((dueMs) => isPlausibleReadyScore(dueMs) && dueMs <= nowMs)
+    .reduce<number | null>(
+      (acc, dueMs) => (acc === null || dueMs < acc ? dueMs : acc),
+      seed,
+    );
+
+  return {
+    oldest,
+    implausible: heads.filter((dueMs) => !isPlausibleReadyScore(dueMs)).length,
+  };
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
@@ -131,7 +131,7 @@ export function fallbackReadyScore(nowMs: number = Date.now()): number {
  * report an age of zero. It degrades ordering within the group from occurrence
  * order to arrival order, and loses nothing.
  *
- * `rejected` distinguishes the two ways of arriving at the fallback, because
+ * `isRejected` distinguishes the two ways of arriving at the fallback, because
  * only one of them is a defect:
  *   - absent (`undefined` / `null`): the producer has no occurrence time and
  *     never claimed to. Scoring it now is the designed default, not a repair.
@@ -148,10 +148,10 @@ export function resolveReadyScore({
 }: {
   score: unknown;
   nowMs?: number;
-}): { score: number; rejected: boolean } {
+}): { score: number; isRejected: boolean } {
   if (score === undefined || score === null) {
-    return { score: fallbackReadyScore(nowMs), rejected: false };
+    return { score: fallbackReadyScore(nowMs), isRejected: false };
   }
-  if (isUsableReadyScore(score, nowMs)) return { score, rejected: false };
-  return { score: fallbackReadyScore(nowMs), rejected: true };
+  if (isUsableReadyScore(score, nowMs)) return { score, isRejected: false };
+  return { score: fallbackReadyScore(nowMs), isRejected: true };
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
@@ -1,45 +1,146 @@
 /**
- * Lowest value a ready score can take and still be a real epoch-milliseconds
- * timestamp: 2020-09-13T12:26:40Z, years before this queue existed and far
- * above every accidental score we have seen (0, 1, a small counter, a value in
- * epoch SECONDS at ~1.7e9).
+ * A ready score is a dispatch-eligibility time, and for the highest-volume
+ * producers it is a value the CUSTOMER supplies: `recordDataPoint`,
+ * `contributeMetricFacts` and `contributeLogFacts` all score off an OTLP
+ * `timeUnixNano`, and nothing clamps it on ingest. So the score's domain is not
+ * "roughly now", it is "any number a client's clock can emit", and it has to be
+ * judged against the clock we are staging on rather than against a constant.
  *
- * The floor exists because a ready score is read back as an age. Anything below
- * it is a scoring bug, and `Date.now() - score` turns that bug into decades of
- * reported backlog: `gq_oldest_pending_age_milliseconds` reported ~1.786e12 ms
- * (about 56 years) in production on 2026-07-31 and 2026-08-03, from a score of
- * roughly 2 to 57,000 - a few seconds past the Unix epoch.
+ * Both directions cause a distinct, observed failure:
+ *
+ *   too far in the past   - the job sits permanently at the head of its group
+ *                           and never yields, and `now - score` is reported as
+ *                           the queue's backlog age. A fixed floor does not
+ *                           bound this: a tenant shipping logs stamped
+ *                           2021-01-01 clears any floor set below it and still
+ *                           reads as ~5 years of backlog.
+ *   too far in the future - dispatch scans `ZRANGEBYSCORE readyKey "-inf" now`,
+ *                           so a score of 2030 makes the group invisible to
+ *                           dispatch until 2030 while its jobs keep counting
+ *                           against `totalPending`. A tenant with a fast clock
+ *                           can park their own ingestion.
+ *
+ * Same shape and vocabulary as `MAX_ANCHOR_FUTURE_SKEW_MS` / `isUsableAnchorMs`
+ * in `traceAnalytics.foldProjection.ts` (ADR-071), which exists for exactly this
+ * "the value is producer-controlled" problem. The two should read as one idea.
+ */
+
+/**
+ * How far behind the staging clock a producer's score may sit and still be used
+ * verbatim.
+ *
+ * A day, matching the anchor bound: telemetry is legitimately batched and
+ * exported late, and a whole day of lateness should still dispatch in its own
+ * occurrence order rather than being flattened onto arrival order. Beyond that
+ * the value stops looking like "when this happened" and starts looking like a
+ * broken clock, and the cost of trusting it (a permanent queue-head squatter,
+ * an age gauge reporting years) outweighs the ordering we would preserve.
+ */
+export const MAX_SCORE_PAST_SKEW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How far ahead of the staging clock a producer's score may sit.
+ *
+ * Much tighter than the past bound, and deliberately tighter than the anchor's
+ * day. The anchor records a customer's own business time for storage, where a
+ * day of skew costs nothing but a partition; a ready score decides WHEN WE DO
+ * THE WORK, so every millisecond of tolerated future skew is a millisecond we
+ * defer our own pipeline on a client's say-so.
+ *
+ * Nothing legitimate needs it wider. Every registered score function returns a
+ * past occurrence or creation time (`queueManager.ts` handler/projection/
+ * command/reactor/job registrations and `projectionRouter.ts`'s `acceptedAt`
+ * ordering); deliberate deferral is expressed as `delay`, which is added AFTER
+ * the score is resolved; and the retry paths compute `Date.now() + backoffMs`
+ * directly without passing through this module. Five minutes is therefore pure
+ * clock-skew allowance for an unsynchronised client, not headroom for a
+ * feature.
+ */
+export const MAX_SCORE_FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+/**
+ * Absolute backstop: below this (2020-09-13, years before this queue existed) a
+ * value is not a wall-clock timestamp at all, whatever the relative bounds say.
+ *
+ * The relative bounds cannot catch every case on their own, because they are
+ * measured against a clock that can itself be wrong. A worker that boots before
+ * its NTP sync reads `Date.now()` in 1970, and every score it stages is then
+ * "plausible" relative to that. This is the check that still fails.
+ *
+ * Also the bound the age gauges apply when reading the ready set, where the
+ * relative test is unusable: a genuine backlog IS arbitrarily far in the past,
+ * so the gauge must distinguish "old" (report it) from "not a timestamp"
+ * (skip it). Rows staged before this module shipped can still hold 0.
  */
 export const MIN_PLAUSIBLE_EPOCH_MS = 1_600_000_000_000;
 
 /**
- * True when `score` can be used as a dispatch-eligibility time.
- *
- * Deliberately stricter than a null check. `??` (the previous guard) passes 0,
- * NaN, a negative number and a Date, and every one of those either ranks a job
- * ahead of all real work or poisons the arithmetic that derives an age from it.
+ * A finite, strictly positive number - the same predicate `SpanTimingService`
+ * applies to span times, and the floor every other check builds on.
  */
-export function isPlausibleReadyScore(score: unknown): score is number {
+function isTimestampLike(value: unknown): value is number {
+  return typeof value === "number" && value > 0 && Number.isFinite(value);
+}
+
+/**
+ * True when `value` is a wall-clock timestamp at all, independent of any
+ * clock we might compare it against.
+ */
+export function isPlausibleReadyScore(value: unknown): value is number {
+  return isTimestampLike(value) && value >= MIN_PLAUSIBLE_EPOCH_MS;
+}
+
+/**
+ * True when `score` can be used as a dispatch-eligibility time against the
+ * clock reading `nowMs`: a real timestamp, not implausibly stale, and not far
+ * enough ahead to hide the group from dispatch.
+ *
+ * `nowMs` is injected rather than read here so callers can validate a batch
+ * against one shared reading, and so the bounds stay testable.
+ */
+export function isUsableReadyScore(
+  score: unknown,
+  nowMs: number,
+): score is number {
   return (
-    typeof score === "number" &&
-    Number.isFinite(score) &&
-    score >= MIN_PLAUSIBLE_EPOCH_MS
+    isPlausibleReadyScore(score) &&
+    score >= nowMs - MAX_SCORE_PAST_SKEW_MS &&
+    score <= nowMs + MAX_SCORE_FUTURE_SKEW_MS
   );
 }
 
 /**
- * Resolves a producer-supplied ready score, falling back to the current time
- * when it is not a usable epoch-milliseconds timestamp.
+ * The clock reading to fall back to, checked rather than trusted.
  *
- * "Now" is the honest fallback: a job whose occurrence time we cannot read is a
- * job we are learning about now, so it should sort with its arrival and report
- * an age of zero. Staging it at the epoch instead claims it has been waiting
- * since 1970, jumps it ahead of every real job in the dispatch order, and makes
- * the oldest-pending-age gauge unusable for the whole queue.
+ * The terminal step is validated for the same reason `firstUsableAnchor` checks
+ * its own: a fallback that is assumed good is how the epoch gets in. Only the
+ * absolute bound applies - `nowMs` is trivially within skew of itself - so a
+ * pre-NTP clock is pinned to the backstop instead of staging 1970 out of the
+ * function whose whole job is to prevent it.
+ */
+export function fallbackReadyScore(nowMs: number = Date.now()): number {
+  return isPlausibleReadyScore(nowMs) ? nowMs : MIN_PLAUSIBLE_EPOCH_MS;
+}
+
+/**
+ * Resolves a producer-supplied ready score, falling back to the staging clock
+ * when the value cannot be used.
+ *
+ * "Now" is the honest fallback: a job whose occurrence time we cannot trust is
+ * a job we are learning about now, so it should sort with its arrival and
+ * report an age of zero. It degrades ordering within the group from occurrence
+ * order to arrival order, and loses nothing.
+ *
+ * `rejected` distinguishes the two ways of arriving at the fallback, because
+ * only one of them is a defect:
+ *   - absent (`undefined` / `null`): the producer has no occurrence time and
+ *     never claimed to. Scoring it now is the designed default, not a repair.
+ *   - present but unusable: the producer supplied something we refused. That is
+ *     a broken score function, and the caller raises a counter for it.
  *
  * @param score - what the producer's score function returned, if it has one.
- * @param nowMs - the fallback clock reading. Batch staging passes one shared
- *   value so a batch keeps its FIFO order.
+ * @param nowMs - the staging clock. Batch staging passes one shared value so a
+ *   batch that falls back keeps its arrival order.
  */
 export function resolveReadyScore({
   score,
@@ -47,6 +148,10 @@ export function resolveReadyScore({
 }: {
   score: unknown;
   nowMs?: number;
-}): number {
-  return isPlausibleReadyScore(score) ? score : nowMs;
+}): { score: number; rejected: boolean } {
+  if (score === undefined || score === null) {
+    return { score: fallbackReadyScore(nowMs), rejected: false };
+  }
+  if (isUsableReadyScore(score, nowMs)) return { score, rejected: false };
+  return { score: fallbackReadyScore(nowMs), rejected: true };
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/readyScore.ts
@@ -1,0 +1,52 @@
+/**
+ * Lowest value a ready score can take and still be a real epoch-milliseconds
+ * timestamp: 2020-09-13T12:26:40Z, years before this queue existed and far
+ * above every accidental score we have seen (0, 1, a small counter, a value in
+ * epoch SECONDS at ~1.7e9).
+ *
+ * The floor exists because a ready score is read back as an age. Anything below
+ * it is a scoring bug, and `Date.now() - score` turns that bug into decades of
+ * reported backlog: `gq_oldest_pending_age_milliseconds` reported ~1.786e12 ms
+ * (about 56 years) in production on 2026-07-31 and 2026-08-03, from a score of
+ * roughly 2 to 57,000 - a few seconds past the Unix epoch.
+ */
+export const MIN_PLAUSIBLE_EPOCH_MS = 1_600_000_000_000;
+
+/**
+ * True when `score` can be used as a dispatch-eligibility time.
+ *
+ * Deliberately stricter than a null check. `??` (the previous guard) passes 0,
+ * NaN, a negative number and a Date, and every one of those either ranks a job
+ * ahead of all real work or poisons the arithmetic that derives an age from it.
+ */
+export function isPlausibleReadyScore(score: unknown): score is number {
+  return (
+    typeof score === "number" &&
+    Number.isFinite(score) &&
+    score >= MIN_PLAUSIBLE_EPOCH_MS
+  );
+}
+
+/**
+ * Resolves a producer-supplied ready score, falling back to the current time
+ * when it is not a usable epoch-milliseconds timestamp.
+ *
+ * "Now" is the honest fallback: a job whose occurrence time we cannot read is a
+ * job we are learning about now, so it should sort with its arrival and report
+ * an age of zero. Staging it at the epoch instead claims it has been waiting
+ * since 1970, jumps it ahead of every real job in the dispatch order, and makes
+ * the oldest-pending-age gauge unusable for the whole queue.
+ *
+ * @param score - what the producer's score function returned, if it has one.
+ * @param nowMs - the fallback clock reading. Batch staging passes one shared
+ *   value so a batch keeps its FIFO order.
+ */
+export function resolveReadyScore({
+  score,
+  nowMs = Date.now(),
+}: {
+  score: unknown;
+  nowMs?: number;
+}): number {
+  return isPlausibleReadyScore(score) ? score : nowMs;
+}

--- a/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.readyScore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.readyScore.unit.test.ts
@@ -94,6 +94,28 @@ describe("QueueManager ready scores", () => {
       );
     });
 
+    /**
+     * The repair belongs to `GroupQueue`, not here. Only there is the queue
+     * name in scope to raise `gq_ready_score_implausible_total`, so quietly
+     * rewriting a supplied-but-broken value at this layer would hide the
+     * producer that needs fixing.
+     */
+    /** @scenario "a supplied occurrence time reaches the queue unrepaired" */
+    it("hands a supplied but implausible occurrence time over untouched", () => {
+      const registry = new Map<string, JobRegistryEntry>();
+      createManager(registry).registerJob({
+        name: "passThrough",
+        process: vi.fn(),
+      });
+
+      const entry = registry.get("test-pipeline:job:passThrough");
+
+      expect(entry?.scoreFn({ tenantId: "t1", occurredAt: 0 })).toBe(0);
+      expect(
+        entry?.scoreFn({ tenantId: "t1", occurredAt: Date.UTC(2021, 0, 1) }),
+      ).toBe(Date.UTC(2021, 0, 1));
+    });
+
     it("keeps an explicitly supplied score function", () => {
       const registry = new Map<string, JobRegistryEntry>();
       createManager(registry).registerJob({

--- a/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.readyScore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.readyScore.unit.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { Command, CommandHandler } from "../../../commands/command";
+import type { CommandHandlerClass } from "../../../commands/commandHandlerClass";
+import { defineCommandSchema } from "../../../commands/commandSchema";
+import type { CommandType } from "../../../domain/commandType";
+import type { Event } from "../../../domain/types";
+import type { EventSourcedQueueProcessor } from "../../../queues";
+import { createTestAggregateType } from "../../__tests__/testHelpers";
+import type { JobRegistryEntry } from "../queueManager";
+import { QueueManager } from "../queueManager";
+
+/**
+ * Above MIN_PLAUSIBLE_EPOCH_MS on purpose. The wider QueueManager suite pins
+ * the clock at 1,000,000 ms, which a ready score can no longer legitimately
+ * take, so these tests carry their own plausible clock.
+ */
+const NOW = 1_786_000_000_000;
+
+function createMockSharedQueue(): EventSourcedQueueProcessor<any> {
+  return {
+    send: vi.fn().mockResolvedValue(void 0),
+    sendBatch: vi.fn().mockResolvedValue(void 0),
+    close: vi.fn().mockResolvedValue(void 0),
+    waitUntilReady: vi.fn().mockResolvedValue(void 0),
+  };
+}
+
+function createMockCommandHandlerClass(): CommandHandlerClass<
+  any,
+  CommandType,
+  Event
+> {
+  class MockCommandHandler implements CommandHandler<Command<any, any>, Event> {
+    static readonly schema = defineCommandSchema(
+      "test.command.readyScore" as CommandType,
+      z.object({
+        tenantId: z.string(),
+        aggregateId: z.string(),
+        occurredAt: z.number().optional(),
+      }),
+    );
+
+    static getAggregateId(payload: any): string {
+      return payload.aggregateId;
+    }
+
+    async handle(_command: Command<any, any>): Promise<Event[]> {
+      return [];
+    }
+  }
+
+  return MockCommandHandler as any;
+}
+
+function createManager(globalJobRegistry: Map<string, JobRegistryEntry>) {
+  return new QueueManager({
+    aggregateType: createTestAggregateType(),
+    pipelineName: "test-pipeline",
+    globalQueue: createMockSharedQueue(),
+    globalJobRegistry,
+  });
+}
+
+describe("QueueManager ready scores", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("given a standalone job registered without its own score function", () => {
+    /**
+     * The source of the 2026-07-31 / 2026-08-03 spurious Events Backed Up
+     * fires: this fallback used to be `?? 0`, so a payload with no occurrence
+     * time staged at the epoch and reported ~56 years of age for the whole
+     * queue.
+     */
+    /** @scenario "a standalone job with no occurrence time is scored at the current time" */
+    it("scores a payload with no occurrence time at the current time", () => {
+      const registry = new Map<string, JobRegistryEntry>();
+      createManager(registry).registerJob({
+        name: "deferredCheck",
+        process: vi.fn(),
+      });
+
+      const entry = registry.get("test-pipeline:job:deferredCheck");
+
+      expect(entry?.scoreFn({ tenantId: "t1" })).toBe(NOW);
+      expect(entry?.scoreFn({ tenantId: "t1", occurredAt: NOW - 30_000 })).toBe(
+        NOW - 30_000,
+      );
+    });
+
+    it("keeps an explicitly supplied score function", () => {
+      const registry = new Map<string, JobRegistryEntry>();
+      createManager(registry).registerJob({
+        name: "customScore",
+        process: vi.fn(),
+        scoreFn: () => NOW - 1_000,
+      });
+
+      expect(registry.get("test-pipeline:job:customScore")?.scoreFn({})).toBe(
+        NOW - 1_000,
+      );
+    });
+  });
+
+  describe("given a command that is not serialized by aggregate", () => {
+    /** @scenario "a command with no occurrence time is scored at the current time" */
+    it("scores a payload with no occurrence time at the current time", () => {
+      const registry = new Map<string, JobRegistryEntry>();
+      createManager(registry).initializeCommandQueues(
+        [
+          {
+            name: "readyScore",
+            handlerClass: createMockCommandHandlerClass() as never,
+            options: {},
+          },
+        ] as never,
+        vi.fn(),
+        "test-pipeline",
+      );
+
+      const entry = registry.get("test-pipeline:command:readyScore");
+
+      expect(entry?.scoreFn({ tenantId: "t1", aggregateId: "a1" })).toBe(NOW);
+      expect(
+        entry?.scoreFn({
+          tenantId: "t1",
+          aggregateId: "a1",
+          occurredAt: NOW - 42,
+        }),
+      ).toBe(NOW - 42);
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
@@ -15,7 +15,6 @@ import type {
   QueueSendOptions,
 } from "../../queues";
 import { resolveDeduplicationStrategy } from "../../queues";
-import { resolveReadyScore } from "../../queues/groupQueue/readyScore";
 import type { JobDelivery } from "../../queues/queue.types";
 import type { EventStoreReadContext } from "../../stores/eventStore.types";
 import {
@@ -30,19 +29,30 @@ const logger = createLogger("langwatch:event-sourcing:queue-manager");
 /**
  * Ready score for a payload whose own occurrence time orders its dispatch.
  *
- * A missing or implausible `occurredAt` means "we never recorded when this
- * happened", not "this happened in January 1970". The previous `?? 0` fallback
- * meant the latter: it staged the job with a ready score of epoch-plus-delay,
- * which both ranks it ahead of every real job and makes
+ * A missing `occurredAt` means "we never recorded when this happened", not
+ * "this happened in January 1970". The previous `?? 0` fallback meant the
+ * latter: it staged the job with a ready score of epoch-plus-delay, which both
+ * ranks it ahead of every real job and makes
  * `gq_oldest_pending_age_milliseconds` report about 56 years of backlog for the
  * whole queue (production, 2026-07-31 and 2026-08-03).
  *
- * Falling back to now matches every other producer in this file - the
- * `serializeByAggregate` branch scores `Date.now()` outright, and
+ * Scoring an absent value at `Date.now()` matches every other producer in this
+ * file - the `serializeByAggregate` branch scores `Date.now()` outright, and
  * `GroupQueue.send` does the same when no score function is registered.
+ *
+ * A value that IS present is handed over untouched, however odd it looks. It is
+ * `GroupQueue`'s guard that judges it against the staging clock, and only there
+ * is the queue name in scope to raise `gq_ready_score_implausible_total`.
+ * Repairing it here would silently hide the producer that needs fixing - which
+ * matters most for the highest-volume paths, where `occurredAt` is a
+ * customer-supplied OTLP timestamp (`recordDataPoint`, `contributeMetricFacts`,
+ * `contributeLogFacts`).
  */
 function occurredAtScore(payload: { occurredAt?: unknown }): number {
-  return resolveReadyScore({ score: payload.occurredAt });
+  const occurredAt = payload.occurredAt;
+  return occurredAt === undefined || occurredAt === null
+    ? Date.now()
+    : (occurredAt as number);
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
@@ -15,6 +15,7 @@ import type {
   QueueSendOptions,
 } from "../../queues";
 import { resolveDeduplicationStrategy } from "../../queues";
+import { resolveReadyScore } from "../../queues/groupQueue/readyScore";
 import type { JobDelivery } from "../../queues/queue.types";
 import type { EventStoreReadContext } from "../../stores/eventStore.types";
 import {
@@ -25,6 +26,24 @@ import {
 import { ConfigurationError, ValidationError } from "../errorHandling";
 
 const logger = createLogger("langwatch:event-sourcing:queue-manager");
+
+/**
+ * Ready score for a payload whose own occurrence time orders its dispatch.
+ *
+ * A missing or implausible `occurredAt` means "we never recorded when this
+ * happened", not "this happened in January 1970". The previous `?? 0` fallback
+ * meant the latter: it staged the job with a ready score of epoch-plus-delay,
+ * which both ranks it ahead of every real job and makes
+ * `gq_oldest_pending_age_milliseconds` report about 56 years of backlog for the
+ * whole queue (production, 2026-07-31 and 2026-08-03).
+ *
+ * Falling back to now matches every other producer in this file - the
+ * `serializeByAggregate` branch scores `Date.now()` outright, and
+ * `GroupQueue.send` does the same when no score function is registered.
+ */
+function occurredAtScore(payload: { occurredAt?: unknown }): number {
+  return resolveReadyScore({ score: payload.occurredAt });
+}
 
 /**
  * Metadata stored per job type in the global job registry.
@@ -654,7 +673,7 @@ export class QueueManager<EventType extends Event = Event> {
         groupKeyFn: commandGroupKeyFn,
         scoreFn: cmdEntry.options.serializeByAggregate
           ? () => Date.now()
-          : (payload: any) => payload.occurredAt as number,
+          : (payload: any) => occurredAtScore(payload),
         process: async (payload: any) => {
           await processCommand({ ...commandProcessParams, payload });
         },
@@ -939,7 +958,7 @@ export class QueueManager<EventType extends Event = Event> {
         : (payload: any) => `${String(payload.tenantId)}/job/${name}`,
       scoreFn: scoreFn
         ? (scoreFn as any)
-        : (payload: any) => (payload.occurredAt as number) ?? 0,
+        : (payload: any) => occurredAtScore(payload),
       process: process as any,
       delay,
       deduplication: deduplication

--- a/specs/event-sourcing/ready-score-integrity.feature
+++ b/specs/event-sourcing/ready-score-integrity.feature
@@ -1,0 +1,96 @@
+Feature: GroupQueue ready-score integrity
+  As an operator reading the group queue's age gauges
+  I want a ready score that is always a real occurrence time
+  So that a producer with a broken score function cannot rank its jobs ahead of
+  everything else, and cannot make a gauge report decades of backlog.
+
+  # why this exists
+  #
+  # gq_oldest_pending_age_milliseconds reported ~1.786e12 ms (about 56 years) in
+  # production on 2026-07-31 14:00-15:00 and 2026-08-03 12:00-13:00 UTC. the
+  # Events Backed Up alert reads max(...)/1000, so every one of those samples was
+  # a guaranteed spurious fire.
+  #
+  # the arithmetic: for each sample, scrape_timestamp_ms - reported_value was
+  # 315,969 / 339,017 / 357,120 ms, i.e. a ready score of roughly 2 to 57,000 - a
+  # few seconds after the Unix epoch, plus the pipeline delay. not epoch-seconds,
+  # not the unblock sentinel (1), and not the empty-queue case (the collector
+  # already reports 0 for that).
+  #
+  # the mechanism was `??`. queueManager's standalone-job score function returned
+  # `payload.occurredAt ?? 0` and GroupQueue.send coalesced with
+  # `this.score?.(payload) ?? Date.now()`. `??` passes 0 and NaN, so a payload
+  # with no occurrence time staged at the epoch and stayed the oldest thing in
+  # the queue forever.
+  #
+  # three layers, because each one alone leaves the class open:
+  #   1. the producer chooses a meaningful fallback (now, not 1970)
+  #   2. GroupQueue validates whatever a score function returns
+  #   3. the gauges refuse to read a score that cannot be a timestamp, and count
+  #      what they refused
+  #
+  # this removes one specific false signal. it does NOT quieten Events Backed Up:
+  # the gauge is legitimately enormous much of the time, because parked and
+  # future-scheduled groups inflate it, as the rule's own annotation says.
+  #
+  # MIN_PLAUSIBLE_EPOCH_MS = 1_600_000_000_000 (2020-09-13), years before this
+  # queue existed and far above every accidental score we have seen. companion
+  # to gq_oldest_backlog_age_milliseconds, which clocks off the per-group jobs
+  # zset and is floored the same way.
+
+  Rule: a producer with no occurrence time means "now", not 1970
+
+    @unit
+    Scenario: a standalone job with no occurrence time is scored at the current time
+      Given a standalone job registered without its own score function
+      When the queue scores a payload that carries no occurrence time
+      Then the score is the current time
+      And a payload that does carry an occurrence time keeps it
+
+    @unit
+    Scenario: a command with no occurrence time is scored at the current time
+      Given a command that is not serialized by aggregate
+      When the queue scores a payload that carries no occurrence time
+      Then the score is the current time
+
+  Rule: GroupQueue validates every score a producer hands it
+
+    @unit
+    Scenario: a score that is not a plausible timestamp falls back to the current time
+      Given a score function that returns 0, NaN, nothing, or a value in epoch seconds
+      When the queue resolves the ready score
+      Then the resolved score is the current time
+
+    @unit
+    Scenario: a plausible timestamp is staged unchanged
+      Given a score function that returns a real epoch-milliseconds timestamp
+      When the queue resolves the ready score
+      Then the resolved score is that timestamp, untouched
+
+    @unit
+    Scenario: a batch that falls back keeps its arrival order
+      Given a batch of payloads whose scores are all unusable
+      When the queue resolves each ready score against one shared clock reading
+      Then every fallback score is identical, so the per-index tiebreak orders them
+
+  Rule: the age gauges cannot report an age that predates the queue
+
+    @unit
+    Scenario: the oldest-pending-age gauge skips a score from just after the Unix epoch
+      Given a ready group scored a few seconds after the Unix epoch
+      When queue metrics are collected
+      Then the oldest-pending-age gauge does not report that group's age
+      And the ready-set probe reads from the plausible-epoch floor upwards
+
+    @unit
+    Scenario: an implausible ready score raises a counter instead of being swallowed
+      Given a ready group scored below the plausible-epoch floor
+      When queue metrics are collected
+      Then the implausible-ready-score counter is raised for that queue
+
+    @unit
+    Scenario: the unblock sentinel is not counted as an implausible score
+      Given a just-unblocked group carrying the unblock sentinel score
+      When queue metrics are collected
+      Then the implausible-ready-score counter stays where it was
+      And the oldest-pending-age gauge reports 0

--- a/specs/event-sourcing/ready-score-integrity.feature
+++ b/specs/event-sourcing/ready-score-integrity.feature
@@ -21,22 +21,28 @@ Feature: GroupQueue ready-score integrity
   # `payload.occurredAt ?? 0` and GroupQueue.send coalesced with
   # `this.score?.(payload) ?? Date.now()`. `??` passes 0 and NaN, so a payload
   # with no occurrence time staged at the epoch and stayed the oldest thing in
-  # the queue forever.
+  # the queue forever. deferredOriginResolution is the producer: no occurredAt
+  # on its payload, and a 5-minute delay, giving a ready score of exactly
+  # 300,000 - which the three residuals above resolve to, leaving 16.0s / 39.0s
+  # / 57.1s of collect-to-scrape lag against a 15s collector interval.
   #
   # three layers, because each one alone leaves the class open:
-  #   1. the producer chooses a meaningful fallback (now, not 1970)
-  #   2. GroupQueue validates whatever a score function returns
-  #   3. the gauges refuse to read a score that cannot be a timestamp, and count
-  #      what they refused
+  #   1. the producer scores an ABSENT occurrence time at now, and hands a
+  #      supplied one over untouched so the queue can judge and report it
+  #   2. GroupQueue bounds every score two-sided against the staging clock
+  #   3. the gauges refuse to read a score that is not a timestamp at all
   #
   # this removes one specific false signal. it does NOT quieten Events Backed Up:
   # the gauge is legitimately enormous much of the time, because parked and
   # future-scheduled groups inflate it, as the rule's own annotation says.
   #
-  # MIN_PLAUSIBLE_EPOCH_MS = 1_600_000_000_000 (2020-09-13), years before this
-  # queue existed and far above every accidental score we have seen. companion
-  # to gq_oldest_backlog_age_milliseconds, which clocks off the per-group jobs
-  # zset and is floored the same way.
+  # bounds: MAX_SCORE_PAST_SKEW_MS (24h) and MAX_SCORE_FUTURE_SKEW_MS (5min),
+  # both relative to the staging clock, plus MIN_PLAUSIBLE_EPOCH_MS
+  # (1_600_000_000_000, 2020-09-13) as the absolute backstop the relative bounds
+  # cannot provide - a worker that boots before its NTP sync reads Date.now() in
+  # 1970 and every score is then "plausible" relative to that. companion to
+  # gq_oldest_backlog_age_milliseconds, which clocks off the per-group jobs zset
+  # and applies the same backstop.
 
   Rule: a producer with no occurrence time means "now", not 1970
 
@@ -53,19 +59,49 @@ Feature: GroupQueue ready-score integrity
       When the queue scores a payload that carries no occurrence time
       Then the score is the current time
 
-  Rule: GroupQueue validates every score a producer hands it
+  Rule: GroupQueue judges every score against the clock it is staging on
+
+    # the bound is two-sided and RELATIVE, not a fixed floor. the score for the
+    # highest-volume producers is a customer-supplied OTLP timestamp, whose
+    # domain is unbounded in both directions, so a constant is the wrong shape:
+    # a tenant shipping logs stamped 2021-01-01 clears any floor and still reads
+    # as years of backlog, and a tenant whose clock says 2030 stages a group
+    # that dispatch cannot see until 2030 while its jobs count against
+    # totalPending. same vocabulary as MAX_ANCHOR_FUTURE_SKEW_MS /
+    # isUsableAnchorMs in traceAnalytics.foldProjection.ts (ADR-071).
 
     @unit
-    Scenario: a score that is not a plausible timestamp falls back to the current time
-      Given a score function that returns 0, NaN, nothing, or a value in epoch seconds
+    Scenario: a score outside the allowed skew around now falls back to the staging time
+      Given a score function that returns 0, NaN, a value in epoch seconds, a timestamp years in the past, or a clock years in the future
       When the queue resolves the ready score
-      Then the resolved score is the current time
+      Then the resolved score is the staging time
+      And the queue reports the producer's score as rejected
 
     @unit
     Scenario: a plausible timestamp is staged unchanged
-      Given a score function that returns a real epoch-milliseconds timestamp
+      Given a score function that returns a timestamp inside the allowed skew
       When the queue resolves the ready score
       Then the resolved score is that timestamp, untouched
+
+    @unit
+    Scenario: a payload with no occurrence time is scored at the staging time without being reported
+      Given a payload that carries no occurrence time at all
+      When the queue resolves the ready score
+      Then the resolved score is the staging time
+      And nothing is reported, because scoring it now is the designed default
+
+    @unit
+    Scenario: a supplied occurrence time reaches the queue unrepaired
+      Given a producer that supplies an occurrence time the queue will reject
+      When the score function runs
+      Then it hands the value over untouched
+      And the queue is what repairs it, so the counter can name the queue
+
+    @unit
+    Scenario: a fallback taken from an unsynchronised clock is itself bounded
+      Given a worker whose clock has not yet synchronised and reads 1970
+      When the queue falls back to that clock
+      Then the fallback is pinned to the plausible-epoch backstop
 
     @unit
     Scenario: a batch that falls back keeps its arrival order
@@ -73,24 +109,36 @@ Feature: GroupQueue ready-score integrity
       When the queue resolves each ready score against one shared clock reading
       Then every fallback score is identical, so the per-index tiebreak orders them
 
+    @integration
+    Scenario: a job staged with an unusable score dispatches behind one that occurred earlier
+      Given a group holding a job whose score function returns 0 and a job that occurred a minute ago
+      When the group is dispatched
+      Then the staged score in Redis is the staging time, not 0
+      And the rescored job is processed after the genuinely older one
+
   Rule: the age gauges cannot report an age that predates the queue
+
+    # the gauges apply the ABSOLUTE backstop only, never the staging skew
+    # bounds. a genuine backlog IS arbitrarily far in the past and reporting it
+    # is the whole job, so "old" must stay reportable while "not a timestamp"
+    # is skipped.
 
     @unit
     Scenario: the oldest-pending-age gauge skips a score from just after the Unix epoch
       Given a ready group scored a few seconds after the Unix epoch
       When queue metrics are collected
       Then the oldest-pending-age gauge does not report that group's age
-      And the ready-set probe reads from the plausible-epoch floor upwards
+      And the ready-set probe reads from the plausible-epoch backstop upwards
 
     @unit
-    Scenario: an implausible ready score raises a counter instead of being swallowed
-      Given a ready group scored below the plausible-epoch floor
+    Scenario: the backlog gauge drops a head job score that is not a timestamp
+      Given a sampled group whose head job score is 0
       When queue metrics are collected
-      Then the implausible-ready-score counter is raised for that queue
+      Then the backlog gauge does not read it as an age
+      And a genuinely old head job is still reported however far past it is
 
     @unit
-    Scenario: the unblock sentinel is not counted as an implausible score
+    Scenario: the unblock sentinel is not read as an age
       Given a just-unblocked group carrying the unblock sentinel score
       When queue metrics are collected
-      Then the implausible-ready-score counter stays where it was
-      And the oldest-pending-age gauge reports 0
+      Then the oldest-pending-age gauge reports 0


### PR DESCRIPTION
`gq_oldest_pending_age_milliseconds` occasionally reports an absolute epoch value (~1.786e12 ms, roughly 56 years of "age") instead of an age. Seen in production on 2026-07-31 14:00-15:00 and 2026-08-03 12:00-13:00 UTC. The `Events Backed Up` alert reads `max(...)/1000`, so each of those samples was a guaranteed spurious fire.

## The arithmetic that identifies the mechanism

For each of the three production samples, `scrape_timestamp_ms - reported_value` was **315,969 / 339,017 / 357,120 ms**. The gauge is set to `now_at_collect - readyScore`, so that residual is `readyScore + (scrape_ts - now_at_collect)`, i.e. the ready score plus however stale the gauge was when Prometheus stamped it.

That rules out the candidates:

- not the empty-queue case: `metricsCollector` already returns 0 when the ready set is empty
- not the unblock sentinel (score 1): it was already dropped by an exclusive `(1` lower bound
- not epoch-seconds (~1.7e9): the residual is three orders of magnitude too small

Subtract a ready score of exactly **300,000** and the three residuals become **15,969 / 39,017 / 57,120 ms** of collect-to-scrape lag. The collector runs on a 15s interval (`GROUP_QUEUE_CONFIG.metricsIntervalMs`), so a gauge is up to 15s stale before the scrape offset is added; 16s to 57s is exactly the expected band, and it is the only assignment that leaves a plausible residual for all three samples at once.

300,000 identifies one producer. `deferredOriginResolution` (`pipelineRegistry.ts:1075`) registers with no `scoreFn` and `delay: DEFERRED_CHECK_DELAY_MS` (5 minutes, `originGate.reactor.ts:13`), and its payload is `DeferredOriginPayload = { id, tenantId, traceId }` (`originGate.reactor.ts:16`) - **no `occurredAt` field at all**. So:

```
scoreFn(payload)  = payload.occurredAt ?? 0        = 0        (queueManager.ts:942)
score             = scoreFn(payload) ?? Date.now() = 0        (groupQueue.ts:486 - `??` does not catch 0)
dispatchAfterMs   = score + delay                 = 300,000
```

Both `??` had to miss for this to happen: the first turned a missing field into `0`, and the second failed to treat that `0` as the absent value it stood for.

- `queueManager.ts:942` - `(payload: any) => (payload.occurredAt as number) ?? 0` returned 0 for a payload with no occurrence time. All three `registerJob` call sites pass no `scoreFn`, and two of the three payload types (`DeferredOriginPayload`, `DatasetNormalizePayload`) have no `occurredAt`
- `groupQueue.ts:486` / `:617` - `this.score?.(payload) ?? Date.now()`. `??` passes `0` and `NaN`
- `queueManager.ts:657` - `payload.occurredAt as number` with no fallback. Note this site could **not** have produced the incident: `commandEnvelopeSchema` (`commands/commandEnvelope.ts:7`) makes `occurredAt` required, so a command payload always carries one. It is hardened for consistency, not because it fired

A job staged that way is also the oldest thing in the queue forever, so it pinned the gauge for the whole queue, not just for itself.

## The three layers

**1. The source.** An **absent** `occurredAt` now means **now**, not January 1970. Two of `queueManager`'s five score registrations read `occurredAt` directly and both route through one `occurredAtScore` helper; the other three (`:380` handler, `:466` projection, `:797` reactor) coalesce their own way onto `occurredAt ?? createdAt` and are covered by layer 2 rather than changed here.

Why "now": the queue's ready score is a dispatch-eligibility time, and "we never recorded when this happened" is a statement about our own bookkeeping, not about the job. Scoring it at the epoch claims it has been waiting since 1970, which (a) ranks it ahead of every real job in a work-conserving dispatch order and (b) makes the age gauge unusable queue-wide. Scoring it now sorts it with its arrival and reports an age of zero. It matches every other producer already in the file: the `serializeByAggregate` command branch scores `Date.now()` outright, and `GroupQueue.send` does the same when no score function is registered.

A value the producer **did** supply is now handed to the queue untouched, however odd it looks. Repairing it here would hide the producer that needs fixing, because only `GroupQueue` has the queue name in scope to report it.

**2. The boundary: two-sided, relative to the staging clock.** New `queues/groupQueue/readyScore.ts`. The bound is **not** a constant, because for the highest-volume producers the score is a customer-supplied OTLP timestamp and its domain is "anything a client's clock can emit":

- `MAX_SCORE_PAST_SKEW_MS` (24h). A fixed floor cannot bound this side at all: a tenant shipping logs stamped `2021-01-01` clears any floor set below it and still reads as ~5 years of backlog. 24h matches `MAX_ANCHOR_FUTURE_SKEW_MS`'s reasoning - telemetry is legitimately batched and exported late, and a day of lateness should still dispatch in occurrence order.
- `MAX_SCORE_FUTURE_SKEW_MS` (5 min). There was no upper bound before. Dispatch scans `ZRANGEBYSCORE readyKey "-inf" now`, so a device whose clock says 2030 stages a group that is invisible to dispatch **for four years** while its jobs keep counting against `totalPending` - a tenant able to park their own ingestion. Deliberately tighter than the anchor's day: the anchor records business time for storage, where skew costs a partition, whereas a ready score decides when we do the work. Nothing legitimate needs it wider - every registered score function returns a past time, deferral is expressed as `delay` which is added *after* the score, and the retry paths compute `Date.now() + backoffMs` without passing through this module.
- `MIN_PLAUSIBLE_EPOCH_MS` (2020-09-13) survives as the absolute backstop the relative bounds structurally cannot provide: a worker that boots before its NTP sync reads `Date.now()` in 1970, and every score is then "plausible" relative to *that*. `fallbackReadyScore` checks the fallback itself for exactly this, the way `firstUsableAnchor` checks its own terminal step.

Same vocabulary and shape as `isUsableAnchorMs` in `traceAnalytics.foldProjection.ts` (ADR-071), so the two read as one idea.

Applied at all **five** score-writing sites, not the four claimed before: `send`, the `sendBatch` twin (sharing one `now`), the exhausted-retry re-stage, the poison-group park, and `restageDrainedSiblings` - which was staging `sibling.originalScore` unvalidated, so a legacy row at 0 was rewritten at 0 on every batch failure and never healed. The three re-stage paths share one guard (absolute check only, since the score was already judged when first staged), which also removes an inversion this PR would otherwise have introduced: the exhausted-retry path re-scored while its drained siblings did not, so on unblock the siblings could dispatch ahead of the job they were drained behind.

**3. The gauge.** `metricsCollector` raises the eligible probe's lower bound from the exclusive `1` to `MIN_PLAUSIBLE_EPOCH_MS`, and the backlog gauge applies the same check to each sampled head-job score. Only the **absolute** bound, never the skew bounds - a genuine backlog IS arbitrarily far in the past and reporting it is the gauge's entire job, so "old" stays reportable while "not a timestamp" is skipped.

`gq_ready_score_implausible_total` is raised **at the staging fallback**, once per job, not by scanning the ready set. The scan version could not work: the guard replaces the bad score before it is written, so the scan would find nothing and report zero for ever while the broken producer carried on. It is now a true monotonic count of events (no `ZCOUNT`-versus-sample mixing, no gauge semantics), and an absent `occurredAt` does not raise it, since scoring those at staging time is the design rather than a defect.

## This does not quieten `Events Backed Up`

Explicitly out of scope. Even with this fixed the gauge is legitimately enormous much of the time - measured p50 2.3s, p90 39.6 min, p95 3.3h, and 24.5% of 5-minute buckets over the alert's 60s threshold. The reason is **not** that parked or future-scheduled groups inflate it, as an earlier draft of this description said and the rule's own annotation claims: parked and blocked groups are `ZREM`ed out of `ready`, and future-scored ones are excluded by the probe's `now` upper bound. What actually keeps it large is that it measures **occurrence** age rather than **queueing** age - the score is when the work happened, not when we accepted it, so ordinary late-arriving telemetry reads as backlog. That is fixable, in the same ingest-layer change described below, and it is worth saying plainly rather than leaving residual noise sounding structural. No alert thresholds were touched; the rules live in a separate infrastructure repository.

## Does a replay produce a score outside the bounds?

Event sourcing replays history by definition, so the obvious objection to bounding the score is that a replayed historical event would be silently rescored to "now". It cannot be, because **replay never stages a job**.

`ReplayService` (`event-sourcing/replay/replayService.ts:21`) takes only `{ clickhouseClientResolver, redis, retentionPolicyResolver }` as dependencies - no queue, no queue manager. Its runtime (`replay/replayPreset.ts:59`) builds raw ClickHouse stores with no queue at all. The seven-phase cycle in `replay/replayFoldPath.ts:300-470` is mark, **pause**, **drain**, cutoff, apply, write, unpause: it streams events page-by-page into an in-memory `FoldAccumulator` (`accumulator.apply(e)` at `:432`, `accumulator.flush()` at `:447`) while the GroupQueue lane is stopped. `grep -rn "\.send(" event-sourcing/replay/` returns nothing. ADR-015 states the same design ("Pause - `SADD ...gq:paused-jobs`. The GroupQueue stops dispatching new jobs for this projection"; "Each page is applied to a `FoldAccumulator` and immediately discarded").

So no `scoreFn` is ever evaluated for replayed work, and there is no ready score to bound. The two adjacent paths are also unaffected:

- **DLQ replay** (`replayFromDlq`) re-inserts a job with the score it already carried, in Lua (`queue.redis.repository.ts:225-233`, `ZADD dstJobsKey jobs[i+1]`). It does not call `scoreFn` and does not pass through `resolveReadyScore`, so this PR does not change it.
- **Live events deferred by a replay marker** retry through normal GroupQueue backoff and keep their ordinary live score.

Worth recording for whoever changes this next: if replay were ever routed through the queue, historical `occurredAt` values would give replayed jobs very low ready scores and they would front-run all live work. The bounds are not what would break that; the design already avoids it.

## What the bounds change for customer-supplied timestamps

Replay is safe, but a score outside the bounds is reachable from a different direction, and this is the case that made the bounds two-sided and relative rather than a constant: **some command envelopes carry a customer-supplied OTLP timestamp**, and nothing clamps it on ingest.

- `recordDataPoint` (OTLP metrics) - the command payload is the canonical record itself, whose `occurredAt = timestampMs(timeUnixNano)` (`metric-processing/canonical/buildPoint.ts:74,206`), passed straight through by `metric-request-collection.service.ts:126`
- `contributeMetricFacts` - `occurredAt: point.timeUnixMs` (`codingAgentMetricFactsDispatch.subscriber.ts:82`)
- `contributeLogFacts` - `occurredAt: record.occurredAt`, which is the customer's log `timeUnixNano` via `effectiveTimestamp` (`canonicalLog.ts:429,544`; `codingAgentLogFactsDispatch.subscriber.ts:98`)

None of these registers `serializeByAggregate`, so each scores through `queueManager.ts:676`. A client with an unset clock, a clock running fast, or a genuine backfill of old telemetry therefore produces a score outside the skew bounds, and this PR rewrites it to the staging time and raises `gq_ready_score_implausible_total` for it.

By contrast, `log_processing`'s own `recordLogRecord` is **not** exposed: it deliberately sets `occurredAt: record.acceptedAt` (`log-request-collection.service.ts:273`), keeping the customer timestamp in the separate `timeUnixMs` field. That looks like the intended convention, and the three paths above look like drift from it.

What changes when it fires: dispatch order within the affected group degrades from occurrence order to arrival order (the coding-agent pipeline's own registration comment states score order is load-bearing for its model-call chain), and the age gauges under-report rather than over-report.

**The bounds stay - please do not weaken them.** The ready score is a *dispatch-eligibility* time, not a data timestamp, so feeding a customer-controlled clock into it is wrong on its own terms, independently of this PR: a job carrying an old `timeUnixNano` sits permanently at the head of its group and never yields, which is precisely the pathology that produced the 56-year gauge reading, and one carrying a future timestamp hides its group from dispatch entirely. For these three paths the bounds do not introduce a regression, they convert one broken ordering into a safe one - degrading to arrival order, with no data loss. The pre-existing behaviour was not a working baseline to regress against.

The real fix is upstream, in the ingest layer: align `recordDataPoint`, `contributeMetricFacts` and `contributeLogFacts` with the convention `recordLogRecord` already follows - score off `acceptedAt`, keep the customer's time in its own field. That is the follow-up, and it is deliberately not in this PR because it is an ingest-layer change with its own blast radius that should not ride in on a metrics fix.

## Relationship to #6597

`gq_oldest_backlog_age_milliseconds` (added there) clocks off the per-group jobs zset rather than the ready score. It is untouched in intent and now applies the same absolute backstop, since a preserved job score can be a non-timestamp for exactly the same reason. The nearest-first deferred sampling and its regression test are unchanged.

## Spec and tests

`specs/event-sourcing/ready-score-integrity.feature`, 12 scenarios, all tagged and all bound (`12/12 scenarios bound`, verified with `pnpm check:feature-parity`).

- `readyScore.unit.test.ts` - the rejection table now covers both directions and the boundaries either side of each bound: `0`, `NaN`, negative, the sentinel, epoch seconds, `Infinity`, a `Date`, a numeric string, a 2021 timestamp, a 2030 clock, and one millisecond past each skew bound; absent-versus-rejected as separate outcomes; a shared `nowMs` keeping batch order; and `fallbackReadyScore` pinning a pre-NTP clock reading
- `metricsCollector.unit.test.ts` - the probe reads from the backstop, a group scored 57,000 reaches neither gauge, and a genuinely 30-day-old head job is **still reported**, which is what stops the gauge's bound from being tightened into blindness
- `queueManager.readyScore.unit.test.ts` - absent `occurredAt` scored at now, and a supplied-but-broken one handed over unrepaired so the queue can report it
- `groupQueue.integration.test.ts` - **the one that closes the real gap.** A queue whose `score` returns 0, a job that genuinely occurred a minute ago, and a blocker holding the group: it reads the staged score back out of the group's own jobs zset (so it fails if `send` stops calling the guard) and asserts the rescored job is processed *after* the older one. It earned its place immediately - it caught a `ReferenceError: gqReadyScoreImplausibleTotal is not defined`, a missing import in `groupQueue.ts` that every unit test passed straight over because none of them constructs a `GroupQueueProcessor`.

Eight existing integration tests scored order with bare ordinals (`value * 1000`), which the bounds now reject; they are anchored to a real recent timestamp via `orderedScore`, preserving their relative order and exercising the shape a production score function actually returns.

7,728 unit tests pass across `src/server/event-sourcing`, and all 22 tests in `groupQueue.integration.test.ts` pass against a real Redis. Biome introduces no new diagnostics (verified against the pre-change baseline).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue scheduling when jobs have missing, invalid, or implausible timestamps.
  * Preserved correct dispatch ordering, including retries, batched jobs, and delayed groups.
  * Improved backlog and eligible-age reporting by excluding invalid timestamp values while retaining genuine older work.

* **Monitoring**
  * Added reporting for rejected producer-provided timestamps, helping identify timing issues in queue activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->