### PR TITLE
fix(traces-v2): the Events column reads real events, and a category verdict stops posing as a passing zero

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -589,7 +589,6 @@ const LEGACY_INERT: string[] = [
   "specs/traces-v2/conversation-turn-ledger.feature",
   "specs/traces-v2/data-layer.feature",
   "specs/traces-v2/editable-trace-name-alignment.feature",
-  "specs/traces-v2/evaluations.feature",
   "specs/traces-v2/facet-perspectives.feature",
   "specs/traces-v2/flame-graph.feature",
   "specs/traces-v2/grouping-engine.feature",

--- a/platform/app/src/features/traces-v2/components/FindBar/useTraceSearchIndex.ts
+++ b/platform/app/src/features/traces-v2/components/FindBar/useTraceSearchIndex.ts
@@ -7,7 +7,7 @@ function buildSearchableText(trace: TraceListItem): string {
   const evaluationText = trace.evaluations
     .map((e) => `${e.evaluatorName ?? ""} ${e.label ?? ""}`)
     .join(" ");
-  const eventText = trace.events.map((e) => e.name).join(" ");
+  const eventText = trace.events.groups.map((e) => e.name).join(" ");
 
   return [
     trace.traceId,

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -16,6 +16,7 @@ import { UserAvatar } from "~/components/UserAvatar";
 import { useAnnotationsByTraceIds } from "~/hooks/useAnnotationsByTraceIds";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
+import type { EvalChipDisplay } from "~/utils/evaluationResults";
 import { getEvalChipDisplay } from "~/utils/evaluationResults";
 import { useConversationTurns } from "../../hooks/useConversationTurns";
 import type { RichEval } from "../../hooks/useTraceEvaluations";
@@ -446,6 +447,41 @@ function buildLastUsedPromptChipDef({
   };
 }
 
+/**
+ * The chip's trailing verdict: a tinted badge for skipped/error, the category
+ * for a categorising evaluator, the numeral for a scoring one, colored
+ * Pass/Fail for a judging one. Mirrors the trace-table EvalChip.
+ */
+function EvalChipVerdict({ display }: { display: EvalChipDisplay }) {
+  if (display.status === "skipped")
+    return <NoVerdictMicroBadge icon={LuCircleSlash} label="SKIPPED" />;
+  if (display.status === "error")
+    return <NoVerdictMicroBadge icon={LuCircleAlert} label="ERROR" />;
+  if (display.categoryLabel)
+    return (
+      <Text textStyle="2xs" fontWeight="semibold" color="blue.fg" truncate>
+        {display.categoryLabel}
+      </Text>
+    );
+  if (display.scoreText)
+    return (
+      <Text textStyle="2xs" fontWeight="semibold" color="fg.muted">
+        {display.scoreText}
+      </Text>
+    );
+  if (display.passLabel)
+    return (
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color={display.passLabel.color}
+      >
+        {display.passLabel.text}
+      </Text>
+    );
+  return null;
+}
+
 function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
   // Single source of truth for color / status label / score formatting.
   // The trace-list `EvalChip`, the v3 EvaluatorChip, and this header
@@ -471,30 +507,7 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
       <Text textStyle="xs" color="fg" fontWeight="medium" truncate>
         {display.displayName}
       </Text>
-      {/* Trailing verdict — for skipped/error this is a tinted badge;
-          for boolean Pass/Fail it's colored text; for numeric it's
-          a muted-foreground numeral. Mirrors the trace-table EvalChip. */}
-      {display.status === "skipped" ? (
-        <NoVerdictMicroBadge icon={LuCircleSlash} label="SKIPPED" />
-      ) : display.status === "error" ? (
-        <NoVerdictMicroBadge icon={LuCircleAlert} label="ERROR" />
-      ) : display.categoryLabel ? (
-        <Text textStyle="2xs" fontWeight="semibold" color="blue.fg" truncate>
-          {display.categoryLabel}
-        </Text>
-      ) : display.scoreText ? (
-        <Text textStyle="2xs" fontWeight="semibold" color="fg.muted">
-          {display.scoreText}
-        </Text>
-      ) : display.passLabel ? (
-        <Text
-          textStyle="2xs"
-          fontWeight="semibold"
-          color={display.passLabel.color}
-        >
-          {display.passLabel.text}
-        </Text>
-      ) : null}
+      <EvalChipVerdict display={display} />
     </HStack>
   );
   return {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -456,6 +456,7 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
     evaluatorId: ev.evaluatorId,
     status: ev.status,
     score: ev.score,
+    scoreType: ev.scoreType,
     label: ev.label,
     passed: ev.passed,
   });
@@ -477,6 +478,10 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
         <NoVerdictMicroBadge icon={LuCircleSlash} label="SKIPPED" />
       ) : display.status === "error" ? (
         <NoVerdictMicroBadge icon={LuCircleAlert} label="ERROR" />
+      ) : display.categoryLabel ? (
+        <Text textStyle="2xs" fontWeight="semibold" color="blue.fg" truncate>
+          {display.categoryLabel}
+        </Text>
       ) : display.scoreText ? (
         <Text textStyle="2xs" fontWeight="semibold" color="fg.muted">
           {display.scoreText}
@@ -503,7 +508,7 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
     dot: display.color,
     tone,
     onClick,
-    ariaLabel: `Eval ${display.displayName}: ${display.statusLabel}${display.scoreText ? ` ${display.scoreText}` : ""}`,
+    ariaLabel: `Eval ${display.displayName}: ${display.categoryLabel ?? display.statusLabel}${display.scoreText ? ` ${display.scoreText}` : ""}`,
     tooltip: (
       <VStack align="stretch" gap={1.5} minWidth="240px" maxWidth="340px">
         <HStack gap={2}>

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRow.separator.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRow.separator.integration.test.tsx
@@ -55,6 +55,7 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 }));
 
 import type { TraceListItem } from "../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../types/trace";
 import { ChatTurnRow } from "../ChatTurnRow";
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -78,7 +79,7 @@ function turn(over: Partial<TraceListItem>): TraceListItem {
     output: null,
     origin: "application",
     evaluations: [],
-    events: [],
+    events: NO_TRACE_EVENTS,
     ...over,
   };
 }

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRowRedaction.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRowRedaction.integration.test.tsx
@@ -58,6 +58,7 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 }));
 
 import type { TraceListItem } from "../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../types/trace";
 import { ChatTurnRow } from "../ChatTurnRow";
 
 function turn(over: Partial<TraceListItem>): TraceListItem {
@@ -79,7 +80,7 @@ function turn(over: Partial<TraceListItem>): TraceListItem {
     output: null,
     origin: "application",
     evaluations: [],
-    events: [],
+    events: NO_TRACE_EVENTS,
     ...over,
   };
 }

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRowTranslate.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/ChatTurnRowTranslate.integration.test.tsx
@@ -82,6 +82,7 @@ vi.mock("~/utils/api", () => ({
 }));
 
 import type { TraceListItem } from "../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../types/trace";
 import { ChatTurnRow } from "../ChatTurnRow";
 
 function turn(over: Partial<TraceListItem>): TraceListItem {
@@ -103,7 +104,7 @@ function turn(over: Partial<TraceListItem>): TraceListItem {
     output: null,
     origin: "application",
     evaluations: [],
-    events: [],
+    events: NO_TRACE_EVENTS,
     ...over,
   };
 }

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/utils.redaction.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/__tests__/utils.redaction.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TraceListItem } from "../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../types/trace";
 import type { ParsedTurn } from "../types";
 import { buildConversationMarkdownChunks } from "../utils";
 
@@ -27,7 +28,7 @@ const trace = (overrides: Partial<TraceListItem> = {}): TraceListItem => ({
   input: null,
   output: null,
   evaluations: [],
-  events: [],
+  events: NO_TRACE_EVENTS,
   origin: "application",
   ...overrides,
 });

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -81,8 +81,10 @@ export function EvalCard({
   // The labeled categorical/boolean verdict is sometimes more informative
   // than the numeric score (e.g. score=1 with label="safe"), so the header
   // carries it alongside the badge. Only a category-only run needs no detail
-  // row for it — there the label IS the header.
-  const hasLabel = !!eval_.label && eval_.label !== String(eval_.score);
+  // row for it — there the label IS the header, which is also why it shows
+  // even when it reads the same as the placeholder score it stands in for.
+  const hasLabel =
+    !!eval_.label && (categoryOnly || eval_.label !== String(eval_.score));
   const showLabelDetailRow = hasLabel && !categoryOnly;
 
   const meta: string[] = [];

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -15,7 +15,13 @@ import { AZURE_SAFETY_NOT_CONFIGURED_MESSAGE } from "~/server/app-layer/evaluati
 import { formatCost, formatDuration } from "../../../utils/formatters";
 import { RunHistorySparkline } from "./RunHistorySparkline";
 import { useEvalInputs } from "./useEvalInputs";
-import { type EvalEntry, formatInputValue, isNoVerdict, STATUS } from "./utils";
+import {
+  type EvalEntry,
+  formatInputValue,
+  isCategoryOnly,
+  isNoVerdict,
+  STATUS,
+} from "./utils";
 
 export function EvalCard({
   eval_,
@@ -27,12 +33,18 @@ export function EvalCard({
   const { name, score, scoreType, status } = eval_;
   const tone = STATUS[status] ?? STATUS.warning;
   const noVerdict = isNoVerdict(status);
+  // A categorising evaluator answers with a category and nothing else — no
+  // score to show and no pass/fail to badge. Its category leads the header
+  // instead: a PASS badge over a run that never judged anything, next to the
+  // zero that stands in for the score it never produced, is two fabrications
+  // burying the one thing the evaluator did say.
+  const categoryOnly = isCategoryOnly(eval_);
 
   let scoreLabel = "";
   let scoreSubLabel = "";
   let barFill = 0;
 
-  if (!noVerdict) {
+  if (!noVerdict && !categoryOnly) {
     if (scoreType === "boolean") {
       scoreLabel = score === true ? "PASS" : "FAIL";
       barFill = score === true ? 100 : 0;
@@ -67,8 +79,11 @@ export function EvalCard({
   const mightHaveInputs = hasListInputs || canLazyLoadInputs;
   const hasRetries = (eval_.retries ?? 0) > 0;
   // The labeled categorical/boolean verdict is sometimes more informative
-  // than the numeric score (e.g. score=1 with label="safe").
+  // than the numeric score (e.g. score=1 with label="safe"), so the header
+  // carries it alongside the badge. Only a category-only run needs no detail
+  // row for it — there the label IS the header.
   const hasLabel = !!eval_.label && eval_.label !== String(eval_.score);
+  const showLabelDetailRow = hasLabel && !categoryOnly;
 
   const meta: string[] = [];
   if (eval_.executionTime !== undefined && eval_.executionTime > 0)
@@ -102,7 +117,7 @@ export function EvalCard({
   const hasExpandableDetails =
     mightHaveInputs ||
     hasStacktrace ||
-    hasLabel ||
+    showLabelDetailRow ||
     showErrorPanel ||
     showErrorIds;
   const hasFooterRow =
@@ -127,29 +142,32 @@ export function EvalCard({
         borderColor="border.muted"
         align="center"
       >
-        <HStack
-          paddingX={2}
-          paddingY={0.5}
-          borderRadius="sm"
-          bg={tone.bg}
-          flexShrink={0}
-          gap={1}
-        >
-          {status === "skipped" && (
-            <Icon as={LuCircleSlash} boxSize={2.5} color={tone.fg} />
-          )}
-          {status === "error" && (
-            <Icon as={LuCircleAlert} boxSize={2.5} color={tone.fg} />
-          )}
-          <Text
-            textStyle="2xs"
-            fontWeight="bold"
-            color={tone.fg}
-            letterSpacing="0.06em"
+        {!categoryOnly && (
+          <HStack
+            paddingX={2}
+            paddingY={0.5}
+            borderRadius="sm"
+            bg={tone.bg}
+            flexShrink={0}
+            gap={1}
           >
-            {tone.label}
-          </Text>
-        </HStack>
+            {status === "skipped" && (
+              <Icon as={LuCircleSlash} boxSize={2.5} color={tone.fg} />
+            )}
+            {status === "error" && (
+              <Icon as={LuCircleAlert} boxSize={2.5} color={tone.fg} />
+            )}
+            <Text
+              textStyle="2xs"
+              fontWeight="bold"
+              color={tone.fg}
+              letterSpacing="0.06em"
+            >
+              {tone.label}
+            </Text>
+          </HStack>
+        )}
+        {hasLabel && <CategoryChip label={eval_.label!} />}
         <Text
           textStyle="sm"
           fontWeight="semibold"
@@ -163,7 +181,7 @@ export function EvalCard({
         {eval_.runHistory && eval_.runHistory.length > 1 && (
           <RunHistorySparkline runs={eval_.runHistory} />
         )}
-        {!noVerdict && (
+        {!noVerdict && !categoryOnly && (
           <HStack gap={0.5} align="baseline" flexShrink={0}>
             <Text
               textStyle="lg"
@@ -183,7 +201,7 @@ export function EvalCard({
       </HStack>
 
       {/* Score bar (numeric, only when the eval actually produced a score) */}
-      {!noVerdict && scoreType === "numeric" && (
+      {!noVerdict && !categoryOnly && scoreType === "numeric" && (
         <Box
           height="3px"
           bg="bg.subtle"
@@ -269,13 +287,38 @@ export function EvalCard({
           tone={tone}
           mightHaveInputs={mightHaveInputs}
           hasStacktrace={hasStacktrace}
-          hasLabel={hasLabel}
+          hasLabel={showLabelDetailRow}
           showErrorPanel={showErrorPanel}
           showErrorIds={showErrorIds}
           hasExpandableDetails={hasExpandableDetails}
         />
       )}
     </Box>
+  );
+}
+
+/**
+ * The evaluator's own word for the verdict. Blue rather than a verdict tone:
+ * a category is not a pass or a fail, and colouring it like one would put a
+ * judgement on it that the evaluator never made.
+ */
+function CategoryChip({ label }: { label: string }) {
+  return (
+    <Text
+      textStyle="2xs"
+      fontWeight="bold"
+      color="blue.fg"
+      bg="blue.subtle"
+      paddingX={2}
+      paddingY={0.5}
+      borderRadius="sm"
+      flexShrink={0}
+      maxWidth="180px"
+      truncate
+      title={label}
+    >
+      {label}
+    </Text>
   );
 }
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -128,3 +128,94 @@ describe("EvalCard evaluator inputs", () => {
     });
   });
 });
+
+describe("EvalCard header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvaluationInputsUseQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
+
+  describe("given a categorising evaluator that returned only a category", () => {
+    // How `langevals/llm_category` arrives: a label, and stand-ins where the
+    // score and verdict would be.
+    const categoryEval: EvalEntry = {
+      name: "Max conversation outcome",
+      score: 0,
+      scoreType: "categorical",
+      status: "pass",
+      label: "resolved",
+      evaluatorType: "langevals/llm_category",
+      evaluationId: "eval-cat",
+    };
+
+    /** @scenario A category verdict leads the card header */
+    it("leads with the category", () => {
+      renderCard(categoryEval);
+      expect(screen.getByText("resolved")).toBeInTheDocument();
+    });
+
+    /** @scenario A category verdict leads the card header */
+    it("shows no PASS badge for a run that judged nothing", () => {
+      renderCard(categoryEval);
+      expect(screen.queryByText("PASS")).not.toBeInTheDocument();
+    });
+
+    /** @scenario A category verdict leads the card header */
+    it("shows no score, the zero being a stand-in for a score never produced", () => {
+      renderCard(categoryEval);
+      expect(screen.queryByText("0")).not.toBeInTheDocument();
+    });
+
+    /** @scenario A category verdict leads the card header */
+    it("does not repeat the category under Show details", () => {
+      renderCard(categoryEval);
+      // Inputs are still lazily loadable, so the toggle may exist; what must
+      // not exist is a second copy of the category.
+      const toggle = screen.queryByText("Show details");
+      if (toggle) fireEvent.click(toggle);
+      expect(screen.queryByText("Label")).not.toBeInTheDocument();
+      expect(screen.getAllByText("resolved")).toHaveLength(1);
+    });
+  });
+
+  describe("given an evaluator that returned a label alongside a real verdict", () => {
+    const labelledEval: EvalEntry = {
+      name: "Toxicity",
+      score: 0.9,
+      scoreType: "numeric",
+      status: "pass",
+      label: "safe",
+      passed: true,
+      evaluationId: "eval-labelled",
+    };
+
+    /** @scenario A label alongside a real verdict rides next to the badge */
+    it("keeps the badge and the score, and adds the label beside them", () => {
+      renderCard(labelledEval);
+      expect(screen.getByText("PASS")).toBeInTheDocument();
+      expect(screen.getByText("safe")).toBeInTheDocument();
+      expect(screen.getByText("0.90")).toBeInTheDocument();
+    });
+  });
+
+  describe("given an evaluator that returned no label", () => {
+    /** @scenario An evaluator with no label is unchanged */
+    it("shows the badge, the name and the score, and no category chip", () => {
+      renderCard({
+        name: "Topic Adherence",
+        score: 8.2,
+        scoreType: "numeric",
+        status: "pass",
+        evaluationId: "eval-plain",
+      });
+
+      expect(screen.getByText("PASS")).toBeInTheDocument();
+      expect(screen.getByText("Topic Adherence")).toBeInTheDocument();
+      expect(screen.getByText("8.2")).toBeInTheDocument();
+      expect(screen.getByText("/ 10")).toBeInTheDocument();
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -129,7 +129,7 @@ describe("EvalCard evaluator inputs", () => {
   });
 });
 
-describe("EvalCard header", () => {
+describe("given a categorising evaluator that returned only a category", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getEvaluationInputsUseQueryMock.mockReturnValue({
@@ -138,19 +138,18 @@ describe("EvalCard header", () => {
     });
   });
 
-  describe("given a categorising evaluator that returned only a category", () => {
-    // How `langevals/llm_category` arrives: a label, and stand-ins where the
-    // score and verdict would be.
-    const categoryEval: EvalEntry = {
-      name: "Max conversation outcome",
-      score: 0,
-      scoreType: "categorical",
-      status: "pass",
-      label: "resolved",
-      evaluatorType: "langevals/llm_category",
-      evaluationId: "eval-cat",
-    };
+  // How a categorising evaluator arrives: a label, and stand-ins where the
+  // score and verdict would be.
+  const categoryEval: EvalEntry = {
+    name: "Max conversation outcome",
+    score: 0,
+    scoreType: "categorical",
+    status: "pass",
+    label: "resolved",
+    evaluationId: "eval-cat",
+  };
 
+  describe("when the card renders", () => {
     /** @scenario A category verdict leads the card header */
     it("leads with the category", () => {
       renderCard(categoryEval);
@@ -170,7 +169,17 @@ describe("EvalCard header", () => {
     });
 
     /** @scenario A category verdict leads the card header */
-    it("does not repeat the category under Show details", () => {
+    it("still leads with a category that reads like the stand-in score", () => {
+      // "0" is a real category here; matching the placeholder score it
+      // displaced must not cost the card its only verdict.
+      renderCard({ ...categoryEval, label: "0" });
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("when the card's details are expanded", () => {
+    /** @scenario A category verdict leads the card header */
+    it("does not repeat the category", () => {
       renderCard(categoryEval);
       // Inputs are still lazily loadable, so the toggle may exist; what must
       // not exist is a second copy of the category.
@@ -180,28 +189,47 @@ describe("EvalCard header", () => {
       expect(screen.getAllByText("resolved")).toHaveLength(1);
     });
   });
+});
 
-  describe("given an evaluator that returned a label alongside a real verdict", () => {
-    const labelledEval: EvalEntry = {
-      name: "Toxicity",
-      score: 0.9,
-      scoreType: "numeric",
-      status: "pass",
-      label: "safe",
-      passed: true,
-      evaluationId: "eval-labelled",
-    };
+describe("given an evaluator that returned a label alongside a real verdict", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvaluationInputsUseQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
 
+  describe("when the card renders", () => {
     /** @scenario A label alongside a real verdict rides next to the badge */
     it("keeps the badge and the score, and adds the label beside them", () => {
-      renderCard(labelledEval);
+      renderCard({
+        name: "Toxicity",
+        score: 0.9,
+        scoreType: "numeric",
+        status: "pass",
+        label: "safe",
+        passed: true,
+        evaluationId: "eval-labelled",
+      });
+
       expect(screen.getByText("PASS")).toBeInTheDocument();
       expect(screen.getByText("safe")).toBeInTheDocument();
       expect(screen.getByText("0.90")).toBeInTheDocument();
     });
   });
+});
 
-  describe("given an evaluator that returned no label", () => {
+describe("given an evaluator that returned no label", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvaluationInputsUseQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
+
+  describe("when the card renders", () => {
     /** @scenario An evaluator with no label is unchanged */
     it("shows the badge, the name and the score, and no category chip", () => {
       renderCard({

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
@@ -49,6 +49,31 @@ export function isNoVerdict(status: EvalSummary["status"]): boolean {
   return status === "skipped" || status === "error";
 }
 
+/**
+ * Whether the evaluator answered with a category and nothing else — a label,
+ * no numeric score, no pass/fail. `langevals/llm_category` is the archetype:
+ * it classifies ("resolved", "escalated") rather than judging.
+ *
+ * Such a run reaches the UI carrying a `pass` status and a score of `0`, both
+ * of which are stand-ins the mapping invents for absent fields rather than
+ * anything the evaluator reported. A card that shows them says the run passed
+ * with a score of zero, which is untrue twice, and buries the category. So
+ * these render as the category alone.
+ *
+ * `scoreType` is the discriminator rather than `score`, because by this point
+ * `score` is one of those stand-ins: `scoreType` is derived from the raw
+ * evaluation and is `categorical` exactly when it reported a label and neither
+ * a number nor a verdict.
+ */
+export function isCategoryOnly(eval_: EvalEntry): boolean {
+  return (
+    !isNoVerdict(eval_.status) &&
+    eval_.scoreType === "categorical" &&
+    !!eval_.label &&
+    eval_.passed == null
+  );
+}
+
 export interface EvalRunHistoryEntry {
   score: number | boolean;
   timestamp: number;

--- a/platform/app/src/features/traces-v2/components/TraceTable/__tests__/conversationGroupEvents.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/__tests__/conversationGroupEvents.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { TraceListItem } from "../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../types/trace";
+import { groupTracesByConversation } from "../conversationGroups";
+
+/**
+ * The Conversations lens totals its turns' events on the group row. It reads
+ * the same rollups the Events column does, so it counts every event a turn
+ * recorded — not how many distinct names those events collapsed into.
+ */
+function turn(traceId: string, events: TraceListItem["events"]): TraceListItem {
+  return {
+    traceId,
+    timestamp: 0,
+    name: traceId,
+    serviceName: "svc",
+    durationMs: 1,
+    totalCost: 0,
+    totalTokens: 0,
+    models: [],
+    labels: [],
+    status: "ok",
+    spanCount: 1,
+    conversationId: "conv-1",
+    evaluations: [],
+    events,
+  } as unknown as TraceListItem;
+}
+
+describe("groupTracesByConversation", () => {
+  describe("given a conversation whose turns recorded events", () => {
+    /** @scenario A group's event count sums its traces' events */
+    it("totals every event across the turns, not the distinct names", () => {
+      const groups = groupTracesByConversation([
+        turn("t1", {
+          groups: [{ name: "tool.output", count: 2, firstTimestamp: 1 }],
+          totalCount: 2,
+          distinctCount: 1,
+        }),
+        turn("t2", {
+          groups: [
+            { name: "tool.output", count: 2, firstTimestamp: 2 },
+            { name: "exception", count: 1, firstTimestamp: 3 },
+          ],
+          totalCount: 3,
+          distinctCount: 2,
+        }),
+      ]);
+
+      expect(groups[0]?.totalEvents).toBe(5);
+    });
+  });
+
+  describe("given a conversation whose turns recorded no events", () => {
+    /** @scenario A conversation whose traces recorded no events shows no counter */
+    it("totals zero, which the row renders as no counter at all", () => {
+      const groups = groupTracesByConversation([
+        turn("t1", NO_TRACE_EVENTS),
+        turn("t2", NO_TRACE_EVENTS),
+      ]);
+
+      expect(groups[0]?.totalEvents).toBe(0);
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceTable/__tests__/conversationGroupEvents.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/__tests__/conversationGroupEvents.unit.test.ts
@@ -8,7 +8,13 @@ import { groupTracesByConversation } from "../conversationGroups";
  * the same rollups the Events column does, so it counts every event a turn
  * recorded — not how many distinct names those events collapsed into.
  */
-function turn(traceId: string, events: TraceListItem["events"]): TraceListItem {
+function turn({
+  traceId,
+  events,
+}: {
+  traceId: string;
+  events: TraceListItem["events"];
+}): TraceListItem {
   return {
     traceId,
     timestamp: 0,
@@ -29,37 +35,47 @@ function turn(traceId: string, events: TraceListItem["events"]): TraceListItem {
 
 describe("groupTracesByConversation", () => {
   describe("given a conversation whose turns recorded events", () => {
-    /** @scenario A group's event count sums its traces' events */
-    it("totals every event across the turns, not the distinct names", () => {
-      const groups = groupTracesByConversation([
-        turn("t1", {
-          groups: [{ name: "tool.output", count: 2, firstTimestamp: 1 }],
-          totalCount: 2,
-          distinctCount: 1,
-        }),
-        turn("t2", {
-          groups: [
-            { name: "tool.output", count: 2, firstTimestamp: 2 },
-            { name: "exception", count: 1, firstTimestamp: 3 },
-          ],
-          totalCount: 3,
-          distinctCount: 2,
-        }),
-      ]);
+    describe("when grouping the conversation", () => {
+      /** @scenario A group's event count sums its traces' events */
+      it("totals every event across the turns, not the distinct names", () => {
+        const groups = groupTracesByConversation([
+          turn({
+            traceId: "t1",
+            events: {
+              groups: [{ name: "tool.output", count: 2, firstTimestamp: 1 }],
+              totalCount: 2,
+              distinctCount: 1,
+            },
+          }),
+          turn({
+            traceId: "t2",
+            events: {
+              groups: [
+                { name: "tool.output", count: 2, firstTimestamp: 2 },
+                { name: "exception", count: 1, firstTimestamp: 3 },
+              ],
+              totalCount: 3,
+              distinctCount: 2,
+            },
+          }),
+        ]);
 
-      expect(groups[0]?.totalEvents).toBe(5);
+        expect(groups[0]?.totalEvents).toBe(5);
+      });
     });
   });
 
   describe("given a conversation whose turns recorded no events", () => {
-    /** @scenario A conversation whose traces recorded no events shows no counter */
-    it("totals zero, which the row renders as no counter at all", () => {
-      const groups = groupTracesByConversation([
-        turn("t1", NO_TRACE_EVENTS),
-        turn("t2", NO_TRACE_EVENTS),
-      ]);
+    describe("when grouping the conversation", () => {
+      /** @scenario A conversation whose traces recorded no events shows no counter */
+      it("totals zero, which the row renders as no counter at all", () => {
+        const groups = groupTracesByConversation([
+          turn({ traceId: "t1", events: NO_TRACE_EVENTS }),
+          turn({ traceId: "t2", events: NO_TRACE_EVENTS }),
+        ]);
 
-      expect(groups[0]?.totalEvents).toBe(0);
+        expect(groups[0]?.totalEvents).toBe(0);
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/TraceTable/columns.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/columns.ts
@@ -221,7 +221,7 @@ const traceColumnDefs = {
     maxSize: 640,
     enableSorting: false,
   }),
-  events: traceCol.accessor((row) => row.events.length, {
+  events: traceCol.accessor((row) => row.events.totalCount, {
     id: "events",
     header: "Events",
     size: 250,

--- a/platform/app/src/features/traces-v2/components/TraceTable/conversationGroups.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/conversationGroups.ts
@@ -67,7 +67,7 @@ export function groupTracesByConversation(
     for (const t of sorted) {
       totalSpans += t.spanCount;
       if (t.status === "error") errorCount++;
-      totalEvents += t.events.length;
+      totalEvents += t.events.totalCount;
       totalEvals += t.evaluations.length;
       for (const ev of t.evaluations) {
         if (ev.passed === true) evalsPassedCount++;

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/addons/conversation/CompactTurns.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/addons/conversation/CompactTurns.tsx
@@ -323,11 +323,11 @@ const TurnPreviewCell: React.FC<{
         value={trace.spanCount}
       />
     )}
-    {trace.events.length > 0 && (
+    {trace.events.totalCount > 0 && (
       <CountChip
         icon={<Zap />}
         iconColor="orange.fg"
-        value={trace.events.length}
+        value={trace.events.totalCount}
       />
     )}
     {trace.evaluations.length > 0 && (

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
@@ -12,6 +12,12 @@ type Density = "compact" | "comfortable";
  */
 const VISIBLE_BADGES = 3;
 
+/**
+ * The cell's four states, in the order it decides between them: pending while
+ * the page's events are still coming, unavailable if they never did, the empty
+ * marker for a trace that recorded none, and otherwise a badge per event name.
+ * The first two exist so the empty marker only ever means "recorded nothing".
+ */
 function renderEvents({
   row,
   density,

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
@@ -1,27 +1,72 @@
-import { HStack, Text } from "@chakra-ui/react";
+import { HStack, Skeleton, Text } from "@chakra-ui/react";
 import type { TraceListItem } from "../../../../../types/trace";
 import { EventBadge } from "../../sharedChips";
 import type { CellDef } from "../../types";
 
 type Density = "compact" | "comfortable";
 
+/**
+ * Badges a row shows before collapsing the rest into a remainder chip. Three
+ * fits the column's default width without wrapping; the chip carries the count
+ * of what it stands for and names them on hover.
+ */
+const VISIBLE_BADGES = 3;
+
 function renderEvents(row: TraceListItem, density: Density) {
   const textStyle = density === "compact" ? "xs" : "sm";
-  if (row.events.length === 0) {
+  const { groups, distinctCount } = row.events;
+
+  if (groups.length === 0) {
+    // While the page's events are still in flight the row has no events yet
+    // but may well have some — the empty marker would be a claim we can't
+    // make, so hold the space instead.
+    if (row.eventsLoading) {
+      return <Skeleton height="16px" width="60px" borderRadius="md" />;
+    }
     return (
       <Text textStyle={textStyle} color="fg.subtle">
         —
       </Text>
     );
   }
+
+  const shown = groups.slice(0, VISIBLE_BADGES);
+  const hiddenCount = distinctCount - shown.length;
   const gap = density === "compact" ? 1 : 1.5;
+
   return (
     <HStack gap={gap} flexWrap="wrap">
-      {row.events.map((evt, i) => (
-        <EventBadge key={`${evt.spanId}-${i}`} event={evt} />
+      {shown.map((event) => (
+        <EventBadge key={event.name} event={event} />
       ))}
+      {hiddenCount > 0 && (
+        <Text
+          textStyle="2xs"
+          fontWeight="medium"
+          color="fg.muted"
+          flexShrink={0}
+          title={remainderTitle(groups.slice(VISIBLE_BADGES), hiddenCount)}
+        >
+          +{hiddenCount}
+        </Text>
+      )}
     </HStack>
   );
+}
+
+/**
+ * Names what the remainder chip stands for. The rollup itself is trimmed
+ * server-side, so past that trim the chip can only report how many more there
+ * were rather than pretend to name them.
+ */
+function remainderTitle(
+  remaining: { name: string }[],
+  hiddenCount: number,
+): string {
+  const named = remaining.map((event) => event.name);
+  const unnamed = hiddenCount - named.length;
+  if (unnamed > 0) named.push(`and ${unnamed.toLocaleString()} more`);
+  return named.join(", ");
 }
 
 export const EventsCell = {

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
@@ -12,7 +12,13 @@ type Density = "compact" | "comfortable";
  */
 const VISIBLE_BADGES = 3;
 
-function renderEvents(row: TraceListItem, density: Density) {
+function renderEvents({
+  row,
+  density,
+}: {
+  row: TraceListItem;
+  density: Density;
+}) {
   const textStyle = density === "compact" ? "xs" : "sm";
   const { groups, distinctCount } = row.events;
 
@@ -22,6 +28,19 @@ function renderEvents(row: TraceListItem, density: Density) {
     // make, so hold the space instead.
     if (row.eventsLoading) {
       return <Skeleton height="16px" width="60px" borderRadius="md" />;
+    }
+    // Same reasoning once the read has failed: the trace may well have events
+    // and we simply cannot say. The rest of the row is unaffected.
+    if (row.eventsUnavailable) {
+      return (
+        <Text
+          textStyle={textStyle}
+          color="fg.subtle"
+          title="Events could not be loaded"
+        >
+          Unavailable
+        </Text>
+      );
     }
     return (
       <Text textStyle={textStyle} color="fg.subtle">
@@ -45,7 +64,10 @@ function renderEvents(row: TraceListItem, density: Density) {
           fontWeight="medium"
           color="fg.muted"
           flexShrink={0}
-          title={remainderTitle(groups.slice(VISIBLE_BADGES), hiddenCount)}
+          title={remainderTitle({
+            remaining: groups.slice(VISIBLE_BADGES),
+            hiddenCount,
+          })}
         >
           +{hiddenCount}
         </Text>
@@ -59,10 +81,13 @@ function renderEvents(row: TraceListItem, density: Density) {
  * server-side, so past that trim the chip can only report how many more there
  * were rather than pretend to name them.
  */
-function remainderTitle(
-  remaining: { name: string }[],
-  hiddenCount: number,
-): string {
+function remainderTitle({
+  remaining,
+  hiddenCount,
+}: {
+  remaining: { name: string }[];
+  hiddenCount: number;
+}): string {
   const named = remaining.map((event) => event.name);
   const unnamed = hiddenCount - named.length;
   if (unnamed > 0) named.push(`and ${unnamed.toLocaleString()} more`);
@@ -72,6 +97,6 @@ function remainderTitle(
 export const EventsCell = {
   id: "events",
   label: "Events",
-  render: ({ row }) => renderEvents(row, "compact"),
-  renderComfortable: ({ row }) => renderEvents(row, "comfortable"),
+  render: ({ row }) => renderEvents({ row, density: "compact" }),
+  renderComfortable: ({ row }) => renderEvents({ row, density: "comfortable" }),
 } as const satisfies CellDef<TraceListItem>;

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Events column. A trace's events are OTel span events read back from
+ * `stored_spans` per page, and a row collapses them by name: an agent turn
+ * that retried a tool 237 times is one badge, not 237.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  TraceListEventGroup,
+  TraceListItem,
+} from "../../../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../../../types/trace";
+import { EventsCell } from "../EventsCell";
+
+afterEach(cleanup);
+
+function group(
+  name: string,
+  count = 1,
+  firstTimestamp = 0,
+): TraceListEventGroup {
+  return { name, count, firstTimestamp };
+}
+
+function row(over: Partial<TraceListItem>): TraceListItem {
+  return {
+    traceId: "t1",
+    timestamp: 0,
+    name: "trace",
+    serviceName: "svc",
+    durationMs: 1,
+    totalCost: 0,
+    totalTokens: 0,
+    models: [],
+    labels: [],
+    status: "ok",
+    spanCount: 1,
+    evaluations: [],
+    events: NO_TRACE_EVENTS,
+    ...over,
+  } as unknown as TraceListItem;
+}
+
+function renderCell(item: TraceListItem) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      {EventsCell.render({ row: item } as never)}
+    </ChakraProvider>,
+  );
+}
+
+describe("EventsCell", () => {
+  describe("given a trace that recorded events", () => {
+    /** @scenario A trace with events shows a badge per event name */
+    it("shows a badge naming the event", () => {
+      renderCell(
+        row({
+          events: {
+            groups: [group("thumbs_up_down")],
+            totalCount: 1,
+            distinctCount: 1,
+          },
+        }),
+      );
+
+      expect(screen.getByText("thumbs_up_down")).toBeInTheDocument();
+    });
+
+    /** @scenario Repeated events of the same name collapse into one badge with a count */
+    it("carries the repeat count on the badge instead of repeating it", () => {
+      renderCell(
+        row({
+          events: {
+            groups: [group("tool.output", 237), group("first_token", 1)],
+            totalCount: 238,
+            distinctCount: 2,
+          },
+        }),
+      );
+
+      expect(screen.getByText("tool.output")).toBeInTheDocument();
+      expect(screen.getByText("237")).toBeInTheDocument();
+      // A single occurrence needs no count — "first_token 1" reads as noise.
+      expect(screen.queryByText("1")).not.toBeInTheDocument();
+    });
+
+    /** @scenario Overflowing badges collapse into a remainder chip */
+    it("shows the first three names and collapses the rest into a remainder chip", () => {
+      const names = ["a.one", "b.two", "c.three", "d.four", "e.five"];
+      renderCell(
+        row({
+          events: {
+            groups: names.map((name, i) => group(name, 1, i)),
+            totalCount: 5,
+            distinctCount: 5,
+          },
+        }),
+      );
+
+      expect(screen.getByText("a.one")).toBeInTheDocument();
+      expect(screen.getByText("c.three")).toBeInTheDocument();
+      expect(screen.queryByText("d.four")).not.toBeInTheDocument();
+      expect(screen.getByText("+2")).toBeInTheDocument();
+    });
+
+    /** @scenario Overflowing badges collapse into a remainder chip */
+    it("names the collapsed events on the remainder chip", () => {
+      const names = ["a.one", "b.two", "c.three", "d.four", "e.five"];
+      renderCell(
+        row({
+          events: {
+            groups: names.map((name, i) => group(name, 1, i)),
+            totalCount: 5,
+            distinctCount: 5,
+          },
+        }),
+      );
+
+      expect(screen.getByText("+2")).toHaveAttribute("title", "d.four, e.five");
+    });
+
+    /** @scenario A trace with a very large number of events stays bounded */
+    it("counts the names trimmed off the rollup into the remainder", () => {
+      renderCell(
+        row({
+          events: {
+            // The read returned 4 of the trace's 40 distinct names.
+            groups: ["a", "b", "c", "d"].map((name, i) => group(name, 1, i)),
+            totalCount: 100,
+            distinctCount: 40,
+          },
+        }),
+      );
+
+      expect(screen.getByText("+37")).toBeInTheDocument();
+      expect(screen.getByText("+37")).toHaveAttribute(
+        "title",
+        "d, and 36 more",
+      );
+    });
+  });
+
+  describe("given a trace that recorded no events", () => {
+    /** @scenario A trace with no events shows the empty marker */
+    it("shows the empty marker", () => {
+      renderCell(row({ events: NO_TRACE_EVENTS }));
+      expect(screen.getByText("—")).toBeInTheDocument();
+    });
+  });
+
+  describe("when the page's events are still loading", () => {
+    /** @scenario The list still renders while events are in flight */
+    it("holds the space rather than claiming the trace recorded nothing", () => {
+      const { container } = renderCell(
+        row({ events: NO_TRACE_EVENTS, eventsLoading: true }),
+      );
+
+      expect(screen.queryByText("—")).not.toBeInTheDocument();
+      expect(container.firstChild).toBeTruthy();
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
@@ -17,6 +17,7 @@ import { EventsCell } from "../EventsCell";
 
 afterEach(cleanup);
 
+/** One event name and how often the trace recorded it, as the read returns it. */
 function group({
   name,
   count = 1,
@@ -29,6 +30,7 @@ function group({
   return { name, count, firstTimestamp };
 }
 
+/** A row carrying nothing the cell reads, so each case sets only its own state. */
 function row(over: Partial<TraceListItem>): TraceListItem {
   return {
     traceId: "t1",
@@ -48,6 +50,10 @@ function row(over: Partial<TraceListItem>): TraceListItem {
   } as unknown as TraceListItem;
 }
 
+/**
+ * Renders the cell the way the table does, through the registry entry rather
+ * than the component, so a change to what the column registers is caught here.
+ */
 function renderCell(item: TraceListItem) {
   return render(
     <ChakraProvider value={defaultSystem}>
@@ -56,6 +62,7 @@ function renderCell(item: TraceListItem) {
   );
 }
 
+/** Five names in first-occurrence order, two past what the cell shows. */
 const NAMES = ["a.one", "b.two", "c.three", "d.four", "e.five"];
 
 describe("EventsCell", () => {

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/EventsCell.integration.test.tsx
@@ -17,11 +17,15 @@ import { EventsCell } from "../EventsCell";
 
 afterEach(cleanup);
 
-function group(
-  name: string,
+function group({
+  name,
   count = 1,
   firstTimestamp = 0,
-): TraceListEventGroup {
+}: {
+  name: string;
+  count?: number;
+  firstTimestamp?: number;
+}): TraceListEventGroup {
   return { name, count, firstTimestamp };
 }
 
@@ -52,114 +56,156 @@ function renderCell(item: TraceListItem) {
   );
 }
 
+const NAMES = ["a.one", "b.two", "c.three", "d.four", "e.five"];
+
 describe("EventsCell", () => {
-  describe("given a trace that recorded events", () => {
-    /** @scenario A trace with events shows a badge per event name */
-    it("shows a badge naming the event", () => {
-      renderCell(
-        row({
-          events: {
-            groups: [group("thumbs_up_down")],
-            totalCount: 1,
-            distinctCount: 1,
-          },
-        }),
-      );
+  describe("given a trace that recorded one event", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario A trace with events shows a badge per event name */
+      it("shows a badge naming the event", () => {
+        renderCell(
+          row({
+            events: {
+              groups: [group({ name: "thumbs_up_down" })],
+              totalCount: 1,
+              distinctCount: 1,
+            },
+          }),
+        );
 
-      expect(screen.getByText("thumbs_up_down")).toBeInTheDocument();
+        expect(screen.getByText("thumbs_up_down")).toBeInTheDocument();
+      });
     });
+  });
 
-    /** @scenario Repeated events of the same name collapse into one badge with a count */
-    it("carries the repeat count on the badge instead of repeating it", () => {
-      renderCell(
-        row({
-          events: {
-            groups: [group("tool.output", 237), group("first_token", 1)],
-            totalCount: 238,
-            distinctCount: 2,
-          },
-        }),
-      );
+  describe("given a trace that repeated the same event", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario Repeated events of the same name collapse into one badge with a count */
+      it("carries the repeat count on the badge instead of repeating it", () => {
+        renderCell(
+          row({
+            events: {
+              groups: [
+                group({ name: "tool.output", count: 237 }),
+                group({ name: "first_token" }),
+              ],
+              totalCount: 238,
+              distinctCount: 2,
+            },
+          }),
+        );
 
-      expect(screen.getByText("tool.output")).toBeInTheDocument();
-      expect(screen.getByText("237")).toBeInTheDocument();
-      // A single occurrence needs no count — "first_token 1" reads as noise.
-      expect(screen.queryByText("1")).not.toBeInTheDocument();
+        expect(screen.getByText("tool.output")).toBeInTheDocument();
+        expect(screen.getByText("237")).toBeInTheDocument();
+        // A single occurrence needs no count — "first_token 1" reads as noise.
+        expect(screen.queryByText("1")).not.toBeInTheDocument();
+      });
     });
+  });
 
-    /** @scenario Overflowing badges collapse into a remainder chip */
-    it("shows the first three names and collapses the rest into a remainder chip", () => {
-      const names = ["a.one", "b.two", "c.three", "d.four", "e.five"];
-      renderCell(
-        row({
-          events: {
-            groups: names.map((name, i) => group(name, 1, i)),
-            totalCount: 5,
-            distinctCount: 5,
-          },
-        }),
-      );
+  describe("given a trace with more event names than the cell can show", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario Overflowing badges collapse into a remainder chip */
+      it("shows the first three names and collapses the rest into a remainder chip", () => {
+        renderCell(
+          row({
+            events: {
+              groups: NAMES.map((name, i) =>
+                group({ name, firstTimestamp: i }),
+              ),
+              totalCount: 5,
+              distinctCount: 5,
+            },
+          }),
+        );
 
-      expect(screen.getByText("a.one")).toBeInTheDocument();
-      expect(screen.getByText("c.three")).toBeInTheDocument();
-      expect(screen.queryByText("d.four")).not.toBeInTheDocument();
-      expect(screen.getByText("+2")).toBeInTheDocument();
+        expect(screen.getByText("a.one")).toBeInTheDocument();
+        expect(screen.getByText("c.three")).toBeInTheDocument();
+        expect(screen.queryByText("d.four")).not.toBeInTheDocument();
+        expect(screen.getByText("+2")).toBeInTheDocument();
+      });
+
+      /** @scenario Overflowing badges collapse into a remainder chip */
+      it("names the collapsed events on the remainder chip", () => {
+        renderCell(
+          row({
+            events: {
+              groups: NAMES.map((name, i) =>
+                group({ name, firstTimestamp: i }),
+              ),
+              totalCount: 5,
+              distinctCount: 5,
+            },
+          }),
+        );
+
+        expect(screen.getByText("+2")).toHaveAttribute(
+          "title",
+          "d.four, e.five",
+        );
+      });
     });
+  });
 
-    /** @scenario Overflowing badges collapse into a remainder chip */
-    it("names the collapsed events on the remainder chip", () => {
-      const names = ["a.one", "b.two", "c.three", "d.four", "e.five"];
-      renderCell(
-        row({
-          events: {
-            groups: names.map((name, i) => group(name, 1, i)),
-            totalCount: 5,
-            distinctCount: 5,
-          },
-        }),
-      );
+  describe("given a trace whose names were trimmed off the read", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario A trace with a very large number of events stays bounded */
+      it("counts the names trimmed off the rollup into the remainder", () => {
+        renderCell(
+          row({
+            events: {
+              // The read returned 4 of the trace's 40 distinct names.
+              groups: ["a", "b", "c", "d"].map((name, i) =>
+                group({ name, firstTimestamp: i }),
+              ),
+              totalCount: 100,
+              distinctCount: 40,
+            },
+          }),
+        );
 
-      expect(screen.getByText("+2")).toHaveAttribute("title", "d.four, e.five");
-    });
-
-    /** @scenario A trace with a very large number of events stays bounded */
-    it("counts the names trimmed off the rollup into the remainder", () => {
-      renderCell(
-        row({
-          events: {
-            // The read returned 4 of the trace's 40 distinct names.
-            groups: ["a", "b", "c", "d"].map((name, i) => group(name, 1, i)),
-            totalCount: 100,
-            distinctCount: 40,
-          },
-        }),
-      );
-
-      expect(screen.getByText("+37")).toBeInTheDocument();
-      expect(screen.getByText("+37")).toHaveAttribute(
-        "title",
-        "d, and 36 more",
-      );
+        expect(screen.getByText("+37")).toBeInTheDocument();
+        expect(screen.getByText("+37")).toHaveAttribute(
+          "title",
+          "d, and 36 more",
+        );
+      });
     });
   });
 
   describe("given a trace that recorded no events", () => {
-    /** @scenario A trace with no events shows the empty marker */
-    it("shows the empty marker", () => {
-      renderCell(row({ events: NO_TRACE_EVENTS }));
-      expect(screen.getByText("—")).toBeInTheDocument();
+    describe("when the Events cell renders", () => {
+      /** @scenario A trace with no events shows the empty marker */
+      it("shows the empty marker", () => {
+        renderCell(row({ events: NO_TRACE_EVENTS }));
+        expect(screen.getByText("—")).toBeInTheDocument();
+      });
     });
   });
 
-  describe("when the page's events are still loading", () => {
-    /** @scenario The list still renders while events are in flight */
-    it("holds the space rather than claiming the trace recorded nothing", () => {
-      const { container } = renderCell(
-        row({ events: NO_TRACE_EVENTS, eventsLoading: true }),
-      );
+  describe("given the page's events are still loading", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario The list still renders while events are in flight */
+      it("holds the space rather than claiming the trace recorded nothing", () => {
+        const { container } = renderCell(
+          row({ events: NO_TRACE_EVENTS, eventsLoading: true }),
+        );
 
-      expect(screen.queryByText("—")).not.toBeInTheDocument();
-      expect(container.firstChild).toBeTruthy();
+        expect(screen.queryByText("—")).not.toBeInTheDocument();
+        expect(container.firstChild).toBeTruthy();
+      });
+    });
+  });
+
+  describe("given the page's events read failed", () => {
+    describe("when the Events cell renders", () => {
+      /** @scenario A failed events read says so rather than reading as empty */
+      it("says the events are unavailable instead of showing the empty marker", () => {
+        renderCell(row({ events: NO_TRACE_EVENTS, eventsUnavailable: true }));
+
+        expect(screen.queryByText("—")).not.toBeInTheDocument();
+        expect(screen.getByText("Unavailable")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/TtftCell.unit.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/__tests__/TtftCell.unit.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { TraceListItem } from "../../../../../../types/trace";
+import { NO_TRACE_EVENTS } from "../../../../../../types/trace";
 import {
   TraceStatisticsProvider,
   useTraceStatistics,
@@ -31,7 +32,7 @@ function makeTrace(overrides: Partial<TraceListItem> = {}): TraceListItem {
     output: null,
     origin: "application",
     evaluations: [],
-    events: [],
+    events: NO_TRACE_EVENTS,
     sizeBytes: 0,
     ...overrides,
   };

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
@@ -10,13 +10,17 @@ import {
 } from "@chakra-ui/react";
 import { ArrowUpRight } from "lucide-react";
 import type React from "react";
+import { useState } from "react";
 import type { IconType } from "react-icons";
 import { LuCircleAlert, LuCircleSlash } from "react-icons/lu";
 import {
   type EvalChipDisplay,
   getEvalChipDisplay,
 } from "~/utils/evaluationResults";
-import type { TraceEvalResult, TraceListEvent } from "../../../types/trace";
+import type {
+  TraceEvalResult,
+  TraceListEventGroup,
+} from "../../../types/trace";
 
 /**
  * Re-exported for callers that already imported from this module — the
@@ -43,6 +47,20 @@ function VerdictSlot({ display }: { display: EvalChipDisplay }) {
     return <NoVerdictBadge label="SKIPPED" icon={LuCircleSlash} />;
   if (display.status === "error")
     return <NoVerdictBadge label="ERROR" icon={LuCircleAlert} />;
+  if (display.categoryLabel) {
+    return (
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color="blue.fg"
+        truncate
+        maxWidth="80px"
+        lineHeight="1.2"
+      >
+        {display.categoryLabel}
+      </Text>
+    );
+  }
   if (display.scoreText) {
     return (
       <Text
@@ -114,9 +132,17 @@ export const EvalChip: React.FC<{
   onViewDefinition?: () => void;
 }> = ({ eval_, onFilter, onViewDefinition }) => {
   const display = getEvalChipDisplay(eval_);
+  // Controlled so "View definition" can close the card before it navigates.
+  // Left uncontrolled, the card outlives the drawer it just opened, and the
+  // dismissal that follows the pointer leaving reads to the drawer as an
+  // interaction outside it — so the drawer closed itself a moment after
+  // opening and the URL sprang back to the list.
+  const [open, setOpen] = useState(false);
 
   return (
     <HoverCard.Root
+      open={open}
+      onOpenChange={(e) => setOpen(e.open)}
       openDelay={200}
       closeDelay={150}
       positioning={{ placement: "top" }}
@@ -227,6 +253,7 @@ export const EvalChip: React.FC<{
                   type="button"
                   onClick={(e: React.MouseEvent) => {
                     e.stopPropagation();
+                    setOpen(false);
                     onViewDefinition();
                   }}
                   display="inline-flex"
@@ -256,7 +283,14 @@ export const EvalChip: React.FC<{
   );
 };
 
-export const EventBadge: React.FC<{ event: TraceListEvent }> = ({ event }) => (
+/**
+ * One event name a trace recorded. A repeat count rides on the badge rather
+ * than repeating it — an agent turn can retry a tool hundreds of times, and
+ * "tool.output 237" says all of it in one chip.
+ */
+export const EventBadge: React.FC<{ event: TraceListEventGroup }> = ({
+  event,
+}) => (
   <HStack
     gap={1}
     paddingX={2}
@@ -266,6 +300,14 @@ export const EventBadge: React.FC<{ event: TraceListEvent }> = ({ event }) => (
     borderColor="border"
     bg="bg.panel"
     flexShrink={0}
+    // Truncate at the cell's edge rather than a fixed width: names differ in
+    // their tail far more often than their head (`session_telemetry.rs:236`
+    // vs `:687`), so every pixel clipped early costs a distinction.
+    maxWidth="100%"
+    minWidth={0}
+    title={
+      event.count > 1 ? `${event.name} — ${event.count} times` : event.name
+    }
   >
     <Circle size="6px" bg="blue.solid" flexShrink={0} />
     <Text
@@ -273,10 +315,20 @@ export const EventBadge: React.FC<{ event: TraceListEvent }> = ({ event }) => (
       fontWeight="medium"
       color="fg"
       truncate
-      maxWidth="100px"
       lineHeight="1.2"
     >
       {event.name}
     </Text>
+    {event.count > 1 && (
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        lineHeight="1.2"
+        flexShrink={0}
+      >
+        {event.count.toLocaleString()}
+      </Text>
+    )}
   </HStack>
 );

--- a/platform/app/src/features/traces-v2/components/TraceTable/skeletonPlaceholders.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/skeletonPlaceholders.ts
@@ -1,4 +1,5 @@
 import type { TraceListItem } from "../../types/trace";
+import { NO_TRACE_EVENTS } from "../../types/trace";
 import type { ConversationGroup } from "./conversationGroups";
 import type { TraceGroup } from "./registry";
 
@@ -35,7 +36,7 @@ export function buildTracePlaceholderRows(count: number): TraceListItem[] {
     output: "",
     origin: "application",
     evaluations: [],
-    events: [],
+    events: NO_TRACE_EVENTS,
   }));
 }
 

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * `useTraceListEvents` merges each row's events in from their own read.
+ * Events are not on the trace summary, so the list asks for them separately —
+ * which makes when it asks, and what a row shows before the answer arrives,
+ * part of the behaviour rather than an implementation detail.
+ *
+ * See specs/traces-v2/trace-list-events-column.feature.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  projectId: { value: "proj-1" as string | undefined },
+  view: { columnOrder: ["time", "trace", "events"], grouping: "flat" },
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: { tracesV2: { listEvents: { useQuery: harness.useQuery } } },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: harness.projectId.value
+      ? { id: harness.projectId.value }
+      : undefined,
+  }),
+}));
+
+vi.mock("../../stores/filterStore", () => ({
+  useFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({ debouncedTimeRange: { from: 1_000, to: 2_000 } }),
+}));
+
+vi.mock("../../stores/viewStore", () => ({
+  useViewStore: (selector: (s: unknown) => unknown) => selector(harness.view),
+}));
+
+import type { TraceListItem } from "../../types/trace";
+import { NO_TRACE_EVENTS } from "../../types/trace";
+import { useTraceListEvents } from "../useTraceListEvents";
+
+function row(traceId: string): TraceListItem {
+  return {
+    traceId,
+    timestamp: 0,
+    name: traceId,
+    serviceName: "svc",
+    durationMs: 1,
+    totalCost: 0,
+    totalTokens: 0,
+    models: [],
+    labels: [],
+    status: "ok",
+    spanCount: 1,
+    evaluations: [],
+    events: NO_TRACE_EVENTS,
+  } as unknown as TraceListItem;
+}
+
+const lastInput = () => harness.useQuery.mock.calls.at(-1)?.[0];
+const lastOpts = () => harness.useQuery.mock.calls.at(-1)?.[1];
+
+function resolveWith(data: unknown, extra: Record<string, unknown> = {}) {
+  harness.useQuery.mockImplementation(() => ({
+    data,
+    isLoading: false,
+    ...extra,
+  }));
+}
+
+beforeEach(() => {
+  harness.useQuery.mockReset();
+  resolveWith(undefined);
+  harness.projectId.value = "proj-1";
+  harness.view = { columnOrder: ["time", "trace", "events"], grouping: "flat" };
+});
+
+describe("useTraceListEvents", () => {
+  describe("given the Events column is visible", () => {
+    /** @scenario Events are fetched for the traces currently on screen */
+    it("asks once for the page's trace ids and the list's time range", () => {
+      renderHook(() => useTraceListEvents([row("t1"), row("t2")]));
+
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+      expect(lastInput()).toEqual(
+        expect.objectContaining({
+          projectId: "proj-1",
+          traceIds: ["t1", "t2"],
+          timeRange: { from: 1_000, to: 2_000 },
+        }),
+      );
+    });
+
+    /** @scenario The list agrees with the drawer */
+    it("merges each trace's events onto its own row", () => {
+      resolveWith({
+        t1: {
+          names: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
+          totalCount: 1,
+          distinctCount: 1,
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useTraceListEvents([row("t1"), row("t2")]),
+      );
+
+      expect(result.current[0]?.events).toEqual({
+        groups: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
+        totalCount: 1,
+        distinctCount: 1,
+      });
+      // A trace the read said nothing about recorded nothing.
+      expect(result.current[1]?.events).toEqual(NO_TRACE_EVENTS);
+    });
+
+    /** @scenario The list still renders while events are in flight */
+    it("marks rows pending while the read is in flight, without claiming they are empty", () => {
+      harness.useQuery.mockImplementation(() => ({
+        data: undefined,
+        isLoading: true,
+      }));
+
+      const { result } = renderHook(() => useTraceListEvents([row("t1")]));
+
+      expect(result.current[0]?.eventsLoading).toBe(true);
+      expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
+    });
+
+    /** @scenario A failed events read leaves the rest of the list intact */
+    it("leaves the rows intact when the read fails", () => {
+      harness.useQuery.mockImplementation(() => ({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      }));
+
+      const rows = [row("t1"), row("t2")];
+      const { result } = renderHook(() => useTraceListEvents(rows));
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0]?.traceId).toBe("t1");
+      // No events to show and nothing pending, so the column falls back to
+      // its empty marker rather than the list falling over.
+      expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
+      expect(result.current[0]?.eventsLoading).toBeFalsy();
+    });
+  });
+
+  describe("given nothing on screen reads a row's events", () => {
+    /** @scenario Hiding the Events column stops the fetch */
+    it("makes no request", () => {
+      harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
+
+      renderHook(() => useTraceListEvents([row("t1")]));
+
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+    });
+
+    /** @scenario An empty page of trace ids skips the query entirely */
+    it("makes no request for an empty page even with the column visible", () => {
+      renderHook(() => useTraceListEvents([]));
+
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+    });
+  });
+
+  describe("when the user enables the Events column", () => {
+    /** @scenario Enabling the Events column triggers the fetch */
+    it("starts asking for the traces already on screen", () => {
+      harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
+      const rows = [row("t1")];
+      const { rerender } = renderHook(() => useTraceListEvents(rows));
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+
+      harness.view = {
+        columnOrder: ["time", "trace", "events"],
+        grouping: "flat",
+      };
+      rerender();
+
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+      expect(lastInput()).toEqual(
+        expect.objectContaining({ traceIds: ["t1"] }),
+      );
+    });
+  });
+
+  describe("given the Conversations lens is active without the Events column", () => {
+    /** @scenario A group's event count sums its traces' events */
+    it("still asks, because the group rows total their turns' events", () => {
+      harness.view = {
+        columnOrder: ["conversation", "turns"],
+        grouping: "by-conversation",
+      };
+
+      renderHook(() => useTraceListEvents([row("t1")]));
+
+      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
@@ -81,126 +81,192 @@ beforeEach(() => {
 
 describe("useTraceListEvents", () => {
   describe("given the Events column is visible", () => {
-    /** @scenario Events are fetched for the traces currently on screen */
-    it("asks once for the page's trace ids and the list's time range", () => {
-      renderHook(() => useTraceListEvents([row("t1"), row("t2")]));
+    describe("when a page of traces is on screen", () => {
+      /** @scenario Events are shown for the traces currently on screen */
+      it("asks once for the page's trace ids and the list's time range", () => {
+        renderHook(() => useTraceListEvents({ rows: [row("t1"), row("t2")] }));
 
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
-      expect(lastInput()).toEqual(
-        expect.objectContaining({
-          projectId: "proj-1",
-          traceIds: ["t1", "t2"],
-          timeRange: { from: 1_000, to: 2_000 },
-        }),
-      );
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+        expect(lastInput()).toEqual(
+          expect.objectContaining({
+            projectId: "proj-1",
+            traceIds: ["t1", "t2"],
+            timeRange: { from: 1_000, to: 2_000 },
+          }),
+        );
+      });
     });
 
-    /** @scenario The list agrees with the drawer */
-    it("merges each trace's events onto its own row", () => {
-      resolveWith({
-        t1: {
-          names: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
+    describe("when the events have arrived", () => {
+      /** @scenario The list agrees with the drawer */
+      it("merges each trace's events onto its own row", () => {
+        resolveWith({
+          t1: {
+            names: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
+            totalCount: 1,
+            distinctCount: 1,
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useTraceListEvents({ rows: [row("t1"), row("t2")] }),
+        );
+
+        expect(result.current[0]?.events).toEqual({
+          groups: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
           totalCount: 1,
           distinctCount: 1,
-        },
+        });
+        // A trace the read said nothing about recorded nothing.
+        expect(result.current[1]?.events).toEqual(NO_TRACE_EVENTS);
       });
-
-      const { result } = renderHook(() =>
-        useTraceListEvents([row("t1"), row("t2")]),
-      );
-
-      expect(result.current[0]?.events).toEqual({
-        groups: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
-        totalCount: 1,
-        distinctCount: 1,
-      });
-      // A trace the read said nothing about recorded nothing.
-      expect(result.current[1]?.events).toEqual(NO_TRACE_EVENTS);
     });
 
-    /** @scenario The list still renders while events are in flight */
-    it("marks rows pending while the read is in flight, without claiming they are empty", () => {
-      harness.useQuery.mockImplementation(() => ({
-        data: undefined,
-        isLoading: true,
-      }));
+    describe("when the events have not arrived yet", () => {
+      /** @scenario The list still renders while events are in flight */
+      it("marks rows pending, without claiming they are empty", () => {
+        harness.useQuery.mockImplementation(() => ({
+          data: undefined,
+          isLoading: true,
+        }));
 
-      const { result } = renderHook(() => useTraceListEvents([row("t1")]));
+        const { result } = renderHook(() =>
+          useTraceListEvents({ rows: [row("t1")] }),
+        );
 
-      expect(result.current[0]?.eventsLoading).toBe(true);
-      expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
+        expect(result.current[0]?.eventsLoading).toBe(true);
+        expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
+      });
     });
 
-    /** @scenario A failed events read leaves the rest of the list intact */
-    it("leaves the rows intact when the read fails", () => {
-      harness.useQuery.mockImplementation(() => ({
-        data: undefined,
-        isLoading: false,
-        isError: true,
-      }));
+    describe("when the page turns and the previous page's answers are still held", () => {
+      /** @scenario Turning the page waits for that page's own events */
+      it("keeps the new rows pending rather than reading them as empty", () => {
+        // React Query hands back the old page's data with `isLoading` already
+        // false, and none of it is keyed by a trace on the new page.
+        resolveWith(
+          {
+            "old-page-trace": {
+              names: [{ name: "tool.output", count: 1, firstTimestamp: 1 }],
+              totalCount: 1,
+              distinctCount: 1,
+            },
+          },
+          { isPreviousData: true },
+        );
 
-      const rows = [row("t1"), row("t2")];
-      const { result } = renderHook(() => useTraceListEvents(rows));
+        const { result } = renderHook(() =>
+          useTraceListEvents({ rows: [row("t9")] }),
+        );
 
-      expect(result.current).toHaveLength(2);
-      expect(result.current[0]?.traceId).toBe("t1");
-      // No events to show and nothing pending, so the column falls back to
-      // its empty marker rather than the list falling over.
-      expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
-      expect(result.current[0]?.eventsLoading).toBeFalsy();
+        expect(result.current[0]?.eventsLoading).toBe(true);
+        expect(result.current[0]?.events).toEqual(NO_TRACE_EVENTS);
+      });
+    });
+
+    describe("when the events could not be loaded", () => {
+      /** @scenario A failed events read says so rather than reading as empty */
+      it("marks the rows unavailable and leaves the rest of them intact", () => {
+        harness.useQuery.mockImplementation(() => ({
+          data: undefined,
+          isLoading: false,
+          isError: true,
+        }));
+
+        const rows = [row("t1"), row("t2")];
+        const { result } = renderHook(() => useTraceListEvents({ rows }));
+
+        expect(result.current).toHaveLength(2);
+        expect(result.current[0]?.traceId).toBe("t1");
+        expect(result.current[0]?.eventsUnavailable).toBe(true);
+        expect(result.current[0]?.eventsLoading).toBeFalsy();
+      });
     });
   });
 
   describe("given nothing on screen reads a row's events", () => {
-    /** @scenario Hiding the Events column stops the fetch */
-    it("makes no request", () => {
-      harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
+    describe("when a page of traces is on screen", () => {
+      /** @scenario Hiding the Events column costs nothing */
+      it("makes no request", () => {
+        harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
 
-      renderHook(() => useTraceListEvents([row("t1")]));
+        renderHook(() => useTraceListEvents({ rows: [row("t1")] }));
 
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
-    });
-
-    /** @scenario An empty page of trace ids skips the query entirely */
-    it("makes no request for an empty page even with the column visible", () => {
-      renderHook(() => useTraceListEvents([]));
-
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+      });
     });
   });
 
-  describe("when the user enables the Events column", () => {
-    /** @scenario Enabling the Events column triggers the fetch */
-    it("starts asking for the traces already on screen", () => {
-      harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
-      const rows = [row("t1")];
-      const { rerender } = renderHook(() => useTraceListEvents(rows));
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+  describe("given the page has no traces on it", () => {
+    describe("when the Events column is visible", () => {
+      /** @scenario A page with no traces on it shows no events */
+      it("makes no request", () => {
+        renderHook(() => useTraceListEvents({ rows: [] }));
 
-      harness.view = {
-        columnOrder: ["time", "trace", "events"],
-        grouping: "flat",
-      };
-      rerender();
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+      });
+    });
+  });
 
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
-      expect(lastInput()).toEqual(
-        expect.objectContaining({ traceIds: ["t1"] }),
-      );
+  describe("given the rows are onboarding sample traces", () => {
+    describe("when the Events column is visible", () => {
+      /** @scenario Onboarding sample traces keep the events they ship with */
+      it("looks nothing up and leaves the fixtures' own events alone", () => {
+        const sample = row("sample-1");
+        sample.events = {
+          groups: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 1 }],
+          totalCount: 1,
+          distinctCount: 1,
+        };
+
+        const { result } = renderHook(() =>
+          useTraceListEvents({ rows: [sample], isSamplePreview: true }),
+        );
+
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+        expect(result.current[0]?.events.groups).toEqual([
+          { name: "thumbs_up_down", count: 1, firstTimestamp: 1 },
+        ]);
+      });
+    });
+  });
+
+  describe("given the Events column was hidden", () => {
+    describe("when the user enables it", () => {
+      /** @scenario Enabling the Events column fills it in place */
+      it("starts asking for the traces already on screen", () => {
+        harness.view = { columnOrder: ["time", "trace"], grouping: "flat" };
+        const rows = [row("t1")];
+        const { rerender } = renderHook(() => useTraceListEvents({ rows }));
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: false }));
+
+        harness.view = {
+          columnOrder: ["time", "trace", "events"],
+          grouping: "flat",
+        };
+        rerender();
+
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+        expect(lastInput()).toEqual(
+          expect.objectContaining({ traceIds: ["t1"] }),
+        );
+      });
     });
   });
 
   describe("given the Conversations lens is active without the Events column", () => {
-    /** @scenario A group's event count sums its traces' events */
-    it("still asks, because the group rows total their turns' events", () => {
-      harness.view = {
-        columnOrder: ["conversation", "turns"],
-        grouping: "by-conversation",
-      };
+    describe("when a page of traces is on screen", () => {
+      /** @scenario A group's event count sums its traces' events */
+      it("still asks, because the group rows total their turns' events", () => {
+        harness.view = {
+          columnOrder: ["conversation", "turns"],
+          grouping: "by-conversation",
+        };
 
-      renderHook(() => useTraceListEvents([row("t1")]));
+        renderHook(() => useTraceListEvents({ rows: [row("t1")] }));
 
-      expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+        expect(lastOpts()).toEqual(expect.objectContaining({ enabled: true }));
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
@@ -64,7 +64,13 @@ function row(traceId: string): TraceListItem {
 const lastInput = () => harness.useQuery.mock.calls.at(-1)?.[0];
 const lastOpts = () => harness.useQuery.mock.calls.at(-1)?.[1];
 
-function resolveWith(data: unknown, extra: Record<string, unknown> = {}) {
+function resolveWith({
+  data,
+  extra = {},
+}: {
+  data: unknown;
+  extra?: Record<string, unknown>;
+}) {
   harness.useQuery.mockImplementation(() => ({
     data,
     isLoading: false,
@@ -74,7 +80,7 @@ function resolveWith(data: unknown, extra: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   harness.useQuery.mockReset();
-  resolveWith(undefined);
+  resolveWith({ data: undefined });
   harness.projectId.value = "proj-1";
   harness.view = { columnOrder: ["time", "trace", "events"], grouping: "flat" };
 });
@@ -101,10 +107,12 @@ describe("useTraceListEvents", () => {
       /** @scenario The list agrees with the drawer */
       it("merges each trace's events onto its own row", () => {
         resolveWith({
-          t1: {
-            names: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
-            totalCount: 1,
-            distinctCount: 1,
+          data: {
+            t1: {
+              names: [{ name: "thumbs_up_down", count: 1, firstTimestamp: 5 }],
+              totalCount: 1,
+              distinctCount: 1,
+            },
           },
         });
 
@@ -144,16 +152,16 @@ describe("useTraceListEvents", () => {
       it("keeps the new rows pending rather than reading them as empty", () => {
         // React Query hands back the old page's data with `isLoading` already
         // false, and none of it is keyed by a trace on the new page.
-        resolveWith(
-          {
+        resolveWith({
+          data: {
             "old-page-trace": {
               names: [{ name: "tool.output", count: 1, firstTimestamp: 1 }],
               totalCount: 1,
               distinctCount: 1,
             },
           },
-          { isPreviousData: true },
-        );
+          extra: { isPreviousData: true },
+        });
 
         const { result } = renderHook(() =>
           useTraceListEvents({ rows: [row("t9")] }),

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceListEvents.integration.test.tsx
@@ -43,6 +43,7 @@ import type { TraceListItem } from "../../types/trace";
 import { NO_TRACE_EVENTS } from "../../types/trace";
 import { useTraceListEvents } from "../useTraceListEvents";
 
+/** A row with no events of its own, so only what the hook merges in shows up. */
 function row(traceId: string): TraceListItem {
   return {
     traceId,
@@ -61,9 +62,15 @@ function row(traceId: string): TraceListItem {
   } as unknown as TraceListItem;
 }
 
+/** What the hook asked for on its most recent render. */
 const lastInput = () => harness.useQuery.mock.calls.at(-1)?.[0];
+/** Whether that render asked at all, and under what caching. */
 const lastOpts = () => harness.useQuery.mock.calls.at(-1)?.[1];
 
+/**
+ * Answers the query with `data`, plus whichever React Query flags the case is
+ * about (`isPreviousData` for a page turn, `isError` for a failed read).
+ */
 function resolveWith({
   data,
   extra = {},

--- a/platform/app/src/features/traces-v2/hooks/useTraceList.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceList.ts
@@ -1,6 +1,7 @@
 import type { TraceListCursor } from "../stores/filterStore";
 import type { TraceListItem } from "../types/trace";
 import { useNewlyArrivedTraceIds } from "./useNewlyArrivedTraceIds";
+import { useTraceListEvents } from "./useTraceListEvents";
 import { useTraceListQuery } from "./useTraceListQuery";
 import { useViewSwitchingDim } from "./useViewSwitchingDim";
 
@@ -18,12 +19,14 @@ export interface TraceListResult {
 
 /**
  * Trace list with side effects: pulse-highlight new arrivals + dim while
- * switching view. Use `useTraceListQuery` directly when you only need the
- * data and totals (no side-effects). Both hooks share the same React Query
- * cache key, so they're free to compose.
+ * switching view, plus each row's events merged in from their own read. Use
+ * `useTraceListQuery` directly when you only need the data and totals (no
+ * side-effects, no events). Both hooks share the same React Query cache key,
+ * so they're free to compose.
  */
 export function useTraceList(): TraceListResult {
   const query = useTraceListQuery();
+  const data = useTraceListEvents(query.data);
   const newIds = useNewlyArrivedTraceIds(query.data);
   useViewSwitchingDim({
     isFetching: query.isFetching,
@@ -32,7 +35,7 @@ export function useTraceList(): TraceListResult {
   });
 
   return {
-    data: query.data,
+    data,
     totalHits: query.totalHits,
     nextCursor: query.nextCursor,
     isLoading: query.isLoading,

--- a/platform/app/src/features/traces-v2/hooks/useTraceList.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceList.ts
@@ -26,7 +26,10 @@ export interface TraceListResult {
  */
 export function useTraceList(): TraceListResult {
   const query = useTraceListQuery();
-  const data = useTraceListEvents(query.data);
+  const data = useTraceListEvents({
+    rows: query.data,
+    isSamplePreview: query.isSamplePreview,
+  });
   const newIds = useNewlyArrivedTraceIds(query.data);
   useViewSwitchingDim({
     isFetching: query.isFetching,

--- a/platform/app/src/features/traces-v2/hooks/useTraceListEvents.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceListEvents.ts
@@ -1,0 +1,90 @@
+import { useMemo } from "react";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { api } from "~/utils/api";
+import { useFilterStore } from "../stores/filterStore";
+import { useViewStore } from "../stores/viewStore";
+import type { TraceListItem } from "../types/trace";
+import { NO_TRACE_EVENTS } from "../types/trace";
+
+/**
+ * Attaches each row's events, read once per visible page.
+ *
+ * Events are OTel span events on `stored_spans`; the trace-summary fold
+ * deliberately stopped hoisting them (it grew the fold state O(span-count)),
+ * so the list reads them back rather than finding them on the summary row.
+ * That read is its own query: the list is what gates first paint, and a page
+ * whose columns and grouping never mention events pays nothing.
+ *
+ * A failed read leaves rows with no events rather than taking the list down —
+ * the column is supplementary to every other thing on the row.
+ */
+export function useTraceListEvents(rows: TraceListItem[]): TraceListItem[] {
+  const { project } = useOrganizationTeamProject();
+  const timeRange = useFilterStore((s) => s.debouncedTimeRange);
+  const needsEvents = useViewStore(rowsNeedEvents);
+
+  // Sorted so two renders of the same page share a query key regardless of
+  // the sort column, and joined because the key is compared structurally.
+  const traceIdsKey = useMemo(
+    () =>
+      rows
+        .map((row) => row.traceId)
+        .sort()
+        .join(","),
+    [rows],
+  );
+  const traceIds = useMemo(
+    () => (traceIdsKey === "" ? [] : traceIdsKey.split(",")),
+    [traceIdsKey],
+  );
+
+  const enabled = !!project?.id && needsEvents && traceIds.length > 0;
+  const query = api.tracesV2.listEvents.useQuery(
+    {
+      projectId: project?.id ?? "",
+      traceIds,
+      timeRange: { from: timeRange.from, to: timeRange.to },
+    },
+    {
+      enabled,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      keepPreviousData: true,
+      trpc: { context: { skipBatch: true } },
+    },
+  );
+
+  const rollups = query.data;
+  const isLoading = enabled && query.isLoading;
+
+  return useMemo(() => {
+    if (!rollups && !isLoading) return rows;
+    return rows.map((row) => {
+      const rollup = rollups?.[row.traceId];
+      return {
+        ...row,
+        events: rollup
+          ? {
+              groups: rollup.names,
+              totalCount: rollup.totalCount,
+              distinctCount: rollup.distinctCount,
+            }
+          : NO_TRACE_EVENTS,
+        eventsLoading: isLoading,
+      };
+    });
+  }, [rows, rollups, isLoading]);
+}
+
+/**
+ * Whether anything on screen reads a row's events: the Events column, or the
+ * Conversations grouping, whose group rows total their turns' events.
+ */
+function rowsNeedEvents(state: {
+  columnOrder: string[];
+  grouping: string;
+}): boolean {
+  return (
+    state.columnOrder.includes("events") || state.grouping === "by-conversation"
+  );
+}

--- a/platform/app/src/features/traces-v2/hooks/useTraceListEvents.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceListEvents.ts
@@ -15,10 +15,19 @@ import { NO_TRACE_EVENTS } from "../types/trace";
  * That read is its own query: the list is what gates first paint, and a page
  * whose columns and grouping never mention events pays nothing.
  *
- * A failed read leaves rows with no events rather than taking the list down —
- * the column is supplementary to every other thing on the row.
+ * A failed read leaves the rest of the list standing rather than taking it
+ * down: the column is supplementary to every other thing on the row. It says
+ * so rather than falling back to the empty marker, which would report a trace
+ * with events as having none.
  */
-export function useTraceListEvents(rows: TraceListItem[]): TraceListItem[] {
+export function useTraceListEvents({
+  rows,
+  isSamplePreview = false,
+}: {
+  rows: TraceListItem[];
+  /** Fixture rows carry their own events and have no ids to read back. */
+  isSamplePreview?: boolean;
+}): TraceListItem[] {
   const { project } = useOrganizationTeamProject();
   const timeRange = useFilterStore((s) => s.debouncedTimeRange);
   const needsEvents = useViewStore(rowsNeedEvents);
@@ -38,7 +47,8 @@ export function useTraceListEvents(rows: TraceListItem[]): TraceListItem[] {
     [traceIdsKey],
   );
 
-  const enabled = !!project?.id && needsEvents && traceIds.length > 0;
+  const enabled =
+    !!project?.id && !isSamplePreview && needsEvents && traceIds.length > 0;
   const query = api.tracesV2.listEvents.useQuery(
     {
       projectId: project?.id ?? "",
@@ -55,10 +65,15 @@ export function useTraceListEvents(rows: TraceListItem[]): TraceListItem[] {
   );
 
   const rollups = query.data;
-  const isLoading = enabled && query.isLoading;
+  // `keepPreviousData` hands back the previous page's rollups with `isLoading`
+  // already false, so a row on the new page would find no entry of its own and
+  // read as eventless. It is still waiting, and says so until its own answer
+  // arrives.
+  const isLoading = enabled && (query.isLoading || query.isPreviousData);
+  const isUnavailable = enabled && query.isError;
 
   return useMemo(() => {
-    if (!rollups && !isLoading) return rows;
+    if (!rollups && !isLoading && !isUnavailable) return rows;
     return rows.map((row) => {
       const rollup = rollups?.[row.traceId];
       return {
@@ -71,9 +86,10 @@ export function useTraceListEvents(rows: TraceListItem[]): TraceListItem[] {
             }
           : NO_TRACE_EVENTS,
         eventsLoading: isLoading,
+        eventsUnavailable: isUnavailable,
       };
     });
-  }, [rows, rollups, isLoading]);
+  }, [rows, rollups, isLoading, isUnavailable]);
 }
 
 /**

--- a/platform/app/src/features/traces-v2/hooks/useTraceListQuery.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceListQuery.ts
@@ -18,6 +18,12 @@ export interface TraceListQueryResult {
   isFetched: boolean;
   isError: boolean;
   error: unknown;
+  /**
+   * Whether the rows are onboarding fixtures rather than the project's own
+   * traces. Their ids exist nowhere but the fixture file, so anything that
+   * would enrich a row from the backend has to sit the preview out.
+   */
+  isSamplePreview: boolean;
 }
 
 /**
@@ -93,6 +99,7 @@ export function useTraceListQuery(): TraceListQueryResult {
       isFetched: true,
       isError: false,
       error: null,
+      isSamplePreview: true,
     };
   }
 
@@ -106,5 +113,6 @@ export function useTraceListQuery(): TraceListQueryResult {
     isFetched: query.isFetched,
     isError: query.isError,
     error: query.error,
+    isSamplePreview: false,
   };
 }

--- a/platform/app/src/features/traces-v2/onboarding/data/samplePreviewTraces.ts
+++ b/platform/app/src/features/traces-v2/onboarding/data/samplePreviewTraces.ts
@@ -5,11 +5,8 @@ import type {
 } from "~/server/api/routers/tracesV2.schemas";
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
 import type { RouterOutputs } from "~/utils/api";
-import type {
-  TraceEvalResult,
-  TraceListEvent,
-  TraceListItem,
-} from "../../types/trace";
+import type { TraceEvalResult, TraceListItem } from "../../types/trace";
+import { NO_TRACE_EVENTS } from "../../types/trace";
 
 /**
  * Conversation turn exactly as the `tracesV2.conversationContext` procedure
@@ -66,7 +63,6 @@ export function isPreviewTraceId(traceId: string): boolean {
 const NOW = () => Date.now();
 const minutesAgo = (n: number) => NOW() - n * 60_000;
 
-const noEvents: TraceListEvent[] = [];
 const noEvals: TraceEvalResult[] = [];
 
 interface MakeTraceArgs {
@@ -124,7 +120,7 @@ function makeTrace(args: MakeTraceArgs): TraceListItem {
     traceName: args.name,
     rootSpanType: args.rootSpanType,
     evaluations: args.evaluations ?? noEvals,
-    events: noEvents,
+    events: NO_TRACE_EVENTS,
   };
 }
 

--- a/platform/app/src/features/traces-v2/types/trace.ts
+++ b/platform/app/src/features/traces-v2/types/trace.ts
@@ -153,4 +153,10 @@ export interface TraceListItem {
    * claim the trace recorded nothing.
    */
   eventsLoading?: boolean;
+  /**
+   * True when the page's events read failed. The column says so instead of
+   * showing its empty marker, which would report a trace that has events as
+   * having none.
+   */
+  eventsUnavailable?: boolean;
 }

--- a/platform/app/src/features/traces-v2/types/trace.ts
+++ b/platform/app/src/features/traces-v2/types/trace.ts
@@ -34,14 +34,38 @@ export interface TraceEvalResult {
 }
 
 /**
- * Lightweight event reference attached to a trace list item.
- * Hoisted from spans during the fold projection.
+ * One event name a trace recorded, with how often it fired. Rows show one
+ * badge per name, not per event: an agent turn that retries a tool 237 times
+ * has 237 `tool.output` events and one thing worth saying about them.
  */
-export interface TraceListEvent {
-  spanId: string;
-  timestamp: number;
+export interface TraceListEventGroup {
   name: string;
+  count: number;
+  /** Epoch ms of the earliest event under this name — the badge order. */
+  firstTimestamp: number;
 }
+
+/**
+ * A trace's events as the list renders them. Read from `stored_spans` by
+ * `tracesV2.listEvents` once per visible page, not carried on the trace
+ * summary — the fold stopped hoisting events so that folding stays O(1) per
+ * span (migration 00025).
+ */
+export interface TraceListEvents {
+  /** Ordered by first occurrence; shorter than `distinctCount` when trimmed. */
+  groups: TraceListEventGroup[];
+  /** Every event the trace recorded, including names beyond the trim. */
+  totalCount: number;
+  /** Distinct names the trace recorded, including those beyond the trim. */
+  distinctCount: number;
+}
+
+/** A trace with no events, and the shape a row carries before they load. */
+export const NO_TRACE_EVENTS: TraceListEvents = {
+  groups: [],
+  totalCount: 0,
+  distinctCount: 0,
+};
 
 /**
  * Shape of a trace as rendered in the trace table.
@@ -122,5 +146,11 @@ export interface TraceListItem {
   traceName?: string;
   rootSpanType?: string | null;
   evaluations: TraceEvalResult[];
-  events: TraceListEvent[];
+  events: TraceListEvents;
+  /**
+   * True while the page's events read is still in flight. The Events column
+   * shows a placeholder rather than its empty marker, which would otherwise
+   * claim the trace recorded nothing.
+   */
+  eventsLoading?: boolean;
 }

--- a/platform/app/src/features/traces-v2/utils/__tests__/mapTraceListPayload.unit.test.ts
+++ b/platform/app/src/features/traces-v2/utils/__tests__/mapTraceListPayload.unit.test.ts
@@ -56,21 +56,26 @@ describe("mapTraceListPayload", () => {
     });
   });
 
-  describe("when items already carry spanCount", () => {
-    it("preserves the supplied value", () => {
-      const rows = mapTraceListPayload({
-        items: [{ traceId: "t1", spanCount: 7 }],
+  describe("given items that already carry spanCount", () => {
+    describe("when mapping the payload", () => {
+      it("preserves the supplied value", () => {
+        const rows = mapTraceListPayload({
+          items: [{ traceId: "t1", spanCount: 7 }],
+        });
+        expect(rows[0]?.spanCount).toBe(7);
       });
-      expect(rows[0]?.spanCount).toBe(7);
     });
   });
 
-  describe("when the list payload carries no events", () => {
-    it("leaves rows eventless for the separate events read to fill in", () => {
-      // Events are not on the trace summary — `useTraceListEvents` merges them
-      // in from `tracesV2.listEvents`, so the list payload never carries any.
-      const rows = mapTraceListPayload({ items: [{ traceId: "t1" }] });
-      expect(rows[0]?.events).toEqual(NO_TRACE_EVENTS);
+  describe("given a list payload that carries no events", () => {
+    describe("when mapping the payload", () => {
+      it("leaves rows eventless for the separate events read to fill in", () => {
+        // Events are not on the trace summary — `useTraceListEvents` merges
+        // them in from `tracesV2.listEvents`, so the list payload never
+        // carries any.
+        const rows = mapTraceListPayload({ items: [{ traceId: "t1" }] });
+        expect(rows[0]?.events).toEqual(NO_TRACE_EVENTS);
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/utils/__tests__/mapTraceListPayload.unit.test.ts
+++ b/platform/app/src/features/traces-v2/utils/__tests__/mapTraceListPayload.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { NO_TRACE_EVENTS } from "../../types/trace";
 import { mapTraceListPayload } from "../mapTraceListPayload";
 
 describe("mapTraceListPayload", () => {
@@ -18,7 +19,7 @@ describe("mapTraceListPayload", () => {
         traceId: "t1",
         spanCount: 0,
         evaluations: [],
-        events: [],
+        events: NO_TRACE_EVENTS,
       });
     });
   });
@@ -55,21 +56,21 @@ describe("mapTraceListPayload", () => {
     });
   });
 
-  describe("when items already carry spanCount and events", () => {
-    it("preserves the supplied values", () => {
+  describe("when items already carry spanCount", () => {
+    it("preserves the supplied value", () => {
       const rows = mapTraceListPayload({
-        items: [
-          {
-            traceId: "t1",
-            spanCount: 7,
-            events: [
-              { spanId: "s1", name: "evt", timestamp: 1, attributes: {} },
-            ],
-          },
-        ],
+        items: [{ traceId: "t1", spanCount: 7 }],
       });
       expect(rows[0]?.spanCount).toBe(7);
-      expect(rows[0]?.events).toHaveLength(1);
+    });
+  });
+
+  describe("when the list payload carries no events", () => {
+    it("leaves rows eventless for the separate events read to fill in", () => {
+      // Events are not on the trace summary — `useTraceListEvents` merges them
+      // in from `tracesV2.listEvents`, so the list payload never carries any.
+      const rows = mapTraceListPayload({ items: [{ traceId: "t1" }] });
+      expect(rows[0]?.events).toEqual(NO_TRACE_EVENTS);
     });
   });
 });

--- a/platform/app/src/features/traces-v2/utils/mapTraceListPayload.ts
+++ b/platform/app/src/features/traces-v2/utils/mapTraceListPayload.ts
@@ -1,4 +1,5 @@
 import type { TraceEvalResult, TraceListItem } from "../types/trace";
+import { NO_TRACE_EVENTS } from "../types/trace";
 
 interface TraceListPayload {
   items: unknown[];
@@ -7,10 +8,13 @@ interface TraceListPayload {
 
 /**
  * Normalize the raw `tracesV2.list` payload into `TraceListItem` rows:
- * attach each trace's evaluations and default the optional spanCount /
- * events fields. Shared by the full /traces list (`useTraceListQuery`)
- * and the compact personal recent-activity table so both render
- * identical rows from the same source.
+ * attach each trace's evaluations and default the optional spanCount field.
+ * Shared by the full /traces list (`useTraceListQuery`) and the compact
+ * personal recent-activity table so both render identical rows from the
+ * same source.
+ *
+ * Rows start eventless: events are not on the trace summary, so the list
+ * reads them separately (`useTraceListEvents`) and merges them in.
  */
 export function mapTraceListPayload(
   data: TraceListPayload | undefined,
@@ -29,6 +33,6 @@ export function mapTraceListPayload(
       passed: e.passed,
       label: e.label,
     })),
-    events: item.events ?? [],
+    events: item.events ?? NO_TRACE_EVENTS,
   }));
 }

--- a/platform/app/src/server/api/routers/tracesV2.ts
+++ b/platform/app/src/server/api/routers/tracesV2.ts
@@ -35,6 +35,7 @@ import { deriveUnmappedCostSuggestion } from "~/server/app-layer/traces/model-co
 import type {
   SpanSummaryPage,
   SpanSummaryRow,
+  TraceEventRollup,
 } from "~/server/app-layer/traces/repositories/span-storage.repository";
 import {
   traceMetadataUpdateSchema,
@@ -864,6 +865,13 @@ const timeRangeSchema = z.object({
   live: z.boolean().optional(),
 });
 
+/**
+ * Ceiling on one `listEvents` call, matching the list's largest page size.
+ * The read is a primary-key `IN` over `(TenantId, TraceId, SpanId)`, so it
+ * scales with the page rather than the project — but only if the page does.
+ */
+const MAX_LIST_EVENT_TRACE_IDS = 1000;
+
 const sortSchema = z.object({
   columnId: z.string(),
   direction: z.enum(["asc", "desc"]),
@@ -1122,6 +1130,32 @@ export const tracesV2Router = createTRPCRouter({
         items: page.items.map((it) => redactV2Content(it, protections)),
       };
     }),
+
+  /**
+   * Event rollups for the trace list's Events column, keyed by trace id.
+   *
+   * Its own query rather than part of `list`: events live in `stored_spans`,
+   * not on the summary fold, so bundling them would put a second table's read
+   * in front of the paint that every user waits on — including the ones whose
+   * columns and grouping never ask for events.
+   */
+  listEvents: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        traceIds: z.array(z.string().min(1)).max(MAX_LIST_EVENT_TRACE_IDS),
+        timeRange: timeRangeSchema,
+      }),
+    )
+    .use(checkProjectPermission("traces:view"))
+    .query(
+      async ({ input }): Promise<Record<string, TraceEventRollup>> =>
+        getApp().traces.spans.getTraceEventRollupsByTraceIds({
+          tenantId: input.projectId,
+          traceIds: input.traceIds,
+          timeRange: input.timeRange,
+        }),
+    ),
 
   facets: protectedProcedure
     .input(

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -392,13 +392,16 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
             }),
           ),
         }),
-        // Same trace id shape, different tenant.
+        // Our own half of the shared trace id, so the read has something to
+        // return for it and the isolation assertion is not vacuous.
         rollupRow({
           traceId: otherTenantTraceId,
           spanId: "other-span",
           events: [{ ts: at(10), name: "thumbs_up_down" }],
         }),
       ]);
+      // The neighbour's half: same trace id, different tenant. A read missing
+      // its tenant predicate would fold this in.
       await insertRows([
         makeEventRow(
           "other-tenant-span",
@@ -507,16 +510,22 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
     });
 
     /** @scenario Only the caller's project is read */
-    it("returns nothing for a trace id belonging to another tenant", async () => {
+    it("leaves out the neighbour's events on a trace id both tenants used", async () => {
       const rollups = await repo.getTraceEventRollupsByTraceIds({
         tenantId: rollupTenantId,
         traceIds: [otherTenantTraceId],
         timeRange,
       });
 
-      expect(
-        rollups[otherTenantTraceId]?.names.map((n) => n.name),
-      ).not.toContain("leaked");
+      // Both tenants recorded against this id, so the read returning nothing
+      // would pass a "does not contain" check without proving anything.
+      expect(rollups[otherTenantTraceId]).toEqual({
+        names: [
+          { name: "thumbs_up_down", count: 1, firstTimestamp: at(10).getTime() },
+        ],
+        totalCount: 1,
+        distinctCount: 1,
+      });
     });
 
     /** @scenario The search is confined to the period on screen */

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../event-sourcing/__tests__/integration/testContainers";
 import type { SpanInsertData } from "../../types";
 import { SpanStorageClickHouseRepository } from "../span-storage.clickhouse.repository";
+import { MAX_EVENT_NAMES_PER_TRACE } from "../span-storage.repository";
 
 const tenantId = `test-span-fetch-${nanoid()}`;
 const traceId = `trace-${nanoid()}`;
@@ -299,6 +300,230 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       ]);
       expect(events.find((e) => e.event_type === "exception")).toBeUndefined();
       expect(events.find((e) => e.event_type === "stale.skip")).toBeUndefined();
+    });
+  });
+
+  // The trace list's Events column. Unlike the two readers above this is
+  // batched over a page of traces and collapses each trace's events by name,
+  // so what it must get right is the grouping, the batching and the trim.
+  describe("when rolling up events for a page of traces", () => {
+    const rollupTenantId = `test-event-rollups-${nanoid()}`;
+    const feedbackTraceId = `trace-feedback-${nanoid()}`;
+    const chattyTraceId = `trace-chatty-${nanoid()}`;
+    const quietTraceId = `trace-quiet-${nanoid()}`;
+    const noisyTraceId = `trace-noisy-${nanoid()}`;
+    const otherTenantTraceId = `trace-other-${nanoid()}`;
+    const rollupBase = new Date(base + 1000);
+    const at = (offsetMs: number) => new Date(rollupBase.getTime() + offsetMs);
+    // The whole fixture sits inside this, so the read's own padding is not
+    // what makes these pass.
+    const timeRange = {
+      from: rollupBase.getTime() - 60_000,
+      to: rollupBase.getTime() + 60_000,
+    };
+
+    function rollupRow(
+      traceId: string,
+      spanId: string,
+      events: { ts: Date; name: string }[],
+      overrides: Record<string, unknown> = {},
+    ) {
+      return makeEventRow(
+        spanId,
+        events.map((e) => ({ ts: e.ts, name: e.name, attrs: {} })),
+        { TenantId: rollupTenantId, TraceId: traceId, ...overrides },
+      );
+    }
+
+    beforeAll(async () => {
+      await insertRows([
+        // One tracked-event trace, the shape a thumbs-up lands as.
+        rollupRow(feedbackTraceId, "fb-span", [
+          { ts: at(10), name: "thumbs_up_down" },
+        ]),
+        // An agent turn: the same two names over and over, across spans.
+        rollupRow(chattyTraceId, "chatty-span-1", [
+          { ts: at(30), name: "gen_ai.request.attempt" },
+          { ts: at(40), name: "tool.output" },
+          { ts: at(50), name: "gen_ai.request.attempt" },
+        ]),
+        rollupRow(chattyTraceId, "chatty-span-2", [
+          { ts: at(60), name: "tool.output" },
+          { ts: at(70), name: "exception" },
+        ]),
+        // Stale version of chatty-span-2 — its events must not be counted.
+        rollupRow(
+          chattyTraceId,
+          "chatty-span-2",
+          [{ ts: at(-500), name: "stale.rollup" }],
+          {
+            StartTime: new Date(base - 90_000),
+            EndTime: new Date(base - 90_000 + 50),
+            UpdatedAt: new Date(base - 90_000),
+            CreatedAt: new Date(base - 90_000),
+          },
+        ),
+        // A trace whose spans carry no events at all.
+        rollupRow(quietTraceId, "quiet-span", []),
+        // More distinct names than one row can show.
+        rollupRow(
+          noisyTraceId,
+          "noisy-span",
+          Array.from({ length: MAX_EVENT_NAMES_PER_TRACE + 5 }, (_, i) => ({
+            ts: at(100 + i),
+            name: `event.kind.${String(i).padStart(2, "0")}`,
+          })),
+        ),
+        // Same trace id shape, different tenant.
+        rollupRow(otherTenantTraceId, "other-span", [
+          { ts: at(10), name: "thumbs_up_down" },
+        ]),
+      ]);
+      await insertRows([
+        makeEventRow(
+          "other-tenant-span",
+          [{ ts: at(10), name: "leaked", attrs: {} }],
+          {
+            TenantId: `${rollupTenantId}-neighbour`,
+            TraceId: otherTenantTraceId,
+          },
+        ),
+      ]);
+    });
+
+    afterAll(async () => {
+      for (const tenant of [rollupTenantId, `${rollupTenantId}-neighbour`]) {
+        await ch.exec({
+          query:
+            "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+          query_params: { tenantId: tenant },
+        });
+      }
+    });
+
+    /** @scenario A trace with events shows a badge per event name */
+    it("returns one entry per event name for a trace", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [feedbackTraceId],
+        timeRange,
+      });
+
+      expect(rollups[feedbackTraceId]).toEqual({
+        names: [
+          {
+            name: "thumbs_up_down",
+            count: 1,
+            firstTimestamp: at(10).getTime(),
+          },
+        ],
+        totalCount: 1,
+        distinctCount: 1,
+      });
+    });
+
+    /** @scenario Repeated events of the same name collapse into one badge with a count */
+    /** @scenario Badges are ordered by when the event first occurred */
+    it("collapses repeats by name, ordered by first occurrence, latest span version only", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [chattyTraceId],
+        timeRange,
+      });
+
+      expect(rollups[chattyTraceId]).toEqual({
+        names: [
+          {
+            name: "gen_ai.request.attempt",
+            count: 2,
+            firstTimestamp: at(30).getTime(),
+          },
+          { name: "tool.output", count: 2, firstTimestamp: at(40).getTime() },
+          { name: "exception", count: 1, firstTimestamp: at(70).getTime() },
+        ],
+        totalCount: 5,
+        distinctCount: 3,
+      });
+    });
+
+    /** @scenario Events are fetched for the traces currently on screen */
+    it("answers a whole page in one call, keyed by trace id", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [feedbackTraceId, chattyTraceId, quietTraceId],
+        timeRange,
+      });
+
+      expect(Object.keys(rollups).sort()).toEqual(
+        [feedbackTraceId, chattyTraceId].sort(),
+      );
+    });
+
+    /** @scenario A trace with no events shows the empty marker */
+    it("omits a trace that recorded no events", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [quietTraceId],
+        timeRange,
+      });
+
+      expect(rollups[quietTraceId]).toBeUndefined();
+    });
+
+    /** @scenario A trace with a very large number of events stays bounded */
+    it("trims to the badge cap while still reporting the true totals", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [noisyTraceId],
+        timeRange,
+      });
+
+      const rollup = rollups[noisyTraceId]!;
+      expect(rollup.names).toHaveLength(MAX_EVENT_NAMES_PER_TRACE);
+      expect(rollup.distinctCount).toBe(MAX_EVENT_NAMES_PER_TRACE + 5);
+      expect(rollup.totalCount).toBe(MAX_EVENT_NAMES_PER_TRACE + 5);
+      // The trim keeps the earliest names, so the row shows what happened first.
+      expect(rollup.names[0]?.name).toBe("event.kind.00");
+    });
+
+    /** @scenario Only the caller's project is read */
+    it("returns nothing for a trace id belonging to another tenant", async () => {
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [otherTenantTraceId],
+        timeRange,
+      });
+
+      expect(
+        rollups[otherTenantTraceId]?.names.map((n) => n.name),
+      ).not.toContain("leaked");
+    });
+
+    /** @scenario The read is pruned to the page's time range */
+    it("returns nothing when the page's time range excludes the spans", async () => {
+      const longAgo = rollupBase.getTime() - 400 * 24 * 60 * 60 * 1000;
+      const rollups = await repo.getTraceEventRollupsByTraceIds({
+        tenantId: rollupTenantId,
+        traceIds: [feedbackTraceId],
+        timeRange: { from: longAgo, to: longAgo + 60_000 },
+      });
+
+      expect(rollups).toEqual({});
+    });
+
+    /** @scenario An empty page of trace ids skips the query entirely */
+    it("issues no query for an empty page", async () => {
+      const failingRepo = new SpanStorageClickHouseRepository(async () => {
+        throw new Error("resolveClient must not be called");
+      });
+
+      await expect(
+        failingRepo.getTraceEventRollupsByTraceIds({
+          tenantId: rollupTenantId,
+          traceIds: [],
+          timeRange,
+        }),
+      ).resolves.toEqual({});
     });
   });
 

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -322,12 +322,17 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       to: rollupBase.getTime() + 60_000,
     };
 
-    function rollupRow(
-      traceId: string,
-      spanId: string,
-      events: { ts: Date; name: string }[],
-      overrides: Record<string, unknown> = {},
-    ) {
+    function rollupRow({
+      traceId,
+      spanId,
+      events,
+      overrides = {},
+    }: {
+      traceId: string;
+      spanId: string;
+      events: { ts: Date; name: string }[];
+      overrides?: Record<string, unknown>;
+    }) {
       return makeEventRow(
         spanId,
         events.map((e) => ({ ts: e.ts, name: e.name, attrs: {} })),
@@ -338,46 +343,61 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
     beforeAll(async () => {
       await insertRows([
         // One tracked-event trace, the shape a thumbs-up lands as.
-        rollupRow(feedbackTraceId, "fb-span", [
-          { ts: at(10), name: "thumbs_up_down" },
-        ]),
+        rollupRow({
+          traceId: feedbackTraceId,
+          spanId: "fb-span",
+          events: [{ ts: at(10), name: "thumbs_up_down" }],
+        }),
         // An agent turn: the same two names over and over, across spans.
-        rollupRow(chattyTraceId, "chatty-span-1", [
-          { ts: at(30), name: "gen_ai.request.attempt" },
-          { ts: at(40), name: "tool.output" },
-          { ts: at(50), name: "gen_ai.request.attempt" },
-        ]),
-        rollupRow(chattyTraceId, "chatty-span-2", [
-          { ts: at(60), name: "tool.output" },
-          { ts: at(70), name: "exception" },
-        ]),
+        rollupRow({
+          traceId: chattyTraceId,
+          spanId: "chatty-span-1",
+          events: [
+            { ts: at(30), name: "gen_ai.request.attempt" },
+            { ts: at(40), name: "tool.output" },
+            { ts: at(50), name: "gen_ai.request.attempt" },
+          ],
+        }),
+        rollupRow({
+          traceId: chattyTraceId,
+          spanId: "chatty-span-2",
+          events: [
+            { ts: at(60), name: "tool.output" },
+            { ts: at(70), name: "exception" },
+          ],
+        }),
         // Stale version of chatty-span-2 — its events must not be counted.
-        rollupRow(
-          chattyTraceId,
-          "chatty-span-2",
-          [{ ts: at(-500), name: "stale.rollup" }],
-          {
+        rollupRow({
+          traceId: chattyTraceId,
+          spanId: "chatty-span-2",
+          events: [{ ts: at(-500), name: "stale.rollup" }],
+          overrides: {
             StartTime: new Date(base - 90_000),
             EndTime: new Date(base - 90_000 + 50),
             UpdatedAt: new Date(base - 90_000),
             CreatedAt: new Date(base - 90_000),
           },
-        ),
+        }),
         // A trace whose spans carry no events at all.
-        rollupRow(quietTraceId, "quiet-span", []),
+        rollupRow({ traceId: quietTraceId, spanId: "quiet-span", events: [] }),
         // More distinct names than one row can show.
-        rollupRow(
-          noisyTraceId,
-          "noisy-span",
-          Array.from({ length: MAX_EVENT_NAMES_PER_TRACE + 5 }, (_, i) => ({
-            ts: at(100 + i),
-            name: `event.kind.${String(i).padStart(2, "0")}`,
-          })),
-        ),
+        rollupRow({
+          traceId: noisyTraceId,
+          spanId: "noisy-span",
+          events: Array.from(
+            { length: MAX_EVENT_NAMES_PER_TRACE + 5 },
+            (_, i) => ({
+              ts: at(100 + i),
+              name: `event.kind.${String(i).padStart(2, "0")}`,
+            }),
+          ),
+        }),
         // Same trace id shape, different tenant.
-        rollupRow(otherTenantTraceId, "other-span", [
-          { ts: at(10), name: "thumbs_up_down" },
-        ]),
+        rollupRow({
+          traceId: otherTenantTraceId,
+          spanId: "other-span",
+          events: [{ ts: at(10), name: "thumbs_up_down" }],
+        }),
       ]);
       await insertRows([
         makeEventRow(
@@ -446,7 +466,7 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       });
     });
 
-    /** @scenario Events are fetched for the traces currently on screen */
+    /** @scenario Events are shown for the traces currently on screen */
     it("answers a whole page in one call, keyed by trace id", async () => {
       const rollups = await repo.getTraceEventRollupsByTraceIds({
         tenantId: rollupTenantId,
@@ -499,7 +519,7 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       ).not.toContain("leaked");
     });
 
-    /** @scenario The read is pruned to the page's time range */
+    /** @scenario The search is confined to the period on screen */
     it("returns nothing when the page's time range excludes the spans", async () => {
       const longAgo = rollupBase.getTime() - 400 * 24 * 60 * 60 * 1000;
       const rollups = await repo.getTraceEventRollupsByTraceIds({
@@ -511,7 +531,7 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       expect(rollups).toEqual({});
     });
 
-    /** @scenario An empty page of trace ids skips the query entirely */
+    /** @scenario A page with no traces on it shows no events */
     it("issues no query for an empty page", async () => {
       const failingRepo = new SpanStorageClickHouseRepository(async () => {
         throw new Error("resolveClient must not be called");

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -521,7 +521,11 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       // would pass a "does not contain" check without proving anything.
       expect(rollups[otherTenantTraceId]).toEqual({
         names: [
-          { name: "thumbs_up_down", count: 1, firstTimestamp: at(10).getTime() },
+          {
+            name: "thumbs_up_down",
+            count: 1,
+            firstTimestamp: at(10).getTime(),
+          },
         ],
         totalCount: 1,
         distinctCount: 1,

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -322,6 +322,11 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       to: rollupBase.getTime() + 60_000,
     };
 
+    /**
+     * A span of this suite's own tenant. Every row goes to `rollupTenantId`
+     * unless `overrides` says otherwise, so a fixture meant to belong to a
+     * neighbouring tenant has to say so explicitly.
+     */
     function rollupRow({
       traceId,
       spanId,

--- a/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -376,6 +376,79 @@ function dedupInTupleForTraceIds(extraInnerWhere: string): string {
 }
 
 /**
+ * One row per (trace, event name) for a page of traces, ordered so the first
+ * name a trace recorded comes first.
+ *
+ * Three stages, innermost out: elect each span's latest version and keep only
+ * the ones carrying events, expand those spans' `Events.*` arrays, then
+ * collapse to one row per (trace, event name).
+ *
+ * The window aggregates run over the whole per-trace partition and
+ * `LIMIT ... BY` trims afterwards, so a trimmed trace still reports the totals
+ * of everything it recorded, not of what survived the trim.
+ */
+function traceEventRollupQuery(): string {
+  const partitionAnd =
+    "AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64}) " +
+    "AND StartTime <= fromUnixTimestamp64Milli({toMs:Int64})";
+
+  return `
+    SELECT
+      traceId,
+      name,
+      nameCount,
+      firstTimestamp,
+      sum(nameCount) OVER (PARTITION BY traceId) AS totalCount,
+      count() OVER (PARTITION BY traceId) AS distinctCount
+    FROM (
+      SELECT
+        TraceId AS traceId,
+        event_name AS name,
+        count() AS nameCount,
+        toUnixTimestamp64Milli(min(event_timestamp)) AS firstTimestamp
+      FROM (
+        SELECT
+          TraceId,
+          "Events.Timestamp" AS Events_Timestamp,
+          "Events.Name" AS Events_Name
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId IN {traceIds:Array(String)}
+          AND notEmpty("Events.Name")
+          ${partitionAnd}
+          AND ${dedupInTupleForTraceIds(partitionAnd)}
+      )
+      ARRAY JOIN
+        Events_Timestamp AS event_timestamp,
+        Events_Name AS event_name
+      GROUP BY traceId, name
+    )
+    ORDER BY traceId ASC, firstTimestamp ASC, name ASC
+    LIMIT {maxNames:UInt32} BY traceId
+  `;
+}
+
+/** Gather {@link traceEventRollupQuery}'s flat rows into one rollup per trace. */
+function toTraceEventRollups(
+  rows: TraceEventRollupRow[],
+): Record<string, TraceEventRollup> {
+  const rollups: Record<string, TraceEventRollup> = {};
+  for (const row of rows) {
+    const rollup = (rollups[row.traceId] ??= {
+      names: [],
+      totalCount: asNumber(row.totalCount),
+      distinctCount: asNumber(row.distinctCount),
+    });
+    rollup.names.push({
+      name: row.name,
+      count: asNumber(row.nameCount),
+      firstTimestamp: asNumber(row.firstTimestamp),
+    });
+  }
+  return rollups;
+}
+
+/**
  * Per-bucket key matchers for the LangWatch signals projection. Each entry
  * compiles to one ClickHouse boolean expression over `mapKeys(SpanAttributes)`.
  * Order must match `LANGWATCH_SIGNAL_BUCKETS` in span-storage.repository.ts —
@@ -1574,55 +1647,13 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       // The page's traces all occurred inside the list's range, and a span
       // starts no earlier than its trace does, so padding both ends by the
       // standard partition window covers every span of every trace on the
-      // page without widening to a full-history scan.
+      // page without widening to a full-history scan. It is the same window
+      // the per-trace detail read uses, which is what keeps the list and the
+      // drawer agreeing on what a trace recorded.
       const fromMs = timeRange.from - DEFAULT_PARTITION_WINDOW_MS;
       const toMs = timeRange.to + DEFAULT_PARTITION_WINDOW_MS;
-      const partitionAnd =
-        "AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64}) " +
-        "AND StartTime <= fromUnixTimestamp64Milli({toMs:Int64})";
-
-      // Three stages, innermost out: elect each span's latest version and keep
-      // only the ones carrying events, expand those spans' `Events.*` arrays,
-      // then collapse to one row per (trace, event name).
-      //
-      // The window aggregates run over the whole per-trace partition and
-      // `LIMIT ... BY` trims afterwards, so a trimmed trace still reports the
-      // totals of everything it recorded, not of what survived the trim.
       const result = await client.query({
-        query: `
-          SELECT
-            traceId,
-            name,
-            nameCount,
-            firstTimestamp,
-            sum(nameCount) OVER (PARTITION BY traceId) AS totalCount,
-            count() OVER (PARTITION BY traceId) AS distinctCount
-          FROM (
-            SELECT
-              TraceId AS traceId,
-              event_name AS name,
-              count() AS nameCount,
-              toUnixTimestamp64Milli(min(event_timestamp)) AS firstTimestamp
-            FROM (
-              SELECT
-                TraceId,
-                "Events.Timestamp" AS Events_Timestamp,
-                "Events.Name" AS Events_Name
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId IN {traceIds:Array(String)}
-                AND notEmpty("Events.Name")
-                ${partitionAnd}
-                AND ${dedupInTupleForTraceIds(partitionAnd)}
-            )
-            ARRAY JOIN
-              Events_Timestamp AS event_timestamp,
-              Events_Name AS event_name
-            GROUP BY traceId, name
-          )
-          ORDER BY traceId ASC, firstTimestamp ASC, name ASC
-          LIMIT {maxNames:UInt32} BY traceId
-        `,
+        query: traceEventRollupQuery(),
         query_params: {
           tenantId,
           traceIds,
@@ -1633,21 +1664,9 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         format: "JSONEachRow",
       });
 
-      const rows = (await result.json()) as TraceEventRollupRow[];
-      const rollups: Record<string, TraceEventRollup> = {};
-      for (const row of rows) {
-        const rollup = (rollups[row.traceId] ??= {
-          names: [],
-          totalCount: asNumber(row.totalCount),
-          distinctCount: asNumber(row.distinctCount),
-        });
-        rollup.names.push({
-          name: row.name,
-          count: asNumber(row.nameCount),
-          firstTimestamp: asNumber(row.firstTimestamp),
-        });
-      }
-      return rollups;
+      return toTraceEventRollups(
+        (await result.json()) as TraceEventRollupRow[],
+      );
     } catch (error) {
       logger.error(
         {

--- a/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -34,11 +34,14 @@ import type {
   SpanSummaryPage,
   SpanSummaryPageCursor,
   SpanSummaryRow,
+  TraceEventRollup,
+  TraceEventRollupParams,
 } from "./span-storage.repository";
 import {
   clampSpanReadLimit,
   LANGWATCH_SIGNAL_BUCKETS,
   MAX_DERIVATION_SPANS,
+  MAX_EVENT_NAMES_PER_TRACE,
   MAX_LIGHT_SPAN_READ_ROWS,
 } from "./span-storage.repository";
 
@@ -357,6 +360,22 @@ function dedupInTuple(extraInnerWhere: string): string {
 }
 
 /**
+ * {@link dedupInTuple} for a batch of traces — same election, same caveat
+ * about which predicates may be pushed into the subquery, `IN` over the page's
+ * ids instead of one `TraceId`.
+ */
+function dedupInTupleForTraceIds(extraInnerWhere: string): string {
+  return `(TenantId, TraceId, SpanId, UpdatedAt) IN (
+    SELECT TenantId, TraceId, SpanId, max(UpdatedAt)
+    FROM ${TABLE_NAME}
+    WHERE TenantId = {tenantId:String}
+      AND TraceId IN {traceIds:Array(String)}
+      ${extraInnerWhere}
+    GROUP BY TenantId, TraceId, SpanId
+  )`;
+}
+
+/**
  * Per-bucket key matchers for the LangWatch signals projection. Each entry
  * compiles to one ClickHouse boolean expression over `mapKeys(SpanAttributes)`.
  * Order must match `LANGWATCH_SIGNAL_BUCKETS` in span-storage.repository.ts —
@@ -510,6 +529,20 @@ interface TraceEventRow {
   timestamp: string | number;
   name: string;
   attributes: Record<string, string>;
+}
+
+interface TraceEventRollupRow {
+  traceId: string;
+  name: string;
+  nameCount: string | number;
+  firstTimestamp: string | number;
+  totalCount: string | number;
+  distinctCount: string | number;
+}
+
+/** JSONEachRow renders 64-bit integers as strings; narrow both back to number. */
+function asNumber(value: string | number): number {
+  return typeof value === "string" ? parseInt(value, 10) : value;
 }
 
 function mapEventRow(row: EventRow): ElasticSearchEvent {
@@ -1519,6 +1552,110 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           error: error instanceof Error ? error.message : String(error),
         },
         "Failed to get trace events by trace ID from ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  async getTraceEventRollupsByTraceIds({
+    tenantId,
+    traceIds,
+    timeRange,
+  }: TraceEventRollupParams): Promise<Record<string, TraceEventRollup>> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "SpanStorageClickHouseRepository.getTraceEventRollupsByTraceIds",
+    );
+
+    if (traceIds.length === 0) return {};
+
+    try {
+      const client = await this.resolveClient(tenantId);
+      // The page's traces all occurred inside the list's range, and a span
+      // starts no earlier than its trace does, so padding both ends by the
+      // standard partition window covers every span of every trace on the
+      // page without widening to a full-history scan.
+      const fromMs = timeRange.from - DEFAULT_PARTITION_WINDOW_MS;
+      const toMs = timeRange.to + DEFAULT_PARTITION_WINDOW_MS;
+      const partitionAnd =
+        "AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64}) " +
+        "AND StartTime <= fromUnixTimestamp64Milli({toMs:Int64})";
+
+      // Three stages, innermost out: elect each span's latest version and keep
+      // only the ones carrying events, expand those spans' `Events.*` arrays,
+      // then collapse to one row per (trace, event name).
+      //
+      // The window aggregates run over the whole per-trace partition and
+      // `LIMIT ... BY` trims afterwards, so a trimmed trace still reports the
+      // totals of everything it recorded, not of what survived the trim.
+      const result = await client.query({
+        query: `
+          SELECT
+            traceId,
+            name,
+            nameCount,
+            firstTimestamp,
+            sum(nameCount) OVER (PARTITION BY traceId) AS totalCount,
+            count() OVER (PARTITION BY traceId) AS distinctCount
+          FROM (
+            SELECT
+              TraceId AS traceId,
+              event_name AS name,
+              count() AS nameCount,
+              toUnixTimestamp64Milli(min(event_timestamp)) AS firstTimestamp
+            FROM (
+              SELECT
+                TraceId,
+                "Events.Timestamp" AS Events_Timestamp,
+                "Events.Name" AS Events_Name
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId IN {traceIds:Array(String)}
+                AND notEmpty("Events.Name")
+                ${partitionAnd}
+                AND ${dedupInTupleForTraceIds(partitionAnd)}
+            )
+            ARRAY JOIN
+              Events_Timestamp AS event_timestamp,
+              Events_Name AS event_name
+            GROUP BY traceId, name
+          )
+          ORDER BY traceId ASC, firstTimestamp ASC, name ASC
+          LIMIT {maxNames:UInt32} BY traceId
+        `,
+        query_params: {
+          tenantId,
+          traceIds,
+          fromMs,
+          toMs,
+          maxNames: MAX_EVENT_NAMES_PER_TRACE,
+        },
+        format: "JSONEachRow",
+      });
+
+      const rows = (await result.json()) as TraceEventRollupRow[];
+      const rollups: Record<string, TraceEventRollup> = {};
+      for (const row of rows) {
+        const rollup = (rollups[row.traceId] ??= {
+          names: [],
+          totalCount: asNumber(row.totalCount),
+          distinctCount: asNumber(row.distinctCount),
+        });
+        rollup.names.push({
+          name: row.name,
+          count: asNumber(row.nameCount),
+          firstTimestamp: asNumber(row.firstTimestamp),
+        });
+      }
+      return rollups;
+    } catch (error) {
+      logger.error(
+        {
+          tenantId,
+          traceCount: traceIds.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to get trace event rollups from ClickHouse",
       );
       throw error;
     }

--- a/platform/app/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -43,6 +43,52 @@ export function clampSpanReadLimit(
 export const MAX_LIGHT_SPAN_READ_ROWS = 10_000;
 
 /**
+ * How many distinct event names one trace contributes to a list-page rollup.
+ *
+ * A trace's events collapse to one entry per name, so this is a distinct-name
+ * ceiling, not an event ceiling: 474 `tool.output` events are one entry. It
+ * exists for instrumentation that mints a fresh name per call site (an OTel
+ * bridge naming events after `file.rs:236` produces dozens per trace), where
+ * the untrimmed list would be neither renderable nor useful. `totalCount` and
+ * `distinctCount` are computed before the trim, so a trimmed rollup still
+ * reports its true size.
+ */
+export const MAX_EVENT_NAMES_PER_TRACE = 12;
+
+/** One event name a trace recorded, with how often and when it first fired. */
+export interface TraceEventNameCount {
+  name: string;
+  count: number;
+  /** Epoch ms of the earliest event under this name — the display order. */
+  firstTimestamp: number;
+}
+
+/** A trace's events as the list renders them: named groups plus true totals. */
+export interface TraceEventRollup {
+  /**
+   * Ordered by first occurrence, at most {@link MAX_EVENT_NAMES_PER_TRACE}
+   * entries. Shorter than `distinctCount` when the trim bit.
+   */
+  names: TraceEventNameCount[];
+  /** Every event the trace recorded, counting names beyond the trim. */
+  totalCount: number;
+  /** Distinct event names the trace recorded, counting those beyond the trim. */
+  distinctCount: number;
+}
+
+export interface TraceEventRollupParams {
+  tenantId: string;
+  /** The visible page's trace ids. An empty list issues no query. */
+  traceIds: string[];
+  /**
+   * The list's time range. Every trace on the page occurred inside it, so the
+   * read is padded by {@link DEFAULT_PARTITION_WINDOW_MS} and pruned to those
+   * partitions rather than scanning every week including the cold tier.
+   */
+  timeRange: { from: number; to: number };
+}
+
+/**
  * Cursor for keyed span-summary pagination: the page starts strictly after
  * `(startTimeMs, spanId)` in `(StartTimeMs ASC, SpanId ASC)` order. Keyed
  * instead of offset-based so pages stay stable while spans are still being
@@ -250,6 +296,17 @@ export interface SpanStorageRepository {
   getTraceEventsByTraceId(
     params: { tenantId: string; traceId: string } & OccurredAtHint,
   ): Promise<DerivedTraceEvent[]>;
+  /**
+   * Event rollups for a page of traces, for the trace list's Events column.
+   *
+   * Same `Events.*` ARRAY JOIN as {@link getTraceEventsByTraceId}, but grouped
+   * by name and batched across the page so the list issues one query instead
+   * of one per row. Attributes are not read: a badge needs a name and a count,
+   * and the attribute map is the expensive part of an event.
+   */
+  getTraceEventRollupsByTraceIds(
+    params: TraceEventRollupParams,
+  ): Promise<Record<string, TraceEventRollup>>;
   getEventsByTraceId(
     params: { tenantId: string; traceId: string } & OccurredAtHint,
   ): Promise<ElasticSearchEvent[]>;
@@ -384,6 +441,12 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
     _params: { tenantId: string; traceId: string } & OccurredAtHint,
   ): Promise<DerivedTraceEvent[]> {
     return [];
+  }
+
+  async getTraceEventRollupsByTraceIds(
+    _params: TraceEventRollupParams,
+  ): Promise<Record<string, TraceEventRollup>> {
+    return {};
   }
 
   async getEventsByTraceId(

--- a/platform/app/src/server/app-layer/traces/span-storage.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-storage.service.ts
@@ -19,6 +19,8 @@ import type {
   SpanSummaryPage,
   SpanSummaryPageCursor,
   SpanSummaryRow,
+  TraceEventRollup,
+  TraceEventRollupParams,
 } from "./repositories/span-storage.repository";
 import type { TraceIOExtractionService } from "./trace-io-extraction.service";
 import type { SpanInsertData } from "./types";
@@ -191,6 +193,19 @@ export class SpanStorageService {
     params: ByTraceId,
   ): Promise<DerivedTraceEvent[]> {
     return this.repository.getTraceEventsByTraceId(params);
+  }
+
+  /**
+   * Event rollups for the trace list's Events column, one query per page.
+   *
+   * Names and counts only, so unlike the per-trace detail read there is no
+   * captured content to gate: redaction blanks event *attributes*, and this
+   * read never asks for them.
+   */
+  async getTraceEventRollupsByTraceIds(
+    params: TraceEventRollupParams,
+  ): Promise<Record<string, TraceEventRollup>> {
+    return this.repository.getTraceEventRollupsByTraceIds(params);
   }
 
   async getEventsByTraceId(params: ByTraceId): Promise<ElasticSearchEvent[]> {

--- a/platform/app/src/server/app-layer/traces/trace-list.service.ts
+++ b/platform/app/src/server/app-layer/traces/trace-list.service.ts
@@ -37,12 +37,6 @@ import type {
 import type { TraceSummaryData } from "./types";
 import { teaserOf } from "./visibility-window.service";
 
-export interface TraceListEvent {
-  spanId: string;
-  timestamp: number;
-  name: string;
-}
-
 export interface TraceListItem {
   traceId: string;
   timestamp: number;
@@ -104,7 +98,6 @@ export interface TraceListItem {
   ttft: number | null;
   traceName: string;
   rootSpanType: string | null;
-  events: TraceListEvent[];
 }
 
 export interface TraceListPage {
@@ -1314,10 +1307,6 @@ function mapToTraceListItem(row: TraceSummaryData): TraceListItem {
   const totalTokens =
     (row.totalPromptTokenCount ?? 0) + (row.totalCompletionTokenCount ?? 0);
 
-  // The list never surfaced trace-level events (the list query selects no
-  // event columns); events are derived per-trace only on the detail read.
-  const events: TraceListEvent[] = [];
-
   return {
     traceId: row.traceId,
     timestamp: row.occurredAt,
@@ -1366,6 +1355,5 @@ function mapToTraceListItem(row: TraceSummaryData): TraceListItem {
     ttft: row.timeToFirstTokenMs,
     traceName: row.traceName,
     rootSpanType: row.rootSpanType,
-    events,
   };
 }

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -241,25 +241,27 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z.array(z.object({ description: z.string() })).default([
-        { description: "The response is incorrect, irrelevant." },
-        {
-          description:
-            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-        },
-      ]),
+      rubrics: z
+        .array(z.object({ description: z.string() }))
+        .default([
+          { description: "The response is incorrect, irrelevant." },
+          {
+            description:
+              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+          },
+        ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -1016,13 +1018,7 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    | "quality"
-    | "rag"
-    | "safety"
-    | "policy"
-    | "other"
-    | "custom"
-    | "similarity";
+    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -241,27 +241,25 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z
-        .array(z.object({ description: z.string() }))
-        .default([
-          { description: "The response is incorrect, irrelevant." },
-          {
-            description:
-              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-          },
-        ]),
+      rubrics: z.array(z.object({ description: z.string() })).default([
+        { description: "The response is incorrect, irrelevant." },
+        {
+          description:
+            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+        },
+      ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -1018,7 +1016,13 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
+    | "quality"
+    | "rag"
+    | "safety"
+    | "policy"
+    | "other"
+    | "custom"
+    | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-	{
-		"id": "agent-best-practices",
-		"label": "Agent best practices",
-		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-		"category": "recipe",
-		"userPrompt": "Where can I improve our agent development best practices?"
-	},
-	{
-		"id": "agent-improve",
-		"label": "Agent improve",
-		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-		"category": "skill",
-		"userPrompt": "What should I do next to improve my agent?"
-	},
-	{
-		"id": "agent-performance",
-		"label": "Agent performance",
-		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-		"category": "skill",
-		"userPrompt": "How is my agent performing?"
-	},
-	{
-		"id": "datasets",
-		"label": "Datasets",
-		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-		"category": "skill"
-	},
-	{
-		"id": "debug-instrumentation",
-		"label": "Debug instrumentation",
-		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-		"category": "recipe"
-	},
-	{
-		"id": "debug-with-langwatch",
-		"label": "Debug with langwatch",
-		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-		"category": "recipe"
-	},
-	{
-		"id": "eval-triage",
-		"label": "Eval triage",
-		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluate-multimodal",
-		"label": "Evaluate multimodal",
-		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluations",
-		"label": "Evaluations",
-		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-		"category": "skill",
-		"userPrompt": "Help me evaluate my agent"
-	},
-	{
-		"id": "experiments",
-		"label": "Experiments",
-		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-		"category": "skill",
-		"userPrompt": "Set up experiments for my agent"
-	},
-	{
-		"id": "generate-rag-dataset",
-		"label": "Generate RAG dataset",
-		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-		"category": "recipe"
-	},
-	{
-		"id": "github",
-		"label": "GitHub",
-		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-		"category": "skill"
-	},
-	{
-		"id": "level-up",
-		"label": "Level up",
-		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-		"category": "skill",
-		"userPrompt": "Take my agent to the next level"
-	},
-	{
-		"id": "online-evaluations",
-		"label": "Online evaluations",
-		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-		"category": "skill",
-		"userPrompt": "Set up online evaluations for my agent"
-	},
-	{
-		"id": "prompts",
-		"label": "Prompts",
-		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-		"category": "skill",
-		"userPrompt": "Version my prompts with LangWatch"
-	},
-	{
-		"id": "scenarios",
-		"label": "Scenarios",
-		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-		"category": "skill",
-		"userPrompt": "Add scenario tests for my agent"
-	},
-	{
-		"id": "setup-lw",
-		"label": "Setup lw",
-		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-cli-usability",
-		"label": "Test CLI usability",
-		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-compliance",
-		"label": "Test compliance",
-		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-		"category": "recipe"
-	},
-	{
-		"id": "tracing",
-		"label": "Tracing",
-		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-		"category": "skill",
-		"userPrompt": "Instrument my code with LangWatch"
-	}
+  {
+    "id": "agent-best-practices",
+    "label": "Agent best practices",
+    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+    "category": "recipe",
+    "userPrompt": "Where can I improve our agent development best practices?"
+  },
+  {
+    "id": "agent-improve",
+    "label": "Agent improve",
+    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+    "category": "skill",
+    "userPrompt": "What should I do next to improve my agent?"
+  },
+  {
+    "id": "agent-performance",
+    "label": "Agent performance",
+    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+    "category": "skill",
+    "userPrompt": "How is my agent performing?"
+  },
+  {
+    "id": "datasets",
+    "label": "Datasets",
+    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+    "category": "skill"
+  },
+  {
+    "id": "debug-instrumentation",
+    "label": "Debug instrumentation",
+    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+    "category": "recipe"
+  },
+  {
+    "id": "debug-with-langwatch",
+    "label": "Debug with langwatch",
+    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+    "category": "recipe"
+  },
+  {
+    "id": "eval-triage",
+    "label": "Eval triage",
+    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluate-multimodal",
+    "label": "Evaluate multimodal",
+    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluations",
+    "label": "Evaluations",
+    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+    "category": "skill",
+    "userPrompt": "Help me evaluate my agent"
+  },
+  {
+    "id": "experiments",
+    "label": "Experiments",
+    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+    "category": "skill",
+    "userPrompt": "Set up experiments for my agent"
+  },
+  {
+    "id": "generate-rag-dataset",
+    "label": "Generate RAG dataset",
+    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+    "category": "recipe"
+  },
+  {
+    "id": "github",
+    "label": "GitHub",
+    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+    "category": "skill"
+  },
+  {
+    "id": "level-up",
+    "label": "Level up",
+    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+    "category": "skill",
+    "userPrompt": "Take my agent to the next level"
+  },
+  {
+    "id": "online-evaluations",
+    "label": "Online evaluations",
+    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+    "category": "skill",
+    "userPrompt": "Set up online evaluations for my agent"
+  },
+  {
+    "id": "prompts",
+    "label": "Prompts",
+    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+    "category": "skill",
+    "userPrompt": "Version my prompts with LangWatch"
+  },
+  {
+    "id": "scenarios",
+    "label": "Scenarios",
+    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+    "category": "skill",
+    "userPrompt": "Add scenario tests for my agent"
+  },
+  {
+    "id": "setup-lw",
+    "label": "Setup lw",
+    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-cli-usability",
+    "label": "Test CLI usability",
+    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-compliance",
+    "label": "Test compliance",
+    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+    "category": "recipe"
+  },
+  {
+    "id": "tracing",
+    "label": "Tracing",
+    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+    "category": "skill",
+    "userPrompt": "Instrument my code with LangWatch"
+  }
 ]

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-  {
-    "id": "agent-best-practices",
-    "label": "Agent best practices",
-    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-    "category": "recipe",
-    "userPrompt": "Where can I improve our agent development best practices?"
-  },
-  {
-    "id": "agent-improve",
-    "label": "Agent improve",
-    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-    "category": "skill",
-    "userPrompt": "What should I do next to improve my agent?"
-  },
-  {
-    "id": "agent-performance",
-    "label": "Agent performance",
-    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-    "category": "skill",
-    "userPrompt": "How is my agent performing?"
-  },
-  {
-    "id": "datasets",
-    "label": "Datasets",
-    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-    "category": "skill"
-  },
-  {
-    "id": "debug-instrumentation",
-    "label": "Debug instrumentation",
-    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-    "category": "recipe"
-  },
-  {
-    "id": "debug-with-langwatch",
-    "label": "Debug with langwatch",
-    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-    "category": "recipe"
-  },
-  {
-    "id": "eval-triage",
-    "label": "Eval triage",
-    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluate-multimodal",
-    "label": "Evaluate multimodal",
-    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-    "category": "recipe"
-  },
-  {
-    "id": "evaluations",
-    "label": "Evaluations",
-    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-    "category": "skill",
-    "userPrompt": "Help me evaluate my agent"
-  },
-  {
-    "id": "experiments",
-    "label": "Experiments",
-    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-    "category": "skill",
-    "userPrompt": "Set up experiments for my agent"
-  },
-  {
-    "id": "generate-rag-dataset",
-    "label": "Generate RAG dataset",
-    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-    "category": "recipe"
-  },
-  {
-    "id": "github",
-    "label": "GitHub",
-    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-    "category": "skill"
-  },
-  {
-    "id": "level-up",
-    "label": "Level up",
-    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-    "category": "skill",
-    "userPrompt": "Take my agent to the next level"
-  },
-  {
-    "id": "online-evaluations",
-    "label": "Online evaluations",
-    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-    "category": "skill",
-    "userPrompt": "Set up online evaluations for my agent"
-  },
-  {
-    "id": "prompts",
-    "label": "Prompts",
-    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-    "category": "skill",
-    "userPrompt": "Version my prompts with LangWatch"
-  },
-  {
-    "id": "scenarios",
-    "label": "Scenarios",
-    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-    "category": "skill",
-    "userPrompt": "Add scenario tests for my agent"
-  },
-  {
-    "id": "setup-lw",
-    "label": "Setup lw",
-    "description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-cli-usability",
-    "label": "Test CLI usability",
-    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-    "category": "recipe"
-  },
-  {
-    "id": "test-compliance",
-    "label": "Test compliance",
-    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-    "category": "recipe"
-  },
-  {
-    "id": "tracing",
-    "label": "Tracing",
-    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-    "category": "skill",
-    "userPrompt": "Instrument my code with LangWatch"
-  }
+	{
+		"id": "agent-best-practices",
+		"label": "Agent best practices",
+		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+		"category": "recipe",
+		"userPrompt": "Where can I improve our agent development best practices?"
+	},
+	{
+		"id": "agent-improve",
+		"label": "Agent improve",
+		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+		"category": "skill",
+		"userPrompt": "What should I do next to improve my agent?"
+	},
+	{
+		"id": "agent-performance",
+		"label": "Agent performance",
+		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+		"category": "skill",
+		"userPrompt": "How is my agent performing?"
+	},
+	{
+		"id": "datasets",
+		"label": "Datasets",
+		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+		"category": "skill"
+	},
+	{
+		"id": "debug-instrumentation",
+		"label": "Debug instrumentation",
+		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+		"category": "recipe"
+	},
+	{
+		"id": "debug-with-langwatch",
+		"label": "Debug with langwatch",
+		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
+		"category": "recipe"
+	},
+	{
+		"id": "eval-triage",
+		"label": "Eval triage",
+		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluate-multimodal",
+		"label": "Evaluate multimodal",
+		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+		"category": "recipe"
+	},
+	{
+		"id": "evaluations",
+		"label": "Evaluations",
+		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+		"category": "skill",
+		"userPrompt": "Help me evaluate my agent"
+	},
+	{
+		"id": "experiments",
+		"label": "Experiments",
+		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+		"category": "skill",
+		"userPrompt": "Set up experiments for my agent"
+	},
+	{
+		"id": "generate-rag-dataset",
+		"label": "Generate RAG dataset",
+		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+		"category": "recipe"
+	},
+	{
+		"id": "github",
+		"label": "GitHub",
+		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+		"category": "skill"
+	},
+	{
+		"id": "level-up",
+		"label": "Level up",
+		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+		"category": "skill",
+		"userPrompt": "Take my agent to the next level"
+	},
+	{
+		"id": "online-evaluations",
+		"label": "Online evaluations",
+		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+		"category": "skill",
+		"userPrompt": "Set up online evaluations for my agent"
+	},
+	{
+		"id": "prompts",
+		"label": "Prompts",
+		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+		"category": "skill",
+		"userPrompt": "Version my prompts with LangWatch"
+	},
+	{
+		"id": "scenarios",
+		"label": "Scenarios",
+		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+		"category": "skill",
+		"userPrompt": "Add scenario tests for my agent"
+	},
+	{
+		"id": "setup-lw",
+		"label": "Setup lw",
+		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-cli-usability",
+		"label": "Test CLI usability",
+		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+		"category": "recipe"
+	},
+	{
+		"id": "test-compliance",
+		"label": "Test compliance",
+		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+		"category": "recipe"
+	},
+	{
+		"id": "tracing",
+		"label": "Tracing",
+		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+		"category": "skill",
+		"userPrompt": "Instrument my code with LangWatch"
+	}
 ]

--- a/platform/app/src/utils/__tests__/evaluationResults.test.ts
+++ b/platform/app/src/utils/__tests__/evaluationResults.test.ts
@@ -594,99 +594,120 @@ describe("getEvalChipDisplay", () => {
   });
 
   describe("given a categorising evaluator that answered with a label only", () => {
-    // `langevals/llm_category` classifies rather than judges. Its runs reach
+    // A categorising evaluator classifies rather than judges. Its runs reach
     // the UI with a `processed`/`pass` status and, from some adapters, a
     // score of 0 — both stand-ins for fields it never filled.
-    /** @scenario A category verdict leads the card header */
-    it("reports the category as the verdict when the caller knows its scoreType", () => {
-      const d = getEvalChipDisplay({
-        name: "Max conversation outcome",
-        status: "processed",
-        scoreType: "categorical",
-        score: 0,
-        label: "resolved",
-        passed: null,
+    describe("when getEvalChipDisplay formats the result", () => {
+      /** @scenario A category verdict leads the card header */
+      it("reports the category as the verdict when the caller knows its scoreType", () => {
+        const d = getEvalChipDisplay({
+          name: "Max conversation outcome",
+          status: "processed",
+          scoreType: "categorical",
+          score: 0,
+          label: "resolved",
+          passed: null,
+        });
+
+        expect(d.categoryLabel).toBe("resolved");
+        // The zero is a stand-in, so it must not reach the chip as a score.
+        expect(d.scoreText).toBeNull();
+        expect(d.passLabel).toBeNull();
       });
 
-      expect(d.categoryLabel).toBe("resolved");
-      // The zero is a stand-in, so it must not reach the chip as a score.
-      expect(d.scoreText).toBeNull();
-      expect(d.passLabel).toBeNull();
-    });
+      /** @scenario A category verdict leads the card header */
+      it("infers the category for a caller that carries no scoreType", () => {
+        // The trace-list payload has no scoreType; an absent score and an
+        // absent verdict beside a label say the same thing.
+        const d = getEvalChipDisplay({
+          evaluatorName: "Max conversation outcome",
+          status: "processed",
+          score: null,
+          label: "resolved",
+          passed: null,
+        });
 
-    /** @scenario A category verdict leads the card header */
-    it("infers the category for a caller that carries no scoreType", () => {
-      // The trace-list payload has no scoreType; an absent score and an
-      // absent verdict beside a label say the same thing.
-      const d = getEvalChipDisplay({
-        evaluatorName: "Max conversation outcome",
-        status: "processed",
-        score: null,
-        label: "resolved",
-        passed: null,
+        expect(d.categoryLabel).toBe("resolved");
+        expect(d.passLabel).toBeNull();
       });
-
-      expect(d.categoryLabel).toBe("resolved");
-      expect(d.passLabel).toBeNull();
     });
   });
 
   describe("given an evaluator that produced a real verdict", () => {
-    /** @scenario A label alongside a real verdict rides next to the badge */
-    it("keeps the score and reports no category when a label accompanies it", () => {
-      const d = getEvalChipDisplay({
-        name: "Toxicity",
-        status: "processed",
-        scoreType: "numeric",
-        score: 0.9,
-        label: "safe",
-        passed: true,
+    describe("when getEvalChipDisplay formats the result", () => {
+      /** @scenario A label alongside a real verdict rides next to the badge */
+      it("keeps the score and reports no category when a label accompanies it", () => {
+        const d = getEvalChipDisplay({
+          name: "Toxicity",
+          status: "processed",
+          scoreType: "numeric",
+          score: 0.9,
+          label: "safe",
+          passed: true,
+        });
+
+        expect(d.categoryLabel).toBeNull();
+        expect(d.scoreText).toBe("0.90");
       });
 
-      expect(d.categoryLabel).toBeNull();
-      expect(d.scoreText).toBe("0.90");
-    });
+      /** @scenario A label alongside a real verdict rides next to the badge */
+      it("keeps the Pass label when a boolean verdict carries a label", () => {
+        const d = getEvalChipDisplay({
+          name: "Guardrail",
+          status: "processed",
+          score: null,
+          label: "safe",
+          passed: true,
+        });
 
-    /** @scenario A label alongside a real verdict rides next to the badge */
-    it("keeps the Pass label when a boolean verdict carries a label", () => {
-      const d = getEvalChipDisplay({
-        name: "Guardrail",
-        status: "processed",
-        score: null,
-        label: "safe",
-        passed: true,
+        expect(d.categoryLabel).toBeNull();
+        expect(d.passLabel).toEqual({ text: "Pass", color: "green.fg" });
       });
 
-      expect(d.categoryLabel).toBeNull();
-      expect(d.passLabel).toEqual({ text: "Pass", color: "green.fg" });
-    });
+      /** @scenario A label alongside a real verdict rides next to the badge */
+      it("reads a labelled boolean score as a verdict rather than a category", () => {
+        // A boolean IS the verdict, whatever it is labelled, so the label
+        // rides beside a Pass rather than replacing it.
+        const d = getEvalChipDisplay({
+          name: "Guardrail",
+          status: "passed",
+          score: true,
+          label: "safe",
+        });
 
-    /** @scenario An evaluator with no label is unchanged */
-    it("reports no category for an evaluator that produced none", () => {
-      const d = getEvalChipDisplay({
-        name: "Topic Adherence",
-        status: "processed",
-        scoreType: "numeric",
-        score: 8.2,
+        expect(d.categoryLabel).toBeNull();
+        expect(d.passLabel).toEqual({ text: "Pass", color: "green.fg" });
       });
 
-      expect(d.categoryLabel).toBeNull();
-      expect(d.scoreText).toBe("8.2");
+      /** @scenario An evaluator with no label is unchanged */
+      it("reports no category for an evaluator that produced none", () => {
+        const d = getEvalChipDisplay({
+          name: "Topic Adherence",
+          status: "processed",
+          scoreType: "numeric",
+          score: 8.2,
+        });
+
+        expect(d.categoryLabel).toBeNull();
+        expect(d.scoreText).toBe("8.2");
+      });
     });
   });
 
   describe("given a categorising evaluator that never ran", () => {
-    it("reports no category for a skipped run, whose label is not a verdict", () => {
-      const d = getEvalChipDisplay({
-        name: "Max conversation outcome",
-        status: "skipped",
-        scoreType: "categorical",
-        label: "resolved",
-        passed: null,
-      });
+    describe("when getEvalChipDisplay formats the result", () => {
+      it("reports no category for a skipped run, whose label is not a verdict", () => {
+        const d = getEvalChipDisplay({
+          name: "Max conversation outcome",
+          status: "skipped",
+          scoreType: "categorical",
+          label: "resolved",
+          passed: null,
+        });
 
-      expect(d.categoryLabel).toBeNull();
-      expect(d.noVerdict).toBe(true);
+        expect(d.categoryLabel).toBeNull();
+        expect(d.noVerdict).toBe(true);
+      });
     });
   });
 });

--- a/platform/app/src/utils/__tests__/evaluationResults.test.ts
+++ b/platform/app/src/utils/__tests__/evaluationResults.test.ts
@@ -592,4 +592,101 @@ describe("getEvalChipDisplay", () => {
       expect(d.statusLabel).toBe(getStatusLabel(d.status));
     }
   });
+
+  describe("given a categorising evaluator that answered with a label only", () => {
+    // `langevals/llm_category` classifies rather than judges. Its runs reach
+    // the UI with a `processed`/`pass` status and, from some adapters, a
+    // score of 0 — both stand-ins for fields it never filled.
+    /** @scenario A category verdict leads the card header */
+    it("reports the category as the verdict when the caller knows its scoreType", () => {
+      const d = getEvalChipDisplay({
+        name: "Max conversation outcome",
+        status: "processed",
+        scoreType: "categorical",
+        score: 0,
+        label: "resolved",
+        passed: null,
+      });
+
+      expect(d.categoryLabel).toBe("resolved");
+      // The zero is a stand-in, so it must not reach the chip as a score.
+      expect(d.scoreText).toBeNull();
+      expect(d.passLabel).toBeNull();
+    });
+
+    /** @scenario A category verdict leads the card header */
+    it("infers the category for a caller that carries no scoreType", () => {
+      // The trace-list payload has no scoreType; an absent score and an
+      // absent verdict beside a label say the same thing.
+      const d = getEvalChipDisplay({
+        evaluatorName: "Max conversation outcome",
+        status: "processed",
+        score: null,
+        label: "resolved",
+        passed: null,
+      });
+
+      expect(d.categoryLabel).toBe("resolved");
+      expect(d.passLabel).toBeNull();
+    });
+  });
+
+  describe("given an evaluator that produced a real verdict", () => {
+    /** @scenario A label alongside a real verdict rides next to the badge */
+    it("keeps the score and reports no category when a label accompanies it", () => {
+      const d = getEvalChipDisplay({
+        name: "Toxicity",
+        status: "processed",
+        scoreType: "numeric",
+        score: 0.9,
+        label: "safe",
+        passed: true,
+      });
+
+      expect(d.categoryLabel).toBeNull();
+      expect(d.scoreText).toBe("0.90");
+    });
+
+    /** @scenario A label alongside a real verdict rides next to the badge */
+    it("keeps the Pass label when a boolean verdict carries a label", () => {
+      const d = getEvalChipDisplay({
+        name: "Guardrail",
+        status: "processed",
+        score: null,
+        label: "safe",
+        passed: true,
+      });
+
+      expect(d.categoryLabel).toBeNull();
+      expect(d.passLabel).toEqual({ text: "Pass", color: "green.fg" });
+    });
+
+    /** @scenario An evaluator with no label is unchanged */
+    it("reports no category for an evaluator that produced none", () => {
+      const d = getEvalChipDisplay({
+        name: "Topic Adherence",
+        status: "processed",
+        scoreType: "numeric",
+        score: 8.2,
+      });
+
+      expect(d.categoryLabel).toBeNull();
+      expect(d.scoreText).toBe("8.2");
+    });
+  });
+
+  describe("given a categorising evaluator that never ran", () => {
+    it("reports no category for a skipped run, whose label is not a verdict", () => {
+      const d = getEvalChipDisplay({
+        name: "Max conversation outcome",
+        status: "skipped",
+        scoreType: "categorical",
+        label: "resolved",
+        passed: null,
+      });
+
+      expect(d.categoryLabel).toBeNull();
+      expect(d.noVerdict).toBe(true);
+    });
+  });
 });

--- a/platform/app/src/utils/evaluationResults.ts
+++ b/platform/app/src/utils/evaluationResults.ts
@@ -396,48 +396,63 @@ export function formatEvalScoreText(
  */
 export function getEvalChipDisplay(input: EvalChipInput): EvalChipDisplay {
   const status = normalizeEvalStatus(input);
-  const color = EVALUATION_STATUS_COLORS[status];
-  const statusLabel = getStatusLabel(status);
-  const displayName =
-    input.name || input.evaluatorName || input.evaluatorId || "Unknown";
   const noVerdict = status === "skipped" || status === "error";
-  // A categorising evaluator's verdict IS its label. Show that, and nothing
-  // where the score and the pass/fail would go: both are stand-ins invented
-  // for fields it never filled, and printing them claims a run that scored
-  // zero and passed.
-  //
-  // A caller that knows its `scoreType` is believed over `score`, because its
-  // `score` may be one of those stand-ins. A caller that doesn't know is read
-  // off the raw fields, where an absent score and an absent verdict beside a
-  // label say the same thing.
-  const isCategorical =
-    input.scoreType === "categorical" ||
-    (input.scoreType == null && typeof input.score !== "number");
-  const categoryLabel =
-    !noVerdict && isCategorical && input.label && input.passed == null
-      ? input.label
-      : null;
+  const categoryLabel = resolveCategoryLabel({ input, noVerdict });
   const scoreText =
     categoryLabel == null && typeof input.score === "number"
       ? formatEvalScoreText(input.score)
       : null;
 
-  // Surface a colored Pass/Fail label only when the evaluator produced a
-  // pure boolean verdict (no numeric score to show in its place).
-  let passLabel: EvalChipDisplay["passLabel"] = null;
-  if (scoreText == null && categoryLabel == null && !noVerdict) {
-    if (status === "passed") passLabel = { text: "Pass", color: "green.fg" };
-    else if (status === "failed") passLabel = { text: "Fail", color: "red.fg" };
-  }
-
   return {
     status,
-    color,
-    statusLabel,
+    color: EVALUATION_STATUS_COLORS[status],
+    statusLabel: getStatusLabel(status),
     categoryLabel,
-    displayName,
+    displayName:
+      input.name || input.evaluatorName || input.evaluatorId || "Unknown",
     scoreText,
     noVerdict,
-    passLabel,
+    passLabel:
+      scoreText == null && categoryLabel == null && !noVerdict
+        ? resolvePassLabel(status)
+        : null,
   };
+}
+
+/**
+ * A categorising evaluator's verdict IS its label. Return it so callers can
+ * show it where the score and the pass/fail would go: both are stand-ins
+ * invented for fields it never filled, and printing them claims a run that
+ * scored zero and passed.
+ *
+ * A caller that knows its `scoreType` is believed over `score`, because its
+ * `score` may be one of those stand-ins. A caller that doesn't know is read
+ * off the raw fields: a label with neither a score nor a verdict beside it
+ * came from an evaluator that only categorised. A boolean score is a verdict,
+ * so it never reads as a category no matter what it is labelled.
+ */
+function resolveCategoryLabel({
+  input,
+  noVerdict,
+}: {
+  input: EvalChipInput;
+  noVerdict: boolean;
+}): string | null {
+  if (noVerdict || !input.label || input.passed != null) return null;
+  const isCategorical =
+    input.scoreType === "categorical" ||
+    (input.scoreType == null && input.score == null);
+  return isCategorical ? input.label : null;
+}
+
+/**
+ * The colored Pass/Fail label, for evaluators that produced a pure boolean
+ * verdict with no numeric score to show in its place.
+ */
+function resolvePassLabel(
+  status: ParsedEvaluationResult["status"],
+): EvalChipDisplay["passLabel"] {
+  if (status === "passed") return { text: "Pass", color: "green.fg" };
+  if (status === "failed") return { text: "Fail", color: "red.fg" };
+  return null;
 }

--- a/platform/app/src/utils/evaluationResults.ts
+++ b/platform/app/src/utils/evaluationResults.ts
@@ -298,6 +298,17 @@ export interface EvalChipInput {
   label?: string | null;
   /** Explicit pass flag from a numeric/categorical evaluator. */
   passed?: boolean | null;
+  /**
+   * What kind of verdict the evaluator produced, where the caller knows.
+   * `"categorical"` means it answered with a label and neither a number
+   * nor a pass/fail — see {@link EvalChipDisplay.categoryLabel}.
+   *
+   * Worth passing wherever it is known, because `score` alone cannot carry
+   * the distinction: some callers substitute `0` for a score the evaluator
+   * never produced, and a chip reading that as a real zero reports a
+   * failing-looking verdict nobody returned.
+   */
+  scoreType?: "numeric" | "boolean" | "categorical" | null;
 }
 
 /** Normalized chip-display contract — single source of truth for both
@@ -319,9 +330,16 @@ export interface EvalChipDisplay {
   /**
    * Color-coded pass/fail label when the evaluator returned an explicit
    * boolean verdict (not a numeric score). `null` for numeric / skipped /
-   * error.
+   * error, and for a categorising evaluator, which passed no judgement to
+   * label.
    */
   passLabel: { text: string; color: string } | null;
+  /**
+   * The category a categorising evaluator answered with — the whole of its
+   * verdict, and what a chip shows where a score or a Pass would otherwise
+   * go. `null` for every evaluator that scored or judged.
+   */
+  categoryLabel: string | null;
 }
 
 /** Map any source's status string onto the canonical v3 status enum. */
@@ -382,14 +400,32 @@ export function getEvalChipDisplay(input: EvalChipInput): EvalChipDisplay {
   const statusLabel = getStatusLabel(status);
   const displayName =
     input.name || input.evaluatorName || input.evaluatorId || "Unknown";
-  const scoreText =
-    typeof input.score === "number" ? formatEvalScoreText(input.score) : null;
   const noVerdict = status === "skipped" || status === "error";
+  // A categorising evaluator's verdict IS its label. Show that, and nothing
+  // where the score and the pass/fail would go: both are stand-ins invented
+  // for fields it never filled, and printing them claims a run that scored
+  // zero and passed.
+  //
+  // A caller that knows its `scoreType` is believed over `score`, because its
+  // `score` may be one of those stand-ins. A caller that doesn't know is read
+  // off the raw fields, where an absent score and an absent verdict beside a
+  // label say the same thing.
+  const isCategorical =
+    input.scoreType === "categorical" ||
+    (input.scoreType == null && typeof input.score !== "number");
+  const categoryLabel =
+    !noVerdict && isCategorical && input.label && input.passed == null
+      ? input.label
+      : null;
+  const scoreText =
+    categoryLabel == null && typeof input.score === "number"
+      ? formatEvalScoreText(input.score)
+      : null;
 
   // Surface a colored Pass/Fail label only when the evaluator produced a
   // pure boolean verdict (no numeric score to show in its place).
   let passLabel: EvalChipDisplay["passLabel"] = null;
-  if (scoreText == null && !noVerdict) {
+  if (scoreText == null && categoryLabel == null && !noVerdict) {
     if (status === "passed") passLabel = { text: "Pass", color: "green.fg" };
     else if (status === "failed") passLabel = { text: "Fail", color: "red.fg" };
   }
@@ -398,6 +434,7 @@ export function getEvalChipDisplay(input: EvalChipInput): EvalChipDisplay {
     status,
     color,
     statusLabel,
+    categoryLabel,
     displayName,
     scoreText,
     noVerdict,

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -7696,7 +7696,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -7897,7 +7897,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8059,7 +8059,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8222,7 +8222,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8379,7 +8379,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8530,7 +8530,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
+                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -7696,7 +7696,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -7897,7 +7897,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8059,7 +8059,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8222,7 +8222,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8379,7 +8379,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;
@@ -8530,7 +8530,7 @@ export interface operations {
                             current_period_started_at: string;
                             /** @description When the current period gives way to the next. Far-future for total and manual windows, which do not roll on their own. */
                             resets_at: string;
-                            /** @description The instant this budget's cycle is phased to, or null when the window is calendar aligned. */
+                            /** @description The instant this budget's cycle is phased to. Null means no anchor: a calendar-aligned cyclic window, or one of the two windows that do not cycle (total, manual). */
                             cycle_anchor_at: string | null;
                             last_reset_at: string | null;
                             archived_at: string | null;

--- a/specs/traces-v2/evaluations.feature
+++ b/specs/traces-v2/evaluations.feature
@@ -81,6 +81,32 @@ Rule: Eval card layout
     When the user clicks "Show details"
     Then a details panel reveals the available rows (Label, Error, IDs, Stacktrace, Inputs)
 
+  # A categorising evaluator (langevals/llm_category and anything else that
+  # answers with a category) returns a label and neither a score nor a
+  # pass/fail. Reading that as a passing run scoring zero is a fabrication
+  # twice over, and it buries the one thing the evaluator actually said.
+  @integration
+  Scenario: A category verdict leads the card header
+    Given the trace has a run of "Max conversation outcome" whose only verdict is the category "resolved"
+    Then the card header shows "resolved" as its leading chip
+    And no PASS badge is shown
+    And no score is shown
+    And no score bar is drawn
+    And the category is not repeated under "Show details"
+
+  @integration
+  Scenario: A label alongside a real verdict rides next to the badge
+    Given the trace has a run of "Toxicity" that passed scoring 0.90 and is labelled "safe"
+    Then the card header shows the PASS badge
+    And the header shows "safe" as a chip next to the badge
+    And the header still shows the score "0.90"
+
+  @integration
+  Scenario: An evaluator with no label is unchanged
+    Given the trace has a run of "Topic Adherence" scoring 8.2 out of 10 with no label
+    Then the card header shows the PASS badge, the name, and the score
+    And no category chip is shown
+
   Scenario: Show details is hidden when no extra context exists
     Given an eval card has only name, score, and reasoning
     Then no "Show details" toggle is rendered

--- a/specs/traces-v2/evaluations.feature
+++ b/specs/traces-v2/evaluations.feature
@@ -81,8 +81,7 @@ Rule: Eval card layout
     When the user clicks "Show details"
     Then a details panel reveals the available rows (Label, Error, IDs, Stacktrace, Inputs)
 
-  # A categorising evaluator (langevals/llm_category and anything else that
-  # answers with a category) returns a label and neither a score nor a
+  # A categorising evaluator returns a label and neither a score nor a
   # pass/fail. Reading that as a passing run scoring zero is a fabrication
   # twice over, and it buries the one thing the evaluator actually said.
   @integration

--- a/specs/traces-v2/trace-list-events-column.feature
+++ b/specs/traces-v2/trace-list-events-column.feature
@@ -1,0 +1,155 @@
+# Trace list Events column — Gherkin Spec
+# Implementation:
+#   platform/app/src/features/traces-v2/components/TraceTable/registry/cells/trace/EventsCell.tsx
+#   platform/app/src/features/traces-v2/hooks/useTraceListEvents.ts
+#   platform/app/src/server/api/routers/tracesV2.ts (`listEvents`)
+#   platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+#
+# Trace-level events are OTel span events, stored on `stored_spans`. They are
+# deliberately NOT folded onto `trace_summaries` (that hoist grew the fold
+# state O(span-count) and made folding O(n^2); migration 00025 dropped the
+# columns), so anything showing them reads them back on demand.
+
+Feature: Trace list Events column
+  As a user scanning the trace list
+  I want each row to show the events its trace recorded
+  So that I can spot feedback, tool output and exceptions without opening every trace
+
+Rule: The Events column shows the trace's own events
+  What a row shows must agree with what the trace drawer's Events section
+  shows for the same trace. A row that reads empty means the trace has no
+  events, never that the list forgot to ask for them.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the Events column is visible
+
+  @integration
+  Scenario: A trace with events shows a badge per event name
+    Given a trace recorded one "thumbs_up_down" event
+    When the trace list renders
+    Then that row's Events column shows a "thumbs_up_down" badge
+
+  @integration
+  Scenario: A trace with no events shows the empty marker
+    Given a trace recorded no events
+    When the trace list renders
+    Then that row's Events column shows the empty-cell marker
+
+  @unit
+  Scenario: Repeated events of the same name collapse into one badge with a count
+    Given a trace recorded 237 "tool.output" events and 237 "gen_ai.request.attempt" events
+    When the trace list renders
+    Then that row shows a "tool.output" badge reading "237"
+    And a "gen_ai.request.attempt" badge reading "237"
+    # A badge per event would render 474 chips in a 250px cell.
+
+  @unit
+  Scenario: Badges are ordered by when the event first occurred
+    Given a trace recorded "exception" after "first_token"
+    When the trace list renders
+    Then the "first_token" badge comes before the "exception" badge
+
+  @unit
+  Scenario: Overflowing badges collapse into a remainder chip
+    Given a trace recorded events under 7 distinct names
+    When the trace list renders
+    Then the first 3 badges are shown
+    And a "+4" chip stands for the rest
+    And hovering the remainder chip names the events it stands for
+
+  @integration
+  Scenario: The list agrees with the drawer
+    Given a trace whose drawer Events section lists 1 event
+    Then that trace's row in the list shows 1 event
+
+Rule: Events are read on demand, per visible page
+  The events read is a second query, not part of the list read: the list is
+  the query that gates first paint, and events live in a different table.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+
+  @integration
+  Scenario: Events are fetched for the traces currently on screen
+    Given the Events column is visible
+    When a page of traces loads
+    Then events are requested once for that page's trace ids
+
+  @integration
+  Scenario: Hiding the Events column stops the fetch
+    Given no visible column or grouping needs events
+    When a page of traces loads
+    Then no events request is made
+
+  @integration
+  Scenario: Enabling the Events column triggers the fetch
+    Given the Events column was hidden
+    When the user enables the Events column
+    Then events are requested for the traces already on screen
+    And the trace list itself is not refetched
+
+  @integration
+  Scenario: The list still renders while events are in flight
+    Given the events request has not resolved
+    Then every other column renders its value
+    And the Events column shows a pending placeholder rather than the empty marker
+    # Showing the empty marker early would read as "this trace has no events".
+
+  @integration
+  Scenario: A failed events read leaves the rest of the list intact
+    Given the events request fails
+    Then the trace rows still render
+    And the Events column shows the empty marker
+    And no error toast interrupts the user
+    # The column is supplementary; losing it must not take the list down.
+
+Rule: Events reads are tenant-scoped and bounded
+  The read goes to `stored_spans`, which is ordered by
+  (TenantId, TraceId, SpanId) and partitioned by week.
+
+  Background:
+    Given a project with traces that carry span events
+
+  @integration
+  Scenario: Only the caller's project is read
+    When events are read for a page of trace ids
+    Then the query filters on the caller's TenantId first
+    And trace ids belonging to another project return nothing
+
+  @integration
+  Scenario: The read is pruned to the page's time range
+    When events are read for a page of trace ids
+    Then the query is bounded by the list's time range
+    And partitions outside that range are not scanned
+
+  @integration
+  Scenario: A trace with a very large number of events stays bounded
+    Given a trace recorded events under more distinct names than a row can show
+    When events are read for it
+    Then the response carries at most the badge cap plus the remainder count
+    And the row never receives one entry per event
+
+  @integration
+  Scenario: An empty page of trace ids skips the query entirely
+    Given the visible page has no traces
+    When the events read runs
+    Then no ClickHouse query is issued
+
+Rule: Conversation groups count the events of their turns
+  The Conversations lens summarises each group, including how many events
+  its traces recorded between them.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the Conversations lens is active
+
+  @unit
+  Scenario: A group's event count sums its traces' events
+    Given a conversation with two traces recording 2 and 3 events
+    Then the conversation row shows 5 events
+
+  @unit
+  Scenario: A conversation whose traces recorded no events shows no counter
+    Given a conversation whose traces recorded no events
+    Then no event counter is shown on the conversation row

--- a/specs/traces-v2/trace-list-events-column.feature
+++ b/specs/traces-v2/trace-list-events-column.feature
@@ -63,78 +63,92 @@ Rule: The Events column shows the trace's own events
     Given a trace whose drawer Events section lists 1 event
     Then that trace's row in the list shows 1 event
 
-Rule: Events are read on demand, per visible page
-  The events read is a second query, not part of the list read: the list is
-  the query that gates first paint, and events live in a different table.
+Rule: The column fills itself in without holding up the list
+  Events live apart from everything else on a row, so they arrive after it.
+  Until they do, and if they never do, the column says which of those two it
+  is rather than answering for the trace.
 
   Background:
     Given the user is authenticated with "traces:view" permission
 
   @integration
-  Scenario: Events are fetched for the traces currently on screen
+  Scenario: Events are shown for the traces currently on screen
     Given the Events column is visible
     When a page of traces loads
-    Then events are requested once for that page's trace ids
+    Then each row on that page shows the events of its own trace
 
   @integration
-  Scenario: Hiding the Events column stops the fetch
+  Scenario: Hiding the Events column costs nothing
     Given no visible column or grouping needs events
     When a page of traces loads
-    Then no events request is made
+    Then the list does not go looking for events
 
   @integration
-  Scenario: Enabling the Events column triggers the fetch
+  Scenario: Enabling the Events column fills it in place
     Given the Events column was hidden
     When the user enables the Events column
-    Then events are requested for the traces already on screen
-    And the trace list itself is not refetched
+    Then the traces already on screen gain their events
+    And the rest of the list is not reloaded
 
   @integration
   Scenario: The list still renders while events are in flight
-    Given the events request has not resolved
+    Given the events have not arrived yet
     Then every other column renders its value
     And the Events column shows a pending placeholder rather than the empty marker
     # Showing the empty marker early would read as "this trace has no events".
 
   @integration
-  Scenario: A failed events read leaves the rest of the list intact
-    Given the events request fails
-    Then the trace rows still render
-    And the Events column shows the empty marker
-    And no error toast interrupts the user
-    # The column is supplementary; losing it must not take the list down.
+  Scenario: Turning the page waits for that page's own events
+    Given the user moves to the next page
+    Then the Events column shows a pending placeholder until the new page's events arrive
+    # The previous page's answers say nothing about these traces.
 
-Rule: Events reads are tenant-scoped and bounded
-  The read goes to `stored_spans`, which is ordered by
-  (TenantId, TraceId, SpanId) and partitioned by week.
+  @integration
+  Scenario: A failed events read says so rather than reading as empty
+    Given the events could not be loaded
+    Then the trace rows still render
+    And the Events column reads as unavailable, not as empty
+    And no error toast interrupts the user
+    # The column is supplementary; losing it must not take the list down, and
+    # an empty marker would report a trace that has events as having none.
+
+  @integration
+  Scenario: Onboarding sample traces keep the events they ship with
+    Given the user is seeing the onboarding sample traces
+    Then their events are shown as the samples describe them
+    And no events are looked up for them
+
+Rule: A row never has to render an unbounded number of events
+  A single agent turn can record hundreds of events. The column stays
+  readable, and one trace's history cannot swell the list's response.
 
   Background:
     Given a project with traces that carry span events
 
   @integration
   Scenario: Only the caller's project is read
-    When events are read for a page of trace ids
-    Then the query filters on the caller's TenantId first
-    And trace ids belonging to another project return nothing
-
-  @integration
-  Scenario: The read is pruned to the page's time range
-    When events are read for a page of trace ids
-    Then the query is bounded by the list's time range
-    And partitions outside that range are not scanned
+    When the list shows events for a page of traces
+    Then traces belonging to another project contribute nothing
 
   @integration
   Scenario: A trace with a very large number of events stays bounded
     Given a trace recorded events under more distinct names than a row can show
-    When events are read for it
-    Then the response carries at most the badge cap plus the remainder count
-    And the row never receives one entry per event
+    When the list shows events for it
+    Then the row receives at most the badge cap plus a count of the rest
+    And it never receives one entry per event
 
   @integration
-  Scenario: An empty page of trace ids skips the query entirely
+  Scenario: The search is confined to the period on screen
+    Given the list is showing a period the trace's events fall outside of
+    When the list shows events for it
+    Then those events are not counted on the row
+    # The drawer reads the same window around a trace, so the two never
+    # disagree about what it recorded.
+
+  @integration
+  Scenario: A page with no traces on it shows no events
     Given the visible page has no traces
-    When the events read runs
-    Then no ClickHouse query is issued
+    Then no events are looked up
 
 Rule: Conversation groups count the events of their turns
   The Conversations lens summarises each group, including how many events

--- a/specs/traces-v2/trace-table.feature
+++ b/specs/traces-v2/trace-table.feature
@@ -610,25 +610,8 @@ Rule: Column visibility and reorder
 #   - the inline summary badges column under "Evals summary column"
 # See dev/docs/adr/029-trace-table-per-evaluator-columns.md.
 
-Rule: Event column display
-  Event columns show counts with exception flags.
-
-  Background:
-    Given the user is authenticated with "traces:view" permission
-    And the Events column is enabled
-
-  Scenario: Events column shows count and exception indicator
-    Given the Events column is enabled
-    And a trace has 3 events including an exception
-    Then the Events column shows "3 ⚠"
-
-  Scenario: Events column shows feedback icon
-    Given a trace has events including a thumbs-up feedback event
-    Then the Events column shows "3 👍"
-
-  Scenario: Clicking events column opens drawer with Events accordion
-    When the user clicks the events count for a trace
-    Then the trace drawer opens with the Events accordion expanded
+# The Events column is owned by specs/traces-v2/trace-list-events-column.feature:
+# what a row shows, where the data comes from, and when it is fetched.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -848,17 +831,12 @@ Rule: Data gating and null handling
     Given a trace has no service set
     Then the Service column shows "—"
 
-  # Not yet implemented as of 2026-05-01 — `tracesV2.list` returns the same
-  # base shape (TraceListItem) regardless of which columns are visible. Eval
-  # scores are bundled into the same response via `evaluations`. Toggling a
-  # column on does not trigger a separate fetch.
+  # `tracesV2.list` returns the same base shape (TraceListItem) regardless of
+  # which columns are visible, and eval scores are bundled into that same
+  # response via `evaluations`. Events are the one exception: they live in
+  # `stored_spans`, not on the summary fold, so they are read on demand — see
+  # specs/traces-v2/trace-list-events-column.feature.
   @planned
   Scenario: Data fetching only queries visible columns
     Given only the default columns are visible
     Then the backend query only fetches fields for visible columns
-
-  @planned
-  Scenario: Enabling an optional column triggers data fetch
-    Given the Events column was hidden
-    When the user enables the Events column
-    Then event count data is fetched for the visible traces


### PR DESCRIPTION
Three defects on the trace list and its drawer, all reported from the same screen.

## The Events column was hardcoded empty

#4205 moved event derivation off the trace-summary fold (the per-span hoist grew the fold state O(span-count) and made folding O(n^2); migration 00025 dropped the columns) and onto a read-time `stored_spans` query — but only wired that read into the drawer. `mapToTraceListItem` was left returning `events: []` under a comment claiming the list never surfaced trace-level events, which the line it replaced (`(row.events ?? []).map(...)`) disproves.

`events` ships in the default **All** and **Errors** lenses, so every user saw a dead column. The Conversations lens event counter was dead the same way, silently, behind a `> 0` guard.

Events now come from `tracesV2.listEvents`: one batched read per visible page, grouped by name in ClickHouse. It is its own query rather than part of `list` because events live in a different table from the summary, `list` is what gates first paint, and a page whose columns and grouping never mention events pays nothing.

A row shows one badge per event **name** with a repeat count, not one per event — an agent turn that retries a tool 237 times has 237 `tool.output` events and one thing worth saying about them. Past three names the rest collapse into a remainder chip that names them on hover.

Because the events arrive after the rest of the row, the column never answers for a trace it has not heard about yet. It holds a placeholder while the read is in flight and while a page turn is still serving the previous page's answers, and it reads as unavailable if the read fails. The empty marker means the trace recorded nothing, and only that. Onboarding sample traces keep the events they ship with and nothing is looked up for them.

## A category verdict posed as a passing zero

`langevals/llm_category` answers with a label and neither a score nor a pass/fail. The UI substituted a `pass` status and a score of `0` for the fields it never filled, so the card claimed a run that **passed scoring zero** and buried the actual category under "Show details".

The category now leads the card, and the same fix lands on the drawer header chip and the trace-list chip through `getEvalChipDisplay` — the module all three already went through for everything else. An evaluator that produced a real verdict keeps its badge and its score, and gains its label beside them.

## "View definition" opened a drawer and lost it

Clicking it from the eval hover card opened the evaluator drawer, then a moment later the drawer vanished and the URL sprang back. The hover card was left open behind the drawer it had just opened; when the pointer left, the card dismissed, the drawer read that as an interaction outside itself and closed — one `push` to the drawer URL, one `push` straight back to the list. The card now closes when its own action navigates.

## Screenshots

**Events column** — every row read `—` before; now each carries its trace's events. The same shot shows the eval chip reading `resolved` rather than a fabricated score.

![Events column](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/events/events-column-light.png)

**Repeat counts and overflow** — one badge per name, a count when it repeated, `+N` for the rest.

![Events overflow](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/events/events-column-overflow.png)

**Both eval shapes in one card list** — `resolved` leads the categorising evaluator with no badge and no score; the scored one keeps `PASS`, gains its `safe` label, and keeps `1.00`. The header chips above show the same.

![Eval cards](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/evals/eval-card-category.png)

**A failed events read** — the column says so; `LABELS`, `EVALS` and `PROMPT` beside it keep showing `—` for the things those traces genuinely do not have. No toast. Reloading with the read working again returns the column to `—`.

![Events unavailable](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/events/events-column-unavailable.png)

**Dark mode**

![Events column dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/events/events-column-dark.png)

**View definition stays open** — the drawer survives the pointer leaving the hover card. Instrumenting `history.pushState` showed one push after the fix where there had been two.

![View definition](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6632/drawer/view-definition-stays-open.png)

## Tests

Specs first: `specs/traces-v2/trace-list-events-column.feature` is new and covers what a row shows, when the read fires, and the tenant/partition bounds; the stale untagged Events scenarios in `trace-table.feature` are replaced by it, and `evaluations.feature` gains the three card-header scenarios.

- **Integration, real ClickHouse** — 8 new cases on `getTraceEventRollupsByTraceIds`: grouping by name, ordering by first occurrence, latest-span-version dedup, batching a whole page, omitting eventless traces, the distinct-name trim still reporting true totals, another tenant's ids returning nothing, and an empty page issuing no query at all.
- **Integration, real render** — `EventsCell` over badges, counts, overflow, the empty marker, the in-flight placeholder and the unavailable state; `EvalCard` over all three verdict shapes, including a category that reads like the placeholder score it displaced.
- **Integration, real hook** — `useTraceListEvents` over what it asks for and when, what a row shows mid-flight, mid-page-turn and after a failure, and the sample-preview case where it asks for nothing.
- **Unit** — `getEvalChipDisplay` for the category case both when the caller knows its `scoreType` and when it doesn't, that a labelled boolean stays a verdict, plus the conversation-group event totals.

`pnpm typecheck:all` clean, 978 traces-v2 unit tests and 56 integration tests green.

## QA

Driven in a real browser against local ClickHouse with real event data, both colour modes: the column populating, badge counts, the overflow chip, both eval card shapes, the header chips, and the drawer surviving the pointer leaving. The `listEvents` response was checked against the raw ClickHouse rows for the same traces. The failure path was driven too, by failing the read in the page: the column reads as unavailable, the rest of the row is untouched, nothing toasts, and it returns to the empty marker once the read works again.

One thing found and deliberately left alone: the online-evaluation drawer renders a blank form for a legacy `checkType`-only monitor with no `evaluatorId`. That is pre-existing and unrelated to the close bug fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer event badges with repeat counts, distinct totals, overflow details, and loading or unavailable states.
  * Event information now loads on demand for relevant trace-list and conversation views.
  * Added category chips for categorical evaluations, with labels shown alongside applicable verdicts.

* **Bug Fixes**
  * Improved event grouping and consistency across trace tables, conversation views, and search.
  * Prevented placeholder scores and verdicts from appearing for category-only evaluations.
  * Enhanced evaluation chip accessibility with category labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
