### PR TITLE
fix(api): stop 500ing every chunked request on bodyLimit-guarded routes

### DIFF
--- a/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@langwatch/observability";
-import { bodyLimit } from "hono/body-limit";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { z } from "zod";
@@ -42,7 +42,7 @@ const secured = createProjectApp({ basePath: "/api/scenario-events" });
 secured.access(requires("scenarios:create")).post(
   "/",
   blockTraceUsageExceededMiddleware,
-  bodyLimit({ maxSize: 50 * 1024 * 1024 }), // 50MB — accommodates inline media payloads
+  wireBodyLimit({ maxSize: 50 * 1024 * 1024 }), // 50MB — accommodates inline media payloads
   describeRoute({
     description: "Create a new scenario event",
     responses: {

--- a/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
@@ -1,10 +1,10 @@
 import { createLogger } from "@langwatch/observability";
-import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { getApp } from "~/server/app-layer/app";
 import {
   SCENARIO_TAB_NAVIGATE_EVENT,

--- a/platform/app/src/server/api/__tests__/no-hono-body-limit.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/no-hono-body-limit.unit.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @scenario "hono's bodyLimit never comes back"
+ *
+ * hono's own `bodyLimit` crashes under @hono/node-server for any request
+ * without Content-Length — see `wire-body-limit.ts` and its test for the
+ * mechanism. Nothing about that middleware looks broken at a call site, so
+ * the only durable guard is refusing the import outright: a future route
+ * reaching for the obvious name reintroduces a 500 on every chunked sender.
+ *
+ * Use `wireBodyLimit` from `~/server/api/wire-body-limit` instead.
+ */
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const APP_ROOT = path.resolve(__dirname, "../../../..");
+
+describe("hono/body-limit imports", () => {
+  it("finds no source file importing hono's bodyLimit", () => {
+    // `git grep` rather than a directory walk: it honours .gitignore, so
+    // build output and node_modules cannot produce a phantom hit.
+    let hits = "";
+    try {
+      hits = execFileSync(
+        "git",
+        ["grep", "-l", "hono/body-limit", "--", "src", "ee"],
+        { cwd: APP_ROOT, encoding: "utf8" },
+      );
+    } catch (error: unknown) {
+      // git grep exits 1 with no output when nothing matches — the passing
+      // case. Any other failure is a broken test, not a clean tree.
+      const status = (error as { status?: number }).status;
+      if (status !== 1) throw error;
+    }
+
+    const offenders = hits
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      // This test names the import it bans, so it matches itself.
+      .filter((file) => !file.endsWith("no-hono-body-limit.unit.test.ts"));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/platform/app/src/server/api/__tests__/wire-body-limit.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/wire-body-limit.unit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @scenario "Chunked request bodies survive the wire byte cap"
+ *
+ * Regression coverage for the hono `bodyLimit` + @hono/node-server crash:
+ * a request WITHOUT Content-Length (chunked transfer — what the OTel JS
+ * exporters send) made hono's middleware rebuild the request via
+ * `new Request(c.req.raw, …)`, which throws
+ * `TypeError: Cannot read private member #state` under @hono/node-server's
+ * lightweight request and turned every chunked OTLP export into a 500.
+ *
+ * The crash only exists over a REAL node socket — hono's `app.request()`
+ * test helper builds genuine undici Requests, which never trip the brand
+ * check — so these tests serve the app with @hono/node-server on an
+ * ephemeral port and speak HTTP to it, executing the exact code path that
+ * failed in production. `overrideGlobalObjects: false` matters: it is what
+ * `start.ts` passes (deliberately — the process's globals stay untouched),
+ * and it is the condition under which hono's middleware crashes. Swapping
+ * `wireBodyLimit` back to hono's `bodyLimit` makes the chunked cases here
+ * fail with 500.
+ */
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { wireBodyLimit } from "../wire-body-limit";
+
+const MAX_SIZE = 1024;
+
+let server: ReturnType<typeof serve>;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = new Hono();
+  app.post("/guarded", wireBodyLimit({ maxSize: MAX_SIZE }), async (c) => {
+    const body = await c.req.text();
+    return c.json({ received: body.length });
+  });
+
+  await new Promise<void>((resolve) => {
+    server = serve(
+      { fetch: app.fetch, port: 0, overrideGlobalObjects: false },
+      (info) => {
+        baseUrl = `http://127.0.0.1:${info.port}`;
+        resolve();
+      },
+    );
+  });
+});
+
+afterAll(() => {
+  server.close();
+});
+
+/** POST with a streamed body — node's fetch sends it chunked, no Content-Length. */
+const postChunked = (payload: string) => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+  return fetch(`${baseUrl}/guarded`, {
+    method: "POST",
+    body: stream,
+    // @ts-expect-error duplex is required by undici for streamed bodies but
+    // missing from the DOM RequestInit type.
+    duplex: "half",
+  });
+};
+
+describe("wireBodyLimit over a real @hono/node-server socket", () => {
+  describe("when the body is sent chunked (no Content-Length)", () => {
+    it("passes a body under the cap through to the handler intact", async () => {
+      const res = await postChunked("a".repeat(100));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ received: 100 });
+    });
+
+    it("rejects a body over the cap with 413", async () => {
+      const res = await postChunked("a".repeat(MAX_SIZE + 1));
+      expect(res.status).toBe(413);
+    });
+  });
+
+  describe("when the body carries a Content-Length", () => {
+    it("passes a body under the cap through to the handler", async () => {
+      const res = await fetch(`${baseUrl}/guarded`, {
+        method: "POST",
+        body: "a".repeat(100),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ received: 100 });
+    });
+
+    it("rejects a declared length over the cap with 413", async () => {
+      const res = await fetch(`${baseUrl}/guarded`, {
+        method: "POST",
+        body: "a".repeat(MAX_SIZE + 1),
+      });
+      expect(res.status).toBe(413);
+    });
+  });
+});

--- a/platform/app/src/server/api/__tests__/wire-body-limit.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/wire-body-limit.unit.test.ts
@@ -51,11 +51,16 @@ afterAll(() => {
   server.close();
 });
 
-/** POST with a streamed body — node's fetch sends it chunked, no Content-Length. */
-const postChunked = (payload: string) => {
+/**
+ * POST with a streamed body — node's fetch sends it chunked, no Content-Length.
+ * Takes the chunks separately so a test can control how the payload is split.
+ */
+const postChunked = (...payloads: string[]) => {
   const stream = new ReadableStream({
     start(controller) {
-      controller.enqueue(new TextEncoder().encode(payload));
+      for (const payload of payloads) {
+        controller.enqueue(new TextEncoder().encode(payload));
+      }
       controller.close();
     },
   });
@@ -79,6 +84,38 @@ describe("wireBodyLimit over a real @hono/node-server socket", () => {
     it("rejects a body over the cap with 413", async () => {
       const res = await postChunked("a".repeat(MAX_SIZE + 1));
       expect(res.status).toBe(413);
+    });
+
+    it("rejects on the running total when every single chunk fits", async () => {
+      // The cap is cumulative, not per-chunk. Four quarter-cap chunks are each
+      // individually acceptable and together one byte too many — a middleware
+      // that checked each chunk in isolation would let this through, so this
+      // is the case that pins `size += value.length` rather than the
+      // one-oversized-chunk case above.
+      const quarter = MAX_SIZE / 4;
+      const res = await postChunked(
+        "a".repeat(quarter),
+        "a".repeat(quarter),
+        "a".repeat(quarter),
+        "a".repeat(quarter + 1),
+      );
+      expect(res.status).toBe(413);
+    });
+
+    it("accepts a multi-chunk body that totals exactly the cap", async () => {
+      // The boundary from the other side: the same split, one byte smaller,
+      // must arrive whole. Guards against an off-by-one that rejects at the
+      // limit instead of past it, and proves the chunks are reassembled in
+      // order rather than merely counted.
+      const quarter = MAX_SIZE / 4;
+      const res = await postChunked(
+        "a".repeat(quarter),
+        "b".repeat(quarter),
+        "c".repeat(quarter),
+        "d".repeat(quarter),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ received: MAX_SIZE });
     });
   });
 

--- a/platform/app/src/server/api/wire-body-limit.ts
+++ b/platform/app/src/server/api/wire-body-limit.ts
@@ -25,6 +25,41 @@ const reject = (): never => {
   throw new HTTPException(413, { res });
 };
 
+/**
+ * True when the declared Content-Length is authoritative. A request carrying
+ * both headers is framed by Transfer-Encoding, so its Content-Length says
+ * nothing about the bytes actually arriving and has to be counted instead.
+ */
+const declaresItsOwnLength = (headers: Headers): boolean =>
+  headers.has("content-length") && !headers.has("transfer-encoding");
+
+/** Reads the stream, rejecting the moment the running total passes the cap. */
+const readCapped = async (
+  body: ReadableStream<Uint8Array>,
+  maxSize: number,
+  // `Uint8Array<ArrayBuffer>` rather than a bare `Uint8Array`: the latter
+  // widens to `ArrayBufferLike`, which `BodyInit` does not accept.
+): Promise<Uint8Array<ArrayBuffer>> => {
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  const reader = body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.length;
+    if (size > maxSize) reject();
+    chunks.push(value);
+  }
+
+  const buffered = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffered.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return buffered;
+};
+
 export const wireBodyLimit = ({
   maxSize,
 }: {
@@ -32,38 +67,18 @@ export const wireBodyLimit = ({
 }): MiddlewareHandler => {
   return async function wireBodyLimitMiddleware(c: Context, next: Next) {
     const body = c.req.raw.body;
-    if (!body) {
-      return next();
-    }
+    if (!body) return next();
 
-    const hasTransferEncoding = c.req.raw.headers.has("transfer-encoding");
-    const hasContentLength = c.req.raw.headers.has("content-length");
-    if (hasContentLength && !hasTransferEncoding) {
-      const contentLength = parseInt(
+    if (declaresItsOwnLength(c.req.raw.headers)) {
+      const declared = parseInt(
         c.req.raw.headers.get("content-length") ?? "0",
         10,
       );
-      if (contentLength > maxSize) reject();
+      if (declared > maxSize) reject();
       return next();
     }
 
-    let size = 0;
-    const chunks: Uint8Array[] = [];
-    const reader = body.getReader();
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      size += value.length;
-      if (size > maxSize) reject();
-      chunks.push(value);
-    }
-
-    const buffered = new Uint8Array(size);
-    let offset = 0;
-    for (const chunk of chunks) {
-      buffered.set(chunk, offset);
-      offset += chunk.length;
-    }
+    const buffered = await readCapped(body, maxSize);
 
     // The rebuilt request carries a fixed body, so the chunked framing header
     // no longer describes it; undici derives Content-Length from the buffer.

--- a/platform/app/src/server/api/wire-body-limit.ts
+++ b/platform/app/src/server/api/wire-body-limit.ts
@@ -1,0 +1,80 @@
+/**
+ * Drop-in replacement for hono's `bodyLimit` that survives @hono/node-server.
+ *
+ * hono's `bodyLimit` handles a request without a Content-Length header (any
+ * chunked sender — the OTel JS exporters among them) by buffering the stream
+ * and then rebuilding the request as `new Request(c.req.raw, { body })`.
+ * Under @hono/node-server the incoming `c.req.raw` is the adapter's lazy
+ * lightweight request, not an undici `Request`, and undici's constructor
+ * rejects it with `TypeError: Cannot read private member #state` — a 500 for
+ * every chunked request on any route the middleware guards (hono 4.12.27 +
+ * @hono/node-server 2.0.6).
+ *
+ * This version keeps hono's semantics — trust Content-Length when there is no
+ * Transfer-Encoding, otherwise count the streamed bytes and reject past the
+ * cap — but rebuilds the request from its URL string and a buffered body, so
+ * no foreign request object ever reaches undici's constructor.
+ */
+import type { Context, MiddlewareHandler, Next } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+const ERROR_MESSAGE = "Payload Too Large";
+
+const reject = (): never => {
+  const res = new Response(ERROR_MESSAGE, { status: 413 });
+  throw new HTTPException(413, { res });
+};
+
+export const wireBodyLimit = ({
+  maxSize,
+}: {
+  maxSize: number;
+}): MiddlewareHandler => {
+  return async function wireBodyLimitMiddleware(c: Context, next: Next) {
+    const body = c.req.raw.body;
+    if (!body) {
+      return next();
+    }
+
+    const hasTransferEncoding = c.req.raw.headers.has("transfer-encoding");
+    const hasContentLength = c.req.raw.headers.has("content-length");
+    if (hasContentLength && !hasTransferEncoding) {
+      const contentLength = parseInt(
+        c.req.raw.headers.get("content-length") ?? "0",
+        10,
+      );
+      if (contentLength > maxSize) reject();
+      return next();
+    }
+
+    let size = 0;
+    const chunks: Uint8Array[] = [];
+    const reader = body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.length;
+      if (size > maxSize) reject();
+      chunks.push(value);
+    }
+
+    const buffered = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      buffered.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // The rebuilt request carries a fixed body, so the chunked framing header
+    // no longer describes it; undici derives Content-Length from the buffer.
+    const headers = new Headers(c.req.raw.headers);
+    headers.delete("transfer-encoding");
+    c.req.raw = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: buffered,
+    });
+
+    return next();
+  };
+};

--- a/platform/app/src/server/api/wire-body-limit.ts
+++ b/platform/app/src/server/api/wire-body-limit.ts
@@ -43,12 +43,15 @@ const declaresItsOwnLength = (headers: Headers): boolean =>
  * pass-through stream would defer it until the route handler had already begun
  * consuming, and a limit the handler can outrun is not a limit.
  */
-const readCapped = async (
-  body: ReadableStream<Uint8Array>,
-  maxSize: number,
+const readCapped = async ({
+  body,
+  maxSize,
+}: {
+  body: ReadableStream<Uint8Array>;
+  maxSize: number;
   // `Uint8Array<ArrayBuffer>` rather than a bare `Uint8Array`: the latter
   // widens to `ArrayBufferLike`, which `BodyInit` does not accept.
-): Promise<Uint8Array<ArrayBuffer>> => {
+}): Promise<Uint8Array<ArrayBuffer>> => {
   const chunks: (Uint8Array | undefined)[] = [];
   let size = 0;
   const reader = body.getReader();
@@ -99,7 +102,7 @@ export const wireBodyLimit = ({
       return next();
     }
 
-    const buffered = await readCapped(body, maxSize);
+    const buffered = await readCapped({ body, maxSize });
 
     // The rebuilt request carries a fixed body, so the chunked framing header
     // no longer describes it; undici derives Content-Length from the buffer.

--- a/platform/app/src/server/api/wire-body-limit.ts
+++ b/platform/app/src/server/api/wire-body-limit.ts
@@ -33,29 +33,50 @@ const reject = (): never => {
 const declaresItsOwnLength = (headers: Headers): boolean =>
   headers.has("content-length") && !headers.has("transfer-encoding");
 
-/** Reads the stream, rejecting the moment the running total passes the cap. */
+/**
+ * Reads the stream, rejecting the moment the running total passes the cap.
+ *
+ * Rejecting on the RUNNING total, and cancelling the source when it trips, is
+ * what bounds this: an oversized sender is cut off at the cap rather than
+ * after the body has fully arrived, so `maxSize` bounds the memory as well as
+ * the request. The cap is deliberately enforced here, before `next()` — a
+ * pass-through stream would defer it until the route handler had already begun
+ * consuming, and a limit the handler can outrun is not a limit.
+ */
 const readCapped = async (
   body: ReadableStream<Uint8Array>,
   maxSize: number,
   // `Uint8Array<ArrayBuffer>` rather than a bare `Uint8Array`: the latter
   // widens to `ArrayBufferLike`, which `BodyInit` does not accept.
 ): Promise<Uint8Array<ArrayBuffer>> => {
-  const chunks: Uint8Array[] = [];
+  const chunks: (Uint8Array | undefined)[] = [];
   let size = 0;
   const reader = body.getReader();
   for (;;) {
     const { done, value } = await reader.read();
     if (done) break;
     size += value.length;
-    if (size > maxSize) reject();
+    if (size > maxSize) {
+      // Stop the sender instead of draining a body already known to be
+      // refused, and drop what was read so the 413 path holds nothing.
+      chunks.length = 0;
+      await reader.cancel().catch(() => undefined);
+      reject();
+    }
     chunks.push(value);
   }
 
   const buffered = new Uint8Array(size);
   let offset = 0;
-  for (const chunk of chunks) {
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    if (!chunk) continue;
     buffered.set(chunk, offset);
     offset += chunk.length;
+    // Release each chunk as it is copied: without this the source chunks and
+    // the concatenated copy are both live at the end, doubling peak memory on
+    // the largest cap (the 50 MiB scenario-events route).
+    chunks[i] = undefined;
   }
   return buffered;
 };

--- a/platform/app/src/server/routes/bug-reports.ts
+++ b/platform/app/src/server/routes/bug-reports.ts
@@ -11,9 +11,9 @@
  */
 import { HandledError } from "@langwatch/handled-error";
 import type { Context } from "hono";
-import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { z } from "zod";
 import { createServiceApp, publicEndpoint } from "~/server/api/security";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { extractCredentials } from "~/server/api-key/auth-middleware";
 import { submitBugReport } from "~/server/app-layer/bug-reports/bug-report.service";
 

--- a/platform/app/src/server/routes/bug-reports.ts
+++ b/platform/app/src/server/routes/bug-reports.ts
@@ -11,7 +11,7 @@
  */
 import { HandledError } from "@langwatch/handled-error";
 import type { Context } from "hono";
-import { bodyLimit } from "hono/body-limit";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { z } from "zod";
 import { createServiceApp, publicEndpoint } from "~/server/api/security";
 import { extractCredentials } from "~/server/api-key/auth-middleware";
@@ -65,7 +65,7 @@ secured
       "Agent issue-report intake; reporters may have no working credentials, an API key only enriches the report with a project link",
     ),
   )
-  .post("/", bodyLimit({ maxSize: MAX_BODY_BYTES }), async (c) => {
+  .post("/", wireBodyLimit({ maxSize: MAX_BODY_BYTES }), async (c) => {
     let json: unknown;
     try {
       json = await c.req.json();

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { createLogger } from "@langwatch/observability";
-import { bodyLimit } from "hono/body-limit";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import type { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
@@ -57,7 +57,7 @@ secured
   )
   .post(
     "/collector",
-    bodyLimit({ maxSize: 10 * 1024 * 1024 }), // 10MB
+    wireBodyLimit({ maxSize: 10 * 1024 * 1024 }), // 10MB
     async (c) => {
       const credentials = extractCredentials((name) => c.req.header(name));
 

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -1,9 +1,9 @@
 import crypto from "node:crypto";
 import { createLogger } from "@langwatch/observability";
-import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import type { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
   captureException,

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -19,7 +19,6 @@ import type { JsonArray } from "@prisma/client/runtime/library";
 import { TRPCError } from "@trpc/server";
 import type { Edge, Node } from "@xyflow/react";
 import type { Context } from "hono";
-import { bodyLimit } from "hono/body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { nanoid } from "nanoid";
@@ -39,6 +38,7 @@ import {
   handlerManagedAuth,
   publicEndpoint,
 } from "~/server/api/security";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import {
   apiKeyCeilingDenialResponse,
   enforceApiKeyCeiling,
@@ -302,7 +302,7 @@ secured.access(legacyEvaluationAuth).post(
       },
     },
   }),
-  bodyLimit({ maxSize: 20 * 1024 * 1024 }),
+  wireBodyLimit({ maxSize: 20 * 1024 * 1024 }),
   async (c) => {
     const auth = await authenticateRequest(c, "evaluations:manage");
     if ("error" in auth) {
@@ -492,7 +492,7 @@ secured.access(legacyEvaluationAuth).post(
     requestBody: evaluateRequestBody,
     responses: evaluateResponses,
   }),
-  bodyLimit({ maxSize: 30 * 1024 * 1024 }),
+  wireBodyLimit({ maxSize: 30 * 1024 * 1024 }),
   async (c) => {
     const evaluatorSlug = c.req.param("evaluator");
     return handleEvaluatorCall(c, evaluatorSlug, false);
@@ -527,7 +527,7 @@ secured.access(legacyEvaluationAuth).post(
     requestBody: evaluateRequestBody,
     responses: evaluateResponses,
   }),
-  bodyLimit({ maxSize: 30 * 1024 * 1024 }),
+  wireBodyLimit({ maxSize: 30 * 1024 * 1024 }),
   async (c) => {
     const evaluatorSlug = `${c.req.param("evaluator")}/${c.req.param("subpath")}`;
     return handleEvaluatorCall(c, evaluatorSlug, false);
@@ -554,7 +554,7 @@ secured.access(legacyEvaluationAuth).post(
     requestBody: evaluateRequestBody,
     responses: evaluateResponses,
   }),
-  bodyLimit({ maxSize: 30 * 1024 * 1024 }),
+  wireBodyLimit({ maxSize: 30 * 1024 * 1024 }),
   async (c) => {
     const evaluatorSlug = c.req.param("evaluator");
     return handleEvaluatorCall(c, evaluatorSlug, true);

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -20,7 +20,6 @@ import type { Project } from "@prisma/client";
 import { AlertType, ExperimentType, TriggerAction } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import crypto from "crypto";
-import { bodyLimit } from "hono/body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { nanoid } from "nanoid";
@@ -43,6 +42,7 @@ import {
   internalSecret,
   publicEndpoint,
 } from "~/server/api/security";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import {
   createUnifiedAuthMiddleware,
   requireApiKeyPermission,
@@ -422,7 +422,7 @@ secured.access(experimentsManageAuth).post(
       },
     },
   }),
-  bodyLimit({ maxSize: 20 * 1024 * 1024 }),
+  wireBodyLimit({ maxSize: 20 * 1024 * 1024 }),
   authMiddleware,
   requireExperimentsManage,
   async (c) => {
@@ -1214,7 +1214,7 @@ async function enforceInstanceRateLimit(
 
 secured
   .access(publicEndpoint("anonymous product telemetry, no credential"))
-  .post("/track_usage", bodyLimit({ maxSize: 10 * 1024 }), async (c) => {
+  .post("/track_usage", wireBodyLimit({ maxSize: 10 * 1024 }), async (c) => {
     const ip = getClientIpFromHonoContext(c) ?? "unknown";
 
     const ipLimit = await enforceGlobalAndIpRateLimit(ip);

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -20,9 +20,9 @@ import { createLogger } from "@langwatch/observability";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
-import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { getLangWatchTracer } from "langwatch";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import {
   apiKeyCeilingDenialResponse,
   collectAuthDiagnostics,
@@ -426,113 +426,117 @@ export function peekCustomerTraceIds(
 
 secured
   .access(otelIngestAuth)
-  .post("/traces", wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
-    const tracer = getLangWatchTracer("langwatch.otel.traces");
+  .post(
+    "/traces",
+    wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }),
+    async (c) => {
+      const tracer = getLangWatchTracer("langwatch.otel.traces");
 
-    return tracer.withActiveSpan(
-      "TracesV1.handleTracesRequest",
-      { kind: SpanKind.SERVER },
-      async (span) => {
-        // Auth first — 401s/permission failures should not pay body decompression
-        // cost, and body content is irrelevant when we don't know who's calling.
-        const authResult = await authenticate(c, loggerTraces);
+      return tracer.withActiveSpan(
+        "TracesV1.handleTracesRequest",
+        { kind: SpanKind.SERVER },
+        async (span) => {
+          // Auth first — 401s/permission failures should not pay body decompression
+          // cost, and body content is irrelevant when we don't know who's calling.
+          const authResult = await authenticate(c, loggerTraces);
 
-        if ("error" in authResult) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: authResult.error,
+          if ("error" in authResult) {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: authResult.error,
+            });
+            return c.json(authResult.body, { status: authResult.status });
+          }
+
+          const { project, resolved } = authResult;
+          span.setAttribute("langwatch.project.id", project.id);
+
+          const body = await readOtlpBody(c.req.raw);
+          const contentType = c.req.header("content-type");
+
+          // Best-effort. If the body can't be peeked (malformed, unsupported
+          // shape, etc.), customerTraceIds stays empty — the projectId is still
+          // logged on every subsequent failure for correlation.
+          const customerTraceIds = peekCustomerTraceIds(body, contentType);
+          if (customerTraceIds.length > 0) {
+            span.setAttribute(
+              "langwatch.otel.customer_trace_ids",
+              customerTraceIds.join(","),
+            );
+          }
+
+          await enforcePlanLimit({
+            project,
+            customerTraceIds,
+            logger: loggerTraces,
           });
-          return c.json(authResult.body, { status: authResult.status });
-        }
 
-        const { project, resolved } = authResult;
-        span.setAttribute("langwatch.project.id", project.id);
+          const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
 
-        const body = await readOtlpBody(c.req.raw);
-        const contentType = c.req.header("content-type");
+          if (body.byteLength === 0) {
+            loggerTraces.debug(
+              { projectId: project.id },
+              "Received empty trace request, ignoring",
+            );
+            return c.json({
+              message: "No traces to process",
+              partialSuccess: emptyPartialSuccess,
+            });
+          }
 
-        // Best-effort. If the body can't be peeked (malformed, unsupported
-        // shape, etc.), customerTraceIds stays empty — the projectId is still
-        // logged on every subsequent failure for correlation.
-        const customerTraceIds = peekCustomerTraceIds(body, contentType);
-        if (customerTraceIds.length > 0) {
-          span.setAttribute(
-            "langwatch.otel.customer_trace_ids",
-            customerTraceIds.join(","),
-          );
-        }
+          const parsed = parseOtlpTraces(body, contentType);
+          if (!parsed.ok) {
+            loggerTraces.error(
+              {
+                error: parsed.error,
+                projectId: project.id,
+                customerTraceIds,
+                ...bodyForensics(body),
+              },
+              "error parsing traces",
+            );
+            captureException(new Error(parsed.error), {
+              extra: {
+                projectId: project.id,
+                customerTraceIds,
+              },
+            });
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: "Failed to parse traces",
+            });
+            return c.json({ error: "Failed to parse traces" }, { status: 400 });
+          }
+          const traceRequest = parsed.request;
 
-        await enforcePlanLimit({
-          project,
-          customerTraceIds,
-          logger: loggerTraces,
-        });
+          // Body successfully parsed — mark the API key as used
+          if (resolved.type === "apiKey") {
+            tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
+          }
 
-        const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
+          await applyReceiverProvenanceToTraces({
+            request: traceRequest,
+            resolved,
+          });
 
-        if (body.byteLength === 0) {
-          loggerTraces.debug(
-            { projectId: project.id },
-            "Received empty trace request, ignoring",
-          );
+          const collectionResult =
+            await getApp().traces.collection.handleOtlpTraceRequest(
+              project.id,
+              traceRequest,
+              DEFAULT_PII_REDACTION_LEVEL,
+            );
+
           return c.json({
-            message: "No traces to process",
-            partialSuccess: emptyPartialSuccess,
-          });
-        }
-
-        const parsed = parseOtlpTraces(body, contentType);
-        if (!parsed.ok) {
-          loggerTraces.error(
-            {
-              error: parsed.error,
-              projectId: project.id,
-              customerTraceIds,
-              ...bodyForensics(body),
-            },
-            "error parsing traces",
-          );
-          captureException(new Error(parsed.error), {
-            extra: {
-              projectId: project.id,
-              customerTraceIds,
+            message: "Trace received successfully.",
+            partialSuccess: {
+              rejectedSpans: collectionResult?.rejectedSpans ?? 0,
+              errorMessage: collectionResult?.errorMessage ?? "",
             },
           });
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: "Failed to parse traces",
-          });
-          return c.json({ error: "Failed to parse traces" }, { status: 400 });
-        }
-        const traceRequest = parsed.request;
-
-        // Body successfully parsed — mark the API key as used
-        if (resolved.type === "apiKey") {
-          tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
-        }
-
-        await applyReceiverProvenanceToTraces({
-          request: traceRequest,
-          resolved,
-        });
-
-        const collectionResult =
-          await getApp().traces.collection.handleOtlpTraceRequest(
-            project.id,
-            traceRequest,
-            DEFAULT_PII_REDACTION_LEVEL,
-          );
-
-        return c.json({
-          message: "Trace received successfully.",
-          partialSuccess: {
-            rejectedSpans: collectionResult?.rejectedSpans ?? 0,
-            errorMessage: collectionResult?.errorMessage ?? "",
-          },
-        });
-      },
-    );
-  });
+        },
+      );
+    },
+  );
 
 // ── POST /logs ───────────────────────────────────────────────────────
 
@@ -636,94 +640,101 @@ secured
 
 secured
   .access(otelIngestAuth)
-  .post("/metrics", wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
-    const tracer = getLangWatchTracer("langwatch.otel.metrics");
+  .post(
+    "/metrics",
+    wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }),
+    async (c) => {
+      const tracer = getLangWatchTracer("langwatch.otel.metrics");
 
-    return tracer.withActiveSpan(
-      "[POST] /api/otel/v1/metrics",
-      { kind: SpanKind.SERVER },
-      async (span) => {
-        const authResult = await authenticate(c, loggerMetrics);
+      return tracer.withActiveSpan(
+        "[POST] /api/otel/v1/metrics",
+        { kind: SpanKind.SERVER },
+        async (span) => {
+          const authResult = await authenticate(c, loggerMetrics);
 
-        if ("error" in authResult) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: authResult.error,
+          if ("error" in authResult) {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: authResult.error,
+            });
+            return c.json(authResult.body, { status: authResult.status });
+          }
+
+          const { project, resolved } = authResult;
+          span.setAttribute("langwatch.project.id", project.id);
+
+          await enforcePlanLimit({
+            project,
+            customerTraceIds: [],
+            logger: loggerMetrics,
           });
-          return c.json(authResult.body, { status: authResult.status });
-        }
 
-        const { project, resolved } = authResult;
-        span.setAttribute("langwatch.project.id", project.id);
+          const body = await readOtlpBody(c.req.raw);
+          const parsed = parseOtlpMetrics(body, c.req.header("content-type"));
+          if (!parsed.ok) {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: "Failed to parse metrics",
+            });
+            span.recordException(new Error(parsed.error));
+            loggerMetrics.error(
+              {
+                error: parsed.error,
+                projectId: project.id,
+                ...bodyForensics(body),
+              },
+              "error parsing metrics",
+            );
+            captureException(new Error(parsed.error), {
+              extra: {
+                projectId: project.id,
+              },
+            });
+            return c.json(
+              { error: "Failed to parse metrics" },
+              { status: 400 },
+            );
+          }
+          const metricsRequest = parsed.request;
 
-        await enforcePlanLimit({
-          project,
-          customerTraceIds: [],
-          logger: loggerMetrics,
-        });
-
-        const body = await readOtlpBody(c.req.raw);
-        const parsed = parseOtlpMetrics(body, c.req.header("content-type"));
-        if (!parsed.ok) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: "Failed to parse metrics",
+          applyReceiverProvenanceToMetrics({
+            request: metricsRequest,
+            resolved,
           });
-          span.recordException(new Error(parsed.error));
-          loggerMetrics.error(
-            {
-              error: parsed.error,
-              projectId: project.id,
-              ...bodyForensics(body),
+
+          // Body successfully parsed — mark the API key as used
+          if (resolved.type === "apiKey") {
+            tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
+          }
+
+          const result =
+            await getApp().traces.metricCollection.handleOtlpMetricRequest({
+              tenantId: project.id,
+              organizationId: project.team.organizationId,
+              metricRequest: metricsRequest,
+              piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
+            });
+
+          // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
+          // with `partialSuccess` as a permanent rejection the client must not
+          // re-send, so answering that here would turn a queue blip into fleet-wide
+          // data loss. 503 is in OTLP's retryable set.
+          if (result.outcome === "unavailable") {
+            return c.json({ error: result.errorMessage }, { status: 503 });
+          }
+
+          if (result.rejectedDataPoints === 0) return c.json({});
+          return c.json({
+            partialSuccess: {
+              rejectedDataPoints: result.rejectedDataPoints,
+              ...(result.errorMessage
+                ? { errorMessage: result.errorMessage }
+                : {}),
             },
-            "error parsing metrics",
-          );
-          captureException(new Error(parsed.error), {
-            extra: {
-              projectId: project.id,
-            },
           });
-          return c.json({ error: "Failed to parse metrics" }, { status: 400 });
-        }
-        const metricsRequest = parsed.request;
-
-        applyReceiverProvenanceToMetrics({
-          request: metricsRequest,
-          resolved,
-        });
-
-        // Body successfully parsed — mark the API key as used
-        if (resolved.type === "apiKey") {
-          tokenResolver.markUsed({ apiKeyId: resolved.apiKeyId });
-        }
-
-        const result =
-          await getApp().traces.metricCollection.handleOtlpMetricRequest({
-            tenantId: project.id,
-            organizationId: project.team.organizationId,
-            metricRequest: metricsRequest,
-            piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
-          });
-
-        // Nothing was durably accepted, and the cause is ours. OTLP treats a 200
-        // with `partialSuccess` as a permanent rejection the client must not
-        // re-send, so answering that here would turn a queue blip into fleet-wide
-        // data loss. 503 is in OTLP's retryable set.
-        if (result.outcome === "unavailable") {
-          return c.json({ error: result.errorMessage }, { status: 503 });
-        }
-
-        if (result.rejectedDataPoints === 0) return c.json({});
-        return c.json({
-          partialSuccess: {
-            rejectedDataPoints: result.rejectedDataPoints,
-            ...(result.errorMessage
-              ? { errorMessage: result.errorMessage }
-              : {}),
-          },
-        });
-      },
-    );
-  });
+        },
+      );
+    },
+  );
 
 export const app = secured.hono;

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -20,7 +20,7 @@ import { createLogger } from "@langwatch/observability";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
-import { bodyLimit } from "hono/body-limit";
+import { wireBodyLimit } from "~/server/api/wire-body-limit";
 import { getLangWatchTracer } from "langwatch";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import {
@@ -426,7 +426,7 @@ export function peekCustomerTraceIds(
 
 secured
   .access(otelIngestAuth)
-  .post("/traces", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+  .post("/traces", wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
     const tracer = getLangWatchTracer("langwatch.otel.traces");
 
     return tracer.withActiveSpan(
@@ -538,7 +538,7 @@ secured
 
 secured
   .access(otelIngestAuth)
-  .post("/logs", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+  .post("/logs", wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
     const tracer = getLangWatchTracer("langwatch.otel.logs");
 
     return tracer.withActiveSpan(
@@ -636,7 +636,7 @@ secured
 
 secured
   .access(otelIngestAuth)
-  .post("/metrics", bodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
+  .post("/metrics", wireBodyLimit({ maxSize: OTLP_MAX_BODY_BYTES }), async (c) => {
     const tracer = getLangWatchTracer("langwatch.otel.metrics");
 
     return tracer.withActiveSpan(


### PR DESCRIPTION
## For humans

Any client that sends a request body without announcing its size up front (chunked transfer — the OTel JavaScript exporters always do this) was getting a 500 from every route that caps request size, including the OpenTelemetry trace/log/metric ingestion endpoints. The SDK's spans never arrived; from the customer's side, tracing silently produced nothing while their exporter logged "Internal Server Error". This replaces the crashing size-cap middleware with one that does the same job without the crash.

## Why

Closes #6636.

#6602 added hono's `bodyLimit` to `/api/otel/v1/traces|logs|metrics`. hono 4.12.27's `bodyLimit` handles a body without Content-Length by buffering it and rebuilding the request as `new Request(c.req.raw, …)`. Under `@hono/node-server` with `overrideGlobalObjects: false` — which `start.ts` passes deliberately — `c.req.raw` is the adapter's lightweight request, and undici's constructor rejects it: `TypeError: Cannot read private member #state from an object whose class did not declare it` → 500. Requests with Content-Length are unaffected, so curl-style testing never saw it.

The SDK observability e2e suite is the only coverage that speaks real HTTP to these routes, and its workflow path-filter means it had not run on main since #6602 merged — it first fired on PR #6181 after a rebase, where every span export failed with `OTLPExporterError: Internal Server Error`. Server-side stack confirmed both locally (production bundle AND dev server) and in CI via the new dump-server-logs-on-failure step in `sdk-javascript-ci.yml` (rides #6181).

## What changed

- `platform/app/src/server/api/wire-body-limit.ts` (new): same semantics as hono's `bodyLimit` — trust Content-Length when there is no Transfer-Encoding, otherwise count the streamed bytes and reject past the cap with 413 — but the rebuilt request is constructed from its URL string and a buffered body, so no foreign request object ever reaches undici's constructor.
- Every `bodyLimit` call site swapped: the three OTLP routes (broken today), plus `/api/collector`, scenario-events, bug reports, legacy evaluations, and `/api/dspy/log_steps` + `/api/track_usage` in `misc.ts` (same latent crash for any chunked sender).
- `no-hono-body-limit.unit.test.ts`: fails if any file under `src/` or `ee/` imports `hono/body-limit` again. Nothing about that import looks wrong at a call site, so a name convention alone would not hold — and the guard earned itself immediately by catching the two `misc.ts` sites my first grep missed.

## Test plan

- `wire-body-limit.unit.test.ts` serves a real `@hono/node-server` socket with `overrideGlobalObjects: false` (the app's exact configuration) and speaks HTTP to it: chunked under-cap → 200 with the body intact, chunked over-cap → 413, Content-Length under/over → 200/413. **Fails without the fix**: swapping `wireBodyLimit` back to hono's `bodyLimit` in the same harness reproduces the 500 (verified).
- Live verification against the production bundle: chunked OTLP POST 500 → 200 after the fix; the previously failing SDK e2e file (`basic-span-ingestion.e2e.test.ts`, 3 tests) passes end-to-end against the fixed server.
- `pnpm typecheck` + `typecheck:tests` clean; the OTLP route suites and both new guards green (37 tests).
- Lint run exactly as CI does — `pnpm lint` (exit 0) **and** `.github/scripts/biome-new-violations.sh` against the merge base: `no new Biome violations`. The first push failed both; the fix is real, not a re-run.

## Anything surprising?

The same commits ride PR #6181, where the e2e suite first exposed the bug — whichever merges first, the other rebases clean (identical content). This standalone PR exists so main does not wait on the Azure work: if #6602 is deployed anywhere, chunked OTLP ingest is 500ing there now.

**Read `otel.ts` with `git diff -w`.** Its ~380-line diff is formatter-driven reindentation — the longer middleware name pushed three `.post()` calls past the line width, so Biome re-wrapped their handler bodies. Ignoring whitespace, the real change is 17 lines. I kept the distinct name rather than aliasing to `bodyLimit` to keep the diff small, because a call site that reads identically to hono's is exactly how this comes back.

## Deployment Impact

Restores ingestion for chunked clients; no config, schema, or API surface change. Size caps and 413 behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized request-body size enforcement across scenario events, bug reports, collection, evaluations, telemetry, and OTLP endpoints.
  * Streamed and non-streamed requests are consistently checked against configured limits, returning HTTP 413 when exceeded.
* **Tests**
  * Added integration coverage for chunked requests, content-length requests, and exact-limit handling.
  * Added regression protection against inconsistent body-limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
