### PR TITLE
fix(ui): give the onboarding accent surfaces a dark mode, and stop the assistant tabs disagreeing with the docs

### DIFF
--- a/platform/app/src/features/onboarding/components/sections/IntentSelectionScreen.tsx
+++ b/platform/app/src/features/onboarding/components/sections/IntentSelectionScreen.tsx
@@ -4,6 +4,12 @@ import { ChartNoAxesColumn, Telescope } from "lucide-react";
 import type React from "react";
 import { useAnalytics } from "react-contextual-analytics";
 import { useOnboardingFormContext } from "../../contexts/form-context";
+import {
+  accentChipBg,
+  accentChipBorder,
+  selectedSurfaceBg,
+  selectedSurfaceBorder,
+} from "./shared/accent-surface";
 
 interface IntentOption {
   value: OrganizationIntent;
@@ -60,8 +66,8 @@ export const IntentSelectionScreen: React.FC = () => {
             textAlign="left"
             borderRadius="2xl"
             border="2px solid"
-            borderColor={isSelected ? "orange.400" : "border.muted"}
-            bg={isSelected ? "orange.50" : "bg.panel"}
+            borderColor={isSelected ? selectedSurfaceBorder : "border.muted"}
+            bg={isSelected ? selectedSurfaceBg : "bg.panel"}
             px={5}
             py={4}
             cursor="pointer"
@@ -74,12 +80,13 @@ export const IntentSelectionScreen: React.FC = () => {
           >
             <HStack gap={4} align="center">
               <Box
+                data-testid="intent-icon-chip"
                 flexShrink={0}
                 p={3}
                 borderRadius="xl"
-                bg="orange.50"
+                bg={accentChipBg}
                 border="1px solid"
-                borderColor="orange.100"
+                borderColor={accentChipBorder}
               >
                 <Icon color="orange.500" boxSize={6}>
                   <opt.icon strokeWidth={1.5} />

--- a/platform/app/src/features/onboarding/components/sections/ProductSelectionScreen.tsx
+++ b/platform/app/src/features/onboarding/components/sections/ProductSelectionScreen.tsx
@@ -10,6 +10,7 @@ import { motion } from "motion/react";
 import type React from "react";
 import { api } from "~/utils/api";
 import type { ProductSelection } from "../../types/types";
+import { accentChipBg, accentChipBorder } from "./shared/accent-surface";
 
 const MotionBox = motion.create(Box);
 
@@ -123,15 +124,23 @@ export const ProductSelectionScreen: React.FC<ProductSelectionScreenProps> = ({
               flexShrink={0}
               p={3}
               borderRadius="xl"
-              bg="orange.50"
+              bg={accentChipBg}
               border="1px solid"
-              borderColor="orange.100"
+              borderColor={accentChipBorder}
               transition="all 0.25s ease"
+              // The hover wash brightens the chip by one step. Written as raw
+              // custom properties because it rides a `button:hover` selector,
+              // so it needs its own dark-mode branch — `_dark` cannot reach
+              // inside a nested `css` selector.
               css={{
                 "button:hover &": {
                   background: "var(--chakra-colors-orange-100)",
                   borderColor: "var(--chakra-colors-orange-200)",
                   transform: "scale(1.05)",
+                },
+                ".dark button:hover &": {
+                  background: "var(--chakra-colors-orange-900)",
+                  borderColor: "var(--chakra-colors-orange-800)",
                 },
               }}
             >

--- a/platform/app/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
+++ b/platform/app/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
@@ -12,6 +12,7 @@ import {
 import type React from "react";
 import { Link } from "~/components/ui/link";
 import { useActiveProject } from "../../contexts/ActiveProjectContext";
+import { accentChipBg } from "./shared/accent-surface";
 
 interface CapabilityProps {
   icon: LucideIcon;
@@ -96,7 +97,7 @@ function CapabilityCard({
           flexShrink={0}
           p={2.5}
           borderRadius="xl"
-          bg="orange.50"
+          bg={accentChipBg}
           color="orange.500"
           display="flex"
           alignItems="center"

--- a/platform/app/src/features/onboarding/components/sections/__tests__/onboarding-surfaces.colorMode.integration.test.tsx
+++ b/platform/app/src/features/onboarding/components/sections/__tests__/onboarding-surfaces.colorMode.integration.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The onboarding screens paint their selected card and their icon chip with an
+ * orange accent. Those surfaces are the only thing between the card's `fg`
+ * title and the reader: when the surface stays light while `fg` flips to
+ * near-white in dark mode, the title vanishes into it. A customer reported
+ * exactly that — the intent card's title became unreadable the moment they
+ * picked it.
+ *
+ * Assertion technique: jsdom's `getComputedStyle` cannot resolve Chakra v3's
+ * emitted rules (it returns `rgba(0, 0, 0, 0)` whatever the mode), so these
+ * read the injected stylesheet instead. A mode-aware value emits a second,
+ * `.dark`-scoped rule for the element's class; a light-only token emits only
+ * the base rule. That second rule is the thing that was missing.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingFormProvider } from "../../../contexts/form-context";
+import { IntentSelectionScreen } from "../IntentSelectionScreen";
+
+const noop = () => void 0;
+
+/**
+ * True when the element's own class carries a `.dark`-scoped rule that repaints
+ * `background` — i.e. the surface is mode-aware rather than light-only.
+ */
+function hasDarkModeBackgroundRule(element: Element): boolean {
+  const classNames = (element.getAttribute("class") ?? "")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (classNames.length === 0) return false;
+
+  const stylesheet = Array.from(document.querySelectorAll("style"))
+    .map((tag) => tag.textContent ?? "")
+    .join("\n");
+
+  return stylesheet
+    .split("}")
+    .some(
+      (rule) =>
+        rule.includes(".dark") &&
+        rule.includes("background:") &&
+        classNames.some((className) => rule.includes(`.${className}`)),
+    );
+}
+
+function renderIntentScreen(intent?: "AGENT_GOVERNANCE" | "LLM_OPS") {
+  const contextValue = {
+    organizationName: undefined,
+    agreement: false,
+    intent,
+    usageStyle: undefined,
+    phoneNumber: undefined,
+    companySize: undefined,
+    solutionType: undefined,
+    selectedDesires: [],
+    role: undefined,
+    attribution: undefined,
+    setOrganizationName: noop,
+    setAgreement: noop,
+    setIntent: vi.fn(),
+    setUsageStyle: noop,
+    setPhoneNumber: noop,
+    setPhoneHasValue: noop,
+    setPhoneIsValid: noop,
+    setCompanySize: noop,
+    setSolutionType: noop,
+    setDesires: noop,
+    setRole: noop,
+  };
+
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <OnboardingFormProvider value={contextValue as any}>
+        <IntentSelectionScreen />
+      </OnboardingFormProvider>
+    </ChakraProvider>,
+  );
+}
+
+describe("given the onboarding intent screen carries orange accent surfaces", () => {
+  afterEach(cleanup);
+
+  describe("when a card is selected", () => {
+    /** @scenario Selected intent card repaints its surface for dark mode */
+    it("gives the selected card a dark-mode background of its own", () => {
+      renderIntentScreen("AGENT_GOVERNANCE");
+
+      const selected = screen
+        .getAllByRole("radio")
+        .find((card) => card.getAttribute("aria-checked") === "true");
+
+      expect(selected).toBeDefined();
+      expect(hasDarkModeBackgroundRule(selected!)).toBe(true);
+    });
+
+    /** @scenario Selected intent card keeps its title legible */
+    it("keeps the unselected cards on the mode-aware panel surface", () => {
+      renderIntentScreen("AGENT_GOVERNANCE");
+
+      const unselected = screen
+        .getAllByRole("radio")
+        .find((card) => card.getAttribute("aria-checked") === "false");
+
+      expect(unselected).toBeDefined();
+      // `bg.panel` is a semantic token and already resolves per mode, so the
+      // unselected card must never be pinned to a raw palette step either.
+      expect(unselected!.getAttribute("class")).toBeTruthy();
+    });
+  });
+
+  describe("when the cards render their icon chip", () => {
+    /** @scenario Onboarding icon chip repaints its surface for dark mode */
+    it("gives the chip a dark-mode background of its own", () => {
+      const { container } = renderIntentScreen();
+
+      const chip = container.querySelector('[data-testid="intent-icon-chip"]');
+
+      expect(chip).not.toBeNull();
+      expect(hasDarkModeBackgroundRule(chip!)).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/features/onboarding/components/sections/__tests__/onboarding-surfaces.colorMode.integration.test.tsx
+++ b/platform/app/src/features/onboarding/components/sections/__tests__/onboarding-surfaces.colorMode.integration.test.tsx
@@ -13,6 +13,9 @@
  * read the injected stylesheet instead. A mode-aware value emits a second,
  * `.dark`-scoped rule for the element's class; a light-only token emits only
  * the base rule. That second rule is the thing that was missing.
+ *
+ * These tests carry no spec-binding annotation on purpose — this is a bug fix,
+ * and the repo does not open feature files for bug fixes.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -27,6 +30,30 @@ const noop = () => void 0;
  * True when the element's own class carries a `.dark`-scoped rule that repaints
  * `background` — i.e. the surface is mode-aware rather than light-only.
  */
+/** Every emitted CSS rule that targets one of the element's own classes. */
+function rulesFor(element: Element): string[] {
+  const classNames = (element.getAttribute("class") ?? "")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (classNames.length === 0) return [];
+
+  return Array.from(document.querySelectorAll("style"))
+    .map((tag) => tag.textContent ?? "")
+    .join("\n")
+    .split("}")
+    .filter((rule) =>
+      classNames.some((className) => rule.includes(`.${className}`)),
+    );
+}
+
+/** The element's base (mode-independent) `background` declaration. */
+function backgroundDeclarationFor(element: Element): string {
+  const base = rulesFor(element).find(
+    (rule) => !rule.includes(".dark") && rule.includes("background:"),
+  );
+  return base ?? "";
+}
+
 function hasDarkModeBackgroundRule(element: Element): boolean {
   const classNames = (element.getAttribute("class") ?? "")
     .split(/\s+/)
@@ -85,7 +112,6 @@ describe("given the onboarding intent screen carries orange accent surfaces", ()
   afterEach(cleanup);
 
   describe("when a card is selected", () => {
-    /** @scenario Selected intent card repaints its surface for dark mode */
     it("gives the selected card a dark-mode background of its own", () => {
       renderIntentScreen("AGENT_GOVERNANCE");
 
@@ -97,8 +123,7 @@ describe("given the onboarding intent screen carries orange accent surfaces", ()
       expect(hasDarkModeBackgroundRule(selected!)).toBe(true);
     });
 
-    /** @scenario Selected intent card keeps its title legible */
-    it("keeps the unselected cards on the mode-aware panel surface", () => {
+    it("keeps the unselected cards on a semantic surface token", () => {
       renderIntentScreen("AGENT_GOVERNANCE");
 
       const unselected = screen
@@ -106,14 +131,17 @@ describe("given the onboarding intent screen carries orange accent surfaces", ()
         .find((card) => card.getAttribute("aria-checked") === "false");
 
       expect(unselected).toBeDefined();
-      // `bg.panel` is a semantic token and already resolves per mode, so the
-      // unselected card must never be pinned to a raw palette step either.
-      expect(unselected!.getAttribute("class")).toBeTruthy();
+      // The unselected card is mode-aware by a different route: `bg.panel` is
+      // a semantic token, so it emits ONE rule pointing at a variable whose
+      // value flips at `:root`, with no `.dark` rule of its own. Assert the
+      // variable it reaches for — a raw palette step would name the palette.
+      const background = backgroundDeclarationFor(unselected!);
+      expect(background).toContain("--chakra-colors-bg");
+      expect(background).not.toMatch(/--chakra-colors-(orange|gray|zinc)-\d/);
     });
   });
 
   describe("when the cards render their icon chip", () => {
-    /** @scenario Onboarding icon chip repaints its surface for dark mode */
     it("gives the chip a dark-mode background of its own", () => {
       const { container } = renderIntentScreen();
 

--- a/platform/app/src/features/onboarding/components/sections/shared/SelectableIconCard.tsx
+++ b/platform/app/src/features/onboarding/components/sections/shared/SelectableIconCard.tsx
@@ -7,6 +7,7 @@ import {
   iconSizeToPixels,
 } from "../../../../../utils/iconSize";
 import type { IconData } from "../../../regions/shared/types";
+import { SELECTED_SURFACE_BG, SELECTED_SURFACE_BORDER } from "./accent-surface";
 
 interface SelectableIconCardProps {
   label: string;
@@ -44,8 +45,14 @@ export function SelectableIconCard(
     actualIcon?.type === "themed" ? actualIcon.lightSrc : "",
     actualIcon?.type === "themed" ? actualIcon.darkSrc : "",
   );
-  const selectedBorderColor = useColorModeValue("orange.400", "orange.800");
-  const selectedBg = useColorModeValue("orange.50", "orange.950/30");
+  const selectedBorderColor = useColorModeValue(
+    SELECTED_SURFACE_BORDER.light,
+    SELECTED_SURFACE_BORDER.dark,
+  );
+  const selectedBg = useColorModeValue(
+    SELECTED_SURFACE_BG.light,
+    SELECTED_SURFACE_BG.dark,
+  );
   const isDark = useColorModeValue(false, true);
 
   const iconSrc =

--- a/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
+++ b/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
@@ -25,25 +25,29 @@ const toConditional = ({ light, dark }: ColorModePair) => ({
   _dark: dark,
 });
 
-/** Background of a card the user has picked. */
+/**
+ * The picked-card surface. Its dark side is a 30% wash rather than solid
+ * `orange.950` so the card still reads as lifted off the panel behind it.
+ */
 export const SELECTED_SURFACE_BG = {
   light: "orange.50",
   dark: "orange.950/30",
 } as const satisfies ColorModePair;
 
-/** Border of a card the user has picked. */
 export const SELECTED_SURFACE_BORDER = {
   light: "orange.400",
   dark: "orange.800",
 } as const satisfies ColorModePair;
 
-/** Background of the small rounded box an accent icon sits in. */
+/**
+ * The icon chip. Slightly denser than the card wash above because it is a
+ * small shape and needs the extra contrast to hold its edge.
+ */
 export const ACCENT_CHIP_BG = {
   light: "orange.50",
   dark: "orange.950/40",
 } as const satisfies ColorModePair;
 
-/** Hairline around that same box. */
 export const ACCENT_CHIP_BORDER = {
   light: "orange.100",
   dark: "orange.900",

--- a/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
+++ b/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
@@ -1,0 +1,55 @@
+/**
+ * The orange accent surfaces the onboarding screens paint on selected cards and
+ * icon chips.
+ *
+ * These exist because a raw palette step is a light-mode-only decision. `bg`
+ * set to `orange.50` renders the same near-white in both modes, while the text
+ * on top of it follows `fg` and flips to near-white in dark mode — so the copy
+ * disappears into its own card. Every accent surface in onboarding therefore
+ * names both sides.
+ *
+ * The pairs are the source; the Chakra conditional objects are the convenient
+ * form. A component that already holds a `useColorModeValue` call consumes the
+ * pair, everything else spreads the conditional object straight onto the prop —
+ * either way there is one place to change the accent.
+ */
+
+/** A light value and its dark-mode counterpart. */
+interface ColorModePair {
+  light: string;
+  dark: string;
+}
+
+const toConditional = ({ light, dark }: ColorModePair) => ({
+  base: light,
+  _dark: dark,
+});
+
+/** Background of a card the user has picked. */
+export const SELECTED_SURFACE_BG: ColorModePair = {
+  light: "orange.50",
+  dark: "orange.950/30",
+};
+
+/** Border of a card the user has picked. */
+export const SELECTED_SURFACE_BORDER: ColorModePair = {
+  light: "orange.400",
+  dark: "orange.800",
+};
+
+/** Background of the small rounded box an accent icon sits in. */
+export const ACCENT_CHIP_BG: ColorModePair = {
+  light: "orange.50",
+  dark: "orange.950/40",
+};
+
+/** Hairline around that same box. */
+export const ACCENT_CHIP_BORDER: ColorModePair = {
+  light: "orange.100",
+  dark: "orange.900",
+};
+
+export const selectedSurfaceBg = toConditional(SELECTED_SURFACE_BG);
+export const selectedSurfaceBorder = toConditional(SELECTED_SURFACE_BORDER);
+export const accentChipBg = toConditional(ACCENT_CHIP_BG);
+export const accentChipBorder = toConditional(ACCENT_CHIP_BORDER);

--- a/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
+++ b/platform/app/src/features/onboarding/components/sections/shared/accent-surface.ts
@@ -16,8 +16,8 @@
 
 /** A light value and its dark-mode counterpart. */
 interface ColorModePair {
-  light: string;
-  dark: string;
+  readonly light: string;
+  readonly dark: string;
 }
 
 const toConditional = ({ light, dark }: ColorModePair) => ({
@@ -26,28 +26,28 @@ const toConditional = ({ light, dark }: ColorModePair) => ({
 });
 
 /** Background of a card the user has picked. */
-export const SELECTED_SURFACE_BG: ColorModePair = {
+export const SELECTED_SURFACE_BG = {
   light: "orange.50",
   dark: "orange.950/30",
-};
+} as const satisfies ColorModePair;
 
 /** Border of a card the user has picked. */
-export const SELECTED_SURFACE_BORDER: ColorModePair = {
+export const SELECTED_SURFACE_BORDER = {
   light: "orange.400",
   dark: "orange.800",
-};
+} as const satisfies ColorModePair;
 
 /** Background of the small rounded box an accent icon sits in. */
-export const ACCENT_CHIP_BG: ColorModePair = {
+export const ACCENT_CHIP_BG = {
   light: "orange.50",
   dark: "orange.950/40",
-};
+} as const satisfies ColorModePair;
 
 /** Hairline around that same box. */
-export const ACCENT_CHIP_BORDER: ColorModePair = {
+export const ACCENT_CHIP_BORDER = {
   light: "orange.100",
   dark: "orange.900",
-};
+} as const satisfies ColorModePair;
 
 export const selectedSurfaceBg = toConditional(SELECTED_SURFACE_BG);
 export const selectedSurfaceBorder = toConditional(SELECTED_SURFACE_BORDER);

--- a/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
+++ b/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
@@ -48,17 +48,93 @@ const ShikiCommandBox = dynamic(
   { ssr: false },
 ) as React.ComponentType<ShikiCommandBoxProps>;
 
-type AssistantTab = "claude-code" | "codex";
 type CodeTab = "env" | "bearer" | "basic";
 
-const EDITOR_PATHS = [
-  { editor: "Claude Code", path: ".claude/settings.json" },
-  { editor: "Cursor", path: ".cursor/mcp.json" },
-  { editor: "Copilot", path: ".vscode/mcp.json" },
-  { editor: "Windsurf", path: "~/.codeium/windsurf/mcp_config.json" },
+/** What a snippet needs to name this project and this freshly minted token. */
+interface CommandContext {
+  apiKey: string;
+  projectId: string | undefined;
+  endpoint: string;
+  isSelfHosted: boolean;
+}
+
+interface CodeAssistant {
+  key: string;
+  label: string;
+  /**
+   * Present only where the assistant ships a one-line installer. Cursor,
+   * Copilot, Windsurf and Claude Desktop are configured by editing a file, so
+   * inventing a `cursor mcp add` for symmetry would hand out a command that
+   * does not exist.
+   */
+  buildCommand?: (context: CommandContext) => string;
+  /** The file this assistant reads its MCP servers from. */
+  configPath?: string;
+}
+
+/**
+ * The coding assistants this dialog knows how to set up, and the ONE place
+ * that decides so.
+ *
+ * This list previously lived twice and disagreed with itself: two hardcoded
+ * tabs (Claude Code, Codex) alongside five config-path chips naming a
+ * different set of editors, which is how a customer came to notice that the
+ * assistants they used were missing. Both surfaces below now read from here.
+ *
+ * Commands are the ones the docs publish — `claude`/`codex`/`gemini mcp add`
+ * (docs/integration/mcp.mdx and the onboarding MCP-client screen). An
+ * assistant with no published installer gets a config path instead.
+ */
+export const CODE_ASSISTANTS: CodeAssistant[] = [
   {
-    editor: "Claude Desktop",
-    path: "~/Library/Application Support/Claude/claude_desktop_config.json",
+    key: "claude-code",
+    label: "Claude Code",
+    configPath: ".claude/settings.json",
+    buildCommand: ({ apiKey, projectId, endpoint, isSelfHosted }) =>
+      [
+        "claude mcp add langwatch",
+        projectId ? ` --env LANGWATCH_PROJECT_ID=${projectId}` : "",
+        " -- npx -y @langwatch/mcp-server",
+        ` --api-key ${apiKey}`,
+        isSelfHosted ? ` --endpoint ${endpoint}` : "",
+      ].join(""),
+  },
+  {
+    key: "codex",
+    label: "Codex",
+    configPath: "~/.codex/config.toml",
+    buildCommand: ({ apiKey, projectId, endpoint, isSelfHosted }) =>
+      [
+        `codex mcp add langwatch --env LANGWATCH_API_KEY=${apiKey}`,
+        projectId ? ` --env LANGWATCH_PROJECT_ID=${projectId}` : "",
+        isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : "",
+        " -- npx -y @langwatch/mcp-server",
+      ].join(""),
+  },
+  {
+    key: "gemini",
+    label: "Gemini",
+    configPath: "~/.gemini/settings.json",
+    buildCommand: ({ apiKey, projectId, endpoint, isSelfHosted }) =>
+      [
+        `gemini mcp add langwatch --env LANGWATCH_API_KEY=${apiKey}`,
+        projectId ? ` --env LANGWATCH_PROJECT_ID=${projectId}` : "",
+        isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : "",
+        " -- npx -y @langwatch/mcp-server",
+      ].join(""),
+  },
+  { key: "cursor", label: "Cursor", configPath: ".cursor/mcp.json" },
+  { key: "copilot", label: "Copilot", configPath: ".vscode/mcp.json" },
+  {
+    key: "windsurf",
+    label: "Windsurf",
+    configPath: "~/.codeium/windsurf/mcp_config.json",
+  },
+  {
+    key: "claude-desktop",
+    label: "Claude Desktop",
+    configPath:
+      "~/Library/Application Support/Claude/claude_desktop_config.json",
   },
 ];
 
@@ -75,7 +151,9 @@ export function TokenCreatedDialog({
   orgProjects: Array<{ id: string; name: string }>;
   onClose: () => void;
 }) {
-  const [assistantTab, setAssistantTab] = useState<AssistantTab>("claude-code");
+  const [assistantKey, setAssistantKey] = useState<string>(
+    CODE_ASSISTANTS[0]!.key,
+  );
   const [codeTab, setCodeTab] = useState<CodeTab>("env");
   const [selectedProjectId, setSelectedProjectId] = useState<string>(
     projectId ?? "",
@@ -92,14 +170,9 @@ export function TokenCreatedDialog({
     [orgProjects],
   );
 
+  // Each assistant's builder decides where its own flags go, so the flag
+  // fragments that used to be assembled here now live in CODE_ASSISTANTS.
   const isSelfHosted = endpoint && endpoint !== CLOUD_ENDPOINT;
-  const endpointFlag = isSelfHosted ? ` --endpoint ${endpoint}` : "";
-  const projectIdEnvBefore = activeProjectId
-    ? ` --env LANGWATCH_PROJECT_ID=${activeProjectId}`
-    : "";
-  const projectIdEnvAfter = activeProjectId
-    ? ` --env LANGWATCH_PROJECT_ID=${activeProjectId}`
-    : "";
 
   const mcpJson = useMemo(
     () =>
@@ -160,13 +233,26 @@ export function TokenCreatedDialog({
       : "";
   const basicMasked = `Authorization: Basic base64(${activeProjectId ?? "<your-project-id>"}:pat-lw-...)`;
 
-  // ── Claude Code command ────────────────────────────────────────────────
-  const claudeCommand = `claude mcp add langwatch${projectIdEnvBefore} -- npx -y @langwatch/mcp-server --api-key ${newToken ?? ""}${endpointFlag}`;
-  const claudeMasked = `claude mcp add langwatch${projectIdEnvBefore} -- npx -y @langwatch/mcp-server --api-key ${maskedKey}${endpointFlag}`;
+  // ── Per-assistant terminal command ─────────────────────────────────────
+  // Both forms come from the same builder, so the value the user copies and
+  // the value they read can never drift apart.
+  const activeAssistant =
+    CODE_ASSISTANTS.find((assistant) => assistant.key === assistantKey) ??
+    CODE_ASSISTANTS[0]!;
 
-  // ── Codex command ──────────────────────────────────────────────────────
-  const codexCommand = `codex mcp add langwatch --env LANGWATCH_API_KEY=${newToken ?? ""}${projectIdEnvAfter}${isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : ""} -- npx -y @langwatch/mcp-server`;
-  const codexMasked = `codex mcp add langwatch --env LANGWATCH_API_KEY=${maskedKey}${projectIdEnvAfter}${isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : ""} -- npx -y @langwatch/mcp-server`;
+  const commandContext = {
+    projectId: activeProjectId,
+    endpoint,
+    isSelfHosted: !!isSelfHosted,
+  };
+  const assistantCommand = activeAssistant.buildCommand?.({
+    ...commandContext,
+    apiKey: newToken ?? "",
+  });
+  const assistantMasked = activeAssistant.buildCommand?.({
+    ...commandContext,
+    apiKey: maskedKey,
+  });
 
   return (
     <Dialog.Root
@@ -314,49 +400,46 @@ export function TokenCreatedDialog({
                 bg="bg.panel/70"
                 boxShadow="sm"
                 width="fit-content"
+                flexWrap="wrap"
               >
-                <TabButton
-                  label="Claude Code"
-                  active={assistantTab === "claude-code"}
-                  onClick={() => setAssistantTab("claude-code")}
-                />
-                <TabButton
-                  label="Codex"
-                  active={assistantTab === "codex"}
-                  onClick={() => setAssistantTab("codex")}
-                />
+                {CODE_ASSISTANTS.map((assistant) => (
+                  <TabButton
+                    key={assistant.key}
+                    label={assistant.label}
+                    active={assistantKey === assistant.key}
+                    onClick={() => setAssistantKey(assistant.key)}
+                  />
+                ))}
               </HStack>
 
-              {/* Claude Code terminal command — bash-highlighted with >_ prompt */}
-              {assistantTab === "claude-code" && newToken && (
+              {/* Terminal command — bash-highlighted with >_ prompt. Only the
+                  assistants that actually ship an installer get one. */}
+              {assistantCommand && assistantMasked && newToken && (
                 <VStack align="stretch" gap={3}>
                   <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
                     Run in your terminal
                   </Text>
                   <ShikiCommandBox
-                    command={claudeCommand}
-                    maskedCommand={claudeMasked}
+                    command={assistantCommand}
+                    maskedCommand={assistantMasked}
                     lang="bash"
                     showPrompt
-                    copyLabel="Claude Code command"
+                    copyLabel={`${activeAssistant.label} command`}
                   />
                 </VStack>
               )}
 
-              {/* Codex terminal command — bash-highlighted with >_ prompt */}
-              {assistantTab === "codex" && newToken && (
-                <VStack align="stretch" gap={3}>
-                  <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
-                    Run in your terminal
+              {/* Config-file-only assistants: say so, rather than leaving the
+                  tab looking broken next to one that offers a command. */}
+              {!assistantCommand && newToken && (
+                <Text fontSize="xs" color="fg.muted">
+                  {activeAssistant.label} has no install command — paste the
+                  config below into{" "}
+                  <Text as="span" fontWeight="semibold" color="fg">
+                    {activeAssistant.configPath}
                   </Text>
-                  <ShikiCommandBox
-                    command={codexCommand}
-                    maskedCommand={codexMasked}
-                    lang="bash"
-                    showPrompt
-                    copyLabel="Codex command"
-                  />
-                </VStack>
+                  .
+                </Text>
               )}
 
               {/* JSON config — existing JsonHighlight wiring unchanged */}
@@ -392,9 +475,9 @@ export function TokenCreatedDialog({
                     <Text fontSize="xs" color="fg.muted" flexShrink={0}>
                       Config path:
                     </Text>
-                    {EDITOR_PATHS.map((ep) => (
+                    {CODE_ASSISTANTS.filter((a) => a.configPath).map((ep) => (
                       <HStack
-                        key={ep.editor}
+                        key={ep.key}
                         asChild
                         gap={1}
                         px={2}
@@ -411,17 +494,17 @@ export function TokenCreatedDialog({
                         }}
                         onClick={() => {
                           void copyToClipboard({
-                            text: ep.path,
-                            successMessage: `${ep.editor} config path copied`,
+                            text: ep.configPath!,
+                            successMessage: `${ep.label} config path copied`,
                           });
                         }}
                       >
                         <button
                           type="button"
-                          aria-label={`Copy ${ep.editor} config path`}
+                          aria-label={`Copy ${ep.label} config path`}
                         >
                           <Text fontSize="2xs" fontWeight="medium" color="fg">
-                            {ep.editor}
+                            {ep.label}
                           </Text>
                         </button>
                       </HStack>

--- a/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
+++ b/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
@@ -58,7 +58,7 @@ interface CommandContext {
   isSelfHosted: boolean;
 }
 
-interface CodeAssistant {
+export interface CodeAssistant {
   key: string;
   label: string;
   /**

--- a/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
+++ b/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
@@ -81,9 +81,10 @@ interface CodeAssistant {
  * different set of editors, which is how a customer came to notice that the
  * assistants they used were missing. Both surfaces below now read from here.
  *
- * Commands are the ones the docs publish — `claude`/`codex`/`gemini mcp add`
- * (docs/integration/mcp.mdx and the onboarding MCP-client screen). An
- * assistant with no published installer gets a config path instead.
+ * Commands are the ones the docs publish — `claude mcp add` / `codex mcp add`
+ * (docs/integration/mcp.mdx). An assistant with no published installer gets a
+ * config path instead; inventing a command for symmetry hands the user a line
+ * that fails at the one moment they can still read their token.
  */
 export const CODE_ASSISTANTS: CodeAssistant[] = [
   {
@@ -102,7 +103,9 @@ export const CODE_ASSISTANTS: CodeAssistant[] = [
   {
     key: "codex",
     label: "Codex",
-    configPath: "~/.codex/config.toml",
+    // Deliberately no configPath: Codex reads TOML, and the chip row sits
+    // under a block rendering JSON. Needs a format marker before it can
+    // appear there — see #6654.
     buildCommand: ({ apiKey, projectId, endpoint, isSelfHosted }) =>
       [
         `codex mcp add langwatch --env LANGWATCH_API_KEY=${apiKey}`,
@@ -111,18 +114,10 @@ export const CODE_ASSISTANTS: CodeAssistant[] = [
         " -- npx -y @langwatch/mcp-server",
       ].join(""),
   },
-  {
-    key: "gemini",
-    label: "Gemini",
-    configPath: "~/.gemini/settings.json",
-    buildCommand: ({ apiKey, projectId, endpoint, isSelfHosted }) =>
-      [
-        `gemini mcp add langwatch --env LANGWATCH_API_KEY=${apiKey}`,
-        projectId ? ` --env LANGWATCH_PROJECT_ID=${projectId}` : "",
-        isSelfHosted ? ` --env LANGWATCH_ENDPOINT=${endpoint}` : "",
-        " -- npx -y @langwatch/mcp-server",
-      ].join(""),
-  },
+  // Gemini is deliberately absent until its command is verified against a
+  // real `gemini` CLI — its `mcp add` takes options BEFORE the server name
+  // and does not use `--` to introduce the command, unlike Codex above.
+  // Tracked in #6654.
   { key: "cursor", label: "Cursor", configPath: ".cursor/mcp.json" },
   { key: "copilot", label: "Copilot", configPath: ".vscode/mcp.json" },
   {

--- a/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
+++ b/platform/app/src/pages/settings/api-keys/TokenCreatedDialog.tsx
@@ -231,6 +231,8 @@ export function TokenCreatedDialog({
   // ── Per-assistant terminal command ─────────────────────────────────────
   // Both forms come from the same builder, so the value the user copies and
   // the value they read can never drift apart.
+  // Only the tab buttons set this key, and they map over the list itself, so
+  // the lookup cannot miss; the fallback only satisfies the compiler.
   const activeAssistant =
     CODE_ASSISTANTS.find((assistant) => assistant.key === assistantKey) ??
     CODE_ASSISTANTS[0]!;

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The "Use with Code Assistants" section offered two tabs — Claude Code and
+ * Codex — while the product documents the LangWatch MCP server for more
+ * assistants than that, and the same file listed five *different* editors for
+ * its config-path chips. A customer noticed the gap.
+ *
+ * @see specs/api-keys/token-created-snippets.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CODE_ASSISTANTS, TokenCreatedDialog } from "../TokenCreatedDialog";
+
+function renderDialog() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <TokenCreatedDialog
+        newToken="sk-lw-test-token-value"
+        projectId="project-abc"
+        endpoint="https://app.langwatch.ai"
+        orgProjects={[{ id: "project-abc", name: "ACME" }]}
+        onClose={() => void 0}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("given a token has just been minted", () => {
+  afterEach(cleanup);
+
+  describe("when the Use with Code Assistants section renders", () => {
+    /** @scenario Every supported coding assistant has a tab */
+    it("offers a tab for every assistant the product supports", () => {
+      renderDialog();
+
+      const section = screen
+        .getByText("Use with Code Assistants")
+        .closest("div")!.parentElement!;
+
+      for (const assistant of CODE_ASSISTANTS) {
+        expect(
+          within(section).getByRole("button", { name: assistant.label }),
+        ).toBeTruthy();
+      }
+    });
+
+    /** @scenario Every supported coding assistant has a tab */
+    it("covers the assistants the customer called out as missing", () => {
+      renderDialog();
+
+      const labels = CODE_ASSISTANTS.map((assistant) => assistant.label);
+      expect(labels).toEqual(
+        expect.arrayContaining(["Claude Code", "Codex", "Cursor", "Gemini"]),
+      );
+    });
+  });
+
+  describe("when an assistant installs from the terminal", () => {
+    /** @scenario An assistant with an install command shows a terminal snippet */
+    it("builds that assistant's own command around the minted token", () => {
+      const withCommand = CODE_ASSISTANTS.filter(
+        (assistant) => assistant.buildCommand,
+      );
+      expect(withCommand.length).toBeGreaterThan(0);
+
+      for (const assistant of withCommand) {
+        const command = assistant.buildCommand!({
+          apiKey: "sk-lw-real",
+          projectId: "project-abc",
+          endpoint: "https://app.langwatch.ai",
+          isSelfHosted: false,
+        });
+        expect(command).toContain("sk-lw-real");
+        expect(command).toContain("@langwatch/mcp-server");
+      }
+    });
+  });
+
+  describe("when an assistant has no terminal installer", () => {
+    /** @scenario An assistant without an install command points at its config file */
+    it("names the config file it reads instead", () => {
+      const configOnly = CODE_ASSISTANTS.filter(
+        (assistant) => !assistant.buildCommand,
+      );
+      expect(configOnly.length).toBeGreaterThan(0);
+
+      for (const assistant of configOnly) {
+        expect(assistant.configPath).toBeTruthy();
+      }
+    });
+  });
+});

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
@@ -97,43 +97,59 @@ describe("given a token has just been minted", () => {
   });
 
   describe("when an assistant that installs from the terminal is selected", () => {
-    /** @scenario An assistant with an install command shows a terminal snippet */
-    it("shows the terminal heading for it", () => {
-      renderDialog();
-      selectAssistant("Codex");
-
-      expect(
-        within(assistantSection()).getByText("Run in your terminal"),
-      ).toBeTruthy();
-    });
+    // The command STRING itself cannot be asserted here: ShikiCommandBox is
+    // loaded via `dynamic(..., { ssr: false })` and renders nothing in jsdom,
+    // so no `codex mcp add …` text ever reaches the DOM. Each assistant's
+    // exact command is pinned in token-created-snippets.unit.test.ts instead;
+    // these prove the tab switches which of the two treatments is shown.
 
     /** @scenario An assistant with an install command shows a terminal snippet */
-    it("offers no config-file pointer in its place", () => {
+    it("brings the terminal treatment back when moving off a config-only tab", () => {
       renderDialog();
-      selectAssistant("Claude Code");
 
+      // Claude Code is the default tab and also has a command, so starting
+      // from a config-only assistant is what makes the selection measurable.
+      selectAssistant("Cursor");
       expect(
-        within(assistantSection()).queryByText(/has no install command/),
+        within(assistantSection()).queryByText("Run in your terminal"),
       ).toBeNull();
+
+      selectAssistant("Codex");
+      const codex = assistantSection().textContent ?? "";
+      expect(codex).toContain("Run in your terminal");
+      expect(codex).not.toContain("has no install command");
     });
   });
 
   describe("when an assistant with no terminal installer is selected", () => {
     /** @scenario An assistant without an install command points at its config file */
-    it("names the config file it reads instead", () => {
+    it("names the config file it reads instead, per assistant", () => {
       renderDialog();
-      selectAssistant("Cursor");
 
-      const section = assistantSection();
-      expect(section.textContent).toContain("has no install command");
-      expect(section.textContent).toContain(".cursor/mcp.json");
+      selectAssistant("Cursor");
+      const cursor = assistantSection().textContent ?? "";
+      expect(cursor).toContain("Cursor has no install command");
+      expect(cursor).toContain(".cursor/mcp.json");
+
+      // A second config-only assistant, so the message is shown to follow the
+      // selection rather than being the same static string either way.
+      selectAssistant("Windsurf");
+      const windsurf = assistantSection().textContent ?? "";
+      expect(windsurf).toContain("Windsurf has no install command");
+      expect(windsurf).toContain("~/.codeium/windsurf/mcp_config.json");
+      expect(windsurf).not.toContain(".cursor/mcp.json");
     });
 
     /** @scenario An assistant without an install command points at its config file */
     it("drops the terminal heading for it", () => {
       renderDialog();
-      selectAssistant("Windsurf");
+      // The default tab has a command, so confirm the heading is there first —
+      // otherwise its absence proves nothing about the selection.
+      expect(
+        within(assistantSection()).getByText("Run in your terminal"),
+      ).toBeTruthy();
 
+      selectAssistant("Windsurf");
       expect(
         within(assistantSection()).queryByText("Run in your terminal"),
       ).toBeNull();

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
@@ -57,12 +57,12 @@ describe("given a token has just been minted", () => {
       );
     });
 
-    /** @scenario An assistant without an install command points at its config file */
-    it("ships no assistant whose command has not been verified", () => {
+    // Deliberately carries no @scenario annotation: this guards a temporary
+    // exclusion, not a behaviour the spec describes. Delete it with #6654.
+    it("does not offer Gemini until its command is verified (#6654)", () => {
       // Gemini's `mcp add` takes its options before the server name and does
       // not use `--` to introduce the command, so the Codex-shaped builder
-      // written for it emitted a line that does not run. It stays out until
-      // that is verified against a real CLI — #6654.
+      // written for it emitted a line that does not run.
       expect(
         CODE_ASSISTANTS.some((assistant) => assistant.key === "gemini"),
       ).toBe(false);

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
@@ -6,25 +6,51 @@
  * assistants than that, and the same file listed five *different* editors for
  * its config-path chips. A customer noticed the gap.
  *
+ * These drive the rendered dialog: pick a tab, read what the user is shown.
+ * The registry's own shape (what each entry builds) is asserted in
+ * token-created-snippets.unit.test.ts, where it costs no render.
+ *
  * @see specs/api-keys/token-created-snippets.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CODE_ASSISTANTS, TokenCreatedDialog } from "../TokenCreatedDialog";
+
+const TOKEN = "sk-lw-test-token-value";
 
 function renderDialog() {
   return render(
     <ChakraProvider value={defaultSystem}>
       <TokenCreatedDialog
-        newToken="sk-lw-test-token-value"
+        newToken={TOKEN}
         projectId="project-abc"
         endpoint="https://app.langwatch.ai"
         orgProjects={[{ id: "project-abc", name: "ACME" }]}
         onClose={() => void 0}
       />
     </ChakraProvider>,
+  );
+}
+
+/** The "Use with Code Assistants" block, tabs and body together. */
+function assistantSection(): HTMLElement {
+  return screen.getByText("Use with Code Assistants").closest("div")!
+    .parentElement!;
+}
+
+function selectAssistant(label: string) {
+  // fireEvent, not a raw .click(): the latter dispatches the event but leaves
+  // the resulting setState outside act(), so the tab never repaints.
+  fireEvent.click(
+    within(assistantSection()).getByRole("button", { name: label }),
   );
 }
 
@@ -36,13 +62,11 @@ describe("given a token has just been minted", () => {
     it("offers a tab for every assistant the product supports", () => {
       renderDialog();
 
-      const section = screen
-        .getByText("Use with Code Assistants")
-        .closest("div")!.parentElement!;
-
       for (const assistant of CODE_ASSISTANTS) {
         expect(
-          within(section).getByRole("button", { name: assistant.label }),
+          within(assistantSection()).getByRole("button", {
+            name: assistant.label,
+          }),
         ).toBeTruthy();
       }
     });
@@ -51,56 +75,68 @@ describe("given a token has just been minted", () => {
     it("covers the assistants the customer called out as missing", () => {
       renderDialog();
 
-      const labels = CODE_ASSISTANTS.map((assistant) => assistant.label);
-      expect(labels).toEqual(
-        expect.arrayContaining(["Claude Code", "Codex", "Cursor", "Copilot"]),
-      );
+      for (const label of ["Claude Code", "Codex", "Cursor", "Copilot"]) {
+        expect(
+          within(assistantSection()).getByRole("button", { name: label }),
+        ).toBeTruthy();
+      }
     });
 
-    // Deliberately carries no @scenario annotation: this guards a temporary
+    // Intentionally unbound to any spec scenario: this guards a temporary
     // exclusion, not a behaviour the spec describes. Delete it with #6654.
     it("does not offer Gemini until its command is verified (#6654)", () => {
+      renderDialog();
+
       // Gemini's `mcp add` takes its options before the server name and does
       // not use `--` to introduce the command, so the Codex-shaped builder
       // written for it emitted a line that does not run.
       expect(
-        CODE_ASSISTANTS.some((assistant) => assistant.key === "gemini"),
-      ).toBe(false);
+        within(assistantSection()).queryByRole("button", { name: "Gemini" }),
+      ).toBeNull();
     });
   });
 
-  describe("when an assistant installs from the terminal", () => {
+  describe("when an assistant that installs from the terminal is selected", () => {
     /** @scenario An assistant with an install command shows a terminal snippet */
-    it("builds that assistant's own command around the minted token", () => {
-      const withCommand = CODE_ASSISTANTS.filter(
-        (assistant) => assistant.buildCommand,
-      );
-      expect(withCommand.length).toBeGreaterThan(0);
+    it("shows the terminal heading for it", () => {
+      renderDialog();
+      selectAssistant("Codex");
 
-      for (const assistant of withCommand) {
-        const command = assistant.buildCommand!({
-          apiKey: "sk-lw-real",
-          projectId: "project-abc",
-          endpoint: "https://app.langwatch.ai",
-          isSelfHosted: false,
-        });
-        expect(command).toContain("sk-lw-real");
-        expect(command).toContain("@langwatch/mcp-server");
-      }
+      expect(
+        within(assistantSection()).getByText("Run in your terminal"),
+      ).toBeTruthy();
+    });
+
+    /** @scenario An assistant with an install command shows a terminal snippet */
+    it("offers no config-file pointer in its place", () => {
+      renderDialog();
+      selectAssistant("Claude Code");
+
+      expect(
+        within(assistantSection()).queryByText(/has no install command/),
+      ).toBeNull();
     });
   });
 
-  describe("when an assistant has no terminal installer", () => {
+  describe("when an assistant with no terminal installer is selected", () => {
     /** @scenario An assistant without an install command points at its config file */
     it("names the config file it reads instead", () => {
-      const configOnly = CODE_ASSISTANTS.filter(
-        (assistant) => !assistant.buildCommand,
-      );
-      expect(configOnly.length).toBeGreaterThan(0);
+      renderDialog();
+      selectAssistant("Cursor");
 
-      for (const assistant of configOnly) {
-        expect(assistant.configPath).toBeTruthy();
-      }
+      const section = assistantSection();
+      expect(section.textContent).toContain("has no install command");
+      expect(section.textContent).toContain(".cursor/mcp.json");
+    });
+
+    /** @scenario An assistant without an install command points at its config file */
+    it("drops the terminal heading for it", () => {
+      renderDialog();
+      selectAssistant("Windsurf");
+
+      expect(
+        within(assistantSection()).queryByText("Run in your terminal"),
+      ).toBeNull();
     });
   });
 });

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-assistants.integration.test.tsx
@@ -53,8 +53,19 @@ describe("given a token has just been minted", () => {
 
       const labels = CODE_ASSISTANTS.map((assistant) => assistant.label);
       expect(labels).toEqual(
-        expect.arrayContaining(["Claude Code", "Codex", "Cursor", "Gemini"]),
+        expect.arrayContaining(["Claude Code", "Codex", "Cursor", "Copilot"]),
       );
+    });
+
+    /** @scenario An assistant without an install command points at its config file */
+    it("ships no assistant whose command has not been verified", () => {
+      // Gemini's `mcp add` takes its options before the server name and does
+      // not use `--` to introduce the command, so the Codex-shaped builder
+      // written for it emitted a line that does not run. It stays out until
+      // that is verified against a real CLI — #6654.
+      expect(
+        CODE_ASSISTANTS.some((assistant) => assistant.key === "gemini"),
+      ).toBe(false);
     });
   });
 

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
@@ -106,6 +106,29 @@ describe("given the token-created-snippets feature is implemented", () => {
     });
   });
 
+  describe("when checking that one list drives the assistant tabs and config paths", () => {
+    /** @scenario One list of coding assistants drives both the tabs and the config paths */
+    it("TokenCreatedDialog no longer keeps a separate EDITOR_PATHS list", () => {
+      const dialog = readFile(
+        "src/pages/settings/api-keys/TokenCreatedDialog.tsx",
+      );
+      expect(dialog).not.toContain("EDITOR_PATHS");
+      expect(dialog).toContain("CODE_ASSISTANTS");
+    });
+
+    /** @scenario One list of coding assistants drives both the tabs and the config paths */
+    it("renders both the tabs and the config-path chips from CODE_ASSISTANTS", () => {
+      const dialog = readFile(
+        "src/pages/settings/api-keys/TokenCreatedDialog.tsx",
+      );
+      // Two map() call sites, both over the same list: the tab strip and the
+      // config-path chip row.
+      const renders =
+        dialog.match(/CODE_ASSISTANTS[\s\S]{0,40}?\.map\(/g) ?? [];
+      expect(renders.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   describe("when checking that ShikiCommandBox is lazy-loaded via dynamic()", () => {
     /** @scenario TokenCreatedDialog lazy-loads the Shiki-backed command box on dialog open */
     it("TokenCreatedDialog imports ShikiCommandBox via dynamic() (ssr:false)", () => {

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
@@ -9,6 +9,7 @@
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
+import { CODE_ASSISTANTS } from "../TokenCreatedDialog";
 
 const LANGWATCH_ROOT = path.resolve(__dirname, "../../../../../");
 
@@ -126,6 +127,39 @@ describe("given the token-created-snippets feature is implemented", () => {
       const renders =
         dialog.match(/CODE_ASSISTANTS[\s\S]{0,40}?\.map\(/g) ?? [];
       expect(renders.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("when checking what each assistant entry builds", () => {
+    /** @scenario An assistant with an install command shows a terminal snippet */
+    it("builds each installer command around the minted token", () => {
+      const withCommand = CODE_ASSISTANTS.filter(
+        (assistant) => assistant.buildCommand,
+      );
+      expect(withCommand.length).toBeGreaterThan(0);
+
+      for (const assistant of withCommand) {
+        const command = assistant.buildCommand!({
+          apiKey: "sk-lw-real",
+          projectId: "project-abc",
+          endpoint: "https://app.langwatch.ai",
+          isSelfHosted: false,
+        });
+        expect(command).toContain("sk-lw-real");
+        expect(command).toContain("@langwatch/mcp-server");
+      }
+    });
+
+    /** @scenario An assistant without an install command points at its config file */
+    it("gives every installer-less assistant a config path", () => {
+      const configOnly = CODE_ASSISTANTS.filter(
+        (assistant) => !assistant.buildCommand,
+      );
+      expect(configOnly.length).toBeGreaterThan(0);
+
+      for (const assistant of configOnly) {
+        expect(assistant.configPath).toBeTruthy();
+      }
     });
   });
 

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
@@ -9,7 +9,7 @@
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
-import { CODE_ASSISTANTS } from "../TokenCreatedDialog";
+import { CODE_ASSISTANTS, type CodeAssistant } from "../TokenCreatedDialog";
 
 const LANGWATCH_ROOT = path.resolve(__dirname, "../../../../../");
 
@@ -131,23 +131,84 @@ describe("given the token-created-snippets feature is implemented", () => {
   });
 
   describe("when checking what each assistant entry builds", () => {
-    /** @scenario An assistant with an install command shows a terminal snippet */
-    it("builds each installer command around the minted token", () => {
-      const withCommand = CODE_ASSISTANTS.filter(
-        (assistant) => assistant.buildCommand,
-      );
-      expect(withCommand.length).toBeGreaterThan(0);
-
-      for (const assistant of withCommand) {
-        const command = assistant.buildCommand!({
+    // Full expected strings, not substrings. The assistants deliberately
+    // differ in where each flag goes — Claude Code puts the project id before
+    // the `--` and its key after, Codex puts everything before — and a
+    // substring check passes happily while those are wrong. A Gemini entry
+    // whose flags sat on the wrong side of the server name shipped and was
+    // pulled for exactly that reason (#6654).
+    const CASES: Array<{
+      key: string;
+      context: Parameters<NonNullable<CodeAssistant["buildCommand"]>>[0];
+      expected: string;
+    }> = [
+      {
+        key: "claude-code",
+        context: {
           apiKey: "sk-lw-real",
           projectId: "project-abc",
           endpoint: "https://app.langwatch.ai",
           isSelfHosted: false,
-        });
-        expect(command).toContain("sk-lw-real");
-        expect(command).toContain("@langwatch/mcp-server");
-      }
+        },
+        expected:
+          "claude mcp add langwatch --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server --api-key sk-lw-real",
+      },
+      {
+        key: "claude-code",
+        context: {
+          apiKey: "sk-lw-real",
+          projectId: undefined,
+          endpoint: "https://self.host",
+          isSelfHosted: true,
+        },
+        expected:
+          "claude mcp add langwatch -- npx -y @langwatch/mcp-server --api-key sk-lw-real --endpoint https://self.host",
+      },
+      {
+        key: "codex",
+        context: {
+          apiKey: "sk-lw-real",
+          projectId: "project-abc",
+          endpoint: "https://app.langwatch.ai",
+          isSelfHosted: false,
+        },
+        expected:
+          "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server",
+      },
+      {
+        key: "codex",
+        context: {
+          apiKey: "sk-lw-real",
+          projectId: undefined,
+          endpoint: "https://self.host",
+          isSelfHosted: true,
+        },
+        expected:
+          "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real --env LANGWATCH_ENDPOINT=https://self.host -- npx -y @langwatch/mcp-server",
+      },
+    ];
+
+    for (const { key, context, expected } of CASES) {
+      /** @scenario An assistant with an install command shows a terminal snippet */
+      it(`builds ${key}'s command exactly, ${
+        context.isSelfHosted ? "self-hosted" : "cloud"
+      }, ${context.projectId ? "with" : "without"} a project id`, () => {
+        const assistant = CODE_ASSISTANTS.find((a) => a.key === key);
+        expect(assistant?.buildCommand).toBeDefined();
+        expect(assistant!.buildCommand!(context)).toBe(expected);
+      });
+    }
+
+    /** @scenario An assistant with an install command shows a terminal snippet */
+    it("covers every installer in the registry", () => {
+      const withCommand = CODE_ASSISTANTS.filter((a) => a.buildCommand).map(
+        (a) => a.key,
+      );
+      // If someone adds an installer, this fails until its exact command is
+      // pinned above — which is the whole point.
+      expect([...new Set(CASES.map((c) => c.key))].sort()).toEqual(
+        withCommand.sort(),
+      );
     });
 
     /** @scenario An assistant without an install command points at its config file */

--- a/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/__tests__/token-created-snippets.unit.test.ts
@@ -137,66 +137,89 @@ describe("given the token-created-snippets feature is implemented", () => {
     // substring check passes happily while those are wrong. A Gemini entry
     // whose flags sat on the wrong side of the server name shipped and was
     // pulled for exactly that reason (#6654).
-    const CASES: Array<{
-      key: string;
-      context: Parameters<NonNullable<CodeAssistant["buildCommand"]>>[0];
-      expected: string;
-    }> = [
+    const API_KEY = "sk-lw-real";
+    const PROJECT_ID = "project-abc";
+    const CLOUD = "https://app.langwatch.ai";
+    const SELF_HOSTED = "https://self.host";
+
+    // Both optional flags, independently: a project id and a self-hosted
+    // endpoint are unrelated choices, and the case where BOTH are present is
+    // the densest line either builder emits — the one where an ordering
+    // mistake is most likely and least visible.
+    const COMBOS = [
       {
-        key: "claude-code",
-        context: {
-          apiKey: "sk-lw-real",
-          projectId: "project-abc",
-          endpoint: "https://app.langwatch.ai",
-          isSelfHosted: false,
-        },
-        expected:
-          "claude mcp add langwatch --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server --api-key sk-lw-real",
+        label: "with a project id, cloud",
+        projectId: PROJECT_ID,
+        endpoint: CLOUD,
+        isSelfHosted: false,
       },
       {
-        key: "claude-code",
-        context: {
-          apiKey: "sk-lw-real",
-          projectId: undefined,
-          endpoint: "https://self.host",
-          isSelfHosted: true,
-        },
-        expected:
+        label: "with a project id, self-hosted",
+        projectId: PROJECT_ID,
+        endpoint: SELF_HOSTED,
+        isSelfHosted: true,
+      },
+      {
+        label: "without a project id, cloud",
+        projectId: undefined,
+        endpoint: CLOUD,
+        isSelfHosted: false,
+      },
+      {
+        label: "without a project id, self-hosted",
+        projectId: undefined,
+        endpoint: SELF_HOSTED,
+        isSelfHosted: true,
+      },
+    ] as const;
+
+    const EXPECTED = {
+      "claude-code": {
+        "with a project id, cloud":
+          "claude mcp add langwatch --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server --api-key sk-lw-real",
+        "with a project id, self-hosted":
+          "claude mcp add langwatch --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server --api-key sk-lw-real --endpoint https://self.host",
+        "without a project id, cloud":
+          "claude mcp add langwatch -- npx -y @langwatch/mcp-server --api-key sk-lw-real",
+        "without a project id, self-hosted":
           "claude mcp add langwatch -- npx -y @langwatch/mcp-server --api-key sk-lw-real --endpoint https://self.host",
       },
-      {
-        key: "codex",
-        context: {
-          apiKey: "sk-lw-real",
-          projectId: "project-abc",
-          endpoint: "https://app.langwatch.ai",
-          isSelfHosted: false,
-        },
-        expected:
+      codex: {
+        "with a project id, cloud":
           "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real --env LANGWATCH_PROJECT_ID=project-abc -- npx -y @langwatch/mcp-server",
-      },
-      {
-        key: "codex",
-        context: {
-          apiKey: "sk-lw-real",
-          projectId: undefined,
-          endpoint: "https://self.host",
-          isSelfHosted: true,
-        },
-        expected:
+        "with a project id, self-hosted":
+          "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real --env LANGWATCH_PROJECT_ID=project-abc --env LANGWATCH_ENDPOINT=https://self.host -- npx -y @langwatch/mcp-server",
+        "without a project id, cloud":
+          "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real -- npx -y @langwatch/mcp-server",
+        "without a project id, self-hosted":
           "codex mcp add langwatch --env LANGWATCH_API_KEY=sk-lw-real --env LANGWATCH_ENDPOINT=https://self.host -- npx -y @langwatch/mcp-server",
       },
-    ];
+    } as const satisfies Record<
+      string,
+      Record<(typeof COMBOS)[number]["label"], string>
+    >;
 
-    for (const { key, context, expected } of CASES) {
-      /** @scenario An assistant with an install command shows a terminal snippet */
-      it(`builds ${key}'s command exactly, ${
-        context.isSelfHosted ? "self-hosted" : "cloud"
-      }, ${context.projectId ? "with" : "without"} a project id`, () => {
-        const assistant = CODE_ASSISTANTS.find((a) => a.key === key);
-        expect(assistant?.buildCommand).toBeDefined();
-        expect(assistant!.buildCommand!(context)).toBe(expected);
-      });
+    for (const key of Object.keys(EXPECTED) as Array<keyof typeof EXPECTED>) {
+      for (const combo of COMBOS) {
+        /** @scenario An assistant with an install command shows a terminal snippet */
+        it(`builds ${key}'s command exactly, ${combo.label}`, () => {
+          const assistant = CODE_ASSISTANTS.find((a) => a.key === key);
+          expect(assistant?.buildCommand).toBeDefined();
+
+          const context: Parameters<
+            NonNullable<CodeAssistant["buildCommand"]>
+          >[0] = {
+            apiKey: API_KEY,
+            projectId: combo.projectId,
+            endpoint: combo.endpoint,
+            isSelfHosted: combo.isSelfHosted,
+          };
+
+          expect(assistant!.buildCommand!(context)).toBe(
+            EXPECTED[key][combo.label],
+          );
+        });
+      }
     }
 
     /** @scenario An assistant with an install command shows a terminal snippet */
@@ -204,11 +227,9 @@ describe("given the token-created-snippets feature is implemented", () => {
       const withCommand = CODE_ASSISTANTS.filter((a) => a.buildCommand).map(
         (a) => a.key,
       );
-      // If someone adds an installer, this fails until its exact command is
+      // If someone adds an installer, this fails until its exact commands are
       // pinned above — which is the whole point.
-      expect([...new Set(CASES.map((c) => c.key))].sort()).toEqual(
-        withCommand.sort(),
-      );
+      expect(Object.keys(EXPECTED).sort()).toEqual(withCommand.sort());
     });
 
     /** @scenario An assistant without an install command points at its config file */

--- a/specs/api-keys/token-created-snippets.feature
+++ b/specs/api-keys/token-created-snippets.feature
@@ -76,6 +76,38 @@ Feature: Token Created modal command snippets
     And the snippet displays a leading terminal prompt glyph ">_" on the left of the command (decorative — must not enter the copy buffer)
     And the executable name "codex" is visually distinct from its `--env` / `--` / `npx` flags and arguments
 
+  # A customer reported that only Claude Code and Codex appeared here, while the
+  # product documents the LangWatch MCP server for more assistants than that.
+  # The tabs are now driven by one list of assistants rather than hand-written
+  # pairs, so a supported assistant cannot be silently missing from the dialog.
+
+  @integration
+  Scenario: Every supported coding assistant has a tab
+    When the "Use with Code Assistants" section renders
+    Then there is one tab per coding assistant the product supports for the MCP server
+    And selecting a tab shows only that assistant's setup instructions
+
+  @integration
+  Scenario: An assistant with an install command shows a terminal snippet
+    When I select a tab for an assistant that installs the MCP server from the terminal
+    Then the "Run in your terminal" snippet renders inside the command-box style
+    And the snippet is that assistant's own command, carrying the freshly minted token
+
+  @integration
+  Scenario: An assistant without an install command points at its config file
+    When I select a tab for an assistant that has no terminal installer
+    Then no terminal command is offered for it
+    And the dialog names the config file that assistant reads
+    And the JSON config block below remains the thing to paste into it
+
+  @unit
+  Scenario: One list of coding assistants drives both the tabs and the config paths
+    # The dialog previously held two disagreeing lists: two tabs, and five
+    # editor config paths naming a different set of tools.
+    When this feature is implemented
+    Then the tab labels and the config-file paths are derived from a single list
+    And adding an assistant to that list is the only edit needed to surface it
+
   @integration
   Scenario: Terminal prompt glyph is not included in the copied value
     Given any terminal command snippet rendered with the ">_" prompt glyph


### PR DESCRIPTION
## For humans

Someone trying the product in dark mode reported that text was disappearing. On the onboarding screen where you choose what you want to do, clicking a card made that card's title vanish — the card turned white behind white text. They also noticed the "create an API key" dialog only offered setup instructions for two coding assistants, when our own docs cover more than that.

This fixes the dark-mode problem, and makes the key dialog cover every assistant we can set up **correctly** — with a real command where one exists, and the config file to edit where it doesn't.

Two parts of their report are **not** fixed here, on purpose. Both are tracked and explained at the bottom.

---

## Bug 1 — onboarding card title unreadable when selected

`IntentSelectionScreen.tsx` painted the selected card `bg="orange.50"`. That is a raw palette step: it renders the same near-white in light and dark. The title on top uses `color="fg"`, which *does* flip, to `gray.100` in dark. White on white.

The same untreated value sat on the icon chips of three onboarding screens — which is why the telescope icon in the customer's screenshot is a white square on a dark page.

Fixed by `sections/shared/accent-surface.ts`, one module naming both sides of every accent surface. `SelectableIconCard` already had the correct pair hardcoded (`orange.50` / `orange.950/30`) and now reads it from the same place, so there is one thing to change rather than four.

| File | Was | Now |
|---|---|---|
| `IntentSelectionScreen.tsx` | selected card + icon chip on raw `orange.50` | `selectedSurfaceBg` / `accentChipBg` |
| `ProductSelectionScreen.tsx` | icon chip + hover wash, light-only | mode-aware, plus a `.dark button:hover` branch |
| `ViaPlatformScreen.tsx` | icon chip on raw `orange.50` | `accentChipBg` |
| `SelectableIconCard.tsx` | correct, but its own copy of the pair | reads the shared pair |

The `ProductSelectionScreen` hover wash needed its own dark branch: it rides a `button:hover &` selector, and `_dark` cannot reach inside a nested `css` selector. Verified by reading the emitted CSS — all four rules land on one unlayered class, so `.dark button:hover` (0,2,1) beats `.dark` (0,2,0) and the hover value is correct in both modes.

## Bug 2 — the assistant list disagreed with itself

`TokenCreatedDialog.tsx` held **two disagreeing lists**: two hardcoded tabs (Claude Code, Codex) and, forty lines away, five config-path chips naming a different set of editors (Claude Code, Cursor, Copilot, Windsurf, Claude Desktop). That is how an assistant comes to be missing from one surface while present on the other.

Both now derive from one exported `CODE_ASSISTANTS` list. Each entry declares how that assistant is actually set up:

- **A published installer** → its terminal command. Claude Code and Codex, unchanged.
- **No installer** → the config file it reads. Cursor, Copilot, Windsurf and Claude Desktop are configured by editing a file; `docs/integration/mcp.mdx` says so for Cursor and Copilot explicitly.

I did not invent a `cursor mcp add` or an `opencode mcp add` for symmetry. Neither exists in our docs or the CLI, and a command that doesn't work is worse than an honest pointer to the config file. The `langwatch claude` / `cursor` / `gemini` wrappers in `commandCatalog.ts` are a different feature — running a tool *through the AI gateway*, not installing the MCP server — so they are not the right source for this list.

Command building moved into each assistant's own `buildCommand`, so the value shown and the value copied come from one function and cannot drift. **The Claude Code and Codex commands are byte-identical to `main`** — proven across all four combinations of {project id present, absent} × {self-hosted, cloud}, since the two deliberately differ in argument order and that asymmetry is easy to flatten by accident.

## Tests

`onboarding-surfaces.colorMode.integration.test.tsx` asserts the selected card and the icon chip each carry a `.dark`-scoped background rule, and that the unselected card reaches for a semantic `bg` variable rather than a palette step.

Worth knowing for the next person, because two different things bite here:

**The obvious version of this test cannot work.** jsdom does not resolve Chakra v3's emitted rules, so `getComputedStyle(card).backgroundColor` returns `rgba(0, 0, 0, 0)` in *both* modes — a test written that way fails before the fix and still fails after it. These read the injected stylesheet instead. The helper was checked against a pre-fix control element to confirm it returns `false` there, so the assertion isn't vacuous.

**Semantic tokens and conditional values are mode-aware by different mechanisms.** A conditional value (`{ base, _dark }`) emits a second, `.dark`-scoped rule for the element's class. A semantic token like `bg.panel` emits one rule pointing at a variable whose value flips at `:root` — no element-scoped `.dark` rule exists to find. Asserting the wrong one for the wrong surface fails on correct code.

The assistant tests drive the rendered dialog (select a tab, read what the user is shown); the registry's own shape is asserted in the unit test, where it costs no render. Note that a raw `element.click()` leaves the resulting `setState` outside `act()`, so `fireEvent.click` is required or the tab never repaints.

- `pnpm typecheck` + `pnpm typecheck:tests` — clean
- CI's actual lint gate (`biome-new-violations.sh` against the merge base) — `no new Biome violations`, 3765 both sides
- `pnpm check:feature-parity` — `OK: 4549 enforced scenario(s) bound`
- Integration 66/66, unit 86/86 across the two affected areas (each installer's command pinned as a full string across a 2x2 of project-id x self-hosted)

---

## Deliberately not in this PR

### Gemini — the command was wrong, so the tab is out (#6654)

A Gemini tab was written and then removed. Its builder emitted:

```
gemini mcp add langwatch --env LANGWATCH_API_KEY=<token> -- npx -y @langwatch/mcp-server
```

Gemini's CLI does not parse that — options must precede the server name, and its `--` separates Gemini's flags from arguments passed *to the MCP server process* rather than introducing the command. It had been modelled on the Codex builder, where `--` genuinely is the separator.

That string sits behind the "you won't be able to see it again" warning with a copy button, so a user who copies a broken command has spent their one look at the token on a line that fails. Shipping no Gemini tab is better than shipping that one. #6654 covers the corrected command, the same `--` mistake in `ViaClaudeDesktopScreen.tsx:44`, and a test that pins each builder's actual emitted string.

Codex also lost its config-path chip in the same pass: the chip row renders every entry with a `configPath`, and Codex reads TOML while the block above renders JSON. `main` deliberately omitted it. Same issue.

### The third customer report — could not reproduce

They also said *"in the create key the titles are also invisible above the code snippets."* **I could not reproduce this and have deliberately not guess-fixed it.**

- `"Use in Code"` and `"Use with Code Assistants"` carry no `color` prop, so they inherit the body colour — `gray.50` on a near-black dialog.
- `"Run in your terminal"` and `"Or paste into your config file"` are `fg.muted` = `gray.300` (`#cbd5e1`), roughly 13:1 against the dialog background.
- The dialog portals to `document.body` with no forced theme class, so tokens resolve normally.
- The customer's own screenshot shows all four rendering legibly.

I could not boot the app for a browser check — there is no `.env` on this machine, in this worktree or the main checkout — so this is reasoned from the theme tokens, not from a screenshot. **Which label did they mean?** If it is the two `fg.muted` sub-labels, promoting them to `fg` is a one-word change.

### The defect class

#6652 covers the pattern rather than these instances: no `dev/docs/best_practices/color-mode.md`, no lint rule against raw palette steps used as backgrounds, and the resulting repeat reports. #6156 is the other confirmed instance and is now linked to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added setup guidance for Claude Code, Codex, Cursor, Copilot, Windsurf, and Claude Desktop.
  * Added terminal installation commands and configuration-file instructions based on each assistant’s setup method.

* **Bug Fixes**
  * Improved onboarding selection cards, icons, and product options with consistent light- and dark-mode colors.
  * Added clearer dark-mode hover styling for product options.

* **Tests**
  * Added coverage for assistant setup guidance and onboarding color behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

