### PR TITLE
fix(observability): make the prod error signal mean something

### DIFF
--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -55,6 +55,7 @@ export type {
 export {
   isTransientClickHouseError,
   jitteredBackoffMs,
+  QUERY_CAUSE_FIELD,
   RETRY_CAUSE_FIELD,
   retryNoticeLevel,
   TRANSIENT_HTTP_STATUSES,

--- a/packages/clickhouse-client/src/resilience.test.ts
+++ b/packages/clickhouse-client/src/resilience.test.ts
@@ -91,6 +91,81 @@ describe("isTransientClickHouseError", () => {
           isTransientClickHouseError({ error: new Error("Timeout error.") }),
         ).toBe(true);
       });
+
+      it("tolerates the message without its trailing stop", () => {
+        expect(
+          isTransientClickHouseError({ error: new Error("Timeout error") }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when the driver names the error instead", () => {
+      it("retries", () => {
+        const error = Object.assign(new Error("socket hang up"), {
+          name: "TimeoutError",
+        });
+
+        expect(isTransientClickHouseError({ error })).toBe(true);
+      });
+    });
+
+    /**
+     * ClickHouse echoes the failing statement back inside its error text. A
+     * message-anywhere match on "timeout" therefore made permanent failures —
+     * a syntax error, a missing table — look transient whenever the QUERY
+     * happened to mention the word, and each one burned the full retry budget
+     * against a server that could never succeed.
+     */
+    describe("when a permanent failure merely quotes a query mentioning timeout", () => {
+      it("does not retry a syntax error", () => {
+        const error = new Error(
+          "Code: 62. DB::Exception: Syntax error: failed at position 8: " +
+            "SELECT timeout_ms FROM traces WHERE. (SYNTAX_ERROR)",
+        );
+
+        expect(isTransientClickHouseError({ error })).toBe(false);
+      });
+
+      it("does not retry an unknown-table error quoting a SETTINGS clause", () => {
+        const error = new Error(
+          "Code: 60. DB::Exception: Table default.nope does not exist. " +
+            "Query: SELECT 1 SETTINGS receive_timeout = 5. (UNKNOWN_TABLE)",
+        );
+
+        expect(isTransientClickHouseError({ error })).toBe(false);
+      });
+
+      it("does not retry an unknown column literally named timeout", () => {
+        const error = new Error(
+          "Code: 47. DB::Exception: Unknown expression identifier 'timeout'. " +
+            "(UNKNOWN_IDENTIFIER)",
+        );
+
+        expect(isTransientClickHouseError({ error })).toBe(false);
+      });
+    });
+
+    /**
+     * The timeouts ClickHouse reports itself still have to retry — they just
+     * arrive as codes or as the caller's fragments rather than as free text.
+     */
+    describe("when ClickHouse reports its own timeout", () => {
+      it("retries TIMEOUT_EXCEEDED via the caller's fragments", () => {
+        expect(
+          isTransientClickHouseError({
+            error: new Error("Code: 159. DB::Exception: TIMEOUT_EXCEEDED"),
+            transientMessageFragments: ["TIMEOUT_EXCEEDED"],
+          }),
+        ).toBe(true);
+      });
+
+      it("retries a socket timeout via its code", () => {
+        const error = Object.assign(new Error("connect ETIMEDOUT 10.0.0.1"), {
+          code: "ETIMEDOUT",
+        });
+
+        expect(isTransientClickHouseError({ error })).toBe(true);
+      });
     });
   });
 

--- a/packages/clickhouse-client/src/resilience.ts
+++ b/packages/clickhouse-client/src/resilience.ts
@@ -44,6 +44,32 @@ function statusOf(error: object): number | undefined {
 }
 
 /**
+ * The driver's own socket timeout, which carries neither a code nor a status —
+ * its message is the only signal it gives, so this one condition has to be
+ * recognised by text.
+ *
+ * Anchored to the WHOLE message, and that is the entire point. The previous
+ * form tested `/timeout/i` anywhere in the message, and ClickHouse echoes the
+ * failing statement back inside its error text: a query naming a `timeout`
+ * column, or setting `max_execution_time` with "timeout" anywhere in a SETTINGS
+ * clause, made a permanent failure — a syntax error, a missing table — read as
+ * transient and burn the full retry budget against a server that was never
+ * going to succeed.
+ *
+ * Every other timeout ClickHouse itself reports (`TIMEOUT_EXCEEDED`,
+ * `SOCKET_TIMEOUT`, `connect ETIMEDOUT`) arrives as a code, a status, or one of
+ * the caller's message fragments, and is matched on those instead.
+ */
+const DRIVER_TIMEOUT_MESSAGE = /^timeout error\.?$/i;
+
+function isDriverTimeout(error: Error): boolean {
+  return (
+    error.name === "TimeoutError" ||
+    DRIVER_TIMEOUT_MESSAGE.test(error.message.trim())
+  );
+}
+
+/**
  * Whether a failure is worth another attempt.
  *
  * Deliberately conservative: anything unrecognised is permanent. Retrying a
@@ -56,7 +82,7 @@ export function isTransientClickHouseError({
 }: TransientClassificationInput): boolean {
   if (!(error instanceof Error)) return false;
 
-  if (/timeout/i.test(error.message)) return true;
+  if (isDriverTimeout(error)) return true;
 
   for (const fragment of transientMessageFragments) {
     if (error.message.includes(fragment)) return true;
@@ -105,3 +131,13 @@ export function retryNoticeLevel(attempt: number): "warn" | "debug" {
 
 /** Where a retry notice attaches its cause. Never `error`; see ./logging.ts. */
 export const RETRY_CAUSE_FIELD = "retryError";
+
+/**
+ * Where a failed-attempt notice attaches its cause. Never `error`; see
+ * ./logging.ts.
+ *
+ * Separate from {@link RETRY_CAUSE_FIELD} so the two are told apart on sight: a
+ * retry notice says an attempt failed and another is coming, this one says the
+ * failure was raised to the caller.
+ */
+export const QUERY_CAUSE_FIELD = "queryError";

--- a/packages/observability/src/__tests__/requestCauseSerialization.unit.test.ts
+++ b/packages/observability/src/__tests__/requestCauseSerialization.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * What a re-keyed cause actually looks like once pino has written it.
+ *
+ * The other request-logging tests assert on the object handed to the logger,
+ * which is one level above the bug this file exists for. pino applies
+ * serializers by exact property name and warns about nothing when a key has
+ * none: the value goes to `JSON.stringify`, and an `Error` has no enumerable
+ * own properties, so it lands as `{}`. Moving a cause from `error` to
+ * `requestError` without registering the second key therefore drops the
+ * message and the stack - the only reasons the cause is logged at all - while
+ * every assertion on the handed-over object still passes.
+ *
+ * So these tests read the emitted line, through the same serializer map
+ * `createLogger` installs.
+ */
+
+import { Writable } from "node:stream";
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import { REQUEST_CAUSE_FIELD } from "../constants";
+import { NODE_LOG_SERIALIZERS } from "../logger";
+import { logHttpRequest } from "../request/requestLogging";
+
+/**
+ * A pino logger wired to the real serializer map, writing where we can read it.
+ * `createLogger` takes no destination, so this reproduces its serializer
+ * configuration by importing it rather than by restating it.
+ */
+function captureRecords(run: (logger: pino.Logger) => void) {
+  const chunks: string[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(String(chunk));
+      cb();
+    },
+  });
+
+  const logger = pino(
+    {
+      level: "debug",
+      serializers: NODE_LOG_SERIALIZERS,
+      formatters: { level: (label) => ({ level: label.toUpperCase() }) },
+    },
+    sink,
+  );
+
+  run(logger);
+
+  return chunks
+    .join("")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, any>);
+}
+
+const handledCustomer = () =>
+  Object.assign(new Error("Free limit of 50000 events reached"), {
+    name: "PlanLimitExceededError",
+    code: "ERR_PLAN_LIMIT",
+    httpStatus: 402,
+    fault: "customer",
+  });
+
+describe("emitted request-log records", () => {
+  describe("given a handled customer error logged below error level", () => {
+    function warnRecord() {
+      const [record] = captureRecords((logger) => {
+        logHttpRequest(logger as never, {
+          method: "POST",
+          url: "/api/otel/v1/traces",
+          statusCode: 402,
+          duration: 5,
+          userAgent: null,
+          error: handledCustomer(),
+        });
+      });
+      return record;
+    }
+
+    it("writes it at warn, not error", () => {
+      expect(warnRecord()?.level).toBe("WARN");
+    });
+
+    it("writes the cause under the re-keyed field", () => {
+      expect(warnRecord()?.[REQUEST_CAUSE_FIELD]).toBeDefined();
+    });
+
+    it("keeps the message a bare Error would have dropped", () => {
+      expect(warnRecord()?.[REQUEST_CAUSE_FIELD]?.message).toContain(
+        "Free limit of 50000 events reached",
+      );
+    });
+
+    it("keeps the stack", () => {
+      expect(warnRecord()?.[REQUEST_CAUSE_FIELD]?.stack).toBeTruthy();
+    });
+
+    it("does not emit the cause as an empty object", () => {
+      expect(
+        Object.keys(warnRecord()?.[REQUEST_CAUSE_FIELD] ?? {}),
+      ).not.toHaveLength(0);
+    });
+
+    it("carries no field named error, so nothing downstream reads it as one", () => {
+      expect(warnRecord()).not.toHaveProperty("error");
+    });
+
+    it("still carries the handled attribution alongside it", () => {
+      expect(warnRecord()).toMatchObject({
+        handledErrorCode: "ERR_PLAN_LIMIT",
+        handledErrorFault: "customer",
+        errorType: "PlanLimitExceededError",
+      });
+    });
+  });
+
+  describe("given an unhandled error logged at error level", () => {
+    function errorRecord() {
+      const [record] = captureRecords((logger) => {
+        logHttpRequest(logger as never, {
+          method: "POST",
+          url: "/fail",
+          statusCode: 500,
+          duration: 10,
+          userAgent: null,
+          error: new Error("boom"),
+        });
+      });
+      return record;
+    }
+
+    it("still writes the cause under error, serialised as before", () => {
+      expect(errorRecord()?.error?.message).toBe("boom");
+      expect(errorRecord()?.error?.stack).toBeTruthy();
+    });
+
+    it("does not also write the re-keyed field", () => {
+      expect(errorRecord()).not.toHaveProperty(REQUEST_CAUSE_FIELD);
+    });
+  });
+});

--- a/packages/observability/src/__tests__/requestCauseSerialization.unit.test.ts
+++ b/packages/observability/src/__tests__/requestCauseSerialization.unit.test.ts
@@ -85,6 +85,7 @@ describe("emitted request-log records", () => {
       expect(warnRecord()?.[REQUEST_CAUSE_FIELD]).toBeDefined();
     });
 
+    /** @scenario A re-keyed cause is still serialised */
     it("keeps the message a bare Error would have dropped", () => {
       expect(warnRecord()?.[REQUEST_CAUSE_FIELD]?.message).toContain(
         "Free limit of 50000 events reached",
@@ -129,6 +130,7 @@ describe("emitted request-log records", () => {
       return record;
     }
 
+    /** @scenario A cause on the error field is serialised as it always was */
     it("still writes the cause under error, serialised as before", () => {
       expect(errorRecord()?.error?.message).toBe("boom");
       expect(errorRecord()?.error?.stack).toBeTruthy();

--- a/packages/observability/src/__tests__/requestLogging.unit.test.ts
+++ b/packages/observability/src/__tests__/requestLogging.unit.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import { REQUEST_CAUSE_FIELD } from "../constants";
 import {
   getLogLevelFromStatusCode,
   getStatusCodeFromError,
   hasAuthorizationToken,
   logHttpRequest,
 } from "../request/requestLogging";
-import { REQUEST_CAUSE_FIELD } from "../constants";
 
 describe("requestLogging", () => {
   describe("getStatusCodeFromError", () => {
@@ -154,6 +154,7 @@ describe("requestLogging", () => {
           fault,
         });
 
+      /** @scenario A handled customer failure is logged below error */
       it("logs customer-fault at warn even for 5xx, with code and fault in the data", () => {
         const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
 
@@ -177,6 +178,7 @@ describe("requestLogging", () => {
         expect(logger.error).not.toHaveBeenCalled();
       });
 
+      /** @scenario A platform fault is logged at error */
       it("logs platform-fault at error", () => {
         const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
 
@@ -222,6 +224,7 @@ describe("requestLogging", () => {
         return logger.warn.mock.calls[0][0];
       }
 
+      /** @scenario A record below error level does not carry a field named error */
       it("does not attach the cause under a field named error", () => {
         expect(warnData()).not.toHaveProperty("error");
       });
@@ -230,6 +233,7 @@ describe("requestLogging", () => {
         expect(warnData()[REQUEST_CAUSE_FIELD]).toBe(handledCustomer);
       });
 
+      /** @scenario The error type stays groupable after the cause is re-keyed */
       it("keeps the error type groupable after the move", () => {
         expect(warnData().errorType).toBe("PlanLimitExceededError");
       });
@@ -257,6 +261,7 @@ describe("requestLogging", () => {
     });
 
     describe("when the record is logged at error level", () => {
+      /** @scenario A record at error level keeps its cause on the error field */
       it("keeps the cause under error so 5xx dashboards are unchanged", () => {
         const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
         const boom = new Error("boom");

--- a/packages/observability/src/__tests__/requestLogging.unit.test.ts
+++ b/packages/observability/src/__tests__/requestLogging.unit.test.ts
@@ -4,8 +4,8 @@ import {
   getStatusCodeFromError,
   hasAuthorizationToken,
   logHttpRequest,
-  REQUEST_CAUSE_FIELD,
 } from "../request/requestLogging";
+import { REQUEST_CAUSE_FIELD } from "../constants";
 
 describe("requestLogging", () => {
   describe("getStatusCodeFromError", () => {

--- a/packages/observability/src/__tests__/requestLogging.unit.test.ts
+++ b/packages/observability/src/__tests__/requestLogging.unit.test.ts
@@ -4,6 +4,7 @@ import {
   getStatusCodeFromError,
   hasAuthorizationToken,
   logHttpRequest,
+  REQUEST_CAUSE_FIELD,
 } from "../request/requestLogging";
 
 describe("requestLogging", () => {
@@ -192,6 +193,88 @@ describe("requestLogging", () => {
           expect.objectContaining({ handledErrorFault: "platform" }),
           "error handling request",
         );
+      });
+    });
+
+    /**
+     * Loki reads a field named `error` to decide a record's level, and that
+     * guess beats the severity we emitted. Records we deliberately log below
+     * error therefore have to carry their cause somewhere else, or they arrive
+     * as errors anyway — which is what buried the real 5xx behind 128k/day of
+     * handled 402s.
+     */
+    describe("when the record is logged below error level", () => {
+      const handledCustomer = Object.assign(new Error("over quota"), {
+        name: "PlanLimitExceededError",
+        code: "ERR_PLAN_LIMIT",
+        httpStatus: 402,
+        fault: "customer",
+      });
+
+      function warnData() {
+        const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+        logHttpRequest(logger, {
+          method: "POST",
+          url: "/api/otel/v1/traces",
+          statusCode: 402,
+          duration: 5,
+          userAgent: null,
+          error: handledCustomer,
+        });
+        return logger.warn.mock.calls[0][0];
+      }
+
+      it("does not attach the cause under a field named error", () => {
+        expect(warnData()).not.toHaveProperty("error");
+      });
+
+      it("still carries the cause for diagnosis", () => {
+        expect(warnData()[REQUEST_CAUSE_FIELD]).toBe(handledCustomer);
+      });
+
+      it("keeps the error type groupable after the move", () => {
+        expect(warnData().errorType).toBe("PlanLimitExceededError");
+      });
+
+      it("keeps the handled attribution", () => {
+        expect(warnData()).toMatchObject({
+          handledErrorCode: "ERR_PLAN_LIMIT",
+          handledErrorFault: "customer",
+        });
+      });
+
+      it("applies to info-level records too", () => {
+        const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+        logHttpRequest(logger, {
+          method: "GET",
+          url: "/missing",
+          statusCode: 404,
+          duration: 1,
+          userAgent: null,
+          error: Object.assign(new Error("nope"), { status: 404 }),
+        });
+
+        expect(logger.info.mock.calls[0][0]).not.toHaveProperty("error");
+      });
+    });
+
+    describe("when the record is logged at error level", () => {
+      it("keeps the cause under error so 5xx dashboards are unchanged", () => {
+        const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+        const boom = new Error("boom");
+
+        logHttpRequest(logger, {
+          method: "POST",
+          url: "/fail",
+          statusCode: 500,
+          duration: 100,
+          userAgent: null,
+          error: boom,
+        });
+
+        const logData = logger.error.mock.calls[0][0];
+        expect(logData.error).toBe(boom);
+        expect(logData).not.toHaveProperty(REQUEST_CAUSE_FIELD);
       });
     });
   });

--- a/packages/observability/src/__tests__/requestLogging.unit.test.ts
+++ b/packages/observability/src/__tests__/requestLogging.unit.test.ts
@@ -197,11 +197,9 @@ describe("requestLogging", () => {
     });
 
     /**
-     * Loki reads a field named `error` to decide a record's level, and that
-     * guess beats the severity we emitted. Records we deliberately log below
-     * error therefore have to carry their cause somewhere else, or they arrive
-     * as errors anyway — which is what buried the real 5xx behind 128k/day of
-     * handled 402s.
+     * A record we chose to log at warn should not carry a key that claims it
+     * failed. The level we meant is on `severity_text`; the payload must not
+     * argue with it.
      */
     describe("when the record is logged below error level", () => {
       const handledCustomer = Object.assign(new Error("over quota"), {

--- a/packages/observability/src/__tests__/validationMeta.unit.test.ts
+++ b/packages/observability/src/__tests__/validationMeta.unit.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_VALIDATION_ISSUES,
+  validationMeta,
+} from "../validation/validationMeta";
+
+/**
+ * The issues are hand-built rather than produced by zod on purpose: this
+ * package does not depend on zod, and the contract under test is the duck-typed
+ * shape, not one zod version's rendering of it. Each fixture mirrors a real
+ * `ZodIssue` for the code it names.
+ */
+
+describe("validationMeta", () => {
+  describe("given a value that is not a validation error", () => {
+    it("returns undefined for a plain error", () => {
+      expect(validationMeta(new Error("boom"))).toBeUndefined();
+    });
+
+    it("returns undefined for null", () => {
+      expect(validationMeta(null)).toBeUndefined();
+    });
+
+    it("returns undefined for an object without issues", () => {
+      expect(validationMeta({ message: "nope" })).toBeUndefined();
+    });
+  });
+
+  describe("when a field has the wrong type", () => {
+    const error = {
+      issues: [
+        {
+          code: "invalid_type",
+          path: ["spans", 0, "timestamps", "started_at"],
+          expected: "number",
+          received: "string",
+          message: "Expected number, received string",
+        },
+      ],
+    };
+
+    it("names the failing path with array indices", () => {
+      expect(validationMeta(error)?.issues[0]?.path).toBe(
+        "spans[0].timestamps.started_at",
+      );
+    });
+
+    /** @scenario A field of the wrong type reports both types by name */
+    it("reports both types by name", () => {
+      const issue = validationMeta(error)?.issues[0];
+      expect(issue?.expected).toBe("number");
+      expect(issue?.received).toBe("string");
+    });
+
+    it("carries the issue code", () => {
+      expect(validationMeta(error)?.issues[0]?.code).toBe("invalid_type");
+    });
+  });
+
+  describe("when the schema refuses an unrecognised key", () => {
+    const error = {
+      issues: [
+        {
+          code: "unrecognized_keys",
+          path: ["spans", 2],
+          keys: ["vendor_latency_ms", "internal_hint"],
+          message: "Unrecognized key(s) in object",
+        },
+      ],
+    };
+
+    /** @scenario A field we do not recognise is named */
+    it("names the rejected keys", () => {
+      expect(validationMeta(error)?.issues[0]?.keys).toEqual([
+        "vendor_latency_ms",
+        "internal_hint",
+      ]);
+    });
+
+    it("reports the code so the rate can be aggregated", () => {
+      expect(validationMeta(error)?.issues[0]?.code).toBe("unrecognized_keys");
+    });
+  });
+
+  describe("when a value is not one of the allowed options", () => {
+    const error = {
+      issues: [
+        {
+          code: "invalid_enum_value",
+          path: ["spans", 0, "type"],
+          options: ["llm", "chain", "tool"],
+          received: "customer-private-span-kind",
+          message:
+            "Invalid enum value. Expected 'llm' | 'chain' | 'tool', received 'customer-private-span-kind'",
+        },
+      ],
+    };
+
+    /** @scenario A rejected enum reports the options without the value */
+    it("names the options the schema allows", () => {
+      expect(validationMeta(error)?.issues[0]?.options).toEqual([
+        "llm",
+        "chain",
+        "tool",
+      ]);
+    });
+
+    it("omits the value that arrived", () => {
+      const serialised = JSON.stringify(validationMeta(error));
+      expect(serialised).not.toContain("customer-private-span-kind");
+    });
+
+    it("omits zod's message, which embeds the value", () => {
+      expect(validationMeta(error)?.issues[0]).not.toHaveProperty("message");
+    });
+  });
+
+  describe("when the failure carries customer content", () => {
+    it("keeps the value out of the metadata for every issue code", () => {
+      const secret = "sk-live-DO-NOT-LOG";
+      const error = {
+        issues: [
+          {
+            code: "invalid_literal",
+            path: ["a"],
+            expected: "fixed",
+            received: secret,
+            message: `Invalid literal value, expected "fixed"`,
+          },
+          {
+            code: "invalid_string",
+            path: ["b"],
+            validation: "url",
+            message: "Invalid url",
+          },
+          {
+            code: "custom",
+            path: ["c"],
+            params: { value: secret },
+            message: `Rejected ${secret}`,
+          },
+        ],
+      };
+
+      expect(JSON.stringify(validationMeta(error))).not.toContain(secret);
+    });
+
+    it("keeps the declared literal, which is the schema's own", () => {
+      const error = {
+        issues: [
+          {
+            code: "invalid_literal",
+            path: ["a"],
+            expected: "fixed",
+            received: "other",
+          },
+        ],
+      };
+      expect(validationMeta(error)?.issues[0]?.expected).toBe("fixed");
+    });
+  });
+
+  describe("when a string rule or bound fails", () => {
+    it("names the string rule", () => {
+      const error = {
+        issues: [{ code: "invalid_string", path: ["url"], validation: "url" }],
+      };
+      expect(validationMeta(error)?.issues[0]?.rule).toBe("url");
+    });
+
+    it("reports the minimum for too_small", () => {
+      const error = {
+        issues: [{ code: "too_small", path: ["name"], minimum: 1 }],
+      };
+      expect(validationMeta(error)?.issues[0]?.limit).toBe(1);
+    });
+
+    it("reports the maximum for too_big", () => {
+      const error = {
+        issues: [{ code: "too_big", path: ["name"], maximum: 128 }],
+      };
+      expect(validationMeta(error)?.issues[0]?.limit).toBe(128);
+    });
+  });
+
+  describe("when the failure is a union", () => {
+    it("follows the branch errors so the real reasons are visible", () => {
+      const error = {
+        issues: [
+          {
+            code: "invalid_union",
+            path: ["input"],
+            unionErrors: [
+              {
+                issues: [
+                  {
+                    code: "invalid_type",
+                    path: ["input", "value"],
+                    expected: "string",
+                    received: "number",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const meta = validationMeta(error);
+      expect(meta?.issueCount).toBe(2);
+      expect(meta?.issues.map((i) => i.code)).toEqual([
+        "invalid_union",
+        "invalid_type",
+      ]);
+    });
+  });
+
+  describe("when the root itself fails", () => {
+    it("labels an empty path as the root", () => {
+      const error = {
+        issues: [
+          {
+            code: "invalid_type",
+            path: [],
+            expected: "object",
+            received: "array",
+          },
+        ],
+      };
+      expect(validationMeta(error)?.issues[0]?.path).toBe("<root>");
+    });
+  });
+
+  describe("when there are more issues than the log will carry", () => {
+    const error = {
+      issues: Array.from({ length: MAX_VALIDATION_ISSUES + 5 }, (_, i) => ({
+        code: "invalid_type",
+        path: ["spans", i, "name"],
+        expected: "string",
+        received: "undefined",
+      })),
+    };
+
+    it("reports the total count", () => {
+      expect(validationMeta(error)?.issueCount).toBe(MAX_VALIDATION_ISSUES + 5);
+    });
+
+    it("caps the entries it carries", () => {
+      expect(validationMeta(error)?.issues).toHaveLength(MAX_VALIDATION_ISSUES);
+    });
+
+    /** @scenario Issue counts survive truncation */
+    it("marks the record as truncated", () => {
+      expect(validationMeta(error)?.truncated).toBe(true);
+    });
+
+    it("does not mark a record that fits as truncated", () => {
+      const small = { issues: [{ code: "invalid_type", path: ["a"] }] };
+      expect(validationMeta(small)).not.toHaveProperty("truncated");
+    });
+  });
+
+  describe("when an unknown issue code arrives", () => {
+    it("keeps the path and code without copying anything else", () => {
+      const error = {
+        issues: [
+          {
+            code: "some_future_code",
+            path: ["a"],
+            received: "customer value",
+            message: "customer value",
+          },
+        ],
+      };
+      const issue = validationMeta(error)?.issues[0];
+      expect(issue).toEqual({ path: "a", code: "some_future_code" });
+    });
+  });
+});

--- a/packages/observability/src/constants.ts
+++ b/packages/observability/src/constants.ts
@@ -4,6 +4,21 @@
  */
 
 /**
+ * Where a cause is attached on a record that is NOT at error level.
+ *
+ * A record we chose to log at warn should not carry a key called `error`,
+ * which is the loudest possible claim that it failed. `severity_text` carries
+ * the level we meant; the payload should not argue with it.
+ *
+ * It lives here rather than beside `logHttpRequest` because `logger.ts` has to
+ * register a serializer for it and cannot import from `request/requestLogging`
+ * without a cycle. Both ends must agree on the name: pino applies serializers
+ * by exact key, so a field named here and not registered there is emitted as a
+ * bare `Error` and loses its message and stack entirely.
+ */
+export const REQUEST_CAUSE_FIELD = "requestError";
+
+/**
  * OpenTelemetry span attribute keys used across LangWatch services.
  */
 export const OTEL_ATTR = {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -10,6 +10,7 @@ export {
   DEFAULT_SERVICE_NAME,
   INVALID_TRACE_ID,
   OTEL_ATTR,
+  REQUEST_CAUSE_FIELD,
   TRACER_NAMES,
 } from "./constants";
 export type {
@@ -28,7 +29,6 @@ export {
   getStatusCodeFromError,
   hasAuthorizationToken,
   logHttpRequest,
-  REQUEST_CAUSE_FIELD,
   type RequestLogData,
 } from "./request/requestLogging";
 export {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -28,5 +28,12 @@ export {
   getStatusCodeFromError,
   hasAuthorizationToken,
   logHttpRequest,
+  REQUEST_CAUSE_FIELD,
   type RequestLogData,
 } from "./request/requestLogging";
+export {
+  MAX_VALIDATION_ISSUES,
+  validationMeta,
+  type ValidationIssueMeta,
+  type ValidationMeta,
+} from "./validation/validationMeta";

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -4,7 +4,7 @@ import pino, {
   type Logger as PinoLogger,
 } from "pino";
 import type SuperJSON from "superjson";
-import { DEFAULT_SERVICE_NAME } from "./constants";
+import { DEFAULT_SERVICE_NAME, REQUEST_CAUSE_FIELD } from "./constants";
 
 type LogContextProvider = () => Record<string, string | null>;
 
@@ -51,6 +51,23 @@ const superjsonErrorSerializer = (error: unknown) => {
     _superjson: serialized.meta,
   };
 };
+
+/**
+ * Every key a cause may be logged under, mapped to the same serializer.
+ *
+ * pino matches serializers by exact property name and nothing warns when a key
+ * has none: the value is passed to `JSON.stringify`, and an `Error` has no
+ * enumerable own properties, so it lands as `{}` with the message and stack -
+ * the only reasons it was logged - gone. Keeping the map in one exported
+ * constant is what lets a test drive the real thing rather than a copy of it.
+ *
+ * `error` for records that ARE failures; {@link REQUEST_CAUSE_FIELD} for the
+ * cause on records deliberately logged below error level.
+ */
+export const NODE_LOG_SERIALIZERS = {
+  error: superjsonErrorSerializer,
+  [REQUEST_CAUSE_FIELD]: superjsonErrorSerializer,
+} as const;
 
 export interface CreateLoggerOptions {
   /**
@@ -141,7 +158,14 @@ function createBrowserLogger(name: string): PinoLogger {
     name,
     level,
     timestamp: pino.stdTimeFunctions.isoTime,
-    serializers: { error: pino.stdSerializers.err },
+    // Both keys, same serializer. pino matches serializers by exact property
+    // name, so a cause moved to REQUEST_CAUSE_FIELD and not registered here is
+    // emitted as a bare Error - which serialises to `{}`, losing the message
+    // and stack that are the whole reason it was logged.
+    serializers: {
+      error: pino.stdSerializers.err,
+      [REQUEST_CAUSE_FIELD]: pino.stdSerializers.err,
+    },
     formatters: {
       bindings: (bindings) => bindings,
       level: (label) => ({ level: label.toUpperCase() }),
@@ -163,7 +187,7 @@ function createNodeLogger(
     name,
     level,
     timestamp: pino.stdTimeFunctions.isoTime,
-    serializers: { error: superjsonErrorSerializer },
+    serializers: NODE_LOG_SERIALIZERS,
     formatters: {
       // Adds process identity alongside pino's own pid/hostname bindings,
       // distinct from `name` (the per-module label like "langwatch:api:hono").

--- a/packages/observability/src/request/requestLogging.ts
+++ b/packages/observability/src/request/requestLogging.ts
@@ -88,14 +88,21 @@ export function getLogLevelForRequest(
 /**
  * Where a cause is attached on a record that is NOT at error level.
  *
- * Loki derives `detected_level` from the presence of a field named `error` and
- * that guess beats the `severity_text` we actually emitted. So a handled 402,
- * logged at warn exactly as intended, arrived in Loki as an error — 128k a day
- * of them on one service, swamping the genuine 5xx and making every dashboard
- * and alert built on `detected_level` read the opposite of the truth.
+ * A record we chose to log at warn should not read as a failure to anything
+ * downstream, and a key called `error` is the loudest possible claim that it
+ * is. `severity_text` carries the level we meant; this keeps the payload from
+ * arguing with it. Same convention as `VENDOR_CAUSE_FIELD` and
+ * `RETRY_CAUSE_FIELD` in `@langwatch/clickhouse-client`, so all three agree.
  *
- * Same rule, and same reason, as `VENDOR_CAUSE_FIELD` in
- * `@langwatch/clickhouse-client`.
+ * What this does NOT fix, despite what those two modules claim: prod Loki's
+ * `detected_level`. Measured 2026-08-07 — Loki 3.3 reads the level by parsing
+ * the LOG LINE as JSON, and our lines are not JSON. fluent-bit promotes these
+ * fields to structured metadata and ships the bare message as the line, so Loki
+ * never sees this field at all and falls back to scanning the message text for
+ * "error" / "warn". `"error handling request"` contains the word, which is what
+ * promoted 129k handled 402s a day. Renaming a field the parser cannot reach
+ * changes nothing there; the fix is `discover_log_levels: false` on the Loki
+ * side, and `severity_text` as the only level anything queries.
  */
 export const REQUEST_CAUSE_FIELD = "requestError";
 
@@ -116,10 +123,10 @@ export function logHttpRequest(logger: Logger, data: RequestLogData): void {
   const level = getLogLevelForRequest(data.error, data.statusCode);
 
   if (data.error) {
-    // At error level the field keeps its name: `detected_level` and
-    // `severity_text` already agree there, and every 5xx dashboard slices on
-    // the `error_*` metadata the serializer derives from it. Only the levels
-    // where the two disagree are re-keyed.
+    // At error level the field keeps its name — the record IS a failure, and
+    // every 5xx dashboard slices on the `error_*` metadata the serializer
+    // derives from it. Only the levels where the name would misrepresent the
+    // record are re-keyed.
     if (level === "error") {
       logData.error = data.error;
     } else {

--- a/packages/observability/src/request/requestLogging.ts
+++ b/packages/observability/src/request/requestLogging.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CAUSE_FIELD } from "../constants";
 import type { Logger } from "../logger";
 
 /**
@@ -86,15 +87,11 @@ export function getLogLevelForRequest(
 }
 
 /**
- * Where a cause is attached on a record that is NOT at error level.
+ * The convention {@link REQUEST_CAUSE_FIELD} belongs to matches
+ * `VENDOR_CAUSE_FIELD` and `RETRY_CAUSE_FIELD` in
+ * `@langwatch/clickhouse-client`, so all three agree.
  *
- * A record we chose to log at warn should not read as a failure to anything
- * downstream, and a key called `error` is the loudest possible claim that it
- * is. `severity_text` carries the level we meant; this keeps the payload from
- * arguing with it. Same convention as `VENDOR_CAUSE_FIELD` and
- * `RETRY_CAUSE_FIELD` in `@langwatch/clickhouse-client`, so all three agree.
- *
- * What this does NOT fix, despite what those two modules claim: prod Loki's
+ * What it does NOT fix, despite what those two modules claim: prod Loki's
  * `detected_level`. Measured 2026-08-07 — Loki 3.3 reads the level by parsing
  * the LOG LINE as JSON, and our lines are not JSON. fluent-bit promotes these
  * fields to structured metadata and ships the bare message as the line, so Loki
@@ -103,10 +100,7 @@ export function getLogLevelForRequest(
  * promoted 129k handled 402s a day. Renaming a field the parser cannot reach
  * changes nothing there; the fix is `discover_log_levels: false` on the Loki
  * side, and `severity_text` as the only level anything queries.
- */
-export const REQUEST_CAUSE_FIELD = "requestError";
-
-/**
+ *
  * Logs an HTTP request with appropriate level based on status code.
  * Uses error level for 5xx, warn for 4xx, info for success.
  */

--- a/packages/observability/src/request/requestLogging.ts
+++ b/packages/observability/src/request/requestLogging.ts
@@ -86,6 +86,20 @@ export function getLogLevelForRequest(
 }
 
 /**
+ * Where a cause is attached on a record that is NOT at error level.
+ *
+ * Loki derives `detected_level` from the presence of a field named `error` and
+ * that guess beats the `severity_text` we actually emitted. So a handled 402,
+ * logged at warn exactly as intended, arrived in Loki as an error — 128k a day
+ * of them on one service, swamping the genuine 5xx and making every dashboard
+ * and alert built on `detected_level` read the opposite of the truth.
+ *
+ * Same rule, and same reason, as `VENDOR_CAUSE_FIELD` in
+ * `@langwatch/clickhouse-client`.
+ */
+export const REQUEST_CAUSE_FIELD = "requestError";
+
+/**
  * Logs an HTTP request with appropriate level based on status code.
  * Uses error level for 5xx, warn for 4xx, info for success.
  */
@@ -99,8 +113,23 @@ export function logHttpRequest(logger: Logger, data: RequestLogData): void {
     userAgent: data.userAgent,
   };
 
+  const level = getLogLevelForRequest(data.error, data.statusCode);
+
   if (data.error) {
-    logData.error = data.error;
+    // At error level the field keeps its name: `detected_level` and
+    // `severity_text` already agree there, and every 5xx dashboard slices on
+    // the `error_*` metadata the serializer derives from it. Only the levels
+    // where the two disagree are re-keyed.
+    if (level === "error") {
+      logData.error = data.error;
+    } else {
+      logData[REQUEST_CAUSE_FIELD] = data.error;
+      // Re-keying costs the derived `error_type`, which is how these records
+      // were grouped. Restated flat so the grouping survives the move.
+      const name = (data.error as { name?: unknown }).name;
+      if (typeof name === "string") logData.errorType = name;
+    }
+
     const fault = handledFaultOf(data.error);
     if (fault) {
       logData.handledErrorCode = (data.error as Record<string, unknown>).code;
@@ -108,7 +137,6 @@ export function logHttpRequest(logger: Logger, data: RequestLogData): void {
     }
   }
 
-  const level = getLogLevelForRequest(data.error, data.statusCode);
   const message = data.error ? "error handling request" : "request handled";
 
   logger[level](logData, message);

--- a/packages/observability/src/validation/validationMeta.ts
+++ b/packages/observability/src/validation/validationMeta.ts
@@ -165,14 +165,28 @@ function metaForIssue(issue: RawIssue): ValidationIssueMeta {
  * Flatten a Zod error into issues, following `invalid_union` into the branch
  * errors it nests. A union failure whose branches are hidden reports only that
  * "something did not match", which is the least useful thing it could say.
+ *
+ * Counts every issue but only builds the ones that will be kept. The input here
+ * is an untrusted body - up to 10 MiB and a couple of hundred spans, each
+ * checked against union schemas that fan out a branch of issues per arm - so
+ * the difference between counting a large tree and materialising one is worth
+ * having on a path that runs per rejected request.
  */
-function collectIssues(issues: RawIssue[], into: ValidationIssueMeta[]): void {
+function collectIssues(
+  issues: RawIssue[],
+  into: ValidationIssueMeta[],
+  counter: { total: number },
+  maxIssues: number,
+): void {
   for (const issue of issues) {
-    into.push(metaForIssue(issue));
+    counter.total += 1;
+    if (into.length < maxIssues) into.push(metaForIssue(issue));
 
     if (Array.isArray(issue.unionErrors)) {
       for (const nested of issue.unionErrors) {
-        if (hasIssues(nested)) collectIssues(nested.issues, into);
+        if (hasIssues(nested)) {
+          collectIssues(nested.issues, into, counter, maxIssues);
+        }
       }
     }
   }
@@ -189,14 +203,12 @@ export function validationMeta(
 ): ValidationMeta | undefined {
   if (!hasIssues(error)) return undefined;
 
-  const all: ValidationIssueMeta[] = [];
-  collectIssues(error.issues, all);
+  const issues: ValidationIssueMeta[] = [];
+  const counter = { total: 0 };
+  collectIssues(error.issues, issues, counter, maxIssues);
 
-  const meta: ValidationMeta = {
-    issueCount: all.length,
-    issues: all.slice(0, maxIssues),
-  };
-  if (all.length > maxIssues) meta.truncated = true;
+  const meta: ValidationMeta = { issueCount: counter.total, issues };
+  if (counter.total > issues.length) meta.truncated = true;
 
   return meta;
 }

--- a/packages/observability/src/validation/validationMeta.ts
+++ b/packages/observability/src/validation/validationMeta.ts
@@ -1,0 +1,202 @@
+/**
+ * Structured metadata describing why a payload failed validation, built so it
+ * can be logged and aggregated without carrying any of the payload.
+ *
+ * The question this exists to answer is "is the sender wrong, or is our schema
+ * too strict?". Answering it needs the shape of the failure — which field, and
+ * what we demanded of it — and never needs the value. So the split this module
+ * enforces is by authorship: a path, an issue code, a bound and a list of
+ * allowed options are our own schema's vocabulary and are safe to emit; the
+ * value that arrived is the customer's and is not.
+ *
+ * That split is why fields are copied by an allow-list per issue code rather
+ * than spread. Two of Zod's own fields would otherwise leak content:
+ *
+ *   - `message` embeds the received value for several codes ("Invalid enum
+ *     value. Expected 'a' | 'b', received '<their value>'").
+ *   - `received` is a type name for `invalid_type` and the literal value for
+ *     `invalid_literal` / `invalid_enum_value`.
+ *
+ * Duck-typed on purpose: this package does not depend on zod, the same way
+ * `handledFaultOf` does not depend on the HandledError class. Anything with an
+ * `issues` array of the documented shape works.
+ */
+
+/** The most issues one record carries before it is truncated. */
+export const MAX_VALIDATION_ISSUES = 20;
+
+export interface ValidationIssueMeta {
+  /** Dotted path with array indices, e.g. `spans[0].timestamps.started_at`. */
+  path: string;
+  /** Zod issue code, e.g. `invalid_type`, `unrecognized_keys`. */
+  code: string;
+  /** Type or literal kind the schema demanded. Never a customer value. */
+  expected?: string;
+  /** Type name that arrived. Only ever set for `invalid_type`. */
+  received?: string;
+  /**
+   * Keys the schema refused.
+   *
+   * These are field NAMES, chosen by the sender's instrumentation rather than
+   * carried as content, and they are the single most useful signal here: the
+   * same key refused across many projects means an SDK emits something we have
+   * not modelled, and the fix is ours.
+   */
+  keys?: string[];
+  /** Values the schema allows. Ours, from the schema definition. */
+  options?: string[];
+  /** Named string rule that failed, e.g. `url`, `uuid`, `datetime`. */
+  rule?: string;
+  /** Bound the value missed, for `too_small` / `too_big`. */
+  limit?: number;
+}
+
+export interface ValidationMeta {
+  /** Total issues found, whether or not they all fit in `issues`. */
+  issueCount: number;
+  issues: ValidationIssueMeta[];
+  /** Present and true only when `issues` holds fewer than `issueCount`. */
+  truncated?: boolean;
+}
+
+interface RawIssue {
+  code?: unknown;
+  path?: unknown;
+  expected?: unknown;
+  received?: unknown;
+  keys?: unknown;
+  options?: unknown;
+  validation?: unknown;
+  minimum?: unknown;
+  maximum?: unknown;
+  unionErrors?: unknown;
+}
+
+function hasIssues(error: unknown): error is { issues: RawIssue[] } {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
+/**
+ * `["spans", 0, "timestamps", "started_at"]` -> `spans[0].timestamps.started_at`.
+ * An empty path means the root, which reads better as `<root>` than as "".
+ */
+function formatPath(path: unknown): string {
+  if (!Array.isArray(path) || path.length === 0) return "<root>";
+
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      out += `[${segment}]`;
+      continue;
+    }
+    out += out === "" ? String(segment) : `.${String(segment)}`;
+  }
+  return out;
+}
+
+function stringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  return value.map((entry) => String(entry));
+}
+
+/**
+ * Copy only the fields this issue code is known to populate with our own
+ * vocabulary. Anything not named here is dropped, so a Zod version that adds a
+ * field cannot start leaking content without this list changing first.
+ */
+function metaForIssue(issue: RawIssue): ValidationIssueMeta {
+  const meta: ValidationIssueMeta = {
+    path: formatPath(issue.path),
+    code: typeof issue.code === "string" ? issue.code : "unknown",
+  };
+
+  switch (meta.code) {
+    case "invalid_type":
+      // Both sides are type names here ("string", "undefined"), not values.
+      if (typeof issue.expected === "string") meta.expected = issue.expected;
+      if (typeof issue.received === "string") meta.received = issue.received;
+      break;
+
+    case "unrecognized_keys":
+      meta.keys = stringList(issue.keys);
+      break;
+
+    case "invalid_enum_value":
+    case "invalid_union_discriminator":
+      // `options` is the schema's own list. `received` is deliberately not
+      // copied: for these codes it holds the value that arrived.
+      meta.options = stringList(issue.options);
+      break;
+
+    case "invalid_literal":
+      // `expected` is the literal our schema declares, so it is ours to log.
+      if (
+        typeof issue.expected === "string" ||
+        typeof issue.expected === "number"
+      ) {
+        meta.expected = String(issue.expected);
+      }
+      break;
+
+    case "invalid_string":
+      if (typeof issue.validation === "string") meta.rule = issue.validation;
+      break;
+
+    case "too_small":
+      if (typeof issue.minimum === "number") meta.limit = issue.minimum;
+      break;
+
+    case "too_big":
+      if (typeof issue.maximum === "number") meta.limit = issue.maximum;
+      break;
+
+    default:
+      break;
+  }
+
+  return meta;
+}
+
+/**
+ * Flatten a Zod error into issues, following `invalid_union` into the branch
+ * errors it nests. A union failure whose branches are hidden reports only that
+ * "something did not match", which is the least useful thing it could say.
+ */
+function collectIssues(issues: RawIssue[], into: ValidationIssueMeta[]): void {
+  for (const issue of issues) {
+    into.push(metaForIssue(issue));
+
+    if (Array.isArray(issue.unionErrors)) {
+      for (const nested of issue.unionErrors) {
+        if (hasIssues(nested)) collectIssues(nested.issues, into);
+      }
+    }
+  }
+}
+
+/**
+ * Build loggable metadata from a validation error, or `undefined` when the
+ * error is not one — so a caller can spread the result and get nothing extra
+ * for a non-validation failure.
+ */
+export function validationMeta(
+  error: unknown,
+  { maxIssues = MAX_VALIDATION_ISSUES }: { maxIssues?: number } = {},
+): ValidationMeta | undefined {
+  if (!hasIssues(error)) return undefined;
+
+  const all: ValidationIssueMeta[] = [];
+  collectIssues(error.issues, all);
+
+  const meta: ValidationMeta = {
+    issueCount: all.length,
+    issues: all.slice(0, maxIssues),
+  };
+  if (all.length > maxIssues) meta.truncated = true;
+
+  return meta;
+}

--- a/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
@@ -257,7 +257,7 @@ describe("createResilientClickHouseClient()", () => {
 
     // Loki derives a record's level from a field called `error`, so leaving the
     // cause there re-promotes exactly the records this change moved down.
-    /** @scenario The cause never rides on a field named error */
+    /** @scenario The cause rides on the named query-cause field */
     it("keeps the cause off a field named error", async () => {
       const mock = makeMockClient({
         query: vi.fn().mockRejectedValue(new Error("Syntax error in query")),

--- a/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import { QUERY_CAUSE_FIELD } from "@langwatch/clickhouse-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockQueryLogger, mockLogger } = vi.hoisted(() => ({
@@ -204,13 +205,33 @@ describe("createResilientClickHouseClient()", () => {
         "Syntax error in query",
       );
 
-      expect(mockQueryLogger.error).toHaveBeenCalledWith(
+      expect(mockQueryLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           source: "clickhouse",
           operation: "query",
         }),
         expect.any(String),
       );
+    });
+
+    // The error is on its way to the caller, which is what knows whether it
+    // ends as a 5xx, a retried job, or a dropped one. Reporting it as an error
+    // here as well counted recovered work as lost.
+    /** @scenario A failed attempt raised to the caller is not itself an error */
+    it("reports the attempt at warn, leaving the verdict to the caller", async () => {
+      const mock = makeMockClient({
+        query: vi.fn().mockRejectedValue(new Error("Syntax error in query")),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+      });
+
+      await expect(client.query({ query: "SELECT 1" })).rejects.toThrow(
+        "Syntax error in query",
+      );
+
+      expect(mockQueryLogger.error).not.toHaveBeenCalled();
     });
 
     it("passes the raw error object for Pino serializer", async () => {
@@ -227,11 +248,32 @@ describe("createResilientClickHouseClient()", () => {
         "Syntax error in query",
       );
 
-      const loggedObj = mockQueryLogger.error.mock.calls[0]![0] as Record<
+      const loggedObj = mockQueryLogger.warn.mock.calls[0]![0] as Record<
         string,
         unknown
       >;
-      expect(loggedObj.error).toBe(err);
+      expect(loggedObj[QUERY_CAUSE_FIELD]).toBe(err);
+    });
+
+    // Loki derives a record's level from a field called `error`, so leaving the
+    // cause there re-promotes exactly the records this change moved down.
+    /** @scenario The cause never rides on a field named error */
+    it("keeps the cause off a field named error", async () => {
+      const mock = makeMockClient({
+        query: vi.fn().mockRejectedValue(new Error("Syntax error in query")),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+      });
+
+      await expect(client.query({ query: "SELECT 1" })).rejects.toThrow(
+        "Syntax error in query",
+      );
+
+      expect(mockQueryLogger.warn.mock.calls[0]![0]).not.toHaveProperty(
+        "error",
+      );
     });
   });
 

--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -1,5 +1,9 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import { RETRY_CAUSE_FIELD, runWithRetry } from "@langwatch/clickhouse-client";
+import {
+  QUERY_CAUSE_FIELD,
+  RETRY_CAUSE_FIELD,
+  runWithRetry,
+} from "@langwatch/clickhouse-client";
 import { createLogger } from "@langwatch/observability";
 import {
   incrementClickHouseQueryCount,
@@ -130,6 +134,22 @@ function extractRawQuery(params: unknown): string {
   return typeof p.query === "string" ? p.query : "";
 }
 
+/**
+ * Report an attempt that failed and was raised to the caller.
+ *
+ * Warn, not error, and the cause off the `error` field — the same two rules,
+ * for the same reason, as the vendor policy in `@langwatch/clickhouse-client`.
+ * This wrapper does not know the outcome: a read's translated error is reported
+ * at the request boundary, and an insert is issued from a job the queue
+ * retries, which logs its own error and increments `gq_jobs_dropped_total` if
+ * it ever truly gives up. Claiming a verdict here made recovered work read as
+ * lost work — 17k records a day against zero jobs actually dropped — and
+ * naming the field `error` had the log pipeline promote the record's level
+ * regardless of the one chosen here.
+ *
+ * The failure is still counted: `incrementClickHouseQueryCount(_, "error")`
+ * runs at every call site, and a rate is what the alerting is built on.
+ */
 function logFailure({
   operation,
   error,
@@ -144,7 +164,7 @@ function logFailure({
   try {
     const meta = safeQueryMeta(params);
 
-    queryLogger.error(
+    queryLogger.warn(
       {
         source: "clickhouse",
         operation,
@@ -152,7 +172,7 @@ function logFailure({
         queryId: meta.queryId,
         format: meta.format,
         paramKeys: meta.paramKeys,
-        error,
+        [QUERY_CAUSE_FIELD]: error,
       },
       `ClickHouse ${operation} failed`,
     );

--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -137,15 +137,20 @@ function extractRawQuery(params: unknown): string {
 /**
  * Report an attempt that failed and was raised to the caller.
  *
- * Warn, not error, and the cause off the `error` field — the same two rules,
- * for the same reason, as the vendor policy in `@langwatch/clickhouse-client`.
- * This wrapper does not know the outcome: a read's translated error is reported
- * at the request boundary, and an insert is issued from a job the queue
- * retries, which logs its own error and increments `gq_jobs_dropped_total` if
- * it ever truly gives up. Claiming a verdict here made recovered work read as
- * lost work — 17k records a day against zero jobs actually dropped — and
- * naming the field `error` had the log pipeline promote the record's level
- * regardless of the one chosen here.
+ * Warn, not error, and the cause off the `error` field — the same two rules as
+ * the vendor policy in `@langwatch/clickhouse-client`.
+ *
+ * The level is the substantive half. This wrapper does not know the outcome: a
+ * read's translated error is reported at the request boundary, and an insert is
+ * issued from a job the queue retries, which logs its own error and increments
+ * `gq_jobs_dropped_total` if it ever truly gives up. Claiming a verdict here
+ * made recovered work read as lost work — 17k records a day against zero jobs
+ * actually dropped.
+ *
+ * The field name is consistency, not a fix: a warn record should not carry a
+ * key asserting it failed. It does NOT change prod Loki's `detected_level`,
+ * which never sees these fields — see the note on `REQUEST_CAUSE_FIELD` in
+ * @langwatch/observability for why, and what actually fixes it.
  *
  * The failure is still counted: `incrementClickHouseQueryCount(_, "error")`
  * runs at every call site, and a rate is what the alerting is built on.

--- a/platform/app/src/server/clickhouse/__tests__/statementLimit.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/statementLimit.unit.test.ts
@@ -2,7 +2,12 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { AcquireAbortedError } from "@langwatch/clickhouse-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ClickHouseOverloadedError } from "~/server/app-layer/traces/errors";
-import { MIN_QUEUE_DEPTH, withStatementLimit } from "../statementLimit";
+import { CLICKHOUSE_REQUEST_TIMEOUT_MS } from "../managedClient";
+import {
+  MIN_QUEUE_DEPTH,
+  STATEMENT_WAIT_TIMEOUT_MS,
+  withStatementLimit,
+} from "../statementLimit";
 
 /**
  * A stand-in for the driver that lets a test decide when each statement
@@ -259,6 +264,95 @@ describe("withStatementLimit", () => {
 
         await expect(abandoned).rejects.toBeInstanceOf(AcquireAbortedError);
         expect(driver.started).toBe(1);
+
+        driver.releaseAll();
+        await admitted;
+      });
+    });
+
+    /**
+     * The queue was bounded by depth but not by time. A statement could wait
+     * for as long as everything ahead of it took and then still spend the
+     * driver's full request timeout on the wire — which is how a 46-second
+     * failure was assembled out of two limits, neither of which was 46 seconds.
+     */
+    describe("when no slot arrives before the wait runs out", () => {
+      /** @scenario a statement that waits too long is refused, not left waiting */
+      it("refuses it as overload rather than waiting indefinitely", async () => {
+        const driver = deferrableClient();
+        const limited = withStatementLimit({
+          client: driver.client,
+          maxConcurrent: 1,
+          instance,
+          waitTimeoutMs: 20,
+        });
+
+        const admitted = limited.query({ query: "SELECT 1" });
+        const waiting = limited.query({ query: "SELECT 2" });
+
+        await expect(waiting).rejects.toBeInstanceOf(ClickHouseOverloadedError);
+
+        // The one already running is untouched — only the wait was bounded.
+        expect(driver.started).toBe(1);
+
+        driver.releaseAll();
+        await admitted;
+      });
+
+      it("keeps the production bound well inside the request timeout", () => {
+        // The two limits compound: a statement pays the wait and then the wire.
+        expect(STATEMENT_WAIT_TIMEOUT_MS).toBeLessThan(
+          CLICKHOUSE_REQUEST_TIMEOUT_MS,
+        );
+      });
+    });
+
+    describe("when a slot arrives before the wait runs out", () => {
+      it("runs the statement normally", async () => {
+        const driver = deferrableClient();
+        const limited = withStatementLimit({
+          client: driver.client,
+          maxConcurrent: 1,
+          instance,
+        });
+
+        const first = limited.query({ query: "SELECT 1" });
+        const second = limited.query({ query: "SELECT 2" });
+        await settleMicrotasks();
+
+        driver.releaseAll();
+        await settleMicrotasks();
+        driver.releaseAll();
+
+        await expect(first).resolves.toEqual({ ok: true });
+        await expect(second).resolves.toEqual({ ok: true });
+      });
+    });
+
+    /**
+     * A caller cancelling its own request is not the server being overloaded,
+     * and must keep surfacing as the cancellation it is.
+     */
+    describe("when the caller aborts while a wait timeout is also armed", () => {
+      it("still reports the abort rather than overload", async () => {
+        const driver = deferrableClient();
+        const limited = withStatementLimit({
+          client: driver.client,
+          maxConcurrent: 1,
+          instance,
+        });
+
+        const admitted = limited.query({ query: "SELECT 1" });
+        const controller = new AbortController();
+        const abandoned = limited.query({
+          query: "SELECT 2",
+          abort_signal: controller.signal,
+        });
+        await settleMicrotasks();
+
+        controller.abort();
+
+        await expect(abandoned).rejects.toBeInstanceOf(AcquireAbortedError);
 
         driver.releaseAll();
         await admitted;

--- a/platform/app/src/server/clickhouse/managedClient.ts
+++ b/platform/app/src/server/clickhouse/managedClient.ts
@@ -19,6 +19,21 @@ const logger = createLogger("langwatch:clickhouse:managed-client");
 export const SHARED_INSTANCE = "shared";
 
 /**
+ * How long one statement may spend on the wire before the driver gives up.
+ *
+ * 30s is the value the driver already applied as its own default, so stating it
+ * changes no behaviour today — that is the point. It was the largest single
+ * term in an observed 46-second failure and nothing in this repo had chosen it,
+ * which also meant a driver upgrade could move it silently.
+ *
+ * It is deliberately longer than the queue wait in `./statementLimit.ts`: a
+ * statement that has reached the wire is doing work, while one still queued has
+ * not started, and the one worth abandoning first is the one that has spent
+ * nothing.
+ */
+export const CLICKHOUSE_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
  * The only place in the platform that builds a ClickHouse client.
  *
  * Every policy the platform applies to a statement is assembled here, in one
@@ -75,6 +90,13 @@ export function createManagedClickHouseClient({
       date_time_input_format: "best_effort",
     },
     max_open_connections: maxOpenConnections,
+    // Stated rather than inherited. It was previously the driver's own default,
+    // which meant the bound on a statement was a number nobody in this repo had
+    // chosen and a driver upgrade could move without anyone noticing. Naming it
+    // also makes the two waits add up: what a caller actually observed on a
+    // stuck insert was this, plus however long it had queued in
+    // `./statementLimit.ts` — which is why that wait is bounded too.
+    request_timeout: CLICKHOUSE_REQUEST_TIMEOUT_MS,
     keep_alive: {
       enabled: true,
       idle_socket_ttl: 1500,

--- a/platform/app/src/server/clickhouse/statementLimit.ts
+++ b/platform/app/src/server/clickhouse/statementLimit.ts
@@ -34,6 +34,23 @@ export const QUEUE_DEPTH_PER_SLOT = 8;
 /** Never so shallow that a small pool sheds on ordinary burstiness. */
 export const MIN_QUEUE_DEPTH = 64;
 
+/**
+ * The longest a statement may wait for a slot before it is refused.
+ *
+ * The queue was bounded by DEPTH but not by TIME, so a caller could sit in it
+ * for as long as the statements ahead took — and then still spend the driver's
+ * full `request_timeout` on the wire. That is how a 46-second failure was
+ * assembled out of two limits, neither of which was 46 seconds.
+ *
+ * Shorter than the request timeout on purpose: a queued statement has done no
+ * work, so abandoning it costs nothing, while one already on the wire may be
+ * about to succeed. Refusal is also not loss — it raises
+ * `ClickHouseOverloadedError`, which classifies as transient, so a read retries
+ * and a job is re-staged by the queue. Waiting a further twenty seconds for a
+ * slot that arrives with no time left to use it serves nobody.
+ */
+export const STATEMENT_WAIT_TIMEOUT_MS = 20_000;
+
 type LimitedOperation = "query" | "insert" | "command" | "exec";
 
 /**
@@ -70,10 +87,13 @@ export function withStatementLimit<T extends ClickHouseClient>({
   client,
   maxConcurrent,
   instance,
+  waitTimeoutMs = STATEMENT_WAIT_TIMEOUT_MS,
 }: {
   client: T;
   maxConcurrent: number;
   instance: string;
+  /** Overridable so a test can prove the bound without spending it. */
+  waitTimeoutMs?: number;
 }): T {
   const maxQueued = Math.max(
     MIN_QUEUE_DEPTH,
@@ -105,9 +125,11 @@ export function withStatementLimit<T extends ClickHouseClient>({
     (limited as Record<string, unknown>)[operation] = (params: unknown) =>
       run({
         limiter,
+        maxConcurrent,
         instance,
         operation,
         signal: signalOf(params),
+        waitTimeoutMs,
         task: () =>
           (inner as (p: unknown) => Promise<unknown>).call(client, params),
       });
@@ -129,32 +151,102 @@ export function withStatementLimit<T extends ClickHouseClient>({
   return limited;
 }
 
+/** An armed wait: what the limiter blocks on, and how it ended. */
+interface ArmedWait {
+  signal: AbortSignal | undefined;
+  /** True only if OUR timer fired — never merely that the signal aborted. */
+  timedOut: () => boolean;
+  dispose: () => void;
+}
+
+const NOT_ARMED = (signal: AbortSignal | undefined): ArmedWait => ({
+  signal,
+  timedOut: () => false,
+  dispose: () => {
+    // Nothing was armed, so there is nothing to clear.
+  },
+});
+
+/**
+ * Arm the wait bound, but only when the limiter is ALREADY saturated.
+ *
+ * On the ordinary path a slot is free and `acquire` resolves without waiting at
+ * all, so arming anything would cost a timer and an `AbortSignal.any` per
+ * statement — millions a day — to bound a wait that never happens.
+ *
+ * A plain timer rather than `AbortSignal.timeout` for two reasons: it can be
+ * CLEARED the moment the statement is admitted, where a timeout signal holds
+ * its timer for the full duration regardless, and a saturated limiter would
+ * accumulate one per queued statement; and it is fakeable, so the test for this
+ * does not have to spend twenty real seconds proving it.
+ */
+function armWait({
+  limiter,
+  maxConcurrent,
+  signal,
+  waitTimeoutMs,
+}: {
+  limiter: ConcurrencyLimiter;
+  maxConcurrent: number;
+  signal: AbortSignal | undefined;
+  waitTimeoutMs: number;
+}): ArmedWait {
+  if (limiter.stats().inFlight < maxConcurrent) return NOT_ARMED(signal);
+
+  const controller = new AbortController();
+  let fired = false;
+  const timer = setTimeout(() => {
+    fired = true;
+    controller.abort();
+  }, waitTimeoutMs);
+  // Never a reason to hold the process open: if nothing else is running there
+  // is no statement ahead of this one to wait for.
+  timer.unref?.();
+
+  return {
+    signal: signal
+      ? AbortSignal.any([signal, controller.signal])
+      : controller.signal,
+    timedOut: () => fired,
+    dispose: () => clearTimeout(timer),
+  };
+}
+
 async function run({
   limiter,
+  maxConcurrent,
   instance,
   operation,
   signal,
+  waitTimeoutMs,
   task,
 }: {
   limiter: ConcurrencyLimiter;
+  maxConcurrent: number;
   instance: string;
   operation: LimitedOperation;
   signal: AbortSignal | undefined;
+  waitTimeoutMs: number;
   task: () => Promise<unknown>;
 }): Promise<unknown> {
   const queuedAt = performance.now();
   let admitted = false;
 
+  const wait = armWait({ limiter, maxConcurrent, signal, waitTimeoutMs });
+
   try {
     return await limiter.run(() => {
       admitted = true;
+      // The wait is over the moment the slot is taken; holding the timer past
+      // here would abort nothing and keep one alive per admitted statement.
+      wait.dispose();
       observeClickHouseStatementWait(
         instance,
         operation,
         (performance.now() - queuedAt) / 1000,
       );
       return task();
-    }, signal);
+    }, wait.signal);
   } catch (error) {
     // Only a refusal is translated. Once admitted, the statement's own errors
     // belong to the layers below - translating them here would relabel a
@@ -167,6 +259,26 @@ async function run({
       );
       throw new ClickHouseOverloadedError({ reasons: [toError(error)] });
     }
+    // A wait that ran out is the same verdict as a full queue — the server has
+    // no capacity for this statement — so it gets the same transient error.
+    // Checked against OUR timeout, never the aborted-ness of the composed
+    // signal: a caller cancelling its own request must keep surfacing as the
+    // cancellation it is, not be relabelled as overload.
+    if (!admitted && wait.timedOut()) {
+      incrementClickHouseStatementsShed(instance, operation);
+      logger.warn(
+        {
+          instance,
+          operation,
+          waitedMs: Math.round(performance.now() - queuedAt),
+          timeoutMs: waitTimeoutMs,
+        },
+        "Refused a ClickHouse statement: waited too long for a slot",
+      );
+      throw new ClickHouseOverloadedError({ reasons: [toError(error)] });
+    }
     throw error;
+  } finally {
+    wait.dispose();
   }
 }

--- a/platform/app/src/server/clickhouse/statementLimit.ts
+++ b/platform/app/src/server/clickhouse/statementLimit.ts
@@ -155,13 +155,13 @@ export function withStatementLimit<T extends ClickHouseClient>({
 interface ArmedWait {
   signal: AbortSignal | undefined;
   /** True only if OUR timer fired — never merely that the signal aborted. */
-  timedOut: () => boolean;
+  hasTimedOut: () => boolean;
   dispose: () => void;
 }
 
 const NOT_ARMED = (signal: AbortSignal | undefined): ArmedWait => ({
   signal,
-  timedOut: () => false,
+  hasTimedOut: () => false,
   dispose: () => {
     // Nothing was armed, so there is nothing to clear.
   },
@@ -194,9 +194,9 @@ function armWait({
   if (limiter.stats().inFlight < maxConcurrent) return NOT_ARMED(signal);
 
   const controller = new AbortController();
-  let fired = false;
+  let hasFired = false;
   const timer = setTimeout(() => {
-    fired = true;
+    hasFired = true;
     controller.abort();
   }, waitTimeoutMs);
   // Never a reason to hold the process open: if nothing else is running there
@@ -207,7 +207,7 @@ function armWait({
     signal: signal
       ? AbortSignal.any([signal, controller.signal])
       : controller.signal,
-    timedOut: () => fired,
+    hasTimedOut: () => hasFired,
     dispose: () => clearTimeout(timer),
   };
 }
@@ -264,7 +264,7 @@ async function run({
     // Checked against OUR timeout, never the aborted-ness of the composed
     // signal: a caller cancelling its own request must keep surfacing as the
     // cancellation it is, not be relabelled as overload.
-    if (!admitted && wait.timedOut()) {
+    if (!admitted && wait.hasTimedOut()) {
       incrementClickHouseStatementsShed(instance, operation);
       logger.warn(
         {

--- a/platform/app/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ClickHouseOverloadedError,
   ClickHouseUnavailableError,
   QueryMemoryExceededError,
 } from "~/server/app-layer/traces/errors";
@@ -350,6 +351,49 @@ describe("categorizeError", () => {
 });
 
 describe("classifyClickHouseError", () => {
+  /**
+   * Shedding exists so a busy platform refuses work instead of queueing it
+   * without limit. That only holds if the refusal is retryable: a job turned
+   * away BECAUSE ClickHouse was busy has to come back, not be dropped.
+   *
+   * The shed signal underneath — a full wait queue, or a wait that expired —
+   * carries no ClickHouse code and matches no transient message fragment, so
+   * classifying by the wrapped reasons alone made every shed statement
+   * CRITICAL. The verdict is on the handled shell, and has to be read there.
+   */
+  describe("when the platform shed the statement rather than queue it", () => {
+    /** @scenario a statement that waits too long is refused, not left waiting */
+    it("returns RECOVERABLE so the job is re-staged, not dropped", () => {
+      const shed = new ClickHouseOverloadedError({
+        reasons: [
+          new Error(
+            "ClickHouse concurrency queue is full (64 waiting). Shedding rather than queueing further.",
+          ),
+        ],
+      });
+
+      expect(classifyClickHouseError(shed)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for an expired wait, whose reason names no ClickHouse code", () => {
+      const shed = new ClickHouseOverloadedError({
+        reasons: [
+          new Error("Aborted while waiting for a ClickHouse concurrency slot."),
+        ],
+      });
+
+      expect(classifyClickHouseError(shed)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("still treats an unrelated handled error by its cause", () => {
+      const notShed = new ClickHouseUnavailableError({
+        reasons: [new Error("some permanent schema problem")],
+      });
+
+      expect(classifyClickHouseError(notShed)).toBe(ErrorCategory.CRITICAL);
+    });
+  });
+
   describe("when error has a transient ClickHouse error code", () => {
     it("returns RECOVERABLE for code 202 (TOO_MANY_SIMULTANEOUS_QUERIES)", () => {
       const err = Object.assign(new Error("Too many simultaneous queries"), {

--- a/platform/app/src/server/event-sourcing/services/errorHandling.ts
+++ b/platform/app/src/server/event-sourcing/services/errorHandling.ts
@@ -444,6 +444,16 @@ const CLICKHOUSE_TRANSIENT_CODES = new Set([
 ]);
 
 /**
+ * Handled error codes that are themselves a transient verdict.
+ *
+ * Kept separate from {@link CLICKHOUSE_TRANSIENT_CODES}, which holds ClickHouse
+ * server codes read off the CAUSE. These are ours, read off the handled shell,
+ * and matching them by message or by wrapped reason is not possible — the
+ * shed signal underneath carries neither.
+ */
+const TRANSIENT_HANDLED_CODES = new Set<string>(["clickhouse_overloaded"]);
+
+/**
  * Message-fragment matchers for the same conditions as
  * CLICKHOUSE_TRANSIENT_CODES, used when the error object surfaced from
  * `@clickhouse/client` embeds the code inside `error.message` rather than
@@ -477,6 +487,22 @@ export const CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS = [
  * errors are CRITICAL.
  */
 export function classifyClickHouseError(error: unknown): ErrorCategory {
+  // Some handled codes ARE the verdict, and unwrapping them loses it. The
+  // platform raises `clickhouse_overloaded` when it sheds a statement rather
+  // than queue it without limit — deliberately, before the statement reaches
+  // the server — and wraps the shed signal (`QueueFullError`, or an expired
+  // wait) in `reasons`. Neither of those carries a ClickHouse code or matches a
+  // transient fragment, so classifying by reasons alone made every shed
+  // statement CRITICAL: a job refused precisely BECAUSE the platform was busy
+  // was then dropped rather than re-staged, which is the one outcome shedding
+  // exists to avoid.
+  if (
+    HandledError.isHandled(error) &&
+    TRANSIENT_HANDLED_CODES.has(error.code)
+  ) {
+    return ErrorCategory.RECOVERABLE;
+  }
+
   // The resilient client's query translation wraps the raw driver error in a
   // HandledError's `reasons` — classify the wrapped causes, not the handled
   // shell. Single shallow pass: the translation wraps the driver error

--- a/platform/app/src/server/otel/errors.ts
+++ b/platform/app/src/server/otel/errors.ts
@@ -48,3 +48,62 @@ export class OtlpBodyTooLargeError extends HandledError {
     this.name = "OtlpBodyTooLargeError";
   }
 }
+
+/**
+ * The request body could not be read to the end.
+ *
+ * Overwhelmingly this is an exporter that gave up mid-upload: its own timeout
+ * fires, it drops the connection, and the half-read stream is torn down under
+ * us. It is also what an already-consumed body raises ("Body is unusable").
+ *
+ * 400 and `customer`, because nothing here is ours to fix — the bytes never
+ * arrived. Left unclassified it reached the request boundary as an unhandled
+ * error and was answered 500, which put a disconnecting client into the same
+ * bucket as a broken receiver and made the 5xx rate unreadable.
+ *
+ * The cause is carried on `reasons` rather than flattened into the message:
+ * which condition ended the read (abort, reset, already-consumed) is the only
+ * diagnosis this error has, and the message cannot hold it.
+ */
+export class OtlpBodyUnreadableError extends HandledError {
+  declare readonly code: "ERR_BODY_UNREADABLE";
+
+  constructor({ cause }: { cause?: unknown } = {}) {
+    super("ERR_BODY_UNREADABLE", "Request body could not be read.", {
+      httpStatus: 400,
+      fault: "customer",
+      reasons: cause instanceof Error ? [cause] : [],
+      tips: [
+        "This usually means the connection closed before the body finished uploading. Retry the export, and raise the exporter's timeout if it is sending large batches.",
+      ],
+    });
+    this.name = "OtlpBodyUnreadableError";
+  }
+}
+
+/**
+ * The body arrived under a `Content-Encoding` the receiver does not implement.
+ *
+ * Named rather than left as a bare Error so it is answered 400 like the other
+ * sender mistakes on this path, instead of reaching the boundary unclassified
+ * and being counted as a server fault.
+ */
+export class OtlpUnsupportedEncodingError extends HandledError {
+  declare readonly code: "ERR_UNSUPPORTED_ENCODING";
+
+  constructor({ encoding }: { encoding: string }) {
+    super(
+      "ERR_UNSUPPORTED_ENCODING",
+      `Unsupported Content-Encoding: ${encoding}`,
+      {
+        meta: { encoding },
+        httpStatus: 400,
+        fault: "customer",
+        tips: [
+          "Send the body uncompressed, or with gzip, deflate or br encoding.",
+        ],
+      },
+    );
+    this.name = "OtlpUnsupportedEncodingError";
+  }
+}

--- a/platform/app/src/server/otel/parseOtlpBody.readFailures.test.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.readFailures.test.ts
@@ -1,0 +1,276 @@
+/**
+ * How the shared OTLP body reader answers a body it cannot read.
+ *
+ * Written against the ~190/day of 500s the `/api/otel/v1/traces` receiver was
+ * returning in production. None of them were server faults: an exporter gave up
+ * mid-upload, the half-read stream was torn down, and nothing on the path
+ * classified that — so it reached the request boundary unhandled and was
+ * answered, logged and alerted on as a 5xx.
+ *
+ * The `releaseLock` scenarios are the subtle half. Releasing the reader lived
+ * in a `finally`, and a throw from `finally` REPLACES the error already
+ * propagating, which is why the logs named a stream-internals TypeError instead
+ * of the disconnect that actually happened.
+ *
+ * Spec: specs/otlp/otlp-body-read-failures.feature
+ */
+
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import {
+  OtlpBodyTooLargeError,
+  OtlpBodyUnreadableError,
+  OtlpUnsupportedEncodingError,
+} from "./errors";
+import { OTLP_MAX_BODY_BYTES, readOtlpBody } from "./parseOtlpBody";
+
+/**
+ * A Request whose body is a stream we control, so a read can be failed at an
+ * arbitrary point and `getReader` can be made to hand back a reader whose
+ * `releaseLock` or `cancel` throws.
+ */
+function requestWithStream(
+  stream: ReadableStream<Uint8Array>,
+  { headers }: { headers?: Record<string, string> } = {},
+): Request {
+  return {
+    body: stream,
+    headers: new Headers(headers ?? {}),
+  } as unknown as Request;
+}
+
+/** A stream that yields one chunk and then errors, like a dropped connection. */
+function streamThatFailsMidRead(
+  error: Error = new Error("aborted"),
+): ReadableStream<Uint8Array> {
+  let sent = false;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!sent) {
+        sent = true;
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        return;
+      }
+      controller.error(error);
+    },
+  });
+}
+
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Wrap a stream so the reader it hands out throws from the named method. Only
+ * the overridden method is replaced; everything else delegates to the real
+ * reader, so the read itself behaves normally.
+ */
+function withThrowingReader(
+  stream: ReadableStream<Uint8Array>,
+  method: "releaseLock" | "cancel",
+  error: Error,
+): ReadableStream<Uint8Array> {
+  const original = stream.getReader.bind(stream);
+  (stream as any).getReader = () => {
+    const reader = original();
+    return new Proxy(reader, {
+      get(target, prop, receiver) {
+        if (prop === method) {
+          return () => {
+            throw error;
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+  };
+  return stream;
+}
+
+describe("readOtlpBody", () => {
+  describe("given a request stream that fails part-way through", () => {
+    /** @scenario A body that cannot be read is the sender's fault */
+    it("reports an unreadable body rather than an unclassified error", async () => {
+      const req = requestWithStream(streamThatFailsMidRead());
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpBodyUnreadableError,
+      );
+    });
+
+    it("answers 400 and attributes the failure to the sender", async () => {
+      const req = requestWithStream(streamThatFailsMidRead());
+
+      await expect(readOtlpBody(req)).rejects.toMatchObject({
+        code: "ERR_BODY_UNREADABLE",
+        httpStatus: 400,
+        fault: "customer",
+      });
+    });
+
+    /** @scenario The underlying cause is kept for diagnosis */
+    it("keeps the original error for diagnosis", async () => {
+      const cause = new Error("ECONNRESET");
+      const req = requestWithStream(streamThatFailsMidRead(cause));
+
+      await expect(readOtlpBody(req)).rejects.toMatchObject({
+        reasons: [cause],
+      });
+    });
+  });
+
+  describe("given a body that has already been consumed", () => {
+    /** @scenario A body that was already consumed is reported the same way */
+    it("reports an unreadable body", async () => {
+      const stream = streamOf(new Uint8Array([1, 2, 3]));
+      // Lock the stream, so the reader the helper asks for cannot be handed out.
+      stream.getReader();
+
+      await expect(
+        readOtlpBody(requestWithStream(stream)),
+      ).rejects.toBeInstanceOf(OtlpBodyUnreadableError);
+    });
+  });
+
+  describe("given releasing the reader throws", () => {
+    const releaseFailure = new TypeError(
+      "Cannot read private member #state from an object whose class did not declare it",
+    );
+
+    describe("when the read also failed", () => {
+      /** @scenario Releasing the reader never replaces the failure being reported */
+      it("still reports the unreadable body, not the release failure", async () => {
+        const stream = withThrowingReader(
+          streamThatFailsMidRead(new Error("aborted")),
+          "releaseLock",
+          releaseFailure,
+        );
+
+        // The regression this whole file exists for: a throw from `finally`
+        // used to overwrite the error on its way out.
+        await expect(
+          readOtlpBody(requestWithStream(stream)),
+        ).rejects.toBeInstanceOf(OtlpBodyUnreadableError);
+      });
+
+      it("does not surface the release failure as the reported error", async () => {
+        const stream = withThrowingReader(
+          streamThatFailsMidRead(new Error("aborted")),
+          "releaseLock",
+          releaseFailure,
+        );
+
+        await expect(
+          readOtlpBody(requestWithStream(stream)),
+        ).rejects.not.toThrow(/private member/);
+      });
+    });
+
+    describe("when the read succeeded", () => {
+      /** @scenario Releasing the reader never fails a successful read */
+      it("returns the body intact", async () => {
+        const payload = new Uint8Array([9, 8, 7]);
+        const stream = withThrowingReader(
+          streamOf(payload),
+          "releaseLock",
+          releaseFailure,
+        );
+
+        const body = await readOtlpBody(requestWithStream(stream));
+        expect(new Uint8Array(body)).toEqual(payload);
+      });
+    });
+  });
+
+  describe("given a body that passes the byte limit", () => {
+    function oversizedStream(): ReadableStream<Uint8Array> {
+      let sent = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          // 1 MiB at a time until the cap is comfortably passed.
+          const chunk = new Uint8Array(1024 * 1024);
+          sent += chunk.byteLength;
+          controller.enqueue(chunk);
+          if (sent > OTLP_MAX_BODY_BYTES + 1024 * 1024) controller.close();
+        },
+      });
+    }
+
+    /** @scenario An over-sized body is still refused as too large */
+    it("is refused as too large, not merely unreadable", async () => {
+      await expect(
+        readOtlpBody(requestWithStream(oversizedStream())),
+      ).rejects.toBeInstanceOf(OtlpBodyTooLargeError);
+    });
+
+    /** @scenario A cancel that throws does not hide the size refusal */
+    it("keeps its 413 when cancelling the reader throws", async () => {
+      const stream = withThrowingReader(
+        oversizedStream(),
+        "cancel",
+        new Error("cancel exploded"),
+      );
+
+      await expect(
+        readOtlpBody(requestWithStream(stream)),
+      ).rejects.toMatchObject({
+        code: "ERR_PAYLOAD_TOO_LARGE",
+        httpStatus: 413,
+      });
+    });
+  });
+
+  describe("given an unsupported content encoding", () => {
+    /** @scenario An unsupported content encoding is answered as a client error */
+    it("is a client error, not a server error", async () => {
+      const req = requestWithStream(streamOf(new Uint8Array([1])), {
+        headers: { "content-encoding": "snappy" },
+      });
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpUnsupportedEncodingError,
+      );
+    });
+
+    it("answers 400 and names the encoding refused", async () => {
+      const req = requestWithStream(streamOf(new Uint8Array([1])), {
+        headers: { "content-encoding": "snappy" },
+      });
+
+      await expect(readOtlpBody(req)).rejects.toMatchObject({
+        httpStatus: 400,
+        meta: { encoding: "snappy" },
+      });
+    });
+  });
+
+  describe("given a body that does not decompress", () => {
+    it("is reported as unreadable rather than as a server fault", async () => {
+      const notGzip = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+      const req = requestWithStream(streamOf(notGzip), {
+        headers: { "content-encoding": "gzip" },
+      });
+
+      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+        OtlpBodyUnreadableError,
+      );
+    });
+
+    it("still reads a well-formed compressed body", async () => {
+      const payload = Buffer.from("hello");
+      const req = requestWithStream(streamOf(gzipSync(payload)), {
+        headers: { "content-encoding": "gzip" },
+      });
+
+      const body = await readOtlpBody(req);
+      expect(Buffer.from(body).toString()).toBe("hello");
+    });
+  });
+});

--- a/platform/app/src/server/otel/parseOtlpBody.readFailures.unit.test.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.readFailures.unit.test.ts
@@ -252,15 +252,25 @@ describe("readOtlpBody", () => {
   });
 
   describe("given a body that does not decompress", () => {
-    it("is reported as unreadable rather than as a server fault", async () => {
-      const notGzip = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
-      const req = requestWithStream(streamOf(notGzip), {
+    /** A fresh request each time - a stream cannot be read twice. */
+    const undecompressable = () =>
+      requestWithStream(streamOf(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7])), {
         headers: { "content-encoding": "gzip" },
       });
 
-      await expect(readOtlpBody(req)).rejects.toBeInstanceOf(
+    /** @scenario A body that does not decompress is the sender's fault */
+    it("is reported as unreadable rather than as a server fault", async () => {
+      await expect(readOtlpBody(undecompressable())).rejects.toBeInstanceOf(
         OtlpBodyUnreadableError,
       );
+    });
+
+    it("answers 400 and attributes it to the sender", async () => {
+      await expect(readOtlpBody(undecompressable())).rejects.toMatchObject({
+        code: "ERR_BODY_UNREADABLE",
+        httpStatus: 400,
+        fault: "customer",
+      });
     });
 
     it("still reads a well-formed compressed body", async () => {

--- a/platform/app/src/server/otel/parseOtlpBody.ts
+++ b/platform/app/src/server/otel/parseOtlpBody.ts
@@ -35,7 +35,11 @@ import type {
   IExportTraceServiceRequest,
 } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
-import { OtlpBodyTooLargeError } from "./errors";
+import {
+  OtlpBodyTooLargeError,
+  OtlpBodyUnreadableError,
+  OtlpUnsupportedEncodingError,
+} from "./errors";
 
 const gunzipAsync = promisify(gunzip);
 const inflateAsync = promisify(inflate);
@@ -104,41 +108,101 @@ function isSupportedEncoding(encoding: string): encoding is SupportedEncoding {
 }
 
 /**
+ * Release the reader without letting it throw.
+ *
+ * A reader whose stream was torn down mid-read can throw from `releaseLock()`
+ * itself, and thrown from a `finally` block that error REPLACES the one already
+ * on its way out. That is how a client disconnect came to be reported as an
+ * unrelated stream-internals TypeError, and — being unclassified — answered
+ * 500. Nothing here is worth reporting: the stream is already gone, and the
+ * failure that matters has been raised.
+ */
+function releaseQuietly(reader: { releaseLock: () => void }): void {
+  try {
+    reader.releaseLock();
+  } catch {
+    // Deliberately swallowed; see above.
+  }
+}
+
+/** Same reasoning as {@link releaseQuietly}, for the over-size cancel path. */
+async function cancelQuietly(reader: {
+  cancel: () => Promise<void>;
+}): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // The refusal we are about to throw is the diagnosis, not this.
+  }
+}
+
+/**
  * Read the wire body, refusing it the moment it passes
  * {@link OTLP_MAX_BODY_BYTES}.
  *
  * Consuming the stream by hand rather than calling `req.arrayBuffer()` is the
  * point: `arrayBuffer()` buffers the whole body and only then hands it over, so
  * measuring afterwards would concede exactly the memory being defended.
+ *
+ * Every way this can fail is the sender's: the body was already consumed, the
+ * connection ended mid-read, or it passed the size bound. None of them is a
+ * server fault, and leaving them unclassified is what had them answered 500.
  */
+/**
+ * "Body is unusable" — the body was already consumed, or another reader holds
+ * the lock. Nothing can be read, and it is not a server fault.
+ */
+function acquireReader(
+  stream: ReadableStream<Uint8Array>,
+): ReadableStreamDefaultReader<Uint8Array> {
+  try {
+    return stream.getReader();
+  } catch (error) {
+    throw new OtlpBodyUnreadableError({ cause: error });
+  }
+}
+
+/** Drain the reader, refusing the body the moment it passes the byte bound. */
+async function drainWithinLimit(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<Buffer> {
+  const chunks: Uint8Array[] = [];
+  let held = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    held += value.byteLength;
+    if (held > OTLP_MAX_BODY_BYTES) {
+      await cancelQuietly(reader);
+      throw new OtlpBodyTooLargeError({
+        maxBytes: OTLP_MAX_BODY_BYTES,
+        encoding: null,
+      });
+    }
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
 async function readWireBody(req: Request): Promise<Buffer> {
   const stream = req.body;
   if (!stream) return Buffer.alloc(0);
 
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let held = 0;
+  const reader = acquireReader(stream);
 
   try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      held += value.byteLength;
-      if (held > OTLP_MAX_BODY_BYTES) {
-        await reader.cancel();
-        throw new OtlpBodyTooLargeError({
-          maxBytes: OTLP_MAX_BODY_BYTES,
-          encoding: null,
-        });
-      }
-      chunks.push(value);
-    }
+    return await drainWithinLimit(reader);
+  } catch (error) {
+    // The size refusal is our own verdict and keeps its own status; anything
+    // else ended the read from the other end of the connection.
+    if (error instanceof OtlpBodyTooLargeError) throw error;
+    throw new OtlpBodyUnreadableError({ cause: error });
   } finally {
-    reader.releaseLock();
+    releaseQuietly(reader);
   }
-
-  return Buffer.concat(chunks);
 }
 
 /**
@@ -159,7 +223,7 @@ export async function readOtlpBody(req: Request): Promise<ArrayBuffer> {
   // Settled before the body is read, so a request we are going to refuse
   // outright does not get to spend the read budget first.
   if (!isSupportedEncoding(encoding)) {
-    throw new Error(`Unsupported Content-Encoding: ${encoding}`);
+    throw new OtlpUnsupportedEncodingError({ encoding });
   }
 
   // Widened to the shared signature deliberately: the three entries differ in
@@ -179,7 +243,10 @@ export async function readOtlpBody(req: Request): Promise<ArrayBuffer> {
         encoding,
       });
     }
-    throw error;
+    // Anything else zlib raises here is a body that does not decompress —
+    // truncated by a disconnect, or not the encoding it claimed. Both are the
+    // sender's, and neither is a reason to answer 500.
+    throw new OtlpBodyUnreadableError({ cause: error });
   }
 }
 

--- a/platform/app/src/server/routes/__tests__/collector-validation-diagnostics.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector-validation-diagnostics.unit.test.ts
@@ -1,0 +1,228 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The route's rejection logs used to carry the whole body and the whole span.
+ * These tests hold the two halves of the replacement: the payload does not
+ * reach the log or Sentry, and what replaces it is specific enough to tell us
+ * whether our schema — rather than the sender — is the thing that is wrong.
+ */
+
+const logCalls: Array<{ level: string; fields: any; message: string }> = [];
+
+vi.mock("@langwatch/observability", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langwatch/observability")>();
+  const record = (level: string) => (fields: any, message?: string) => {
+    logCalls.push({ level, fields, message: message ?? "" });
+  };
+  return {
+    ...actual,
+    // validationMeta stays real — it is the unit under test here.
+    createLogger: () => ({
+      debug: record("debug"),
+      info: record("info"),
+      warn: record("warn"),
+      error: record("error"),
+    }),
+  };
+});
+
+const mockIngestNormalizedSpan = vi.fn();
+const mockCheckLimit = vi.fn();
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    usage: { checkLimit: mockCheckLimit },
+    traces: { collection: { ingestNormalizedSpan: mockIngestNormalizedSpan } },
+    evaluations: { reportEvaluation: vi.fn() },
+    planProvider: { getActivePlan: vi.fn() },
+    usageLimits: { notifyPlanLimitReached: vi.fn() },
+  })),
+}));
+
+const mockResolve = vi.fn();
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({ resolve: mockResolve, markUsed: vi.fn() })),
+  },
+}));
+
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: vi.fn(() => ({
+      token: "test-token",
+      projectId: "project-123",
+    })),
+    enforceApiKeyCeiling: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+const mockCaptureException = vi.fn();
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  getCurrentScope: vi.fn(() => undefined),
+}));
+
+const { app: collectorApp } = await import("../collector");
+
+const testApp = new Hono();
+testApp.route("/", collectorApp);
+
+const fakeProject = {
+  id: "project-123",
+  teamId: "team-1",
+  team: { id: "team-1", organizationId: "org-1" },
+};
+
+const NOW = Date.now();
+
+/** Distinctive enough that finding it anywhere in a log is unambiguous. */
+const CUSTOMER_SECRET = "sk-live-CUSTOMER-PROMPT-DO-NOT-LOG";
+
+function postCollector(body: unknown) {
+  return testApp.request("http://localhost/api/collector", {
+    method: "POST",
+    headers: {
+      "X-Auth-Token": "test-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function rejectionLog() {
+  return logCalls.find((c) => c.message.startsWith("invalid "));
+}
+
+/** Everything we handed the log sink and Sentry, as one searchable string. */
+function everythingLogged() {
+  return JSON.stringify({ logCalls, sentry: mockCaptureException.mock.calls });
+}
+
+describe("POST /api/collector validation diagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logCalls.length = 0;
+    mockResolve.mockResolvedValue({
+      type: "legacyProjectKey",
+      project: fakeProject,
+    });
+    mockCheckLimit.mockResolvedValue({ exceeded: false });
+    mockIngestNormalizedSpan.mockResolvedValue({ status: "collected" });
+  });
+
+  describe("given a span that fails schema validation", () => {
+    describe("when a field has the wrong type", () => {
+      const badSpan = {
+        type: "span",
+        span_id: "span-1",
+        trace_id: "trace-1",
+        timestamps: { started_at: CUSTOMER_SECRET, finished_at: NOW },
+      };
+
+      it("answers 400", async () => {
+        const res = await postCollector({
+          trace_id: "trace-1",
+          spans: [badSpan],
+        });
+        expect(res.status).toBe(400);
+      });
+
+      /** @scenario A validation failure is a client error, not a server error */
+      it("logs the rejection as a client error, not a server error", async () => {
+        await postCollector({ trace_id: "trace-1", spans: [badSpan] });
+        expect(rejectionLog()?.level).toBe("warn");
+      });
+
+      /** @scenario A rejected span reports the failing path and rule */
+      it("names the failing path", async () => {
+        await postCollector({ trace_id: "trace-1", spans: [badSpan] });
+        const paths = rejectionLog()?.fields.issues.map((i: any) => i.path);
+        expect(paths.join(" ")).toContain("timestamps.started_at");
+      });
+
+      it("reports the rule that rejected it", async () => {
+        await postCollector({ trace_id: "trace-1", spans: [badSpan] });
+        const codes = rejectionLog()?.fields.issues.map((i: any) => i.code);
+        expect(codes).toContain("invalid_type");
+      });
+
+      it("counts the issues", async () => {
+        await postCollector({ trace_id: "trace-1", spans: [badSpan] });
+        expect(rejectionLog()?.fields.issueCount).toBeGreaterThan(0);
+      });
+
+      /** @scenario Customer values never reach the log */
+      it("keeps the offending value out of the log and out of Sentry", async () => {
+        await postCollector({ trace_id: "trace-1", spans: [badSpan] });
+        expect(everythingLogged()).not.toContain(CUSTOMER_SECRET);
+      });
+
+      it("still tells the sender what was wrong", async () => {
+        const res = await postCollector({
+          trace_id: "trace-1",
+          spans: [badSpan],
+        });
+        expect((await res.json()).error).toMatch(/timestamps/);
+      });
+    });
+
+    describe("when the span carries customer content in other fields", () => {
+      it("does not log the rest of the span either", async () => {
+        await postCollector({
+          trace_id: "trace-1",
+          spans: [
+            {
+              type: "span",
+              span_id: "span-1",
+              trace_id: "trace-1",
+              input: { type: "text", value: CUSTOMER_SECRET },
+              timestamps: { started_at: "not-a-number", finished_at: NOW },
+            },
+          ],
+        });
+
+        expect(everythingLogged()).not.toContain(CUSTOMER_SECRET);
+      });
+    });
+  });
+
+  describe("given a trace body that fails schema validation", () => {
+    /** @scenario The request body is not logged */
+    it("does not log the body", async () => {
+      await postCollector({
+        trace_id: { nested: CUSTOMER_SECRET },
+        spans: [],
+      });
+
+      expect(everythingLogged()).not.toContain(CUSTOMER_SECRET);
+    });
+
+    it("logs the rejection at warning level", async () => {
+      await postCollector({ trace_id: { nested: "bad" }, spans: [] });
+      expect(rejectionLog()?.level).toBe("warn");
+    });
+
+    it("carries structured issues rather than a serialised error", async () => {
+      await postCollector({ trace_id: { nested: "bad" }, spans: [] });
+      expect(Array.isArray(rejectionLog()?.fields.issues)).toBe(true);
+    });
+  });
+
+  describe("given a spans field that is not an array", () => {
+    it("reports the type without the value", async () => {
+      await postCollector({ trace_id: "trace-1", spans: CUSTOMER_SECRET });
+
+      const log = logCalls.find((c) => c.message.includes("expecting array"));
+      expect(log?.fields.receivedType).toBe("string");
+      expect(everythingLogged()).not.toContain(CUSTOMER_SECRET);
+    });
+  });
+});

--- a/platform/app/src/server/routes/__tests__/collector-validation-diagnostics.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector-validation-diagnostics.unit.test.ts
@@ -97,8 +97,19 @@ function postCollector(body: unknown) {
   });
 }
 
+/**
+ * The rejection record, insisted upon. Returning it optionally let a missing
+ * record surface as "cannot read .issues of undefined" from whichever
+ * assertion happened to run first, which names neither the test nor the cause.
+ */
 function rejectionLog() {
-  return logCalls.find((c) => c.message.startsWith("invalid "));
+  const log = logCalls.find((c) => c.message.startsWith("invalid "));
+  if (!log) {
+    throw new Error(
+      `no rejection was logged; saw: ${logCalls.map((c) => c.message).join(", ") || "nothing"}`,
+    );
+  }
+  return log;
 }
 
 /** Everything we handed the log sink and Sentry, as one searchable string. */
@@ -138,25 +149,25 @@ describe("POST /api/collector validation diagnostics", () => {
       /** @scenario A validation failure is a client error, not a server error */
       it("logs the rejection as a client error, not a server error", async () => {
         await postCollector({ trace_id: "trace-1", spans: [badSpan] });
-        expect(rejectionLog()?.level).toBe("warn");
+        expect(rejectionLog().level).toBe("warn");
       });
 
       /** @scenario A rejected span reports the failing path and rule */
       it("names the failing path", async () => {
         await postCollector({ trace_id: "trace-1", spans: [badSpan] });
-        const paths = rejectionLog()?.fields.issues.map((i: any) => i.path);
+        const paths = rejectionLog().fields.issues.map((i: any) => i.path);
         expect(paths.join(" ")).toContain("timestamps.started_at");
       });
 
       it("reports the rule that rejected it", async () => {
         await postCollector({ trace_id: "trace-1", spans: [badSpan] });
-        const codes = rejectionLog()?.fields.issues.map((i: any) => i.code);
+        const codes = rejectionLog().fields.issues.map((i: any) => i.code);
         expect(codes).toContain("invalid_type");
       });
 
       it("counts the issues", async () => {
         await postCollector({ trace_id: "trace-1", spans: [badSpan] });
-        expect(rejectionLog()?.fields.issueCount).toBeGreaterThan(0);
+        expect(rejectionLog().fields.issueCount).toBeGreaterThan(0);
       });
 
       /** @scenario Customer values never reach the log */
@@ -207,12 +218,12 @@ describe("POST /api/collector validation diagnostics", () => {
 
     it("logs the rejection at warning level", async () => {
       await postCollector({ trace_id: { nested: "bad" }, spans: [] });
-      expect(rejectionLog()?.level).toBe("warn");
+      expect(rejectionLog().level).toBe("warn");
     });
 
     it("carries structured issues rather than a serialised error", async () => {
       await postCollector({ trace_id: { nested: "bad" }, spans: [] });
-      expect(Array.isArray(rejectionLog()?.fields.issues)).toBe(true);
+      expect(Array.isArray(rejectionLog().fields.issues)).toBe(true);
     });
   });
 

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { createLogger } from "@langwatch/observability";
+import { createLogger, validationMeta } from "@langwatch/observability";
 import type { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
@@ -284,14 +284,20 @@ secured
       try {
         params = collectorRESTParamsValidatorSchema.parse(body);
       } catch (error) {
+        const validation = validationMeta(error);
+
         captureException(new Error("ZodError on parsing body"), {
-          extra: { projectId: project.id, body, zodError: error },
+          extra: { projectId: project.id, ...validation },
         });
 
         const validationError = fromZodError(error as ZodError);
 
-        logger.error(
-          { error, body, validationError },
+        // Shape, never the body. The rendered `validationError.message` quotes
+        // the offending values, so it answers the sender and stays out of the
+        // log; `validation` is the schema's own vocabulary and is what tells us
+        // whether the rule, rather than the payload, is the thing that is wrong.
+        logger.warn(
+          { projectId: project.id, ...validation },
           "invalid trace received",
         );
 
@@ -308,10 +314,12 @@ secured
         params;
 
       if (body.spans && !Array.isArray(body.spans)) {
-        logger.error(
+        // The type, not the value: whatever arrived in place of the array is
+        // still the sender's content, and the type is the whole diagnosis.
+        logger.warn(
           {
             projectId: project.id,
-            spans: body.spans,
+            receivedType: typeof body.spans,
             traceId: nullableTraceId,
           },
           "invalid spans field, expecting array",
@@ -378,20 +386,17 @@ secured
         }
       } catch (error) {
         const validationError = fromZodError(error as ZodError);
+        const validation = validationMeta(error);
+
         captureException(new Error("ZodError on parsing metadata"), {
-          extra: {
-            projectId: project.id,
-            metadata: params.metadata,
-            zodError: error,
-          },
+          extra: { projectId: project.id, ...validation },
         });
 
-        logger.error(
-          {
-            projectId: project.id,
-            metadata: params.metadata,
-            zodError: error,
-          },
+        // Metadata is customer-authored key/value content, so the values stay
+        // out. The rejected KEY names do not: a key refused across many
+        // projects is how we learn our reserved-metadata list is too narrow.
+        logger.warn(
+          { projectId: project.id, ...validation },
           "invalid metadata received",
         );
 
@@ -519,14 +524,16 @@ secured
         try {
           spans[index] = spanValidatorSchema.parse(span);
         } catch (error) {
+          const validation = validationMeta(error);
+
           captureException(new Error("ZodError on parsing spans"), {
-            extra: { projectId: project.id, span, zodError: error },
+            extra: { projectId: project.id, index, ...validation },
           });
 
           const validationError = fromZodError(error as ZodError);
 
-          logger.error(
-            { error, span, projectId: project.id, index, validationError },
+          logger.warn(
+            { projectId: project.id, index, ...validation },
             "invalid span received",
           );
 

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -37,10 +37,14 @@ Feature: Structured Logging for ClickHouse Queries
     Then the attempt is logged at warning level
     And the failure is still counted for alerting
 
+  # The field name is a contract, not just "anything but error" — log queries
+  # read it by name, so a rename to some other wrong key breaks them just as
+  # thoroughly as leaving it on "error" would.
   @unit @regression
-  Scenario: The cause never rides on a field named error
+  Scenario: The cause rides on the named query-cause field
     When a ClickHouse attempt fails
-    Then the cause is attached under a field that is not named "error"
+    Then the cause is attached under the field "queryError"
+    And no field named "error" is emitted
     And the record does not claim a failure the level did not
 
   @unit @regression

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -41,7 +41,7 @@ Feature: Structured Logging for ClickHouse Queries
   Scenario: The cause never rides on a field named error
     When a ClickHouse attempt fails
     Then the cause is attached under a field that is not named "error"
-    And the record's level is not promoted by the log pipeline
+    And the record does not claim a failure the level did not
 
   @unit @regression
   Scenario: Query successes are logged at debug level

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -14,8 +14,34 @@ Feature: Structured Logging for ClickHouse Queries
   @unit @regression
   Scenario: Query failures are logged with structured metadata
     When a ClickHouse query fails
-    Then a structured error log is emitted with source, operation, durationMs, and error
+    Then a structured log is emitted with source, operation, durationMs, and the cause
     And the log is tagged with source "clickhouse" to distinguish from general application errors
+
+  # ---------------------------------------------------------------------------
+  # Who owns the verdict
+  #
+  # A failed attempt is raised to a caller, and the caller is what knows how the
+  # story ends: a read has its translated error surfaced at the request
+  # boundary, and an insert is issued from a job the queue retries and, if it
+  # finally gives up, drops loudly with its own error record and counter.
+  #
+  # This wrapper sees none of that. Reporting each attempt as an error made
+  # recovered work indistinguishable from lost work — 17k records a day on one
+  # service against zero jobs actually dropped. So the attempt is reported, and
+  # the verdict is left to whoever has it.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A failed attempt raised to the caller is not itself an error
+    When a ClickHouse query fails and the error is raised to the caller
+    Then the attempt is logged at warning level
+    And the failure is still counted for alerting
+
+  @unit @regression
+  Scenario: The cause never rides on a field named error
+    When a ClickHouse attempt fails
+    Then the cause is attached under a field that is not named "error"
+    And the record's level is not promoted by the log pipeline
 
   @unit @regression
   Scenario: Query successes are logged at debug level

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -45,7 +45,7 @@ Feature: Structured Logging for ClickHouse Queries
     When a ClickHouse attempt fails
     Then the cause is attached under the field "queryError"
     And no field named "error" is emitted
-    And the record does not claim a failure the level did not
+    And the record does not claim a failure that the level did not establish
 
   @unit @regression
   Scenario: Query successes are logged at debug level

--- a/specs/clickhouse/single-client-access.feature
+++ b/specs/clickhouse/single-client-access.feature
@@ -64,6 +64,7 @@ Feature: One ClickHouse client, reached one way, bounded where it can be seen
     Given a statement is waiting for a slot
     When no slot frees before the wait bound elapses
     Then it is refused with an error that names overload as the cause
+    And the refusal is classified as recoverable, so the job is re-staged rather than dropped
     And the statement already running is left alone
     And the wait bound is shorter than the time one statement may spend on the wire
 

--- a/specs/clickhouse/single-client-access.feature
+++ b/specs/clickhouse/single-client-access.feature
@@ -53,6 +53,20 @@ Feature: One ClickHouse client, reached one way, bounded where it can be seen
     When the caller abandons the request
     Then the statement leaves the queue instead of occupying it until a slot frees
 
+  # The queue was bounded by depth but not by time, so a statement could wait
+  # for as long as everything ahead of it took and THEN still spend the driver's
+  # full request timeout on the wire. That is how a 46-second failure was
+  # assembled out of two limits, neither of which was 46 seconds. Refusing is
+  # not losing: overload classifies as transient, so a read retries and a job is
+  # re-staged.
+  @unit
+  Scenario: a statement that waits too long is refused, not left waiting
+    Given a statement is waiting for a slot
+    When no slot frees before the wait bound elapses
+    Then it is refused with an error that names overload as the cause
+    And the statement already running is left alone
+    And the wait bound is shorter than the time one statement may spend on the wire
+
   @unit
   Scenario: ClickHouse is reached through a repository, from the application object
     Given a service needs data that lives in ClickHouse

--- a/specs/observability/ingest-validation-diagnostics.feature
+++ b/specs/observability/ingest-validation-diagnostics.feature
@@ -1,0 +1,86 @@
+Feature: Ingest validation diagnostics
+
+  When we reject a customer's trace or span for failing validation, the log has
+  to answer one question: is the payload wrong, or is our schema too strict?
+
+  Today it cannot. The rejection logs the whole request body and the whole span,
+  which is customer content — prompts, completions, host identifiers — going to
+  the log sink and to Sentry, and the same content is what makes the record too
+  noisy to read. Meanwhile the thing an engineer actually needs, which field
+  failed and what we demanded of it, is buried inside a serialised error.
+
+  So the payload comes out and the shape goes in. Every rejection carries
+  structured metadata naming the failing path, the rule that rejected it, and —
+  for a field we did not expect — the key name we refused. Those are our own
+  schema's terms, not the customer's data, so they are safe to log and safe to
+  aggregate. A field name that shows up across many projects is the signal that
+  we, not the sender, are the ones who need to change.
+
+  Background:
+    Given a project sending traces to the REST collector
+
+  # ---------------------------------------------------------------------------
+  # What the metadata says
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A rejected span reports the failing path and rule
+    When a span fails schema validation
+    Then the log carries one entry per validation issue
+    And each entry names the path of the failing field
+    And each entry names the validation rule that rejected it
+
+  @unit @regression
+  Scenario: A field we do not recognise is named
+    When a span carries a field the schema does not allow
+    Then the log names the rejected key
+    And the issue is reported as an unrecognised key
+
+  @unit @regression
+  Scenario: A field of the wrong type reports both types by name
+    When a span sends a field as the wrong type
+    Then the log names the type the schema expected
+    And the log names the type that arrived
+
+  @unit @regression
+  Scenario: Issue counts survive truncation
+    Given a payload that fails validation in more ways than the log will carry
+    Then the log carries the total number of issues
+    And the entries it carries are marked as truncated
+
+  # ---------------------------------------------------------------------------
+  # What the metadata must never say
+  #
+  # The distinction is who authored the string. A path, a rule name and a
+  # rejected key are our schema's vocabulary. A value is the customer's.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: Customer values never reach the log
+    When a span fails validation on a field holding customer content
+    Then the value of that field does not appear in the metadata
+
+  @unit @regression
+  Scenario: A rejected enum reports the options without the value
+    When a field fails because its value is not one of the allowed options
+    Then the log names the options the schema allows
+    And the value that arrived does not appear in the metadata
+
+  @unit @regression
+  Scenario: The request body is not logged
+    When a trace body fails schema validation
+    Then the body does not appear in the log
+    And the body does not appear in the error report sent to Sentry
+
+  # ---------------------------------------------------------------------------
+  # Level
+  #
+  # A validation failure is the sender's error, answered with a 400. It is
+  # expected traffic, and it is watched by rate rather than by incident.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A validation failure is a client error, not a server error
+    When a span fails schema validation
+    Then the rejection is logged at warning level
+    And the response status is 400

--- a/specs/observability/ingest-validation-diagnostics.feature
+++ b/specs/observability/ingest-validation-diagnostics.feature
@@ -70,7 +70,7 @@ Feature: Ingest validation diagnostics
   Scenario: The request body is not logged
     When a trace body fails schema validation
     Then the body does not appear in the log
-    And the body does not appear in the error report sent to Sentry
+    And the body does not appear in the captured error report
 
   # ---------------------------------------------------------------------------
   # Level

--- a/specs/observability/request-log-cause-and-level.feature
+++ b/specs/observability/request-log-cause-and-level.feature
@@ -1,0 +1,77 @@
+Feature: Request log level and where the cause is attached
+
+  Every request that fails leaves one record, and that record answers two
+  questions independently: how bad was it, and what went wrong. The level
+  answers the first. The field the cause is attached to must not quietly answer
+  it a second time, differently.
+
+  A handled failure attributed to the customer - over quota, malformed payload,
+  not found - is expected traffic. It is watched by rate, not woken up for. So
+  it is logged below error, and the record must not then carry a key called
+  `error`, which is the loudest possible claim that it failed.
+
+  The catch is that moving the cause is not free. pino applies serializers by
+  exact property name and warns about nothing when a key has none: an `Error`
+  has no enumerable own properties, so an unserialised one is written as `{}`
+  and the message and stack - the only reasons a cause is logged at all - are
+  gone. The record still looks well-formed. This is a real regression that
+  shipped in this branch and was caught in review, which is why the last two
+  scenarios read the emitted line rather than the object handed to the logger.
+
+  Background:
+    Given a request that failed
+
+  # ---------------------------------------------------------------------------
+  # The level
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A handled customer failure is logged below error
+    When the failure is attributed to the customer
+    Then the record is logged at warning level
+    And the handled code and fault are carried on the record
+
+  @unit @regression
+  Scenario: A platform fault is logged at error
+    When the failure is attributed to the platform
+    Then the record is logged at error level
+
+  # ---------------------------------------------------------------------------
+  # Where the cause goes
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A record below error level does not carry a field named error
+    When the record is logged below error level
+    Then the cause is attached under the request-cause field
+    And no field named "error" is emitted
+
+  @unit @regression
+  Scenario: A record at error level keeps its cause on the error field
+    When the record is logged at error level
+    Then the cause is attached under "error"
+    And the request-cause field is not emitted
+
+  @unit @regression
+  Scenario: The error type stays groupable after the cause is re-keyed
+    When the record is logged below error level
+    Then the type of the failure is stated on the record in its own right
+
+  # ---------------------------------------------------------------------------
+  # What the emitted line actually contains
+  #
+  # Asserting on the object handed to the logger passes whether or not a
+  # serializer is registered, so these read the written line.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A re-keyed cause is still serialised
+    When the record is logged below error level
+    Then the emitted line carries the failure's message
+    And the emitted line carries the failure's stack
+
+  @unit @regression
+  Scenario: A cause on the error field is serialised as it always was
+    When the record is logged at error level
+    Then the emitted line carries the failure's message
+    And the emitted line carries the failure's stack

--- a/specs/otlp/otlp-body-read-failures.feature
+++ b/specs/otlp/otlp-body-read-failures.feature
@@ -1,0 +1,87 @@
+Feature: OTLP body read failures
+
+  An OTLP exporter that gives up mid-upload leaves the receiver holding a torn
+  request stream. That is the sender's connection ending, not a fault in the
+  receiver, and it has to be answered as one.
+
+  In production it was not. Reading such a body raised whatever the stream
+  implementation happened to throw, nothing classified it, and the request
+  boundary saw an unhandled error and answered 500 — roughly 190 a day, every
+  one of them counted as a server fault and paged on as one.
+
+  Two things made the failure harder to read than it needed to be. The reader
+  was released in a `finally` block, and a release that throws from `finally`
+  REPLACES the error on its way out, so the log named a stream-internals
+  TypeError rather than the disconnect that caused it. And an unsupported
+  `Content-Encoding` — plainly the sender's mistake — took the same unclassified
+  path to the same 500.
+
+  Background:
+    Given the shared OTLP body reader used by the traces, logs and metrics routes
+
+  # ---------------------------------------------------------------------------
+  # Classification
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: A body that cannot be read is the sender's fault
+    When the request stream fails part-way through being read
+    Then the failure is reported as an unreadable body
+    And the response status is 400
+    And the failure is attributed to the sender
+
+  @unit @regression
+  Scenario: A body that was already consumed is reported the same way
+    When the request stream has already been read
+    Then the failure is reported as an unreadable body
+    And the response status is 400
+
+  @unit @regression
+  Scenario: An unsupported content encoding is answered as a client error
+    When a body arrives under a Content-Encoding we do not support
+    Then the response status is 400
+    And the response names the encoding that was refused
+
+  # ---------------------------------------------------------------------------
+  # The original error survives
+  #
+  # The whole diagnosis is which condition ended the read, so nothing on the way
+  # out is allowed to overwrite it.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: Releasing the reader never replaces the failure being reported
+    Given releasing the reader throws
+    When the request stream fails part-way through being read
+    Then the reported failure is still the unreadable body
+    And the error raised by releasing the reader is not reported
+
+  @unit @regression
+  Scenario: Releasing the reader never fails a successful read
+    Given releasing the reader throws
+    When the body is read to completion
+    Then the body is returned intact
+
+  @unit @regression
+  Scenario: The underlying cause is kept for diagnosis
+    When the request stream fails part-way through being read
+    Then the reported failure carries the original error as its cause
+
+  # ---------------------------------------------------------------------------
+  # The size bound still wins
+  #
+  # An over-sized body is refused with its own status, and must not be
+  # reclassified as merely unreadable by the handling added around it.
+  # ---------------------------------------------------------------------------
+
+  @unit @regression
+  Scenario: An over-sized body is still refused as too large
+    When a body passes the byte limit while being read
+    Then the failure is reported as a body that is too large
+    And the response status is 413
+
+  @unit @regression
+  Scenario: A cancel that throws does not hide the size refusal
+    Given cancelling the reader throws
+    When a body passes the byte limit while being read
+    Then the failure is still reported as a body that is too large

--- a/specs/otlp/otlp-body-read-failures.feature
+++ b/specs/otlp/otlp-body-read-failures.feature
@@ -42,6 +42,15 @@ Feature: OTLP body read failures
     Then the response status is 400
     And the response names the encoding that was refused
 
+  # A body truncated by a disconnect, or one that was never the encoding it
+  # claimed, both surface from zlib rather than from the read. Same fault, so
+  # the same answer - it reached the boundary unclassified before.
+  @unit @regression
+  Scenario: A body that does not decompress is the sender's fault
+    When a body arrives that does not decompress under its declared encoding
+    Then the failure is reported as an unreadable body
+    And the response status is 400
+
   # ---------------------------------------------------------------------------
   # The original error survives
   #


### PR DESCRIPTION
## Why

I pulled 24 hours of production logs out of Grafana on 07-08. 143k records at ERROR, of which about 190 were an actual defect. Everything else was either an expected 4xx rejection or one retried infrastructure condition that recovered completely.

That ratio is the problem. The error signal was loud enough that nobody could read it, and it was wrong in both directions at once:

| service | `detected_level=error` | `severity_text=ERROR` |
|---|---|---|
| langwatch-app | 134,530 | 6,694 |
| langwatch-service-worker | 8,464 | 32,242 |

Loki 3.3 resolves a record's level in three steps: a level **label**, then a level field in **structured metadata**, then `detectLogLevelFromLogEntry`, which reads `OTLPSeverityNumber` and otherwise scans the raw line. Both metadata checks match against a fixed allow-list — `{level, severity, lvl}` and their case variants. We emit **`severity_text`**, which is one underscore outside that set, and the log agent sets no `severity_number`. So all three checks miss, Loki scans the message, and `"error handling request"` contains the word.

That is the whole mechanism, and it is wrong in both directions. 129,127 WARN records a day get promoted purely on their message text, 1.15M more get `unknown` because no level word appears at all - not one WARN record in the window was ever labelled `warn` - and on the worker 28,129 of 32,242 real errors are hidden as `unknown`. Anyone filtering on `detected_level`, which is what Explore and the log-level column default to, reads the opposite of the truth.

**The fix for that is a one-line Loki config change, not this PR** - see "Anything surprising". What's here is everything underneath the noise: one real bug, one privacy problem I wasn't looking for, and a lot of records claiming to be failures when they weren't.

## What changed

Six things, roughly in order of how much they matter.

**The cause moves off the `error` field on records below error level.** `logHttpRequest` attached it there regardless of the level it had just chosen, so a record we deliberately logged at warn carried a key asserting it had failed. It now goes to `requestError`, with `errorType` restated flat so the grouping survives the move, and `logger.ts` registers the same pino serializer for both keys - without which the cause goes out as `{}` and loses its message and stack. At error level nothing changes at all, so every existing 5xx dashboard keeps working. This puts `requestLogging` on the same convention as `VENDOR_CAUSE_FIELD` and `RETRY_CAUSE_FIELD` in `@langwatch/clickhouse-client`. It is hygiene, not the `detected_level` fix - those two modules claim it is, and they are wrong; commit 2 corrects that.

**A shed ClickHouse statement is now retryable.** `classifyClickHouseError` unwraps a `HandledError` and classifies its `reasons`, and both shed signals - `QueueFullError`, and the wait expiry added here - carry neither a ClickHouse code nor a transient message fragment. So every shed statement classified `CRITICAL`: a job refused precisely *because* the platform was busy was dropped rather than re-staged, which is the one outcome shedding exists to avoid. `clickhouse_overloaded` is now read off the handled shell where that verdict lives. The pre-existing queue-full path was wrong the same way and is fixed with it.

**`POST /api/otel/v1/traces` stops answering 500 to things that aren't our fault.** Around 190 a day. Every way `readWireBody` can fail belongs to the sender - an exporter that gave up mid-upload, a body already consumed, an encoding we don't implement, a body that won't decompress - and none of them were classified, so all four reached the request boundary unhandled. They now raise `OtlpBodyUnreadableError` or `OtlpUnsupportedEncodingError`, both 400 and customer-fault, carrying the original error on `reasons`.

**Ingest validation failures log what was wrong instead of what was sent.** The collector was logging the entire request body and the entire span on every rejection, so customer prompts and completions went to the log sink and to Sentry, and the part an engineer actually needs stayed buried inside a serialised error. New `validationMeta()` replaces the payload with the failing path, the rule that rejected it, and the keys we refused.

**ClickHouse attempts stop claiming a verdict they don't have.** `logFailure` reported every failed attempt at error, 17k records a day, against zero jobs actually dropped. Now warn, with the cause on `queryError`. Still counted, so the alerting is unaffected.

**Two ClickHouse timeouts become numbers somebody chose.** `request_timeout` was whatever the driver defaulted to, and the wait queue in front of the pool was bounded by depth but not by time. Both are stated now, and the wait bound sits inside the request bound.

**The transient classifier stops reading query text.** `/timeout/i` matched anywhere in the message, and ClickHouse echoes the failing statement back in its errors.

## How it works

Three bits are worth explaining, because in each case the obvious reading is wrong.

**Why the 500s reported a `TypeError` about `#state`.** Releasing the stream reader lived in a bare `finally`. A throw from `finally` replaces the error already on its way out, so a client disconnect was overwritten by whatever the stream internals happened to raise on release, and the logs named that instead of the disconnect. `releaseQuietly` swallows it; the failure that matters is already in flight. This is also why the symptom looked like an undici bug rather than a client hanging up.

**Why the validation metadata is an allow-list per issue code rather than a spread.** The split is by who authored the string. A path, an issue code, a bound and a list of allowed options are our schema's vocabulary and are safe to log and to aggregate. The value that arrived is the customer's and is not. Zod hands both to you in the same object: `message` embeds the received value for several codes, and `received` is a type name for `invalid_type` but the literal value for `invalid_literal` and `invalid_enum_value`. Copying by allow-list means a future Zod version can't quietly start leaking content without this list changing first.

The refused key names are deliberately kept, and they're the point of the whole change. A key we reject across many projects means an SDK emits something we haven't modelled, and the fix is ours rather than the sender's. That question was unanswerable before.

**Why a failed ClickHouse attempt isn't an error.** The wrapper doesn't know the outcome. A read has its translated error surfaced at the request boundary; an insert is issued from a job the queue retries and, if it ever truly gives up, drops loudly with its own error record and its own counter. Over the window I measured there were 33,989 retries against 16.4M completions, 0.21%, and `gq_jobs_dropped_total` had no series at all. So the 17k/day described work that succeeded.

The wait-queue timer is armed only when the limiter is already saturated, and cleared the moment the statement is admitted. On the ordinary path a slot is free and nothing is allocated, which matters on something that runs millions of times a day.

## Test plan

- [x] `validationMeta` unit tests - a planted secret never reaches the metadata, for every issue code including the ones where Zod puts it in two places
- [x] Collector route tests - payload absent from both the log sink and Sentry, rejection logged at warn, sender still told what was wrong
- [x] `readOtlpBody` failure tests - disconnect, already-consumed body, unsupported encoding, undecompressable body; plus a reader whose `releaseLock` throws, which is the regression that produced the 500s
- [x] Oversize bodies still refused as 413, including when `cancel` throws
- [x] Classifier regression tests - a syntax error quoting a query that mentions "timeout" is no longer retried, while every genuine timeout still is
- [x] Statement wait bound refuses as overload, and a caller's own abort still reports as an abort rather than being relabelled
- [x] 481 tests green across `@langwatch/web`, `observability`, `clickhouse-client` and `api`
- [x] `pnpm typecheck` and `pnpm typecheck:tests` both clean
- [x] `pnpm check:feature-parity` passes, all 32 new scenarios bound
- [x] Biome at baseline on touched paths, no new diagnostics
- [x] Emitted-line tests for the re-keyed cause - deleting the second serializer key fails them, which is what the object-level assertions could not do
- [x] Classifier tests for a shed statement, covering both the full-queue and expired-wait reasons

Specs: `specs/observability/ingest-validation-diagnostics.feature`, `specs/otlp/otlp-body-read-failures.feature`, `specs/observability/request-log-cause-and-level.feature`, plus scenarios added to `specs/analytics/clickhouse-structured-logging-alerting.feature` and `specs/clickhouse/single-client-access.feature`.

## Anything surprising?

**I had the `detected_level` mechanism wrong when I opened this, and the second commit says so.** I'd assumed Loki was reading a field called `error`, which is what `VENDOR_CAUSE_FIELD` and `RETRY_CAUSE_FIELD` already assert in comments. It isn't - it never sees our fields at all, because the line isn't JSON. It scans the message text. Renaming a field the parser can't reach changes nothing there, so nothing in this PR reduces that 129k.

What does is six lines in the OTel log agent's `transform/normalize`, put up separately against `langwatch-saas`: a `set(severity_number, N)` beside each existing `set(severity_text, ...)` (TRACE 1 / DEBUG 5 / INFO 9 / WARN 13 / ERROR 17 / FATAL 21). `detectLogLevelFromLogEntry` reads `OTLPSeverityNumber` before it falls back to scanning, so populating it settles the level correctly at the source.

**Corrected 08-10.** An earlier revision of this section proposed `discover_log_levels: false` and claimed the proper fix was `log_level_fields`, pending a Loki upgrade. Both were wrong, and I'd asserted them before reading the distributor source. No Loki config change and no upgrade are needed — the gap is entirely on our side of the wire. Also stale in the paragraph above: fluent-bit is gone, replaced by the OTel log agent that tails every pod.

`severity_text` is correct, present on every langwatch service, and already what the 42 live alert rules query - I checked, none of them touch `detected_level`.

Worth knowing either way: **stop querying `detected_level`.** It is noise on this pipeline.

**Two defects came out of review, and both were mine.** The field rename above silently dropped the message and stack, because pino matches serializers by exact key and only `error` was registered - every test still passed, because they asserted on the object handed to the logger rather than the line that comes out. And the wait-bound scenario claimed a retryability the classifier did not deliver. Both are fixed, both now have tests that fail without the fix, and the second turned out to be a pre-existing bug on the queue-full path too. Flagging it because it says something about where to look: in both cases I had tested the layer above the bug.

**Re-keying costs the derived `error_type` on warn records.** That's why `errorType` is restated flat. Worth knowing if you have a saved query relying on `error_message` or `error_type` for 4xx - those become `requestError_*`. Error-level records are untouched.

**The wait bound starts refusing work that previously succeeded.** `statementLimit.ts` deliberately shipped without one, on the grounds that the first pass should make waiting measurable rather than start shedding. I think the measurement now justifies it: refusal raises a transient error, so a read retries and a job is re-staged, and waiting 20 more seconds for a slot that arrives with no time left to use it helps nobody. It's a behaviour change though, and `clickhouse_statement_wait_seconds` is there to tune it.

**Not done, and needing the infra repo rather than this one:** the collector level-detection config, and alerts on `gq_jobs_dropped_total` and the retry rate. Nothing currently watches either, and dropped jobs are the only metric here that actually means data loss.

**Two things the review turned up that are customer-facing, not code:** one project sends 6,302 unparseable OTLP bodies a day, which is 97% of all parse failures, and 399k 401s plus 61k 403s a day are 13% of all ingest traffic. Both look like misconfigured exporters retrying forever, and both are worth a reach-out rather than a patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer structured diagnostics for validation failures, including paths, rules, types, and issue counts.
  - Added distinct handling for unreadable OTLP request bodies and unsupported content encodings.
  - Added bounded ClickHouse statement queue waits with overload responses and recoverable classification.
  - Added consistent cause fields for structured request and query logging.

- **Bug Fixes**
  - Improved timeout detection to avoid misclassifying unrelated errors.
  - Preserved original causes while improving warning and error-level logging.
  - Prevented customer payload contents and request bodies from appearing in validation logs or reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
