### PR TITLE
chore(release): single-footer shadow Release-As 3.10.0

### DIFF
--- a/.release-please-shim
+++ b/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker (v3), next: 3.10.0


### PR DESCRIPTION
## Why

#6477 proposes **4.0.0**. It should be 3.10.0.

The email gateway consolidation (#6567) landed with a `BREAKING CHANGE:` footer for removing the `app.email.enabled` helm value. That is accurate in the narrow sense, but the root release-please package drives a single version across `charts/langwatch`, `charts/gateway`, `charts/langyagent`, `platform/app/package.json` and the root `package.json`. So one renamed helm key takes the whole product to a major.

Nothing else in the range is breaking, confirmed rather than assumed:

```
$ git log v3.9.0..main --grep="BREAKING CHANGE" --format="%h|%s"
60d98f9631|feat(helm): one switch for email, and a self-hosting page to set it up (#6567)

$ git log v3.9.0..main --format="%s" | grep -E "^[a-z]+(\([^)]*\))?!:"
(no matches)
```

Nothing on the application, API, data or SDK side changes, and no install is using the email gateways yet, so the values rename costs nobody an upgrade. A product major would announce far more than happened.

## What

A single-footer shadow commit pinning the release, following the pattern this repo already uses for the same job (`chore(langevals): single-footer shadow Release-As 2.3.0`, `feat(skills): graduate to 1.0.0`): one component, one path-routed file change, exactly one `Release-As:` footer.

The root component was the only one of the seven without a shadow marker of its own, so it gets one on the same terms. The file is inert, nothing reads it, it exists so the commit routes to the root package and its footer applies there rather than being ambiguous across components.

Once this lands, release-please regenerates #6477 as 3.10.0 and rewrites the version in every file it owns. No version file is hand-edited here, which is the point of letting the tool own them.

## What this does not change

The `BREAKING CHANGES` note stays in the changelog, because the footer is in main's history and rewriting that is worse than the inconsistency. That reads correctly anyway: anyone who did set `app.email.enabled` still has to act, and the chart fails the render with the instruction until they do. Only the version number changes.

## Verification

- Exactly one `Release-As:` footer in the commit, checked with `grep -c`. Stacked footers across components are what broke this last time (#3627).
- `.release-please-shim` at the repo root matches none of the root package's `exclude-paths` (`sdks/*`, `mcp/typescript`, `services/langevals`, `charts/clickhouse-serverless`, `skills`, `.github`, `.cursor`, `assets`), so it routes to the root component.
- Repo is squash-only with `squash_title: PR_TITLE` and `squash_message: COMMIT_MESSAGES`, so the single commit's body carries the footer onto main intact. **Merge this with the footer preserved, and do not add commits to it**, otherwise the footer stacks or gets buried.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release metadata for the upcoming 3.10.0 version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->