### PR TITLE
fix(ci): scope the secrets gate to the pull request's own commits

### DIFF
--- a/.github/scripts/__tests__/secrets-scan.test.sh
+++ b/.github/scripts/__tests__/secrets-scan.test.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# Tests for secrets-scan.sh — the scoping of the blocking secrets gate.
+#
+# Every case builds a THROWAWAY repository pair and runs the real scanners
+# against it. The fixture reproduces the ref layout `actions/checkout` actually
+# leaves behind on a pull request with `fetch-depth: 0`, because that layout is
+# the whole bug: every branch of the repository is present as a
+# remote-tracking ref, and HEAD is detached with refs/heads/* empty. Asserting
+# on the command string instead would pass just as happily with `--branch`
+# spelled wrong.
+#
+# Requires `git`, `gitleaks` and `trufflehog` on PATH. It does NOT skip when
+# they are missing: a secrets test that quietly reports success because the
+# scanner was absent is the same false green the gate exists to prevent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN="$SCRIPT_DIR/../secrets-scan.sh"
+
+PASS=0
+FAIL=0
+
+# A syntactically valid AWS key pair. It is not a live credential — no such
+# account exists — which is exactly why the scans below run in offline mode.
+readonly PLANTED_SECRET='AWS_ACCESS_KEY_ID=AKIAQYLPMN5HHHFPZAM2
+AWS_SECRET_ACCESS_KEY=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'
+
+WORKSPACE="$(mktemp -d)"
+trap 'rm -rf "$WORKSPACE"' EXIT
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "FATAL: $1 is not on PATH. These tests run the real scanners." >&2
+    exit 2
+  fi
+}
+
+commit_at() {
+  local repo="$1" date="$2" message="$3"
+  git -C "$repo" add -A
+  GIT_AUTHOR_DATE="$date" GIT_COMMITTER_DATE="$date" \
+    git -C "$repo" commit -qm "$message"
+}
+
+# Builds an origin repository plus the working checkout CI would produce for a
+# pull request against `main`. `$1` names the fixture (and its directory);
+# `$2` says where the planted secret goes. Echoes the working checkout's path.
+build_checkout() {
+  local name="$1" secret_at="$2"
+  local root="$WORKSPACE/$name"
+  local origin="$root/origin" work="$root/work"
+  mkdir -p "$root"
+
+  git init -q -b main "$origin"
+  git -C "$origin" config user.email ci@example.test
+  git -C "$origin" config user.name "CI Fixture"
+  echo "hello" >"$origin/README.md"
+  [ "$secret_at" = "base" ] && printf '%s\n' "$PLANTED_SECRET" >"$origin/base-leak.env"
+  commit_at "$origin" "2026-08-01T00:00:00Z" "base"
+
+  # An unrelated branch, pushed after the merge base. Its commit is NEWER than
+  # the base, which is what puts it ahead of the base in `git log --all`'s
+  # date order and therefore inside an unscoped walk.
+  git -C "$origin" checkout -q -b unrelated
+  printf '%s\n' "$PLANTED_SECRET" >"$origin/unrelated-leak.env"
+  if [ "$secret_at" = "other-branch" ]; then
+    commit_at "$origin" "2026-08-05T00:00:00Z" "unrelated branch adds a secret"
+  else
+    rm -f "$origin/unrelated-leak.env"
+    echo "unrelated work" >"$origin/unrelated.md"
+    commit_at "$origin" "2026-08-05T00:00:00Z" "unrelated branch"
+  fi
+
+  git -C "$origin" checkout -q main
+  git -C "$origin" checkout -q -b pr
+  echo "a harmless line" >>"$origin/README.md"
+  case "$secret_at" in
+    pr | pr-then-deleted)
+      printf '%s\n' "$PLANTED_SECRET" >"$origin/pr-leak.env"
+      ;;
+  esac
+  commit_at "$origin" "2026-08-06T00:00:00Z" "pull request commit"
+  if [ "$secret_at" = "pr-then-deleted" ]; then
+    rm -f "$origin/pr-leak.env"
+    commit_at "$origin" "2026-08-06T01:00:00Z" "remove the file again"
+  fi
+  local head_sha
+  head_sha="$(git -C "$origin" rev-parse HEAD)"
+  git -C "$origin" checkout -q main
+
+  # actions/checkout@v6, fetch-depth: 0, pull_request event — the refspec and
+  # the detached checkout are copied from a real run's log.
+  git init -q "$work"
+  git -C "$work" config user.email ci@example.test
+  git -C "$work" config user.name "CI Fixture"
+  git -C "$work" remote add origin "$origin"
+  git -C "$work" fetch -q --no-tags --prune --no-recurse-submodules origin \
+    "+refs/heads/*:refs/remotes/origin/*" \
+    "+${head_sha}:refs/remotes/pull/1/merge"
+  git -C "$work" checkout -q --force refs/remotes/pull/1/merge
+
+  echo "$work"
+}
+
+# Runs the gate the way the workflow does. Echoes nothing; returns the exit
+# code and leaves the combined output in $LAST_OUTPUT.
+LAST_OUTPUT=""
+run_scan() {
+  local scanner="$1" work="$2"
+  local rc=0
+  set +e
+  LAST_OUTPUT="$(
+    EVENT_NAME=pull_request \
+      BASE_REF=main \
+      SECRETS_SCAN_TRUFFLEHOG_MODE=offline \
+      bash "$SCAN" "$scanner" "$work" 2>&1
+  )"
+  rc=$?
+  set -e
+  return $rc
+}
+
+record() {
+  local ok="$1" description="$2"
+  if [ "$ok" = "yes" ]; then
+    echo "PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $description"
+    echo "----- scan output -----"
+    echo "$LAST_OUTPUT"
+    echo "-----------------------"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_scan_passes() {
+  local scanner="$1" work="$2" description="$3"
+  if run_scan "$scanner" "$work"; then
+    record yes "$description"
+  else
+    record no "$description (exit $?)"
+  fi
+}
+
+assert_scan_fails() {
+  local scanner="$1" work="$2" description="$3"
+  if run_scan "$scanner" "$work"; then
+    record no "$description — the scan passed and should not have"
+  else
+    record yes "$description"
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1" description="$2"
+  if printf '%s' "$LAST_OUTPUT" | grep -qF "$needle"; then
+    record yes "$description"
+  else
+    record no "$description — no '$needle' in the output"
+  fi
+}
+
+# @scenario "A secret on an unrelated branch does not fail the pull request"
+test_secret_on_an_unrelated_branch_does_not_fail_the_pull_request() {
+  local work
+  work="$(build_checkout unrelated-branch other-branch)"
+  assert_scan_passes trufflehog "$work" \
+    "trufflehog ignores a secret that lives only on another branch"
+}
+
+# @scenario "A secret already on the base branch does not fail the pull request"
+test_secret_on_the_base_branch_does_not_fail_the_pull_request() {
+  local work
+  work="$(build_checkout base-branch base)"
+  assert_scan_passes trufflehog "$work" \
+    "trufflehog ignores a secret that was already on the base branch"
+}
+
+# @scenario "A secret the pull request adds fails the check"
+test_secret_added_by_the_pull_request_fails_the_check() {
+  local work
+  work="$(build_checkout pr-adds pr)"
+  assert_scan_fails trufflehog "$work" \
+    "trufflehog fails on a secret the pull request itself adds"
+  assert_output_contains "pr-leak.env" \
+    "the failure names the file the secret is in"
+}
+
+# @scenario "A secret the pull request adds and then deletes still fails the check"
+test_secret_added_then_deleted_within_the_pull_request_still_fails() {
+  local work
+  work="$(build_checkout pr-adds-then-deletes pr-then-deleted)"
+  assert_scan_fails trufflehog "$work" \
+    "trufflehog fails on a secret that is added and removed inside the same pull request"
+}
+
+# @scenario "A scan that examines no content while the pull request changes files fails loudly"
+test_scan_that_examines_no_content_fails_loudly() {
+  local work stub
+  work="$(build_checkout vacuous none)"
+
+  # A stand-in that reports a clean, entirely empty scan — the shape a mis-aimed
+  # `--branch` produces, and the one that is indistinguishable from a real pass
+  # by exit code alone.
+  stub="$WORKSPACE/stub-bin"
+  mkdir -p "$stub"
+  cat >"$stub/trufflehog" <<'STUB'
+#!/usr/bin/env bash
+echo 'info-0 trufflehog finished scanning {"chunks": 0, "bytes": 0, "verified_secrets": 0}'
+exit 0
+STUB
+  chmod +x "$stub/trufflehog"
+
+  local rc=0
+  set +e
+  LAST_OUTPUT="$(
+    PATH="$stub:$PATH" \
+      EVENT_NAME=pull_request \
+      BASE_REF=main \
+      SECRETS_SCAN_TRUFFLEHOG_MODE=offline \
+      bash "$SCAN" trufflehog "$work" 2>&1
+  )"
+  rc=$?
+  set -e
+
+  if [ "$rc" -ne 0 ]; then
+    record yes "an empty scan over a non-empty pull request is a failure"
+  else
+    record no "an empty scan over a non-empty pull request is a failure"
+  fi
+  assert_output_contains "reached no commits" \
+    "the failure says the scan reached no commits"
+}
+
+# @scenario "The pattern scanner ignores a secret on an unrelated branch"
+test_pattern_scanner_ignores_a_secret_on_an_unrelated_branch() {
+  local work
+  work="$(build_checkout gitleaks-unrelated other-branch)"
+  assert_scan_passes gitleaks "$work" \
+    "gitleaks ignores a secret that lives only on another branch"
+}
+
+# @scenario "The pattern scanner still fails on a secret the pull request adds"
+test_pattern_scanner_fails_on_a_secret_the_pull_request_adds() {
+  local work
+  work="$(build_checkout gitleaks-pr pr)"
+  assert_scan_fails gitleaks "$work" \
+    "gitleaks fails on a secret the pull request itself adds"
+}
+
+require_tool git
+require_tool gitleaks
+require_tool trufflehog
+
+test_secret_on_an_unrelated_branch_does_not_fail_the_pull_request
+test_secret_on_the_base_branch_does_not_fail_the_pull_request
+test_secret_added_by_the_pull_request_fails_the_check
+test_secret_added_then_deleted_within_the_pull_request_still_fails
+test_scan_that_examines_no_content_fails_loudly
+test_pattern_scanner_ignores_a_secret_on_an_unrelated_branch
+test_pattern_scanner_fails_on_a_secret_the_pull_request_adds
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/.github/scripts/__tests__/secrets-scan.test.sh
+++ b/.github/scripts/__tests__/secrets-scan.test.sh
@@ -196,42 +196,65 @@ test_secret_added_then_deleted_within_the_pull_request_still_fails() {
     "trufflehog fails on a secret that is added and removed inside the same pull request"
 }
 
-# @scenario "A scan that examines no content while the pull request changes files fails loudly"
-test_scan_that_examines_no_content_fails_loudly() {
-  local work stub
-  work="$(build_checkout vacuous none)"
-
-  # A stand-in that reports a clean, entirely empty scan — the shape a mis-aimed
-  # `--branch` produces, and the one that is indistinguishable from a real pass
-  # by exit code alone.
-  stub="$WORKSPACE/stub-bin"
+# Runs the gate with a stubbed scanner that reports a clean, entirely empty
+# scan — the shape a mis-aimed scope produces, and the one that is
+# indistinguishable from a real pass by exit code alone.
+run_scan_with_empty_stub() {
+  local scanner="$1" work="$2" stub rc=0
+  stub="$WORKSPACE/stub-bin-$scanner"
   mkdir -p "$stub"
-  cat >"$stub/trufflehog" <<'STUB'
+  case "$scanner" in
+    trufflehog)
+      cat >"$stub/trufflehog" <<'STUB'
 #!/usr/bin/env bash
 echo 'info-0 trufflehog finished scanning {"chunks": 0, "bytes": 0, "verified_secrets": 0}'
 exit 0
 STUB
-  chmod +x "$stub/trufflehog"
+      ;;
+    gitleaks)
+      cat >"$stub/gitleaks" <<'STUB'
+#!/usr/bin/env bash
+echo '12:00AM INF 0 commits scanned.'
+echo '12:00AM INF no leaks found'
+exit 0
+STUB
+      ;;
+  esac
+  chmod +x "$stub"/*
 
-  local rc=0
   set +e
   LAST_OUTPUT="$(
     PATH="$stub:$PATH" \
       EVENT_NAME=pull_request \
       BASE_REF=main \
       SECRETS_SCAN_TRUFFLEHOG_MODE=offline \
-      bash "$SCAN" trufflehog "$work" 2>&1
+      bash "$SCAN" "$scanner" "$work" 2>&1
   )"
   rc=$?
   set -e
+  return $rc
+}
 
-  if [ "$rc" -ne 0 ]; then
-    record yes "an empty scan over a non-empty pull request is a failure"
+# @scenario "A scan that examines no content while the pull request changes files fails loudly"
+test_scan_that_examines_no_content_fails_loudly() {
+  local work
+  work="$(build_checkout vacuous none)"
+
+  if run_scan_with_empty_stub trufflehog "$work"; then
+    record no "an empty trufflehog scan over a non-empty pull request is a failure"
   else
-    record no "an empty scan over a non-empty pull request is a failure"
+    record yes "an empty trufflehog scan over a non-empty pull request is a failure"
   fi
   assert_output_contains "reached no commits" \
     "the failure says the scan reached no commits"
+
+  # The same safeguard covers gitleaks — the spec rule is "both scanners are
+  # scoped the same way", and a scope can be mis-aimed on either.
+  if run_scan_with_empty_stub gitleaks "$work"; then
+    record no "an empty gitleaks scan over a non-empty pull request is a failure"
+  else
+    record yes "an empty gitleaks scan over a non-empty pull request is a failure"
+  fi
 }
 
 # @scenario "The pattern scanner ignores a secret on an unrelated branch"

--- a/.github/scripts/secrets-scan.sh
+++ b/.github/scripts/secrets-scan.sh
@@ -35,7 +35,14 @@ git branch --force "$scan_branch" HEAD >/dev/null
 
 if [ "$event" = "pull_request" ]; then
   base_ref="${BASE_REF:?BASE_REF is required on a pull_request}"
-  git fetch --no-tags --quiet origin "+refs/heads/$base_ref:refs/remotes/origin/$base_ref"
+  # actions/checkout with fetch-depth: 0 already brings this ref, so in CI the
+  # fetch is a freshness refresh, not a requirement. It must not fail the gate
+  # when the ref is already present: under `set -e` a transient network error
+  # (or a credential-less fetch on a private fork) would otherwise paint a red
+  # check that has nothing to do with secrets.
+  git fetch --no-tags --quiet origin "+refs/heads/$base_ref:refs/remotes/origin/$base_ref" \
+    || git rev-parse --verify --quiet "refs/remotes/origin/$base_ref" >/dev/null \
+    || { echo "::error::cannot fetch or resolve base ref $base_ref" >&2; exit 1; }
   base_commit="$(git merge-base "$scan_branch" "origin/$base_ref")"
 else
   base_commit=""
@@ -55,15 +62,17 @@ fi
 
 # A scan can be scoped to nothing as easily as to the wrong thing, and both
 # report the same green check. If the range under test adds or modifies a file,
-# the scanner has to have read something.
+# the scanner has to have read something. `$1` is the scanner's parsed
+# work-done counter — chunks for trufflehog, commits for gitleaks; empty when
+# the counter line was missing, which fails too (an unparseable report proves
+# as little as an empty one).
 assert_scan_was_not_empty() {
-  local output="$1" chunks
+  local counted="$1"
 
   [ -n "$base_commit" ] || return 0
   git diff --quiet --diff-filter=AM "$base_commit" "$scan_branch" && return 0
 
-  chunks="$(printf '%s' "$output" | sed -n 's/.*"chunks": *\([0-9][0-9]*\).*/\1/p' | tail -1)"
-  if [ -n "$chunks" ] && [ "$chunks" -gt 0 ]; then
+  if [ -n "$counted" ] && [ "$counted" -gt 0 ]; then
     return 0
   fi
 
@@ -85,7 +94,16 @@ case "$scanner" in
     else
       log_opts="-1"
     fi
-    exec gitleaks git --redact --no-banner --no-color --verbose --log-opts="$log_opts" .
+    set +e
+    output="$(gitleaks git --redact --no-banner --no-color --verbose --log-opts="$log_opts" . 2>&1)"
+    status=$?
+    set -e
+    printf '%s\n' "$output"
+
+    # gitleaks reports "N commits scanned." where trufflehog reports chunks.
+    commits="$(printf '%s' "$output" | sed -n 's/.*INF \([0-9][0-9]*\) commits scanned.*/\1/p' | tail -1)"
+    assert_scan_was_not_empty "$commits" || exit 1
+    exit "$status"
     ;;
 
   trufflehog)
@@ -108,7 +126,8 @@ case "$scanner" in
     set -e
     printf '%s\n' "$output"
 
-    assert_scan_was_not_empty "$output" || exit 1
+    chunks="$(printf '%s' "$output" | sed -n 's/.*"chunks": *\([0-9][0-9]*\).*/\1/p' | tail -1)"
+    assert_scan_was_not_empty "$chunks" || exit 1
     exit "$status"
     ;;
 

--- a/.github/scripts/secrets-scan.sh
+++ b/.github/scripts/secrets-scan.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# The blocking secrets gate, scoped to the commits under test and nothing else.
+#
+#   secrets-scan.sh <gitleaks|trufflehog> [repository-path]
+#
+# Environment:
+#   EVENT_NAME  github.event_name. Defaults to $GITHUB_EVENT_NAME.
+#   BASE_REF    github.base_ref. Required when EVENT_NAME is `pull_request`.
+#   SECRETS_SCAN_TRUFFLEHOG_MODE
+#               `offline` drops verification and reports unverified matches.
+#               The gate itself never sets this — see the comment on
+#               trufflehog_flags below for why the tests must.
+#
+# Both scanners used to be invoked inline in code-scanners.yml, and only one of
+# them was scoped. They live here together so the range is computed once, and so
+# the scoping can be tested — see __tests__/secrets-scan.test.sh.
+
+set -euo pipefail
+
+scanner="${1:?usage: secrets-scan.sh <gitleaks|trufflehog> [repository-path]}"
+repository="${2:-$PWD}"
+cd "$repository"
+
+event="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+
+# The scan range, as one local ref.
+#
+# TruffleHog resolves `--branch` inside a fresh clone it makes of this working
+# copy, and `git clone` carries refs/heads/*. On a pull request actions/checkout
+# leaves HEAD DETACHED at refs/remotes/pull/N/merge with refs/heads/* empty, so
+# there is no branch name to hand it — this creates the only one that matters.
+scan_branch="__secrets-scan-head"
+git branch --force "$scan_branch" HEAD >/dev/null
+
+if [ "$event" = "pull_request" ]; then
+  base_ref="${BASE_REF:?BASE_REF is required on a pull_request}"
+  git fetch --no-tags --quiet origin "+refs/heads/$base_ref:refs/remotes/origin/$base_ref"
+  base_commit="$(git merge-base "$scan_branch" "origin/$base_ref")"
+else
+  base_commit=""
+fi
+
+# TruffleHog verifies candidates against the provider, so `--only-verified`
+# is what makes a blocking gate affordable: a rotated credential in old history
+# does not stop the queue. Nothing planted by a test can ever verify, though,
+# and a test that could only assert "no verified secrets found" would pass
+# whether the scan was correctly scoped or scanned nothing at all. `offline`
+# turns verification off and reports the matches themselves, so the tests can
+# assert on WHICH COMMITS were scanned — the property this script exists for.
+trufflehog_flags=(--only-verified)
+if [ "${SECRETS_SCAN_TRUFFLEHOG_MODE:-}" = "offline" ]; then
+  trufflehog_flags=(--no-verification "--results=verified,unknown,unverified")
+fi
+
+# A scan can be scoped to nothing as easily as to the wrong thing, and both
+# report the same green check. If the range under test adds or modifies a file,
+# the scanner has to have read something.
+assert_scan_was_not_empty() {
+  local output="$1" chunks
+
+  [ -n "$base_commit" ] || return 0
+  git diff --quiet --diff-filter=AM "$base_commit" "$scan_branch" && return 0
+
+  chunks="$(printf '%s' "$output" | sed -n 's/.*"chunks": *\([0-9][0-9]*\).*/\1/p' | tail -1)"
+  if [ -n "$chunks" ] && [ "$chunks" -gt 0 ]; then
+    return 0
+  fi
+
+  echo "::error::Secrets scan reached no commits, but ${base_commit:0:12}..HEAD adds or modifies files." >&2
+  echo "The gate examined nothing and would have passed regardless of content. Failing instead." >&2
+  return 1
+}
+
+case "$scanner" in
+  gitleaks)
+    # --verbose because without it gitleaks prints only "leaks found: N" and
+    # nothing about WHERE, which makes a blocking gate impossible to act on
+    # from the log alone. --redact keeps the matched value itself out of CI
+    # output; the file, line, rule id and fingerprint still print, which is what
+    # an author needs — and rule + path is exactly what a `.gitleaks.toml` entry
+    # is keyed on.
+    if [ "$event" = "pull_request" ]; then
+      log_opts="origin/$base_ref..$scan_branch"
+    else
+      log_opts="-1"
+    fi
+    exec gitleaks git --redact --no-banner --no-color --verbose --log-opts="$log_opts" .
+    ;;
+
+  trufflehog)
+    # `--branch` is the scope. Without it TruffleHog's git source shells out to
+    # `git log --all` — every ref in the clone, including branches belonging to
+    # other people's pull requests. `--since-commit` is not a substitute: it
+    # only stops the walk on reaching that exact commit, and `--all` interleaves
+    # other refs' newer commits ahead of it, so they are scanned first. That is
+    # how one branch's finding came to fail every open pull request (#6681).
+    args=(git "file://$PWD" --branch "$scan_branch" --fail --no-update "${trufflehog_flags[@]}")
+    if [ -n "$base_commit" ]; then
+      args+=(--since-commit "$base_commit")
+    else
+      args+=(--max-depth=1)
+    fi
+
+    set +e
+    output="$(trufflehog "${args[@]}" 2>&1)"
+    status=$?
+    set -e
+    printf '%s\n' "$output"
+
+    assert_scan_was_not_empty "$output" || exit 1
+    exit "$status"
+    ;;
+
+  *)
+    echo "unknown scanner: $scanner (expected gitleaks or trufflehog)" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/code-scanners.yml
+++ b/.github/workflows/code-scanners.yml
@@ -114,17 +114,31 @@ jobs:
       # first-party actions/* or an already-approved pin, and this workflow's
       # first run ended in startup_failure with the third-party action as its
       # only unapproved reference. A pinned release tarball needs no allowlist.
+      # Each tarball is verified against the checksum file its release
+      # publishes before anything is extracted — this job exists to catch
+      # compromised credentials, so its own supply chain does not get to be a
+      # `curl | tar`. The checksum file comes from the same release, so this
+      # does not defend against a compromised release, only against a swapped
+      # or truncated asset — which is also what pipefail is for: without it a
+      # failed curl is masked by the tar it feeds.
       - name: Install scanners
         run: |
-          gitleaks_version=8.30.0
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${gitleaks_version}/gitleaks_${gitleaks_version}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
-          gitleaks --version
-
-          trufflehog_version=3.96.0
-          curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/trufflehog_${trufflehog_version}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin trufflehog
-          trufflehog --version
+          set -euo pipefail
+          install_verified() {
+            local name="$1" version="$2" repo="$3" asset="$4" checksums="$5"
+            local dir
+            dir="$(mktemp -d)"
+            curl -sSfL "https://github.com/${repo}/releases/download/v${version}/${asset}" -o "$dir/$asset"
+            curl -sSfL "https://github.com/${repo}/releases/download/v${version}/${checksums}" -o "$dir/checksums.txt"
+            (cd "$dir" && grep -F "  $asset" checksums.txt | sha256sum --check --strict)
+            tar -xz -C /usr/local/bin -f "$dir/$asset" "$name"
+            rm -rf "$dir"
+            "$name" --version
+          }
+          install_verified gitleaks 8.30.0 gitleaks/gitleaks \
+            gitleaks_8.30.0_linux_x64.tar.gz gitleaks_8.30.0_checksums.txt
+          install_verified trufflehog 3.96.0 trufflesecurity/trufflehog \
+            trufflehog_3.96.0_linux_amd64.tar.gz trufflehog_3.96.0_checksums.txt
 
       # Runs BEFORE the gate it protects, against throwaway repositories built
       # to match the ref layout actions/checkout leaves behind. A gate scoped to

--- a/.github/workflows/code-scanners.yml
+++ b/.github/workflows/code-scanners.yml
@@ -107,59 +107,53 @@ jobs:
       # A committed credential is never acceptable, so this is blocking from
       # the start rather than phased. #5708 is the precedent.
       #
-      # The binary, not gitleaks-action: that action requires a paid
-      # GITLEAKS_LICENSE for organisation-owned repositories and fails without
-      # one. The CLI is Apache-2.0 and unrestricted.
-      - name: gitleaks
+      # The binaries, not gitleaks-action / trufflesecurity/trufflehog. The
+      # gitleaks action requires a paid GITLEAKS_LICENSE for organisation-owned
+      # repositories and fails without one; the CLI is Apache-2.0 and
+      # unrestricted. For trufflehog, every other `uses:` in this repo is a
+      # first-party actions/* or an already-approved pin, and this workflow's
+      # first run ended in startup_failure with the third-party action as its
+      # only unapproved reference. A pinned release tarball needs no allowlist.
+      - name: Install scanners
         run: |
-          version=8.30.0
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
+          gitleaks_version=8.30.0
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${gitleaks_version}/gitleaks_${gitleaks_version}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks --version
-          # Scoped to this branch's own commits, not all history. A repository
-          # this age has rotated credentials still sitting in old objects
-          # (#5708); scanning everything would fail every PR for something no
-          # PR author did, and the gate would be off within a day.
-          # --verbose because without it gitleaks prints only "leaks found: N"
-          # and nothing about WHERE, which makes a blocking gate impossible to
-          # act on from the log alone. --redact keeps the matched value itself
-          # out of CI output; the file, line, rule id and fingerprint still
-          # print, which is what an author needs. Rule + path is also exactly
-          # what an entry in `.gitleaks.toml` is keyed on.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.base_ref }}"
-            git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
-            gitleaks git --redact --no-banner --no-color --verbose --log-opts="origin/$BASE..HEAD" .
-          else
-            gitleaks git --redact --no-banner --no-color --verbose --log-opts="-1" .
-          fi
 
-      # gitleaks matches patterns; trufflehog additionally VERIFIES a candidate
-      # against the provider, so it catches live credentials that do not match
-      # a known shape. --only-verified keeps it to secrets proven live, which
-      # is what makes it safe to block on.
-      #
-      # The binary rather than trufflesecurity/trufflehog, for the same reason
-      # as gitleaks above: every other `uses:` in this repo is a first-party
-      # actions/* or an already-approved pin, and this workflow's first run
-      # ended in startup_failure with the third-party action as its only
-      # unapproved reference. A pinned release tarball needs no allowlist.
-      - name: trufflehog
-        run: |
-          version=3.96.0
-          curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${version}/trufflehog_${version}_linux_amd64.tar.gz" \
+          trufflehog_version=3.96.0
+          curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${trufflehog_version}/trufflehog_${trufflehog_version}_linux_amd64.tar.gz" \
             | tar -xz -C /usr/local/bin trufflehog
           trufflehog --version
-          # Same scoping as gitleaks. --only-verified means it blocks only on a
-          # credential the provider confirms is live, so a historical rotated
-          # one does not stop the queue.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            trufflehog git "file://$(pwd)" \
-              --since-commit "$(git merge-base HEAD "origin/${{ github.base_ref }}")" \
-              --only-verified --fail --no-update
-          else
-            trufflehog git "file://$(pwd)" --max-depth=1 --only-verified --fail --no-update
-          fi
+
+      # Runs BEFORE the gate it protects, against throwaway repositories built
+      # to match the ref layout actions/checkout leaves behind. A gate scoped to
+      # the wrong commits is indistinguishable from a correct one by exit code
+      # alone — this is what tells them apart, on this runner, with these binary
+      # versions. See specs/ci/secrets-scan-scoping.feature.
+      - name: Scoping tests
+        run: bash .github/scripts/__tests__/secrets-scan.test.sh
+
+      # Both scanners are scoped to the commits under test and nothing else, by
+      # .github/scripts/secrets-scan.sh. They ran inline here until #6681, when
+      # only one of the two turned out to be scoped: trufflehog's git source
+      # walks `git log --all` — every ref in the clone — unless it is given a
+      # `--branch`, so one branch's finding failed every open pull request in
+      # the repository. Separate steps so a failure names which scanner found it.
+      - name: gitleaks
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: bash .github/scripts/secrets-scan.sh gitleaks
+
+      # gitleaks matches patterns; trufflehog additionally VERIFIES a candidate
+      # against the provider, so it catches live credentials that do not match a
+      # known shape, and blocks only on ones the provider confirms are live.
+      - name: trufflehog
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: bash .github/scripts/secrets-scan.sh trufflehog
 
   sast:
     name: semgrep (changed lines)

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -139,6 +139,7 @@ jobs:
               - 'services/langevals/**'
               - 'langwatch_server/**'
               - 'dev/scripts/**'
+              - '.github/scripts/**'
               - '.github/workflows/langwatch-app-ci.yml'
 
   typecheck:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -79,6 +79,28 @@ matchCondition = "AND"
 paths = ['''\.github/workflows/langwatch-app-ci\.yml''']
 regexes = ['''(0123456789abcdef){4}''']
 
+# The two AWS-shaped literals the secrets-gate tests plant into throwaway
+# repositories. The tests exist to prove the gate fails on a credential a pull
+# request adds and passes on one it did not (#6681), and a fixture that no
+# scanner recognises would prove neither half. No such AWS account exists, and
+# the tests run the scanners in offline mode precisely because these values
+# cannot verify against a provider.
+#
+# Scoped by VALUE and by nothing else, so any OTHER credential — in this file
+# or any other — is still caught by every rule. Deliberately NOT scoped by path
+# with `matchCondition = "AND"`, the shape the CREDENTIALS_SECRET entry above
+# uses: gitleaks 8.30 does not narrow that way. A `paths` entry allowlists the
+# whole file, AND or no AND, and the accompanying `regexes` change nothing —
+# verified by planting a second, unrelated AWS key in this file and watching it
+# go unreported. Fixing that entry (and its comment, which claims a narrowing it
+# does not get) is #6681's deferred half.
+[[allowlists]]
+description = "AWS-shaped fixture credentials planted by the secrets-gate scoping tests"
+regexes = [
+  '''AKIAQYLPMN5HHHFPZAM2''',
+  '''A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0''',
+]
+
 # `Idempotency-Key: signup-acme-4171` and its SDK equivalents in the billing
 # docs. An idempotency key is a value the CALLER invents to make a retry safe,
 # and it is meaningless to anyone who is not already authenticated: it names a

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -93,7 +93,7 @@ regexes = ['''(0123456789abcdef){4}''']
 # whole file, AND or no AND, and the accompanying `regexes` change nothing —
 # verified by planting a second, unrelated AWS key in this file and watching it
 # go unreported. Fixing that entry (and its comment, which claims a narrowing it
-# does not get) is #6681's deferred half.
+# does not get) is tracked in #6684.
 [[allowlists]]
 description = "AWS-shaped fixture credentials planted by the secrets-gate scoping tests"
 regexes = [

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -104,6 +104,11 @@ const DEFAULT_BATS_TEST_ROOTS: string[] = [
  * comments may sit between the two.
  */
 const DEFAULT_SHELL_TEST_ROOTS: string[] = [
+  // CI's own shell steps. The secrets gate is scoped by a shell script and
+  // proved correct by running the real scanners against fixture repositories,
+  // which is neither a vitest nor a bats suite — without this root, scenarios
+  // about which commits a blocking gate examines could only be @unimplemented.
+  ".github/scripts/__tests__",
   "charts/langwatch/tests",
   // The gateway subchart carries its own drain-timing suite, run by the
   // `helm` job in go-services.yaml rather than by the umbrella chart's

--- a/specs/ci/secrets-scan-scoping.feature
+++ b/specs/ci/secrets-scan-scoping.feature
@@ -1,0 +1,83 @@
+Feature: The secrets gate only fails a pull request for what that pull request adds
+  As a contributor
+  I want the secrets scan to judge my own commits and nothing else
+  So that a finding somebody else pushed to their branch cannot block my work
+
+  # The gate is blocking, so its blast radius is the whole merge queue. A scan
+  # that reaches outside the branch under test turns one bad commit anywhere in
+  # the repository into a red check on every open pull request — which is what
+  # happened, and it took a false positive to expose it rather than a real
+  # credential.
+  #
+  # The mechanism is in TruffleHog itself: with no `--branch`, its git source
+  # shells out to `git log --all`, i.e. every ref in the clone. `--since-commit`
+  # is NOT a scope — it only stops the walk when it happens to reach that exact
+  # commit, and `--all` interleaves other refs' newer commits ahead of it.
+  # `gitleaks` beside it was already scoped, via `--log-opts=origin/BASE..HEAD`.
+  #
+  # Both scanners now go through .github/scripts/secrets-scan.sh so the scoping
+  # rule is written once and tested, rather than living twice in YAML.
+  Background:
+    Given the checkout has every branch of the repository present as a remote-tracking ref
+    And on a pull request the checkout leaves HEAD detached, with no local branch
+    And the scan range is the commits between the merge base and the pull request head
+
+  Rule: A finding outside the pull request's own commits never fails it
+
+    @unit @regression
+    Scenario: A secret on an unrelated branch does not fail the pull request
+      Given another branch in the same checkout contains a secret
+      And the pull request's own commits contain no secret
+      When the secrets scan runs
+      Then the scan passes
+
+    @unit @regression
+    Scenario: A secret already on the base branch does not fail the pull request
+      Given the base branch already contains a secret
+      And the pull request's own commits contain no secret
+      When the secrets scan runs
+      Then the scan passes
+
+  Rule: A finding inside the pull request's own commits still fails it
+
+    @unit
+    Scenario: A secret the pull request adds fails the check
+      Given the pull request's own commits add a secret
+      When the secrets scan runs
+      Then the scan fails
+      And the failure names the file the secret is in
+
+    @unit
+    Scenario: A secret the pull request adds and then deletes still fails the check
+      Given the pull request adds a secret in one commit and deletes the file in the next
+      When the secrets scan runs
+      Then the scan fails
+
+  Rule: A scan that reaches nothing is a failure, not a pass
+
+    # Scoping a scanner is one edit away from scoping it to nothing, and a
+    # secrets gate that examines zero commits reports exactly the same green
+    # check as one that examined them all. This is the assertion that tells the
+    # two apart.
+    @unit
+    Scenario: A scan that examines no content while the pull request changes files fails loudly
+      Given the pull request modifies files
+      But the scanner reports that it examined no content
+      When the secrets scan runs
+      Then the scan fails
+      And the failure says the scan reached no commits
+
+  Rule: Both scanners are scoped the same way
+
+    @unit @regression
+    Scenario: The pattern scanner ignores a secret on an unrelated branch
+      Given another branch in the same checkout contains a secret
+      And the pull request's own commits contain no secret
+      When the pattern scan runs
+      Then the scan passes
+
+    @unit
+    Scenario: The pattern scanner still fails on a secret the pull request adds
+      Given the pull request's own commits add a secret
+      When the pattern scan runs
+      Then the scan fails


### PR DESCRIPTION
# Related Issue

- Resolves #6681

## For humans

Our automated "is there a password in this change?" check was reading the whole
repository instead of just the change in front of it. So the moment anybody's
branch contained something that looked like a credential, **every** open pull
request went red — including ones that touched nothing related. The check
blocks merging, so this stopped the whole queue rather than one change.

This scopes the check to the commits the pull request actually adds, and adds
tests that prove it: plant a fake credential on somebody else's branch, and the
check has to pass; plant one in the pull request itself, and it has to fail.

Closes #6681.

## What was wrong

The job runs two scanners. `gitleaks` was already scoped to the branch's own
commits. `trufflehog`, a few lines below, was not — and the reason is in
TruffleHog itself:

```go
// pkg/gitparse/gitparse.go, v3.96.0
if head != "" {
    args = append(args, head)
} else {
    args = append(args, "--all")   // <- every ref in the clone
}
```

`head` is only set by `--branch`, which we were not passing. `--since-commit`
does not fill that gap: it sets `BaseHash`, which merely *stops* the walk on
reaching that exact commit — and `git log --all` interleaves other refs'
newer commits ahead of it, so they get scanned first.

`actions/checkout` with `fetch-depth: 0` fetches
`+refs/heads/*:refs/remotes/origin/*`, so the working clone carries every
branch in the repository. That is how a string on one branch came to fail
runs on unrelated pull requests from different scan bases.

Reproduced locally, which the issue could not do: build the origin/checkout
pair with the exact refspec from a failing run's log, put a secret only on a
third branch, and the pre-fix invocation exits 183 on it. Adding `--branch`
exits 0. The same fixture is now the test.

## What changed

- **`.github/scripts/secrets-scan.sh`** — both scanners, one place, one range.
  It forces a local ref at HEAD (on a pull request `actions/checkout` leaves
  HEAD *detached* with `refs/heads/*` empty, so there is otherwise no branch
  name to hand TruffleHog, and TruffleHog resolves `--branch` inside a clone
  that only carries `refs/heads/*`), then scopes both scanners to it.
- **A not-empty assertion.** A scan can be scoped to nothing as easily as to
  the wrong thing, and both report the same green check. If the range adds or
  modifies a file, the scanner has to have read something, or the job fails
  and says so.
- **`.github/scripts/__tests__/secrets-scan.test.sh`** — 7 cases, running the
  real `gitleaks` and `trufflehog` against throwaway repositories built to the
  real CI ref layout. It refuses to run if either binary is missing rather than
  skipping. Wired into the `secrets` job itself, *before* the gate it protects,
  so it runs with the same pinned versions on the same runner.
- **`specs/ci/secrets-scan-scoping.feature`** — the scenarios, all bound.
- **`.gitleaks.toml`** — allowlists the two fixture credentials by value.

After review (`d0483e9274`): the empty-scan safeguard covers gitleaks too (it
was trufflehog-only), a failed base-ref fetch no longer reds the gate when the
ref is already local, and both scanner tarballs are checksum-verified against
their release manifests before extraction.

## Verification

```
Results: 9 passed, 0 failed          # the new suite
```

Mutation check — delete `--branch` from the script and the bug comes back,
exactly one case:

```
FAIL: trufflehog ignores a secret that lives only on another branch (exit 183)
Results: 8 passed, 1 failed
```

Also run against this repository: `gitleaks` and `trufflehog` both clean on
this branch's own commit, and on the push path.

`pnpm typecheck`, `pnpm typecheck:tests`, `pnpm check:feature-parity`,
`biome ci`/`format` on the changed file, `shellcheck` on both new scripts, and
`scripts/__tests__/check-feature-parity.unit.test.ts` (16/16) — all clean.

## Two things deliberately left

1. **#6616's Lob false positive.** The matched string is a shell function name,
   `test_scaling_one_deployment_resizes_both`; Lob keys are `test_…`/`live_…`
   and the value "verifies" because Lob's test environment answers, not because
   a credential exists. After this change only #6616 is failed by it, which is
   what the issue asks for. Renaming the function or an exclusion is that PR's
   call, not this one's.

2. **The `matchCondition = "AND"` allowlist entries in `.gitleaks.toml` do not
   narrow.** The existing `CREDENTIALS_SECRET` entry claims that pairing
   `paths` with `regexes` under `AND` keeps every other high-entropy string in
   that file caught. It does not — on gitleaks 8.30 a `paths` entry allowlists
   the whole file regardless, verified by planting a second unrelated AWS key
   and watching it go unreported. The new entry here avoids the shape (it is
   scoped by value only, and the negative control passes), and says why in a
   comment. Tracked in #6684.

3. **A pre-existing merge-commit blind spot, found while red-teaming this fix.**
   A secret introduced only in a merge commit's conflict resolution (in neither
   parent's diff) is invisible to both scanners — `git log -p` prints no patch
   for merges. Reproduced against `main`'s pre-fix invocations too: inherited,
   not introduced here. Tracked in #6686.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added scoped secret scanning for pull requests using Gitleaks and TruffleHog.
  * Scans detect secrets introduced by changes, including those later deleted, while ignoring unrelated history.
  * Checks fail clearly when changed content is not scanned or required scanners are unavailable.

* **CI**
  * Added automated coverage for secret-scanning behavior and detached-checkout scenarios.
  * Feature-parity checks now include changes to CI scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
