### PR TITLE
fix(ops): publish the pending-drift metric so every collector reports the same figure (#4703)

### DIFF
--- a/platform/app/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -4,7 +4,10 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "../../../../event-sourcing/__tests__/integration/testContainers";
-import { QueueRedisRepository } from "../../repositories/queue.redis.repository";
+import {
+  QueueRedisRepository,
+  RECONCILE_WRITE_LUA,
+} from "../../repositories/queue.redis.repository";
 
 let redis: Redis;
 beforeAll(async () => {
@@ -424,6 +427,186 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         expect(result).toBeNull();
         expect(await redis.get(markerKey)).toBe("other-instance-token");
         expect(await redis.pttl(markerKey)).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  /**
+   * Seed a queue so a reconcile measures exactly `drift`, then run one.
+   *
+   * `counter - groundTruth` is the drift, so the counter is seeded at
+   * `jobs + drift` against `jobs` real jobs.
+   */
+  const reconcileWithDrift = async (params: {
+    queue: string;
+    jobs: number;
+    drift: number;
+    by?: QueueRedisRepository;
+  }) => {
+    const { queue, jobs, drift, by } = params;
+    const prefix = `${queue}:gq:`;
+    // The counter is read as `Math.max(0, ...)`, so a seeded counter below zero
+    // silently becomes zero and the measured drift is not the requested one.
+    const counter = jobs + drift;
+    if (counter < 0) {
+      throw new Error(
+        `fixture asks for counter ${counter}; raise jobs above ${-drift}`,
+      );
+    }
+    // The test containers are reused between runs and the queue names come from
+    // a per-process counter, so the same names recur. Clear everything this
+    // fixture asserts on, or a previous run's published drift is still readable
+    // and the assertions pass without this run having written anything.
+    await redis.del(
+      `${prefix}stats:pending-recon-ts`,
+      `${prefix}stats:pending-drift`,
+      `${prefix}stats:total-pending`,
+      `${prefix}group:g:jobs`,
+      `${prefix}ready`,
+      `${prefix}pending-groups`,
+    );
+    for (let i = 0; i < jobs; i++) {
+      await redis.zadd(`${prefix}group:g:jobs`, 1000 + i, `job-${i}`);
+    }
+    if (jobs > 0) await redis.zadd(`${prefix}ready`, 1, "g");
+    await redis.set(`${prefix}stats:total-pending`, String(counter));
+    return await (by ?? repo).reconcileTotalPending(queue);
+  };
+
+  describe("given one instance reconciled a queue and measured a drift", () => {
+    describe("when a second instance that won no marker reports drift", () => {
+      /** @scenario An instance that measured nothing reports the drift another instance measured */
+      it("reports the same drift as the instance that measured it", async () => {
+        const measured = await reconcileWithDrift({
+          queue: queueName,
+          jobs: 5,
+          drift: 95,
+        });
+        expect(measured!.drift).toBe(95);
+
+        // A second repository standing in for a second process. It wins no
+        // marker (the first pass holds it for the rest of the window), so it
+        // measures nothing of its own.
+        const otherInstance = new QueueRedisRepository(redis);
+        expect(await otherInstance.reconcileTotalPending(queueName)).toBeNull();
+
+        expect(await otherInstance.readPublishedPendingDrift([queueName])).toBe(
+          95,
+        );
+      });
+    });
+  });
+
+  // Runs the real script against real Redis. The reconcile unit suite drives a
+  // fake that models these semantics, so reordering the script cannot fail it:
+  // the fake would keep modelling the old order. This is the binding to the
+  // script itself.
+  describe("given the marker is held by somebody else", () => {
+    describe("when the fenced write script runs", () => {
+      /** @scenario A pass that loses the marker publishes neither the count nor the drift */
+      it("writes neither the counter nor the drift", async () => {
+        const prefix = `${queueName}:gq:`;
+        const counterKey = `${prefix}stats:total-pending`;
+        const driftKey = `${prefix}stats:pending-drift`;
+        await redis.del(counterKey, driftKey);
+        await redis.set(markerKey, "another-instances-token");
+
+        const wrote = await redis.eval(
+          RECONCILE_WRITE_LUA,
+          3,
+          markerKey,
+          counterKey,
+          driftKey,
+          "our-token",
+          "17",
+          "35",
+          "180000",
+        );
+
+        expect(Number(wrote)).toBe(0);
+        expect(await redis.get(counterKey)).toBeNull();
+        expect(await redis.get(driftKey)).toBeNull();
+      });
+
+      it("writes both once the marker is ours", async () => {
+        const prefix = `${queueName}:gq:`;
+        const counterKey = `${prefix}stats:total-pending`;
+        const driftKey = `${prefix}stats:pending-drift`;
+        await redis.del(counterKey, driftKey);
+        await redis.set(markerKey, "our-token");
+
+        const wrote = await redis.eval(
+          RECONCILE_WRITE_LUA,
+          3,
+          markerKey,
+          counterKey,
+          driftKey,
+          "our-token",
+          "17",
+          "35",
+          "180000",
+        );
+
+        expect(Number(wrote)).toBe(1);
+        expect(await redis.get(counterKey)).toBe("17");
+        expect(await redis.get(driftKey)).toBe("35");
+        expect(await redis.pttl(driftKey)).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("given one queue has published a drift and another never reconciled", () => {
+    describe("when drift is reported", () => {
+      /** @scenario A queue with no published drift does not suppress the queues that have one */
+      it("still reports the drift of the queue that published one", async () => {
+        const neverReconciled = `${queueName}-silent`;
+        await redis.del(`${neverReconciled}:gq:stats:pending-drift`);
+        await reconcileWithDrift({ queue: queueName, jobs: 2, drift: 7 });
+
+        expect(
+          await repo.readPublishedPendingDrift([neverReconciled, queueName]),
+        ).toBe(7);
+      });
+
+      it("survives a figure that is not a number at all", async () => {
+        // The script only ever writes an integer, so this is reachable through
+        // a hand-edited key rather than through the code. Worth a case anyway:
+        // a total that gives up on one bad value reports the fleet as clean.
+        const poked = `${queueName}-poked`;
+        await redis.set(`${poked}:gq:stats:pending-drift`, "not-a-number");
+        await reconcileWithDrift({ queue: queueName, jobs: 2, drift: 7 });
+
+        expect(await repo.readPublishedPendingDrift([poked, queueName])).toBe(
+          7,
+        );
+      });
+    });
+  });
+
+  describe("given two queues whose drifts were measured by different instances", () => {
+    describe("when either instance reports drift", () => {
+      /** @scenario Drift is summed across queues whichever instance measured each one */
+      it("reports the total across both queues", async () => {
+        const second = `${queueName}-b`;
+        // Opposing directions, measured by two different repository instances
+        // standing in for two processes. A sum that let them cancel would
+        // report 20; the tile is meant to show total magnitude.
+        const a = await reconcileWithDrift({
+          queue: queueName,
+          jobs: 4,
+          drift: 30,
+        });
+        const b = await reconcileWithDrift({
+          queue: second,
+          jobs: 14,
+          drift: -10,
+          by: new QueueRedisRepository(redis),
+        });
+        expect([a!.drift, b!.drift]).toEqual([30, -10]);
+
+        expect(await repo.readPublishedPendingDrift([queueName, second])).toBe(
+          40,
+        );
       });
     });
   });

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -580,6 +580,20 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
           7,
         );
       });
+
+      it("survives a figure that is only partly a number", async () => {
+        // The dangerous shape is not the one that fails to parse, it is the one
+        // that half parses: a lenient read takes "7oops" as 7 and adds it, so a
+        // value nobody measured is indistinguishable in the total from one
+        // somebody did. Skipping it keeps "unusable" meaning the same thing.
+        const partial = `${queueName}-partial`;
+        await redis.set(`${partial}:gq:stats:pending-drift`, "7oops");
+        await reconcileWithDrift({ queue: queueName, jobs: 2, drift: 7 });
+
+        expect(await repo.readPublishedPendingDrift([partial, queueName])).toBe(
+          7,
+        );
+      });
     });
   });
 

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -72,6 +72,7 @@ function createMockRepo(
       .fn()
       .mockResolvedValue({ groupsDrained: 0, jobsDrained: 0 }),
     reconcileTotalPending: vi.fn().mockResolvedValue(null),
+    readPublishedPendingDrift: vi.fn().mockResolvedValue(0),
     ...overrides,
   };
 }

--- a/platform/app/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
@@ -61,20 +61,39 @@ function createMockRepo(
       .fn()
       .mockResolvedValue({ groupsDrained: 0, jobsDrained: 0 }),
     reconcileTotalPending: vi.fn().mockResolvedValue(null),
+    readPublishedPendingDrift: vi.fn().mockResolvedValue(0),
     ...overrides,
   };
 }
 
+/**
+ * Drive the private reconcile through the public discovery path, then read the
+ * dashboard the way the UI does.
+ */
+const runReconcile = async (queueRepo: QueueRepository) => {
+  const collector = new OpsMetricsCollector({
+    redis: createMockRedis(),
+    queueRepo,
+  });
+  await collector.discoverQueues();
+  // Access via bracket notation to avoid exposing a test-only public API.
+  await (
+    collector as unknown as { reconcilePending(): Promise<void> }
+  ).reconcilePending();
+  return collector.getDashboardData().pendingDrift;
+};
+
 describe("OpsMetricsCollector", () => {
   describe("reconcilePending()", () => {
-    describe("given two queues with opposing drifts", () => {
+    describe("given this instance measured the drift itself", () => {
       describe("when reconcilePending runs", () => {
         /**
-         * Opposing per-queue drifts (+30 and -10) must not cancel each other.
-         * The health signal accumulates absolute values so the dashboard tile
-         * always shows total magnitude of drift regardless of direction.
+         * The published figure and the locally measured one are deliberately
+         * different here. Reporting the local sum (40) would pass on a test
+         * that used matching numbers, so they are kept apart to make the two
+         * outcomes distinguishable.
          */
-        it("accumulates absolute drift values so opposing drifts do not cancel", async () => {
+        it("reports the published drift rather than its own measurement", async () => {
           const queueRepo = createMockRepo({
             discoverQueueNames: vi
               .fn()
@@ -91,23 +110,45 @@ describe("OpsMetricsCollector", () => {
                 groundTruth: 50,
                 drift: -10,
               }),
+            readPublishedPendingDrift: vi.fn().mockResolvedValue(97),
           });
 
-          const collector = new OpsMetricsCollector({
-            redis: createMockRedis(),
-            queueRepo,
+          expect(await runReconcile(queueRepo)).toBe(97);
+        });
+      });
+    });
+
+    // The reconcile is single-flighted, so on any cycle most instances win no
+    // marker and measure nothing. Reporting what they measured would report 0
+    // drift for a queue that has plenty.
+    describe("given this instance won no single-flight marker", () => {
+      describe("when reconcilePending runs", () => {
+        it("still reports the drift another instance published", async () => {
+          const queueRepo = createMockRepo({
+            discoverQueueNames: vi
+              .fn()
+              .mockResolvedValue(["queue-alpha", "queue-beta"]),
+            reconcileTotalPending: vi.fn().mockResolvedValue(null),
+            readPublishedPendingDrift: vi.fn().mockResolvedValue(42),
           });
 
-          // Populate groupQueueNames via the public discovery path
-          await collector.discoverQueues();
+          expect(await runReconcile(queueRepo)).toBe(42);
+        });
+      });
+    });
 
-          // Call the private method through the public reconcile path.
-          // Access via bracket notation to avoid exposing a test-only public API.
-          await (
-            collector as unknown as { reconcilePending(): Promise<void> }
-          ).reconcilePending();
+    describe("given every queue reports no drift", () => {
+      describe("when reconcilePending runs", () => {
+        it("reports zero", async () => {
+          const queueRepo = createMockRepo({
+            discoverQueueNames: vi.fn().mockResolvedValue(["queue-alpha"]),
+            reconcileTotalPending: vi
+              .fn()
+              .mockResolvedValue({ counter: 5, groundTruth: 5, drift: 0 }),
+            readPublishedPendingDrift: vi.fn().mockResolvedValue(0),
+          });
 
-          expect(collector.getDashboardData().pendingDrift).toBe(40);
+          expect(await runReconcile(queueRepo)).toBe(0);
         });
       });
     });

--- a/platform/app/src/server/app-layer/ops/metrics-collector.ts
+++ b/platform/app/src/server/app-layer/ops/metrics-collector.ts
@@ -293,6 +293,10 @@ export class OpsMetricsCollector {
   >();
   private currentJobNameMetrics: JobNameMetrics[] = [];
   private currentPausedKeys: string[] = [];
+  /**
+   * Last drift figure read back from the shared publication, not the one this
+   * instance measured. See {@link reconcilePending}.
+   */
   private latestPendingDrift = 0;
   private knownPipelinePaths: string[] = [];
   private isCollecting = false;
@@ -426,15 +430,29 @@ export class OpsMetricsCollector {
 
   private async reconcilePending(): Promise<void> {
     try {
-      let totalDrift = 0;
+      let measuredDrift = 0;
+      let measuredAny = false;
       for (const queueName of this.groupQueueNames) {
         const result = await this.queueRepo.reconcileTotalPending(queueName);
-        if (result) totalDrift += Math.abs(result.drift);
+        if (result) {
+          measuredDrift += Math.abs(result.drift);
+          measuredAny = true;
+        }
       }
-      this.latestPendingDrift = totalDrift;
-      if (totalDrift !== 0) {
+
+      // Read back what every instance published rather than keeping what this
+      // one measured. The reconcile is single-flighted, so an instance that won
+      // no marker measured nothing and would otherwise report 0 drift for a
+      // queue that has plenty, and an instance that won some of the queues would
+      // report a partial total. Reading the shared figures is what makes every
+      // instance agree, and agree on the whole.
+      this.latestPendingDrift = await this.queueRepo.readPublishedPendingDrift(
+        this.groupQueueNames,
+      );
+
+      if (measuredAny && measuredDrift !== 0) {
         logger.info(
-          { pendingDrift: totalDrift },
+          { pendingDrift: measuredDrift },
           "Reconciled GroupQueue pending counter to ground truth",
         );
       }

--- a/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/__tests__/queue.redis.repository.reconcile-pending.unit.test.ts
@@ -6,6 +6,7 @@ const QUEUE_NAME = "test-queue";
 const PREFIX = `${QUEUE_NAME}:gq:`;
 const COUNTER_KEY = `${PREFIX}stats:total-pending`;
 const MARKER_KEY = `${PREFIX}stats:pending-recon-ts`;
+const DRIFT_KEY = `${PREFIX}stats:pending-drift`;
 const SINGLE_FLIGHT_WINDOW_MS = 55_000;
 const LEASE_MS = 30_000;
 
@@ -193,20 +194,30 @@ class FakeRedis {
   // biome-ignore lint/complexity/useMaxParams: mirrors ioredis's positional evalsha signature
   async evalsha(
     _sha: string,
-    _numKeys: number,
+    numKeys: number,
     key: string,
     ...rest: (string | number)[]
   ): Promise<number> {
     if (key.endsWith("pending-groups")) {
       return this.applyPrune(key, rest as string[]);
     }
-    if (rest.length === 3) {
+    // Three keys is the fenced write (marker, counter, drift); the marker re-arm
+    // takes one. Keyed on the script's own arity rather than on the argument
+    // count, so adding an argument to either does not silently reroute it here.
+    if (numKeys === 3) {
       // Fires in the one window the fence exists for: after the last lease
       // re-arm succeeded, before the write lands.
       this.onBeforeFencedWrite?.();
-      const [counterKey, token, value] = rest as [string, string, string];
+      const [counterKey, driftKey, token, value, drift] = rest as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
       if (this.strings.get(key) !== token) return 0;
       this.strings.set(counterKey, String(value));
+      this.strings.set(driftKey, String(drift));
       return 1;
     }
     const [token, ttlMs] = rest as [string, number];
@@ -547,6 +558,19 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         expect(result).toBeNull();
         expect(redis.strings.get(COUNTER_KEY)).toBe("42");
+      });
+
+      /**
+       * @scenario "A pass that loses the marker publishes neither the count nor the drift"
+       *
+       * The drift describes the count published beside it, so it has to be
+       * behind the same ownership check. Written before it, this pass would
+       * announce a drift of 35 for a heal it never landed.
+       */
+      it("publishes no drift either, having published no count", async () => {
+        await repo.reconcileTotalPending(QUEUE_NAME);
+
+        expect(redis.strings.get(DRIFT_KEY)).toBeUndefined();
       });
     });
   });

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1839,8 +1839,14 @@ export class QueueRedisRepository implements QueueRepository {
       // Surfacing that difference needs a signal beside the total, which the
       // dashboard does not have a place for yet.
       if (value === null) continue;
-      const drift = parseInt(value, 10);
-      if (Number.isNaN(drift)) continue;
+      // Whole value or nothing. A lenient parse stops at the first character it
+      // cannot use, so "7oops" reads as 7 and "1.5" as 1, and the result lands
+      // in the total looking exactly like a real measurement. A value that is
+      // only partly a number is not a measurement, so it is skipped like any
+      // other unusable one rather than half-believed.
+      if (!/^-?\d+$/.test(value)) continue;
+      const drift = Number(value);
+      if (!Number.isSafeInteger(drift)) continue;
       total += Math.abs(drift);
     }
     return total;

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -17,6 +17,7 @@ import {
   GROUP_QUEUE_REGISTRY_KEY,
   PARK_HELPER_LUA,
   PENDING_INDEX_HELPER_LUA,
+  pendingDriftKey,
   pendingGroupsKey,
   TTL_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
@@ -280,14 +281,23 @@ return redis.call("PEXPIRE", markerKey, ttlMs)
 // a fresher value; a late write from the old pass would put a stale count back.
 // The check and the write have to be one step, so a marker lost between them
 // cannot leave the stale write to land anyway.
-const RECONCILE_WRITE_LUA = `
+/**
+ * Exported so the fence can be tested against the real script and a real Redis.
+ * The reconcile unit suite runs against a fake that models these semantics, and
+ * a model cannot fail when the thing it models changes.
+ */
+export const RECONCILE_WRITE_LUA = `
 local markerKey  = KEYS[1]
 local counterKey = KEYS[2]
+local driftKey   = KEYS[3]
 local holderToken = ARGV[1]
 local groundTruth = ARGV[2]
+local drift       = ARGV[3]
+local driftTtlMs  = ARGV[4]
 
 if redis.call("GET", markerKey) ~= holderToken then return 0 end
 redis.call("SET", counterKey, groundTruth)
+redis.call("SET", driftKey, drift, "PX", driftTtlMs)
 return 1
 `;
 
@@ -349,6 +359,18 @@ const PENDING_RECONCILE_ZCARD_BATCH = 1000;
  * another instance may take over.
  */
 const PENDING_RECONCILE_LEASE_MS = 30_000;
+
+/**
+ * How long a published drift figure stays readable.
+ *
+ * Three reconcile cycles (the collector runs one per minute). The value has to
+ * outlive the gap between passes or every instance would read null for most of
+ * the minute, and it has to expire or a queue whose reconcile has stopped
+ * entirely would pin its last drift on the dashboard forever. Expiring is the
+ * safer end of that trade: a missing figure reads as "unknown" and drops out of
+ * the aggregate, where a stale one reads as a live measurement.
+ */
+const PENDING_DRIFT_TTL_MS = 180_000;
 
 /**
  * How long the keyspace sweep waits once it has nothing left to adopt.
@@ -1763,13 +1785,20 @@ export class QueueRedisRepository implements QueueRepository {
       // Fenced write: a pass that lost the marker must not put its count back
       // over a newer pass's. `0` means the marker moved on, so this pass reports
       // nothing rather than a result it did not manage to publish.
+      //
+      // The drift goes out under the same fence as the counter it describes.
+      // Publishing it separately would let a pass write the counter, lose the
+      // marker, and still announce a drift for a count it did not land.
       const wrote = await reconcileWriteScript.run(
         this.redis,
-        2,
+        3,
         markerKey,
         counterKey,
+        pendingDriftKey(prefix),
         holderToken,
         String(groundTruth),
+        String(drift),
+        String(PENDING_DRIFT_TTL_MS),
       );
       if (Number(wrote) !== 1) {
         logger.warn(
@@ -1793,6 +1822,28 @@ export class QueueRedisRepository implements QueueRepository {
         ttlMs: singleFlightWindowMs - (Date.now() - startedAtMs),
       });
     }
+  }
+
+  async readPublishedPendingDrift(queueNames: string[]): Promise<number> {
+    if (queueNames.length === 0) return 0;
+
+    const raw = await this.redis.mget(
+      ...queueNames.map((queueName) => pendingDriftKey(`${queueName}:gq:`)),
+    );
+
+    let total = 0;
+    for (const value of raw) {
+      // A key that is absent or unparseable is a queue with no live figure. It
+      // contributes nothing either way, so this is hygiene rather than a
+      // behaviour: no sum can tell "no drift" apart from "no measurement".
+      // Surfacing that difference needs a signal beside the total, which the
+      // dashboard does not have a place for yet.
+      if (value === null) continue;
+      const drift = parseInt(value, 10);
+      if (Number.isNaN(drift)) continue;
+      total += Math.abs(drift);
+    }
+    return total;
   }
 
   /**

--- a/platform/app/src/server/app-layer/ops/repositories/queue.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.repository.ts
@@ -139,6 +139,17 @@ export interface QueueRepository {
   }): Promise<DrainPreview>;
 
   reconcileTotalPending(queueName: string): Promise<ReconcileResult | null>;
+
+  /**
+   * The drift the most recent reconcile pass published for each named queue,
+   * summed as absolute values.
+   *
+   * Every instance reads this, including the ones that won no marker and so
+   * computed nothing themselves. `null` for a queue with no live figure (never
+   * reconciled, or the last one has aged out) is skipped rather than counted as
+   * zero, so a queue that has stopped reconciling does not read as healthy.
+   */
+  readPublishedPendingDrift(queueNames: string[]): Promise<number>;
 }
 
 export class NullQueueRepository implements QueueRepository {
@@ -240,5 +251,9 @@ export class NullQueueRepository implements QueueRepository {
 
   async reconcileTotalPending(): Promise<ReconcileResult | null> {
     return null;
+  }
+
+  async readPublishedPendingDrift(): Promise<number> {
+    return 0;
   }
 }

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -2454,3 +2454,15 @@ export class GroupStagingScripts {
 export function pendingGroupsKey(keyPrefix: string): string {
   return `${keyPrefix}pending-groups`;
 }
+
+/**
+ * Key holding the drift the last reconcile pass measured for this queue, from
+ * its key prefix (`<name>:gq:`).
+ *
+ * Shared rather than per-process because the reconcile is single-flighted: only
+ * the instance that wins the marker computes a drift, so any other instance
+ * reporting its own local figure reports zero for a queue it never recomputed.
+ */
+export function pendingDriftKey(keyPrefix: string): string {
+  return `${keyPrefix}stats:pending-drift`;
+}

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -161,3 +161,38 @@ Feature: GroupQueue pending counter ground-truth reconcile
     Given a group listed in a lifecycle index whose jobs have all gone
     When reconciles keep running
     Then the sweep still backs off to its interval
+
+  # The reconcile is single-flighted, so on any given cycle only one instance
+  # measures a drift. An instance reporting the drift it computed itself
+  # therefore reports zero for every queue it did not win, and no instance ever
+  # reports the true total. The measurement is shared, so the signal has to be.
+  @integration
+  Scenario: An instance that measured nothing reports the drift another instance measured
+    Given one instance has reconciled a queue and measured a drift
+    When a second instance that won no marker reports its drift
+    Then it reports the same drift as the instance that measured it
+
+  @integration
+  Scenario: Drift is summed across queues whichever instance measured each one
+    Given two queues whose drifts were measured by different instances
+    When either instance reports its drift
+    Then it reports the total across both queues
+
+  # A queue that has never reconciled has no figure to read. It cannot
+  # contribute to the total, but it must not take the rest of the total with it
+  # either: one silent queue would otherwise report the whole fleet as clean.
+  @integration
+  Scenario: A queue with no published drift does not suppress the queues that have one
+    Given one queue with a published drift and another that has never reconciled
+    When drift is reported
+    Then the total is the drift of the queue that published one
+
+  # A published drift describes the count that was published with it. Letting
+  # the two land separately would allow a pass to write the counter, lose the
+  # marker, and still announce a drift for a count it never landed.
+  @unit
+  Scenario: A pass that loses the marker publishes neither the count nor the drift
+    Given a reconcile pass that is overtaken before its write
+    When it goes to publish
+    Then neither the counter nor the drift is written
+


### PR DESCRIPTION
## Ticket

Closes #4703. Two P2 follow-ups from the GroupQueue pending-counter reconcile review. **Only P2-2 needed doing** — P2-1 is already fixed on main; evidence is on the issue.

## Change

The reconcile is single-flighted through a shared Redis marker, so on any cycle only the instance that wins a queue recomputes it. The drift it measured was kept in process memory and surfaced through that instance's own dashboard. With more than one collector the signal disagreed with itself: an instance that won no marker reported 0 drift for a queue with plenty, and one that won some of the queues reported a partial total. The counter in Redis was always correct; only the number an operator reads was wrong.

- The reconcile publishes its drift to `<queue>:gq:stats:pending-drift`, written by the same Lua script that writes the counter, behind the same ownership check. Writing it separately would let a pass write the counter, lose the marker, and still announce a drift for a heal it never landed.
- Every collector reads the published figures for all known queues instead of reporting what it measured itself.
- The figure expires after three reconcile cycles. It has to outlive the gap between passes, or every instance reads nothing for most of the minute; and it has to expire, or a queue whose reconcile has stopped pins its last drift on the dashboard forever.

Production Redis was not touched. Code and tests only, per the ticket's constraint.

## P2-1 was already fixed

The ticket describes `reconcileTotalPending` accumulating `SCAN` results into a plain array, so a key returned twice is counted twice. On current main it collects into a `Set<string>`, and the keyspace walk is a backstop behind the `pending-groups` index rather than the primary enumeration:

```ts
private async collectPendingGroupIds(params: {
  prefix: string;
  refreshLease: () => Promise<boolean>;
}): Promise<Set<string> | null> {
```

Nothing to do there.

## Evidence

| Acceptance criterion | Where |
| --- | --- |
| Two collectors reading the same key report the same drift | `given one instance reconciled a queue and measured a drift` (integration, real Redis, two repository instances) |
| An instance that won no marker still reports the shared value | `given this instance won no single-flight marker` (unit) and the integration case above |
| Drift is the total across queues, whoever measured each | `given two queues whose drifts were measured by different instances` |
| Freshness: a stale value is not shown indefinitely | TTL of three cycles, pinned by the `M6` mutation below |
| Spec parity | 23/23 scenarios bound, `check-feature-parity.ts` exit 0 |

`specs/ops/pending-counter-reconcile.feature` gains five scenarios, each `@unit`/`@integration` tagged and bound by a `@scenario` annotation.

Suites: 19 integration, 51 unit across the three touched files. `pnpm typecheck:all` clean.

### Mutation results

Every guard was mutated and every mutation fails the suite:

| mutation | caught by |
| --- | --- |
| collector reports its own measurement again | unit, 2 failed |
| drift published outside the fence | integration, 1 failed |
| drift never published | integration, 3 failed |
| drift summed without `Math.abs` (opposing drifts cancel) | integration, 1 failed |
| TTL shortened so the figure is gone by the read | integration, 1 failed |
| one missing figure abandons the whole total | integration, 1 failed |
| one unparseable figure abandons the whole total | integration, 1 failed |

Two of those took a second pass and are worth stating, because the first pass was wrong both times:

**The fence test was bound to a model, not the code.** The reconcile unit suite drives a hand-written fake Redis whose `evalsha` reimplements the script's semantics. Reordering the real Lua so the drift is written before the ownership check left that suite green, because the fake kept modelling the old order. `RECONCILE_WRITE_LUA` is now exported and exercised directly against a real Redis, which is what makes that mutation fail.

**The integration fixtures were reading a previous run's state.** Test containers are reused between runs and the queue names come from a per-process counter, so the same names recur. A drift key published by an earlier run was still live under its TTL, and `drift never published` passed against it. The fixture now clears every key it asserts on.

I also removed, then restored, the "missing figure" case. My first mutation for it (`total += 0` instead of `continue`) is a no-op, so I wrongly concluded the behaviour was unobservable and deleted the test. It is not: a missing figure abandoning the whole total is very observable, and that is what the case now pins.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared pending-counter drift reporting across queues and reconciliation instances.
  - Reconciliation now publishes corrected counters and drift measurements atomically.
  - Drift values expire automatically and aggregate safely across queues.

- **Bug Fixes**
  - Prevented stale or invalid drift values from affecting reported metrics.
  - Ensured incomplete reconciliation writes publish neither counters nor drift data.

- **Tests**
  - Expanded coverage for multi-queue aggregation, cross-instance reporting, invalid values, and atomic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->