### PR TITLE
fix(observability): stop tracing every Redis command, which was 93% of all spans

### DIFF
--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -190,6 +190,13 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # (CPU, memory, event loop, GC). Requires OTEL_EXPORTER_OTLP_ENDPOINT.
 #OTEL_METRICS_ENABLED=true
 
+# Emit a span per Redis command. Off by default: BullMQ runs every queue
+# operation through Redis, so in the worker this produced about 32 Redis spans
+# per job against 1 span for the job itself, which was 93% of all spans the
+# platform emitted. Enable it only while debugging Redis latency, and prefer a
+# process without a job queue attached.
+#OTEL_TRACE_REDIS_COMMANDS=true
+
 # Browser telemetry (RUM): traces what happens in the tab and joins it to the
 # server's traces, so a click and the work behind it read as one trace instead
 # of two. The browser exports to the app's own origin

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -190,7 +190,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # (CPU, memory, event loop, GC). Requires OTEL_EXPORTER_OTLP_ENDPOINT.
 #OTEL_METRICS_ENABLED=true
 
-# Emit a span per Redis command. Off by default: BullMQ runs every queue
+# Emit a span for Redis commands that run inside an active parent span (an
+# unparented command never produces one). Off by default: BullMQ runs every queue
 # operation through Redis, so in the worker this produced about 32 Redis spans
 # per job against 1 span for the job itself, which was 93% of all spans the
 # platform emitted. Enable it only while debugging Redis latency, and prefer a

--- a/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
+++ b/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRedisCommandTracingEnabled,
+  redisInstrumentationConfig,
+  redisStatementSerializer,
+} from "../instrumentation.redis";
+
+/**
+ * The flag exists because instrumenting ioredis in a process that owns a BullMQ
+ * queue traces the queue's own bookkeeping: measured in production at ~32 Redis
+ * spans per job, 93% of every span the platform emitted. A regression that
+ * turns this back on is silent and is only noticed on a bill, so the default
+ * and the exact-match parsing are pinned here rather than left to a comment.
+ */
+describe("isRedisCommandTracingEnabled", () => {
+  it("is off when the variable is absent", () => {
+    expect(isRedisCommandTracingEnabled({})).toBe(false);
+  });
+
+  it('is on only for exactly "true"', () => {
+    expect(
+      isRedisCommandTracingEnabled({ OTEL_TRACE_REDIS_COMMANDS: "true" }),
+    ).toBe(true);
+  });
+
+  // Being wrong in this direction costs money, so anything that merely looks
+  // affirmative stays off.
+  it.each([
+    "false",
+    "1",
+    "yes",
+    "TRUE",
+    "True",
+    " true",
+    "",
+  ])("stays off for %j", (value) => {
+    expect(
+      isRedisCommandTracingEnabled({ OTEL_TRACE_REDIS_COMMANDS: value }),
+    ).toBe(false);
+  });
+
+  it("reads process.env when no environment is passed", () => {
+    const previous = process.env.OTEL_TRACE_REDIS_COMMANDS;
+    try {
+      process.env.OTEL_TRACE_REDIS_COMMANDS = "true";
+      expect(isRedisCommandTracingEnabled()).toBe(true);
+
+      delete process.env.OTEL_TRACE_REDIS_COMMANDS;
+      expect(isRedisCommandTracingEnabled()).toBe(false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OTEL_TRACE_REDIS_COMMANDS;
+      } else {
+        process.env.OTEL_TRACE_REDIS_COMMANDS = previous;
+      }
+    }
+  });
+});
+
+describe("redisStatementSerializer", () => {
+  it("keeps the command and its first key", () => {
+    expect(redisStatementSerializer("get", ["session:abc"])).toBe(
+      "get session:abc",
+    );
+  });
+
+  it("drops the values, so a span cannot carry secrets", () => {
+    expect(
+      redisStatementSerializer("set", ["session:abc", "a-secret-token"]),
+    ).toBe("set session:abc");
+  });
+
+  it("returns the bare command when there are no arguments", () => {
+    expect(redisStatementSerializer("ping", [])).toBe("ping");
+  });
+
+  it("returns the bare command when the first argument is not a string", () => {
+    expect(redisStatementSerializer("expire", [42])).toBe("expire");
+    expect(redisStatementSerializer("mset", [["a", "b"]])).toBe("mset");
+    expect(redisStatementSerializer("get", [Buffer.from("key")])).toBe("get");
+  });
+
+  it("returns the bare command for an empty-string key", () => {
+    expect(redisStatementSerializer("get", [""])).toBe("get");
+  });
+});
+
+describe("redisInstrumentationConfig", () => {
+  // Without this, the connection pool's connect/auth/info and the queue
+  // dispatcher's blocking brpop/xread become root spans and bury real traces.
+  it("requires a parent span", () => {
+    expect(redisInstrumentationConfig.requireParentSpan).toBe(true);
+  });
+
+  it("uses the truncating serializer", () => {
+    expect(redisInstrumentationConfig.dbStatementSerializer).toBe(
+      redisStatementSerializer,
+    );
+  });
+});

--- a/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
+++ b/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isRedisCommandTracingEnabled,
+  MAX_DB_STATEMENT_CHARS,
   redisInstrumentationConfig,
   redisStatementSerializer,
 } from "../instrumentation.redis";
@@ -79,6 +80,40 @@ describe("redisStatementSerializer", () => {
     expect(redisStatementSerializer("expire", [42])).toBe("expire");
     expect(redisStatementSerializer("mset", [["a", "b"]])).toBe("mset");
     expect(redisStatementSerializer("get", [Buffer.from("key")])).toBe("get");
+  });
+
+  // Dropping the values is not enough on its own: the key is caller-controlled,
+  // so an unbounded one would reintroduce the large attribute this exists to
+  // prevent.
+  describe("when the key would exceed the cap", () => {
+    const hugeKey = "k".repeat(MAX_DB_STATEMENT_CHARS * 2);
+
+    it("caps the statement at the maximum, marker included", () => {
+      const statement = redisStatementSerializer("get", [hugeKey]);
+
+      expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
+    });
+
+    it("marks the truncation, so a shortened key cannot pass for a real one", () => {
+      expect(redisStatementSerializer("get", [hugeKey])).toMatch(/\.\.\.$/);
+      expect(redisStatementSerializer("get", [hugeKey])).toMatch(
+        /^get k+\.\.\.$/,
+      );
+    });
+
+    it("leaves a statement exactly at the cap untouched", () => {
+      const exactKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length);
+      const statement = redisStatementSerializer("get", [exactKey]);
+
+      expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
+      expect(statement).not.toMatch(/\.\.\.$/);
+    });
+
+    it("leaves a statement one under the cap untouched", () => {
+      const nearKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length - 1);
+
+      expect(redisStatementSerializer("get", [nearKey])).toBe(`get ${nearKey}`);
+    });
   });
 
   it("returns the bare command for an empty-string key", () => {

--- a/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
+++ b/platform/app/src/__tests__/instrumentation.redis.unit.test.ts
@@ -85,34 +85,47 @@ describe("redisStatementSerializer", () => {
   // Dropping the values is not enough on its own: the key is caller-controlled,
   // so an unbounded one would reintroduce the large attribute this exists to
   // prevent.
-  describe("when the key would exceed the cap", () => {
+  describe("given a key longer than the cap", () => {
     const hugeKey = "k".repeat(MAX_DB_STATEMENT_CHARS * 2);
 
-    it("caps the statement at the maximum, marker included", () => {
-      const statement = redisStatementSerializer("get", [hugeKey]);
+    describe("when serializing", () => {
+      it("caps the statement at the maximum, marker included", () => {
+        const statement = redisStatementSerializer("get", [hugeKey]);
 
-      expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
+        expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
+      });
+
+      it("marks the truncation, so a shortened key cannot pass for a real one", () => {
+        expect(redisStatementSerializer("get", [hugeKey])).toMatch(/\.\.\.$/);
+        expect(redisStatementSerializer("get", [hugeKey])).toMatch(
+          /^get k+\.\.\.$/,
+        );
+      });
     });
+  });
 
-    it("marks the truncation, so a shortened key cannot pass for a real one", () => {
-      expect(redisStatementSerializer("get", [hugeKey])).toMatch(/\.\.\.$/);
-      expect(redisStatementSerializer("get", [hugeKey])).toMatch(
-        /^get k+\.\.\.$/,
-      );
+  describe("given a key exactly at the cap", () => {
+    const exactKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length);
+
+    describe("when serializing", () => {
+      it("leaves the statement untouched", () => {
+        const statement = redisStatementSerializer("get", [exactKey]);
+
+        expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
+        expect(statement).not.toMatch(/\.\.\.$/);
+      });
     });
+  });
 
-    it("leaves a statement exactly at the cap untouched", () => {
-      const exactKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length);
-      const statement = redisStatementSerializer("get", [exactKey]);
+  describe("given a key one character under the cap", () => {
+    const nearKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length - 1);
 
-      expect(statement).toHaveLength(MAX_DB_STATEMENT_CHARS);
-      expect(statement).not.toMatch(/\.\.\.$/);
-    });
-
-    it("leaves a statement one under the cap untouched", () => {
-      const nearKey = "k".repeat(MAX_DB_STATEMENT_CHARS - "get ".length - 1);
-
-      expect(redisStatementSerializer("get", [nearKey])).toBe(`get ${nearKey}`);
+    describe("when serializing", () => {
+      it("leaves the statement untouched", () => {
+        expect(redisStatementSerializer("get", [nearKey])).toBe(
+          `get ${nearKey}`,
+        );
+      });
     });
   });
 

--- a/platform/app/src/instrumentation.node.ts
+++ b/platform/app/src/instrumentation.node.ts
@@ -18,6 +18,18 @@ const explicitEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.replace(
 );
 const langwatchTracingEnabled = !!process.env.LANGWATCH_API_KEY;
 
+// Off by default because BullMQ drives every queue operation through Redis, so
+// tracing ioredis means tracing the queue's own bookkeeping. Measured in
+// production: the worker emitted 317 job spans/sec and ~10,116 Redis command
+// spans/sec, about 32 Redis spans per job. That was 93% of every span the
+// platform produced (966M spans/day, 370 GiB/day into Tempo) to record that a
+// queue was being a queue, which is never the answer to a question. `evalsha`
+// alone ran at 1,771/sec: BullMQ's Lua scripts.
+//
+// Turn it on per-deployment when Redis latency itself is the thing under
+// investigation, and prefer doing that somewhere without a job queue attached.
+const traceRedisCommands = isEnvTrue(process.env.OTEL_TRACE_REDIS_COMMANDS);
+
 // Load the OTel SDK + instrumentation packages ONLY when observability is
 // actually configured (an OTLP endpoint or a LangWatch API key). When neither
 // is set — the common local-dev / self-hosted case — none of these modules
@@ -50,14 +62,34 @@ if (explicitEndpoint || langwatchTracingEnabled) {
     require("langwatch/observability/node") as typeof import("langwatch/observability/node");
   const { AwsInstrumentation } =
     require("@opentelemetry/instrumentation-aws-sdk") as typeof import("@opentelemetry/instrumentation-aws-sdk");
-  const { IORedisInstrumentation } =
-    require("@opentelemetry/instrumentation-ioredis") as typeof import("@opentelemetry/instrumentation-ioredis");
   const { OpenAIInstrumentation } =
     require("@opentelemetry/instrumentation-openai") as typeof import("@opentelemetry/instrumentation-openai");
   const { PinoInstrumentation } =
     require("@opentelemetry/instrumentation-pino") as typeof import("@opentelemetry/instrumentation-pino");
   const { RuntimeNodeInstrumentation } =
     require("@opentelemetry/instrumentation-runtime-node") as typeof import("@opentelemetry/instrumentation-runtime-node");
+
+  const redisInstrumentation = () => {
+    const { IORedisInstrumentation } =
+      require("@opentelemetry/instrumentation-ioredis") as typeof import("@opentelemetry/instrumentation-ioredis");
+
+    return new IORedisInstrumentation({
+      // Redis calls are only interesting as part of some larger operation.
+      // Without this, the connection pool's `connect`/`auth`/`info` and the
+      // queue dispatcher's blocking `brpop`/`xread`, none of which have a
+      // parent, each became a root span, burying real traces in noise.
+      requireParentSpan: true,
+      // Truncate db.statement to command + first key (avoid logging content +
+      // large attributes).
+      dbStatementSerializer: (
+        cmdName: string,
+        cmdArgs: Array<string | Buffer | number | unknown[]>,
+      ) => {
+        const key = typeof cmdArgs[0] === "string" ? cmdArgs[0] : "";
+        return key ? `${cmdName} ${key}` : cmdName;
+      },
+    });
+  };
 
   const spanProcessors = [] as Array<InstanceType<typeof BatchSpanProcessor>>;
   const logRecordProcessors = [] as Array<
@@ -112,30 +144,15 @@ if (explicitEndpoint || langwatchTracingEnabled) {
     // the aggregate loads all ~41 instrumentation packages at import time even
     // though the old config disabled most and the rest target frameworks this
     // server doesn't run (express, koa, hapi, connect, grpc, nest, restify, pg).
-    // These five are the ones that actually emit telemetry here; the emitted
-    // spans/metrics are unchanged. Add a new library worth tracing by adding its
-    // instrumentation package to the Promise.all above and a `new …()` here.
+    // These are the ones that actually emit telemetry here. Add a new library
+    // worth tracing by adding its gated `require` above and a `new ...()` here.
+    // ioredis is opt-in; see traceRedisCommands for the volume it produces.
     instrumentations: [
       new AwsInstrumentation(),
       new OpenAIInstrumentation(),
       new PinoInstrumentation(),
       new RuntimeNodeInstrumentation(),
-      // Truncate ioredis db.statement to command + first key
-      // (avoid logging content + large attributes)
-      new IORedisInstrumentation({
-        // Redis calls are only interesting as part of some larger operation.
-        // Without this, the connection pool's `connect`/`auth`/`info` and the
-        // queue dispatcher's blocking `brpop`/`xread` — none of which have a
-        // parent — each became a root span, burying real traces in noise.
-        requireParentSpan: true,
-        dbStatementSerializer: (
-          cmdName: string,
-          cmdArgs: Array<string | Buffer | number | unknown[]>,
-        ) => {
-          const key = typeof cmdArgs[0] === "string" ? cmdArgs[0] : "";
-          return key ? `${cmdName} ${key}` : cmdName;
-        },
-      }),
+      ...(traceRedisCommands ? [redisInstrumentation()] : []),
     ],
   });
 } else {

--- a/platform/app/src/instrumentation.node.ts
+++ b/platform/app/src/instrumentation.node.ts
@@ -8,6 +8,11 @@ import "./langwatchPlatformGuard.boot";
 
 import { metrics } from "@opentelemetry/api";
 
+import {
+  isRedisCommandTracingEnabled,
+  redisInstrumentationConfig,
+} from "./instrumentation.redis";
+
 const isEnvTrue = (value: string | undefined) => value === "true";
 
 // A trailing slash on the endpoint would produce `//v1/traces`, which some
@@ -18,17 +23,7 @@ const explicitEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.replace(
 );
 const langwatchTracingEnabled = !!process.env.LANGWATCH_API_KEY;
 
-// Off by default because BullMQ drives every queue operation through Redis, so
-// tracing ioredis means tracing the queue's own bookkeeping. Measured in
-// production: the worker emitted 317 job spans/sec and ~10,116 Redis command
-// spans/sec, about 32 Redis spans per job. That was 93% of every span the
-// platform produced (966M spans/day, 370 GiB/day into Tempo) to record that a
-// queue was being a queue, which is never the answer to a question. `evalsha`
-// alone ran at 1,771/sec: BullMQ's Lua scripts.
-//
-// Turn it on per-deployment when Redis latency itself is the thing under
-// investigation, and prefer doing that somewhere without a job queue attached.
-const traceRedisCommands = isEnvTrue(process.env.OTEL_TRACE_REDIS_COMMANDS);
+const redisCommandTracingEnabled = isRedisCommandTracingEnabled();
 
 // Load the OTel SDK + instrumentation packages ONLY when observability is
 // actually configured (an OTLP endpoint or a LangWatch API key). When neither
@@ -73,22 +68,7 @@ if (explicitEndpoint || langwatchTracingEnabled) {
     const { IORedisInstrumentation } =
       require("@opentelemetry/instrumentation-ioredis") as typeof import("@opentelemetry/instrumentation-ioredis");
 
-    return new IORedisInstrumentation({
-      // Redis calls are only interesting as part of some larger operation.
-      // Without this, the connection pool's `connect`/`auth`/`info` and the
-      // queue dispatcher's blocking `brpop`/`xread`, none of which have a
-      // parent, each became a root span, burying real traces in noise.
-      requireParentSpan: true,
-      // Truncate db.statement to command + first key (avoid logging content +
-      // large attributes).
-      dbStatementSerializer: (
-        cmdName: string,
-        cmdArgs: Array<string | Buffer | number | unknown[]>,
-      ) => {
-        const key = typeof cmdArgs[0] === "string" ? cmdArgs[0] : "";
-        return key ? `${cmdName} ${key}` : cmdName;
-      },
-    });
+    return new IORedisInstrumentation(redisInstrumentationConfig);
   };
 
   const spanProcessors = [] as Array<InstanceType<typeof BatchSpanProcessor>>;
@@ -144,15 +124,14 @@ if (explicitEndpoint || langwatchTracingEnabled) {
     // the aggregate loads all ~41 instrumentation packages at import time even
     // though the old config disabled most and the rest target frameworks this
     // server doesn't run (express, koa, hapi, connect, grpc, nest, restify, pg).
-    // These are the ones that actually emit telemetry here. Add a new library
-    // worth tracing by adding its gated `require` above and a `new ...()` here.
-    // ioredis is opt-in; see traceRedisCommands for the volume it produces.
+    // ioredis is opt-in; see redisCommandTracingEnabled for the volume it
+    // produces when a job queue shares the process.
     instrumentations: [
       new AwsInstrumentation(),
       new OpenAIInstrumentation(),
       new PinoInstrumentation(),
       new RuntimeNodeInstrumentation(),
-      ...(traceRedisCommands ? [redisInstrumentation()] : []),
+      ...(redisCommandTracingEnabled ? [redisInstrumentation()] : []),
     ],
   });
 } else {

--- a/platform/app/src/instrumentation.redis.ts
+++ b/platform/app/src/instrumentation.redis.ts
@@ -1,0 +1,47 @@
+/**
+ * ioredis tracing policy, kept separate from instrumentation.node so it can be
+ * tested without booting the OTel SDK.
+ *
+ * instrumentation.node loads its dependencies through gated `require` calls so
+ * nothing is pulled in when observability is off. That makes the module itself
+ * awkward to exercise in a test, but the two decisions worth protecting are
+ * pure: whether Redis tracing is on, and what a Redis span records.
+ */
+
+/**
+ * Off unless explicitly enabled.
+ *
+ * BullMQ drives every queue operation through Redis, so tracing ioredis in a
+ * process that owns a job queue traces the queue's own bookkeeping rather than
+ * the work. Measured in production: ~10,116 Redis command spans/sec against 317
+ * job spans/sec, about 32 Redis spans per job, which was 93% of every span the
+ * platform emitted. Enable it while debugging Redis latency itself, preferably
+ * somewhere without a job queue attached.
+ *
+ * Exact match on "true": a half-recognised value like "1" or "yes" silently
+ * turning this on is the expensive direction to be wrong in.
+ */
+export const isRedisCommandTracingEnabled = (
+  env: NodeJS.ProcessEnv = process.env,
+): boolean => env.OTEL_TRACE_REDIS_COMMANDS === "true";
+
+/**
+ * Records the command and its first key, never the values, so a span cannot
+ * carry secrets or grow an unbounded attribute.
+ */
+export const redisStatementSerializer = (
+  cmdName: string,
+  cmdArgs: Array<string | Buffer | number | unknown[]>,
+): string => {
+  const key = typeof cmdArgs[0] === "string" ? cmdArgs[0] : "";
+  return key ? `${cmdName} ${key}` : cmdName;
+};
+
+export const redisInstrumentationConfig = {
+  // Redis calls are only interesting as part of some larger operation. Without
+  // this, the connection pool's `connect`/`auth`/`info` and the queue
+  // dispatcher's blocking `brpop`/`xread`, none of which have a parent, each
+  // became a root span, burying real traces in noise.
+  requireParentSpan: true,
+  dbStatementSerializer: redisStatementSerializer,
+};

--- a/platform/app/src/instrumentation.redis.ts
+++ b/platform/app/src/instrumentation.redis.ts
@@ -26,6 +26,19 @@ export const isRedisCommandTracingEnabled = (
 ): boolean => env.OTEL_TRACE_REDIS_COMMANDS === "true";
 
 /**
+ * Upper bound on the serialized statement, marker included.
+ *
+ * Dropping the values is not enough on its own: a key is caller-controlled and
+ * can be arbitrarily long, so an unbounded key would reintroduce exactly the
+ * large attribute this serializer exists to prevent. 256 characters is far
+ * beyond any key this codebase constructs, so truncation should be a symptom
+ * worth noticing rather than routine.
+ */
+export const MAX_DB_STATEMENT_CHARS = 256;
+
+const TRUNCATION_MARKER = "...";
+
+/**
  * Records the command and its first key, never the values, so a span cannot
  * carry secrets or grow an unbounded attribute.
  */
@@ -34,7 +47,18 @@ export const redisStatementSerializer = (
   cmdArgs: Array<string | Buffer | number | unknown[]>,
 ): string => {
   const key = typeof cmdArgs[0] === "string" ? cmdArgs[0] : "";
-  return key ? `${cmdName} ${key}` : cmdName;
+  const statement = key ? `${cmdName} ${key}` : cmdName;
+
+  if (statement.length <= MAX_DB_STATEMENT_CHARS) {
+    return statement;
+  }
+
+  // Truncation is visible on purpose: a silently shortened key reads as a real
+  // key and sends whoever is debugging after a span that never existed.
+  return `${statement.slice(
+    0,
+    MAX_DB_STATEMENT_CHARS - TRUNCATION_MARKER.length,
+  )}${TRUNCATION_MARKER}`;
 };
 
 export const redisInstrumentationConfig = {
@@ -44,4 +68,4 @@ export const redisInstrumentationConfig = {
   // became a root span, burying real traces in noise.
   requireParentSpan: true,
   dbStatementSerializer: redisStatementSerializer,
-};
+} as const;


### PR DESCRIPTION
## What this does

Makes ioredis instrumentation opt-in behind `OTEL_TRACE_REDIS_COMMANDS`, because tracing every Redis command was producing **93% of all spans the platform emits** and none of them answer a question.

## The measurement

Taken from production via Tempo's span metrics, not estimated.

Total platform ingest: **11,177 spans/sec**, which is **966 million spans/day** and **370.8 GiB/day** into Tempo.

By service:

| Service | spans/sec | share |
|---|---|---|
| `langwatch-service-worker` | 10,433 | **93.3%** |
| `langwatch-app` | 707 | 6.3% |
| `langwatch-service-aigateway` | 1 | ~0% |
| `langwatch-service-langyagent` | 0 | ~0% |

Inside the worker, by span name:

| spans/sec | span |
|---|---|
| 1,771 | `evalsha` |
| 1,545 | `del` |
| 937 | `expire` |
| 849 | `get` |
| 635 | `multi` |
| 635 | `exec` |
| 318 | `incr` |
| 317 | `ltrim` |
| 317 | `lpush` |
| **317** | **`{event-sourcing/jobs}/queue`** |
| 312 | `zrange` |
| 309 | `sadd` |
| 309 | `hincrby` |
| 309 | `hdel` |
| 297 | `brpop` |

One of those lines is the work. The rest is BullMQ. `evalsha` at 1,771/sec is BullMQ executing its own Lua scripts; `brpop` is its poll loop; the `lpush`/`ltrim`/`zrange`/`hdel` traffic is queue bookkeeping.

**Ratio: about 32 Redis spans for every 1 span describing a job.**

## Why this is the right fix rather than sampling

These spans are not low-value telemetry that sampling would thin out. They are a mechanical restatement of "a queue is running", emitted once per internal Redis call. Sampling would keep a representative 1% of a signal whose information content is zero, and would also thin the job spans that are actually useful. Not emitting them keeps 100% fidelity on the part worth having.

The instrumentation itself was not misconfigured. `requireParentSpan: true` was already there and doing its job: it is what stops rootless `connect`/`auth`/`info` and blocking `brpop`/`xread` from becoming root spans. The problem is the opposite one, that a legitimate parent span exists for every job, so every Redis call BullMQ makes underneath it gets adopted.

## Note on an earlier diagnosis

`infrastructure/internal-tracing.tf` in langwatch-saas records that the worker emitted "event-sourcing traces of 330k-413k spans each" during the 2026-07-17 Tempo OOM incidents. **That is no longer what is happening.** Sampling live traces now shows the worker's `{event-sourcing/jobs}/queue` traces at 8 spans each, and the largest in a 2-hour window ran 7.3 seconds. The giant-trace problem was fixed; the volume problem was not, and the volume problem is what costs money now. Worth knowing before anyone goes hunting for a 400k-span trace that no longer exists.

## Behaviour

- **Off (new default):** no Redis command spans. Job spans, HTTP spans, AWS SDK spans, OpenAI spans, Pino logs and runtime metrics are all unchanged.
- **On (`OTEL_TRACE_REDIS_COMMANDS=true`):** byte-for-byte the previous behaviour, including `requireParentSpan` and the `db.statement` truncation to command plus first key.

The `require` moves inside the factory so the package is not loaded at boot when the flag is off, which is the same gating pattern the rest of this file already uses for the SDK and the other instrumentation packages.

## Expected effect

Platform span volume drops from ~11,177/sec to roughly ~1,100/sec, a ~90% reduction. Tempo ingest drops from ~370 GiB/day proportionally.

This is the app-side half of the Tempo cost work. The infrastructure half is langwatch-saas#921, which cuts trace retention from 90 days to 3 and stops replicating traces to eu-west-1. The two are independent: retention fixes what is stored, this fixes what is sent. Landing only the retention cut would have left the ingest curve growing linearly at ~180 GiB/day.

## Verification

- Typechecks clean. `@types/node` is unavailable in the module tree I had to borrow (disk constraints prevented a full monorepo install in the worktree), so the run reports `Cannot find namespace 'NodeJS'` in an unrelated file, `langwatchPlatformGuard.ts`. No error in the changed file. CI will run the full typecheck.
- No test is added: this is a boot-time side-effecting module that registers instrumentations, it has no existing test harness, and the change is a conditional around an unchanged configuration object.
- `.env.example` documents the new flag alongside the other OTEL toggles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting for detailed Redis command tracing.
  * Redis tracing remains disabled by default to limit trace volume.
  * When enabled, traces include concise command and key details without recording values.
  * Long trace statements are automatically truncated for readability.

* **Documentation**
  * Updated the environment configuration example with guidance for enabling Redis tracing during latency debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

**Env vars.** One added: `OTEL_TRACE_REDIS_COMMANDS`, optional, unset means off. Parsing is an exact match on `"true"`, so `1`/`yes`/`TRUE` deliberately leave it off. No existing variable changes name, default or meaning. Documented in `platform/app/.env.example` next to the other OTEL toggles.

**Helm values.** None added, removed or changed. The flag is read straight from the process environment, so an operator who wants Redis spans sets it through whatever mechanism already supplies `OTEL_EXPORTER_OTLP_ENDPOINT`.

**Default behavior on a vanilla `helm install` with no overrides.** Redis command spans stop being emitted. Everything else is untouched: job spans, HTTP spans, AWS SDK spans, OpenAI spans, Pino logs and runtime metrics are all unchanged, and the OTLP endpoint gating is unchanged. Installs with no observability configured are unaffected either way, since the whole SDK stays unloaded there. The visible effect is roughly a 90% drop in span volume, which reduces collector and backend load. Nothing fails closed: no dashboard, alert or query breaks unless it specifically groups by `db.system=redis` span names, and any such consumer can restore the old behavior with a single env var and no redeploy of anything else.

**BYOC dataplane impact.** Dataplanes running the worker get the same reduction automatically and need no action. There is no schema, API or wire-format change, no migration, and no coordination required between dataplane and control plane versions. Rollback is the env var, or reverting the commit; neither leaves persistent state behind.
