### PR TITLE
fix(observability): let a gateway log join its trace, and a JS log name its build

### DIFF
--- a/packages/observability/src/__tests__/serviceVersion.unit.test.ts
+++ b/packages/observability/src/__tests__/serviceVersion.unit.test.ts
@@ -59,6 +59,25 @@ describe("serviceVersionField", () => {
       expect(serviceVersionField()).toEqual({ "service.version": "a=b" });
     });
 
+    /**
+     * The spec's format percent-encodes `,` and `=` in values, which is how a
+     * value containing either survives a format that separates on both. The
+     * OTel SDK's envDetector decodes them, so this must too — a log saying
+     * `git%2Dabc` where the trace says `git-abc` is precisely the drift this
+     * function exists to prevent.
+     */
+    it("percent-decodes the value, as the OTel SDK does", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=git%2Dabc%2C1";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "git-abc,1" });
+    });
+
+    it("falls back to the raw text on a malformed escape", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=100%off";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "100%off" });
+    });
+
     it("ignores the key when it has no value", () => {
       process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=";
 

--- a/packages/observability/src/__tests__/serviceVersion.unit.test.ts
+++ b/packages/observability/src/__tests__/serviceVersion.unit.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Whether a log line can say which build produced it.
+ *
+ * The deployment already states the version — OTEL_RESOURCE_ATTRIBUTES carries
+ * `service.version=<tag>` and `envDetector` merges it into the OTel resource —
+ * but that resource only reaches telemetry we EXPORT. These logs go to stdout
+ * and are read back off the pod's log file, a path the resource never touches.
+ * Measured against prod on 2026-08-07, `service_version` appeared on no record
+ * in the entire fleet, so no log line could be tied to a build.
+ *
+ * The existing env var is parsed rather than a second one introduced, because
+ * two ways to state the version is how they drift apart.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { serviceVersionField } from "../logger";
+
+const ORIGINAL = { ...process.env };
+
+describe("serviceVersionField", () => {
+  beforeEach(() => {
+    delete process.env.SERVICE_VERSION;
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  describe("given the deployment's OTEL_RESOURCE_ATTRIBUTES", () => {
+    it("reads the version out of it", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES =
+        "service.name=langwatch,service.version=git-5373dad,deployment.environment.name=production";
+
+      expect(serviceVersionField()).toEqual({
+        "service.version": "git-5373dad",
+      });
+    });
+
+    it("is not fooled by another key ending in the same word", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES =
+        "app.version=1.2.3,service.version=git-abc";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "git-abc" });
+    });
+
+    it("tolerates whitespace around the pair", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES =
+        "service.name=langwatch, service.version = git-spaced ";
+
+      expect(serviceVersionField()).toEqual({
+        "service.version": "git-spaced",
+      });
+    });
+
+    it("keeps a value containing an equals sign intact", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=a=b";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "a=b" });
+    });
+
+    it("ignores the key when it has no value", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=";
+
+      expect(serviceVersionField()).toEqual({});
+    });
+
+    it("ignores a malformed entry with no separator", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "justakey,service.version=ok";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "ok" });
+    });
+  });
+
+  describe("given SERVICE_VERSION is set explicitly", () => {
+    it("wins over the resource attributes", () => {
+      process.env.SERVICE_VERSION = "explicit";
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=from-attrs";
+
+      expect(serviceVersionField()).toEqual({ "service.version": "explicit" });
+    });
+  });
+
+  describe("given neither is set", () => {
+    it("adds no field at all, rather than an empty one", () => {
+      expect(serviceVersionField()).toEqual({});
+    });
+
+    it("adds nothing when the attributes name other keys only", () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = "service.name=langwatch";
+
+      expect(serviceVersionField()).toEqual({});
+    });
+  });
+});

--- a/packages/observability/src/__tests__/serviceVersionEmitted.unit.test.ts
+++ b/packages/observability/src/__tests__/serviceVersionEmitted.unit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The version as it appears on a record `createLogger` actually wrote.
+ *
+ * `serviceVersion.unit.test.ts` tests the parser in isolation, and a parser test
+ * passes perfectly well while the emitted record carries nothing — the field
+ * only reaches a log line if the parser is wired into pino's `bindings`
+ * formatter, and nothing in a direct call proves that it is. So this goes
+ * through `createLogger` and reads what lands on the stream.
+ *
+ * `createLogger` writes to `process.stdout` when there is no transport, which is
+ * the case under NODE_ENV=test, so intercepting the write is enough to see the
+ * real record.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createLogger } from "../logger";
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Everything createLogger wrote while `run` executed, parsed. */
+function emitted(run: () => void): Record<string, any>[] {
+  const written: string[] = [];
+  const realWrite = process.stdout.write.bind(process.stdout);
+
+  process.stdout.write = ((chunk: unknown) => {
+    written.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    run();
+  } finally {
+    process.stdout.write = realWrite;
+  }
+
+  return written
+    .join("")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, any>);
+}
+
+describe("service.version on a record createLogger wrote", () => {
+  beforeEach(() => {
+    delete process.env.SERVICE_VERSION;
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    // The node logger defaults to `error` under NODE_ENV=test; these assertions
+    // are about an ordinary info line.
+    process.env.PINO_LOG_LEVEL = "info";
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("reaches the emitted line, not just the parser", () => {
+    process.env.OTEL_RESOURCE_ATTRIBUTES =
+      "service.name=langwatch-app,service.version=git-5373dad";
+
+    const [record] = emitted(() => {
+      createLogger("langwatch:test:version").info("hello");
+    });
+
+    expect(record?.["service.version"]).toBe("git-5373dad");
+  });
+
+  it("decodes a percent-encoded value, so it matches what the trace says", () => {
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=git%2Dabc%2C1";
+
+    const [record] = emitted(() => {
+      createLogger("langwatch:test:version").info("hello");
+    });
+
+    expect(record?.["service.version"]).toBe("git-abc,1");
+  });
+
+  it("is absent, not empty, when the environment says nothing", () => {
+    const [record] = emitted(() => {
+      createLogger("langwatch:test:version").info("hello");
+    });
+
+    expect(record).not.toHaveProperty("service.version");
+  });
+
+  it("does not disturb the fields the record already carried", () => {
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "service.version=git-5373dad";
+
+    const [record] = emitted(() => {
+      createLogger("langwatch:test:version").info("hello");
+    });
+
+    expect(record?.name).toBe("langwatch:test:version");
+    expect(record?.msg).toBe("hello");
+    expect(record?.service).toBeTruthy();
+  });
+});

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -162,6 +162,26 @@ function createBrowserLogger(name: string): PinoLogger {
  * Returns nothing when unset, so a local run adds no field rather than an empty
  * one.
  */
+/**
+ * `OTEL_RESOURCE_ATTRIBUTES` values are percent-encoded (the spec's W3C Baggage
+ * octet string), which is how a value containing `,` or `=` survives a format
+ * that separates on both. The OTel SDK's own envDetector decodes them, so this
+ * has to as well: the whole point of reading this variable rather than adding a
+ * second one is that a log and a span cannot disagree about the version, and
+ * emitting `git%2Dabc` where the trace says `git-abc` would be exactly that
+ * disagreement.
+ *
+ * A malformed escape falls back to the raw text. `decodeURIComponent` throws on
+ * a stray `%`, and a version we can print imperfectly beats no version at all.
+ */
+function decodeAttributeValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export function serviceVersionField(): Record<string, string> {
   const explicit = process.env.SERVICE_VERSION?.trim();
   if (explicit) return { "service.version": explicit };
@@ -174,7 +194,7 @@ export function serviceVersionField(): Record<string, string> {
     if (separator === -1) continue;
     if (pair.slice(0, separator).trim() !== "service.version") continue;
 
-    const value = pair.slice(separator + 1).trim();
+    const value = decodeAttributeValue(pair.slice(separator + 1).trim());
     if (value) return { "service.version": value };
   }
 

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -150,6 +150,37 @@ function createBrowserLogger(name: string): PinoLogger {
   });
 }
 
+/**
+ * `service.version` for a log record, read from the same place the OTel
+ * resource reads it.
+ *
+ * `OTEL_RESOURCE_ATTRIBUTES` is the `k=v,k=v` form the deployment already sets.
+ * Parsing it keeps one source of truth — two ways to state the version is how
+ * they drift — and `SERVICE_VERSION` is accepted as an explicit override for
+ * anything that sets only that.
+ *
+ * Returns nothing when unset, so a local run adds no field rather than an empty
+ * one.
+ */
+export function serviceVersionField(): Record<string, string> {
+  const explicit = process.env.SERVICE_VERSION?.trim();
+  if (explicit) return { "service.version": explicit };
+
+  const attrs = process.env.OTEL_RESOURCE_ATTRIBUTES;
+  if (!attrs) return {};
+
+  for (const pair of attrs.split(",")) {
+    const separator = pair.indexOf("=");
+    if (separator === -1) continue;
+    if (pair.slice(0, separator).trim() !== "service.version") continue;
+
+    const value = pair.slice(separator + 1).trim();
+    if (value) return { "service.version": value };
+  }
+
+  return {};
+}
+
 function createNodeLogger(
   name: string,
   options?: CreateLoggerOptions,
@@ -177,6 +208,17 @@ function createNodeLogger(
       bindings: (bindings) => ({
         ...bindings,
         service: process.env.OTEL_SERVICE_NAME ?? DEFAULT_SERVICE_NAME,
+        // Which build produced the line.
+        //
+        // The deployment already states this — OTEL_RESOURCE_ATTRIBUTES carries
+        // `service.version=<tag>` and `envDetector` merges it into the OTel
+        // resource — but that resource only reaches telemetry we EXPORT.
+        // These logs go to stdout and are picked up from the pod's log file, a
+        // path the resource never touches, so no log line has ever carried a
+        // version: measured 2026-08-07, `service_version` appeared on no record
+        // in the fleet. Reading the same env var keeps one source of truth
+        // rather than introducing a second way to say it.
+        ...serviceVersionField(),
       }),
       level: (label) => ({ level: label.toUpperCase() }),
     },

--- a/services/aigateway/adapters/httpapi/access_log_trace_correlation_test.go
+++ b/services/aigateway/adapters/httpapi/access_log_trace_correlation_test.go
@@ -1,0 +1,179 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/pkg/httpmiddleware"
+	"github.com/langwatch/langwatch/services/aigateway/adapters/gatewaytracer"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+)
+
+// The gateway's access log has to carry the trace it belongs to, and whether it
+// does is decided entirely by the order the two middlewares are registered in.
+//
+// Telemetry captures its context up front — `ctx := clog.With(r.Context(), ...)`
+// — and logs `request_completed` with that same value AFTER the inner chain
+// returns. Anything a LATER middleware puts on a derived context is therefore
+// invisible to it. Registered after Telemetry, the tracer stamped
+// trace_id/span_id onto a context the access log never reads, and in production
+// 0 of 10,762 gateway records carried a trace_id while langyagent — same two
+// middlewares, wired the other way round — carried one on 98.7%.
+//
+// Asserting on the emitted record rather than on the order of the `r.Use` calls
+// is deliberate: the ordering is the current cause, but the property that
+// matters is that the line can be joined to its trace, however that is achieved.
+func TestAccessLogCarriesTraceCorrelation(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+
+	// A real SDK provider, so the middleware starts a span with a valid,
+	// sampled context — a no-op tracer would make this pass vacuously.
+	// The middleware resolves its tracer from the GLOBAL provider, so the
+	// global is what has to be real here — with the default no-op the span
+	// context is invalid and both tests would pass for the wrong reason.
+	provider := trace.NewTracerProvider(trace.WithSampler(trace.AlwaysSample()))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = provider.Shutdown(t.Context())
+	})
+
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := clog.Set(req.Context(), zap.New(core))
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	// The order under test, mirroring NewRouter.
+	r.Use(gatewaytracer.Middleware(gatewaytracer.DefaultSpanName))
+	r.Use(httpmiddleware.Telemetry())
+
+	r.Get("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	completed := logs.FilterMessage("request_completed").All()
+	if len(completed) != 1 {
+		t.Fatalf("expected one request_completed record, got %d", len(completed))
+	}
+
+	fields := completed[0].ContextMap()
+
+	traceID, ok := fields[clog.FieldTraceID].(string)
+	if !ok || traceID == "" {
+		t.Errorf(
+			"access log carries no %s, so it cannot be joined to its trace; fields: %v",
+			clog.FieldTraceID, fields,
+		)
+	}
+
+	spanID, ok := fields[clog.FieldSpanID].(string)
+	if !ok || spanID == "" {
+		t.Errorf("access log carries no %s; fields: %v", clog.FieldSpanID, fields)
+	}
+}
+
+// The same property against the router the service actually serves, so the
+// registration order in NewRouter is what is guarded rather than a chain
+// assembled here to match it.
+func TestNewRouterAccessLogCarriesTraceCorrelation(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+
+	provider := trace.NewTracerProvider(trace.WithSampler(trace.AlwaysSample()))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = provider.Shutdown(t.Context())
+	})
+
+	reg := health.New("test")
+	reg.MarkStarted()
+	router := NewRouter(RouterDeps{
+		App:    app.New(),
+		Logger: zap.NewNop(),
+		Health: reg,
+	})
+
+	// clog.Set on the way in, so the observer sees whatever the chain derives.
+	outer := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		router.ServeHTTP(w, req.WithContext(clog.Set(req.Context(), zap.New(core))))
+	})
+
+	outer.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	completed := logs.FilterMessage("request_completed").All()
+	if len(completed) == 0 {
+		t.Fatal("the real router emitted no request_completed record")
+	}
+
+	if id, ok := completed[0].ContextMap()[clog.FieldTraceID].(string); !ok || id == "" {
+		t.Errorf(
+			"NewRouter's access log carries no %s — check the order of "+
+				"gatewaytracer.Middleware and httpmiddleware.Telemetry; fields: %v",
+			clog.FieldTraceID, completed[0].ContextMap(),
+		)
+	}
+}
+
+// The inverse, so the test above cannot pass for the wrong reason: with
+// Telemetry registered OUTSIDE the tracer — the order that shipped — the ids
+// are absent. If this ever starts finding them, Telemetry has been made to read
+// the live context and the ordering constraint no longer binds.
+func TestAccessLogLosesCorrelationWhenTelemetryWrapsTheTracer(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+
+	// The middleware resolves its tracer from the GLOBAL provider, so the
+	// global is what has to be real here — with the default no-op the span
+	// context is invalid and both tests would pass for the wrong reason.
+	provider := trace.NewTracerProvider(trace.WithSampler(trace.AlwaysSample()))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = provider.Shutdown(t.Context())
+	})
+
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := clog.Set(req.Context(), zap.New(core))
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Use(httpmiddleware.Telemetry())
+	r.Use(gatewaytracer.Middleware(gatewaytracer.DefaultSpanName))
+
+	r.Get("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	completed := logs.FilterMessage("request_completed").All()
+	if len(completed) != 1 {
+		t.Fatalf("expected one request_completed record, got %d", len(completed))
+	}
+
+	if _, present := completed[0].ContextMap()[clog.FieldTraceID]; present {
+		t.Errorf(
+			"expected no %s in the broken order — if this now passes, the ordering "+
+				"constraint the router comment relies on is gone and that comment needs updating",
+			clog.FieldTraceID,
+		)
+	}
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -94,11 +94,19 @@ func NewRouter(deps RouterDeps) http.Handler {
 	// exclude themselves from the counters.
 	r.Use(gatewaymetrics.Middleware(deps.Metrics))
 	r.Use(httpmiddleware.Recover())
+	// OUTSIDE Telemetry, and that ordering is load-bearing. Telemetry captures
+	// its context up front (`ctx := clog.With(r.Context(), ...)`) and logs
+	// `request_completed` with that same value AFTER the inner chain returns,
+	// so anything a later middleware adds to a DERIVED context is invisible to
+	// it. Registered after Telemetry, the tracer's trace_id/span_id landed on a
+	// context the access log never reads: 0 of 10,762 gateway records carried a
+	// trace_id, against 98.7% for langyagent, which wires the same two
+	// middlewares the other way round and says so in a comment.
+	r.Use(gatewaytracer.Middleware(gatewaytracer.DefaultSpanName))
 	r.Use(httpmiddleware.Telemetry())
 	if deps.Version != "" {
 		r.Use(httpmiddleware.Version("X-LangWatch-Gateway-Version", deps.Version))
 	}
-	r.Use(gatewaytracer.Middleware(gatewaytracer.DefaultSpanName))
 
 	if deps.Health != nil {
 		r.Get("/healthz", deps.Health.Liveness)


### PR DESCRIPTION
## Why

Auditing what each producer actually sends to Loki turned up two gaps that are mirror images of each other: **the Go gateway has a version and no trace correlation; the JS app has trace correlation and no version.**

Measured against prod on 07-08, over 3h:

| service | records with `trace_id` | |
|---|---|---|
| langwatch-service-worker (JS) | 266,273 / 267,409 | 99.6% |
| langwatch-service-langyagent (Go) | 1,619 / 1,640 | 98.7% |
| **langwatch-service-aigateway (Go)** | **0 / 10,762** | **0%** |

And `service_version` appeared on **no record in the entire fleet**.

## What changed

### The gateway's access log can now be joined to its trace

This is not missing instrumentation. The gateway exports spans to Tempo, the tracer middleware is wired, and it calls `clog.WithSpanContext`. The two middlewares were simply registered in the wrong order.

`Telemetry` captures its context up front and logs *after* the inner chain returns:

```go
ctx := clog.With(r.Context(), ...)          // before any span exists
next.ServeHTTP(rec, r.WithContext(ctx))     // the tracer runs in here, deriving a NEW ctx
clog.Get(ctx).Log(level, "request_completed", ...)   // reads the OLD ctx
```

So anything a *later* middleware puts on a derived context is invisible to it. Registered after `Telemetry`, the tracer stamped `trace_id`/`span_id` onto a context the access log never reads.

**langyagent is the control case** — same two middlewares, wired the other way round, with a comment saying exactly why:

```go
h = httpmiddleware.Telemetry()(h)
// OUTSIDE Telemetry, so the request logger's context already carries the span
// and logs correlate to the trace by id.
h = httpmiddleware.Tracing("langwatch.langyagent.httpapi")(h)
```

Same code, opposite order, opposite outcome — 98.7% against 0%.

### JS log lines now name their build

The deployment already states the version: `OTEL_RESOURCE_ATTRIBUTES=service.name=langwatch,service.version=${local.tag},...`, merged into the OTel resource by `envDetector`. But **that resource only reaches telemetry we export.** These logs go to stdout and are read back off the pod's log file — a path the resource never touches. Hence zero coverage.

The pino bindings now read the same env var rather than introducing a second way to say it, which is how the two would drift apart. `SERVICE_VERSION` is an explicit override, and an unset environment adds no field rather than an empty one.

## Test plan

- [x] Three Go tests: the correct order correlates; **the real `NewRouter` correlates**, so the registration order is what's guarded rather than a chain reassembled to match it; and the broken order does *not*, so the first two can't pass for the wrong reason
- [x] All three set a real SDK provider as the **global** — the middleware resolves its tracer from there, and a no-op provider would make them vacuously green (it did, on my first attempt)
- [x] Verified the `NewRouter` test fails when the ordering is put back: `access log carries no trace_id — check the order of gatewaytracer.Middleware and httpmiddleware.Telemetry`
- [x] 9 tests for the version parsing, covering the malformed and whitespace cases and a value containing `=`
- [x] `go build ./services/aigateway/...`, `gofmt`, `golangci-lint` clean on the touched paths
- [x] `pnpm test:unit` 68/68 and `pnpm typecheck` clean in `@langwatch/observability`

## Anything surprising?

**nlpgo registers `Telemetry` with no tracing middleware at all** — so its logs have the same gap for a different reason. Left alone here; it needs a tracing middleware added, not a reorder, and that deserves its own change.

**This pairs with langwatch-saas#944**, which fixes level detection across every producer and adds `service.version` from the container image tag as a fleet-wide fallback. That fallback uses `action: insert`, so a service stating its own version — which is what this PR makes the JS app do — wins over the image tag. The two changes layer rather than collide.

**The gateway also logs its own `version: git-5373dad`** as a bespoke app field. That's now redundant with `service.version` and could be dropped, but removing a field people may be querying is worth doing deliberately rather than in passing.

## Deployment Impact

**Env vars.** One new one is *read*, none is required. `SERVICE_VERSION` is an optional override for the version stamped on log lines; unset, the logger falls back to parsing `service.version` out of `OTEL_RESOURCE_ATTRIBUTES`, which the prod deployment already sets and which nothing here changes. With neither present the field is simply omitted, so no environment gains a new obligation.

**Helm values.** None added, changed or removed. Nothing in `charts/` is touched.

**Default `helm install` with no overrides.** Behaviour is unchanged in every respect a user would notice. A vanilla install sets no `SERVICE_VERSION` and no `OTEL_RESOURCE_ATTRIBUTES`, so log records look exactly as they do today — the version field is absent rather than empty. The gateway middleware reorder changes only the *context* the access log reads from, not the routes, the status codes, the response headers, or the log's message and existing fields; the sole difference is that `trace_id`/`span_id` are now present on `request_completed` when tracing is enabled, and absent when it is not, exactly as before.

**BYOC dataplane.** The gateway is a dataplane component, so the reorder ships to BYOC. It is safe there for the same reason: no new configuration, no new dependency, no change to request handling or to what the gateway sends anywhere. A BYOC operator running without an OTel exporter sees no difference at all, because with no tracer provider the span context is invalid and no ids are stamped — the pre-existing behaviour. One that does run tracing gains the correlation on its own logs, locally, and nothing is transmitted to us that was not already.

**Rollback** is a revert of two files with no state, no schema and no migration behind them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Logs now include the service version when configured through supported environment settings.
  - Access logs can include trace and span identifiers for improved request tracing.

- **Bug Fixes**
  - Corrected middleware ordering so telemetry consistently captures tracing context and correlates access logs with requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
