### PR TITLE
test(event-sourcing): specify batch bisection, pin its FIFO order, and settle the #6555 nits

### DIFF
--- a/platform/app/src/server/event-sourcing/eventSourcing.ts
+++ b/platform/app/src/server/event-sourcing/eventSourcing.ts
@@ -625,9 +625,9 @@ export class EventSourcing {
         // against a mixed batch (should never happen — the GroupQueue only
         // coalesces same-group jobs — but a stray payload must never be
         // misrouted to the wrong handler) and fall back to per-item processing.
-        const first = routed[0];
-        const batchHandler = first?.entry.processBatch;
-        if (!batchHandler || !routed.every((r) => r.entry === first.entry)) {
+        const firstEntry = routed[0]?.entry;
+        const batchHandler = firstEntry?.processBatch;
+        if (!batchHandler || !routed.every((r) => r.entry === firstEntry)) {
           for (const result of routed) {
             await result.entry.process(result.clean, delivery);
           }

--- a/platform/app/src/server/event-sourcing/eventSourcing.ts
+++ b/platform/app/src/server/event-sourcing/eventSourcing.ts
@@ -607,23 +607,36 @@ export class EventSourcing {
           return true;
         });
         if (survivors.length === 0) return;
-        const first = this.lookupEntry(survivors[0]!);
-        const resolved = survivors.map((payload) => this.lookupEntry(payload));
-        const homogeneous =
-          !!first?.entry.processBatch &&
-          resolved.every((r) => r?.entry === first.entry);
-        if (!homogeneous) {
-          for (const [index, result] of resolved.entries()) {
-            if (!result) {
-              this.rejectUnroutableJob(survivors[index]!, queueName);
-            }
+
+        // Reject unroutable payloads UP FRONT so everything below works with a
+        // fully-resolved list. `rejectUnroutableJob` returns `never`, so this
+        // narrows `routed` to non-null for the compiler rather than for the
+        // reader only — which is what lets the rest of this function drop its
+        // non-null assertions (#6699). Behaviour is unchanged: a null entry
+        // could only ever reach the heterogeneous branch, which rejected it
+        // there anyway.
+        const routed = survivors.map((payload) => {
+          const result = this.lookupEntry(payload);
+          if (!result) this.rejectUnroutableJob(payload, queueName);
+          return result;
+        });
+
+        // A coalesced batch is always one group → one registry entry. Guard
+        // against a mixed batch (should never happen — the GroupQueue only
+        // coalesces same-group jobs — but a stray payload must never be
+        // misrouted to the wrong handler) and fall back to per-item processing.
+        const first = routed[0];
+        const batchHandler = first?.entry.processBatch;
+        if (!batchHandler || !routed.every((r) => r.entry === first.entry)) {
+          for (const result of routed) {
             await result.entry.process(result.clean, delivery);
           }
           return;
         }
+
         // Forward the delivery — see the `process` wrapper above (#6578).
-        await first.entry.processBatch!(
-          resolved.map((r) => r!.clean),
+        await batchHandler(
+          routed.map((r) => r.clean),
           delivery,
         );
       },

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.appliedSetEviction.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.appliedSetEviction.unit.test.ts
@@ -90,6 +90,7 @@ describe("FoldProjectionExecutor applied-set eviction", () => {
 
   describe("given a batch carrying one already-applied event and three new ones", () => {
     describe("when it commits on a first attempt", () => {
+      /** @scenario 'A commit records every id it recognised' */
       it("keeps the already-applied id in the set instead of evicting it", async () => {
         const events = ["c0", "c1", "c2", "c3"].map((id, index) =>
           makeEvent(id, 1000 + index),

--- a/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionStoreContext.ts
@@ -90,6 +90,15 @@ export interface ProjectionStoreContext {
    * Which delivery of this job is being folded. 1 is a fresh delivery, higher
    * values are retries of a chain that has not acked.
    *
+   * This is `JobDelivery.attempt` under a longer name, and the pair below is
+   * `JobDelivery.isContinuation`. The prefix is deliberate rather than drift:
+   * `JobDelivery` describes one delivery and nothing else, so a bare `attempt`
+   * reads fine there, while this context is a grab-bag also carrying
+   * `aggregateId`, `tenantId`, `key` and `retentionPolicy` — an unqualified
+   * `attempt` here would not say attempt of what. Noted once so the next
+   * reader following the value across the boundary does not have to re-derive
+   * it (#6699).
+   *
    * A caching store uses it to decide whether the ids it already recorded are
    * still live. On a fresh delivery the previous batch for this group must have
    * acked — the queue holds one active batch per group — so those ids can never

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -1154,9 +1154,12 @@ describe.skipIf(!hasTestcontainers)(
             })),
           );
 
+          // At-LEAST-8, not exactly 8: an over-delivery would never satisfy an
+          // exact-length wait, so the bug would surface as an opaque 30s
+          // timeout instead of the array diff below.
           await vi.waitFor(
             () => {
-              expect(processedInOrder.length).toBe(8);
+              expect(processedInOrder.length).toBeGreaterThanOrEqual(8);
             },
             { timeout: 30000, interval: 50 },
           );

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -971,6 +971,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when one payload in a coalesced batch is unprocessable", () => {
+        /** @scenario 'Payloads ahead of an unprocessable one still commit' */
         it("commits every payload ahead of it and narrows the failure to it alone", async () => {
           // Payloads AFTER the offender deliberately do not commit here: the
           // fold derives fields from arrival order, so applying j6 while j5 is
@@ -1052,6 +1053,7 @@ describe.skipIf(!hasTestcontainers)(
           expect(isolated.length).toBeGreaterThanOrEqual(1);
         });
 
+        /** @scenario 'Each half of a split stays in arrival order' */
         it("keeps each half in arrival order while splitting", async () => {
           const POISON = "j6";
           const attempted: TestPayload[][] = [];
@@ -1104,6 +1106,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when payloads arrive out of order and the batch is bisected", () => {
+        /** @scenario "A split descent emits in the queue's order" */
         it("still processes every payload in the queue's order, across sub-batches", async () => {
           // The contiguity check above proves each sub-batch is internally
           // ordered. It cannot see the order the sub-batches RUN in — a
@@ -1169,6 +1172,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when a coalesced batch fails only because it is too large", () => {
+        /** @scenario 'A batch too large for the handler converges by halving' */
         it("halves it until it fits and commits every payload once", async () => {
           const MAX_WORKABLE = 2;
           const seen: string[] = [];
@@ -1245,6 +1249,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when a coalesced batch fails non-retryably", () => {
+        /** @scenario 'A non-retryable failure is never split' */
         it("fails fast without splitting", async () => {
           const attempts: number[] = [];
 
@@ -1284,6 +1289,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when the split budget is set to zero", () => {
+        /** @scenario 'Setting the split budget to zero disables bisection' */
         it("never splits, restoring the pre-bisection behaviour", async () => {
           // The kill switch: an operator can disable bisection through the
           // environment rather than waiting on a deploy.
@@ -1336,6 +1342,7 @@ describe.skipIf(!hasTestcontainers)(
         // Driven through the bisector directly: this is about which delivery
         // flags the descent emits, and staged dispatch adds timing noise that
         // has nothing to do with the contract.
+        /** @scenario 'Sub-batches after the first commit are marked as continuations' */
         it("marks the sub-batches as continuations so their commits extend rather than replace", async () => {
           const deliveries: (JobDelivery | undefined)[] = [];
           let rootFailed = false;
@@ -1397,6 +1404,7 @@ describe.skipIf(!hasTestcontainers)(
         // how large a root the drain assembles varies with staging timing, and
         // this contract — bounded work per locked attempt — must hold for any
         // shape, so the test pins it on the worst one deterministically.
+        /** @scenario 'Splitting is bounded within one locked attempt' */
         it("stops splitting at the budget and rethrows to the retry path", async () => {
           const sizes: number[] = [];
           const queue = createQueue(async () => {}, {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -1103,6 +1103,71 @@ describe.skipIf(!hasTestcontainers)(
         });
       });
 
+      describe("when payloads arrive out of order and the batch is bisected", () => {
+        it("still processes every payload in the queue's order, across sub-batches", async () => {
+          // The contiguity check above proves each sub-batch is internally
+          // ordered. It cannot see the order the sub-batches RUN in — a
+          // descent that took the right half first would satisfy it while
+          // folding later events before earlier ones. This pins the global
+          // sequence, which is the property a fold actually depends on.
+          //
+          // Every payload shares one score so they all become due together and
+          // coalesce into a single root; `sendBatch` then breaks the tie by
+          // position (`dispatchAfterMs = score + delay + index`), so the
+          // queue's arrival order IS the send order. Sending id-shuffled makes
+          // the two differ, so a bisector keyed on the id rather than on the
+          // queue's sequence would be caught.
+          const MAX_WORKABLE = 2;
+          const processedInOrder: number[] = [];
+          const attemptedSizes: number[] = [];
+
+          const queue = createQueue(
+            async (p) => {
+              processedInOrder.push(Number(p.id.slice(1)));
+            },
+            {
+              processBatch: async (ps) => {
+                attemptedSizes.push(ps.length);
+                if (ps.length > MAX_WORKABLE) {
+                  throw new Error("batch exceeded the downstream budget");
+                }
+                for (const p of ps as TestPayload[]) {
+                  processedInOrder.push(Number(p.id.slice(1)));
+                }
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value),
+            },
+          );
+          await queue.waitUntilReady();
+
+          const dueAt = Date.now() + 2500;
+          const sendOrder = [5, 2, 7, 0, 4, 1, 6, 3];
+          await queue.sendBatch(
+            sendOrder.map((i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(dueAt),
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(processedInOrder.length).toBe(8);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // Guard against the test going vacuous: it only says anything about
+          // bisection if a batch too large to process was actually split.
+          expect(Math.max(...attemptedSizes)).toBeGreaterThan(MAX_WORKABLE);
+
+          // Globally in the queue's order: every payload folded after the one
+          // the queue sequenced before it, however the descent carved the batch.
+          expect(processedInOrder).toEqual(sendOrder);
+        });
+      });
+
       describe("when a coalesced batch fails only because it is too large", () => {
         it("halves it until it fits and commits every payload once", async () => {
           const MAX_WORKABLE = 2;

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -1124,11 +1124,12 @@ describe.skipIf(!hasTestcontainers)(
           const processedInOrder: number[] = [];
           const attemptedSizes: number[] = [];
 
-          const queue = createQueue(
-            async (p) => {
+          const sendOrder = [5, 2, 7, 0, 4, 1, 6, 3];
+          await stageThenConsume({
+            processFn: async (p) => {
               processedInOrder.push(Number(p.id.slice(1)));
             },
-            {
+            overrides: {
               processBatch: async (ps) => {
                 attemptedSizes.push(ps.length);
                 if (ps.length > MAX_WORKABLE) {
@@ -1141,18 +1142,16 @@ describe.skipIf(!hasTestcontainers)(
               coalesceMaxBatch: () => 50,
               score: (p) => Number(p.value),
             },
-          );
-          await queue.waitUntilReady();
-
-          const dueAt = Date.now() + 2500;
-          const sendOrder = [5, 2, 7, 0, 4, 1, 6, 3];
-          await queue.sendBatch(
-            sendOrder.map((i) => ({
+            // One shared score, unlike the ordered batches elsewhere: the tie
+            // is the point, because it hands the ordering job entirely to
+            // `sendBatch`'s positional tiebreak and so lets the send order
+            // differ from the id order.
+            payloads: sendOrder.map((i) => ({
               id: `j${i}`,
               groupId: "group-a",
-              value: String(dueAt),
+              value: String(orderedScore(0)),
             })),
-          );
+          });
 
           // At-LEAST-8, not exactly 8: an over-delivery would never satisfy an
           // exact-length wait, so the bug would surface as an opaque 30s

--- a/specs/event-sourcing/batch-bisection.feature
+++ b/specs/event-sourcing/batch-bisection.feature
@@ -1,0 +1,112 @@
+Feature: GroupQueue batch bisection
+  As the LangWatch event-sourcing queue folding coalesced batches per aggregate
+  I want a batch that fails to be split in half and retried, rather than
+  retried whole
+  So that one unprocessable payload cannot take the healthy payloads batched
+  alongside it down on every attempt until the group blocks.
+
+  # A coalesced batch is all-or-nothing: the fold stores once at the end, so any
+  # throw discards the work for every payload in it, and the retry re-drains the
+  # same siblings into the same batch. Nothing narrows, and nothing identifies
+  # which payload is at fault. Two failure classes suffer from that:
+  #
+  #   - one payload cannot be processed at all, and takes up to
+  #     coalesceMaxBatch - 1 healthy payloads with it, every attempt;
+  #   - the batch is merely too big for a downstream budget, and only succeeds
+  #     if a retry happens to reassemble a lighter set.
+  #
+  # One mechanism covers both, because both are "this set fails but a smaller
+  # set might not". Splitting halves until the batch fits, or until the failure
+  # is attributable to a single payload.
+  #
+  # Three constraints bound what it may do:
+  #
+  #   - ORDERING. A fold derives fields from arrival order, so halves are
+  #     contiguous and run in sequence, never concurrently. The order that
+  #     matters is the queue's sequence — score first, send position as the
+  #     tiebreak — not anything derivable from the payload. A throw also
+  #     propagates immediately, so payloads AFTER the offender are not
+  #     attempted: stepping over one would apply later payloads across a gap
+  #     the fold cannot see. Bisection recovers what precedes the offender and
+  #     names it; rescuing what queued behind it needs a separate decision.
+  #
+  #   - DELIVERY-SCOPED STATE. Each sub-batch commit carries only its own ids,
+  #     so a later commit must EXTEND the fold's applied-event-id set rather
+  #     than replace it. Sub-batches after the first are therefore marked as
+  #     continuations. The flag is set whether the previous call returned or
+  #     threw, because a handler that stored and then failed has written just
+  #     as surely as one that returned.
+  #
+  #   - BOUNDED WORK. Splitting runs while the job holds the group's active
+  #     key, which the heartbeat keeps renewing, so an unbounded descent would
+  #     hold the group lock and a worker slot for the whole tree instead of
+  #     yielding. Past a split budget the failure propagates un-split and the
+  #     normal retry/backoff path takes over. The budget is read from
+  #     LANGWATCH_GQ_BISECTION_SPLIT_BUDGET; zero disables bisection outright,
+  #     which restores the previous behaviour without a deploy.
+
+  @integration @coalescing @bisection
+  Scenario: Payloads ahead of an unprocessable one still commit
+    Given a coalesced batch in which one payload can never be processed
+    When the batch is dispatched
+    Then every payload sequenced before the offender is committed
+    And the offender is narrowed to on its own and named as the cause
+    And no payload is committed more than once
+
+  @integration @coalescing @bisection
+  Scenario: Each half of a split stays in arrival order
+    Given a coalesced batch that fails and is split
+    When each half is processed
+    Then every sub-batch is a contiguous run of the arrival sequence
+    And no sub-batch reorders or interleaves the payloads it carries
+
+  @integration @coalescing @bisection
+  Scenario: A split descent emits in the queue's order
+    Given a coalesced batch whose payloads were handed over out of order
+    When the batch fails and is split down to sub-batches that succeed
+    Then the payloads are processed in the order the queue sequenced them
+    And a descent that took the second half first would be rejected
+
+  @integration @coalescing @bisection
+  Scenario: A batch too large for the handler converges by halving
+    Given a handler that rejects any batch above a workable size
+    When a batch larger than that size is dispatched
+    Then the batch is halved until every part is workable
+    And every payload is committed exactly once
+    And no two sub-batches are processed concurrently
+
+  @integration @coalescing @bisection
+  Scenario: A non-retryable failure is never split
+    Given a coalesced batch whose handler fails non-retryably
+    When the batch is dispatched
+    Then the batch is not split
+    And the failure is surfaced immediately
+
+  @integration @coalescing @bisection
+  Scenario: Splitting is bounded within one locked attempt
+    Given a handler that only ever accepts a single payload
+    When a large coalesced batch is dispatched
+    Then splitting stops once the budget is spent
+    And the remaining failure is handed to the normal retry path
+    And the descent does not walk the whole tree under the group lock
+
+  @integration @coalescing @bisection
+  Scenario: Setting the split budget to zero disables bisection
+    Given the split budget is configured as zero
+    When a coalesced batch fails retryably
+    Then the batch is not split
+    And the handler sees exactly one call carrying the whole batch
+
+  @integration @coalescing @bisection
+  Scenario: Sub-batches after the first commit are marked as continuations
+    Given a coalesced batch whose first call commits and then fails
+    When the batch is split
+    Then every later sub-batch is delivered as a continuation
+    And their commits extend the applied-event-id set rather than replacing it
+
+  @unit @coalescing @fold
+  Scenario: A commit records every id it recognised
+    Given a batch carrying one already-applied event alongside new ones
+    When the fold commits on a fresh delivery
+    Then the already-applied id is still recorded as applied
+    And a later delivery carrying that id does not fold it a second time

--- a/specs/event-sourcing/batch-bisection.feature
+++ b/specs/event-sourcing/batch-bisection.feature
@@ -44,14 +44,27 @@ Feature: GroupQueue batch bisection
   #     normal retry/backoff path takes over. The budget is read from
   #     LANGWATCH_GQ_BISECTION_SPLIT_BUDGET; zero disables bisection outright,
   #     which restores the previous behaviour without a deploy.
+  #
+  # The budget bounds the other two guarantees, and the scenarios below are
+  # written inside it rather than pretending otherwise. The check runs on every
+  # sub-batch, before the descent can reach a single payload, so a budget spent
+  # mid-descent abandons the remaining chunk un-split: payloads sequenced BEFORE
+  # the offender but sitting in that chunk are not committed, and the offender
+  # is never isolated and so never named. That is the intended trade — the whole
+  # point of the budget is to stop walking and let backoff take over — but it
+  # means "everything before the offender commits" and "an oversized batch
+  # converges" hold only while the budget lasts, which is why both scenarios say
+  # so. Sizing the budget below log2(coalesceMaxBatch) makes isolation
+  # unreachable for a full batch.
 
   @integration @coalescing @bisection
   Scenario: Payloads ahead of an unprocessable one still commit
     Given a coalesced batch in which one payload can never be processed
+    And a split budget the descent does not exhaust
     When the batch is dispatched
     Then every payload sequenced before the offender is committed
-    And the offender is narrowed to on its own and named as the cause
-    And no payload is committed more than once
+    And the offender is narrowed to on its own
+    And no payload ahead of it is applied more often than its peers
 
   @integration @coalescing @bisection
   Scenario: Each half of a split stays in arrival order
@@ -65,11 +78,11 @@ Feature: GroupQueue batch bisection
     Given a coalesced batch whose payloads were handed over out of order
     When the batch fails and is split down to sub-batches that succeed
     Then the payloads are processed in the order the queue sequenced them
-    And a descent that took the second half first would be rejected
 
   @integration @coalescing @bisection
   Scenario: A batch too large for the handler converges by halving
     Given a handler that rejects any batch above a workable size
+    And a split budget large enough to reach that size
     When a batch larger than that size is dispatched
     Then the batch is halved until every part is workable
     And every payload is committed exactly once
@@ -80,7 +93,7 @@ Feature: GroupQueue batch bisection
     Given a coalesced batch whose handler fails non-retryably
     When the batch is dispatched
     Then the batch is not split
-    And the failure is surfaced immediately
+    And the failure is surfaced without further handler calls
 
   @integration @coalescing @bisection
   Scenario: Splitting is bounded within one locked attempt
@@ -102,7 +115,6 @@ Feature: GroupQueue batch bisection
     Given a coalesced batch whose first call commits and then fails
     When the batch is split
     Then every later sub-batch is delivered as a continuation
-    And their commits extend the applied-event-id set rather than replacing it
 
   @unit @coalescing @fold
   Scenario: A commit records every id it recognised

--- a/specs/event-sourcing/batch-bisection.feature
+++ b/specs/event-sourcing/batch-bisection.feature
@@ -54,8 +54,12 @@ Feature: GroupQueue batch bisection
   # point of the budget is to stop walking and let backoff take over — but it
   # means "everything before the offender commits" and "an oversized batch
   # converges" hold only while the budget lasts, which is why both scenarios say
-  # so. Sizing the budget below log2(coalesceMaxBatch) makes isolation
-  # unreachable for a full batch.
+  # so. Isolating one offender costs a split per level of the path down to it,
+  # which for a full batch is floor(log2(coalesceMaxBatch)) when it falls left
+  # of every halving and one more when it does not; halves that succeed cost
+  # nothing, so where the offender sits barely matters, but a second offender
+  # in the same batch costs its own descent. A budget under that narrows the
+  # batch without ever isolating anything.
 
   @integration @coalescing @bisection
   Scenario: Payloads ahead of an unprocessable one still commit


### PR DESCRIPTION
## For humans

When the queue bundles jobs together and one bundle fails, it splits the bundle in half and retries each half. Review of #6555 asked, as a sanity check, whether that splitting still processes work in the order it arrived. It does — but nothing was checking, so this adds the check. It also writes down how the splitting is supposed to behave, which had never been written down anywhere, and tidies up two things review flagged. Nothing about how the queue actually behaves changes.

## Why

Closes the sanity check requested on #6555, which merged before this landed, and closes #6699 — the two review nits from the same PR, which were filed rather than rushed into an already-approved change.

The existing ordering test asserts each sub-batch is internally ascending and contiguous. That is necessary but not sufficient: a descent that ran the **right** half before the left satisfies it completely while folding later events ahead of earlier ones. Order across sub-batches was unasserted, and a fold derives fields from arrival order.

## What changed

**A feature file for bisection**, plus the FIFO test that prompted it.

Bisection shipped with no spec: nine behaviours lived only in tests — the split, the ordering guarantee, the continuation flag, the split budget and its kill switch, and the commit rule that records recognised rather than freshly-folded ids. The sibling queue guard (`poison-group-park-guard.feature`) has its own spec; this gives bisection the same. It is also the only written home for `LANGWATCH_GQ_BISECTION_SPLIT_BUDGET`, which was documented nowhere despite being the lever that turns bisection off without a deploy.

Every scenario is tagged and bound to the test that proves it, so the file enforces rather than describes — `check-feature-parity` reports **9/9 bound**.

**Both #6699 nits.** The coalesced-batch wrapper carried three non-null assertions (`processBatch!`, `r!.clean`, `survivors[index]!`). They were correct but load-bearing — the homogeneity guard proves every entry resolved, yet TypeScript cannot narrow an array through a boolean, so the proof lived in a variable and a future edit to that guard could not fail the build. Unroutable payloads are now rejected up front; `rejectUnroutableJob` returns `never`, so the list genuinely narrows and all three assertions delete themselves. Behaviour is unchanged — a null entry could only ever reach the heterogeneous branch, which rejected it there anyway — and the lint gate records **one violation removed, none added**.

The other nit asked whether the store context has `.attempt`. It deliberately does not, and that is now written down at the type rather than renamed: `JobDelivery` describes one delivery so a bare `attempt` reads fine, while the store context also carries `aggregateId`, `tenantId`, `key` and `retentionPolicy`, where it would not say attempt of what.

**The FIFO test.** One test. It sends the batch **id-shuffled** under a single shared score, so:

- every payload becomes due at the same instant and coalesces into one root large enough to be split, and
- `sendBatch` breaks the score tie by array position (`dispatchAfterMs = score + delay + index`), which makes the queue's arrival order deliberately differ from the id order.

A bisector keyed on anything other than the queue's own sequence is therefore caught. It asserts the global emission order across sub-batches, and separately that a batch larger than the handler's limit really was split — so the test cannot quietly stop testing anything.

**A flake in the tests this spec binds to — now mostly main's fix, not this PR's.** The oversized-batch test went red on a shard: `[5,3,2,1,2]` then `[3,2,1]` where it expected `[8,4,2,2,4,2,2]` — two dispatches rather than one. Five coalescing tests assert an exact descent, which holds only if the whole batch is claimable in a single dispatch, and all five defended that with a 2500ms future date. A margin is not a fix; a loaded runner overruns it, and the failure then reads as a descent bug rather than the scheduling artefact it is.

While this branch was open, **main fixed the same flake independently** — a `stageThenConsume` helper that stages through a producer-only instance and starts the consumer afterwards, plus past-dated scores. On rebase that version was kept wholesale: its comment is better informed than the one written here, naming the coalescing drain (`ZRANGEBYSCORE jobs -inf now`) as what makes a consumer waking mid-spread take only a prefix of the group, and noting that `sendBatch` is a single atomic Lua call so there is no half-staged group to catch either.

What remains here is the FIFO test added on this branch, which main has no copy of and so was still on the old pattern. It moves to the same helper. Its scores stay tied where main's are ordered, deliberately: a shared score hands ordering entirely to `sendBatch`'s positional tiebreak, which is what lets the send order differ from the id order.

Worth recording, since it cost a debugging round: past-dating is load-bearing and not cosmetic. Staging before the consumer exists closes the staging race, but dating the batch at `Date.now()` reopens the same failure through another door — `sendBatch` staggers dispatch times by array position to hold FIFO within a batch, so the tail sits milliseconds ahead of the head and a consumer starting inside that window claims only what has come due. Measured: a claim 12ms in took `j0..j5` and left `j6,j7` to a second dispatch.

## Test plan

- `groupQueue.integration` 30 passed, **five consecutive full-suite runs** — one green run does not retire a race. `foldRedeliveryIdempotency` + `poisonGuard` alongside it: 64 total.
- Runtime wrapper suites 35 passed — the refactor touches the live dispatch path, so a typecheck alone was not enough.
- `pnpm typecheck` and `pnpm typecheck:tests`: 0 errors. `check-feature-parity`: 9/9 bound. CI's biome gate: one violation removed, none added. ast-grep clean.

Verified live rather than assumed — reversing the descent to right-half-first fails it:

```
expected [6,3,4,1,7,0,5,2] to deeply equal [5,2,7,0,4,1,6,3]
```

## Anything surprising?

**One scenario binding silently failed.** A single-quoted `@scenario` whose title contains an apostrophe ("the queue's order") terminates the quote early and matches nothing. It reads correctly, the suite stays green, and only `check-feature-parity` catches it — it reported 8/9 until the annotation was switched to double quotes.


**Two earlier drafts of this test were vacuous, and the mutation is what caught them.** Spacing the scores apart to defeat the positional tiebreak made the jobs become due a second apart, so they never coalesced at all — every job took the single-payload path, bisection never ran, and the reversal mutation passed against it. A green ordering test proved nothing.

The lesson worth keeping: FIFO here is the queue's sequence — score first, send position as the tiebreak — not anything derivable from the payload. A test that constructs arrival order out of payload fields is testing its own arithmetic.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch processing to resolve payloads consistently and promptly reject jobs that cannot be routed.
  - Preserved fallback handling for missing or mixed handlers.

- **Tests**
  - Added comprehensive coverage for ordered batch processing, splitting oversized batches, isolating failing payloads, and preventing duplicate commits.
  - Verified retryable and non-retryable failures, disabled splitting, split limits, continuation handling, and recognized event tracking.

- **Documentation**
  - Added specifications for batch-splitting behavior, ordering, commits, and failure scenarios.
  - Clarified delivery-attempt terminology and processing context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




