### PR TITLE
refactor(lint): burn useMaxParams to zero and promote it to error

### DIFF
--- a/platform/app/biome.jsonc
+++ b/platform/app/biome.jsonc
@@ -19,7 +19,16 @@
 	//
 	//   noExcessiveLinesPerFunction     3592
 	//   noExcessiveCognitiveComplexity  2055
-	//   useMaxParams                     324
+	//   useMaxParams                     324  — burned to 0 in 2026-08 and
+	//                                          promoted to error. The only
+	//                                          exemptions are inline
+	//                                          biome-ignore pragmas on ~10
+	//                                          signatures a library fixes
+	//                                          (React Profiler onRender,
+	//                                          ioredis set/eval fakes,
+	//                                          TanStack MutationCache
+	//                                          onError, ohm-js semantic
+	//                                          actions, an MCP SDK fake)
 	//   noEmptyBlockStatements            93
 	//   noFloatingPromises                39
 	//   noMisusedPromises                 19
@@ -105,7 +114,7 @@
 					}
 				},
 				"useMaxParams": {
-					"level": "warn",
+					"level": "error",
 					"options": { "max": 3 }
 				}
 			},

--- a/platform/app/ee/governance/reactors/__tests__/governanceReactorsPreEnqueueGate.unit.test.ts
+++ b/platform/app/ee/governance/reactors/__tests__/governanceReactorsPreEnqueueGate.unit.test.ts
@@ -76,11 +76,11 @@ function createRouterWithGovernanceReactors(foldState: TraceSummaryData) {
     hasReactorQueues: true,
     getReactorQueue: vi.fn().mockReturnValue({ send }),
   });
-  const router = new ProjectionRouter(
-    TEST_CONSTANTS.AGGREGATE_TYPE,
-    TEST_CONSTANTS.PIPELINE_NAME,
+  const router = new ProjectionRouter({
+    aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+    pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
     queueManager,
-  );
+  });
 
   const store = createMockFoldProjectionStore<TraceSummaryData>();
   (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -115,11 +115,11 @@ describe("governance reactors on the trace-processing router", () => {
 
         await router.dispatch(
           [
-            createTestEvent(
-              TEST_CONSTANTS.AGGREGATE_ID,
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+            createTestEvent({
+              aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-            ),
+            }),
           ],
           { tenantId },
         );
@@ -134,11 +134,11 @@ describe("governance reactors on the trace-processing router", () => {
 
         await router.dispatch(
           [
-            createTestEvent(
-              TEST_CONSTANTS.AGGREGATE_ID,
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+            createTestEvent({
+              aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-            ),
+            }),
           ],
           { tenantId },
         );
@@ -174,11 +174,11 @@ describe("governance reactors on the trace-processing router", () => {
 
         await router.dispatch(
           [
-            createTestEvent(
-              TEST_CONSTANTS.AGGREGATE_ID,
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+            createTestEvent({
+              aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-            ),
+            }),
           ],
           { tenantId },
         );
@@ -200,11 +200,11 @@ describe("governance reactors on the trace-processing router", () => {
 
         await router.dispatch(
           [
-            createTestEvent(
-              TEST_CONSTANTS.AGGREGATE_ID,
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+            createTestEvent({
+              aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-            ),
+            }),
           ],
           { tenantId },
         );

--- a/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
@@ -107,12 +107,17 @@ async function insertGovernanceTraceSummary(
   });
 }
 
-async function insertGovernanceLogRecord(
-  ch: ClickHouseClient,
-  tenantId: string,
-  attrs: Record<string, string>,
-  occurredAt: Date,
-): Promise<void> {
+async function insertGovernanceLogRecord({
+  ch,
+  tenantId,
+  attrs,
+  occurredAt,
+}: {
+  ch: ClickHouseClient;
+  tenantId: string;
+  attrs: Record<string, string>;
+  occurredAt: Date;
+}): Promise<void> {
   await ch.insert({
     table: "stored_log_records",
     values: [
@@ -280,17 +285,17 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     // Webhook log_record path (governance-origin) for ingestionSourcesHealth
-    await insertGovernanceLogRecord(
+    await insertGovernanceLogRecord({
       ch,
-      primaryGovProject.id,
-      {
+      tenantId: primaryGovProject.id,
+      attrs: {
         [ORIGIN_KEY]: ORIGIN_VALUE,
         [SOURCE_ID_KEY]: secondarySourceId,
         [SOURCE_TYPE_KEY]: "claude_cowork",
         [ORG_ID_KEY]: primaryOrg.id,
       },
-      inWindow,
-    );
+      occurredAt: inWindow,
+    });
 
     // Persist the IngestionSource rows so ingestionSourcesHealth has metadata
     // to roll up. The PG side is the source of truth for source identity;

--- a/platform/app/ee/governance/services/activity-monitor/ottlGatewayClient.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ottlGatewayClient.ts
@@ -117,12 +117,17 @@ class OttlGatewayUnavailableError extends Error {
  * pulls in Hono context types we don't want in this lightweight EE
  * service module.
  */
-function canonical(
-  method: string,
-  path: string,
-  timestamp: string,
-  body: string,
-): string {
+function canonical({
+  method,
+  path,
+  timestamp,
+  body,
+}: {
+  method: string;
+  path: string;
+  timestamp: string;
+  body: string;
+}): string {
   const bodyHash = createHash("sha256").update(body).digest("hex");
   return `${method}\n${path}\n${timestamp}\n${bodyHash}`;
 }
@@ -185,7 +190,10 @@ async function postSigned(path: string, body: unknown): Promise<Response> {
   }
   const ts = Math.floor(Date.now() / 1000).toString();
   const bodyJson = JSON.stringify(body);
-  const sig = sign(secret, canonical("POST", path, ts, bodyJson));
+  const sig = sign(
+    secret,
+    canonical({ method: "POST", path, timestamp: ts, body: bodyJson }),
+  );
   const url = `${baseUrl.replace(/\/$/, "")}${path}`;
   return await fetch(url, {
     method: "POST",

--- a/platform/app/ee/governance/services/personalVirtualKey.service.ts
+++ b/platform/app/ee/governance/services/personalVirtualKey.service.ts
@@ -50,26 +50,41 @@ export interface IssuedPersonalVk {
 }
 
 export class PersonalVirtualKeyService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    private readonly personalWorkspace: PersonalWorkspaceService,
-    private readonly routingPolicy: RoutingPolicyService,
-    private readonly gatewayBaseUrl: string,
-  ) {}
+  private readonly prisma: PrismaClient;
+  private readonly personalWorkspace: PersonalWorkspaceService;
+  private readonly routingPolicy: RoutingPolicyService;
+  private readonly gatewayBaseUrl: string;
+
+  constructor({
+    prisma,
+    personalWorkspace,
+    routingPolicy,
+    gatewayBaseUrl,
+  }: {
+    prisma: PrismaClient;
+    personalWorkspace: PersonalWorkspaceService;
+    routingPolicy: RoutingPolicyService;
+    gatewayBaseUrl: string;
+  }) {
+    this.prisma = prisma;
+    this.personalWorkspace = personalWorkspace;
+    this.routingPolicy = routingPolicy;
+    this.gatewayBaseUrl = gatewayBaseUrl;
+  }
 
   static create(
     prisma: PrismaClient,
     options?: { gatewayBaseUrl?: string; isSaas?: boolean },
   ): PersonalVirtualKeyService {
-    return new PersonalVirtualKeyService(
+    return new PersonalVirtualKeyService({
       prisma,
-      new PersonalWorkspaceService(prisma),
-      new RoutingPolicyService(prisma),
-      resolveGatewayBaseUrl({
+      personalWorkspace: new PersonalWorkspaceService(prisma),
+      routingPolicy: new RoutingPolicyService(prisma),
+      gatewayBaseUrl: resolveGatewayBaseUrl({
         publicUrl: options?.gatewayBaseUrl,
         isSaas: options?.isSaas,
       }),
-    );
+    });
   }
 
   /**

--- a/platform/app/scripts/migrations/backfill-vk-config-to-rp.ts
+++ b/platform/app/scripts/migrations/backfill-vk-config-to-rp.ts
@@ -104,17 +104,24 @@ function todayYYYYMMDD(): string {
   return `${y}${m}${day}`;
 }
 
-async function backfillAliasesAndRules(
-  vkId: string,
-  vkName: string,
-  orgId: string,
+async function backfillAliasesAndRules({
+  vkId,
+  vkName,
+  orgId,
+  scopes,
+  modelAliases,
+  policyRules,
+}: {
+  vkId: string;
+  vkName: string;
+  orgId: string;
   scopes: Array<{
     scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
     scopeId: string;
-  }>,
-  modelAliases: Record<string, string> | undefined,
-  policyRules: LegacyConfig["policyRules"],
-): Promise<string> {
+  }>;
+  modelAliases: Record<string, string> | undefined;
+  policyRules: LegacyConfig["policyRules"];
+}): Promise<string> {
   const rpId = `rp_migr_${nanoid()}`;
   const rpName = `${vkName}-migrated-aliases-${todayYYYYMMDD()}`;
   const primary = scopes[0]!;
@@ -249,14 +256,14 @@ async function main() {
 
     let routingPolicyId: string | null = vk.routingPolicyId;
     if ((hasAliases || hasRules) && !routingPolicyId) {
-      routingPolicyId = await backfillAliasesAndRules(
-        vk.id,
-        vk.name,
-        vk.organizationId,
+      routingPolicyId = await backfillAliasesAndRules({
+        vkId: vk.id,
+        vkName: vk.name,
+        orgId: vk.organizationId,
         scopes,
-        config.modelAliases,
-        config.policyRules,
-      );
+        modelAliases: config.modelAliases,
+        policyRules: config.policyRules,
+      });
     }
 
     let attachments: GuardrailAttachment[] = [];

--- a/platform/app/src/app/api/middleware/__tests__/error-handler.unit.test.ts
+++ b/platform/app/src/app/api/middleware/__tests__/error-handler.unit.test.ts
@@ -135,12 +135,12 @@ describe("handleError()", () => {
 
   describe("when error is a ModelNotConfiguredError", () => {
     it("returns 400 with the missing-model cause instead of a generic 500", async () => {
-      const error = new ModelNotConfiguredError(
-        "evaluator.create_default",
-        "DEFAULT",
-        "Evaluator default model",
-        "project_123",
-      );
+      const error = new ModelNotConfiguredError({
+        featureKey: "evaluator.create_default",
+        role: "DEFAULT",
+        featureDisplayName: "Evaluator default model",
+        projectId: "project_123",
+      });
       const app = createTestApp(error);
 
       const res = await app.request("/");

--- a/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/platform/app/src/app/api/scenario-events/[[...route]]/app.ts
@@ -487,12 +487,12 @@ async function broadcastStreamingEvent(
         ? ("delta" as const)
         : ("structural" as const);
 
-    await getApp().broadcast.broadcastToTenantRateLimited(
-      projectId,
-      payload,
-      "simulation_updated",
+    await getApp().broadcast.broadcastToTenantRateLimited({
+      tenantId: projectId,
+      event: payload,
+      eventType: "simulation_updated",
       tier,
-    );
+    });
   } catch (err) {
     logger.warn({ err, projectId }, "Failed to broadcast streaming event");
   }

--- a/platform/app/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
+++ b/platform/app/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
@@ -158,12 +158,12 @@ describe("GET /:traceId", () => {
       const res = await makeRequest("trace-abc", { format: "json" });
 
       expect(res.status).toBe(200);
-      expect(mockGetById).toHaveBeenCalledWith(
-        "project-123",
-        "trace-abc",
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetById).toHaveBeenCalledWith({
+        projectId: "project-123",
+        traceId: "trace-abc",
+        protections: expect.any(Object),
+        opts: { full: true },
+      });
     });
 
     it("fetches evaluations via TraceService.getEvaluationsMultiple", async () => {

--- a/platform/app/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/traces/[[...route]]/app.v1.ts
@@ -384,7 +384,11 @@ export function registerTracesRoutes(
 
       let trace;
       try {
-        trace = await traceService.getById(project.id, traceId, protections);
+        trace = await traceService.getById({
+          projectId: project.id,
+          traceId,
+          protections,
+        });
       } catch (err) {
         if (err instanceof AmbiguousTraceIdPrefixError) {
           return c.json(
@@ -500,8 +504,11 @@ export function registerTracesRoutes(
 
       let trace;
       try {
-        trace = await traceService.getById(project.id, traceId, protections, {
-          full: true,
+        trace = await traceService.getById({
+          projectId: project.id,
+          traceId,
+          protections,
+          opts: { full: true },
         });
       } catch (err) {
         if (err instanceof AmbiguousTraceIdPrefixError) {

--- a/platform/app/src/app/api/workflows/post_event/__tests__/post-event-routing.test.ts
+++ b/platform/app/src/app/api/workflows/post_event/__tests__/post-event-routing.test.ts
@@ -29,13 +29,15 @@ vi.mock("../../../../../optimization_studio/server/addEnvs", async () => {
 const capturedPaths: string[] = [];
 vi.mock("../../../../../optimization_studio/server/lambda", () => ({
   invokeLambda: vi.fn(
-    async (
-      _projectId: string,
-      _event: StudioClientEvent,
-      _s3CacheKey: string | undefined,
-      options: { path?: string } = {},
-    ) => {
-      capturedPaths.push(options.path ?? "/studio/execute");
+    async ({
+      path,
+    }: {
+      projectId: string;
+      event: StudioClientEvent;
+      s3CacheKey: string | undefined;
+      path?: string;
+    }) => {
+      capturedPaths.push(path ?? "/studio/execute");
       // One valid `done` frame so studioBackendPostEvent's reader exits
       // cleanly via its `serverEvent.type === "done"` short-circuit
       // instead of logging a "Studio invalid response" error on close.

--- a/platform/app/src/app/api/workflows/post_event/post-event.ts
+++ b/platform/app/src/app/api/workflows/post_event/post-event.ts
@@ -99,7 +99,10 @@ export const studioBackendPostEvent = async ({
 
     const s3CacheKey = getS3CacheKey(projectId);
 
-    reader = await invokeLambda(projectId, message, s3CacheKey, {
+    reader = await invokeLambda({
+      projectId,
+      event: message,
+      s3CacheKey,
       path: "/go/studio/execute",
       headers: { "X-LangWatch-Origin": "workflow" },
       supportsStaging: true,

--- a/platform/app/src/components/ModelMultiSelect.tsx
+++ b/platform/app/src/components/ModelMultiSelect.tsx
@@ -27,11 +27,11 @@ export function ModelMultiSelect({
   onChange: (next: string[]) => void;
   mode?: "chat" | "embedding";
 }) {
-  const { groupedByProvider, isLoading, isEmpty } = useModelSelectionOptions(
-    allModelOptions,
-    "",
+  const { groupedByProvider, isLoading, isEmpty } = useModelSelectionOptions({
+    options: allModelOptions,
+    model: "",
     mode,
-  );
+  });
   const [search, setSearch] = useState("");
   const selected = useMemo(() => new Set(value), [value]);
 

--- a/platform/app/src/components/ModelSelector.tsx
+++ b/platform/app/src/components/ModelSelector.tsx
@@ -91,12 +91,17 @@ export const filterRestrictedModels = ({
       : isModelAllowedForFeature({ modelId: model, featureKey }),
   );
 
-export const useModelSelectionOptions = (
-  options: string[],
-  model: string,
-  mode: "chat" | "embedding" = "chat",
-  opts?: { featureKey?: string | undefined },
-) => {
+export const useModelSelectionOptions = ({
+  options,
+  model,
+  mode = "chat",
+  featureKey,
+}: {
+  options: string[];
+  model: string;
+  mode?: "chat" | "embedding";
+  featureKey?: string | undefined;
+}) => {
   const { project } = useOrganizationTeamProject();
   // `listAllForProjectForFrontend` returns the providers actually
   // stored against any scope reachable from this project. The legacy
@@ -138,7 +143,7 @@ export const useModelSelectionOptions = (
 
   const allModels = filterRestrictedModels({
     models: getCustomModels(providersByKey, options, mode),
-    featureKey: opts?.featureKey,
+    featureKey,
   });
 
   // Build a set of custom model IDs for quick lookup
@@ -248,7 +253,7 @@ export const ModelSelector = React.memo(function ModelSelector({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { selectOptions, groupedByProvider, isEmpty, isLoading } =
-    useModelSelectionOptions(options, model, mode);
+    useModelSelectionOptions({ options, model, mode });
 
   // ALL hooks must run unconditionally — keep the empty-state early
   // return *after* every hook below so we don't violate React's rules

--- a/platform/app/src/components/WorkspaceSwitcher.tsx
+++ b/platform/app/src/components/WorkspaceSwitcher.tsx
@@ -167,12 +167,17 @@ function entryIsCurrent(
   return current.kind === "project" && current.projectId === entry.projectId;
 }
 
-function currentLabel(
-  current: WorkspaceSwitcherCurrent,
-  personals: WorkspaceSwitcherProps["personals"],
-  teams: WorkspaceSwitcherProps["teams"],
-  projects: WorkspaceSwitcherProps["projects"],
-): { label: string; kind: keyof typeof ICON_BY_KIND } {
+function currentLabel({
+  current,
+  personals,
+  teams,
+  projects,
+}: {
+  current: WorkspaceSwitcherCurrent;
+  personals: WorkspaceSwitcherProps["personals"];
+  teams: WorkspaceSwitcherProps["teams"];
+  projects: WorkspaceSwitcherProps["projects"];
+}): { label: string; kind: keyof typeof ICON_BY_KIND } {
   if (current.kind === "personal") {
     const match =
       personals?.find((p) => (p.orgId ?? null) === (current.orgId ?? null)) ??
@@ -225,12 +230,12 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
   const derivedCurrent = useWorkspaceCurrent({ teams, projects });
   const current = currentProp ?? derivedCurrent;
 
-  const { label: triggerLabel, kind: triggerKind } = currentLabel(
+  const { label: triggerLabel, kind: triggerKind } = currentLabel({
     current,
     personals,
     teams,
     projects,
-  );
+  });
   const TriggerIcon = ICON_BY_KIND[triggerKind];
   // For project context, render the colored ProjectAvatar in the trigger to
   // preserve parity with the legacy ProjectSelector — projects are visually

--- a/platform/app/src/components/__tests__/useModelSelectionOptions.codexGating.integration.test.tsx
+++ b/platform/app/src/components/__tests__/useModelSelectionOptions.codexGating.integration.test.tsx
@@ -58,7 +58,11 @@ describe("useModelSelectionOptions()", () => {
     describe("when the caller passes no featureKey", () => {
       it("excludes codex models from the options", () => {
         const { result } = renderHook(() =>
-          useModelSelectionOptions(OPTIONS, "openai/gpt-5-mini", "chat"),
+          useModelSelectionOptions({
+            options: OPTIONS,
+            model: "openai/gpt-5-mini",
+            mode: "chat",
+          }),
         );
 
         const values = result.current.selectOptions.map((o) => o.value);
@@ -70,12 +74,12 @@ describe("useModelSelectionOptions()", () => {
     describe("when the caller declares the langy.chat featureKey", () => {
       it("includes codex models alongside the unrestricted ones", () => {
         const { result } = renderHook(() =>
-          useModelSelectionOptions(
-            OPTIONS,
-            "openai_codex/gpt-5.6-terra",
-            "chat",
-            { featureKey: "langy.chat" },
-          ),
+          useModelSelectionOptions({
+            options: OPTIONS,
+            model: "openai_codex/gpt-5.6-terra",
+            mode: "chat",
+            featureKey: "langy.chat",
+          }),
         );
 
         const values = result.current.selectOptions.map((o) => o.value);
@@ -87,7 +91,10 @@ describe("useModelSelectionOptions()", () => {
     describe("when the caller declares a featureKey codex is not licensed for", () => {
       it("excludes codex models from the options", () => {
         const { result } = renderHook(() =>
-          useModelSelectionOptions(OPTIONS, "openai/gpt-5-mini", "chat", {
+          useModelSelectionOptions({
+            options: OPTIONS,
+            model: "openai/gpt-5-mini",
+            mode: "chat",
             featureKey: "prompt.create_default",
           }),
         );

--- a/platform/app/src/components/__tests__/useNavigationFooter.cursor.integration.test.ts
+++ b/platform/app/src/components/__tests__/useNavigationFooter.cursor.integration.test.ts
@@ -30,12 +30,17 @@ vi.mock("~/utils/compat/next-router", () => ({
 const { useMessagesNavigationFooter } = await import("../NavigationFooter");
 
 // A valid base64-encoded cursor that decodes to a ClickHouse scroll cursor
-function makeCursor(
-  lastTimestamp: number,
-  lastTraceId: string,
+function makeCursor({
+  lastTimestamp,
+  lastTraceId,
   pageSize = 25,
-  sortDirection: "asc" | "desc" = "desc",
-): string {
+  sortDirection = "desc",
+}: {
+  lastTimestamp: number;
+  lastTraceId: string;
+  pageSize?: number;
+  sortDirection?: "asc" | "desc";
+}): string {
   return btoa(
     JSON.stringify({ lastTimestamp, lastTraceId, pageSize, sortDirection }),
   );
@@ -54,8 +59,14 @@ describe("useMessagesNavigationFooter()", () => {
           useMessagesNavigationFooter(),
         );
 
-        const cursor1 = makeCursor(1700000000000, "trace-page2");
-        const cursor2 = makeCursor(1699999000000, "trace-page3");
+        const cursor1 = makeCursor({
+          lastTimestamp: 1700000000000,
+          lastTraceId: "trace-page2",
+        });
+        const cursor2 = makeCursor({
+          lastTimestamp: 1699999000000,
+          lastTraceId: "trace-page3",
+        });
 
         // Navigate forward: page 1 → page 2 (cursor mode activates)
         act(() => {
@@ -97,7 +108,10 @@ describe("useMessagesNavigationFooter()", () => {
           useMessagesNavigationFooter(),
         );
 
-        const cursor1 = makeCursor(1700000000000, "trace-page2");
+        const cursor1 = makeCursor({
+          lastTimestamp: 1700000000000,
+          lastTraceId: "trace-page2",
+        });
 
         // Navigate forward: page 1 → page 2
         act(() => {

--- a/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -88,15 +88,23 @@ function getHttpConfig(config: AgentComponentConfig): HttpComponentConfig {
 /**
  * Build DSL-compatible config for HTTP agent
  */
-function buildHttpConfig(
-  url: string,
-  method: HttpMethod,
-  bodyTemplate: string,
-  outputPath: string,
-  headers: HttpHeader[],
-  auth: HttpAuth | undefined,
-  scenarioMappings: Record<string, FieldMapping>,
-): HttpComponentConfig {
+function buildHttpConfig({
+  url,
+  method,
+  bodyTemplate,
+  outputPath,
+  headers,
+  auth,
+  scenarioMappings,
+}: {
+  url: string;
+  method: HttpMethod;
+  bodyTemplate: string;
+  outputPath: string;
+  headers: HttpHeader[];
+  auth: HttpAuth | undefined;
+  scenarioMappings: Record<string, FieldMapping>;
+}): HttpComponentConfig {
   return {
     name: "HTTP",
     description: "HTTP API endpoint",
@@ -361,7 +369,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
   const handleSave = useCallback(() => {
     if (!project?.id || !isValid) return;
 
-    const config = buildHttpConfig(
+    const config = buildHttpConfig({
       url,
       method,
       bodyTemplate,
@@ -369,7 +377,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
       headers,
       auth,
       scenarioMappings,
-    );
+    });
 
     if (agentId) {
       // Editing existing agent

--- a/platform/app/src/components/analytics/CustomGraph.tsx
+++ b/platform/app/src/components/analytics/CustomGraph.tsx
@@ -553,12 +553,12 @@ const CustomGraph_ = React.memo(
     // Calculate pie/donut data using shapeDataForSummary (same logic as summary charts)
     const pieData = useMemo(() => {
       if (input.graphType === "pie" || input.graphType === "donnut") {
-        const summaryData = shapeDataForSummary(
+        const summaryData = shapeDataForSummary({
           input,
           seriesByKey,
           timeseries,
           nameForSeries,
-        );
+        });
         return summaryData.current.filter((item) => item.value > 0);
       }
       return [];
@@ -763,12 +763,12 @@ const CustomGraph_ = React.memo(
     };
 
     if (input.graphType === "summary") {
-      const summaryData = shapeDataForSummary(
+      const summaryData = shapeDataForSummary({
         input,
         seriesByKey,
         timeseries,
         nameForSeries,
-      );
+      });
 
       // Create a map for key-based lookup to match current with previous values correctly
       const previousByKey = Object.fromEntries(
@@ -894,12 +894,12 @@ const CustomGraph_ = React.memo(
       ["bar", "horizontal_bar"].includes(input.graphType) &&
       input.timeScale === "full"
     ) {
-      const summaryData = shapeDataForSummary(
+      const summaryData = shapeDataForSummary({
         input,
         seriesByKey,
         timeseries,
         nameForSeries,
-      );
+      });
       const sortedCurrentData = summaryData.current.toSorted(
         (a, b) => b.value - a.value,
       );
@@ -1362,15 +1362,20 @@ const shapeDataForGraph = (
     | undefined;
 };
 
-const shapeDataForSummary = (
-  input: CustomGraphInput,
-  seriesByKey: Record<string, Series>,
+const shapeDataForSummary = ({
+  input,
+  seriesByKey,
+  timeseries,
+  nameForSeries,
+}: {
+  input: CustomGraphInput;
+  seriesByKey: Record<string, Series>;
   timeseries: UseTRPCQueryResult<
     inferRouterOutputs<AppRouter>["analytics"]["getTimeseries"],
     TRPCClientErrorLike<AppRouter>
-  >,
-  nameForSeries: (aggKey: string) => string,
-) => {
+  >;
+  nameForSeries: (aggKey: string) => string;
+}) => {
   const flattenCurrentPeriod =
     timeseries.data && flattenGroupData(input, timeseries.data.currentPeriod);
   const flattenPreviousPeriod =

--- a/platform/app/src/components/batch-evaluation-results/ComparisonCharts.tsx
+++ b/platform/app/src/components/batch-evaluation-results/ComparisonCharts.tsx
@@ -84,12 +84,17 @@ const formatLatency = (value: number): string => {
  * Calculate optimal Y-axis width based on formatted value lengths.
  * Uses approximate character width (7px per char) + padding.
  */
-const calculateYAxisWidth = (
-  values: number[],
-  formatter: (value: number) => string,
+const calculateYAxisWidth = ({
+  values,
+  formatter,
   minWidth = 35,
   maxWidth = 80,
-): number => {
+}: {
+  values: number[];
+  formatter: (value: number) => string;
+  minWidth?: number;
+  maxWidth?: number;
+}): number => {
   if (values.length === 0) return minWidth;
 
   // Get the max formatted string length
@@ -833,8 +838,11 @@ export const ComparisonCharts = ({
     const latencyValues = chartData.map((d) => (d.latency as number) ?? 0);
 
     return {
-      cost: calculateYAxisWidth(costValues, formatCost),
-      latency: calculateYAxisWidth(latencyValues, formatLatency),
+      cost: calculateYAxisWidth({ values: costValues, formatter: formatCost }),
+      latency: calculateYAxisWidth({
+        values: latencyValues,
+        formatter: formatLatency,
+      }),
     };
   }, [chartData]);
 

--- a/platform/app/src/components/checks/DynamicZodForm.tsx
+++ b/platform/app/src/components/checks/DynamicZodForm.tsx
@@ -52,11 +52,11 @@ const ModelSelectorWithWarning = ({
   fieldName: string;
   variant: string;
 }) => {
-  const { modelOption } = useModelSelectionOptions(
-    selectorOptions,
-    field.value,
-    fieldName === "model" ? "chat" : "embedding",
-  );
+  const { modelOption } = useModelSelectionOptions({
+    options: selectorOptions,
+    model: field.value,
+    mode: fieldName === "model" ? "chat" : "embedding",
+  });
   const isModelDisabled = modelOption?.isDisabled ?? false;
 
   return (
@@ -212,11 +212,12 @@ const ArrayField = <T extends EvaluatorTypes>({
   prefix: string;
   evaluator: EvaluatorDefinition<T> | undefined;
   variant?: "default" | "studio";
-  renderField: <T extends EvaluatorTypes>(
-    fieldSchema: ZodType,
-    fieldName: string,
-    evaluator: EvaluatorDefinition<T> | undefined,
-  ) => React.JSX.Element | null;
+  renderField: <T extends EvaluatorTypes>(args: {
+    fieldSchema: ZodType;
+    fieldName: string;
+    evaluator: EvaluatorDefinition<T> | undefined;
+    isTopLevel?: boolean;
+  }) => React.JSX.Element | null;
 }) => {
   const { control } = useFormContext();
   const fullPath = prefix ? `${prefix}.${fieldName}` : fieldName;
@@ -289,11 +290,11 @@ const ArrayField = <T extends EvaluatorTypes>({
               {variant === "studio" ? <Trash2 size={14} /> : <X size={18} />}
             </Button>
             <Box width={variant === "studio" ? "100%" : "95%"}>
-              {renderField(
-                arraySchema.element,
-                `${fieldName}.${index}`,
+              {renderField({
+                fieldSchema: arraySchema.element,
+                fieldName: `${fieldName}.${index}`,
                 evaluator,
-              )}
+              })}
             </Box>
           </HStack>
         </Box>
@@ -339,17 +340,22 @@ const DynamicZodForm = ({
       { enabled: !!project?.id },
     );
 
-  const renderField = <T extends EvaluatorTypes>(
-    fieldSchema: ZodType,
-    fieldName: string,
-    evaluator: EvaluatorDefinition<T> | undefined,
+  const renderField = <T extends EvaluatorTypes>({
+    fieldSchema,
+    fieldName,
+    evaluator,
     // True when the caller (HorizontalFormControl / PropertySectionTitle)
     // already renders this field's title above/beside it — suppresses the
     // boolean branch's own inline label so it isn't shown twice at two
     // different sizes. Nested ZodObject fields render with no outer label
     // for booleans, so they keep passing false (the default) here.
     isTopLevel = false,
-  ): React.JSX.Element | null => {
+  }: {
+    fieldSchema: ZodType;
+    fieldName: string;
+    evaluator: EvaluatorDefinition<T> | undefined;
+    isTopLevel?: boolean;
+  }): React.JSX.Element | null => {
     const fullPath = prefix ? `${prefix}.${fieldName}` : fieldName;
     let defaultValue =
       evaluator?.settings?.[fieldName as keyof Evaluators[T]["settings"]]
@@ -368,12 +374,12 @@ const DynamicZodForm = ({
     const fieldKey = fieldName.split(".").toReversed()[0] ?? "";
 
     if (fieldSchema_ instanceof z.ZodDefault) {
-      return renderField(
-        fieldSchema_._def.innerType,
+      return renderField({
+        fieldSchema: fieldSchema_._def.innerType,
         fieldName,
         evaluator,
         isTopLevel,
-      );
+      });
     } else if (fieldSchema_ instanceof z.ZodNumber) {
       return (
         <Input
@@ -562,11 +568,11 @@ const DynamicZodForm = ({
                     : titleCase(key)}
                 </SmallLabel>
               )}
-              {renderField(
-                fieldSchema_.shape[key],
-                `${fieldName}.${key}`,
+              {renderField({
+                fieldSchema: fieldSchema_.shape[key],
+                fieldName: `${fieldName}.${key}`,
                 evaluator,
-              )}
+              })}
             </VStack>
           ))}
         </VStack>
@@ -657,12 +663,12 @@ const DynamicZodForm = ({
                   )}
                 </HStack>
                 <Field.Root invalid={isInvalid}>
-                  {renderField(
-                    field,
-                    basePath ? `${basePath}.${key}` : key,
-                    evaluatorDefinition,
-                    true,
-                  )}
+                  {renderField({
+                    fieldSchema: field,
+                    fieldName: basePath ? `${basePath}.${key}` : key,
+                    evaluator: evaluatorDefinition,
+                    isTopLevel: true,
+                  })}
                 </Field.Root>
               </VStack>
             );
@@ -678,12 +684,12 @@ const DynamicZodForm = ({
                 tooltip={helperOverride?.tooltip ?? helperText}
                 invalid={isInvalid}
               >
-                {renderField(
-                  field,
-                  basePath ? `${basePath}.${key}` : key,
-                  evaluatorDefinition,
-                  true,
-                )}
+                {renderField({
+                  fieldSchema: field,
+                  fieldName: basePath ? `${basePath}.${key}` : key,
+                  evaluator: evaluatorDefinition,
+                  isTopLevel: true,
+                })}
               </HorizontalFormControl>
             </React.Fragment>
           );

--- a/platform/app/src/components/checks/EvaluatorLLMConfigField.tsx
+++ b/platform/app/src/components/checks/EvaluatorLLMConfigField.tsx
@@ -84,11 +84,11 @@ export const EvaluatorLLMConfigField = ({ prefix }: { prefix: string }) => {
   // playground and workflow LLM-node pickers. While the providers
   // query is in flight, render a skeleton so the empty state doesn't
   // flash before the data resolves.
-  const { isEmpty, isLoading } = useModelSelectionOptions(
-    allModelOptions,
-    llmConfig.model,
-    "chat",
-  );
+  const { isEmpty, isLoading } = useModelSelectionOptions({
+    options: allModelOptions,
+    model: llmConfig.model,
+    mode: "chat",
+  });
   if (isLoading) {
     return <Skeleton width="full" height="40px" borderRadius="md" />;
   }

--- a/platform/app/src/components/datasets/editor/DatasetPreviewTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetPreviewTable.tsx
@@ -127,7 +127,7 @@ export function DatasetPreviewTable({
       expandedCells,
       editingCell,
       selectedCell,
-      setCellValue: (_datasetId, rowIndex, columnId, value) => {
+      setCellValue: ({ row: rowIndex, columnId, value }) => {
         const column = visibleColumns.find((col) => col.id === columnId);
         if (!column) return;
         let parsed: unknown = value;

--- a/platform/app/src/components/datasets/editor/DatasetTableContext.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetTableContext.tsx
@@ -33,12 +33,12 @@ export type DatasetTableContextValue = {
   expandedCells: Set<string>;
   editingCell: CellPosition | undefined;
   selectedCell: CellPosition | undefined;
-  setCellValue: (
-    datasetId: string,
-    row: number,
-    columnId: string,
-    value: string,
-  ) => void;
+  setCellValue: (params: {
+    datasetId: string;
+    row: number;
+    columnId: string;
+    value: string;
+  }) => void;
   setEditingCell: (cell: CellPosition | undefined) => void;
   setSelectedCell: (cell: CellPosition | undefined) => void;
   toggleCellExpanded: (row: number, columnId: string) => void;

--- a/platform/app/src/components/datasets/editor/EditableCell.tsx
+++ b/platform/app/src/components/datasets/editor/EditableCell.tsx
@@ -275,7 +275,7 @@ export function EditableCell({
         setValidationError(true);
         return;
       }
-      setCellValue(datasetId, row, columnId, result.normalized);
+      setCellValue({ datasetId, row, columnId, value: result.normalized });
       setValidationError(false);
       setEditingCell(undefined);
       return;
@@ -288,14 +288,14 @@ export function EditableCell({
         setValidationError(true);
         return;
       }
-      setCellValue(datasetId, row, columnId, result.normalized);
+      setCellValue({ datasetId, row, columnId, value: result.normalized });
       setValidationError(false);
       setEditingCell(undefined);
       return;
     }
 
     // Other types: save as-is
-    setCellValue(datasetId, row, columnId, editValue);
+    setCellValue({ datasetId, row, columnId, value: editValue });
     setEditingCell(undefined);
   }, [
     datasetId,
@@ -668,7 +668,7 @@ export function EditableCell({
                   }
                   colorPalette="green"
                   onClick={() => {
-                    setCellValue(datasetId, row, columnId, "true");
+                    setCellValue({ datasetId, row, columnId, value: "true" });
                     setEditingCell(undefined);
                   }}
                   onMouseDown={(e) => e.preventDefault()}
@@ -682,7 +682,7 @@ export function EditableCell({
                   }
                   colorPalette="red"
                   onClick={() => {
-                    setCellValue(datasetId, row, columnId, "false");
+                    setCellValue({ datasetId, row, columnId, value: "false" });
                     setEditingCell(undefined);
                   }}
                   onMouseDown={(e) => e.preventDefault()}

--- a/platform/app/src/components/datasets/editor/__tests__/useDatasetEditorStore.deleteSelectedRows.unit.test.ts
+++ b/platform/app/src/components/datasets/editor/__tests__/useDatasetEditorStore.deleteSelectedRows.unit.test.ts
@@ -57,7 +57,12 @@ describe("given a saved-mode dataset editor", () => {
   describe("when deleting a new_ row that still has an unsaved edit queued", () => {
     it("replaces the queued edit with a deletion", () => {
       const store = seedSaved();
-      store.getState().setCellValue("ds-1", 1, "input_0", "edited");
+      store.getState().setCellValue({
+        datasetId: "ds-1",
+        row: 1,
+        columnId: "input_0",
+        value: "edited",
+      });
       store.getState().toggleRowSelection(1);
       store.getState().deleteSelectedRows();
 

--- a/platform/app/src/components/datasets/editor/useDatasetEditorStore.ts
+++ b/platform/app/src/components/datasets/editor/useDatasetEditorStore.ts
@@ -95,12 +95,12 @@ export type DatasetEditorActions = {
   upsertExternalRecord: (record: EditorRecord) => void;
   /** Display-sync removal counterpart to upsertExternalRecord. */
   removeExternalRecord: (recordId: string) => void;
-  setCellValue: (
-    datasetId: string,
-    row: number,
-    columnId: string,
-    value: string,
-  ) => void;
+  setCellValue: (params: {
+    datasetId: string;
+    row: number;
+    columnId: string;
+    value: string;
+  }) => void;
   addRow: () => number;
   deleteSelectedRows: () => void;
   setEditingCell: (cell: CellPosition | undefined) => void;
@@ -163,7 +163,7 @@ export function createDatasetEditorStore(): StoreApi<DatasetEditorStore> {
       set({ records: get().records.filter((r) => r.id !== recordId) });
     },
 
-    setCellValue: (_datasetId, row, columnId, value) => {
+    setCellValue: ({ row, columnId, value }) => {
       const { columns, records, dbDatasetId, pendingSavedChanges } = get();
       const column = columns.find((c) => c.id === columnId);
       if (!column) return;

--- a/platform/app/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
+++ b/platform/app/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
@@ -12,50 +12,58 @@ describe("resolveProviderDefaultModel", () => {
   describe("when the provider is a self-hosted custom endpoint", () => {
     it("uses the first custom model in resolver-safe vendor/model form", () => {
       expect(
-        resolveProviderDefaultModel(
-          "custom",
-          "Custom",
-          [],
-          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
-        ),
+        resolveProviderDefaultModel({
+          providerKey: "custom",
+          providerLabel: "Custom",
+          providerModels: [],
+          customModels: [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        }),
       ).toBe("custom/Qwen2.5-0.5B-Instruct");
     });
 
     it("does not fall back to the OpenAI-only gpt-5-mini", () => {
       expect(
-        resolveProviderDefaultModel(
-          "custom",
-          "Custom",
-          [],
-          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
-        ),
+        resolveProviderDefaultModel({
+          providerKey: "custom",
+          providerLabel: "Custom",
+          providerModels: [],
+          customModels: [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        }),
       ).not.toContain("gpt-5-mini");
     });
 
     it("prefers a registry chat model over a custom model when both exist", () => {
       expect(
-        resolveProviderDefaultModel(
-          "custom",
-          "Custom",
-          ["llama-3"],
-          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
-        ),
+        resolveProviderDefaultModel({
+          providerKey: "custom",
+          providerLabel: "Custom",
+          providerModels: ["llama-3"],
+          customModels: [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        }),
       ).toBe("custom/llama-3");
     });
   });
 
   describe("when the provider is a first-class registry provider", () => {
     it("prefixes the registry default with the provider key", () => {
-      const result = resolveProviderDefaultModel("openai", "OpenAI", []);
+      const result = resolveProviderDefaultModel({
+        providerKey: "openai",
+        providerLabel: "OpenAI",
+        providerModels: [],
+      });
       expect(result.startsWith("openai/")).toBe(true);
     });
   });
 
   describe("when no model can be resolved", () => {
     it("returns the bare provider label so the gateway surfaces a readable error", () => {
-      expect(resolveProviderDefaultModel("custom", "My vLLM", [])).toBe(
-        "my vllm",
-      );
+      expect(
+        resolveProviderDefaultModel({
+          providerKey: "custom",
+          providerLabel: "My vLLM",
+          providerModels: [],
+        }),
+      ).toBe("my vllm");
     });
   });
 });

--- a/platform/app/src/components/gateway/eligibleModelProviders.ts
+++ b/platform/app/src/components/gateway/eligibleModelProviders.ts
@@ -69,12 +69,17 @@ export type ScopeHierarchy = {
  * last resort so the gateway surfaces a readable 404 instead of an empty
  * model field.
  */
-export function resolveProviderDefaultModel(
-  providerKey: string,
-  providerLabel: string,
-  providerModels: string[],
-  customModels?: Array<{ modelId: string }> | null,
-): string {
+export function resolveProviderDefaultModel({
+  providerKey,
+  providerLabel,
+  providerModels,
+  customModels,
+}: {
+  providerKey: string;
+  providerLabel: string;
+  providerModels: string[];
+  customModels?: Array<{ modelId: string }> | null;
+}): string {
   const registry = modelProviderRegistry.find(
     (entry) => entry.backendModelProviderKey === providerKey,
   );
@@ -180,12 +185,12 @@ export function resolveEligible(
       label,
       modelCount: chatModels.length + customCount,
       definedAt,
-      defaultModel: resolveProviderDefaultModel(
-        provider.provider,
-        label,
-        chatModels,
-        provider.customModels,
-      ),
+      defaultModel: resolveProviderDefaultModel({
+        providerKey: provider.provider,
+        providerLabel: label,
+        providerModels: chatModels,
+        customModels: provider.customModels,
+      }),
     });
   }
   return Array.from(result.values()).sort((a, b) =>

--- a/platform/app/src/components/llmPromptConfigs/LLMConfigPopover.tsx
+++ b/platform/app/src/components/llmPromptConfigs/LLMConfigPopover.tsx
@@ -196,13 +196,12 @@ export function LLMConfigPopover({
             onChange={(model) => {
               const newModelMetadata = modelMetadata?.[model];
               onChange(
-                buildModelChangeValues(
-                  model,
-                  undefined,
+                buildModelChangeValues({
+                  newModel: model,
                   newModelMetadata,
-                  values,
-                  currentModelMetadata,
-                ),
+                  previousValues: values,
+                  previousModelMetadata: currentModelMetadata,
+                }),
               );
             }}
             mode="chat"

--- a/platform/app/src/components/llmPromptConfigs/LLMModelDisplay.tsx
+++ b/platform/app/src/components/llmPromptConfigs/LLMModelDisplay.tsx
@@ -26,7 +26,7 @@ export function LLMModelDisplay({
   ...props
 }: LLMModelDisplayProps) {
   const { modelOption, groupedByProvider, isLoading } =
-    useModelSelectionOptions(allModelOptions, model, "chat");
+    useModelSelectionOptions({ options: allModelOptions, model, mode: "chat" });
 
   // Model is disabled if explicitly marked or if provider is disabled
   const isDisabled = modelOption?.isDisabled ?? false;

--- a/platform/app/src/components/llmPromptConfigs/__tests__/LLMModelDisplay.test.tsx
+++ b/platform/app/src/components/llmPromptConfigs/__tests__/LLMModelDisplay.test.tsx
@@ -33,11 +33,13 @@ vi.mock("~/utils/auth-client", () => ({
 // Mock useModelSelectionOptions
 vi.mock("../../ModelSelector", () => ({
   allModelOptions: ["openai/gpt-4.1", "openai/gpt-5"],
-  useModelSelectionOptions: (
-    _options: string[],
-    model: string,
-    _mode: string,
-  ) => {
+  useModelSelectionOptions: ({
+    model,
+  }: {
+    options: string[];
+    model: string;
+    mode: string;
+  }) => {
     const knownModels: Record<
       string,
       { label: string; icon: React.ReactNode; isDisabled: boolean }

--- a/platform/app/src/components/llmPromptConfigs/utils/__tests__/tokenUtils.test.ts
+++ b/platform/app/src/components/llmPromptConfigs/utils/__tests__/tokenUtils.test.ts
@@ -11,89 +11,86 @@ import {
 describe("buildModelChangeValues", () => {
   describe("when called with a model name", () => {
     it("returns the model name in the result", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.model).toBe(DEFAULT_MODEL);
     });
 
     it("handles full model paths", () => {
-      const result = buildModelChangeValues("openai/gpt-4.1");
+      const result = buildModelChangeValues({ newModel: "openai/gpt-4.1" });
       expect(result.model).toBe("openai/gpt-4.1");
     });
 
     it("handles empty string model", () => {
-      const result = buildModelChangeValues("");
+      const result = buildModelChangeValues({ newModel: "" });
       expect(result.model).toBe("");
     });
   });
 
   describe("when setting slider parameter defaults", () => {
     it("sets temperature to registry default (1)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.temperature).toBe(1);
     });
 
     it("sets topP to registry default (1)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL) as Record<
-        string,
-        unknown
-      >;
+      const result = buildModelChangeValues({
+        newModel: DEFAULT_MODEL,
+      }) as Record<string, unknown>;
       expect(result.topP).toBe(1);
     });
 
     it("sets frequencyPenalty to registry default (0)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL) as Record<
-        string,
-        unknown
-      >;
+      const result = buildModelChangeValues({
+        newModel: DEFAULT_MODEL,
+      }) as Record<string, unknown>;
       expect(result.frequencyPenalty).toBe(0);
     });
 
     it("sets presencePenalty to registry default (0)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL) as Record<
-        string,
-        unknown
-      >;
+      const result = buildModelChangeValues({
+        newModel: DEFAULT_MODEL,
+      }) as Record<string, unknown>;
       expect(result.presencePenalty).toBe(0);
     });
 
     it("sets seed to registry default (0)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.seed).toBe(0);
     });
 
     it("leaves maxTokens undefined without model metadata", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.maxTokens).toBeUndefined();
     });
   });
 
   describe("when setting select parameter defaults", () => {
     it("sets reasoning to registry default (medium)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.reasoning).toBe("medium");
     });
 
     it("sets verbosity to registry default (medium)", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.verbosity).toBe("medium");
     });
   });
 
   describe("when clearing snake_case variants", () => {
     it("explicitly sets max_tokens key to undefined", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(result.max_tokens).toBeUndefined();
     });
 
     it("includes max_tokens key in result", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       expect(Object.hasOwn(result, "max_tokens")).toBe(true);
     });
   });
 
   describe("when staying in sync with parameterRegistry", () => {
     it("includes all registered parameters in result", () => {
-      const result = buildModelChangeValues(DEFAULT_MODEL);
+      const result = buildModelChangeValues({ newModel: DEFAULT_MODEL });
       const registeredParams = parameterRegistry.getAllNames();
 
       for (const param of registeredParams) {
@@ -107,11 +104,10 @@ describe("buildModelChangeValues", () => {
       const metadata = {
         maxCompletionTokens: 16384,
       } as ModelMetadataForFrontend;
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        metadata,
-      );
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: metadata,
+      });
       expect(result.maxTokens).toBe(16384);
     });
 
@@ -119,11 +115,10 @@ describe("buildModelChangeValues", () => {
       const metadata = {
         maxCompletionTokens: 16384,
       } as ModelMetadataForFrontend;
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        metadata,
-      );
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: metadata,
+      });
       expect(result.max_tokens).toBe(16384);
     });
 
@@ -131,21 +126,19 @@ describe("buildModelChangeValues", () => {
       const metadata = {
         maxCompletionTokens: 128000,
       } as ModelMetadataForFrontend;
-      const result = buildModelChangeValues(
-        "openai/gpt-5.2",
-        undefined,
-        metadata,
-      );
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-5.2",
+        newModelMetadata: metadata,
+      });
       expect(result.maxTokens).toBe(128000);
     });
 
     it("uses contextLength when maxCompletionTokens not available", () => {
       const metadata = { contextLength: 8192 } as ModelMetadataForFrontend;
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        metadata,
-      );
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: metadata,
+      });
       expect(result.maxTokens).toBe(8192);
     });
   });
@@ -160,13 +153,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-4.1", maxTokens: 32768 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-5.2",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-5.2",
+        newModelMetadata: newMetadata,
         previousValues,
-        previousMetadata,
-      );
+        previousModelMetadata: previousMetadata,
+      });
 
       expect(result.maxTokens).toBe(128000);
     });
@@ -180,13 +172,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-5.2", maxTokens: 128000 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: newMetadata,
         previousValues,
-        previousMetadata,
-      );
+        previousModelMetadata: previousMetadata,
+      });
 
       expect(result.maxTokens).toBe(32768);
     });
@@ -200,13 +191,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-4.1", maxTokens: 8000 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-5.2",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-5.2",
+        newModelMetadata: newMetadata,
         previousValues,
-        previousMetadata,
-      );
+        previousModelMetadata: previousMetadata,
+      });
 
       expect(result.maxTokens).toBe(8000);
     });
@@ -220,13 +210,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-5.2", maxTokens: 50000 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: newMetadata,
         previousValues,
-        previousMetadata,
-      );
+        previousModelMetadata: previousMetadata,
+      });
 
       expect(result.maxTokens).toBe(32768);
     });
@@ -240,13 +229,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-5.2", max_tokens: 128000 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: newMetadata,
         previousValues,
-        previousMetadata,
-      );
+        previousModelMetadata: previousMetadata,
+      });
 
       expect(result.maxTokens).toBe(32768);
     });
@@ -257,13 +245,12 @@ describe("buildModelChangeValues", () => {
       } as ModelMetadataForFrontend;
       const previousValues = { model: "openai/gpt-5.2", maxTokens: 128000 };
 
-      const result = buildModelChangeValues(
-        "openai/gpt-4.1",
-        undefined,
-        newMetadata,
+      const result = buildModelChangeValues({
+        newModel: "openai/gpt-4.1",
+        newModelMetadata: newMetadata,
         previousValues,
-        undefined,
-      );
+        previousModelMetadata: undefined,
+      });
 
       expect(result.maxTokens).toBe(32768);
     });
@@ -309,13 +296,17 @@ describe("normalizeMaxTokens", () => {
 
   describe("when integrating with buildModelChangeValues", () => {
     it("preserves maxTokens from model change", () => {
-      const afterModelChange = buildModelChangeValues(DEFAULT_MODEL);
+      const afterModelChange = buildModelChangeValues({
+        newModel: DEFAULT_MODEL,
+      });
       const afterTokenUpdate = normalizeMaxTokens(afterModelChange, 8000);
       expect(afterTokenUpdate.maxTokens).toBe(8000);
     });
 
     it("preserves model from model change", () => {
-      const afterModelChange = buildModelChangeValues(DEFAULT_MODEL);
+      const afterModelChange = buildModelChangeValues({
+        newModel: DEFAULT_MODEL,
+      });
       const afterTokenUpdate = normalizeMaxTokens(afterModelChange, 8000);
       expect(afterTokenUpdate.model).toBe(DEFAULT_MODEL);
     });

--- a/platform/app/src/components/llmPromptConfigs/utils/tokenUtils.ts
+++ b/platform/app/src/components/llmPromptConfigs/utils/tokenUtils.ts
@@ -65,13 +65,19 @@ export function calculateSensibleDefaults(
  * @param previousValues - Optional previous config values (for smart max_tokens handling)
  * @param previousModelMetadata - Optional metadata for the previous model
  */
-export function buildModelChangeValues(
-  newModel: string,
-  registry: typeof defaultRegistry = defaultRegistry,
-  newModelMetadata?: ModelMetadataForFrontend,
-  previousValues?: LLMConfigValues,
-  previousModelMetadata?: ModelMetadataForFrontend,
-): LLMConfigValues {
+export function buildModelChangeValues({
+  newModel,
+  registry = defaultRegistry,
+  newModelMetadata,
+  previousValues,
+  previousModelMetadata,
+}: {
+  newModel: string;
+  registry?: typeof defaultRegistry;
+  newModelMetadata?: ModelMetadataForFrontend;
+  previousValues?: LLMConfigValues;
+  previousModelMetadata?: ModelMetadataForFrontend;
+}): LLMConfigValues {
   const result: LLMConfigValues = { model: newModel };
   const resultRecord = result as Record<string, unknown>;
 

--- a/platform/app/src/components/notFoundCanvasRenderer.ts
+++ b/platform/app/src/components/notFoundCanvasRenderer.ts
@@ -128,12 +128,17 @@ export function createNotFoundRenderer() {
       return [sx, sy, scale];
     };
 
-    const projectLine = (
-      gx1: number,
-      gz1: number,
-      gx2: number,
-      gz2: number,
-    ): [[number, number, number], [number, number, number]] | null => {
+    const projectLine = ({
+      gx1,
+      gz1,
+      gx2,
+      gz2,
+    }: {
+      gx1: number;
+      gz1: number;
+      gx2: number;
+      gz2: number;
+    }): [[number, number, number], [number, number, number]] | null => {
       let [x1, y1, z1] = toCamera(gx1, gz1);
       let [x2, y2, z2] = toCamera(gx2, gz2);
 
@@ -310,14 +315,21 @@ export function createNotFoundRenderer() {
     // Line segments — recomputed each frame for camera wobble
     const lineSegments: GridLineSegment[] = [];
 
-    const pushLine = (
-      id: number,
-      x1: number,
-      y1: number,
-      x2: number,
-      y2: number,
-      alpha: number,
-    ) => {
+    const pushLine = ({
+      id,
+      x1,
+      y1,
+      x2,
+      y2,
+      alpha,
+    }: {
+      id: number;
+      x1: number;
+      y1: number;
+      x2: number;
+      y2: number;
+      alpha: number;
+    }) => {
       const depthFade = getDepthFade(y1, y2);
       const nearBoost = getNearBoost(y1, y2);
       const startAlpha = Math.min(1, alpha * getAtmosphereFade(y1) * nearBoost);
@@ -357,22 +369,39 @@ export function createNotFoundRenderer() {
     };
 
     for (let gz = -gridExtent; gz <= gridExtent; gz += step) {
-      const result = projectLine(-gridExtent, gz, gridExtent, gz);
+      const result = projectLine({
+        gx1: -gridExtent,
+        gz1: gz,
+        gx2: gridExtent,
+        gz2: gz,
+      });
       if (result) {
         const [[sx1, sy1], [sx2, sy2]] = result;
         const dist = Math.abs(gz) / gridExtent;
         const alpha = 0.65 * edgeFade(dist) * alphaScale;
-        pushLine(gz, sx1, sy1, sx2, sy2, alpha);
+        pushLine({ id: gz, x1: sx1, y1: sy1, x2: sx2, y2: sy2, alpha });
       }
     }
 
     for (let gx = -gridExtent; gx <= gridExtent; gx += step) {
-      const result = projectLine(gx, -gridExtent, gx, gridExtent);
+      const result = projectLine({
+        gx1: gx,
+        gz1: -gridExtent,
+        gx2: gx,
+        gz2: gridExtent,
+      });
       if (result) {
         const [[sx1, sy1], [sx2, sy2]] = result;
         const dist = Math.abs(gx) / gridExtent;
         const alpha = 0.65 * edgeFade(dist) * alphaScale;
-        pushLine(gx + 10000, sx1, sy1, sx2, sy2, alpha);
+        pushLine({
+          id: gx + 10000,
+          x1: sx1,
+          y1: sy1,
+          x2: sx2,
+          y2: sy2,
+          alpha,
+        });
       }
     }
 

--- a/platform/app/src/components/ops/foundry/traceExecutor.ts
+++ b/platform/app/src/components/ops/foundry/traceExecutor.ts
@@ -112,14 +112,14 @@ function createFoundryExecutor(opts: ExecutorOpts): FoundryExecutor {
     const now = Date.now();
     let traceId = "";
     for (const spanConfig of traceConfig.spans) {
-      const id = buildSpan(
+      const id = buildSpan({
         tracer,
-        spanConfig,
-        ROOT_CONTEXT,
-        now,
+        config: spanConfig,
+        parentContext: ROOT_CONTEXT,
+        baseTime: now,
         traceConfig,
-        otelDeps,
-      );
+        otel: otelDeps,
+      });
       if (!traceId) traceId = id;
     }
     return traceId;
@@ -159,18 +159,25 @@ function createFoundryExecutor(opts: ExecutorOpts): FoundryExecutor {
   };
 }
 
-function buildSpan(
-  tracer: Tracer,
-  config: SpanConfig,
-  parentContext: Context,
-  baseTime: number,
-  traceConfig: TraceConfig,
+function buildSpan({
+  tracer,
+  config,
+  parentContext,
+  baseTime,
+  traceConfig,
+  otel,
+}: {
+  tracer: Tracer;
+  config: SpanConfig;
+  parentContext: Context;
+  baseTime: number;
+  traceConfig: TraceConfig;
   otel: {
     context: typeof import("@opentelemetry/api").context;
     trace: typeof import("@opentelemetry/api").trace;
     SpanStatusCode: typeof import("@opentelemetry/api").SpanStatusCode;
-  },
-): string {
+  };
+}): string {
   const startTimeMs = baseTime + config.offsetMs;
   const endTimeMs = startTimeMs + config.durationMs;
 
@@ -385,7 +392,14 @@ function buildSpan(
 
   const childContext = otel.trace.setSpan(parentContext, span);
   for (const child of config.children) {
-    buildSpan(tracer, child, childContext, startTimeMs, traceConfig, otel);
+    buildSpan({
+      tracer,
+      config: child,
+      parentContext: childContext,
+      baseTime: startTimeMs,
+      traceConfig,
+      otel,
+    });
   }
 
   span.end(new Date(endTimeMs));

--- a/platform/app/src/components/ops/foundry/views/GraphView.tsx
+++ b/platform/app/src/components/ops/foundry/views/GraphView.tsx
@@ -98,13 +98,19 @@ const nodeTypes: NodeTypes = {
   spanNode: SpanNode,
 };
 
-function buildNodesAndEdges(
-  spans: SpanConfig[],
-  selectedId: string | null,
-  parentId: string | null = null,
+function buildNodesAndEdges({
+  spans,
+  selectedId,
+  parentId = null,
   x = 0,
   y = 0,
-): { nodes: Node<SpanNodeData>[]; edges: Edge[]; width: number } {
+}: {
+  spans: SpanConfig[];
+  selectedId: string | null;
+  parentId?: string | null;
+  x?: number;
+  y?: number;
+}): { nodes: Node<SpanNodeData>[]; edges: Edge[]; width: number } {
   const nodes: Node<SpanNodeData>[] = [];
   const edges: Edge[] = [];
   const nodeGap = 180;
@@ -112,13 +118,13 @@ function buildNodesAndEdges(
   let currentX = x;
 
   for (const span of spans) {
-    const childResult = buildNodesAndEdges(
-      span.children,
+    const childResult = buildNodesAndEdges({
+      spans: span.children,
       selectedId,
-      span.id,
-      currentX,
-      y + levelGap,
-    );
+      parentId: span.id,
+      x: currentX,
+      y: y + levelGap,
+    });
 
     const childWidth = Math.max(childResult.width, nodeGap);
     const nodeX = currentX + childWidth / 2 - nodeGap / 2;
@@ -161,7 +167,7 @@ export function GraphView() {
   const colorMode = useColorMode();
 
   const { nodes, edges } = useMemo(
-    () => buildNodesAndEdges(spans, selectedSpanId),
+    () => buildNodesAndEdges({ spans, selectedId: selectedSpanId }),
     [spans, selectedSpanId],
   );
 

--- a/platform/app/src/components/prompt-textarea/hooks/useVariableMenu.ts
+++ b/platform/app/src/components/prompt-textarea/hooks/useVariableMenu.ts
@@ -136,12 +136,17 @@ export const useVariableMenu = ({
 
   // Insert variable at current position (undo-able via Ctrl+Z)
   const insertVariable = useCallback(
-    (
-      fieldName: string,
-      fieldType: FieldType,
-      sourceId: string,
-      isOtherNodeField: boolean,
-    ) => {
+    ({
+      fieldName,
+      fieldType,
+      sourceId,
+      isOtherNodeField,
+    }: {
+      fieldName: string;
+      fieldType: FieldType;
+      sourceId: string;
+      isOtherNodeField: boolean;
+    }) => {
       if (triggerStart === null) return;
 
       const nativeTextarea = containerRef.current?.querySelector("textarea");
@@ -238,12 +243,12 @@ export const useVariableMenu = ({
         otherNodesFields,
         option.source.id,
       );
-      insertVariable(
-        option.field.name,
-        option.field.type,
-        option.source.id,
+      insertVariable({
+        fieldName: option.field.name,
+        fieldType: option.field.type,
+        sourceId: option.source.id,
         isOtherNodeField,
-      );
+      });
     } else if (option.type === "create" && onCreateVariable) {
       const normalizedName = option.name.replace(/ /g, "_").toLowerCase();
       if (triggerStart === null) return;
@@ -295,12 +300,12 @@ export const useVariableMenu = ({
         otherNodesFields,
         field.sourceId,
       );
-      insertVariable(
-        field.fieldName,
-        field.fieldType,
-        field.sourceId,
+      insertVariable({
+        fieldName: field.fieldName,
+        fieldType: field.fieldType,
+        sourceId: field.sourceId,
         isOtherNodeField,
-      );
+      });
     },
     [insertVariable, otherNodesFields],
   );

--- a/platform/app/src/components/settings/DefaultModelsSection.tsx
+++ b/platform/app/src/components/settings/DefaultModelsSection.tsx
@@ -481,7 +481,12 @@ function ConfigCell({
   // update; AI features for this role are disabled at this scope until
   // they do.
   const resolvedRole = anchorScope
-    ? resolveAtScope(role, configs, anchorScope.type, anchorScope.id)
+    ? resolveAtScope({
+        key: role,
+        configs,
+        scopeType: anchorScope.type,
+        scopeId: anchorScope.id,
+      })
     : null;
   const resolvedRoleModel = resolvedRole?.model ?? config[role] ?? null;
 
@@ -596,12 +601,17 @@ function mostSpecificScope(
  * configs by createdAt DESC and taking the first that has the key.
  * Returns null if no config in the visible set carries the key.
  */
-function resolveAtScope(
-  key: string,
-  configs: ConfigRow[],
-  scopeType: "ORGANIZATION" | "TEAM" | "PROJECT",
-  scopeId: string,
-): NonNullable<Payload["effective"][ModelRoleKey]> | null {
+function resolveAtScope({
+  key,
+  configs,
+  scopeType,
+  scopeId,
+}: {
+  key: string;
+  configs: ConfigRow[];
+  scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+  scopeId: string;
+}): NonNullable<Payload["effective"][ModelRoleKey]> | null {
   const tier =
     scopeType === "PROJECT"
       ? ["PROJECT", "TEAM", "ORGANIZATION"]

--- a/platform/app/src/components/settings/ModelProviderForm.tsx
+++ b/platform/app/src/components/settings/ModelProviderForm.tsx
@@ -313,13 +313,13 @@ export const EditModelProviderForm = ({
     isValidating: isValidatingApiKey,
     validationError: apiKeyValidationError,
     clearError: clearApiKeyError,
-  } = useModelProviderApiKeyValidation(
-    provider.provider,
-    state.customKeys,
+  } = useModelProviderApiKeyValidation({
+    provider: provider.provider,
+    customKeys: state.customKeys,
     projectId,
-    organization?.id,
-    state.scopes,
-  );
+    organizationId: organization?.id,
+    scopes: state.scopes,
+  });
 
   // Shared with onboarding and the Langy model gate, so a refusal is not the
   // end of the road on one surface and a hard block on the next.

--- a/platform/app/src/components/settings/ScopeFilter.tsx
+++ b/platform/app/src/components/settings/ScopeFilter.tsx
@@ -52,7 +52,12 @@ export function ScopeFilter({
 }: Props) {
   const [moreOpen, setMoreOpen] = useState(false);
 
-  const label = filterLabel(value, available, currentTeamId, currentProjectId);
+  const label = filterLabel({
+    filter: value,
+    available,
+    currentTeamId,
+    currentProjectId,
+  });
 
   return (
     <Menu.Root>
@@ -191,12 +196,17 @@ function ScopeOptionItem({
   );
 }
 
-function filterLabel(
-  filter: ScopeFilter,
-  available: AvailableScopes,
-  currentTeamId?: string | null,
-  currentProjectId?: string | null,
-): string {
+function filterLabel({
+  filter,
+  available,
+  currentTeamId,
+  currentProjectId,
+}: {
+  filter: ScopeFilter;
+  available: AvailableScopes;
+  currentTeamId?: string | null;
+  currentProjectId?: string | null;
+}): string {
   if (filter.kind === "all") return "All you can see";
   if (filter.kind === "team-current") {
     const team = available.teams.find((t) => t.id === currentTeamId);

--- a/platform/app/src/components/traces/ThreadMapping.tsx
+++ b/platform/app/src/components/traces/ThreadMapping.tsx
@@ -110,12 +110,9 @@ const mapThreadToDatasetEntry = (
             const traceMapping =
               TRACE_MAPPINGS[field as keyof typeof TRACE_MAPPINGS];
             if (traceMapping) {
-              filteredTrace[field] = traceMapping.mapping(
-                trace as any,
-                "",
-                "",
-                {},
-              );
+              filteredTrace[field] = traceMapping.mapping({
+                trace: trace as any,
+              });
             }
           }
           return filteredTrace;

--- a/platform/app/src/components/traces/TracesMapping.tsx
+++ b/platform/app/src/components/traces/TracesMapping.tsx
@@ -491,13 +491,13 @@ export const TracesMapping = ({
       .map(([col, m]) => ({ col, source: m.source }));
 
     for (const trace of traces_) {
-      const mappedEntries = mapTraceToDatasetEntry(
+      const mappedEntries = mapTraceToDatasetEntry({
         trace,
         mapping,
         expansions,
-        getAnnotationScoreOptions.data,
-        allThreadTraces.data ?? traces_,
-      );
+        annotationScoreOptions: getAnnotationScoreOptions.data,
+        allTraces: allThreadTraces.data ?? traces_,
+      });
 
       // Add each expanded entry to the final results
       for (const entry of mappedEntries) {

--- a/platform/app/src/experiments-v3/__tests__/AutosaveEvaluation.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/AutosaveEvaluation.integration.test.tsx
@@ -142,9 +142,12 @@ describe("Autosave evaluation state", () => {
 
     // Make a change to the store
     act(() => {
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "test value");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "test value",
+      });
     });
 
     // Force re-render to pick up store changes
@@ -168,9 +171,12 @@ describe("Autosave evaluation state", () => {
 
     // Make a change
     act(() => {
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "trigger save");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "trigger save",
+      });
     });
 
     // Advance past debounce - should trigger save and go to "saving" then "saved"
@@ -206,9 +212,12 @@ describe("Autosave evaluation state", () => {
 
     // Make a change - this should trigger the rejected mock
     act(() => {
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "will fail");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "will fail",
+      });
     });
 
     // Advance past debounce to trigger save

--- a/platform/app/src/experiments-v3/__tests__/ColumnVisibility.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/ColumnVisibility.integration.test.tsx
@@ -216,13 +216,18 @@ describe("Column visibility", () => {
     it("hides cell data for hidden columns", () => {
       // Set up some data
       const store = useEvaluationsV3Store.getState();
-      store.setCellValue("test-data", 0, "input", "test input value");
-      store.setCellValue(
-        "test-data",
-        0,
-        "expected_output",
-        "test output value",
-      );
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "test input value",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "expected_output",
+        value: "test output value",
+      });
 
       // Hide the 'input' column
       store.toggleColumnVisibility("input");

--- a/platform/app/src/experiments-v3/__tests__/DatasetInlineEditing.unit.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/DatasetInlineEditing.unit.test.tsx
@@ -26,12 +26,17 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 // Helper to render with store reset and Chakra provider
-const renderCell = (
-  value: string,
-  row: number,
-  columnId: string,
-  datasetId: string = DEFAULT_TEST_DATA_ID,
-) => {
+const renderCell = ({
+  value,
+  row,
+  columnId,
+  datasetId = DEFAULT_TEST_DATA_ID,
+}: {
+  value: string;
+  row: number;
+  columnId: string;
+  datasetId?: string;
+}) => {
   return render(
     <EditableCell
       value={value}
@@ -75,7 +80,7 @@ describe("Dataset inline editing", () => {
 
   describe("Edit a cell by setting editingCell in store", () => {
     it("enters edit mode and shows textarea", async () => {
-      renderCell("original", 0, "input");
+      renderCell({ value: "original", row: 0, columnId: "input" });
 
       // Set editing cell directly (in real app, this is done by DatasetCellTd on double-click)
       useEvaluationsV3Store
@@ -96,7 +101,7 @@ describe("Dataset inline editing", () => {
       // Get the initial store value before any edits
       const initialValue = getActiveDatasetRecords()?.input?.[0];
 
-      renderCell("original", 0, "input");
+      renderCell({ value: "original", row: 0, columnId: "input" });
 
       // Enter edit mode
       useEvaluationsV3Store
@@ -120,7 +125,7 @@ describe("Dataset inline editing", () => {
   describe("Confirm cell edit with Enter", () => {
     it("saves value on Enter", async () => {
       const user = userEvent.setup();
-      renderCell("", 0, "input");
+      renderCell({ value: "", row: 0, columnId: "input" });
 
       // Enter edit mode
       useEvaluationsV3Store
@@ -145,7 +150,7 @@ describe("Dataset inline editing", () => {
   describe("Commit cell edit by clicking outside", () => {
     it("saves the value on blur instead of discarding it", async () => {
       const user = userEvent.setup();
-      renderCell("", 0, "input");
+      renderCell({ value: "", row: 0, columnId: "input" });
 
       useEvaluationsV3Store
         .getState()
@@ -168,7 +173,7 @@ describe("Dataset inline editing", () => {
       const user = userEvent.setup();
       const initialValue = getActiveDatasetRecords()?.input?.[0];
 
-      renderCell("original", 0, "input");
+      renderCell({ value: "original", row: 0, columnId: "input" });
 
       useEvaluationsV3Store
         .getState()
@@ -194,7 +199,7 @@ describe("Dataset inline editing", () => {
 
   describe("Cell editor positioning", () => {
     it("shows editor with help text", async () => {
-      renderCell("original", 0, "input");
+      renderCell({ value: "original", row: 0, columnId: "input" });
 
       // Enter edit mode
       useEvaluationsV3Store
@@ -214,7 +219,7 @@ describe("Dataset inline editing", () => {
       // Get the initial store value before any edits
       const initialValue = getActiveDatasetRecords()?.input?.[0];
 
-      renderCell("", 0, "input");
+      renderCell({ value: "", row: 0, columnId: "input" });
 
       // Make an edit
       useEvaluationsV3Store
@@ -251,7 +256,7 @@ describe("Dataset inline editing", () => {
       // Get the initial store value before any edits
       const initialValue = getActiveDatasetRecords()?.input?.[0];
 
-      renderCell("", 0, "input");
+      renderCell({ value: "", row: 0, columnId: "input" });
 
       // Make an edit
       useEvaluationsV3Store

--- a/platform/app/src/experiments-v3/__tests__/DatasetSaveAndRemove.test.ts
+++ b/platform/app/src/experiments-v3/__tests__/DatasetSaveAndRemove.test.ts
@@ -151,10 +151,30 @@ describe("Dataset save and remove edge cases", () => {
       const store = useEvaluationsV3Store.getState();
 
       // Set up an inline dataset with data
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "input", "hello");
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "expected_output", "world");
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 1, "input", "foo");
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 1, "expected_output", "bar");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "input",
+        value: "hello",
+      });
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "expected_output",
+        value: "world",
+      });
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 1,
+        columnId: "input",
+        value: "foo",
+      });
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 1,
+        columnId: "expected_output",
+        value: "bar",
+      });
 
       // Get the inline records
       const state = useEvaluationsV3Store.getState();

--- a/platform/app/src/experiments-v3/__tests__/HttpAgentMappings.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/HttpAgentMappings.integration.test.tsx
@@ -65,12 +65,17 @@ const createTestDataset = (
 /**
  * Create an HTTP agent target for testing.
  */
-const createHttpAgentTarget = (
-  id: string,
-  inputs: Array<{ identifier: string; type: string }>,
-  bodyTemplate: string,
-  mappings: TargetConfig["mappings"] = {},
-): TargetConfig => ({
+const createHttpAgentTarget = ({
+  id,
+  inputs,
+  bodyTemplate,
+  mappings = {},
+}: {
+  id: string;
+  inputs: Array<{ identifier: string; type: string }>;
+  bodyTemplate: string;
+  mappings?: TargetConfig["mappings"];
+}): TargetConfig => ({
   id,
   type: "agent",
   agentType: "http",
@@ -179,15 +184,15 @@ describe("HTTP agent target shows input mapping section", () => {
   });
 
   it("validates HTTP agent inputs against mappings", () => {
-    const target = createHttpAgentTarget(
-      "http-1",
-      [
+    const target = createHttpAgentTarget({
+      id: "http-1",
+      inputs: [
         { identifier: "thread_id", type: "str" },
         { identifier: "input", type: "str" },
       ],
-      `{"thread_id": "{{thread_id}}", "input": "{{input}}"}`,
-      {},
-    );
+      bodyTemplate: `{"thread_id": "{{thread_id}}", "input": "{{input}}"}`,
+      mappings: {},
+    });
 
     const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
 
@@ -202,15 +207,15 @@ describe("HTTP agent target shows input mapping section", () => {
   });
 
   it("is valid when at least one HTTP agent input is mapped", () => {
-    const target = createHttpAgentTarget(
-      "http-partial",
-      [
+    const target = createHttpAgentTarget({
+      id: "http-partial",
+      inputs: [
         { identifier: "thread_id", type: "str" },
         { identifier: "input", type: "str" },
         { identifier: "messages", type: "str" },
       ],
-      `{"thread_id": "{{thread_id}}", "input": "{{input}}", "messages": {{messages}}}`,
-      {
+      bodyTemplate: `{"thread_id": "{{thread_id}}", "input": "{{input}}", "messages": {{messages}}}`,
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           // Only input is mapped, thread_id and messages are not
           input: {
@@ -221,7 +226,7 @@ describe("HTTP agent target shows input mapping section", () => {
           },
         },
       },
-    );
+    });
 
     const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
 
@@ -232,14 +237,14 @@ describe("HTTP agent target shows input mapping section", () => {
   });
 
   it("accepts value mappings for HTTP agent inputs", () => {
-    const target = createHttpAgentTarget(
-      "http-1",
-      [
+    const target = createHttpAgentTarget({
+      id: "http-1",
+      inputs: [
         { identifier: "thread_id", type: "str" },
         { identifier: "input", type: "str" },
       ],
-      `{"thread_id": "{{thread_id}}", "input": "{{input}}"}`,
-      {
+      bodyTemplate: `{"thread_id": "{{thread_id}}", "input": "{{input}}"}`,
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           thread_id: {
             type: "value",
@@ -253,7 +258,7 @@ describe("HTTP agent target shows input mapping section", () => {
           },
         },
       },
-    );
+    });
 
     const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
     expect(result.isValid).toBe(true);
@@ -385,12 +390,12 @@ describe("HTTP agent mappings auto-infer from dataset columns", () => {
 
 describe("Missing HTTP agent mappings show alert on target chip", () => {
   it("shows alert icon when HTTP agent has unmapped required input", () => {
-    const target = createHttpAgentTarget(
-      "http-missing",
-      [{ identifier: "messages", type: "str" }],
-      `{"messages": {{messages}}}`,
-      {}, // No mappings
-    );
+    const target = createHttpAgentTarget({
+      id: "http-missing",
+      inputs: [{ identifier: "messages", type: "str" }],
+      bodyTemplate: `{"messages": {{messages}}}`,
+      mappings: {}, // No mappings
+    });
 
     renderWithProviders(
       <TargetHeader
@@ -406,11 +411,11 @@ describe("Missing HTTP agent mappings show alert on target chip", () => {
   });
 
   it("does not show alert when all HTTP agent inputs are mapped", () => {
-    const target = createHttpAgentTarget(
-      "http-complete",
-      [{ identifier: "messages", type: "str" }],
-      `{"messages": {{messages}}}`,
-      {
+    const target = createHttpAgentTarget({
+      id: "http-complete",
+      inputs: [{ identifier: "messages", type: "str" }],
+      bodyTemplate: `{"messages": {{messages}}}`,
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           messages: {
             type: "source",
@@ -420,7 +425,7 @@ describe("Missing HTTP agent mappings show alert on target chip", () => {
           },
         },
       },
-    );
+    });
 
     renderWithProviders(
       <TargetHeader
@@ -438,12 +443,12 @@ describe("Missing HTTP agent mappings show alert on target chip", () => {
   });
 
   it("calls onEdit when play button is clicked with missing mappings", () => {
-    const target = createHttpAgentTarget(
-      "http-missing-play",
-      [{ identifier: "messages", type: "str" }],
-      `{"messages": {{messages}}}`,
-      {}, // No mappings
-    );
+    const target = createHttpAgentTarget({
+      id: "http-missing-play",
+      inputs: [{ identifier: "messages", type: "str" }],
+      bodyTemplate: `{"messages": {{messages}}}`,
+      mappings: {}, // No mappings
+    });
     const onEdit = vi.fn();
     const onRun = vi.fn();
 
@@ -473,14 +478,14 @@ describe("Missing HTTP agent mappings show alert on target chip", () => {
 describe("HTTP agent has different validation than code agent", () => {
   it("HTTP agent is valid with partial mappings, code agent requires all", () => {
     // HTTP agent target with partial mappings (only 'input' mapped)
-    const httpTarget = createHttpAgentTarget(
-      "http-target",
-      [
+    const httpTarget = createHttpAgentTarget({
+      id: "http-target",
+      inputs: [
         { identifier: "input", type: "str" },
         { identifier: "context", type: "str" },
       ],
-      `{"input": "{{input}}", "context": "{{context}}"}`,
-      {
+      bodyTemplate: `{"input": "{{input}}", "context": "{{context}}"}`,
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           input: {
             type: "source",
@@ -491,7 +496,7 @@ describe("HTTP agent has different validation than code agent", () => {
           // context is NOT mapped
         },
       },
-    );
+    });
 
     // Code agent target with same partial mappings
     const codeTarget: TargetConfig = {
@@ -533,12 +538,12 @@ describe("HTTP agent has different validation than code agent", () => {
   });
 
   it("both are invalid with no mappings", () => {
-    const httpTarget = createHttpAgentTarget(
-      "http-target",
-      [{ identifier: "input", type: "str" }],
-      `{"input": "{{input}}"}`,
-      {},
-    );
+    const httpTarget = createHttpAgentTarget({
+      id: "http-target",
+      inputs: [{ identifier: "input", type: "str" }],
+      bodyTemplate: `{"input": "{{input}}"}`,
+      mappings: {},
+    });
 
     const codeTarget: TargetConfig = {
       id: "code-target",

--- a/platform/app/src/experiments-v3/__tests__/MappingValidation.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/MappingValidation.integration.test.tsx
@@ -1371,12 +1371,17 @@ describe("Target play button validation", () => {
 // Tests: Evaluator validation with required/optional fields
 // ============================================================================
 
-const createTestEvaluator = (
-  id: string,
-  evaluatorType: string,
-  inputs: Array<{ identifier: string; type: string }>,
-  mappings: EvaluatorConfig["mappings"] = {},
-): EvaluatorConfig => ({
+const createTestEvaluator = ({
+  id,
+  evaluatorType,
+  inputs,
+  mappings = {},
+}: {
+  id: string;
+  evaluatorType: string;
+  inputs: Array<{ identifier: string; type: string }>;
+  mappings?: EvaluatorConfig["mappings"];
+}): EvaluatorConfig => ({
   id,
   evaluatorType: evaluatorType as EvaluatorConfig["evaluatorType"],
   inputs: inputs.map((i) => ({ ...i, type: i.type as "str" })),
@@ -1388,15 +1393,15 @@ describe("Evaluator validation with required/optional fields", () => {
 
   it("marks evaluator as valid when all required fields are mapped", () => {
     // legacy/ragas_answer_correctness has requiredFields: ["output", "expected_output"], optionalFields: ["input"]
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "legacy/ragas_answer_correctness",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "legacy/ragas_answer_correctness",
+      inputs: [
         { identifier: "output", type: "str" },
         { identifier: "expected_output", type: "str" },
         { identifier: "input", type: "str" },
       ],
-      {
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           [targetId]: {
             output: {
@@ -1415,7 +1420,7 @@ describe("Evaluator validation with required/optional fields", () => {
           },
         },
       },
-    );
+    });
 
     const result = getEvaluatorMissingMappings(
       evaluator,
@@ -1429,14 +1434,14 @@ describe("Evaluator validation with required/optional fields", () => {
 
   it("marks evaluator as invalid when required field is missing", () => {
     // legacy/ragas_answer_correctness has requiredFields: ["output", "expected_output"]
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "legacy/ragas_answer_correctness",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "legacy/ragas_answer_correctness",
+      inputs: [
         { identifier: "output", type: "str" },
         { identifier: "expected_output", type: "str" },
       ],
-      {
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           [targetId]: {
             output: {
@@ -1449,7 +1454,7 @@ describe("Evaluator validation with required/optional fields", () => {
           },
         },
       },
-    );
+    });
 
     const result = getEvaluatorMissingMappings(
       evaluator,
@@ -1465,15 +1470,15 @@ describe("Evaluator validation with required/optional fields", () => {
 
   it("marks evaluator as valid when only optional fields are unmapped (llm_boolean)", () => {
     // langevals/llm_boolean has requiredFields: [], optionalFields: ["input", "output", "contexts"]
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "langevals/llm_boolean",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "langevals/llm_boolean",
+      inputs: [
         { identifier: "input", type: "str" },
         { identifier: "output", type: "str" },
         { identifier: "contexts", type: "str" },
       ],
-      {
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           [targetId]: {
             input: {
@@ -1492,7 +1497,7 @@ describe("Evaluator validation with required/optional fields", () => {
           },
         },
       },
-    );
+    });
 
     const result = getEvaluatorMissingMappings(
       evaluator,
@@ -1506,18 +1511,18 @@ describe("Evaluator validation with required/optional fields", () => {
 
   it("marks evaluator as invalid when ALL fields are empty (even if all optional)", () => {
     // langevals/llm_boolean has requiredFields: [], optionalFields: ["input", "output", "contexts"]
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "langevals/llm_boolean",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "langevals/llm_boolean",
+      inputs: [
         { identifier: "input", type: "str" },
         { identifier: "output", type: "str" },
         { identifier: "contexts", type: "str" },
       ],
-      {
+      mappings: {
         // No mappings at all
       },
-    );
+    });
 
     const result = getEvaluatorMissingMappings(
       evaluator,
@@ -1533,15 +1538,15 @@ describe("Evaluator validation with required/optional fields", () => {
 
   it("evaluatorHasMissingMappings returns false for valid evaluator with optional unmapped", () => {
     // langevals/llm_boolean with input and output mapped, contexts unmapped (optional)
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "langevals/llm_boolean",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "langevals/llm_boolean",
+      inputs: [
         { identifier: "input", type: "str" },
         { identifier: "output", type: "str" },
         { identifier: "contexts", type: "str" },
       ],
-      {
+      mappings: {
         [DEFAULT_TEST_DATA_ID]: {
           [targetId]: {
             input: {
@@ -1559,7 +1564,7 @@ describe("Evaluator validation with required/optional fields", () => {
           },
         },
       },
-    );
+    });
 
     expect(
       evaluatorHasMissingMappings(evaluator, DEFAULT_TEST_DATA_ID, targetId),
@@ -1567,15 +1572,15 @@ describe("Evaluator validation with required/optional fields", () => {
   });
 
   it("evaluatorHasMissingMappings returns true when all fields empty", () => {
-    const evaluator = createTestEvaluator(
-      "eval-1",
-      "langevals/llm_boolean",
-      [
+    const evaluator = createTestEvaluator({
+      id: "eval-1",
+      evaluatorType: "langevals/llm_boolean",
+      inputs: [
         { identifier: "input", type: "str" },
         { identifier: "output", type: "str" },
       ],
-      {},
-    );
+      mappings: {},
+    });
 
     expect(
       evaluatorHasMissingMappings(evaluator, DEFAULT_TEST_DATA_ID, targetId),

--- a/platform/app/src/experiments-v3/__tests__/PerDatasetMappings.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/PerDatasetMappings.test.tsx
@@ -70,11 +70,16 @@ describe("Per-Dataset Mappings", () => {
       const store = useEvaluationsV3Store.getState();
 
       store.addTarget(createTestTarget("target-1"));
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
 
       const state = useEvaluationsV3Store.getState();
@@ -101,19 +106,29 @@ describe("Per-Dataset Mappings", () => {
       store.addTarget(createTestTarget("target-1"));
 
       // Set mapping for default dataset
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
 
       // Set different mapping for dataset-2
-      store.setTargetMapping("target-1", "dataset-2", "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: "dataset-2",
-        sourceField: "foo",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: "dataset-2",
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: "dataset-2",
+          sourceField: "foo",
+        },
       });
 
       const state = useEvaluationsV3Store.getState();
@@ -134,15 +149,22 @@ describe("Per-Dataset Mappings", () => {
       const store = useEvaluationsV3Store.getState();
 
       store.addTarget(createTestTarget("target-1"));
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "context", {
-        type: "value",
-        value: "some context",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "context",
+        mapping: { type: "value", value: "some context" },
       });
 
       store.removeTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question");
@@ -177,11 +199,16 @@ describe("Per-Dataset Mappings", () => {
       const store = useEvaluationsV3Store.getState();
 
       store.addTarget(createTestTarget("target-1"));
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
 
       const { result } = renderHook(() => useEvaluationMappings("target-1"));
@@ -206,17 +233,27 @@ describe("Per-Dataset Mappings", () => {
       );
       store.addTarget(createTestTarget("target-1"));
 
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
-      store.setTargetMapping("target-1", "dataset-2", "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: "dataset-2",
-        sourceField: "foo",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: "dataset-2",
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: "dataset-2",
+          sourceField: "foo",
+        },
       });
 
       const { result, rerender } = renderHook(() =>
@@ -257,11 +294,16 @@ describe("Per-Dataset Mappings", () => {
       store.addTarget(createTestTarget("target-1"));
 
       // Only add mapping for default dataset
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
 
       const { result, rerender } = renderHook(() =>
@@ -311,18 +353,18 @@ describe("Per-Dataset Mappings", () => {
         mappings: {},
       });
 
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-1",
-        "output",
-        {
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-1",
+        inputField: "output",
+        mapping: {
           type: "source",
           source: "target",
           sourceId: "target-1",
           sourceField: "output",
         },
-      );
+      });
 
       const state = useEvaluationsV3Store.getState();
       const evaluator = state.evaluators.find((e) => e.id === "eval-1");
@@ -361,23 +403,29 @@ describe("Per-Dataset Mappings", () => {
       });
 
       // Different expected_output mappings for different datasets
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-1",
-        "expected",
-        {
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-1",
+        inputField: "expected",
+        mapping: {
           type: "source",
           source: "dataset",
           sourceId: DEFAULT_TEST_DATA_ID,
           sourceField: "expected_output",
         },
-      );
-      store.setEvaluatorMapping("eval-1", "dataset-2", "target-1", "expected", {
-        type: "source",
-        source: "dataset",
-        sourceId: "dataset-2",
-        sourceField: "expected",
+      });
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: "dataset-2",
+        targetId: "target-1",
+        inputField: "expected",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: "dataset-2",
+          sourceField: "expected",
+        },
       });
 
       const state = useEvaluationsV3Store.getState();
@@ -420,9 +468,11 @@ describe("Per-Dataset Mappings", () => {
       });
 
       // Manually set a custom mapping for "question"
-      store.setTargetMapping("target-1", "ds-1", "question", {
-        type: "value",
-        value: "hardcoded value",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: "ds-1",
+        inputField: "question",
+        mapping: { type: "value", value: "hardcoded value" },
       });
 
       // Update target (doesn't touch inputs)

--- a/platform/app/src/experiments-v3/__tests__/SavedDatasets.test.ts
+++ b/platform/app/src/experiments-v3/__tests__/SavedDatasets.test.ts
@@ -239,7 +239,12 @@ describe("Saved datasets in workbench", () => {
       store.addDataset(savedDataset);
 
       // Update value
-      store.updateSavedRecordValue("saved_abc123", 0, "input", "updated value");
+      store.updateSavedRecordValue({
+        datasetId: "saved_abc123",
+        rowIndex: 0,
+        columnId: "input",
+        value: "updated value",
+      });
 
       const state = useEvaluationsV3Store.getState();
       const dataset = state.datasets.find((d) => d.id === "saved_abc123");
@@ -260,7 +265,12 @@ describe("Saved datasets in workbench", () => {
       };
 
       store.addDataset(savedDataset);
-      store.updateSavedRecordValue("saved_abc123", 0, "input", "changed");
+      store.updateSavedRecordValue({
+        datasetId: "saved_abc123",
+        rowIndex: 0,
+        columnId: "input",
+        value: "changed",
+      });
 
       // Should track that rec1 has pending changes
       const pendingChanges =

--- a/platform/app/src/experiments-v3/__tests__/SelectionToolbar.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/SelectionToolbar.integration.test.tsx
@@ -282,9 +282,24 @@ describe("Row deletion - inline dataset", () => {
       const store = useEvaluationsV3Store.getState();
 
       // Set up initial data
-      store.setCellValue("test-data", 0, "input", "row 0 input");
-      store.setCellValue("test-data", 1, "input", "row 1 input");
-      store.setCellValue("test-data", 2, "input", "row 2 input");
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "row 0 input",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 1,
+        columnId: "input",
+        value: "row 1 input",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 2,
+        columnId: "input",
+        value: "row 2 input",
+      });
 
       // Select rows 0 and 2
       store.toggleRowSelection(0);
@@ -304,7 +319,12 @@ describe("Row deletion - inline dataset", () => {
     it("deleteSelectedRows clears row selection after delete", () => {
       const store = useEvaluationsV3Store.getState();
 
-      store.setCellValue("test-data", 0, "input", "row 0");
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "row 0",
+      });
       store.toggleRowSelection(0);
 
       // Get fresh state after toggle
@@ -336,11 +356,36 @@ describe("Row deletion - inline dataset", () => {
     it("deleteSelectedRows deletes rows in correct order (no index shifting issues)", () => {
       const store = useEvaluationsV3Store.getState();
 
-      store.setCellValue("test-data", 0, "input", "A");
-      store.setCellValue("test-data", 1, "input", "B");
-      store.setCellValue("test-data", 2, "input", "C");
-      store.setCellValue("test-data", 3, "input", "D");
-      store.setCellValue("test-data", 4, "input", "E");
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "A",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 1,
+        columnId: "input",
+        value: "B",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 2,
+        columnId: "input",
+        value: "C",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 3,
+        columnId: "input",
+        value: "D",
+      });
+      store.setCellValue({
+        datasetId: "test-data",
+        row: 4,
+        columnId: "input",
+        value: "E",
+      });
 
       // Select non-consecutive rows
       store.toggleRowSelection(1); // B
@@ -369,8 +414,18 @@ describe("Selected row visual indication", () => {
 
   it("adds data-selected attribute to selected rows", async () => {
     const store = useEvaluationsV3Store.getState();
-    store.setCellValue("test-data", 0, "input", "row 0");
-    store.setCellValue("test-data", 1, "input", "row 1");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "row 0",
+    });
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 1,
+      columnId: "input",
+      value: "row 1",
+    });
     store.toggleRowSelection(0);
 
     render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });

--- a/platform/app/src/experiments-v3/__tests__/TableDisplay.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/TableDisplay.integration.test.tsx
@@ -387,7 +387,12 @@ describe("Value truncation", () => {
 
     // Create a very long string (over 5000 chars)
     const longValue = "a".repeat(6000);
-    store.setCellValue("test-data", 0, "input", longValue);
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: longValue,
+    });
 
     render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
 

--- a/platform/app/src/experiments-v3/__tests__/UndoRedo.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/UndoRedo.integration.test.tsx
@@ -72,9 +72,12 @@ describe("UndoRedo Component", () => {
       render(<UndoRedo />, { wrapper: Wrapper });
 
       // Make a change
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "hello");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "hello",
+      });
 
       // Wait for the debounce in temporal middleware
       await vi.advanceTimersByTimeAsync(150);
@@ -89,9 +92,12 @@ describe("UndoRedo Component", () => {
       render(<UndoRedo />, { wrapper: Wrapper });
 
       // Make a change
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "hello");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "hello",
+      });
       await vi.advanceTimersByTimeAsync(150);
 
       // Undo
@@ -110,13 +116,19 @@ describe("UndoRedo Component", () => {
       render(<UndoRedo />, { wrapper: Wrapper });
 
       // Make two changes (temporal requires distinct state changes for history)
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "first");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "first",
+      });
       await vi.advanceTimersByTimeAsync(150);
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "second");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "second",
+      });
       await vi.advanceTimersByTimeAsync(150);
 
       // Verify change was made
@@ -145,13 +157,19 @@ describe("UndoRedo Component", () => {
       render(<UndoRedo />, { wrapper: Wrapper });
 
       // Make two changes
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "first");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "first",
+      });
       await vi.advanceTimersByTimeAsync(150);
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "second");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "second",
+      });
       await vi.advanceTimersByTimeAsync(150);
 
       // Undo
@@ -192,13 +210,19 @@ describe("UndoRedo Component", () => {
       );
 
       // Make two changes
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "first");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "first",
+      });
       await vi.advanceTimersByTimeAsync(150);
-      useEvaluationsV3Store
-        .getState()
-        .setCellValue("test-data", 0, "input", "second");
+      useEvaluationsV3Store.getState().setCellValue({
+        datasetId: "test-data",
+        row: 0,
+        columnId: "input",
+        value: "second",
+      });
       await vi.advanceTimersByTimeAsync(150);
 
       // Focus textarea and simulate Cmd+Z
@@ -324,11 +348,21 @@ describe("Undo/Redo store actions (unit)", () => {
     const store = useEvaluationsV3Store.getState();
 
     // First change
-    store.setCellValue("test-data", 0, "input", "first");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "first",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // Second change
-    store.setCellValue("test-data", 0, "input", "second");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "second",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     expect(getRecords()?.input?.[0]).toBe("second");
@@ -343,11 +377,21 @@ describe("Undo/Redo store actions (unit)", () => {
     const store = useEvaluationsV3Store.getState();
 
     // First change
-    store.setCellValue("test-data", 0, "input", "first");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "first",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // Second change
-    store.setCellValue("test-data", 0, "input", "second");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "second",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     expect(getRecords()?.input?.[0]).toBe("second");
@@ -365,9 +409,24 @@ describe("Undo/Redo store actions (unit)", () => {
     const store = useEvaluationsV3Store.getState();
 
     // Set up some data
-    store.setCellValue("test-data", 0, "input", "row0");
-    store.setCellValue("test-data", 1, "input", "row1");
-    store.setCellValue("test-data", 2, "input", "row2");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "row0",
+    });
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 1,
+      columnId: "input",
+      value: "row1",
+    });
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 2,
+      columnId: "input",
+      value: "row2",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     expect(getRecords()?.input?.[0]).toBe("row0");
@@ -403,14 +462,24 @@ describe("Undo/Redo store actions (unit)", () => {
     store.setEditingCell({ row: 0, columnId: "input" });
 
     // User types and saves (which clears editingCell and updates value)
-    store.setCellValue("test-data", 0, "input", "first edit");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "first edit",
+    });
     store.setEditingCell(undefined);
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // User edits another cell
     store.setSelectedCell({ row: 1, columnId: "input" });
     store.setEditingCell({ row: 1, columnId: "input" });
-    store.setCellValue("test-data", 1, "input", "second edit");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 1,
+      columnId: "input",
+      value: "second edit",
+    });
     store.setEditingCell(undefined);
     await new Promise((resolve) => setTimeout(resolve, 110));
 
@@ -437,7 +506,12 @@ describe("Undo/Redo store actions (unit)", () => {
     store.setEditingCell({ row: 0, columnId: "input" });
 
     // User types - this happens WHILE editingCell is still set
-    store.setCellValue("test-data", 0, "input", "first");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "first",
+    });
 
     // Wait for debounce - state is saved to history with editingCell still set
     await new Promise((resolve) => setTimeout(resolve, 110));
@@ -450,7 +524,12 @@ describe("Undo/Redo store actions (unit)", () => {
     store.setEditingCell({ row: 0, columnId: "input" });
 
     // User types
-    store.setCellValue("test-data", 0, "input", "second");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "second",
+    });
 
     // Wait for debounce
     await new Promise((resolve) => setTimeout(resolve, 110));
@@ -482,12 +561,22 @@ describe("Undo/Redo store actions (unit)", () => {
 
     // Edit cell at row 0
     store.setSelectedCell({ row: 0, columnId: "input" });
-    store.setCellValue("test-data", 0, "input", "first");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: "first",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // Edit cell at row 1
     store.setSelectedCell({ row: 1, columnId: "input" });
-    store.setCellValue("test-data", 1, "input", "second");
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 1,
+      columnId: "input",
+      value: "second",
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // Current selection is row 1
@@ -532,7 +621,12 @@ describe("Undo/Redo store actions (unit)", () => {
     // User makes a content change (use unique value to avoid matching previous test state)
     const uniqueValue = `navigation-test-${Date.now()}`;
     store.setSelectedCell({ row: 0, columnId: "input" });
-    store.setCellValue("test-data", 0, "input", uniqueValue);
+    store.setCellValue({
+      datasetId: "test-data",
+      row: 0,
+      columnId: "input",
+      value: uniqueValue,
+    });
     await new Promise((resolve) => setTimeout(resolve, 110));
 
     // Count history entries after content change

--- a/platform/app/src/experiments-v3/__tests__/useEvaluationsV3Store.unit.test.ts
+++ b/platform/app/src/experiments-v3/__tests__/useEvaluationsV3Store.unit.test.ts
@@ -18,7 +18,12 @@ describe("useEvaluationsV3Store", () => {
   describe("Dataset operations", () => {
     it("sets cell value in active dataset", () => {
       const store = useEvaluationsV3Store.getState();
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "input", "Hello world");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "input",
+        value: "Hello world",
+      });
 
       const state = useEvaluationsV3Store.getState();
       const activeDataset = state.datasets.find(
@@ -29,7 +34,12 @@ describe("useEvaluationsV3Store", () => {
 
     it("expands records array when setting value at higher row index", () => {
       const store = useEvaluationsV3Store.getState();
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 5, "input", "Value at row 5");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 5,
+        columnId: "input",
+        value: "Value at row 5",
+      });
 
       const state = useEvaluationsV3Store.getState();
       const activeDataset = state.datasets.find(
@@ -98,7 +108,12 @@ describe("useEvaluationsV3Store", () => {
       // Initial state has 3 empty rows
       expect(store.getRowCount(DEFAULT_TEST_DATA_ID)).toBe(3);
 
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 10, "input", "Value");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 10,
+        columnId: "input",
+        value: "Value",
+      });
 
       expect(
         useEvaluationsV3Store.getState().getRowCount(DEFAULT_TEST_DATA_ID),
@@ -283,15 +298,22 @@ describe("useEvaluationsV3Store", () => {
       });
 
       // Add mappings for both inputs
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "question", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "question",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "context", {
-        type: "value",
-        value: "some context",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "context",
+        mapping: { type: "value", value: "some context" },
       });
 
       // Verify both mappings exist
@@ -324,12 +346,16 @@ describe("useEvaluationsV3Store", () => {
     it("sets target mapping for specific dataset", () => {
       const store = useEvaluationsV3Store.getState();
       store.addTarget(createTestTarget("target-1"));
-      // setTargetMapping now takes: targetId, datasetId, inputField, mapping
-      store.setTargetMapping("target-1", DEFAULT_TEST_DATA_ID, "input", {
-        type: "source",
-        source: "dataset",
-        sourceId: DEFAULT_TEST_DATA_ID,
-        sourceField: "input",
+      store.setTargetMapping({
+        targetId: "target-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "input",
+        mapping: {
+          type: "source",
+          source: "dataset",
+          sourceId: DEFAULT_TEST_DATA_ID,
+          sourceField: "input",
+        },
       });
 
       const state = useEvaluationsV3Store.getState();
@@ -347,19 +373,18 @@ describe("useEvaluationsV3Store", () => {
       const store = useEvaluationsV3Store.getState();
       store.addTarget(createTestTarget("target-1"));
       store.addEvaluator(createTestEvaluator("eval-1"));
-      // setEvaluatorMapping now takes: evaluatorId, datasetId, targetId, inputField, mapping
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-1",
-        "output",
-        {
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-1",
+        inputField: "output",
+        mapping: {
           type: "source",
           source: "target",
           sourceId: "target-1",
           sourceField: "output",
         },
-      );
+      });
       store.removeTarget("target-1");
 
       const state = useEvaluationsV3Store.getState();
@@ -375,12 +400,16 @@ describe("useEvaluationsV3Store", () => {
       const store = useEvaluationsV3Store.getState();
       store.addTarget(createTestTarget("target-1"));
       store.addTarget(createTestTarget("target-2"));
-      // setTargetMapping now takes: targetId, datasetId, inputField, mapping
-      store.setTargetMapping("target-2", DEFAULT_TEST_DATA_ID, "input", {
-        type: "source",
-        source: "target",
-        sourceId: "target-1",
-        sourceField: "output",
+      store.setTargetMapping({
+        targetId: "target-2",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        inputField: "input",
+        mapping: {
+          type: "source",
+          source: "target",
+          sourceId: "target-1",
+          sourceField: "output",
+        },
       });
       store.removeTarget("target-1");
 
@@ -485,19 +514,18 @@ describe("useEvaluationsV3Store", () => {
       const store = useEvaluationsV3Store.getState();
       store.addTarget(createTestTarget("target-1"));
       store.addEvaluator(createTestEvaluator("eval-1"));
-      // setEvaluatorMapping now takes: evaluatorId, datasetId, targetId, inputField, mapping
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-1",
-        "output",
-        {
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-1",
+        inputField: "output",
+        mapping: {
           type: "source",
           source: "target",
           sourceId: "target-1",
           sourceField: "output",
         },
-      );
+      });
 
       const state = useEvaluationsV3Store.getState();
       const evaluator = state.evaluators.find((e) => e.id === "eval-1");
@@ -523,30 +551,30 @@ describe("useEvaluationsV3Store", () => {
       expect(state.evaluators).toHaveLength(1);
       expect(state.targets).toHaveLength(2);
       // Both targets can have mappings set for this evaluator
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-1",
-        "output",
-        {
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-1",
+        inputField: "output",
+        mapping: {
           type: "source",
           source: "target",
           sourceId: "target-1",
           sourceField: "output",
         },
-      );
-      store.setEvaluatorMapping(
-        "eval-1",
-        DEFAULT_TEST_DATA_ID,
-        "target-2",
-        "output",
-        {
+      });
+      store.setEvaluatorMapping({
+        evaluatorId: "eval-1",
+        datasetId: DEFAULT_TEST_DATA_ID,
+        targetId: "target-2",
+        inputField: "output",
+        mapping: {
           type: "source",
           source: "target",
           sourceId: "target-2",
           sourceField: "output",
         },
-      );
+      });
 
       const updatedState = useEvaluationsV3Store.getState();
       const evaluator = updatedState.evaluators.find((e) => e.id === "eval-1");
@@ -726,13 +754,23 @@ describe("useEvaluationsV3Store", () => {
       const store = useEvaluationsV3Store.getState();
 
       // Make a change
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "input", "First value");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "input",
+        value: "First value",
+      });
 
       // Wait for debounce
       await new Promise((resolve) => setTimeout(resolve, 150));
 
       // Make another change
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "input", "Second value");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "input",
+        value: "Second value",
+      });
 
       // Wait for debounce
       await new Promise((resolve) => setTimeout(resolve, 150));
@@ -761,7 +799,12 @@ describe("useEvaluationsV3Store", () => {
       const store = useEvaluationsV3Store.getState();
 
       // Set initial data
-      store.setCellValue(DEFAULT_TEST_DATA_ID, 0, "input", "Initial");
+      store.setCellValue({
+        datasetId: DEFAULT_TEST_DATA_ID,
+        row: 0,
+        columnId: "input",
+        value: "Initial",
+      });
 
       // Wait for debounce
       await new Promise((resolve) => setTimeout(resolve, 150));

--- a/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -160,12 +160,17 @@ export const isComparisonConfigured = (e: EvaluatorConfig) => {
  * silently drop every column-target comparison's row data. Exported so it can
  * be unit-tested directly instead of only through a full table render.
  */
-export const buildTargetEvaluatorsForRow = (
-  target: TargetConfig,
-  evaluators: EvaluatorConfig[],
-  results: EvaluationResults,
-  rowIndex: number,
-): Record<string, unknown> =>
+export const buildTargetEvaluatorsForRow = ({
+  target,
+  evaluators,
+  results,
+  rowIndex,
+}: {
+  target: TargetConfig;
+  evaluators: EvaluatorConfig[];
+  results: EvaluationResults;
+  rowIndex: number;
+}): Record<string, unknown> =>
   Object.fromEntries([
     ...evaluators.map(
       (evaluator) =>
@@ -1318,12 +1323,12 @@ export function EvaluationsV3Table({
             {
               output: results.targetOutputs[target.id]?.[index] ?? null,
               // All evaluators apply to all targets
-              evaluators: buildTargetEvaluatorsForRow(
+              evaluators: buildTargetEvaluatorsForRow({
                 target,
                 evaluators,
                 results,
-                index,
-              ),
+                rowIndex: index,
+              }),
               // Error for this target/row: the engine's raw string, plus the
               // code the cell reads its customer-facing copy from.
               error: results.errors[target.id]?.[index] ?? null,

--- a/platform/app/src/experiments-v3/components/RunEvaluationButton.tsx
+++ b/platform/app/src/experiments-v3/components/RunEvaluationButton.tsx
@@ -149,20 +149,20 @@ export const RunEvaluationButton = ({
           mapping: UIFieldMapping | undefined,
         ) => {
           if (mapping) {
-            setEvaluatorMapping(
-              evaluator.id,
-              activeDatasetId,
+            setEvaluatorMapping({
+              evaluatorId: evaluator.id,
+              datasetId: activeDatasetId,
               targetId,
-              identifier,
-              convertFromUIMapping(mapping, isDatasetSource),
-            );
+              inputField: identifier,
+              mapping: convertFromUIMapping(mapping, isDatasetSource),
+            });
           } else {
-            removeEvaluatorMapping(
-              evaluator.id,
-              activeDatasetId,
+            removeEvaluatorMapping({
+              evaluatorId: evaluator.id,
+              datasetId: activeDatasetId,
               targetId,
-              identifier,
-            );
+              inputField: identifier,
+            });
           }
         };
 

--- a/platform/app/src/experiments-v3/components/TargetSection/TargetHeader.tsx
+++ b/platform/app/src/experiments-v3/components/TargetSection/TargetHeader.tsx
@@ -260,12 +260,12 @@ export const TargetHeader = memo(function TargetHeader({
             results,
             effectiveRowCount,
           )
-        : computeTargetAggregates(
-            target.id,
+        : computeTargetAggregates({
+            targetId: target.id,
             results,
             evaluators,
-            effectiveRowCount,
-          ),
+            rowCount: effectiveRowCount,
+          }),
     [target, results, evaluators, effectiveRowCount],
   );
 

--- a/platform/app/src/experiments-v3/components/__tests__/EvaluationsV3Table.test.ts
+++ b/platform/app/src/experiments-v3/components/__tests__/EvaluationsV3Table.test.ts
@@ -232,12 +232,12 @@ describe("buildTargetEvaluatorsForRow", () => {
         [comparisonTarget.id]: [{ status: "processed", label: "target-a" }],
       };
 
-      const evaluators = buildTargetEvaluatorsForRow(
-        comparisonTarget,
-        [],
+      const evaluators = buildTargetEvaluatorsForRow({
+        target: comparisonTarget,
+        evaluators: [],
         results,
-        0,
-      );
+        rowIndex: 0,
+      });
 
       expect(evaluators[comparisonTarget.id]).toEqual({
         status: "processed",
@@ -249,12 +249,12 @@ describe("buildTargetEvaluatorsForRow", () => {
       it("resolves to null rather than being dropped", () => {
         const results = createInitialResults();
 
-        const evaluators = buildTargetEvaluatorsForRow(
-          comparisonTarget,
-          [],
+        const evaluators = buildTargetEvaluatorsForRow({
+          target: comparisonTarget,
+          evaluators: [],
           results,
-          0,
-        );
+          rowIndex: 0,
+        });
 
         expect(evaluators[comparisonTarget.id]).toBeNull();
       });
@@ -268,12 +268,12 @@ describe("buildTargetEvaluatorsForRow", () => {
         [gradingEvaluator.id]: [{ status: "processed", passed: true }],
       };
 
-      const evaluators = buildTargetEvaluatorsForRow(
-        plainTarget,
-        [gradingEvaluator],
+      const evaluators = buildTargetEvaluatorsForRow({
+        target: plainTarget,
+        evaluators: [gradingEvaluator],
         results,
-        0,
-      );
+        rowIndex: 0,
+      });
 
       expect(evaluators[gradingEvaluator.id]).toEqual({
         status: "processed",

--- a/platform/app/src/experiments-v3/hooks/useEvaluationsV3Store.ts
+++ b/platform/app/src/experiments-v3/hooks/useEvaluationsV3Store.ts
@@ -211,13 +211,18 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
   // Inline dataset cell/column actions (scoped to a dataset)
   // -------------------------------------------------------------------------
 
-  setCellValue: (datasetId, row, columnId, value) => {
+  setCellValue: ({ datasetId, row, columnId, value }) => {
     const dataset = get().datasets.find((d) => d.id === datasetId);
     if (!dataset) return;
 
     // For saved datasets, use updateSavedRecordValue
     if (dataset.type === "saved") {
-      get().updateSavedRecordValue(datasetId, row, columnId, value);
+      get().updateSavedRecordValue({
+        datasetId,
+        rowIndex: row,
+        columnId,
+        value,
+      });
       return;
     }
 
@@ -416,7 +421,7 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
     return "";
   },
 
-  updateSavedRecordValue: (datasetId, rowIndex, columnId, value) => {
+  updateSavedRecordValue: ({ datasetId, rowIndex, columnId, value }) => {
     set((state) => {
       const dataset = state.datasets.find((d) => d.id === datasetId);
       if (dataset?.type !== "saved" || !dataset.datasetId) {
@@ -748,7 +753,7 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
     });
   },
 
-  setTargetMapping: (targetId, datasetId, inputField, mapping) => {
+  setTargetMapping: ({ targetId, datasetId, inputField, mapping }) => {
     set((state) => ({
       targets: state.targets.map((r) =>
         r.id === targetId
@@ -828,13 +833,13 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
   // Evaluator mapping actions (per-dataset, per-target mappings stored inside evaluator)
   // -------------------------------------------------------------------------
 
-  setEvaluatorMapping: (
+  setEvaluatorMapping: ({
     evaluatorId,
     datasetId,
     targetId,
     inputField,
     mapping,
-  ) => {
+  }) => {
     set((state) => ({
       evaluators: state.evaluators.map((e) =>
         e.id === evaluatorId
@@ -856,7 +861,12 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
     }));
   },
 
-  removeEvaluatorMapping: (evaluatorId, datasetId, targetId, inputField) => {
+  removeEvaluatorMapping: ({
+    evaluatorId,
+    datasetId,
+    targetId,
+    inputField,
+  }) => {
     set((state) => ({
       evaluators: state.evaluators.map((e) => {
         if (e.id !== evaluatorId) return e;

--- a/platform/app/src/experiments-v3/hooks/useExecuteEvaluation.ts
+++ b/platform/app/src/experiments-v3/hooks/useExecuteEvaluation.ts
@@ -131,12 +131,17 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
    * Also marks all evaluators for this cell as "running" since they start after target output.
    */
   const updateTargetOutput = useCallback(
-    (
-      rowIndex: number,
-      targetId: string,
-      output: unknown,
-      metadata?: { cost?: number; duration?: number; traceId?: string },
-    ) => {
+    ({
+      rowIndex,
+      targetId,
+      output,
+      metadata,
+    }: {
+      rowIndex: number;
+      targetId: string;
+      output: unknown;
+      metadata?: { cost?: number; duration?: number; traceId?: string };
+    }) => {
       // Use the store's setState directly for atomic updates
       useEvaluationsV3Store.setState((state) => {
         // Deep copy the target's array, or create new if doesn't exist
@@ -192,12 +197,17 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
    * into the workbench's autosaved state, then re-parsed them with a regex.
    */
   const updateTargetError = useCallback(
-    (
-      rowIndex: number,
-      targetId: string,
-      errorMsg: string,
-      domainError?: SerializedHandledError,
-    ) => {
+    ({
+      rowIndex,
+      targetId,
+      errorMsg,
+      domainError,
+    }: {
+      rowIndex: number;
+      targetId: string;
+      errorMsg: string;
+      domainError?: SerializedHandledError;
+    }) => {
       useEvaluationsV3Store.setState((state) => {
         const existingErrors = state.results.errors[targetId] ?? [];
         const newErrors = [...existingErrors];
@@ -235,12 +245,17 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
    * Also removes the evaluator from runningEvaluators since it has completed.
    */
   const updateEvaluatorResult = useCallback(
-    (
-      rowIndex: number,
-      targetId: string,
-      evaluatorId: string,
-      result: unknown,
-    ) => {
+    ({
+      rowIndex,
+      targetId,
+      evaluatorId,
+      result,
+    }: {
+      rowIndex: number;
+      targetId: string;
+      evaluatorId: string;
+      result: unknown;
+    }) => {
       useEvaluationsV3Store.setState((state) => {
         const existingTargetResults =
           state.results.evaluatorResults[targetId] ?? {};
@@ -305,17 +320,22 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
             // The code and the engine's raw string, side by side. The cell
             // shows the registry's copy for the code and keeps the raw string
             // for whoever asks — never as the headline.
-            updateTargetError(
-              event.rowIndex,
-              event.targetId,
-              event.error ?? UNNAMED_FAILURE,
-              event.domainError,
-            );
+            updateTargetError({
+              rowIndex: event.rowIndex,
+              targetId: event.targetId,
+              errorMsg: event.error ?? UNNAMED_FAILURE,
+              domainError: event.domainError,
+            });
           } else {
-            updateTargetOutput(event.rowIndex, event.targetId, event.output, {
-              cost: event.cost,
-              duration: event.duration,
-              traceId: event.traceId,
+            updateTargetOutput({
+              rowIndex: event.rowIndex,
+              targetId: event.targetId,
+              output: event.output,
+              metadata: {
+                cost: event.cost,
+                duration: event.duration,
+                traceId: event.traceId,
+              },
             });
           }
           if (event.cost) {
@@ -324,12 +344,12 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
           break;
 
         case "evaluator_result":
-          updateEvaluatorResult(
-            event.rowIndex,
-            event.targetId,
-            event.evaluatorId,
-            event.result,
-          );
+          updateEvaluatorResult({
+            rowIndex: event.rowIndex,
+            targetId: event.targetId,
+            evaluatorId: event.evaluatorId,
+            result: event.result,
+          });
           break;
 
         case "progress":
@@ -359,11 +379,11 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
           if (event.rowIndex !== undefined && event.targetId) {
             if (event.evaluatorId) {
               // Evaluator error
-              updateEvaluatorResult(
-                event.rowIndex,
-                event.targetId,
-                event.evaluatorId,
-                {
+              updateEvaluatorResult({
+                rowIndex: event.rowIndex,
+                targetId: event.targetId,
+                evaluatorId: event.evaluatorId,
+                result: {
                   status: "error",
                   error_type: "EvaluatorError",
                   details: detail,
@@ -372,15 +392,15 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
                     ? { domainError: event.domainError }
                     : {}),
                 },
-              );
+              });
             } else {
               // Target error — the code, not the sentence it renders as.
-              updateTargetError(
-                event.rowIndex,
-                event.targetId,
-                event.message,
-                event.domainError,
-              );
+              updateTargetError({
+                rowIndex: event.rowIndex,
+                targetId: event.targetId,
+                errorMsg: event.message,
+                domainError: event.domainError,
+              });
             }
           } else {
             // Fatal error
@@ -897,8 +917,11 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
         state.results.targetMetadata[targetId]?.[rowIndex]?.traceId;
 
       // Immediately set the evaluator result to "running" for UI feedback
-      updateEvaluatorResult(rowIndex, targetId, evaluatorId, {
-        status: "running",
+      updateEvaluatorResult({
+        rowIndex,
+        targetId,
+        evaluatorId,
+        result: { status: "running" },
       });
 
       // Build the evaluator scope with pre-computed target output

--- a/platform/app/src/experiments-v3/hooks/useOpenEvaluatorEditor.ts
+++ b/platform/app/src/experiments-v3/hooks/useOpenEvaluatorEditor.ts
@@ -170,20 +170,20 @@ export const useOpenEvaluatorEditor = () => {
         mapping: UIFieldMapping | undefined,
       ) => {
         if (mapping) {
-          setEvaluatorMapping(
-            evaluator.id,
-            activeDatasetId,
-            target.id,
-            identifier,
-            convertFromUIMapping(mapping, isDatasetSource),
-          );
+          setEvaluatorMapping({
+            evaluatorId: evaluator.id,
+            datasetId: activeDatasetId,
+            targetId: target.id,
+            inputField: identifier,
+            mapping: convertFromUIMapping(mapping, isDatasetSource),
+          });
         } else {
-          removeEvaluatorMapping(
-            evaluator.id,
-            activeDatasetId,
-            target.id,
-            identifier,
-          );
+          removeEvaluatorMapping({
+            evaluatorId: evaluator.id,
+            datasetId: activeDatasetId,
+            targetId: target.id,
+            inputField: identifier,
+          });
         }
       };
 

--- a/platform/app/src/experiments-v3/hooks/useOpenTargetEditor.ts
+++ b/platform/app/src/experiments-v3/hooks/useOpenTargetEditor.ts
@@ -230,12 +230,12 @@ export const useOpenTargetEditor = () => {
                 mapping: UIFieldMapping | undefined,
               ) => {
                 if (mapping) {
-                  setTargetMapping(
-                    target.id,
-                    activeDatasetId,
-                    identifier,
-                    convertFromUIMapping(mapping, isDatasetSource),
-                  );
+                  setTargetMapping({
+                    targetId: target.id,
+                    datasetId: activeDatasetId,
+                    inputField: identifier,
+                    mapping: convertFromUIMapping(mapping, isDatasetSource),
+                  });
                 } else {
                   removeTargetMapping(target.id, activeDatasetId, identifier);
                 }
@@ -269,12 +269,12 @@ export const useOpenTargetEditor = () => {
                 mapping: UIFieldMapping | undefined,
               ) => {
                 if (mapping) {
-                  setTargetMapping(
-                    target.id,
-                    activeDatasetId,
-                    identifier,
-                    convertFromUIMapping(mapping, isDatasetSource),
-                  );
+                  setTargetMapping({
+                    targetId: target.id,
+                    datasetId: activeDatasetId,
+                    inputField: identifier,
+                    mapping: convertFromUIMapping(mapping, isDatasetSource),
+                  });
                 } else {
                   removeTargetMapping(target.id, activeDatasetId, identifier);
                 }
@@ -309,12 +309,12 @@ export const useOpenTargetEditor = () => {
                 mapping: UIFieldMapping | undefined,
               ) => {
                 if (mapping) {
-                  setTargetMapping(
-                    target.id,
-                    activeDatasetId,
-                    identifier,
-                    convertFromUIMapping(mapping, isDatasetSource),
-                  );
+                  setTargetMapping({
+                    targetId: target.id,
+                    datasetId: activeDatasetId,
+                    inputField: identifier,
+                    mapping: convertFromUIMapping(mapping, isDatasetSource),
+                  });
                 } else {
                   removeTargetMapping(target.id, activeDatasetId, identifier);
                 }
@@ -404,12 +404,12 @@ export const useOpenTargetEditor = () => {
           mapping: UIFieldMapping | undefined,
         ) => {
           if (mapping) {
-            setTargetMapping(
-              target.id,
-              activeDatasetId,
-              identifier,
-              convertFromUIMapping(mapping, isDatasetSource),
-            );
+            setTargetMapping({
+              targetId: target.id,
+              datasetId: activeDatasetId,
+              inputField: identifier,
+              mapping: convertFromUIMapping(mapping, isDatasetSource),
+            });
           } else {
             removeTargetMapping(target.id, activeDatasetId, identifier);
           }

--- a/platform/app/src/experiments-v3/types.ts
+++ b/platform/app/src/experiments-v3/types.ts
@@ -633,22 +633,22 @@ export type EvaluationsV3Actions = {
   exportInlineToSaved: (datasetId: string, savedDatasetId: string) => void;
 
   // Dataset cell/column actions (works for both inline and saved)
-  setCellValue: (
-    datasetId: string,
-    row: number,
-    columnId: string,
-    value: string,
-  ) => void;
+  setCellValue: (params: {
+    datasetId: string;
+    row: number;
+    columnId: string;
+    value: string;
+  }) => void;
   getCellValue: (datasetId: string, row: number, columnId: string) => string;
   getRowCount: (datasetId: string) => number;
 
   // Saved dataset actions
-  updateSavedRecordValue: (
-    datasetId: string,
-    rowIndex: number,
-    columnId: string,
-    value: string,
-  ) => void;
+  updateSavedRecordValue: (params: {
+    datasetId: string;
+    rowIndex: number;
+    columnId: string;
+    value: string;
+  }) => void;
   clearPendingChange: (dbDatasetId: string, recordId: string) => void;
   getSavedRecordInfo: (
     datasetId: string,
@@ -673,12 +673,12 @@ export type EvaluationsV3Actions = {
   updateTarget: (targetId: string, updates: Partial<TargetConfig>) => void;
   removeTarget: (targetId: string) => void;
   /** Set a mapping for a target input field for a specific dataset */
-  setTargetMapping: (
-    targetId: string,
-    datasetId: string,
-    inputField: string,
-    mapping: FieldMapping,
-  ) => void;
+  setTargetMapping: (params: {
+    targetId: string;
+    datasetId: string;
+    inputField: string;
+    mapping: FieldMapping;
+  }) => void;
   /** Remove a mapping for a target input field for a specific dataset */
   removeTargetMapping: (
     targetId: string,
@@ -704,20 +704,20 @@ export type EvaluationsV3Actions = {
   removeEvaluator: (evaluatorId: string) => void;
 
   /** Set a mapping for an evaluator input field for a specific dataset and target */
-  setEvaluatorMapping: (
-    evaluatorId: string,
-    datasetId: string,
-    targetId: string,
-    inputField: string,
-    mapping: FieldMapping,
-  ) => void;
+  setEvaluatorMapping: (params: {
+    evaluatorId: string;
+    datasetId: string;
+    targetId: string;
+    inputField: string;
+    mapping: FieldMapping;
+  }) => void;
   /** Remove a mapping for an evaluator input field for a specific dataset and target */
-  removeEvaluatorMapping: (
-    evaluatorId: string,
-    datasetId: string,
-    targetId: string,
-    inputField: string,
-  ) => void;
+  removeEvaluatorMapping: (params: {
+    evaluatorId: string;
+    datasetId: string;
+    targetId: string;
+    inputField: string;
+  }) => void;
 
   // Results actions
   setResults: (results: Partial<EvaluationResults>) => void;

--- a/platform/app/src/experiments-v3/utils/__tests__/computeAggregates.test.ts
+++ b/platform/app/src/experiments-v3/utils/__tests__/computeAggregates.test.ts
@@ -26,12 +26,12 @@ describe("computeTargetAggregates", () => {
     const results = createResults();
     const evaluators = [{ id: "eval-1", name: "Exact Match" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.completedRows).toBe(0);
     expect(aggregates.totalRows).toBe(3);
@@ -55,12 +55,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Exact Match" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.completedRows).toBe(2);
     expect(aggregates.totalRows).toBe(3);
@@ -81,12 +81,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Exact Match" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     // Only 1 row is complete (row 0 has both target and evaluator done)
     expect(aggregates.completedRows).toBe(1);
@@ -102,12 +102,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.completedRows).toBe(2);
     expect(aggregates.totalRows).toBe(3);
@@ -128,12 +128,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.completedRows).toBe(2);
     expect(aggregates.errorRows).toBe(1);
@@ -156,12 +156,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Exact Match" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.evaluators[0]?.total).toBe(3);
     expect(aggregates.evaluators[0]?.passed).toBe(2);
@@ -184,12 +184,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Score Evaluator" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.evaluators[0]?.averageScore).toBeCloseTo(0.667, 2);
   });
@@ -208,12 +208,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Exact Match" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.evaluators[0]?.errors).toBe(1);
     expect(aggregates.evaluators[0]?.total).toBe(3);
@@ -234,12 +234,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "LLM Score" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     // Score-only results should have null passRate
     expect(aggregates.evaluators[0]?.passRate).toBeNull();
@@ -273,12 +273,12 @@ describe("computeTargetAggregates", () => {
       { id: "eval-score-only", name: "LLM Score" },
     ];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     // Pass/fail evaluator should have pass rate
     expect(aggregates.evaluators[0]?.passRate).toBe(50); // 1 passed / 2 total
@@ -308,12 +308,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators = [{ id: "eval-1", name: "Score Evaluator" }];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     // passed: null should be treated as score-only, not pass/fail
     expect(aggregates.evaluators[0]?.passRate).toBeNull();
@@ -340,12 +340,12 @@ describe("computeTargetAggregates", () => {
       { id: "eval-2", name: "Evaluator 2" },
     ];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     expect(aggregates.evaluators).toHaveLength(2);
     expect(aggregates.evaluators[0]?.passRate).toBe(100);
@@ -369,12 +369,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     expect(aggregates.averageCost).toBeCloseTo(0.002, 6);
     expect(aggregates.totalCost).toBeCloseTo(0.006, 6);
@@ -401,12 +401,12 @@ describe("computeTargetAggregates", () => {
       { id: "eval-2", name: "Evaluator 2" },
     ];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     // eval-1 avg = 1.0, eval-2 avg = 0.0, overall avg = 0.5
     expect(aggregates.overallAverageScore).toBeCloseTo(0.5, 2);
@@ -427,12 +427,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     // Only 2 rows have cost
     expect(aggregates.averageCost).toBeCloseTo(0.002, 6);
@@ -456,12 +456,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      3,
-    );
+      rowCount: 3,
+    });
 
     // Total duration should be sum: 500 + 300 + 700 = 1500
     expect(aggregates.totalDuration).toBe(1500);
@@ -483,12 +483,12 @@ describe("computeTargetAggregates", () => {
     });
     const evaluators: Array<{ id: string; name: string }> = [];
 
-    const aggregates = computeTargetAggregates(
-      "target-1",
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
       results,
       evaluators,
-      2,
-    );
+      rowCount: 2,
+    });
 
     expect(aggregates.totalDuration).toBeNull();
     expect(aggregates.averageLatency).toBeNull();
@@ -635,7 +635,12 @@ describe("computeTargetAggregates latencyStats and costStats", () => {
       },
     });
 
-    const aggregates = computeTargetAggregates("target-1", results, [], 3);
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
+      results,
+      evaluators: [],
+      rowCount: 3,
+    });
 
     expect(aggregates.latencyStats).not.toBeNull();
     expect(aggregates.latencyStats!.min).toBe(500);
@@ -659,7 +664,12 @@ describe("computeTargetAggregates latencyStats and costStats", () => {
       },
     });
 
-    const aggregates = computeTargetAggregates("target-1", results, [], 1);
+    const aggregates = computeTargetAggregates({
+      targetId: "target-1",
+      results,
+      evaluators: [],
+      rowCount: 1,
+    });
 
     expect(aggregates.latencyStats).toBeNull();
     expect(aggregates.costStats).toBeNull();

--- a/platform/app/src/experiments-v3/utils/__tests__/mappingInference.test.ts
+++ b/platform/app/src/experiments-v3/utils/__tests__/mappingInference.test.ts
@@ -46,12 +46,17 @@ const createTestDataset = (
   columns,
 });
 
-const createTestTarget = (
-  id: string,
-  inputs: Field[],
-  outputs: Field[] = [{ identifier: "output", type: "str" }],
-  mappings: TargetConfig["mappings"] = {},
-): TargetConfig => ({
+const createTestTarget = ({
+  id,
+  inputs,
+  outputs = [{ identifier: "output", type: "str" }],
+  mappings = {},
+}: {
+  id: string;
+  inputs: Field[];
+  outputs?: Field[];
+  mappings?: TargetConfig["mappings"];
+}): TargetConfig => ({
   id,
   type: "prompt",
   inputs,
@@ -456,12 +461,17 @@ describe("inferEvaluatorMappings", () => {
       createTestColumn("input"),
       createTestColumn("expected_output"),
     ]);
-    const target = createTestTarget("target-1", [
-      { identifier: "input", type: "str" },
-    ]);
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+    });
     const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     expect(mappings.output).toEqual({
       type: "source",
@@ -476,14 +486,19 @@ describe("inferEvaluatorMappings", () => {
       createTestColumn("input"),
       createTestColumn("expected_output"),
     ]);
-    const target = createTestTarget("target-1", [
-      { identifier: "input", type: "str" },
-    ]);
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+    });
     const evaluatorInputs: Field[] = [
       { identifier: "expected_output", type: "str" },
     ];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     expect(mappings.expected_output).toEqual({
       type: "source",
@@ -499,12 +514,17 @@ describe("inferEvaluatorMappings", () => {
       createTestColumn("output"), // Dataset also has "output"
       createTestColumn("expected_output"),
     ]);
-    const target = createTestTarget("target-1", [
-      { identifier: "input", type: "str" },
-    ]);
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+    });
     const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     // Should map to target output, not dataset column
     expect(mappings.output?.type).toBe("source");
@@ -518,16 +538,20 @@ describe("inferEvaluatorMappings", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("input"),
     ]);
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      [
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [
         { identifier: "answer", type: "str" }, // Target outputs "answer" not "output"
       ],
-    );
+    });
     const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     expect(mappings.output?.type).toBe("source");
     if (mappings.output?.type === "source") {
@@ -544,21 +568,21 @@ describe("inferEvaluatorMappings", () => {
           createTestColumn("input"),
           createTestColumn("expected_output"),
         ]);
-        const target = createTestTarget(
-          "target-1",
-          [{ identifier: "input", type: "str" }],
+        const target = createTestTarget({
+          id: "target-1",
+          inputs: [{ identifier: "input", type: "str" }],
           // Single output whose name does not match "output" by any rule
-          [{ identifier: "category", type: "str" }],
-        );
+          outputs: [{ identifier: "category", type: "str" }],
+        });
         const evaluatorInputs: Field[] = [
           { identifier: "output", type: "str" },
         ];
 
-        const mappings = inferEvaluatorMappings(
+        const mappings = inferEvaluatorMappings({
           evaluatorInputs,
           dataset,
           target,
-        );
+        });
 
         expect(mappings.output).toEqual({
           type: "source",
@@ -575,23 +599,23 @@ describe("inferEvaluatorMappings", () => {
         const dataset = createTestDataset("ds-1", "Dataset 1", [
           createTestColumn("input"),
         ]);
-        const target = createTestTarget(
-          "target-1",
-          [{ identifier: "input", type: "str" }],
-          [
+        const target = createTestTarget({
+          id: "target-1",
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [
             { identifier: "category", type: "str" },
             { identifier: "confidence", type: "str" },
           ],
-        );
+        });
         const evaluatorInputs: Field[] = [
           { identifier: "output", type: "str" },
         ];
 
-        const mappings = inferEvaluatorMappings(
+        const mappings = inferEvaluatorMappings({
           evaluatorInputs,
           dataset,
           target,
-        );
+        });
 
         expect(mappings.output).toBeUndefined();
       });
@@ -602,9 +626,10 @@ describe("inferEvaluatorMappings", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("input"),
     ]);
-    const target = createTestTarget("target-1", [
-      { identifier: "input", type: "str" },
-    ]);
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+    });
     const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
     const existingMappings = {
       output: {
@@ -613,12 +638,12 @@ describe("inferEvaluatorMappings", () => {
       },
     };
 
-    const mappings = inferEvaluatorMappings(
+    const mappings = inferEvaluatorMappings({
       evaluatorInputs,
       dataset,
       target,
       existingMappings,
-    );
+    });
 
     expect(mappings.output).toBeUndefined(); // Should not override
   });
@@ -627,19 +652,23 @@ describe("inferEvaluatorMappings", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("expected_output"),
     ]);
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      [
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [
         { identifier: "output", type: "str" },
         { identifier: "expected_output", type: "str" }, // Target also has "expected_output"
       ],
-    );
+    });
     const evaluatorInputs: Field[] = [
       { identifier: "expected_output", type: "str" },
     ];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     // Should map to dataset, not target
     expect(mappings.expected_output?.type).toBe("source");
@@ -653,17 +682,21 @@ describe("inferEvaluatorMappings", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("input"),
     ]);
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      [
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [
         { identifier: "output", type: "str" },
         { identifier: "input", type: "str" }, // Target also has "input" as output
       ],
-    );
+    });
     const evaluatorInputs: Field[] = [{ identifier: "input", type: "str" }];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+    const mappings = inferEvaluatorMappings({
+      evaluatorInputs,
+      dataset,
+      target,
+    });
 
     // Should map to dataset, not target output
     expect(mappings.input?.type).toBe("source");
@@ -691,17 +724,21 @@ describe("inferEvaluatorMappings", () => {
       // shortcut, so `output` must stay empty rather than grab the dataset's
       // "output" column (the customer-reported self-grading bug). The
       // single-output auto-map is covered separately above.
-      const target = createTestTarget(
-        "target-1",
-        [{ identifier: "input", type: "str" }],
-        [
+      const target = createTestTarget({
+        id: "target-1",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [
           { identifier: "irrelevant", type: "str" },
           { identifier: "also_irrelevant", type: "str" },
         ],
-      );
+      });
       const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
 
-      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+      const mappings = inferEvaluatorMappings({
+        evaluatorInputs,
+        dataset,
+        target,
+      });
 
       expect(mappings.output).toBeUndefined();
     });
@@ -711,16 +748,20 @@ describe("inferEvaluatorMappings", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("irrelevant"),
       ]);
-      const target = createTestTarget(
-        "target-1",
-        [{ identifier: "input", type: "str" }],
-        [{ identifier: "expected_output", type: "str" }], // target has expected_output
-      );
+      const target = createTestTarget({
+        id: "target-1",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "expected_output", type: "str" }], // target has expected_output
+      });
       const evaluatorInputs: Field[] = [
         { identifier: "expected_output", type: "str" },
       ];
 
-      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+      const mappings = inferEvaluatorMappings({
+        evaluatorInputs,
+        dataset,
+        target,
+      });
 
       expect(mappings.expected_output).toBeUndefined();
     });
@@ -730,14 +771,18 @@ describe("inferEvaluatorMappings", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("irrelevant"),
       ]);
-      const target = createTestTarget(
-        "target-1",
-        [{ identifier: "input", type: "str" }],
-        [{ identifier: "input", type: "str" }], // target also emits an "input" output
-      );
+      const target = createTestTarget({
+        id: "target-1",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "input", type: "str" }], // target also emits an "input" output
+      });
       const evaluatorInputs: Field[] = [{ identifier: "input", type: "str" }];
 
-      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+      const mappings = inferEvaluatorMappings({
+        evaluatorInputs,
+        dataset,
+        target,
+      });
 
       expect(mappings.input).toBeUndefined();
     });
@@ -748,14 +793,18 @@ describe("inferEvaluatorMappings", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("irrelevant"),
       ]);
-      const target = createTestTarget(
-        "target-1",
-        [{ identifier: "input", type: "str" }],
-        [{ identifier: "score", type: "float" }],
-      );
+      const target = createTestTarget({
+        id: "target-1",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "score", type: "float" }],
+      });
       const evaluatorInputs: Field[] = [{ identifier: "score", type: "float" }];
 
-      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+      const mappings = inferEvaluatorMappings({
+        evaluatorInputs,
+        dataset,
+        target,
+      });
 
       expect(mappings.score?.type).toBe("source");
       if (mappings.score?.type === "source") {
@@ -772,10 +821,13 @@ describe("inferEvaluatorMappings", () => {
 
 describe("inferAllTargetMappings", () => {
   it("infers mappings for all datasets", () => {
-    const target = createTestTarget("target-1", [
-      { identifier: "input", type: "str" },
-      { identifier: "context", type: "str" },
-    ]);
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [
+        { identifier: "input", type: "str" },
+        { identifier: "context", type: "str" },
+      ],
+    });
     const datasets = [
       createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("input"),
@@ -815,11 +867,11 @@ describe("inferAllTargetMappings", () => {
   });
 
   it("preserves existing mappings", () => {
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      [{ identifier: "output", type: "str" }],
-      {
+    const target = createTestTarget({
+      id: "target-1",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      mappings: {
         "ds-1": {
           input: {
             type: "value",
@@ -827,7 +879,7 @@ describe("inferAllTargetMappings", () => {
           },
         },
       },
-    );
+    });
     const datasets = [
       createTestDataset("ds-1", "Dataset 1", [createTestColumn("input")]),
     ];

--- a/platform/app/src/experiments-v3/utils/computeAggregates.ts
+++ b/platform/app/src/experiments-v3/utils/computeAggregates.ts
@@ -65,12 +65,17 @@ export type TargetAggregate = {
 /**
  * Computes aggregate statistics for a target from evaluation results.
  */
-export const computeTargetAggregates = (
-  targetId: string,
-  results: EvaluationResults,
-  evaluators: Array<{ id: string }>,
-  rowCount: number,
-): TargetAggregate => {
+export const computeTargetAggregates = ({
+  targetId,
+  results,
+  evaluators,
+  rowCount,
+}: {
+  targetId: string;
+  results: EvaluationResults;
+  evaluators: Array<{ id: string }>;
+  rowCount: number;
+}): TargetAggregate => {
   const targetOutputs = results.targetOutputs[targetId] ?? [];
   const targetMetadata = results.targetMetadata?.[targetId] ?? [];
   const targetErrors = results.errors[targetId] ?? [];

--- a/platform/app/src/experiments-v3/utils/dslAdapter.ts
+++ b/platform/app/src/experiments-v3/utils/dslAdapter.ts
@@ -78,13 +78,13 @@ export const stateToWorkflow = (
     // Create evaluator nodes for ALL evaluators (they apply to all targets)
     // Evaluators are duplicated per-target in the DSL
     state.evaluators.forEach((evaluator, evalIndex) => {
-      const evaluatorNode = createEvaluatorNode(
+      const evaluatorNode = createEvaluatorNode({
         evaluator,
-        datasetId,
-        target.id,
+        activeDatasetId: datasetId,
+        targetId: target.id,
         targetIndex,
         evalIndex,
-      );
+      });
       evaluatorNodes.push(evaluatorNode);
     });
   });
@@ -257,13 +257,19 @@ const createHttpNode = (
  * Node ID is {targetId}.{evaluatorId} for clear result mapping back to the table.
  * Sets default values on inputs that have value mappings.
  */
-const createEvaluatorNode = (
-  evaluator: EvaluatorConfig,
-  activeDatasetId: string,
-  targetId: string,
-  targetIndex: number,
-  evalIndex: number,
-): Node<Evaluator> => {
+const createEvaluatorNode = ({
+  evaluator,
+  activeDatasetId,
+  targetId,
+  targetIndex,
+  evalIndex,
+}: {
+  evaluator: EvaluatorConfig;
+  activeDatasetId: string;
+  targetId: string;
+  targetIndex: number;
+  evalIndex: number;
+}): Node<Evaluator> => {
   // Get the mappings for this dataset and target
   const datasetMappings = evaluator.mappings[activeDatasetId];
   const targetMappings = datasetMappings?.[targetId] ?? {};

--- a/platform/app/src/experiments-v3/utils/executionScope.ts
+++ b/platform/app/src/experiments-v3/utils/executionScope.ts
@@ -175,15 +175,20 @@ export const countCellsForTarget = (
  * Count completed cells for a target based on results.
  * A cell is completed if it has an output or error.
  */
-export const countCompletedCellsForTarget = (
-  cellSet: Set<string>,
-  targetId: string,
+export const countCompletedCellsForTarget = ({
+  cellSet,
+  targetId,
+  results,
+  maxRowIndex,
+}: {
+  cellSet: Set<string>;
+  targetId: string;
   results: {
     targetOutputs: Record<string, unknown[]>;
     errors: Record<string, string[]>;
-  },
-  maxRowIndex: number,
-): number => {
+  };
+  maxRowIndex: number;
+}): number => {
   let count = 0;
   for (let i = 0; i <= maxRowIndex; i++) {
     if (cellSet.has(`${i}:${targetId}`)) {

--- a/platform/app/src/experiments-v3/utils/mappingInference.ts
+++ b/platform/app/src/experiments-v3/utils/mappingInference.ts
@@ -334,12 +334,17 @@ const DATASET_INPUT_FIELDS = new Set([
  * @param existingMappings - Any existing mappings to preserve
  * @returns New mappings to apply
  */
-export const inferEvaluatorMappings = (
-  evaluatorInputs: Field[],
-  dataset: DatasetReference,
-  target: TargetConfig,
-  existingMappings: Record<string, FieldMapping> = {},
-): Record<string, FieldMapping> => {
+export const inferEvaluatorMappings = ({
+  evaluatorInputs,
+  dataset,
+  target,
+  existingMappings = {},
+}: {
+  evaluatorInputs: Field[];
+  dataset: DatasetReference;
+  target: TargetConfig;
+  existingMappings?: Record<string, FieldMapping>;
+}): Record<string, FieldMapping> => {
   const newMappings: Record<string, FieldMapping> = {};
 
   for (const input of evaluatorInputs) {
@@ -477,12 +482,12 @@ export const inferAllEvaluatorMappings = (
   for (const dataset of datasets) {
     for (const target of targets) {
       const existingMappings = result[dataset.id]?.[target.id] ?? {};
-      const newMappings = inferEvaluatorMappings(
-        evaluator.inputs,
+      const newMappings = inferEvaluatorMappings({
+        evaluatorInputs: evaluator.inputs,
         dataset,
         target,
         existingMappings,
-      );
+      });
 
       if (Object.keys(newMappings).length > 0) {
         if (!result[dataset.id]) {

--- a/platform/app/src/experiments-v3/utils/promptEditorCallbacks.ts
+++ b/platform/app/src/experiments-v3/utils/promptEditorCallbacks.ts
@@ -43,12 +43,12 @@ export type CreatePromptEditorCallbacksParams = {
       }>;
     },
   ) => void;
-  setTargetMapping: (
-    targetId: string,
-    datasetId: string,
-    inputIdentifier: string,
-    mapping: StoreFieldMapping,
-  ) => void;
+  setTargetMapping: (params: {
+    targetId: string;
+    datasetId: string;
+    inputField: string;
+    mapping: StoreFieldMapping;
+  }) => void;
   removeTargetMapping: (
     targetId: string,
     datasetId: string,
@@ -168,12 +168,12 @@ export const createPromptEditorCallbacks = ({
       currentDatasets.some((d) => d.id === sourceId);
 
     if (mapping) {
-      setTargetMapping(
+      setTargetMapping({
         targetId,
-        currentActiveDatasetId,
-        identifier,
-        convertFromUIMapping(mapping, checkIsDatasetSource),
-      );
+        datasetId: currentActiveDatasetId,
+        inputField: identifier,
+        mapping: convertFromUIMapping(mapping, checkIsDatasetSource),
+      });
     } else {
       removeTargetMapping(targetId, currentActiveDatasetId, identifier);
     }

--- a/platform/app/src/features/automations/editors/liquidMonaco.ts
+++ b/platform/app/src/features/automations/editors/liquidMonaco.ts
@@ -626,9 +626,12 @@ export function setupLiquidJsonSchema(params: {
   // separators while a plain `*` does not, so `**/<basename>` is the right
   // shape. Basenames must be unique per editor — that's the caller's
   // responsibility (different editors must use different shadow URIs).
-  registerJsonSchema(monaco, shadowUri, schema, [
-    `**/${basenameOfUri(shadowUri)}`,
-  ]);
+  registerJsonSchema({
+    monaco,
+    modelUri: shadowUri,
+    schema,
+    fileMatch: [`**/${basenameOfUri(shadowUri)}`],
+  });
   const shadowResource = monaco.Uri.parse(shadowUri);
   // Re-mount safety: another instance with the same shadow URI may have left
   // a model behind if it was disposed mid-update.

--- a/platform/app/src/features/automations/editors/monacoSchemas.ts
+++ b/platform/app/src/features/automations/editors/monacoSchemas.ts
@@ -184,12 +184,17 @@ const registered = new Map<string, RegisteredEntry>();
  * stable editors). Callers with dynamic shadow URIs (e.g. the Liquid
  * substitution shadow) pass a basename pattern like `["**\/<basename>"]`.
  */
-export function registerJsonSchema(
-  monaco: Monaco,
-  modelUri: string,
-  schema: object,
-  fileMatch: string[] = [modelUri],
-): void {
+export function registerJsonSchema({
+  monaco,
+  modelUri,
+  schema,
+  fileMatch = [modelUri],
+}: {
+  monaco: Monaco;
+  modelUri: string;
+  schema: object;
+  fileMatch?: string[];
+}): void {
   registered.set(modelUri, { schema, fileMatch });
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
     validate: true,

--- a/platform/app/src/features/briefing/mocks/briefingMocks.ts
+++ b/platform/app/src/features/briefing/mocks/briefingMocks.ts
@@ -52,12 +52,17 @@ interface ScenarioShape {
   sessionHref?: string;
 }
 
-const bar = (
-  id: string,
-  label: string,
-  status: ScenarioBar["status"],
-  fillPct: number,
-): ScenarioBar => ({
+const bar = ({
+  id,
+  label,
+  status,
+  fillPct,
+}: {
+  id: string;
+  label: string;
+  status: ScenarioBar["status"];
+  fillPct: number;
+}): ScenarioBar => ({
   id,
   label,
   status,
@@ -104,9 +109,24 @@ const SCENARIOS: Record<ScenarioKey, ScenarioShape> = {
     pills: [{ label: "3 scenario sets" }],
     scenariosLabel: "Last run · 32 concurrent",
     bars: [
-      bar("a", "refund · within policy", "pass", 98),
-      bar("b", "refund · outside policy", "pass", 96),
-      bar("c", "partial refund · negotiation", "pass", 94),
+      bar({
+        id: "a",
+        label: "refund · within policy",
+        status: "pass",
+        fillPct: 98,
+      }),
+      bar({
+        id: "b",
+        label: "refund · outside policy",
+        status: "pass",
+        fillPct: 96,
+      }),
+      bar({
+        id: "c",
+        label: "partial refund · negotiation",
+        status: "pass",
+        fillPct: 94,
+      }),
     ],
     judge: { pass: 32, regressions: 0, note: "rubric audited" },
     sessionHref: "#",
@@ -127,10 +147,30 @@ const SCENARIOS: Record<ScenarioKey, ScenarioShape> = {
     ],
     scenariosLabel: "Last run · 32 concurrent · 6 to 9 turns each",
     bars: [
-      bar("a", "refund · within policy", "pass", 97),
-      bar("b", "refund · outside policy", "pass", 94),
-      bar("c", "angry escalation (DE)", "fail", 100),
-      bar("d", "partial refund · negotiation", "pass", 92),
+      bar({
+        id: "a",
+        label: "refund · within policy",
+        status: "pass",
+        fillPct: 97,
+      }),
+      bar({
+        id: "b",
+        label: "refund · outside policy",
+        status: "pass",
+        fillPct: 94,
+      }),
+      bar({
+        id: "c",
+        label: "angry escalation (DE)",
+        status: "fail",
+        fillPct: 100,
+      }),
+      bar({
+        id: "d",
+        label: "partial refund · negotiation",
+        status: "pass",
+        fillPct: 92,
+      }),
     ],
     judge: { pass: 28, regressions: 4, note: "rubric audited" },
     sessionHref: "#",
@@ -147,10 +187,25 @@ const SCENARIOS: Record<ScenarioKey, ScenarioShape> = {
     pills: [{ label: "2 scenario sets" }],
     scenariosLabel: "Last run · 18 concurrent",
     bars: [
-      bar("a", "checkout · happy path", "pass", 95),
-      bar("b", "checkout · declined card", "fail", 100),
-      bar("c", "address · ambiguous", "fail", 100),
-      bar("d", "refund · partial", "pass", 90),
+      bar({
+        id: "a",
+        label: "checkout · happy path",
+        status: "pass",
+        fillPct: 95,
+      }),
+      bar({
+        id: "b",
+        label: "checkout · declined card",
+        status: "fail",
+        fillPct: 100,
+      }),
+      bar({
+        id: "c",
+        label: "address · ambiguous",
+        status: "fail",
+        fillPct: 100,
+      }),
+      bar({ id: "d", label: "refund · partial", status: "pass", fillPct: 90 }),
     ],
     judge: { pass: 13, regressions: 5, note: "rubric audited" },
     sessionHref: "#",

--- a/platform/app/src/features/command-bar/CommandPalette.tsx
+++ b/platform/app/src/features/command-bar/CommandPalette.tsx
@@ -289,18 +289,18 @@ export function CommandPalette({
     typeof navigator !== "undefined" &&
     navigator.platform.toUpperCase().indexOf("MAC") >= 0;
 
-  const filteredCommands = useFilteredCommands(
+  const filteredCommands = useFilteredCommands({
     query,
-    publicEnv.data?.IS_SAAS,
-    project?.id,
-    publicEnv.data?.NODE_ENV === "development",
-  );
-  const filteredProjects = useFilteredProjects(
+    isSaas: publicEnv.data?.IS_SAAS,
+    projectId: project?.id,
+    isDevMode: publicEnv.data?.NODE_ENV === "development",
+  });
+  const filteredProjects = useFilteredProjects({
     query,
     organizations,
-    project?.slug,
-    session?.user?.id,
-  );
+    currentProjectSlug: project?.slug,
+    currentUserId: session?.user?.id,
+  });
 
   const {
     allItems,
@@ -309,16 +309,16 @@ export function CommandPalette({
     searchInDocsItem,
     easterEggItem,
     askLangyItem,
-  } = useCommandBarItems(
+  } = useCommandBarItems({
     query,
     filteredCommands,
     filteredProjects,
     searchResults,
     idResult,
     groupedItems,
-    project?.slug,
+    projectSlug: project?.slug,
     langyEnabled,
-  );
+  });
 
   const { triggerEffect } = useEasterEggEffects();
 
@@ -429,17 +429,28 @@ export function CommandPalette({
           return;
         }
 
-        handleCommandSelect(cmd, projectSlug, ctx, addRecentItem, openDrawer);
-      } else if (item.type === "search") {
-        handleSearchResultSelect(
-          item.data,
+        handleCommandSelect({
+          cmd,
           projectSlug,
           ctx,
           addRecentItem,
           openDrawer,
-        );
+        });
+      } else if (item.type === "search") {
+        handleSearchResultSelect({
+          result: item.data,
+          projectSlug,
+          ctx,
+          addRecentItem,
+          openDrawer,
+        });
       } else if (item.type === "recent") {
-        handleRecentItemSelect(item.data, ctx, addRecentItem, openDrawer);
+        handleRecentItemSelect({
+          item: item.data,
+          ctx,
+          addRecentItem,
+          openDrawer,
+        });
       } else if (item.type === "project") {
         handleProjectSelect(item.data, ctx, addRecentItem);
       }
@@ -524,15 +535,15 @@ export function CommandPalette({
   // straight to Langy. Reaching the assistant by arrowing to the bottom of a
   // list of places to go made the more capable of the two routes read as the
   // fallback after navigation failed to match.
-  const handleKeyDown = useCommandBarKeyboard(
+  const handleKeyDown = useCommandBarKeyboard({
     allItems,
     selectedIndex,
     setSelectedIndex,
     handleSelect,
     handleCopyLink,
     isMac,
-    langyEnabled ? enterLangyMode : undefined,
-  );
+    onAskLangy: langyEnabled ? enterLangyMode : undefined,
+  });
 
   if (langyMode) {
     return (

--- a/platform/app/src/features/command-bar/hooks/useCommandBarItems.ts
+++ b/platform/app/src/features/command-bar/hooks/useCommandBarItems.ts
@@ -15,16 +15,25 @@ import type { FilteredProject } from "./useFilteredProjects";
 /**
  * Hook that builds the flat list of all items for keyboard navigation and display.
  */
-export function useCommandBarItems(
-  query: string,
-  filteredCommands: FilteredCommands,
-  filteredProjects: FilteredProject[],
-  searchResults: SearchResult[],
-  idResult: SearchResult | null,
-  groupedItems: GroupedRecentItems,
-  projectSlug: string | undefined,
-  langyEnabled: boolean,
-): {
+export function useCommandBarItems({
+  query,
+  filteredCommands,
+  filteredProjects,
+  searchResults,
+  idResult,
+  groupedItems,
+  projectSlug,
+  langyEnabled,
+}: {
+  query: string;
+  filteredCommands: FilteredCommands;
+  filteredProjects: FilteredProject[];
+  searchResults: SearchResult[];
+  idResult: SearchResult | null;
+  groupedItems: GroupedRecentItems;
+  projectSlug: string | undefined;
+  langyEnabled: boolean;
+}): {
   allItems: ListItem[];
   recentItemsLimited: RecentItem[];
   searchInTracesItem: ListItem | null;

--- a/platform/app/src/features/command-bar/hooks/useCommandBarKeyboard.ts
+++ b/platform/app/src/features/command-bar/hooks/useCommandBarKeyboard.ts
@@ -4,13 +4,21 @@ import type { ListItem } from "../getIconInfo";
 /**
  * Hook that handles keyboard navigation and shortcuts for the command bar.
  */
-export function useCommandBarKeyboard(
-  allItems: ListItem[],
-  selectedIndex: number,
-  setSelectedIndex: (index: number | ((prev: number) => number)) => void,
-  handleSelect: (item: ListItem, newTab?: boolean) => void,
-  handleCopyLink: () => void,
-  isMac: boolean,
+export function useCommandBarKeyboard({
+  allItems,
+  selectedIndex,
+  setSelectedIndex,
+  handleSelect,
+  handleCopyLink,
+  isMac,
+  onAskLangy,
+}: {
+  allItems: ListItem[];
+  selectedIndex: number;
+  setSelectedIndex: (index: number | ((prev: number) => number)) => void;
+  handleSelect: (item: ListItem, newTab?: boolean) => void;
+  handleCopyLink: () => void;
+  isMac: boolean;
   /**
    * Hand what is typed to Langy, on Tab.
    *
@@ -18,8 +26,8 @@ export function useCommandBarKeyboard(
    * through to its normal job of moving focus: a shortcut that silently does
    * nothing is worse than one that was never offered.
    */
-  onAskLangy?: () => void,
-) {
+  onAskLangy?: () => void;
+}) {
   return useCallback(
     (e: React.KeyboardEvent) => {
       const modKey = isMac ? e.metaKey : e.ctrlKey;

--- a/platform/app/src/features/command-bar/hooks/useFilteredCommands.ts
+++ b/platform/app/src/features/command-bar/hooks/useFilteredCommands.ts
@@ -34,12 +34,17 @@ export interface FilteredCommands {
  * Hook for filtering commands based on search query.
  * Handles category-based and keyword-based filtering.
  */
-export function useFilteredCommands(
-  query: string,
-  isSaas: boolean | undefined,
-  projectId: string | undefined,
-  isDevMode: boolean,
-): FilteredCommands {
+export function useFilteredCommands({
+  query,
+  isSaas,
+  projectId,
+  isDevMode,
+}: {
+  query: string;
+  isSaas: boolean | undefined;
+  projectId: string | undefined;
+  isDevMode: boolean;
+}): FilteredCommands {
   const { hasAccess: hasOpsAccess } = useOpsPermission();
 
   const availableNavCommands = useMemo(() => {

--- a/platform/app/src/features/command-bar/hooks/useFilteredProjects.ts
+++ b/platform/app/src/features/command-bar/hooks/useFilteredProjects.ts
@@ -28,12 +28,17 @@ interface Organization {
  * Filters by project name, organization name, or team name.
  * Only includes projects from teams where the current user is a member.
  */
-export function useFilteredProjects(
-  query: string,
-  organizations: Organization[] | undefined,
-  currentProjectSlug: string | undefined,
-  currentUserId: string | undefined,
-): FilteredProject[] {
+export function useFilteredProjects({
+  query,
+  organizations,
+  currentProjectSlug,
+  currentUserId,
+}: {
+  query: string;
+  organizations: Organization[] | undefined;
+  currentProjectSlug: string | undefined;
+  currentUserId: string | undefined;
+}): FilteredProject[] {
   return useMemo(() => {
     if (!organizations || !query.trim()) return [];
 

--- a/platform/app/src/features/command-bar/selectHandlers.ts
+++ b/platform/app/src/features/command-bar/selectHandlers.ts
@@ -40,13 +40,19 @@ export function createNavigate(ctx: NavigationContext) {
 /**
  * Handle selection of a command item.
  */
-export function handleCommandSelect(
-  cmd: Command,
-  projectSlug: string,
-  ctx: NavigationContext,
-  addRecentItem: AddRecentItem,
-  openDrawer: OpenDrawer,
-) {
+export function handleCommandSelect({
+  cmd,
+  projectSlug,
+  ctx,
+  addRecentItem,
+  openDrawer,
+}: {
+  cmd: Command;
+  projectSlug: string;
+  ctx: NavigationContext;
+  addRecentItem: AddRecentItem;
+  openDrawer: OpenDrawer;
+}) {
   const navigate = createNavigate(ctx);
 
   if (cmd.category === "navigation" && cmd.path) {
@@ -121,13 +127,19 @@ export function handleCommandSelect(
 /**
  * Handle selection of a search result item.
  */
-export function handleSearchResultSelect(
-  result: SearchResult,
-  projectSlug: string,
-  ctx: NavigationContext,
-  addRecentItem: AddRecentItem,
-  openDrawer: OpenDrawer,
-) {
+export function handleSearchResultSelect({
+  result,
+  projectSlug,
+  ctx,
+  addRecentItem,
+  openDrawer,
+}: {
+  result: SearchResult;
+  projectSlug: string;
+  ctx: NavigationContext;
+  addRecentItem: AddRecentItem;
+  openDrawer: OpenDrawer;
+}) {
   const navigate = createNavigate(ctx);
 
   // Check if this should open a drawer instead of navigating
@@ -159,12 +171,17 @@ export function handleSearchResultSelect(
 /**
  * Handle selection of a recent item.
  */
-export function handleRecentItemSelect(
-  item: RecentItem,
-  ctx: NavigationContext,
-  addRecentItem: AddRecentItem,
-  openDrawer: OpenDrawer,
-) {
+export function handleRecentItemSelect({
+  item,
+  ctx,
+  addRecentItem,
+  openDrawer,
+}: {
+  item: RecentItem;
+  ctx: NavigationContext;
+  addRecentItem: AddRecentItem;
+  openDrawer: OpenDrawer;
+}) {
   const navigate = createNavigate(ctx);
 
   addRecentItem({

--- a/platform/app/src/features/errors/logic/__tests__/readHandledError.unit.test.ts
+++ b/platform/app/src/features/errors/logic/__tests__/readHandledError.unit.test.ts
@@ -427,12 +427,17 @@ describe("readAuthoredMessage", () => {
   // the only place that can tell copy from an accident — it needs `cause`, and
   // `cause` never crosses the wire. Default it on here so each test says what
   // it is actually about.
-  const trpcError = (
-    httpStatus: number,
-    message: string,
-    error: unknown = null,
+  const trpcError = ({
+    httpStatus,
+    message,
+    error = null,
     authored = true,
-  ) => ({
+  }: {
+    httpStatus: number;
+    message: string;
+    error?: unknown;
+    authored?: boolean;
+  }) => ({
     message,
     data: { httpStatus, error, authored },
   });
@@ -442,12 +447,17 @@ describe("readAuthoredMessage", () => {
     it("returns the prose the procedure authored", () => {
       // These are real: user.register throws them, and #5984 deliberately
       // left non-5xx messages alone.
-      expect(readAuthoredMessage(trpcError(409, "User already exists"))).toBe(
-        "User already exists",
-      );
       expect(
         readAuthoredMessage(
-          trpcError(429, "Too many signup attempts. Please try again later."),
+          trpcError({ httpStatus: 409, message: "User already exists" }),
+        ),
+      ).toBe("User already exists");
+      expect(
+        readAuthoredMessage(
+          trpcError({
+            httpStatus: 429,
+            message: "Too many signup attempts. Please try again later.",
+          }),
         ),
       ).toBe("Too many signup attempts. Please try again later.");
     });
@@ -457,9 +467,10 @@ describe("readAuthoredMessage", () => {
     it("declines a handled error — its copy comes from the registry", () => {
       expect(
         readAuthoredMessage(
-          trpcError(404, "trace_not_found", {
-            code: "trace_not_found",
+          trpcError({
             httpStatus: 404,
+            message: "trace_not_found",
+            error: { code: "trace_not_found", httpStatus: 404 },
           }),
         ),
       ).toBeUndefined();
@@ -467,13 +478,20 @@ describe("readAuthoredMessage", () => {
 
     it("declines a 5xx — its message can carry internals", () => {
       expect(
-        readAuthoredMessage(trpcError(500, "connect ECONNREFUSED 10.0.0.4")),
+        readAuthoredMessage(
+          trpcError({
+            httpStatus: 500,
+            message: "connect ECONNREFUSED 10.0.0.4",
+          }),
+        ),
       ).toBeUndefined();
     });
 
     it("declines anything shaped like a code slug", () => {
       expect(
-        readAuthoredMessage(trpcError(422, "validation_error")),
+        readAuthoredMessage(
+          trpcError({ httpStatus: 422, message: "validation_error" }),
+        ),
       ).toBeUndefined();
     });
 
@@ -481,7 +499,10 @@ describe("readAuthoredMessage", () => {
       // The registry has several. Matching on shape alone let these through
       // and rendered a slug as though it were a sentence.
       for (const code of ["unauthorized", "not_found", "internal_error"]) {
-        expect(readAuthoredMessage(trpcError(401, code)), code).toBeUndefined();
+        expect(
+          readAuthoredMessage(trpcError({ httpStatus: 401, message: code })),
+          code,
+        ).toBeUndefined();
       }
     });
 
@@ -505,7 +526,14 @@ describe("readAuthoredMessage", () => {
       // `new TRPCError({ code: "NOT_FOUND" })` with no message: tRPC uses the
       // code name, so the customer read "NOT_FOUND".
       expect(
-        readAuthoredMessage(trpcError(404, "NOT_FOUND", null, false)),
+        readAuthoredMessage(
+          trpcError({
+            httpStatus: 404,
+            message: "NOT_FOUND",
+            error: null,
+            authored: false,
+          }),
+        ),
       ).toBeUndefined();
     });
 
@@ -514,15 +542,33 @@ describe("readAuthoredMessage", () => {
       // `new TRPCError({ code: "BAD_REQUEST", cause: err })` inherits the
       // caught error's message — a driver string, presented as our own copy.
       expect(
-        readAuthoredMessage(trpcError(400, "fetch failed", null, false)),
+        readAuthoredMessage(
+          trpcError({
+            httpStatus: 400,
+            message: "fetch failed",
+            error: null,
+            authored: false,
+          }),
+        ),
       ).toBeUndefined();
       expect(
-        readAuthoredMessage(trpcError(400, "Invalid time value", null, false)),
+        readAuthoredMessage(
+          trpcError({
+            httpStatus: 400,
+            message: "Invalid time value",
+            error: null,
+            authored: false,
+          }),
+        ),
       ).toBeUndefined();
     });
 
     it("declines SCREAMING_CASE even if something marked it authored", () => {
-      expect(readAuthoredMessage(trpcError(404, "NOT_FOUND"))).toBeUndefined();
+      expect(
+        readAuthoredMessage(
+          trpcError({ httpStatus: 404, message: "NOT_FOUND" }),
+        ),
+      ).toBeUndefined();
     });
   });
 
@@ -539,7 +585,9 @@ describe("readAuthoredMessage", () => {
       "This is only available at Enterprise (contact sales).",
       "The IP 10.0.0.1 is not allowed as a webhook destination.",
     ])("keeps %s", (message) => {
-      expect(readAuthoredMessage(trpcError(400, message))).toBe(message);
+      expect(readAuthoredMessage(trpcError({ httpStatus: 400, message }))).toBe(
+        message,
+      );
     });
 
     /** @scenario "A machine's diagnostic is not mistaken for authored copy" */
@@ -550,7 +598,9 @@ describe("readAuthoredMessage", () => {
       ["a stack frame", "boom\n    at Object.handler (/app/index.js:1:1)"],
       ["a runtime error prefix", "TypeError: cannot read properties of null"],
     ])("still refuses %s", (_label, message) => {
-      expect(readAuthoredMessage(trpcError(400, message))).toBeUndefined();
+      expect(
+        readAuthoredMessage(trpcError({ httpStatus: 400, message })),
+      ).toBeUndefined();
     });
   });
 });

--- a/platform/app/src/features/langy/__tests__/Composer.modelPicker.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/Composer.modelPicker.integration.test.tsx
@@ -23,7 +23,13 @@ vi.mock("~/components/ModelSelector", () => ({
   ModelSelector: ({ model }: { model: string }) => (
     <div data-testid="model-selector">{model}</div>
   ),
-  useModelSelectionOptions: (options: string[], model: string) => ({
+  useModelSelectionOptions: ({
+    options,
+    model,
+  }: {
+    options: string[];
+    model: string;
+  }) => ({
     selectOptions: options.map((value) => ({
       value,
       label: value.split("/").slice(1).join("/"),

--- a/platform/app/src/features/langy/__tests__/ComposerPalettes.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/ComposerPalettes.integration.test.tsx
@@ -20,7 +20,13 @@ vi.mock("~/components/ModelSelector", () => ({
   ModelSelector: ({ model }: { model: string }) => (
     <div data-testid="model-selector">{model}</div>
   ),
-  useModelSelectionOptions: (options: string[], model: string) => ({
+  useModelSelectionOptions: ({
+    options,
+    model,
+  }: {
+    options: string[];
+    model: string;
+  }) => ({
     selectOptions: options.map((value) => ({
       value,
       label: value,

--- a/platform/app/src/features/langy/__tests__/LangyComposerRecordedTurn.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/LangyComposerRecordedTurn.integration.test.tsx
@@ -27,7 +27,13 @@ vi.mock("~/components/ModelSelector", () => ({
   ModelSelector: ({ model }: { model: string }) => (
     <div data-testid="model-selector">{model}</div>
   ),
-  useModelSelectionOptions: (options: string[], model: string) => ({
+  useModelSelectionOptions: ({
+    options,
+    model,
+  }: {
+    options: string[];
+    model: string;
+  }) => ({
     selectOptions: options.map((value) => ({
       value,
       label: value,

--- a/platform/app/src/features/langy/__tests__/langyTimeTravel.unit.test.ts
+++ b/platform/app/src/features/langy/__tests__/langyTimeTravel.unit.test.ts
@@ -77,12 +77,17 @@ const responded = (atMs: number, turnId: string, eventAt: number) =>
     },
   } as never);
 
-const historyRow = (
-  id: string,
-  role: "user" | "assistant",
-  createdAtMs: number,
-  text: string,
-): LangyMessageDto => ({
+const historyRow = ({
+  id,
+  role,
+  createdAtMs,
+  text,
+}: {
+  id: string;
+  role: "user" | "assistant";
+  createdAtMs: number;
+  text: string;
+}): LangyMessageDto => ({
   id,
   role,
   parts: [{ type: "text", text }],
@@ -158,7 +163,12 @@ describe("buildTimeTravelView", () => {
         records,
         scrubSeq: 1,
         historyMessages: [
-          historyRow("msg-t1", "assistant", 1_999, "the full answer"),
+          historyRow({
+            id: "msg-t1",
+            role: "assistant",
+            createdAtMs: 1_999,
+            text: "the full answer",
+          }),
         ],
       });
       expect(view!.messages.filter((m) => m.id === "msg-t1")).toHaveLength(1);
@@ -177,8 +187,18 @@ describe("buildTimeTravelView", () => {
         records,
         scrubSeq: 1,
         historyMessages: [
-          historyRow("q1", "user", 1_000, "first question"),
-          historyRow("q2", "user", 2_400, "second question"),
+          historyRow({
+            id: "q1",
+            role: "user",
+            createdAtMs: 1_000,
+            text: "first question",
+          }),
+          historyRow({
+            id: "q2",
+            role: "user",
+            createdAtMs: 2_400,
+            text: "second question",
+          }),
         ],
       });
       expect(view!.messages.map((m) => m.id)).toEqual(["q1", "msg-t1", "q2"]);
@@ -196,7 +216,14 @@ describe("buildTimeTravelView", () => {
       const view = buildTimeTravelView({
         records,
         scrubSeq: 3,
-        historyMessages: [historyRow("q1", "user", 1_500, "same question")],
+        historyMessages: [
+          historyRow({
+            id: "q1",
+            role: "user",
+            createdAtMs: 1_500,
+            text: "same question",
+          }),
+        ],
       });
       expect(view!.messages.filter((m) => m.role === "user")).toHaveLength(1);
       expect(view!.messages[0]!.id).toBe("q1");
@@ -223,9 +250,14 @@ describe("buildTimeTravelView", () => {
         records,
         scrubSeq: 5,
         historyMessages: [
-          historyRow("q1", "user", 990, "hey"),
+          historyRow({ id: "q1", role: "user", createdAtMs: 990, text: "hey" }),
           // Server clock: stamped just BEFORE the client saw the last delta.
-          historyRow("a1", "assistant", 1_390, "How can I help?"),
+          historyRow({
+            id: "a1",
+            role: "assistant",
+            createdAtMs: 1_390,
+            text: "How can I help?",
+          }),
         ],
       });
       expect(view!.messages.filter((m) => m.role === "assistant")).toHaveLength(
@@ -249,8 +281,13 @@ describe("buildTimeTravelView", () => {
         // The FIRST delta: the row (1_390) is later than this moment (1_300).
         scrubSeq: 3,
         historyMessages: [
-          historyRow("q1", "user", 990, "hey"),
-          historyRow("a1", "assistant", 1_390, "How can I help?"),
+          historyRow({ id: "q1", role: "user", createdAtMs: 990, text: "hey" }),
+          historyRow({
+            id: "a1",
+            role: "assistant",
+            createdAtMs: 1_390,
+            text: "How can I help?",
+          }),
         ],
       });
       const assistants = view!.messages.filter((m) => m.role === "assistant");
@@ -273,8 +310,13 @@ describe("buildTimeTravelView", () => {
         records,
         scrubSeq: 4,
         historyMessages: [
-          historyRow("q1", "user", 990, "hey"),
-          historyRow("a1", "assistant", 1_390, "How can I help?"),
+          historyRow({ id: "q1", role: "user", createdAtMs: 990, text: "hey" }),
+          historyRow({
+            id: "a1",
+            role: "assistant",
+            createdAtMs: 1_390,
+            text: "How can I help?",
+          }),
         ],
       });
       // The landed answer suppresses ITS partial, not the follow-up question.
@@ -297,8 +339,18 @@ describe("buildTimeTravelView", () => {
         records,
         scrubSeq: 1,
         historyMessages: [
-          historyRow("m-old", "assistant", 500, "before the moment"),
-          historyRow("m-future", "assistant", 5_000, "after the moment"),
+          historyRow({
+            id: "m-old",
+            role: "assistant",
+            createdAtMs: 500,
+            text: "before the moment",
+          }),
+          historyRow({
+            id: "m-future",
+            role: "assistant",
+            createdAtMs: 5_000,
+            text: "after the moment",
+          }),
         ],
       });
       expect(view!.messages.map((m) => m.id)).toContain("m-old");

--- a/platform/app/src/features/langy/components/LangyModelPill.tsx
+++ b/platform/app/src/features/langy/components/LangyModelPill.tsx
@@ -122,12 +122,12 @@ export function LangyModelPill({
 }) {
   // Langy is a licensed codex surface: declaring `langy.chat` re-admits
   // codex models the shared hook fail-closes everywhere else.
-  const { selectOptions, modelOption } = useModelSelectionOptions(
+  const { selectOptions, modelOption } = useModelSelectionOptions({
     options,
     model,
-    "chat",
-    { featureKey: LANGY_CHAT_FEATURE_KEY },
-  );
+    mode: "chat",
+    featureKey: LANGY_CHAT_FEATURE_KEY,
+  });
   const currentProvider = model.split("/")[0] ?? "";
   const hasCurrentProvider = currentProvider in modelProviderIcons;
   const modelsLoading = options.length === 0 && selectOptions.length === 0;

--- a/platform/app/src/features/langy/components/LangyPanel.tsx
+++ b/platform/app/src/features/langy/components/LangyPanel.tsx
@@ -264,6 +264,7 @@ function useViewportWidth(): number {
   return width;
 }
 
+// biome-ignore lint/complexity/useMaxParams: React's <Profiler onRender> callback contract fixes this positional parameter list
 function onLangyProfilerRender(
   id: string,
   phase: "mount" | "update" | "nested-update",

--- a/platform/app/src/features/langy/logic/langyWaveMotion.ts
+++ b/platform/app/src/features/langy/logic/langyWaveMotion.ts
@@ -188,12 +188,17 @@ export function deriveWaveActivity({
 }
 
 /** Exponential approach with a real time constant — frame-rate independent. */
-function approach(
-  current: number,
-  target: number,
-  dt: number,
-  tau: number,
-): number {
+function approach({
+  current,
+  target,
+  dt,
+  tau,
+}: {
+  current: number;
+  target: number;
+  dt: number;
+  tau: number;
+}): number {
   return current + (target - current) * (1 - Math.exp(-dt / tau));
 }
 
@@ -212,22 +217,33 @@ export function stepWaveMotion({
 }): LangyWaveMotion {
   const target = WAVE_MOTION_TARGETS[activity];
   return {
-    energy: approach(
-      current.energy,
-      target.energy,
+    energy: approach({
+      current: current.energy,
+      target: target.energy,
       dt,
-      target.energy > current.energy
-        ? WAVE_ENERGY_RISE_TAU_S
-        : WAVE_ENERGY_FALL_TAU_S,
-    ),
-    drift: approach(current.drift, target.drift, dt, WAVE_CHARACTER_TAU_S),
-    flutter: approach(
-      current.flutter,
-      target.flutter,
+      tau:
+        target.energy > current.energy
+          ? WAVE_ENERGY_RISE_TAU_S
+          : WAVE_ENERGY_FALL_TAU_S,
+    }),
+    drift: approach({
+      current: current.drift,
+      target: target.drift,
       dt,
-      WAVE_CHARACTER_TAU_S,
-    ),
-    pulse: approach(current.pulse, target.pulse, dt, WAVE_CHARACTER_TAU_S),
+      tau: WAVE_CHARACTER_TAU_S,
+    }),
+    flutter: approach({
+      current: current.flutter,
+      target: target.flutter,
+      dt,
+      tau: WAVE_CHARACTER_TAU_S,
+    }),
+    pulse: approach({
+      current: current.pulse,
+      target: target.pulse,
+      dt,
+      tau: WAVE_CHARACTER_TAU_S,
+    }),
   };
 }
 

--- a/platform/app/src/features/onboarding/components/sections/model-provider/ModelProviderSetup.tsx
+++ b/platform/app/src/features/onboarding/components/sections/model-provider/ModelProviderSetup.tsx
@@ -219,13 +219,13 @@ export const ModelProviderSetup: React.FC<ModelProviderSetupProps> = ({
     isValidating: isValidatingApiKey,
     validationError: apiKeyValidationError,
     clearError: clearApiKeyError,
-  } = useModelProviderApiKeyValidation(
-    backendModelProviderKey,
-    state.customKeys,
+  } = useModelProviderApiKeyValidation({
+    provider: backendModelProviderKey,
+    customKeys: state.customKeys,
     projectId,
-    organization?.id,
-    state.scopes,
-  );
+    organizationId: organization?.id,
+    scopes: state.scopes,
+  });
 
   // The same gate the settings drawer uses. Without it this surface — which
   // includes the "Langy needs a model to get started" step, where there is no

--- a/platform/app/src/features/traces-v2/components/SearchBar/filterHighlight.ts
+++ b/platform/app/src/features/traces-v2/components/SearchBar/filterHighlight.ts
@@ -222,12 +222,17 @@ function isPositionCoveredBySlot(
   return false;
 }
 
-function walkAst(
-  node: LiqeQuery,
-  negated: boolean,
-  baseOffset: number,
-  plan: DecorationPlan,
-): void {
+function walkAst({
+  node,
+  negated,
+  baseOffset,
+  plan,
+}: {
+  node: LiqeQuery;
+  negated: boolean;
+  baseOffset: number;
+  plan: DecorationPlan;
+}): void {
   switch (node.type) {
     case "Tag": {
       const tag = node as TagToken;
@@ -280,12 +285,17 @@ function walkAst(
         to: baseOffset + unary.location.start + kwLen,
         className: "filter-keyword filter-keyword-not",
       });
-      walkAst(unary.operand, negated !== isNeg, baseOffset, plan);
+      walkAst({
+        node: unary.operand,
+        negated: negated !== isNeg,
+        baseOffset,
+        plan,
+      });
       return;
     }
     case "LogicalExpression": {
       const logic = node as LogicalExpressionToken;
-      walkAst(logic.left, negated, baseOffset, plan);
+      walkAst({ node: logic.left, negated, baseOffset, plan });
       if (logic.operator.type === "BooleanOperator") {
         const op = logic.operator;
         plan.slots.push({
@@ -298,7 +308,7 @@ function walkAst(
           opLoc: { start: op.location.start, end: op.location.end },
         });
       }
-      walkAst(logic.right, negated, baseOffset, plan);
+      walkAst({ node: logic.right, negated, baseOffset, plan });
       return;
     }
     case "ParenthesizedExpression": {
@@ -313,7 +323,7 @@ function walkAst(
         to: baseOffset + paren.location.end,
         className: "filter-paren",
       });
-      walkAst(paren.expression, negated, baseOffset, plan);
+      walkAst({ node: paren.expression, negated, baseOffset, plan });
       return;
     }
   }
@@ -371,7 +381,12 @@ export function buildDecorationPlan(
   try {
     const ast = cachedParse(trimmed);
     const plan: DecorationPlan = { slots: [], tokens: [], leadingWs };
-    walkAst(ast, false, baseOffset + leadingWs, plan);
+    walkAst({
+      node: ast,
+      negated: false,
+      baseOffset: baseOffset + leadingWs,
+      plan,
+    });
     flagOperatorShapedTypos(normalized, baseOffset, plan);
     return plan;
   } catch {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/LlmPanel.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/LlmPanel.tsx
@@ -58,7 +58,7 @@ export function LlmPanel({ trace, spans }: LlmPanelProps) {
   const { events } = useTraceEvents();
 
   const markdown = useMemo(
-    () => buildTraceMarkdown(trace, spans, config, fullSpans, events),
+    () => buildTraceMarkdown({ trace, spans, opts: config, fullSpans, events }),
     [trace, spans, config, fullSpans, events],
   );
   const chunks = useMemo(() => splitTraceMarkdown(markdown), [markdown]);

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/buildTraceMarkdown.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/buildTraceMarkdown.ts
@@ -581,13 +581,19 @@ function renderUnicodeFlame(spans: SpanTreeNode[], width: number): string[] {
   return lines;
 }
 
-export function buildTraceMarkdown(
-  trace: TraceHeader,
-  spans: SpanTreeNode[],
-  opts: MarkdownConfig,
-  fullSpans?: FullSpan[],
-  events: DerivedTraceEvent[] = [],
-): string {
+export function buildTraceMarkdown({
+  trace,
+  spans,
+  opts,
+  fullSpans,
+  events = [],
+}: {
+  trace: TraceHeader;
+  spans: SpanTreeNode[];
+  opts: MarkdownConfig;
+  fullSpans?: FullSpan[];
+  events?: DerivedTraceEvent[];
+}): string {
   const lines: string[] = [];
 
   // Header — real markdown so the rendered view has hierarchy: an h1

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/sequenceView/mermaid.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/sequenceView/mermaid.ts
@@ -80,12 +80,17 @@ interface BuildContext {
   processed: Set<string>;
 }
 
-function registerParticipant(
-  ctx: BuildContext,
-  span: SpanTreeNode,
-  id: string,
-  display: string,
-) {
+function registerParticipant({
+  ctx,
+  span,
+  id,
+  display,
+}: {
+  ctx: BuildContext;
+  span: SpanTreeNode;
+  id: string;
+  display: string;
+}) {
   if (!ctx.participants.has(id)) {
     ctx.participants.add(id);
     ctx.participantDisplay.set(id, display);
@@ -156,7 +161,7 @@ function processSpan(
   const display = getParticipantDisplay(span);
   const currentParticipant = id && display ? id : null;
   if (currentParticipant && display) {
-    registerParticipant(ctx, span, currentParticipant, display);
+    registerParticipant({ ctx, span, id: currentParticipant, display });
   }
 
   const isInteraction =
@@ -227,7 +232,7 @@ export function generateMermaidSyntax(
   for (const span of ordered) {
     const id = getParticipantId(span);
     const display = getParticipantDisplay(span);
-    if (id && display) registerParticipant(ctx, span, id, display);
+    if (id && display) registerParticipant({ ctx, span, id, display });
   }
 
   const spanById = new Map(spans.map((s) => [s.spanId, s]));

--- a/platform/app/src/features/traces-v2/components/TraceTable/TraceTableShell.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/TraceTableShell.tsx
@@ -633,18 +633,23 @@ function SortableHeaderButton({
   );
 }
 
-export function cellPropsFor(
+export function cellPropsFor({
+  cell,
+  leftBorderColor,
+  index,
+  rightBorderColor,
+}: {
   cell: {
     column: {
       id: string;
       getSize: () => number;
       columnDef: { size?: number; minSize?: number; meta?: unknown };
     };
-  },
-  leftBorderColor?: Color,
-  index?: number,
-  rightBorderColor?: Color,
-): {
+  };
+  leftBorderColor?: Color;
+  index?: number;
+  rightBorderColor?: Color;
+}): {
   textAlign: "left" | "right";
   width: string | undefined;
   minWidth: string;

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/RegistryRow.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/RegistryRow.tsx
@@ -186,6 +186,18 @@ function RegistryRowComponent<TRow>({
   // direct hover.
   const showExpandedBg = hoverScope === "split" && isExpanded && !!expandedBg;
 
+  // Cell-independent render context, built once per row rather than per cell.
+  const cellCtx = {
+    row: tanstackRow.original,
+    density: tokens,
+    densityMode,
+    isExpanded,
+    isSelected,
+    isFocused,
+    actions,
+    enabledAddonIds: addons,
+  };
+
   const mainRow = (
     <Tr
       outline={isFocused ? "1px solid" : undefined}
@@ -290,7 +302,11 @@ function RegistryRowComponent<TRow>({
             // `whiteSpace=nowrap` themselves; the Td-level clip is the
             // belt-and-suspenders that catches anything that doesn't.
             overflow="hidden"
-            {...cellPropsFor(cell, style.borderColor, i)}
+            {...cellPropsFor({
+              cell,
+              leftBorderColor: style.borderColor,
+              index: i,
+            })}
           >
             {isLoading ? (
               isSelectCell ? (
@@ -303,15 +319,11 @@ function RegistryRowComponent<TRow>({
                 />
               )
             ) : (
-              pickCell(registry, cell.column.id, densityMode, {
-                row: tanstackRow.original,
-                density: tokens,
-                densityMode,
-                isExpanded,
-                isSelected,
-                isFocused,
-                actions,
-                enabledAddonIds: addons,
+              pickCell({
+                registry,
+                id: cell.column.id,
+                density: densityMode,
+                ctx: cellCtx,
               })
             )}
           </Td>

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/addons/conversation/CompactTurns.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/addons/conversation/CompactTurns.tsx
@@ -192,7 +192,7 @@ const ConversationTurnRow: React.FC<ConversationTurnRowProps> = ({
             style={i === 0 ? { backgroundColor: firstCellBg } : undefined}
             padding={`${density.rowPaddingY} 8px`}
             overflow="hidden"
-            {...cellPropsFor(cell, borderColor, i)}
+            {...cellPropsFor({ cell, leftBorderColor: borderColor, index: i })}
           >
             {turnCellContent({ columnId: cell.column.id, trace, turnIndex })}
           </Td>

--- a/platform/app/src/features/traces-v2/components/TraceTable/registry/types.ts
+++ b/platform/app/src/features/traces-v2/components/TraceTable/registry/types.ts
@@ -79,12 +79,17 @@ export interface Registry<TRow> {
   addons: Record<string, AddonDef<TRow>>;
 }
 
-export function pickCell<TRow>(
-  registry: Registry<TRow>,
-  id: string,
-  density: Density,
-  ctx: CellRenderContext<TRow>,
-): ReactNode {
+export function pickCell<TRow>({
+  registry,
+  id,
+  density,
+  ctx,
+}: {
+  registry: Registry<TRow>;
+  id: string;
+  density: Density;
+  ctx: CellRenderContext<TRow>;
+}): ReactNode {
   const def = registry.cells[id];
   if (!def) return null;
   if (density === "compact" && def.renderCompact) return def.renderCompact(ctx);

--- a/platform/app/src/features/traces-v2/onboarding/spotlights/DrawerSpotlights.tsx
+++ b/platform/app/src/features/traces-v2/onboarding/spotlights/DrawerSpotlights.tsx
@@ -114,7 +114,12 @@ export function DrawerSpotlights({
         next !== null &&
         isAnchorParkedOffscreen(next, window.innerWidth, window.scrollX);
       if (
-        isAnchorSettled(next, previous, window.innerWidth, window.scrollX) ||
+        isAnchorSettled({
+          next,
+          previous,
+          viewportWidth: window.innerWidth,
+          scrollX: window.scrollX,
+        }) ||
         frames >= MAX_FRAMES
       ) {
         setAnchorRect(next);

--- a/platform/app/src/features/traces-v2/onboarding/spotlights/SpotlightOverlay.tsx
+++ b/platform/app/src/features/traces-v2/onboarding/spotlights/SpotlightOverlay.tsx
@@ -129,12 +129,17 @@ export function isAnchorParkedOffscreen(
  * strand the fixed ring and its full-viewport scrim off the visible screen.
  * Spec: the drawer companion ride, specs/langy/langy-panel-layout.feature.
  */
-export function isAnchorSettled(
-  next: AnchorRect | null,
-  previous: AnchorRect | null,
-  viewportWidth: number,
-  scrollX: number,
-): boolean {
+export function isAnchorSettled({
+  next,
+  previous,
+  viewportWidth,
+  scrollX,
+}: {
+  next: AnchorRect | null;
+  previous: AnchorRect | null;
+  viewportWidth: number;
+  scrollX: number;
+}): boolean {
   if (next === null || previous === null) return false;
   if (isAnchorParkedOffscreen(next, viewportWidth, scrollX)) return false;
   return (

--- a/platform/app/src/features/traces-v2/onboarding/spotlights/__tests__/SpotlightOverlay.unit.test.tsx
+++ b/platform/app/src/features/traces-v2/onboarding/spotlights/__tests__/SpotlightOverlay.unit.test.tsx
@@ -334,29 +334,62 @@ describe("anchor settle predicates", () => {
   describe("isAnchorSettled", () => {
     describe("given the anchor is on-screen and unchanged since the last frame", () => {
       it("reports it settled", () => {
-        expect(isAnchorSettled(rect(), rect(), VW, 0)).toBe(true);
+        expect(
+          isAnchorSettled({
+            next: rect(),
+            previous: rect(),
+            viewportWidth: VW,
+            scrollX: 0,
+          }),
+        ).toBe(true);
       });
     });
 
     describe("given the anchor is still parked off-screen", () => {
       it("is never settled, even if unchanged (parked, not resting)", () => {
         const parked = rect({ left: VW });
-        expect(isAnchorSettled(parked, parked, VW, 0)).toBe(false);
+        expect(
+          isAnchorSettled({
+            next: parked,
+            previous: parked,
+            viewportWidth: VW,
+            scrollX: 0,
+          }),
+        ).toBe(false);
       });
     });
 
     describe("given the anchor moved since the last frame", () => {
       it("is not settled (still riding in)", () => {
         expect(
-          isAnchorSettled(rect({ left: 200 }), rect({ left: 260 }), VW, 0),
+          isAnchorSettled({
+            next: rect({ left: 200 }),
+            previous: rect({ left: 260 }),
+            viewportWidth: VW,
+            scrollX: 0,
+          }),
         ).toBe(false);
       });
     });
 
     describe("given there is no prior frame to compare", () => {
       it("is not settled yet", () => {
-        expect(isAnchorSettled(rect(), null, VW, 0)).toBe(false);
-        expect(isAnchorSettled(null, rect(), VW, 0)).toBe(false);
+        expect(
+          isAnchorSettled({
+            next: rect(),
+            previous: null,
+            viewportWidth: VW,
+            scrollX: 0,
+          }),
+        ).toBe(false);
+        expect(
+          isAnchorSettled({
+            next: null,
+            previous: rect(),
+            viewportWidth: VW,
+            scrollX: 0,
+          }),
+        ).toBe(false);
       });
     });
   });

--- a/platform/app/src/hooks/__tests__/useModelProviderApiKeyValidation.unit.test.ts
+++ b/platform/app/src/hooks/__tests__/useModelProviderApiKeyValidation.unit.test.ts
@@ -66,13 +66,13 @@ const wireErrorFor = (domainError: Error) =>
 
 const renderValidation = () =>
   renderHook(() =>
-    useModelProviderApiKeyValidation(
-      "gemini",
-      { GEMINI_API_KEY: "AIzaSyTheCustomersKey" },
-      undefined,
-      "org-1",
-      [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
-    ),
+    useModelProviderApiKeyValidation({
+      provider: "gemini",
+      customKeys: { GEMINI_API_KEY: "AIzaSyTheCustomersKey" },
+      projectId: undefined,
+      organizationId: "org-1",
+      scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+    }),
   );
 
 describe("useModelProviderApiKeyValidation", () => {
@@ -193,12 +193,12 @@ describe("useModelProviderApiKeyValidation", () => {
      */
     it("refuses to send the key anywhere", async () => {
       const { result } = renderHook(() =>
-        useModelProviderApiKeyValidation(
-          "gemini",
-          { GEMINI_API_KEY: "AIzaSyTheCustomersKey" },
-          undefined,
-          undefined,
-        ),
+        useModelProviderApiKeyValidation({
+          provider: "gemini",
+          customKeys: { GEMINI_API_KEY: "AIzaSyTheCustomersKey" },
+          projectId: undefined,
+          organizationId: undefined,
+        }),
       );
 
       let valid: boolean | undefined;

--- a/platform/app/src/hooks/useCredentialKeys.ts
+++ b/platform/app/src/hooks/useCredentialKeys.ts
@@ -84,14 +84,13 @@ export function useCredentialKeys({
   }, [provider.provider, useApiGateway, originalSchemaShape]);
 
   const [customKeys, setCustomKeys] = useState<Record<string, string>>(() =>
-    buildCustomKeyState(
-      displayKeys,
-      originalStoredKeysRef.current ?? {},
-      undefined,
-      {
+    buildCustomKeyState({
+      displayKeyMap: displayKeys,
+      storedKeys: originalStoredKeysRef.current ?? {},
+      options: {
         providerEnabledWithEnvVars: provider.enabled,
       },
-    ),
+    }),
   );
 
   const setUseApiGateway = useCallback(
@@ -109,11 +108,11 @@ export function useCredentialKeys({
           originalSchemaShape,
         );
 
-        return buildCustomKeyState(
-          nextDisplayKeys,
-          originalStoredKeysRef.current,
+        return buildCustomKeyState({
+          displayKeyMap: nextDisplayKeys,
+          storedKeys: originalStoredKeysRef.current,
           previousKeys,
-        );
+        });
       });
 
       onGatewayToggle?.(use);
@@ -149,8 +148,12 @@ export function useCredentialKeys({
       );
 
       setCustomKeys(() =>
-        buildCustomKeyState(nextDisplayKeys, storedKeys, undefined, {
-          providerEnabledWithEnvVars: nextProvider.enabled,
+        buildCustomKeyState({
+          displayKeyMap: nextDisplayKeys,
+          storedKeys,
+          options: {
+            providerEnabledWithEnvVars: nextProvider.enabled,
+          },
         }),
       );
 

--- a/platform/app/src/hooks/useModelProviderApiKeyValidation.ts
+++ b/platform/app/src/hooks/useModelProviderApiKeyValidation.ts
@@ -22,25 +22,31 @@ const describeRefusal = (domainError: SerializedHandledError): string => {
  * Provides validation state and functions to trigger validation.
  * Uses tRPC to call the backend validation endpoints.
  *
- * @param provider - The provider key (e.g., "openai", "gemini")
- * @param customKeys - The form state containing API keys and configuration
- * @param projectId - Project handle for the tenant, when there is one
- * @param organizationId - Organization handle for the tenant
- * @param scopes - Scopes the credential is being set up for. On the
+ * @param params.provider - The provider key (e.g., "openai", "gemini")
+ * @param params.customKeys - The form state containing API keys and configuration
+ * @param params.projectId - Project handle for the tenant, when there is one
+ * @param params.organizationId - Organization handle for the tenant
+ * @param params.scopes - Scopes the credential is being set up for. On the
  *   no-project path these are what the probe is authorized against, so a
  *   caller who cannot manage them cannot reach the outbound request.
  * @returns Object containing validation state and functions
  */
-export function useModelProviderApiKeyValidation(
-  provider: string,
-  customKeys: Record<string, string>,
-  projectId: string | undefined,
-  organizationId: string | undefined,
+export function useModelProviderApiKeyValidation({
+  provider,
+  customKeys,
+  projectId,
+  organizationId,
+  scopes,
+}: {
+  provider: string;
+  customKeys: Record<string, string>;
+  projectId: string | undefined;
+  organizationId: string | undefined;
   scopes?: Array<{
     scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
     scopeId: string;
-  }>,
-) {
+  }>;
+}) {
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string | undefined>();
   const utils = api.useContext();

--- a/platform/app/src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts
@@ -56,6 +56,7 @@ function mockMcpServer(): {
 } {
   const tools = new Map<string, CapturedTool>();
   return {
+    // biome-ignore lint/complexity/useMaxParams: fake of the MCP SDK's positional McpServer.tool(name, description, schema, cb)
     tool(name, description, schema, cb) {
       tools.set(name, { name, description, schema, cb });
       return null;

--- a/platform/app/src/mcp/handler.ts
+++ b/platform/app/src/mcp/handler.ts
@@ -492,12 +492,17 @@ export function createMcpHandler(): McpHandler {
     return createHash("sha256").update(randomUUID()).digest("hex");
   }
 
-  async function storeOAuthToken(
-    accessToken: string,
-    apiKey: string,
-    expiresIn: number,
-    userId?: string,
-  ): Promise<void> {
+  async function storeOAuthToken({
+    accessToken,
+    apiKey,
+    expiresIn,
+    userId,
+  }: {
+    accessToken: string;
+    apiKey: string;
+    expiresIn: number;
+    userId?: string;
+  }): Promise<void> {
     const entry: OAuthTokenEntry = {
       apiKey,
       userId,
@@ -946,7 +951,12 @@ export function createMcpHandler(): McpHandler {
     const expiresIn = TOKEN_TTL_SECONDS;
     const accessToken = generateAccessToken();
 
-    await storeOAuthToken(accessToken, apiKey, expiresIn, stored.userId);
+    await storeOAuthToken({
+      accessToken,
+      apiKey,
+      expiresIn,
+      userId: stored.userId,
+    });
 
     sendJson(res, 200, {
       access_token: accessToken,

--- a/platform/app/src/optimization_studio/components/VersionToBeUsed.tsx
+++ b/platform/app/src/optimization_studio/components/VersionToBeUsed.tsx
@@ -94,11 +94,11 @@ export function NewVersionFields({
   );
 
   const defaultModel = resolvedDefault.data?.model ?? "";
-  const { modelOption } = useModelSelectionOptions(
-    allModelOptions,
-    defaultModel,
-    "chat",
-  );
+  const { modelOption } = useModelSelectionOptions({
+    options: allModelOptions,
+    model: defaultModel,
+    mode: "chat",
+  });
   const isDefaultModelDisabled = modelOption?.isDisabled ?? false;
   const isModelConfigured =
     resolvedDefault.data != null && !isDefaultModelDisabled;

--- a/platform/app/src/optimization_studio/components/code/monaco/python/completion.ts
+++ b/platform/app/src/optimization_studio/components/code/monaco/python/completion.ts
@@ -42,12 +42,17 @@ function itemKind(
   }
 }
 
-function memberCompletion(
-  monaco: Monaco,
-  module: PyModule | null,
-  member: PyMember,
-  range: IRange,
-): languages.CompletionItem {
+function memberCompletion({
+  monaco,
+  module,
+  member,
+  range,
+}: {
+  monaco: Monaco;
+  module: PyModule | null;
+  member: PyMember;
+  range: IRange;
+}): languages.CompletionItem {
   const label = member.name;
   const moduleHeader = module ? `${module.name}.${member.name}` : member.name;
   const sig = member.signature ?? label;
@@ -102,7 +107,12 @@ export function registerCompletion(
         if (mod) {
           return {
             suggestions: mod.members.map((m) =>
-              memberCompletion(monaco, mod, m, replaceRange),
+              memberCompletion({
+                monaco,
+                module: mod,
+                member: m,
+                range: replaceRange,
+              }),
             ),
           };
         }
@@ -150,7 +160,12 @@ export function registerCompletion(
         if (mod) {
           return {
             suggestions: mod.members.map((m) =>
-              memberCompletion(monaco, mod, m, replaceRange),
+              memberCompletion({
+                monaco,
+                module: mod,
+                member: m,
+                range: replaceRange,
+              }),
             ),
           };
         }

--- a/platform/app/src/optimization_studio/components/properties/AgentPropertiesPanel.tsx
+++ b/platform/app/src/optimization_studio/components/properties/AgentPropertiesPanel.tsx
@@ -80,14 +80,21 @@ function getHttpConfig(config: AgentComponentConfig): HttpComponentConfig {
   return config as HttpComponentConfig;
 }
 
-function buildHttpConfig(
-  url: string,
-  method: HttpMethod,
-  bodyTemplate: string,
-  outputPath: string,
-  headers: HttpHeader[],
-  auth: HttpAuth | undefined,
-): HttpComponentConfig {
+function buildHttpConfig({
+  url,
+  method,
+  bodyTemplate,
+  outputPath,
+  headers,
+  auth,
+}: {
+  url: string;
+  method: HttpMethod;
+  bodyTemplate: string;
+  outputPath: string;
+  headers: HttpHeader[];
+  auth: HttpAuth | undefined;
+}): HttpComponentConfig {
   return {
     name: "HTTP",
     description: "HTTP API endpoint",
@@ -485,14 +492,14 @@ function DbAgentPanel({
 
     let config: AgentComponentConfig | undefined;
     if (agentType === "http") {
-      config = buildHttpConfig(
+      config = buildHttpConfig({
         url,
         method,
         bodyTemplate,
         outputPath,
         headers,
         auth,
-      );
+      });
     } else if (agentType === "code") {
       config = buildCodeConfig({
         code,

--- a/platform/app/src/optimization_studio/components/properties/llm-configs/OptimizationStudioLLMConfigField.tsx
+++ b/platform/app/src/optimization_studio/components/properties/llm-configs/OptimizationStudioLLMConfigField.tsx
@@ -38,11 +38,11 @@ export function OptimizationStudioLLMConfigField({
   showStructuredOutputs = false,
 }: OptimizationStudioLLMConfigFieldProps) {
   const model = llmConfig?.model ?? "";
-  const { modelOption, isEmpty } = useModelSelectionOptions(
-    allModelOptions,
+  const { modelOption, isEmpty } = useModelSelectionOptions({
+    options: allModelOptions,
     model,
-    "chat",
-  );
+    mode: "chat",
+  });
 
   const { hasCodeNodes } = useWorkflowStore((state) => ({
     hasCodeNodes: state.nodes.some((node) => node.type === "code"),

--- a/platform/app/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/SignaturePropertiesPanelForm.tsx
+++ b/platform/app/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/SignaturePropertiesPanelForm.tsx
@@ -296,12 +296,17 @@ export function SignaturePropertiesPanelForm({
     return newHandle;
   };
 
-  const onAddMessageEdge = (
-    id: string,
-    handle: string,
-    content: PromptTextAreaOnAddMention,
-    idx: number,
-  ): string | undefined => {
+  const onAddMessageEdge = ({
+    id,
+    handle,
+    content,
+    idx,
+  }: {
+    id: string;
+    handle: string;
+    content: PromptTextAreaOnAddMention;
+    idx: number;
+  }): string | undefined => {
     const {
       node: stateNode,
       newPrompt,

--- a/platform/app/src/optimization_studio/hooks/__tests__/workflowStoreCore.convergence.unit.test.ts
+++ b/platform/app/src/optimization_studio/hooks/__tests__/workflowStoreCore.convergence.unit.test.ts
@@ -21,13 +21,19 @@ const node = (id: string, type: string): Node => ({
   data: { name: id },
 });
 
-const edge = (
-  id: string,
-  source: string,
-  sourceHandle: string,
-  target: string,
-  targetHandle: string,
-): Edge => ({
+const edge = ({
+  id,
+  source,
+  sourceHandle,
+  target,
+  targetHandle,
+}: {
+  id: string;
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}): Edge => ({
   id,
   source,
   target,
@@ -46,9 +52,27 @@ const forkNodes = [
   node("end", "end"),
 ];
 const forkEdges = [
-  edge("e1", "entry", "q", "gate", "context"),
-  edge("e2", "gate", "true", "codeA", "gate"),
-  edge("e3", "gate", "false", "codeB", "gate"),
+  edge({
+    id: "e1",
+    source: "entry",
+    sourceHandle: "q",
+    target: "gate",
+    targetHandle: "context",
+  }),
+  edge({
+    id: "e2",
+    source: "gate",
+    sourceHandle: "true",
+    target: "codeA",
+    targetHandle: "gate",
+  }),
+  edge({
+    id: "e3",
+    source: "gate",
+    sourceHandle: "false",
+    target: "codeB",
+    targetHandle: "gate",
+  }),
 ];
 
 const edgesIntoAnswer = (edges: Edge[]) =>
@@ -66,7 +90,16 @@ describe("workflowStoreCore - branch convergence on connect", () => {
     it("accepts the second, converging connection", () => {
       store.setState({
         nodes: forkNodes as unknown as Node[],
-        edges: [...forkEdges, edge("c1", "codeA", "out", "end", "answer")],
+        edges: [
+          ...forkEdges,
+          edge({
+            id: "c1",
+            source: "codeA",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
+        ],
       });
 
       const result = store.getState().onConnect({
@@ -92,9 +125,27 @@ describe("workflowStoreCore - branch convergence on connect", () => {
           node("end", "end"),
         ] as unknown as Node[],
         edges: [
-          edge("e1", "entry", "q", "x", "in"),
-          edge("e2", "entry", "q", "y", "in"),
-          edge("c1", "x", "out", "end", "answer"),
+          edge({
+            id: "e1",
+            source: "entry",
+            sourceHandle: "q",
+            target: "x",
+            targetHandle: "in",
+          }),
+          edge({
+            id: "e2",
+            source: "entry",
+            sourceHandle: "q",
+            target: "y",
+            targetHandle: "in",
+          }),
+          edge({
+            id: "c1",
+            source: "x",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
         ],
       });
 

--- a/platform/app/src/optimization_studio/server/lambda/index.ts
+++ b/platform/app/src/optimization_studio/server/lambda/index.ts
@@ -286,12 +286,17 @@ const createProjectLambda = async (
   return response;
 };
 
-const pollLambdaUntilReady = async (
-  lambda: LambdaClient,
-  functionName: string,
+const pollLambdaUntilReady = async ({
+  lambda,
+  functionName,
   maxAttempts = 60, // 5 minutes with 5-second intervals
   intervalMs = 500,
-): Promise<void> => {
+}: {
+  lambda: LambdaClient;
+  functionName: string;
+  maxAttempts?: number;
+  intervalMs?: number;
+}): Promise<void> => {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const config = await checkLambdaExists(lambda, functionName);
 
@@ -322,12 +327,17 @@ const pollLambdaUntilReady = async (
   );
 };
 
-const updateProjectLambdaImage = async (
-  lambda: LambdaClient,
-  functionName: string,
-  newImageUri: string,
-  projectId: string,
-): Promise<FunctionConfiguration> => {
+const updateProjectLambdaImage = async ({
+  lambda,
+  functionName,
+  newImageUri,
+  projectId,
+}: {
+  lambda: LambdaClient;
+  functionName: string;
+  newImageUri: string;
+  projectId: string;
+}): Promise<FunctionConfiguration> => {
   logger.info(
     { projectId },
     `Updating Lambda function ${functionName} with new image: ${newImageUri}`,
@@ -489,12 +499,12 @@ const resolveProjectLambdaArn = async (
       );
 
       try {
-        lambdaConfig = await updateProjectLambdaImage(
+        lambdaConfig = await updateProjectLambdaImage({
           lambda,
           functionName,
-          config.image_uri,
+          newImageUri: config.image_uri,
           projectId,
-        );
+        });
       } catch (error) {
         if (
           error instanceof Error &&
@@ -512,7 +522,7 @@ const resolveProjectLambdaArn = async (
   }
 
   // Poll until Lambda is ready
-  await pollLambdaUntilReady(lambda, functionName);
+  await pollLambdaUntilReady({ lambda, functionName });
 
   // Return the ARN
   if (!lambdaConfig.FunctionArn) {
@@ -522,30 +532,34 @@ const resolveProjectLambdaArn = async (
   return lambdaConfig.FunctionArn;
 };
 
-export const invokeLambda = async (
-  projectId: string,
-  event: StudioClientEvent,
-  s3CacheKey: string | undefined,
-  options: {
-    /** Path under the NLP service. Defaults to `/studio/execute` for the
-     *  legacy Python SSE handler. Set to `/go/studio/execute` to route
-     *  the same SSE event shape to the Go engine. */
-    path?: string;
-    /** Extra headers merged after the defaults (e.g. X-LangWatch-Origin). */
-    headers?: Record<string, string>;
-    /** When true, an oversized invoke body is offloaded to S3 and replaced
-     *  with an X-Payload-S3-URL header so it doesn't hit the 6 MB Lambda
-     *  invoke cap. Only set this for receivers that fetch the header (the Go
-     *  engine — services/nlpgo/adapters/httpapi/staged_payload.go). The legacy
-     *  Python handler does not, so leave it false there. */
-    supportsStaging?: boolean;
-  } = {},
-): Promise<ReadableStreamDefaultReader<Uint8Array>> => {
-  const path = options.path ?? "/studio/execute";
+export const invokeLambda = async ({
+  projectId,
+  event,
+  s3CacheKey,
+  path = "/studio/execute",
+  headers: extraHeaders,
+  supportsStaging,
+}: {
+  projectId: string;
+  event: StudioClientEvent;
+  s3CacheKey: string | undefined;
+  /** Path under the NLP service. Defaults to `/studio/execute` for the
+   *  legacy Python SSE handler. Set to `/go/studio/execute` to route
+   *  the same SSE event shape to the Go engine. */
+  path?: string;
+  /** Extra headers merged after the defaults (e.g. X-LangWatch-Origin). */
+  headers?: Record<string, string>;
+  /** When true, an oversized invoke body is offloaded to S3 and replaced
+   *  with an X-Payload-S3-URL header so it doesn't hit the 6 MB Lambda
+   *  invoke cap. Only set this for receivers that fetch the header (the Go
+   *  engine — services/nlpgo/adapters/httpapi/staged_payload.go). The legacy
+   *  Python handler does not, so leave it false there. */
+  supportsStaging?: boolean;
+}): Promise<ReadableStreamDefaultReader<Uint8Array>> => {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(s3CacheKey ? { "X-S3-Cache-Key": s3CacheKey } : {}),
-    ...(options.headers ?? {}),
+    ...(extraHeaders ?? {}),
   };
   const payload: { body: string; headers: Record<string, string> } = {
     body: JSON.stringify(event),
@@ -582,7 +596,7 @@ export const invokeLambda = async (
     // only crosses the cap after escaping is still offloaded.
     let stagedInvoke: StagedObject | null = null;
     let invokeBody = buildInvokeBody(payload);
-    if (options.supportsStaging) {
+    if (supportsStaging) {
       const invokeBytes = Buffer.byteLength(invokeBody, "utf-8");
       const threshold =
         env.LANGEVALS_STAGING_THRESHOLD_BYTES ??

--- a/platform/app/src/optimization_studio/utils/__tests__/edgeConvergence.unit.test.ts
+++ b/platform/app/src/optimization_studio/utils/__tests__/edgeConvergence.unit.test.ts
@@ -14,13 +14,19 @@ const node = (id: string, type: string): Node => ({
   data: {},
 });
 
-const edge = (
-  id: string,
-  source: string,
-  sourceHandle: string,
-  target: string,
-  targetHandle: string,
-): Edge => ({
+const edge = ({
+  id,
+  source,
+  sourceHandle,
+  target,
+  targetHandle,
+}: {
+  id: string;
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}): Edge => ({
   id,
   source,
   target,
@@ -29,12 +35,17 @@ const edge = (
   type: "default",
 });
 
-const connection = (
-  source: string,
-  sourceHandle: string,
-  target: string,
-  targetHandle: string,
-): Connection => ({
+const connection = ({
+  source,
+  sourceHandle,
+  target,
+  targetHandle,
+}: {
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}): Connection => ({
   source,
   target,
   sourceHandle: `outputs.${sourceHandle}`,
@@ -51,9 +62,27 @@ const forkNodes: Node[] = [
   node("end", "end"),
 ];
 const forkEdges: Edge[] = [
-  edge("e1", "entry", "q", "gate", "context"),
-  edge("e2", "gate", "true", "codeA", "gate"),
-  edge("e3", "gate", "false", "codeB", "gate"),
+  edge({
+    id: "e1",
+    source: "entry",
+    sourceHandle: "q",
+    target: "gate",
+    targetHandle: "context",
+  }),
+  edge({
+    id: "e2",
+    source: "gate",
+    sourceHandle: "true",
+    target: "codeA",
+    targetHandle: "gate",
+  }),
+  edge({
+    id: "e3",
+    source: "gate",
+    sourceHandle: "false",
+    target: "codeB",
+    targetHandle: "gate",
+  }),
 ];
 
 describe("computeNodeGuards", () => {
@@ -82,8 +111,20 @@ describe("computeNodeGuards", () => {
       const nodes = [...forkNodes, node("merge", "code")];
       const edges = [
         ...forkEdges,
-        edge("m1", "codeA", "out", "merge", "x"),
-        edge("m2", "codeB", "out", "merge", "x"),
+        edge({
+          id: "m1",
+          source: "codeA",
+          sourceHandle: "out",
+          target: "merge",
+          targetHandle: "x",
+        }),
+        edge({
+          id: "m2",
+          source: "codeB",
+          sourceHandle: "out",
+          target: "merge",
+          targetHandle: "x",
+        }),
       ];
       const guards = computeNodeGuards({ nodes, edges });
       expect([...(guards.get("merge") ?? [])]).toEqual([]);
@@ -95,8 +136,20 @@ describe("computeNodeGuards", () => {
       const nodes = [...forkNodes, node("either", "code")];
       const edges = [
         ...forkEdges,
-        edge("b1", "gate", "true", "either", "x"),
-        edge("b2", "gate", "false", "either", "x"),
+        edge({
+          id: "b1",
+          source: "gate",
+          sourceHandle: "true",
+          target: "either",
+          targetHandle: "x",
+        }),
+        edge({
+          id: "b2",
+          source: "gate",
+          sourceHandle: "false",
+          target: "either",
+          targetHandle: "x",
+        }),
       ];
       const guards = computeNodeGuards({ nodes, edges });
       // gate itself has no guards, and neither side is required -> empty.
@@ -113,9 +166,27 @@ describe("computeNodeGuards", () => {
         node("leaf", "code"),
       ];
       const edges = [
-        edge("e1", "entry", "q", "outer", "c"),
-        edge("e2", "outer", "true", "inner", "c"),
-        edge("e3", "inner", "true", "leaf", "g"),
+        edge({
+          id: "e1",
+          source: "entry",
+          sourceHandle: "q",
+          target: "outer",
+          targetHandle: "c",
+        }),
+        edge({
+          id: "e2",
+          source: "outer",
+          sourceHandle: "true",
+          target: "inner",
+          targetHandle: "c",
+        }),
+        edge({
+          id: "e3",
+          source: "inner",
+          sourceHandle: "true",
+          target: "leaf",
+          targetHandle: "g",
+        }),
       ];
       const guards = computeNodeGuards({ nodes, edges });
       expect(guards.get("inner")).toEqual(new Set(["outer:true"]));
@@ -174,7 +245,12 @@ describe("canConvergeOnInput", () => {
         canConvergeOnInput({
           nodes: forkNodes,
           edges: forkEdges,
-          connection: connection("codeA", "out", "end", "answer"),
+          connection: connection({
+            source: "codeA",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
         }),
       ).toBe(true);
     });
@@ -184,13 +260,24 @@ describe("canConvergeOnInput", () => {
     it("allows two mutually exclusive branches to converge", () => {
       const edges = [
         ...forkEdges,
-        edge("conv", "codeA", "out", "end", "answer"),
+        edge({
+          id: "conv",
+          source: "codeA",
+          sourceHandle: "out",
+          target: "end",
+          targetHandle: "answer",
+        }),
       ];
       expect(
         canConvergeOnInput({
           nodes: forkNodes,
           edges,
-          connection: connection("codeB", "out", "end", "answer"),
+          connection: connection({
+            source: "codeB",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
         }),
       ).toBe(true);
     });
@@ -205,15 +292,38 @@ describe("canConvergeOnInput", () => {
         node("end", "end"),
       ];
       const edges = [
-        edge("e1", "entry", "q", "x", "in"),
-        edge("e2", "entry", "q", "y", "in"),
-        edge("conv", "x", "out", "end", "answer"),
+        edge({
+          id: "e1",
+          source: "entry",
+          sourceHandle: "q",
+          target: "x",
+          targetHandle: "in",
+        }),
+        edge({
+          id: "e2",
+          source: "entry",
+          sourceHandle: "q",
+          target: "y",
+          targetHandle: "in",
+        }),
+        edge({
+          id: "conv",
+          source: "x",
+          sourceHandle: "out",
+          target: "end",
+          targetHandle: "answer",
+        }),
       ];
       expect(
         canConvergeOnInput({
           nodes,
           edges,
-          connection: connection("y", "out", "end", "answer"),
+          connection: connection({
+            source: "y",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
         }),
       ).toBe(false);
     });
@@ -224,13 +334,24 @@ describe("canConvergeOnInput", () => {
     it("rejects two outputs of one node on the same input", () => {
       const edges = [
         ...forkEdges,
-        edge("conv", "codeA", "out1", "end", "answer"),
+        edge({
+          id: "conv",
+          source: "codeA",
+          sourceHandle: "out1",
+          target: "end",
+          targetHandle: "answer",
+        }),
       ];
       expect(
         canConvergeOnInput({
           nodes: forkNodes,
           edges,
-          connection: connection("codeA", "out2", "end", "answer"),
+          connection: connection({
+            source: "codeA",
+            sourceHandle: "out2",
+            target: "end",
+            targetHandle: "answer",
+          }),
         }),
       ).toBe(false);
     });
@@ -252,19 +373,66 @@ describe("canConvergeOnInput", () => {
         node("end", "end"),
       ];
       const baseEdges = [
-        edge("e1", "entry", "q", "outer", "c"),
-        edge("e2", "outer", "false", "leafOuterFalse", "g"),
-        edge("e3", "outer", "true", "inner", "c"),
-        edge("e4", "inner", "true", "leafInnerTrue", "g"),
-        edge("e5", "inner", "false", "leafInnerFalse", "g"),
-        edge("c1", "leafOuterFalse", "out", "end", "answer"),
-        edge("c2", "leafInnerTrue", "out", "end", "answer"),
+        edge({
+          id: "e1",
+          source: "entry",
+          sourceHandle: "q",
+          target: "outer",
+          targetHandle: "c",
+        }),
+        edge({
+          id: "e2",
+          source: "outer",
+          sourceHandle: "false",
+          target: "leafOuterFalse",
+          targetHandle: "g",
+        }),
+        edge({
+          id: "e3",
+          source: "outer",
+          sourceHandle: "true",
+          target: "inner",
+          targetHandle: "c",
+        }),
+        edge({
+          id: "e4",
+          source: "inner",
+          sourceHandle: "true",
+          target: "leafInnerTrue",
+          targetHandle: "g",
+        }),
+        edge({
+          id: "e5",
+          source: "inner",
+          sourceHandle: "false",
+          target: "leafInnerFalse",
+          targetHandle: "g",
+        }),
+        edge({
+          id: "c1",
+          source: "leafOuterFalse",
+          sourceHandle: "out",
+          target: "end",
+          targetHandle: "answer",
+        }),
+        edge({
+          id: "c2",
+          source: "leafInnerTrue",
+          sourceHandle: "out",
+          target: "end",
+          targetHandle: "answer",
+        }),
       ];
       expect(
         canConvergeOnInput({
           nodes,
           edges: baseEdges,
-          connection: connection("leafInnerFalse", "out", "end", "answer"),
+          connection: connection({
+            source: "leafInnerFalse",
+            sourceHandle: "out",
+            target: "end",
+            targetHandle: "answer",
+          }),
         }),
       ).toBe(true);
     });

--- a/platform/app/src/optimization_studio/utils/__tests__/edgeMappingUtils.unit.test.ts
+++ b/platform/app/src/optimization_studio/utils/__tests__/edgeMappingUtils.unit.test.ts
@@ -29,12 +29,17 @@ function createNode(
   };
 }
 
-function createEdge(
-  source: string,
-  target: string,
-  sourceHandle: string,
-  targetHandle: string,
-): Edge {
+function createEdge({
+  source,
+  target,
+  sourceHandle,
+  targetHandle,
+}: {
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}): Edge {
   return {
     id: `edge-${source}-${target}-${sourceHandle}`,
     source,
@@ -93,7 +98,12 @@ describe("buildAvailableSources", () => {
         createNode("end", "end", {}),
       ];
       const edges: Edge[] = [
-        createEdge("llm1", "llm2", "outputs.result", "inputs.context"),
+        createEdge({
+          source: "llm1",
+          target: "llm2",
+          sourceHandle: "outputs.result",
+          targetHandle: "inputs.context",
+        }),
       ];
 
       const result = buildAvailableSources({
@@ -188,8 +198,18 @@ describe("buildInputMappingsFromEdges", () => {
   describe("when edges connect to the node", () => {
     it("builds mappings from edge handles", () => {
       const edges: Edge[] = [
-        createEdge("entry", "llm1", "outputs.question", "inputs.input"),
-        createEdge("entry", "llm1", "outputs.context", "inputs.context"),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.question",
+          targetHandle: "inputs.input",
+        }),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.context",
+          targetHandle: "inputs.context",
+        }),
       ];
 
       const result = buildInputMappingsFromEdges({
@@ -207,7 +227,12 @@ describe("buildInputMappingsFromEdges", () => {
   describe("when no edges target the node", () => {
     it("returns an empty mapping", () => {
       const edges: Edge[] = [
-        createEdge("entry", "other_node", "outputs.data", "inputs.input"),
+        createEdge({
+          source: "entry",
+          target: "other_node",
+          sourceHandle: "outputs.data",
+          targetHandle: "inputs.input",
+        }),
       ];
 
       const result = buildInputMappingsFromEdges({
@@ -271,8 +296,18 @@ describe("applyMappingChangeToEdges", () => {
   describe("when removing a mapping", () => {
     it("removes the existing edge for that input", () => {
       const currentEdges: Edge[] = [
-        createEdge("entry", "llm1", "outputs.input", "inputs.question"),
-        createEdge("entry", "llm1", "outputs.context", "inputs.context"),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.input",
+          targetHandle: "inputs.question",
+        }),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.context",
+          targetHandle: "inputs.context",
+        }),
       ];
 
       const result = applyMappingChangeToEdges({
@@ -290,7 +325,12 @@ describe("applyMappingChangeToEdges", () => {
   describe("when replacing a mapping", () => {
     it("removes the old edge and adds a new one", () => {
       const currentEdges: Edge[] = [
-        createEdge("entry", "llm1", "outputs.old_field", "inputs.question"),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.old_field",
+          targetHandle: "inputs.question",
+        }),
       ];
 
       const result = applyMappingChangeToEdges({
@@ -317,7 +357,12 @@ describe("applyMappingChangeToEdges", () => {
   describe("when mapping is a value type (not source)", () => {
     it("only removes existing edges without adding new ones", () => {
       const currentEdges: Edge[] = [
-        createEdge("entry", "llm1", "outputs.input", "inputs.question"),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.input",
+          targetHandle: "inputs.question",
+        }),
       ];
 
       const result = applyMappingChangeToEdges({
@@ -334,8 +379,18 @@ describe("applyMappingChangeToEdges", () => {
   describe("when unrelated edges exist", () => {
     it("preserves edges not targeting this node input", () => {
       const currentEdges: Edge[] = [
-        createEdge("entry", "llm1", "outputs.input", "inputs.question"),
-        createEdge("entry", "llm2", "outputs.input", "inputs.context"),
+        createEdge({
+          source: "entry",
+          target: "llm1",
+          sourceHandle: "outputs.input",
+          targetHandle: "inputs.question",
+        }),
+        createEdge({
+          source: "entry",
+          target: "llm2",
+          sourceHandle: "outputs.input",
+          targetHandle: "inputs.context",
+        }),
       ];
 
       const result = applyMappingChangeToEdges({

--- a/platform/app/src/pages/settings/api-keys/__tests__/api-keys-ingestion-split.integration.test.tsx
+++ b/platform/app/src/pages/settings/api-keys/__tests__/api-keys-ingestion-split.integration.test.tsx
@@ -150,12 +150,17 @@ function makeRegularKey(id: string, name: string) {
   };
 }
 
-function makeIngestionKey(
-  id: string,
-  name: string,
-  sourceType: string,
-  createdByDeviceLabel: string | null = "Rogerio's MacBook Pro",
-) {
+function makeIngestionKey({
+  id,
+  name,
+  sourceType,
+  createdByDeviceLabel = "Rogerio's MacBook Pro",
+}: {
+  id: string;
+  name: string;
+  sourceType: string;
+  createdByDeviceLabel?: string | null;
+}) {
   return {
     id,
     name,
@@ -210,7 +215,11 @@ describe("<ApiKeysSection /> ingestion-key split", () => {
       it("renders an 'Ingestion keys' heading", () => {
         mockApiKeyList.mockReturnValue({
           data: [
-            makeIngestionKey("key-ingest", "claude_code ingest", "claude_code"),
+            makeIngestionKey({
+              id: "key-ingest",
+              name: "claude_code ingest",
+              sourceType: "claude_code",
+            }),
             makeRegularKey("key-ci", "CI Pipeline"),
           ],
           isLoading: false,
@@ -226,7 +235,11 @@ describe("<ApiKeysSection /> ingestion-key split", () => {
       it("gives the regular keys table no heading of its own, keeping the security warning", () => {
         mockApiKeyList.mockReturnValue({
           data: [
-            makeIngestionKey("key-ingest", "claude_code ingest", "claude_code"),
+            makeIngestionKey({
+              id: "key-ingest",
+              name: "claude_code ingest",
+              sourceType: "claude_code",
+            }),
             makeRegularKey("key-ci", "CI Pipeline"),
           ],
           isLoading: false,
@@ -248,7 +261,11 @@ describe("<ApiKeysSection /> ingestion-key split", () => {
       it("shows the ingestion key's source tool and a revoke button without a permissions editor", () => {
         mockApiKeyList.mockReturnValue({
           data: [
-            makeIngestionKey("key-ingest", "claude_code ingest", "claude_code"),
+            makeIngestionKey({
+              id: "key-ingest",
+              name: "claude_code ingest",
+              sourceType: "claude_code",
+            }),
             makeRegularKey("key-ci", "CI Pipeline"),
           ],
           isLoading: false,
@@ -304,7 +321,11 @@ describe("<ApiKeysSection /> ingestion-key split", () => {
     beforeEach(() => {
       mockApiKeyList.mockReturnValue({
         data: [
-          makeIngestionKey("key-ingest", "claude_code ingest", "claude_code"),
+          makeIngestionKey({
+            id: "key-ingest",
+            name: "claude_code ingest",
+            sourceType: "claude_code",
+          }),
           makeRegularKey("key-ci", "CI Pipeline"),
         ],
         isLoading: false,
@@ -350,7 +371,14 @@ describe("<ApiKeysSection /> ingestion-key split", () => {
     /** @scenario Ingestion key names the device session that minted it */
     it("falls back to 'Unknown device' when no device label was captured", () => {
       mockApiKeyList.mockReturnValue({
-        data: [makeIngestionKey("key-x", "no-device ingest", "codex", null)],
+        data: [
+          makeIngestionKey({
+            id: "key-x",
+            name: "no-device ingest",
+            sourceType: "codex",
+            createdByDeviceLabel: null,
+          }),
+        ],
         isLoading: false,
       });
       renderSection();

--- a/platform/app/src/prompts/forms/fields/ModelSelectField.tsx
+++ b/platform/app/src/prompts/forms/fields/ModelSelectField.tsx
@@ -20,11 +20,11 @@ export function ModelSelectField() {
   const currentModel = currentLLMConfig?.model ?? "";
 
   // Check if the current model is disabled
-  const { modelOption, isEmpty } = useModelSelectionOptions(
-    allModelOptions,
-    currentModel,
-    "chat",
-  );
+  const { modelOption, isEmpty } = useModelSelectionOptions({
+    options: allModelOptions,
+    model: currentModel,
+    mode: "chat",
+  });
   const isModelDisabled = modelOption?.isDisabled ?? false;
 
   return (

--- a/platform/app/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/platform/app/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -85,11 +85,11 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
   // form value lives in form state; reading it here for the empty-state
   // check is cheap and the picker re-renders on form changes anyway.
   const watchedLlm = useWatch({ control, name: "version.configData.llm" });
-  const { isEmpty, isLoading } = useModelSelectionOptions(
-    allModelOptions,
-    watchedLlm?.model ?? "",
-    "chat",
-  );
+  const { isEmpty, isLoading } = useModelSelectionOptions({
+    options: allModelOptions,
+    model: watchedLlm?.model ?? "",
+    mode: "chat",
+  });
 
   if (isLoading) {
     // While the providers query is in flight, render a chip-shaped

--- a/platform/app/src/prompts/forms/fields/message-history-fields/PromptMessagesField.tsx
+++ b/platform/app/src/prompts/forms/fields/message-history-fields/PromptMessagesField.tsx
@@ -62,12 +62,12 @@ type MessageRowProps = {
     sourceId: string,
     field: string,
   ) => void;
-  onAddEdge?: (
-    id: string,
-    handle: string,
-    content: PromptTextAreaOnAddMention,
-    idx: number,
-  ) => string | void;
+  onAddEdge?: (params: {
+    id: string;
+    handle: string;
+    content: PromptTextAreaOnAddMention;
+    idx: number;
+  }) => string | void;
   /** Whether to show role label and remove button */
   showControls?: boolean;
   /** Whether to render textarea in borderless mode (for horizontal layout) */
@@ -145,7 +145,7 @@ function MessageRow({
                 onCreateVariable={onCreateVariable}
                 onSetVariableMapping={onSetVariableMapping}
                 onAddEdge={(id, handle, content) => {
-                  return onAddEdge?.(id, handle, content, idx);
+                  return onAddEdge?.({ id, handle, content, idx });
                 }}
                 showAddContextButton
                 borderless={borderless}
@@ -199,7 +199,7 @@ function MessageRow({
             onCreateVariable={onCreateVariable}
             onSetVariableMapping={onSetVariableMapping}
             onAddEdge={(id, handle, content) => {
-              return onAddEdge?.(id, handle, content, idx);
+              return onAddEdge?.({ id, handle, content, idx });
             }}
             showAddContextButton
             borderless={borderless}
@@ -247,12 +247,12 @@ export function PromptMessagesField({
     sourceId: string,
     field: string,
   ) => void;
-  onAddEdge?: (
-    id: string,
-    handle: string,
-    content: PromptTextAreaOnAddMention,
-    idx: number,
-  ) => string | void;
+  onAddEdge?: (params: {
+    id: string;
+    handle: string;
+    content: PromptTextAreaOnAddMention;
+    idx: number;
+  }) => string | void;
 }) {
   const form = useFormContext<PromptConfigFormValues>();
   const { formState, control } = form;

--- a/platform/app/src/prompts/prompt-playground/components/prompt-browser/ExperimentFromPlaygroundButton.tsx
+++ b/platform/app/src/prompts/prompt-playground/components/prompt-browser/ExperimentFromPlaygroundButton.tsx
@@ -125,12 +125,17 @@ const hasUnsavedChanges = (
  * @param datasets - Datasets for auto-mapping
  * @param savedPrompt - The saved prompt from database (for comparison)
  */
-const convertTabToTarget = (
-  tabData: TabData,
-  index: number,
-  datasets: DatasetReference[],
-  savedPrompt: VersionedPrompt | null | undefined,
-): TargetConfig => {
+const convertTabToTarget = ({
+  tabData,
+  index,
+  datasets,
+  savedPrompt,
+}: {
+  tabData: TabData;
+  index: number;
+  datasets: DatasetReference[];
+  savedPrompt: VersionedPrompt | null | undefined;
+}): TargetConfig => {
   const configId = tabData.form.currentValues.configId;
   const versionId = tabData.form.currentValues.versionMetadata?.versionId;
 
@@ -292,12 +297,12 @@ export function ExperimentFromPlaygroundButton({
       (tab, index) => {
         const configId = tab.data.form.currentValues.configId;
         const savedPrompt = configId ? savedPromptsMap.get(configId) : null;
-        return convertTabToTarget(
-          tab.data,
+        return convertTabToTarget({
+          tabData: tab.data,
           index,
-          initialState.datasets,
+          datasets: initialState.datasets,
           savedPrompt,
-        );
+        });
       },
     );
     initialState.targets = targets;

--- a/platform/app/src/prompts/utils/invokeLLM.ts
+++ b/platform/app/src/prompts/utils/invokeLLM.ts
@@ -43,7 +43,7 @@ export async function invokeLLM({
     const inputs = extractInputs(data);
 
     // Create the event payload
-    const event = createEventPayload(traceId, workflow, nodeId, inputs);
+    const event = createEventPayload({ traceId, workflow, nodeId, inputs });
 
     // Result object that we'll update as events arrive
     const result: PromptExecutionResult = { status: "waiting" };
@@ -169,12 +169,17 @@ function extractInputs(
 /**
  * Creates the event payload for the API request
  */
-function createEventPayload(
-  traceId: string,
-  workflow: Workflow,
-  nodeId: string,
-  inputs: Record<string, string>,
-) {
+function createEventPayload({
+  traceId,
+  workflow,
+  nodeId,
+  inputs,
+}: {
+  traceId: string;
+  workflow: Workflow;
+  nodeId: string;
+  inputs: Record<string, string>;
+}) {
   return {
     type: "execute_component",
     payload: {

--- a/platform/app/src/server/analytics/__tests__/analytics-comparator.test.ts
+++ b/platform/app/src/server/analytics/__tests__/analytics-comparator.test.ts
@@ -296,12 +296,12 @@ describe("AnalyticsComparator", () => {
 
       // Does not throw
       expect(() => {
-        comparator.compare(
-          "getTimeseries",
-          { projectId: "test" },
+        comparator.compare({
+          operation: "getTimeseries",
+          input: { projectId: "test" },
           esResult,
           chResult,
-        );
+        });
       }).not.toThrow();
     });
 
@@ -313,12 +313,12 @@ describe("AnalyticsComparator", () => {
       };
 
       expect(() => {
-        comparator.compare(
-          "getTimeseries",
-          { projectId: "test" },
-          result,
-          result,
-        );
+        comparator.compare({
+          operation: "getTimeseries",
+          input: { projectId: "test" },
+          esResult: result,
+          chResult: result,
+        });
       }).not.toThrow();
     });
   });

--- a/platform/app/src/server/analytics/analytics-comparator.ts
+++ b/platform/app/src/server/analytics/analytics-comparator.ts
@@ -35,12 +35,17 @@ export class AnalyticsComparator {
   /**
    * Compare results from two backends and log discrepancies
    */
-  compare<T>(
-    operation: string,
-    input: unknown,
-    esResult: T,
-    chResult: T,
-  ): void {
+  compare<T>({
+    operation,
+    input,
+    esResult,
+    chResult,
+  }: {
+    operation: string;
+    input: unknown;
+    esResult: T;
+    chResult: T;
+  }): void {
     const discrepancies = this.findDiscrepancies(esResult, chResult);
 
     if (discrepancies.length > 0) {

--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -1380,12 +1380,12 @@ describe("aggregation-builder", () => {
     const endDate = new Date("2024-01-02T00:00:00Z");
 
     it("builds query for topics.topics", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "topics.topics",
+        field: "topics.topics",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("ts.TopicId AS field");
       expect(result.sql).toContain("count() AS count");
@@ -1395,69 +1395,69 @@ describe("aggregation-builder", () => {
     });
 
     it("builds query for topics.subtopics", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "topics.subtopics",
+        field: "topics.subtopics",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("ts.SubTopicId AS field");
     });
 
     it("builds query for metadata.user_id", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "metadata.user_id",
+        field: "metadata.user_id",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("Attributes['langwatch.user_id']");
     });
 
     it("builds query for metadata.thread_id", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "metadata.thread_id",
+        field: "metadata.thread_id",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("Attributes['gen_ai.conversation.id']");
     });
 
     it("builds query for spans.model with JOIN", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "spans.model",
+        field: "spans.model",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("FROM stored_spans");
       expect(result.sql).toContain("gen_ai.request.model");
     });
 
     it("builds query for spans.type with JOIN", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "spans.type",
+        field: "spans.type",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("FROM stored_spans");
       expect(result.sql).toContain("langwatch.span.type");
     });
 
     it("builds query for evaluations.evaluator_id with JOIN", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "evaluations.evaluator_id",
+        field: "evaluations.evaluator_id",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("FROM evaluation_runs");
       expect(result.sql).toContain("GROUP BY TenantId, EvaluationId");
@@ -1465,23 +1465,23 @@ describe("aggregation-builder", () => {
     });
 
     it("filters guardrails only for evaluations.evaluator_id.guardrails_only", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "evaluations.evaluator_id.guardrails_only",
+        field: "evaluations.evaluator_id.guardrails_only",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("es.IsGuardrail = 1");
     });
 
     it("builds query for traces.error", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "traces.error",
+        field: "traces.error",
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("ContainsErrorStatus");
       expect(result.sql).toContain("'Traces with error'");
@@ -1489,27 +1489,25 @@ describe("aggregation-builder", () => {
     });
 
     it("adds search query filter when provided", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "topics.topics",
+        field: "topics.topics",
         startDate,
         endDate,
-        undefined,
-        undefined,
-        "search-term",
-      );
+        searchQuery: "search-term",
+      });
 
       expect(result.sql).toContain("ILIKE");
       expect(result.params.searchQuery).toBe("%search-term%");
     });
 
     it("returns empty result for unknown field", () => {
-      const result = buildDataForFilterQuery(
+      const result = buildDataForFilterQuery({
         projectId,
-        "unknown.field" as any,
+        field: "unknown.field" as any,
         startDate,
         endDate,
-      );
+      });
 
       expect(result.sql).toContain("WHERE 1=0");
     });
@@ -1521,7 +1519,7 @@ describe("aggregation-builder", () => {
     const endDate = new Date("2024-01-02T00:00:00Z");
 
     it("builds query for top documents", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("documentId");
       expect(result.sql).toContain("count");
@@ -1532,13 +1530,13 @@ describe("aggregation-builder", () => {
     });
 
     it("includes JOIN with stored_spans", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("JOIN stored_spans");
     });
 
     it("prunes the stored_spans join to the StartTime partition window", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       // stored_spans is partitioned by toYearWeek(StartTime); without a
       // StartTime bound the join scans every weekly partition (incl. cold S3).
@@ -1556,7 +1554,7 @@ describe("aggregation-builder", () => {
     });
 
     it("includes query for total unique documents", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       // Query has two parts separated by semicolon
       expect(result.sql).toContain(";");
@@ -1568,24 +1566,24 @@ describe("aggregation-builder", () => {
       const filters = {
         "topics.topics": ["topic-1"],
       };
-      const result = buildTopDocumentsQuery(
+      const result = buildTopDocumentsQuery({
         projectId,
         startDate,
         endDate,
         filters,
-      );
+      });
 
       expect(result.sql).toContain("ts.TopicId IN");
     });
 
     it("limits results to top 10", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("LIMIT 10");
     });
 
     it("prunes the deduped trace_summaries read to identity columns", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+      const result = buildTopDocumentsQuery({ projectId, startDate, endDate });
 
       // The document payload comes from the stored_spans ARRAY JOIN, so the
       // deduped trace_summaries subquery only needs identity/date columns and
@@ -1596,8 +1594,13 @@ describe("aggregation-builder", () => {
     });
 
     it("adds filter-referenced columns to the deduped read so filtered queries stay valid", () => {
-      const result = buildTopDocumentsQuery(projectId, startDate, endDate, {
-        "topics.topics": ["topic-1"],
+      const result = buildTopDocumentsQuery({
+        projectId,
+        startDate,
+        endDate,
+        filters: {
+          "topics.topics": ["topic-1"],
+        },
       });
 
       // TopicId is referenced by the filter WHERE, so the deduped subquery must
@@ -1615,7 +1618,7 @@ describe("aggregation-builder", () => {
     const endDate = new Date("2024-01-02T00:00:00Z");
 
     it("builds query for feedbacks", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("trace_id");
       expect(result.sql).toContain("event_id");
@@ -1626,13 +1629,13 @@ describe("aggregation-builder", () => {
     });
 
     it("filters for thumbs_up_down events", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("event_name = 'thumbs_up_down'");
     });
 
     it("filters for thumbs_up_down events with vote metric", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain(
         "mapContains(event_attrs, 'event.metrics.vote')",
@@ -1640,7 +1643,7 @@ describe("aggregation-builder", () => {
     });
 
     it("includes ARRAY JOIN for event arrays", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("ARRAY JOIN");
       expect(result.sql).toContain('Events.Timestamp"');
@@ -1649,7 +1652,7 @@ describe("aggregation-builder", () => {
     });
 
     it("prunes the stored_spans join to the StartTime partition window", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       // Same partition-pruning rationale as the documents query: bound the
       // stored_spans scan to the date window instead of every weekly partition.
@@ -1665,12 +1668,12 @@ describe("aggregation-builder", () => {
       const filters = {
         "metadata.user_id": ["user-1"],
       };
-      const result = buildFeedbacksQuery(
+      const result = buildFeedbacksQuery({
         projectId,
         startDate,
         endDate,
         filters,
-      );
+      });
 
       // Filter values are now parameterized, key is in params
       expect(result.sql).toContain("ts.Attributes[{metaValues_");
@@ -1682,19 +1685,19 @@ describe("aggregation-builder", () => {
     });
 
     it("limits results to 100", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("LIMIT 100");
     });
 
     it("orders by timestamp descending", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       expect(result.sql).toContain("ORDER BY event_timestamp DESC");
     });
 
     it("prunes the deduped trace_summaries read to identity columns", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+      const result = buildFeedbacksQuery({ projectId, startDate, endDate });
 
       // Feedback payload comes from the stored_spans Events arrays, so the
       // deduped trace_summaries subquery only needs identity/date columns.
@@ -1704,8 +1707,13 @@ describe("aggregation-builder", () => {
     });
 
     it("adds a filter-referenced Attributes read to the deduped subquery", () => {
-      const result = buildFeedbacksQuery(projectId, startDate, endDate, {
-        "metadata.user_id": ["user-1"],
+      const result = buildFeedbacksQuery({
+        projectId,
+        startDate,
+        endDate,
+        filters: {
+          "metadata.user_id": ["user-1"],
+        },
       });
 
       // The user_id filter references ts.Attributes[...], so Attributes must be

--- a/platform/app/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/evaluation-runs-join-time-bounds.integration.test.ts
@@ -312,12 +312,12 @@ describe("evaluation_runs JOIN time bounds", () => {
     /** @scenario A late-scheduled evaluator is still offered as a filter value */
     it("lists the evaluator in the filter values for the window", async () => {
       resetParamCounter();
-      const { sql, params } = buildDataForFilterQuery(
-        TENANT_ID,
-        "evaluations.evaluator_id" as FilterField,
-        baseInput.startDate,
-        baseInput.endDate,
-      );
+      const { sql, params } = buildDataForFilterQuery({
+        projectId: TENANT_ID,
+        field: "evaluations.evaluator_id" as FilterField,
+        startDate: baseInput.startDate,
+        endDate: baseInput.endDate,
+      });
 
       const result = await ch.query({
         query: sql,

--- a/platform/app/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
@@ -15,7 +15,10 @@ describe("filter-translator", () => {
   describe("translateFilter", () => {
     describe("topic filters", () => {
       it("translates topics.topics filter with parameterized query", () => {
-        const result = translateFilter("topics.topics", ["topic-1", "topic-2"]);
+        const result = translateFilter({
+          field: "topics.topics",
+          values: ["topic-1", "topic-2"],
+        });
         expect(result.whereClause).toContain("ts.TopicId IN");
         expect(result.whereClause).toContain("{topicIds_0:Array(String)}");
         expect(result.params).toEqual({ topicIds_0: ["topic-1", "topic-2"] });
@@ -23,7 +26,10 @@ describe("filter-translator", () => {
       });
 
       it("translates topics.subtopics filter with parameterized query", () => {
-        const result = translateFilter("topics.subtopics", ["subtopic-1"]);
+        const result = translateFilter({
+          field: "topics.subtopics",
+          values: ["subtopic-1"],
+        });
         expect(result.whereClause).toContain("ts.SubTopicId IN");
         expect(result.whereClause).toContain("{subtopicIds_0:Array(String)}");
         expect(result.params).toEqual({ subtopicIds_0: ["subtopic-1"] });
@@ -32,10 +38,10 @@ describe("filter-translator", () => {
 
     describe("metadata filters", () => {
       it("translates metadata.user_id filter with parameterized query", () => {
-        const result = translateFilter("metadata.user_id", [
-          "user-1",
-          "user-2",
-        ]);
+        const result = translateFilter({
+          field: "metadata.user_id",
+          values: ["user-1", "user-2"],
+        });
         expect(result.whereClause).toContain(
           "ts.Attributes[{metaValues_0_key:String}]",
         );
@@ -49,7 +55,10 @@ describe("filter-translator", () => {
       });
 
       it("translates metadata.thread_id filter with parameterized query", () => {
-        const result = translateFilter("metadata.thread_id", ["thread-1"]);
+        const result = translateFilter({
+          field: "metadata.thread_id",
+          values: ["thread-1"],
+        });
         expect(result.whereClause).toContain(
           "ts.Attributes[{metaValues_0_key:String}]",
         );
@@ -60,7 +69,10 @@ describe("filter-translator", () => {
       });
 
       it("translates metadata.customer_id filter with parameterized query", () => {
-        const result = translateFilter("metadata.customer_id", ["customer-1"]);
+        const result = translateFilter({
+          field: "metadata.customer_id",
+          values: ["customer-1"],
+        });
         expect(result.params).toHaveProperty(
           "metaValues_0_key",
           "langwatch.customer_id",
@@ -68,7 +80,10 @@ describe("filter-translator", () => {
       });
 
       it("translates metadata.labels filter with parameterized query", () => {
-        const result = translateFilter("metadata.labels", ["label1", "label2"]);
+        const result = translateFilter({
+          field: "metadata.labels",
+          values: ["label1", "label2"],
+        });
         expect(result.whereClause).toContain("hasAny");
         expect(result.whereClause).toContain("JSONExtract");
         expect(result.whereClause).toContain("langwatch.labels");
@@ -77,7 +92,10 @@ describe("filter-translator", () => {
       });
 
       it("translates metadata.key filter with parameterized query", () => {
-        const result = translateFilter("metadata.key", ["custom_key"]);
+        const result = translateFilter({
+          field: "metadata.key",
+          values: ["custom_key"],
+        });
         expect(result.whereClause).toContain("arrayExists");
         expect(result.whereClause).toContain("mapContains");
         expect(result.whereClause).toContain("{metaKeys_0:Array(String)}");
@@ -85,11 +103,11 @@ describe("filter-translator", () => {
       });
 
       it("translates metadata.value filter with key using parameterized query", () => {
-        const result = translateFilter(
-          "metadata.value",
-          ["value1", "value2"],
-          "custom_key",
-        );
+        const result = translateFilter({
+          field: "metadata.value",
+          values: ["value1", "value2"],
+          key: "custom_key",
+        });
         expect(result.whereClause).toContain(
           "ts.Attributes[{metaValue_0_key:String}]",
         );
@@ -103,11 +121,11 @@ describe("filter-translator", () => {
       });
 
       it("handles dots replaced with · in metadata.value key", () => {
-        const result = translateFilter(
-          "metadata.value",
-          ["value"],
-          "key·with·dots",
-        );
+        const result = translateFilter({
+          field: "metadata.value",
+          values: ["value"],
+          key: "key·with·dots",
+        });
         expect(result.params).toHaveProperty(
           "metaValue_0_key",
           "key.with.dots",
@@ -119,7 +137,10 @@ describe("filter-translator", () => {
       describe("when filtering by origin", () => {
         /** @scenario "ClickHouse origin filter for specific values" */
         it("translates non-application origin values with IN clause", () => {
-          const result = translateFilter("traces.origin", ["evaluation"]);
+          const result = translateFilter({
+            field: "traces.origin",
+            values: ["evaluation"],
+          });
           expect(result.whereClause).toContain(
             "ts.Attributes['langwatch.origin'] IN",
           );
@@ -132,7 +153,10 @@ describe("filter-translator", () => {
 
         /** @scenario 'ClickHouse origin filter for "application" matches absent values' */
         it("translates application origin as empty-or-null-or-literal check", () => {
-          const result = translateFilter("traces.origin", ["application"]);
+          const result = translateFilter({
+            field: "traces.origin",
+            values: ["application"],
+          });
           expect(result.whereClause).toContain(
             "ts.Attributes['langwatch.origin'] = ''",
           );
@@ -143,11 +167,10 @@ describe("filter-translator", () => {
 
         /** @scenario 'ClickHouse origin filter for mixed values including "application"' */
         it("combines application and other origins with OR", () => {
-          const result = translateFilter("traces.origin", [
-            "application",
-            "simulation",
-            "playground",
-          ]);
+          const result = translateFilter({
+            field: "traces.origin",
+            values: ["application", "simulation", "playground"],
+          });
           expect(result.whereClause).toContain("OR");
           expect(result.whereClause).toContain(
             "ts.Attributes['langwatch.origin'] = ''",
@@ -162,20 +185,29 @@ describe("filter-translator", () => {
         });
 
         it("returns 1=0 for empty values array (no origins selected)", () => {
-          const result = translateFilter("traces.origin", []);
+          const result = translateFilter({
+            field: "traces.origin",
+            values: [],
+          });
           expect(result.whereClause).toBe("1=1"); // empty array returns noOp from translateFilter
         });
       });
 
       it("translates traces.error filter for true using ContainsErrorStatus", () => {
-        const result = translateFilter("traces.error", ["true"]);
+        const result = translateFilter({
+          field: "traces.error",
+          values: ["true"],
+        });
         expect(result.whereClause).toContain("ts.ContainsErrorStatus = 1");
         expect(result.params).toEqual({});
         expect(result.requiredJoins).toHaveLength(0);
       });
 
       it("translates traces.error filter for false using ContainsErrorStatus", () => {
-        const result = translateFilter("traces.error", ["false"]);
+        const result = translateFilter({
+          field: "traces.error",
+          values: ["false"],
+        });
         expect(result.whereClause).toContain("ts.ContainsErrorStatus = 0");
         expect(result.whereClause).toContain("IS NULL");
         expect(result.params).toEqual({});
@@ -183,7 +215,10 @@ describe("filter-translator", () => {
       });
 
       it("returns no-op when both true and false are specified", () => {
-        const result = translateFilter("traces.error", ["true", "false"]);
+        const result = translateFilter({
+          field: "traces.error",
+          values: ["true", "false"],
+        });
         expect(result.whereClause).toBe("1=1");
         expect(result.params).toEqual({});
       });
@@ -191,7 +226,10 @@ describe("filter-translator", () => {
 
     describe("span filters", () => {
       it("translates spans.type filter with parameterized IN subquery", () => {
-        const result = translateFilter("spans.type", ["llm", "agent"]);
+        const result = translateFilter({
+          field: "spans.type",
+          values: ["llm", "agent"],
+        });
         // Regression guard: issue #2660
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
@@ -203,7 +241,10 @@ describe("filter-translator", () => {
       });
 
       it("translates spans.model filter with parameterized IN subquery", () => {
-        const result = translateFilter("spans.model", ["gpt-4", "claude-3"]);
+        const result = translateFilter({
+          field: "spans.model",
+          values: ["gpt-4", "claude-3"],
+        });
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
@@ -234,32 +275,29 @@ describe("filter-translator", () => {
 
       for (const { field, values, key } of SPAN_SUBQUERY_FILTERS) {
         it(`injects the StartTime predicate into the ${field} subquery`, () => {
-          const result = translateFilter(
+          const result = translateFilter({
             field,
-            [...values],
+            values: [...values],
             key,
-            undefined,
-            SPAN_TIME,
-          );
+            spanTimePredicate: SPAN_TIME,
+          });
           expect(result.whereClause).toContain("stored_spans");
           expect(result.whereClause).toContain(SPAN_TIME);
         });
 
         it(`omits the StartTime predicate for ${field} when none is given (unchanged behavior)`, () => {
-          const result = translateFilter(field, [...values], key);
+          const result = translateFilter({ field, values: [...values], key });
           expect(result.whereClause).toContain("stored_spans");
           expect(result.whereClause).not.toContain("StartTime");
         });
       }
 
       it("leaves non-span filters untouched even when a predicate is supplied", () => {
-        const result = translateFilter(
-          "topics.topics",
-          ["topic-1"],
-          undefined,
-          undefined,
-          SPAN_TIME,
-        );
+        const result = translateFilter({
+          field: "topics.topics",
+          values: ["topic-1"],
+          spanTimePredicate: SPAN_TIME,
+        });
         expect(result.whereClause).not.toContain("StartTime");
         expect(result.whereClause).not.toContain("stored_spans");
       });
@@ -267,10 +305,10 @@ describe("filter-translator", () => {
 
     describe("evaluation filters", () => {
       it("translates evaluations.evaluator_id filter with parameterized IN subquery", () => {
-        const result = translateFilter("evaluations.evaluator_id", [
-          "eval-1",
-          "eval-2",
-        ]);
+        const result = translateFilter({
+          field: "evaluations.evaluator_id",
+          values: ["eval-1", "eval-2"],
+        });
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
@@ -282,9 +320,10 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.evaluator_id.has_passed filter with Passed IS NOT NULL predicate", () => {
-        const result = translateFilter("evaluations.evaluator_id.has_passed", [
-          "eval-1",
-        ]);
+        const result = translateFilter({
+          field: "evaluations.evaluator_id.has_passed",
+          values: ["eval-1"],
+        });
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain(
           "EvaluatorId IN ({evaluatorIds_0:Array(String)})",
@@ -294,9 +333,10 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.evaluator_id.has_score filter with Score IS NOT NULL predicate", () => {
-        const result = translateFilter("evaluations.evaluator_id.has_score", [
-          "eval-1",
-        ]);
+        const result = translateFilter({
+          field: "evaluations.evaluator_id.has_score",
+          values: ["eval-1"],
+        });
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain(
           "EvaluatorId IN ({evaluatorIds_0:Array(String)})",
@@ -306,9 +346,10 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.evaluator_id.has_label filter with Label exclusion predicate", () => {
-        const result = translateFilter("evaluations.evaluator_id.has_label", [
-          "eval-1",
-        ]);
+        const result = translateFilter({
+          field: "evaluations.evaluator_id.has_label",
+          values: ["eval-1"],
+        });
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain(
           "EvaluatorId IN ({evaluatorIds_0:Array(String)})",
@@ -322,7 +363,10 @@ describe("filter-translator", () => {
       });
 
       it("translates base evaluations.evaluator_id without additional predicates", () => {
-        const result = translateFilter("evaluations.evaluator_id", ["eval-1"]);
+        const result = translateFilter({
+          field: "evaluations.evaluator_id",
+          values: ["eval-1"],
+        });
         expect(result.whereClause).toContain(
           "EvaluatorId IN ({evaluatorIds_0:Array(String)})",
         );
@@ -332,7 +376,10 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.passed filter with parameterized IN subquery", () => {
-        const result = translateFilter("evaluations.passed", ["true"]);
+        const result = translateFilter({
+          field: "evaluations.passed",
+          values: ["true"],
+        });
         // Regression guard: issue #2660
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
@@ -344,11 +391,11 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.passed filter with evaluator key", () => {
-        const result = translateFilter(
-          "evaluations.passed",
-          ["true"],
-          "eval-123",
-        );
+        const result = translateFilter({
+          field: "evaluations.passed",
+          values: ["true"],
+          key: "eval-123",
+        });
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
         expect(result.whereClause).toContain(
           "EvaluatorId = {evaluatorId_1:String}",
@@ -363,11 +410,11 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.score filter with parameterized numeric range", () => {
-        const result = translateFilter(
-          "evaluations.score",
-          ["0.5", "1.0"],
-          "eval-123",
-        );
+        const result = translateFilter({
+          field: "evaluations.score",
+          values: ["0.5", "1.0"],
+          key: "eval-123",
+        });
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
         expect(result.whereClause).toContain("Score >= {scoreMin_0:Float64}");
         expect(result.whereClause).toContain("Score <= {scoreMax_1:Float64}");
@@ -377,11 +424,11 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.label filter with parameterized IN subquery", () => {
-        const result = translateFilter(
-          "evaluations.label",
-          ["good", "bad"],
-          "eval-123",
-        );
+        const result = translateFilter({
+          field: "evaluations.label",
+          values: ["good", "bad"],
+          key: "eval-123",
+        });
         // Regression guard: issue #2660
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
@@ -394,7 +441,10 @@ describe("filter-translator", () => {
       });
 
       it("translates evaluations.state filter with parameterized IN subquery", () => {
-        const result = translateFilter("evaluations.state", ["processed"]);
+        const result = translateFilter({
+          field: "evaluations.state",
+          values: ["processed"],
+        });
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
@@ -407,10 +457,10 @@ describe("filter-translator", () => {
 
     describe("event filters", () => {
       it("translates events.event_type filter with parameterized IN subquery", () => {
-        const result = translateFilter("events.event_type", [
-          "thumbs_up_down",
-          "feedback",
-        ]);
+        const result = translateFilter({
+          field: "events.event_type",
+          values: ["thumbs_up_down", "feedback"],
+        });
         // Regression guard: issue #2660
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
@@ -424,11 +474,11 @@ describe("filter-translator", () => {
       });
 
       it("translates events.metrics.key filter with parameterized IN subquery", () => {
-        const result = translateFilter(
-          "events.metrics.key",
-          ["vote"],
-          "thumbs_up_down",
-        );
+        const result = translateFilter({
+          field: "events.metrics.key",
+          values: ["vote"],
+          key: "thumbs_up_down",
+        });
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
@@ -440,12 +490,12 @@ describe("filter-translator", () => {
       });
 
       it("translates events.metrics.value filter with parameterized range", () => {
-        const result = translateFilter(
-          "events.metrics.value",
-          ["0", "1"],
-          "thumbs_up_down",
-          "vote",
-        );
+        const result = translateFilter({
+          field: "events.metrics.value",
+          values: ["0", "1"],
+          key: "thumbs_up_down",
+          subkey: "vote",
+        });
         expect(result.whereClause).not.toContain("EXISTS");
         expect(result.whereClause).toContain("ts.TraceId IN");
         expect(result.whereClause).toContain("TenantId = {tenantId:String}");
@@ -461,13 +511,19 @@ describe("filter-translator", () => {
 
     describe("annotation filters", () => {
       it("translates annotations.hasAnnotation filter for true", () => {
-        const result = translateFilter("annotations.hasAnnotation", ["true"]);
+        const result = translateFilter({
+          field: "annotations.hasAnnotation",
+          values: ["true"],
+        });
         expect(result.whereClause).toContain("ts.HasAnnotation = true");
         expect(result.params).toEqual({});
       });
 
       it("translates annotations.hasAnnotation filter for false", () => {
-        const result = translateFilter("annotations.hasAnnotation", ["false"]);
+        const result = translateFilter({
+          field: "annotations.hasAnnotation",
+          values: ["false"],
+        });
         expect(result.whereClause).toContain("ts.HasAnnotation = false");
         expect(result.params).toEqual({});
       });
@@ -475,20 +531,26 @@ describe("filter-translator", () => {
 
     describe("edge cases", () => {
       it("returns no-op for empty values array", () => {
-        const result = translateFilter("topics.topics", []);
+        const result = translateFilter({ field: "topics.topics", values: [] });
         expect(result.whereClause).toBe("1=1");
         expect(result.params).toEqual({});
       });
 
       it("returns no-op for unknown filter field", () => {
-        const result = translateFilter("unknown.field" as any, ["value"]);
+        const result = translateFilter({
+          field: "unknown.field" as any,
+          values: ["value"],
+        });
         expect(result.whereClause).toBe("1=1");
         expect(result.params).toEqual({});
       });
 
       it("passes malicious values safely through parameters", () => {
         // With parameterized queries, SQL injection attempts are safely contained
-        const result = translateFilter("topics.topics", ["topic'with'quotes"]);
+        const result = translateFilter({
+          field: "topics.topics",
+          values: ["topic'with'quotes"],
+        });
         expect(result.whereClause).not.toContain("topic'with'quotes");
         expect(result.params.topicIds_0).toContain("topic'with'quotes");
       });
@@ -622,9 +684,10 @@ describe("filter-translator", () => {
 
   describe("SQL injection prevention", () => {
     it("safely handles malicious topic values", () => {
-      const result = translateFilter("topics.topics", [
-        "'; DROP TABLE trace_summaries; --",
-      ]);
+      const result = translateFilter({
+        field: "topics.topics",
+        values: ["'; DROP TABLE trace_summaries; --"],
+      });
       // With parameterized queries, value goes in params, not SQL string
       expect(result.whereClause).not.toContain("DROP TABLE");
       expect(result.params.topicIds_0).toContain(
@@ -633,9 +696,10 @@ describe("filter-translator", () => {
     });
 
     it("safely handles malicious metadata values", () => {
-      const result = translateFilter("metadata.user_id", [
-        "user'); DELETE FROM users; --",
-      ]);
+      const result = translateFilter({
+        field: "metadata.user_id",
+        values: ["user'); DELETE FROM users; --"],
+      });
       expect(result.whereClause).not.toContain("DELETE");
       expect(result.params.metaValues_0).toContain(
         "user'); DELETE FROM users; --",
@@ -643,25 +707,28 @@ describe("filter-translator", () => {
     });
 
     it("safely handles backslash injection attempts", () => {
-      const result = translateFilter("topics.topics", [
-        "topic\\'; DROP TABLE--",
-      ]);
+      const result = translateFilter({
+        field: "topics.topics",
+        values: ["topic\\'; DROP TABLE--"],
+      });
       expect(result.whereClause).not.toContain("DROP TABLE");
       expect(result.params.topicIds_0).toContain("topic\\'; DROP TABLE--");
     });
 
     it("safely handles null byte injection attempts", () => {
-      const result = translateFilter("topics.topics", [
-        "topic\x00'; DROP TABLE--",
-      ]);
+      const result = translateFilter({
+        field: "topics.topics",
+        values: ["topic\x00'; DROP TABLE--"],
+      });
       expect(result.whereClause).not.toContain("DROP TABLE");
       expect(result.params.topicIds_0).toContain("topic\x00'; DROP TABLE--");
     });
 
     it("safely handles unicode injection attempts", () => {
-      const result = translateFilter("evaluations.label", [
-        "label＇; DROP TABLE--",
-      ]);
+      const result = translateFilter({
+        field: "evaluations.label",
+        values: ["label＇; DROP TABLE--"],
+      });
       expect(result.whereClause).not.toContain("DROP TABLE");
       expect(result.params.evalLabels_0).toContain("label＇; DROP TABLE--");
     });

--- a/platform/app/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/join-time-bound-partition-column.unit.test.ts
@@ -280,12 +280,12 @@ describe("analytics JOIN time bounds", () => {
         "evaluations.evaluator_id.guardrails_only",
       ] as FilterField[]) {
         resetParamCounter();
-        const { sql } = buildDataForFilterQuery(
-          baseInput.projectId,
+        const { sql } = buildDataForFilterQuery({
+          projectId: baseInput.projectId,
           field,
-          baseInput.startDate,
-          baseInput.endDate,
-        );
+          startDate: baseInput.startDate,
+          endDate: baseInput.endDate,
+        });
         violations.push(
           ...missingJoinViolations(sql, "evaluation_runs"),
           ...partitionBoundViolations(sql),
@@ -361,12 +361,12 @@ describe("analytics JOIN time bounds", () => {
      */
     it("bounds stored_spans on StartTime", () => {
       resetParamCounter();
-      const { sql } = buildDataForFilterQuery(
-        baseInput.projectId,
-        "spans.model" as FilterField,
-        baseInput.startDate,
-        baseInput.endDate,
-      );
+      const { sql } = buildDataForFilterQuery({
+        projectId: baseInput.projectId,
+        field: "spans.model" as FilterField,
+        startDate: baseInput.startDate,
+        endDate: baseInput.endDate,
+      });
 
       expect(missingJoinViolations(sql, "stored_spans")).toEqual([]);
       expect(rangeBoundColumnsByTable(sql).get("stored_spans")).toEqual(

--- a/platform/app/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
@@ -34,41 +34,69 @@ describe("metric-translator", () => {
 
   describe("buildMetricAlias", () => {
     it("builds basic alias with index, metric, and aggregation", () => {
-      expect(buildMetricAlias(0, "performance.total_cost", "sum")).toBe(
-        "0__performance_total_cost__sum",
-      );
+      expect(
+        buildMetricAlias({
+          index: 0,
+          metric: "performance.total_cost",
+          aggregation: "sum",
+        }),
+      ).toBe("0__performance_total_cost__sum");
     });
 
     it("includes key in alias when provided", () => {
       expect(
-        buildMetricAlias(1, "evaluations.evaluation_score", "avg", "eval-123"),
+        buildMetricAlias({
+          index: 1,
+          metric: "evaluations.evaluation_score",
+          aggregation: "avg",
+          key: "eval-123",
+        }),
       ).toBe("1__evaluations_evaluation_score__avg__eval_123");
     });
 
     it("includes both key and subkey in alias", () => {
       expect(
-        buildMetricAlias(2, "events.event_score", "avg", "thumbs_up", "vote"),
+        buildMetricAlias({
+          index: 2,
+          metric: "events.event_score",
+          aggregation: "avg",
+          key: "thumbs_up",
+          subkey: "vote",
+        }),
       ).toBe("2__events_event_score__avg__thumbs_up__vote");
     });
 
     it("sanitizes special characters in key and subkey", () => {
-      expect(buildMetricAlias(0, "test", "avg", "key-with-dashes")).toBe(
-        "0__test__avg__key_with_dashes",
-      );
+      expect(
+        buildMetricAlias({
+          index: 0,
+          metric: "test",
+          aggregation: "avg",
+          key: "key-with-dashes",
+        }),
+      ).toBe("0__test__avg__key_with_dashes");
     });
   });
 
   describe("translateMetric", () => {
     describe("metadata metrics", () => {
       it("translates metadata.trace_id", () => {
-        const result = translateMetric("metadata.trace_id", "cardinality", 0);
+        const result = translateMetric({
+          metric: "metadata.trace_id",
+          aggregation: "cardinality",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("uniq(");
         expect(result.selectExpression).toContain("ts.TraceId");
         expect(result.requiredJoins).toHaveLength(0);
       });
 
       it("translates metadata.user_id", () => {
-        const result = translateMetric("metadata.user_id", "cardinality", 0);
+        const result = translateMetric({
+          metric: "metadata.user_id",
+          aggregation: "cardinality",
+          index: 0,
+        });
         // Uses uniqIf to filter out empty user_ids to match ES behavior
         expect(result.selectExpression).toContain("uniqIf(");
         expect(result.selectExpression).toContain(
@@ -78,7 +106,11 @@ describe("metric-translator", () => {
       });
 
       it("translates metadata.thread_id", () => {
-        const result = translateMetric("metadata.thread_id", "cardinality", 0);
+        const result = translateMetric({
+          metric: "metadata.thread_id",
+          aggregation: "cardinality",
+          index: 0,
+        });
         // Uses uniqIf to filter out empty thread_ids to match ES behavior
         expect(result.selectExpression).toContain("uniqIf(");
         expect(result.selectExpression).toContain(
@@ -92,18 +124,22 @@ describe("metric-translator", () => {
         // incorrectly required, causing fan-out that inflated trace-level SUM metrics
         // (TotalCost, TotalTokens) when combined in the same query.
         it("does not require stored_spans JOIN for cardinality aggregation", () => {
-          const result = translateMetric(
-            "metadata.span_type",
-            "cardinality",
-            0,
-          );
+          const result = translateMetric({
+            metric: "metadata.span_type",
+            aggregation: "cardinality",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("uniq(");
           expect(result.selectExpression).toContain("ts.TraceId");
           expect(result.requiredJoins).not.toContain("stored_spans");
         });
 
         it("requires stored_spans JOIN for non-cardinality aggregations", () => {
-          const result = translateMetric("metadata.span_type", "terms", 0);
+          const result = translateMetric({
+            metric: "metadata.span_type",
+            aggregation: "terms",
+            index: 0,
+          });
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });
@@ -111,20 +147,32 @@ describe("metric-translator", () => {
 
     describe("performance metrics", () => {
       it("translates performance.completion_time with avg", () => {
-        const result = translateMetric("performance.completion_time", "avg", 0);
+        const result = translateMetric({
+          metric: "performance.completion_time",
+          aggregation: "avg",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("avg(");
         expect(result.selectExpression).toContain("TotalDurationMs");
         expect(result.requiredJoins).toHaveLength(0);
       });
 
       it("translates performance.total_cost with sum", () => {
-        const result = translateMetric("performance.total_cost", "sum", 0);
+        const result = translateMetric({
+          metric: "performance.total_cost",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("sum(");
         expect(result.selectExpression).toContain("TotalCost");
       });
 
       it("translates performance.cost_billed to TotalCost minus the bundled portion", () => {
-        const result = translateMetric("performance.cost_billed", "sum", 0);
+        const result = translateMetric({
+          metric: "performance.cost_billed",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("sum(");
         // billed = grand total minus the folded non-billed amount.
         expect(result.selectExpression).toContain(
@@ -139,7 +187,11 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.cost_non_billed to the folded bundled amount with legacy fallback", () => {
-        const result = translateMetric("performance.cost_non_billed", "sum", 0);
+        const result = translateMetric({
+          metric: "performance.cost_non_billed",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("sum(");
         // prefers the fold-time column ...
         expect(result.selectExpression).toContain("coalesce(ts.NonBilledCost,");
@@ -150,7 +202,11 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.first_token with p95 using quantileTDigest", () => {
-        const result = translateMetric("performance.first_token", "p95", 0);
+        const result = translateMetric({
+          metric: "performance.first_token",
+          aggregation: "p95",
+          index: 0,
+        });
         // performance.* metrics opt into quantileTDigest for percentile
         // aggregations - ±5% tail error is fine on latency dashboards, and the
         // memory profile is bounded, not O(N).
@@ -159,11 +215,11 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.tokens_per_second using pre-aggregated trace-level column", () => {
-        const result = translateMetric(
-          "performance.tokens_per_second",
-          "avg",
-          0,
-        );
+        const result = translateMetric({
+          metric: "performance.tokens_per_second",
+          aggregation: "avg",
+          index: 0,
+        });
         // Uses pre-aggregated TokensPerSecond from trace_summaries to avoid
         // reading SpanAttributes (Map column with large LLM text), which causes OOM.
         expect(result.selectExpression).toContain("TokensPerSecond");
@@ -176,28 +232,32 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.tokens_per_second with percentile aggregation using quantileTDigest", () => {
-        const result = translateMetric(
-          "performance.tokens_per_second",
-          "p95",
-          0,
-        );
+        const result = translateMetric({
+          metric: "performance.tokens_per_second",
+          aggregation: "p95",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("quantileTDigest(0.95)");
         expect(result.selectExpression).toContain("TokensPerSecond");
         expect(result.requiredJoins).not.toContain("stored_spans");
       });
 
       it("translates performance.total_tokens", () => {
-        const result = translateMetric("performance.total_tokens", "sum", 0);
+        const result = translateMetric({
+          metric: "performance.total_tokens",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("TotalPromptTokenCount");
         expect(result.selectExpression).toContain("TotalCompletionTokenCount");
       });
 
       it("translates performance.cache_read_tokens from the reserved attribute key", () => {
-        const result = translateMetric(
-          "performance.cache_read_tokens",
-          "sum",
-          0,
-        );
+        const result = translateMetric({
+          metric: "performance.cache_read_tokens",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain(
           "Attributes['langwatch.reserved.cache_read_tokens']",
         );
@@ -205,22 +265,22 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.cache_write_tokens from the reserved attribute key", () => {
-        const result = translateMetric(
-          "performance.cache_write_tokens",
-          "sum",
-          0,
-        );
+        const result = translateMetric({
+          metric: "performance.cache_write_tokens",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain(
           "Attributes['langwatch.reserved.cache_creation_tokens']",
         );
       });
 
       it("translates performance.total_processed_tokens as input+output+cache", () => {
-        const result = translateMetric(
-          "performance.total_processed_tokens",
-          "sum",
-          0,
-        );
+        const result = translateMetric({
+          metric: "performance.total_processed_tokens",
+          aggregation: "sum",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("TotalPromptTokenCount");
         expect(result.selectExpression).toContain("TotalCompletionTokenCount");
         expect(result.selectExpression).toContain(
@@ -234,23 +294,23 @@ describe("metric-translator", () => {
 
     describe("evaluation metrics", () => {
       it("translates evaluations.evaluation_score and requires JOIN", () => {
-        const result = translateMetric(
-          "evaluations.evaluation_score",
-          "avg",
-          0,
-        );
+        const result = translateMetric({
+          metric: "evaluations.evaluation_score",
+          aggregation: "avg",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("es.Score");
         expect(result.selectExpression).toContain("Status = 'processed'");
         expect(result.requiredJoins).toContain("evaluation_runs");
       });
 
       it("translates evaluations.evaluation_score with evaluator key using parameterized query", () => {
-        const result = translateMetric(
-          "evaluations.evaluation_score",
-          "avg",
-          0,
-          "eval-123",
-        );
+        const result = translateMetric({
+          metric: "evaluations.evaluation_score",
+          aggregation: "avg",
+          index: 0,
+          key: "eval-123",
+        });
         // Should use parameterized query for evaluator ID (SQL injection prevention)
         expect(result.selectExpression).toMatch(
           /es\.EvaluatorId = \{m_evaluatorId_[a-f0-9]+:String\}/,
@@ -264,21 +324,21 @@ describe("metric-translator", () => {
       });
 
       it("translates evaluations.evaluation_pass_rate", () => {
-        const result = translateMetric(
-          "evaluations.evaluation_pass_rate",
-          "avg",
-          0,
-        );
+        const result = translateMetric({
+          metric: "evaluations.evaluation_pass_rate",
+          aggregation: "avg",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("es.Passed");
         expect(result.requiredJoins).toContain("evaluation_runs");
       });
 
       it("translates evaluations.evaluation_runs", () => {
-        const result = translateMetric(
-          "evaluations.evaluation_runs",
-          "cardinality",
-          0,
-        );
+        const result = translateMetric({
+          metric: "evaluations.evaluation_runs",
+          aggregation: "cardinality",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("uniqIf");
         expect(result.selectExpression).toContain("EvaluationId");
       });
@@ -286,17 +346,21 @@ describe("metric-translator", () => {
 
     describe("event metrics", () => {
       it("translates events.event_type and requires stored_spans JOIN", () => {
-        const result = translateMetric("events.event_type", "cardinality", 0);
+        const result = translateMetric({
+          metric: "events.event_type",
+          aggregation: "cardinality",
+          index: 0,
+        });
         expect(result.requiredJoins).toContain("stored_spans");
       });
 
       it("translates events.event_type with event type key using parameterized query", () => {
-        const result = translateMetric(
-          "events.event_type",
-          "cardinality",
-          0,
-          "thumbs_up_down",
-        );
+        const result = translateMetric({
+          metric: "events.event_type",
+          aggregation: "cardinality",
+          index: 0,
+          key: "thumbs_up_down",
+        });
         expect(result.selectExpression).toContain("countIf");
         // Should use parameterized query for event type (SQL injection prevention)
         expect(result.selectExpression).toMatch(
@@ -314,11 +378,11 @@ describe("metric-translator", () => {
     describe("sentiment metrics", () => {
       describe("when aggregation is cardinality", () => {
         it("counts traces with thumbs_up_down events using countIf", () => {
-          const result = translateMetric(
-            "sentiment.thumbs_up_down",
-            "cardinality",
-            0,
-          );
+          const result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "cardinality",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("countIf");
           expect(result.selectExpression).toMatch(
             /\{m_sentimentEventType_[a-f0-9]+:String\}/,
@@ -336,7 +400,11 @@ describe("metric-translator", () => {
         let result: ReturnType<typeof translateMetric>;
 
         beforeEach(() => {
-          result = translateMetric("sentiment.thumbs_up_down", "sum", 0);
+          result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "sum",
+            index: 0,
+          });
         });
 
         it("extracts vote values and applies sumArray", () => {
@@ -370,7 +438,11 @@ describe("metric-translator", () => {
 
       describe("when aggregation is avg", () => {
         it("extracts vote values and applies avgArray", () => {
-          const result = translateMetric("sentiment.thumbs_up_down", "avg", 0);
+          const result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "avg",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("avgArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -379,7 +451,11 @@ describe("metric-translator", () => {
 
       describe("when aggregation is min", () => {
         it("extracts vote values and applies minArray", () => {
-          const result = translateMetric("sentiment.thumbs_up_down", "min", 0);
+          const result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "min",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("minArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -388,7 +464,11 @@ describe("metric-translator", () => {
 
       describe("when aggregation is max", () => {
         it("extracts vote values and applies maxArray", () => {
-          const result = translateMetric("sentiment.thumbs_up_down", "max", 0);
+          const result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "max",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("maxArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -397,7 +477,11 @@ describe("metric-translator", () => {
 
       describe("when aggregation is a percentile", () => {
         it("extracts vote values and applies quantileExactArray", () => {
-          const result = translateMetric("sentiment.thumbs_up_down", "p95", 0);
+          const result = translateMetric({
+            metric: "sentiment.thumbs_up_down",
+            aggregation: "p95",
+            index: 0,
+          });
           expect(result.selectExpression).toContain("quantileExactArray(0.95)");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -407,11 +491,11 @@ describe("metric-translator", () => {
 
     describe("threads metrics", () => {
       it("translates threads.average_duration_per_thread with subquery", () => {
-        const result = translateMetric(
-          "threads.average_duration_per_thread",
-          "avg",
-          0,
-        );
+        const result = translateMetric({
+          metric: "threads.average_duration_per_thread",
+          aggregation: "avg",
+          index: 0,
+        });
         expect(result.requiresSubquery).toBe(true);
         expect(result.subquery).toBeDefined();
         expect(result.subquery?.innerSelect).toContain("thread_id");
@@ -421,41 +505,49 @@ describe("metric-translator", () => {
 
     describe("aggregation types", () => {
       it("uses uniq() for cardinality aggregation", () => {
-        const result = translateMetric("metadata.trace_id", "cardinality", 0);
+        const result = translateMetric({
+          metric: "metadata.trace_id",
+          aggregation: "cardinality",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("uniq(");
       });
 
       it("uses quantileTDigest for performance.* percentile aggregations", () => {
-        const result = translateMetric("performance.completion_time", "p99", 0);
+        const result = translateMetric({
+          metric: "performance.completion_time",
+          aggregation: "p99",
+          index: 0,
+        });
         expect(result.selectExpression).toContain("quantileTDigest(0.99)");
       });
 
       it("keeps quantileExact for evaluation score percentiles", () => {
         // Evaluation scores stay on quantileExact - their distributions are
         // narrow enough that ±5% can flip threshold-based dashboard outcomes.
-        const result = translateMetric(
-          "evaluations.evaluation_score",
-          "p99",
-          0,
-          "eval-1",
-        );
+        const result = translateMetric({
+          metric: "evaluations.evaluation_score",
+          aggregation: "p99",
+          index: 0,
+          key: "eval-1",
+        });
         expect(result.selectExpression).toContain("quantileExactIf(0.99)");
         expect(result.selectExpression).not.toContain("quantileTDigest");
       });
 
       it("uses correct aggregation for min/max", () => {
-        const minResult = translateMetric(
-          "performance.completion_time",
-          "min",
-          0,
-        );
+        const minResult = translateMetric({
+          metric: "performance.completion_time",
+          aggregation: "min",
+          index: 0,
+        });
         expect(minResult.selectExpression).toContain("min(");
 
-        const maxResult = translateMetric(
-          "performance.completion_time",
-          "max",
-          1,
-        );
+        const maxResult = translateMetric({
+          metric: "performance.completion_time",
+          aggregation: "max",
+          index: 1,
+        });
         expect(maxResult.selectExpression).toContain("max(");
       });
     });
@@ -463,13 +555,13 @@ describe("metric-translator", () => {
 
   describe("translatePipelineAggregation", () => {
     it("creates subquery for per-user aggregation", () => {
-      const result = translatePipelineAggregation(
-        "performance.total_cost",
-        "sum",
-        "user_id",
-        "avg",
-        0,
-      );
+      const result = translatePipelineAggregation({
+        metric: "performance.total_cost",
+        aggregation: "sum",
+        pipelineField: "user_id",
+        pipelineAggregation: "avg",
+        index: 0,
+      });
       expect(result.requiresSubquery).toBe(true);
       expect(result.subquery?.innerSelect).toContain(
         "Attributes['langwatch.user_id']",
@@ -479,13 +571,13 @@ describe("metric-translator", () => {
     });
 
     it("creates subquery for per-thread aggregation", () => {
-      const result = translatePipelineAggregation(
-        "performance.completion_time",
-        "avg",
-        "thread_id",
-        "sum",
-        0,
-      );
+      const result = translatePipelineAggregation({
+        metric: "performance.completion_time",
+        aggregation: "avg",
+        pipelineField: "thread_id",
+        pipelineAggregation: "sum",
+        index: 0,
+      });
       expect(result.requiresSubquery).toBe(true);
       expect(result.subquery?.innerSelect).toContain(
         "Attributes['gen_ai.conversation.id']",
@@ -494,26 +586,26 @@ describe("metric-translator", () => {
     });
 
     it("creates subquery for per-trace aggregation", () => {
-      const result = translatePipelineAggregation(
-        "performance.total_cost",
-        "sum",
-        "trace_id",
-        "max",
-        0,
-      );
+      const result = translatePipelineAggregation({
+        metric: "performance.total_cost",
+        aggregation: "sum",
+        pipelineField: "trace_id",
+        pipelineAggregation: "max",
+        index: 0,
+      });
       expect(result.subquery?.innerSelect).toContain("TraceId");
       expect(result.subquery?.outerAggregation).toContain("max(inner_value)");
     });
 
     it("inherits required JOINs from inner metric", () => {
-      const result = translatePipelineAggregation(
-        "evaluations.evaluation_score",
-        "avg",
-        "user_id",
-        "avg",
-        0,
-        "eval-123",
-      );
+      const result = translatePipelineAggregation({
+        metric: "evaluations.evaluation_score",
+        aggregation: "avg",
+        pipelineField: "user_id",
+        pipelineAggregation: "avg",
+        index: 0,
+        key: "eval-123",
+      });
       expect(result.requiredJoins).toContain("evaluation_runs");
     });
 
@@ -522,13 +614,13 @@ describe("metric-translator", () => {
       // 1. Group by (user_id, thread_id), compute thread duration
       // 2. Group by user_id, compute avg thread duration per user
       // 3. Compute avg across users
-      const result = translatePipelineAggregation(
-        "threads.average_duration_per_thread",
-        "avg",
-        "user_id",
-        "avg",
-        0,
-      );
+      const result = translatePipelineAggregation({
+        metric: "threads.average_duration_per_thread",
+        aggregation: "avg",
+        pipelineField: "user_id",
+        pipelineAggregation: "avg",
+        index: 0,
+      });
 
       // Returns a subquery with nested structure
       expect(result.requiresSubquery).toBe(true);

--- a/platform/app/src/server/analytics/clickhouse/__tests__/result-parsing.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/result-parsing.test.ts
@@ -27,11 +27,11 @@ describe("result-parsing", () => {
       };
 
       // This is the alias used when parsing results (always index 0 for first series)
-      const parsingAlias = buildMetricAlias(
-        0,
-        series.metric,
-        series.aggregation,
-      );
+      const parsingAlias = buildMetricAlias({
+        index: 0,
+        metric: series.metric,
+        aggregation: series.aggregation,
+      });
 
       // Build a query with this metric
       const input = {
@@ -263,13 +263,11 @@ describe("result-parsing", () => {
 
         for (let i = 0; i < series.length; i++) {
           const seriesItem = series[i]!;
-          const alias = buildMetricAlias(
-            i,
-            seriesItem.metric,
-            seriesItem.aggregation,
-            undefined,
-            undefined,
-          );
+          const alias = buildMetricAlias({
+            index: i,
+            metric: seriesItem.metric,
+            aggregation: seriesItem.aggregation,
+          });
 
           // This is how parseTimeseriesResults looks up values
           const value = (row as Record<string, unknown>)[alias];
@@ -349,13 +347,13 @@ describe("result-parsing", () => {
 
           for (let i = 0; i < series.length; i++) {
             const seriesItem = series[i]!;
-            const alias = buildMetricAlias(
-              i,
-              seriesItem.metric,
-              seriesItem.aggregation,
-              seriesItem.key,
-              seriesItem.subkey,
-            );
+            const alias = buildMetricAlias({
+              index: i,
+              metric: seriesItem.metric,
+              aggregation: seriesItem.aggregation,
+              key: seriesItem.key,
+              subkey: seriesItem.subkey,
+            });
             const aggregation =
               seriesItem.aggregation === "terms"
                 ? "cardinality"
@@ -374,13 +372,13 @@ describe("result-parsing", () => {
           // Non-grouped results — mirrors parseTimeseriesResults lines 271-288
           for (let i = 0; i < series.length; i++) {
             const seriesItem = series[i]!;
-            const alias = buildMetricAlias(
-              i,
-              seriesItem.metric,
-              seriesItem.aggregation,
-              seriesItem.key,
-              seriesItem.subkey,
-            );
+            const alias = buildMetricAlias({
+              index: i,
+              metric: seriesItem.metric,
+              aggregation: seriesItem.aggregation,
+              key: seriesItem.key,
+              subkey: seriesItem.subkey,
+            });
             const aggregation =
               seriesItem.aggregation === "terms"
                 ? "cardinality"

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -747,23 +747,23 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
     let translation: MetricTranslation;
 
     if (series.pipeline) {
-      translation = translatePipelineAggregation(
-        series.metric,
-        series.aggregation,
-        series.pipeline.field,
-        series.pipeline.aggregation,
-        i,
-        series.key,
-        series.subkey,
-      );
+      translation = translatePipelineAggregation({
+        metric: series.metric,
+        aggregation: series.aggregation,
+        pipelineField: series.pipeline.field,
+        pipelineAggregation: series.pipeline.aggregation,
+        index: i,
+        key: series.key,
+        subkey: series.subkey,
+      });
     } else {
-      translation = translateMetric(
-        series.metric,
-        series.aggregation,
-        i,
-        series.key,
-        series.subkey,
-      );
+      translation = translateMetric({
+        metric: series.metric,
+        aggregation: series.aggregation,
+        index: i,
+        key: series.key,
+        subkey: series.subkey,
+      });
     }
 
     metricTranslations.push(translation);
@@ -930,17 +930,17 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   // When groupBy is present, fall through to the standard query path which correctly
   // handles GROUP BY group_key — the CTE path doesn't support grouped results.
   if (input.timeScale === "full" && !groupByColumn) {
-    return buildSubqueryTimeseriesQuery(
+    return buildSubqueryTimeseriesQuery({
       input,
       simpleMetrics,
       subqueryMetrics,
       joinClauses,
       baseWhere,
       filterWhere,
-      allTranslationParams,
+      filterParams: allTranslationParams,
       groupByColumn,
       groupByHandlesUnknown,
-    );
+    });
   }
 
   // Pipeline metrics with numeric timeScale: use date-bucketed two-level aggregation
@@ -1472,13 +1472,13 @@ function buildArrayJoinTimeseriesQuery({
       series.pipeline.field === "trace_id" &&
       TRACE_ID_PIPELINE_SAFE_AGGS.has(series.pipeline.aggregation)
     ) {
-      const innerTranslation = translateMetric(
-        series.metric,
-        series.aggregation,
-        i,
-        series.key,
-        series.subkey,
-      );
+      const innerTranslation = translateMetric({
+        metric: series.metric,
+        aggregation: series.aggregation,
+        index: i,
+        key: series.key,
+        subkey: series.subkey,
+      });
       // Swap alias to match the pipeline translation's alias (they're identical
       // for trace_id pipelines, but be explicit for clarity)
       const escapedAlias = innerTranslation.alias.replace(
@@ -1910,17 +1910,27 @@ function buildGroupByUnionAllQuery({
  * Build a timeseries query using CTEs for subquery (pipeline) metrics.
  * This handles metrics that require two-level aggregation (e.g., avg threads per user).
  */
-function buildSubqueryTimeseriesQuery(
-  input: TimeseriesQueryInput,
-  simpleMetrics: MetricTranslation[],
-  subqueryMetrics: MetricTranslation[],
-  joinClauses: string,
-  baseWhere: string,
-  filterWhere: string,
-  filterParams: Record<string, unknown>,
-  groupByColumn: string | null = null,
+function buildSubqueryTimeseriesQuery({
+  input,
+  simpleMetrics,
+  subqueryMetrics,
+  joinClauses,
+  baseWhere,
+  filterWhere,
+  filterParams,
+  groupByColumn = null,
   groupByHandlesUnknown = false,
-): BuiltQuery {
+}: {
+  input: TimeseriesQueryInput;
+  simpleMetrics: MetricTranslation[];
+  subqueryMetrics: MetricTranslation[];
+  joinClauses: string;
+  baseWhere: string;
+  filterWhere: string;
+  filterParams: Record<string, unknown>;
+  groupByColumn?: string | null;
+  groupByHandlesUnknown?: boolean;
+}): BuiltQuery {
   const ts = tableAliases.trace_summaries;
   const traceColumns = referencedTraceColumns(
     [...simpleMetrics, ...subqueryMetrics],
@@ -2106,13 +2116,13 @@ function buildSubqueryTimeseriesQuery(
       .map((series, index) => ({ series, index }))
       .filter(({ series }) => isZeroWhenAbsentSeries(series))
       .map(({ series, index }) =>
-        buildMetricAlias(
+        buildMetricAlias({
           index,
-          series.metric,
-          series.aggregation,
-          series.key,
-          series.subkey,
-        ),
+          metric: series.metric,
+          aggregation: series.aggregation,
+          key: series.key,
+          subkey: series.subkey,
+        }),
       ),
   );
   const scalarExpr = (
@@ -2733,14 +2743,23 @@ function transformMetricForDedup(
 /**
  * Build a query for dataForFilter (dropdown data)
  */
-export function buildDataForFilterQuery(
-  projectId: string,
-  field: FilterField,
-  startDate: Date,
-  endDate: Date,
-  key?: string,
-  subkey?: string,
-  searchQuery?: string,
+export function buildDataForFilterQuery({
+  projectId,
+  field,
+  startDate,
+  endDate,
+  key,
+  subkey,
+  searchQuery,
+  filters,
+}: {
+  projectId: string;
+  field: FilterField;
+  startDate: Date;
+  endDate: Date;
+  key?: string;
+  subkey?: string;
+  searchQuery?: string;
   filters?: Partial<
     Record<
       FilterField,
@@ -2748,8 +2767,8 @@ export function buildDataForFilterQuery(
       | Record<string, string[]>
       | Record<string, Record<string, string[]>>
     >
-  >,
-): BuiltQuery {
+  >;
+}): BuiltQuery {
   const ts = tableAliases.trace_summaries;
   const ss = tableAliases.stored_spans;
   const es = tableAliases.evaluation_runs;
@@ -2980,10 +2999,15 @@ export function buildDataForFilterQuery(
 /**
  * Build a query for top used documents (RAG analytics)
  */
-export function buildTopDocumentsQuery(
-  projectId: string,
-  startDate: Date,
-  endDate: Date,
+export function buildTopDocumentsQuery({
+  projectId,
+  startDate,
+  endDate,
+  filters,
+}: {
+  projectId: string;
+  startDate: Date;
+  endDate: Date;
   filters?: Partial<
     Record<
       FilterField,
@@ -2991,8 +3015,8 @@ export function buildTopDocumentsQuery(
       | Record<string, string[]>
       | Record<string, Record<string, string[]>>
     >
-  >,
-): BuiltQuery {
+  >;
+}): BuiltQuery {
   const ts = tableAliases.trace_summaries;
   const ss = tableAliases.stored_spans;
 
@@ -3078,10 +3102,15 @@ export function buildTopDocumentsQuery(
 /**
  * Build a query for feedbacks
  */
-export function buildFeedbacksQuery(
-  projectId: string,
-  startDate: Date,
-  endDate: Date,
+export function buildFeedbacksQuery({
+  projectId,
+  startDate,
+  endDate,
+  filters,
+}: {
+  projectId: string;
+  startDate: Date;
+  endDate: Date;
   filters?: Partial<
     Record<
       FilterField,
@@ -3089,8 +3118,8 @@ export function buildFeedbacksQuery(
       | Record<string, string[]>
       | Record<string, Record<string, string[]>>
     >
-  >,
-): BuiltQuery {
+  >;
+}): BuiltQuery {
   const ts = tableAliases.trace_summaries;
   const ss = tableAliases.stored_spans;
 

--- a/platform/app/src/server/analytics/clickhouse/clickhouse-analytics.service.ts
+++ b/platform/app/src/server/analytics/clickhouse/clickhouse-analytics.service.ts
@@ -73,11 +73,20 @@ export class ClickHouseAnalyticsService {
   /**
    * Get data for filter dropdown
    */
-  async getDataForFilter(
-    projectId: string,
-    field: FilterField,
-    startDate: number,
-    endDate: number,
+  async getDataForFilter({
+    projectId,
+    field,
+    startDate,
+    endDate,
+    filters,
+    key,
+    subkey,
+    searchQuery,
+  }: {
+    projectId: string;
+    field: FilterField;
+    startDate: number;
+    endDate: number;
     filters?: Partial<
       Record<
         FilterField,
@@ -85,11 +94,11 @@ export class ClickHouseAnalyticsService {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-    key?: string,
-    subkey?: string,
-    searchQuery?: string,
-  ): Promise<FilterDataResult> {
+    >;
+    key?: string;
+    subkey?: string;
+    searchQuery?: string;
+  }): Promise<FilterDataResult> {
     return this.tracer.withActiveSpan(
       "ClickHouseAnalyticsService.getDataForFilter",
       { attributes: { "tenant.id": projectId, "filter.field": field } },
@@ -116,10 +125,15 @@ export class ClickHouseAnalyticsService {
   /**
    * Get top used documents (RAG analytics)
    */
-  async getTopUsedDocuments(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+  async getTopUsedDocuments({
+    projectId,
+    startDate,
+    endDate,
+    filters,
+  }: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters?: Partial<
       Record<
         FilterField,
@@ -127,8 +141,8 @@ export class ClickHouseAnalyticsService {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<TopDocumentsResult> {
+    >;
+  }): Promise<TopDocumentsResult> {
     return this.tracer.withActiveSpan(
       "ClickHouseAnalyticsService.getTopUsedDocuments",
       { attributes: { "tenant.id": projectId } },
@@ -151,10 +165,15 @@ export class ClickHouseAnalyticsService {
   /**
    * Get feedbacks (thumbs up/down events with feedback text)
    */
-  async getFeedbacks(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+  async getFeedbacks({
+    projectId,
+    startDate,
+    endDate,
+    filters,
+  }: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters?: Partial<
       Record<
         FilterField,
@@ -162,8 +181,8 @@ export class ClickHouseAnalyticsService {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<FeedbacksResult> {
+    >;
+  }): Promise<FeedbacksResult> {
     return this.tracer.withActiveSpan(
       "ClickHouseAnalyticsService.getFeedbacks",
       { attributes: { "tenant.id": projectId } },

--- a/platform/app/src/server/analytics/clickhouse/filter-translator.ts
+++ b/platform/app/src/server/analytics/clickhouse/filter-translator.ts
@@ -40,12 +40,12 @@ export interface FilterTranslation {
  * range instead of cold-scanning every weekly partition (incl. cold S3).
  * Handlers that don't touch `stored_spans` ignore it.
  */
-type FilterHandler = (
-  values: string[],
-  key?: string,
-  subkey?: string,
-  spanTimePredicate?: string,
-) => FilterTranslation;
+type FilterHandler = (params: {
+  values: string[];
+  key?: string;
+  subkey?: string;
+  spanTimePredicate?: string;
+}) => FilterTranslation;
 
 /**
  * Parameter counter for generating unique parameter names
@@ -75,66 +75,74 @@ function genParamName(prefix: string): string {
  */
 const filterHandlers: Record<FilterField, FilterHandler | null> = {
   // Topic Filters
-  "topics.topics": (values) => translateTopicFilter(values),
-  "topics.subtopics": (values) => translateSubtopicFilter(values),
+  "topics.topics": ({ values }) => translateTopicFilter(values),
+  "topics.subtopics": ({ values }) => translateSubtopicFilter(values),
 
   // Metadata Filters
-  "metadata.user_id": (values) =>
+  "metadata.user_id": ({ values }) =>
     translateMetadataFilter("langwatch.user_id", values),
-  "metadata.thread_id": (values) =>
+  "metadata.thread_id": ({ values }) =>
     translateMetadataFilter("gen_ai.conversation.id", values),
-  "metadata.customer_id": (values) =>
+  "metadata.customer_id": ({ values }) =>
     translateMetadataFilter("langwatch.customer_id", values),
-  "metadata.labels": (values) => translateLabelsFilter(values),
-  "metadata.key": (values) => translateMetadataKeyFilter(values),
-  "metadata.value": (values, key) => translateMetadataValueFilter(values, key),
-  "metadata.prompt_ids": (values) => translatePromptIdsFilter(values),
+  "metadata.labels": ({ values }) => translateLabelsFilter(values),
+  "metadata.key": ({ values }) => translateMetadataKeyFilter(values),
+  "metadata.value": ({ values, key }) =>
+    translateMetadataValueFilter(values, key),
+  "metadata.prompt_ids": ({ values }) => translatePromptIdsFilter(values),
 
   // Trace Filters
-  "traces.origin": (values) => translateOriginFilter(values),
-  "traces.error": (values) => translateErrorFilter(values),
-  "traces.name": (values) => translateTraceNameFilter(values),
+  "traces.origin": ({ values }) => translateOriginFilter(values),
+  "traces.error": ({ values }) => translateErrorFilter(values),
+  "traces.name": ({ values }) => translateTraceNameFilter(values),
 
   // Span Filters
-  "spans.type": (values, _key, _subkey, spanTime) =>
-    translateSpanTypeFilter(values, spanTime),
-  "spans.model": (values, _key, _subkey, spanTime) =>
-    translateSpanModelFilter(values, spanTime),
+  "spans.type": ({ values, spanTimePredicate }) =>
+    translateSpanTypeFilter(values, spanTimePredicate),
+  "spans.model": ({ values, spanTimePredicate }) =>
+    translateSpanModelFilter(values, spanTimePredicate),
 
   // Evaluation Filters
-  "evaluations.evaluator_id": (values) => translateEvaluatorIdFilter(values),
-  "evaluations.evaluator_id.guardrails_only": (values) =>
+  "evaluations.evaluator_id": ({ values }) =>
     translateEvaluatorIdFilter(values),
-  "evaluations.evaluator_id.has_passed": (values) =>
+  "evaluations.evaluator_id.guardrails_only": ({ values }) =>
+    translateEvaluatorIdFilter(values),
+  "evaluations.evaluator_id.has_passed": ({ values }) =>
     translateEvaluatorIdFilter(values, "AND Passed IS NOT NULL"),
-  "evaluations.evaluator_id.has_score": (values) =>
+  "evaluations.evaluator_id.has_score": ({ values }) =>
     translateEvaluatorIdFilter(values, "AND Score IS NOT NULL"),
-  "evaluations.evaluator_id.has_label": (values) =>
+  "evaluations.evaluator_id.has_label": ({ values }) =>
     translateEvaluatorIdFilter(
       values,
       "AND Label IS NOT NULL AND Label != '' AND Label NOT IN ('succeeded', 'failed')",
     ),
-  "evaluations.passed": (values, key) =>
+  "evaluations.passed": ({ values, key }) =>
     translateEvaluationPassedFilter(values, key),
-  "evaluations.score": (values, key) =>
+  "evaluations.score": ({ values, key }) =>
     translateEvaluationScoreFilter(values, key),
-  "evaluations.label": (values, key) =>
+  "evaluations.label": ({ values, key }) =>
     translateEvaluationLabelFilter(values, key),
-  "evaluations.state": (values, key) =>
+  "evaluations.state": ({ values, key }) =>
     translateEvaluationStateFilter(values, key),
 
   // Event Filters
-  "events.event_type": (values, _key, _subkey, spanTime) =>
-    translateEventTypeFilter(values, spanTime),
-  "events.metrics.key": (values, key, _subkey, spanTime) =>
-    translateEventMetricKeyFilter(values, key, spanTime),
-  "events.metrics.value": (values, key, subkey, spanTime) =>
-    translateEventMetricValueFilter(values, key, subkey, spanTime),
-  "events.event_details.key": (values, key, _subkey, spanTime) =>
-    translateEventDetailKeyFilter(values, key, spanTime),
+  "events.event_type": ({ values, spanTimePredicate }) =>
+    translateEventTypeFilter(values, spanTimePredicate),
+  "events.metrics.key": ({ values, key, spanTimePredicate }) =>
+    translateEventMetricKeyFilter(values, key, spanTimePredicate),
+  "events.metrics.value": ({ values, key, subkey, spanTimePredicate }) =>
+    translateEventMetricValueFilter({
+      values,
+      eventType: key,
+      metricKey: subkey,
+      spanTimePredicate,
+    }),
+  "events.event_details.key": ({ values, key, spanTimePredicate }) =>
+    translateEventDetailKeyFilter(values, key, spanTimePredicate),
 
   // Annotation Filters
-  "annotations.hasAnnotation": (values) => translateAnnotationFilter(values),
+  "annotations.hasAnnotation": ({ values }) =>
+    translateAnnotationFilter(values),
 };
 
 /**
@@ -151,19 +159,27 @@ const noOpFilter: FilterTranslation = {
  *
  * Uses registry lookup instead of switch statement for better extensibility.
  */
-export function translateFilter(
-  field: FilterField,
-  values: string[],
-  key?: string,
-  subkey?: string,
-  spanTimePredicate?: string,
-): FilterTranslation {
+export function translateFilter({
+  field,
+  values,
+  key,
+  subkey,
+  spanTimePredicate,
+}: {
+  field: FilterField;
+  values: string[];
+  key?: string;
+  subkey?: string;
+  spanTimePredicate?: string;
+}): FilterTranslation {
   if (values.length === 0) {
     return noOpFilter;
   }
 
   const handler = filterHandlers[field];
-  return handler ? handler(values, key, subkey, spanTimePredicate) : noOpFilter;
+  return handler
+    ? handler({ values, key, subkey, spanTimePredicate })
+    : noOpFilter;
 }
 
 /**
@@ -657,12 +673,17 @@ function translateEventMetricKeyFilter(
  * Uses paired arrayExists to correlate Events.Name with Events.Attributes at the same index.
  * This prevents false positives where event type matches at one index but value matches at another.
  */
-function translateEventMetricValueFilter(
-  values: string[],
-  eventType?: string,
-  metricKey?: string,
+function translateEventMetricValueFilter({
+  values,
+  eventType,
+  metricKey,
   spanTimePredicate = "",
-): FilterTranslation {
+}: {
+  values: string[];
+  eventType?: string;
+  metricKey?: string;
+  spanTimePredicate?: string;
+}): FilterTranslation {
   const ts = tableAliases.trace_summaries;
 
   if (!metricKey) {
@@ -815,39 +836,36 @@ export function translateAllFilters(
     if (Array.isArray(value)) {
       // Simple array filter
       translations.push(
-        translateFilter(
-          field as FilterField,
-          value,
-          undefined,
-          undefined,
+        translateFilter({
+          field: field as FilterField,
+          values: value,
           spanTimePredicate,
-        ),
+        }),
       );
     } else if (typeof value === "object") {
       // Nested filter with key
       for (const [key, subValue] of Object.entries(value)) {
         if (Array.isArray(subValue)) {
           translations.push(
-            translateFilter(
-              field as FilterField,
-              subValue,
+            translateFilter({
+              field: field as FilterField,
+              values: subValue,
               key,
-              undefined,
               spanTimePredicate,
-            ),
+            }),
           );
         } else if (typeof subValue === "object") {
           // Double nested with key and subkey
           for (const [subkey, subSubValue] of Object.entries(subValue)) {
             if (Array.isArray(subSubValue)) {
               translations.push(
-                translateFilter(
-                  field as FilterField,
-                  subSubValue,
+                translateFilter({
+                  field: field as FilterField,
+                  values: subSubValue,
                   key,
                   subkey,
                   spanTimePredicate,
-                ),
+                }),
               );
             }
           }

--- a/platform/app/src/server/analytics/clickhouse/metric-translator.ts
+++ b/platform/app/src/server/analytics/clickhouse/metric-translator.ts
@@ -151,12 +151,17 @@ function getConditionalAggregation(aggregation: AggregationTypes): string {
 /**
  * Translate a simple numeric aggregation (avg, sum, min, max)
  */
-function translateSimpleAggregation(
-  columnExpr: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  percentileMode: PercentileMode = "exact",
-): string {
+function translateSimpleAggregation({
+  columnExpr,
+  aggregation,
+  alias,
+  percentileMode = "exact",
+}: {
+  columnExpr: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  percentileMode?: PercentileMode;
+}): string {
   switch (aggregation) {
     case "avg":
       return `avg(${columnExpr}) AS ${alias}`;
@@ -187,12 +192,17 @@ function translateSimpleAggregation(
  * Uses ClickHouse array functions (arraySum, arrayAvg, etc.)
  * to aggregate values extracted from arrays.
  */
-function translateArrayAggregation(
-  arrayExpr: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  percentileMode: PercentileMode = "exact",
-): string {
+function translateArrayAggregation({
+  arrayExpr,
+  aggregation,
+  alias,
+  percentileMode = "exact",
+}: {
+  arrayExpr: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  percentileMode?: PercentileMode;
+}): string {
   switch (aggregation) {
     case "avg":
       // Flatten arrays across rows and compute average
@@ -223,13 +233,19 @@ function translateArrayAggregation(
 /**
  * Build alias for a metric aggregation
  */
-export function buildMetricAlias(
-  index: number,
-  metric: string,
-  aggregation: AggregationTypes,
-  key?: string,
-  subkey?: string,
-): string {
+export function buildMetricAlias({
+  index,
+  metric,
+  aggregation,
+  key,
+  subkey,
+}: {
+  index: number;
+  metric: string;
+  aggregation: AggregationTypes;
+  key?: string;
+  subkey?: string;
+}): string {
   const parts = [index.toString(), metric.replace(/\./g, "_"), aggregation];
   if (key) parts.push(key.replace(/[^a-zA-Z0-9]/g, "_"));
   if (subkey) parts.push(subkey.replace(/[^a-zA-Z0-9]/g, "_"));
@@ -245,57 +261,78 @@ export function buildMetricAlias(
  * JOINs and has different column mappings. The prefix routing ensures each
  * metric type gets its specialized translation logic.
  */
-export function translateMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  index: number,
-  key?: string,
-  subkey?: string,
-): MetricTranslation {
-  const alias = buildMetricAlias(index, metric, aggregation, key, subkey);
+export function translateMetric({
+  metric,
+  aggregation,
+  index,
+  key,
+  subkey,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  index: number;
+  key?: string;
+  subkey?: string;
+}): MetricTranslation {
+  const alias = buildMetricAlias({ index, metric, aggregation, key, subkey });
   const requiredJoins: CHTable[] = [];
 
   // Handle specific metric categories
   if (metric.startsWith("metadata.")) {
-    return translateMetadataMetric(metric, aggregation, alias, requiredJoins);
+    return translateMetadataMetric({
+      metric,
+      aggregation,
+      alias,
+      requiredJoins,
+    });
   }
 
   if (metric.startsWith("performance.")) {
-    return translatePerformanceMetric(
+    return translatePerformanceMetric({
       metric,
       aggregation,
       alias,
       requiredJoins,
-    );
+    });
   }
 
   if (metric.startsWith("evaluations.")) {
-    return translateEvaluationMetric(
+    return translateEvaluationMetric({
       metric,
       aggregation,
       alias,
       requiredJoins,
-      key,
-    );
+      evaluatorId: key,
+    });
   }
 
   if (metric.startsWith("events.")) {
-    return translateEventMetric(
+    return translateEventMetric({
       metric,
       aggregation,
       alias,
       requiredJoins,
-      key,
-      subkey,
-    );
+      eventType: key,
+      metricKey: subkey,
+    });
   }
 
   if (metric.startsWith("sentiment.")) {
-    return translateSentimentMetric(metric, aggregation, alias, requiredJoins);
+    return translateSentimentMetric({
+      metric,
+      aggregation,
+      alias,
+      requiredJoins,
+    });
   }
 
   if (metric.startsWith("threads.")) {
-    return translateThreadsMetric(metric, aggregation, alias, requiredJoins);
+    return translateThreadsMetric({
+      metric,
+      aggregation,
+      alias,
+      requiredJoins,
+    });
   }
 
   // Default: try to map directly
@@ -306,7 +343,11 @@ export function translateMetric(
       requiredJoins.push(mapping.table);
     }
     return {
-      selectExpression: translateSimpleAggregation(column, aggregation, alias),
+      selectExpression: translateSimpleAggregation({
+        columnExpr: column,
+        aggregation,
+        alias,
+      }),
       alias,
       requiredJoins,
       params: {},
@@ -325,22 +366,27 @@ export function translateMetric(
 /**
  * Translate metadata metrics (trace_id, user_id, thread_id, span_type)
  */
-function translateMetadataMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-): MetricTranslation {
+function translateMetadataMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+}): MetricTranslation {
   const ts = tableAliases.trace_summaries;
 
   switch (metric) {
     case "metadata.trace_id":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TraceId`,
+        selectExpression: translateSimpleAggregation({
+          columnExpr: `${ts}.TraceId`,
           aggregation,
           alias,
-        ),
+        }),
         alias,
         requiredJoins,
         params: {},
@@ -357,11 +403,11 @@ function translateMetadataMetric(
         };
       }
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.Attributes['langwatch.user_id']`,
+        selectExpression: translateSimpleAggregation({
+          columnExpr: `${ts}.Attributes['langwatch.user_id']`,
           aggregation,
           alias,
-        ),
+        }),
         alias,
         requiredJoins,
         params: {},
@@ -378,11 +424,11 @@ function translateMetadataMetric(
         };
       }
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.Attributes['gen_ai.conversation.id']`,
+        selectExpression: translateSimpleAggregation({
+          columnExpr: `${ts}.Attributes['gen_ai.conversation.id']`,
           aggregation,
           alias,
-        ),
+        }),
         alias,
         requiredJoins,
         params: {},
@@ -399,11 +445,11 @@ function translateMetadataMetric(
         requiredJoins.push("stored_spans");
       }
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TraceId`,
+        selectExpression: translateSimpleAggregation({
+          columnExpr: `${ts}.TraceId`,
           aggregation,
           alias,
-        ),
+        }),
         alias,
         requiredJoins,
         params: {},
@@ -428,18 +474,29 @@ function translateMetadataMetric(
  * thread the literal at every call site - forgetting silently regresses to
  * `quantileExact` (the helper's default) and the O(N) memory bug only surfaces
  * under heavy analytics load. If you ever want a per-call override, drop back
- * to the raw `translateSimpleAggregation(col, aggregation, alias, mode)` form.
+ * to the raw `translateSimpleAggregation({ columnExpr, aggregation, alias,
+ * percentileMode })` form.
  */
-function translatePerformanceMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-): MetricTranslation {
+function translatePerformanceMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+}): MetricTranslation {
   const ts = tableAliases.trace_summaries;
   const ss = tableAliases.stored_spans;
   const perfAgg = (col: string): string =>
-    translateSimpleAggregation(col, aggregation, alias, "tdigest");
+    translateSimpleAggregation({
+      columnExpr: col,
+      aggregation,
+      alias,
+      percentileMode: "tdigest",
+    });
 
   switch (metric) {
     case "performance.completion_time":
@@ -613,13 +670,19 @@ function translatePerformanceMetric(
 /**
  * Translate evaluation metrics
  */
-function translateEvaluationMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-  evaluatorId?: string,
-): MetricTranslation {
+function translateEvaluationMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+  evaluatorId,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+  evaluatorId?: string;
+}): MetricTranslation {
   requiredJoins.push("evaluation_runs");
   const es = tableAliases.evaluation_runs;
 
@@ -689,14 +752,21 @@ function translateEvaluationMetric(
 /**
  * Translate event metrics (event_type, event_score, event_details)
  */
-function translateEventMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-  eventType?: string,
-  metricKey?: string,
-): MetricTranslation {
+function translateEventMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+  eventType,
+  metricKey,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+  eventType?: string;
+  metricKey?: string;
+}): MetricTranslation {
   requiredJoins.push("stored_spans");
   const ss = tableAliases.stored_spans;
 
@@ -755,11 +825,11 @@ function translateEventMetric(
       }
 
       // Apply aggregation to the extracted scores array
-      const aggExpr = translateArrayAggregation(
-        scoreExtraction,
+      const aggExpr = translateArrayAggregation({
+        arrayExpr: scoreExtraction,
         aggregation,
         alias,
-      );
+      });
       return {
         selectExpression: aggExpr,
         alias,
@@ -800,12 +870,17 @@ function translateEventMetric(
  * { "events.metrics.value": 0 } } to exclude zero votes. Zeros represent
  * neutral/missing values that would skew aggregation results.
  */
-function translateSentimentMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-): MetricTranslation {
+function translateSentimentMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+}): MetricTranslation {
   const ss = tableAliases.stored_spans;
 
   switch (metric) {
@@ -843,11 +918,11 @@ function translateSentimentMetric(
           )
         )`;
 
-      const aggExpr = translateArrayAggregation(
-        voteExtraction,
+      const aggExpr = translateArrayAggregation({
+        arrayExpr: voteExtraction,
         aggregation,
         alias,
-      );
+      });
       return {
         selectExpression: aggExpr,
         alias,
@@ -869,12 +944,17 @@ function translateSentimentMetric(
 /**
  * Translate threads metrics (average_duration_per_thread)
  */
-function translateThreadsMetric(
-  metric: string,
-  aggregation: AggregationTypes,
-  alias: string,
-  requiredJoins: CHTable[],
-): MetricTranslation {
+function translateThreadsMetric({
+  metric,
+  aggregation,
+  alias,
+  requiredJoins,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  alias: string;
+  requiredJoins: CHTable[];
+}): MetricTranslation {
   const ts = tableAliases.trace_summaries;
 
   switch (metric) {
@@ -909,17 +989,25 @@ function translateThreadsMetric(
 /**
  * Translate a pipeline aggregation (per-user, per-thread metrics)
  */
-export function translatePipelineAggregation(
-  metric: string,
-  aggregation: AggregationTypes,
-  pipelineField: string,
-  pipelineAggregation: PipelineAggregationTypes,
-  index: number,
-  key?: string,
-  subkey?: string,
-): MetricTranslation {
+export function translatePipelineAggregation({
+  metric,
+  aggregation,
+  pipelineField,
+  pipelineAggregation,
+  index,
+  key,
+  subkey,
+}: {
+  metric: string;
+  aggregation: AggregationTypes;
+  pipelineField: string;
+  pipelineAggregation: PipelineAggregationTypes;
+  index: number;
+  key?: string;
+  subkey?: string;
+}): MetricTranslation {
   const ts = tableAliases.trace_summaries;
-  const alias = buildMetricAlias(index, metric, aggregation, key, subkey);
+  const alias = buildMetricAlias({ index, metric, aggregation, key, subkey });
 
   // Get the pipeline field expression
   // ES terms aggregation excludes null/missing values, so we just use the column directly
@@ -943,7 +1031,13 @@ export function translatePipelineAggregation(
   }
 
   // Get the inner metric translation
-  const innerMetric = translateMetric(metric, aggregation, index, key, subkey);
+  const innerMetric = translateMetric({
+    metric,
+    aggregation,
+    index,
+    key,
+    subkey,
+  });
 
   // Special handling for threads.average_duration_per_thread with pipeline
   // This requires a 3-level aggregation:

--- a/platform/app/src/server/analytics/types.ts
+++ b/platform/app/src/server/analytics/types.ts
@@ -181,11 +181,11 @@ export interface FeedbacksResult {
  * semantics to drift.
  */
 export interface AnalyticsBackend {
-  getDataForFilter(
-    projectId: string,
-    field: FilterField,
-    startDate: number,
-    endDate: number,
+  getDataForFilter(params: {
+    projectId: string;
+    field: FilterField;
+    startDate: number;
+    endDate: number;
     filters: Partial<
       Record<
         FilterField,
@@ -193,15 +193,15 @@ export interface AnalyticsBackend {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-    key?: string,
-    subkey?: string,
-    searchQuery?: string,
-  ): Promise<FilterDataResult>;
-  getTopUsedDocuments(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+    >;
+    key?: string;
+    subkey?: string;
+    searchQuery?: string;
+  }): Promise<FilterDataResult>;
+  getTopUsedDocuments(params: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters?: Partial<
       Record<
         FilterField,
@@ -209,12 +209,12 @@ export interface AnalyticsBackend {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<TopDocumentsResult>;
-  getFeedbacks(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+    >;
+  }): Promise<TopDocumentsResult>;
+  getFeedbacks(params: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters?: Partial<
       Record<
         FilterField,
@@ -222,7 +222,7 @@ export interface AnalyticsBackend {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<FeedbacksResult>;
+    >;
+  }): Promise<FeedbacksResult>;
   isAvailable(): boolean;
 }

--- a/platform/app/src/server/api/__tests__/modelNotConfigured.trpc.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/modelNotConfigured.trpc.unit.test.ts
@@ -19,12 +19,12 @@ import { errorFormatter } from "../trpc";
 describe("tRPC wire mapping for ModelNotConfiguredError", () => {
   /** @scenario A tRPC procedure forwards ModelNotConfiguredError as a typed TRPCError */
   it("serialises the typed error into data.cause for the frontend interceptor", () => {
-    const cause = new ModelNotConfiguredError(
-      "traces.ai_search",
-      "FAST",
-      "AI search",
-      "proj_abc",
-    );
+    const cause = new ModelNotConfiguredError({
+      featureKey: "traces.ai_search",
+      role: "FAST",
+      featureDisplayName: "AI search",
+      projectId: "proj_abc",
+    });
     const trpcError = new TRPCError({
       code: "BAD_REQUEST",
       message: cause.message,

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -857,12 +857,15 @@ async function checkPermissionFromBindings({
     if (!bindingScopeCanGrant(RoleBindingScopeType.TEAM, permission)) {
       return false;
     }
-    return resolveBindingPermission(
-      { role: teamUser.role, customRoleId: teamUser.assignedRoleId ?? null },
+    return resolveBindingPermission({
+      binding: {
+        role: teamUser.role,
+        customRoleId: teamUser.assignedRoleId ?? null,
+      },
       organizationRole,
       permission,
       prisma,
-    );
+    });
   }
 
   // Union permissions across ALL matching bindings — permitted if any grants it
@@ -890,12 +893,12 @@ async function checkPermissionFromBindings({
       continue;
     }
 
-    const permitted = await resolveBindingPermission(
+    const permitted = await resolveBindingPermission({
       binding,
       organizationRole,
       permission,
       prisma,
-    );
+    });
     if (permitted) return true;
   }
 
@@ -910,12 +913,17 @@ async function checkPermissionFromBindings({
  * implements parallel CUSTOM-role logic for API key resolution and must
  * stay in sync with the non-empty/empty fallthrough semantics here.
  */
-async function resolveBindingPermission(
-  binding: { role: TeamUserRole; customRoleId: string | null },
-  organizationRole: OrganizationUserRole | null,
-  permission: Permission,
-  prisma: PrismaClient,
-): Promise<boolean> {
+async function resolveBindingPermission({
+  binding,
+  organizationRole,
+  permission,
+  prisma,
+}: {
+  binding: { role: TeamUserRole; customRoleId: string | null };
+  organizationRole: OrganizationUserRole | null;
+  permission: Permission;
+  prisma: PrismaClient;
+}): Promise<boolean> {
   if (binding.customRoleId) {
     const customRole = await prisma.customRole.findUnique({
       where: { id: binding.customRoleId },
@@ -1206,12 +1214,12 @@ export async function hasOrganizationPermission(
     select: { role: true, assignedRoleId: true },
   });
   for (const tu of teamMemberships) {
-    const permitted = await resolveBindingPermission(
-      { role: tu.role, customRoleId: tu.assignedRoleId ?? null },
-      orgMember.role,
+    const permitted = await resolveBindingPermission({
+      binding: { role: tu.role, customRoleId: tu.assignedRoleId ?? null },
+      organizationRole: orgMember.role,
       permission,
-      ctx.prisma,
-    );
+      prisma: ctx.prisma,
+    });
     if (permitted) return true;
   }
   return false;

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -122,13 +122,12 @@ beforeEach(() => {
 
 function expectFullResolution() {
   expect(mockCreate).toHaveBeenCalledWith(expect.anything(), BLOB_DEPS);
-  expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
-    "project_123",
-    ["t1"],
-    expect.any(Object),
-    undefined,
-    { full: true },
-  );
+  expect(mockGetTracesWithSpans).toHaveBeenCalledWith({
+    projectId: "project_123",
+    traceIds: ["t1"],
+    protections: expect.any(Object),
+    opts: { full: true },
+  });
 }
 
 describe("annotation router — #4991 AC3 annotation-queue reads", () => {

--- a/platform/app/src/server/api/routers/__tests__/langy.conversationVisibility.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.conversationVisibility.integration.test.ts
@@ -121,7 +121,7 @@ const recordedSteps = (
 
 /** The ClickHouse event-log read, the one boundary this file substitutes. */
 const eventsReader = {
-  getEventsOccurredSince: async (aggregateId: string) =>
+  getEventsOccurredSince: async ({ aggregateId }: { aggregateId: string }) =>
     recordedSteps(aggregateId),
 };
 
@@ -236,12 +236,11 @@ describe("Langy conversation updates reach exactly the members who may read", ()
     });
 
     broadcast = new BroadcastService(null);
-    const conversations = new LangyConversationService(
-      new PrismaLangyConversationRepository(prisma),
-      {} as never,
-      undefined,
-      eventsReader,
-    );
+    const conversations = new LangyConversationService({
+      repository: new PrismaLangyConversationRepository(prisma),
+      commands: {} as never,
+      events: eventsReader,
+    });
     appHolder.current = { broadcast, langy: { conversations } };
 
     const subscriber = createLangyConversationUpdateBroadcastSubscriber({

--- a/platform/app/src/server/api/routers/__tests__/optimization-publish.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/optimization-publish.integration.test.ts
@@ -15,12 +15,17 @@ import { createInnerTRPCContext } from "../../trpc";
  * Retry a query until it returns a result or max attempts reached.
  * Helps with occasional DB sync delays in integration tests.
  */
-async function waitForEvaluator(
-  workflowId: string,
-  projectId: string,
+async function waitForEvaluator({
+  workflowId,
+  projectId,
   maxAttempts = 3,
   delayMs = 50,
-) {
+}: {
+  workflowId: string;
+  projectId: string;
+  maxAttempts?: number;
+  delayMs?: number;
+}) {
   for (let i = 0; i < maxAttempts; i++) {
     const evaluator = await prisma.evaluator.findFirst({
       where: { workflowId, projectId, archivedAt: null },
@@ -123,7 +128,10 @@ describe("Optimization Publish - Evaluator Integration", () => {
       expect(updatedWorkflow?.isComponent).toBe(false);
 
       // Verify evaluator was created (with retry for DB sync)
-      const evaluator = await waitForEvaluator(workflow.id, projectId);
+      const evaluator = await waitForEvaluator({
+        workflowId: workflow.id,
+        projectId,
+      });
 
       expect(evaluator).not.toBeNull();
       expect(evaluator?.name).toBe("Bias Detection Evaluator");
@@ -147,7 +155,10 @@ describe("Optimization Publish - Evaluator Integration", () => {
       });
 
       // Get the evaluator (with retry for DB sync)
-      const evaluator = await waitForEvaluator(workflow.id, projectId);
+      const evaluator = await waitForEvaluator({
+        workflowId: workflow.id,
+        projectId,
+      });
       expect(evaluator?.name).toBe("Original Name");
       createdEvaluatorIds.push(evaluator!.id);
 

--- a/platform/app/src/server/api/routers/__tests__/role.authorization.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/role.authorization.integration.test.ts
@@ -44,12 +44,17 @@ describe("Feature: role router caller authorization", () => {
   let memberCaller: ReturnType<typeof callerFor>;
   let outsiderAdminCaller: ReturnType<typeof callerFor>;
 
-  const makeUser = async (
-    label: string,
-    orgId: string,
-    role: OrganizationUserRole,
-    bindingRole: TeamUserRole,
-  ) => {
+  const makeUser = async ({
+    label,
+    orgId,
+    role,
+    bindingRole,
+  }: {
+    label: string;
+    orgId: string;
+    role: OrganizationUserRole;
+    bindingRole: TeamUserRole;
+  }) => {
     const user = await prisma.user.create({
       data: { name: `${label} ${ns}`, email: `${label}-${ns}@example.com` },
     });
@@ -89,24 +94,24 @@ describe("Feature: role router caller authorization", () => {
     });
     otherOrganizationId = other.id;
 
-    const adminUserId = await makeUser(
-      "admin",
-      organizationId,
-      OrganizationUserRole.ADMIN,
-      TeamUserRole.ADMIN,
-    );
-    memberUserId = await makeUser(
-      "member",
-      organizationId,
-      OrganizationUserRole.MEMBER,
-      TeamUserRole.MEMBER,
-    );
-    const outsiderAdminUserId = await makeUser(
-      "outsider",
-      otherOrganizationId,
-      OrganizationUserRole.ADMIN,
-      TeamUserRole.ADMIN,
-    );
+    const adminUserId = await makeUser({
+      label: "admin",
+      orgId: organizationId,
+      role: OrganizationUserRole.ADMIN,
+      bindingRole: TeamUserRole.ADMIN,
+    });
+    memberUserId = await makeUser({
+      label: "member",
+      orgId: organizationId,
+      role: OrganizationUserRole.MEMBER,
+      bindingRole: TeamUserRole.MEMBER,
+    });
+    const outsiderAdminUserId = await makeUser({
+      label: "outsider",
+      orgId: otherOrganizationId,
+      role: OrganizationUserRole.ADMIN,
+      bindingRole: TeamUserRole.ADMIN,
+    });
 
     const customRole = await prisma.customRole.create({
       data: {

--- a/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -179,12 +179,12 @@ describe("traces router — #4991 AC2 thread reads", () => {
         projectId: "project_123",
         threadId: "thread-1",
       });
-      expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
-        "project_123",
-        "thread-1",
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetTracesByThreadId).toHaveBeenCalledWith({
+        projectId: "project_123",
+        threadId: "thread-1",
+        protections: expect.any(Object),
+        opts: { full: true },
+      });
     });
   });
 
@@ -195,12 +195,12 @@ describe("traces router — #4991 AC2 thread reads", () => {
         threadIds: ["thread-1"],
       });
       expectConstructedWithBlobDeps();
-      expect(mockGetTracesWithSpansByThreadIds).toHaveBeenCalledWith(
-        "project_123",
-        ["thread-1"],
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetTracesWithSpansByThreadIds).toHaveBeenCalledWith({
+        projectId: "project_123",
+        threadIds: ["thread-1"],
+        protections: expect.any(Object),
+        opts: { full: true },
+      });
     });
   });
 });
@@ -224,13 +224,13 @@ describe("traces router — #4991 AC4 dataset/sample builders", () => {
     it("constructs with deps and resolves spans full", async () => {
       await caller.getSampleTracesDataset(baseFilters);
       expectConstructedWithBlobDeps();
-      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
-        "project_123",
-        ["t1"],
-        expect.any(Object),
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith({
+        projectId: "project_123",
+        traceIds: ["t1"],
+        protections: expect.any(Object),
+        occurredAt: expect.any(Object),
+        opts: { full: true },
+      });
     });
   });
 
@@ -243,13 +243,13 @@ describe("traces router — #4991 AC4 dataset/sample builders", () => {
         expectedResults: 10,
       });
       expectConstructedWithBlobDeps();
-      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
-        "project_123",
-        ["t1"],
-        expect.any(Object),
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith({
+        projectId: "project_123",
+        traceIds: ["t1"],
+        protections: expect.any(Object),
+        occurredAt: expect.any(Object),
+        opts: { full: true },
+      });
     });
   });
 });
@@ -323,11 +323,11 @@ describe("traces router — #4991 AC5 list grid stays preview", () => {
       });
       expect(mockBuildDeps).not.toHaveBeenCalled();
       // getTracesWithSpans called with NO { full: true } opts (preview only).
-      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
-        "project_123",
-        ["t1"],
-        expect.any(Object),
-      );
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith({
+        projectId: "project_123",
+        traceIds: ["t1"],
+        protections: expect.any(Object),
+      });
     });
   });
 });

--- a/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -173,12 +173,12 @@ describe("translateRouter.translate()", () => {
 
   describe("when the model cannot be resolved", () => {
     it("propagates a typed MODEL_NOT_CONFIGURED cause to its own toast surface", async () => {
-      const modelError = new ModelNotConfiguredError(
-        "translate.text",
-        "FAST",
-        "Inline translation",
-        "project_abc123",
-      );
+      const modelError = new ModelNotConfiguredError({
+        featureKey: "translate.text",
+        role: "FAST",
+        featureDisplayName: "Inline translation",
+        projectId: "project_abc123",
+      });
       mockGetVercelAIModel.mockRejectedValue(modelError);
 
       await expect(
@@ -196,16 +196,16 @@ describe("translateRouter.translate()", () => {
     });
 
     it("propagates a typed MODEL_PROVIDER_DISABLED cause to its own toast surface", async () => {
-      const modelError = new ModelProviderDisabledError(
-        "translate.text",
-        "Inline translation",
-        "FAST",
-        "project_abc123",
-        "project",
-        "openai/gpt-5-mini",
-        "openai",
-        null,
-      );
+      const modelError = new ModelProviderDisabledError({
+        featureKey: "translate.text",
+        featureDisplayName: "Inline translation",
+        role: "FAST",
+        projectId: "project_abc123",
+        resolvedScope: "project",
+        resolvedModel: "openai/gpt-5-mini",
+        providerKey: "openai",
+        alternate: null,
+      });
       mockGetVercelAIModel.mockRejectedValue(modelError);
 
       const error = await caller

--- a/platform/app/src/server/api/routers/analytics/documents.ts
+++ b/platform/app/src/server/api/routers/analytics/documents.ts
@@ -8,10 +8,10 @@ export const topUsedDocuments = protectedProcedure
   .use(checkProjectPermission("cost:view"))
   .query(async ({ input }) => {
     const analyticsService = getApp().analytics.service;
-    return analyticsService.getTopUsedDocuments(
-      input.projectId,
-      input.startDate,
-      input.endDate,
-      input.filters,
-    );
+    return analyticsService.getTopUsedDocuments({
+      projectId: input.projectId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      filters: input.filters,
+    });
   });

--- a/platform/app/src/server/api/routers/analytics/feedbacks.ts
+++ b/platform/app/src/server/api/routers/analytics/feedbacks.ts
@@ -11,10 +11,10 @@ export const feedbacks = protectedProcedure
   .use(checkProjectPermission("cost:view"))
   .query(async ({ input }) => {
     const analyticsService = getApp().analytics.service;
-    return analyticsService.getFeedbacks(
-      input.projectId,
-      input.startDate,
-      input.endDate,
-      input.filters,
-    );
+    return analyticsService.getFeedbacks({
+      projectId: input.projectId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      filters: input.filters,
+    });
   });

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -27,12 +27,17 @@ const scoreOptionSchema = z.object({
 const scoreOptions = z.record(z.string(), scoreOptionSchema);
 
 // Helper function to fetch and enrich queue items with traces and annotations
-const enrichQueueItemsWithTracesAndAnnotations = async (
-  ctx: { prisma: PrismaClient; session: Session | null },
-  projectId: string,
-  queueItems: AnnotationQueueItem[],
-  protections: Protections,
-) => {
+const enrichQueueItemsWithTracesAndAnnotations = async ({
+  ctx,
+  projectId,
+  queueItems,
+  protections,
+}: {
+  ctx: { prisma: PrismaClient; session: Session | null };
+  projectId: string;
+  queueItems: AnnotationQueueItem[];
+  protections: Protections;
+}) => {
   // Get all unique trace IDs from queue items
   const traceIds = [...new Set(queueItems.map((item) => item.traceId))];
 
@@ -58,13 +63,12 @@ const enrichQueueItemsWithTracesAndAnnotations = async (
     ctx.prisma,
     buildTraceBlobResolutionDeps(),
   );
-  const traces = await traceService.getTracesWithSpans(
+  const traces = await traceService.getTracesWithSpans({
     projectId,
     traceIds,
     protections,
-    undefined,
-    { full: true },
-  );
+    opts: { full: true },
+  });
 
   // Create lookup maps for O(1) access
   const traceMap = new Map(traces.map((trace) => [trace.trace_id, trace]));
@@ -496,13 +500,12 @@ export const annotationRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      const traces = await traceService.getTracesWithSpans(
-        input.projectId,
+      const traces = await traceService.getTracesWithSpans({
+        projectId: input.projectId,
         traceIds,
         protections,
-        undefined,
-        { full: true },
-      );
+        opts: { full: true },
+      });
       const traceMap = new Map(traces.map((trace) => [trace.trace_id, trace]));
 
       return queueItems.map((item) => ({
@@ -859,10 +862,12 @@ export const annotationRouter = createTRPCRouter({
 
       // Enrich the paginated queue items with traces and annotations
       const enrichedQueueItems = await enrichQueueItemsWithTracesAndAnnotations(
-        ctx,
-        input.projectId,
-        queueItems,
-        protections,
+        {
+          ctx,
+          projectId: input.projectId,
+          queueItems,
+          protections,
+        },
       );
 
       // Create a map of enriched items by their original ID for easy lookup

--- a/platform/app/src/server/api/routers/copyEvaluatorToProject.ts
+++ b/platform/app/src/server/api/routers/copyEvaluatorToProject.ts
@@ -36,12 +36,17 @@ async function loadSourceEvaluator(
  * if a workflow evaluator has no saved version to copy — creating the evaluator
  * without a workflow would leave a structurally broken replica.
  */
-async function copyWorkflowForEvaluator(
-  ctx: CopyEvaluatorCtx,
-  source: SourceEvaluator,
-  targetProjectId: string,
-  sourceProjectId: string,
-): Promise<string | null> {
+async function copyWorkflowForEvaluator({
+  ctx,
+  source,
+  targetProjectId,
+  sourceProjectId,
+}: {
+  ctx: CopyEvaluatorCtx;
+  source: SourceEvaluator;
+  targetProjectId: string;
+  sourceProjectId: string;
+}): Promise<string | null> {
   if (source.type !== "workflow") return null;
 
   if (!source.workflowId || !source.workflow?.latestVersion?.dsl) {
@@ -110,12 +115,12 @@ export async function copyEvaluatorToProject({
   newEvaluatorId?: string;
 }) {
   const source = await loadSourceEvaluator(ctx, evaluatorId, sourceProjectId);
-  const newWorkflowId = await copyWorkflowForEvaluator(
+  const newWorkflowId = await copyWorkflowForEvaluator({
     ctx,
     source,
     targetProjectId,
     sourceProjectId,
-  );
+  });
 
   const evaluatorService = EvaluatorService.create(ctx.prisma);
   try {

--- a/platform/app/src/server/api/routers/group.ts
+++ b/platform/app/src/server/api/routers/group.ts
@@ -17,12 +17,17 @@ import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
 import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
-async function findUniqueGroupSlug(
-  prisma: Pick<PrismaClient, "group">,
-  organizationId: string,
-  baseSlug: string,
-  excludeId?: string,
-): Promise<string> {
+async function findUniqueGroupSlug({
+  prisma,
+  organizationId,
+  baseSlug,
+  excludeId,
+}: {
+  prisma: Pick<PrismaClient, "group">;
+  organizationId: string;
+  baseSlug: string;
+  excludeId?: string;
+}): Promise<string> {
   if (!baseSlug) {
     throw new TRPCError({
       code: "BAD_REQUEST",
@@ -281,11 +286,11 @@ export const groupRouter = createTRPCRouter({
       }
 
       return ctx.prisma.$transaction(async (tx) => {
-        const slug = await findUniqueGroupSlug(
-          tx,
-          input.organizationId,
+        const slug = await findUniqueGroupSlug({
+          prisma: tx,
+          organizationId: input.organizationId,
           baseSlug,
-        );
+        });
 
         const group = await tx.group.create({
           data: {
@@ -511,12 +516,12 @@ export const groupRouter = createTRPCRouter({
       }
 
       const baseSlug = slugify(input.name, { lower: true, strict: true });
-      const slug = await findUniqueGroupSlug(
-        ctx.prisma,
-        input.organizationId,
+      const slug = await findUniqueGroupSlug({
+        prisma: ctx.prisma,
+        organizationId: input.organizationId,
         baseSlug,
-        input.groupId,
-      );
+        excludeId: input.groupId,
+      });
 
       return ctx.prisma.group.update({
         where: { id: input.groupId },
@@ -636,12 +641,12 @@ export const groupRouter = createTRPCRouter({
           lower: true,
           strict: true,
         });
-        const slug = await findUniqueGroupSlug(
-          ctx.prisma,
-          input.organizationId,
+        const slug = await findUniqueGroupSlug({
+          prisma: ctx.prisma,
+          organizationId: input.organizationId,
           baseSlug,
-          input.groupId,
-        );
+          excludeId: input.groupId,
+        });
         resolvedRename = { name: input.rename.name, slug };
       }
 

--- a/platform/app/src/server/api/routers/modelProviders.ts
+++ b/platform/app/src/server/api/routers/modelProviders.ts
@@ -488,12 +488,12 @@ export const modelProviderRouter = createTRPCRouter({
     .use(checkProjectPermission("project:update"))
     .query(async ({ input, ctx }) => {
       const { projectId, provider, customBaseUrl } = input;
-      return validateKeyWithCustomUrl(
+      return validateKeyWithCustomUrl({
         projectId,
         provider,
         customBaseUrl,
-        ctx.prisma,
-      );
+        prisma: ctx.prisma,
+      });
     }),
 
   // ────────────────────────────────────────────────────────────────────────

--- a/platform/app/src/server/api/routers/organization.ts
+++ b/platform/app/src/server/api/routers/organization.ts
@@ -363,12 +363,12 @@ export const organizationRouter = createTRPCRouter({
           // NOTE: imported as a standalone function (not a service method) because
           // getApp().organizations is wrapped by traced() which would turn this
           // sync call into a Promise and silently drop team.members.
-          const enriched = enrichTeamWithRoleBindings(
+          const enriched = enrichTeamWithRoleBindings({
             team,
             userId,
             userRoleBindings,
-            organization.id,
-          );
+            organizationId: organization.id,
+          });
           team.members = enriched.members;
 
           if (isDemoOrg) return true;
@@ -1403,24 +1403,24 @@ export const organizationRouter = createTRPCRouter({
               })()
             : undefined;
 
-          const changeType = getRoleChangeType(
-            OrganizationUserRole.EXTERNAL,
+          const changeType = getRoleChangeType({
+            oldRole: OrganizationUserRole.EXTERNAL,
             oldPermissions,
-            OrganizationUserRole.EXTERNAL,
-            undefined,
-          );
+            newRole: OrganizationUserRole.EXTERNAL,
+            newPermissions: undefined,
+          });
 
           const subscriptionLimits = await getApp().planProvider.getActivePlan({
             organizationId: team.organizationId,
             user: ctx.session.user,
           });
           const licenseRepo = new LicenseEnforcementRepository(prisma);
-          await assertMemberTypeLimitNotExceeded(
+          await assertMemberTypeLimitNotExceeded({
             changeType,
-            team.organizationId,
+            organizationId: team.organizationId,
             licenseRepo,
-            subscriptionLimits,
-          );
+            limits: subscriptionLimits,
+          });
         }
       }
 
@@ -1543,24 +1543,24 @@ export const organizationRouter = createTRPCRouter({
         return allPermissions.length > 0 ? allPermissions : undefined;
       })();
 
-      const changeType = getRoleChangeType(
-        currentMember.role,
-        userPermissions,
-        input.role,
-        undefined,
-      );
+      const changeType = getRoleChangeType({
+        oldRole: currentMember.role,
+        oldPermissions: userPermissions,
+        newRole: input.role,
+        newPermissions: undefined,
+      });
 
       const subscriptionLimits = await getApp().planProvider.getActivePlan({
         organizationId: input.organizationId,
         user: ctx.session.user,
       });
       const licenseRepo = new LicenseEnforcementRepository(prisma);
-      await assertMemberTypeLimitNotExceeded(
+      await assertMemberTypeLimitNotExceeded({
         changeType,
-        input.organizationId,
+        organizationId: input.organizationId,
         licenseRepo,
-        subscriptionLimits,
-      );
+        limits: subscriptionLimits,
+      });
 
       const hasCustomRoleAssignment = (input.teamRoleUpdates ?? []).some(
         (update) =>

--- a/platform/app/src/server/api/routers/providerValidation.ts
+++ b/platform/app/src/server/api/routers/providerValidation.ts
@@ -827,18 +827,23 @@ async function runProbeChain({
  * Validates an API key against a custom URL or default URL.
  * Gets API key from stored DB value OR env var (whichever exists).
  *
- * @param projectId - The project ID to look up stored keys
- * @param provider - The provider key (e.g., "openai", "anthropic")
- * @param customBaseUrl - Optional custom base URL to validate against. If not provided, uses default URL.
- * @param prisma - Prisma client instance
+ * @param params.projectId - The project ID to look up stored keys
+ * @param params.provider - The provider key (e.g., "openai", "anthropic")
+ * @param params.customBaseUrl - Optional custom base URL to validate against. If not provided, uses default URL.
+ * @param params.prisma - Prisma client instance
  * @returns Promise resolving to validation result
  */
-export async function validateKeyWithCustomUrl(
-  projectId: string,
-  provider: string,
-  customBaseUrl: string | undefined,
-  prisma: PrismaClient,
-): Promise<ValidationResult> {
+export async function validateKeyWithCustomUrl({
+  projectId,
+  provider,
+  customBaseUrl,
+  prisma,
+}: {
+  projectId: string;
+  provider: string;
+  customBaseUrl: string | undefined;
+  prisma: PrismaClient;
+}): Promise<ValidationResult> {
   const providerDef = modelProviders[provider as keyof typeof modelProviders];
   if (!providerDef) {
     return { valid: true }; // Unknown provider, skip validation

--- a/platform/app/src/server/api/routers/spans.ts
+++ b/platform/app/src/server/api/routers/spans.ts
@@ -19,13 +19,12 @@ export const spansRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      const traces = await traceService.getTracesWithSpans(
-        input.projectId,
-        [input.traceId],
+      const traces = await traceService.getTracesWithSpans({
+        projectId: input.projectId,
+        traceIds: [input.traceId],
         protections,
-        undefined,
-        { full: true },
-      );
+        opts: { full: true },
+      });
       if (traces.length === 0) {
         return [];
       }

--- a/platform/app/src/server/api/routers/traces.ts
+++ b/platform/app/src/server/api/routers/traces.ts
@@ -50,12 +50,12 @@ export const tracesRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      const trace = await traceService.getById(
-        input.projectId,
-        input.traceId,
+      const trace = await traceService.getById({
+        projectId: input.projectId,
+        traceId: input.traceId,
         protections,
-        { full: true },
-      );
+        opts: { full: true },
+      });
 
       if (!trace) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Trace not found." });
@@ -205,14 +205,12 @@ export const tracesRouter = createTRPCRouter({
         buildTraceBlobResolutionDeps(),
       );
 
-      return traceService.getTracesByThreadId(
+      return traceService.getTracesByThreadId({
         projectId,
         threadId,
         protections,
-        {
-          full: true,
-        },
-      );
+        opts: { full: true },
+      });
     }),
 
   getTracesWithSpans: protectedProcedure
@@ -228,13 +226,12 @@ export const tracesRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      return traceService.getTracesWithSpans(
+      return traceService.getTracesWithSpans({
         projectId,
         traceIds,
         protections,
-        undefined,
-        { full: true },
-      );
+        opts: { full: true },
+      });
     }),
 
   getFormattedSpansDigest: protectedProcedure
@@ -247,11 +244,11 @@ export const tracesRouter = createTRPCRouter({
       });
 
       const traceService = TraceService.create(ctx.prisma);
-      const traces = await traceService.getTracesWithSpans(
+      const traces = await traceService.getTracesWithSpans({
         projectId,
         traceIds,
         protections,
-      );
+      });
 
       return Object.fromEntries(
         await Promise.all(
@@ -277,12 +274,12 @@ export const tracesRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      return traceService.getTracesWithSpansByThreadIds(
+      return traceService.getTracesWithSpansByThreadIds({
         projectId,
         threadIds,
         protections,
-        { full: true },
-      );
+        opts: { full: true },
+      });
     }),
 
   getSampleTracesDataset: protectedProcedure
@@ -323,13 +320,13 @@ export const tracesRouter = createTRPCRouter({
         return [];
       }
 
-      return traceService.getTracesWithSpans(
-        input.projectId,
+      return traceService.getTracesWithSpans({
+        projectId: input.projectId,
         traceIds,
         protections,
-        { from: input.startDate, to: input.endDate },
-        { full: true },
-      );
+        occurredAt: { from: input.startDate, to: input.endDate },
+        opts: { full: true },
+      });
     }),
 
   getFieldNames: protectedProcedure
@@ -394,13 +391,13 @@ export const tracesRouter = createTRPCRouter({
       const { projectId, evaluatorType, preconditions, expectedResults } =
         input;
 
-      const traceWithSpans = await traceService.getTracesWithSpans(
+      const traceWithSpans = await traceService.getTracesWithSpans({
         projectId,
         traceIds,
         protections,
-        { from: input.startDate, to: input.endDate },
-        { full: true },
-      );
+        occurredAt: { from: input.startDate, to: input.endDate },
+        opts: { full: true },
+      });
 
       const passedPreconditions = traceWithSpans.filter((trace) => {
         if (!evaluatorType) return false;

--- a/platform/app/src/server/api/routers/tracesV2.ts
+++ b/platform/app/src/server/api/routers/tracesV2.ts
@@ -907,7 +907,11 @@ async function enrichSpanDetailFromCodingAgentLogs({
       typeof (span.params as Record<string, unknown> | null)?.request_id ===
       "string";
     const [logRows, summaryRows] = await Promise.all([
-      app.traces.logRecords.getLogsByTraceId(tenantId, traceId, occurredAtMs),
+      app.traces.logRecords.getLogsByTraceId({
+        tenantId,
+        traceId,
+        occurredAtMs,
+      }),
       needsSiblingRefs
         ? app.traces.spans.getSpanSummaryByTraceId({
             tenantId,
@@ -1032,11 +1036,11 @@ async function loadTraceLogsWithProtections({
 }): Promise<TraceLogRecordDto[]> {
   const app = getApp();
   const visibilityCutoffMs = await getVisibilityCutoffMsForProject(projectId);
-  const rows = await app.traces.logRecords.getLogsByTraceId(
-    projectId,
+  const rows = await app.traces.logRecords.getLogsByTraceId({
+    tenantId: projectId,
     traceId,
     occurredAtMs,
-  );
+  });
   return rows.map((row) =>
     gateTraceLogVisibility(
       {

--- a/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
@@ -222,12 +222,12 @@ describe("AnalyticsService", () => {
       const { deps, spies } = makeDeps();
       const service = new AnalyticsService(deps);
 
-      const result = await service.getTopUsedDocuments(
-        "test-project",
-        Date.now() - 86400000,
-        Date.now(),
-        {},
-      );
+      const result = await service.getTopUsedDocuments({
+        projectId: "test-project",
+        startDate: Date.now() - 86400000,
+        endDate: Date.now(),
+        filters: {},
+      });
 
       expect(result.topDocuments).toHaveLength(1);
       expect(spies.getTopUsedDocuments).toHaveBeenCalledTimes(1);
@@ -239,12 +239,12 @@ describe("AnalyticsService", () => {
       const { deps, spies } = makeDeps();
       const service = new AnalyticsService(deps);
 
-      const result = await service.getFeedbacks(
-        "test-project",
-        Date.now() - 86400000,
-        Date.now(),
-        {},
-      );
+      const result = await service.getFeedbacks({
+        projectId: "test-project",
+        startDate: Date.now() - 86400000,
+        endDate: Date.now(),
+        filters: {},
+      });
 
       expect(result.events).toHaveLength(1);
       expect(spies.getFeedbacks).toHaveBeenCalledTimes(1);

--- a/platform/app/src/server/app-layer/analytics/__tests__/timeseries-row-parser.unit.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/timeseries-row-parser.unit.test.ts
@@ -20,7 +20,12 @@ import {
 } from "../repositories/_timeseries-row-parser";
 
 const alias = (series: SeriesInputType, index: number) =>
-  buildMetricAlias(index, series.metric, series.aggregation, series.key);
+  buildMetricAlias({
+    index,
+    metric: series.metric,
+    aggregation: series.aggregation,
+    key: series.key,
+  });
 
 const passRateSeries: SeriesInputType = {
   metric: "evaluations.evaluation_pass_rate",

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -149,10 +149,15 @@ export class AnalyticsService {
     );
   }
 
-  async getFeedbacks(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+  async getFeedbacks({
+    projectId,
+    startDate,
+    endDate,
+    filters,
+  }: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters: Partial<
       Record<
         FilterField,
@@ -160,25 +165,30 @@ export class AnalyticsService {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<FeedbacksResult> {
+    >;
+  }): Promise<FeedbacksResult> {
     return this.tracer.withActiveSpan(
       "AnalyticsService.getFeedbacks",
       { attributes: { "tenant.id": projectId } },
       () =>
-        this.deps.legacyBackend.getFeedbacks(
+        this.deps.legacyBackend.getFeedbacks({
           projectId,
           startDate,
           endDate,
           filters,
-        ),
+        }),
     );
   }
 
-  async getTopUsedDocuments(
-    projectId: string,
-    startDate: number,
-    endDate: number,
+  async getTopUsedDocuments({
+    projectId,
+    startDate,
+    endDate,
+    filters,
+  }: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
     filters: Partial<
       Record<
         FilterField,
@@ -186,18 +196,18 @@ export class AnalyticsService {
         | Record<string, string[]>
         | Record<string, Record<string, string[]>>
       >
-    >,
-  ): Promise<TopDocumentsResult> {
+    >;
+  }): Promise<TopDocumentsResult> {
     return this.tracer.withActiveSpan(
       "AnalyticsService.getTopUsedDocuments",
       { attributes: { "tenant.id": projectId } },
       () =>
-        this.deps.legacyBackend.getTopUsedDocuments(
+        this.deps.legacyBackend.getTopUsedDocuments({
           projectId,
           startDate,
           endDate,
           filters,
-        ),
+        }),
     );
   }
 

--- a/platform/app/src/server/app-layer/analytics/query-builders/eval-rollup-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/eval-rollup-timeseries-query.ts
@@ -212,7 +212,13 @@ export function buildEvalRollupTimeseriesQuery(
         `Eval rollup builder cannot serve series with key="${s.key}" — the router should have routed this to slim or evaluation_runs (no EvaluatorId column on evaluation_analytics_rollup; see migration 00039).`,
       );
     }
-    const alias = buildMetricAlias(i, s.metric, s.aggregation, s.key, s.subkey);
+    const alias = buildMetricAlias({
+      index: i,
+      metric: s.metric,
+      aggregation: s.aggregation,
+      key: s.key,
+      subkey: s.subkey,
+    });
     const expr = evalRollupAggExpression(s.metric, s.aggregation);
     selectExprs.push(`${expr} AS ${alias}`);
   }

--- a/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
@@ -273,7 +273,13 @@ export function buildEvalSlimTimeseriesQuery(
         `Eval slim builder cannot filter by evaluator key "${String(s.key)}" — evaluation_analytics has no EvaluatorId column. The router should have routed this to evaluation_runs.`,
       );
     }
-    const alias = buildMetricAlias(i, s.metric, s.aggregation, s.key, s.subkey);
+    const alias = buildMetricAlias({
+      index: i,
+      metric: s.metric,
+      aggregation: s.aggregation,
+      key: s.key,
+      subkey: s.subkey,
+    });
     const expr = evalSlimAggExpression(
       s.aggregation,
       evalSlimColumnFor(s.metric),

--- a/platform/app/src/server/app-layer/analytics/query-builders/rollup-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/rollup-timeseries-query.ts
@@ -205,7 +205,13 @@ export function buildRollupTimeseriesQuery(
         `Rollup builder cannot serve aggregation "${s.aggregation}". Percentiles, min/max + distinct counts go to slim.`,
       );
     }
-    const alias = buildMetricAlias(i, s.metric, s.aggregation, s.key, s.subkey);
+    const alias = buildMetricAlias({
+      index: i,
+      metric: s.metric,
+      aggregation: s.aggregation,
+      key: s.key,
+      subkey: s.subkey,
+    });
     const expr = rollupAggExpression({
       agg: s.aggregation,
       column: rollupColumnFor(s.metric),

--- a/platform/app/src/server/app-layer/analytics/query-builders/slim-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/slim-timeseries-query.ts
@@ -415,7 +415,13 @@ export function buildSlimTimeseriesQuery(
         `Slim builder cannot serve metric "${s.metric}". The router should have routed this to trace_summaries.`,
       );
     }
-    const alias = buildMetricAlias(i, s.metric, s.aggregation, s.key, s.subkey);
+    const alias = buildMetricAlias({
+      index: i,
+      metric: s.metric,
+      aggregation: s.aggregation,
+      key: s.key,
+      subkey: s.subkey,
+    });
     const expr = slimAggExpression(s.aggregation, slimColumnFor(s.metric));
     selectExprs.push(`${expr} AS ${alias}`);
   }

--- a/platform/app/src/server/app-layer/analytics/repositories/_timeseries-row-parser.ts
+++ b/platform/app/src/server/app-layer/analytics/repositories/_timeseries-row-parser.ts
@@ -90,13 +90,13 @@ export function parseTimeseriesRows(
 
       for (let i = 0; i < series.length; i++) {
         const s = series[i]!;
-        const alias = buildMetricAlias(
-          i,
-          s.metric,
-          s.aggregation,
-          s.key,
-          s.subkey,
-        );
+        const alias = buildMetricAlias({
+          index: i,
+          metric: s.metric,
+          aggregation: s.aggregation,
+          key: s.key,
+          subkey: s.subkey,
+        });
         const seriesName = buildSeriesName(s, i);
         const coerced = coerceNumber(row[alias]);
         if (coerced !== null) groupData[groupKey]![seriesName] = coerced;
@@ -104,13 +104,13 @@ export function parseTimeseriesRows(
     } else {
       for (let i = 0; i < series.length; i++) {
         const s = series[i]!;
-        const alias = buildMetricAlias(
-          i,
-          s.metric,
-          s.aggregation,
-          s.key,
-          s.subkey,
-        );
+        const alias = buildMetricAlias({
+          index: i,
+          metric: s.metric,
+          aggregation: s.aggregation,
+          key: s.key,
+          subkey: s.subkey,
+        });
         const seriesName = buildSeriesName(s, i);
         const coerced = coerceNumber(row[alias]);
         if (coerced !== null) bucket[seriesName] = coerced;
@@ -136,7 +136,12 @@ export function parseTimeseriesRows(
     Math.max(0, previousPeriod.length - currentPeriod.length),
   );
 
-  normalizeMetricKeys(correctedPrevious, currentPeriod, series, groupBy);
+  normalizeMetricKeys({
+    previousPeriod: correctedPrevious,
+    currentPeriod,
+    series,
+    groupBy,
+  });
 
   return { previousPeriod: correctedPrevious, currentPeriod };
 }
@@ -177,12 +182,17 @@ export function buildSeriesName(
  * a bucket — do NOT spawn new groups from the other period, that would bleed
  * stale dimension values across periods.
  */
-function normalizeMetricKeys(
-  previousPeriod: TimeseriesBucket[],
-  currentPeriod: TimeseriesBucket[],
-  series: readonly SeriesInputType[],
-  groupBy?: string,
-): void {
+function normalizeMetricKeys({
+  previousPeriod,
+  currentPeriod,
+  series,
+  groupBy,
+}: {
+  previousPeriod: TimeseriesBucket[];
+  currentPeriod: TimeseriesBucket[];
+  series: readonly SeriesInputType[];
+  groupBy?: string;
+}): void {
   const zeroFillableKeys = new Set<string>();
   series.forEach((s, i) => {
     if (isZeroWhenAbsentSeries(s)) zeroFillableKeys.add(buildSeriesName(s, i));

--- a/platform/app/src/server/app-layer/analytics/repositories/analyticsWriteBase.ts
+++ b/platform/app/src/server/app-layer/analytics/repositories/analyticsWriteBase.ts
@@ -38,12 +38,12 @@ function assertSingleTenant<TRow extends { tenantId: string }>(
 ): void {
   for (const row of rows) {
     if (row.tenantId !== tenantId) {
-      throw new SecurityError(
-        scope,
-        "all rows in a single batch must share the same tenantId",
+      throw new SecurityError({
+        operation: scope,
+        message: "all rows in a single batch must share the same tenantId",
         tenantId,
-        { mismatchedTenantId: row.tenantId },
-      );
+        context: { mismatchedTenantId: row.tenantId },
+      });
     }
   }
 }

--- a/platform/app/src/server/app-layer/analytics/repositories/legacy-analytics-backend.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/analytics/repositories/legacy-analytics-backend.clickhouse.repository.ts
@@ -86,16 +86,16 @@ export class LegacyAnalyticsBackendClickHouseRepository
     const client = await this.resolveClient(projectId);
     if (!client) throw new AnalyticsClientUnavailableError(projectId);
 
-    const { sql, params } = buildDataForFilterQuery(
+    const { sql, params } = buildDataForFilterQuery({
       projectId,
       field,
-      new Date(startDate),
-      new Date(endDate),
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       key,
       subkey,
       searchQuery,
       filters,
-    );
+    });
 
     logger.debug({ sql, params }, "Executing dataForFilter query");
 
@@ -139,12 +139,12 @@ export class LegacyAnalyticsBackendClickHouseRepository
     const client = await this.resolveClient(projectId);
     if (!client) throw new AnalyticsClientUnavailableError(projectId);
 
-    const { sql, params } = buildTopDocumentsQuery(
+    const { sql, params } = buildTopDocumentsQuery({
       projectId,
-      new Date(startDate),
-      new Date(endDate),
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       filters,
-    );
+    });
 
     logger.debug({ sql, params }, "Executing topDocuments query");
 
@@ -216,12 +216,12 @@ export class LegacyAnalyticsBackendClickHouseRepository
     const client = await this.resolveClient(projectId);
     if (!client) throw new AnalyticsClientUnavailableError(projectId);
 
-    const { sql, params } = buildFeedbacksQuery(
+    const { sql, params } = buildFeedbacksQuery({
       projectId,
-      new Date(startDate),
-      new Date(endDate),
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       filters,
-    );
+    });
 
     logger.debug({ sql, params }, "Executing feedbacks query");
 

--- a/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-heartbeat.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-heartbeat.unit.test.ts
@@ -16,12 +16,17 @@ const TRIGGER_NO_DATA = "trig-no-data";
 const TRIGGER_OPEN = "trig-open";
 const TRIGGER_NORMAL = "trig-normal";
 
-function makeTrigger(
-  id: string,
-  projectId: string,
-  actionParams: Record<string, unknown>,
+function makeTrigger({
+  id,
+  projectId,
+  actionParams,
   customGraphId = `graph-${id}`,
-): TriggerSummary {
+}: {
+  id: string;
+  projectId: string;
+  actionParams: Record<string, unknown>;
+  customGraphId?: string;
+}): TriggerSummary {
   return {
     id,
     projectId,
@@ -143,10 +148,14 @@ describe("decideGraphTriggerHeartbeat", () => {
     it("emits no enqueues — real-time path handles them", async () => {
       const triggers = makeTriggersService({
         [PROJECT_A]: [
-          makeTrigger(TRIGGER_NORMAL, PROJECT_A, {
-            threshold: 50,
-            operator: "gt",
-            timePeriod: 60,
+          makeTrigger({
+            id: TRIGGER_NORMAL,
+            projectId: PROJECT_A,
+            actionParams: {
+              threshold: 50,
+              operator: "gt",
+              timePeriod: 60,
+            },
           }),
         ],
       });
@@ -172,10 +181,14 @@ describe("decideGraphTriggerHeartbeat", () => {
       chStub = makeClickHouseStub({ [PROJECT_A]: null });
       const triggers = makeTriggersService({
         [PROJECT_A]: [
-          makeTrigger(TRIGGER_NO_DATA, PROJECT_A, {
-            threshold: 1,
-            operator: "lt",
-            timePeriod: 5,
+          makeTrigger({
+            id: TRIGGER_NO_DATA,
+            projectId: PROJECT_A,
+            actionParams: {
+              threshold: 1,
+              operator: "lt",
+              timePeriod: 5,
+            },
           }),
         ],
       });
@@ -205,10 +218,14 @@ describe("decideGraphTriggerHeartbeat", () => {
       chStub = makeClickHouseStub({ [PROJECT_A]: recentMs });
       const triggers = makeTriggersService({
         [PROJECT_A]: [
-          makeTrigger(TRIGGER_NO_DATA, PROJECT_A, {
-            threshold: 1,
-            operator: "lt",
-            timePeriod: 5,
+          makeTrigger({
+            id: TRIGGER_NO_DATA,
+            projectId: PROJECT_A,
+            actionParams: {
+              threshold: 1,
+              operator: "lt",
+              timePeriod: 5,
+            },
           }),
         ],
       });
@@ -236,10 +253,14 @@ describe("decideGraphTriggerHeartbeat", () => {
       prismaStub = makePrismaStub({ [PROJECT_B]: [TRIGGER_OPEN] });
       const triggers = makeTriggersService({
         [PROJECT_B]: [
-          makeTrigger(TRIGGER_OPEN, PROJECT_B, {
-            threshold: 100,
-            operator: "gt",
-            timePeriod: 5,
+          makeTrigger({
+            id: TRIGGER_OPEN,
+            projectId: PROJECT_B,
+            actionParams: {
+              threshold: 100,
+              operator: "gt",
+              timePeriod: 5,
+            },
           }),
         ],
       });
@@ -272,17 +293,25 @@ describe("decideGraphTriggerHeartbeat", () => {
       });
       const triggers = makeTriggersService({
         [PROJECT_A]: [
-          makeTrigger(TRIGGER_NO_DATA, PROJECT_A, {
-            threshold: 1,
-            operator: "lt",
-            timePeriod: 5,
+          makeTrigger({
+            id: TRIGGER_NO_DATA,
+            projectId: PROJECT_A,
+            actionParams: {
+              threshold: 1,
+              operator: "lt",
+              timePeriod: 5,
+            },
           }),
         ],
         [PROJECT_B]: [
-          makeTrigger(TRIGGER_NO_DATA, PROJECT_B, {
-            threshold: 1,
-            operator: "lt",
-            timePeriod: 5,
+          makeTrigger({
+            id: TRIGGER_NO_DATA,
+            projectId: PROJECT_B,
+            actionParams: {
+              threshold: 1,
+              operator: "lt",
+              timePeriod: 5,
+            },
           }),
         ],
       });

--- a/platform/app/src/server/app-layer/automations/dispatch/triggerActionDispatch.ts
+++ b/platform/app/src/server/app-layer/automations/dispatch/triggerActionDispatch.ts
@@ -268,13 +268,11 @@ async function addTraceToDataset({
 
   const entries: DatasetRecordEntry[] = [];
 
-  const mappedEntries = mapTraceToDatasetEntry(
+  const mappedEntries = mapTraceToDatasetEntry({
     trace,
-    mapping as TraceMapping,
+    mapping: mapping as TraceMapping,
     expansions,
-    undefined,
-    undefined,
-  );
+  });
 
   for (let i = 0; i < mappedEntries.length; i++) {
     const entry = mappedEntries[i]!;

--- a/platform/app/src/server/app-layer/broadcast/broadcast.service.ts
+++ b/platform/app/src/server/app-layer/broadcast/broadcast.service.ts
@@ -207,12 +207,17 @@ export class BroadcastService {
    * (and silently drops the event) when the per-tenant per-tier bucket is
    * exhausted, preventing upstream overload on high-frequency delta streams.
    */
-  async broadcastToTenantRateLimited(
-    tenantId: string,
-    event: string,
-    eventType: BroadcastEventType = "trace_updated",
-    tier: "structural" | "delta" = "structural",
-  ): Promise<boolean> {
+  async broadcastToTenantRateLimited({
+    tenantId,
+    event,
+    eventType = "trace_updated",
+    tier = "structural",
+  }: {
+    tenantId: string;
+    event: string;
+    eventType?: BroadcastEventType;
+    tier?: "structural" | "delta";
+  }): Promise<boolean> {
     if (!this.active) throw new BroadcasterNotActiveError();
     if (!this.senderRateLimiter.tryConsume(tenantId, tier)) {
       return false;

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -656,11 +656,11 @@ export class CodingAgentSessionClickHouseRepository
     // written into this tenant's ClickHouse. Refuse rather than cross the line.
     for (const { row } of entries) {
       if (row.tenantId !== tenantId) {
-        throw new SecurityError(
-          "CodingAgentSessionClickHouseRepository.upsertBatch",
-          "coding agent session batch spans multiple tenants",
+        throw new SecurityError({
+          operation: "CodingAgentSessionClickHouseRepository.upsertBatch",
+          message: "coding agent session batch spans multiple tenants",
           tenantId,
-        );
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-trace-session.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-trace-session.repository.ts
@@ -72,11 +72,11 @@ export class CodingAgentTraceSessionClickHouseRepository
     // line.
     for (const record of records) {
       if (record.tenantId !== tenantId) {
-        throw new SecurityError(
-          "CodingAgentTraceSessionClickHouseRepository.ensure",
-          "coding agent trace-session batch spans multiple tenants",
+        throw new SecurityError({
+          operation: "CodingAgentTraceSessionClickHouseRepository.ensure",
+          message: "coding agent trace-session batch spans multiple tenants",
           tenantId,
-        );
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/coding-agent/repositories/session-metric-series.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/session-metric-series.repository.ts
@@ -95,11 +95,11 @@ export class SessionMetricSeriesClickHouseRepository
     // line.
     for (const record of records) {
       if (record.tenantId !== tenantId) {
-        throw new SecurityError(
-          "SessionMetricSeriesClickHouseRepository.ensure",
-          "session metric series batch spans multiple tenants",
+        throw new SecurityError({
+          operation: "SessionMetricSeriesClickHouseRepository.ensure",
+          message: "session metric series batch spans multiple tenants",
           tenantId,
-        );
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/dspy-steps/dspy-step.service.ts
+++ b/platform/app/src/server/app-layer/dspy-steps/dspy-step.service.ts
@@ -30,12 +30,12 @@ export class DspyStepService {
     runId: string;
     stepIndex: string;
   }): Promise<DspyStepData> {
-    const result = await this.repository.getStep(
+    const result = await this.repository.getStep({
       tenantId,
       experimentId,
       runId,
       stepIndex,
-    );
+    });
     if (!result) {
       throw new DspyStepNotFoundError(
         `${tenantId}/${experimentId}/${runId}/${stepIndex}`,

--- a/platform/app/src/server/app-layer/dspy-steps/repositories/__tests__/in-memory-dspy-step.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/dspy-steps/repositories/__tests__/in-memory-dspy-step.repository.unit.test.ts
@@ -34,7 +34,12 @@ describe("given InMemoryDspyStepRepository", () => {
       const step = makeStep();
       await repo.upsertStep(step);
 
-      const result = await repo.getStep("tenant-1", "exp-1", "run-1", "0");
+      const result = await repo.getStep({
+        tenantId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        stepIndex: "0",
+      });
       expect(result).toEqual(step);
     });
   });
@@ -59,7 +64,12 @@ describe("given InMemoryDspyStepRepository", () => {
         }),
       );
 
-      const result = await repo.getStep("tenant-1", "exp-1", "run-1", "0");
+      const result = await repo.getStep({
+        tenantId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        stepIndex: "0",
+      });
       expect(result!.examples).toHaveLength(2);
       expect(result!.examples.map((e) => e.hash)).toEqual(["aaa", "bbb"]);
     });
@@ -83,7 +93,12 @@ describe("given InMemoryDspyStepRepository", () => {
         }),
       );
 
-      const result = await repo.getStep("tenant-1", "exp-1", "run-1", "0");
+      const result = await repo.getStep({
+        tenantId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        stepIndex: "0",
+      });
       expect(result!.llmCalls).toHaveLength(2);
       expect(result!.llmCalls.map((c) => c.hash)).toEqual(["c1", "c2"]);
     });
@@ -101,7 +116,12 @@ describe("given InMemoryDspyStepRepository", () => {
         }),
       );
 
-      const result = await repo.getStep("tenant-1", "exp-1", "run-1", "0");
+      const result = await repo.getStep({
+        tenantId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        stepIndex: "0",
+      });
       expect(result!.score).toBe(0.8);
       expect(result!.createdAt).toBe(1000);
       expect(result!.insertedAt).toBe(1000);
@@ -168,8 +188,22 @@ describe("given InMemoryDspyStepRepository", () => {
 
       await repo.deleteByExperiment("t1", "e1");
 
-      expect(await repo.getStep("t1", "e1", "r1", "0")).toBeNull();
-      expect(await repo.getStep("t1", "e2", "r2", "0")).not.toBeNull();
+      expect(
+        await repo.getStep({
+          tenantId: "t1",
+          experimentId: "e1",
+          runId: "r1",
+          stepIndex: "0",
+        }),
+      ).toBeNull();
+      expect(
+        await repo.getStep({
+          tenantId: "t1",
+          experimentId: "e2",
+          runId: "r2",
+          stepIndex: "0",
+        }),
+      ).not.toBeNull();
     });
   });
 

--- a/platform/app/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
@@ -151,12 +151,12 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
 
   async upsertStep(data: DspyStepData): Promise<void> {
     try {
-      const existing = await this.getStep(
-        data.tenantId,
-        data.experimentId,
-        data.runId,
-        data.stepIndex,
-      );
+      const existing = await this.getStep({
+        tenantId: data.tenantId,
+        experimentId: data.experimentId,
+        runId: data.runId,
+        stepIndex: data.stepIndex,
+      });
       const retentionDays = await this.resolveTracesRetentionDays(
         data.tenantId,
       );
@@ -291,12 +291,17 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
     }
   }
 
-  async getStep(
-    tenantId: string,
-    experimentId: string,
-    runId: string,
-    stepIndex: string,
-  ): Promise<DspyStepData | null> {
+  async getStep({
+    tenantId,
+    experimentId,
+    runId,
+    stepIndex,
+  }: {
+    tenantId: string;
+    experimentId: string;
+    runId: string;
+    stepIndex: string;
+  }): Promise<DspyStepData | null> {
     try {
       const client = await this.resolveClient(tenantId);
       // IN-tuple dedup over the ReplacingMergeTree (see

--- a/platform/app/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
+++ b/platform/app/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
@@ -6,12 +6,12 @@ export interface DspyStepRepository {
     tenantId: string,
     experimentId: string,
   ): Promise<DspyStepSummaryData[]>;
-  getStep(
-    tenantId: string,
-    experimentId: string,
-    runId: string,
-    stepIndex: string,
-  ): Promise<DspyStepData | null>;
+  getStep(params: {
+    tenantId: string;
+    experimentId: string;
+    runId: string;
+    stepIndex: string;
+  }): Promise<DspyStepData | null>;
   deleteByExperiment(tenantId: string, experimentId: string): Promise<void>;
 }
 
@@ -98,12 +98,17 @@ export class InMemoryDspyStepRepository implements DspyStepRepository {
     return results.sort((a, b) => a.createdAt - b.createdAt);
   }
 
-  async getStep(
-    tenantId: string,
-    experimentId: string,
-    runId: string,
-    stepIndex: string,
-  ): Promise<DspyStepData | null> {
+  async getStep({
+    tenantId,
+    experimentId,
+    runId,
+    stepIndex,
+  }: {
+    tenantId: string;
+    experimentId: string;
+    runId: string;
+    stepIndex: string;
+  }): Promise<DspyStepData | null> {
     return (
       this.store.get(`${tenantId}/${experimentId}/${runId}/${stepIndex}`) ??
       null

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -51,7 +51,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/gemini-2.5-pro",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).resolves.toBeDefined();
     });
   });
@@ -71,7 +75,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/gemini-1.5-pro", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/gemini-1.5-pro",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).resolves.toBeDefined();
     });
 
@@ -89,7 +97,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/custom-embed", true, "proj-1"),
+        setupModelEnv({
+          model: "gemini/custom-embed",
+          embeddings: true,
+          projectId: "proj-1",
+        }),
       ).resolves.toBeDefined();
     });
   });
@@ -101,7 +113,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/nonexistent-model", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/nonexistent-model",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).rejects.toThrow(EvaluatorConfigError);
     });
   });
@@ -113,7 +129,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/any-model", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/any-model",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).resolves.toBeDefined();
     });
   });
@@ -123,7 +143,11 @@ describe("setupModelEnv", () => {
       vi.mocked(getProjectModelProviders).mockResolvedValue({});
 
       await expect(
-        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/gemini-2.5-pro",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).rejects.toThrow("Provider gemini is not configured");
     });
   });
@@ -135,7 +159,11 @@ describe("setupModelEnv", () => {
       });
 
       await expect(
-        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+        setupModelEnv({
+          model: "gemini/gemini-2.5-pro",
+          embeddings: false,
+          projectId: "proj-1",
+        }),
       ).rejects.toThrow("Provider gemini is not enabled");
     });
   });

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -438,20 +438,21 @@ describe("EvaluationExecutionService", () => {
         });
 
         expect(mockWorkflowExecutor.runEvaluationWorkflow).toHaveBeenCalledWith(
-          "my-workflow",
-          "proj-1",
-          expect.objectContaining({
-            trace_id: "trace-1",
-            do_not_trace: true,
-          }),
-          undefined,
-          expect.any(Number),
-          // parentTrace: defaultTrace's trace_id is "trace-1" (not
-          // 32-hex), so extractParentTraceForNlpgo returns undefined.
-          // Adapter-level OTel trace_ids would set this to a real
-          // {traceId, parentSpanId} — separately covered by
-          // extractParentTraceForNlpgo's own tests.
-          undefined,
+          {
+            workflowId: "my-workflow",
+            projectId: "proj-1",
+            inputs: expect.objectContaining({
+              trace_id: "trace-1",
+              do_not_trace: true,
+            }),
+            causalityDepth: expect.any(Number),
+            // parentTrace: defaultTrace's trace_id is "trace-1" (not
+            // 32-hex), so extractParentTraceForNlpgo returns undefined.
+            // Adapter-level OTel trace_ids would set this to a real
+            // {traceId, parentSpanId} — separately covered by
+            // extractParentTraceForNlpgo's own tests.
+            parentTrace: undefined,
+          },
         );
       });
 
@@ -516,16 +517,16 @@ describe("EvaluationExecutionService", () => {
 
           expect(
             mockTraceService.getTracesWithSpansByThreadIds,
-          ).toHaveBeenCalledWith(
-            "proj-1",
-            ["thread-1"],
-            expect.objectContaining({
+          ).toHaveBeenCalledWith({
+            projectId: "proj-1",
+            threadIds: ["thread-1"],
+            protections: expect.objectContaining({
               canSeeCosts: true,
               canSeeCapturedInput: true,
               canSeeCapturedOutput: true,
             }),
-            { full: true },
-          );
+            opts: { full: true },
+          });
         });
 
         /** @scenario a thread-based monitor still runs for a trace with a thread_id */

--- a/platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
+++ b/platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
@@ -43,12 +43,12 @@ export function createDefaultModelEnvResolver(): ModelEnvResolver {
         typeof settings.model === "string" &&
         evaluatorType !== "openai/moderation"
       ) {
-        const modelEnv = await setupModelEnv(
-          settings.model,
-          false,
+        const modelEnv = await setupModelEnv({
+          model: settings.model,
+          embeddings: false,
           projectId,
           settings,
-        );
+        });
         evaluatorEnv = { ...evaluatorEnv, ...modelEnv };
       }
 
@@ -57,12 +57,12 @@ export function createDefaultModelEnvResolver(): ModelEnvResolver {
         "embeddings_model" in settings &&
         typeof settings.embeddings_model === "string"
       ) {
-        const embeddingsEnv = await setupModelEnv(
-          settings.embeddings_model,
-          true,
+        const embeddingsEnv = await setupModelEnv({
+          model: settings.embeddings_model,
+          embeddings: true,
           projectId,
           settings,
-        );
+        });
         evaluatorEnv = { ...evaluatorEnv, ...embeddingsEnv };
       }
 
@@ -80,12 +80,17 @@ export function createDefaultModelEnvResolver(): ModelEnvResolver {
  * Throws `EvaluatorConfigError` for misconfigured providers — callers who
  * need a per-worker error class should catch and rewrap.
  */
-export async function setupModelEnv(
-  model: string,
-  embeddings: boolean,
-  projectId: string,
-  settings?: Record<string, unknown>,
-): Promise<Record<string, string>> {
+export async function setupModelEnv({
+  model,
+  embeddings,
+  projectId,
+  settings,
+}: {
+  model: string;
+  embeddings: boolean;
+  projectId: string;
+  settings?: Record<string, unknown>;
+}): Promise<Record<string, string>> {
   const modelProviders = await getProjectModelProviders(projectId);
   const provider = model.split("/")[0]!;
   const modelProvider = modelProviders[provider];

--- a/platform/app/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/platform/app/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -74,14 +74,14 @@ export interface ModelEnvResolver {
 }
 
 export interface WorkflowExecutor {
-  runEvaluationWorkflow(
-    workflowId: string,
-    projectId: string,
-    inputs: Record<string, string>,
-    versionId?: string,
-    causalityDepth?: number,
-    parentTrace?: { traceId: string; parentSpanId: string },
-  ): Promise<{ result: SingleEvaluationResult; status: string }>;
+  runEvaluationWorkflow(params: {
+    workflowId: string;
+    projectId: string;
+    inputs: Record<string, string>;
+    versionId?: string;
+    causalityDepth?: number;
+    parentTrace?: { traceId: string; parentSpanId: string };
+  }): Promise<{ result: SingleEvaluationResult; status: string }>;
 }
 
 const TRACE_ID_HEX = /^[0-9a-fA-F]{32}$/;
@@ -225,13 +225,12 @@ export class EvaluationExecutionService {
     // preview), so opt into blob resolution (#4888). Under the per-call gate
     // (replacing construction-time gating) this is what keeps the eval path
     // resolving offloaded event refs.
-    const traces = await this.deps.traceService.getTracesWithSpans(
+    const traces = await this.deps.traceService.getTracesWithSpans({
       projectId,
-      [traceId],
-      INTERNAL_PROTECTIONS,
-      undefined,
-      { full: true },
-    );
+      traceIds: [traceId],
+      protections: INTERNAL_PROTECTIONS,
+      opts: { full: true },
+    });
     const trace = traces[0];
 
     if (!trace) {
@@ -391,12 +390,12 @@ export class EvaluationExecutionService {
           trace,
           mappings,
           getThreadTraces: (threadId) =>
-            this.deps.traceService.getTracesWithSpansByThreadIds(
+            this.deps.traceService.getTracesWithSpansByThreadIds({
               projectId,
-              [threadId],
-              INTERNAL_PROTECTIONS,
-              { full: true },
-            ),
+              threadIds: [threadId],
+              protections: INTERNAL_PROTECTIONS,
+              opts: { full: true },
+            }),
         });
       }
     }
@@ -455,12 +454,12 @@ export class EvaluationExecutionService {
     }
 
     const threadTraces =
-      await this.deps.traceService.getTracesWithSpansByThreadIds(
+      await this.deps.traceService.getTracesWithSpansByThreadIds({
         projectId,
-        [threadId],
-        INTERNAL_PROTECTIONS,
-        { full: true },
-      );
+        threadIds: [threadId],
+        protections: INTERNAL_PROTECTIONS,
+        opts: { full: true },
+      });
 
     const result: Record<string, unknown> = {};
 
@@ -520,13 +519,11 @@ export class EvaluationExecutionService {
             key: mappingConfig.key,
             subkey: mappingConfig.subkey,
           };
-          const mapped = mapTraceToDatasetEntry(
+          const mapped = mapTraceToDatasetEntry({
             trace,
-            { [targetField]: traceMappingConfig },
-            new Set(),
-            undefined,
-            undefined,
-          )[0];
+            mapping: { [targetField]: traceMappingConfig },
+            expansions: new Set(),
+          })[0];
           result[targetField] = mapped?.[targetField];
         }
       }
@@ -571,14 +568,14 @@ export class EvaluationExecutionService {
           parentTrace: extractParentTraceForNlpgo(trace),
         });
       }
-      return this.runCustomEvaluation(
+      return this.runCustomEvaluation({
         projectId,
         evaluatorType,
-        data.data,
+        data: data.data,
         trace,
         workflowId,
         parentCausalityDepth,
-      );
+      });
     }
 
     // Built-in evaluators
@@ -630,14 +627,21 @@ export class EvaluationExecutionService {
     });
   }
 
-  private async runCustomEvaluation(
-    projectId: string,
-    evaluatorType: string,
-    data: Record<string, unknown>,
-    trace?: Trace,
-    workflowId?: string | null,
-    parentCausalityDepth?: number,
-  ): Promise<SingleEvaluationResult> {
+  private async runCustomEvaluation({
+    projectId,
+    evaluatorType,
+    data,
+    trace,
+    workflowId,
+    parentCausalityDepth,
+  }: {
+    projectId: string;
+    evaluatorType: string;
+    data: Record<string, unknown>;
+    trace?: Trace;
+    workflowId?: string | null;
+    parentCausalityDepth?: number;
+  }): Promise<SingleEvaluationResult> {
     const resolvedWorkflowId = workflowId ?? evaluatorType.split("/")[1];
 
     if (!resolvedWorkflowId) {
@@ -656,14 +660,13 @@ export class EvaluationExecutionService {
     // bug rchaves caught in prod).
     const parentTrace = extractParentTraceForNlpgo(trace);
 
-    const response = await this.deps.workflowExecutor.runEvaluationWorkflow(
-      resolvedWorkflowId,
+    const response = await this.deps.workflowExecutor.runEvaluationWorkflow({
+      workflowId: resolvedWorkflowId,
       projectId,
-      requestBody as Record<string, string>,
-      undefined,
-      parentCausalityDepth,
+      inputs: requestBody as Record<string, string>,
+      causalityDepth: parentCausalityDepth,
       parentTrace,
-    );
+    });
 
     if (response.status !== "success") {
       return { ...response.result, status: "error" } as SingleEvaluationResult;
@@ -686,9 +689,9 @@ function switchMapping(
       ? mapping_
       : migrateLegacyMappings(mapping_ as unknown as Record<string, string>);
 
-  return mapTraceToDatasetEntry(
+  return mapTraceToDatasetEntry({
     trace,
-    mapping.mapping as Record<
+    mapping: mapping.mapping as Record<
       string,
       {
         source: string;
@@ -696,8 +699,6 @@ function switchMapping(
         subkey?: string;
       }
     >,
-    new Set(),
-    undefined,
-    undefined,
-  )[0];
+    expansions: new Set(),
+  })[0];
 }

--- a/platform/app/src/server/app-layer/evaluations/repositories/evaluation-analytics.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/evaluations/repositories/evaluation-analytics.clickhouse.repository.ts
@@ -170,12 +170,12 @@ export class EvaluationAnalyticsClickHouseRepository
     );
     for (const { row } of entries) {
       if (row.tenantId !== tenantId) {
-        throw new SecurityError(
-          "EvaluationAnalyticsClickHouseRepository.upsertBatch",
-          "all rows in a single batch must share the same tenantId",
+        throw new SecurityError({
+          operation: "EvaluationAnalyticsClickHouseRepository.upsertBatch",
+          message: "all rows in a single batch must share the same tenantId",
           tenantId,
-          { mismatchedTenantId: row.tenantId },
-        );
+          context: { mismatchedTenantId: row.tenantId },
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -86,13 +86,13 @@ export class EvaluationRunClickHouseRepository
 
     try {
       const client = await this.resolveClient(tenantId);
-      const record = this.toClickHouseRecord(
+      const record = this.toClickHouseRecord({
         data,
         tenantId,
         projectionId,
-        EVALUATION_PROJECTION_VERSIONS.STATE,
+        version: EVALUATION_PROJECTION_VERSIONS.STATE,
         retentionDays,
-      );
+      });
 
       await client.insert({
         table: TABLE_NAME,
@@ -136,13 +136,13 @@ export class EvaluationRunClickHouseRepository
                 data.scheduledAt,
               )
             : data.evaluationId;
-          return this.toClickHouseRecord(
+          return this.toClickHouseRecord({
             data,
-            tid,
+            tenantId: tid,
             projectionId,
-            EVALUATION_PROJECTION_VERSIONS.STATE,
-            rd,
-          );
+            version: EVALUATION_PROJECTION_VERSIONS.STATE,
+            retentionDays: rd,
+          });
         },
       );
 
@@ -569,13 +569,19 @@ export class EvaluationRunClickHouseRepository
     };
   }
 
-  private toClickHouseRecord(
-    data: EvaluationRunData,
-    tenantId: string,
-    projectionId: string,
-    version: string,
+  private toClickHouseRecord({
+    data,
+    tenantId,
+    projectionId,
+    version,
     retentionDays = PLATFORM_DEFAULT_RETENTION_DAYS,
-  ): ClickHouseEvaluationRunWriteRecord {
+  }: {
+    data: EvaluationRunData;
+    tenantId: string;
+    projectionId: string;
+    version: string;
+    retentionDays?: number;
+  }): ClickHouseEvaluationRunWriteRecord {
     // Belt-and-braces write caps (ADR-040): unconditional, flag-independent,
     // last line of defence that keeps the part merge-safe even if the offload
     // path is off, failed open, or a different writer inserted a fat payload.

--- a/platform/app/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
@@ -98,7 +98,10 @@ describe("LangyConversationService", () => {
             .fn()
             .mockResolvedValue({ token: "t", turnId: "turn-1" }),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         const pending = svc.getById({
           id: "c1",
           projectId: "p1",
@@ -121,7 +124,10 @@ describe("LangyConversationService", () => {
           findVisibleById,
           findPendingHandoff: vi.fn().mockResolvedValue(null),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         const pending = svc.getById({
           id: "c-unknown",
           projectId: "p1",
@@ -161,7 +167,10 @@ describe("LangyConversationService", () => {
             .mockResolvedValueOnce(null)
             .mockResolvedValue({ token: "t", turnId: "turn-1" }),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         const pending = svc.getById({
           id: "c1",
           projectId: "p1",
@@ -184,7 +193,10 @@ describe("LangyConversationService", () => {
             .fn()
             .mockResolvedValue({ token: "t", turnId: "turn-1" }),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         const pending = svc.getById({
           id: "c1",
           projectId: "p1",
@@ -210,7 +222,10 @@ describe("LangyConversationService", () => {
         const repo = makeRepo({
           findVisibleById: vi.fn().mockResolvedValue(null),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         await expect(
           svc.getById({ id: "c1", projectId: "p1", userId: "alice" }),
         ).rejects.toThrow(LangyConversationNotFoundError);
@@ -220,7 +235,10 @@ describe("LangyConversationService", () => {
         const repo = makeRepo({
           findVisibleById: vi.fn().mockResolvedValue(null),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         expect(
           await svc.findByIdVisible({
             id: "c1",
@@ -239,7 +257,10 @@ describe("LangyConversationService", () => {
         const repo = makeRepo({
           findVisibleById: vi.fn().mockResolvedValue(null),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         await expect(
           svc.getById({ id: "c1", projectId: "p1", userId: "alice" }),
         ).rejects.toThrow(LangyConversationNotFoundError);
@@ -253,7 +274,10 @@ describe("LangyConversationService", () => {
             .fn()
             .mockResolvedValue(row({ userId: "bob", isShared: true })),
         });
-        const svc = new LangyConversationService(repo, makeCommands());
+        const svc = new LangyConversationService({
+          repository: repo,
+          commands: makeCommands(),
+        });
         const result = await svc.getById({
           id: "c1",
           projectId: "p1",
@@ -276,10 +300,10 @@ describe("LangyConversationService", () => {
           .fn()
           .mockResolvedValue(row({ userId: "bob", isShared: true })),
       });
-      const svc = new LangyConversationService(
-        repo,
-        makeCommands({ archiveConversation }),
-      );
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands({ archiveConversation }),
+      });
       const result = await svc.deleteById({
         id: "c1",
         projectId: "p1",
@@ -296,10 +320,10 @@ describe("LangyConversationService", () => {
       const repo = makeRepo({
         findVisibleById: vi.fn().mockResolvedValue(row({ userId: "alice" })),
       });
-      const svc = new LangyConversationService(
-        repo,
-        makeCommands({ archiveConversation }),
-      );
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands({ archiveConversation }),
+      });
       const result = await svc.deleteById({
         id: "c1",
         projectId: "p1",
@@ -315,7 +339,10 @@ describe("LangyConversationService", () => {
   describe("when ensureConversation is called with no id", () => {
     it("mints a fresh conversation id without writing", async () => {
       const repo = makeRepo();
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       const result = await svc.ensureConversation({
         projectId: "p1",
         userId: "alice",
@@ -330,7 +357,10 @@ describe("LangyConversationService", () => {
       const repo = makeRepo({
         findOwnership: vi.fn().mockResolvedValue("owned"),
       });
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       const result = await svc.ensureConversation({
         projectId: "p1",
         userId: "alice",
@@ -345,7 +375,10 @@ describe("LangyConversationService", () => {
       const repo = makeRepo({
         findOwnership: vi.fn().mockResolvedValue("other"),
       });
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       await expect(
         svc.ensureConversation({
           projectId: "p1",
@@ -361,7 +394,10 @@ describe("LangyConversationService", () => {
       const repo = makeRepo({
         findOwnership: vi.fn().mockResolvedValue("missing"),
       });
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       const result = await svc.ensureConversation({
         projectId: "p1",
         userId: "alice",
@@ -382,7 +418,10 @@ describe("LangyConversationService", () => {
             row({ title: "t", lastActivityAtMs, messageCount: 3 }),
           ]),
       });
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       const result = await svc.getAll({ projectId: "p1", userId: "alice" });
       expect(result[0]).toMatchObject({
         id: "c1",
@@ -400,7 +439,10 @@ describe("LangyConversationService", () => {
           .fn()
           .mockResolvedValue([row({ lastActivityAtMs: 0, createdAtMs })]),
       });
-      const svc = new LangyConversationService(repo, makeCommands());
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands(),
+      });
       const result = await svc.getAll({ projectId: "p1", userId: "alice" });
       expect(result[0]?.lastActivityAt).toEqual(new Date(createdAtMs));
     });
@@ -416,10 +458,10 @@ describe("LangyConversationService", () => {
           row({ id: "c2", lastActivityAtMs: 180 }),
           row({ id: "c1", lastActivityAtMs: 170 }),
         ]);
-      const svc = new LangyConversationService(
-        makeRepo({ findAllForUser }),
-        makeCommands(),
-      );
+      const svc = new LangyConversationService({
+        repository: makeRepo({ findAllForUser }),
+        commands: makeCommands(),
+      });
 
       const result = await svc.getPage({
         projectId: "p1",
@@ -444,8 +486,8 @@ describe("LangyConversationService", () => {
     });
 
     it("preserves a null activity cursor and omits nextCursor on the last page", async () => {
-      const svcWithMore = new LangyConversationService(
-        makeRepo({
+      const svcWithMore = new LangyConversationService({
+        repository: makeRepo({
           findAllForUser: vi.fn().mockResolvedValue([
             row({
               id: "c2",
@@ -455,20 +497,20 @@ describe("LangyConversationService", () => {
             row({ id: "c1" }),
           ]),
         }),
-        makeCommands(),
-      );
+        commands: makeCommands(),
+      });
       await expect(
         svcWithMore.getPage({ projectId: "p1", userId: "alice", limit: 1 }),
       ).resolves.toMatchObject({
         nextCursor: { lastActivityAtMs: null, id: "c2" },
       });
 
-      const svcAtEnd = new LangyConversationService(
-        makeRepo({
+      const svcAtEnd = new LangyConversationService({
+        repository: makeRepo({
           findAllForUser: vi.fn().mockResolvedValue([row({ id: "only" })]),
         }),
-        makeCommands(),
-      );
+        commands: makeCommands(),
+      });
       await expect(
         svcAtEnd.getPage({ projectId: "p1", userId: "alice", limit: 2 }),
       ).resolves.toMatchObject({ nextCursor: null });
@@ -481,10 +523,10 @@ describe("LangyConversationService", () => {
       const repo = makeRepo({
         findActiveOwnedIds: vi.fn().mockResolvedValue(["c1", "c2", "c3"]),
       });
-      const svc = new LangyConversationService(
-        repo,
-        makeCommands({ archiveConversation }),
-      );
+      const svc = new LangyConversationService({
+        repository: repo,
+        commands: makeCommands({ archiveConversation }),
+      });
       const result = await svc.clearAllForUser({
         projectId: "p1",
         userId: "alice",
@@ -497,10 +539,10 @@ describe("LangyConversationService", () => {
   describe("when recordUserMessage is called", () => {
     it("dispatches one RecordMessage command carrying the owner and parts", async () => {
       const recordMessage = vi.fn(async () => {});
-      const svc = new LangyConversationService(
-        makeRepo(),
-        makeCommands({ recordMessage }),
-      );
+      const svc = new LangyConversationService({
+        repository: makeRepo(),
+        commands: makeCommands({ recordMessage }),
+      });
       await svc.recordUserMessage({
         projectId: "p1",
         conversationId: "c1",
@@ -525,10 +567,10 @@ describe("LangyConversationService", () => {
     describe("when the handoff token is recorded", () => {
       it("dispatches recordTurnHandoff with the opaque token", async () => {
         const recordTurnHandoff = vi.fn(async () => {});
-        const svc = new LangyConversationService(
-          makeRepo(),
-          makeCommands({ recordTurnHandoff }),
-        );
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands({ recordTurnHandoff }),
+        });
 
         await svc.recordTurnHandoff({
           projectId: "p1",
@@ -556,10 +598,10 @@ describe("LangyConversationService", () => {
           turnId: "t1",
         }));
         const consumeTurnHandoff = vi.fn(async () => {});
-        const svc = new LangyConversationService(
-          makeRepo({ findPendingHandoff }),
-          makeCommands({ consumeTurnHandoff }),
-        );
+        const svc = new LangyConversationService({
+          repository: makeRepo({ findPendingHandoff }),
+          commands: makeCommands({ consumeTurnHandoff }),
+        });
 
         const pending = await svc.getPendingHandoff({
           projectId: "p1",
@@ -585,7 +627,10 @@ describe("LangyConversationService", () => {
 
     describe("when there is no pending handoff", () => {
       it("returns null so the next turn cold-starts", async () => {
-        const svc = new LangyConversationService(makeRepo(), makeCommands());
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands(),
+        });
         const pending = await svc.getPendingHandoff({
           projectId: "p1",
           conversationId: "c1",
@@ -601,10 +646,10 @@ describe("LangyConversationService", () => {
         const recordAgentResponse = vi.fn<
           LangyConversationCommands["recordAgentResponse"]
         >(async () => {});
-        const svc = new LangyConversationService(
-          makeRepo(),
-          makeCommands({ recordAgentResponse }),
-        );
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands({ recordAgentResponse }),
+        });
 
         await svc.ingestAgentTurnResult({
           projectId: "p1",
@@ -643,10 +688,10 @@ describe("LangyConversationService", () => {
         const recordAgentResponse = vi.fn<
           LangyConversationCommands["recordAgentResponse"]
         >(async () => {});
-        const svc = new LangyConversationService(
-          makeRepo(),
-          makeCommands({ recordAgentResponse }),
-        );
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands({ recordAgentResponse }),
+        });
 
         await svc.ingestAgentTurnResult({
           projectId: "p1",
@@ -686,10 +731,10 @@ describe("LangyConversationService", () => {
         const failAgentResponse = vi.fn<
           LangyConversationCommands["failAgentResponse"]
         >(async () => {});
-        const svc = new LangyConversationService(
-          makeRepo(),
-          makeCommands({ failAgentResponse }),
-        );
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands({ failAgentResponse }),
+        });
 
         await svc.ingestAgentTurnResult({
           projectId: "p1",
@@ -746,12 +791,11 @@ describe("LangyConversationService", () => {
     describe("when the conversation is not visible to the caller", () => {
       it("throws not-found and never touches the event log", async () => {
         const events = makeEvents([]);
-        const svc = new LangyConversationService(
-          makeRepo(),
-          makeCommands(),
-          undefined,
+        const svc = new LangyConversationService({
+          repository: makeRepo(),
+          commands: makeCommands(),
           events,
-        );
+        });
         await expect(
           svc.getEventsAfter({
             projectId: "p1",
@@ -766,7 +810,10 @@ describe("LangyConversationService", () => {
 
     describe("when no event reader is configured", () => {
       it("answers with an honest empty tail at the caller's own cursor", async () => {
-        const svc = new LangyConversationService(visibleRepo(), makeCommands());
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+        });
         const after = { acceptedAt: 5, eventId: "e5" };
         expect(
           await svc.getEventsAfter({
@@ -781,16 +828,15 @@ describe("LangyConversationService", () => {
 
     describe("given a stream with events before and after the cursor", () => {
       it("returns only the strict tail, advances the cursor to its last event", async () => {
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
-          makeEvents([
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+          events: makeEvents([
             plainTurnEvent({ id: "e1", createdAt: 100 }),
             plainTurnEvent({ id: "e2", createdAt: 200 }),
             plainTurnEvent({ id: "e3", createdAt: 300 }),
           ]),
-        );
+        });
         const result = await svc.getEventsAfter({
           projectId: "p1",
           conversationId: "c1",
@@ -807,12 +853,11 @@ describe("LangyConversationService", () => {
         // so it must sit a full safety window below the cursor — pruning old
         // partitions without ever excluding a delayed event's occurred-at.
         const events = makeEvents([]);
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
           events,
-        );
+        });
         const acceptedAt = REHYDRATION_WINDOW_MS + 5_000;
         await svc.getEventsAfter({
           projectId: "p1",
@@ -820,12 +865,12 @@ describe("LangyConversationService", () => {
           userId: "alice",
           after: { acceptedAt, eventId: "e1" },
         });
-        expect(events.getEventsOccurredSince).toHaveBeenCalledWith(
-          "c1",
-          expect.anything(),
-          "langy_conversation",
-          5_000,
-        );
+        expect(events.getEventsOccurredSince).toHaveBeenCalledWith({
+          aggregateId: "c1",
+          context: expect.anything(),
+          aggregateType: "langy_conversation",
+          occurredAtFromMs: 5_000,
+        });
 
         await svc.getEventsAfter({
           projectId: "p1",
@@ -833,24 +878,23 @@ describe("LangyConversationService", () => {
           userId: "alice",
           after: { acceptedAt: 10, eventId: "e1" },
         });
-        expect(events.getEventsOccurredSince).toHaveBeenLastCalledWith(
-          "c1",
-          expect.anything(),
-          "langy_conversation",
-          0,
-        );
+        expect(events.getEventsOccurredSince).toHaveBeenLastCalledWith({
+          aggregateId: "c1",
+          context: expect.anything(),
+          aggregateType: "langy_conversation",
+          occurredAtFromMs: 0,
+        });
       });
 
       it("tie-breaks same-millisecond events by event id, byte-wise", async () => {
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
-          makeEvents([
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+          events: makeEvents([
             plainTurnEvent({ id: "2AAa", createdAt: 100 }),
             plainTurnEvent({ id: "2AAb", createdAt: 100 }),
           ]),
-        );
+        });
         const result = await svc.getEventsAfter({
           projectId: "p1",
           conversationId: "c1",
@@ -865,11 +909,10 @@ describe("LangyConversationService", () => {
       it("serves ONLY the turn vocabulary — a runToken can never ride the tail", async () => {
         // The security pin: conversation_started carries the server-only
         // runToken. It must be excluded by TYPE, not by field-stripping.
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
-          makeEvents([
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+          events: makeEvents([
             plainTurnEvent({
               id: "e1",
               createdAt: 100,
@@ -882,7 +925,7 @@ describe("LangyConversationService", () => {
             }),
             plainTurnEvent({ id: "e2", createdAt: 200 }),
           ]),
-        );
+        });
         const result = await svc.getEventsAfter({
           projectId: "p1",
           conversationId: "c1",
@@ -894,12 +937,11 @@ describe("LangyConversationService", () => {
       });
 
       it("serves the wire envelope only — no tenant or aggregate fields", async () => {
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
-          makeEvents([plainTurnEvent({ id: "e1", createdAt: 100 })]),
-        );
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+          events: makeEvents([plainTurnEvent({ id: "e1", createdAt: 100 })]),
+        });
         const result = await svc.getEventsAfter({
           projectId: "p1",
           conversationId: "c1",
@@ -924,12 +966,11 @@ describe("LangyConversationService", () => {
             createdAt: 1_000 + i,
           }),
         );
-        const svc = new LangyConversationService(
-          visibleRepo(),
-          makeCommands(),
-          undefined,
-          makeEvents(events),
-        );
+        const svc = new LangyConversationService({
+          repository: visibleRepo(),
+          commands: makeCommands(),
+          events: makeEvents(events),
+        });
         const result = await svc.getEventsAfter({
           projectId: "p1",
           conversationId: "c1",

--- a/platform/app/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyGithubAppToken.unit.test.ts
@@ -44,6 +44,7 @@ function fakeRedis(): RedisLike & { store: Map<string, string> } {
       return store.delete(k) ? 1 : 0;
     },
     // Implements the compare-and-delete release script: eval(script, 1, key, token).
+    // biome-ignore lint/complexity/useMaxParams: fake of ioredis's positional eval(script, numKeys, ...args)
     async eval(_script, _numKeys, key, token) {
       if (store.get(key) === token) {
         store.delete(key);

--- a/platform/app/src/server/app-layer/langy/langy-conversation.service.ts
+++ b/platform/app/src/server/app-layer/langy/langy-conversation.service.ts
@@ -72,12 +72,17 @@ export type { LangyConversationRepository as LangyConversationReadRepository } f
  * cold-scanning a long conversation's whole history on every tail fetch.
  */
 export interface LangyConversationEventsReader {
-  getEventsOccurredSince(
-    aggregateId: string,
-    context: { tenantId: TenantId },
-    aggregateType: "langy_conversation",
-    occurredAtFromMs: number,
-  ): Promise<readonly LangyConversationProcessingEvent[]>;
+  getEventsOccurredSince({
+    aggregateId,
+    context,
+    aggregateType,
+    occurredAtFromMs,
+  }: {
+    aggregateId: string;
+    context: { tenantId: TenantId };
+    aggregateType: "langy_conversation";
+    occurredAtFromMs: number;
+  }): Promise<readonly LangyConversationProcessingEvent[]>;
 }
 
 /**
@@ -234,12 +239,27 @@ function toListItem(
  * projection; writes remain event-sourcing commands.
  */
 export class LangyConversationService {
-  constructor(
-    private readonly repository: LangyConversationRepository,
-    private readonly commands: LangyConversationCommands,
-    private readonly messages: LangyMessageRepository = new NullLangyMessageRepository(),
-    private readonly events: LangyConversationEventsReader | null = null,
-  ) {}
+  private readonly repository: LangyConversationRepository;
+  private readonly commands: LangyConversationCommands;
+  private readonly messages: LangyMessageRepository;
+  private readonly events: LangyConversationEventsReader | null;
+
+  constructor({
+    repository,
+    commands,
+    messages = new NullLangyMessageRepository(),
+    events = null,
+  }: {
+    repository: LangyConversationRepository;
+    commands: LangyConversationCommands;
+    messages?: LangyMessageRepository;
+    events?: LangyConversationEventsReader | null;
+  }) {
+    this.repository = repository;
+    this.commands = commands;
+    this.messages = messages;
+    this.events = events;
+  }
 
   /**
    * The visibility read, tolerant of the DISPATCH window.
@@ -379,12 +399,12 @@ export class LangyConversationService {
     // durable events at all — an empty tail is the honest answer.
     if (!this.events) return { events: [], cursor: after, truncated: false };
 
-    const all = await this.events.getEventsOccurredSince(
-      conversationId,
-      { tenantId: createTenantId(projectId) },
-      "langy_conversation",
-      Math.max(0, after.acceptedAt - REHYDRATION_WINDOW_MS),
-    );
+    const all = await this.events.getEventsOccurredSince({
+      aggregateId: conversationId,
+      context: { tenantId: createTenantId(projectId) },
+      aggregateType: "langy_conversation",
+      occurredAtFromMs: Math.max(0, after.acceptedAt - REHYDRATION_WINDOW_MS),
+    });
 
     const turnTypes: readonly string[] = LANGY_CONVERSATION_TURN_EVENT_TYPES;
     const tail = all.filter(
@@ -1182,12 +1202,22 @@ export class LangyConversationService {
     return { deletedCount: ids.length };
   }
 
-  static create(
-    commands: LangyConversationCommands,
-    repository: LangyConversationRepository,
-    messages?: LangyMessageRepository,
-    events?: LangyConversationEventsReader | null,
-  ): LangyConversationService {
-    return new LangyConversationService(repository, commands, messages, events);
+  static create({
+    commands,
+    repository,
+    messages,
+    events,
+  }: {
+    commands: LangyConversationCommands;
+    repository: LangyConversationRepository;
+    messages?: LangyMessageRepository;
+    events?: LangyConversationEventsReader | null;
+  }): LangyConversationService {
+    return new LangyConversationService({
+      repository,
+      commands,
+      messages,
+      events,
+    });
   }
 }

--- a/platform/app/src/server/app-layer/langy/streaming/langyTurnRelay.ts
+++ b/platform/app/src/server/app-layer/langy/streaming/langyTurnRelay.ts
@@ -567,7 +567,7 @@ export class LangyTurnRelay {
         // see `resourceLinks`); everything else goes through the normal path.
         const invocation = this.soleNavigateInvocationOf(frame);
         if (invocation) {
-          return this.applyNavigateTool(projectId, at, frame, invocation);
+          return this.applyNavigateTool({ projectId, at, frame, invocation });
         }
 
         // The model sometimes CHAINS the navigate onto its lookup
@@ -579,7 +579,12 @@ export class LangyTurnRelay {
         // (Remembering stays sole-invocation-gated — stdout provenance.)
         if (frame.phase === "end" && !frame.isError) {
           for (const chained of this.chainedNavigateInvocationsOf(frame)) {
-            await this.applyNavigateTool(projectId, at, frame, chained);
+            await this.applyNavigateTool({
+              projectId,
+              at,
+              frame,
+              invocation: chained,
+            });
           }
         }
         return this.applyTool(projectId, at, frame);
@@ -837,12 +842,17 @@ export class LangyTurnRelay {
    * (an unknown/unresolvable/inaccessible destination silently drops — the
    * turn is otherwise unaffected).
    */
-  private async applyNavigateTool(
-    projectId: string,
-    at: { conversationId: string; turnId: string },
-    frame: Extract<LangyRelayFrame, { type: "tool" }>,
-    invocation: { resourceId: string },
-  ): Promise<LangyRelayOutcome> {
+  private async applyNavigateTool({
+    projectId,
+    at,
+    frame,
+    invocation,
+  }: {
+    projectId: string;
+    at: { conversationId: string; turnId: string };
+    frame: Extract<LangyRelayFrame, { type: "tool" }>;
+    invocation: { resourceId: string };
+  }): Promise<LangyRelayOutcome> {
     if (frame.phase === "start" || frame.isError) return { status: "applied" };
 
     // The conversation's remembered link first; on a miss, the platform's own

--- a/platform/app/src/server/app-layer/logs/repositories/canonical-log-record.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/logs/repositories/canonical-log-record.clickhouse.repository.ts
@@ -22,7 +22,11 @@ function dedupVersion(acceptedAt: number): string {
 function validate(record: CanonicalLogRecord, operation: string) {
   EventUtils.validateTenantId({ tenantId: record.tenantId }, operation);
   if (!/^[a-f0-9]{64}$/.test(record.recordId)) {
-    throw new SecurityError(operation, "invalid RecordId", record.tenantId);
+    throw new SecurityError({
+      operation,
+      message: "invalid RecordId",
+      tenantId: record.tenantId,
+    });
   }
 }
 

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -628,10 +628,10 @@ export class MetricDataPointClickHouseRepository
     query: MetricUsageEstimateQuery,
   ): Promise<MetricUsageEstimate[]> {
     if (!query.organizationId) {
-      throw new SecurityError(
-        "MetricDataPointClickHouseRepository.queryUsageEstimates",
-        "organizationId is required",
-      );
+      throw new SecurityError({
+        operation: "MetricDataPointClickHouseRepository.queryUsageEstimates",
+        message: "organizationId is required",
+      });
     }
     const client = query.tenantId
       ? await this.resolveClient(query.tenantId)
@@ -651,10 +651,11 @@ export class MetricDataPointClickHouseRepository
     fromMs: number;
   }): Promise<SeriesTotalByPointAttribute[]> {
     if (!tenantId) {
-      throw new SecurityError(
-        "MetricDataPointClickHouseRepository.getSeriesTotalsByPointAttribute",
-        "tenantId is required",
-      );
+      throw new SecurityError({
+        operation:
+          "MetricDataPointClickHouseRepository.getSeriesTotalsByPointAttribute",
+        message: "tenantId is required",
+      });
     }
     const client = await this.resolveClient(tenantId);
     // Two hops in one query: the series catalog names the label-matched

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
@@ -391,6 +391,10 @@ export function validatePoint({
 }): void {
   EventUtils.validateTenantId({ tenantId: point.tenantId }, operation);
   if (!/^[a-f0-9]{64}$/.test(point.pointId)) {
-    throw new SecurityError(operation, "invalid PointId", point.tenantId);
+    throw new SecurityError({
+      operation,
+      message: "invalid PointId",
+      tenantId: point.tenantId,
+    });
   }
 }

--- a/platform/app/src/server/app-layer/organizations/organization.service.ts
+++ b/platform/app/src/server/app-layer/organizations/organization.service.ts
@@ -57,12 +57,17 @@ export function enrichTeamWithRoleBindings<
     id: string;
     projects: { id: string }[];
   },
->(
-  team: T,
-  userId: string,
-  userRoleBindings: RoleBindingForSynthesis[],
-  organizationId: string,
-): T {
+>({
+  team,
+  userId,
+  userRoleBindings,
+  organizationId,
+}: {
+  team: T;
+  userId: string;
+  userRoleBindings: RoleBindingForSynthesis[];
+  organizationId: string;
+}): T {
   const teamProjectIds = new Set(team.projects.map((p) => p.id));
   // TEAM scope takes precedence over PROJECT scope so the synthesized role is
   // deterministic when a user has both kinds of binding for the same team.

--- a/platform/app/src/server/app-layer/presence/presence.service.ts
+++ b/platform/app/src/server/app-layer/presence/presence.service.ts
@@ -44,12 +44,27 @@ export interface PresenceLeaveInput {
 export class PresenceService {
   private readonly logger = createLogger("langwatch:presence-service");
 
-  constructor(
-    private readonly repository: PresenceRepository,
-    private readonly broadcast: BroadcastService,
-    private readonly projects: PresenceProjectLookup,
-    private readonly ttlSeconds: number = PRESENCE_TTL_SECONDS,
-  ) {}
+  private readonly repository: PresenceRepository;
+  private readonly broadcast: BroadcastService;
+  private readonly projects: PresenceProjectLookup;
+  private readonly ttlSeconds: number;
+
+  constructor({
+    repository,
+    broadcast,
+    projects,
+    ttlSeconds = PRESENCE_TTL_SECONDS,
+  }: {
+    repository: PresenceRepository;
+    broadcast: BroadcastService;
+    projects: PresenceProjectLookup;
+    ttlSeconds?: number;
+  }) {
+    this.repository = repository;
+    this.broadcast = broadcast;
+    this.projects = projects;
+    this.ttlSeconds = ttlSeconds;
+  }
 
   /**
    * Whether multiplayer presence is allowed for the given project. Org-level
@@ -134,12 +149,12 @@ export class PresenceService {
       emittedAt: Date.now(),
     };
     try {
-      await this.broadcast.broadcastToTenantRateLimited(
-        input.projectId,
-        JSON.stringify(event),
-        "presence_cursor",
-        "delta",
-      );
+      await this.broadcast.broadcastToTenantRateLimited({
+        tenantId: input.projectId,
+        event: JSON.stringify(event),
+        eventType: "presence_cursor",
+        tier: "delta",
+      });
     } catch (error) {
       this.logger.warn(
         { error, projectId: input.projectId },

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -365,13 +365,13 @@ export function initializeDefaultApp(options?: {
     new ProjectService(new PrismaProjectRepository(prisma)),
     "ProjectService",
   );
-  const presence = new PresenceService(
-    redis
+  const presence = new PresenceService({
+    repository: redis
       ? new RedisPresenceRepository(redis)
       : new InMemoryPresenceRepository(),
     broadcast,
     projects,
-  );
+  });
   const spanDedup = createSpanDedupeService(redis);
 
   // ADR-022: construct blob/IO deps before the summary + span services so
@@ -434,11 +434,11 @@ export function initializeDefaultApp(options?: {
       tenantId,
       timestamp: Date.now(),
     });
-    void broadcast.broadcastToTenantRateLimited(
+    void broadcast.broadcastToTenantRateLimited({
       tenantId,
-      payload,
-      "discover_updated",
-    );
+      event: payload,
+      eventType: "discover_updated",
+    });
   });
   const spanStorage = traced(
     new SpanStorageService(spanStorageRepository, {
@@ -551,13 +551,13 @@ export function initializeDefaultApp(options?: {
   const traceUsageService = TraceUsageService.create(prisma);
   const eventUsageService = new EventUsageService();
   const orgRepo = new OrganizationRepository(prisma);
-  const usage = new UsageService(
-    organizations,
+  const usage = new UsageService({
+    organizationService: organizations,
     traceUsageService,
     eventUsageService,
     planResolver,
-    orgRepo,
-  );
+    organizationRepository: orgRepo,
+  });
 
   const planProvider = config.isSaas
     ? PlanProviderService.create(
@@ -1133,12 +1133,12 @@ export function initializeDefaultApp(options?: {
   // commands against the canonical ClickHouse event log. The event READER feeds
   // only the tail read (conversationEventsAfter, ADR-059) — null when event
   // sourcing is disabled, in which case the tail is honestly empty.
-  const langyConversations = LangyConversationService.create(
-    commands.langy,
-    langyConversationRepository,
-    langyMessageRepository,
-    es.getEventStore<LangyConversationProcessingEvent>() ?? null,
-  );
+  const langyConversations = LangyConversationService.create({
+    commands: commands.langy,
+    repository: langyConversationRepository,
+    messages: langyMessageRepository,
+    events: es.getEventStore<LangyConversationProcessingEvent>() ?? null,
+  });
   const langyMessages = new LangyMessageService(
     langyMessageRepository,
     langyConversationRepository,
@@ -1561,11 +1561,11 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
   return new App({
     config,
     broadcast: testBroadcast,
-    presence: new PresenceService(
-      new InMemoryPresenceRepository(),
-      testBroadcast,
-      nullProjects,
-    ),
+    presence: new PresenceService({
+      repository: new InMemoryPresenceRepository(),
+      broadcast: testBroadcast,
+      projects: nullProjects,
+    }),
     traces: (() => {
       const nullEvalRuns = new EvaluationRunService(
         new NullEvaluationRunRepository(),
@@ -1734,8 +1734,8 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       service: new OpsExplainService(new OpsExplainClickHouseRepository()),
     },
     langy: {
-      conversations: LangyConversationService.create(
-        {
+      conversations: LangyConversationService.create({
+        commands: {
           createConversation: noop,
           forkConversation: noop,
           recordMessage: noop,
@@ -1753,8 +1753,8 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           consumeTurnHandoff: noop,
           generateConversationTitle: noop,
         },
-        new NullLangyConversationRepository(),
-      ),
+        repository: new NullLangyConversationRepository(),
+      }),
       turns: LangyTurnService.create({
         conversations: void 0 as unknown as LangyConversationService,
         credentials: void 0 as unknown as LangyCredentialService,
@@ -1793,13 +1793,13 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
     organizations: nullOrganizations,
     projects: nullProjects,
     tokenizer: new TokenizerService(new NullTokenizerClient()),
-    usage: new UsageService(
-      nullOrganizations,
-      TraceUsageService.create(),
-      new EventUsageService(),
-      async () => FREE_PLAN,
-      null,
-    ),
+    usage: new UsageService({
+      organizationService: nullOrganizations,
+      traceUsageService: TraceUsageService.create(),
+      eventUsageService: new EventUsageService(),
+      planResolver: async () => FREE_PLAN,
+      organizationRepository: null,
+    }),
     planProvider: PlanProviderService.create({
       getActivePlan: async () => FREE_PLAN,
     }),

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering-error.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering-error.unit.test.ts
@@ -49,12 +49,12 @@ describe("classifyClusteringError", () => {
       ["analytics.topic_clustering_llm", "FAST" as const],
       ["analytics.topic_clustering_embeddings", "EMBEDDINGS" as const],
     ])("classifies %s as user-actionable", (featureKey, role) => {
-      const error = new ModelNotConfiguredError(
+      const error = new ModelNotConfiguredError({
         featureKey,
         role,
-        "Topic clustering",
-        "project_mDIreHYSk8qhfNVnbpPyb",
-      );
+        featureDisplayName: "Topic clustering",
+        projectId: "project_mDIreHYSk8qhfNVnbpPyb",
+      });
 
       expect(classifyClusteringError(error)).toEqual({
         code: "model_not_configured",

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering-no-result.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering-no-result.unit.test.ts
@@ -177,14 +177,22 @@ describe("storeResults", () => {
   describe("given the clustering call returned no result", () => {
     describe("when storing in batch mode", () => {
       it("leaves the existing topic model in place", async () => {
-        await storeResults("proj-1", undefined, false);
+        await storeResults({
+          projectId: "proj-1",
+          clusteringResult: undefined,
+          isIncremental: false,
+        });
 
         expect(recordTopicsMock).not.toHaveBeenCalled();
       });
 
       it("returns null so the caller can report a skip", async () => {
         await expect(
-          storeResults("proj-1", undefined, false),
+          storeResults({
+            projectId: "proj-1",
+            clusteringResult: undefined,
+            isIncremental: false,
+          }),
         ).resolves.toBeNull();
       });
     });
@@ -195,11 +203,16 @@ describe("storeResults", () => {
       it("keeps the previous topics rather than replacing them with nothing", async () => {
         // An empty replacement would leave the project with no topics at
         // all, which is strictly worse than keeping the previous model.
-        await storeResults(
-          "proj-1",
-          { topics: [], subtopics: [], traces: [], cost: undefined } as any,
-          false,
-        );
+        await storeResults({
+          projectId: "proj-1",
+          clusteringResult: {
+            topics: [],
+            subtopics: [],
+            traces: [],
+            cost: undefined,
+          } as any,
+          isIncremental: false,
+        });
 
         expect(recordTopicsMock).not.toHaveBeenCalled();
       });
@@ -209,9 +222,9 @@ describe("storeResults", () => {
   describe("given the clustering call returned topics", () => {
     describe("when storing in batch mode", () => {
       it("replaces the topic model as before", async () => {
-        await storeResults(
-          "proj-1",
-          {
+        await storeResults({
+          projectId: "proj-1",
+          clusteringResult: {
             topics: [
               {
                 id: "topic_a",
@@ -224,8 +237,8 @@ describe("storeResults", () => {
             traces: [],
             cost: undefined,
           } as any,
-          false,
-        );
+          isIncremental: false,
+        });
 
         expect(recordTopicsMock).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/clustering.unit.test.ts
@@ -403,13 +403,13 @@ describe("fetchTracesFromClickHouse de-duplication", () => {
       }),
     } as any;
 
-    const res = await fetchTracesFromClickHouse(
-      mockCh,
-      "proj-1",
-      false,
-      [],
-      [],
-    );
+    const res = await fetchTracesFromClickHouse({
+      clickhouse: mockCh,
+      projectId: "proj-1",
+      isIncrementalProcessing: false,
+      topicIds: [],
+      subtopicIds: [],
+    });
 
     expect(res.returnedCount).toBe(2); // t-0 counted once + t-1
     expect(res.traces).toHaveLength(2);

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/fetchTraces-memory-guard.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/fetchTraces-memory-guard.unit.test.ts
@@ -32,7 +32,13 @@ describe("topicClustering page fetch memory guard", () => {
         },
       } as unknown as ClickHouseClient;
 
-      await fetchTracesFromClickHouse(clickhouse, "project-1", false, [], []);
+      await fetchTracesFromClickHouse({
+        clickhouse,
+        projectId: "project-1",
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+      });
 
       const pageFetch = captured.find((c) => c.query.includes("ComputedInput"));
       expect(pageFetch).toBeDefined();

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -104,7 +104,13 @@ describe("fetchTracesFromClickHouse integration", () => {
 
   describe("when fetching a full batch", () => {
     it("returns the 2000 newest traces, newest first, all with input", async () => {
-      const res = await fetchTracesFromClickHouse(ch, TENANT_ID, false, [], []);
+      const res = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: TENANT_ID,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+      });
 
       expect(res.traces).toHaveLength(2000);
       expect(res.returnedCount).toBe(2000);
@@ -116,21 +122,21 @@ describe("fetchTracesFromClickHouse integration", () => {
 
   describe("when the search cursor advances", () => {
     it("returns strictly older, non-overlapping traces", async () => {
-      const first = await fetchTracesFromClickHouse(
-        ch,
-        TENANT_ID,
-        false,
-        [],
-        [],
-      );
-      const second = await fetchTracesFromClickHouse(
-        ch,
-        TENANT_ID,
-        false,
-        [],
-        [],
-        first.lastSort!,
-      );
+      const first = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: TENANT_ID,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+      });
+      const second = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: TENANT_ID,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+        searchAfter: first.lastSort!,
+      });
 
       expect(second.traces.length).toBeGreaterThan(0);
       const firstIds = new Set(first.traces.map((t) => t.trace_id));
@@ -164,13 +170,13 @@ describe("fetchTracesFromClickHouse integration", () => {
     });
 
     it("advances the cursor past a full empty page to reach older traces", async () => {
-      const page1 = await fetchTracesFromClickHouse(
-        ch,
-        EMPTY_TENANT,
-        false,
-        [],
-        [],
-      );
+      const page1 = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: EMPTY_TENANT,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+      });
 
       // Page 1 is a full page of empty-input traces: nothing to cluster, but
       // the cursor must still track the page boundary (the 2000th trace).
@@ -180,14 +186,14 @@ describe("fetchTracesFromClickHouse integration", () => {
 
       // Page 2, seeked from that cursor, reaches the older input-bearing
       // traces that the pre-fix SQL filter would have stranded.
-      const page2 = await fetchTracesFromClickHouse(
-        ch,
-        EMPTY_TENANT,
-        false,
-        [],
-        [],
-        page1.lastSort!,
-      );
+      const page2 = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: EMPTY_TENANT,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+        searchAfter: page1.lastSort!,
+      });
       expect(page2.traces).toHaveLength(OLDER_WITH_INPUT);
       expect(page2.traces.every((t) => t.input.length > 0)).toBe(true);
       expect(page2.traces[0]?.trace_id).toBe(`${EMPTY_TENANT}-trace-002000`);
@@ -222,13 +228,13 @@ describe("fetchTracesFromClickHouse integration", () => {
     });
 
     it("returns the in-window trace and excludes the older one", async () => {
-      const res = await fetchTracesFromClickHouse(
-        ch,
-        WINDOW_TENANT,
-        false,
-        [],
-        [],
-      );
+      const res = await fetchTracesFromClickHouse({
+        clickhouse: ch,
+        projectId: WINDOW_TENANT,
+        isIncrementalProcessing: false,
+        topicIds: [],
+        subtopicIds: [],
+      });
       const ids = res.traces.map((t) => t.trace_id);
       expect(ids).toContain(`${WINDOW_TENANT}-recent`);
       expect(ids).not.toContain(`${WINDOW_TENANT}-stale`);

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/storeResults.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/storeResults.unit.test.ts
@@ -82,7 +82,11 @@ describe("storeResults", () => {
       // accidentally re-grew an ES code path, the missing module would
       // surface as an import-time failure or a vi.fn() not configured —
       // either way the test fails. The absence is the assertion.
-      await storeResults("project_regression", sampleClusteringResult, false);
+      await storeResults({
+        projectId: "project_regression",
+        clusteringResult: sampleClusteringResult,
+        isIncremental: false,
+      });
 
       expect(assignTopicMock).toHaveBeenCalledTimes(2);
       expect(assignTopicMock).toHaveBeenCalledWith(

--- a/platform/app/src/server/app-layer/topic-clustering/__tests__/topicClusteringBootstrapGate.unit.test.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/__tests__/topicClusteringBootstrapGate.unit.test.ts
@@ -9,6 +9,7 @@ import {
 function fakeRedis() {
   const keys = new Set<string>();
   const set = vi.fn(
+    // biome-ignore lint/complexity/useMaxParams: fake of ioredis's positional set(key, value, "EX", ttl, "NX")
     async (key: string, _v: string, _ex: string, _ttl: number, _nx: string) => {
       if (keys.has(key)) return null;
       keys.add(key);

--- a/platform/app/src/server/app-layer/topic-clustering/clustering.ts
+++ b/platform/app/src/server/app-layer/topic-clustering/clustering.ts
@@ -208,14 +208,14 @@ export const clusterTopicsForProject = async ({
     "Starting trace search for topic clustering",
   );
 
-  const { traces, lastSort, returnedCount } = await fetchTracesFromClickHouse(
+  const { traces, lastSort, returnedCount } = await fetchTracesFromClickHouse({
     clickhouse,
     projectId,
     isIncrementalProcessing,
     topicIds,
     subtopicIds,
     searchAfter,
-  );
+  });
 
   const minimumTraces = isIncrementalProcessing ? 1 : 10;
 
@@ -358,14 +358,21 @@ export async function fetchCountsFromClickHouse({
   };
 }
 
-export async function fetchTracesFromClickHouse(
-  clickhouse: ClickHouseClient,
-  projectId: string,
-  isIncrementalProcessing: boolean,
-  topicIds: string[],
-  subtopicIds: string[],
-  searchAfter?: [number, string],
-): Promise<TraceSearchResult> {
+export async function fetchTracesFromClickHouse({
+  clickhouse,
+  projectId,
+  isIncrementalProcessing,
+  topicIds,
+  subtopicIds,
+  searchAfter,
+}: {
+  clickhouse: ClickHouseClient;
+  projectId: string;
+  isIncrementalProcessing: boolean;
+  topicIds: string[];
+  subtopicIds: string[];
+  searchAfter?: [number, string];
+}): Promise<TraceSearchResult> {
   // Narrow FETCH window (49d, hot-tier only): bounds how far cursor-paging
   // reads the heavy ComputedInput column, keeping it off S3 cold storage.
   const fetchWindowStartMs = Date.now() - CLUSTERING_FETCH_WINDOW_DAYS * DAY_MS;
@@ -651,7 +658,12 @@ export const batchClusterTraces = async (
     traces,
   });
 
-  return await storeResults(project.id, clusteringResult, false, runContext);
+  return await storeResults({
+    projectId: project.id,
+    clusteringResult,
+    isIncremental: false,
+    runContext,
+  });
 };
 
 export const incrementalClustering = async (
@@ -720,15 +732,25 @@ export const incrementalClustering = async (
     subtopics,
   });
 
-  return await storeResults(project.id, clusteringResult, true, runContext);
+  return await storeResults({
+    projectId: project.id,
+    clusteringResult,
+    isIncremental: true,
+    runContext,
+  });
 };
 
-export const storeResults = async (
-  projectId: string,
-  clusteringResult: TopicClusteringResponse | undefined,
-  isIncremental: boolean,
-  runContext?: ClusteringRunContext,
-): Promise<ClusteringStoreSummary | null> => {
+export const storeResults = async ({
+  projectId,
+  clusteringResult,
+  isIncremental,
+  runContext,
+}: {
+  projectId: string;
+  clusteringResult: TopicClusteringResponse | undefined;
+  isIncremental: boolean;
+  runContext?: ClusteringRunContext;
+}): Promise<ClusteringStoreSummary | null> => {
   // NO RESULT IS A SKIP, NOT AN EMPTY CLUSTERING.
   //
   // This used to default an absent result to empty arrays and fall through.

--- a/platform/app/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
@@ -53,33 +53,36 @@ describe("LogRecordStorageService.getLogsByTraceId", () => {
     it("delegates to the repository with the tenant, trace, time hint, and row cap", async () => {
       const { service, getLogsByTraceId } = makeService();
 
-      const result = await service.getLogsByTraceId(
-        "project_test",
-        "trace-1",
-        1_700_000_000_000,
-        250,
-      );
+      const result = await service.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+        limit: 250,
+      });
 
-      expect(getLogsByTraceId).toHaveBeenCalledWith(
-        "project_test",
-        "trace-1",
-        1_700_000_000_000,
-        250,
-      );
+      expect(getLogsByTraceId).toHaveBeenCalledWith({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+        limit: 250,
+      });
       expect(result).toEqual([row]);
     });
 
     it("passes an undefined time hint and cap straight through so the repository default applies", async () => {
       const { service, getLogsByTraceId } = makeService();
 
-      await service.getLogsByTraceId("project_test", "trace-1");
+      await service.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+      });
 
-      expect(getLogsByTraceId).toHaveBeenCalledWith(
-        "project_test",
-        "trace-1",
-        undefined,
-        undefined,
-      );
+      expect(getLogsByTraceId).toHaveBeenCalledWith({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: undefined,
+        limit: undefined,
+      });
     });
 
     it("queries the canonical store with the same read and returns rows only it holds", async () => {
@@ -91,12 +94,12 @@ describe("LogRecordStorageService.getLogsByTraceId", () => {
         canonicalRows: [canonicalRow],
       });
 
-      const result = await service.getLogsByTraceId(
-        "project_test",
-        "trace-1",
-        1_700_000_000_000,
-        250,
-      );
+      const result = await service.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+        limit: 250,
+      });
 
       expect(canonicalGetLogsByTraceId).toHaveBeenCalledWith({
         tenantId: "project_test",
@@ -113,7 +116,10 @@ describe("LogRecordStorageService.getLogsByTraceId", () => {
         canonicalRows: [canonicalRow],
       });
 
-      const result = await service.getLogsByTraceId("project_test", "trace-1");
+      const result = await service.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+      });
 
       expect(result).toEqual([row, canonicalRow]);
     });

--- a/platform/app/src/server/app-layer/traces/__tests__/span-normalization.evaluations.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-normalization.evaluations.unit.test.ts
@@ -50,12 +50,12 @@ describe("SpanNormalizationPipelineService — SDK evaluation events", () => {
         label: "safe",
       });
 
-      const normalized = service.normalizeSpanReceived(
-        "tenant-1",
+      const normalized = service.normalizeSpanReceived({
+        tenantId: "tenant-1",
         otlpSpan,
-        null,
-        null,
-      );
+        otlpResource: null,
+        otlpInstrumentationScope: null,
+      });
 
       expect(normalized.spanAttributes[ATTR_KEYS.GEN_AI_EVALUATION_NAME]).toBe(
         "toxicity",
@@ -71,12 +71,12 @@ describe("SpanNormalizationPipelineService — SDK evaluation events", () => {
         score: 1,
       });
 
-      const normalized = service.normalizeSpanReceived(
-        "tenant-1",
+      const normalized = service.normalizeSpanReceived({
+        tenantId: "tenant-1",
         otlpSpan,
-        null,
-        null,
-      );
+        otlpResource: null,
+        otlpInstrumentationScope: null,
+      });
 
       expect(
         normalized.spanAttributes[ATTR_KEYS.LANGWATCH_RESERVED_EVALUATIONS],
@@ -89,12 +89,12 @@ describe("SpanNormalizationPipelineService — SDK evaluation events", () => {
         score: 1,
       });
 
-      const normalized = service.normalizeSpanReceived(
-        "tenant-1",
+      const normalized = service.normalizeSpanReceived({
+        tenantId: "tenant-1",
         otlpSpan,
-        null,
-        null,
-      );
+        otlpResource: null,
+        otlpInstrumentationScope: null,
+      });
 
       const evalEvents = normalized.events.filter(
         (e: { name: string }) => e.name === "langwatch.evaluation.custom",

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.nativeScopedPolicy.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.nativeScopedPolicy.test.ts
@@ -121,7 +121,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const key = "sk-proj-aB3dEf_gHi-jKlMnOpQrStUvWx0123456789xYaB-cD_eF";
       const span = spanWith({ input: `my key is ${key} thanks` });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).not.toContain(key);
       expect(attr(span, "input")).not.toContain("sk-proj-");
@@ -136,7 +141,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
         input: "db is postgres://app:s3cr3tpw@db.acme.internal:5432/main",
       });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       const value = attr(span, "input")!;
       expect(value).not.toContain("s3cr3tpw");
@@ -150,7 +160,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const { service, batchSpy } = makeService(mkPolicy({}));
       const span = spanWith({ authorization: "Bearer abc123def456ghi789" });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "authorization")).toBe("[SECRET]");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -162,7 +177,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const text = "The quick brown fox jumps over the lazy dog.";
       const span = spanWith({ input: text });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toBe(text);
       expect(batchSpy).not.toHaveBeenCalled();
@@ -176,7 +196,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const { service, batchSpy } = makeService(policy);
       const span = spanWith({ input: "token acme_live_abcd1234 end" });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toBe("token [SECRET] end");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -191,7 +216,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const key = "sk-" + "B".repeat(40);
       const span = spanWith({ input: `key ${key}` });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toContain(key);
       expect(batchSpy).not.toHaveBeenCalled();
@@ -206,7 +236,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
         input: "reach me at jane@example.com or +14155552671 anytime",
       });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       const value = attr(span, "input")!;
       expect(value).not.toContain("jane@example.com");
@@ -221,7 +256,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const { service, batchSpy } = makeService(mkPolicy({}));
       const span = spanWith({ input: "My name is Alexander Hamilton." });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toContain("Alexander Hamilton");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -234,7 +274,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
         input: "card 4242424242424242 order 1234567890123456",
       });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       const value = attr(span, "input")!;
       expect(value).not.toContain("4242424242424242");
@@ -251,7 +296,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       );
       const span = spanWith({ input: "My name is Alexander Hamilton." });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(batchSpy).toHaveBeenCalledTimes(1);
       expect(attr(span, "input")).toBe("[REDACTED]");
@@ -276,7 +326,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
           "email jane@example.com card 4242424242424242 name Alexander Hamilton",
       });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       const value = attr(span, "input")!;
       expect(value).not.toContain("jane@example.com");
@@ -296,7 +351,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       );
       const span = spanWith({ input: "contact jane@example.com please" });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toContain("jane@example.com");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -309,7 +369,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const { service, batchSpy } = makeService(mkPolicy({}));
       const span = spanWith({ input: "cpf 529.982.247-25 done" });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toBe("cpf [BR_CPF] done");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -329,7 +394,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
         input: "mail jane@example.com cpf 529.982.247-25 card 4111111111111111",
       });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       const value = attr(span, "input")!;
       expect(value).toContain("[EMAIL_ADDRESS]");
@@ -346,7 +416,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       );
       const span = spanWith({ input: "My name is Alexander Hamilton." });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(batchSpy).toHaveBeenCalledTimes(1);
       expect(batchSpy.mock.calls[0]![1].entities).toEqual(["PERSON"]);
@@ -358,7 +433,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       );
       const span = spanWith({ input: "mail jane@example.com" });
 
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).toContain("[EMAIL_ADDRESS]");
       expect(batchSpy).not.toHaveBeenCalled();
@@ -397,7 +477,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       });
       const span = spanWith({ input: "mail a@b.com, I am John from New York" });
 
-      await service.redactSpan(span, null, "STRICT", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+        tenantId: TENANT,
+      });
 
       // The native floor still scrubbed the email, but names/locations slip
       // through, so the span is marked rather than presented as fully scrubbed.
@@ -417,7 +502,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       });
       const span = spanWith({ input: "mail a@b.com" });
 
-      await service.redactSpan(span, null, "STRICT", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, "input")).not.toContain("a@b.com");
       expect(attr(span, PII_INCOMPLETE)).toBe("strict");
@@ -439,7 +529,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       });
       const span = spanWith({ input: "mail a@b.com, I am John from New York" });
 
-      await service.redactSpan(span, null, "STRICT", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+        tenantId: TENANT,
+      });
 
       expect(attr(span, PII_INCOMPLETE)).toBeUndefined();
       expect(batchSpy).not.toHaveBeenCalled();
@@ -457,7 +552,12 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       const span = spanWith({ input: "mail a@b.com" });
 
       await expect(
-        service.redactSpan(span, null, "STRICT", TENANT),
+        service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+          tenantId: TENANT,
+        }),
       ).rejects.toThrow();
       expect(attr(span, PII_INCOMPLETE)).toBeUndefined();
     });
@@ -474,7 +574,12 @@ describe("OtlpSpanPiiRedactionService PII exception patterns", () => {
       const span = spanWith({
         "gen_ai.prompt": "reservation 00528000043000 for test@example.com",
       });
-      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "ESSENTIAL",
+        tenantId: TENANT,
+      });
       expect(attr(span, "gen_ai.prompt")).toBe(
         "reservation 00528000043000 for [EMAIL_ADDRESS]",
       );
@@ -490,7 +595,12 @@ describe("OtlpSpanPiiRedactionService PII exception patterns", () => {
       const span = spanWith({
         "gen_ai.prompt": "reservation 00528000043000 here",
       });
-      await service.redactSpan(span, null, "STRICT", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+        tenantId: TENANT,
+      });
 
       expect(batchSpy).toHaveBeenCalledTimes(1);
       const options = batchSpy.mock.calls[0]![1];
@@ -507,7 +617,12 @@ describe("OtlpSpanPiiRedactionService PII exception patterns", () => {
         mkPolicy({ piiLevel: "strict" }),
       );
       const span = spanWith({ "gen_ai.prompt": "hello there" });
-      await service.redactSpan(span, null, "STRICT", TENANT);
+      await service.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+        tenantId: TENANT,
+      });
 
       expect(batchSpy).toHaveBeenCalledTimes(1);
       const options = batchSpy.mock.calls[0]![1];
@@ -524,7 +639,12 @@ describe("OtlpSpanPiiRedactionService api key id attribute", () => {
     const span = spanWith({
       "langwatch.api_key.id": "key_abc123def456",
     });
-    await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "ESSENTIAL",
+      tenantId: TENANT,
+    });
     expect(attr(span, "langwatch.api_key.id")).toBe("key_abc123def456");
   });
 
@@ -534,7 +654,12 @@ describe("OtlpSpanPiiRedactionService api key id attribute", () => {
     const span = spanWith({
       "langwatch.api_key.id": "sk-lw-" + "a".repeat(40),
     });
-    await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "ESSENTIAL",
+      tenantId: TENANT,
+    });
     expect(attr(span, "langwatch.api_key.id")).toContain("[SECRET]");
     expect(attr(span, "langwatch.api_key.id")).not.toContain("sk-lw-");
   });
@@ -545,14 +670,24 @@ describe("OtlpSpanPiiRedactionService api key id attribute", () => {
   it("still nukes other api_key-named attributes by name", async () => {
     const { service } = makeService(mkPolicy({}));
     const span = spanWith({ "user.api_key": "plain text value" });
-    await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "ESSENTIAL",
+      tenantId: TENANT,
+    });
     expect(attr(span, "user.api_key")).toBe("[SECRET]");
   });
 
   it("nukes a near-miss name that only looks like the exempt one", async () => {
     const { service } = makeService(mkPolicy({}));
     const span = spanWith({ "langwatch.api_key.id.extra": "plain text value" });
-    await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "ESSENTIAL",
+      tenantId: TENANT,
+    });
     expect(attr(span, "langwatch.api_key.id.extra")).toBe("[SECRET]");
   });
 });
@@ -592,7 +727,12 @@ describe("OtlpSpanPiiRedactionService strict-only exception scoping", () => {
       }),
     );
     const span = spanWith({ "conversation.text": "Acme Support Bot" });
-    await service.redactSpan(span, null, "STRICT", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "STRICT",
+      tenantId: TENANT,
+    });
 
     // The mock stands in for the real Presidio call: it always anonymizes,
     // exactly like the production endpoint, because exceptPatterns never
@@ -614,7 +754,12 @@ describe("OtlpSpanPiiRedactionService strict-only exception scoping", () => {
     const span = spanWith({
       "conversation.text": "reservation 00528000043000 confirmed",
     });
-    await service.redactSpan(span, null, "STRICT", TENANT);
+    await service.redactSpan({
+      span,
+      resource: null,
+      piiRedactionLevel: "STRICT",
+      tenantId: TENANT,
+    });
 
     expect(attr(span, "conversation.text")).toBe(
       "reservation 00528000043000 confirmed",

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.service.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.service.test.ts
@@ -97,7 +97,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         ]);
         const originalValue = span.attributes[0]!.value.stringValue;
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe(originalValue);
         expect(batchSpy).not.toHaveBeenCalled();
@@ -110,7 +114,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         ]);
         const originalValue = span.attributes[0]!.value.stringValue;
 
-        await service.redactSpan(span, null, "ESSENTIAL");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "ESSENTIAL",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe(originalValue);
         expect(batchSpy).not.toHaveBeenCalled();
@@ -124,7 +132,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         ]);
         const originalValue = span.attributes[0]!.value.stringValue;
 
-        await service.redactSpan(span, null, "DISABLED");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "DISABLED",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe(originalValue);
         expect(batchSpy).not.toHaveBeenCalled();
@@ -140,7 +152,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.prompt", value: { stringValue: "user@email.com" } },
         ]);
 
-        await service.redactSpan(span, null, level);
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: level,
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       });
@@ -153,7 +169,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       });
@@ -166,7 +186,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       });
@@ -181,7 +205,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       });
@@ -199,7 +227,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
         expect(span.attributes[1]!.value.stringValue).toBe("[REDACTED]");
@@ -222,7 +254,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
         expect(span.attributes[1]!.value.stringValue).toBe("[REDACTED]");
@@ -236,7 +272,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "other.key", value: { stringValue: "third" } },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(batchSpy).toHaveBeenCalledTimes(1);
         expect(batchSpy.mock.calls[0]![0]).toEqual([
@@ -251,7 +291,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.prompt", value: { stringValue: "user@email.com" } },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         const statusAttr = span.attributes.find(
           (a) => a.key === "langwatch.reserved.pii_redaction_status",
@@ -264,7 +308,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.usage.input_tokens", value: { intValue: 123 } },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.intValue).toBe(123);
         expect(span.attributes[0]!.value.stringValue).toBeUndefined();
@@ -277,7 +325,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         ]);
 
         await expect(
-          service.redactSpan(span, null, "STRICT"),
+          service.redactSpan({
+            span,
+            resource: null,
+            piiRedactionLevel: "STRICT",
+          }),
         ).resolves.not.toThrow();
         expect(batchSpy).not.toHaveBeenCalled();
       });
@@ -287,7 +339,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.prompt", value: { stringValue: "test" } },
         ]);
 
-        await service.redactSpan(span, null, "ESSENTIAL");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "ESSENTIAL",
+        });
 
         expect(batchSpy).toHaveBeenCalledTimes(1);
         const options = batchSpy.mock.calls[0]?.[1] as PIICheckOptions;
@@ -298,7 +354,11 @@ describe("OtlpSpanPiiRedactionService", () => {
       it("does not redact span.name", async () => {
         const span = createMockOtlpSpan([]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.name).toBe("test-span");
       });
@@ -320,7 +380,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ];
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.events[0]!.name).toBe("event-name");
         expect(span.events[0]!.attributes[0]!.value.stringValue).toBe(
@@ -335,7 +399,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         const span = createMockOtlpSpan([]);
         span.status = { message: "error: user john@example.com not found" };
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.status.message).toBe("[REDACTED]");
       });
@@ -358,7 +426,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ];
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.links[0]!.attributes[0]!.value.stringValue).toBe(
           "[REDACTED]",
@@ -383,7 +455,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           },
         ]);
 
-        await service.redactSpan(span, resource, "STRICT");
+        await service.redactSpan({
+          span,
+          resource,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
         expect(resource.attributes[0]!.value.stringValue).toBe("[REDACTED]");
@@ -398,7 +474,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.prompt", value: { stringValue: "content" } },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       });
@@ -410,7 +490,11 @@ describe("OtlpSpanPiiRedactionService", () => {
           { key: "gen_ai.prompt", value: { stringValue: "test" } },
         ]);
 
-        await service.redactSpan(span, null, "STRICT");
+        await service.redactSpan({
+          span,
+          resource: null,
+          piiRedactionLevel: "STRICT",
+        });
 
         expect(batchSpy).toHaveBeenCalled();
         const options = batchSpy.mock.calls[0]?.[1] as PIICheckOptions;
@@ -433,7 +517,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         ]);
 
         await expect(
-          errorService.redactSpan(span, null, "STRICT"),
+          errorService.redactSpan({
+            span,
+            resource: null,
+            piiRedactionLevel: "STRICT",
+          }),
         ).rejects.toThrow("PII service unavailable");
       });
     });
@@ -461,7 +549,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "gen_ai.prompt", value: { stringValue: oversizedValue } },
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       expect(span.attributes[0]!.value.stringValue).toBe(oversizedValue);
       expect(maxLengthBatchSpy).not.toHaveBeenCalled();
@@ -473,7 +565,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "gen_ai.prompt", value: { stringValue: oversizedValue } },
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       const statusAttr = span.attributes.find(
         (a) => a.key === "langwatch.reserved.pii_redaction_status",
@@ -488,7 +584,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "gen_ai.prompt", value: { stringValue: exactValue } },
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       expect(maxLengthBatchSpy).toHaveBeenCalledTimes(1);
@@ -506,7 +606,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "langwatch.input", value: { stringValue: normalValue } },
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       expect(span.attributes[0]!.value.stringValue).toBe(oversizedValue);
       expect(span.attributes[1]!.value.stringValue).toBe("[REDACTED]");
@@ -526,7 +630,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "langwatch.input", value: { stringValue: oversized2 } },
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       expect(maxLengthBatchSpy).not.toHaveBeenCalled();
       const statusAttr = span.attributes.find(
@@ -543,7 +651,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "attr.b", value: { stringValue: "bbbbbb" } }, // 6 chars, cumulative would be 12 (skipped)
       ]);
 
-      await maxLengthService.redactSpan(span, null, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource: null,
+        piiRedactionLevel: "STRICT",
+      });
 
       // First fits within budget, second is skipped
       expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
@@ -567,7 +679,11 @@ describe("OtlpSpanPiiRedactionService", () => {
         { key: "resource.attr", value: { stringValue: "bbbbbb" } }, // 6 chars, would exceed
       ]);
 
-      await maxLengthService.redactSpan(span, resource, "STRICT");
+      await maxLengthService.redactSpan({
+        span,
+        resource,
+        piiRedactionLevel: "STRICT",
+      });
 
       expect(span.attributes[0]!.value.stringValue).toBe("[REDACTED]");
       expect(resource.attributes[0]!.value.stringValue).toBe("bbbbbb");

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
@@ -470,12 +470,12 @@ describe.skipIf(!hasTestcontainers)(
 
             // Even full:true cannot resolve without deps: the resolve gate needs
             // `this.resolveTraceSpans`, which is undefined for a no-deps service.
-            const trace = await service.getById(
-              tenantId,
+            const trace = await service.getById({
+              projectId: tenantId,
               traceId,
-              openProtections,
-              { full: true },
-            );
+              protections: openProtections,
+              opts: { full: true },
+            });
 
             expect(trace).toBeDefined();
             if (!trace) throw new Error("trace is null/undefined");
@@ -512,12 +512,12 @@ describe.skipIf(!hasTestcontainers)(
               buildTraceBlobResolutionDeps(),
             );
 
-            const trace = await service.getById(
-              tenantId,
+            const trace = await service.getById({
+              projectId: tenantId,
               traceId,
-              openProtections,
-              { full: true },
-            );
+              protections: openProtections,
+              opts: { full: true },
+            });
 
             expect(trace).toBeDefined();
             if (!trace) throw new Error("trace is null/undefined");
@@ -543,12 +543,12 @@ describe.skipIf(!hasTestcontainers)(
               buildTraceBlobResolutionDeps(),
             );
 
-            const trace = await service.getById(
-              tenantId,
+            const trace = await service.getById({
+              projectId: tenantId,
               traceId,
-              openProtections,
-              { full: true },
-            );
+              protections: openProtections,
+              opts: { full: true },
+            });
 
             expect(trace).toBeDefined();
             if (!trace) throw new Error("trace is null/undefined");
@@ -575,12 +575,12 @@ describe.skipIf(!hasTestcontainers)(
               buildTraceBlobResolutionDeps(),
             );
 
-            const trace = await service.getById(
-              tenantId,
+            const trace = await service.getById({
+              projectId: tenantId,
               traceId,
-              openProtections,
-              { full: true },
-            );
+              protections: openProtections,
+              opts: { full: true },
+            });
 
             expect(trace).toBeDefined();
             if (!trace) throw new Error("trace is null/undefined");
@@ -613,12 +613,12 @@ describe.skipIf(!hasTestcontainers)(
             );
 
             // AC5: the missing row must NOT break the read.
-            const trace = await service.getById(
-              tenantId,
+            const trace = await service.getById({
+              projectId: tenantId,
               traceId,
-              openProtections,
-              { full: true },
-            );
+              protections: openProtections,
+              opts: { full: true },
+            });
 
             expect(trace).toBeDefined();
             if (!trace) throw new Error("trace is null/undefined");

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/_testHelpers.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/_testHelpers.ts
@@ -23,12 +23,17 @@ export { parseJsonStringAttrs };
  * raw string values instead, exercising an extractor's own defensive
  * safeJsonParse path.
  */
-export function createExtractorContext(
-  attrs: Record<string, unknown>,
-  spanOverrides?: Partial<ExtractorContext["span"]>,
-  events?: NormalizedEvent[],
-  options?: { skipJsonParsing?: boolean },
-): ExtractorContext {
+export function createExtractorContext({
+  attrs,
+  spanOverrides,
+  events,
+  options,
+}: {
+  attrs: Record<string, unknown>;
+  spanOverrides?: Partial<ExtractorContext["span"]>;
+  events?: NormalizedEvent[];
+  options?: { skipJsonParsing?: boolean };
+}): ExtractorContext {
   const parsed = options?.skipJsonParsing ? attrs : parseJsonStringAttrs(attrs);
   const bag = new SpanDataBag(parsed as NormalizedAttributes, events ?? []);
   const out: NormalizedAttributes = {};

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/claudeCode.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/claudeCode.unit.test.ts
@@ -96,16 +96,16 @@ describe("ClaudeCodeExtractor.applyLog", () => {
 
 describe("ClaudeCodeExtractor.apply (span side)", () => {
   it("lifts the CLI's bare-named token + model attrs onto canonical gen_ai.usage.* on the native llm_request span", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         model: "claude-opus-4-7",
         input_tokens: 120,
         output_tokens: 45,
         cache_read_tokens: 900,
         cache_creation_tokens: 30,
       },
-      { name: "claude_code.llm_request" },
-    );
+      spanOverrides: { name: "claude_code.llm_request" },
+    });
 
     new ClaudeCodeExtractor().apply(ctx);
 
@@ -123,10 +123,10 @@ describe("ClaudeCodeExtractor.apply (span side)", () => {
     // Gateway-proxied traffic (and every other claude_code span, like the
     // tool span) must not be touched here — this method exists ONLY for the
     // CLI's own native model-call span.
-    const ctx = createExtractorContext(
-      { model: "claude-opus-4-7", input_tokens: 120 },
-      { name: "claude_code.tool" },
-    );
+    const ctx = createExtractorContext({
+      attrs: { model: "claude-opus-4-7", input_tokens: 120 },
+      spanOverrides: { name: "claude_code.tool" },
+    });
 
     new ClaudeCodeExtractor().apply(ctx);
 
@@ -137,10 +137,10 @@ describe("ClaudeCodeExtractor.apply (span side)", () => {
   it("never overwrites a canonical attribute a gateway-proxied gen_ai.* span already set", () => {
     // setAttrIfAbsent semantics: if GenAIExtractor (or an earlier rule) already
     // claimed the canonical key, this extractor must not clobber it.
-    const ctx = createExtractorContext(
-      { input_tokens: 999 },
-      { name: "claude_code.llm_request" },
-    );
+    const ctx = createExtractorContext({
+      attrs: { input_tokens: 999 },
+      spanOverrides: { name: "claude_code.llm_request" },
+    });
     ctx.out["gen_ai.usage.input_tokens"] = 10;
 
     new ClaudeCodeExtractor().apply(ctx);
@@ -149,10 +149,10 @@ describe("ClaudeCodeExtractor.apply (span side)", () => {
   });
 
   it("does not fire for a zero-valued token count", () => {
-    const ctx = createExtractorContext(
-      { input_tokens: 0, output_tokens: 0 },
-      { name: "claude_code.llm_request" },
-    );
+    const ctx = createExtractorContext({
+      attrs: { input_tokens: 0, output_tokens: 0 },
+      spanOverrides: { name: "claude_code.llm_request" },
+    });
 
     new ClaudeCodeExtractor().apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
@@ -126,8 +126,8 @@ describe("CodexExtractor.applyLog", () => {
 
   describe("CodexExtractor.apply (span side)", () => {
     it("lifts codex.turn.token_usage.* + model + turn.id off the codex_cli_rs session_task.turn span", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           model: "gpt-5.5",
           "codex.turn.token_usage.input_tokens": "14365",
           "codex.turn.token_usage.output_tokens": "6",
@@ -136,11 +136,11 @@ describe("CodexExtractor.applyLog", () => {
           "codex.turn.reasoning_effort": "high",
           "turn.id": "019e939c-48a1-7021-a71d-714f74d6ad64",
         },
-        {
+        spanOverrides: {
           name: "session_task.turn",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -159,16 +159,16 @@ describe("CodexExtractor.applyLog", () => {
 
     /** @scenario "Codex reasoning effort is canonicalised from the turn span" */
     it("canonicalises codex.turn.reasoning_effort to gen_ai.request.reasoning_effort", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           model: "gpt-5.5",
           "codex.turn.reasoning_effort": "high",
         },
-        {
+        spanOverrides: {
           name: "session_task.turn",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -177,18 +177,18 @@ describe("CodexExtractor.applyLog", () => {
 
     /** @scenario "Codex reasoning output tokens are captured" */
     it("lifts codex.turn.token_usage.reasoning_output_tokens to gen_ai.usage.reasoning_tokens", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           model: "gpt-5.5",
           "codex.turn.token_usage.input_tokens": "1000",
           "codex.turn.token_usage.output_tokens": "50",
           "codex.turn.token_usage.reasoning_output_tokens": "10",
         },
-        {
+        spanOverrides: {
           name: "session_task.turn",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -196,16 +196,16 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("flags a non-turn codex span carrying usage as a redundant token copy", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.usage.input_tokens": 13297,
           "gen_ai.usage.output_tokens": 23,
         },
-        {
+        spanOverrides: {
           name: "handle_responses",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -219,16 +219,16 @@ describe("CodexExtractor.applyLog", () => {
       // A hypothetical future codex span that carries usage NOT folded into the
       // turn rollup must be counted, not silently dropped — so it is typed as a
       // model call but NOT marked skip_token_accumulation.
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.usage.input_tokens": 4096,
           "gen_ai.usage.output_tokens": 128,
         },
-        {
+        spanOverrides: {
           name: "handle_completions",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -242,13 +242,13 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("does not flag a non-turn codex span without usage", () => {
-      const ctx = createExtractorContext(
-        { "code.module.name": "session" },
-        {
+      const ctx = createExtractorContext({
+        attrs: { "code.module.name": "session" },
+        spanOverrides: {
           name: "build_tool_call",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -258,16 +258,16 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("is a no-op for codex_cli_rs spans other than session_task.turn", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           model: "gpt-5.5",
           turn_id: "abc",
         },
-        {
+        spanOverrides: {
           name: "run_sampling_request",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -276,19 +276,19 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("is a no-op for non-codex scopes (Path A gen_ai.* spans are GenAIExtractor's lane)", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.request.model": "gpt-5.5",
           "gen_ai.usage.input_tokens": "100",
         },
-        {
+        spanOverrides: {
           name: "session_task.turn",
           instrumentationScope: {
             name: "@langwatch/aigateway",
             version: null,
           },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -297,15 +297,15 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("lifts only present fields", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           model: "gpt-5.5",
         },
-        {
+        spanOverrides: {
           name: "session_task.turn",
           instrumentationScope: { name: "codex_cli_rs", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -321,21 +321,21 @@ describe("CodexExtractor.applyLog", () => {
   describe("when the span identifies the codex account provider", () => {
     /** @scenario "A gateway codex span is stamped with the non-billable marker" */
     it("stamps langwatch.cost.non_billable off the gateway's provider name", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.provider.name": "openai_codex",
           "gen_ai.request.model": "gpt-5.6-terra",
           "gen_ai.usage.input_tokens": "37749",
           "gen_ai.usage.output_tokens": "181",
         },
-        {
+        spanOverrides: {
           name: "gen_ai.responses",
           instrumentationScope: {
             name: "langwatch-service-aigateway",
             version: null,
           },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -345,17 +345,17 @@ describe("CodexExtractor.applyLog", () => {
 
     /** @scenario "A span running a codex-prefixed model is stamped with the non-billable marker" */
     it("stamps langwatch.cost.non_billable off the openai_codex/ model prefix", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.request.model": "openai_codex/gpt-5.6-terra",
           "gen_ai.usage.input_tokens": "1000",
           "gen_ai.usage.output_tokens": "50",
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -364,15 +364,15 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("stamps the marker when only the response model carries the prefix", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.response.model": "openai_codex/gpt-5.6-terra",
         },
-        {
+        spanOverrides: {
           name: "gen_ai.responses",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -381,20 +381,20 @@ describe("CodexExtractor.applyLog", () => {
 
     /** @scenario "An explicit wire-level non-billable marker is left untouched" */
     it("leaves an explicit wire-level marker untouched", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.provider.name": "openai_codex",
           "gen_ai.request.model": "gpt-5.6-terra",
           "langwatch.cost.non_billable": "false",
         },
-        {
+        spanOverrides: {
           name: "gen_ai.responses",
           instrumentationScope: {
             name: "langwatch-service-aigateway",
             version: null,
           },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -403,17 +403,17 @@ describe("CodexExtractor.applyLog", () => {
     });
 
     it("does not stamp a plain OpenAI span running the same underlying model", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.provider.name": "openai.responses",
           "gen_ai.request.model": "gpt-5.6-terra",
           "gen_ai.usage.input_tokens": "1000",
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       new CodexExtractor().apply(ctx);
 
@@ -425,17 +425,17 @@ describe("CodexExtractor.applyLog", () => {
 
 describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollup)", () => {
   it("keeps the response span's tokens counted: no skip marker under codex_exec", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         "gen_ai.usage.input_tokens": 13005,
         "gen_ai.usage.output_tokens": 10,
         "gen_ai.usage.cache_read.input_tokens": "12032",
       },
-      {
+      spanOverrides: {
         name: "handle_responses",
         instrumentationScope: { name: "codex_exec", version: null },
       },
-    );
+    });
 
     new CodexExtractor().apply(ctx);
 
@@ -445,16 +445,16 @@ describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollu
   });
 
   it("still types the response span as a model call, which the skip marker is independent of", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         "gen_ai.usage.input_tokens": 13005,
         "gen_ai.usage.output_tokens": 10,
       },
-      {
+      spanOverrides: {
         name: "handle_responses",
         instrumentationScope: { name: "codex_exec", version: null },
       },
-    );
+    });
 
     new CodexExtractor().apply(ctx);
 
@@ -463,8 +463,8 @@ describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollu
 
   /** @scenario "Codex reasoning effort is canonicalised from the response span when no turn rollup exists" */
   it("lifts reasoning effort, reasoning tokens, and cache writes from the response span", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         "codex.request.reasoning_effort": "max",
         "codex.usage.reasoning_output_tokens": "233",
         "codex.usage.total_tokens": "13015",
@@ -472,11 +472,11 @@ describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollu
         "gen_ai.usage.input_tokens": 13005,
         "gen_ai.usage.output_tokens": 240,
       },
-      {
+      spanOverrides: {
         name: "handle_responses",
         instrumentationScope: { name: "codex_exec", version: null },
       },
-    );
+    });
 
     new CodexExtractor().apply(ctx);
 
@@ -486,17 +486,17 @@ describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollu
   });
 
   it("still lifts the response-span extras under the TUI scope while keeping the skip marker", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         "codex.request.reasoning_effort": "high",
         "gen_ai.usage.input_tokens": 13297,
         "gen_ai.usage.output_tokens": 23,
       },
-      {
+      spanOverrides: {
         name: "handle_responses",
         instrumentationScope: { name: "codex_cli_rs", version: null },
       },
-    );
+    });
 
     new CodexExtractor().apply(ctx);
 
@@ -508,17 +508,17 @@ describe("CodexExtractor.apply on the codex_exec scope (exec wire, no turn rollu
 describe("CodexExtractor turn-span cache writes", () => {
   /** @scenario "Codex cache write tokens are canonicalised from the turn span" */
   it("lifts cache_write_input_tokens onto the canonical cache creation key", () => {
-    const ctx = createExtractorContext(
-      {
+    const ctx = createExtractorContext({
+      attrs: {
         model: "gpt-5.5",
         "codex.turn.token_usage.input_tokens": "1000",
         "codex.turn.token_usage.cache_write_input_tokens": "384",
       },
-      {
+      spanOverrides: {
         name: "session_task.turn",
         instrumentationScope: { name: "codex_cli_rs", version: null },
       },
-    );
+    });
 
     new CodexExtractor().apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/fallback.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/fallback.unit.test.ts
@@ -10,7 +10,9 @@ describe("FallbackExtractor", () => {
   describe("when no span type set and tool indicators present", () => {
     it("infers tool from operation.name = ai.toolCall", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPERATION_NAME]: "ai.toolCall",
+        attrs: {
+          [ATTR_KEYS.OPERATION_NAME]: "ai.toolCall",
+        },
       });
 
       extractor.apply(ctx);
@@ -20,7 +22,9 @@ describe("FallbackExtractor", () => {
 
     it("infers tool from ai.toolCall.name presence", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.AI_TOOL_CALL_NAME]: "search",
+        attrs: {
+          [ATTR_KEYS.AI_TOOL_CALL_NAME]: "search",
+        },
       });
 
       extractor.apply(ctx);
@@ -30,7 +34,9 @@ describe("FallbackExtractor", () => {
 
     it("infers tool from gen_ai.operation.name = tool", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_OPERATION_NAME]: "tool",
+        attrs: {
+          [ATTR_KEYS.GEN_AI_OPERATION_NAME]: "tool",
+        },
       });
 
       extractor.apply(ctx);
@@ -42,7 +48,9 @@ describe("FallbackExtractor", () => {
   describe("when no span type set and agent indicators present", () => {
     it("infers agent from gen_ai.agent.name presence", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_AGENT_NAME]: "my-agent",
+        attrs: {
+          [ATTR_KEYS.GEN_AI_AGENT_NAME]: "my-agent",
+        },
       });
 
       extractor.apply(ctx);
@@ -54,7 +62,9 @@ describe("FallbackExtractor", () => {
   describe("when no span type set and LLM indicators present", () => {
     it("infers llm from gen_ai.request.model", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "gpt-4",
+        attrs: {
+          [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "gpt-4",
+        },
       });
 
       extractor.apply(ctx);
@@ -64,7 +74,9 @@ describe("FallbackExtractor", () => {
 
     it("infers llm from ai.prompt (Vercel)", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.AI_PROMPT]: "Hello",
+        attrs: {
+          [ATTR_KEYS.AI_PROMPT]: "Hello",
+        },
       });
 
       extractor.apply(ctx);
@@ -74,7 +86,9 @@ describe("FallbackExtractor", () => {
 
     it("infers llm from llm.model_name (legacy)", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_MODEL_NAME]: "claude-3",
+        attrs: {
+          [ATTR_KEYS.LLM_MODEL_NAME]: "claude-3",
+        },
       });
 
       extractor.apply(ctx);
@@ -86,8 +100,10 @@ describe("FallbackExtractor", () => {
   describe("when span type already set", () => {
     it("does nothing", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "gpt-4",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "gpt-4",
+        },
       });
 
       extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/genAi.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/genAi.unit.test.ts
@@ -10,7 +10,7 @@ describe("GenAIExtractor", () => {
   describe("when gen_ai.system is present", () => {
     it("maps to gen_ai.provider.name and consumes original", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_SYSTEM]: "openai",
+        attrs: { [ATTR_KEYS.GEN_AI_SYSTEM]: "openai" },
       });
 
       extractor.apply(ctx);
@@ -23,7 +23,7 @@ describe("GenAIExtractor", () => {
   describe("when gen_ai.agent.name is present", () => {
     it("passes through as-is", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_AGENT_NAME]: "my-agent",
+        attrs: { [ATTR_KEYS.GEN_AI_AGENT_NAME]: "my-agent" },
       });
 
       extractor.apply(ctx);
@@ -35,7 +35,7 @@ describe("GenAIExtractor", () => {
   describe("when gen_ai.agent (legacy) is present", () => {
     it("maps to gen_ai.agent.name", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_AGENT]: "legacy-agent",
+        attrs: { [ATTR_KEYS.GEN_AI_AGENT]: "legacy-agent" },
       });
 
       extractor.apply(ctx);
@@ -47,7 +47,7 @@ describe("GenAIExtractor", () => {
   describe("when agent.name is present", () => {
     it("maps to gen_ai.agent.name", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.AGENT_NAME]: "named-agent",
+        attrs: { [ATTR_KEYS.AGENT_NAME]: "named-agent" },
       });
 
       extractor.apply(ctx);
@@ -59,7 +59,7 @@ describe("GenAIExtractor", () => {
   describe("when llm.model_name is present", () => {
     it("maps to both gen_ai.request.model and gen_ai.response.model", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_MODEL_NAME]: "gpt-4",
+        attrs: { [ATTR_KEYS.LLM_MODEL_NAME]: "gpt-4" },
       });
 
       extractor.apply(ctx);
@@ -72,7 +72,7 @@ describe("GenAIExtractor", () => {
   describe("when gen_ai.prompt is present", () => {
     it("maps to gen_ai.input.messages as user message", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_PROMPT]: "What is 2+2?",
+        attrs: { [ATTR_KEYS.GEN_AI_PROMPT]: "What is 2+2?" },
       });
 
       extractor.apply(ctx);
@@ -88,7 +88,7 @@ describe("GenAIExtractor", () => {
         { role: "user", content: "Hi" },
       ];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_PROMPT]: JSON.stringify(messages),
+        attrs: { [ATTR_KEYS.GEN_AI_PROMPT]: JSON.stringify(messages) },
       });
 
       extractor.apply(ctx);
@@ -107,7 +107,7 @@ describe("GenAIExtractor", () => {
         { role: "assistant", content: "Hi there" },
       ];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: messages,
+        attrs: { [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: messages },
       });
 
       extractor.apply(ctx);
@@ -127,7 +127,7 @@ describe("GenAIExtractor", () => {
         { role: "assistant", content: "Hi" },
       ];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: messages,
+        attrs: { [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: messages },
       });
 
       extractor.apply(ctx);
@@ -141,7 +141,7 @@ describe("GenAIExtractor", () => {
   describe("when gen_ai.completion is present", () => {
     it("maps to gen_ai.output.messages as assistant message", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_COMPLETION]: "The answer is 4.",
+        attrs: { [ATTR_KEYS.GEN_AI_COMPLETION]: "The answer is 4." },
       });
 
       extractor.apply(ctx);
@@ -156,7 +156,7 @@ describe("GenAIExtractor", () => {
     it("maps to gen_ai.input.messages", () => {
       const messages = [{ role: "user", content: "Hello" }];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_INPUT_MESSAGES]: JSON.stringify(messages),
+        attrs: { [ATTR_KEYS.LLM_INPUT_MESSAGES]: JSON.stringify(messages) },
       });
 
       extractor.apply(ctx);
@@ -169,7 +169,7 @@ describe("GenAIExtractor", () => {
     it("maps to gen_ai.output.messages", () => {
       const messages = [{ role: "assistant", content: "Hi there" }];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_OUTPUT_MESSAGES]: JSON.stringify(messages),
+        attrs: { [ATTR_KEYS.LLM_OUTPUT_MESSAGES]: JSON.stringify(messages) },
       });
 
       extractor.apply(ctx);
@@ -181,7 +181,7 @@ describe("GenAIExtractor", () => {
   describe("when usage tokens are present", () => {
     it("maps gen_ai.usage.input_tokens", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]: 100,
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]: 100 },
       });
 
       extractor.apply(ctx);
@@ -191,7 +191,7 @@ describe("GenAIExtractor", () => {
 
     it("maps gen_ai.usage.prompt_tokens (legacy) to input_tokens", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_PROMPT_TOKENS]: 50,
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_PROMPT_TOKENS]: 50 },
       });
 
       extractor.apply(ctx);
@@ -201,7 +201,7 @@ describe("GenAIExtractor", () => {
 
     it("maps gen_ai.usage.output_tokens", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS]: 200,
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS]: 200 },
       });
 
       extractor.apply(ctx);
@@ -211,7 +211,7 @@ describe("GenAIExtractor", () => {
 
     it("maps gen_ai.usage.completion_tokens (legacy) to output_tokens", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_COMPLETION_TOKENS]: 75,
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_COMPLETION_TOKENS]: 75 },
       });
 
       extractor.apply(ctx);
@@ -223,7 +223,7 @@ describe("GenAIExtractor", () => {
   describe("when reasoning tokens arrive as a string", () => {
     it("coerces string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS]: "720",
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS]: "720" },
       });
 
       extractor.apply(ctx);
@@ -233,7 +233,7 @@ describe("GenAIExtractor", () => {
 
     it("leaves numeric values untouched (passes through remaining)", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS]: 500,
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS]: 500 },
       });
 
       extractor.apply(ctx);
@@ -248,7 +248,7 @@ describe("GenAIExtractor", () => {
   describe("when cache tokens arrive as strings", () => {
     it("coerces cache_read.input_tokens string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]: "1024",
+        attrs: { [ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]: "1024" },
       });
 
       extractor.apply(ctx);
@@ -260,7 +260,9 @@ describe("GenAIExtractor", () => {
 
     it("coerces cache_creation.input_tokens string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]: "256",
+        attrs: {
+          [ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]: "256",
+        },
       });
 
       extractor.apply(ctx);
@@ -274,7 +276,7 @@ describe("GenAIExtractor", () => {
   describe("when request parameters arrive as strings", () => {
     it("coerces temperature string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE]: "1",
+        attrs: { [ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE]: "1" },
       });
 
       extractor.apply(ctx);
@@ -284,7 +286,7 @@ describe("GenAIExtractor", () => {
 
     it("coerces max_tokens string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_REQUEST_MAX_TOKENS]: "4096",
+        attrs: { [ATTR_KEYS.GEN_AI_REQUEST_MAX_TOKENS]: "4096" },
       });
 
       extractor.apply(ctx);
@@ -294,7 +296,7 @@ describe("GenAIExtractor", () => {
 
     it("coerces top_p string to number", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_REQUEST_TOP_P]: "0.9",
+        attrs: { [ATTR_KEYS.GEN_AI_REQUEST_TOP_P]: "0.9" },
       });
 
       extractor.apply(ctx);
@@ -304,7 +306,7 @@ describe("GenAIExtractor", () => {
 
     it("leaves numeric values untouched (passes through remaining)", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE]: 0.7,
+        attrs: { [ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE]: 0.7 },
       });
 
       extractor.apply(ctx);
@@ -317,14 +319,16 @@ describe("GenAIExtractor", () => {
   describe("when llm.invocation_parameters JSON is present", () => {
     it("extracts temperature, max_tokens, top_p, frequency_penalty, presence_penalty, seed", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({
-          temperature: 0.7,
-          max_tokens: 1000,
-          top_p: 0.9,
-          frequency_penalty: 0.5,
-          presence_penalty: 0.3,
-          seed: 42,
-        }),
+        attrs: {
+          [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({
+            temperature: 0.7,
+            max_tokens: 1000,
+            top_p: 0.9,
+            frequency_penalty: 0.5,
+            presence_penalty: 0.3,
+            seed: 42,
+          }),
+        },
       });
 
       extractor.apply(ctx);
@@ -339,9 +343,11 @@ describe("GenAIExtractor", () => {
 
     it("extracts stop sequences as string array", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({
-          stop: ["END", "STOP"],
-        }),
+        attrs: {
+          [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({
+            stop: ["END", "STOP"],
+          }),
+        },
       });
 
       extractor.apply(ctx);
@@ -354,7 +360,9 @@ describe("GenAIExtractor", () => {
 
     it("skips choice count when n=1", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({ n: 1 }),
+        attrs: {
+          [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({ n: 1 }),
+        },
       });
 
       extractor.apply(ctx);
@@ -364,7 +372,9 @@ describe("GenAIExtractor", () => {
 
     it("sets choice count when n>1", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({ n: 3 }),
+        attrs: {
+          [ATTR_KEYS.LLM_INVOCATION_PARAMETERS]: JSON.stringify({ n: 3 }),
+        },
       });
 
       extractor.apply(ctx);
@@ -376,7 +386,7 @@ describe("GenAIExtractor", () => {
   describe("when span type is llm", () => {
     it("sets gen_ai.operation.name to chat", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "llm",
+        attrs: { [ATTR_KEYS.SPAN_TYPE]: "llm" },
       });
 
       extractor.apply(ctx);
@@ -388,7 +398,7 @@ describe("GenAIExtractor", () => {
   describe("when span type is tool", () => {
     it("sets gen_ai.operation.name to tool", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "tool",
+        attrs: { [ATTR_KEYS.SPAN_TYPE]: "tool" },
       });
 
       extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/haystack.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/haystack.unit.test.ts
@@ -20,10 +20,10 @@ describe("HaystackExtractor", () => {
         { document: { content: "Document 1 content", id: "doc-1" } },
         { document: { content: "Document 2 content" } },
       ];
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 
@@ -35,10 +35,10 @@ describe("HaystackExtractor", () => {
 
     it("infers span type as rag", () => {
       const docs = [{ document: { content: "Some content" } }];
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 
@@ -47,10 +47,10 @@ describe("HaystackExtractor", () => {
 
     it("extracts document_id when present", () => {
       const docs = [{ document: { content: "Content", id: "my-doc-id" } }];
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 
@@ -67,10 +67,10 @@ describe("HaystackExtractor", () => {
         { document: { content: "" } },
         { document: { id: "no-content" } },
       ];
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 
@@ -83,10 +83,12 @@ describe("HaystackExtractor", () => {
   describe("when instrumentationScope.name is NOT haystack", () => {
     it("does nothing", () => {
       const docs = [{ document: { content: "Content" } }];
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
-        { instrumentationScope: { name: "other", version: null } },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify(docs) },
+        spanOverrides: {
+          instrumentationScope: { name: "other", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 
@@ -96,10 +98,10 @@ describe("HaystackExtractor", () => {
 
   describe("when retrieval.documents is empty or malformed", () => {
     it("does nothing for empty array", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify([]) },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: JSON.stringify([]) },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 
@@ -107,10 +109,10 @@ describe("HaystackExtractor", () => {
     });
 
     it("does nothing for non-array", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: "not-json" },
-        haystackScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.RETRIEVAL_DOCUMENTS]: "not-json" },
+        spanOverrides: haystackScope,
+      });
 
       extractor.apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.metrics.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.metrics.unit.test.ts
@@ -11,10 +11,12 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.metrics has valid cost", () => {
       it("sets langwatch.span.cost via setAttrIfAbsent", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
+            }),
+          },
         });
 
         extractor.apply(ctx);
@@ -30,10 +32,12 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.metrics has token counts", () => {
       it("sets gen_ai.usage.input_tokens and gen_ai.usage.output_tokens", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
+            }),
+          },
         });
 
         extractor.apply(ctx);
@@ -54,10 +58,12 @@ describe("LangWatchExtractor", () => {
     describe("when gen_ai.usage.input_tokens is already set", () => {
       it("does not override (setAttrIfAbsent)", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
+            }),
+          },
         });
         // Pre-set token values (as if GenAI extractor ran first)
         ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS] = 200;
@@ -74,7 +80,9 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.metrics is malformed", () => {
       it("skips gracefully for invalid JSON", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: "{not valid json",
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: "{not valid json",
+          },
         });
 
         expect(() => extractor.apply(ctx)).not.toThrow();
@@ -84,10 +92,12 @@ describe("LangWatchExtractor", () => {
 
       it("skips gracefully when value is not an object", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: "not-an-object",
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: "not-an-object",
+            }),
+          },
         });
 
         expect(() => extractor.apply(ctx)).not.toThrow();
@@ -96,9 +106,11 @@ describe("LangWatchExtractor", () => {
 
       it("skips gracefully when missing type/value structure", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            promptTokens: 100,
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              promptTokens: 100,
+            }),
+          },
         });
 
         expect(() => extractor.apply(ctx)).not.toThrow();
@@ -109,15 +121,17 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.metrics has tokensEstimated: true", () => {
       it("sets langwatch.tokens.estimated", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: {
-              promptTokens: 100,
-              completionTokens: 50,
-              cost: 0.005,
-              tokensEstimated: true,
-            },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: {
+                promptTokens: 100,
+                completionTokens: 50,
+                cost: 0.005,
+                tokensEstimated: true,
+              },
+            }),
+          },
         });
 
         extractor.apply(ctx);
@@ -133,10 +147,12 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.span.cost is already in the bag", () => {
       it("does not override (setAttrIfAbsent)", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: { promptTokens: 100, completionTokens: 50, cost: 0.005 },
+            }),
+          },
         });
         // Pre-set cost (as if enrichment or another extractor already set it)
         ctx.out[ATTR_KEYS.LANGWATCH_SPAN_COST] = 0.01;
@@ -151,10 +167,12 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.metrics has zero cost", () => {
       it("does not set langwatch.span.cost", () => {
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
-            type: "json",
-            value: { promptTokens: 0, completionTokens: 0, cost: 0 },
-          }),
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_METRICS]: JSON.stringify({
+              type: "json",
+              value: { promptTokens: 0, completionTokens: 0, cost: 0 },
+            }),
+          },
         });
 
         extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
@@ -11,7 +11,9 @@ describe("LangWatchExtractor", () => {
     describe("when metadata JSON contains user_id", () => {
       it("promotes to langwatch.user.id via setAttrIfAbsent", () => {
         const ctx = createExtractorContext({
-          metadata: JSON.stringify({ user_id: "meta-user-1" }),
+          attrs: {
+            metadata: JSON.stringify({ user_id: "meta-user-1" }),
+          },
         });
 
         extractor.apply(ctx);
@@ -27,7 +29,9 @@ describe("LangWatchExtractor", () => {
     describe("when metadata JSON contains userId (camelCase)", () => {
       it("promotes to langwatch.user.id via setAttrIfAbsent", () => {
         const ctx = createExtractorContext({
-          metadata: JSON.stringify({ userId: "meta-user-camel" }),
+          attrs: {
+            metadata: JSON.stringify({ userId: "meta-user-camel" }),
+          },
         });
 
         extractor.apply(ctx);
@@ -43,7 +47,9 @@ describe("LangWatchExtractor", () => {
     describe("when langwatch.user.id is already set in out", () => {
       it("does not overwrite the existing value", () => {
         const ctx = createExtractorContext({
-          metadata: JSON.stringify({ user_id: "meta-user" }),
+          attrs: {
+            metadata: JSON.stringify({ user_id: "meta-user" }),
+          },
         });
         // Pre-set via explicit attribute processing (simulated)
         ctx.out[ATTR_KEYS.LANGWATCH_USER_ID] = "explicit-user";
@@ -57,7 +63,9 @@ describe("LangWatchExtractor", () => {
     describe("when metadata contains thread_id", () => {
       it("promotes to gen_ai.conversation.id", () => {
         const ctx = createExtractorContext({
-          metadata: JSON.stringify({ thread_id: "thread-abc" }),
+          attrs: {
+            metadata: JSON.stringify({ thread_id: "thread-abc" }),
+          },
         });
 
         extractor.apply(ctx);
@@ -73,7 +81,9 @@ describe("LangWatchExtractor", () => {
     describe("when metadata contains customer_id", () => {
       it("promotes to langwatch.customer.id", () => {
         const ctx = createExtractorContext({
-          metadata: JSON.stringify({ customer_id: "cust-xyz" }),
+          attrs: {
+            metadata: JSON.stringify({ customer_id: "cust-xyz" }),
+          },
         });
 
         extractor.apply(ctx);
@@ -89,7 +99,9 @@ describe("LangWatchExtractor", () => {
     describe("when metadata is invalid JSON", () => {
       it("does not throw", () => {
         const ctx = createExtractorContext({
-          metadata: "{not valid json",
+          attrs: {
+            metadata: "{not valid json",
+          },
         });
 
         expect(() => extractor.apply(ctx)).not.toThrow();
@@ -97,7 +109,9 @@ describe("LangWatchExtractor", () => {
 
       it("does not set any promoted attributes", () => {
         const ctx = createExtractorContext({
-          metadata: "{not valid json",
+          attrs: {
+            metadata: "{not valid json",
+          },
         });
 
         extractor.apply(ctx);
@@ -112,19 +126,22 @@ describe("LangWatchExtractor", () => {
   describe("evaluation events (langwatch.evaluation.custom)", () => {
     describe("when span has a langwatch.evaluation.custom event", () => {
       it("maps first evaluation to GenAI semconv attributes", () => {
-        const ctx = createExtractorContext({}, undefined, [
-          {
-            name: "langwatch.evaluation.custom",
-            timeUnixMs: Date.now(),
-            attributes: {
-              json_encoded_event: JSON.stringify({
-                name: "toxicity",
-                score: 0.95,
-                label: "safe",
-              }),
+        const ctx = createExtractorContext({
+          attrs: {},
+          events: [
+            {
+              name: "langwatch.evaluation.custom",
+              timeUnixMs: Date.now(),
+              attributes: {
+                json_encoded_event: JSON.stringify({
+                  name: "toxicity",
+                  score: 0.95,
+                  label: "safe",
+                }),
+              },
             },
-          },
-        ]);
+          ],
+        });
 
         extractor.apply(ctx);
 
@@ -143,16 +160,19 @@ describe("LangWatchExtractor", () => {
       });
 
       it("handles already-parsed json_encoded_event (from parseJsonStringValues)", () => {
-        const ctx = createExtractorContext({}, undefined, [
-          {
-            name: "langwatch.evaluation.custom",
-            timeUnixMs: Date.now(),
-            attributes: {
-              // After parseJsonStringValues, JSON strings become objects
-              json_encoded_event: { name: "toxicity", score: 0.8 },
+        const ctx = createExtractorContext({
+          attrs: {},
+          events: [
+            {
+              name: "langwatch.evaluation.custom",
+              timeUnixMs: Date.now(),
+              attributes: {
+                // After parseJsonStringValues, JSON strings become objects
+                json_encoded_event: { name: "toxicity", score: 0.8 },
+              },
             },
-          },
-        ]);
+          ],
+        });
 
         extractor.apply(ctx);
 
@@ -165,7 +185,7 @@ describe("LangWatchExtractor", () => {
 
     describe("when span has no evaluation events", () => {
       it("does not set GenAI evaluation attributes", () => {
-        const ctx = createExtractorContext({});
+        const ctx = createExtractorContext({ attrs: {} });
 
         extractor.apply(ctx);
 
@@ -175,15 +195,18 @@ describe("LangWatchExtractor", () => {
 
     describe("when span has no langwatch.reserved.evaluations attribute", () => {
       it("does not leak reserved attributes to metadata", () => {
-        const ctx = createExtractorContext({}, undefined, [
-          {
-            name: "langwatch.evaluation.custom",
-            timeUnixMs: Date.now(),
-            attributes: {
-              json_encoded_event: JSON.stringify({ name: "test", score: 1 }),
+        const ctx = createExtractorContext({
+          attrs: {},
+          events: [
+            {
+              name: "langwatch.evaluation.custom",
+              timeUnixMs: Date.now(),
+              attributes: {
+                json_encoded_event: JSON.stringify({ name: "test", score: 1 }),
+              },
             },
-          },
-        ]);
+          ],
+        });
 
         extractor.apply(ctx);
 
@@ -201,7 +224,9 @@ describe("LangWatchExtractor", () => {
           { document_id: "doc-1", chunk_id: "chunk-1", content: "hello world" },
         ];
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]: contexts,
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]: contexts,
+          },
         });
 
         extractor.apply(ctx);
@@ -220,7 +245,9 @@ describe("LangWatchExtractor", () => {
           { document_id: "doc-2", chunk_id: "chunk-2", content: "legacy data" },
         ];
         const ctx = createExtractorContext({
-          [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS_LEGACY]: contexts,
+          attrs: {
+            [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS_LEGACY]: contexts,
+          },
         });
 
         extractor.apply(ctx);
@@ -240,10 +267,12 @@ describe("LangWatchExtractor", () => {
         ];
         // Old TS SDK (<=0.26.0) sent "langwatch.contexts" which is not recognized
         const ctx = createExtractorContext({
-          "langwatch.contexts": JSON.stringify({
-            type: "json",
-            value: contexts,
-          }),
+          attrs: {
+            "langwatch.contexts": JSON.stringify({
+              type: "json",
+              value: contexts,
+            }),
+          },
         });
 
         extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/legacyOtel.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/legacyOtel.unit.test.ts
@@ -10,7 +10,9 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when type attribute is present", () => {
     it("maps to langwatch.span.type", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.TYPE]: "llm",
+        attrs: {
+          [ATTR_KEYS.TYPE]: "llm",
+        },
       });
 
       extractor.apply(ctx);
@@ -22,7 +24,9 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when span.kind includes SERVER", () => {
     it("sets langwatch.span.type to server", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_KIND]: "SERVER",
+        attrs: {
+          [ATTR_KEYS.SPAN_KIND]: "SERVER",
+        },
       });
 
       extractor.apply(ctx);
@@ -34,7 +38,9 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when llm.request.type is chat", () => {
     it("infers llm span type", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.LLM_REQUEST_TYPE]: "chat",
+        attrs: {
+          [ATTR_KEYS.LLM_REQUEST_TYPE]: "chat",
+        },
       });
 
       extractor.apply(ctx);
@@ -46,7 +52,9 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when input.value is present", () => {
     it("maps to langwatch.input", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.INPUT_VALUE]: "some input data",
+        attrs: {
+          [ATTR_KEYS.INPUT_VALUE]: "some input data",
+        },
       });
 
       extractor.apply(ctx);
@@ -59,7 +67,9 @@ describe("LegacyOtelTracesExtractor", () => {
 
     it("does not overwrite existing langwatch.input", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.INPUT_VALUE]: "legacy input",
+        attrs: {
+          [ATTR_KEYS.INPUT_VALUE]: "legacy input",
+        },
       });
       ctx.out[ATTR_KEYS.LANGWATCH_INPUT] = "existing";
 
@@ -72,7 +82,9 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when output.value is present", () => {
     it("maps to langwatch.output", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OUTPUT_VALUE]: "some output data",
+        attrs: {
+          [ATTR_KEYS.OUTPUT_VALUE]: "some output data",
+        },
       });
 
       extractor.apply(ctx);
@@ -88,7 +100,9 @@ describe("LegacyOtelTracesExtractor", () => {
     it("maps to langwatch.input for tool spans", () => {
       const args = JSON.stringify({ query: "test" });
       const ctx = createExtractorContext({
-        [ATTR_KEYS.AI_TOOL_CALL_ARGS]: args,
+        attrs: {
+          [ATTR_KEYS.AI_TOOL_CALL_ARGS]: args,
+        },
       });
 
       extractor.apply(ctx);
@@ -103,8 +117,10 @@ describe("LegacyOtelTracesExtractor", () => {
   describe("when error indicators are present", () => {
     it("extracts error.message from span.error.has_error + span.error.message", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_ERROR_HAS_ERROR]: true,
-        [ATTR_KEYS.SPAN_ERROR_MESSAGE]: "Something went wrong",
+        attrs: {
+          [ATTR_KEYS.SPAN_ERROR_HAS_ERROR]: true,
+          [ATTR_KEYS.SPAN_ERROR_MESSAGE]: "Something went wrong",
+        },
       });
 
       extractor.apply(ctx);
@@ -117,8 +133,10 @@ describe("LegacyOtelTracesExtractor", () => {
 
     it("accepts string 'true' for span.error.has_error", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_ERROR_HAS_ERROR]: "true",
-        [ATTR_KEYS.SPAN_ERROR_MESSAGE]: "Something went wrong",
+        attrs: {
+          [ATTR_KEYS.SPAN_ERROR_HAS_ERROR]: "true",
+          [ATTR_KEYS.SPAN_ERROR_MESSAGE]: "Something went wrong",
+        },
       });
 
       extractor.apply(ctx);
@@ -131,8 +149,10 @@ describe("LegacyOtelTracesExtractor", () => {
 
     it("extracts separate error.type and error.message from exception attributes", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.EXCEPTION_TYPE]: "ValueError",
-        [ATTR_KEYS.EXCEPTION_MESSAGE]: "Invalid input",
+        attrs: {
+          [ATTR_KEYS.EXCEPTION_TYPE]: "ValueError",
+          [ATTR_KEYS.EXCEPTION_MESSAGE]: "Invalid input",
+        },
       });
 
       extractor.apply(ctx);
@@ -149,7 +169,9 @@ describe("LegacyOtelTracesExtractor", () => {
 
     it("extracts error.message from status.message as fallback", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.STATUS_MESSAGE]: "Request failed",
+        attrs: {
+          [ATTR_KEYS.STATUS_MESSAGE]: "Request failed",
+        },
       });
 
       extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/logfire.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/logfire.unit.test.ts
@@ -105,7 +105,7 @@ describe("LogfireExtractor", () => {
 
   describe("when neither raw_input nor gen_ai.choice events exist", () => {
     it("does nothing", () => {
-      const ctx = createExtractorContext({});
+      const ctx = createExtractorContext({ attrs: {} });
 
       extractor.apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/mastra.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/mastra.unit.test.ts
@@ -13,10 +13,10 @@ describe("MastraExtractor", () => {
     };
 
     it("maps agent_run to agent", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -24,10 +24,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps workflow_run to workflow", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "workflow_run" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "workflow_run" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -35,10 +35,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps model_generation to llm", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -46,10 +46,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps tool_call to tool", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "tool_call" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "tool_call" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -57,10 +57,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps mcp_tool_call to tool", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "mcp_tool_call" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "mcp_tool_call" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -68,10 +68,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps generic to span", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "generic" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "generic" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -79,10 +79,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps unknown types to span (default)", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "something_new" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "something_new" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -96,10 +96,10 @@ describe("MastraExtractor", () => {
     };
 
     it("maps agent_run to agent", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
-        mastraBridgeScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
+        spanOverrides: mastraBridgeScope,
+      });
 
       extractor.apply(ctx);
 
@@ -107,10 +107,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps processor_run to component", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "processor_run" },
-        mastraBridgeScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "processor_run" },
+        spanOverrides: mastraBridgeScope,
+      });
 
       extractor.apply(ctx);
 
@@ -118,10 +118,10 @@ describe("MastraExtractor", () => {
     });
 
     it("maps model_generation to llm", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation" },
-        mastraBridgeScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation" },
+        spanOverrides: mastraBridgeScope,
+      });
 
       extractor.apply(ctx);
 
@@ -131,10 +131,12 @@ describe("MastraExtractor", () => {
 
   describe("when detected by mastra.span.type attribute only", () => {
     it("maps span type even without @mastra/* scope", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "tool_call" },
-        { instrumentationScope: { name: "unknown-scope", version: null } },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "tool_call" },
+        spanOverrides: {
+          instrumentationScope: { name: "unknown-scope", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 
@@ -142,10 +144,12 @@ describe("MastraExtractor", () => {
     });
 
     it("maps model_step to llm without @mastra/* scope", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
-        { instrumentationScope: { name: "other-lib", version: null } },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
+        spanOverrides: {
+          instrumentationScope: { name: "other-lib", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 
@@ -155,10 +159,12 @@ describe("MastraExtractor", () => {
 
   describe("when instrumentationScope.name is NOT mastra and no mastra attributes", () => {
     it("does nothing (no span type set)", () => {
-      const ctx = createExtractorContext(
-        {},
-        { instrumentationScope: { name: "other-lib", version: null } },
-      );
+      const ctx = createExtractorContext({
+        attrs: {},
+        spanOverrides: {
+          instrumentationScope: { name: "other-lib", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 
@@ -169,13 +175,15 @@ describe("MastraExtractor", () => {
 
   describe("when langwatch.span.type already exists in bag", () => {
     it("preserves user-explicit span type over Mastra mapping", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.SPAN_TYPE]: "agent",
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation",
         },
-        { instrumentationScope: { name: "@mastra/otel", version: null } },
-      );
+        spanOverrides: {
+          instrumentationScope: { name: "@mastra/otel", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 
@@ -186,12 +194,14 @@ describe("MastraExtractor", () => {
 
   describe("when span type was set by a prior extractor (ctx.out)", () => {
     it("overrides extractor-inferred span type with Mastra mapping", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation",
         },
-        { instrumentationScope: { name: "@mastra/otel", version: null } },
-      );
+        spanOverrides: {
+          instrumentationScope: { name: "@mastra/otel", version: null },
+        },
+      });
       // Simulate a prior extractor having set span type
       ctx.out[ATTR_KEYS.SPAN_TYPE] = "span";
 
@@ -215,13 +225,13 @@ describe("MastraExtractor", () => {
           content: [{ type: "text", text: "what's the weather in london?" }],
         },
       ]);
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_INPUT]: messages,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -235,13 +245,13 @@ describe("MastraExtractor", () => {
         { role: "system", content: "You are helpful" },
         { role: "user", content: "hello world" },
       ]);
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_INPUT]: messages,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -254,13 +264,13 @@ describe("MastraExtractor", () => {
         { role: "assistant", content: "first answer" },
         { role: "user", content: "second question" },
       ]);
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_INPUT]: messages,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -271,14 +281,14 @@ describe("MastraExtractor", () => {
       const messages = JSON.stringify([
         { role: "user", content: "from mastra" },
       ]);
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_INPUT]: messages,
           [ATTR_KEYS.LANGWATCH_INPUT]: "already set",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -296,13 +306,13 @@ describe("MastraExtractor", () => {
         text: "The weather in London is sunny, 15°C.",
         files: [],
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -313,13 +323,13 @@ describe("MastraExtractor", () => {
 
     it("does not set langwatch.output for empty text", () => {
       const output = JSON.stringify({ text: "", files: [] });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -328,14 +338,14 @@ describe("MastraExtractor", () => {
 
     it("does not overwrite existing langwatch.output", () => {
       const output = JSON.stringify({ text: "from mastra", files: [] });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_AGENT_RUN_OUTPUT]: output,
           [ATTR_KEYS.LANGWATCH_OUTPUT]: "already set",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -349,13 +359,13 @@ describe("MastraExtractor", () => {
     };
 
     it("maps mastra.metadata.threadId to gen_ai.conversation.id", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           "mastra.metadata.threadId": "thread-abc",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -363,13 +373,13 @@ describe("MastraExtractor", () => {
     });
 
     it("does not overwrite existing gen_ai.conversation.id", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           "mastra.metadata.threadId": "mastra-thread",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       // Pre-set conversation.id
       ctx.out[ATTR_KEYS.GEN_AI_CONVERSATION_ID] = "existing-thread";
@@ -380,8 +390,8 @@ describe("MastraExtractor", () => {
     });
 
     it("leaves non-threadId metadata keys untouched in the bag", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           "mastra.metadata.runId": "run-42",
           "mastra.metadata.headers": JSON.stringify({
@@ -389,8 +399,8 @@ describe("MastraExtractor", () => {
           }),
           "mastra.metadata.body": JSON.stringify({ key: "value" }),
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -405,14 +415,14 @@ describe("MastraExtractor", () => {
     });
 
     it("consumes only threadId from the bag", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           "mastra.metadata.threadId": "t1",
           "mastra.metadata.runId": "r1",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -427,13 +437,13 @@ describe("MastraExtractor", () => {
     };
 
     it("maps to gen_ai.usage.cache_read.input_tokens", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.GEN_AI_USAGE_CACHED_INPUT_TOKENS]: "150",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -441,13 +451,13 @@ describe("MastraExtractor", () => {
     });
 
     it("does not overwrite existing cache_read.input_tokens", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.GEN_AI_USAGE_CACHED_INPUT_TOKENS]: "150",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       // Pre-set canonical name
       ctx.out[ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = 200;
@@ -458,13 +468,13 @@ describe("MastraExtractor", () => {
     });
 
     it("coerces string value to number", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.GEN_AI_USAGE_CACHED_INPUT_TOKENS]: "720",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -485,13 +495,13 @@ describe("MastraExtractor", () => {
         text: "The current weather in London is sunny, 15°C.",
         toolCalls: [],
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -505,13 +515,13 @@ describe("MastraExtractor", () => {
         text: "The answer is 42.",
         toolCalls: [],
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -525,13 +535,13 @@ describe("MastraExtractor", () => {
         text: "Hello",
         toolCalls: [],
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -546,13 +556,13 @@ describe("MastraExtractor", () => {
         object: { score: 9 },
         text: "",
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -561,13 +571,13 @@ describe("MastraExtractor", () => {
 
     it("does not set langwatch.output for empty text", () => {
       const output = JSON.stringify({ text: "", toolCalls: [] });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -576,14 +586,14 @@ describe("MastraExtractor", () => {
 
     it("does not set langwatch.output when already exists", () => {
       const output = JSON.stringify({ text: "from mastra", toolCalls: [] });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
           [ATTR_KEYS.LANGWATCH_OUTPUT]: "already set",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -592,13 +602,13 @@ describe("MastraExtractor", () => {
 
     it("does not set langwatch.output for agent_run spans", () => {
       const output = JSON.stringify({ text: "concatenated text" });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -618,13 +628,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hello" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -642,13 +652,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -670,13 +680,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -694,13 +704,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -720,13 +730,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -742,14 +752,14 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
           [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "existing-model",
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -764,13 +774,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -784,13 +794,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_generation",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -804,8 +814,8 @@ describe("MastraExtractor", () => {
     };
 
     it("uses modelMetadata.modelId as fallback for model name", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           "mastra.metadata.modelMetadata": JSON.stringify({
             modelId: "gpt-4o",
@@ -813,8 +823,8 @@ describe("MastraExtractor", () => {
             modelProvider: "openai",
           }),
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -829,16 +839,16 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
           "mastra.metadata.modelMetadata": JSON.stringify({
             modelId: "gpt-4o",
           }),
         },
-        mastraScope,
-      );
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -852,10 +862,10 @@ describe("MastraExtractor", () => {
     };
 
     it("maps to evaluation type instead of llm", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
-        { ...mastraScope, parentSpanId: null },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -875,13 +885,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -895,13 +905,13 @@ describe("MastraExtractor", () => {
         object: { score: 9, reason: "Accurate translation" },
         text: "",
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -915,13 +925,13 @@ describe("MastraExtractor", () => {
       const output = JSON.stringify({
         text: "Score: 8/10",
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_OUTPUT]: output,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -938,13 +948,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -962,13 +972,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -982,13 +992,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "test" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: null },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -996,10 +1006,10 @@ describe("MastraExtractor", () => {
     });
 
     it("uses bare Eval when no model or system prompt available", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
-        { ...mastraScope, parentSpanId: null },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
+        spanOverrides: { ...mastraScope, parentSpanId: null },
+      });
 
       extractor.apply(ctx);
 
@@ -1020,13 +1030,13 @@ describe("MastraExtractor", () => {
           ],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: "parent-agent-run" },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: "parent-agent-run" },
+      });
 
       extractor.apply(ctx);
 
@@ -1040,13 +1050,13 @@ describe("MastraExtractor", () => {
           messages: [{ role: "user", content: "hi" }],
         },
       });
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step",
           [ATTR_KEYS.MASTRA_MODEL_STEP_INPUT]: input,
         },
-        { ...mastraScope, parentSpanId: "parent-123" },
-      );
+        spanOverrides: { ...mastraScope, parentSpanId: "parent-123" },
+      });
 
       extractor.apply(ctx);
 
@@ -1060,10 +1070,10 @@ describe("MastraExtractor", () => {
     };
 
     it("does not set display name for agent_run", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
-        { ...mastraScope, name: "invoke_agent Weather Agent" },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "agent_run" },
+        spanOverrides: { ...mastraScope, name: "invoke_agent Weather Agent" },
+      });
 
       extractor.apply(ctx);
 
@@ -1071,10 +1081,10 @@ describe("MastraExtractor", () => {
     });
 
     it("does not set display name for model_step without model", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_step" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 
@@ -1082,10 +1092,10 @@ describe("MastraExtractor", () => {
     });
 
     it("does not set display name for model_chunk", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_chunk" },
-        mastraScope,
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.MASTRA_SPAN_TYPE]: "model_chunk" },
+        spanOverrides: mastraScope,
+      });
 
       extractor.apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/openinference.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/openinference.unit.test.ts
@@ -10,7 +10,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when openinference.span.kind is present", () => {
     it("maps lowercase kind to langwatch.span.type", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        },
       });
 
       extractor.apply(ctx);
@@ -20,7 +22,9 @@ describe("OpenInferenceExtractor", () => {
 
     it("takes the attribute from the bag", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        },
       });
 
       extractor.apply(ctx);
@@ -30,7 +34,9 @@ describe("OpenInferenceExtractor", () => {
 
     it("records a rule", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        },
       });
 
       extractor.apply(ctx);
@@ -44,8 +50,10 @@ describe("OpenInferenceExtractor", () => {
   describe("when langwatch.span.type already set to a valid type", () => {
     it("does not overwrite the existing span type", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.OPENINFERENCE_SPAN_KIND]: "LLM",
+        },
       });
 
       extractor.apply(ctx);
@@ -57,8 +65,10 @@ describe("OpenInferenceExtractor", () => {
 
     it("still processes user.id", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-123",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-123",
+        },
       });
 
       extractor.apply(ctx);
@@ -68,8 +78,10 @@ describe("OpenInferenceExtractor", () => {
 
     it("still processes session.id", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "sess-456",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "sess-456",
+        },
       });
 
       extractor.apply(ctx);
@@ -79,8 +91,10 @@ describe("OpenInferenceExtractor", () => {
 
     it("still processes tag.tags", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: "tag-a",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: "tag-a",
+        },
       });
 
       extractor.apply(ctx);
@@ -92,7 +106,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when user.id is present", () => {
     it("maps to langwatch.user.id via setAttrIfAbsent", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-abc",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-abc",
+        },
       });
 
       extractor.apply(ctx);
@@ -106,7 +122,9 @@ describe("OpenInferenceExtractor", () => {
 
     it("records a rule", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-abc",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_USER_ID]: "user-abc",
+        },
       });
 
       extractor.apply(ctx);
@@ -118,7 +136,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when user.id is an empty string", () => {
     it("does not set langwatch.user.id", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_USER_ID]: "",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_USER_ID]: "",
+        },
       });
 
       extractor.apply(ctx);
@@ -130,7 +150,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when langwatch.user.id is already set in out", () => {
     it("does not overwrite the existing value", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_USER_ID]: "openinference-user",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_USER_ID]: "openinference-user",
+        },
       });
       // Pre-set the output attribute
       ctx.out[ATTR_KEYS.LANGWATCH_USER_ID] = "existing-user";
@@ -144,7 +166,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when session.id is present", () => {
     it("maps to gen_ai.conversation.id via setAttrIfAbsent", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "sess-xyz",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "sess-xyz",
+        },
       });
 
       extractor.apply(ctx);
@@ -160,7 +184,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when gen_ai.conversation.id is already set", () => {
     it("does not overwrite the existing value", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "new-session",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_SESSION_ID]: "new-session",
+        },
       });
       ctx.out[ATTR_KEYS.GEN_AI_CONVERSATION_ID] = "existing-thread";
 
@@ -173,7 +199,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when tag.tags is a string", () => {
     it("sets langwatch.labels to the string value", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: "my-tag",
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: "my-tag",
+        },
       });
 
       extractor.apply(ctx);
@@ -185,7 +213,9 @@ describe("OpenInferenceExtractor", () => {
   describe("when tag.tags is an array", () => {
     it("JSON-stringifies and sets langwatch.labels", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: ["tag-a", "tag-b"],
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_TAG_TAGS]: ["tag-a", "tag-b"],
+        },
       });
 
       extractor.apply(ctx);
@@ -199,9 +229,11 @@ describe("OpenInferenceExtractor", () => {
   describe("when llm.token_count.* attributes are present", () => {
     it("maps prompt/completion counts to canonical gen_ai.usage.*", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
+        },
       });
 
       extractor.apply(ctx);
@@ -212,9 +244,11 @@ describe("OpenInferenceExtractor", () => {
 
     it("maps reasoning + cache_read + cache_write to canonical keys", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]: 12,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]: 120,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]: 30,
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]: 12,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]: 120,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]: 30,
+        },
       });
 
       extractor.apply(ctx);
@@ -228,12 +262,14 @@ describe("OpenInferenceExtractor", () => {
 
     it("consumes all llm.token_count.* keys so they don't leak into params", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]: 12,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]: 120,
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]: 30,
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]: 12,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]: 120,
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]: 30,
+        },
       });
 
       extractor.apply(ctx);
@@ -253,7 +289,9 @@ describe("OpenInferenceExtractor", () => {
 
     it("records a rule when any token-count attribute is present", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 10,
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 10,
+        },
       });
 
       extractor.apply(ctx);
@@ -265,7 +303,9 @@ describe("OpenInferenceExtractor", () => {
 
     it("does not overwrite a canonical token already set by gen_ai.usage.*", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 999,
+        attrs: {
+          [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 999,
+        },
       });
       ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS] = 42;
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
@@ -265,10 +265,12 @@ describe("StrandsExtractor", () => {
 
   describe("when NOT a Strands span", () => {
     it("does nothing", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.GEN_AI_OPERATION_NAME]: "chat" },
-        { instrumentationScope: { name: "opentelemetry", version: null } },
-      );
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.GEN_AI_OPERATION_NAME]: "chat" },
+        spanOverrides: {
+          instrumentationScope: { name: "opentelemetry", version: null },
+        },
+      });
 
       extractor.apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/traceloop.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/traceloop.unit.test.ts
@@ -10,7 +10,7 @@ describe("TraceloopExtractor", () => {
   describe("when traceloop.span.kind is present", () => {
     it("maps llm to langwatch.span.type llm", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "llm",
+        attrs: { [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "llm" },
       });
 
       extractor.apply(ctx);
@@ -20,7 +20,7 @@ describe("TraceloopExtractor", () => {
 
     it("maps tool to langwatch.span.type tool", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "tool",
+        attrs: { [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "tool" },
       });
 
       extractor.apply(ctx);
@@ -30,8 +30,10 @@ describe("TraceloopExtractor", () => {
 
     it("consumes traceloop.span.kind even when langwatch.span.type already set", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.SPAN_TYPE]: "agent",
-        [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "llm",
+        attrs: {
+          [ATTR_KEYS.SPAN_TYPE]: "agent",
+          [ATTR_KEYS.TRACELOOP_SPAN_KIND]: "llm",
+        },
       });
 
       extractor.apply(ctx);
@@ -47,7 +49,7 @@ describe("TraceloopExtractor", () => {
     it("maps to gen_ai.input.messages", () => {
       const messages = [{ role: "user", content: "Hello" }];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.TRACELOOP_ENTITY_INPUT]: JSON.stringify(messages),
+        attrs: { [ATTR_KEYS.TRACELOOP_ENTITY_INPUT]: JSON.stringify(messages) },
       });
 
       extractor.apply(ctx);
@@ -57,12 +59,14 @@ describe("TraceloopExtractor", () => {
 
     it("does not overwrite existing gen_ai.input.messages", () => {
       const ctx = createExtractorContext({
-        [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: JSON.stringify([
-          { role: "user", content: "existing" },
-        ]),
-        [ATTR_KEYS.TRACELOOP_ENTITY_INPUT]: JSON.stringify([
-          { role: "user", content: "traceloop" },
-        ]),
+        attrs: {
+          [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: JSON.stringify([
+            { role: "user", content: "existing" },
+          ]),
+          [ATTR_KEYS.TRACELOOP_ENTITY_INPUT]: JSON.stringify([
+            { role: "user", content: "traceloop" },
+          ]),
+        },
       });
 
       extractor.apply(ctx);
@@ -76,7 +80,9 @@ describe("TraceloopExtractor", () => {
     it("maps to gen_ai.output.messages", () => {
       const messages = [{ role: "assistant", content: "Hi there" }];
       const ctx = createExtractorContext({
-        [ATTR_KEYS.TRACELOOP_ENTITY_OUTPUT]: JSON.stringify(messages),
+        attrs: {
+          [ATTR_KEYS.TRACELOOP_ENTITY_OUTPUT]: JSON.stringify(messages),
+        },
       });
 
       extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vercel.unit.test.ts
@@ -9,13 +9,13 @@ describe("VercelExtractor", () => {
 
   describe("when instrumentationScope.name is 'ai'", () => {
     it("processes the span and sets span type from span name", () => {
-      const ctx = createExtractorContext(
-        {},
-        {
+      const ctx = createExtractorContext({
+        attrs: {},
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "ai", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -24,13 +24,13 @@ describe("VercelExtractor", () => {
     });
 
     it("records a rule for span type mapping", () => {
-      const ctx = createExtractorContext(
-        {},
-        {
+      const ctx = createExtractorContext({
+        attrs: {},
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "ai", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -40,18 +40,18 @@ describe("VercelExtractor", () => {
     });
 
     it("sets model attributes when ai.model is provided", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "gpt-4",
             provider: "openai.chat",
           }),
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "ai", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -68,14 +68,14 @@ describe("VercelExtractor", () => {
 
     it("extracts ai.response.object as output messages", () => {
       const objectPayload = { name: "Alice", age: 30 };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE]: JSON.stringify({
             object: JSON.stringify(objectPayload),
           }),
         },
-        aiSpan,
-      );
+        spanOverrides: aiSpan,
+      });
 
       extractor.apply(ctx);
 
@@ -86,12 +86,12 @@ describe("VercelExtractor", () => {
 
     it("extracts ai.response.object as flat attribute fallback", () => {
       const objectPayload = { name: "Bob", score: 42 };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE_OBJECT]: JSON.stringify(objectPayload),
         },
-        aiSpan,
-      );
+        spanOverrides: aiSpan,
+      });
 
       extractor.apply(ctx);
 
@@ -101,15 +101,15 @@ describe("VercelExtractor", () => {
     });
 
     it("prefers .text over .object when both are present", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE]: JSON.stringify({
             text: "hello",
             object: JSON.stringify({ key: "val" }),
           }),
         },
-        aiSpan,
-      );
+        spanOverrides: aiSpan,
+      });
 
       extractor.apply(ctx);
 
@@ -121,18 +121,18 @@ describe("VercelExtractor", () => {
 
   describe("when instrumentationScope.name is not 'ai' but ai.* attrs are present", () => {
     it("still lifts (covers opencode/embedded-Vercel-SDK case)", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "gpt-4",
             provider: "openai.chat",
           }),
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -143,15 +143,15 @@ describe("VercelExtractor", () => {
 
     it("lifts flat structured output from a non-ai instrumentation scope", () => {
       const objectPayload = { greeting: "Hallo" };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE_OBJECT]: objectPayload,
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -163,16 +163,16 @@ describe("VercelExtractor", () => {
 
     it("uses structured output when the text attribute is empty", () => {
       const objectPayload = { greeting: "Hallo" };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE_TEXT]: "",
           [ATTR_KEYS.AI_RESPONSE_OBJECT]: objectPayload,
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -183,16 +183,16 @@ describe("VercelExtractor", () => {
 
     it("falls back to response text when the response attribute is empty", () => {
       const objectPayload = { greeting: "Hallo" };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE]: "",
           [ATTR_KEYS.AI_RESPONSE_TEXT]: JSON.stringify(objectPayload),
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -203,15 +203,15 @@ describe("VercelExtractor", () => {
 
     it("handles a parsed JSON response text value", () => {
       const objectPayload = { text: "structured field" };
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_RESPONSE_TEXT]: objectPayload,
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -223,15 +223,15 @@ describe("VercelExtractor", () => {
 
   describe("when scope is unrelated AND no ai.* attrs are present", () => {
     it("returns early with nothing in out", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.GEN_AI_REQUEST_MODEL]: "claude-haiku-4-5",
         },
-        {
+        spanOverrides: {
           name: "spanWithoutAiAttrs",
           instrumentationScope: { name: "opentelemetry", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -243,21 +243,21 @@ describe("VercelExtractor", () => {
 
   describe("when instrumentationScope.name is undefined but ai.* attrs are present", () => {
     it("still lifts via attrs-presence fallback", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "gpt-4",
             provider: "openai.chat",
           }),
         },
-        {
+        spanOverrides: {
           name: "ai.generateText",
           instrumentationScope: {
             name: undefined as unknown as string,
             version: null,
           },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -268,8 +268,8 @@ describe("VercelExtractor", () => {
   describe("when the AI SDK reports cache token details", () => {
     /** @scenario "A cached turn's input is split into fresh and cached buckets" */
     it("maps inputTokenDetails.cacheWriteTokens to gen_ai cache_creation (opencode Path B)", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "claude-haiku-4-5",
             provider: "anthropic",
@@ -278,11 +278,11 @@ describe("VercelExtractor", () => {
           [ATTR_KEYS.AI_USAGE_CACHE_WRITE_TOKENS]: 12629,
           [ATTR_KEYS.AI_USAGE_CACHE_READ_TOKENS]: 0,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -299,8 +299,8 @@ describe("VercelExtractor", () => {
     });
 
     it("maps inputTokenDetails.cacheReadTokens to gen_ai cache_read on a cached turn", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "claude-haiku-4-5",
             provider: "anthropic",
@@ -308,11 +308,11 @@ describe("VercelExtractor", () => {
           "gen_ai.usage.input_tokens": 13000,
           [ATTR_KEYS.AI_USAGE_CACHE_READ_TOKENS]: 12629,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -323,8 +323,8 @@ describe("VercelExtractor", () => {
     });
 
     it("falls back to the cachedInputTokens alias for the read count", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_MODEL]: JSON.stringify({
             id: "claude-haiku-4-5",
             provider: "anthropic",
@@ -332,11 +332,11 @@ describe("VercelExtractor", () => {
           "gen_ai.usage.input_tokens": 9000,
           [ATTR_KEYS.AI_USAGE_CACHED_INPUT_TOKENS]: 8745,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -348,17 +348,17 @@ describe("VercelExtractor", () => {
 
     /** @scenario "The SDK's own fresh-input count is trusted when reported" */
     it("prefers the SDK's own noCacheTokens for the fresh input remainder", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.usage.input_tokens": 25449,
           [ATTR_KEYS.AI_USAGE_CACHED_INPUT_TOKENS]: 20000,
           [ATTR_KEYS.AI_USAGE_NO_CACHE_TOKENS]: 5449,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -374,17 +374,17 @@ describe("VercelExtractor", () => {
       // the provider-call child but carries no gen_ai.usage.input_tokens;
       // mapping cache onto it would count the cached share twice in the
       // trace fold.
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_USAGE_INPUT_TOKENS]: 25449,
           [ATTR_KEYS.AI_USAGE_CACHED_INPUT_TOKENS]: 20000,
           [ATTR_KEYS.AI_USAGE_NO_CACHE_TOKENS]: 5449,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -396,17 +396,17 @@ describe("VercelExtractor", () => {
 
     /** @scenario "Reasoning tokens reported by the SDK reach the trace" */
     it("maps the flat reasoningTokens count to gen_ai reasoning_tokens", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.usage.input_tokens": 9000,
           [ATTR_KEYS.AI_USAGE_INPUT_TOKENS]: 9000,
           [ATTR_KEYS.AI_USAGE_REASONING_TOKENS]: 384,
         },
-        {
+        spanOverrides: {
           name: "ai.streamText.doStream",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -417,17 +417,17 @@ describe("VercelExtractor", () => {
   describe("when the span is an ai.toolCall tool span under the opencode scope", () => {
     /** @scenario "Opencode tool-call spans capture the tool name, arguments, and result" */
     it("lifts ai.toolCall.{name,args,result} to the tool name + input/output", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           [ATTR_KEYS.AI_TOOL_CALL_NAME]: "bash",
           [ATTR_KEYS.AI_TOOL_CALL_ARGS]: '{"command":"ls -la"}',
           [ATTR_KEYS.AI_TOOL_CALL_RESULT]: "total 4\ndrwxr-xr-x",
         },
-        {
+        spanOverrides: {
           name: "ai.toolCall",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 
@@ -444,13 +444,13 @@ describe("VercelExtractor", () => {
     });
 
     it("detects the tool span even though the scope is not 'ai'", () => {
-      const ctx = createExtractorContext(
-        { [ATTR_KEYS.AI_TOOL_CALL_NAME]: "read_file" },
-        {
+      const ctx = createExtractorContext({
+        attrs: { [ATTR_KEYS.AI_TOOL_CALL_NAME]: "read_file" },
+        spanOverrides: {
           name: "ai.toolCall",
           instrumentationScope: { name: "opencode", version: null },
         },
-      );
+      });
 
       extractor.apply(ctx);
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
@@ -130,7 +130,7 @@ describe("VertexAdkExtractor", () => {
   describe("given a generate_content span", () => {
     describe("when the span is canonicalised", () => {
       it("extracts the conversation as gen_ai.input.messages", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -165,7 +165,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("extracts the model reply as gen_ai.output.messages", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -188,7 +188,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("surfaces the system instruction separately from the chat messages", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -202,7 +202,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("annotates input and output messages as chat_messages", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -213,7 +213,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("lifts tool declarations to gen_ai.tool.definitions", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -223,7 +223,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("types the span as llm", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -231,7 +231,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("consumes the vendor request/response payload attributes", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -240,7 +240,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("keeps the vendor session/invocation ids as passthrough attributes", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -251,7 +251,7 @@ describe("VertexAdkExtractor", () => {
 
     describe("when the span already reports standard token usage", () => {
       it("keeps the explicitly reported token counts", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -263,7 +263,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("still lifts cached prompt tokens as cache-read tokens", () => {
-        const ctx = createExtractorContext(llmSpanAttrs());
+        const ctx = createExtractorContext({ attrs: llmSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -278,7 +278,7 @@ describe("VertexAdkExtractor", () => {
         const attrs = llmSpanAttrs();
         delete attrs["gen_ai.usage.input_tokens"];
         delete attrs["gen_ai.usage.output_tokens"];
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -291,8 +291,10 @@ describe("VertexAdkExtractor", () => {
       it("does not overwrite the existing messages", () => {
         const existing = [{ role: "user", content: "already extracted" }];
         const ctx = createExtractorContext({
-          ...llmSpanAttrs(),
-          [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: existing,
+          attrs: {
+            ...llmSpanAttrs(),
+            [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: existing,
+          },
         });
 
         extractor.apply(ctx);
@@ -311,7 +313,7 @@ describe("VertexAdkExtractor", () => {
           content: { parts: [{ text: "Done." }], role: "model" },
           finish_reason: "STOP",
         });
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -334,7 +336,7 @@ describe("VertexAdkExtractor", () => {
             },
           ],
         });
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -356,7 +358,7 @@ describe("VertexAdkExtractor", () => {
           },
           contents: [{ parts: [{ text: "hi" }], role: "user" }],
         });
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -379,7 +381,7 @@ describe("VertexAdkExtractor", () => {
           },
           contents: [{ parts: [{ text: "hi" }], role: "user" }],
         });
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -394,7 +396,7 @@ describe("VertexAdkExtractor", () => {
   describe("given an execute_tool span", () => {
     describe("when the span is canonicalised", () => {
       it("types the span as tool", () => {
-        const ctx = createExtractorContext(toolSpanAttrs());
+        const ctx = createExtractorContext({ attrs: toolSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -402,7 +404,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("lifts the call arguments to langwatch.input and gen_ai.tool.call.arguments", () => {
-        const ctx = createExtractorContext(toolSpanAttrs());
+        const ctx = createExtractorContext({ attrs: toolSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -412,7 +414,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("lifts the tool response to langwatch.output and gen_ai.tool.call.result", () => {
-        const ctx = createExtractorContext(toolSpanAttrs());
+        const ctx = createExtractorContext({ attrs: toolSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -425,7 +427,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("does not produce chat messages from the empty request/response payloads", () => {
-        const ctx = createExtractorContext(toolSpanAttrs());
+        const ctx = createExtractorContext({ attrs: toolSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -434,7 +436,7 @@ describe("VertexAdkExtractor", () => {
       });
 
       it("consumes the vendor tool payload attributes", () => {
-        const ctx = createExtractorContext(toolSpanAttrs());
+        const ctx = createExtractorContext({ attrs: toolSpanAttrs() });
 
         extractor.apply(ctx);
 
@@ -450,11 +452,13 @@ describe("VertexAdkExtractor", () => {
     describe("when the tool input/output were already set by an earlier source", () => {
       it("does not record the tool lift rules", () => {
         const ctx = createExtractorContext({
-          ...toolSpanAttrs(),
-          [ATTR_KEYS.LANGWATCH_INPUT]: "already set",
-          [ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS]: "already set",
-          [ATTR_KEYS.LANGWATCH_OUTPUT]: "already set",
-          [ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT]: "already set",
+          attrs: {
+            ...toolSpanAttrs(),
+            [ATTR_KEYS.LANGWATCH_INPUT]: "already set",
+            [ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS]: "already set",
+            [ATTR_KEYS.LANGWATCH_OUTPUT]: "already set",
+            [ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT]: "already set",
+          },
         });
 
         extractor.apply(ctx);
@@ -472,8 +476,10 @@ describe("VertexAdkExtractor", () => {
     describe("when the span type is explicitly set", () => {
       it("respects the explicit type", () => {
         const ctx = createExtractorContext({
-          ...toolSpanAttrs(),
-          [ATTR_KEYS.SPAN_TYPE]: "component",
+          attrs: {
+            ...toolSpanAttrs(),
+            [ATTR_KEYS.SPAN_TYPE]: "component",
+          },
         });
 
         extractor.apply(ctx);
@@ -487,9 +493,11 @@ describe("VertexAdkExtractor", () => {
     describe("when the span is canonicalised", () => {
       it("types the span as agent", () => {
         const ctx = createExtractorContext({
-          "gen_ai.operation.name": "invoke_agent",
-          "gen_ai.provider.name": "gcp.vertex.agent",
-          "gen_ai.agent.name": "TravelPlanner",
+          attrs: {
+            "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.provider.name": "gcp.vertex.agent",
+            "gen_ai.agent.name": "TravelPlanner",
+          },
         });
 
         extractor.apply(ctx);
@@ -504,7 +512,7 @@ describe("VertexAdkExtractor", () => {
       it("falls back to gcp.vertex.agent.session_id", () => {
         const attrs = llmSpanAttrs();
         delete attrs["gen_ai.conversation.id"];
-        const ctx = createExtractorContext(attrs);
+        const ctx = createExtractorContext({ attrs });
 
         extractor.apply(ctx);
 
@@ -517,18 +525,16 @@ describe("VertexAdkExtractor", () => {
 
   describe("given the payload arrives as a JSON string that bypassed pre-parsing", () => {
     it("parses the request payload itself", () => {
-      const ctx = createExtractorContext(
-        {
+      const ctx = createExtractorContext({
+        attrs: {
           "gen_ai.provider.name": "gcp.vertex.agent",
           "gcp.vertex.agent.llm_request": JSON.stringify({
             model: "gemini-2.5-pro",
             contents: [{ parts: [{ text: "hello" }], role: "user" }],
           }),
         },
-        undefined,
-        undefined,
-        { skipJsonParsing: true },
-      );
+        options: { skipJsonParsing: true },
+      });
 
       extractor.apply(ctx);
 
@@ -542,9 +548,11 @@ describe("VertexAdkExtractor", () => {
     describe("when the span is canonicalised", () => {
       it("does nothing", () => {
         const ctx = createExtractorContext({
-          "gen_ai.operation.name": "chat",
-          "gen_ai.provider.name": "openai",
-          "gen_ai.request.model": "gpt-5-mini",
+          attrs: {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.provider.name": "openai",
+            "gen_ai.request.model": "gpt-5-mini",
+          },
         });
 
         extractor.apply(ctx);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_extraction.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_extraction.ts
@@ -23,12 +23,17 @@ type ExtractMessagesConfig = {
   extractSystemInstructions: boolean;
 };
 
-const extractMessages = (
-  ctx: ExtractorContext,
-  sources: MessageSource[],
-  ruleId: string,
-  config: ExtractMessagesConfig,
-): boolean => {
+const extractMessages = ({
+  ctx,
+  sources,
+  ruleId,
+  config,
+}: {
+  ctx: ExtractorContext;
+  sources: MessageSource[];
+  ruleId: string;
+  config: ExtractMessagesConfig;
+}): boolean => {
   if (
     ctx.bag.attrs.has(config.attrKey) ||
     ctx.out[config.attrKey] !== undefined
@@ -99,10 +104,15 @@ export const extractInputMessages = (
   sources: MessageSource[],
   ruleId: string,
 ): boolean =>
-  extractMessages(ctx, sources, ruleId, {
-    attrKey: ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
-    defaultRole: "user",
-    extractSystemInstructions: true,
+  extractMessages({
+    ctx,
+    sources,
+    ruleId,
+    config: {
+      attrKey: ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
+      defaultRole: "user",
+      extractSystemInstructions: true,
+    },
   });
 
 export const extractOutputMessages = (
@@ -110,19 +120,28 @@ export const extractOutputMessages = (
   sources: MessageSource[],
   ruleId: string,
 ): boolean =>
-  extractMessages(ctx, sources, ruleId, {
-    attrKey: ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES,
-    defaultRole: "assistant",
-    extractSystemInstructions: false,
+  extractMessages({
+    ctx,
+    sources,
+    ruleId,
+    config: {
+      attrKey: ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES,
+      defaultRole: "assistant",
+      extractSystemInstructions: false,
+    },
   });
 
-export const extractModelToBoth = (
-  ctx: ExtractorContext,
-  sourceKey: string,
-  transform: (raw: unknown) => string | null = (raw) =>
-    typeof raw === "string" ? raw : null,
-  ruleId: string,
-): boolean => {
+export const extractModelToBoth = ({
+  ctx,
+  sourceKey,
+  transform = (raw) => (typeof raw === "string" ? raw : null),
+  ruleId,
+}: {
+  ctx: ExtractorContext;
+  sourceKey: string;
+  transform?: (raw: unknown) => string | null;
+  ruleId: string;
+}): boolean => {
   if (
     ctx.bag.attrs.has(ATTR_KEYS.GEN_AI_REQUEST_MODEL) ||
     ctx.bag.attrs.has(ATTR_KEYS.GEN_AI_RESPONSE_MODEL)

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/genAi.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/genAi.ts
@@ -106,12 +106,12 @@ export class GenAIExtractor implements CanonicalAttributesExtractor {
     // ─────────────────────────────────────────────────────────────────────────
     // Model (from legacy llm.model_name if gen_ai.*.model not present)
     // ─────────────────────────────────────────────────────────────────────────
-    extractModelToBoth(
+    extractModelToBoth({
       ctx,
-      ATTR_KEYS.LLM_MODEL_NAME,
-      (raw) => (typeof raw === "string" ? raw : null),
-      `${this.id}:model(llm.model_name)`,
-    );
+      sourceKey: ATTR_KEYS.LLM_MODEL_NAME,
+      transform: (raw) => (typeof raw === "string" ? raw : null),
+      ruleId: `${this.id}:model(llm.model_name)`,
+    });
 
     // ─────────────────────────────────────────────────────────────────────────
     // Input Messages

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/mastra.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/mastra.ts
@@ -63,14 +63,14 @@ export class MastraExtractor implements CanonicalAttributesExtractor {
 
     this.mapSpanType(ctx, mastraType, isEvalModelStep);
     const modelName = this.extractModelInfo(ctx, modelStepBody);
-    this.extractIO(ctx, mastraType, isEvalModelStep, modelStepBody);
-    this.setDisplayName(
+    this.extractIO({ ctx, mastraType, isEvalModelStep, modelStepBody });
+    this.setDisplayName({
       ctx,
       mastraType,
       modelName,
       isEvalModelStep,
       modelStepBody,
-    );
+    });
     this.extractThreadId(ctx);
     this.mapTokenNames(ctx);
   }
@@ -181,12 +181,17 @@ export class MastraExtractor implements CanonicalAttributesExtractor {
   }
 
   /** Map Mastra-specific I/O attributes to canonical langwatch.input/output. */
-  private extractIO(
-    ctx: ExtractorContext,
-    mastraType: unknown,
-    isEvalModelStep: boolean,
-    modelStepBody: Record<string, unknown> | null,
-  ): void {
+  private extractIO({
+    ctx,
+    mastraType,
+    isEvalModelStep,
+    modelStepBody,
+  }: {
+    ctx: ExtractorContext;
+    mastraType: unknown;
+    isEvalModelStep: boolean;
+    modelStepBody: Record<string, unknown> | null;
+  }): void {
     const { attrs } = ctx.bag;
 
     // For agent_run spans: extract I/O from mastra.agent_run.input/output
@@ -267,13 +272,19 @@ export class MastraExtractor implements CanonicalAttributesExtractor {
   }
 
   /** Set contextual display names based on span type and model. */
-  private setDisplayName(
-    ctx: ExtractorContext,
-    mastraType: unknown,
-    modelName: string | null,
-    isEvalModelStep: boolean,
-    modelStepBody: Record<string, unknown> | null,
-  ): void {
+  private setDisplayName({
+    ctx,
+    mastraType,
+    modelName,
+    isEvalModelStep,
+    modelStepBody,
+  }: {
+    ctx: ExtractorContext;
+    mastraType: unknown;
+    modelName: string | null;
+    isEvalModelStep: boolean;
+    modelStepBody: Record<string, unknown> | null;
+  }): void {
     const displayName = deriveDisplayName({
       mastraType,
       modelName,

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/vercel.ts
@@ -122,12 +122,12 @@ export class VercelExtractor implements CanonicalAttributesExtractor {
     // Normalized to "openai/gpt-4" format
     // ─────────────────────────────────────────────────────────────────────────
     if (
-      !extractModelToBoth(
+      !extractModelToBoth({
         ctx,
-        ATTR_KEYS.AI_MODEL,
-        (raw) => normaliseModelFromAiModelObject(raw),
-        `${this.id}:ai.model->gen_ai.*.model`,
-      )
+        sourceKey: ATTR_KEYS.AI_MODEL,
+        transform: (raw) => normaliseModelFromAiModelObject(raw),
+        ruleId: `${this.id}:ai.model->gen_ai.*.model`,
+      })
     ) {
       // Consume attribute even if not used, to reduce leftovers
       attrs.take(ATTR_KEYS.AI_MODEL);

--- a/platform/app/src/server/app-layer/traces/claude-code-log-enrichment.ts
+++ b/platform/app/src/server/app-layer/traces/claude-code-log-enrichment.ts
@@ -407,11 +407,11 @@ export async function enrichCodingAgentSpansFromLogs({
   if (!hasCodingAgentJoinableSpans(spans)) return spans;
 
   try {
-    const logRows = await logRecords.getLogsByTraceId(
+    const logRows = await logRecords.getLogsByTraceId({
       tenantId,
       traceId,
       occurredAtMs,
-    );
+    });
     return enrichSpansWithClaudeLogContent({ spans, logRows });
   } catch (error) {
     logger?.warn(

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/ast.ts
@@ -142,20 +142,20 @@ function translateTag(
   // so saved queries from the previous schema still translate cleanly.
   if (fieldName.startsWith(TRACE_ATTRIBUTE_PREFIX)) {
     const key = fieldName.slice(TRACE_ATTRIBUTE_PREFIX.length);
-    return translateTraceAttribute(key, tag, negated, ctx);
+    return translateTraceAttribute({ attrKey: key, tag, negated, ctx });
   }
   if (fieldName.startsWith(SPAN_ATTRIBUTE_PREFIX)) {
     const key = fieldName.slice(SPAN_ATTRIBUTE_PREFIX.length);
-    return translateSpanAttribute(key, tag, negated, ctx);
+    return translateSpanAttribute({ attrKey: key, tag, negated, ctx });
   }
   if (fieldName.startsWith(EVENT_ATTRIBUTE_PREFIX)) {
     const key = fieldName.slice(EVENT_ATTRIBUTE_PREFIX.length);
-    return translateEventAttribute(key, tag, negated, ctx);
+    return translateEventAttribute({ attrKey: key, tag, negated, ctx });
   }
   // Legacy alias — `attribute.<k>`. Identical SQL to `trace.attribute.<k>`.
   if (fieldName.startsWith(TRACE_ATTRIBUTE_PREFIX_LEGACY)) {
     const key = fieldName.slice(TRACE_ATTRIBUTE_PREFIX_LEGACY.length);
-    return translateTraceAttribute(key, tag, negated, ctx);
+    return translateTraceAttribute({ attrKey: key, tag, negated, ctx });
   }
   // Legacy alias — `event.<k>` (single-dot form). Skips the bare `event`
   // field so `event:<name>` still routes to the static handler map.
@@ -164,7 +164,7 @@ function translateTag(
     fieldName !== "event"
   ) {
     const key = fieldName.slice(EVENT_ATTRIBUTE_PREFIX_LEGACY.length);
-    return translateEventAttribute(key, tag, negated, ctx);
+    return translateEventAttribute({ attrKey: key, tag, negated, ctx });
   }
 
   // `.get()` — own keys only. A plain-object index would resolve a field named
@@ -179,12 +179,17 @@ function translateTag(
   return def.toClickHouse(tag, negated, ctx);
 }
 
-function translateTraceAttribute(
-  attrKey: string,
-  tag: TagToken,
-  negated: boolean,
-  ctx: TranslationContext,
-): string {
+function translateTraceAttribute({
+  attrKey,
+  tag,
+  negated,
+  ctx,
+}: {
+  attrKey: string;
+  tag: TagToken;
+  negated: boolean;
+  ctx: TranslationContext;
+}): string {
   if (!attrKey) {
     throw new FilterParseError(
       "trace.attribute.<key> requires a key after the dot",
@@ -208,12 +213,17 @@ function translateTraceAttribute(
  * String))` — `arrayExists` short-circuits on the first match, cheap
  * relative to materialising the nested column for each row.
  */
-function translateEventAttribute(
-  attrKey: string,
-  tag: TagToken,
-  negated: boolean,
-  ctx: TranslationContext,
-): string {
+function translateEventAttribute({
+  attrKey,
+  tag,
+  negated,
+  ctx,
+}: {
+  attrKey: string;
+  tag: TagToken;
+  negated: boolean;
+  ctx: TranslationContext;
+}): string {
   if (!attrKey) {
     throw new FilterParseError(
       "event.attribute.<key> requires a key after the dot",
@@ -244,12 +254,17 @@ function translateEventAttribute(
  * payloads, so this stays cheap even on traces with megabyte-class
  * `gen_ai.input.messages` blobs.
  */
-function translateSpanAttribute(
-  attrKey: string,
-  tag: TagToken,
-  negated: boolean,
-  ctx: TranslationContext,
-): string {
+function translateSpanAttribute({
+  attrKey,
+  tag,
+  negated,
+  ctx,
+}: {
+  attrKey: string;
+  tag: TagToken;
+  negated: boolean;
+  ctx: TranslationContext;
+}): string {
   if (!attrKey) {
     throw new FilterParseError(
       "span.attribute.<key> requires a key after the dot",

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
@@ -75,14 +75,14 @@ function crossCategoricalFacet(
   if (def.kind !== "categorical") {
     throw new Error(`facet '${key}' is not a categorical facet`);
   }
-  return crossTableCategorical(
-    def.table,
-    TABLE_TIME_COLUMNS[def.table],
-    def.expression,
+  return crossTableCategorical({
+    table: def.table,
+    timeColumn: TABLE_TIME_COLUMNS[def.table],
+    expression: def.expression,
     read,
     needs,
-    def.key,
-  );
+    name: def.key,
+  });
 }
 
 function crossRangeFacet(
@@ -94,14 +94,14 @@ function crossRangeFacet(
   if (def.kind !== "range") {
     throw new Error(`facet '${key}' is not a range facet`);
   }
-  return crossTableRange(
-    def.table,
-    TABLE_TIME_COLUMNS[def.table],
-    def.expression,
+  return crossTableRange({
+    table: def.table,
+    timeColumn: TABLE_TIME_COLUMNS[def.table],
+    expression: def.expression,
     read,
     needs,
-    def.key,
-  );
+    name: def.key,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/evaluate.ts
@@ -69,7 +69,7 @@ export function evaluateQueryInMemory(
   }
 
   const state: WalkState = { nodeCount: 0, unsupportedFields: [] };
-  const result = evaluateNode(ast, false, trace, state);
+  const result = evaluateNode({ node: ast, negated: false, trace, state });
 
   // A field that can never evaluate positively at dispatch (span-scoped fields,
   // `size`, the scenario dimensions) compiles to valid SQL and passes the
@@ -98,12 +98,17 @@ interface WalkState {
   unsupportedFields: string[];
 }
 
-function evaluateNode(
-  node: LiqeQuery,
-  negated: boolean,
-  trace: InMemoryTrace,
-  state: WalkState,
-): boolean | Unsupported {
+function evaluateNode({
+  node,
+  negated,
+  trace,
+  state,
+}: {
+  node: LiqeQuery;
+  negated: boolean;
+  trace: InMemoryTrace;
+  state: WalkState;
+}): boolean | Unsupported {
   state.nodeCount++;
   if (state.nodeCount > MAX_NODE_COUNT) return UNSUPPORTED;
 
@@ -124,9 +129,14 @@ function evaluateNode(
       const logExpr = node as LogicalExpressionToken;
       // Negation threads down unchanged and the operator stays as-is — the
       // exact shape `translateNode` compiles, so both sides always agree.
-      const left = evaluateNode(logExpr.left, negated, trace, state);
+      const left = evaluateNode({ node: logExpr.left, negated, trace, state });
       if (left === UNSUPPORTED) return UNSUPPORTED;
-      const right = evaluateNode(logExpr.right, negated, trace, state);
+      const right = evaluateNode({
+        node: logExpr.right,
+        negated,
+        trace,
+        state,
+      });
       if (right === UNSUPPORTED) return UNSUPPORTED;
       return logExpr.operator.operator === "OR" ? left || right : left && right;
     }
@@ -134,12 +144,17 @@ function evaluateNode(
     case "UnaryOperator": {
       const unary = node as UnaryOperatorToken;
       const isNeg = unary.operator === "NOT" || unary.operator === "-";
-      return evaluateNode(unary.operand, negated !== isNeg, trace, state);
+      return evaluateNode({
+        node: unary.operand,
+        negated: negated !== isNeg,
+        trace,
+        state,
+      });
     }
 
     case "ParenthesizedExpression": {
       const paren = node as ParenthesizedExpressionToken;
-      return evaluateNode(paren.expression, negated, trace, state);
+      return evaluateNode({ node: paren.expression, negated, trace, state });
     }
 
     default:
@@ -160,12 +175,12 @@ function evaluateTag(
 
   // Attribute prefixes — mirror `translateTag`'s routing order exactly.
   if (fieldName.startsWith(TRACE_ATTRIBUTE_PREFIX)) {
-    return evaluateTraceAttribute(
-      fieldName.slice(TRACE_ATTRIBUTE_PREFIX.length),
+    return evaluateTraceAttribute({
+      key: fieldName.slice(TRACE_ATTRIBUTE_PREFIX.length),
       tag,
       negated,
       trace,
-    );
+    });
   }
   if (fieldName.startsWith(SPAN_ATTRIBUTE_PREFIX)) {
     // span.attribute.<k> resolves via stored_spans; spans aren't derived at
@@ -173,31 +188,31 @@ function evaluateTag(
     return UNSUPPORTED;
   }
   if (fieldName.startsWith(EVENT_ATTRIBUTE_PREFIX)) {
-    return evaluateEventAttribute(
-      fieldName.slice(EVENT_ATTRIBUTE_PREFIX.length),
+    return evaluateEventAttribute({
+      key: fieldName.slice(EVENT_ATTRIBUTE_PREFIX.length),
       tag,
       negated,
       trace,
-    );
+    });
   }
   if (fieldName.startsWith(TRACE_ATTRIBUTE_PREFIX_LEGACY)) {
-    return evaluateTraceAttribute(
-      fieldName.slice(TRACE_ATTRIBUTE_PREFIX_LEGACY.length),
+    return evaluateTraceAttribute({
+      key: fieldName.slice(TRACE_ATTRIBUTE_PREFIX_LEGACY.length),
       tag,
       negated,
       trace,
-    );
+    });
   }
   if (
     fieldName.startsWith(EVENT_ATTRIBUTE_PREFIX_LEGACY) &&
     fieldName !== "event"
   ) {
-    return evaluateEventAttribute(
-      fieldName.slice(EVENT_ATTRIBUTE_PREFIX_LEGACY.length),
+    return evaluateEventAttribute({
+      key: fieldName.slice(EVENT_ATTRIBUTE_PREFIX_LEGACY.length),
       tag,
       negated,
       trace,
-    );
+    });
   }
 
   // `.get()` — own keys only, so `constructor` / `toString` / `__proto__` are
@@ -265,12 +280,17 @@ function ilikeContains(
   return column.toLowerCase().includes(lowerValue);
 }
 
-function evaluateTraceAttribute(
-  key: string,
-  tag: TagToken,
-  negated: boolean,
-  trace: InMemoryTrace,
-): boolean | Unsupported {
+function evaluateTraceAttribute({
+  key,
+  tag,
+  negated,
+  trace,
+}: {
+  key: string;
+  tag: TagToken;
+  negated: boolean;
+  trace: InMemoryTrace;
+}): boolean | Unsupported {
   // Empty key throws on the SQL side (422) — fail closed.
   if (!key) return UNSUPPORTED;
   const value = extractStringValue(tag);
@@ -278,12 +298,17 @@ function evaluateTraceAttribute(
   return negated ? !matched : matched;
 }
 
-function evaluateEventAttribute(
-  key: string,
-  tag: TagToken,
-  negated: boolean,
-  trace: InMemoryTrace,
-): boolean | Unsupported {
+function evaluateEventAttribute({
+  key,
+  tag,
+  negated,
+  trace,
+}: {
+  key: string;
+  tag: TagToken;
+  negated: boolean;
+  trace: InMemoryTrace;
+}): boolean | Unsupported {
   if (!key) return UNSUPPORTED;
   if (trace.events == null) return UNSUPPORTED;
   const value = extractStringValue(tag);

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/generic-translators.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/generic-translators.ts
@@ -24,13 +24,19 @@ import {
 // ClickHouse compilation (unchanged output — the byte-identical invariant)
 // ---------------------------------------------------------------------------
 
-export function translateNumericField(
-  columnExpr: string,
-  tag: TagToken,
-  negated: boolean,
-  ctx: TranslationContext,
+export function translateNumericField({
+  columnExpr,
+  tag,
+  negated,
+  ctx,
   name = "value",
-): string {
+}: {
+  columnExpr: string;
+  tag: TagToken;
+  negated: boolean;
+  ctx: TranslationContext;
+  name?: string;
+}): string {
   if (tag.expression.type === "RangeExpression") {
     const min = tag.expression.range.min;
     const max = tag.expression.range.max;
@@ -65,13 +71,19 @@ export function translateNumericField(
   }
 }
 
-export function translateStringField(
-  columnExpr: string,
-  tag: TagToken,
-  negated: boolean,
-  ctx: TranslationContext,
+export function translateStringField({
+  columnExpr,
+  tag,
+  negated,
+  ctx,
   name = "value",
-): string {
+}: {
+  columnExpr: string;
+  tag: TagToken;
+  negated: boolean;
+  ctx: TranslationContext;
+  name?: string;
+}): string {
   const value = extractStringValue(tag);
   validateValueLength(value);
   const p = nextParam(ctx, name);
@@ -84,7 +96,7 @@ function stringEqualityHandler(
   name?: string,
 ): FieldHandler {
   return (tag, negated, ctx) =>
-    translateStringField(expression, tag, negated, ctx, name);
+    translateStringField({ columnExpr: expression, tag, negated, ctx, name });
 }
 
 function numericComparisonHandler(
@@ -92,15 +104,20 @@ function numericComparisonHandler(
   name?: string,
 ): FieldHandler {
   return (tag, negated, ctx) =>
-    translateNumericField(expression, tag, negated, ctx, name);
+    translateNumericField({ columnExpr: expression, tag, negated, ctx, name });
 }
 
-function crossTableStringHandler(
-  table: string,
-  timeColumn: string,
-  expression: string,
+function crossTableStringHandler({
+  table,
+  timeColumn,
+  expression,
   name = "value",
-): FieldHandler {
+}: {
+  table: string;
+  timeColumn: string;
+  expression: string;
+  name?: string;
+}): FieldHandler {
   return (tag, negated, ctx) => {
     const value = extractStringValue(tag);
     validateValueLength(value);
@@ -121,12 +138,17 @@ const NUMERIC_OP_MAP: Record<string, string> = {
   ":<=": "<=",
 };
 
-function crossTableNumericHandler(
-  table: string,
-  timeColumn: string,
-  expression: string,
+function crossTableNumericHandler({
+  table,
+  timeColumn,
+  expression,
   name = "value",
-): FieldHandler {
+}: {
+  table: string;
+  timeColumn: string;
+  expression: string;
+  name?: string;
+}): FieldHandler {
   return (tag, negated, ctx) => {
     if (tag.expression.type === "RangeExpression") {
       const min = tag.expression.range.min;
@@ -193,12 +215,17 @@ export function matchNumericInMemory(value: number, tag: TagToken): boolean {
   }
 }
 
-function evaluateCategorical(
-  read: CategoricalRead,
-  tag: TagToken,
-  negated: boolean,
-  trace: InMemoryTrace,
-): boolean | Unsupported {
+function evaluateCategorical({
+  read,
+  tag,
+  negated,
+  trace,
+}: {
+  read: CategoricalRead;
+  tag: TagToken;
+  negated: boolean;
+  trace: InMemoryTrace;
+}): boolean | Unsupported {
   const actual = read(trace);
   if (actual === UNSUPPORTED) return UNSUPPORTED;
   const target = extractStringValue(tag);
@@ -210,12 +237,17 @@ function evaluateCategorical(
   return negated ? !matched : matched;
 }
 
-function evaluateRange(
-  read: RangeRead,
-  tag: TagToken,
-  negated: boolean,
-  trace: InMemoryTrace,
-): boolean | Unsupported {
+function evaluateRange({
+  read,
+  tag,
+  negated,
+  trace,
+}: {
+  read: RangeRead;
+  tag: TagToken;
+  negated: boolean;
+  trace: InMemoryTrace;
+}): boolean | Unsupported {
   const actual = read(trace);
   if (actual === UNSUPPORTED) return UNSUPPORTED;
   // NULL numeric column: excluded under both polarities (see above).
@@ -238,7 +270,7 @@ export function categorical(
   return {
     toClickHouse: stringEqualityHandler(expression, name),
     evaluateInMemory: (tag, negated, trace) =>
-      evaluateCategorical(read, tag, negated, trace),
+      evaluateCategorical({ read, tag, negated, trace }),
   };
 }
 
@@ -251,7 +283,7 @@ export function range(
   return {
     toClickHouse: numericComparisonHandler(expression, name),
     evaluateInMemory: (tag, negated, trace) =>
-      evaluateRange(read, tag, negated, trace),
+      evaluateRange({ read, tag, negated, trace }),
   };
 }
 
@@ -260,35 +292,59 @@ export function range(
  * (`evaluation_runs` / `stored_spans`). `read` collects the candidate values
  * from the referenced collection (or {@link UNSUPPORTED} when it isn't loaded).
  */
-export function crossTableCategorical(
-  table: string,
-  timeColumn: string,
-  expression: string,
-  read: CategoricalRead,
-  needs: FieldNeeds,
+export function crossTableCategorical({
+  table,
+  timeColumn,
+  expression,
+  read,
+  needs,
   name = "value",
-): FieldDef {
+}: {
+  table: string;
+  timeColumn: string;
+  expression: string;
+  read: CategoricalRead;
+  needs: FieldNeeds;
+  name?: string;
+}): FieldDef {
   return {
     needs,
-    toClickHouse: crossTableStringHandler(table, timeColumn, expression, name),
+    toClickHouse: crossTableStringHandler({
+      table,
+      timeColumn,
+      expression,
+      name,
+    }),
     evaluateInMemory: (tag, negated, trace) =>
-      evaluateCategorical(read, tag, negated, trace),
+      evaluateCategorical({ read, tag, negated, trace }),
   };
 }
 
 /** Numeric comparison answered by a partition-pruned cross-table subquery. */
-export function crossTableRange(
-  table: string,
-  timeColumn: string,
-  expression: string,
-  read: RangeRead,
-  needs: FieldNeeds,
+export function crossTableRange({
+  table,
+  timeColumn,
+  expression,
+  read,
+  needs,
   name = "value",
-): FieldDef {
+}: {
+  table: string;
+  timeColumn: string;
+  expression: string;
+  read: RangeRead;
+  needs: FieldNeeds;
+  name?: string;
+}): FieldDef {
   return {
     needs,
-    toClickHouse: crossTableNumericHandler(table, timeColumn, expression, name),
+    toClickHouse: crossTableNumericHandler({
+      table,
+      timeColumn,
+      expression,
+      name,
+    }),
     evaluateInMemory: (tag, negated, trace) =>
-      evaluateRange(read, tag, negated, trace),
+      evaluateRange({ read, tag, negated, trace }),
   };
 }

--- a/platform/app/src/server/app-layer/traces/log-record-storage.service.ts
+++ b/platform/app/src/server/app-layer/traces/log-record-storage.service.ts
@@ -44,14 +44,24 @@ export class LogRecordStorageService {
    * inspector, drawer log accordions, the coding-agent transcript) and the
    * read-path Claude Code content enrichment.
    */
-  async getLogsByTraceId(
-    tenantId: string,
-    traceId: string,
-    occurredAtMs?: number,
-    limit?: number,
-  ): Promise<StoredLogRecordRow[]> {
+  async getLogsByTraceId({
+    tenantId,
+    traceId,
+    occurredAtMs,
+    limit,
+  }: {
+    tenantId: string;
+    traceId: string;
+    occurredAtMs?: number;
+    limit?: number;
+  }): Promise<StoredLogRecordRow[]> {
     const [legacy, canonical] = await Promise.all([
-      this.repository.getLogsByTraceId(tenantId, traceId, occurredAtMs, limit),
+      this.repository.getLogsByTraceId({
+        tenantId,
+        traceId,
+        occurredAtMs,
+        limit,
+      }),
       this.canonical.getLogsByTraceId({
         tenantId,
         traceId,

--- a/platform/app/src/server/app-layer/traces/query-language/__tests__/queryLanguage.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/__tests__/queryLanguage.unit.test.ts
@@ -183,11 +183,15 @@ describe("parse LRU cache", () => {
 describe("parse operator matrix", () => {
   describe("comparison operators", () => {
     it.each([
-      [">", "cost:>5", ":>", 5],
-      [">=", "cost:>=5", ":>=", 5],
-      ["<", "cost:<5", ":<", 5],
-      ["<=", "cost:<=5", ":<=", 5],
-    ])("parses `%s` as a Tag with the matching liqe operator", (_, query, op, value) => {
+      { label: ">", query: "cost:>5", op: ":>", value: 5 },
+      { label: ">=", query: "cost:>=5", op: ":>=", value: 5 },
+      { label: "<", query: "cost:<5", op: ":<", value: 5 },
+      { label: "<=", query: "cost:<=5", op: ":<=", value: 5 },
+    ])("parses `$label` as a Tag with the matching liqe operator", ({
+      query,
+      op,
+      value,
+    }) => {
       const ast = parse(query) as unknown as {
         type: string;
         operator: { operator: string };

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -32,7 +32,11 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
       const { repo, query } = repoCapturingQuery();
       const occurredAtMs = 1_700_000_000_000;
 
-      await repo.getLogsByTraceId("project_test", "trace-1", occurredAtMs);
+      await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs,
+      });
 
       const { query: sql, query_params } = capturedQuery(query);
       expect(sql.match(/TimeUnixMs >= fromUnixTimestamp64Milli/g)).toHaveLength(
@@ -52,7 +56,11 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
     it("does not re-widen — it issues exactly one query", async () => {
       const { repo, query } = repoCapturingQuery([]);
 
-      await repo.getLogsByTraceId("project_test", "trace-1", 1_700_000_000_000);
+      await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+      });
 
       expect(query).toHaveBeenCalledTimes(1);
       const { query_params } = capturedQuery(query);
@@ -69,7 +77,10 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
       const { repo, query } = repoCapturingQuery();
       const before = Date.now();
 
-      await repo.getLogsByTraceId("project_test", "trace-1");
+      await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+      });
 
       const after = Date.now();
       const { query: sql, query_params } = capturedQuery(query);
@@ -106,7 +117,11 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
     it("bounds the query at the default cap plus one detection row", async () => {
       const { repo, query } = repoCapturingQuery();
 
-      await repo.getLogsByTraceId("project_test", "trace-1", 1_700_000_000_000);
+      await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+      });
 
       const { query: sql, query_params } = capturedQuery(query);
       expect(sql).toContain("LIMIT {limitPlusOne:UInt32}");
@@ -120,12 +135,12 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
         storedRow(2),
       ]);
 
-      const rows = await repo.getLogsByTraceId(
-        "project_test",
-        "trace-1",
-        1_700_000_000_000,
-        2,
-      );
+      const rows = await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+        limit: 2,
+      });
 
       expect(rows.map((row) => row.spanId)).toEqual(["span-0", "span-1"]);
     });
@@ -135,7 +150,11 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
     it("selects the Body + Attributes and does not filter on the claude kind attr", async () => {
       const { repo, query } = repoCapturingQuery();
 
-      await repo.getLogsByTraceId("project_test", "trace-1", 1_700_000_000_000);
+      await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+      });
 
       const { query: sql, query_params } = capturedQuery(query);
       expect(sql).toContain("Body");
@@ -161,11 +180,11 @@ describe("LogRecordStorageClickHouseRepository.getLogsByTraceId", () => {
         },
       ]);
 
-      const rows = await repo.getLogsByTraceId(
-        "project_test",
-        "trace-1",
-        1_700_000_000_000,
-      );
+      const rows = await repo.getLogsByTraceId({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+      });
 
       expect(rows).toEqual([
         {

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -984,12 +984,17 @@ describe("SpanStorageClickHouseRepository per-span cost columns (integration)", 
 // are deterministic and the heavy single-trace dataset above is untouched.
 const pageTenantId = `test-span-page-${nanoid()}`;
 
-function makePageSpanRow(
-  pageTraceId: string,
-  spanId: string,
-  startTime: Date,
-  overrides: Record<string, unknown> = {},
-): ReturnType<typeof makeSpanRow> {
+function makePageSpanRow({
+  pageTraceId,
+  spanId,
+  startTime,
+  overrides = {},
+}: {
+  pageTraceId: string;
+  spanId: string;
+  startTime: Date;
+  overrides?: Record<string, unknown>;
+}): ReturnType<typeof makeSpanRow> {
   return {
     ...makeSpanRow(0, {
       TenantId: pageTenantId,
@@ -1039,12 +1044,19 @@ describe("SpanStorageClickHouseRepository cursor-paged span summaries (integrati
     // stale earlier version of one mid-trace span that dedup must not emit.
     await insertRows(
       Array.from({ length: EXACT_SPANS }, (_, i) =>
-        makePageSpanRow(exactTraceId, spanIdFor(i), new Date(base + i * 10)),
+        makePageSpanRow({
+          pageTraceId: exactTraceId,
+          spanId: spanIdFor(i),
+          startTime: new Date(base + i * 10),
+        }),
       ),
     );
     await insertRows([
-      makePageSpanRow(exactTraceId, spanIdFor(25), new Date(base - 5_000), {
-        SpanAttributes: { idx: spanIdFor(25), stale: "yes" },
+      makePageSpanRow({
+        pageTraceId: exactTraceId,
+        spanId: spanIdFor(25),
+        startTime: new Date(base - 5_000),
+        overrides: { SpanAttributes: { idx: spanIdFor(25), stale: "yes" } },
       }),
     ]);
 
@@ -1052,7 +1064,11 @@ describe("SpanStorageClickHouseRepository cursor-paged span summaries (integrati
     // same-millisecond rows and only the SpanId tiebreak separates pages.
     await insertRows(
       ["tie-a", "tie-b", "tie-c", "tie-d"].map((spanId) =>
-        makePageSpanRow(tieTraceId, spanId, new Date(base + 500)),
+        makePageSpanRow({
+          pageTraceId: tieTraceId,
+          spanId,
+          startTime: new Date(base + 500),
+        }),
       ),
     );
 
@@ -1060,14 +1076,18 @@ describe("SpanStorageClickHouseRepository cursor-paged span summaries (integrati
     // three days later — past the hint's +2-day partition window.
     await insertRows([
       ...[0, 1, 2].map((i) =>
-        makePageSpanRow(longTraceId, `early-${i}`, new Date(base + i)),
+        makePageSpanRow({
+          pageTraceId: longTraceId,
+          spanId: `early-${i}`,
+          startTime: new Date(base + i),
+        }),
       ),
       ...[0, 1].map((i) =>
-        makePageSpanRow(
-          longTraceId,
-          `late-${i}`,
-          new Date(base + 3 * 24 * 60 * 60 * 1000 + i),
-        ),
+        makePageSpanRow({
+          pageTraceId: longTraceId,
+          spanId: `late-${i}`,
+          startTime: new Date(base + 3 * 24 * 60 * 60 * 1000 + i),
+        }),
       ),
     ]);
   }, 60_000);
@@ -1126,10 +1146,17 @@ describe("SpanStorageClickHouseRepository langwatch signals read (integration)",
 
   beforeAll(async () => {
     await insertRows([
-      makePageSpanRow(signalsTraceId, "sig-prompt", new Date(base), {
-        SpanAttributes: { "langwatch.prompt.id": "prompt-1" },
+      makePageSpanRow({
+        pageTraceId: signalsTraceId,
+        spanId: "sig-prompt",
+        startTime: new Date(base),
+        overrides: { SpanAttributes: { "langwatch.prompt.id": "prompt-1" } },
       }),
-      makePageSpanRow(signalsTraceId, "sig-none", new Date(base + 1)),
+      makePageSpanRow({
+        pageTraceId: signalsTraceId,
+        spanId: "sig-none",
+        startTime: new Date(base + 1),
+      }),
     ]);
   }, 60_000);
 

--- a/platform/app/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -33,12 +33,17 @@ export class LogRecordStorageClickHouseRepository
 {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
-  async getLogsByTraceId(
-    tenantId: string,
-    traceId: string,
-    occurredAtMs?: number,
-    limit: number = TRACE_LOG_READ_CAP,
-  ): Promise<StoredLogRecordRow[]> {
+  async getLogsByTraceId({
+    tenantId,
+    traceId,
+    occurredAtMs,
+    limit = TRACE_LOG_READ_CAP,
+  }: {
+    tenantId: string;
+    traceId: string;
+    occurredAtMs?: number;
+    limit?: number;
+  }): Promise<StoredLogRecordRow[]> {
     EventUtils.validateTenantId(
       { tenantId },
       "LogRecordStorageClickHouseRepository.getLogsByTraceId",

--- a/platform/app/src/server/app-layer/traces/repositories/log-record-storage.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/log-record-storage.repository.ts
@@ -39,12 +39,12 @@ export interface LogRecordStorageRepository {
    * `occurredAtMs` is an optional partition-pruning hint on the `TimeUnixMs`
    * partition key.
    */
-  getLogsByTraceId(
-    tenantId: string,
-    traceId: string,
-    occurredAtMs?: number,
-    limit?: number,
-  ): Promise<StoredLogRecordRow[]>;
+  getLogsByTraceId(params: {
+    tenantId: string;
+    traceId: string;
+    occurredAtMs?: number;
+    limit?: number;
+  }): Promise<StoredLogRecordRow[]>;
 }
 
 /**
@@ -80,12 +80,12 @@ export function mergeStoredLogRows(
 export class NullLogRecordStorageRepository
   implements LogRecordStorageRepository
 {
-  async getLogsByTraceId(
-    _tenantId: string,
-    _traceId: string,
-    _occurredAtMs?: number,
-    _limit?: number,
-  ): Promise<StoredLogRecordRow[]> {
+  async getLogsByTraceId(_params: {
+    tenantId: string;
+    traceId: string;
+    occurredAtMs?: number;
+    limit?: number;
+  }): Promise<StoredLogRecordRow[]> {
     return [];
   }
 }

--- a/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -992,12 +992,12 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     const tenantId = spans[0]!.tenantId;
     for (const span of spans) {
       if (span.tenantId !== tenantId) {
-        throw new SecurityError(
-          "SpanStorageClickHouseRepository.insertSpans",
-          "all spans in a single batch must share the same tenantId",
+        throw new SecurityError({
+          operation: "SpanStorageClickHouseRepository.insertSpans",
+          message: "all spans in a single batch must share the same tenantId",
           tenantId,
-          { mismatchedTenantId: span.tenantId },
-        );
+          context: { mismatchedTenantId: span.tenantId },
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/traces/repositories/trace-analytics-rollup.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-analytics-rollup.clickhouse.repository.ts
@@ -123,12 +123,12 @@ export class TraceAnalyticsRollupClickHouseRepository
     const tenantId = rows[0]!.tenantId;
     for (const row of rows) {
       if (row.tenantId !== tenantId) {
-        throw new SecurityError(
-          "TraceAnalyticsRollupClickHouseRepository.insertRows",
-          "all rows in a single batch must share the same tenantId",
+        throw new SecurityError({
+          operation: "TraceAnalyticsRollupClickHouseRepository.insertRows",
+          message: "all rows in a single batch must share the same tenantId",
           tenantId,
-          { mismatchedTenantId: row.tenantId },
-        );
+          context: { mismatchedTenantId: row.tenantId },
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/traces/repositories/trace-analytics.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-analytics.clickhouse.repository.ts
@@ -211,12 +211,12 @@ export class TraceAnalyticsClickHouseRepository
     );
     for (const { row } of entries) {
       if (row.tenantId !== tenantId) {
-        throw new SecurityError(
-          "TraceAnalyticsClickHouseRepository.upsertBatch",
-          "all rows in a single batch must share the same tenantId",
+        throw new SecurityError({
+          operation: "TraceAnalyticsClickHouseRepository.upsertBatch",
+          message: "all rows in a single batch must share the same tenantId",
           tenantId,
-          { mismatchedTenantId: row.tenantId },
-        );
+          context: { mismatchedTenantId: row.tenantId },
+        });
       }
     }
 

--- a/platform/app/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -102,13 +102,13 @@ export class TraceSummaryClickHouseRepository
 
     try {
       const client = await this.resolveClient(tenantId);
-      const record = this.toClickHouseRecord(
+      const record = this.toClickHouseRecord({
         data,
         tenantId,
         projectionId,
-        TRACE_SUMMARY_PROJECTION_VERSION_LATEST,
+        version: TRACE_SUMMARY_PROJECTION_VERSION_LATEST,
         retentionDays,
-      );
+      });
 
       await client.insert({
         table: TABLE_NAME,
@@ -151,13 +151,13 @@ export class TraceSummaryClickHouseRepository
               data.traceId,
               data.occurredAt,
             );
-          return this.toClickHouseRecord(
+          return this.toClickHouseRecord({
             data,
-            tid,
+            tenantId: tid,
             projectionId,
-            TRACE_SUMMARY_PROJECTION_VERSION_LATEST,
-            rd,
-          );
+            version: TRACE_SUMMARY_PROJECTION_VERSION_LATEST,
+            retentionDays: rd,
+          });
         },
       );
 
@@ -527,13 +527,19 @@ export class TraceSummaryClickHouseRepository
     };
   }
 
-  private toClickHouseRecord(
-    data: TraceSummaryData,
-    tenantId: string,
-    projectionId: string,
-    version: string,
+  private toClickHouseRecord({
+    data,
+    tenantId,
+    projectionId,
+    version,
     retentionDays = PLATFORM_DEFAULT_RETENTION_DAYS,
-  ): ClickHouseSummaryWriteRecord {
+  }: {
+    data: TraceSummaryData;
+    tenantId: string;
+    projectionId: string;
+    version: string;
+    retentionDays?: number;
+  }): ClickHouseSummaryWriteRecord {
     return {
       ProjectionId: projectionId,
       TenantId: tenantId,

--- a/platform/app/src/server/app-layer/traces/span-normalization.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-normalization.service.ts
@@ -30,12 +30,17 @@ export class SpanNormalizationPipelineService {
     private readonly canonicalizeSpanAttributesService: CanonicalizeSpanAttributesService,
   ) {}
 
-  normalizeSpanReceived(
-    tenantId: string,
-    otlpSpan: OtlpSpan,
-    otlpResource: OtlpResource | null,
-    otlpInstrumentationScope: OtlpInstrumentationScope | null,
-  ): NormalizedSpan {
+  normalizeSpanReceived({
+    tenantId,
+    otlpSpan,
+    otlpResource,
+    otlpInstrumentationScope,
+  }: {
+    tenantId: string;
+    otlpSpan: OtlpSpan;
+    otlpResource: OtlpResource | null;
+    otlpInstrumentationScope: OtlpInstrumentationScope | null;
+  }): NormalizedSpan {
     return this.tracer.withActiveSpan(
       "SpanNormalizationPipelineService.normalizeSpanReceived",
       {
@@ -52,12 +57,12 @@ export class SpanNormalizationPipelineService {
           "SpanNormalizationPipelineService.normalizeSpanReceived",
         );
 
-        const normalizedSpan = this.decodeOtlpSpan(
+        const normalizedSpan = this.decodeOtlpSpan({
           tenantId,
           otlpSpan,
           otlpResource,
           otlpInstrumentationScope,
-        );
+        });
 
         span.setAttributes({
           "span.record_id": normalizedSpan.id,
@@ -83,12 +88,17 @@ export class SpanNormalizationPipelineService {
     );
   }
 
-  private decodeOtlpSpan(
-    tenantId: string,
-    otlpSpan: OtlpSpan,
-    otlpResource: OtlpResource | null,
-    otlpInstrumentationScope: OtlpInstrumentationScope | null,
-  ): NormalizedSpan {
+  private decodeOtlpSpan({
+    tenantId,
+    otlpSpan,
+    otlpResource,
+    otlpInstrumentationScope,
+  }: {
+    tenantId: string;
+    otlpSpan: OtlpSpan;
+    otlpResource: OtlpResource | null;
+    otlpInstrumentationScope: OtlpInstrumentationScope | null;
+  }): NormalizedSpan {
     // decode span data
     const { traceId, spanId } =
       TraceRequestUtils.normalizeOtlpSpanIds(otlpSpan);
@@ -111,12 +121,12 @@ export class SpanNormalizationPipelineService {
       );
 
     return {
-      id: IdUtils.generateDeterministicSpanRecordIdFromData(
+      id: IdUtils.generateDeterministicSpanRecordIdFromData({
         tenantId,
         traceId,
         spanId,
         startTimeUnixMs,
-      ),
+      }),
       tenantId,
       traceId,
       spanId,

--- a/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
@@ -459,24 +459,34 @@ export class OtlpSpanPiiRedactionService {
    * batch for those. Without a tenant (or with the kill switch set) the
    * analysis-service batch path runs unchanged.
    */
-  async redactSpan(
-    span: OtlpSpan,
-    resource: OtlpResource | null,
-    piiRedactionLevel: PIIRedactionLevel,
-    tenantId?: TenantId,
-  ): Promise<void> {
+  async redactSpan({
+    span,
+    resource,
+    piiRedactionLevel,
+    tenantId,
+  }: {
+    span: OtlpSpan;
+    resource: OtlpResource | null;
+    piiRedactionLevel: PIIRedactionLevel;
+    tenantId?: TenantId;
+  }): Promise<void> {
     const native = await this.resolveNativeContext(tenantId, piiRedactionLevel);
     if (!native) {
-      await this.lambdaRedactSpan(span, resource, piiRedactionLevel);
+      await this.lambdaRedactSpan({ span, resource, piiRedactionLevel });
       return;
     }
     this.applyNativeSpanPass(span, resource, native.policy);
     const lambda = this.lambdaAfterNative(native.policy);
     if (lambda) {
       try {
-        const ran = await this.lambdaRedactSpan(span, resource, "STRICT", {
-          entities: lambda.entities,
-          exceptPatterns: lambda.exceptPatterns,
+        const ran = await this.lambdaRedactSpan({
+          span,
+          resource,
+          piiRedactionLevel: "STRICT",
+          lambda: {
+            entities: lambda.entities,
+            exceptPatterns: lambda.exceptPatterns,
+          },
         });
         // Mark the span only when strict could not run because the analysis
         // service is genuinely unavailable (not configured in dev): the native
@@ -525,15 +535,20 @@ export class OtlpSpanPiiRedactionService {
    * then sends them in a single batch to the PII detection service. Used for the
    * strict level and the legacy (no-policy) fallback. Mutates in place.
    */
-  private async lambdaRedactSpan(
-    span: OtlpSpan,
-    resource: OtlpResource | null,
-    piiRedactionLevel: PIIRedactionLevel,
+  private async lambdaRedactSpan({
+    span,
+    resource,
+    piiRedactionLevel,
+    lambda,
+  }: {
+    span: OtlpSpan;
+    resource: OtlpResource | null;
+    piiRedactionLevel: PIIRedactionLevel;
     lambda?: {
       entities?: readonly string[];
       exceptPatterns?: readonly string[];
-    },
-  ): Promise<boolean> {
+    };
+  }): Promise<boolean> {
     const options = await this.buildOptions(
       piiRedactionLevel,
       lambda?.entities,

--- a/platform/app/src/server/app-layer/traces/trace-list.service.ts
+++ b/platform/app/src/server/app-layer/traces/trace-list.service.ts
@@ -945,25 +945,31 @@ export class TraceListService {
     // Assemble in registry order so the sidebar's group ordering is preserved.
     const facets: FacetDescriptor[] = [];
     for (const def of FACET_REGISTRY) {
-      const descriptor = await this.materializeDescriptor(
+      const descriptor = await this.materializeDescriptor({
         def,
         params,
         batchByTable,
         standaloneByKey,
         discreteByKey,
-      );
+      });
       if (descriptor) facets.push(descriptor);
     }
     return facets;
   }
 
-  private async materializeDescriptor(
-    def: FacetDefinition,
-    params: DiscoverParams,
-    batchByTable: Map<FacetTable, BatchedFacetResult>,
-    standaloneByKey: Map<string, FacetDescriptor>,
-    discreteByKey: Map<string, DiscreteFacetResult>,
-  ): Promise<FacetDescriptor | null> {
+  private async materializeDescriptor({
+    def,
+    params,
+    batchByTable,
+    standaloneByKey,
+    discreteByKey,
+  }: {
+    def: FacetDefinition;
+    params: DiscoverParams;
+    batchByTable: Map<FacetTable, BatchedFacetResult>;
+    standaloneByKey: Map<string, FacetDescriptor>;
+    discreteByKey: Map<string, DiscreteFacetResult>;
+  }): Promise<FacetDescriptor | null> {
     if (def.kind === "categorical" && isExpressionCategorical(def)) {
       if (def.expression.includes("arrayJoin")) {
         return standaloneByKey.get(def.key) ?? null;

--- a/platform/app/src/server/app-layer/usage/usage.service.ts
+++ b/platform/app/src/server/app-layer/usage/usage.service.ts
@@ -47,13 +47,30 @@ export class UsageService {
   private readonly countCache: TtlCache<number>;
   private readonly decisionCache: TtlCache<MeterDecision>;
 
-  constructor(
-    private readonly organizationService: OrganizationService,
-    private readonly traceUsageService: TraceUsageService,
-    private readonly eventUsageService: EventUsageService,
-    private readonly planResolver: PlanResolver,
-    private readonly organizationRepository: OrganizationRepository | null,
-  ) {
+  private readonly organizationService: OrganizationService;
+  private readonly traceUsageService: TraceUsageService;
+  private readonly eventUsageService: EventUsageService;
+  private readonly planResolver: PlanResolver;
+  private readonly organizationRepository: OrganizationRepository | null;
+
+  constructor({
+    organizationService,
+    traceUsageService,
+    eventUsageService,
+    planResolver,
+    organizationRepository,
+  }: {
+    organizationService: OrganizationService;
+    traceUsageService: TraceUsageService;
+    eventUsageService: EventUsageService;
+    planResolver: PlanResolver;
+    organizationRepository: OrganizationRepository | null;
+  }) {
+    this.organizationService = organizationService;
+    this.traceUsageService = traceUsageService;
+    this.eventUsageService = eventUsageService;
+    this.planResolver = planResolver;
+    this.organizationRepository = organizationRepository;
     this.countCache = new TtlCache<number>(
       CACHE_TTL_MS,
       "ttlcache:usage:count:",

--- a/platform/app/src/server/data-privacy/__tests__/resolveDataPrivacy.unit.test.ts
+++ b/platform/app/src/server/data-privacy/__tests__/resolveDataPrivacy.unit.test.ts
@@ -19,12 +19,17 @@ const hrProject: DataPrivacyScopeFacts = {
   departmentId: "hr",
 };
 
-function rule(
-  scopeType: DataPrivacyRow["scopeType"],
-  scopeId: string,
-  config: DataPrivacyConfig,
+function rule({
+  scopeType,
+  scopeId,
+  config,
   personalOnly = false,
-): DataPrivacyRow {
+}: {
+  scopeType: DataPrivacyRow["scopeType"];
+  scopeId: string;
+  config: DataPrivacyConfig;
+  personalOnly?: boolean;
+}): DataPrivacyRow {
   return { scopeType, scopeId, personalOnly, config };
 }
 
@@ -45,8 +50,10 @@ describe("resolveDataPrivacy", () => {
     /** @scenario An organization rule applies to every project in the org */
     it("applies to a project with no closer rule", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", {
-          categories: { input: { disposition: "drop" } },
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: { categories: { input: { disposition: "drop" } } },
         }),
       ];
 
@@ -60,11 +67,15 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A project rule beats an organization rule */
     it("lets the project rule win", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", {
-          categories: { input: { disposition: "drop" } },
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: { categories: { input: { disposition: "drop" } } },
         }),
-        rule("PROJECT", "web-app", {
-          categories: { input: { disposition: "capture" } },
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: { categories: { input: { disposition: "capture" } } },
         }),
       ];
 
@@ -78,11 +89,15 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A team rule sits between organization and project */
     it("lets the team rule win over the organization rule", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", {
-          categories: { input: { disposition: "capture" } },
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: { categories: { input: { disposition: "capture" } } },
         }),
-        rule("TEAM", "platform", {
-          categories: { input: { disposition: "drop" } },
+        rule({
+          scopeType: "TEAM",
+          scopeId: "platform",
+          config: { categories: { input: { disposition: "drop" } } },
         }),
       ];
 
@@ -96,9 +111,13 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A department rule applies to projects assigned to that department */
     it("applies the department rule", () => {
       const rows = [
-        rule("DEPARTMENT", "hr", {
-          categories: {
-            output: { disposition: "restrict", audience: { admins: true } },
+        rule({
+          scopeType: "DEPARTMENT",
+          scopeId: "hr",
+          config: {
+            categories: {
+              output: { disposition: "restrict", audience: { admins: true } },
+            },
           },
         }),
       ];
@@ -112,11 +131,15 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A department rule beats a team rule for the same project */
     it("lets the department rule win over the team rule", () => {
       const rows = [
-        rule("TEAM", "platform", {
-          categories: { output: { disposition: "capture" } },
+        rule({
+          scopeType: "TEAM",
+          scopeId: "platform",
+          config: { categories: { output: { disposition: "capture" } } },
         }),
-        rule("DEPARTMENT", "hr", {
-          categories: { output: { disposition: "drop" } },
+        rule({
+          scopeType: "DEPARTMENT",
+          scopeId: "hr",
+          config: { categories: { output: { disposition: "drop" } } },
         }),
       ];
 
@@ -130,13 +153,23 @@ describe("resolveDataPrivacy", () => {
     /** @scenario Settings resolve independently across tiers */
     it("resolves each field from its own most-specific rule", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", { pii: { level: "strict" } }),
-        rule("TEAM", "platform", {
-          categories: { input: { disposition: "drop" } },
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: { pii: { level: "strict" } },
         }),
-        rule("PROJECT", "web-app", {
-          categories: {
-            output: { disposition: "restrict", audience: { admins: true } },
+        rule({
+          scopeType: "TEAM",
+          scopeId: "platform",
+          config: { categories: { input: { disposition: "drop" } } },
+        }),
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: {
+            categories: {
+              output: { disposition: "restrict", audience: { admins: true } },
+            },
           },
         }),
       ];
@@ -161,12 +194,12 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A rule for all personal projects covers a personal workspace but not a team project */
     it("covers a personal workspace but leaves a team project at the default", () => {
       const rows = [
-        rule(
-          "ORGANIZATION",
-          "acme",
-          { categories: { input: { disposition: "drop" } } },
-          true,
-        ),
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: { categories: { input: { disposition: "drop" } } },
+          personalOnly: true,
+        }),
       ];
 
       expect(
@@ -192,12 +225,12 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A department rule narrowed to personal projects follows the owner's department */
     it("applies to a personal project whose owner is in that department", () => {
       const rows = [
-        rule(
-          "DEPARTMENT",
-          "hr",
-          { categories: { input: { disposition: "drop" } } },
-          true,
-        ),
+        rule({
+          scopeType: "DEPARTMENT",
+          scopeId: "hr",
+          config: { categories: { input: { disposition: "drop" } } },
+          personalOnly: true,
+        }),
       ];
 
       const resolved = resolveDataPrivacy({ rows, facts: bobWorkspace });
@@ -210,15 +243,23 @@ describe("resolveDataPrivacy", () => {
     /** @scenario Custom attribute rules accumulate down the cascade */
     it("unions the distinct patterns from every matching rule", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", {
-          customAttributes: [
-            { pattern: "http.request.body", disposition: "drop" },
-          ],
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: {
+            customAttributes: [
+              { pattern: "http.request.body", disposition: "drop" },
+            ],
+          },
         }),
-        rule("PROJECT", "web-app", {
-          customAttributes: [
-            { pattern: "app.session_token", disposition: "drop" },
-          ],
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: {
+            customAttributes: [
+              { pattern: "app.session_token", disposition: "drop" },
+            ],
+          },
         }),
       ];
 
@@ -232,19 +273,27 @@ describe("resolveDataPrivacy", () => {
     /** @scenario A narrower scope overrides the same attribute pattern from a wider scope */
     it("lets the most-specific scope win when both set the same pattern", () => {
       const rows = [
-        rule("ORGANIZATION", "acme", {
-          customAttributes: [
-            { pattern: "app.session_token", disposition: "drop" },
-          ],
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: {
+            customAttributes: [
+              { pattern: "app.session_token", disposition: "drop" },
+            ],
+          },
         }),
-        rule("PROJECT", "web-app", {
-          customAttributes: [
-            {
-              pattern: "app.session_token",
-              disposition: "restrict",
-              audience: { admins: true },
-            },
-          ],
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: {
+            customAttributes: [
+              {
+                pattern: "app.session_token",
+                disposition: "restrict",
+                audience: { admins: true },
+              },
+            ],
+          },
         }),
       ];
 
@@ -262,8 +311,12 @@ describe("resolveDataPrivacy", () => {
   describe("when a custom PII level selects entities", () => {
     it("carries the level and its entities through the cascade", () => {
       const rows = [
-        rule("PROJECT", "web-app", {
-          pii: { level: "custom", entities: ["EMAIL_ADDRESS", "BR_CPF"] },
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: {
+            pii: { level: "custom", entities: ["EMAIL_ADDRESS", "BR_CPF"] },
+          },
         }),
       ];
 
@@ -280,9 +333,21 @@ describe("resolveDataPrivacy", () => {
   // what makes the settings page's effective summary follow the scope filter.
   describe("given org, team, and project rules on PII", () => {
     const rows = [
-      rule("ORGANIZATION", "acme", { pii: { level: "essential" } }),
-      rule("TEAM", "platform", { pii: { level: "strict" } }),
-      rule("PROJECT", "web-app", { pii: { level: "disabled" } }),
+      rule({
+        scopeType: "ORGANIZATION",
+        scopeId: "acme",
+        config: { pii: { level: "essential" } },
+      }),
+      rule({
+        scopeType: "TEAM",
+        scopeId: "platform",
+        config: { pii: { level: "strict" } },
+      }),
+      rule({
+        scopeType: "PROJECT",
+        scopeId: "web-app",
+        config: { pii: { level: "disabled" } },
+      }),
     ];
 
     /** @scenario The effective summary resolves a baseline for the selected scope tier */
@@ -321,11 +386,22 @@ describe("resolveDataPrivacy PII exception patterns", () => {
   it("unions exceptions across the chain while the level stays first-set-wins", () => {
     const resolved = resolveDataPrivacy({
       rows: [
-        rule("ORGANIZATION", "acme", {
-          pii: { level: "essential", exceptPatterns: ["00\\d{12}"] },
+        rule({
+          scopeType: "ORGANIZATION",
+          scopeId: "acme",
+          config: {
+            pii: { level: "essential", exceptPatterns: ["00\\d{12}"] },
+          },
         }),
-        rule("PROJECT", "web-app", {
-          pii: { level: "strict", exceptPatterns: ["orders@acme\\.example"] },
+        rule({
+          scopeType: "PROJECT",
+          scopeId: "web-app",
+          config: {
+            pii: {
+              level: "strict",
+              exceptPatterns: ["orders@acme\\.example"],
+            },
+          },
         }),
       ],
       facts: teamProject,

--- a/platform/app/src/server/data-retention/__tests__/resolveRetention.unit.test.ts
+++ b/platform/app/src/server/data-retention/__tests__/resolveRetention.unit.test.ts
@@ -9,18 +9,30 @@ const CHAIN = resolveScopeChain({
   projectId: "proj-1",
 });
 
-const row = (
-  scopeType: RetentionRow["scopeType"],
-  scopeId: string,
-  category: string,
-  retentionDays: number,
-): RetentionRow => ({ scopeType, scopeId, category, retentionDays });
+const row = ({
+  scopeType,
+  scopeId,
+  category,
+  retentionDays,
+}: {
+  scopeType: RetentionRow["scopeType"];
+  scopeId: string;
+  category: string;
+  retentionDays: number;
+}): RetentionRow => ({ scopeType, scopeId, category, retentionDays });
 
 describe("resolveRetention", () => {
   describe("given a project-level override", () => {
     it("returns the project value for that category", () => {
       const resolved = resolveRetention({
-        rows: [row("PROJECT", "proj-1", "traces", 90)],
+        rows: [
+          row({
+            scopeType: "PROJECT",
+            scopeId: "proj-1",
+            category: "traces",
+            retentionDays: 90,
+          }),
+        ],
         chain: CHAIN,
       });
       expect(resolved.traces).toBe(90);
@@ -31,9 +43,24 @@ describe("resolveRetention", () => {
     it("the project tier wins (most specific)", () => {
       const resolved = resolveRetention({
         rows: [
-          row("ORGANIZATION", "org-1", "traces", 30),
-          row("TEAM", "team-1", "traces", 60),
-          row("PROJECT", "proj-1", "traces", 90),
+          row({
+            scopeType: "ORGANIZATION",
+            scopeId: "org-1",
+            category: "traces",
+            retentionDays: 30,
+          }),
+          row({
+            scopeType: "TEAM",
+            scopeId: "team-1",
+            category: "traces",
+            retentionDays: 60,
+          }),
+          row({
+            scopeType: "PROJECT",
+            scopeId: "proj-1",
+            category: "traces",
+            retentionDays: 90,
+          }),
         ],
         chain: CHAIN,
       });
@@ -45,8 +72,18 @@ describe("resolveRetention", () => {
     it("the team tier sits between org and project", () => {
       const resolved = resolveRetention({
         rows: [
-          row("ORGANIZATION", "org-1", "traces", 30),
-          row("TEAM", "team-1", "traces", 60),
+          row({
+            scopeType: "ORGANIZATION",
+            scopeId: "org-1",
+            category: "traces",
+            retentionDays: 30,
+          }),
+          row({
+            scopeType: "TEAM",
+            scopeId: "team-1",
+            category: "traces",
+            retentionDays: 60,
+          }),
         ],
         chain: CHAIN,
       });
@@ -57,7 +94,14 @@ describe("resolveRetention", () => {
   describe("given only an organization override", () => {
     it("the org value applies when no closer override exists", () => {
       const resolved = resolveRetention({
-        rows: [row("ORGANIZATION", "org-1", "scenarios", 45)],
+        rows: [
+          row({
+            scopeType: "ORGANIZATION",
+            scopeId: "org-1",
+            category: "scenarios",
+            retentionDays: 45,
+          }),
+        ],
         chain: CHAIN,
       });
       expect(resolved.scenarios).toBe(45);
@@ -68,9 +112,24 @@ describe("resolveRetention", () => {
     it("resolves each category independently", () => {
       const resolved = resolveRetention({
         rows: [
-          row("PROJECT", "proj-1", "traces", 90),
-          row("TEAM", "team-1", "scenarios", 60),
-          row("ORGANIZATION", "org-1", "experiments", 30),
+          row({
+            scopeType: "PROJECT",
+            scopeId: "proj-1",
+            category: "traces",
+            retentionDays: 90,
+          }),
+          row({
+            scopeType: "TEAM",
+            scopeId: "team-1",
+            category: "scenarios",
+            retentionDays: 60,
+          }),
+          row({
+            scopeType: "ORGANIZATION",
+            scopeId: "org-1",
+            category: "experiments",
+            retentionDays: 30,
+          }),
         ],
         chain: CHAIN,
       });
@@ -81,7 +140,14 @@ describe("resolveRetention", () => {
   describe("given no row for a category", () => {
     it("falls back to the platform default", () => {
       const resolved = resolveRetention({
-        rows: [row("PROJECT", "proj-1", "traces", 91)],
+        rows: [
+          row({
+            scopeType: "PROJECT",
+            scopeId: "proj-1",
+            category: "traces",
+            retentionDays: 91,
+          }),
+        ],
         chain: CHAIN,
       });
       expect(resolved.scenarios).toBe(PLATFORM_DEFAULT_RETENTION_DAYS);
@@ -92,7 +158,14 @@ describe("resolveRetention", () => {
   describe("given a row from a sibling scope not in the chain", () => {
     it("is ignored", () => {
       const resolved = resolveRetention({
-        rows: [row("PROJECT", "other-project", "traces", 91)],
+        rows: [
+          row({
+            scopeType: "PROJECT",
+            scopeId: "other-project",
+            category: "traces",
+            retentionDays: 91,
+          }),
+        ],
         chain: CHAIN,
       });
       expect(resolved.traces).toBe(PLATFORM_DEFAULT_RETENTION_DAYS);

--- a/platform/app/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -26,12 +26,12 @@ const makeService = (overrides: {
   recordRepository?: Record<string, unknown>;
   prisma?: unknown;
 }) => {
-  const service = new DatasetService(
-    {} as never,
-    (overrides.repository ?? {}) as never,
-    (overrides.recordRepository ?? {}) as never,
-    {} as never,
-  );
+  const service = new DatasetService({
+    prisma: {} as never,
+    repository: (overrides.repository ?? {}) as never,
+    recordRepository: (overrides.recordRepository ?? {}) as never,
+    experimentRepository: {} as never,
+  });
   if (overrides.prisma) {
     (service as unknown as { prisma: unknown }).prisma = overrides.prisma;
   }

--- a/platform/app/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
@@ -19,7 +19,12 @@ import {
 import { UPLOAD_MAX_BYTES } from "../presigned-upload";
 
 const makeService = (repo: Record<string, unknown>) =>
-  new DatasetService({} as any, repo as any, {} as any, {} as any);
+  new DatasetService({
+    prisma: {} as any,
+    repository: repo as any,
+    recordRepository: {} as any,
+    experimentRepository: {} as any,
+  });
 
 describe("DatasetService", () => {
   beforeEach(() => vi.clearAllMocks());

--- a/platform/app/src/server/datasets/__tests__/dataset.service.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset.service.test.ts
@@ -83,12 +83,12 @@ describe("DatasetService", () => {
           findDatasetRecords: vi.fn().mockResolvedValue(records),
           updateDatasetRecordsTransaction: vi.fn().mockResolvedValue(void 0),
         };
-        const service = new DatasetService(
-          prisma as never,
-          repository as never,
-          recordRepository as never,
-          {} as never,
-        );
+        const service = new DatasetService({
+          prisma: prisma as never,
+          repository: repository as never,
+          recordRepository: recordRepository as never,
+          experimentRepository: {} as never,
+        });
         return {
           service,
           prisma,

--- a/platform/app/src/server/datasets/__tests__/self-hosted-no-s3.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/self-hosted-no-s3.unit.test.ts
@@ -80,12 +80,12 @@ const makeService = (overrides: {
   recordRepository?: Record<string, unknown>;
   prisma?: unknown;
 }) =>
-  new DatasetService(
-    (overrides.prisma ?? {}) as never,
-    (overrides.repository ?? {}) as never,
-    (overrides.recordRepository ?? {}) as never,
-    {} as never,
-  );
+  new DatasetService({
+    prisma: (overrides.prisma ?? {}) as never,
+    repository: (overrides.repository ?? {}) as never,
+    recordRepository: (overrides.recordRepository ?? {}) as never,
+    experimentRepository: {} as never,
+  });
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -129,12 +129,27 @@ export type ValidateDatasetNameResult = {
  * Throws domain-specific errors that can be mapped by the router layer.
  */
 export class DatasetService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    private readonly repository: DatasetRepository,
-    private readonly recordRepository: DatasetRecordRepository,
-    private readonly experimentRepository: ExperimentRepository,
-  ) {}
+  private readonly prisma: PrismaClient;
+  private readonly repository: DatasetRepository;
+  private readonly recordRepository: DatasetRecordRepository;
+  private readonly experimentRepository: ExperimentRepository;
+
+  constructor({
+    prisma,
+    repository,
+    recordRepository,
+    experimentRepository,
+  }: {
+    prisma: PrismaClient;
+    repository: DatasetRepository;
+    recordRepository: DatasetRecordRepository;
+    experimentRepository: ExperimentRepository;
+  }) {
+    this.prisma = prisma;
+    this.repository = repository;
+    this.recordRepository = recordRepository;
+    this.experimentRepository = experimentRepository;
+  }
 
   /**
    * Static factory method for creating a DatasetService with proper DI.
@@ -143,12 +158,12 @@ export class DatasetService {
     const repository = new DatasetRepository(prisma);
     const recordRepository = new DatasetRecordRepository(prisma);
     const experimentRepository = new ExperimentRepository(prisma);
-    return new DatasetService(
+    return new DatasetService({
       prisma,
       repository,
       recordRepository,
       experimentRepository,
-    );
+    });
   }
 
   /**

--- a/platform/app/src/server/evaluations/__tests__/runEvaluation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/evaluations/__tests__/runEvaluation.4991-full-resolution.unit.test.ts
@@ -145,12 +145,12 @@ describe("runEvaluation — #4991 full blob resolution on evaluator reads", () =
         });
 
         expectConstructedWithDeps();
-        expect(getByIdMock).toHaveBeenCalledWith(
-          "project-1",
-          "trace-1",
-          expect.anything(),
-          { full: true },
-        );
+        expect(getByIdMock).toHaveBeenCalledWith({
+          projectId: "project-1",
+          traceId: "trace-1",
+          protections: expect.anything(),
+          opts: { full: true },
+        });
       });
     });
   });
@@ -179,12 +179,12 @@ describe("runEvaluation — #4991 full blob resolution on evaluator reads", () =
         });
 
         expectConstructedWithDeps();
-        expect(getTracesByThreadIdMock).toHaveBeenCalledWith(
-          "project-1",
-          "thread-1",
-          expect.anything(),
-          { full: true },
-        );
+        expect(getTracesByThreadIdMock).toHaveBeenCalledWith({
+          projectId: "project-1",
+          threadId: "thread-1",
+          protections: expect.anything(),
+          opts: { full: true },
+        });
       });
     });
   });

--- a/platform/app/src/server/evaluations/preconditions.ts
+++ b/platform/app/src/server/evaluations/preconditions.ts
@@ -52,7 +52,7 @@ function resolveFieldValue({
     return null;
   }
 
-  return matcher(data, value, key, subkey);
+  return matcher({ data, value, key, subkey });
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/app/src/server/evaluations/runEvaluation.ts
+++ b/platform/app/src/server/evaluations/runEvaluation.ts
@@ -68,12 +68,17 @@ export type EvaluationResultWithThreadId = SingleEvaluationResult & {
   inputs?: Record<string, any>;
 };
 
-const buildThreadData = async (
-  projectId: string,
-  trace: Trace,
-  mappingState: MappingState | null,
-  protections: Protections,
-): Promise<Record<string, any>> => {
+const buildThreadData = async ({
+  projectId,
+  trace,
+  mappingState,
+  protections,
+}: {
+  projectId: string;
+  trace: Trace;
+  mappingState: MappingState | null;
+  protections: Protections;
+}): Promise<Record<string, any>> => {
   if (!mappingState) {
     throw new Error("Mapping state is required for thread-based evaluation");
   }
@@ -90,12 +95,12 @@ const buildThreadData = async (
     undefined,
     buildTraceBlobResolutionDeps(),
   );
-  const threadTraces = await traceService.getTracesByThreadId(
+  const threadTraces = await traceService.getTracesByThreadId({
     projectId,
     threadId,
     protections,
-    { full: true },
-  );
+    opts: { full: true },
+  });
 
   const result: Record<string, any> = {};
 
@@ -148,13 +153,11 @@ const buildThreadData = async (
           key: mappingConfig.key,
           subkey: mappingConfig.subkey,
         };
-        const mapped = mapTraceToDatasetEntry(
+        const mapped = mapTraceToDatasetEntry({
           trace,
-          { [targetField]: traceMappingConfig as any },
-          new Set(),
-          undefined,
-          undefined,
-        )[0];
+          mapping: { [targetField]: traceMappingConfig as any },
+          expansions: new Set(),
+        })[0];
         result[targetField] = mapped?.[targetField];
       }
     }
@@ -173,9 +176,9 @@ const switchMapping = (
       ? mapping_
       : migrateLegacyMappings(mapping_ as any);
 
-  return mapTraceToDatasetEntry(
+  return mapTraceToDatasetEntry({
     trace,
-    mapping.mapping as Record<
+    mapping: mapping.mapping as Record<
       string,
       {
         source: keyof typeof TRACE_MAPPINGS | "";
@@ -183,24 +186,34 @@ const switchMapping = (
         subkey?: string;
       }
     >,
-    new Set(),
-    undefined,
-    undefined,
-  )[0];
+    expansions: new Set(),
+  })[0];
 };
 
-const buildDataForEvaluation = async (
-  evaluatorType: EvaluatorTypes | "workflow",
-  trace: Trace,
-  mappings: MappingState | null,
-  isThreadLevel: boolean,
-  projectId: string,
-  protections: Protections,
-): Promise<DataForEvaluation> => {
+const buildDataForEvaluation = async ({
+  evaluatorType,
+  trace,
+  mappings,
+  isThreadLevel,
+  projectId,
+  protections,
+}: {
+  evaluatorType: EvaluatorTypes | "workflow";
+  trace: Trace;
+  mappings: MappingState | null;
+  isThreadLevel: boolean;
+  projectId: string;
+  protections: Protections;
+}): Promise<DataForEvaluation> => {
   let data: Record<string, any>;
 
   if (isThreadLevel) {
-    data = await buildThreadData(projectId, trace, mappings, protections);
+    data = await buildThreadData({
+      projectId,
+      trace,
+      mappingState: mappings,
+      protections,
+    });
   } else {
     const mappedData = switchMapping(trace, mappings ?? DEFAULT_MAPPINGS);
     if (!mappedData) {
@@ -234,8 +247,11 @@ const buildDataForEvaluation = async (
         trace,
         mappings,
         getThreadTraces: (threadId) =>
-          traceService.getTracesByThreadId(projectId, threadId, protections, {
-            full: true,
+          traceService.getTracesByThreadId({
+            projectId,
+            threadId,
+            protections,
+            opts: { full: true },
           }),
       });
     }
@@ -279,8 +295,11 @@ export const runEvaluationForTrace = async ({
     undefined,
     buildTraceBlobResolutionDeps(),
   );
-  const trace = await traceService.getById(projectId, traceId, protections, {
-    full: true,
+  const trace = await traceService.getById({
+    projectId,
+    traceId,
+    protections,
+    opts: { full: true },
   });
   if (!trace) {
     throw new Error("trace not found");
@@ -317,14 +336,14 @@ export const runEvaluationForTrace = async ({
     trace.evaluations = evaluationsByTrace[traceId] ?? [];
   }
 
-  const data = await buildDataForEvaluation(
+  const data = await buildDataForEvaluation({
     evaluatorType,
     trace,
     mappings,
     isThreadLevel,
     projectId,
     protections,
-  );
+  });
 
   const result = await runEvaluation({
     projectId,
@@ -382,14 +401,14 @@ export const runEvaluation = async ({
         parentTrace: extractParentTraceForNlpgo(trace),
       });
     }
-    return customEvaluation(
+    return customEvaluation({
       projectId,
       evaluatorType,
-      data.data,
+      data: data.data,
       trace,
       workflowId,
       parentCausalityDepth,
-    );
+    });
   }
 
   const builtInEvaluatorType = (
@@ -447,12 +466,12 @@ export const runEvaluation = async ({
     builtInEvaluatorType !== "openai/moderation"
   ) {
     try {
-      const modelEnv = await setupModelEnv(
-        settings.model,
-        false,
+      const modelEnv = await setupModelEnv({
+        model: settings.model,
+        embeddings: false,
         projectId,
         settings,
-      );
+      });
       evaluatorEnv = { ...evaluatorEnv, ...modelEnv };
     } catch (error) {
       if (error instanceof EvaluatorConfigError) {
@@ -475,12 +494,12 @@ export const runEvaluation = async ({
     typeof settings.embeddings_model === "string"
   ) {
     try {
-      const embeddingsEnv = await setupModelEnv(
-        settings.embeddings_model,
-        true,
+      const embeddingsEnv = await setupModelEnv({
+        model: settings.embeddings_model,
+        embeddings: true,
         projectId,
         settings,
-      );
+      });
       evaluatorEnv = { ...evaluatorEnv, ...embeddingsEnv };
     } catch (error) {
       if (error instanceof EvaluatorConfigError) {
@@ -616,14 +635,21 @@ export const runEvaluation = async ({
   });
 };
 
-const customEvaluation = async (
-  projectId: string,
-  evaluatorType: EvaluatorTypes | "workflow",
-  data: Record<string, any>,
-  trace?: Trace,
-  workflowId?: string | null,
-  parentCausalityDepth?: number,
-): Promise<SingleEvaluationResult> => {
+const customEvaluation = async ({
+  projectId,
+  evaluatorType,
+  data,
+  trace,
+  workflowId,
+  parentCausalityDepth,
+}: {
+  projectId: string;
+  evaluatorType: EvaluatorTypes | "workflow";
+  data: Record<string, any>;
+  trace?: Trace;
+  workflowId?: string | null;
+  parentCausalityDepth?: number;
+}): Promise<SingleEvaluationResult> => {
   const resolvedWorkflowId = workflowId ?? evaluatorType.split("/")[1];
 
   const requestBody: Record<string, any> = {
@@ -638,14 +664,13 @@ const customEvaluation = async (
 
   const parentTrace = extractParentTraceForNlpgo(trace);
 
-  const response = await runEvaluationWorkflow(
-    resolvedWorkflowId,
+  const response = await runEvaluationWorkflow({
+    workflowId: resolvedWorkflowId,
     projectId,
-    requestBody,
-    undefined,
-    parentCausalityDepth,
+    inputs: requestBody,
     parentTrace,
-  );
+    causalityDepth: parentCausalityDepth,
+  });
 
   const { result, status } = response;
 

--- a/platform/app/src/server/event-sourcing/__tests__/integration/eventLogDurability.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/integration/eventLogDurability.integration.test.ts
@@ -287,11 +287,11 @@ describe.skipIf(!hasTestcontainers)(
           format: "JSONEachRow",
         });
 
-        const events = await eventStore.getEvents(
-          traceId,
-          { tenantId: createTenantId(tenantId) },
-          "trace" as AggregateType,
-        );
+        const events = await eventStore.getEvents({
+          aggregateId: traceId,
+          context: { tenantId: createTenantId(tenantId) },
+          aggregateType: "trace" as AggregateType,
+        });
 
         expect(events.length).toBeGreaterThanOrEqual(1);
         const evt = events[0]!;
@@ -389,11 +389,11 @@ describe.skipIf(!hasTestcontainers)(
         await deleteStoredSpansForTenant(client, tenantId);
         await new Promise((r) => setTimeout(r, 1000));
 
-        const events = await eventStore.getEvents(
-          traceId,
-          { tenantId: createTenantId(tenantId) },
-          "trace" as AggregateType,
-        );
+        const events = await eventStore.getEvents({
+          aggregateId: traceId,
+          context: { tenantId: createTenantId(tenantId) },
+          aggregateType: "trace" as AggregateType,
+        });
 
         expect(events.length).toBeGreaterThanOrEqual(1);
         const evt = events.find((e: any) => e.type === "SpanReceivedEvent");
@@ -449,16 +449,16 @@ describe.skipIf(!hasTestcontainers)(
         await deleteStoredSpansForTenant(client, tenantId);
         await new Promise((r) => setTimeout(r, 1500));
 
-        const eventsA = await eventStore.getEvents(
-          traceA,
-          { tenantId: createTenantId(tenantId) },
-          "trace" as AggregateType,
-        );
-        const eventsB = await eventStore.getEvents(
-          traceB,
-          { tenantId: createTenantId(tenantId) },
-          "trace" as AggregateType,
-        );
+        const eventsA = await eventStore.getEvents({
+          aggregateId: traceA,
+          context: { tenantId: createTenantId(tenantId) },
+          aggregateType: "trace" as AggregateType,
+        });
+        const eventsB = await eventStore.getEvents({
+          aggregateId: traceB,
+          context: { tenantId: createTenantId(tenantId) },
+          aggregateType: "trace" as AggregateType,
+        });
 
         expect(eventsA.length).toBeGreaterThanOrEqual(1);
         expect(eventsB.length).toBeGreaterThanOrEqual(1);
@@ -493,16 +493,16 @@ describe.skipIf(!hasTestcontainers)(
           format: "JSONEachRow",
         });
 
-        const eventsForOwner = await eventStore.getEvents(
-          traceId,
-          { tenantId: createTenantId(ownerTenant) },
-          "trace" as AggregateType,
-        );
-        const eventsForOther = await eventStore.getEvents(
-          traceId,
-          { tenantId: createTenantId(otherTenant) },
-          "trace" as AggregateType,
-        );
+        const eventsForOwner = await eventStore.getEvents({
+          aggregateId: traceId,
+          context: { tenantId: createTenantId(ownerTenant) },
+          aggregateType: "trace" as AggregateType,
+        });
+        const eventsForOther = await eventStore.getEvents({
+          aggregateId: traceId,
+          context: { tenantId: createTenantId(otherTenant) },
+          aggregateType: "trace" as AggregateType,
+        });
 
         expect(eventsForOwner.length).toBeGreaterThanOrEqual(1);
         expect(eventsForOther.length).toBe(0);
@@ -535,11 +535,11 @@ describe.skipIf(!hasTestcontainers)(
         });
         await new Promise((r) => setTimeout(r, 500));
 
-        const events = await eventStore.getEvents(
-          traceId,
-          { tenantId: createTenantId(tenantId) },
-          "trace" as AggregateType,
-        );
+        const events = await eventStore.getEvents({
+          aggregateId: traceId,
+          context: { tenantId: createTenantId(tenantId) },
+          aggregateType: "trace" as AggregateType,
+        });
 
         const matchingEventIds = events
           .filter((e: any) => e.type === "SpanReceivedEvent")

--- a/platform/app/src/server/event-sourcing/__tests__/integration/testHelpers.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/integration/testHelpers.ts
@@ -122,7 +122,15 @@ export function createTestPipeline(): PipelineWithCommandHandlers<
  * Waits for a fold projection to reach the expected event count.
  * Replaces checkpoint-based waiting — the fold state IS the checkpoint.
  */
-export async function waitForProjection(
+export async function waitForProjection({
+  pipeline,
+  projectionName,
+  aggregateId,
+  tenantId,
+  expectedEventCount,
+  timeoutMs = 5000,
+  pollIntervalMs = 100,
+}: {
   pipeline: {
     service: {
       getProjectionByName: (
@@ -131,23 +139,23 @@ export async function waitForProjection(
         context: any,
       ) => Promise<any>;
     };
-  },
-  projectionName: string,
-  aggregateId: string,
-  tenantId: ReturnType<typeof createTenantId>,
-  expectedEventCount: number,
-  timeoutMs = 5000,
-  pollIntervalMs = 100,
-): Promise<void> {
+  };
+  projectionName: string;
+  aggregateId: string;
+  tenantId: ReturnType<typeof createTenantId>;
+  expectedEventCount: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}): Promise<void> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
     try {
-      const projection = (await pipeline.service.getProjectionByName(
+      const projection = (await pipeline.service.getProjectionByName({
         projectionName,
         aggregateId,
-        { tenantId },
-      )) as TestProjection | null;
+        context: { tenantId },
+      })) as TestProjection | null;
 
       if (projection && projection.data.eventCount >= expectedEventCount) {
         return;
@@ -169,11 +177,11 @@ export async function waitForProjection(
 
   // Final attempt
   try {
-    const projection = (await pipeline.service.getProjectionByName(
+    const projection = (await pipeline.service.getProjectionByName({
       projectionName,
       aggregateId,
-      { tenantId },
-    )) as TestProjection | null;
+      context: { tenantId },
+    })) as TestProjection | null;
 
     if (projection && projection.data.eventCount >= expectedEventCount) {
       return;
@@ -199,13 +207,19 @@ export async function waitForProjection(
  * Waits for an event handler (map projection) to process an event.
  * Polls the test_event_handler_log table in ClickHouse.
  */
-export async function waitForEventHandler(
-  aggregateId: string,
-  tenantId: string,
-  expectedCount: number,
+export async function waitForEventHandler({
+  aggregateId,
+  tenantId,
+  expectedCount,
   timeoutMs = 5000,
   pollIntervalMs = 100,
-): Promise<void> {
+}: {
+  aggregateId: string;
+  tenantId: string;
+  expectedCount: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}): Promise<void> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {

--- a/platform/app/src/server/event-sourcing/commands/__tests__/command.test.ts
+++ b/platform/app/src/server/event-sourcing/commands/__tests__/command.test.ts
@@ -12,12 +12,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { action: "test" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.tenantId).toBe(tenantId);
     });
@@ -28,12 +28,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { action: "test" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.aggregateId).toBe(aggregateId);
     });
@@ -44,12 +44,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { action: "test" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.type).toBe(commandType);
     });
@@ -60,12 +60,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { action: "test", value: 42 };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toEqual(payload);
     });
@@ -78,12 +78,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { action: "test" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.metadata).toBeUndefined();
     });
@@ -97,13 +97,13 @@ describe("createCommand", () => {
       const payload = { action: "test" };
       const metadata = { correlationId: "corr-123", traceId: "trace-456" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
+        type: commandType,
+        data: payload,
         metadata,
-      );
+      });
 
       expect(command.metadata).toEqual(metadata);
     });
@@ -123,13 +123,13 @@ describe("createCommand", () => {
         array: [1, 2, 3],
       };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
+        type: commandType,
+        data: payload,
         metadata,
-      );
+      });
 
       expect(command.metadata).toEqual(metadata);
     });
@@ -142,12 +142,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = "string-payload";
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toBe(payload);
     });
@@ -158,12 +158,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = 42;
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toBe(payload);
     });
@@ -174,12 +174,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = { key: "value", number: 123 };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toEqual(payload);
     });
@@ -190,12 +190,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = [1, 2, 3, "four"];
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toEqual(payload);
     });
@@ -206,12 +206,12 @@ describe("createCommand", () => {
       const commandType = COMMAND_TYPES[0];
       const payload = null;
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
-      );
+        type: commandType,
+        data: payload,
+      });
 
       expect(command.data).toBeNull();
     });
@@ -225,13 +225,13 @@ describe("createCommand", () => {
       const payload = { action: "test" };
       const metadata = { key: "value" };
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
+        type: commandType,
+        data: payload,
         metadata,
-      );
+      });
 
       expect(command.metadata).toEqual(metadata);
     });
@@ -243,13 +243,13 @@ describe("createCommand", () => {
       const payload = { action: "test" };
       const metadata = null;
 
-      const command = createCommand(
+      const command = createCommand({
         tenantId,
         aggregateId,
-        commandType,
-        payload,
+        type: commandType,
+        data: payload,
         metadata,
-      );
+      });
 
       expect(command.metadata).toBeNull();
     });

--- a/platform/app/src/server/event-sourcing/commands/command.ts
+++ b/platform/app/src/server/event-sourcing/commands/command.ts
@@ -127,13 +127,19 @@ export function validateCommand(
 export function createCommand<
   Payload = unknown,
   Metadata = Record<string, unknown>,
->(
-  tenantId: TenantId,
-  aggregateId: string,
-  type: CommandType,
-  data: Payload,
-  metadata?: Metadata,
-): Command<Payload, Metadata> {
+>({
+  tenantId,
+  aggregateId,
+  type,
+  data,
+  metadata,
+}: {
+  tenantId: TenantId;
+  aggregateId: string;
+  type: CommandType;
+  data: Payload;
+  metadata?: Metadata;
+}): Command<Payload, Metadata> {
   return {
     tenantId,
     aggregateId,

--- a/platform/app/src/server/event-sourcing/domain/tenantId.ts
+++ b/platform/app/src/server/event-sourcing/domain/tenantId.ts
@@ -35,7 +35,7 @@ export function createTenantId(value: string): TenantId {
       const message =
         error.issues[0]?.message ??
         "TenantId must be a non-empty string for tenant isolation";
-      throw new SecurityError("createTenantId", message);
+      throw new SecurityError({ operation: "createTenantId", message });
     }
     throw error;
   }

--- a/platform/app/src/server/event-sourcing/eventSourcing.ts
+++ b/platform/app/src/server/event-sourcing/eventSourcing.ts
@@ -466,12 +466,12 @@ export class EventSourcing {
       identity,
       "No handler registered for this job in this worker; rejecting it for retry rather than dropping it",
     );
-    throw new QueueError(
+    throw new QueueError({
       queueName,
-      "process",
-      "job routing key is not registered in this worker",
-      identity,
-    );
+      operation: "process",
+      message: "job routing key is not registered in this worker",
+      context: identity,
+    });
   }
 
   private initializeStores(): void {

--- a/platform/app/src/server/event-sourcing/pipeline/__tests__/testHelpers.ts
+++ b/platform/app/src/server/event-sourcing/pipeline/__tests__/testHelpers.ts
@@ -21,7 +21,10 @@ import type {
 import type { EventSourcedQueueProcessor } from "../../queues";
 import { createTestEvent } from "../../services/__tests__/testHelpers";
 import type { JobRegistryEntry } from "../../services/queues/queueManager";
-import type { EventStore } from "../../stores/eventStore.types";
+import type {
+  EventStore,
+  EventStoreReadContext,
+} from "../../stores/eventStore.types";
 import { definePipeline } from "../staticBuilder";
 
 /**
@@ -35,13 +38,23 @@ export function createMockEventStore<T extends Event>(): EventStore<T> {
     getEventsUpTo: vi
       .fn()
       .mockImplementation(
-        async (aggregateId, context, aggregateType, upToEvent) => {
+        async ({
+          aggregateId,
+          context,
+          aggregateType,
+          upToEvent,
+        }: {
+          aggregateId: string;
+          context: EventStoreReadContext<T>;
+          aggregateType: AggregateType;
+          upToEvent: T;
+        }) => {
           // Default implementation: get all events and filter
-          const allEvents = await mockStore.getEvents(
+          const allEvents = await mockStore.getEvents({
             aggregateId,
             context,
             aggregateType,
-          );
+          });
           const upToIndex = allEvents.findIndex(
             (e: T) => e.id === upToEvent.id,
           );
@@ -250,19 +263,29 @@ export function createTestEventForBuilder(
   tenantId = createTenantId(TEST_CONSTANTS.TENANT_ID_VALUE),
   aggregateType: AggregateType = "trace",
 ): TestEvent {
-  return createTestEvent(aggregateId, aggregateType, tenantId) as TestEvent;
+  return createTestEvent({
+    aggregateId,
+    aggregateType,
+    tenantId,
+  }) as TestEvent;
 }
 
 /**
  * Creates a test projection with proper typing.
  */
-export function createTestProjection<TData = unknown>(
-  id: string,
-  aggregateId: string,
-  tenantId: ReturnType<typeof createTenantId>,
-  version: string = TEST_CONSTANTS.PROJECTION_VERSION,
-  data: TData = {} as TData,
-): Projection<TData> {
+export function createTestProjection<TData = unknown>({
+  id,
+  aggregateId,
+  tenantId,
+  version = TEST_CONSTANTS.PROJECTION_VERSION,
+  data = {} as TData,
+}: {
+  id: string;
+  aggregateId: string;
+  tenantId: ReturnType<typeof createTenantId>;
+  version?: string;
+  data?: TData;
+}): Projection<TData> {
   return {
     id,
     aggregateId,

--- a/platform/app/src/server/event-sourcing/pipeline/staticBuilder.ts
+++ b/platform/app/src/server/event-sourcing/pipeline/staticBuilder.ts
@@ -566,12 +566,17 @@ export class StaticPipelineBuilderWithNameAndType<
   withCommandInstance<
     TStatic extends CommandHandlerClassStatic<any, any>,
     Name extends string,
-  >(
-    name: Name,
-    handlerClass: TStatic,
-    instance: CommandHandler<any, any>,
-    options?: CommandHandlerOptions,
-  ): StaticPipelineBuilderWithNameAndType<
+  >({
+    name,
+    handlerClass,
+    instance,
+    options,
+  }: {
+    name: Name;
+    handlerClass: TStatic;
+    instance: CommandHandler<any, any>;
+    options?: CommandHandlerOptions;
+  }): StaticPipelineBuilderWithNameAndType<
     EventType,
     RegisteredProjections,
     | RegisteredCommands

--- a/platform/app/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
@@ -88,7 +88,11 @@ describe("automations pipeline", () => {
 
         const events = await eventSourcing
           .getEventStore<AutomationEvent>()!
-          .getEvents("trigger-1", { tenantId }, "trigger");
+          .getEvents({
+            aggregateId: "trigger-1",
+            context: { tenantId },
+            aggregateType: "trigger",
+          });
         const process = await processStore.findByRef<SettlementState>({
           ref: {
             processName: "triggerSettlement",
@@ -121,7 +125,11 @@ describe("automations pipeline", () => {
 
         const events = await eventSourcing
           .getEventStore<AutomationEvent>()!
-          .getEvents("trigger-1", { tenantId }, "trigger");
+          .getEvents({
+            aggregateId: "trigger-1",
+            context: { tenantId },
+            aggregateType: "trigger",
+          });
         const process = await processStore.findByRef<SettlementState>({
           ref: {
             processName: "triggerSettlement",
@@ -176,7 +184,11 @@ describe("automations pipeline", () => {
 
         const events = await eventSourcing
           .getEventStore<AutomationEvent>()!
-          .getEvents("trigger-1", { tenantId }, "trigger");
+          .getEvents({
+            aggregateId: "trigger-1",
+            context: { tenantId },
+            aggregateType: "trigger",
+          });
 
         expect(events.map((event) => event.idempotencyKey)).toEqual([
           "trigger-1:trace-1:30000-0",
@@ -314,11 +326,11 @@ describe.skipIf(!hasRedis)(
 
             await vi.waitFor(
               async () => {
-                const events = await eventStore.getEvents(
-                  "trigger-1",
-                  { tenantId },
-                  "trigger",
-                );
+                const events = await eventStore.getEvents({
+                  aggregateId: "trigger-1",
+                  context: { tenantId },
+                  aggregateType: "trigger",
+                });
                 expect(events).toHaveLength(3);
               },
               { timeout: 15_000, interval: 50 },

--- a/platform/app/src/server/event-sourcing/pipelines/automations/automationDispatch.wiring.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/automationDispatch.wiring.ts
@@ -268,7 +268,7 @@ export function buildAutomationDispatchPorts({
       emailSuppressions.filterSuppressed({ projectId, triggerId, emails }),
     traceById: async (projectId, traceId) => {
       const protections = await getProtectionsDeduped(projectId);
-      return traceService.getById(projectId, traceId, protections);
+      return traceService.getById({ projectId, traceId, protections });
     },
     addToAnnotationQueue: async (params) => {
       await createOrUpdateQueueItems({ ...params, prisma });

--- a/platform/app/src/server/event-sourcing/pipelines/billing-reporting/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/billing-reporting/pipeline.ts
@@ -21,11 +21,11 @@ export function createBillingReportingPipeline(
   return definePipeline<Event>()
     .withName(BILLING_REPORTING_PIPELINE_NAME)
     .withAggregateType("billing_report")
-    .withCommandInstance(
-      "reportUsageForMonth",
-      ReportUsageForMonthCommand,
-      deps.reportUsageForMonthCommand,
-      {
+    .withCommandInstance({
+      name: "reportUsageForMonth",
+      handlerClass: ReportUsageForMonthCommand,
+      instance: deps.reportUsageForMonthCommand,
+      options: {
         delay: 300_000, // 5 min delay (initial + re-trigger)
         deduplication: {
           makeId: (p: { organizationId: string; billingMonth: string }) =>
@@ -33,6 +33,6 @@ export function createBillingReportingPipeline(
           ttlMs: 310_000, // 310s > 300s delay — prevents thundering herd, self-dispatch still works via replace logic
         },
       },
-    )
+    })
     .build();
 }

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -105,12 +105,12 @@ const normalization = new SpanNormalizationPipelineService(
 );
 
 function normalizedFrom(event: SpanReceivedEvent): NormalizedSpan {
-  return normalization.normalizeSpanReceived(
-    event.tenantId,
-    event.data.span,
-    event.data.resource,
-    event.data.instrumentationScope,
-  );
+  return normalization.normalizeSpanReceived({
+    tenantId: event.tenantId,
+    otlpSpan: event.data.span,
+    otlpResource: event.data.resource,
+    otlpInstrumentationScope: event.data.instrumentationScope,
+  });
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -166,12 +166,12 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
       // unreadable shape — a build that poisons the queue with every ordinary
       // span is worse than the loss this refusal prevents.
       if (!isCodingAgentSpan(event)) return;
-      const span = normalization.normalizeSpanReceived(
-        event.tenantId,
-        event.data.span,
-        event.data.resource,
-        event.data.instrumentationScope,
-      );
+      const span = normalization.normalizeSpanReceived({
+        tenantId: event.tenantId,
+        otlpSpan: event.data.span,
+        otlpResource: event.data.resource,
+        otlpInstrumentationScope: event.data.instrumentationScope,
+      });
       await deps.contributeSpanFacts(
         liftContribution({
           span,

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -187,9 +187,13 @@ export class ExecuteEvaluationCommand
         { tenantId: tenantId, evaluatorId: data.evaluatorId },
         "Monitor not found — skipping evaluation",
       );
-      return emitReported(data, tenantId, {
-        status: "skipped",
-        details: "Monitor not found",
+      return emitReported({
+        data,
+        tenantId,
+        result: {
+          status: "skipped",
+          details: "Monitor not found",
+        },
       });
     }
 
@@ -210,9 +214,13 @@ export class ExecuteEvaluationCommand
           },
           "Azure Safety provider not configured — skipping evaluation",
         );
-        return emitReported(data, tenantId, {
-          status: "skipped",
-          details: AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+        return emitReported({
+          data,
+          tenantId,
+          result: {
+            status: "skipped",
+            details: AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+          },
         });
       }
     }
@@ -363,10 +371,10 @@ export class ExecuteEvaluationCommand
         ? (result.error ?? result.details ?? "Evaluator failed")
         : result.error;
 
-      return await emitReported(
+      return await emitReported({
         data,
         tenantId,
-        {
+        result: {
           status: result.status,
           score: result.score,
           passed: result.passed,
@@ -377,8 +385,8 @@ export class ExecuteEvaluationCommand
           inputs: result.inputs ?? null,
           costId,
         },
-        this.deps.offloadInputs,
-      );
+        offloadInputs: this.deps.offloadInputs,
+      });
     } catch (error) {
       // Customer-fixable errors (see isCustomerFixable above) are skipped,
       // not errored — mirrors the pre-execution config gates above.
@@ -401,9 +409,13 @@ export class ExecuteEvaluationCommand
           "Customer-fixable evaluator failure — skipping evaluation",
         );
 
-        return emitReported(data, tenantId, {
-          status: "skipped",
-          details: error.message,
+        return emitReported({
+          data,
+          tenantId,
+          result: {
+            status: "skipped",
+            details: error.message,
+          },
         });
       }
 
@@ -418,18 +430,27 @@ export class ExecuteEvaluationCommand
         "Evaluation execution failed",
       );
 
-      return emitReported(data, tenantId, {
-        status: "error",
-        error: extractErrorMessage(error),
-        errorDetails: error instanceof Error ? (error.stack ?? null) : null,
+      return emitReported({
+        data,
+        tenantId,
+        result: {
+          status: "error",
+          error: extractErrorMessage(error),
+          errorDetails: error instanceof Error ? (error.stack ?? null) : null,
+        },
       });
     }
   }
 }
 
-async function emitReported(
-  data: ExecuteEvaluationCommandData,
-  tenantId: ReturnType<typeof createTenantId>,
+async function emitReported({
+  data,
+  tenantId,
+  result,
+  offloadInputs,
+}: {
+  data: ExecuteEvaluationCommandData;
+  tenantId: ReturnType<typeof createTenantId>;
   result: {
     status: "processed" | "error" | "skipped";
     score?: number;
@@ -440,9 +461,9 @@ async function emitReported(
     error?: string;
     errorDetails?: string | null;
     costId?: string | null;
-  },
-  offloadInputs?: ExecuteEvaluationCommandDeps["offloadInputs"],
-): Promise<EvaluationProcessingEvent[]> {
+  };
+  offloadInputs?: ExecuteEvaluationCommandDeps["offloadInputs"];
+}): Promise<EvaluationProcessingEvent[]> {
   // ADR-040: offload oversized inputs to durable object storage BEFORE the
   // event is created, so the S3 PUT precedes the event_log append (matching
   // the PUT-then-row ordering used by stored-objects) and the event carries

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -125,11 +125,11 @@ export function createEvaluationProcessingPipeline(
   }
 
   return builder
-    .withCommandInstance(
-      "executeEvaluation",
-      ExecuteEvaluationCommand,
-      deps.executeEvaluationCommand,
-      {
+    .withCommandInstance({
+      name: "executeEvaluation",
+      handlerClass: ExecuteEvaluationCommand,
+      instance: deps.executeEvaluationCommand,
+      options: {
         serializeByAggregate: true,
         delay: 30_000,
         deduplication: {
@@ -137,7 +137,7 @@ export function createEvaluationProcessingPipeline(
           ttlMs: 30_000,
         },
       },
-    )
+    })
     .withCommand("startEvaluation", StartEvaluationCommand, {
       serializeByAggregate: true,
     })

--- a/platform/app/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -108,14 +108,21 @@ export class ExperimentRunStateRepositoryClickHouse<
     };
   }
 
-  private mapProjectionDataToClickHouseRecord(
-    data: ExperimentRunStateData,
-    tenantId: string,
-    projectionId: string,
-    projectionVersion: string,
-    lastProcessedEventId: string,
-    runId: string,
-  ): ClickHouseExperimentRunWriteRecord {
+  private mapProjectionDataToClickHouseRecord({
+    data,
+    tenantId,
+    projectionId,
+    projectionVersion,
+    lastProcessedEventId,
+    runId,
+  }: {
+    data: ExperimentRunStateData;
+    tenantId: string;
+    projectionId: string;
+    projectionVersion: string;
+    lastProcessedEventId: string;
+    runId: string;
+  }): ClickHouseExperimentRunWriteRecord {
     return {
       ProjectionId: projectionId,
       TenantId: tenantId,
@@ -230,14 +237,14 @@ export class ExperimentRunStateRepositoryClickHouse<
         { runId, tenantId: context.tenantId, error: errorMessage },
         "Failed to get projection from ClickHouse",
       );
-      throw new StoreError(
-        "getProjection",
-        "ExperimentRunStateRepositoryClickHouse",
-        `Failed to get projection for run ${runId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { runId },
-        error,
-      );
+      throw new StoreError({
+        operation: "getProjection",
+        store: "ExperimentRunStateRepositoryClickHouse",
+        message: `Failed to get projection for run ${runId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { runId },
+        cause: error,
+      });
     }
   }
 
@@ -251,33 +258,34 @@ export class ExperimentRunStateRepositoryClickHouse<
     );
 
     if (!EventUtils.isValidProjection(projection)) {
-      throw new ValidationError(
-        "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
-        "projection",
-        projection,
-      );
+      throw new ValidationError({
+        reason:
+          "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
+        field: "projection",
+        value: projection,
+      });
     }
 
     if (projection.tenantId !== context.tenantId) {
-      throw new SecurityError(
-        "storeProjection",
-        `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-        projection.tenantId,
-        { contextTenantId: context.tenantId },
-      );
+      throw new SecurityError({
+        operation: "storeProjection",
+        message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+        tenantId: projection.tenantId,
+        context: { contextTenantId: context.tenantId },
+      });
     }
 
     try {
       const client = await this.resolveClient(context.tenantId);
       const { runId } = parseExperimentRunKey(String(projection.aggregateId));
-      const projectionRecord = this.mapProjectionDataToClickHouseRecord(
-        projection.data as ExperimentRunStateData,
-        String(context.tenantId),
-        projection.id,
-        projection.version,
-        projection.id,
+      const projectionRecord = this.mapProjectionDataToClickHouseRecord({
+        data: projection.data as ExperimentRunStateData,
+        tenantId: String(context.tenantId),
+        projectionId: projection.id,
+        projectionVersion: projection.version,
+        lastProcessedEventId: projection.id,
         runId,
-      );
+      });
 
       const retentionPolicy = context.metadata?.retentionPolicy as
         | { experiments?: number | null }
@@ -303,14 +311,17 @@ export class ExperimentRunStateRepositoryClickHouse<
         },
         "Failed to store projection in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjection",
-        "ExperimentRunStateRepositoryClickHouse",
-        `Failed to store projection ${projection.id} for run ${projection.aggregateId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { projectionId: projection.id, runId: String(projection.aggregateId) },
-        error,
-      );
+      throw new StoreError({
+        operation: "storeProjection",
+        store: "ExperimentRunStateRepositoryClickHouse",
+        message: `Failed to store projection ${projection.id} for run ${projection.aggregateId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: {
+          projectionId: projection.id,
+          runId: String(projection.aggregateId),
+        },
+        cause: error,
+      });
     }
   }
 
@@ -327,12 +338,12 @@ export class ExperimentRunStateRepositoryClickHouse<
 
     for (const projection of projections) {
       if (projection.tenantId !== context.tenantId) {
-        throw new SecurityError(
-          "storeProjectionBatch",
-          `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-          projection.tenantId,
-          { contextTenantId: context.tenantId },
-        );
+        throw new SecurityError({
+          operation: "storeProjectionBatch",
+          message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+          tenantId: projection.tenantId,
+          context: { contextTenantId: context.tenantId },
+        });
       }
     }
 
@@ -344,14 +355,14 @@ export class ExperimentRunStateRepositoryClickHouse<
         retentionPolicy?.experiments ?? PLATFORM_DEFAULT_RETENTION_DAYS;
       const records = projections.map((projection) => {
         const { runId } = parseExperimentRunKey(String(projection.aggregateId));
-        const record = this.mapProjectionDataToClickHouseRecord(
-          projection.data as ExperimentRunStateData,
-          String(context.tenantId),
-          projection.id,
-          projection.version,
-          projection.id,
+        const record = this.mapProjectionDataToClickHouseRecord({
+          data: projection.data as ExperimentRunStateData,
+          tenantId: String(context.tenantId),
+          projectionId: projection.id,
+          projectionVersion: projection.version,
+          lastProcessedEventId: projection.id,
           runId,
-        );
+        });
         record._retention_days = retentionDays;
         return record;
       });
@@ -374,14 +385,14 @@ export class ExperimentRunStateRepositoryClickHouse<
         },
         "Failed to batch store projections in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjectionBatch",
-        "ExperimentRunStateRepositoryClickHouse",
-        `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { count: projections.length },
-        error,
-      );
+      throw new StoreError({
+        operation: "storeProjectionBatch",
+        store: "ExperimentRunStateRepositoryClickHouse",
+        message: `Failed to batch store ${projections.length} projections: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { count: projections.length },
+        cause: error,
+      });
     }
   }
 }

--- a/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationState.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationState.foldProjection.unit.test.ts
@@ -21,12 +21,17 @@ const fold = new LangyConversationStateFoldProjection({ store: noopStore });
 const TENANT = createTenantId("project-1");
 const CONVERSATION = "conv-1";
 
-function event(
-  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES,
-  version: string,
-  data: Record<string, unknown>,
-  occurredAt: number,
-): LangyConversationProcessingEvent {
+function event({
+  typeKey,
+  version,
+  data,
+  occurredAt,
+}: {
+  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES;
+  version: string;
+  data: Record<string, unknown>;
+  occurredAt: number;
+}): LangyConversationProcessingEvent {
   return {
     id: `event-${occurredAt}`,
     aggregateId: CONVERSATION,
@@ -44,12 +49,18 @@ const messageSent = (
   data: Record<string, unknown>,
   occurredAt: number,
 ): LangyConversationProcessingEvent =>
-  event(
-    "MESSAGE_RECORDED",
-    LANGY_CONVERSATION_EVENT_VERSIONS.MESSAGE_RECORDED,
-    { userId: "alice", messageId: "m1", role: "user", parts: [], ...data },
+  event({
+    typeKey: "MESSAGE_RECORDED",
+    version: LANGY_CONVERSATION_EVENT_VERSIONS.MESSAGE_RECORDED,
+    data: {
+      userId: "alice",
+      messageId: "m1",
+      role: "user",
+      parts: [],
+      ...data,
+    },
     occurredAt,
-  );
+  });
 
 describe("LangyConversationStateFoldProjection", () => {
   describe("given a fresh conversation", () => {
@@ -57,12 +68,12 @@ describe("LangyConversationStateFoldProjection", () => {
       it("seeds owner and title, active status, and no message yet", () => {
         const state = fold.apply(
           fold.init(),
-          event(
-            "CONVERSATION_STARTED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
-            { userId: "alice", title: "seeded" },
-            1000,
-          ),
+          event({
+            typeKey: "CONVERSATION_STARTED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
+            data: { userId: "alice", title: "seeded" },
+            occurredAt: 1000,
+          }),
         );
 
         expect(state.ConversationId).toBe(CONVERSATION);
@@ -75,12 +86,12 @@ describe("LangyConversationStateFoldProjection", () => {
       it("keeps the original owner when a later message arrives from another user", () => {
         const created = fold.apply(
           fold.init(),
-          event(
-            "CONVERSATION_STARTED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
-            { userId: "alice" },
-            1000,
-          ),
+          event({
+            typeKey: "CONVERSATION_STARTED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
+            data: { userId: "alice" },
+            occurredAt: 1000,
+          }),
         );
         const state = fold.apply(
           created,
@@ -93,12 +104,12 @@ describe("LangyConversationStateFoldProjection", () => {
 
     describe("when it carries a runToken (§0a)", () => {
       const started = (runToken: unknown, occurredAt: number) =>
-        event(
-          "CONVERSATION_STARTED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
-          { userId: "alice", runToken },
+        event({
+          typeKey: "CONVERSATION_STARTED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
+          data: { userId: "alice", runToken },
           occurredAt,
-        );
+        });
 
       it("folds the runToken onto the server-only state column", () => {
         const state = fold.apply(fold.init(), started("rt-secret-abc", 1000));
@@ -166,12 +177,12 @@ describe("LangyConversationStateFoldProjection", () => {
   describe("given an agent turn is in progress", () => {
     const started = fold.apply(
       fold.apply(fold.init(), messageSent({}, 1000)),
-      event(
-        "AGENT_TURN_ACCEPTED",
-        LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
-        { turnId: "turn-1" },
-        1500,
-      ),
+      event({
+        typeKey: "AGENT_TURN_ACCEPTED",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
+        data: { turnId: "turn-1" },
+        occurredAt: 1500,
+      }),
     );
 
     it("marks the conversation running and records the current turn", () => {
@@ -183,18 +194,18 @@ describe("LangyConversationStateFoldProjection", () => {
       it("appends the assistant message, returns to idle, and clears the turn", () => {
         const state = fold.apply(
           started,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               turnId: "turn-1",
               messageId: "a1",
               role: "assistant",
               parts: [],
               outcome: "completed",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
 
         expect(state.MessageCount).toBe(2);
@@ -210,18 +221,18 @@ describe("LangyConversationStateFoldProjection", () => {
       it("keeps the partial answer and returns the conversation to idle, continuable — not failed", () => {
         const state = fold.apply(
           started,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               turnId: "turn-1",
               messageId: "a1",
               role: "assistant",
               parts: [{ type: "text", text: "half an answer" }],
               outcome: "stopped",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
 
         // The conversation spine reads a stop as a non-failed terminal: the
@@ -239,12 +250,12 @@ describe("LangyConversationStateFoldProjection", () => {
       it("fails the conversation and records the error", () => {
         const state = fold.apply(
           started,
-          event(
-            "AGENT_RESPONSE_FAILED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
-            { turnId: "turn-1", error: "worker stopped" },
-            2000,
-          ),
+          event({
+            typeKey: "AGENT_RESPONSE_FAILED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
+            data: { turnId: "turn-1", error: "worker stopped" },
+            occurredAt: 2000,
+          }),
         );
 
         expect(state.Status).toBe(LANGY_CONVERSATION_STATUS.FAILED);
@@ -257,12 +268,12 @@ describe("LangyConversationStateFoldProjection", () => {
       it("ignores it and leaves the in-flight turn untouched", () => {
         const state = fold.apply(
           started,
-          event(
-            "AGENT_RESPONSE_FAILED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
-            { turnId: "turn-0-stale", error: "worker stopped" },
-            2000,
-          ),
+          event({
+            typeKey: "AGENT_RESPONSE_FAILED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
+            data: { turnId: "turn-0-stale", error: "worker stopped" },
+            occurredAt: 2000,
+          }),
         );
 
         expect(state.Status).toBe(LANGY_CONVERSATION_STATUS.RUNNING);
@@ -275,30 +286,30 @@ describe("LangyConversationStateFoldProjection", () => {
       it("keeps the completed answer — idle status, no error", () => {
         const completed = fold.apply(
           started,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               turnId: "turn-1",
               messageId: "a1",
               role: "assistant",
               parts: [],
               outcome: "completed",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
 
         // The late failure for the SAME turn — e.g. a liveness sweep that
         // decided on a stale snapshot. It must not bury the answer.
         const state = fold.apply(
           completed,
-          event(
-            "AGENT_RESPONSE_FAILED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
-            { turnId: "turn-1", error: "worker stopped" },
-            3000,
-          ),
+          event({
+            typeKey: "AGENT_RESPONSE_FAILED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
+            data: { turnId: "turn-1", error: "worker stopped" },
+            occurredAt: 3000,
+          }),
         );
 
         expect(state.Status).toBe(LANGY_CONVERSATION_STATUS.IDLE);
@@ -312,10 +323,10 @@ describe("LangyConversationStateFoldProjection", () => {
       it("records the failure status and error", () => {
         const state = fold.apply(
           started,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               turnId: "turn-1",
               messageId: "a1",
               role: "assistant",
@@ -323,8 +334,8 @@ describe("LangyConversationStateFoldProjection", () => {
               outcome: "failed",
               error: "model timeout",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
 
         expect(state.Status).toBe(LANGY_CONVERSATION_STATUS.FAILED);
@@ -336,7 +347,12 @@ describe("LangyConversationStateFoldProjection", () => {
   describe("given an archived conversation", () => {
     const archived = fold.apply(
       fold.apply(fold.init(), messageSent({}, 1000)),
-      event("ARCHIVED", LANGY_CONVERSATION_EVENT_VERSIONS.ARCHIVED, {}, 3000),
+      event({
+        typeKey: "ARCHIVED",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.ARCHIVED,
+        data: {},
+        occurredAt: 3000,
+      }),
     );
 
     it("flips status to archived and stamps ArchivedAt", () => {
@@ -360,12 +376,12 @@ describe("LangyConversationStateFoldProjection", () => {
       const base = fold.apply(fold.init(), messageSent({ title: "old" }, 1000));
       const state = fold.apply(
         base,
-        event(
-          "METADATA_UPDATED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
-          { title: "new name", isShared: true, sharedById: "alice" },
-          2000,
-        ),
+        event({
+          typeKey: "METADATA_UPDATED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
+          data: { title: "new name", isShared: true, sharedById: "alice" },
+          occurredAt: 2000,
+        }),
       );
 
       expect(state.Title).toBe("new name");
@@ -381,17 +397,17 @@ describe("LangyConversationStateFoldProjection", () => {
       data: Record<string, unknown>,
       occurredAt: number,
     ): LangyConversationProcessingEvent =>
-      event(
-        "TITLE_GENERATED",
-        LANGY_CONVERSATION_EVENT_VERSIONS.TITLE_GENERATED,
-        {
+      event({
+        typeKey: "TITLE_GENERATED",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.TITLE_GENERATED,
+        data: {
           title: "Generated Title",
           source: "auto",
           model: "openai/gpt-5-mini",
           ...data,
         },
         occurredAt,
-      );
+      });
 
     describe("when the first message derives a placeholder title", () => {
       it("records the title source as derived", () => {
@@ -437,12 +453,12 @@ describe("LangyConversationStateFoldProjection", () => {
         );
         const state = fold.apply(
           base,
-          event(
-            "METADATA_UPDATED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
-            { title: "My Own Name" },
-            2000,
-          ),
+          event({
+            typeKey: "METADATA_UPDATED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
+            data: { title: "My Own Name" },
+            occurredAt: 2000,
+          }),
         );
         expect(state.Title).toBe("My Own Name");
         expect(state.TitleSource).toBe(LANGY_TITLE_SOURCE.USER);
@@ -453,12 +469,12 @@ describe("LangyConversationStateFoldProjection", () => {
       it("never overrides the user's title", () => {
         const renamed = fold.apply(
           fold.apply(fold.init(), messageSent({ title: "placeholder" }, 1000)),
-          event(
-            "METADATA_UPDATED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
-            { title: "My Own Name" },
-            2000,
-          ),
+          event({
+            typeKey: "METADATA_UPDATED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.METADATA_UPDATED,
+            data: { title: "My Own Name" },
+            occurredAt: 2000,
+          }),
         );
         const state = fold.apply(renamed, titleGenerated({}, 3000));
         expect(state.Title).toBe("My Own Name");
@@ -487,12 +503,16 @@ describe("LangyConversationStateFoldProjection", () => {
       const base = fold.apply(fold.init(), messageSent({}, 1000));
       const state = fold.apply(
         base,
-        event(
-          "TOOL_CALL_INITIATED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_INITIATED,
-          { turnId: "turn-1", toolCallId: "tc-1", toolName: "search_traces" },
-          1200,
-        ),
+        event({
+          typeKey: "TOOL_CALL_INITIATED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_INITIATED,
+          data: {
+            turnId: "turn-1",
+            toolCallId: "tc-1",
+            toolName: "search_traces",
+          },
+          occurredAt: 1200,
+        }),
       );
 
       expect(state.LastActivityAt).toBe(1200);
@@ -504,22 +524,22 @@ describe("LangyConversationStateFoldProjection", () => {
   describe("given an agent turn in progress that hands off on shutdown (ADR-048)", () => {
     const started = fold.apply(
       fold.apply(fold.init(), messageSent({}, 1000)),
-      event(
-        "AGENT_TURN_ACCEPTED",
-        LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
-        { turnId: "turn-1" },
-        1500,
-      ),
+      event({
+        typeKey: "AGENT_TURN_ACCEPTED",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
+        data: { turnId: "turn-1" },
+        occurredAt: 1500,
+      }),
     );
 
     const handedOff = fold.apply(
       started,
-      event(
-        "CONVERSATION_HANDOFF_PENDING",
-        LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_PENDING,
-        { turnId: "turn-1", token: "opaque-resume-token" },
-        1800,
-      ),
+      event({
+        typeKey: "CONVERSATION_HANDOFF_PENDING",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_PENDING,
+        data: { turnId: "turn-1", token: "opaque-resume-token" },
+        occurredAt: 1800,
+      }),
     );
 
     describe("when the turn checkpoints and hands off", () => {
@@ -539,12 +559,13 @@ describe("LangyConversationStateFoldProjection", () => {
     describe("when the next turn consumes the pending handoff", () => {
       const consumed = fold.apply(
         handedOff,
-        event(
-          "CONVERSATION_HANDOFF_CONSUMED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
-          { turnId: "turn-1" },
-          2000,
-        ),
+        event({
+          typeKey: "CONVERSATION_HANDOFF_CONSUMED",
+          version:
+            LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+          data: { turnId: "turn-1" },
+          occurredAt: 2000,
+        }),
       );
 
       it("clears the pending token", () => {
@@ -555,12 +576,13 @@ describe("LangyConversationStateFoldProjection", () => {
       it("consuming again is a no-op on an already-cleared fold (idempotent)", () => {
         const consumedTwice = fold.apply(
           consumed,
-          event(
-            "CONVERSATION_HANDOFF_CONSUMED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
-            { turnId: "turn-1" },
-            2100,
-          ),
+          event({
+            typeKey: "CONVERSATION_HANDOFF_CONSUMED",
+            version:
+              LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+            data: { turnId: "turn-1" },
+            occurredAt: 2100,
+          }),
         );
         expect(consumedTwice.PendingHandoffToken).toBeNull();
         expect(consumedTwice.PendingHandoffTurnId).toBeNull();

--- a/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationTurn.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationTurn.foldProjection.unit.test.ts
@@ -24,12 +24,17 @@ const TENANT = createTenantId("project-1");
 const CONVERSATION = "conv-1";
 const TURN = "turn-1";
 
-function event(
-  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES,
-  version: string,
-  data: Record<string, unknown>,
-  occurredAt: number,
-): LangyConversationProcessingEvent {
+function event({
+  typeKey,
+  version,
+  data,
+  occurredAt,
+}: {
+  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES;
+  version: string;
+  data: Record<string, unknown>;
+  occurredAt: number;
+}): LangyConversationProcessingEvent {
   return {
     id: `event-${occurredAt}`,
     aggregateId: CONVERSATION,
@@ -44,23 +49,23 @@ function event(
 }
 
 const started = (occurredAt: number) =>
-  event(
-    "AGENT_TURN_ACCEPTED",
-    LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
-    {},
+  event({
+    typeKey: "AGENT_TURN_ACCEPTED",
+    version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
+    data: {},
     occurredAt,
-  );
+  });
 
 const toolInitiated = (
   data: Record<string, unknown>,
   occurredAt: number,
 ): LangyConversationProcessingEvent =>
-  event(
-    "TOOL_CALL_INITIATED",
-    LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_INITIATED,
-    { toolCallId: "tc-1", toolName: "bash", ...data },
+  event({
+    typeKey: "TOOL_CALL_INITIATED",
+    version: LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_INITIATED,
+    data: { toolCallId: "tc-1", toolName: "bash", ...data },
     occurredAt,
-  );
+  });
 
 describe("LangyConversationTurnFoldProjection", () => {
   describe("the composite key", () => {
@@ -92,12 +97,12 @@ describe("LangyConversationTurnFoldProjection", () => {
     it("folds the question parts into the turn document when carried", () => {
       const state = fold.apply(
         fold.init(),
-        event(
-          "AGENT_TURN_ACCEPTED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
-          { questionParts: [{ type: "text", text: "why failing?" }] },
-          1000,
-        ),
+        event({
+          typeKey: "AGENT_TURN_ACCEPTED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
+          data: { questionParts: [{ type: "text", text: "why failing?" }] },
+          occurredAt: 1000,
+        }),
       );
       expect(state.QuestionParts).toEqual([
         { type: "text", text: "why failing?" },
@@ -127,12 +132,12 @@ describe("LangyConversationTurnFoldProjection", () => {
 
         const succeeded = fold.apply(
           initiated,
-          event(
-            "TOOL_CALL_SUCCEEDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_SUCCEEDED,
-            { toolCallId: "tc-1", toolName: "bash", durationMs: 42 },
-            1200,
-          ),
+          event({
+            typeKey: "TOOL_CALL_SUCCEEDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_SUCCEEDED,
+            data: { toolCallId: "tc-1", toolName: "bash", durationMs: 42 },
+            occurredAt: 1200,
+          }),
         );
         expect(succeeded.ToolCalls).toHaveLength(1);
         expect(succeeded.ToolCalls[0]).toMatchObject({
@@ -149,12 +154,12 @@ describe("LangyConversationTurnFoldProjection", () => {
         const initiated = fold.apply(running, toolInitiated({}, 1100));
         const failed = fold.apply(
           initiated,
-          event(
-            "TOOL_CALL_FAILED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_FAILED,
-            { toolCallId: "tc-1", toolName: "bash", errorText: "boom" },
-            1200,
-          ),
+          event({
+            typeKey: "TOOL_CALL_FAILED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_FAILED,
+            data: { toolCallId: "tc-1", toolName: "bash", errorText: "boom" },
+            occurredAt: 1200,
+          }),
         );
         expect(failed.ToolCalls[0]).toMatchObject({
           status: LANGY_TURN_TOOL_CALL_STATUS.FAILED,
@@ -167,12 +172,12 @@ describe("LangyConversationTurnFoldProjection", () => {
       it("still records the tool call", () => {
         const succeeded = fold.apply(
           running,
-          event(
-            "TOOL_CALL_SUCCEEDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_SUCCEEDED,
-            { toolCallId: "tc-9", toolName: "read", durationMs: 5 },
-            1200,
-          ),
+          event({
+            typeKey: "TOOL_CALL_SUCCEEDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.TOOL_CALL_SUCCEEDED,
+            data: { toolCallId: "tc-9", toolName: "read", durationMs: 5 },
+            occurredAt: 1200,
+          }),
         );
         expect(succeeded.ToolCalls).toHaveLength(1);
         expect(succeeded.ToolCalls[0]).toMatchObject({
@@ -190,17 +195,17 @@ describe("LangyConversationTurnFoldProjection", () => {
       it("stores the answer parts and marks the turn completed", () => {
         const state = fold.apply(
           running,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               messageId: "a1",
               role: "assistant",
               parts: [{ type: "text", text: "here is why" }],
               outcome: "completed",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
         expect(state.Status).toBe(LANGY_CONVERSATION_TURN_STATUS.COMPLETED);
         expect(state.AnswerParts).toEqual([
@@ -215,18 +220,18 @@ describe("LangyConversationTurnFoldProjection", () => {
       it("marks the turn failed and carries the error", () => {
         const state = fold.apply(
           running,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               messageId: "a1",
               role: "assistant",
               parts: [],
               outcome: "failed",
               error: "model timeout",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
         expect(state.Status).toBe(LANGY_CONVERSATION_TURN_STATUS.FAILED);
         expect(state.Error).toBe("model timeout");
@@ -238,17 +243,17 @@ describe("LangyConversationTurnFoldProjection", () => {
       it("marks the turn stopped, keeps the partial answer, and is not an error", () => {
         const state = fold.apply(
           running,
-          event(
-            "AGENT_RESPONDED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-            {
+          event({
+            typeKey: "AGENT_RESPONDED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+            data: {
               messageId: "a1",
               role: "assistant",
               parts: [{ type: "text", text: "here is what I had so f" }],
               outcome: "stopped",
             },
-            2000,
-          ),
+            occurredAt: 2000,
+          }),
         );
         // A stop is its own terminal: the partial stays, it renders distinctly
         // from a clean completion, and it is never a red error (ADR-078).
@@ -265,12 +270,12 @@ describe("LangyConversationTurnFoldProjection", () => {
       it("marks the turn failed with the error and no answer parts", () => {
         const state = fold.apply(
           running,
-          event(
-            "AGENT_RESPONSE_FAILED",
-            LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
-            { error: "turn stalled" },
-            2000,
-          ),
+          event({
+            typeKey: "AGENT_RESPONSE_FAILED",
+            version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONSE_FAILED,
+            data: { error: "turn stalled" },
+            occurredAt: 2000,
+          }),
         );
         expect(state.Status).toBe(LANGY_CONVERSATION_TURN_STATUS.FAILED);
         expect(state.Error).toBe("turn stalled");
@@ -285,12 +290,12 @@ describe("LangyConversationTurnFoldProjection", () => {
       items: Array<{ content: string; status: string }>,
       occurredAt: number,
     ) =>
-      event(
-        "PLAN_UPDATED",
-        LANGY_CONVERSATION_EVENT_VERSIONS.PLAN_UPDATED,
-        { items },
+      event({
+        typeKey: "PLAN_UPDATED",
+        version: LANGY_CONVERSATION_EVENT_VERSIONS.PLAN_UPDATED,
+        data: { items },
         occurredAt,
-      );
+      });
 
     it("starts with no plan", () => {
       expect(fold.init().Plan).toBeNull();

--- a/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyRunTokenExclusion.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyRunTokenExclusion.unit.test.ts
@@ -27,12 +27,17 @@ const CONVERSATION = "conv-1";
 const TURN = "turn-1";
 const RUN_TOKEN = "rt-super-secret-never-show-the-client";
 
-function event(
-  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES,
-  version: string,
-  data: Record<string, unknown>,
-  occurredAt: number,
-): LangyConversationProcessingEvent {
+function event({
+  typeKey,
+  version,
+  data,
+  occurredAt,
+}: {
+  typeKey: keyof typeof LANGY_CONVERSATION_EVENT_TYPES;
+  version: string;
+  data: Record<string, unknown>;
+  occurredAt: number;
+}): LangyConversationProcessingEvent {
   return {
     id: `event-${occurredAt}`,
     aggregateId: CONVERSATION,
@@ -60,12 +65,12 @@ const hasRunTokenKey = (o: object) =>
 
 describe("runToken projection exclusion", () => {
   describe("given a conversation created with a runToken", () => {
-    const startedEvent = event(
-      "CONVERSATION_STARTED",
-      LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
-      { userId: "alice", runToken: RUN_TOKEN },
-      1000,
-    );
+    const startedEvent = event({
+      typeKey: "CONVERSATION_STARTED",
+      version: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_STARTED,
+      data: { userId: "alice", runToken: RUN_TOKEN },
+      occurredAt: 1000,
+    });
 
     it("keeps the token on the server-only state fold", () => {
       const state = new LangyConversationStateFoldProjection({
@@ -84,16 +89,16 @@ describe("runToken projection exclusion", () => {
       // the runToken — the turn fold has no field for it — but assert on the
       // serialised doc so a future leak (a stray field, a spread of state) fails.
       for (const e of [
-        event(
-          "AGENT_TURN_ACCEPTED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
-          { turnId: TURN },
-          2000,
-        ),
-        event(
-          "AGENT_RESPONDED",
-          LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
-          {
+        event({
+          typeKey: "AGENT_TURN_ACCEPTED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_ACCEPTED,
+          data: { turnId: TURN },
+          occurredAt: 2000,
+        }),
+        event({
+          typeKey: "AGENT_RESPONDED",
+          version: LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_RESPONDED,
+          data: {
             turnId: TURN,
             messageId: "m1",
             role: "assistant",
@@ -101,8 +106,8 @@ describe("runToken projection exclusion", () => {
             outcome: "completed",
             error: null,
           },
-          3000,
-        ),
+          occurredAt: 3000,
+        }),
       ]) {
         doc = turn.apply(doc, e);
       }

--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/pipeline.ts
@@ -116,16 +116,16 @@ export function createSimulationProcessingPipeline(
     .withCommand("finishRun", FinishRunCommand)
     .withCommand("cancelRun", CancelRunCommand)
     .withCommand("deleteRun", DeleteRunCommand)
-    .withCommandInstance(
-      "computeRunMetrics",
-      ComputeRunMetricsCommand,
-      deps.computeRunMetricsCommand,
-      {
+    .withCommandInstance({
+      name: "computeRunMetrics",
+      handlerClass: ComputeRunMetricsCommand,
+      instance: deps.computeRunMetricsCommand,
+      options: {
         deduplication: {
           makeId: ComputeRunMetricsCommand.makeJobId,
           ttlMs: 60_000,
         },
       },
-    )
+    })
     .build();
 }

--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -345,9 +345,9 @@ export class SimulationRunStateFoldProjection
       LastSnapshotOccurredAt: event.occurredAt,
       Messages: event.data.messages.map((m, i) => {
         if (!isRecord(m)) {
-          throw new ValidationError(
-            `Simulation ${state.ScenarioRunId} failed with invalid message on index ${i}`,
-          );
+          throw new ValidationError({
+            reason: `Simulation ${state.ScenarioRunId} failed with invalid message on index ${i}`,
+          });
         }
 
         // Content can be either:

--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -137,13 +137,19 @@ export class SimulationRunStateRepositoryClickHouse<
     };
   }
 
-  private mapProjectionDataToClickHouseRecord(
-    data: SimulationRunStateData,
-    tenantId: string,
-    projectionId: string,
-    projectionVersion: string,
-    scenarioRunId: string,
-  ): ClickHouseSimulationRunWriteRecord {
+  private mapProjectionDataToClickHouseRecord({
+    data,
+    tenantId,
+    projectionId,
+    projectionVersion,
+    scenarioRunId,
+  }: {
+    data: SimulationRunStateData;
+    tenantId: string;
+    projectionId: string;
+    projectionVersion: string;
+    scenarioRunId: string;
+  }): ClickHouseSimulationRunWriteRecord {
     return {
       ProjectionId: projectionId,
       TenantId: tenantId,
@@ -295,14 +301,14 @@ export class SimulationRunStateRepositoryClickHouse<
         { scenarioRunId, tenantId: context.tenantId, error: errorMessage },
         "Failed to get projection from ClickHouse",
       );
-      throw new StoreError(
-        "getProjection",
-        "SimulationRunStateRepositoryClickHouse",
-        `Failed to get projection for scenario run ${scenarioRunId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { scenarioRunId },
-        error,
-      );
+      throw new StoreError({
+        operation: "getProjection",
+        store: "SimulationRunStateRepositoryClickHouse",
+        message: `Failed to get projection for scenario run ${scenarioRunId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { scenarioRunId },
+        cause: error,
+      });
     }
   }
 
@@ -316,31 +322,32 @@ export class SimulationRunStateRepositoryClickHouse<
     );
 
     if (!EventUtils.isValidProjection(projection)) {
-      throw new ValidationError(
-        "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
-        "projection",
-        projection,
-      );
+      throw new ValidationError({
+        reason:
+          "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
+        field: "projection",
+        value: projection,
+      });
     }
 
     if (projection.tenantId !== context.tenantId) {
-      throw new SecurityError(
-        "storeProjection",
-        `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-        projection.tenantId,
-        { contextTenantId: context.tenantId },
-      );
+      throw new SecurityError({
+        operation: "storeProjection",
+        message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+        tenantId: projection.tenantId,
+        context: { contextTenantId: context.tenantId },
+      });
     }
 
     try {
       const scenarioRunId = String(projection.aggregateId);
-      const projectionRecord = this.mapProjectionDataToClickHouseRecord(
-        projection.data as SimulationRunStateData,
-        String(context.tenantId),
-        projection.id,
-        projection.version,
+      const projectionRecord = this.mapProjectionDataToClickHouseRecord({
+        data: projection.data as SimulationRunStateData,
+        tenantId: String(context.tenantId),
+        projectionId: projection.id,
+        projectionVersion: projection.version,
         scenarioRunId,
-      );
+      });
 
       const retentionPolicy = context.metadata?.retentionPolicy as
         | { scenarios?: number | null }
@@ -370,17 +377,17 @@ export class SimulationRunStateRepositoryClickHouse<
         },
         "Failed to store projection in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjection",
-        "SimulationRunStateRepositoryClickHouse",
-        `Failed to store projection ${projection.id} for scenario run ${projection.aggregateId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        {
+      throw new StoreError({
+        operation: "storeProjection",
+        store: "SimulationRunStateRepositoryClickHouse",
+        message: `Failed to store projection ${projection.id} for scenario run ${projection.aggregateId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: {
           projectionId: projection.id,
           scenarioRunId: String(projection.aggregateId),
         },
-        error,
-      );
+        cause: error,
+      });
     }
   }
 
@@ -397,12 +404,12 @@ export class SimulationRunStateRepositoryClickHouse<
 
     for (const projection of projections) {
       if (projection.tenantId !== context.tenantId) {
-        throw new SecurityError(
-          "storeProjectionBatch",
-          `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-          projection.tenantId,
-          { contextTenantId: context.tenantId },
-        );
+        throw new SecurityError({
+          operation: "storeProjectionBatch",
+          message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+          tenantId: projection.tenantId,
+          context: { contextTenantId: context.tenantId },
+        });
       }
     }
 
@@ -414,13 +421,13 @@ export class SimulationRunStateRepositoryClickHouse<
         retentionPolicy?.scenarios ?? PLATFORM_DEFAULT_RETENTION_DAYS;
       const records = projections.map((projection) => {
         const scenarioRunId = String(projection.aggregateId);
-        const record = this.mapProjectionDataToClickHouseRecord(
-          projection.data as SimulationRunStateData,
-          String(context.tenantId),
-          projection.id,
-          projection.version,
+        const record = this.mapProjectionDataToClickHouseRecord({
+          data: projection.data as SimulationRunStateData,
+          tenantId: String(context.tenantId),
+          projectionId: projection.id,
+          projectionVersion: projection.version,
           scenarioRunId,
-        );
+        });
         record._retention_days = retentionDays;
         return record;
       });
@@ -443,14 +450,14 @@ export class SimulationRunStateRepositoryClickHouse<
         },
         "Failed to batch store simulation projections in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjectionBatch",
-        "SimulationRunStateRepositoryClickHouse",
-        `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { count: projections.length },
-        error,
-      );
+      throw new StoreError({
+        operation: "storeProjectionBatch",
+        store: "SimulationRunStateRepositoryClickHouse",
+        message: `Failed to batch store ${projections.length} projections: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { count: projections.length },
+        cause: error,
+      });
     }
   }
 }

--- a/platform/app/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
@@ -87,12 +87,17 @@ export class SuiteRunStateRepositoryClickHouse<
     };
   }
 
-  private mapProjectionDataToClickHouseRecord(
-    data: SuiteRunStateData,
-    tenantId: string,
-    projectionId: string,
-    projectionVersion: string,
-  ): ClickHouseSuiteRunWriteRecord {
+  private mapProjectionDataToClickHouseRecord({
+    data,
+    tenantId,
+    projectionId,
+    projectionVersion,
+  }: {
+    data: SuiteRunStateData;
+    tenantId: string;
+    projectionId: string;
+    projectionVersion: string;
+  }): ClickHouseSuiteRunWriteRecord {
     return {
       ProjectionId: projectionId,
       TenantId: tenantId,
@@ -192,14 +197,14 @@ export class SuiteRunStateRepositoryClickHouse<
         { batchRunId, tenantId: context.tenantId, error: errorMessage },
         "Failed to get projection from ClickHouse",
       );
-      throw new StoreError(
-        "getProjection",
-        "SuiteRunStateRepositoryClickHouse",
-        `Failed to get projection for batch run ${batchRunId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { batchRunId },
-        error,
-      );
+      throw new StoreError({
+        operation: "getProjection",
+        store: "SuiteRunStateRepositoryClickHouse",
+        message: `Failed to get projection for batch run ${batchRunId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { batchRunId },
+        cause: error,
+      });
     }
   }
 
@@ -213,30 +218,31 @@ export class SuiteRunStateRepositoryClickHouse<
     );
 
     if (!EventUtils.isValidProjection(projection)) {
-      throw new ValidationError(
-        "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
-        "projection",
-        projection,
-      );
+      throw new ValidationError({
+        reason:
+          "Invalid projection: projection must have id, aggregateId, tenantId, version, and data",
+        field: "projection",
+        value: projection,
+      });
     }
 
     if (projection.tenantId !== context.tenantId) {
-      throw new SecurityError(
-        "storeProjection",
-        `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-        projection.tenantId,
-        { contextTenantId: context.tenantId },
-      );
+      throw new SecurityError({
+        operation: "storeProjection",
+        message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+        tenantId: projection.tenantId,
+        context: { contextTenantId: context.tenantId },
+      });
     }
 
     try {
       const client = await this.resolveClient(context.tenantId);
-      const projectionRecord = this.mapProjectionDataToClickHouseRecord(
-        projection.data as SuiteRunStateData,
-        String(context.tenantId),
-        projection.id,
-        projection.version,
-      );
+      const projectionRecord = this.mapProjectionDataToClickHouseRecord({
+        data: projection.data as SuiteRunStateData,
+        tenantId: String(context.tenantId),
+        projectionId: projection.id,
+        projectionVersion: projection.version,
+      });
 
       const retentionPolicy = context.metadata?.retentionPolicy as
         | { scenarios?: number | null }
@@ -262,17 +268,17 @@ export class SuiteRunStateRepositoryClickHouse<
         },
         "Failed to store projection in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjection",
-        "SuiteRunStateRepositoryClickHouse",
-        `Failed to store projection ${projection.id} for batch run ${projection.aggregateId}: ${errorMessage}`,
-        classifyClickHouseError(error),
-        {
+      throw new StoreError({
+        operation: "storeProjection",
+        store: "SuiteRunStateRepositoryClickHouse",
+        message: `Failed to store projection ${projection.id} for batch run ${projection.aggregateId}: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: {
           projectionId: projection.id,
           batchRunId: String(projection.aggregateId),
         },
-        error,
-      );
+        cause: error,
+      });
     }
   }
 
@@ -289,12 +295,12 @@ export class SuiteRunStateRepositoryClickHouse<
 
     for (const projection of projections) {
       if (projection.tenantId !== context.tenantId) {
-        throw new SecurityError(
-          "storeProjectionBatch",
-          `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
-          projection.tenantId,
-          { contextTenantId: context.tenantId },
-        );
+        throw new SecurityError({
+          operation: "storeProjectionBatch",
+          message: `Projection has tenantId '${projection.tenantId}' that does not match context tenantId '${context.tenantId}'`,
+          tenantId: projection.tenantId,
+          context: { contextTenantId: context.tenantId },
+        });
       }
     }
 
@@ -305,12 +311,12 @@ export class SuiteRunStateRepositoryClickHouse<
       const retentionDays =
         retentionPolicy?.scenarios ?? PLATFORM_DEFAULT_RETENTION_DAYS;
       const records = projections.map((projection) => {
-        const record = this.mapProjectionDataToClickHouseRecord(
-          projection.data as SuiteRunStateData,
-          String(context.tenantId),
-          projection.id,
-          projection.version,
-        );
+        const record = this.mapProjectionDataToClickHouseRecord({
+          data: projection.data as SuiteRunStateData,
+          tenantId: String(context.tenantId),
+          projectionId: projection.id,
+          projectionVersion: projection.version,
+        });
         record._retention_days = retentionDays;
         return record;
       });
@@ -333,14 +339,14 @@ export class SuiteRunStateRepositoryClickHouse<
         },
         "Failed to batch store suite projections in ClickHouse",
       );
-      throw new StoreError(
-        "storeProjectionBatch",
-        "SuiteRunStateRepositoryClickHouse",
-        `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        classifyClickHouseError(error),
-        { count: projections.length },
-        error,
-      );
+      throw new StoreError({
+        operation: "storeProjectionBatch",
+        store: "SuiteRunStateRepositoryClickHouse",
+        message: `Failed to batch store ${projections.length} projections: ${errorMessage}`,
+        category: classifyClickHouseError(error),
+        context: { count: projections.length },
+        cause: error,
+      });
     }
   }
 }

--- a/platform/app/src/server/event-sourcing/pipelines/topic-clustering-processing/process-manager/__tests__/topicClusteringIntentHandlers.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/topic-clustering-processing/process-manager/__tests__/topicClusteringIntentHandlers.unit.test.ts
@@ -254,16 +254,14 @@ describe("createTopicClusteringRunHandler", () => {
       const commands = makeCommands();
       const run = createTopicClusteringRunHandler({
         runPort: {
-          runClusteringPage: vi
-            .fn()
-            .mockRejectedValue(
-              new ModelNotConfiguredError(
-                "analytics.topic_clustering_llm",
-                "FAST",
-                "Topic clustering",
-                "project-1",
-              ),
-            ),
+          runClusteringPage: vi.fn().mockRejectedValue(
+            new ModelNotConfiguredError({
+              featureKey: "analytics.topic_clustering_llm",
+              role: "FAST",
+              featureDisplayName: "Topic clustering",
+              projectId: "project-1",
+            }),
+          ),
         },
         commands: () => commands,
         clock: () => 999,

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
@@ -18,13 +18,19 @@ import {
   type RecordSpanCommandDependencies,
 } from "../recordSpanCommand";
 
-function createMockCommand(
-  tenantId: string,
-  traceId: string,
-  spanId: string,
-  attributes: Array<{ key: string; value: { stringValue?: string } }> = [],
-  piiRedactionLevel?: PIIRedactionLevel,
-): Command<RecordSpanCommandData> {
+function createMockCommand({
+  tenantId,
+  traceId,
+  spanId,
+  attributes = [],
+  piiRedactionLevel,
+}: {
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+  attributes?: Array<{ key: string; value: { stringValue?: string } }>;
+  piiRedactionLevel?: PIIRedactionLevel;
+}): Command<RecordSpanCommandData> {
   return {
     type: RECORD_SPAN_COMMAND_TYPE,
     aggregateId: traceId,
@@ -107,54 +113,63 @@ describe("RecordSpanCommand", () => {
   describe("handle", () => {
     describe("PII redaction", () => {
       it("calls PII redaction service with piiRedactionLevel from command", async () => {
-        const command = createMockCommand(
-          "project-123",
-          "trace-1",
-          "span-1",
-          [{ key: "gen_ai.prompt", value: { stringValue: "sensitive data" } }],
-          "STRICT",
-        );
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            { key: "gen_ai.prompt", value: { stringValue: "sensitive data" } },
+          ],
+          piiRedactionLevel: "STRICT",
+        });
 
         await handler.handle(command);
 
-        expect(mockRedactSpan).toHaveBeenCalledWith(
-          expect.objectContaining({ traceId: "trace-1", spanId: "span-1" }),
-          expect.any(Object),
-          "STRICT",
-          "project-123",
-        );
+        expect(mockRedactSpan).toHaveBeenCalledWith({
+          span: expect.objectContaining({
+            traceId: "trace-1",
+            spanId: "span-1",
+          }),
+          resource: expect.any(Object),
+          piiRedactionLevel: "STRICT",
+          tenantId: "project-123",
+        });
       });
 
       it("defaults to ESSENTIAL when piiRedactionLevel is not provided", async () => {
-        const command = createMockCommand("project-456", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-456",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
 
         await handler.handle(command);
 
-        expect(mockRedactSpan).toHaveBeenCalledWith(
-          expect.any(Object),
-          expect.anything(),
-          "ESSENTIAL",
-          "project-456",
-        );
+        expect(mockRedactSpan).toHaveBeenCalledWith({
+          span: expect.any(Object),
+          resource: expect.anything(),
+          piiRedactionLevel: "ESSENTIAL",
+          tenantId: "project-456",
+        });
       });
 
       it("uses DISABLED level when specified", async () => {
-        const command = createMockCommand(
-          "project-789",
-          "trace-1",
-          "span-1",
-          [],
-          "DISABLED",
-        );
+        const command = createMockCommand({
+          tenantId: "project-789",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [],
+          piiRedactionLevel: "DISABLED",
+        });
 
         await handler.handle(command);
 
-        expect(mockRedactSpan).toHaveBeenCalledWith(
-          expect.any(Object),
-          expect.anything(),
-          "DISABLED",
-          "project-789",
-        );
+        expect(mockRedactSpan).toHaveBeenCalledWith({
+          span: expect.any(Object),
+          resource: expect.anything(),
+          piiRedactionLevel: "DISABLED",
+          tenantId: "project-789",
+        });
       });
     });
 
@@ -164,7 +179,11 @@ describe("RecordSpanCommand", () => {
         mockRedactSpan.mockRejectedValue(new Error("PII service unavailable"));
         const cmd = new RecordSpanCommand(deps);
 
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
 
         await expect(cmd.handle(command)).rejects.toThrow(
           "PII service unavailable",
@@ -176,7 +195,11 @@ describe("RecordSpanCommand", () => {
         mockEnrichSpan.mockRejectedValue(new Error("Cost API timeout"));
         const cmd = new RecordSpanCommand(deps);
 
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
 
         const events = await cmd.handle(command);
 
@@ -191,7 +214,11 @@ describe("RecordSpanCommand", () => {
         mockEnrichSpan.mockRejectedValue(new Error("Cost failure"));
         const cmd = new RecordSpanCommand(deps);
 
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
 
         await expect(cmd.handle(command)).rejects.toThrow("PII failure");
       });
@@ -201,8 +228,15 @@ describe("RecordSpanCommand", () => {
       it("creates SpanReceivedEvent with redacted span data", async () => {
         // Mock redactSpan to mutate the span (simulating redaction)
         mockRedactSpan.mockImplementation(
-          async (span: {
-            attributes: Array<{ key: string; value: { stringValue?: string } }>;
+          async ({
+            span,
+          }: {
+            span: {
+              attributes: Array<{
+                key: string;
+                value: { stringValue?: string };
+              }>;
+            };
           }) => {
             const attr = span.attributes.find((a) => a.key === "gen_ai.prompt");
             if (attr?.value.stringValue) {
@@ -211,13 +245,15 @@ describe("RecordSpanCommand", () => {
           },
         );
 
-        const command = createMockCommand(
-          "project-123",
-          "trace-1",
-          "span-1",
-          [{ key: "gen_ai.prompt", value: { stringValue: "sensitive" } }],
-          "STRICT",
-        );
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            { key: "gen_ai.prompt", value: { stringValue: "sensitive" } },
+          ],
+          piiRedactionLevel: "STRICT",
+        });
 
         const events = await handler.handle(command);
 
@@ -231,11 +267,11 @@ describe("RecordSpanCommand", () => {
       });
 
       it("creates valid SpanReceivedEvent structure", async () => {
-        const command = createMockCommand(
-          "project-123",
-          "trace-abc",
-          "span-def",
-        );
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-abc",
+          spanId: "span-def",
+        });
 
         const events = await handler.handle(command);
 
@@ -250,11 +286,17 @@ describe("RecordSpanCommand", () => {
       });
 
       it("does not mutate the original command data", async () => {
-        mockRedactSpan.mockImplementation(async (span: { name: string }) => {
-          span.name = "[REDACTED]";
-        });
+        mockRedactSpan.mockImplementation(
+          async ({ span }: { span: { name: string } }) => {
+            span.name = "[REDACTED]";
+          },
+        );
 
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
         const originalName = command.data.span.name;
 
         await handler.handle(command);
@@ -266,13 +308,18 @@ describe("RecordSpanCommand", () => {
 
     describe("when reserved attributes are present", () => {
       it("strips langwatch.reserved.* attributes from span before processing", async () => {
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          {
-            key: "langwatch.reserved.pii_redaction_status",
-            value: { stringValue: "true" },
-          },
-          { key: "gen_ai.prompt", value: { stringValue: "hello" } },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            {
+              key: "langwatch.reserved.pii_redaction_status",
+              value: { stringValue: "true" },
+            },
+            { key: "gen_ai.prompt", value: { stringValue: "hello" } },
+          ],
+        });
 
         const events = await handler.handle(command);
 
@@ -289,7 +336,11 @@ describe("RecordSpanCommand", () => {
       });
 
       it("strips langwatch.reserved.* attributes from events", async () => {
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
         command.data.span.events = [
           {
             timeUnixNano: { low: 0, high: 0 },
@@ -318,17 +369,22 @@ describe("RecordSpanCommand", () => {
         // The fix is a passthrough allowlist; this test pins the
         // attribute name as load-bearing — renaming or removing the
         // entry would silently re-break loop prevention in production.
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          {
-            key: "langwatch.reserved.causality_depth",
-            value: { stringValue: "1" },
-          },
-          {
-            key: "langwatch.reserved.pii_redaction_status",
-            value: { stringValue: "true" },
-          },
-          { key: "gen_ai.prompt", value: { stringValue: "hello" } },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            {
+              key: "langwatch.reserved.causality_depth",
+              value: { stringValue: "1" },
+            },
+            {
+              key: "langwatch.reserved.pii_redaction_status",
+              value: { stringValue: "true" },
+            },
+            { key: "gen_ai.prompt", value: { stringValue: "hello" } },
+          ],
+        });
 
         const events = await handler.handle(command);
 
@@ -353,12 +409,17 @@ describe("RecordSpanCommand", () => {
         // the meter, and the trace-summary fold reads the stamp to count
         // the usage once. Stripping it would silently double every Langy
         // turn's token/cost totals.
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          {
-            key: "langwatch.reserved.skip_token_accumulation",
-            value: { stringValue: "true" },
-          },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            {
+              key: "langwatch.reserved.skip_token_accumulation",
+              value: { stringValue: "true" },
+            },
+          ],
+        });
 
         const events = await handler.handle(command);
 
@@ -371,12 +432,17 @@ describe("RecordSpanCommand", () => {
       });
 
       it("preserves original command data when stripping reserved attributes", async () => {
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          {
-            key: "langwatch.reserved.something",
-            value: { stringValue: "value" },
-          },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            {
+              key: "langwatch.reserved.something",
+              value: { stringValue: "value" },
+            },
+          ],
+        });
 
         await handler.handle(command);
 
@@ -394,7 +460,11 @@ describe("RecordSpanCommand", () => {
       // namespaces, so a provenance name that lands in one is deleted between
       // the receiver writing it and the span being stored.
       async function emittedResourceAfterReceiver(apiKeyId: string | null) {
-        const command = createMockCommand("project-123", "trace-1", "span-1");
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+        });
         const request = {
           resourceSpans: [{ resource: command.data.resource }],
         };
@@ -439,9 +509,14 @@ describe("RecordSpanCommand", () => {
     describe("when an attribute value is oversized", () => {
       it("caps a multi-MB base64 image attribute on the emitted span", async () => {
         const bigDataUrl = `data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`;
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          { key: "langwatch.input", value: { stringValue: bigDataUrl } },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            { key: "langwatch.input", value: { stringValue: bigDataUrl } },
+          ],
+        });
 
         const events = await handler.handle(command);
 
@@ -461,9 +536,14 @@ describe("RecordSpanCommand", () => {
       });
 
       it("leaves a normal small span attribute unchanged", async () => {
-        const command = createMockCommand("project-123", "trace-1", "span-1", [
-          { key: "langwatch.input", value: { stringValue: "what is 2+2?" } },
-        ]);
+        const command = createMockCommand({
+          tenantId: "project-123",
+          traceId: "trace-1",
+          spanId: "span-1",
+          attributes: [
+            { key: "langwatch.input", value: { stringValue: "what is 2+2?" } },
+          ],
+        });
 
         const events = await handler.handle(command);
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -282,12 +282,12 @@ export class RecordSpanCommand
         // Run PII redaction, cost enrichment, and token estimation in parallel.
         // Safe: PII modifies existing attr values; cost and tokens push new entries.
         const [piiResult, costResult, tokenResult] = await Promise.allSettled([
-          this.deps.piiRedactionService.redactSpan(
-            spanToProcess,
-            resourceToProcess,
+          this.deps.piiRedactionService.redactSpan({
+            span: spanToProcess,
+            resource: resourceToProcess,
             piiRedactionLevel,
             tenantId,
-          ),
+          }),
           this.deps.costEnrichmentService.enrichSpan(
             spanToProcess,
             tenantIdStr,

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -315,12 +315,12 @@ export function createTraceProcessingPipeline(
   // (no spool support) when blobStore is absent. Either way the recordSpan
   // command carries the dedup config and span-command sharding from main.
   const recordSpanBuilder = deps.blobStore
-    ? builder.withCommandInstance(
-        "recordSpan",
-        RecordSpanCommand,
-        new RecordSpanCommand({ blobStore: deps.blobStore }),
-        recordSpanOptions,
-      )
+    ? builder.withCommandInstance({
+        name: "recordSpan",
+        handlerClass: RecordSpanCommand,
+        instance: new RecordSpanCommand({ blobStore: deps.blobStore }),
+        options: recordSpanOptions,
+      })
     : builder.withCommand("recordSpan", RecordSpanCommand, recordSpanOptions);
 
   return recordSpanBuilder

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/scenarioRoleMetricsDerivation.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/scenarioRoleMetricsDerivation.unit.test.ts
@@ -36,12 +36,17 @@ function llmSpan(spanId: string, parentSpanId: string | null): NormalizedSpan {
   });
 }
 
-function agentSpan(
-  spanId: string,
-  parentSpanId: string | null,
-  role: string,
+function agentSpan({
+  spanId,
+  parentSpanId,
+  role,
   durationMs = 3000,
-): NormalizedSpan {
+}: {
+  spanId: string;
+  parentSpanId: string | null;
+  role: string;
+  durationMs?: number;
+}): NormalizedSpan {
   return createTestSpan({
     id: spanId,
     spanId,
@@ -225,9 +230,19 @@ describe("aggregateScenarioRoleMetrics", () => {
 });
 
 describe("deriveScenarioRoleMetricsFromSpans", () => {
-  const userAgent = agentSpan("user-agent", null, "user", 1500);
+  const userAgent = agentSpan({
+    spanId: "user-agent",
+    parentSpanId: null,
+    role: "user",
+    durationMs: 1500,
+  });
   const userLlm = llmSpan("user-llm", "user-agent");
-  const asstAgent = agentSpan("asst-agent", null, "assistant", 2500);
+  const asstAgent = agentSpan({
+    spanId: "asst-agent",
+    parentSpanId: null,
+    role: "assistant",
+    durationMs: 2500,
+  });
   const asstLlm = llmSpan("asst-llm", "asst-agent");
   const asstNestedLlm = llmSpan("asst-nested", "asst-llm");
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.mapProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.mapProjection.ts
@@ -56,12 +56,12 @@ export class SpanStorageMapProjection
   }
 
   mapTraceSpanReceived(event: SpanReceivedEvent): NormalizedSpan {
-    const span = spanNormalizationPipelineService.normalizeSpanReceived(
-      event.tenantId,
-      event.data.span,
-      event.data.resource,
-      event.data.instrumentationScope,
-    );
+    const span = spanNormalizationPipelineService.normalizeSpanReceived({
+      tenantId: event.tenantId,
+      otlpSpan: event.data.span,
+      otlpResource: event.data.resource,
+      otlpInstrumentationScope: event.data.instrumentationScope,
+    });
     enrichRagContextIds(span);
     // Compute the per-span cost the same way the trace-summary fold does (same
     // SpanCostService, run on the same normalized span the fold sees) so the

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.foldProjection.ts
@@ -1298,12 +1298,12 @@ export class TraceAnalyticsFoldProjection
     }
 
     const normalizedSpan =
-      spanNormalizationPipelineService.normalizeSpanReceived(
-        event.tenantId,
-        event.data.span,
-        event.data.resource,
-        event.data.instrumentationScope,
-      );
+      spanNormalizationPipelineService.normalizeSpanReceived({
+        tenantId: event.tenantId,
+        otlpSpan: event.data.span,
+        otlpResource: event.data.resource,
+        otlpInstrumentationScope: event.data.instrumentationScope,
+      });
     enrichRagContextIds(normalizedSpan);
 
     return applySpanToAnalytics({ state, span: normalizedSpan });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalyticsRollup.mapProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceAnalyticsRollup.mapProjection.ts
@@ -109,12 +109,12 @@ export class TraceAnalyticsRollupMapProjection
     // so the rollup contribution matches the trace total to the cent. Reusing
     // the pipeline service guarantees we never drift from the canonical
     // SpanAttributes shape the fold reads.
-    const span = spanNormalizationPipelineService.normalizeSpanReceived(
-      event.tenantId,
-      event.data.span,
-      event.data.resource,
-      event.data.instrumentationScope,
-    );
+    const span = spanNormalizationPipelineService.normalizeSpanReceived({
+      tenantId: event.tenantId,
+      otlpSpan: event.data.span,
+      otlpResource: event.data.resource,
+      otlpInstrumentationScope: event.data.instrumentationScope,
+    });
     enrichRagContextIds(span);
 
     const isRoot = span.parentSpanId === null;

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -703,12 +703,12 @@ export class TraceSummaryFoldProjection
     }
 
     const normalizedSpan =
-      spanNormalizationPipelineService.normalizeSpanReceived(
-        event.tenantId,
-        event.data.span,
-        event.data.resource,
-        event.data.instrumentationScope,
-      );
+      spanNormalizationPipelineService.normalizeSpanReceived({
+        tenantId: event.tenantId,
+        otlpSpan: event.data.span,
+        otlpResource: event.data.resource,
+        otlpInstrumentationScope: event.data.instrumentationScope,
+      });
     enrichRagContextIds(normalizedSpan);
 
     return {

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/id.utils.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/id.utils.ts
@@ -52,20 +52,25 @@ function generateDeterministicSpanRecordId(event: SpanReceivedEvent): string {
   const startTimeUnixMs = TraceRequestUtils.convertUnixNanoToUnixMs(
     TraceRequestUtils.normalizeOtlpUnixNano(event.data.span.startTimeUnixNano),
   );
-  return generateDeterministicSpanRecordIdFromData(
-    String(event.tenantId),
+  return generateDeterministicSpanRecordIdFromData({
+    tenantId: String(event.tenantId),
     traceId,
     spanId,
     startTimeUnixMs,
-  );
+  });
 }
 
-function generateDeterministicSpanRecordIdFromData(
-  tenantId: string,
-  traceId: string,
-  spanId: string,
-  startTimeUnixMs: number,
-): string {
+function generateDeterministicSpanRecordIdFromData({
+  tenantId,
+  traceId,
+  spanId,
+  startTimeUnixMs,
+}: {
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+  startTimeUnixMs: number;
+}): string {
   EventUtils.validateTenantId(
     { tenantId },
     "generateDeterministicSpanRecordIdFromData",

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
@@ -50,16 +50,13 @@ describe("fold failures after the state was stored", () => {
 
   const events = (count: number): Event[] =>
     Array.from({ length: count }, (_, i) =>
-      createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        undefined,
-        1_000 + i,
-        undefined,
-        undefined,
-        `event-${i}`,
-      ),
+        createdAt: 1_000 + i,
+        id: `event-${i}`,
+      }),
     );
 
   /**
@@ -75,11 +72,11 @@ describe("fold failures after the state was stored", () => {
     shouldStoreFail?: boolean;
   }): ReturnType<typeof vi.fn> {
     const queueManager = createMockQueueManager({ hasReactorQueues: false });
-    const router = new ProjectionRouter<Event>(
-      TEST_CONSTANTS.AGGREGATE_TYPE,
-      TEST_CONSTANTS.PIPELINE_NAME,
+    const router = new ProjectionRouter<Event>({
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+      pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
       queueManager,
-    );
+    });
 
     const store = createMockFoldProjectionStore<{ count: number }>();
     (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -115,7 +112,8 @@ describe("fold failures after the state was stored", () => {
     shouldReactorFail?: boolean;
     shouldStoreFail?: boolean;
   }): Promise<unknown> {
-    const onEventBatch = buildFoldQueues(options).mock.calls[0]?.[2] as (
+    const onEventBatch = buildFoldQueues(options).mock.calls[0]?.[0]
+      ?.onEventBatch as (
       projectionName: string,
       events: Event[],
       context: unknown,
@@ -132,7 +130,7 @@ describe("fold failures after the state was stored", () => {
     shouldReactorFail?: boolean;
     shouldStoreFail?: boolean;
   }): Promise<unknown> {
-    const onEvent = buildFoldQueues(options).mock.calls[0]?.[1] as (
+    const onEvent = buildFoldQueues(options).mock.calls[0]?.[0]?.onEvent as (
       projectionName: string,
       event: Event,
       context: unknown,

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.durableDedup.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.durableDedup.unit.test.ts
@@ -31,16 +31,14 @@ describe("FoldProjectionExecutor durable dedup", () => {
   const init = (): FoldState => ({ ids: [], LastEventOccurredAt: 0 });
 
   function makeEvent(id: string, createdAt: number): Event {
-    return createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    return createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
       createdAt,
-      undefined,
-      {},
+      data: {},
       id,
-    );
+    });
   }
 
   /**

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.readWindow.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.readWindow.unit.test.ts
@@ -82,13 +82,12 @@ describe("FoldProjectionExecutor declared read window", () => {
   });
 
   const eventAt = (occurredAt: number) =>
-    createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
-      occurredAt,
-    );
+      createdAt: occurredAt,
+    });
 
   describe("given the fold declares a read window", () => {
     describe("when the windowed read hits", () => {

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
@@ -78,13 +78,12 @@ describe("FoldProjectionExecutor out-of-order re-fold", () => {
   let executor: FoldProjectionExecutor;
 
   const eventAt = (occurredAt: number) =>
-    createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
-      occurredAt,
-    );
+      createdAt: occurredAt,
+    });
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
@@ -41,16 +41,14 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
   };
 
   function makeEvent(id: string, createdAt: number): Event {
-    return createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    return createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
       createdAt,
-      undefined,
-      {},
+      data: {},
       id,
-    );
+    });
   }
 
   beforeEach(() => {
@@ -394,16 +392,14 @@ describe("FoldProjectionExecutor refoldOnStoreMiss instrumentation", () => {
     describe("when the executor re-folds it", () => {
       it("counts the refold as performed", async () => {
         const executor = new FoldProjectionExecutor();
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          undefined,
-          2000,
-          undefined,
-          {},
-          "e2",
-        );
+          createdAt: 2000,
+          data: {},
+          id: "e2",
+        });
         const foldDef = missingStoreFold("counted-performed");
         foldDef.eventLoaderUpTo = vi.fn().mockResolvedValue([event]);
         const before = await refoldCount("counted-performed", "performed");
@@ -421,16 +417,14 @@ describe("FoldProjectionExecutor refoldOnStoreMiss instrumentation", () => {
     describe("when the executor falls through to init", () => {
       it("counts it as absent rather than as transitional debt", async () => {
         const executor = new FoldProjectionExecutor();
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          undefined,
-          2000,
-          undefined,
-          {},
-          "e1",
-        );
+          createdAt: 2000,
+          data: {},
+          id: "e1",
+        });
         const foldDef = missingStoreFold("counted-absent");
         foldDef.eventLoaderUpTo = vi.fn().mockResolvedValue([]);
         const before = await refoldCount("counted-absent", "absent");

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
@@ -42,16 +42,14 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
   };
 
   function ev(id: string, createdAt: number, idempotencyKey?: string): Event {
-    const base = createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    const base = createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
       createdAt,
-      undefined,
-      {},
+      data: {},
       id,
-    );
+    });
     return idempotencyKey ? { ...base, idempotencyKey } : base;
   }
 

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.test.ts
@@ -38,11 +38,11 @@ describe("FoldProjectionExecutor.execute", () => {
         }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -78,11 +78,11 @@ describe("FoldProjectionExecutor.execute", () => {
         }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -113,11 +113,11 @@ describe("FoldProjectionExecutor.execute", () => {
         eventTypes: [],
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -148,11 +148,11 @@ describe("FoldProjectionExecutor.execute", () => {
         eventTypes: ["some.other.event"],
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -180,11 +180,11 @@ describe("FoldProjectionExecutor.execute", () => {
         }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -213,11 +213,11 @@ describe("FoldProjectionExecutor.execute", () => {
         }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
       // No usable occurredAt -> the context must be passed through unchanged.
       (event as { occurredAt?: number }).occurredAt = 0;
 
@@ -271,16 +271,14 @@ describe("FoldProjectionExecutor.executeBatch", () => {
   };
 
   const makeEvent = (occurredAt: number, id: string) =>
-    createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
-      occurredAt,
-      undefined,
-      {},
+      createdAt: occurredAt,
+      data: {},
       id,
-    );
+    });
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.trustAbsentMiss.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.trustAbsentMiss.unit.test.ts
@@ -103,13 +103,12 @@ describe("FoldProjectionExecutor trustAbsentMiss", () => {
   });
 
   const eventAt = (occurredAt: number) =>
-    createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      undefined,
-      occurredAt,
-    );
+      createdAt: occurredAt,
+    });
 
   describe("given a fold that trusts an absent miss", () => {
     describe("when the windowed read misses on a get()-only store", () => {

--- a/platform/app/src/server/event-sourcing/projections/__tests__/foldRedeliveryTelemetry.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/foldRedeliveryTelemetry.unit.test.ts
@@ -52,16 +52,13 @@ describe("fold redelivery telemetry", () => {
 
   const events = (count: number): Event[] =>
     Array.from({ length: count }, (_, i) =>
-      createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        undefined,
-        1_000 + i,
-        undefined,
-        undefined,
-        `event-${i}`,
-      ),
+        createdAt: 1_000 + i,
+        id: `event-${i}`,
+      }),
     );
 
   describe("given a retry whose applied-event-id set did not survive", () => {

--- a/platform/app/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.dedupeByIdempotencyKey.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.dedupeByIdempotencyKey.unit.test.ts
@@ -28,16 +28,14 @@ describe("MapProjectionExecutor dedupeByIdempotencyKey", () => {
 
   function makeEvent(id: string, idempotencyKey?: string): Event {
     return {
-      ...createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      ...createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        undefined,
-        1000,
-        undefined,
-        {},
+        createdAt: 1000,
+        data: {},
         id,
-      ),
+      }),
       idempotencyKey,
     };
   }

--- a/platform/app/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
@@ -33,11 +33,11 @@ describe("MapProjectionExecutor.execute", () => {
         map: (_event) => ({ name: "mapped-record" }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -63,11 +63,11 @@ describe("MapProjectionExecutor.execute", () => {
         map: (_event) => null,
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -92,11 +92,11 @@ describe("MapProjectionExecutor.execute", () => {
         },
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -121,11 +121,11 @@ describe("MapProjectionExecutor.execute", () => {
         map: (_event) => ({ name: "mapped-record" }),
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       const context: ProjectionStoreContext = {
         aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
@@ -152,7 +152,11 @@ describe("MapProjectionExecutor.executeBatch", () => {
       map: (event) => ({ aggregateId: String(event.aggregateId) }),
     });
     const events = ["one", "two"].map((aggregateId) =>
-      createTestEvent(aggregateId, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
+      createTestEvent({
+        aggregateId,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+      }),
     );
     const contexts = events.map((event) => ({
       aggregateId: String(event.aggregateId),
@@ -191,8 +195,16 @@ describe("MapProjectionExecutor.executeBatch", () => {
         const tenantA = createTestTenantId("tenant-a");
         const tenantB = createTestTenantId("tenant-b");
         const events = [
-          createTestEvent("one", TEST_CONSTANTS.AGGREGATE_TYPE, tenantA),
-          createTestEvent("two", TEST_CONSTANTS.AGGREGATE_TYPE, tenantB),
+          createTestEvent({
+            aggregateId: "one",
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId: tenantA,
+          }),
+          createTestEvent({
+            aggregateId: "two",
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId: tenantB,
+          }),
         ];
         const contexts = events.map((event) => ({
           aggregateId: String(event.aggregateId),

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRegistry.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRegistry.test.ts
@@ -131,11 +131,11 @@ describe("ProjectionRegistry", () => {
       it("logs warning and drops events", async () => {
         const registry = new ProjectionRegistry();
         const events = [
-          createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          ),
+          }),
         ];
 
         // Does not throw, just warns
@@ -156,11 +156,11 @@ describe("ProjectionRegistry", () => {
         registry.initialize(globalQueue, globalJobRegistry);
 
         const events = [
-          createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          ),
+          }),
         ];
 
         await registry.dispatch(events, { tenantId });

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.mapReactorCollapse.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.mapReactorCollapse.unit.test.ts
@@ -53,16 +53,13 @@ describe("ProjectionRouter map-reactor dispatch over a coalesced batch", () => {
   /** Five events for one aggregate, already in occurredAt order. */
   const batch = (): Event[] =>
     Array.from({ length: BATCH_SIZE }, (_, i) =>
-      createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        undefined,
-        1_000 + i,
-        undefined,
-        undefined,
-        `event-${i}`,
-      ),
+        createdAt: 1_000 + i,
+        id: `event-${i}`,
+      }),
     );
 
   /**
@@ -84,11 +81,11 @@ describe("ProjectionRouter map-reactor dispatch over a coalesced batch", () => {
       getReactorQueue: vi.fn().mockReturnValue({ send }),
     });
 
-    const router = new ProjectionRouter<Event>(
-      TEST_CONSTANTS.AGGREGATE_TYPE,
-      TEST_CONSTANTS.PIPELINE_NAME,
+    const router = new ProjectionRouter<Event>({
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+      pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
       queueManager,
-    );
+    });
 
     const mapProj = createMockMapProjectionDefinition("spans", {
       store: createMockAppendStore<Record<string, unknown>>(),

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
@@ -49,16 +49,13 @@ describe("ProjectionRouter reactor dispatch over a coalesced batch", () => {
   /** Five events for one aggregate, already in occurredAt order. */
   const batch = (): Event[] =>
     Array.from({ length: BATCH_SIZE }, (_, i) =>
-      createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        undefined,
-        1_000 + i,
-        undefined,
-        undefined,
-        `event-${i}`,
-      ),
+        createdAt: 1_000 + i,
+        id: `event-${i}`,
+      }),
     );
 
   /**
@@ -75,11 +72,11 @@ describe("ProjectionRouter reactor dispatch over a coalesced batch", () => {
       getReactorQueue: vi.fn().mockReturnValue({ send }),
     });
 
-    const router = new ProjectionRouter<Event>(
-      TEST_CONSTANTS.AGGREGATE_TYPE,
-      TEST_CONSTANTS.PIPELINE_NAME,
+    const router = new ProjectionRouter<Event>({
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+      pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
       queueManager,
-    );
+    });
 
     const store = createMockFoldProjectionStore<{ count: number }>();
     (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -96,7 +93,7 @@ describe("ProjectionRouter reactor dispatch over a coalesced batch", () => {
     const initialize = queueManager.initializeProjectionQueues as ReturnType<
       typeof vi.fn
     >;
-    const onEventBatch = initialize.mock.calls[0]?.[2] as (
+    const onEventBatch = initialize.mock.calls[0]?.[0]?.onEventBatch as (
       projectionName: string,
       events: Event[],
       context: unknown,

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.registrationGuard.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.registrationGuard.unit.test.ts
@@ -33,11 +33,11 @@ function createDurableWatermarkStore<State>(): FoldProjectionStore<State> {
 function createRouter(
   aggregateType: AggregateType = TEST_CONSTANTS.AGGREGATE_TYPE,
 ) {
-  return new ProjectionRouter(
+  return new ProjectionRouter({
     aggregateType,
-    TEST_CONSTANTS.PIPELINE_NAME,
-    createMockQueueManager(),
-  );
+    pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+    queueManager: createMockQueueManager(),
+  });
 }
 
 describe("ProjectionRouter registration guard", () => {

--- a/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -41,11 +41,11 @@ describe("ProjectionRouter", () => {
     describe("when fold projection has eventTypes filter (inline)", () => {
       it("skips events that do not match the fold's eventTypes", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -59,18 +59,18 @@ describe("ProjectionRouter", () => {
 
         router.registerFoldProjection(fold);
 
-        const matchingEvent = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const matchingEvent = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          TEST_CONSTANTS.EVENT_TYPE_1,
-        );
-        const nonMatchingEvent = createTestEvent(
-          "other-agg",
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+          type: TEST_CONSTANTS.EVENT_TYPE_1,
+        });
+        const nonMatchingEvent = createTestEvent({
+          aggregateId: "other-agg",
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          TEST_CONSTANTS.EVENT_TYPE_2,
-        );
+          type: TEST_CONSTANTS.EVENT_TYPE_2,
+        });
 
         await router.dispatch([matchingEvent, nonMatchingEvent], { tenantId });
 
@@ -93,11 +93,11 @@ describe("ProjectionRouter", () => {
           sendBatch: mockSendBatch,
         });
 
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         const fold = createMockFoldProjectionDefinition("filtered-fold", {
@@ -109,18 +109,18 @@ describe("ProjectionRouter", () => {
 
         router.registerFoldProjection(fold);
 
-        const matchingEvent = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const matchingEvent = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          TEST_CONSTANTS.EVENT_TYPE_1,
-        );
-        const nonMatchingEvent = createTestEvent(
-          "other-agg",
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+          type: TEST_CONSTANTS.EVENT_TYPE_1,
+        });
+        const nonMatchingEvent = createTestEvent({
+          aggregateId: "other-agg",
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          TEST_CONSTANTS.EVENT_TYPE_2,
-        );
+          type: TEST_CONSTANTS.EVENT_TYPE_2,
+        });
 
         await router.dispatch([matchingEvent, nonMatchingEvent], { tenantId });
 
@@ -140,11 +140,11 @@ describe("ProjectionRouter", () => {
           sendBatch: mockSendBatch,
         });
 
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         const fold = createMockFoldProjectionDefinition("filtered-fold", {
@@ -156,12 +156,12 @@ describe("ProjectionRouter", () => {
 
         router.registerFoldProjection(fold);
 
-        const nonMatchingEvent = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const nonMatchingEvent = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          TEST_CONSTANTS.EVENT_TYPE_2,
-        );
+          type: TEST_CONSTANTS.EVENT_TYPE_2,
+        });
 
         await router.dispatch([nonMatchingEvent], { tenantId });
 
@@ -172,11 +172,11 @@ describe("ProjectionRouter", () => {
     describe("when a fold projection fails inline", () => {
       it("attempts all projections and throws AggregateError", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const failingStore = createMockFoldProjectionStore<{ count: number }>();
         (failingStore.get as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -201,11 +201,11 @@ describe("ProjectionRouter", () => {
         router.registerFoldProjection(failingFold);
         router.registerFoldProjection(successFold);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -220,11 +220,11 @@ describe("ProjectionRouter", () => {
     describe("when fold projection fails but map projections exist", () => {
       it("still dispatches to map projections", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const failingStore = createMockFoldProjectionStore<{ count: number }>();
         (failingStore.get as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -246,11 +246,11 @@ describe("ProjectionRouter", () => {
         router.registerFoldProjection(failingFold);
         router.registerMapProjection(successMap);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -264,11 +264,11 @@ describe("ProjectionRouter", () => {
     describe("when both fold and map projections fail", () => {
       it("throws single AggregateError with all errors", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const foldStore = createMockFoldProjectionStore<{ count: number }>();
         (foldStore.get as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -294,11 +294,11 @@ describe("ProjectionRouter", () => {
         router.registerFoldProjection(failingFold);
         router.registerMapProjection(failingMap);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         try {
           await router.dispatch([event], { tenantId });
@@ -315,11 +315,11 @@ describe("ProjectionRouter", () => {
     describe("when a fold projection throws", () => {
       it("does not dispatch to reactors registered on that fold", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const failingStore = createMockFoldProjectionStore<{ count: number }>();
         (failingStore.get as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -341,11 +341,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerReactor("exploding-fold", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -358,11 +358,11 @@ describe("ProjectionRouter", () => {
     describe("when a map projection fails inline (only map registered)", () => {
       it("attempts all projections and throws AggregateError", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const failingStore = createMockAppendStore<Record<string, unknown>>();
         (failingStore.append as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -384,11 +384,11 @@ describe("ProjectionRouter", () => {
         router.registerMapProjection(failingMap);
         router.registerMapProjection(successMap);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -402,11 +402,11 @@ describe("ProjectionRouter", () => {
     describe("when a reactor fails inline", () => {
       it("throws AggregateError", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -428,11 +428,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerReactor("my-fold", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -446,11 +446,11 @@ describe("ProjectionRouter", () => {
       const setupRouterWithFold = (
         queueManager: ReturnType<typeof createMockQueueManager>,
       ) => {
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -482,11 +482,11 @@ describe("ProjectionRouter", () => {
           };
           router.registerReactor("my-fold", reactor);
 
-          const event = createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          const event = createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          );
+          });
 
           await router.dispatch([event], { tenantId });
 
@@ -511,11 +511,11 @@ describe("ProjectionRouter", () => {
           };
           router.registerReactor("my-fold", reactor);
 
-          const event = createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          const event = createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          );
+          });
 
           await router.dispatch([event], { tenantId });
 
@@ -540,11 +540,11 @@ describe("ProjectionRouter", () => {
           };
           router.registerReactor("my-fold", reactor);
 
-          const event = createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          const event = createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          );
+          });
 
           await router.dispatch([event], { tenantId });
 
@@ -581,11 +581,11 @@ describe("ProjectionRouter", () => {
           };
           router.registerReactor("my-fold", reactor);
 
-          const event = createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
+          const event = createTestEvent({
+            aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+            aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
             tenantId,
-          );
+          });
 
           await router.dispatch([event], { tenantId });
 
@@ -603,11 +603,11 @@ describe("ProjectionRouter", () => {
           hasReactorQueues: true,
           getReactorQueue: vi.fn().mockReturnValue({ send: mockSend }),
         });
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -626,11 +626,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerReactor("my-fold", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -644,11 +644,11 @@ describe("ProjectionRouter", () => {
           hasReactorQueues: true,
           getReactorQueue: vi.fn().mockReturnValue(undefined),
         });
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -668,11 +668,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerReactor("my-fold", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await router.dispatch([event], { tenantId });
 
@@ -686,11 +686,11 @@ describe("ProjectionRouter", () => {
           hasReactorQueues: true,
           getReactorQueue: vi.fn().mockReturnValue(undefined),
         });
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -712,11 +712,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerReactor("my-fold", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -731,11 +731,11 @@ describe("ProjectionRouter", () => {
     describe("when a map reactor is registered on a map projection", () => {
       it("fires after map projection succeeds inline", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const mapStore = createMockAppendStore<Record<string, unknown>>();
         const mapProj = createMockMapProjectionDefinition("my-map", {
@@ -752,11 +752,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerMapReactor("my-map", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await router.dispatch([event], { tenantId });
 
@@ -768,11 +768,11 @@ describe("ProjectionRouter", () => {
     describe("when a map projection fails", () => {
       it("does not dispatch to map reactors", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const failingStore = createMockAppendStore<Record<string, unknown>>();
         (failingStore.append as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -793,11 +793,11 @@ describe("ProjectionRouter", () => {
         };
         router.registerMapReactor("failing-map", reactor);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await expect(router.dispatch([event], { tenantId })).rejects.toThrow(
           AggregateError,
@@ -810,11 +810,11 @@ describe("ProjectionRouter", () => {
     describe("when registering a map reactor on a non-existent map", () => {
       it("throws ConfigurationError", () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const reactor: ReactorDefinition<Event> = {
           name: "orphan-reactor",
@@ -832,11 +832,11 @@ describe("ProjectionRouter", () => {
     describe("when a custom key is provided", () => {
       it("calls store.get with the custom key", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue({ count: 5 });
@@ -850,12 +850,12 @@ describe("ProjectionRouter", () => {
         router.registerFoldProjection(fold);
 
         const customKey = "tenant-1:2025-01-01";
-        await router.getProjectionByName(
-          "myProjection",
-          TEST_CONSTANTS.AGGREGATE_ID,
-          { tenantId },
-          { key: customKey },
-        );
+        await router.getProjectionByName({
+          projectionName: "myProjection",
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          context: { tenantId },
+          options: { key: customKey },
+        });
 
         expect(store.get).toHaveBeenCalledWith(
           customKey,
@@ -870,11 +870,11 @@ describe("ProjectionRouter", () => {
     describe("when no custom key is provided", () => {
       it("calls store.get with aggregateId", async () => {
         const queueManager = createMockQueueManager();
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
 
         const store = createMockFoldProjectionStore<{ count: number }>();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue({ count: 5 });
@@ -887,11 +887,11 @@ describe("ProjectionRouter", () => {
 
         router.registerFoldProjection(fold);
 
-        await router.getProjectionByName(
-          "myProjection",
-          TEST_CONSTANTS.AGGREGATE_ID,
-          { tenantId },
-        );
+        await router.getProjectionByName({
+          projectionName: "myProjection",
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          context: { tenantId },
+        });
 
         expect(store.get).toHaveBeenCalledWith(
           TEST_CONSTANTS.AGGREGATE_ID,
@@ -906,16 +906,15 @@ describe("ProjectionRouter", () => {
 
   describe("processFoldProjectionBatch (coalescing)", () => {
     function makeBatchEvent(id: string, occurredAt: number): Event {
-      return createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      return createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        TEST_CONSTANTS.EVENT_TYPE_1,
-        occurredAt,
-        undefined,
-        {},
+        type: TEST_CONSTANTS.EVENT_TYPE_1,
+        createdAt: occurredAt,
+        data: {},
         id,
-      );
+      });
     }
 
     function batchFold(
@@ -938,11 +937,11 @@ describe("ProjectionRouter", () => {
     describe("when several events for one aggregate are coalesced", () => {
       /** @scenario 'Coalescing still dispatches per-span reactors for every event' */
       it("folds the batch once but fires reactors for every event", async () => {
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          createMockQueueManager(),
-        );
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: createMockQueueManager(),
+        });
         const store = createMockFoldProjectionStore();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
         const fold = batchFold(store);
@@ -963,12 +962,12 @@ describe("ProjectionRouter", () => {
           makeBatchEvent("e3", 3000),
         ];
 
-        await (router as any).processFoldProjectionBatch(
-          "my-fold",
+        await (router as any).processFoldProjectionBatch({
+          projectionName: "my-fold",
           fold,
           events,
-          { tenantId },
-        );
+          context: { tenantId },
+        });
 
         // The expensive fold load/store happens once — the O(n) win.
         expect(store.get).toHaveBeenCalledTimes(1);
@@ -979,11 +978,11 @@ describe("ProjectionRouter", () => {
       });
 
       it("evaluates shouldReact per coalesced event, not once per batch", async () => {
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          createMockQueueManager(),
-        );
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: createMockQueueManager(),
+        });
         const store = createMockFoldProjectionStore();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
         const fold = batchFold(store);
@@ -1005,22 +1004,22 @@ describe("ProjectionRouter", () => {
           makeBatchEvent("e3", 3000),
         ];
 
-        await (router as any).processFoldProjectionBatch(
-          "my-fold",
+        await (router as any).processFoldProjectionBatch({
+          projectionName: "my-fold",
           fold,
           events,
-          { tenantId },
-        );
+          context: { tenantId },
+        });
 
         expect(seen).toEqual(["e1", "e3"]);
       });
 
       it("dispatches reactors in occurredAt order even when events arrive shuffled", async () => {
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          createMockQueueManager(),
-        );
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: createMockQueueManager(),
+        });
         const store = createMockFoldProjectionStore();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
         const fold = batchFold(store);
@@ -1040,12 +1039,12 @@ describe("ProjectionRouter", () => {
           makeBatchEvent("second", 2000),
         ];
 
-        await (router as any).processFoldProjectionBatch(
-          "my-fold",
+        await (router as any).processFoldProjectionBatch({
+          projectionName: "my-fold",
           fold,
           events,
-          { tenantId },
-        );
+          context: { tenantId },
+        });
 
         expect(seen).toEqual(["first", "second", "third"]);
       });
@@ -1053,26 +1052,25 @@ describe("ProjectionRouter", () => {
       /** @scenario Batched fold projections use the tenant retention policy */
       it("stores the folded state with the tenant retention policy", async () => {
         const retentionPolicy = { traces: 30, scenarios: 60, experiments: 90 };
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          createMockQueueManager(),
-          undefined,
-          undefined,
-          undefined,
-          { resolve: vi.fn().mockResolvedValue(retentionPolicy) },
-        );
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: createMockQueueManager(),
+          retentionPolicyResolver: {
+            resolve: vi.fn().mockResolvedValue(retentionPolicy),
+          },
+        });
         const store = createMockFoldProjectionStore();
         (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
         const fold = batchFold(store);
         router.registerFoldProjection(fold);
 
-        await (router as any).processFoldProjectionBatch(
-          "my-fold",
+        await (router as any).processFoldProjectionBatch({
+          projectionName: "my-fold",
           fold,
-          [makeBatchEvent("e1", 1000), makeBatchEvent("e2", 2000)],
-          { tenantId },
-        );
+          events: [makeBatchEvent("e1", 1000), makeBatchEvent("e2", 2000)],
+          context: { tenantId },
+        });
 
         expect(store.store).toHaveBeenCalledWith(
           expect.anything(),
@@ -1089,14 +1087,12 @@ describe("ProjectionRouter", () => {
         const markerChecker = {
           check: vi.fn().mockResolvedValue("skip" as const),
         };
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-          undefined,
-          undefined,
-          markerChecker,
-        );
+          replayMarkerChecker: markerChecker,
+        });
 
         const store = createMockAppendStore<Record<string, unknown>>();
         const mapProj = createMockMapProjectionDefinition("skipped-map", {
@@ -1105,11 +1101,11 @@ describe("ProjectionRouter", () => {
         });
         router.registerMapProjection(mapProj);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await router.dispatch([event], { tenantId });
 
@@ -1124,14 +1120,12 @@ describe("ProjectionRouter", () => {
         const markerChecker = {
           check: vi.fn().mockResolvedValue("process" as const),
         };
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-          undefined,
-          undefined,
-          markerChecker,
-        );
+          replayMarkerChecker: markerChecker,
+        });
 
         const store = createMockAppendStore<Record<string, unknown>>();
         const mapProj = createMockMapProjectionDefinition("allowed-map", {
@@ -1140,11 +1134,11 @@ describe("ProjectionRouter", () => {
         });
         router.registerMapProjection(mapProj);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         await router.dispatch([event], { tenantId });
 
@@ -1164,14 +1158,12 @@ describe("ProjectionRouter", () => {
         const markerChecker = {
           check: vi.fn().mockRejectedValue(deferError),
         };
-        const router = new ProjectionRouter(
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          TEST_CONSTANTS.PIPELINE_NAME,
+        const router = new ProjectionRouter({
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-          undefined,
-          undefined,
-          markerChecker,
-        );
+          replayMarkerChecker: markerChecker,
+        });
 
         const store = createMockAppendStore<Record<string, unknown>>();
         const mapProj = createMockMapProjectionDefinition("deferred-map", {
@@ -1180,11 +1172,11 @@ describe("ProjectionRouter", () => {
         });
         router.registerMapProjection(mapProj);
 
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        );
+        });
 
         const rejection = await router.dispatch([event], { tenantId }).then(
           () => {

--- a/platform/app/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -100,6 +100,7 @@ function createRedis() {
     values,
     get: vi.fn(async (key: string) => values.get(key)?.value ?? null),
     set: vi.fn(
+      // biome-ignore lint/complexity/useMaxParams: fake of ioredis's positional set(key, value, "EX", ttl)
       async (key: string, value: string, _mode: string, ttlSeconds: number) => {
         values.set(key, { value, ttlSeconds });
         return "OK";

--- a/platform/app/src/server/event-sourcing/projections/__tests__/replayMarkerCheck.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/replayMarkerCheck.unit.test.ts
@@ -26,24 +26,59 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
 
 describe("isAtOrBeforeCutoff", () => {
   it("returns true when event timestamp is before cutoff", () => {
-    expect(isAtOrBeforeCutoff(1000, "evt-001", 2000, "evt-999")).toBe(true);
+    expect(
+      isAtOrBeforeCutoff({
+        eventTimestamp: 1000,
+        eventId: "evt-001",
+        cutoffTimestamp: 2000,
+        cutoffEventId: "evt-999",
+      }),
+    ).toBe(true);
   });
 
   it("returns false when event timestamp is after cutoff", () => {
-    expect(isAtOrBeforeCutoff(3000, "evt-001", 2000, "evt-999")).toBe(false);
+    expect(
+      isAtOrBeforeCutoff({
+        eventTimestamp: 3000,
+        eventId: "evt-001",
+        cutoffTimestamp: 2000,
+        cutoffEventId: "evt-999",
+      }),
+    ).toBe(false);
   });
 
   describe("when timestamps are equal", () => {
     it("returns true when eventId is before cutoffEventId", () => {
-      expect(isAtOrBeforeCutoff(1000, "evt-001", 1000, "evt-002")).toBe(true);
+      expect(
+        isAtOrBeforeCutoff({
+          eventTimestamp: 1000,
+          eventId: "evt-001",
+          cutoffTimestamp: 1000,
+          cutoffEventId: "evt-002",
+        }),
+      ).toBe(true);
     });
 
     it("returns true when eventId equals cutoffEventId", () => {
-      expect(isAtOrBeforeCutoff(1000, "evt-002", 1000, "evt-002")).toBe(true);
+      expect(
+        isAtOrBeforeCutoff({
+          eventTimestamp: 1000,
+          eventId: "evt-002",
+          cutoffTimestamp: 1000,
+          cutoffEventId: "evt-002",
+        }),
+      ).toBe(true);
     });
 
     it("returns false when eventId is after cutoffEventId", () => {
-      expect(isAtOrBeforeCutoff(1000, "evt-003", 1000, "evt-002")).toBe(false);
+      expect(
+        isAtOrBeforeCutoff({
+          eventTimestamp: 1000,
+          eventId: "evt-003",
+          cutoffTimestamp: 1000,
+          cutoffEventId: "evt-002",
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/platform/app/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -796,12 +796,12 @@ export class FoldProjectionExecutor {
       projection.eventLoaderUpToPaged &&
       projection.options?.refoldOnOutOfOrder === false
     ) {
-      return this.streamRefoldUpToDelivered(
+      return this.streamRefoldUpToDelivered({
         projection,
         delivered,
         context,
         upToEvent,
-      );
+      });
     }
 
     const history = await projection.eventLoaderUpTo!({
@@ -856,12 +856,17 @@ export class FoldProjectionExecutor {
    * - Missing delivered: any delivered event the history read did not return
    *   (event-log read lag) is applied on top, as the array path does.
    */
-  private async streamRefoldUpToDelivered<State, E extends Event>(
-    projection: FoldProjectionDefinition<State, E>,
-    delivered: E[],
-    context: ProjectionStoreContext,
-    upToEvent: E,
-  ): Promise<State | null> {
+  private async streamRefoldUpToDelivered<State, E extends Event>({
+    projection,
+    delivered,
+    context,
+    upToEvent,
+  }: {
+    projection: FoldProjectionDefinition<State, E>;
+    delivered: E[];
+    context: ProjectionStoreContext;
+    upToEvent: E;
+  }): Promise<State | null> {
     const PAGE_SIZE = this.refoldPageSize;
     // Safety net only: the paged loader's cursor is expected to strictly
     // advance every call. If that contract is ever violated (e.g. a

--- a/platform/app/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
@@ -35,11 +35,11 @@ import type { BillableEventRecord } from "../orgBillableEventsMeter.store";
  */
 function createMeterRouterWithSpyStore() {
   const appendSpy = vi.fn().mockResolvedValue(void 0);
-  const router = new ProjectionRouter(
-    TEST_CONSTANTS.AGGREGATE_TYPE,
-    TEST_CONSTANTS.PIPELINE_NAME,
-    createMockQueueManager(),
-  );
+  const router = new ProjectionRouter({
+    aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+    pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+    queueManager: createMockQueueManager(),
+  });
   router.registerMapProjection({
     ...orgBillableEventsMeterProjection,
     store: {
@@ -59,12 +59,12 @@ function createReportedEvent(
   evaluationId: string,
 ): Event {
   return {
-    ...createTestEvent(
-      evaluationId,
-      TEST_CONSTANTS.AGGREGATE_TYPE,
+    ...createTestEvent({
+      aggregateId: evaluationId,
+      aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
       tenantId,
-      EVALUATION_EVENT_TYPES.REPORTED,
-    ),
+      type: EVALUATION_EVENT_TYPES.REPORTED,
+    }),
     idempotencyKey: `${tenantId}:${evaluationId}:reported`,
   };
 }
@@ -123,18 +123,18 @@ describe("orgBillableEventsMeter — evaluation billing (issue #5124)", () => {
 
         await router.dispatch(
           [
-            createTestEvent(
-              "eval-1",
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+            createTestEvent({
+              aggregateId: "eval-1",
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-              EVALUATION_EVENT_TYPES.SCHEDULED,
-            ),
-            createTestEvent(
-              "eval-2",
-              TEST_CONSTANTS.AGGREGATE_TYPE,
+              type: EVALUATION_EVENT_TYPES.SCHEDULED,
+            }),
+            createTestEvent({
+              aggregateId: "eval-2",
+              aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
               tenantId,
-              EVALUATION_EVENT_TYPES.STARTED,
-            ),
+              type: EVALUATION_EVENT_TYPES.STARTED,
+            }),
           ],
           { tenantId },
         );
@@ -151,12 +151,12 @@ describe("orgBillableEventsMeter — canonical metrics remain shadow-only", () =
       it("keeps the production billable store untouched", async () => {
         const tenantId = createTestTenantId();
         const { router, appendSpy } = createMeterRouterWithSpyStore();
-        const metricEvent = createTestEvent(
-          "a".repeat(64),
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        const metricEvent = createTestEvent({
+          aggregateId: "a".repeat(64),
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          METRIC_DATA_POINT_RECEIVED_EVENT_TYPE,
-        );
+          type: METRIC_DATA_POINT_RECEIVED_EVENT_TYPE,
+        });
 
         await router.dispatch([metricEvent], { tenantId });
 

--- a/platform/app/src/server/event-sourcing/projections/projectionRegistry.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionRegistry.ts
@@ -150,13 +150,12 @@ export class ProjectionRegistry<EventType extends Event = Event> {
     });
 
     // Create router — all projections are incremental
-    this.router = new ProjectionRouter<EventType>(
+    this.router = new ProjectionRouter<EventType>({
       aggregateType,
-      "global",
-      this.queueManager,
-      undefined, // featureFlagService
+      pipelineName: "global",
+      queueManager: this.queueManager,
       processRole,
-    );
+    });
 
     for (const fold of this.foldProjections.values()) {
       this.router.registerFoldProjection(fold);

--- a/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
@@ -147,15 +147,39 @@ export class ProjectionRouter<
     EventSubscriberDefinition<EventType>
   >();
 
-  constructor(
-    private readonly aggregateType: AggregateType,
-    private readonly pipelineName: string,
-    private readonly queueManager: QueueManager<EventType>,
-    private readonly featureFlagService?: FeatureFlagServiceInterface,
-    private readonly processRole?: ProcessRole,
-    private readonly replayMarkerChecker?: ReplayMarkerChecker,
-    private readonly retentionPolicyResolver?: RetentionPolicyResolver,
-  ) {}
+  private readonly aggregateType: AggregateType;
+  private readonly pipelineName: string;
+  private readonly queueManager: QueueManager<EventType>;
+  private readonly featureFlagService?: FeatureFlagServiceInterface;
+  private readonly processRole?: ProcessRole;
+  private readonly replayMarkerChecker?: ReplayMarkerChecker;
+  private readonly retentionPolicyResolver?: RetentionPolicyResolver;
+
+  constructor({
+    aggregateType,
+    pipelineName,
+    queueManager,
+    featureFlagService,
+    processRole,
+    replayMarkerChecker,
+    retentionPolicyResolver,
+  }: {
+    aggregateType: AggregateType;
+    pipelineName: string;
+    queueManager: QueueManager<EventType>;
+    featureFlagService?: FeatureFlagServiceInterface;
+    processRole?: ProcessRole;
+    replayMarkerChecker?: ReplayMarkerChecker;
+    retentionPolicyResolver?: RetentionPolicyResolver;
+  }) {
+    this.aggregateType = aggregateType;
+    this.pipelineName = pipelineName;
+    this.queueManager = queueManager;
+    this.featureFlagService = featureFlagService;
+    this.processRole = processRole;
+    this.replayMarkerChecker = replayMarkerChecker;
+    this.retentionPolicyResolver = retentionPolicyResolver;
+  }
 
   registerFoldProjection(
     projection: FoldProjectionDefinition<any, EventType>,
@@ -554,12 +578,12 @@ export class ProjectionRouter<
             { projectionName },
           );
         }
-        await this.processStateProjectionEvents(
+        await this.processStateProjectionEvents({
           projectionName,
           projection,
-          [event],
+          events: [event],
           context,
-        );
+        });
       },
       async (projectionName, events, context) => {
         const projection = this.stateProjections.get(projectionName);
@@ -570,12 +594,12 @@ export class ProjectionRouter<
             { projectionName },
           );
         }
-        await this.processStateProjectionEvents(
+        await this.processStateProjectionEvents({
           projectionName,
           projection,
           events,
           context,
-        );
+        });
       },
     );
   }
@@ -625,9 +649,9 @@ export class ProjectionRouter<
       };
     }
 
-    this.queueManager.initializeProjectionQueues(
-      projectionDefs,
-      async (projectionName, triggerEvent, context) => {
+    this.queueManager.initializeProjectionQueues({
+      projections: projectionDefs,
+      onEvent: async (projectionName, triggerEvent, context) => {
         const fold = this.foldProjections.get(projectionName);
         if (!fold) {
           throw new ConfigurationError(
@@ -637,19 +661,19 @@ export class ProjectionRouter<
           );
         }
 
-        await this.processFoldProjectionEvent(
+        await this.processFoldProjectionEvent({
           projectionName,
           fold,
-          triggerEvent,
-          {
+          event: triggerEvent,
+          context: {
             tenantId: triggerEvent.tenantId,
             ...(context.deliveryAttempt !== undefined
               ? { deliveryAttempt: context.deliveryAttempt }
               : {}),
           },
-        );
+        });
       },
-      async (projectionName, events, context) => {
+      onEventBatch: async (projectionName, events, context) => {
         const fold = this.foldProjections.get(projectionName);
         if (!fold) {
           throw new ConfigurationError(
@@ -659,14 +683,19 @@ export class ProjectionRouter<
           );
         }
 
-        await this.processFoldProjectionBatch(projectionName, fold, events, {
-          tenantId: events[0]!.tenantId,
-          ...(context.deliveryAttempt !== undefined
-            ? { deliveryAttempt: context.deliveryAttempt }
-            : {}),
+        await this.processFoldProjectionBatch({
+          projectionName,
+          fold,
+          events,
+          context: {
+            tenantId: events[0]!.tenantId,
+            ...(context.deliveryAttempt !== undefined
+              ? { deliveryAttempt: context.deliveryAttempt }
+              : {}),
+          },
         });
       },
-    );
+    });
   }
 
   /**
@@ -997,18 +1026,23 @@ export class ProjectionRouter<
             continue;
           }
           try {
-            await this.processFoldProjectionEvent(
+            await this.processFoldProjectionEvent({
               projectionName,
               fold,
               event,
               context,
-            );
+            });
           } catch (error) {
             const category = categorizeError(error);
-            handleError(error, category, this.logger, {
-              projectionName,
-              aggregateId: String(event.aggregateId),
-              tenantId: context.tenantId,
+            handleError({
+              error,
+              category,
+              logger: this.logger,
+              context: {
+                projectionName,
+                aggregateId: String(event.aggregateId),
+                tenantId: context.tenantId,
+              },
             });
             errors.push(toError(error));
           }
@@ -1050,12 +1084,12 @@ export class ProjectionRouter<
         }
 
         for (const event of matching) {
-          await this.processStateProjectionEvents(
-            name,
+          await this.processStateProjectionEvents({
+            projectionName: name,
             projection,
-            [event],
+            events: [event],
             context,
-          );
+          });
         }
       } catch (error) {
         this.logger.error(
@@ -1207,11 +1241,16 @@ export class ProjectionRouter<
               });
             }
           } catch (error) {
-            handleError(error, categorizeError(error), this.logger, {
-              handlerName: name,
-              eventType: event.type,
-              aggregateId: String(event.aggregateId),
-              tenantId: event.tenantId,
+            handleError({
+              error,
+              category: categorizeError(error),
+              logger: this.logger,
+              context: {
+                handlerName: name,
+                eventType: event.type,
+                aggregateId: String(event.aggregateId),
+                tenantId: event.tenantId,
+              },
             });
             errors.push(toError(error));
           }
@@ -1444,12 +1483,17 @@ export class ProjectionRouter<
     );
   }
 
-  private async processStateProjectionEvents(
-    projectionName: string,
-    projection: StateProjectionDefinition<any, EventType>,
-    events: EventType[],
-    context: EventStoreReadContext<EventType>,
-  ): Promise<void> {
+  private async processStateProjectionEvents({
+    projectionName,
+    projection,
+    events,
+    context,
+  }: {
+    projectionName: string;
+    projection: StateProjectionDefinition<any, EventType>;
+    events: EventType[];
+    context: EventStoreReadContext<EventType>;
+  }): Promise<void> {
     if (events.length === 0) return;
     const first = events[0]!;
 
@@ -1577,12 +1621,17 @@ export class ProjectionRouter<
    * Processes a single event for a fold projection (incremental).
    * The fold state in the store serves as the checkpoint — no separate checkpoint tracking needed.
    */
-  private async processFoldProjectionEvent(
-    projectionName: string,
-    fold: FoldProjectionDefinition<any, EventType>,
-    event: EventType,
-    context: EventStoreReadContext<EventType>,
-  ): Promise<void> {
+  private async processFoldProjectionEvent({
+    projectionName,
+    fold,
+    event,
+    context,
+  }: {
+    projectionName: string;
+    fold: FoldProjectionDefinition<any, EventType>;
+    event: EventType;
+    context: EventStoreReadContext<EventType>;
+  }): Promise<void> {
     await this.tracer.withActiveSpan(
       "ProjectionRouter.processFoldProjectionEvent",
       {
@@ -1750,12 +1799,17 @@ export class ProjectionRouter<
    * Reactors fire once with the final folded state (using the last event), which
    * is the correct coalesced behavior for the trace's debounced reactors.
    */
-  private async processFoldProjectionBatch(
-    projectionName: string,
-    fold: FoldProjectionDefinition<any, EventType>,
-    events: EventType[],
-    context: EventStoreReadContext<EventType>,
-  ): Promise<void> {
+  private async processFoldProjectionBatch({
+    projectionName,
+    fold,
+    events,
+    context,
+  }: {
+    projectionName: string;
+    fold: FoldProjectionDefinition<any, EventType>;
+    events: EventType[];
+    context: EventStoreReadContext<EventType>;
+  }): Promise<void> {
     if (events.length === 0) return;
 
     await this.tracer.withActiveSpan(
@@ -2176,12 +2230,17 @@ export class ProjectionRouter<
    */
   async getProjectionByName<
     ProjectionName extends keyof ProjectionTypes & string,
-  >(
-    projectionName: ProjectionName,
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    options?: { key?: string },
-  ): Promise<ProjectionTypes[ProjectionName] | null> {
+  >({
+    projectionName,
+    aggregateId,
+    context,
+    options,
+  }: {
+    projectionName: ProjectionName;
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    options?: { key?: string };
+  }): Promise<ProjectionTypes[ProjectionName] | null> {
     EventUtils.validateTenantId(context, "getProjectionByName");
 
     const fold = this.foldProjections.get(projectionName);
@@ -2217,18 +2276,23 @@ export class ProjectionRouter<
    */
   async hasProjectionByName<
     ProjectionName extends keyof ProjectionTypes & string,
-  >(
-    projectionName: ProjectionName,
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    options?: { key?: string },
-  ): Promise<boolean> {
-    const projection = await this.getProjectionByName(
+  >({
+    projectionName,
+    aggregateId,
+    context,
+    options,
+  }: {
+    projectionName: ProjectionName;
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    options?: { key?: string };
+  }): Promise<boolean> {
+    const projection = await this.getProjectionByName({
       projectionName,
       aggregateId,
       context,
       options,
-    );
+    });
     return projection !== null;
   }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.failureLogging.integration.test.ts
@@ -149,7 +149,10 @@ describe.skipIf(!hasTestcontainers)(
       describe("when the job skips retries and the group is blocked", () => {
         it("logs the full Error on both the non-retryable and blocked records", async () => {
           function invalidPayloadHandlerForStackAssertion(): never {
-            throw new ValidationError("bad payload", "field");
+            throw new ValidationError({
+              reason: "bad payload",
+              field: "field",
+            });
           }
           const queue = createQueue(async () => {
             invalidPayloadHandlerForStackAssertion();

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.retries.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.retries.unit.test.ts
@@ -13,7 +13,10 @@ import { isRetryableJobError, retryBackoffMsFor } from "../groupQueue";
 describe("groupQueue retry categorization", () => {
   describe("when error is a ValidationError", () => {
     it("categorizes as CRITICAL (non-retryable)", () => {
-      const error = new ValidationError("invalid schema", "traceId");
+      const error = new ValidationError({
+        reason: "invalid schema",
+        field: "traceId",
+      });
 
       const category = categorizeError(error);
 
@@ -23,7 +26,11 @@ describe("groupQueue retry categorization", () => {
 
   describe("when error is a SecurityError", () => {
     it("categorizes as CRITICAL (non-retryable)", () => {
-      const error = new SecurityError("checkTenant", "tenant mismatch", "t1");
+      const error = new SecurityError({
+        operation: "checkTenant",
+        message: "tenant mismatch",
+        tenantId: "t1",
+      });
 
       const category = categorizeError(error);
 
@@ -43,7 +50,11 @@ describe("groupQueue retry categorization", () => {
 
   describe("when error is a QueueError", () => {
     it("categorizes as RECOVERABLE (retryable)", () => {
-      const error = new QueueError("test-queue", "send", "connection lost");
+      const error = new QueueError({
+        queueName: "test-queue",
+        operation: "send",
+        message: "connection lost",
+      });
 
       const category = categorizeError(error);
 
@@ -71,13 +82,17 @@ describe("groupQueue retry categorization", () => {
 
   describe("retry decision logic", () => {
     it("skips retries for ValidationError on first attempt", () => {
-      const error = new ValidationError("bad data", "field");
+      const error = new ValidationError({ reason: "bad data", field: "field" });
 
       expect(isRetryableJobError(error)).toBe(false);
     });
 
     it("allows retries for QueueError", () => {
-      const error = new QueueError("q", "op", "transient");
+      const error = new QueueError({
+        queueName: "q",
+        operation: "op",
+        message: "transient",
+      });
 
       expect(isRetryableJobError(error)).toBe(true);
     });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
@@ -33,7 +33,12 @@ export class CachedLuaScript {
     numKeys: number,
     ...keysAndArgs: Array<string | number>
   ): Promise<unknown> {
-    return await this.runCancellable(redis, null, numKeys, ...keysAndArgs);
+    return await this.runCancellable({
+      redis,
+      isCancelled: null,
+      numKeys,
+      keysAndArgs,
+    });
   }
 
   /**
@@ -51,12 +56,17 @@ export class CachedLuaScript {
    * Returns null when withdrawn, which every caller treats as "no refresh
    * happened" — the same outcome as a heartbeat that never fired.
    */
-  async runCancellable(
-    redis: IORedis | Cluster,
-    isCancelled: (() => boolean) | null,
-    numKeys: number,
-    ...keysAndArgs: Array<string | number>
-  ): Promise<unknown> {
+  async runCancellable({
+    redis,
+    isCancelled,
+    numKeys,
+    keysAndArgs,
+  }: {
+    redis: IORedis | Cluster;
+    isCancelled: (() => boolean) | null;
+    numKeys: number;
+    keysAndArgs: Array<string | number>;
+  }): Promise<unknown> {
     try {
       return await redis.evalsha(this.sha, numKeys, ...keysAndArgs);
     } catch (err) {

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -207,11 +207,11 @@ function assertNoReservedKeys(
 ): void {
   for (const key of Object.keys(payload)) {
     if (key.startsWith("__") && !CALLER_RESERVED_KEYS.has(key)) {
-      throw new QueueError(
+      throw new QueueError({
         queueName,
-        method,
-        `Payload key "${key}" is in the reserved __* namespace (queue machinery). User payloads must not start with "__" except __pipelineName / __jobType / __jobName.`,
-      );
+        operation: method,
+        message: `Payload key "${key}" is in the reserved __* namespace (queue machinery). User payloads must not start with "__" except __pipelineName / __jobType / __jobName.`,
+      });
     }
   }
 }
@@ -528,11 +528,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     options?: QueueSendOptions<Payload>,
   ): Promise<void> {
     if (this.shutdownRequested) {
-      throw new QueueError(
-        this.queueName,
-        "send",
-        "Cannot send to queue after shutdown has been requested",
-      );
+      throw new QueueError({
+        queueName: this.queueName,
+        operation: "send",
+        message: "Cannot send to queue after shutdown has been requested",
+      });
     }
     assertNoReservedKeys(
       payload as Record<string, unknown>,
@@ -644,11 +644,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     options?: QueueSendOptions<Payload>,
   ): Promise<void> {
     if (this.shutdownRequested) {
-      throw new QueueError(
-        this.queueName,
-        "sendBatch",
-        "Cannot send to queue after shutdown has been requested",
-      );
+      throw new QueueError({
+        queueName: this.queueName,
+        operation: "sendBatch",
+        message: "Cannot send to queue after shutdown has been requested",
+      });
     }
 
     if (payloads.length === 0) {
@@ -2339,11 +2339,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           shutdownTimer = setTimeout(
             () =>
               reject(
-                new QueueError(
-                  this.queueName,
-                  "close",
-                  `Shutdown timed out after ${GROUP_QUEUE_CONFIG.shutdownTimeoutMs}ms`,
-                ),
+                new QueueError({
+                  queueName: this.queueName,
+                  operation: "close",
+                  message: `Shutdown timed out after ${GROUP_QUEUE_CONFIG.shutdownTimeoutMs}ms`,
+                }),
               ),
             GROUP_QUEUE_CONFIG.shutdownTimeoutMs,
           );

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -2181,18 +2181,20 @@ export class GroupStagingScripts {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const readyKey = `${this.keyPrefix}ready`;
 
-    const result = await refreshScript.runCancellable(
-      this.redis,
-      isCancelled ?? null,
-      2,
-      activeKey,
-      readyKey,
-      stagedJobId,
-      String(activeTtlSec),
-      groupId,
-      String(Date.now()),
-      `${this.keyPrefix}tenant_active_z:`,
-    );
+    const result = await refreshScript.runCancellable({
+      redis: this.redis,
+      isCancelled: isCancelled ?? null,
+      numKeys: 2,
+      keysAndArgs: [
+        activeKey,
+        readyKey,
+        stagedJobId,
+        String(activeTtlSec),
+        groupId,
+        String(Date.now()),
+        `${this.keyPrefix}tenant_active_z:`,
+      ],
+    });
 
     return result === 1;
   }

--- a/platform/app/src/server/event-sourcing/replay/__tests__/replayMarkers.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/replay/__tests__/replayMarkers.unit.test.ts
@@ -58,6 +58,7 @@ function createRedisMock() {
           });
           return pipe;
         },
+        // biome-ignore lint/complexity/useMaxParams: fake of ioredis's positional pipeline set(key, value, "EX", seconds)
         set: (key: string, value: string, mode?: string, seconds?: number) => {
           pipelineOps.push(() => {
             strings.set(key, value);

--- a/platform/app/src/server/event-sourcing/replay/replayConstants.ts
+++ b/platform/app/src/server/event-sourcing/replay/replayConstants.ts
@@ -47,12 +47,17 @@ export function doneMarkerKey(
  *
  * Returns true if the event is at or before the cutoff (replay handles it).
  */
-export function isAtOrBeforeCutoff(
-  eventTimestamp: number,
-  eventId: string,
-  cutoffTimestamp: number,
-  cutoffEventId: string,
-): boolean {
+export function isAtOrBeforeCutoff({
+  eventTimestamp,
+  eventId,
+  cutoffTimestamp,
+  cutoffEventId,
+}: {
+  eventTimestamp: number;
+  eventId: string;
+  cutoffTimestamp: number;
+  cutoffEventId: string;
+}): boolean {
   if (eventTimestamp < cutoffTimestamp) return true;
   if (eventTimestamp > cutoffTimestamp) return false;
   return eventId <= cutoffEventId;
@@ -79,10 +84,10 @@ export function isAtOrBeforeCutoffMarker(
     return false; // Corrupted marker
   }
 
-  return isAtOrBeforeCutoff(
+  return isAtOrBeforeCutoff({
     eventTimestamp,
     eventId,
     cutoffTimestamp,
     cutoffEventId,
-  );
+  });
 }

--- a/platform/app/src/server/event-sourcing/replay/replayFoldPath.ts
+++ b/platform/app/src/server/event-sourcing/replay/replayFoldPath.ts
@@ -427,7 +427,12 @@ async function replayBatch({
       const cutoff = cutoffs.get(key);
       if (
         cutoff != null &&
-        isAtOrBeforeCutoff(e.timestamp, e.id, cutoff.timestamp, cutoff.eventId)
+        isAtOrBeforeCutoff({
+          eventTimestamp: e.timestamp,
+          eventId: e.id,
+          cutoffTimestamp: cutoff.timestamp,
+          cutoffEventId: cutoff.eventId,
+        })
       ) {
         accumulator.apply(e);
         onBatchPhase("replay", accumulator.processed);

--- a/platform/app/src/server/event-sourcing/replay/replayMapPath.ts
+++ b/platform/app/src/server/event-sourcing/replay/replayMapPath.ts
@@ -428,7 +428,12 @@ async function replayMapBatch({
       const cutoff = cutoffs.get(key);
       if (
         cutoff != null &&
-        isAtOrBeforeCutoff(e.timestamp, e.id, cutoff.timestamp, cutoff.eventId)
+        isAtOrBeforeCutoff({
+          eventTimestamp: e.timestamp,
+          eventId: e.id,
+          cutoffTimestamp: cutoff.timestamp,
+          cutoffEventId: cutoff.eventId,
+        })
       ) {
         await accumulator.apply(e);
         eventsProcessed++;

--- a/platform/app/src/server/event-sourcing/replay/replayStatePath.ts
+++ b/platform/app/src/server/event-sourcing/replay/replayStatePath.ts
@@ -321,7 +321,12 @@ async function replayStateBatch({
       const cutoff = cutoffs.get(key);
       if (
         cutoff != null &&
-        isAtOrBeforeCutoff(e.timestamp, e.id, cutoff.timestamp, cutoff.eventId)
+        isAtOrBeforeCutoff({
+          eventTimestamp: e.timestamp,
+          eventId: e.id,
+          cutoffTimestamp: cutoff.timestamp,
+          cutoffEventId: cutoff.eventId,
+        })
       ) {
         accumulator.apply(e);
         eventsApplied++;

--- a/platform/app/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -31,13 +31,21 @@ const createMockLogger = () => ({
 describe("Error classes", () => {
   describe("SecurityError", () => {
     it("has correct name and CRITICAL category", () => {
-      const err = new SecurityError("op", "breach detected", "tenant-1");
+      const err = new SecurityError({
+        operation: "op",
+        message: "breach detected",
+        tenantId: "tenant-1",
+      });
       expect(err.name).toBe("SecurityError");
       expect(err.category).toBe(ErrorCategory.CRITICAL);
     });
 
     it("getLogContext() includes operation and tenantId", () => {
-      const err = new SecurityError("op", "breach", "t-1");
+      const err = new SecurityError({
+        operation: "op",
+        message: "breach",
+        tenantId: "t-1",
+      });
       const ctx = err.getLogContext();
       expect(ctx).toMatchObject({
         errorName: "SecurityError",
@@ -51,13 +59,21 @@ describe("Error classes", () => {
 
   describe("ValidationError", () => {
     it("has correct name and CRITICAL category", () => {
-      const err = new ValidationError("bad input", "email", "notanemail");
+      const err = new ValidationError({
+        reason: "bad input",
+        field: "email",
+        value: "notanemail",
+      });
       expect(err.name).toBe("ValidationError");
       expect(err.category).toBe(ErrorCategory.CRITICAL);
     });
 
     it("getLogContext() includes field, value, and reason", () => {
-      const err = new ValidationError("bad input", "email", "x");
+      const err = new ValidationError({
+        reason: "bad input",
+        field: "email",
+        value: "x",
+      });
       const ctx = err.getLogContext();
       expect(ctx).toMatchObject({
         errorName: "ValidationError",
@@ -69,12 +85,12 @@ describe("Error classes", () => {
     });
 
     it("message omits field when not provided", () => {
-      const err = new ValidationError("missing data");
+      const err = new ValidationError({ reason: "missing data" });
       expect(err.message).toBe("[VALIDATION] missing data");
     });
 
     it("message includes field when provided", () => {
-      const err = new ValidationError("too long", "name");
+      const err = new ValidationError({ reason: "too long", field: "name" });
       expect(err.message).toBe("[VALIDATION] too long (field: name)");
     });
   });
@@ -100,42 +116,42 @@ describe("Error classes", () => {
 
   describe("StoreError", () => {
     it("has correct name", () => {
-      const err = new StoreError(
-        "insert",
-        "clickhouse",
-        "timeout",
-        ErrorCategory.RECOVERABLE,
-      );
+      const err = new StoreError({
+        operation: "insert",
+        store: "clickhouse",
+        message: "timeout",
+        category: ErrorCategory.RECOVERABLE,
+      });
       expect(err.name).toBe("StoreError");
     });
 
     it("can be CRITICAL", () => {
-      const err = new StoreError(
-        "insert",
-        "clickhouse",
-        "corruption",
-        ErrorCategory.CRITICAL,
-      );
+      const err = new StoreError({
+        operation: "insert",
+        store: "clickhouse",
+        message: "corruption",
+        category: ErrorCategory.CRITICAL,
+      });
       expect(err.category).toBe(ErrorCategory.CRITICAL);
     });
 
     it("can be RECOVERABLE", () => {
-      const err = new StoreError(
-        "query",
-        "clickhouse",
-        "timeout",
-        ErrorCategory.RECOVERABLE,
-      );
+      const err = new StoreError({
+        operation: "query",
+        store: "clickhouse",
+        message: "timeout",
+        category: ErrorCategory.RECOVERABLE,
+      });
       expect(err.category).toBe(ErrorCategory.RECOVERABLE);
     });
 
     it("getLogContext() includes operation and store", () => {
-      const err = new StoreError(
-        "insert",
-        "clickhouse",
-        "fail",
-        ErrorCategory.RECOVERABLE,
-      );
+      const err = new StoreError({
+        operation: "insert",
+        store: "clickhouse",
+        message: "fail",
+        category: ErrorCategory.RECOVERABLE,
+      });
       const ctx = err.getLogContext();
       expect(ctx).toMatchObject({
         errorName: "StoreError",
@@ -148,13 +164,21 @@ describe("Error classes", () => {
 
   describe("QueueError", () => {
     it("has correct name and RECOVERABLE category", () => {
-      const err = new QueueError("events", "enqueue", "redis down");
+      const err = new QueueError({
+        queueName: "events",
+        operation: "enqueue",
+        message: "redis down",
+      });
       expect(err.name).toBe("QueueError");
       expect(err.category).toBe(ErrorCategory.RECOVERABLE);
     });
 
     it("getLogContext() includes queueName and operation", () => {
-      const ctx = new QueueError("events", "enqueue", "fail").getLogContext();
+      const ctx = new QueueError({
+        queueName: "events",
+        operation: "enqueue",
+        message: "fail",
+      }).getLogContext();
       expect(ctx).toMatchObject({
         errorName: "QueueError",
         queueName: "events",
@@ -165,13 +189,21 @@ describe("Error classes", () => {
 
   describe("HandlerError", () => {
     it("has correct name and NON_CRITICAL category", () => {
-      const err = new HandlerError("myHandler", "evt-1", "oops");
+      const err = new HandlerError({
+        handlerName: "myHandler",
+        eventId: "evt-1",
+        message: "oops",
+      });
       expect(err.name).toBe("HandlerError");
       expect(err.category).toBe(ErrorCategory.NON_CRITICAL);
     });
 
     it("getLogContext() includes handlerName and eventId", () => {
-      const ctx = new HandlerError("h", "e-1", "fail").getLogContext();
+      const ctx = new HandlerError({
+        handlerName: "h",
+        eventId: "e-1",
+        message: "fail",
+      }).getLogContext();
       expect(ctx).toMatchObject({
         errorName: "HandlerError",
         handlerName: "h",
@@ -182,13 +214,21 @@ describe("Error classes", () => {
 
   describe("ProjectionError", () => {
     it("has correct name and NON_CRITICAL category", () => {
-      const err = new ProjectionError("proj", "evt-1", "oops");
+      const err = new ProjectionError({
+        projectionName: "proj",
+        eventId: "evt-1",
+        message: "oops",
+      });
       expect(err.name).toBe("ProjectionError");
       expect(err.category).toBe(ErrorCategory.NON_CRITICAL);
     });
 
     it("getLogContext() includes projectionName and eventId", () => {
-      const ctx = new ProjectionError("proj", "e-1", "fail").getLogContext();
+      const ctx = new ProjectionError({
+        projectionName: "proj",
+        eventId: "e-1",
+        message: "fail",
+      }).getLogContext();
       expect(ctx).toMatchObject({
         errorName: "ProjectionError",
         projectionName: "proj",
@@ -201,15 +241,25 @@ describe("Error classes", () => {
 describe("handleError", () => {
   describe("with BaseEventSourcingError", () => {
     it("throws when category is CRITICAL", () => {
-      const err = new SecurityError("op", "breach");
-      expect(() => handleError(err, ErrorCategory.NON_CRITICAL)).toThrow(err);
+      const err = new SecurityError({ operation: "op", message: "breach" });
+      expect(() =>
+        handleError({ error: err, category: ErrorCategory.NON_CRITICAL }),
+      ).toThrow(err);
     });
 
     it("logs error and does not throw when NON_CRITICAL with logger", () => {
       const logger = createMockLogger();
-      const err = new HandlerError("h", "e-1", "minor issue");
+      const err = new HandlerError({
+        handlerName: "h",
+        eventId: "e-1",
+        message: "minor issue",
+      });
       expect(() =>
-        handleError(err, ErrorCategory.CRITICAL, logger as any),
+        handleError({
+          error: err,
+          category: ErrorCategory.CRITICAL,
+          logger: logger as any,
+        }),
       ).not.toThrow();
       expect(logger.error).toHaveBeenCalledOnce();
       expect(logger.error).toHaveBeenCalledWith(
@@ -219,15 +269,29 @@ describe("handleError", () => {
     });
 
     it("does not throw or crash when NON_CRITICAL without logger", () => {
-      const err = new HandlerError("h", "e-1", "minor");
-      expect(() => handleError(err, ErrorCategory.CRITICAL)).not.toThrow();
+      const err = new HandlerError({
+        handlerName: "h",
+        eventId: "e-1",
+        message: "minor",
+      });
+      expect(() =>
+        handleError({ error: err, category: ErrorCategory.CRITICAL }),
+      ).not.toThrow();
     });
 
     it("logs warning and does not throw when RECOVERABLE with logger", () => {
       const logger = createMockLogger();
-      const err = new QueueError("q", "enqueue", "redis timeout");
+      const err = new QueueError({
+        queueName: "q",
+        operation: "enqueue",
+        message: "redis timeout",
+      });
       expect(() =>
-        handleError(err, ErrorCategory.CRITICAL, logger as any),
+        handleError({
+          error: err,
+          category: ErrorCategory.CRITICAL,
+          logger: logger as any,
+        }),
       ).not.toThrow();
       expect(logger.warn).toHaveBeenCalledOnce();
       expect(logger.warn).toHaveBeenCalledWith(
@@ -237,15 +301,28 @@ describe("handleError", () => {
     });
 
     it("does not throw or crash when RECOVERABLE without logger", () => {
-      const err = new QueueError("q", "enqueue", "timeout");
-      expect(() => handleError(err, ErrorCategory.CRITICAL)).not.toThrow();
+      const err = new QueueError({
+        queueName: "q",
+        operation: "enqueue",
+        message: "timeout",
+      });
+      expect(() =>
+        handleError({ error: err, category: ErrorCategory.CRITICAL }),
+      ).not.toThrow();
     });
 
     it("merges additional context with error context", () => {
       const logger = createMockLogger();
-      const err = new HandlerError("h", "e-1", "oops");
-      handleError(err, ErrorCategory.NON_CRITICAL, logger as any, {
-        extra: "data",
+      const err = new HandlerError({
+        handlerName: "h",
+        eventId: "e-1",
+        message: "oops",
+      });
+      handleError({
+        error: err,
+        category: ErrorCategory.NON_CRITICAL,
+        logger: logger as any,
+        context: { extra: "data" },
       });
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -263,14 +340,20 @@ describe("handleError", () => {
   describe("with plain Error", () => {
     it("throws when category is CRITICAL", () => {
       const err = new Error("boom");
-      expect(() => handleError(err, ErrorCategory.CRITICAL)).toThrow(err);
+      expect(() =>
+        handleError({ error: err, category: ErrorCategory.CRITICAL }),
+      ).toThrow(err);
     });
 
     it("logs error and does not throw when NON_CRITICAL with logger", () => {
       const logger = createMockLogger();
       const err = new Error("oops");
       expect(() =>
-        handleError(err, ErrorCategory.NON_CRITICAL, logger as any),
+        handleError({
+          error: err,
+          category: ErrorCategory.NON_CRITICAL,
+          logger: logger as any,
+        }),
       ).not.toThrow();
       expect(logger.error).toHaveBeenCalledOnce();
       expect(logger.error).toHaveBeenCalledWith(
@@ -283,7 +366,11 @@ describe("handleError", () => {
       const logger = createMockLogger();
       const err = new Error("transient");
       expect(() =>
-        handleError(err, ErrorCategory.RECOVERABLE, logger as any),
+        handleError({
+          error: err,
+          category: ErrorCategory.RECOVERABLE,
+          logger: logger as any,
+        }),
       ).not.toThrow();
       expect(logger.warn).toHaveBeenCalledOnce();
       expect(logger.warn).toHaveBeenCalledWith(
@@ -297,7 +384,11 @@ describe("handleError", () => {
     it("logs and does not throw when NON_CRITICAL with logger", () => {
       const logger = createMockLogger();
       expect(() =>
-        handleError("string error", ErrorCategory.NON_CRITICAL, logger as any),
+        handleError({
+          error: "string error",
+          category: ErrorCategory.NON_CRITICAL,
+          logger: logger as any,
+        }),
       ).not.toThrow();
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({ error: "string error" }),
@@ -309,33 +400,43 @@ describe("handleError", () => {
 
 describe("categorizeError", () => {
   it("returns CRITICAL for SecurityError", () => {
-    expect(categorizeError(new SecurityError("op", "msg"))).toBe(
-      ErrorCategory.CRITICAL,
-    );
+    expect(
+      categorizeError(new SecurityError({ operation: "op", message: "msg" })),
+    ).toBe(ErrorCategory.CRITICAL);
   });
 
   it("returns CRITICAL for ValidationError", () => {
-    expect(categorizeError(new ValidationError("reason"))).toBe(
+    expect(categorizeError(new ValidationError({ reason: "reason" }))).toBe(
       ErrorCategory.CRITICAL,
     );
   });
 
   it("returns RECOVERABLE for QueueError", () => {
-    expect(categorizeError(new QueueError("q", "op", "msg"))).toBe(
-      ErrorCategory.RECOVERABLE,
-    );
+    expect(
+      categorizeError(
+        new QueueError({ queueName: "q", operation: "op", message: "msg" }),
+      ),
+    ).toBe(ErrorCategory.RECOVERABLE);
   });
 
   it("returns NON_CRITICAL for HandlerError", () => {
-    expect(categorizeError(new HandlerError("h", "e", "msg"))).toBe(
-      ErrorCategory.NON_CRITICAL,
-    );
+    expect(
+      categorizeError(
+        new HandlerError({ handlerName: "h", eventId: "e", message: "msg" }),
+      ),
+    ).toBe(ErrorCategory.NON_CRITICAL);
   });
 
   it("returns NON_CRITICAL for ProjectionError", () => {
-    expect(categorizeError(new ProjectionError("p", "e", "msg"))).toBe(
-      ErrorCategory.NON_CRITICAL,
-    );
+    expect(
+      categorizeError(
+        new ProjectionError({
+          projectionName: "p",
+          eventId: "e",
+          message: "msg",
+        }),
+      ),
+    ).toBe(ErrorCategory.NON_CRITICAL);
   });
 
   it("returns RECOVERABLE for plain Error", () => {

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.errors.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.errors.test.ts
@@ -40,11 +40,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).rejects.toThrow(
@@ -69,11 +69,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).rejects.toThrow(
@@ -115,11 +115,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
         logger: logger as any,
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await expect(
         service.storeEvents([event], context),
@@ -145,11 +145,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
         mapProjections: [mapDef1, mapDef2],
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await expect(
         service.storeEvents([event], context),
@@ -175,11 +175,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await expect(
         service.storeEvents([event], context),
@@ -207,11 +207,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).resolves.not.toThrow();
@@ -222,11 +222,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       const foldDef1 = createMockFoldProjectionDefinition("projection1");
       const foldDef2 = createMockFoldProjectionDefinition("projection2");
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       (foldDef1.apply as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -251,11 +251,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       const eventStore = createMockEventStore<Event>();
       const foldDef = createMockFoldProjectionDefinition("projection");
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       (foldDef.apply as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -280,8 +280,16 @@ describe("EventSourcingService - Error Handling Flows", () => {
       const aggregate1 = "aggregate-1";
       const aggregate2 = "aggregate-2";
       const events = [
-        createTestEvent(aggregate1, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
-        createTestEvent(aggregate2, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
+        createTestEvent({
+          aggregateId: aggregate1,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+        createTestEvent({
+          aggregateId: aggregate2,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
       ];
 
       // Fail apply only for the first event (aggregate-1)
@@ -320,11 +328,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).resolves.not.toThrow();
@@ -339,11 +347,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).resolves.not.toThrow();
@@ -360,11 +368,11 @@ describe("EventSourcingService - Error Handling Flows", () => {
       });
 
       await expect(
-        service.getProjectionByName(
-          "nonexistent" as any,
-          TEST_CONSTANTS.AGGREGATE_ID,
+        service.getProjectionByName({
+          projectionName: "nonexistent" as any,
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           context,
-        ),
+        }),
       ).rejects.toThrow(/nonexistent/);
     });
   });

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.handlers.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.handlers.test.ts
@@ -51,11 +51,11 @@ describe("EventSourcingService - Handler Flows", () => {
         logger: logger as any,
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await expect(
         service.storeEvents([event], context),
@@ -83,11 +83,11 @@ describe("EventSourcingService - Handler Flows", () => {
         mapProjections: [mapDef1, mapDef2],
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await expect(
         service.storeEvents([event], context),
@@ -120,11 +120,11 @@ describe("EventSourcingService - Handler Flows", () => {
         globalJobRegistry,
       });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-      );
+      });
 
       await service.storeEvents([event], context);
 

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.projections.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.projections.test.ts
@@ -43,11 +43,11 @@ describe("EventSourcingService - Projection Flows", () => {
         foldProjections: [foldDef],
       });
 
-      const result = await service.getProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const result = await service.getProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
-      );
+      });
 
       expect(result).not.toBeNull();
       expect(foldStore.get).toHaveBeenCalledWith(
@@ -69,11 +69,11 @@ describe("EventSourcingService - Projection Flows", () => {
       });
 
       await expect(
-        service.getProjectionByName(
-          "nonexistent" as any,
-          TEST_CONSTANTS.AGGREGATE_ID,
+        service.getProjectionByName({
+          projectionName: "nonexistent" as any,
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           context,
-        ),
+        }),
       ).rejects.toThrow(/nonexistent/);
     });
 
@@ -86,11 +86,11 @@ describe("EventSourcingService - Projection Flows", () => {
       });
 
       await expect(
-        service.getProjectionByName(
-          "projection",
-          TEST_CONSTANTS.AGGREGATE_ID,
+        service.getProjectionByName({
+          projectionName: "projection",
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           context,
-        ),
+        }),
       ).rejects.toThrow(/projection/i);
     });
   });
@@ -114,11 +114,11 @@ describe("EventSourcingService - Projection Flows", () => {
         foldProjections: [foldDef],
       });
 
-      const result = await service.hasProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const result = await service.hasProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
-      );
+      });
 
       expect(result).toBe(true);
     });
@@ -139,11 +139,11 @@ describe("EventSourcingService - Projection Flows", () => {
         foldProjections: [foldDef],
       });
 
-      const result = await service.hasProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const result = await service.hasProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
-      );
+      });
 
       expect(result).toBe(false);
     });
@@ -158,11 +158,11 @@ describe("EventSourcingService - Projection Flows", () => {
       });
 
       await expect(
-        service.hasProjectionByName(
-          "nonexistent" as any,
-          TEST_CONSTANTS.AGGREGATE_ID,
+        service.hasProjectionByName({
+          projectionName: "nonexistent" as any,
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           context,
-        ),
+        }),
       ).rejects.toThrow(/nonexistent/);
     });
 
@@ -175,11 +175,11 @@ describe("EventSourcingService - Projection Flows", () => {
       });
 
       await expect(
-        service.hasProjectionByName(
-          "projection",
-          TEST_CONSTANTS.AGGREGATE_ID,
+        service.hasProjectionByName({
+          projectionName: "projection",
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           context,
-        ),
+        }),
       ).rejects.toThrow(/projection/i);
     });
   });
@@ -213,11 +213,11 @@ describe("EventSourcingService - Projection Flows", () => {
       const foldDef = createMockFoldProjectionDefinition("projection");
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       const service = new EventSourcingService({
@@ -240,11 +240,11 @@ describe("EventSourcingService - Projection Flows", () => {
       const foldDef1 = createMockFoldProjectionDefinition("projection1");
       const foldDef2 = createMockFoldProjectionDefinition("projection2");
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       const service = new EventSourcingService({
@@ -269,8 +269,16 @@ describe("EventSourcingService - Projection Flows", () => {
       const aggregate1 = "aggregate-1";
       const aggregate2 = "aggregate-2";
       const events = [
-        createTestEvent(aggregate1, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
-        createTestEvent(aggregate2, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
+        createTestEvent({
+          aggregateId: aggregate1,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+        createTestEvent({
+          aggregateId: aggregate2,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
       ];
 
       const service = new EventSourcingService({

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.recovery.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.recovery.test.ts
@@ -38,20 +38,20 @@ describe("EventSourcingService - Recovery Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
 
       // Store events
       await eventStore.storeEvents([event1, event2], context, aggregateType);
@@ -89,27 +89,27 @@ describe("EventSourcingService - Recovery Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
-      const event3 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
+      const event3 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
+      });
 
       // Store events
       await eventStore.storeEvents(
@@ -149,13 +149,13 @@ describe("EventSourcingService - Recovery Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event
       await eventStore.storeEvents([event1], context, aggregateType);
@@ -196,13 +196,13 @@ describe("EventSourcingService - Recovery Flows", () => {
         foldProjections: [foldDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event
       await eventStore.storeEvents([event1], context, aggregateType);
@@ -235,20 +235,20 @@ describe("EventSourcingService - Recovery Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
 
       // Make map fail for event1 initially then succeed
       (mapDef.map as ReturnType<typeof vi.fn>)
@@ -263,11 +263,11 @@ describe("EventSourcingService - Recovery Flows", () => {
       ).resolves.not.toThrow();
 
       // Verify event1 is stored (even though map failed)
-      const eventsBefore = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const eventsBefore = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       expect(eventsBefore).toHaveLength(1);
       expect(eventsBefore[0]?.id).toBe(event1.id);
 
@@ -278,11 +278,11 @@ describe("EventSourcingService - Recovery Flows", () => {
       expect(mapDef.map).toHaveBeenCalledTimes(2);
 
       // Verify both events are stored
-      const eventsAfter = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const eventsAfter = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       expect(eventsAfter).toHaveLength(2);
 
       // Fix map
@@ -294,11 +294,11 @@ describe("EventSourcingService - Recovery Flows", () => {
       await service.storeEvents([event1], context);
 
       // event1 is only stored once (duplicate prevention)
-      const finalEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const finalEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       const event1Count = finalEvents.filter((e) => e.id === event1.id).length;
       expect(event1Count).toBe(1);
       expect(finalEvents).toHaveLength(2);

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.security.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.security.test.ts
@@ -39,11 +39,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
 
       // Context without tenantId should fail
@@ -63,11 +63,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
 
       // Empty tenantId should fail
@@ -88,11 +88,11 @@ describe("EventSourcingService - Security Flows", () => {
 
       const context1 = createTestEventStoreReadContext(tenantId1);
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
 
       await service.storeEvents(events, context1);
@@ -125,11 +125,11 @@ describe("EventSourcingService - Security Flows", () => {
         foldProjections: [foldDef],
       });
 
-      await service.getProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
-        context1,
-      );
+      await service.getProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        context: context1,
+      });
 
       expect(foldStore.get).toHaveBeenCalledWith(
         TEST_CONSTANTS.AGGREGATE_ID,
@@ -151,11 +151,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
 
       await expect(
@@ -172,11 +172,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
 
       const invalidContexts = [
@@ -210,11 +210,11 @@ describe("EventSourcingService - Security Flows", () => {
         foldProjections: [foldDef],
       });
 
-      await service.getProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
+      await service.getProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
-      );
+      });
 
       expect(foldStore.get).toHaveBeenCalledWith(
         TEST_CONSTANTS.AGGREGATE_ID,
@@ -237,11 +237,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
       const context = createTestEventStoreReadContext(tenantId1);
 
@@ -272,11 +272,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
       const context = createTestEventStoreReadContext(tenantId1);
 
@@ -308,18 +308,18 @@ describe("EventSourcingService - Security Flows", () => {
       const context1 = createTestEventStoreReadContext(tenantId1);
       const context2 = createTestEventStoreReadContext(tenantId2);
       const events1 = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
       const events2 = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId2,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId2,
+        }),
       ];
 
       await service.storeEvents(events1, context1);
@@ -351,11 +351,11 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
       await service.storeEvents(events, context1);
 
@@ -381,16 +381,16 @@ describe("EventSourcingService - Security Flows", () => {
         foldProjections: [foldDef],
       });
 
-      await service.getProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
-        context1,
-      );
-      await service.getProjectionByName(
-        "projection",
-        TEST_CONSTANTS.AGGREGATE_ID,
-        context2,
-      );
+      await service.getProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        context: context1,
+      });
+      await service.getProjectionByName({
+        projectionName: "projection",
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        context: context2,
+      });
 
       // Verify different tenantIds are passed to fold store
       expect(foldStore.get).toHaveBeenCalledWith(
@@ -417,18 +417,18 @@ describe("EventSourcingService - Security Flows", () => {
       });
 
       const events1 = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId1,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId1,
+        }),
       ];
       const events2 = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
-          tenantId2,
-        ),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId: tenantId2,
+        }),
       ];
 
       await service.storeEvents(events1, context1);

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.sequential.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.sequential.test.ts
@@ -38,20 +38,20 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
 
       // Store event1 first (but don't process it via service yet)
       await eventStore.storeEvents([event1], context, aggregateType);
@@ -82,27 +82,27 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
-      const event3 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
+      const event3 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
+      });
 
       // Store all events
       await eventStore.storeEvents(
@@ -137,13 +137,13 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event
       await eventStore.storeEvents([event1], context, aggregateType);
@@ -170,36 +170,36 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
 
       // Create events with same timestamp but different IDs
       const sameTimestamp = TEST_CONSTANTS.BASE_TIMESTAMP;
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        sameTimestamp,
-        eventVersion,
-        {},
-        `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:a`,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: sameTimestamp,
+        version: eventVersion,
+        data: {},
+        id: `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:a`,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        sameTimestamp,
-        eventVersion,
-        {},
-        `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:b`,
-      );
-      const event3 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: sameTimestamp,
+        version: eventVersion,
+        data: {},
+        id: `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:b`,
+      });
+      const event3 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        sameTimestamp,
-        eventVersion,
-        {},
-        `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:c`,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: sameTimestamp,
+        version: eventVersion,
+        data: {},
+        id: `${sameTimestamp}:${tenantId}:${TEST_CONSTANTS.AGGREGATE_ID}:${aggregateType}:c`,
+      });
 
       // Store all events
       await eventStore.storeEvents(
@@ -233,13 +233,13 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event1 via service (stores and processes)
       await service.storeEvents([event1], context);
@@ -248,11 +248,11 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       await service.storeEvents([event1], context);
 
       // Verify event is only stored once in the repository
-      const allEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const allEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       const event1Count = allEvents.filter((e) => e.id === event1.id).length;
       expect(event1Count).toBe(1);
 
@@ -273,13 +273,13 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event1 directly in event store
       await eventStore.storeEvents([event1], context, aggregateType);
@@ -288,11 +288,11 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       await service.storeEvents([event1], context);
 
       // Verify event is only stored once
-      const allEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const allEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       const event1Count = allEvents.filter((e) => e.id === event1.id).length;
       expect(event1Count).toBe(1);
 
@@ -313,30 +313,30 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
 
       // Store batch with duplicate event1
       await service.storeEvents([event1, event2, event1], context);
 
       // Verify each event is only stored once
-      const allEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const allEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       expect(allEvents).toHaveLength(2);
       expect(allEvents.find((e) => e.id === event1.id)).toBeDefined();
       expect(allEvents.find((e) => e.id === event2.id)).toBeDefined();
@@ -360,13 +360,13 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef1, mapDef2],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
 
       // Store event1 via service (both handlers should process)
       await service.storeEvents([event1], context);
@@ -375,11 +375,11 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       await service.storeEvents([event1], context);
 
       // Verify event is only stored once in the repository
-      const allEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const allEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       const event1Count = allEvents.filter((e) => e.id === event1.id).length;
       expect(event1Count).toBe(1);
 
@@ -408,20 +408,20 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       const sameTimestamp = TEST_CONSTANTS.BASE_TIMESTAMP;
 
       // Create events for different aggregates (will have different IDs due to different aggregate IDs)
-      const event1_agg1 = createTestEvent(
-        aggregateId1,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1_agg1 = createTestEvent({
+        aggregateId: aggregateId1,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        sameTimestamp,
-      );
-      const event1_agg2 = createTestEvent(
-        aggregateId2,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: sameTimestamp,
+      });
+      const event1_agg2 = createTestEvent({
+        aggregateId: aggregateId2,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        sameTimestamp,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: sameTimestamp,
+      });
 
       // Verify they have different IDs (due to different aggregate IDs in ID generation)
       expect(event1_agg1.id).not.toBe(event1_agg2.id);
@@ -433,16 +433,16 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       await service.storeEvents([event1_agg2], context);
 
       // Verify both events are stored (they're in different partitions)
-      const events_agg1 = await eventStore.getEvents(
-        aggregateId1,
+      const events_agg1 = await eventStore.getEvents({
+        aggregateId: aggregateId1,
         context,
         aggregateType,
-      );
-      const events_agg2 = await eventStore.getEvents(
-        aggregateId2,
+      });
+      const events_agg2 = await eventStore.getEvents({
+        aggregateId: aggregateId2,
         context,
         aggregateType,
-      );
+      });
       expect(events_agg1).toHaveLength(1);
       expect(events_agg2).toHaveLength(1);
       expect(events_agg1[0]?.id).toBe(event1_agg1.id);
@@ -466,27 +466,27 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
         mapProjections: [mapDef],
       });
 
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP,
-      );
-      const event2 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      });
+      const event2 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
-      );
-      const event3 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 1000,
+      });
+      const event3 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        EVENT_TYPES[0],
-        TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
-      );
+        type: EVENT_TYPES[0],
+        createdAt: TEST_CONSTANTS.BASE_TIMESTAMP + 2000,
+      });
 
       // Store event1 first
       await service.storeEvents([event1], context);
@@ -496,11 +496,11 @@ describe("EventSourcingService - Sequential Ordering Flows", () => {
       await service.storeEvents([event1, event2, event3], context);
 
       // Verify all events are stored (event1 once, event2 once, event3 once)
-      const allEvents = await eventStore.getEvents(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const allEvents = await eventStore.getEvents({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         context,
         aggregateType,
-      );
+      });
       expect(allEvents).toHaveLength(3);
       expect(allEvents.find((e) => e.id === event1.id)).toBeDefined();
       expect(allEvents.find((e) => e.id === event2.id)).toBeDefined();

--- a/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.storeEvents.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/eventSourcingService.flows.storeEvents.test.ts
@@ -37,11 +37,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);
@@ -79,11 +79,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).resolves.not.toThrow();
@@ -111,11 +111,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);
@@ -138,11 +138,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);
@@ -166,9 +166,21 @@ describe("EventSourcingService - Store Events Flow", () => {
       const aggregate1 = "aggregate-1";
       const aggregate2 = "aggregate-2";
       const events = [
-        createTestEvent(aggregate1, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
-        createTestEvent(aggregate2, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
-        createTestEvent(aggregate1, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId), // Same aggregate again
+        createTestEvent({
+          aggregateId: aggregate1,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+        createTestEvent({
+          aggregateId: aggregate2,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+        createTestEvent({
+          aggregateId: aggregate1,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }), // Same aggregate again
       ];
 
       await service.storeEvents(events, context);
@@ -190,11 +202,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       eventStore.getEvents = vi.fn().mockResolvedValue(events);
@@ -236,22 +248,20 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const timestamp = 1000000;
-      const event1 = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
-        TEST_CONSTANTS.AGGREGATE_TYPE,
+      const event1 = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
         tenantId,
-        void 0,
-        timestamp,
-      );
+        createdAt: timestamp,
+      });
       // Create event2 with same Event ID (same timestamp/tenant/aggregate/type)
       const event2 = {
-        ...createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        ...createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-          void 0,
-          timestamp,
-        ),
+          createdAt: timestamp,
+        }),
         id: event1.id, // Same Event ID
       };
 
@@ -285,15 +295,13 @@ describe("EventSourcingService - Store Events Flow", () => {
           return event;
         },
       );
-      eventStore.getEvents = vi
-        .fn()
-        .mockResolvedValue([
-          createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
-            tenantId,
-          ),
-        ]);
+      eventStore.getEvents = vi.fn().mockResolvedValue([
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+      ]);
       (foldDef.apply as ReturnType<typeof vi.fn>).mockImplementation(
         (_state: any) => {
           callOrder.push("projection");
@@ -322,11 +330,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       // Mock getEvents to return the same events that are being stored
@@ -348,15 +356,13 @@ describe("EventSourcingService - Store Events Flow", () => {
       const mapDef = createMockMapProjectionDefinition("handler");
       const foldDef = createMockFoldProjectionDefinition("projection");
 
-      eventStore.getEvents = vi
-        .fn()
-        .mockResolvedValue([
-          createTestEvent(
-            TEST_CONSTANTS.AGGREGATE_ID,
-            TEST_CONSTANTS.AGGREGATE_TYPE,
-            tenantId,
-          ),
-        ]);
+      eventStore.getEvents = vi.fn().mockResolvedValue([
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+          tenantId,
+        }),
+      ]);
       (foldDef.apply as ReturnType<typeof vi.fn>).mockImplementation(
         (_state: any) => ({
           id: "proj-id",
@@ -376,11 +382,11 @@ describe("EventSourcingService - Store Events Flow", () => {
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       // Mock getEvents to return the same events that are being stored

--- a/platform/app/src/server/event-sourcing/services/__tests__/interposition.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/interposition.unit.test.ts
@@ -80,11 +80,11 @@ describe("given EventSourcingService is configured with a map projection", () =>
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);
@@ -119,21 +119,21 @@ describe("given EventSourcingService is configured with a map projection", () =>
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        }),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        }),
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);
@@ -162,11 +162,11 @@ describe("given EventSourcingService is configured with a map projection", () =>
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await expect(service.storeEvents(events, context)).rejects.toThrow(
@@ -212,11 +212,11 @@ describe("given EventSourcingService is configured with a map projection", () =>
       });
 
       const events = [
-        createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
-          TEST_CONSTANTS.AGGREGATE_TYPE,
+        createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
           tenantId,
-        ),
+        }),
       ];
 
       await service.storeEvents(events, context);

--- a/platform/app/src/server/event-sourcing/services/__tests__/testHelpers.ts
+++ b/platform/app/src/server/event-sourcing/services/__tests__/testHelpers.ts
@@ -60,13 +60,23 @@ export function createMockEventStore<T extends Event>(): EventStore<T> {
     getEventsUpTo: vi
       .fn()
       .mockImplementation(
-        async (aggregateId, context, aggregateType, upToEvent) => {
+        async ({
+          aggregateId,
+          context,
+          aggregateType,
+          upToEvent,
+        }: {
+          aggregateId: string;
+          context: EventStoreReadContext<T>;
+          aggregateType: AggregateType;
+          upToEvent: T;
+        }) => {
           // Default implementation: get all events and filter
-          const allEvents = await mockStore.getEvents(
+          const allEvents = await mockStore.getEvents({
             aggregateId,
             context,
             aggregateType,
-          );
+          });
           const upToIndex = allEvents.findIndex(
             (e: T) => e.id === upToEvent.id,
           );
@@ -186,16 +196,25 @@ let testEventIdCounter = 0;
  * Creates a test event with predictable values.
  * IDs are auto-generated to be unique even for events with the same timestamp.
  */
-export function createTestEvent(
-  aggregateId: string,
-  aggregateType: AggregateType,
-  tenantId: TenantId,
-  type: EventType = EVENT_TYPES[0],
+export function createTestEvent({
+  aggregateId,
+  aggregateType,
+  tenantId,
+  type = EVENT_TYPES[0],
   createdAt = 1000000,
   version = "2025-12-17",
-  data: unknown = {},
-  id?: string,
-): Event {
+  data = {},
+  id,
+}: {
+  aggregateId: string;
+  aggregateType: AggregateType;
+  tenantId: TenantId;
+  type?: EventType;
+  createdAt?: number;
+  version?: string;
+  data?: unknown;
+  id?: string;
+}): Event {
   const uniqueId =
     id ??
     `${createdAt}:${tenantId}:${aggregateId}:${aggregateType}:${testEventIdCounter++}`;
@@ -215,13 +234,19 @@ export function createTestEvent(
 /**
  * Creates a test projection with predictable values.
  */
-export function createTestProjection<Data = unknown>(
-  aggregateId: string,
-  tenantId: TenantId,
-  data: Data = {} as Data,
+export function createTestProjection<Data = unknown>({
+  aggregateId,
+  tenantId,
+  data = {} as Data,
   version = "2025-12-17",
-  id?: string,
-): Projection<Data> {
+  id,
+}: {
+  aggregateId: string;
+  tenantId: TenantId;
+  data?: Data;
+  version?: string;
+  id?: string;
+}): Projection<Data> {
   return {
     id: id ?? `projection-${aggregateId}`,
     aggregateId,

--- a/platform/app/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
@@ -43,13 +43,13 @@ describe("processCommand", () => {
 
   // Build a valid event via the test helper
   function makeValidEvent(overrides?: Partial<Event>): Event {
-    return createTestEvent(
-      overrides?.aggregateId ?? TEST_CONSTANTS.AGGREGATE_ID,
-      overrides?.aggregateType ?? aggregateType,
-      overrides?.tenantId ?? tenantId,
-      overrides?.type ?? TEST_CONSTANTS.EVENT_TYPE_1,
-      overrides?.createdAt ?? TEST_CONSTANTS.BASE_TIMESTAMP,
-    );
+    return createTestEvent({
+      aggregateId: overrides?.aggregateId ?? TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType: overrides?.aggregateType ?? aggregateType,
+      tenantId: overrides?.tenantId ?? tenantId,
+      type: overrides?.type ?? TEST_CONSTANTS.EVENT_TYPE_1,
+      createdAt: overrides?.createdAt ?? TEST_CONSTANTS.BASE_TIMESTAMP,
+    });
   }
 
   // ---- Reusable mock factories ----
@@ -349,13 +349,13 @@ describe("processCommandBatch", () => {
   });
 
   function makeValidEvent(): Event {
-    return createTestEvent(
-      TEST_CONSTANTS.AGGREGATE_ID,
+    return createTestEvent({
+      aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
       aggregateType,
-      createTestTenantId(),
-      TEST_CONSTANTS.EVENT_TYPE_1,
-      TEST_CONSTANTS.BASE_TIMESTAMP,
-    );
+      tenantId: createTestTenantId(),
+      type: TEST_CONSTANTS.EVENT_TYPE_1,
+      createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+    });
   }
 
   // A valid event carrying an idempotency key derived from its command, so the

--- a/platform/app/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/platform/app/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -64,32 +64,32 @@ function validateHandlerEvents(
   commandType: CommandType,
 ): void {
   if (!events) {
-    throw new ValidationError(
-      `Command handler for "${commandType}" returned undefined. Handler must return an array of events.`,
-      "events",
-      void 0,
-      { commandType },
-    );
+    throw new ValidationError({
+      reason: `Command handler for "${commandType}" returned undefined. Handler must return an array of events.`,
+      field: "events",
+      value: void 0,
+      context: { commandType },
+    });
   }
 
   if (!Array.isArray(events)) {
-    throw new ValidationError(
-      `Command handler for "${commandType}" returned a non-array value. Handler must return an array of events, but got: ${typeof events}`,
-      "events",
-      undefined,
-      { commandType },
-    );
+    throw new ValidationError({
+      reason: `Command handler for "${commandType}" returned a non-array value. Handler must return an array of events, but got: ${typeof events}`,
+      field: "events",
+      value: undefined,
+      context: { commandType },
+    });
   }
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
     if (!event) {
-      throw new ValidationError(
-        `Command handler for "${commandType}" returned an array with undefined at index ${i}. All events must be defined.`,
-        "events",
-        undefined,
-        { commandType, index: i },
-      );
+      throw new ValidationError({
+        reason: `Command handler for "${commandType}" returned an array with undefined at index ${i}. All events must be defined.`,
+        field: "events",
+        value: undefined,
+        context: { commandType, index: i },
+      });
     }
 
     if (!EventUtils.isValidEvent(event)) {
@@ -101,11 +101,11 @@ function validateHandlerEvents(
               .join(", ")}`
           : "Unknown validation error";
 
-      throw new ValidationError(
-        `Command handler for "${commandType}" returned an invalid event at index ${i}. Event must have id, aggregateId, timestamp, type, and data. ${validationError}.`,
-        "events",
-        undefined,
-        {
+      throw new ValidationError({
+        reason: `Command handler for "${commandType}" returned an invalid event at index ${i}. Event must have id, aggregateId, timestamp, type, and data. ${validationError}.`,
+        field: "events",
+        value: undefined,
+        context: {
           commandType,
           index: i,
           zodIssues:
@@ -113,9 +113,36 @@ function validateHandlerEvents(
               ? mapZodIssuesToLogContext(parseResult.error.issues)
               : void 0,
         },
-      );
+      });
     }
   }
+}
+
+/**
+ * Schema-validate a single command payload, throwing the same ValidationError
+ * shape the dispatcher has always raised on malformed input.
+ */
+function validateCommandPayload<EventType extends Event>({
+  commandSchema,
+  payload,
+  commandType,
+}: Pick<
+  ProcessCommandParams<EventType>,
+  "commandSchema" | "payload" | "commandType"
+>) {
+  const validation = commandSchema.validate(payload);
+  if (!validation.success) {
+    throw new ValidationError({
+      reason: `Invalid payload for command type "${commandType}". Validation failed.`,
+      field: "payload",
+      value: undefined,
+      context: {
+        commandType,
+        zodIssues: mapZodIssuesToLogContext(validation.error.issues),
+      },
+    });
+  }
+  return validation.data;
 }
 
 /**
@@ -142,20 +169,11 @@ export async function processCommand<EventType extends Event>(
     logger: log,
   } = params;
 
-  const validation = commandSchema.validate(payload);
-  if (!validation.success) {
-    throw new ValidationError(
-      `Invalid payload for command type "${commandType}". Validation failed.`,
-      "payload",
-      undefined,
-      {
-        commandType,
-        zodIssues: mapZodIssuesToLogContext(validation.error.issues),
-      },
-    );
-  }
-
-  const validated = validation.data;
+  const validated = validateCommandPayload<EventType>({
+    commandSchema,
+    payload,
+    commandType,
+  });
   const tenantId = createTenantId(String(validated.tenantId));
   const aggregateId = getAggregateId(validated);
 
@@ -172,7 +190,12 @@ export async function processCommand<EventType extends Event>(
     return;
   }
 
-  const command = createCommand(tenantId, aggregateId, commandType, validated);
+  const command = createCommand({
+    tenantId,
+    aggregateId,
+    type: commandType,
+    data: validated,
+  });
 
   const commandStartTime = performance.now();
   try {
@@ -245,15 +268,15 @@ function validateBatchPayloads<EventType extends Event>(
   return payloads.map((payload) => {
     const validation = commandSchema.validate(payload);
     if (!validation.success) {
-      throw new ValidationError(
-        `Invalid payload for command type "${commandType}". Validation failed.`,
-        "payload",
-        undefined,
-        {
+      throw new ValidationError({
+        reason: `Invalid payload for command type "${commandType}". Validation failed.`,
+        field: "payload",
+        value: undefined,
+        context: {
           commandType,
           zodIssues: mapZodIssuesToLogContext(validation.error.issues),
         },
-      );
+      });
     }
     return validation.data;
   });
@@ -273,12 +296,12 @@ function resolveBatchTenantId(args: {
   const tenantId = createTenantId(String(validatedPayloads[0]!.tenantId));
   for (const validated of validatedPayloads) {
     if (createTenantId(String(validated.tenantId)) !== tenantId) {
-      throw new ValidationError(
-        `Coalesced batch for command type "${commandType}" mixes tenants. All payloads in one group share a tenant.`,
-        "tenantId",
-        undefined,
-        { commandType },
-      );
+      throw new ValidationError({
+        reason: `Coalesced batch for command type "${commandType}" mixes tenants. All payloads in one group share a tenant.`,
+        field: "tenantId",
+        value: undefined,
+        context: { commandType },
+      });
     }
   }
   return tenantId;
@@ -328,12 +351,12 @@ async function handleBatchCommands<EventType extends Event>(args: {
     }
 
     progress.attempted++;
-    const command = createCommand(
-      payloadTenantId,
+    const command = createCommand({
+      tenantId: payloadTenantId,
       aggregateId,
-      commandType,
-      validated,
-    );
+      type: commandType,
+      data: validated,
+    });
     const events = await handler.handle(command);
     validateHandlerEvents(events, commandType);
     handledCommands.push(command);

--- a/platform/app/src/server/event-sourcing/services/errorHandling.ts
+++ b/platform/app/src/server/event-sourcing/services/errorHandling.ts
@@ -31,12 +31,17 @@ export abstract class BaseEventSourcingError extends Error {
   readonly context: Record<string, unknown>;
   readonly cause?: unknown;
 
-  constructor(
-    message: string,
-    category: ErrorCategory,
-    context: Record<string, unknown> = {},
-    cause?: unknown,
-  ) {
+  constructor({
+    message,
+    category,
+    context = {},
+    cause,
+  }: {
+    message: string;
+    category: ErrorCategory;
+    context?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
     super(message);
     this.name = "EventSourcingError";
     this.category = category;
@@ -71,7 +76,7 @@ export abstract class CriticalError extends BaseEventSourcingError {
     context: Record<string, unknown> = {},
     cause?: unknown,
   ) {
-    super(message, ErrorCategory.CRITICAL, context, cause);
+    super({ message, category: ErrorCategory.CRITICAL, context, cause });
   }
 }
 
@@ -84,7 +89,7 @@ export abstract class RecoverableError extends BaseEventSourcingError {
     context: Record<string, unknown> = {},
     cause?: unknown,
   ) {
-    super(message, ErrorCategory.RECOVERABLE, context, cause);
+    super({ message, category: ErrorCategory.RECOVERABLE, context, cause });
   }
 }
 
@@ -97,7 +102,7 @@ export abstract class NonCriticalError extends BaseEventSourcingError {
     context: Record<string, unknown> = {},
     cause?: unknown,
   ) {
-    super(message, ErrorCategory.NON_CRITICAL, context, cause);
+    super({ message, category: ErrorCategory.NON_CRITICAL, context, cause });
   }
 }
 
@@ -109,12 +114,17 @@ export class SecurityError extends CriticalError {
   readonly operation: string;
   readonly tenantId?: string;
 
-  constructor(
-    operation: string,
-    message: string,
-    tenantId?: string,
-    context: Record<string, unknown> = {},
-  ) {
+  constructor({
+    operation,
+    message,
+    tenantId,
+    context = {},
+  }: {
+    operation: string;
+    message: string;
+    tenantId?: string;
+    context?: Record<string, unknown>;
+  }) {
     super(`[SECURITY] ${message}`, {
       ...context,
       operation,
@@ -134,12 +144,17 @@ export class ValidationError extends CriticalError {
   readonly value?: unknown;
   readonly reason: string;
 
-  constructor(
-    reason: string,
-    field?: string,
-    value?: unknown,
-    context: Record<string, unknown> = {},
-  ) {
+  constructor({
+    reason,
+    field,
+    value,
+    context = {},
+  }: {
+    reason: string;
+    field?: string;
+    value?: unknown;
+    context?: Record<string, unknown>;
+  }) {
     const message = field
       ? `[VALIDATION] ${reason} (field: ${field})`
       : `[VALIDATION] ${reason}`;
@@ -187,24 +202,31 @@ export class StoreError extends BaseEventSourcingError {
   readonly operation: string;
   readonly store: string;
 
-  constructor(
-    operation: string,
-    store: string,
-    message: string,
-    category: ErrorCategory,
-    context: Record<string, unknown> = {},
-    cause?: unknown,
-  ) {
-    super(
+  constructor({
+    operation,
+    store,
+    message,
+    category,
+    context = {},
+    cause,
+  }: {
+    operation: string;
+    store: string;
+    message: string;
+    category: ErrorCategory;
+    context?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super({
       message,
       category,
-      {
+      context: {
         ...context,
         operation,
         store,
       },
       cause,
-    );
+    });
     this.operation = operation;
     this.store = store;
   }
@@ -218,13 +240,19 @@ export class QueueError extends RecoverableError {
   readonly queueName: string;
   readonly operation: string;
 
-  constructor(
-    queueName: string,
-    operation: string,
-    message: string,
-    context: Record<string, unknown> = {},
-    cause?: unknown,
-  ) {
+  constructor({
+    queueName,
+    operation,
+    message,
+    context = {},
+    cause,
+  }: {
+    queueName: string;
+    operation: string;
+    message: string;
+    context?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
     super(
       message,
       {
@@ -247,13 +275,19 @@ export class HandlerError extends NonCriticalError {
   readonly handlerName: string;
   readonly eventId: string;
 
-  constructor(
-    handlerName: string,
-    eventId: string,
-    message: string,
-    context: Record<string, unknown> = {},
-    cause?: unknown,
-  ) {
+  constructor({
+    handlerName,
+    eventId,
+    message,
+    context = {},
+    cause,
+  }: {
+    handlerName: string;
+    eventId: string;
+    message: string;
+    context?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
     super(
       message,
       {
@@ -276,13 +310,19 @@ export class ProjectionError extends NonCriticalError {
   readonly projectionName: string;
   readonly eventId: string;
 
-  constructor(
-    projectionName: string,
-    eventId: string,
-    message: string,
-    context: Record<string, unknown> = {},
-    cause?: unknown,
-  ) {
+  constructor({
+    projectionName,
+    eventId,
+    message,
+    context = {},
+    cause,
+  }: {
+    projectionName: string;
+    eventId: string;
+    message: string;
+    context?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
     super(
       message,
       {
@@ -308,12 +348,17 @@ export class ProjectionError extends NonCriticalError {
  * @param context - Additional context for logging (merged with error context if available)
  * @throws {Error} If category is CRITICAL
  */
-export function handleError(
-  error: unknown,
-  category: ErrorCategory,
-  logger?: ReturnType<typeof createLogger>,
-  context?: Record<string, unknown>,
-): void {
+export function handleError({
+  error,
+  category,
+  logger,
+  context,
+}: {
+  error: unknown;
+  category: ErrorCategory;
+  logger?: ReturnType<typeof createLogger>;
+  context?: Record<string, unknown>;
+}): void {
   // If error is a BaseEventSourcingError, use its category and merge contexts
   if (error instanceof BaseEventSourcingError) {
     const errorCategory = error.category;

--- a/platform/app/src/server/event-sourcing/services/eventSourcingService.ts
+++ b/platform/app/src/server/event-sourcing/services/eventSourcingService.ts
@@ -110,15 +110,15 @@ export class EventSourcingService<
     });
 
     // Create ProjectionRouter (no event store needed — incremental only)
-    this.router = new ProjectionRouter<EventType, ProjectionTypes>(
+    this.router = new ProjectionRouter<EventType, ProjectionTypes>({
       aggregateType,
       pipelineName,
-      this.queueManager,
+      queueManager: this.queueManager,
       featureFlagService,
       processRole,
       replayMarkerChecker,
       retentionPolicyResolver,
-    );
+    });
 
     // Register fold projections and auto-wire event loaders for out-of-order re-fold
     if (foldProjections) {
@@ -133,12 +133,12 @@ export class EventSourcingService<
             aggregateId: string;
             occurredAtMs?: number;
           }) => {
-            const events = await capturedEventStore.getEvents(
-              ctx.aggregateId,
-              { tenantId: createTenantId(ctx.tenantId) },
-              capturedAggregateType,
-              ctx.occurredAtMs,
-            );
+            const events = await capturedEventStore.getEvents({
+              aggregateId: ctx.aggregateId,
+              context: { tenantId: createTenantId(ctx.tenantId) },
+              aggregateType: capturedAggregateType,
+              anchorOccurredAtMs: ctx.occurredAtMs,
+            });
             return [...events].sort(
               (a, b) => (a.occurredAt ?? 0) - (b.occurredAt ?? 0),
             );
@@ -156,12 +156,12 @@ export class EventSourcingService<
             aggregateId: string;
             upToEvent: Event;
           }) => {
-            const events = await capturedEventStore.getEventsUpTo(
-              ctx.aggregateId,
-              { tenantId: createTenantId(ctx.tenantId) },
-              capturedAggregateType,
-              ctx.upToEvent as EventType,
-            );
+            const events = await capturedEventStore.getEventsUpTo({
+              aggregateId: ctx.aggregateId,
+              context: { tenantId: createTenantId(ctx.tenantId) },
+              aggregateType: capturedAggregateType,
+              upToEvent: ctx.upToEvent as EventType,
+            });
             return [...events].sort(
               (a, b) => (a.occurredAt ?? 0) - (b.occurredAt ?? 0),
             );
@@ -223,12 +223,12 @@ export class EventSourcingService<
             aggregateId: string;
             upToEvent: Event;
           }) => {
-            const events = await capturedEventStore.getEventsUpTo(
-              ctx.aggregateId,
-              { tenantId: createTenantId(ctx.tenantId) },
-              capturedAggregateType,
-              ctx.upToEvent as EventType,
-            );
+            const events = await capturedEventStore.getEventsUpTo({
+              aggregateId: ctx.aggregateId,
+              context: { tenantId: createTenantId(ctx.tenantId) },
+              aggregateType: capturedAggregateType,
+              upToEvent: ctx.upToEvent as EventType,
+            });
             return [...events].sort(
               (a, b) => (a.occurredAt ?? 0) - (b.occurredAt ?? 0),
             );
@@ -445,18 +445,23 @@ export class EventSourcingService<
    */
   async getProjectionByName<
     ProjectionName extends keyof ProjectionTypes & string,
-  >(
-    projectionName: ProjectionName,
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    options?: { key?: string },
-  ): Promise<ProjectionTypes[ProjectionName] | null> {
-    return this.router.getProjectionByName(
+  >({
+    projectionName,
+    aggregateId,
+    context,
+    options,
+  }: {
+    projectionName: ProjectionName;
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    options?: { key?: string };
+  }): Promise<ProjectionTypes[ProjectionName] | null> {
+    return this.router.getProjectionByName({
       projectionName,
       aggregateId,
       context,
       options,
-    );
+    });
   }
 
   /**
@@ -464,18 +469,23 @@ export class EventSourcingService<
    */
   async hasProjectionByName<
     ProjectionName extends keyof ProjectionTypes & string,
-  >(
-    projectionName: ProjectionName,
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    options?: { key?: string },
-  ): Promise<boolean> {
-    return await this.router.hasProjectionByName(
+  >({
+    projectionName,
+    aggregateId,
+    context,
+    options,
+  }: {
+    projectionName: ProjectionName;
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    options?: { key?: string };
+  }): Promise<boolean> {
+    return await this.router.hasProjectionByName({
       projectionName,
       aggregateId,
       context,
       options,
-    );
+    });
   }
 
   /**

--- a/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.groupKeyFn.test.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.groupKeyFn.test.ts
@@ -52,7 +52,7 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
         },
       };
 
-      manager.initializeProjectionQueues(projections, vi.fn());
+      manager.initializeProjectionQueues({ projections, onEvent: vi.fn() });
 
       // The registry entry's groupKeyFn dispatches to the projection's custom groupKeyFn
       const entry = globalJobRegistry.get(
@@ -61,11 +61,11 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
       expect(entry?.groupKeyFn).toBeDefined();
 
       // Call groupKeyFn with the event
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
         `${tenantId}/fold/myProjection/by-tenant:${tenantId}`,
@@ -97,18 +97,18 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
         },
       };
 
-      manager.initializeProjectionQueues(projections, vi.fn());
+      manager.initializeProjectionQueues({ projections, onEvent: vi.fn() });
 
       const entry = globalJobRegistry.get(
         "test-pipeline:projection:myProjection",
       );
       expect(entry?.groupKeyFn).toBeDefined();
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
         `${tenantId}/fold/myProjection/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
@@ -146,7 +146,7 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
         },
       };
 
-      manager.initializeProjectionQueues(projections, vi.fn());
+      manager.initializeProjectionQueues({ projections, onEvent: vi.fn() });
 
       // Both entries registered
       expect(
@@ -156,11 +156,11 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
         globalJobRegistry.has("test-pipeline:projection:defaultProjection"),
       ).toBe(true);
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       // Custom projection uses its custom groupKeyFn
       const customEntry = globalJobRegistry.get(

--- a/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.reactorGroupKey.test.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.reactorGroupKey.test.ts
@@ -60,11 +60,11 @@ describe("QueueManager.initializeReactorQueues with hierarchical group keys", ()
       const entry = globalJobRegistry.get(
         "test-pipeline:reactor:evaluationTrigger",
       );
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       const groupKey = entry?.groupKeyFn({ event, foldState: {} });
       expect(groupKey).toBe(
@@ -100,11 +100,11 @@ describe("QueueManager.initializeReactorQueues with hierarchical group keys", ()
       const entry = globalJobRegistry.get(
         "test-pipeline:reactor:spanStorageBroadcast",
       );
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       const groupKey = entry?.groupKeyFn({ event, foldState: {} });
       expect(groupKey).toBe(
@@ -147,11 +147,11 @@ describe("QueueManager.initializeReactorQueues with hierarchical group keys", ()
         "test-pipeline:reactor:customReactor",
       );
       const event = {
-        ...createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
+        ...createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           aggregateType,
           tenantId,
-        ),
+        }),
         data: { runId: "run-42" },
       };
 
@@ -192,11 +192,11 @@ describe("QueueManager.initializeReactorQueues with hierarchical group keys", ()
         vi.fn(),
       );
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       const payload = { event, foldState: {} };
 
       const evalTriggerEntry = globalJobRegistry.get(

--- a/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
@@ -169,10 +169,10 @@ describe("QueueManager", () => {
         { h1: createMockEventHandlerDefinition("h1") },
         vi.fn(),
       );
-      manager.initializeProjectionQueues(
-        { p1: createMockProjectionDefinition("p1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: { p1: createMockProjectionDefinition("p1") },
+        onEvent: vi.fn(),
+      });
       manager.initializeCommandQueues(
         [{ name: "c1", handlerClass: createMockCommandHandlerClass("c1") }],
         vi.fn(),
@@ -232,16 +232,16 @@ describe("QueueManager", () => {
         { h1: createMockEventHandlerDefinition("h1") },
         vi.fn(),
       );
-      manager.initializeProjectionQueues(
-        { p1: createMockProjectionDefinition("p1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: { p1: createMockProjectionDefinition("p1") },
+        onEvent: vi.fn(),
+      });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       // Handler job groupKey — hierarchical: tenantId/map/name/domainKey
       const handlerEntry = globalJobRegistry.get("test-pipeline:handler:h1");
@@ -276,13 +276,12 @@ describe("QueueManager", () => {
         vi.fn(),
       );
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-        undefined,
-        42000,
-      );
+        createdAt: 42000,
+      });
 
       const handlerEntry = globalJobRegistry.get("test-pipeline:handler:h1");
       const score = handlerEntry?.scoreFn(event);
@@ -307,11 +306,11 @@ describe("QueueManager", () => {
         handleEventCallback,
       );
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       const handlerEntry = globalJobRegistry.get("test-pipeline:handler:h1");
       await handlerEntry?.process(event);
@@ -337,16 +336,16 @@ describe("QueueManager", () => {
         globalJobRegistry,
       });
 
-      manager.initializeProjectionQueues(
-        { p1: createMockProjectionDefinition("p1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: { p1: createMockProjectionDefinition("p1") },
+        onEvent: vi.fn(),
+      });
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       const projectionEntry = globalJobRegistry.get(
         "test-pipeline:projection:p1",
@@ -452,8 +451,8 @@ describe("QueueManager", () => {
       );
       const entry = globalJobRegistry.get("test-pipeline:handler:handler1")!;
       const events = [
-        createTestEvent("one", aggregateType, tenantId),
-        createTestEvent("two", aggregateType, tenantId),
+        createTestEvent({ aggregateId: "one", aggregateType, tenantId }),
+        createTestEvent({ aggregateId: "two", aggregateType, tenantId }),
       ];
 
       await entry.processBatch!(events);
@@ -479,11 +478,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       expect(mockQueueProcessor.send).toHaveBeenCalledWith(
@@ -513,8 +512,16 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event1 = createTestEvent("agg-1", aggregateType, tenantId);
-      const event2 = createTestEvent("agg-2", aggregateType, tenantId);
+      const event1 = createTestEvent({
+        aggregateId: "agg-1",
+        aggregateType,
+        tenantId,
+      });
+      const event2 = createTestEvent({
+        aggregateId: "agg-2",
+        aggregateType,
+        tenantId,
+      });
       await facade.sendBatch([event1, event2]);
 
       expect(mockQueueProcessor.sendBatch).toHaveBeenCalledWith(
@@ -555,11 +562,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       expect(mockQueueProcessor.send).toHaveBeenCalledWith(
@@ -590,11 +597,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       // The per-send dedup should be namespaced
@@ -627,11 +634,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       const sendOptions = (mockQueueProcessor.send as any).mock.calls[0]?.[1];
@@ -659,11 +666,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getHandlerQueue("handler1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       const sendOptions = (mockQueueProcessor.send as any).mock.calls[0]?.[1];
@@ -695,10 +702,10 @@ describe("QueueManager", () => {
       };
       const processProjectionEventCallback = vi.fn();
 
-      manager.initializeProjectionQueues(
+      manager.initializeProjectionQueues({
         projections,
-        processProjectionEventCallback,
-      );
+        onEvent: processProjectionEventCallback,
+      });
 
       expect(manager.hasProjectionQueues()).toBe(false);
     });
@@ -720,10 +727,10 @@ describe("QueueManager", () => {
       };
       const processProjectionEventCallback = vi.fn();
 
-      manager.initializeProjectionQueues(
+      manager.initializeProjectionQueues({
         projections,
-        processProjectionEventCallback,
-      );
+        onEvent: processProjectionEventCallback,
+      });
 
       // Registry entries exist for each projection
       expect(
@@ -748,17 +755,19 @@ describe("QueueManager", () => {
         globalJobRegistry,
       });
 
-      manager.initializeProjectionQueues(
-        { projection1: createMockProjectionDefinition("projection1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: {
+          projection1: createMockProjectionDefinition("projection1"),
+        },
+        onEvent: vi.fn(),
+      });
 
       const facade = manager.getProjectionQueue("projection1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send(event);
 
       expect(mockQueueProcessor.send).toHaveBeenCalledWith(
@@ -782,21 +791,23 @@ describe("QueueManager", () => {
         globalJobRegistry,
       });
 
-      manager.initializeProjectionQueues(
-        { projection1: createMockProjectionDefinition("projection1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: {
+          projection1: createMockProjectionDefinition("projection1"),
+        },
+        onEvent: vi.fn(),
+      });
 
       const entry = globalJobRegistry.get(
         "test-pipeline:projection:projection1",
       );
       expect(entry?.groupKeyFn).toBeDefined();
 
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
         `${tenantId}/fold/projection1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
@@ -1059,11 +1070,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getReactorQueue("reactor1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send({ event, foldState: { count: 1 } });
 
       expect(mockQueueProcessor.send).toHaveBeenCalledWith(
@@ -1102,11 +1113,11 @@ describe("QueueManager", () => {
       );
 
       const entry = globalJobRegistry.get("test-pipeline:reactor:reactor1");
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
 
       const groupKey = entry?.groupKeyFn({
         event,
@@ -1134,13 +1145,12 @@ describe("QueueManager", () => {
       );
 
       const entry = globalJobRegistry.get("test-pipeline:reactor:reactor1");
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-        undefined,
-        55000,
-      );
+        createdAt: 55000,
+      });
 
       const score = entry?.scoreFn({
         event,
@@ -1166,11 +1176,11 @@ describe("QueueManager", () => {
       );
 
       const facade = manager.getReactorQueue("reactor1")!;
-      const event = createTestEvent(
-        TEST_CONSTANTS.AGGREGATE_ID,
+      const event = createTestEvent({
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
         aggregateType,
         tenantId,
-      );
+      });
       await facade.send({ event, foldState: {} });
 
       expect(mockQueueProcessor.send).toHaveBeenCalledWith(
@@ -1196,10 +1206,12 @@ describe("QueueManager", () => {
         { handler1: createMockEventHandlerDefinition("handler1") },
         vi.fn(),
       );
-      manager.initializeProjectionQueues(
-        { projection1: createMockProjectionDefinition("projection1") },
-        vi.fn(),
-      );
+      manager.initializeProjectionQueues({
+        projections: {
+          projection1: createMockProjectionDefinition("projection1"),
+        },
+        onEvent: vi.fn(),
+      });
       manager.initializeCommandQueues(
         [
           {

--- a/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/platform/app/src/server/event-sourcing/services/queues/queueManager.ts
@@ -421,7 +421,12 @@ export class QueueManager<EventType extends Event = Event> {
     }
   }
 
-  initializeProjectionQueues(
+  initializeProjectionQueues({
+    projections,
+    onEvent,
+    onEventBatch,
+    lane = { queueType: "projection", jobPath: "fold" },
+  }: {
     projections: Record<
       string,
       {
@@ -433,22 +438,22 @@ export class QueueManager<EventType extends Event = Event> {
           killSwitch?: KillSwitchOptions;
         };
       }
-    >,
+    >;
     onEvent: (
       projectionName: string,
       event: EventType,
       context: EventStoreReadContext<EventType>,
-    ) => Promise<void>,
+    ) => Promise<void>;
     onEventBatch?: (
       projectionName: string,
       events: EventType[],
       context: EventStoreReadContext<EventType>,
-    ) => Promise<void>,
-    lane: {
+    ) => Promise<void>;
+    lane?: {
       queueType: "projection" | "stateProjection";
       jobPath: "fold" | "state";
-    } = { queueType: "projection", jobPath: "fold" },
-  ): void {
+    };
+  }): void {
     if (!this.globalQueue) {
       return;
     }
@@ -518,17 +523,19 @@ export class QueueManager<EventType extends Event = Event> {
   initializeStateProjectionQueues(
     projections: Parameters<
       QueueManager<EventType>["initializeProjectionQueues"]
-    >[0],
+    >[0]["projections"],
     onEvent: Parameters<
       QueueManager<EventType>["initializeProjectionQueues"]
-    >[1],
+    >[0]["onEvent"],
     onEventBatch?: Parameters<
       QueueManager<EventType>["initializeProjectionQueues"]
-    >[2],
+    >[0]["onEventBatch"],
   ): void {
-    this.initializeProjectionQueues(projections, onEvent, onEventBatch, {
-      queueType: "stateProjection",
-      jobPath: "state",
+    this.initializeProjectionQueues({
+      projections,
+      onEvent,
+      onEventBatch,
+      lane: { queueType: "stateProjection", jobPath: "state" },
     });
   }
 
@@ -717,15 +724,14 @@ export class QueueManager<EventType extends Event = Event> {
         send: async (payload: any, options?: QueueSendOptions<any>) => {
           const validation = cmdEntry.schema.validate(payload);
           if (!validation.success) {
-            throw new ValidationError(
-              `Invalid payload for command type "${cmdEntry.commandType}". Validation failed.`,
-              "payload",
-              undefined,
-              {
+            throw new ValidationError({
+              reason: `Invalid payload for command type "${cmdEntry.commandType}". Validation failed.`,
+              field: "payload",
+              context: {
                 commandType: cmdEntry.commandType,
                 zodIssues: mapZodIssuesToLogContext(validation.error.issues),
               },
-            );
+            });
           }
           return baseFacade.send(payload, options);
         },
@@ -733,15 +739,14 @@ export class QueueManager<EventType extends Event = Event> {
           for (const payload of payloads) {
             const validation = cmdEntry.schema.validate(payload);
             if (!validation.success) {
-              throw new ValidationError(
-                `Invalid payload for command type "${cmdEntry.commandType}". Validation failed.`,
-                "payload",
-                undefined,
-                {
+              throw new ValidationError({
+                reason: `Invalid payload for command type "${cmdEntry.commandType}". Validation failed.`,
+                field: "payload",
+                context: {
                   commandType: cmdEntry.commandType,
                   zodIssues: mapZodIssuesToLogContext(validation.error.issues),
                 },
-              );
+              });
             }
           }
           return baseFacade.sendBatch(payloads, options);

--- a/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.countEventsBefore.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.countEventsBefore.unit.test.ts
@@ -38,13 +38,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        eventId,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(0);
       expect(mockClickHouseClient.query).toHaveBeenCalledWith(
@@ -75,13 +75,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        eventId,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(1);
       expect(mockClickHouseClient.query).toHaveBeenCalledWith(
@@ -108,13 +108,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        sameTimestamp,
-        eventId,
-      );
+        beforeTimestamp: sameTimestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(1);
       expect(mockClickHouseClient.query).toHaveBeenCalledWith(
@@ -141,13 +141,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        eventId,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(0);
     });
@@ -165,13 +165,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      await store.countEventsBefore(
+      await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        eventId,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: eventId,
+      });
 
       // Verify query includes tenantId filter
       expect(mockClickHouseClient.query).toHaveBeenCalledWith(
@@ -190,13 +190,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
       const eventId = "event-1";
 
       await expect(
-        store.countEventsBefore(
+        store.countEventsBefore({
           aggregateId,
-          invalidContext,
+          context: invalidContext,
           aggregateType,
-          timestamp,
-          eventId,
-        ),
+          beforeTimestamp: timestamp,
+          beforeEventId: eventId,
+        }),
       ).rejects.toThrow("tenantId");
 
       // Verify query was not executed
@@ -216,13 +216,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
         mockClickHouseClient.query as ReturnType<typeof vi.fn>
       ).mockResolvedValue(mockResult);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        sameTimestamp,
-        eventId,
-      );
+        beforeTimestamp: sameTimestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(2);
       // Verify query includes both timestamp and ID comparison
@@ -252,13 +252,13 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
       ).mockRejectedValue(queryError);
 
       await expect(
-        store.countEventsBefore(
+        store.countEventsBefore({
           aggregateId,
           context,
           aggregateType,
-          timestamp,
-          eventId,
-        ),
+          beforeTimestamp: timestamp,
+          beforeEventId: eventId,
+        }),
       ).rejects.toThrow("ClickHouse connection failed");
     });
   });

--- a/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
@@ -42,11 +42,11 @@ describe("EventStoreClickHouse - empty aggregateId guard", () => {
   ])("given $label", ({ aggregateId }) => {
     describe("when getEvents is called", () => {
       it("returns no events without touching ClickHouse", async () => {
-        const events = await store.getEvents(
+        const events = await store.getEvents({
           aggregateId,
-          { tenantId },
+          context: { tenantId },
           aggregateType,
-        );
+        });
 
         expect(events).toEqual([]);
         expect(mockClickHouseClient.query).not.toHaveBeenCalled();
@@ -55,12 +55,12 @@ describe("EventStoreClickHouse - empty aggregateId guard", () => {
 
     describe("when getEventsUpTo is called", () => {
       it("returns no events without touching ClickHouse", async () => {
-        const events = await store.getEventsUpTo(
+        const events = await store.getEventsUpTo({
           aggregateId,
-          { tenantId },
+          context: { tenantId },
           aggregateType,
           upToEvent,
-        );
+        });
 
         expect(events).toEqual([]);
         expect(mockClickHouseClient.query).not.toHaveBeenCalled();
@@ -69,13 +69,13 @@ describe("EventStoreClickHouse - empty aggregateId guard", () => {
 
     describe("when countEventsBefore is called", () => {
       it("returns 0 without touching ClickHouse", async () => {
-        const count = await store.countEventsBefore(
+        const count = await store.countEventsBefore({
           aggregateId,
-          { tenantId },
+          context: { tenantId },
           aggregateType,
-          1000,
-          "event-1",
-        );
+          beforeTimestamp: 1000,
+          beforeEventId: "event-1",
+        });
 
         expect(count).toBe(0);
         expect(mockClickHouseClient.query).not.toHaveBeenCalled();
@@ -90,7 +90,11 @@ describe("EventStoreClickHouse - empty aggregateId guard", () => {
           mockClickHouseClient.query as ReturnType<typeof vi.fn>
         ).mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
 
-        await store.getEvents("trace-123", { tenantId }, aggregateType);
+        await store.getEvents({
+          aggregateId: "trace-123",
+          context: { tenantId },
+          aggregateType,
+        });
 
         expect(mockClickHouseClient.query).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.refoldPartitionPruning.unit.test.ts
@@ -53,13 +53,23 @@ const lastCall = () =>
 
 describe("re-fold reads prune partitions — unpaged, time-local aggregate", () => {
   it("filters on EventOccurredAt so ClickHouse can prune partitions", async () => {
-    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
+    await store.getEventsUpTo({
+      aggregateId: "trace-1",
+      context: { tenantId },
+      aggregateType: TIME_LOCAL,
+      upToEvent,
+    });
 
     expect(lastCall().query).toContain("EventOccurredAt >=");
   });
 
   it("anchors the window on the triggering event, one window back", async () => {
-    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
+    await store.getEventsUpTo({
+      aggregateId: "trace-1",
+      context: { tenantId },
+      aggregateType: TIME_LOCAL,
+      upToEvent,
+    });
 
     expect(lastCall().query_params.occurredAtFromMs).toBe(
       OCCURRED_AT - REHYDRATION_WINDOW_MS,
@@ -67,7 +77,12 @@ describe("re-fold reads prune partitions — unpaged, time-local aggregate", () 
   });
 
   it("keeps rows with an unknown occurred time, so the bound can never drop one", async () => {
-    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, upToEvent);
+    await store.getEventsUpTo({
+      aggregateId: "trace-1",
+      context: { tenantId },
+      aggregateType: TIME_LOCAL,
+      upToEvent,
+    });
 
     expect(lastCall().query).toContain("EventOccurredAt = 0 OR");
   });
@@ -112,12 +127,12 @@ describe("re-fold reads prune partitions — paged, time-local aggregate", () =>
  */
 describe("re-fold reads prune partitions — long-lived aggregate type", () => {
   it("issues no lower bound, leaving the scan unbounded", async () => {
-    await store.getEventsUpTo(
-      "global-1",
-      { tenantId },
-      "global" as AggregateType,
+    await store.getEventsUpTo({
+      aggregateId: "global-1",
+      context: { tenantId },
+      aggregateType: "global" as AggregateType,
       upToEvent,
-    );
+    });
 
     expect(lastCall().query).not.toContain("EventOccurredAt >=");
     expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();
@@ -145,11 +160,16 @@ describe("re-fold reads prune partitions — event with no usable occurred time"
   it("issues no lower bound rather than anchoring on zero", async () => {
     // Anchoring on 0 would produce a bound in 1970 and prune nothing, or
     // worse, a negative bound. Better to skip it.
-    await store.getEventsUpTo("trace-1", { tenantId }, TIME_LOCAL, {
-      id: "event-1",
-      createdAt: 1000,
-      occurredAt: 0,
-    } as unknown as Event);
+    await store.getEventsUpTo({
+      aggregateId: "trace-1",
+      context: { tenantId },
+      aggregateType: TIME_LOCAL,
+      upToEvent: {
+        id: "event-1",
+        createdAt: 1000,
+        occurredAt: 0,
+      } as unknown as Event,
+    });
 
     expect(lastCall().query).not.toContain("EventOccurredAt >=");
     expect(lastCall().query_params.occurredAtFromMs).toBeUndefined();

--- a/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreMemory.countEventsBefore.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreMemory.countEventsBefore.integration.test.ts
@@ -35,13 +35,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
 
       await store.storeEvents([event1], context, aggregateType);
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        event1.id,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: event1.id,
+      });
 
       expect(count).toBe(0);
     });
@@ -80,13 +80,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       await store.storeEvents([event1, event2, event3], context, aggregateType);
 
       // Count events before event2 (timestamp 2000)
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        2000,
-        event2.id,
-      );
+        beforeTimestamp: 2000,
+        beforeEventId: event2.id,
+      });
 
       // Should count event1 (timestamp 1000 < 2000)
       expect(count).toBe(1);
@@ -139,13 +139,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       await store.storeEvents([event1, event2, event3], context, aggregateType);
 
       // Count events before event2 (same timestamp, but ID comparison)
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        sameTimestamp,
-        event2.id,
-      );
+        beforeTimestamp: sameTimestamp,
+        beforeEventId: event2.id,
+      });
 
       // Should count event1 (same timestamp but earlier ID)
       expect(count).toBe(1);
@@ -156,13 +156,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       const timestamp = 1000;
       const eventId = "non-existent-event";
 
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        timestamp,
-        eventId,
-      );
+        beforeTimestamp: timestamp,
+        beforeEventId: eventId,
+      });
 
       expect(count).toBe(0);
     });
@@ -196,13 +196,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       await store.storeEvents([event2], context2, aggregateType);
 
       // Count events before event2 in tenant2's context
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
-        context2,
+        context: context2,
         aggregateType,
-        1000,
-        event2.id,
-      );
+        beforeTimestamp: 1000,
+        beforeEventId: event2.id,
+      });
 
       // Should only count events from tenant2 (0, since event2 is the first)
       expect(count).toBe(0);
@@ -212,13 +212,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       const invalidContext = {} as any;
 
       await expect(
-        store.countEventsBefore(
+        store.countEventsBefore({
           aggregateId,
-          invalidContext,
+          context: invalidContext,
           aggregateType,
-          1000,
-          "event-id",
-        ),
+          beforeTimestamp: 1000,
+          beforeEventId: "event-id",
+        }),
       ).rejects.toThrow("tenantId");
     });
 
@@ -268,13 +268,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       await store.storeEvents([event1, event2, event3], context, aggregateType);
 
       // Count events before event3
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        sameTimestamp,
-        event3.id,
-      );
+        beforeTimestamp: sameTimestamp,
+        beforeEventId: event3.id,
+      });
 
       // Should count event1 and event2 (both have same timestamp but earlier IDs)
       // Note: All events now have manually set IDs to ensure predictable ordering
@@ -331,13 +331,13 @@ describe("EventStoreMemory - countEventsBefore", () => {
       );
 
       // Count events before event4 (timestamp 3000)
-      const count = await store.countEventsBefore(
+      const count = await store.countEventsBefore({
         aggregateId,
         context,
         aggregateType,
-        3000,
-        event4.id,
-      );
+        beforeTimestamp: 3000,
+        beforeEventId: event4.id,
+      });
 
       // Should count event1, event2, event3 (all have timestamp < 3000)
       expect(count).toBe(3);

--- a/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreMemory.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/__tests__/eventStoreMemory.integration.test.ts
@@ -53,11 +53,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
       await store.storeEvents([event2], context, aggregateType);
 
       // Get events - should return only one (first occurrence)
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
 
       expect(retrieved.length).toBe(1);
       expect(retrieved[0]?.id).toBe(event1.id);
@@ -109,11 +109,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
       // Store all events
       await store.storeEvents([event1, event2, event3], context, aggregateType);
 
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
 
       expect(retrieved.length).toBe(1);
       expect(retrieved[0]?.data).toEqual({ value: "first" });
@@ -164,11 +164,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
       // Store in order - first one should be kept
       await store.storeEvents([event1, event2, event3], context, aggregateType);
 
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
 
       // Should keep the first one when sorted (earliest timestamp, first in array)
       expect(retrieved.length).toBe(1);
@@ -201,11 +201,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
 
       await store.storeEvents([event1, event2], context, aggregateType);
 
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
 
       expect(retrieved.length).toBe(2);
       expect(retrieved.map((e) => e.id).sort()).toEqual(
@@ -250,11 +250,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
       await store.storeEvents([event2], context, aggregateType);
 
       // Should only have one event
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
       expect(retrieved.length).toBe(1);
       expect(retrieved[0]?.data).toEqual({ value: 1 });
     });
@@ -285,11 +285,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
       await store.storeEvents([event1], context, aggregateType);
       await store.storeEvents([event2], context, aggregateType);
 
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
       expect(retrieved.length).toBe(2);
     });
   });
@@ -340,11 +340,11 @@ describe("EventStoreMemory - Event ID Deduplication", () => {
         },
       ]);
 
-      const retrieved = await store.getEvents(
+      const retrieved = await store.getEvents({
         aggregateId,
         context,
         aggregateType,
-      );
+      });
 
       // The old event (EventOccurredAt=0) should fall back to its timestamp
       const oldRetrieved = retrieved.find((e) => e.id === oldEvent.id);

--- a/platform/app/src/server/event-sourcing/stores/abstractEventStore.ts
+++ b/platform/app/src/server/event-sourcing/stores/abstractEventStore.ts
@@ -140,12 +140,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
     return String(aggregateId).trim().length === 0;
   }
 
-  async getEvents(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    anchorOccurredAtMs?: number,
-  ): Promise<readonly EventType[]> {
+  async getEvents({
+    aggregateId,
+    context,
+    aggregateType,
+    anchorOccurredAtMs,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    anchorOccurredAtMs?: number;
+  }): Promise<readonly EventType[]> {
     // For time-local aggregate types, lower-bound the event_log scan to a
     // window around the triggering work's time so ClickHouse prunes old weekly
     // partitions instead of cold-scanning every partition on S3. Returns
@@ -177,12 +182,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
    * occurred-at can fall under it (rows with an unknown occurred time are
    * always kept by the repositories, so the bound can never drop those).
    */
-  async getEventsOccurredSince(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    occurredAtFromMs: number,
-  ): Promise<readonly EventType[]> {
+  async getEventsOccurredSince({
+    aggregateId,
+    context,
+    aggregateType,
+    occurredAtFromMs,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    occurredAtFromMs: number;
+  }): Promise<readonly EventType[]> {
     return await this.readEvents({
       operation: "getEventsOccurredSince",
       aggregateId,
@@ -226,12 +236,12 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       },
       async () => {
         try {
-          const records = await this.repository.getEventRecords(
-            context.tenantId,
+          const records = await this.repository.getEventRecords({
+            tenantId: context.tenantId,
             aggregateType,
             aggregateId,
             occurredAtFromMs,
-          );
+          });
 
           const events = records.map((record) =>
             recordToEvent<EventType>(record, aggregateId),
@@ -255,12 +265,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
     );
   }
 
-  async getEventsUpTo(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    upToEvent: EventType,
-  ): Promise<readonly EventType[]> {
+  async getEventsUpTo({
+    aggregateId,
+    context,
+    aggregateType,
+    upToEvent,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    upToEvent: EventType;
+  }): Promise<readonly EventType[]> {
     EventUtils.validateTenantId(
       context,
       `${this.constructor.name}.getEventsUpTo`,
@@ -438,13 +453,19 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
     );
   }
 
-  async countEventsBefore(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    beforeTimestamp: number,
-    beforeEventId: string,
-  ): Promise<number> {
+  async countEventsBefore({
+    aggregateId,
+    context,
+    aggregateType,
+    beforeTimestamp,
+    beforeEventId,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    beforeTimestamp: number;
+    beforeEventId: string;
+  }): Promise<number> {
     EventUtils.validateTenantId(
       context,
       `${this.constructor.name}.countEventsBefore`,
@@ -470,13 +491,13 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       },
       async () => {
         try {
-          return await this.repository.countEventRecords(
-            context.tenantId,
+          return await this.repository.countEventRecords({
+            tenantId: context.tenantId,
             aggregateType,
             aggregateId,
             beforeTimestamp,
             beforeEventId,
-          );
+          });
         } catch (error) {
           this.logError(
             `${this.constructor.name}.countEventsBefore`,
@@ -522,22 +543,22 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
           for (let i = 0; i < events.length; i++) {
             const event = events[i];
             if (!event) {
-              throw new ValidationError(
-                `Event at index ${i} is undefined`,
-                "event",
-                void 0,
-                { index: i },
-              );
+              throw new ValidationError({
+                reason: `Event at index ${i} is undefined`,
+                field: "event",
+                value: void 0,
+                context: { index: i },
+              });
             }
             validateEventTenant(event, context, i);
             validateEventAggregateType(event, aggregateType, i);
             if (!EventUtils.isValidEvent(event)) {
-              throw new ValidationError(
-                `Invalid event at index ${i}: event must have id, aggregateId, timestamp, type, and data`,
-                "event",
-                event,
-                { index: i },
-              );
+              throw new ValidationError({
+                reason: `Invalid event at index ${i}: event must have id, aggregateId, timestamp, type, and data`,
+                field: "event",
+                value: event,
+                context: { index: i },
+              });
             }
           }
 

--- a/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
+++ b/platform/app/src/server/event-sourcing/stores/eventStore.types.ts
@@ -84,12 +84,17 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
    * **Security:** Implementations MUST call validateTenantId(context, 'getEvents')
    * before executing the query to ensure tenant isolation.
    */
-  getEvents(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    anchorOccurredAtMs?: number,
-  ): Promise<readonly EventType[]>;
+  getEvents({
+    aggregateId,
+    context,
+    aggregateType,
+    anchorOccurredAtMs,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    anchorOccurredAtMs?: number;
+  }): Promise<readonly EventType[]>;
 
   /**
    * Retrieves events with an EXPLICIT occurred-at lower bound (ms), applied
@@ -104,12 +109,17 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
    * **Security:** Implementations MUST validate tenantId exactly as for
    * `getEvents`.
    */
-  getEventsOccurredSince(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    occurredAtFromMs: number,
-  ): Promise<readonly EventType[]>;
+  getEventsOccurredSince({
+    aggregateId,
+    context,
+    aggregateType,
+    occurredAtFromMs,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    occurredAtFromMs: number;
+  }): Promise<readonly EventType[]>;
 
   /**
    * Retrieves events for a given aggregate up to and including a specific event.
@@ -125,12 +135,17 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
    * **Security:** Implementations MUST call validateTenantId(context, 'getEventsUpTo')
    * before executing the query to ensure tenant isolation.
    */
-  getEventsUpTo(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    upToEvent: EventType,
-  ): Promise<readonly EventType[]>;
+  getEventsUpTo({
+    aggregateId,
+    context,
+    aggregateType,
+    upToEvent,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    upToEvent: EventType;
+  }): Promise<readonly EventType[]>;
 
   /**
    * Cursor-paginated variant of {@link getEventsUpTo}: returns at most `limit`
@@ -177,13 +192,19 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
    * **Security:** Implementations MUST call validateTenantId(context, 'countEventsBefore')
    * before executing the query to ensure tenant isolation.
    */
-  countEventsBefore(
-    aggregateId: string,
-    context: EventStoreReadContext<EventType>,
-    aggregateType: AggregateType,
-    beforeTimestamp: number,
-    beforeEventId: string,
-  ): Promise<number>;
+  countEventsBefore({
+    aggregateId,
+    context,
+    aggregateType,
+    beforeTimestamp,
+    beforeEventId,
+  }: {
+    aggregateId: string;
+    context: EventStoreReadContext<EventType>;
+    aggregateType: AggregateType;
+    beforeTimestamp: number;
+    beforeEventId: string;
+  }): Promise<number>;
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/stores/eventStoreMemory.ts
+++ b/platform/app/src/server/event-sourcing/stores/eventStoreMemory.ts
@@ -61,12 +61,17 @@ export class EventStoreMemory<
    * Seeds the event store with events for a given aggregate.
    * Useful in tests.
    */
-  async seed(
-    _aggregateId: string,
-    events: EventType[],
-    _tenantId: string,
-    _aggregateType: AggregateType,
-  ): Promise<void> {
+  async seed({
+    _aggregateId,
+    events,
+    _tenantId,
+    _aggregateType,
+  }: {
+    _aggregateId: string;
+    events: EventType[];
+    _tenantId: string;
+    _aggregateType: AggregateType;
+  }): Promise<void> {
     const records = events.map((event) => eventToRecord(event));
     await this.repository.insertEventRecords(records);
   }

--- a/platform/app/src/server/event-sourcing/stores/eventStoreUtils.ts
+++ b/platform/app/src/server/event-sourcing/stores/eventStoreUtils.ts
@@ -91,24 +91,24 @@ export function parseEventPayload(rawPayload: unknown): unknown {
     try {
       return JSON.parse(rawPayload);
     } catch (error) {
-      throw new StoreError(
-        "parsePayload",
-        "EventStore",
-        `Failed to parse EventPayload JSON: ${error instanceof Error ? error.message : String(error)}`,
-        ErrorCategory.CRITICAL,
-        { rawPayloadLength: rawPayload.length },
-      );
+      throw new StoreError({
+        operation: "parsePayload",
+        store: "EventStore",
+        message: `Failed to parse EventPayload JSON: ${error instanceof Error ? error.message : String(error)}`,
+        category: ErrorCategory.CRITICAL,
+        context: { rawPayloadLength: rawPayload.length },
+      });
     }
   } else if (typeof rawPayload === "object") {
     return rawPayload;
   } else {
-    throw new StoreError(
-      "parsePayload",
-      "EventStore",
-      `EventPayload is not a string or object, it is of type ${typeof rawPayload}`,
-      ErrorCategory.CRITICAL,
-      { rawPayloadType: typeof rawPayload },
-    );
+    throw new StoreError({
+      operation: "parsePayload",
+      store: "EventStore",
+      message: `EventPayload is not a string or object, it is of type ${typeof rawPayload}`,
+      category: ErrorCategory.CRITICAL,
+      context: { rawPayloadType: typeof rawPayload },
+    });
   }
 }
 
@@ -147,20 +147,20 @@ export function validateEventTenant<EventType extends Event>(
 ): void {
   const eventTenantId = event.tenantId;
   if (!eventTenantId) {
-    throw new SecurityError(
-      "validateEventTenant",
-      `Event at index ${index} has no tenantId`,
-      void 0,
-      { index },
-    );
+    throw new SecurityError({
+      operation: "validateEventTenant",
+      message: `Event at index ${index} has no tenantId`,
+      tenantId: void 0,
+      context: { index },
+    });
   }
   if (eventTenantId !== context.tenantId) {
-    throw new SecurityError(
-      "validateEventTenant",
-      `Event at index ${index} has a tenantId that does not match the context`,
-      void 0,
-      { index },
-    );
+    throw new SecurityError({
+      operation: "validateEventTenant",
+      message: `Event at index ${index} has a tenantId that does not match the context`,
+      tenantId: void 0,
+      context: { index },
+    });
   }
 }
 
@@ -173,11 +173,11 @@ export function validateEventAggregateType<EventType extends Event>(
   index: number,
 ): void {
   if (event.aggregateType !== aggregateType) {
-    throw new ValidationError(
-      `Event at index ${index} has aggregate type '${event.aggregateType}' that does not match pipeline aggregate type '${aggregateType}'`,
-      "aggregateType",
-      event.aggregateType,
-      { index, expectedAggregateType: aggregateType },
-    );
+    throw new ValidationError({
+      reason: `Event at index ${index} has aggregate type '${event.aggregateType}' that does not match pipeline aggregate type '${aggregateType}'`,
+      field: "aggregateType",
+      value: event.aggregateType,
+      context: { index, expectedAggregateType: aggregateType },
+    });
   }
 }

--- a/platform/app/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
@@ -30,7 +30,11 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
     });
 
     const repository = new EventRepositoryClickHouse(async () => client);
-    const rows = await repository.getEventRecords("tenant", "agg", "id");
+    const rows = await repository.getEventRecords({
+      tenantId: "tenant",
+      aggregateType: "agg",
+      aggregateId: "id",
+    });
 
     expect(rows[0]?.EventPayload).toEqual({
       data: {
@@ -48,7 +52,11 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
     );
 
     const repository = new EventRepositoryClickHouse(async () => client);
-    const rows = await repository.getEventRecords("tenant", "agg", "id");
+    const rows = await repository.getEventRecords({
+      tenantId: "tenant",
+      aggregateType: "agg",
+      aggregateId: "id",
+    });
 
     expect(rows[0]?.EventPayload).toEqual(
       '{"data":{"value":"123.45","text":"still-string"}}',
@@ -60,7 +68,12 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       const client = createMockClient({});
       const repository = new EventRepositoryClickHouse(async () => client);
 
-      await repository.getEventRecords("tenant", "trace", "id", 1700000000000);
+      await repository.getEventRecords({
+        tenantId: "tenant",
+        aggregateType: "trace",
+        aggregateId: "id",
+        occurredAtFromMs: 1700000000000,
+      });
 
       const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.query).toContain(
@@ -77,7 +90,11 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       const client = createMockClient({});
       const repository = new EventRepositoryClickHouse(async () => client);
 
-      await repository.getEventRecords("tenant", "trace", "id");
+      await repository.getEventRecords({
+        tenantId: "tenant",
+        aggregateType: "trace",
+        aggregateId: "id",
+      });
 
       const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.query).not.toContain("EventOccurredAt >=");
@@ -88,7 +105,12 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       const client = createMockClient({});
       const repository = new EventRepositoryClickHouse(async () => client);
 
-      await repository.getEventRecords("tenant", "trace", "id", 0);
+      await repository.getEventRecords({
+        tenantId: "tenant",
+        aggregateType: "trace",
+        aggregateId: "id",
+        occurredAtFromMs: 0,
+      });
 
       const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.query).not.toContain("EventOccurredAt >=");

--- a/platform/app/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.lowerBound.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.lowerBound.unit.test.ts
@@ -35,9 +35,13 @@ describe("EventRepositoryMemory.getEventRecords lower bound", () => {
   describe("when no lower bound is passed", () => {
     it("returns every event", async () => {
       const repo = await seeded();
-      const ids = (await repo.getEventRecords("tenant", "trace", "agg")).map(
-        (r) => r.EventId,
-      );
+      const ids = (
+        await repo.getEventRecords({
+          tenantId: "tenant",
+          aggregateType: "trace",
+          aggregateId: "agg",
+        })
+      ).map((r) => r.EventId);
       expect(new Set(ids)).toEqual(
         new Set(["before", "at", "after", "unknown-time"]),
       );
@@ -48,7 +52,12 @@ describe("EventRepositoryMemory.getEventRecords lower bound", () => {
     it("keeps events at/after the bound and unknown-time events, drops older ones", async () => {
       const repo = await seeded();
       const ids = (
-        await repo.getEventRecords("tenant", "trace", "agg", bound)
+        await repo.getEventRecords({
+          tenantId: "tenant",
+          aggregateType: "trace",
+          aggregateId: "agg",
+          occurredAtFromMs: bound,
+        })
       ).map((r) => r.EventId);
 
       expect(new Set(ids)).toEqual(new Set(["at", "after", "unknown-time"]));

--- a/platform/app/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
+++ b/platform/app/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
@@ -37,12 +37,17 @@ export interface EventRepository {
    * `rehydrationLowerBoundMs`. It is purely a partition-pruning optimisation and
    * must never change the result set for a correctly-classified aggregate.
    */
-  getEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]>;
+  getEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    occurredAtFromMs,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]>;
 
   /**
    * Retrieves event records up to and including a specific event.
@@ -94,13 +99,19 @@ export interface EventRepository {
    * Counts event records that come before a given event.
    * Returns raw count without validation.
    */
-  countEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    beforeTimestamp: number,
-    beforeEventId: string,
-  ): Promise<number>;
+  countEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    beforeTimestamp,
+    beforeEventId,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    beforeTimestamp: number;
+    beforeEventId: string;
+  }): Promise<number>;
 
   /**
    * Inserts event records into storage.

--- a/platform/app/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
+++ b/platform/app/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
@@ -81,12 +81,17 @@ export class EventRepositoryClickHouse implements EventRepository {
     return this.resolveClient(tenantId);
   }
 
-  async getEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]> {
+  async getEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    occurredAtFromMs,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]> {
     try {
       const client = await this.getClient(tenantId);
       // When a lower bound is supplied, add a predicate on EventOccurredAt so
@@ -419,13 +424,19 @@ export class EventRepositoryClickHouse implements EventRepository {
     }));
   }
 
-  async countEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    beforeTimestamp: number,
-    beforeEventId: string,
-  ): Promise<number> {
+  async countEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    beforeTimestamp,
+    beforeEventId,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    beforeTimestamp: number;
+    beforeEventId: string;
+  }): Promise<number> {
     try {
       const client = await this.getClient(tenantId);
       const result = await client.query({

--- a/platform/app/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
+++ b/platform/app/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
@@ -15,12 +15,17 @@ export class EventRepositoryMemory implements EventRepository {
   // Partition by tenant + aggregateType + aggregateId
   private readonly eventsByKey = new Map<string, EventRecord[]>();
 
-  async getEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    occurredAtFromMs?: number,
-  ): Promise<EventRecord[]> {
+  async getEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    occurredAtFromMs,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    occurredAtFromMs?: number;
+  }): Promise<EventRecord[]> {
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
     // Mirror the ClickHouse lower-bound semantics so tests exercise the same
@@ -174,13 +179,19 @@ export class EventRepositoryMemory implements EventRepository {
     return sorted.slice(0, limit).map((record) => ({ ...record }));
   }
 
-  async countEventRecords(
-    tenantId: string,
-    aggregateType: string,
-    aggregateId: string,
-    beforeTimestamp: number,
-    beforeEventId: string,
-  ): Promise<number> {
+  async countEventRecords({
+    tenantId,
+    aggregateType,
+    aggregateId,
+    beforeTimestamp,
+    beforeEventId,
+  }: {
+    tenantId: string;
+    aggregateType: string;
+    aggregateId: string;
+    beforeTimestamp: number;
+    beforeEventId: string;
+  }): Promise<number> {
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
 

--- a/platform/app/src/server/event-sourcing/subscribers/__tests__/eventSubscriber.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/subscribers/__tests__/eventSubscriber.unit.test.ts
@@ -42,11 +42,11 @@ describe("event subscribers", () => {
           eventStore,
           subscribers: [subscriber],
         });
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           aggregateType,
           tenantId,
-        );
+        });
 
         await service.storeEvents([event], context);
 
@@ -81,11 +81,11 @@ describe("event subscribers", () => {
           eventStore,
           subscribers: [subscriber],
         });
-        const event = createTestEvent(
-          TEST_CONSTANTS.AGGREGATE_ID,
+        const event = createTestEvent({
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
           aggregateType,
           tenantId,
-        );
+        });
 
         await service.storeEvents([event], context);
 

--- a/platform/app/src/server/event-sourcing/subscribers/__tests__/eventSubscriberRuntime.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/subscribers/__tests__/eventSubscriberRuntime.unit.test.ts
@@ -110,16 +110,16 @@ afterEach(() => {
 });
 
 function makeEvent(id: string): Event {
-  return createTestEvent(
-    TEST_CONSTANTS.AGGREGATE_ID,
+  return createTestEvent({
+    aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
     aggregateType,
     tenantId,
-    TEST_CONSTANTS.EVENT_TYPE_1,
-    TEST_CONSTANTS.BASE_TIMESTAMP,
-    "2025-12-17",
-    { marker: id },
+    type: TEST_CONSTANTS.EVENT_TYPE_1,
+    createdAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+    version: "2025-12-17",
+    data: { marker: id },
     id,
-  );
+  });
 }
 
 describe("event-subscriber runtime boundary", () => {

--- a/platform/app/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/subscribers/__tests__/subscriberEnqueueDispatch.unit.test.ts
@@ -50,11 +50,11 @@ function makeQueueManager() {
 }
 
 function makeRouter(...subscribers: EventSubscriberDefinition<Event>[]) {
-  const router = new ProjectionRouter<Event>(
+  const router = new ProjectionRouter<Event>({
     aggregateType,
-    TEST_CONSTANTS.PIPELINE_NAME,
-    makeQueueManager(),
-  );
+    pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+    queueManager: makeQueueManager(),
+  });
   for (const subscriber of subscribers) {
     router.registerEventSubscriber(subscriber);
   }
@@ -62,16 +62,16 @@ function makeRouter(...subscribers: EventSubscriberDefinition<Event>[]) {
 }
 
 function makeEvent(id: string): Event {
-  return createTestEvent(
-    TEST_CONSTANTS.AGGREGATE_ID,
+  return createTestEvent({
+    aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
     aggregateType,
     tenantId,
-    TEST_CONSTANTS.EVENT_TYPE_1,
-    1000,
-    "2025-12-17",
-    { marker: id },
+    type: TEST_CONSTANTS.EVENT_TYPE_1,
+    createdAt: 1000,
+    version: "2025-12-17",
+    data: { marker: id },
     id,
-  );
+  });
 }
 
 async function enqueueOutcomeCount(outcome: string): Promise<number> {
@@ -135,13 +135,13 @@ describe("subscriber enqueue-time contract", () => {
         // this switch's entire distinguishing claim.
         const asked: Array<{ key: string; projectId?: string }> = [];
         const killedTenant = createTestTenantId(`${tenantId}-killed`);
-        const router = new ProjectionRouter<Event>(
+        const router = new ProjectionRouter<Event>({
           aggregateType,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          makeQueueManager(),
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: makeQueueManager(),
           // The seam drops events irreversibly, so "off" has to be reachable at
           // runtime; every other dispatch path already resolves this flag.
-          {
+          featureFlagService: {
             isEnabled: async (
               key: string,
               options: { projectId?: string },
@@ -150,7 +150,7 @@ describe("subscriber enqueue-time contract", () => {
               return options.projectId === killedTenant;
             },
           } as never,
-        );
+        });
         router.registerEventSubscriber({
           name: "seamSubscriber",
           eventTypes: [],
@@ -202,17 +202,17 @@ describe("subscriber enqueue-time contract", () => {
         // cache read and a span on the busiest path in the product to answer a
         // question that cannot change within one batch.
         let lookups = 0;
-        const router = new ProjectionRouter<Event>(
+        const router = new ProjectionRouter<Event>({
           aggregateType,
-          TEST_CONSTANTS.PIPELINE_NAME,
-          makeQueueManager(),
-          {
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager: makeQueueManager(),
+          featureFlagService: {
             isEnabled: async (): Promise<boolean> => {
               lookups += 1;
               return false;
             },
           } as never,
-        );
+        });
         router.registerEventSubscriber({
           name: "seamSubscriber",
           eventTypes: [],
@@ -442,11 +442,11 @@ describe("subscriber enqueue-time contract", () => {
           send: vi.fn().mockRejectedValue(new Error("queue unavailable")),
         } as never);
 
-        const router = new ProjectionRouter<Event>(
+        const router = new ProjectionRouter<Event>({
           aggregateType,
-          TEST_CONSTANTS.PIPELINE_NAME,
+          pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
           queueManager,
-        );
+        });
         router.registerEventSubscriber({
           name: "seamSubscriber",
           eventTypes: [],

--- a/platform/app/src/server/event-sourcing/utils/event.utils.ts
+++ b/platform/app/src/server/event-sourcing/utils/event.utils.ts
@@ -193,13 +193,19 @@ function buildEventMetadataWithCurrentProcessingTraceparent<
  * @param version - Version/timestamp (defaults to current time)
  * @returns A new projection object
  */
-function createProjection<Data = unknown>(
-  id: string,
-  aggregateId: string,
-  tenantId: TenantId,
-  data: Data,
-  version: string,
-): Projection<Data> {
+function createProjection<Data = unknown>({
+  id,
+  aggregateId,
+  tenantId,
+  data,
+  version,
+}: {
+  id: string;
+  aggregateId: string;
+  tenantId: TenantId;
+  data: Data;
+  version: string;
+}): Projection<Data> {
   return {
     id,
     aggregateId,
@@ -266,17 +272,17 @@ function validateTenantId(
   operation: string,
 ): void {
   if (!context) {
-    throw new SecurityError(
+    throw new SecurityError({
       operation,
-      `${operation} requires a context with tenantId for tenant isolation`,
-    );
+      message: `${operation} requires a context with tenantId for tenant isolation`,
+    });
   }
 
   if (!context.tenantId) {
-    throw new SecurityError(
+    throw new SecurityError({
       operation,
-      `${operation} requires a tenantId for tenant isolation`,
-    );
+      message: `${operation} requires a tenantId for tenant isolation`,
+    });
   }
 
   // Use TenantIdSchema for consistent validation (handles empty strings, whitespace, etc.)
@@ -285,7 +291,7 @@ function validateTenantId(
     const errorMessage =
       result.error.issues[0]?.message ??
       "TenantId must be a non-empty string for tenant isolation";
-    throw new SecurityError(operation, errorMessage);
+    throw new SecurityError({ operation, message: errorMessage });
   }
 }
 

--- a/platform/app/src/server/experiments-v3/execution/__tests__/dataLoader.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/dataLoader.integration.test.ts
@@ -97,12 +97,16 @@ describe("loadExecutionData", () => {
       });
       cleanupAgentIds.push(agent.id);
 
-      const result = await loadExecutionData(
+      const result = await loadExecutionData({
         projectId,
-        { type: "inline", columns: [], inline: { columns: [], records: {} } },
-        [{ type: "agent", dbAgentId: agent.id }],
-        [],
-      );
+        dataset: {
+          type: "inline",
+          columns: [],
+          inline: { columns: [], records: {} },
+        },
+        targets: [{ type: "agent", dbAgentId: agent.id }],
+        evaluators: [],
+      });
 
       if ("error" in result) {
         throw new Error(`loadExecutionData failed: ${result.error}`);
@@ -146,12 +150,16 @@ describe("loadExecutionData", () => {
       });
       cleanupAgentIds.push(agent.id);
 
-      const result = await loadExecutionData(
+      const result = await loadExecutionData({
         projectId,
-        { type: "inline", columns: [], inline: { columns: [], records: {} } },
-        [{ type: "agent", dbAgentId: agent.id }],
-        [],
-      );
+        dataset: {
+          type: "inline",
+          columns: [],
+          inline: { columns: [], records: {} },
+        },
+        targets: [{ type: "agent", dbAgentId: agent.id }],
+        evaluators: [],
+      });
 
       expect("error" in result).toBe(true);
       if ("error" in result) {

--- a/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
@@ -57,7 +57,11 @@ const makeCell = (overrides?: Partial<ExecutionCell>): ExecutionCell => ({
 
 const run = async (cell: ExecutionCell): Promise<EvaluationV3Event[]> => {
   const events: EvaluationV3Event[] = [];
-  for await (const event of executeWorkflowCell(cell, "p1", workflowDsl)) {
+  for await (const event of executeWorkflowCell({
+    cell,
+    projectId: "p1",
+    workflowDsl,
+  })) {
     events.push(event);
   }
   return events;

--- a/platform/app/src/server/experiments-v3/execution/__tests__/orchestrator.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/orchestrator.test.ts
@@ -103,7 +103,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(3);
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(6); // 3 rows × 2 targets
 
@@ -123,7 +123,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(3);
       const scope: ExecutionScope = { type: "rows", rowIndices: [1] };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(2); // 1 row × 2 targets
       expect(cells.every((c) => c.rowIndex === 1)).toBe(true);
@@ -134,7 +134,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(5);
       const scope: ExecutionScope = { type: "rows", rowIndices: [0, 2, 4] };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(6); // 3 rows × 2 targets
       const rowIndices = new Set(cells.map((c) => c.rowIndex));
@@ -146,7 +146,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(3);
       const scope: ExecutionScope = { type: "target", targetId: "target-1" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(3); // 3 rows × 1 target
       expect(cells.every((c) => c.targetId === "target-1")).toBe(true);
@@ -161,7 +161,7 @@ describe("orchestrator", () => {
         targetId: "target-2",
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(1);
       expect(cells[0]?.rowIndex).toBe(2);
@@ -176,7 +176,7 @@ describe("orchestrator", () => {
         targetId: "non-existent",
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(0);
     });
@@ -186,7 +186,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(3); // 0, 1, 2
       const scope: ExecutionScope = { type: "rows", rowIndices: [1, 10, 20] };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(2); // Only row 1 × 2 targets
       expect(cells.every((c) => c.rowIndex === 1)).toBe(true);
@@ -197,7 +197,7 @@ describe("orchestrator", () => {
       const datasetRows = [{ question: "Hello", expected: "World" }];
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells[0]?.datasetEntry).toEqual({
         _datasetId: "dataset-1",
@@ -211,7 +211,7 @@ describe("orchestrator", () => {
       const datasetRows = [{ question: "Test", expected: "Test" }];
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells[0]?.evaluatorConfigs).toHaveLength(3);
     });
@@ -238,7 +238,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(1);
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(2);
       expect(
@@ -272,7 +272,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(1);
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells.map((cell) => cell.targetId)).toEqual([
         "target-1",
@@ -303,7 +303,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(1);
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells.map((cell) => cell.targetId)).toEqual([
         "target-1",
@@ -338,10 +338,15 @@ describe("orchestrator", () => {
         targetId: "comparison-target",
       };
 
-      const cells = generateCells(state, datasetRows, scope, {
-        seedTargetOutputs: {
-          "0:target-1": { output: "variant 1" },
-          "0:target-2": { output: "variant 2" },
+      const cells = generateCells({
+        state,
+        datasetRows,
+        scope,
+        options: {
+          seedTargetOutputs: {
+            "0:target-1": { output: "variant 1" },
+            "0:target-2": { output: "variant 2" },
+          },
         },
       });
 
@@ -375,9 +380,14 @@ describe("orchestrator", () => {
         targetId: "comparison-target",
       };
 
-      const cells = generateCells(state, datasetRows, scope, {
-        seedTargetOutputs: {
-          "0:target-1": { output: "variant 1" },
+      const cells = generateCells({
+        state,
+        datasetRows,
+        scope,
+        options: {
+          seedTargetOutputs: {
+            "0:target-1": { output: "variant 1" },
+          },
         },
       });
 
@@ -409,7 +419,7 @@ describe("orchestrator", () => {
         const datasetRows = createTestDataset(1);
         const scope: ExecutionScope = { type: "full" };
 
-        const cells = generateCells(state, datasetRows, scope);
+        const cells = generateCells({ state, datasetRows, scope });
 
         expect(cells.length).toBeGreaterThan(0);
         for (const cell of cells) {
@@ -1645,7 +1655,7 @@ describe("orchestrator", () => {
         },
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       // Only rows 0, 1, 3 have outputs - row 2 is skipped
       expect(cells).toHaveLength(3);
@@ -1667,7 +1677,7 @@ describe("orchestrator", () => {
         traceIds: {},
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       for (const cell of cells) {
         expect(cell.skipTarget).toBe(true);
@@ -1688,7 +1698,7 @@ describe("orchestrator", () => {
         traceIds: {},
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       for (const cell of cells) {
         expect(cell.evaluatorConfigs).toHaveLength(1);
@@ -1713,7 +1723,7 @@ describe("orchestrator", () => {
         },
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells[0]?.precomputedTargetOutput).toEqual({ output: "result-0" });
       expect(cells[0]?.traceId).toBe("trace-0");
@@ -1734,7 +1744,7 @@ describe("orchestrator", () => {
         traceIds: {},
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(0);
     });
@@ -1752,7 +1762,7 @@ describe("orchestrator", () => {
         traceIds: {},
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(0);
     });
@@ -1789,7 +1799,7 @@ describe("orchestrator", () => {
         traceIds: {},
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(0);
     });
@@ -1824,7 +1834,7 @@ describe("orchestrator", () => {
         targetOutput: { output: "result-0" },
       };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       expect(cells).toHaveLength(0);
     });
@@ -1836,7 +1846,7 @@ describe("orchestrator", () => {
       const datasetRows = createTestDataset(2);
       const scope: ExecutionScope = { type: "full" };
 
-      const cells = generateCells(state, datasetRows, scope);
+      const cells = generateCells({ state, datasetRows, scope });
 
       // Expected order: (0, t1), (0, t2), (1, t1), (1, t2)
       expect(cells[0]?.rowIndex).toBe(0);

--- a/platform/app/src/server/experiments-v3/execution/__tests__/resultMapper.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/resultMapper.test.ts
@@ -232,11 +232,15 @@ describe("resultMapper", () => {
 
   describe("mapTargetResult", () => {
     it("maps successful target result", () => {
-      const result = mapTargetResult("target-1", 0, {
-        outputs: { output: "Hello world" },
-        cost: 0.001,
-        timestamps: { started_at: 1000, finished_at: 2000 },
-        trace_id: "trace-123",
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 0,
+        executionState: {
+          outputs: { output: "Hello world" },
+          cost: 0.001,
+          timestamps: { started_at: 1000, finished_at: 2000 },
+          trace_id: "trace-123",
+        },
       });
 
       expect(result).toEqual({
@@ -252,9 +256,13 @@ describe("resultMapper", () => {
     });
 
     it("maps target error result", () => {
-      const result = mapTargetResult("target-1", 2, {
-        error: "API key invalid",
-        timestamps: { finished_at: 3000 },
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 2,
+        executionState: {
+          error: "API key invalid",
+          timestamps: { finished_at: 3000 },
+        },
       });
 
       expect(result).toEqual({
@@ -270,11 +278,15 @@ describe("resultMapper", () => {
     });
 
     it("lifts a coded engine failure onto the handled channel", () => {
-      const result = mapTargetResult("target-1", 1, {
-        error:
-          'httpblock: Post "https://api.example.com": lookup api.example.com: no such host',
-        error_type: "http_error",
-        trace_id: "trace-9",
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 1,
+        executionState: {
+          error:
+            'httpblock: Post "https://api.example.com": lookup api.example.com: no such host',
+          error_type: "http_error",
+          trace_id: "trace-9",
+        },
       });
 
       if (result.type !== "target_result") throw new Error("wrong event");
@@ -287,10 +299,14 @@ describe("resultMapper", () => {
     });
 
     it("carries the upstream status for an upstream_http_error", () => {
-      const result = mapTargetResult("target-1", 0, {
-        error: "httpblock: upstream returned 500",
-        error_type: "upstream_http_error",
-        upstream_status: 500,
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 0,
+        executionState: {
+          error: "httpblock: upstream returned 500",
+          error_type: "upstream_http_error",
+          upstream_status: 500,
+        },
       });
 
       if (result.type !== "target_result") throw new Error("wrong event");
@@ -298,7 +314,11 @@ describe("resultMapper", () => {
     });
 
     it("leaves domainError unset when the engine sent no code", () => {
-      const result = mapTargetResult("target-1", 0, { error: "plain string" });
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 0,
+        executionState: { error: "plain string" },
+      });
 
       if (result.type !== "target_result") throw new Error("wrong event");
       expect(result.domainError).toBeUndefined();
@@ -306,8 +326,10 @@ describe("resultMapper", () => {
     });
 
     it("handles missing timestamps", () => {
-      const result = mapTargetResult("target-1", 0, {
-        outputs: { output: "test" },
+      const result = mapTargetResult({
+        nodeId: "target-1",
+        rowIndex: 0,
+        executionState: { outputs: { output: "test" } },
       });
 
       expect(result.type).toBe("target_result");
@@ -319,11 +341,15 @@ describe("resultMapper", () => {
 
   describe("mapEvaluatorResult", () => {
     it("maps successful evaluator result with passed=true", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: true, score: 1.0 },
-        cost: 0.0001,
-        timestamps: { started_at: 1000, finished_at: 1500 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: true, score: 1.0 },
+          cost: 0.0001,
+          timestamps: { started_at: 1000, finished_at: 1500 },
+        },
       });
 
       expect(result).toEqual({
@@ -344,10 +370,14 @@ describe("resultMapper", () => {
     });
 
     it("includes duration when timestamps are present", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: true, score: 1.0 },
-        timestamps: { started_at: 1000, finished_at: 2500 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: true, score: 1.0 },
+          timestamps: { started_at: 1000, finished_at: 2500 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -357,9 +387,13 @@ describe("resultMapper", () => {
     });
 
     it("omits duration when timestamps are missing", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: true, score: 1.0 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: true, score: 1.0 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -370,15 +404,15 @@ describe("resultMapper", () => {
 
     it("includes the evaluator's request inputs when provided", () => {
       const candidates = [{ id: "target-a" }, { id: "target-b" }];
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
           status: "success",
           outputs: { label: "target-a" },
         },
-        { inputs: { candidates } },
-      );
+        options: { inputs: { candidates } },
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -390,11 +424,11 @@ describe("resultMapper", () => {
       // Everything but the ids duplicates what the run already stores per
       // target, and this column reaches ClickHouse twice, the browser via a
       // `SELECT *`, and the storage meter — at rows x targets x evaluators.
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        { status: "success", outputs: { label: "target-a" } },
-        {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: { status: "success", outputs: { label: "target-a" } },
+        options: {
           inputs: {
             candidates: [
               { id: "target-a", output: "a long answer", cost: 0.01 },
@@ -404,7 +438,7 @@ describe("resultMapper", () => {
             input: "the task",
           },
         },
-      );
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -417,12 +451,15 @@ describe("resultMapper", () => {
     it("omits inputs for an evaluator that has no candidate list", () => {
       // A non-Comparison evaluator persists nothing here rather than an
       // empty object.
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        { status: "success", outputs: { passed: true, score: 1.0 } },
-        { inputs: { input: "the task", output: "the answer" } },
-      );
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: true, score: 1.0 },
+        },
+        options: { inputs: { input: "the task", output: "the answer" } },
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -431,9 +468,13 @@ describe("resultMapper", () => {
     });
 
     it("omits inputs when none are provided", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: true, score: 1.0 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: true, score: 1.0 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -443,9 +484,13 @@ describe("resultMapper", () => {
     });
 
     it("maps successful evaluator result with passed=false", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 1, {
-        status: "success",
-        outputs: { passed: false, score: 0.0 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 1,
+        executionState: {
+          status: "success",
+          outputs: { passed: false, score: 0.0 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -459,9 +504,13 @@ describe("resultMapper", () => {
     });
 
     it("maps evaluator result with label", () => {
-      const result = mapEvaluatorResult("target-1.eval-2", 0, {
-        status: "success",
-        outputs: { label: "positive", score: 0.85 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-2",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { label: "positive", score: 0.85 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -475,9 +524,13 @@ describe("resultMapper", () => {
     });
 
     it("maps evaluator error result from execution-level error", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "error",
-        error: "Evaluator timeout",
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "error",
+          error: "Evaluator timeout",
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -494,9 +547,13 @@ describe("resultMapper", () => {
     describe("given the evaluator failed with provider auth", () => {
       /** @scenario Judge auth failures are serialized as domain errors */
       it("serializes a domain error for raw 403 responses", () => {
-        const result = mapEvaluatorResult("target-1.eval-1", 0, {
-          status: "error",
-          error: '403 {\n  "message": "Missing Authentication Token"\n}',
+        const result = mapEvaluatorResult({
+          nodeId: "target-1.eval-1",
+          rowIndex: 0,
+          executionState: {
+            status: "error",
+            error: '403 {\n  "message": "Missing Authentication Token"\n}',
+          },
         });
 
         expect(result.type).toBe("evaluator_result");
@@ -512,9 +569,13 @@ describe("resultMapper", () => {
       });
 
       it("does not reclassify non-auth error strings", () => {
-        const result = mapEvaluatorResult("target-1.eval-1", 0, {
-          status: "error",
-          error: "Evaluator timeout",
+        const result = mapEvaluatorResult({
+          nodeId: "target-1.eval-1",
+          rowIndex: 0,
+          executionState: {
+            status: "error",
+            error: "Evaluator timeout",
+          },
         });
 
         expect(result.type).toBe("evaluator_result");
@@ -527,12 +588,16 @@ describe("resultMapper", () => {
     it("maps evaluator error result from outputs.status === 'error'", () => {
       // This covers the case where the NLP execution succeeds but the evaluator
       // returns an error in its outputs (e.g., langevals returns 404)
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success", // Execution succeeded
-        outputs: {
-          status: "error", // But evaluator itself returned error
-          details:
-            "EvaluatorException('404 Evaluator not found: langevals/invalid')",
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success", // Execution succeeded
+          outputs: {
+            status: "error", // But evaluator itself returned error
+            details:
+              "EvaluatorException('404 Evaluator not found: langevals/invalid')",
+          },
         },
       });
 
@@ -549,12 +614,16 @@ describe("resultMapper", () => {
     });
 
     it("prefers execution-level error over outputs.status error", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "error",
-        error: "Execution failed",
-        outputs: {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
           status: "error",
-          details: "Evaluator error",
+          error: "Execution failed",
+          outputs: {
+            status: "error",
+            details: "Evaluator error",
+          },
         },
       });
 
@@ -567,20 +636,24 @@ describe("resultMapper", () => {
 
     it("throws for non-evaluator node ID", () => {
       expect(() =>
-        mapEvaluatorResult("target-1", 0, { status: "success" }),
+        mapEvaluatorResult({
+          nodeId: "target-1",
+          rowIndex: 0,
+          executionState: { status: "success" },
+        }),
       ).toThrow("Expected evaluator node ID");
     });
 
     it("strips score when stripScore option is true", () => {
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
           status: "success",
           outputs: { passed: true, score: 1.0, label: "exact" },
         },
-        { stripScore: true },
-      );
+        options: { stripScore: true },
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -594,15 +667,15 @@ describe("resultMapper", () => {
     });
 
     it("preserves score when stripScore option is false", () => {
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
           status: "success",
           outputs: { passed: true, score: 0.85 },
         },
-        { stripScore: false },
-      );
+        options: { stripScore: false },
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -615,9 +688,13 @@ describe("resultMapper", () => {
     });
 
     it("preserves score when no options provided", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: false, score: 0.0 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: false, score: 0.0 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -630,9 +707,13 @@ describe("resultMapper", () => {
     });
 
     it("coerces string score from workflow evaluators", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { score: "0.85", passed: true },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { score: "0.85", passed: true },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -646,9 +727,13 @@ describe("resultMapper", () => {
     });
 
     it("coerces string passed from workflow evaluators", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: "true", score: 1.0 },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: "true", score: 1.0 },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -662,9 +747,13 @@ describe("resultMapper", () => {
     });
 
     it("coerces string 'false' passed value", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { passed: "False", score: "0" },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { passed: "False", score: "0" },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -678,9 +767,13 @@ describe("resultMapper", () => {
     });
 
     it("returns undefined for non-numeric string score", () => {
-      const result = mapEvaluatorResult("target-1.eval-1", 0, {
-        status: "success",
-        outputs: { score: "not-a-number", passed: true },
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
+          status: "success",
+          outputs: { score: "not-a-number", passed: true },
+        },
       });
 
       expect(result.type).toBe("evaluator_result");
@@ -695,9 +788,13 @@ describe("resultMapper", () => {
 
     describe("when details is null (regression: sticky details)", () => {
       it("does not include details in the result", () => {
-        const result = mapEvaluatorResult("target-1.eval-1", 0, {
-          status: "success",
-          outputs: { passed: true, score: 1.0, details: null },
+        const result = mapEvaluatorResult({
+          nodeId: "target-1.eval-1",
+          rowIndex: 0,
+          executionState: {
+            status: "success",
+            outputs: { passed: true, score: 1.0, details: null },
+          },
         });
 
         expect(result.type).toBe("evaluator_result");
@@ -712,9 +809,13 @@ describe("resultMapper", () => {
 
     describe("when details is an empty string", () => {
       it("does not include details in the result", () => {
-        const result = mapEvaluatorResult("target-1.eval-1", 0, {
-          status: "success",
-          outputs: { passed: true, score: 1.0, details: "" },
+        const result = mapEvaluatorResult({
+          nodeId: "target-1.eval-1",
+          rowIndex: 0,
+          executionState: {
+            status: "success",
+            outputs: { passed: true, score: 1.0, details: "" },
+          },
         });
 
         expect(result.type).toBe("evaluator_result");
@@ -729,12 +830,16 @@ describe("resultMapper", () => {
 
     describe("when details is a non-empty string", () => {
       it("includes details in the result", () => {
-        const result = mapEvaluatorResult("target-1.eval-1", 0, {
-          status: "success",
-          outputs: {
-            passed: true,
-            score: 1.0,
-            details: "Output matched exactly",
+        const result = mapEvaluatorResult({
+          nodeId: "target-1.eval-1",
+          rowIndex: 0,
+          executionState: {
+            status: "success",
+            outputs: {
+              passed: true,
+              score: 1.0,
+              details: "Output matched exactly",
+            },
           },
         });
 
@@ -749,15 +854,15 @@ describe("resultMapper", () => {
     });
 
     it("does not affect error results when stripScore is true", () => {
-      const result = mapEvaluatorResult(
-        "target-1.eval-1",
-        0,
-        {
+      const result = mapEvaluatorResult({
+        nodeId: "target-1.eval-1",
+        rowIndex: 0,
+        executionState: {
           status: "error",
           error: "Failed",
         },
-        { stripScore: true },
-      );
+        options: { stripScore: true },
+      });
 
       expect(result.type).toBe("evaluator_result");
       if (result.type === "evaluator_result") {
@@ -774,13 +879,16 @@ describe("resultMapper", () => {
   describe("mapWorkflowEvaluatorResult", () => {
     describe("when the evaluator node has a display name", () => {
       it("carries the name on the event so results show it over the raw node id", () => {
-        const result = mapWorkflowEvaluatorResult(
-          0,
-          "workflow-target",
-          "evaluator_node_abc",
-          "Exact Match",
-          { status: "success", outputs: { passed: true, score: 1 } },
-        );
+        const result = mapWorkflowEvaluatorResult({
+          rowIndex: 0,
+          targetId: "workflow-target",
+          evaluatorId: "evaluator_node_abc",
+          evaluatorName: "Exact Match",
+          executionState: {
+            status: "success",
+            outputs: { passed: true, score: 1 },
+          },
+        });
 
         expect(result.type).toBe("evaluator_result");
         if (result.type === "evaluator_result") {
@@ -796,13 +904,13 @@ describe("resultMapper", () => {
 
     describe("when the evaluator node has no display name", () => {
       it("leaves the name undefined so storage falls back to null", () => {
-        const result = mapWorkflowEvaluatorResult(
-          1,
-          "workflow-target",
-          "evaluator_node_xyz",
-          undefined,
-          { status: "success", outputs: { score: 0.5 } },
-        );
+        const result = mapWorkflowEvaluatorResult({
+          rowIndex: 1,
+          targetId: "workflow-target",
+          evaluatorId: "evaluator_node_xyz",
+          evaluatorName: undefined,
+          executionState: { status: "success", outputs: { score: 0.5 } },
+        });
 
         expect(result.type).toBe("evaluator_result");
         if (result.type === "evaluator_result") {

--- a/platform/app/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
@@ -344,13 +344,13 @@ describe("WorkflowBuilder", () => {
       const evaluator = createBasicEvaluatorConfig();
       const cell = createBasicCell();
 
-      const node = buildEvaluatorNode(
+      const node = buildEvaluatorNode({
         evaluator,
-        "target-1.eval-1",
-        "target-1",
+        nodeId: "target-1.eval-1",
+        targetId: "target-1",
         cell,
-        0,
-      );
+        index: 0,
+      });
 
       expect(node.id).toBe("target-1.eval-1");
       expect(node.type).toBe("evaluator");
@@ -361,13 +361,13 @@ describe("WorkflowBuilder", () => {
       const evaluator = createBasicEvaluatorConfig();
       const cell = createBasicCell();
 
-      const node = buildEvaluatorNode(
+      const node = buildEvaluatorNode({
         evaluator,
-        "target-1.eval-1",
-        "target-1",
+        nodeId: "target-1.eval-1",
+        targetId: "target-1",
         cell,
-        0,
-      );
+        index: 0,
+      });
 
       // Full evaluator type including namespace
       expect(node.data.evaluator).toBe("langevals/exact_match");
@@ -377,13 +377,13 @@ describe("WorkflowBuilder", () => {
       const evaluator = createBasicEvaluatorConfig();
       const cell = createBasicCell();
 
-      const node = buildEvaluatorNode(
+      const node = buildEvaluatorNode({
         evaluator,
-        "target-1.eval-1",
-        "target-1",
+        nodeId: "target-1.eval-1",
+        targetId: "target-1",
         cell,
-        0,
-      );
+        index: 0,
+      });
 
       expect(node.data.inputs).toHaveLength(2);
       expect(node.data.inputs?.map((i) => i.identifier)).toEqual([
@@ -396,13 +396,13 @@ describe("WorkflowBuilder", () => {
       const evaluator = createBasicEvaluatorConfig();
       const cell = createBasicCell();
 
-      const node = buildEvaluatorNode(
+      const node = buildEvaluatorNode({
         evaluator,
-        "target-1.eval-1",
-        "target-1",
+        nodeId: "target-1.eval-1",
+        targetId: "target-1",
         cell,
-        0,
-      );
+        index: 0,
+      });
 
       expect(node.data.outputs?.map((o) => o.identifier)).toEqual([
         "passed",
@@ -514,12 +514,12 @@ describe("WorkflowBuilder", () => {
       });
       const cell = createBasicCell({ targetConfig });
 
-      const node = buildCodeNodeFromAgent(
-        "test-node",
+      const node = buildCodeNodeFromAgent({
+        nodeId: "test-node",
         agent,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.id).toBe("test-node");
       expect(node.type).toBe("code");
@@ -535,12 +535,12 @@ describe("WorkflowBuilder", () => {
       });
       const cell = createBasicCell({ targetConfig });
 
-      const node = buildCodeNodeFromAgent(
-        "test-node",
+      const node = buildCodeNodeFromAgent({
+        nodeId: "test-node",
         agent,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.data.inputs).toHaveLength(1);
       expect(node.data.inputs?.[0]?.identifier).toBe("input");
@@ -557,12 +557,12 @@ describe("WorkflowBuilder", () => {
       });
       const cell = createBasicCell({ targetConfig });
 
-      const node = buildCodeNodeFromAgent(
-        "test-node",
+      const node = buildCodeNodeFromAgent({
+        nodeId: "test-node",
         agent,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.data.parameters).toBeDefined();
       expect(node.data.parameters?.length).toBeGreaterThan(0);

--- a/platform/app/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
@@ -82,16 +82,16 @@ describe("buildEvaluatorNode", () => {
       max_tokens: 100,
     };
 
-    const node = buildEvaluatorNode(
+    const node = buildEvaluatorNode({
       evaluator,
-      "target-1.eval-1",
-      "target-1",
+      nodeId: "target-1.eval-1",
+      targetId: "target-1",
       cell,
-      0,
+      index: 0,
       settings,
-      undefined, // dbEvaluatorId
-      "Custom LLM Score", // name
-    );
+      dbEvaluatorId: undefined,
+      name: "Custom LLM Score",
+    });
 
     // Settings should be in parameters array (format expected by langwatch_nlp)
     const parameters = (node.data as Record<string, unknown>)
@@ -124,16 +124,16 @@ describe("buildEvaluatorNode", () => {
     const cell = createBasicCell();
 
     // No settings passed (defaults to empty)
-    const node = buildEvaluatorNode(
+    const node = buildEvaluatorNode({
       evaluator,
-      "target-1.eval-1",
-      "target-1",
+      nodeId: "target-1.eval-1",
+      targetId: "target-1",
       cell,
-      0,
-      {}, // settings
-      undefined, // dbEvaluatorId
-      "Exact Match", // name
-    );
+      index: 0,
+      settings: {},
+      dbEvaluatorId: undefined,
+      name: "Exact Match",
+    });
 
     // Should have empty parameters array when no settings
     const parameters = (node.data as Record<string, unknown>)
@@ -154,13 +154,13 @@ describe("buildEvaluatorNode", () => {
     const evaluator = createBasicEvaluatorConfig();
     const cell = createBasicCell();
 
-    const node = buildEvaluatorNode(
+    const node = buildEvaluatorNode({
       evaluator,
-      "target-1.eval-1",
-      "target-1",
+      nodeId: "target-1.eval-1",
+      targetId: "target-1",
       cell,
-      0,
-    );
+      index: 0,
+    });
 
     expect(node.data.evaluator).toBe("langevals/exact_match");
   });
@@ -169,13 +169,13 @@ describe("buildEvaluatorNode", () => {
     const evaluator = createBasicEvaluatorConfig();
     const cell = createBasicCell();
 
-    const node = buildEvaluatorNode(
+    const node = buildEvaluatorNode({
       evaluator,
-      "target-1.eval-1",
-      "target-1",
+      nodeId: "target-1.eval-1",
+      targetId: "target-1",
       cell,
-      0,
-    );
+      index: 0,
+    });
 
     expect(node.data.outputs?.map((o) => o.identifier)).toEqual([
       "passed",
@@ -278,12 +278,12 @@ describe("buildSignatureNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildSignatureNodeFromAgent(
-      "target-1",
+    const node = buildSignatureNodeFromAgent({
+      nodeId: "target-1",
       agent,
       targetConfig,
       cell,
-    );
+    });
 
     expect(node.type).toBe("signature");
   });
@@ -293,12 +293,12 @@ describe("buildSignatureNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildSignatureNodeFromAgent(
-      "target-1",
+    const node = buildSignatureNodeFromAgent({
+      nodeId: "target-1",
       agent,
       targetConfig,
       cell,
-    );
+    });
 
     // LLM config should be in parameters array
     const llmParam = node.data.parameters?.find(
@@ -317,12 +317,12 @@ describe("buildSignatureNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildSignatureNodeFromAgent(
-      "target-1",
+    const node = buildSignatureNodeFromAgent({
+      nodeId: "target-1",
       agent,
       targetConfig,
       cell,
-    );
+    });
 
     // Prompt should be converted to instructions parameter
     const instructionsParam = node.data.parameters?.find(
@@ -337,12 +337,12 @@ describe("buildSignatureNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildSignatureNodeFromAgent(
-      "target-1",
+    const node = buildSignatureNodeFromAgent({
+      nodeId: "target-1",
       agent,
       targetConfig,
       cell,
-    );
+    });
 
     // Messages should be in parameters array
     const messagesParam = node.data.parameters?.find(
@@ -359,12 +359,12 @@ describe("buildSignatureNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildSignatureNodeFromAgent(
-      "target-1",
+    const node = buildSignatureNodeFromAgent({
+      nodeId: "target-1",
       agent,
       targetConfig,
       cell,
-    );
+    });
 
     // LLM config should still be from parameters array
     const llmParam = node.data.parameters?.find(
@@ -446,7 +446,12 @@ describe("buildHttpNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildHttpNodeFromAgent("target-1", agent, targetConfig, cell);
+    const node = buildHttpNodeFromAgent({
+      nodeId: "target-1",
+      agent,
+      targetConfig,
+      cell,
+    });
 
     expect(node.type).toBe("http");
   });
@@ -456,7 +461,12 @@ describe("buildHttpNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildHttpNodeFromAgent("target-1", agent, targetConfig, cell);
+    const node = buildHttpNodeFromAgent({
+      nodeId: "target-1",
+      agent,
+      targetConfig,
+      cell,
+    });
 
     // Should extract {{input}} and {{threadId}} from body template
     const inputIdentifiers = node.data.inputs?.map((i) => i.identifier);
@@ -469,7 +479,12 @@ describe("buildHttpNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildHttpNodeFromAgent("target-1", agent, targetConfig, cell);
+    const node = buildHttpNodeFromAgent({
+      nodeId: "target-1",
+      agent,
+      targetConfig,
+      cell,
+    });
 
     // threadId has a value mapping, should have that value
     const threadIdInput = node.data.inputs?.find(
@@ -487,7 +502,12 @@ describe("buildHttpNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildHttpNodeFromAgent("target-1", agent, targetConfig, cell);
+    const node = buildHttpNodeFromAgent({
+      nodeId: "target-1",
+      agent,
+      targetConfig,
+      cell,
+    });
 
     // HTTP config is stored in parameters (consistent with other node types)
     const params = node.data.parameters ?? [];
@@ -509,7 +529,12 @@ describe("buildHttpNodeFromAgent", () => {
     const targetConfig = createTargetConfig();
     const cell = createCell();
 
-    const node = buildHttpNodeFromAgent("target-1", agent, targetConfig, cell);
+    const node = buildHttpNodeFromAgent({
+      nodeId: "target-1",
+      agent,
+      targetConfig,
+      cell,
+    });
 
     expect(node.data.outputs).toHaveLength(1);
     expect(node.data.outputs?.[0]?.identifier).toBe("output");
@@ -555,7 +580,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     // Node ID should be the target ID, not a composite ID
     expect(node.id).toBe("target-eval-1");
@@ -566,7 +595,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     expect(node.type).toBe("evaluator");
   });
@@ -575,7 +608,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     expect(node.data.evaluator).toBe("evaluators/eval-abc-123");
   });
@@ -591,7 +628,7 @@ describe("buildEvaluatorTargetNode", () => {
     };
 
     expect(() =>
-      buildEvaluatorTargetNode("target-eval-1", targetConfig, cell),
+      buildEvaluatorTargetNode({ nodeId: "target-eval-1", targetConfig, cell }),
     ).toThrow(
       'Evaluator target "target-eval-1" has no evaluator ID. targetEvaluatorId must be set.',
     );
@@ -601,7 +638,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     expect(node.data.outputs?.map((o) => o.identifier)).toEqual([
       "passed",
@@ -619,7 +660,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     // The 'output' input should NOT have a value (it comes from edge/dataset)
     const outputInput = node.data.inputs?.find(
@@ -647,7 +692,11 @@ describe("buildEvaluatorTargetNode", () => {
       targetConfig,
     };
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     const outputInput = node.data.inputs?.find(
       (i) => i.identifier === "output",
@@ -677,12 +726,12 @@ describe("buildEvaluatorTargetNode", () => {
       ],
     ]);
 
-    const node = buildEvaluatorTargetNode(
-      "target-eval-1",
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
       targetConfig,
       cell,
       loadedEvaluators,
-    );
+    });
 
     // Settings should be converted to parameters
     const params = node.data.parameters ?? [];
@@ -699,7 +748,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     expect(node.data.cls).toBe("LangWatchEvaluator");
   });
@@ -720,12 +773,12 @@ describe("buildEvaluatorTargetNode", () => {
       ],
     ]);
 
-    const node = buildEvaluatorTargetNode(
-      "target-eval-1",
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
       targetConfig,
       cell,
       loadedEvaluators,
-    );
+    });
 
     expect(node.data.name).toBe("Sentiment Evaluator");
   });
@@ -734,7 +787,11 @@ describe("buildEvaluatorTargetNode", () => {
     const targetConfig = createEvaluatorTargetConfig();
     const cell = createCell();
 
-    const node = buildEvaluatorTargetNode("target-eval-1", targetConfig, cell);
+    const node = buildEvaluatorTargetNode({
+      nodeId: "target-eval-1",
+      targetConfig,
+      cell,
+    });
 
     expect(node.data.name).toBe("target-eval-1");
   });

--- a/platform/app/src/server/experiments-v3/execution/dataLoader.ts
+++ b/platform/app/src/server/experiments-v3/execution/dataLoader.ts
@@ -325,13 +325,19 @@ export type ExecutionDataInputs = {
   parameters?: Record<string, string | number | boolean>;
 };
 
-export const loadExecutionData = async (
-  projectId: string,
-  dataset: DatasetInput,
-  targets: TargetForLoading[],
-  evaluators: EvaluatorForLoading[],
-  inputs?: ExecutionDataInputs,
-): Promise<LoadedExecutionData | { error: string; status: number }> => {
+export const loadExecutionData = async ({
+  projectId,
+  dataset,
+  targets,
+  evaluators,
+  inputs,
+}: {
+  projectId: string;
+  dataset: DatasetInput;
+  targets: TargetForLoading[];
+  evaluators: EvaluatorForLoading[];
+  inputs?: ExecutionDataInputs;
+}): Promise<LoadedExecutionData | { error: string; status: number }> => {
   // Resolve the base rows + columns: inline data, a saved dataset id, or the
   // attached dataset reference, in that precedence.
   let baseDataset: LoadedDataset;

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -147,20 +147,25 @@ export const resolveScopedRowIndices = ({
 /**
  * Generates all cells to execute based on the scope.
  */
-export const generateCells = (
+export const generateCells = ({
+  state,
+  datasetRows,
+  scope,
+  options = {},
+}: {
   state: Pick<
     EvaluationsV3State,
     "datasets" | "activeDatasetId" | "targets" | "evaluators"
-  >,
-  datasetRows: Array<Record<string, unknown>>,
-  scope: ExecutionScope,
-  options: {
+  >;
+  datasetRows: Array<Record<string, unknown>>;
+  scope: ExecutionScope;
+  options?: {
     seedTargetOutputs?: Record<
       string,
       { output: unknown; cost?: number; duration?: number }
     >;
-  } = {},
-): ExecutionCell[] => {
+  };
+}): ExecutionCell[] => {
   const cells: ExecutionCell[] = [];
   const datasetId =
     state.datasets[0]?.id ?? state.activeDatasetId ?? "dataset-1";
@@ -708,13 +713,18 @@ export const generateComparisonCells = ({
    * the config's variant order — that order is what the judge's deterministic
    * shuffle is seeded against.
    */
-  const buildCandidates = (
-    cfg: ComparisonEvaluatorConfig,
-    resolvedVariants: TargetConfig[],
-    variantIds: string[],
-    variantDisplayNames: string[],
-    rowIndex: number,
-  ):
+  const buildCandidates = ({
+    cfg,
+    variantIds,
+    variantDisplayNames,
+    rowIndex,
+  }: {
+    cfg: ComparisonEvaluatorConfig;
+    resolvedVariants: TargetConfig[];
+    variantIds: string[];
+    variantDisplayNames: string[];
+    rowIndex: number;
+  }):
     | {
         candidates: ExecutionCell["comparison"];
         missing?: never;
@@ -781,13 +791,13 @@ export const generateComparisonCells = ({
       const datasetEntry = datasetRows[rowIndex];
       if (!datasetEntry) continue;
 
-      const built = buildCandidates(
+      const built = buildCandidates({
         cfg,
         resolvedVariants,
         variantIds,
         variantDisplayNames,
         rowIndex,
-      );
+      });
       if (built.missing || built.empty) {
         skipReasons.push({
           rowIndex,
@@ -850,13 +860,13 @@ export const generateComparisonCells = ({
       const datasetEntry = datasetRows[rowIndex];
       if (!datasetEntry) continue;
 
-      const built = buildCandidates(
+      const built = buildCandidates({
         cfg,
         resolvedVariants,
         variantIds,
         variantDisplayNames,
         rowIndex,
-      );
+      });
       if (built.missing || built.empty) {
         skipReasons.push({
           rowIndex,
@@ -1025,18 +1035,25 @@ export const priceMetrics = async (
  * Executes a single cell and yields events.
  * @param isAborted - Optional function to check if execution should be aborted
  */
-export async function* executeCell(
-  cell: ExecutionCell,
-  projectId: string,
-  datasetColumns: Array<{ id: string; name: string; type: string }>,
+export async function* executeCell({
+  cell,
+  projectId,
+  datasetColumns,
+  loadedData,
+  resultMapperConfig,
+  isAborted,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  datasetColumns: Array<{ id: string; name: string; type: string }>;
   loadedData: {
     prompt?: VersionedPrompt;
     agent?: TypedAgent;
     evaluators?: Map<string, { id: string; name: string; config: unknown }>;
-  },
-  resultMapperConfig?: ResultMapperConfig,
-  isAborted?: () => Promise<boolean>,
-): AsyncGenerator<EvaluationV3Event> {
+  };
+  resultMapperConfig?: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+}): AsyncGenerator<EvaluationV3Event> {
   // Emit cell_started
   yield {
     type: "cell_started",
@@ -1303,12 +1320,17 @@ export async function* executeCell(
  * evaluator result. This replaces the legacy nlpgo execute_evaluation loop,
  * keeping orchestration (parallelism, abort, storage) in TypeScript.
  */
-export async function* executeWorkflowCell(
-  cell: ExecutionCell,
-  projectId: string,
-  workflowDsl: Workflow,
-  isAborted?: () => Promise<boolean>,
-): AsyncGenerator<EvaluationV3Event> {
+export async function* executeWorkflowCell({
+  cell,
+  projectId,
+  workflowDsl,
+  isAborted,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  workflowDsl: Workflow;
+  isAborted?: () => Promise<boolean>;
+}): AsyncGenerator<EvaluationV3Event> {
   yield {
     type: "cell_started",
     rowIndex: cell.rowIndex,
@@ -1429,12 +1451,12 @@ export async function* executeWorkflowCell(
           execution_state.status === "error")
       ) {
         evaluatorEvents.push(
-          mapWorkflowEvaluatorResult(
-            cell.rowIndex,
-            cell.targetId,
-            component_id,
-            evaluatorNodeNames.get(component_id),
-            {
+          mapWorkflowEvaluatorResult({
+            rowIndex: cell.rowIndex,
+            targetId: cell.targetId,
+            evaluatorId: component_id,
+            evaluatorName: evaluatorNodeNames.get(component_id),
+            executionState: {
               status: execution_state.status,
               outputs: execution_state.outputs,
               cost: execution_state.cost,
@@ -1445,7 +1467,7 @@ export async function* executeWorkflowCell(
               upstream_status: execution_state.upstream_status,
               trace_id: execution_state.trace_id ?? finalTraceId,
             },
-          ),
+          }),
         );
       }
     }
@@ -1880,8 +1902,11 @@ export async function* runOrchestrator(
   const runId = providedRunId ?? generateHumanReadableId();
 
   // Generate cells to execute
-  const cells = generateCells(state, datasetRows, scope, {
-    seedTargetOutputs,
+  const cells = generateCells({
+    state,
+    datasetRows,
+    scope,
+    options: { seedTargetOutputs },
   });
   // Phase-1 count only; grows by the Phase-2 (comparison) cell count once
   // those are generated after Phase 1 finishes, so the final summary's
@@ -2257,12 +2282,12 @@ export async function* runOrchestrator(
 
             // Get loaded data for this target
             const loadedData = {
-              ...getLoadedDataForTarget(
-                cell.targetConfig,
+              ...getLoadedDataForTarget({
+                targetConfig: cell.targetConfig,
                 loadedPrompts,
                 loadedAgents,
                 loadedWorkflows,
-              ),
+              }),
               evaluators: loadedEvaluators,
             };
 
@@ -2281,20 +2306,20 @@ export async function* runOrchestrator(
               !!loadedData.workflow;
 
             const cellEvents = runsAsWorkflow
-              ? executeWorkflowCell(
+              ? executeWorkflowCell({
                   cell,
                   projectId,
-                  loadedData.workflow!.dsl,
-                  checkAbort,
-                )
-              : executeCell(
+                  workflowDsl: loadedData.workflow!.dsl,
+                  isAborted: checkAbort,
+                })
+              : executeCell({
                   cell,
                   projectId,
                   datasetColumns,
                   loadedData,
                   resultMapperConfig,
-                  checkAbort,
-                );
+                  isAborted: checkAbort,
+                });
 
             // Execute cell and collect events
             let cellFailed = false;
@@ -2511,25 +2536,25 @@ export async function* runOrchestrator(
                 if (await abortManager.isAborted(runId)) return;
 
                 const loadedData = {
-                  ...getLoadedDataForTarget(
-                    cell.targetConfig,
+                  ...getLoadedDataForTarget({
+                    targetConfig: cell.targetConfig,
                     loadedPrompts,
                     loadedAgents,
-                  ),
+                  }),
                   evaluators: loadedEvaluators,
                 };
 
                 const checkAbort = () => abortManager.isAborted(runId);
 
                 let cellFailed = false;
-                for await (const event of executeCell(
+                for await (const event of executeCell({
                   cell,
                   projectId,
                   datasetColumns,
                   loadedData,
                   resultMapperConfig,
-                  checkAbort,
-                )) {
+                  isAborted: checkAbort,
+                })) {
                   if (await abortManager.isAborted(runId)) break;
                   pushEvent(event);
                   await processEventForStorage(event);
@@ -2662,12 +2687,17 @@ export async function* runOrchestrator(
 /**
  * Gets loaded prompt/agent data for a target.
  */
-const getLoadedDataForTarget = (
-  targetConfig: TargetConfig,
-  loadedPrompts: Map<string, VersionedPrompt>,
-  loadedAgents: Map<string, TypedAgent>,
-  loadedWorkflows?: Map<string, LoadedWorkflow>,
-): {
+const getLoadedDataForTarget = ({
+  targetConfig,
+  loadedPrompts,
+  loadedAgents,
+  loadedWorkflows,
+}: {
+  targetConfig: TargetConfig;
+  loadedPrompts: Map<string, VersionedPrompt>;
+  loadedAgents: Map<string, TypedAgent>;
+  loadedWorkflows?: Map<string, LoadedWorkflow>;
+}): {
   prompt?: VersionedPrompt;
   agent?: TypedAgent;
   workflow?: LoadedWorkflow;

--- a/platform/app/src/server/experiments-v3/execution/resultMapper.ts
+++ b/platform/app/src/server/experiments-v3/execution/resultMapper.ts
@@ -182,9 +182,14 @@ const durationOf = (
 /**
  * Maps a target completion event to a target_result SSE event.
  */
-export const mapTargetResult = (
-  nodeId: string,
-  rowIndex: number,
+export const mapTargetResult = ({
+  nodeId,
+  rowIndex,
+  executionState,
+  options,
+}: {
+  nodeId: string;
+  rowIndex: number;
   executionState: {
     outputs?: Record<string, unknown>;
     cost?: number;
@@ -193,9 +198,9 @@ export const mapTargetResult = (
     error?: string;
     error_type?: string;
     upstream_status?: number;
-  },
-  options?: { isEvaluatorAsTarget?: boolean },
-): EvaluationV3Event => {
+  };
+  options?: { isEvaluatorAsTarget?: boolean };
+}): EvaluationV3Event => {
   const { targetId } = parseNodeId(nodeId);
 
   const duration = durationOf(executionState.timestamps);
@@ -269,16 +274,21 @@ const persistableInputs = (
  * @param options - Additional options
  * @param options.stripScore - If true, the score will be omitted from the result
  */
-export const mapEvaluatorResult = (
-  nodeId: string,
-  rowIndex: number,
+export const mapEvaluatorResult = ({
+  nodeId,
+  rowIndex,
+  executionState,
+  options,
+}: {
+  nodeId: string;
+  rowIndex: number;
   executionState: {
     status: string;
     outputs?: Record<string, unknown>;
     cost?: number;
     timestamps?: { started_at?: number; finished_at?: number };
     error?: string;
-  },
+  };
   options?: {
     stripScore?: boolean;
     /**
@@ -289,8 +299,8 @@ export const mapEvaluatorResult = (
      * only names the winner, not the full candidate set.
      */
     inputs?: Record<string, unknown>;
-  },
-): EvaluationV3Event => {
+  };
+}): EvaluationV3Event => {
   const { targetId, evaluatorId } = parseNodeId(nodeId);
 
   if (!evaluatorId) {
@@ -412,10 +422,10 @@ export const mapNlpEvent = ({
     // Target node
     const isEvaluatorAsTarget =
       config?.evaluatorTargetNodeIds?.has(component_id) ?? false;
-    return mapTargetResult(
-      component_id,
+    return mapTargetResult({
+      nodeId: component_id,
       rowIndex,
-      {
+      executionState: {
         outputs: execution_state.outputs,
         cost: execution_state.cost,
         timestamps: execution_state.timestamps,
@@ -424,8 +434,8 @@ export const mapNlpEvent = ({
         error_type: isError ? execution_state.error_type : undefined,
         upstream_status: isError ? execution_state.upstream_status : undefined,
       },
-      { isEvaluatorAsTarget },
-    );
+      options: { isEvaluatorAsTarget },
+    });
   } else if (isEvaluatorNode(component_id)) {
     // Evaluator node - check if score should be stripped
     const { evaluatorId } = parseNodeId(component_id);
@@ -433,18 +443,18 @@ export const mapNlpEvent = ({
       ? config?.stripScoreEvaluatorIds?.has(evaluatorId)
       : false;
 
-    return mapEvaluatorResult(
-      component_id,
+    return mapEvaluatorResult({
+      nodeId: component_id,
       rowIndex,
-      {
+      executionState: {
         status: execution_state.status,
         outputs: execution_state.outputs,
         cost: execution_state.cost,
         timestamps: execution_state.timestamps,
         error: isError ? execution_state.error : undefined,
       },
-      { stripScore, inputs: evaluatorInputs },
-    );
+      options: { stripScore, inputs: evaluatorInputs },
+    });
   }
 
   // Unknown node type
@@ -512,11 +522,17 @@ export const mapThrownErrorEvent = ({
  * Workflow evaluators can return stringy score/passed values, so they go
  * through coerceScore/coercePassed like the legacy workflow-evaluation path.
  */
-export const mapWorkflowEvaluatorResult = (
-  rowIndex: number,
-  targetId: string,
-  evaluatorId: string,
-  evaluatorName: string | undefined,
+export const mapWorkflowEvaluatorResult = ({
+  rowIndex,
+  targetId,
+  evaluatorId,
+  evaluatorName,
+  executionState,
+}: {
+  rowIndex: number;
+  targetId: string;
+  evaluatorId: string;
+  evaluatorName: string | undefined;
   executionState: {
     status: string;
     outputs?: Record<string, unknown>;
@@ -533,8 +549,8 @@ export const mapWorkflowEvaluatorResult = (
     nodeErrorCode?: string;
     upstream_status?: number;
     trace_id?: string;
-  },
-): EvaluationV3Event => {
+  };
+}): EvaluationV3Event => {
   const hasExecutionError = !!executionState.error;
   const hasEvaluatorError =
     executionState.status === "error" ||

--- a/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
+++ b/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
@@ -77,31 +77,31 @@ export const buildCellWorkflow = (
   const entryNode = buildEntryNode(datasetColumns, datasetEntry);
 
   // Build target node
-  const { targetNode, targetNodeId } = buildTargetNode(
+  const { targetNode, targetNodeId } = buildTargetNode({
     targetConfig,
     loadedData,
     cell,
-    loadedData.evaluators, // Pass evaluators for evaluator-as-target case
-  );
+    loadedEvaluators: loadedData.evaluators, // Pass evaluators for evaluator-as-target case
+  });
 
   // Build evaluator nodes
-  const { evaluatorNodes, evaluatorNodeIds } = buildEvaluatorNodes(
+  const { evaluatorNodes, evaluatorNodeIds } = buildEvaluatorNodes({
     evaluatorConfigs,
-    targetConfig.id,
+    targetId: targetConfig.id,
     cell,
-    loadedData.evaluators,
-  );
+    loadedEvaluators: loadedData.evaluators,
+  });
 
   // Build edges
-  const edges = buildEdges(
-    entryNode.id,
+  const edges = buildEdges({
+    entryNodeId: entryNode.id,
     targetNodeId,
     targetConfig,
     evaluatorConfigs,
     evaluatorNodeIds,
     cell,
     datasetColumns,
-  );
+  });
 
   const workflow: Workflow = {
     spec_version: LATEST_SPEC_VERSION,
@@ -187,12 +187,17 @@ type LoadedTargetData = {
 /**
  * Builds the target node based on whether it's a prompt, agent, or evaluator.
  */
-const buildTargetNode = (
-  targetConfig: TargetConfig,
-  loadedData: LoadedTargetData,
-  cell: ExecutionCell,
-  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>,
-): {
+const buildTargetNode = ({
+  targetConfig,
+  loadedData,
+  cell,
+  loadedEvaluators,
+}: {
+  targetConfig: TargetConfig;
+  loadedData: LoadedTargetData;
+  cell: ExecutionCell;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+}): {
   targetNode: Node<Signature | Code | HttpNodeData | Evaluator>;
   targetNodeId: string;
 } => {
@@ -235,12 +240,12 @@ const buildTargetNode = (
   } else if (targetConfig.type === "evaluator") {
     // Evaluator target - build evaluator node with target ID
     return {
-      targetNode: buildEvaluatorTargetNode(
-        targetNodeId,
+      targetNode: buildEvaluatorTargetNode({
+        nodeId: targetNodeId,
         targetConfig,
         cell,
         loadedEvaluators,
-      ),
+      }),
       targetNodeId,
     };
   } else {
@@ -249,32 +254,32 @@ const buildTargetNode = (
       switch (loadedData.agent.type) {
         case "http":
           return {
-            targetNode: buildHttpNodeFromAgent(
-              targetNodeId,
-              loadedData.agent,
+            targetNode: buildHttpNodeFromAgent({
+              nodeId: targetNodeId,
+              agent: loadedData.agent,
               targetConfig,
               cell,
-            ),
+            }),
             targetNodeId,
           };
         case "signature":
           return {
-            targetNode: buildSignatureNodeFromAgent(
-              targetNodeId,
-              loadedData.agent,
+            targetNode: buildSignatureNodeFromAgent({
+              nodeId: targetNodeId,
+              agent: loadedData.agent,
               targetConfig,
               cell,
-            ),
+            }),
             targetNodeId,
           };
         case "code":
           return {
-            targetNode: buildCodeNodeFromAgent(
-              targetNodeId,
-              loadedData.agent,
+            targetNode: buildCodeNodeFromAgent({
+              nodeId: targetNodeId,
+              agent: loadedData.agent,
               targetConfig,
               cell,
-            ),
+            }),
             targetNodeId,
           };
         case "workflow":
@@ -302,12 +307,17 @@ const buildTargetNode = (
  * Builds an evaluator node when an evaluator is used as a target.
  * The node ID is the target ID (not a composite ID like regular evaluators).
  */
-export const buildEvaluatorTargetNode = (
-  nodeId: string,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
-  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>,
-): Node<Evaluator> => {
+export const buildEvaluatorTargetNode = ({
+  nodeId,
+  targetConfig,
+  cell,
+  loadedEvaluators,
+}: {
+  nodeId: string;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+}): Node<Evaluator> => {
   // Get settings: prefer local config if available, otherwise use DB settings
   const dbEvaluator = targetConfig.targetEvaluatorId
     ? loadedEvaluators?.get(targetConfig.targetEvaluatorId)
@@ -618,12 +628,17 @@ export const buildSignatureNodeFromLocalConfig = ({
  * - prompt: top-level or as "instructions" in parameters
  * - messages: top-level or in parameters array
  */
-export const buildSignatureNodeFromAgent = (
-  nodeId: string,
-  agent: TypedAgent,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
-): Node<Signature> => {
+export const buildSignatureNodeFromAgent = ({
+  nodeId,
+  agent,
+  targetConfig,
+  cell,
+}: {
+  nodeId: string;
+  agent: TypedAgent;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
+}): Node<Signature> => {
   const config = agent.config;
 
   // Get inputs with value mappings applied
@@ -724,12 +739,17 @@ const buildSignatureNodeParameters = (
  * its own LLM calls. Parameters are passed directly - no LLM config
  * normalization needed.
  */
-export const buildCodeNodeFromAgent = (
-  nodeId: string,
-  agent: TypedAgent,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
-): Node<Code> => {
+export const buildCodeNodeFromAgent = ({
+  nodeId,
+  agent,
+  targetConfig,
+  cell,
+}: {
+  nodeId: string;
+  agent: TypedAgent;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
+}): Node<Code> => {
   const config = agent.config;
 
   // Get inputs with value mappings applied
@@ -771,12 +791,17 @@ const HTTP_AGENT_FIXED_INPUTS = ["threadId", "messages", "input"] as const;
  * HTTP config is stored in `parameters` like other node types (Code, Signature, etc.)
  * This ensures consistent handling in the Python parser via parse_fields().
  */
-export const buildHttpNodeFromAgent = (
-  nodeId: string,
-  agent: TypedAgent,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
-): Node<HttpNodeData> => {
+export const buildHttpNodeFromAgent = ({
+  nodeId,
+  agent,
+  targetConfig,
+  cell,
+}: {
+  nodeId: string;
+  agent: TypedAgent;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
+}): Node<HttpNodeData> => {
   // The agent.type === "http" check is done before calling this function,
   // so we can safely cast the config to HttpComponentConfig
   const config = agent.config as HttpComponentConfig;
@@ -912,12 +937,17 @@ export const buildHttpNodeFromAgent = (
 /**
  * Builds evaluator nodes for all evaluators in the cell.
  */
-const buildEvaluatorNodes = (
-  evaluatorConfigs: EvaluatorConfig[],
-  targetId: string,
-  cell: ExecutionCell,
-  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>,
-): {
+const buildEvaluatorNodes = ({
+  evaluatorConfigs,
+  targetId,
+  cell,
+  loadedEvaluators,
+}: {
+  evaluatorConfigs: EvaluatorConfig[];
+  targetId: string;
+  cell: ExecutionCell;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+}): {
   evaluatorNodes: Array<Node<Evaluator>>;
   evaluatorNodeIds: Record<string, string>;
 } => {
@@ -940,16 +970,16 @@ const buildEvaluatorNodes = (
     // Get name from loaded evaluator, fall back to evaluator ID
     const evaluatorName = dbEvaluator?.name ?? evaluator.id;
 
-    const node = buildEvaluatorNode(
+    const node = buildEvaluatorNode({
       evaluator,
       nodeId,
       targetId,
       cell,
       index,
       settings,
-      evaluator.dbEvaluatorId, // Pass dbEvaluatorId to use evaluators/{id} path
-      evaluatorName,
-    );
+      dbEvaluatorId: evaluator.dbEvaluatorId, // Pass dbEvaluatorId to use evaluators/{id} path
+      name: evaluatorName,
+    });
     evaluatorNodes.push(node);
   });
 
@@ -962,16 +992,25 @@ const buildEvaluatorNodes = (
  * @param dbEvaluatorId - Database evaluator ID for using evaluators/{id} path
  * @param name - Display name for the evaluator (from loaded DB evaluator)
  */
-export const buildEvaluatorNode = (
-  evaluator: EvaluatorConfig,
-  nodeId: string,
-  targetId: string,
-  cell: ExecutionCell,
-  index: number,
-  settings: Record<string, unknown> = {},
-  dbEvaluatorId?: string,
-  name?: string,
-): Node<Evaluator> => {
+export const buildEvaluatorNode = ({
+  evaluator,
+  nodeId,
+  targetId,
+  cell,
+  index,
+  settings = {},
+  dbEvaluatorId,
+  name,
+}: {
+  evaluator: EvaluatorConfig;
+  nodeId: string;
+  targetId: string;
+  cell: ExecutionCell;
+  index: number;
+  settings?: Record<string, unknown>;
+  dbEvaluatorId?: string;
+  name?: string;
+}): Node<Evaluator> => {
   // Get evaluator definition to know what inputs it expects
   const _evaluatorDef =
     AVAILABLE_EVALUATORS[evaluator.evaluatorType as EvaluatorTypes];
@@ -980,7 +1019,12 @@ export const buildEvaluatorNode = (
   const inputs: Field[] = evaluator.inputs.map((input) => ({
     identifier: input.identifier,
     type: input.type,
-    value: getEvaluatorInputValue(input.identifier, evaluator, targetId, cell),
+    value: getEvaluatorInputValue({
+      inputIdentifier: input.identifier,
+      evaluator,
+      targetId,
+      cell,
+    }),
   }));
 
   // Convert evaluator settings to parameters format expected by langwatch_nlp
@@ -1025,15 +1069,23 @@ export const buildEvaluatorNode = (
 /**
  * Builds edges connecting entry -> target and target/entry -> evaluators.
  */
-const buildEdges = (
-  entryNodeId: string,
-  targetNodeId: string,
-  targetConfig: TargetConfig,
-  evaluatorConfigs: EvaluatorConfig[],
-  evaluatorNodeIds: Record<string, string>,
-  cell: ExecutionCell,
-  datasetColumns: Array<{ id: string; name: string; type: string }>,
-): Edge[] => {
+const buildEdges = ({
+  entryNodeId,
+  targetNodeId,
+  targetConfig,
+  evaluatorConfigs,
+  evaluatorNodeIds,
+  cell,
+  datasetColumns,
+}: {
+  entryNodeId: string;
+  targetNodeId: string;
+  targetConfig: TargetConfig;
+  evaluatorConfigs: EvaluatorConfig[];
+  evaluatorNodeIds: Record<string, string>;
+  cell: ExecutionCell;
+  datasetColumns: Array<{ id: string; name: string; type: string }>;
+}): Edge[] => {
   const edges: Edge[] = [];
   const datasetId = cell.datasetEntry._datasetId as string | undefined;
 
@@ -1157,12 +1209,17 @@ const getInputValue = (
 /**
  * Gets the input value for an evaluator, applying value mappings if present.
  */
-const getEvaluatorInputValue = (
-  inputIdentifier: string,
-  evaluator: EvaluatorConfig,
-  targetId: string,
-  cell: ExecutionCell,
-): unknown => {
+const getEvaluatorInputValue = ({
+  inputIdentifier,
+  evaluator,
+  targetId,
+  cell,
+}: {
+  inputIdentifier: string;
+  evaluator: EvaluatorConfig;
+  targetId: string;
+  cell: ExecutionCell;
+}): unknown => {
   const datasetId = cell.datasetEntry._datasetId as string | undefined;
   if (!datasetId) return undefined;
 

--- a/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
+++ b/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
@@ -552,12 +552,12 @@ export class ExperimentRunService {
           // Enrich target items with costs from trace_summaries.
           // The SDK doesn't send costs in recordTargetResult, but the
           // trace processing pipeline computes them from LLM span data.
-          const enrichedItems = await this.enrichItemsWithTraceCosts(
+          const enrichedItems = await this.enrichItemsWithTraceCosts({
             clickHouseClient,
             projectId,
-            itemRows,
+            items: itemRows,
             occurredAtRange,
-          );
+          });
 
           const result = mapClickHouseItemsToRunWithItems({
             runRecord,
@@ -750,12 +750,17 @@ export class ExperimentRunService {
    * the trace cost is split evenly across items (each target execution is
    * a child span of the same iteration trace).
    */
-  private async enrichItemsWithTraceCosts(
-    clickHouseClient: ProjectClickHouseClient,
-    projectId: string,
-    items: ClickHouseExperimentRunItemRow[],
-    occurredAtRange: { minOccurredAt: string; maxOccurredAt: string },
-  ): Promise<ClickHouseExperimentRunItemRow[]> {
+  private async enrichItemsWithTraceCosts({
+    clickHouseClient,
+    projectId,
+    items,
+    occurredAtRange,
+  }: {
+    clickHouseClient: ProjectClickHouseClient;
+    projectId: string;
+    items: ClickHouseExperimentRunItemRow[];
+    occurredAtRange: { minOccurredAt: string; maxOccurredAt: string };
+  }): Promise<ClickHouseExperimentRunItemRow[]> {
     // Collect unique traceIds from target items that are missing costs
     const traceIds = [
       ...new Set(

--- a/platform/app/src/server/filters/__tests__/filter-conditions.integration.test.ts
+++ b/platform/app/src/server/filters/__tests__/filter-conditions.integration.test.ts
@@ -63,12 +63,17 @@ async function insertTraceSummary(
   });
 }
 
-async function insertStoredSpan(
-  ch: ClickHouseClient,
-  traceId: string,
-  spanType: string,
-  startTimeMs: number = now,
-) {
+async function insertStoredSpan({
+  ch,
+  traceId,
+  spanType,
+  startTimeMs = now,
+}: {
+  ch: ClickHouseClient;
+  traceId: string;
+  spanType: string;
+  startTimeMs?: number;
+}) {
   await ch.insert({
     table: "stored_spans",
     values: [
@@ -152,8 +157,8 @@ describe("filter-conditions ClickHouse integration", () => {
       "langwatch.user_id": "user-3",
     });
 
-    await insertStoredSpan(ch, traceCanonical, "llm");
-    await insertStoredSpan(ch, traceLwPrefix, "tool");
+    await insertStoredSpan({ ch, traceId: traceCanonical, spanType: "llm" });
+    await insertStoredSpan({ ch, traceId: traceLwPrefix, spanType: "tool" });
   });
 
   afterAll(async () => {
@@ -253,7 +258,12 @@ describe("filter-conditions ClickHouse integration", () => {
       await insertTraceSummary(ch, oldTraceId, {
         "langwatch.user_id": "user-old",
       });
-      await insertStoredSpan(ch, oldTraceId, "llm", now - 60 * DAY);
+      await insertStoredSpan({
+        ch,
+        traceId: oldTraceId,
+        spanType: "llm",
+        startTimeMs: now - 60 * DAY,
+      });
     });
 
     it("still returns in-window matches when bounded", async () => {

--- a/platform/app/src/server/filters/__tests__/filter-conditions.test.ts
+++ b/platform/app/src/server/filters/__tests__/filter-conditions.test.ts
@@ -11,7 +11,7 @@ describe("clickHouseFilterConditions", () => {
     it("generates IN clause with parameterized values", () => {
       const builder = clickHouseFilterConditions["topics.topics"];
       expect(builder).not.toBeNull();
-      const result = builder!(["topic1", "topic2"], "f0");
+      const result = builder!({ values: ["topic1", "topic2"], paramId: "f0" });
       expect(result.sql).toBe("ts.TopicId IN ({f0_values:Array(String)})");
       expect(result.params).toEqual({ f0_values: ["topic1", "topic2"] });
     });
@@ -21,26 +21,26 @@ describe("clickHouseFilterConditions", () => {
     it("returns true condition when only true selected", () => {
       const builder = clickHouseFilterConditions["traces.error"];
       expect(builder).not.toBeNull();
-      const result = builder!(["true"], "f0");
+      const result = builder!({ values: ["true"], paramId: "f0" });
       expect(result.sql).toBe("ts.ContainsErrorStatus = true");
       expect(result.params).toEqual({});
     });
 
     it("returns false condition when only false selected", () => {
       const builder = clickHouseFilterConditions["traces.error"];
-      const result = builder!(["false"], "f0");
+      const result = builder!({ values: ["false"], paramId: "f0" });
       expect(result.sql).toBe("ts.ContainsErrorStatus = false");
     });
 
     it("returns 1=1 when both true and false selected", () => {
       const builder = clickHouseFilterConditions["traces.error"];
-      const result = builder!(["true", "false"], "f0");
+      const result = builder!({ values: ["true", "false"], paramId: "f0" });
       expect(result.sql).toBe("1=1");
     });
 
     it("returns 1=0 when no values selected", () => {
       const builder = clickHouseFilterConditions["traces.error"];
-      const result = builder!([], "f0");
+      const result = builder!({ values: [], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
   });
@@ -53,21 +53,24 @@ describe("clickHouseFilterConditions", () => {
     it("maps empty/NULL origins to 'application' via ifNull, matching the dropdown", () => {
       const builder = clickHouseFilterConditions["traces.origin"];
       expect(builder).not.toBeNull();
-      const result = builder!(["application"], "f0");
+      const result = builder!({ values: ["application"], paramId: "f0" });
       expect(result.sql).toBe(expectedSql);
       expect(result.params).toEqual({ f0_values: ["application"] });
     });
 
     it("passes non-application values through directly", () => {
       const builder = clickHouseFilterConditions["traces.origin"];
-      const result = builder!(["evaluation"], "f0");
+      const result = builder!({ values: ["evaluation"], paramId: "f0" });
       expect(result.sql).toBe(expectedSql);
       expect(result.params).toEqual({ f0_values: ["evaluation"] });
     });
 
     it("handles mixed application and other values", () => {
       const builder = clickHouseFilterConditions["traces.origin"];
-      const result = builder!(["application", "evaluation"], "f0");
+      const result = builder!({
+        values: ["application", "evaluation"],
+        paramId: "f0",
+      });
       expect(result.sql).toBe(expectedSql);
       expect(result.params).toEqual({
         f0_values: ["application", "evaluation"],
@@ -76,7 +79,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("returns 1=0 when no values selected", () => {
       const builder = clickHouseFilterConditions["traces.origin"];
-      const result = builder!([], "f0");
+      const result = builder!({ values: [], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
   });
@@ -84,7 +87,7 @@ describe("clickHouseFilterConditions", () => {
   describe("metadata filters", () => {
     it("generates user_id filter with langwatch.user_id attribute key", () => {
       const builder = clickHouseFilterConditions["metadata.user_id"];
-      const result = builder!(["user1"], "f0");
+      const result = builder!({ values: ["user1"], paramId: "f0" });
       expect(result.sql).toBe(
         "ts.Attributes['langwatch.user_id'] IN ({f0_values:Array(String)})",
       );
@@ -92,7 +95,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("generates thread_id filter with gen_ai.conversation.id attribute key", () => {
       const builder = clickHouseFilterConditions["metadata.thread_id"];
-      const result = builder!(["thread1"], "f0");
+      const result = builder!({ values: ["thread1"], paramId: "f0" });
       expect(result.sql).toBe(
         "ts.Attributes['gen_ai.conversation.id'] IN ({f0_values:Array(String)})",
       );
@@ -100,7 +103,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("generates customer_id filter with langwatch.customer_id attribute key", () => {
       const builder = clickHouseFilterConditions["metadata.customer_id"];
-      const result = builder!(["cust1"], "f0");
+      const result = builder!({ values: ["cust1"], paramId: "f0" });
       expect(result.sql).toBe(
         "ts.Attributes['langwatch.customer_id'] IN ({f0_values:Array(String)})",
       );
@@ -111,7 +114,7 @@ describe("clickHouseFilterConditions", () => {
     it("checks all three key formats for existence", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
       expect(builder).not.toBeNull();
-      const result = builder!(["canary"], "f0");
+      const result = builder!({ values: ["canary"], paramId: "f0" });
       expect(result.sql).toContain("f0_k0_canonical");
       expect(result.sql).toContain("f0_k0_lw");
       expect(result.sql).toContain("f0_k0_bare");
@@ -124,7 +127,10 @@ describe("clickHouseFilterConditions", () => {
 
     it("generates OR conditions for multiple keys", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
-      const result = builder!(["canary", "environment"], "f0");
+      const result = builder!({
+        values: ["canary", "environment"],
+        paramId: "f0",
+      });
       expect(result.sql).toContain(" OR ");
       expect(result.params).toHaveProperty(
         "f0_k0_canonical",
@@ -138,7 +144,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("converts dot-encoded keys back to dots", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
-      const result = builder!(["nested·key"], "f0");
+      const result = builder!({ values: ["nested·key"], paramId: "f0" });
       expect(result.params).toHaveProperty(
         "f0_k0_canonical",
         "metadata.nested.key",
@@ -148,7 +154,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("returns 1=0 when no values", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
-      const result = builder!([], "f0");
+      const result = builder!({ values: [], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
   });
@@ -157,7 +163,11 @@ describe("clickHouseFilterConditions", () => {
     it("checks all three key formats for value match", () => {
       const builder = clickHouseFilterConditions["metadata.value"];
       expect(builder).not.toBeNull();
-      const result = builder!(["true"], "f0", "canary");
+      const result = builder!({
+        values: ["true"],
+        paramId: "f0",
+        key: "canary",
+      });
       expect(result.sql).toContain("f0_canonical");
       expect(result.sql).toContain("f0_lw");
       expect(result.sql).toContain("f0_bare");
@@ -171,13 +181,17 @@ describe("clickHouseFilterConditions", () => {
 
     it("returns 1=0 when key is missing", () => {
       const builder = clickHouseFilterConditions["metadata.value"];
-      const result = builder!(["true"], "f0");
+      const result = builder!({ values: ["true"], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
 
     it("converts dot-encoded keys back to dots", () => {
       const builder = clickHouseFilterConditions["metadata.value"];
-      const result = builder!(["val"], "f0", "nested·key");
+      const result = builder!({
+        values: ["val"],
+        paramId: "f0",
+        key: "nested·key",
+      });
       expect(result.params).toHaveProperty(
         "f0_canonical",
         "metadata.nested.key",
@@ -190,7 +204,7 @@ describe("clickHouseFilterConditions", () => {
     it("generates EXISTS subquery on stored_spans", () => {
       const builder = clickHouseFilterConditions["spans.type"];
       expect(builder).not.toBeNull();
-      const result = builder!(["llm", "tool"], "f0");
+      const result = builder!({ values: ["llm", "tool"], paramId: "f0" });
       expect(result.sql).toContain("EXISTS (");
       expect(result.sql).toContain("stored_spans sp");
       expect(result.sql).toContain("sp.SpanAttributes['langwatch.span.type']");
@@ -199,7 +213,7 @@ describe("clickHouseFilterConditions", () => {
 
     it("does not bound StartTime when no spanTimeBound option is given", () => {
       const builder = clickHouseFilterConditions["spans.type"];
-      const result = builder!(["llm"], "f0");
+      const result = builder!({ values: ["llm"], paramId: "f0" });
       expect(result.sql).not.toContain("sp.StartTime");
     });
 
@@ -207,8 +221,10 @@ describe("clickHouseFilterConditions", () => {
       const builder = clickHouseFilterConditions["spans.type"];
       const bound =
         " AND sp.StartTime >= fromUnixTimestamp64Milli({spanWindowStart:UInt64}) AND sp.StartTime <= fromUnixTimestamp64Milli({spanWindowEnd:UInt64})";
-      const result = builder!(["llm"], "f0", undefined, undefined, {
-        spanTimeBound: bound,
+      const result = builder!({
+        values: ["llm"],
+        paramId: "f0",
+        options: { spanTimeBound: bound },
       });
       expect(result.sql).toContain("sp.StartTime >=");
       expect(result.sql).toContain("spanWindowStart");
@@ -221,7 +237,7 @@ describe("clickHouseFilterConditions", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
       expect(builder).not.toBeNull();
-      const result = builder!(["eval-1", "eval-2"], "f0");
+      const result = builder!({ values: ["eval-1", "eval-2"], paramId: "f0" });
       expect(result.sql).toContain("EXISTS (");
       expect(result.sql).toContain(
         "es.EvaluatorId IN ({f0_values:Array(String)})",
@@ -233,7 +249,7 @@ describe("clickHouseFilterConditions", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -245,7 +261,7 @@ describe("clickHouseFilterConditions", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
       expect(builder).not.toBeNull();
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("EXISTS (");
       expect(result.sql).toContain(
         "es.EvaluatorId IN ({f0_values:Array(String)})",
@@ -257,7 +273,7 @@ describe("clickHouseFilterConditions", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -269,7 +285,7 @@ describe("clickHouseFilterConditions", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
       expect(builder).not.toBeNull();
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("EXISTS (");
       expect(result.sql).toContain(
         "es.EvaluatorId IN ({f0_values:Array(String)})",
@@ -283,7 +299,7 @@ describe("clickHouseFilterConditions", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -294,7 +310,7 @@ describe("clickHouseFilterConditions", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder =
         clickHouseFilterConditions["evaluations.evaluator_id.guardrails_only"];
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -304,7 +320,7 @@ describe("clickHouseFilterConditions", () => {
   describe("evaluations.evaluator_id (base)", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder = clickHouseFilterConditions["evaluations.evaluator_id"];
-      const result = builder!(["eval-1"], "f0");
+      const result = builder!({ values: ["eval-1"], paramId: "f0" });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -314,13 +330,17 @@ describe("clickHouseFilterConditions", () => {
   describe("evaluations.passed", () => {
     it("returns 1=0 when key is missing", () => {
       const builder = clickHouseFilterConditions["evaluations.passed"];
-      const result = builder!(["true"], "f0");
+      const result = builder!({ values: ["true"], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
 
     it("generates EXISTS subquery with key when provided", () => {
       const builder = clickHouseFilterConditions["evaluations.passed"];
-      const result = builder!(["true"], "f0", "evaluator-123");
+      const result = builder!({
+        values: ["true"],
+        paramId: "f0",
+        key: "evaluator-123",
+      });
       expect(result.sql).toContain("EXISTS (");
       expect(result.sql).toContain("es.EvaluatorId = {f0_key:String}");
       expect(result.params).toHaveProperty("f0_key", "evaluator-123");
@@ -328,13 +348,21 @@ describe("clickHouseFilterConditions", () => {
 
     it("converts true/false strings to 1/0", () => {
       const builder = clickHouseFilterConditions["evaluations.passed"];
-      const result = builder!(["true", "false"], "f0", "eval-1");
+      const result = builder!({
+        values: ["true", "false"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.params.f0_values).toEqual([1, 0]);
     });
 
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder = clickHouseFilterConditions["evaluations.passed"];
-      const result = builder!(["true"], "f0", "eval-1");
+      const result = builder!({
+        values: ["true"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -344,19 +372,27 @@ describe("clickHouseFilterConditions", () => {
   describe("evaluations.score", () => {
     it("returns 1=0 when key is missing", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["0", "1"], "f0");
+      const result = builder!({ values: ["0", "1"], paramId: "f0" });
       expect(result.sql).toBe("1=0");
     });
 
     it("returns 1=0 when values has less than 2 elements", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["0"], "f0", "eval-1");
+      const result = builder!({
+        values: ["0"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toBe("1=0");
     });
 
     it("generates range condition with min and max", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["0.5", "0.9"], "f0", "eval-1");
+      const result = builder!({
+        values: ["0.5", "0.9"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toContain("es.Score >= {f0_min:Float64}");
       expect(result.sql).toContain("es.Score <= {f0_max:Float64}");
       expect(result.params.f0_min).toBe(0.5);
@@ -365,7 +401,11 @@ describe("clickHouseFilterConditions", () => {
 
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["0.5", "0.9"], "f0", "eval-1");
+      const result = builder!({
+        values: ["0.5", "0.9"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -373,14 +413,22 @@ describe("clickHouseFilterConditions", () => {
 
     it("returns no-match condition for invalid numeric values", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["invalid", "NaN"], "f0", "eval-1");
+      const result = builder!({
+        values: ["invalid", "NaN"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toBe("1=0");
       expect(result.params).toEqual({});
     });
 
     it("returns no-match condition when min > max", () => {
       const builder = clickHouseFilterConditions["evaluations.score"];
-      const result = builder!(["0.9", "0.5"], "f0", "eval-1");
+      const result = builder!({
+        values: ["0.9", "0.5"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toBe("1=0");
       expect(result.params).toEqual({});
     });
@@ -389,7 +437,11 @@ describe("clickHouseFilterConditions", () => {
   describe("evaluations.state", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder = clickHouseFilterConditions["evaluations.state"];
-      const result = builder!(["processed"], "f0", "eval-1");
+      const result = builder!({
+        values: ["processed"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);
@@ -399,7 +451,11 @@ describe("clickHouseFilterConditions", () => {
   describe("evaluations.label", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
       const builder = clickHouseFilterConditions["evaluations.label"];
-      const result = builder!(["positive"], "f0", "eval-1");
+      const result = builder!({
+        values: ["positive"],
+        paramId: "f0",
+        key: "eval-1",
+      });
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
       expect(result.sql).not.toMatch(/es\.TraceId = ts\.TraceId/);

--- a/platform/app/src/server/filters/__tests__/precondition-matchers.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/precondition-matchers.unit.test.ts
@@ -45,11 +45,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS.input!;
 
     it("returns the input value from trace data", () => {
-      expect(matcher(makeTraceData({ input: "hello" }), "")).toBe("hello");
+      expect(
+        matcher({ data: makeTraceData({ input: "hello" }), value: "" }),
+      ).toBe("hello");
     });
 
     it("returns null when input is null", () => {
-      expect(matcher(makeTraceData({ input: null }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ input: null }), value: "" }),
+      ).toBeNull();
     });
   });
 
@@ -57,11 +61,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS.output!;
 
     it("returns the output value from trace data", () => {
-      expect(matcher(makeTraceData({ output: "world" }), "")).toBe("world");
+      expect(
+        matcher({ data: makeTraceData({ output: "world" }), value: "" }),
+      ).toBe("world");
     });
 
     it("returns null when output is null", () => {
-      expect(matcher(makeTraceData({ output: null }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ output: null }), value: "" }),
+      ).toBeNull();
     });
   });
 
@@ -69,27 +77,33 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["traces.origin"]!;
 
     it("returns null when origin is undefined", () => {
-      expect(matcher(makeTraceData({ origin: undefined }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ origin: undefined }), value: "" }),
+      ).toBeNull();
     });
 
     it("returns null when origin is null", () => {
-      expect(matcher(makeTraceData({ origin: null }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ origin: null }), value: "" }),
+      ).toBeNull();
     });
 
     it("returns empty string when origin is empty string", () => {
-      expect(matcher(makeTraceData({ origin: "" }), "")).toBe("");
+      expect(matcher({ data: makeTraceData({ origin: "" }), value: "" })).toBe(
+        "",
+      );
     });
 
     it("returns 'application' when origin is explicitly 'application'", () => {
-      expect(matcher(makeTraceData({ origin: "application" }), "")).toBe(
-        "application",
-      );
+      expect(
+        matcher({ data: makeTraceData({ origin: "application" }), value: "" }),
+      ).toBe("application");
     });
 
     it("returns the origin value when present", () => {
-      expect(matcher(makeTraceData({ origin: "playground" }), "")).toBe(
-        "playground",
-      );
+      expect(
+        matcher({ data: makeTraceData({ origin: "playground" }), value: "" }),
+      ).toBe("playground");
     });
   });
 
@@ -97,15 +111,21 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["traces.error"]!;
 
     it("returns 'true' when hasError is true", () => {
-      expect(matcher(makeTraceData({ hasError: true }), "")).toBe("true");
+      expect(
+        matcher({ data: makeTraceData({ hasError: true }), value: "" }),
+      ).toBe("true");
     });
 
     it("returns 'false' when hasError is false", () => {
-      expect(matcher(makeTraceData({ hasError: false }), "")).toBe("false");
+      expect(
+        matcher({ data: makeTraceData({ hasError: false }), value: "" }),
+      ).toBe("false");
     });
 
     it("returns 'false' when hasError is null", () => {
-      expect(matcher(makeTraceData({ hasError: null }), "")).toBe("false");
+      expect(
+        matcher({ data: makeTraceData({ hasError: null }), value: "" }),
+      ).toBe("false");
     });
   });
 
@@ -113,11 +133,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["metadata.user_id"]!;
 
     it("returns userId from trace data", () => {
-      expect(matcher(makeTraceData({ userId: "user_1" }), "")).toBe("user_1");
+      expect(
+        matcher({ data: makeTraceData({ userId: "user_1" }), value: "" }),
+      ).toBe("user_1");
     });
 
     it("returns undefined when userId is not set", () => {
-      expect(matcher(makeTraceData({ userId: undefined }), "")).toBeUndefined();
+      expect(
+        matcher({ data: makeTraceData({ userId: undefined }), value: "" }),
+      ).toBeUndefined();
     });
   });
 
@@ -125,7 +149,9 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["metadata.thread_id"]!;
 
     it("returns threadId from trace data", () => {
-      expect(matcher(makeTraceData({ threadId: "t_1" }), "")).toBe("t_1");
+      expect(
+        matcher({ data: makeTraceData({ threadId: "t_1" }), value: "" }),
+      ).toBe("t_1");
     });
   });
 
@@ -133,9 +159,9 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["metadata.customer_id"]!;
 
     it("returns customerId from trace data", () => {
-      expect(matcher(makeTraceData({ customerId: "cust_1" }), "")).toBe(
-        "cust_1",
-      );
+      expect(
+        matcher({ data: makeTraceData({ customerId: "cust_1" }), value: "" }),
+      ).toBe("cust_1");
     });
   });
 
@@ -143,14 +169,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["metadata.labels"]!;
 
     it("returns labels array from trace data", () => {
-      expect(matcher(makeTraceData({ labels: ["a", "b"] }), "")).toEqual([
-        "a",
-        "b",
-      ]);
+      expect(
+        matcher({ data: makeTraceData({ labels: ["a", "b"] }), value: "" }),
+      ).toEqual(["a", "b"]);
     });
 
     it("returns empty array when labels is empty", () => {
-      expect(matcher(makeTraceData({ labels: [] }), "")).toEqual([]);
+      expect(
+        matcher({ data: makeTraceData({ labels: [] }), value: "" }),
+      ).toEqual([]);
     });
   });
 
@@ -158,10 +185,12 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["metadata.prompt_ids"]!;
 
     it("returns promptIds array from trace data", () => {
-      expect(matcher(makeTraceData({ promptIds: ["p1", "p2"] }), "")).toEqual([
-        "p1",
-        "p2",
-      ]);
+      expect(
+        matcher({
+          data: makeTraceData({ promptIds: ["p1", "p2"] }),
+          value: "",
+        }),
+      ).toEqual(["p1", "p2"]);
     });
   });
 
@@ -179,14 +208,14 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
         const data = makeTraceData({
           customMetadata: { env: "prod", region: "us" },
         });
-        expect(matcher(data, "", "env")).toBe("prod");
+        expect(matcher({ data, value: "", key: "env" })).toBe("prod");
       });
 
       it("returns null when key is missing from metadata", () => {
         const data = makeTraceData({
           customMetadata: { env: "prod" },
         });
-        expect(matcher(data, "", "region")).toBeNull();
+        expect(matcher({ data, value: "", key: "region" })).toBeNull();
       });
     });
 
@@ -195,14 +224,14 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
         const data = makeTraceData({
           customMetadata: { env: "prod" },
         });
-        expect(matcher(data, "")).toBeNull();
+        expect(matcher({ data, value: "" })).toBeNull();
       });
     });
 
     describe("when customMetadata is null", () => {
       it("returns null", () => {
         const data = makeTraceData({ customMetadata: null });
-        expect(matcher(data, "", "env")).toBeNull();
+        expect(matcher({ data, value: "", key: "env" })).toBeNull();
       });
     });
   });
@@ -211,9 +240,12 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["spans.type"]!;
 
     it("returns spanTypes array from trace data", () => {
-      expect(matcher(makeTraceData({ spanTypes: ["llm", "rag"] }), "")).toEqual(
-        ["llm", "rag"],
-      );
+      expect(
+        matcher({
+          data: makeTraceData({ spanTypes: ["llm", "rag"] }),
+          value: "",
+        }),
+      ).toEqual(["llm", "rag"]);
     });
   });
 
@@ -221,9 +253,9 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["spans.model"]!;
 
     it("returns spanModels array from trace data", () => {
-      expect(matcher(makeTraceData({ spanModels: ["gpt-4"] }), "")).toEqual([
-        "gpt-4",
-      ]);
+      expect(
+        matcher({ data: makeTraceData({ spanModels: ["gpt-4"] }), value: "" }),
+      ).toEqual(["gpt-4"]);
     });
   });
 
@@ -231,13 +263,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["topics.topics"]!;
 
     it("returns topicId wrapped in array when present", () => {
-      expect(matcher(makeTraceData({ topicId: "topic_1" }), "")).toEqual([
-        "topic_1",
-      ]);
+      expect(
+        matcher({ data: makeTraceData({ topicId: "topic_1" }), value: "" }),
+      ).toEqual(["topic_1"]);
     });
 
     it("returns null when topicId is not set", () => {
-      expect(matcher(makeTraceData({ topicId: undefined }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ topicId: undefined }), value: "" }),
+      ).toBeNull();
     });
   });
 
@@ -245,13 +279,15 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["topics.subtopics"]!;
 
     it("returns subTopicId wrapped in array when present", () => {
-      expect(matcher(makeTraceData({ subTopicId: "sub_1" }), "")).toEqual([
-        "sub_1",
-      ]);
+      expect(
+        matcher({ data: makeTraceData({ subTopicId: "sub_1" }), value: "" }),
+      ).toEqual(["sub_1"]);
     });
 
     it("returns null when subTopicId is not set", () => {
-      expect(matcher(makeTraceData({ subTopicId: undefined }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ subTopicId: undefined }), value: "" }),
+      ).toBeNull();
     });
   });
 
@@ -259,18 +295,26 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
     const matcher = PRECONDITION_FIELD_MATCHERS["annotations.hasAnnotation"]!;
 
     it("returns 'true' when annotationIds is non-empty", () => {
-      expect(matcher(makeTraceData({ annotationIds: ["ann-1"] }), "")).toBe(
-        "true",
-      );
+      expect(
+        matcher({
+          data: makeTraceData({ annotationIds: ["ann-1"] }),
+          value: "",
+        }),
+      ).toBe("true");
     });
 
     it("returns 'false' when annotationIds is empty", () => {
-      expect(matcher(makeTraceData({ annotationIds: [] }), "")).toBe("false");
+      expect(
+        matcher({ data: makeTraceData({ annotationIds: [] }), value: "" }),
+      ).toBe("false");
     });
 
     it("returns null when annotationIds is undefined", () => {
       expect(
-        matcher(makeTraceData({ annotationIds: undefined }), ""),
+        matcher({
+          data: makeTraceData({ annotationIds: undefined }),
+          value: "",
+        }),
       ).toBeNull();
     });
   });
@@ -285,11 +329,16 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           { event_type: "purchase", metrics: [], event_details: [] },
         ],
       });
-      expect(matcher(data, "")).toEqual(["thumbs_up_down", "purchase"]);
+      expect(matcher({ data, value: "" })).toEqual([
+        "thumbs_up_down",
+        "purchase",
+      ]);
     });
 
     it("returns null when events is null", () => {
-      expect(matcher(makeTraceData({ events: null }), "")).toBeNull();
+      expect(
+        matcher({ data: makeTraceData({ events: null }), value: "" }),
+      ).toBeNull();
     });
   });
 
@@ -306,7 +355,9 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           },
         ],
       });
-      expect(matcher(data, "", "thumbs_up_down")).toEqual(["vote"]);
+      expect(matcher({ data, value: "", key: "thumbs_up_down" })).toEqual([
+        "vote",
+      ]);
     });
 
     it("returns null when key (event_type) is not provided", () => {
@@ -319,7 +370,7 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           },
         ],
       });
-      expect(matcher(data, "")).toBeNull();
+      expect(matcher({ data, value: "" })).toBeNull();
     });
 
     it("returns null when no matching event type", () => {
@@ -332,7 +383,7 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           },
         ],
       });
-      expect(matcher(data, "", "thumbs_up_down")).toBeNull();
+      expect(matcher({ data, value: "", key: "thumbs_up_down" })).toBeNull();
     });
   });
 
@@ -349,7 +400,7 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           },
         ],
       });
-      expect(matcher(data, "", "purchase")).toEqual(["item"]);
+      expect(matcher({ data, value: "", key: "purchase" })).toEqual(["item"]);
     });
 
     it("returns null when key (event_type) is not provided", () => {
@@ -362,7 +413,7 @@ describe("PRECONDITION_FIELD_MATCHERS", () => {
           },
         ],
       });
-      expect(matcher(data, "")).toBeNull();
+      expect(matcher({ data, value: "" })).toBeNull();
     });
   });
 

--- a/platform/app/src/server/filters/clickhouse/filter-conditions.ts
+++ b/platform/app/src/server/filters/clickhouse/filter-conditions.ts
@@ -21,7 +21,7 @@ const STATUS_LABEL_VALUES = ["succeeded", "failed"] as const;
 function buildEvaluatorExistsCondition(
   additionalWhere: string,
 ): FilterConditionBuilder {
-  return (values, paramId) => ({
+  return ({ values, paramId }) => ({
     sql: `EXISTS (
       SELECT 1 FROM evaluation_runs es
       WHERE es.TenantId = ts.TenantId
@@ -44,33 +44,33 @@ export const clickHouseFilterConditions: Record<
   FilterConditionBuilder | null
 > = {
   // Topics
-  "topics.topics": (values, paramId) => ({
+  "topics.topics": ({ values, paramId }) => ({
     sql: `ts.TopicId IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
-  "topics.subtopics": (values, paramId) => ({
+  "topics.subtopics": ({ values, paramId }) => ({
     sql: `ts.SubTopicId IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
 
   // Metadata
-  "metadata.user_id": (values, paramId) => ({
+  "metadata.user_id": ({ values, paramId }) => ({
     sql: `ts.Attributes['langwatch.user_id'] IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
-  "metadata.thread_id": (values, paramId) => ({
+  "metadata.thread_id": ({ values, paramId }) => ({
     sql: `ts.Attributes['gen_ai.conversation.id'] IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
-  "metadata.customer_id": (values, paramId) => ({
+  "metadata.customer_id": ({ values, paramId }) => ({
     sql: `ts.Attributes['langwatch.customer_id'] IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
-  "metadata.labels": (values, paramId) => ({
+  "metadata.labels": ({ values, paramId }) => ({
     sql: `hasAny(JSONExtractArrayRaw(ts.Attributes['langwatch.labels']), arrayMap(x -> concat('"', x, '"'), {${paramId}_values:Array(String)}))`,
     params: { [`${paramId}_values`]: values },
   }),
-  "metadata.key": (values, paramId) => {
+  "metadata.key": ({ values, paramId }) => {
     if (values.length === 0) return { sql: "1=0", params: {} };
     // Check all three legacy key formats for each metadata key:
     // - metadata.{key} (canonical, from Python SDK canonicalization)
@@ -94,7 +94,7 @@ export const clickHouseFilterConditions: Record<
       params,
     };
   },
-  "metadata.value": (values, paramId, key) => {
+  "metadata.value": ({ values, paramId, key }) => {
     if (!key) return { sql: "1=0", params: {} };
     const rawKey = key.replaceAll("·", ".");
     // Match all three legacy key formats for existing data:
@@ -111,7 +111,7 @@ export const clickHouseFilterConditions: Record<
       },
     };
   },
-  "metadata.prompt_ids": (values, paramId) => ({
+  "metadata.prompt_ids": ({ values, paramId }) => ({
     sql: `hasAny(JSONExtractArrayRaw(ts.Attributes['langwatch.prompt_ids']), arrayMap(x -> concat('"', x, '"'), {${paramId}_values:Array(String)}))`,
     params: { [`${paramId}_values`]: values },
   }),
@@ -119,7 +119,7 @@ export const clickHouseFilterConditions: Record<
   // Traces
   // The dropdown maps empty/NULL origin to "application" via ifNull().
   // Apply the same mapping here so the condition matches what the dropdown counted.
-  "traces.origin": (values, paramId) => {
+  "traces.origin": ({ values, paramId }) => {
     if (values.length === 0) {
       return { sql: "1=0", params: {} };
     }
@@ -130,7 +130,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "traces.error": (values, _paramId) => {
+  "traces.error": ({ values }) => {
     const hasTrue = values.includes("true");
     const hasFalse = values.includes("false");
     if (hasTrue && hasFalse) return { sql: "1=1", params: {} };
@@ -138,13 +138,13 @@ export const clickHouseFilterConditions: Record<
     if (hasFalse) return { sql: "ts.ContainsErrorStatus = false", params: {} };
     return { sql: "1=0", params: {} };
   },
-  "traces.name": (values, paramId) => ({
+  "traces.name": ({ values, paramId }) => ({
     sql: `ts.TraceName IN ({${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
 
   // Spans
-  "spans.type": (values, paramId, _key, _subkey, options) => ({
+  "spans.type": ({ values, paramId, options }) => ({
     sql: `EXISTS (
       SELECT 1 FROM stored_spans sp
       WHERE sp.TenantId = ts.TenantId
@@ -153,13 +153,13 @@ export const clickHouseFilterConditions: Record<
     )`,
     params: { [`${paramId}_values`]: values },
   }),
-  "spans.model": (values, paramId) => ({
+  "spans.model": ({ values, paramId }) => ({
     sql: `hasAny(ts.Models, {${paramId}_values:Array(String)})`,
     params: { [`${paramId}_values`]: values },
   }),
 
   // Annotations
-  "annotations.hasAnnotation": (values, _paramId) => {
+  "annotations.hasAnnotation": ({ values }) => {
     const hasTrue = values.includes("true");
     const hasFalse = values.includes("false");
     if (hasTrue && hasFalse) return { sql: "1=1", params: {} };
@@ -191,7 +191,7 @@ export const clickHouseFilterConditions: Record<
     `AND es.Label IS NOT NULL AND es.Label != '' AND es.Label NOT IN ('${STATUS_LABEL_VALUES.join("', '")}')`,
   ),
 
-  "evaluations.passed": (values, paramId, key) => {
+  "evaluations.passed": ({ values, paramId, key }) => {
     if (!key) return { sql: "1=0", params: {} };
     const passedValues = values.map((v) => (v === "true" || v === "1" ? 1 : 0));
     return {
@@ -210,7 +210,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "evaluations.score": (values, paramId, key) => {
+  "evaluations.score": ({ values, paramId, key }) => {
     if (!key || values.length < 2) return { sql: "1=0", params: {} };
     const minScore = parseFloat(values[0] ?? "");
     const maxScore = parseFloat(values[1] ?? "");
@@ -239,7 +239,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "evaluations.state": (values, paramId, key) => {
+  "evaluations.state": ({ values, paramId, key }) => {
     if (!key) return { sql: "1=0", params: {} };
     return {
       sql: `EXISTS (
@@ -257,7 +257,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "evaluations.label": (values, paramId, key) => {
+  "evaluations.label": ({ values, paramId, key }) => {
     if (!key) return { sql: "1=0", params: {} };
     return {
       sql: `EXISTS (
@@ -276,7 +276,7 @@ export const clickHouseFilterConditions: Record<
   },
 
   // Events - using stored_spans table with span attributes
-  "events.event_type": (values, paramId, _key, _subkey, options) => ({
+  "events.event_type": ({ values, paramId, options }) => ({
     sql: `EXISTS (
       SELECT 1 FROM stored_spans sp
       WHERE sp.TenantId = ts.TenantId
@@ -286,7 +286,7 @@ export const clickHouseFilterConditions: Record<
     params: { [`${paramId}_values`]: values },
   }),
 
-  "events.metrics.key": (values, paramId, key, _subkey, options) => {
+  "events.metrics.key": ({ values, paramId, key, options }) => {
     if (!key) return { sql: "1=0", params: {} };
     // Build OR conditions for each metric key - these are attribute names, not values
     // Since attribute names are controlled internally, we use them directly
@@ -311,7 +311,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "events.metrics.value": (values, paramId, key, subkey, options) => {
+  "events.metrics.value": ({ values, paramId, key, subkey, options }) => {
     if (!key || !subkey || values.length < 2) return { sql: "1=0", params: {} };
     const minValue = parseFloat(values[0] ?? "");
     const maxValue = parseFloat(values[1] ?? "");
@@ -340,7 +340,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "events.event_details.key": (values, paramId, key, _subkey, options) => {
+  "events.event_details.key": ({ values, paramId, key, options }) => {
     if (!key) return { sql: "1=0", params: {} };
     // Build OR conditions for each detail key
     const detailConditions = values.map(
@@ -375,14 +375,21 @@ export const clickHouseFilterConditions: Record<
  * @param allParams - Accumulated query parameters
  * @returns Object with conditions array and unsupported filter flag
  */
-function collectClickHouseConditions(
-  field: FilterField,
-  params: string[] | Record<string, unknown>,
-  keys: string[],
-  paramCounter: { value: number },
-  allParams: Record<string, unknown>,
-  options: FilterConditionOptions,
-): { conditions: string[]; hasUnsupported: boolean } {
+function collectClickHouseConditions({
+  field,
+  params,
+  keys,
+  paramCounter,
+  allParams,
+  options,
+}: {
+  field: FilterField;
+  params: string[] | Record<string, unknown>;
+  keys: string[];
+  paramCounter: { value: number };
+  allParams: Record<string, unknown>;
+  options: FilterConditionOptions;
+}): { conditions: string[]; hasUnsupported: boolean } {
   const key = keys[0];
   const subkey = keys[1];
   const conditionBuilder = clickHouseFilterConditions[field];
@@ -398,7 +405,13 @@ function collectClickHouseConditions(
     }
 
     const paramId = `f${paramCounter.value++}`;
-    const result = conditionBuilder(params, paramId, key, subkey, options);
+    const result = conditionBuilder({
+      values: params,
+      paramId,
+      key,
+      subkey,
+      options,
+    });
     Object.assign(allParams, result.params);
 
     return { conditions: [result.sql], hasUnsupported: false };
@@ -410,14 +423,14 @@ function collectClickHouseConditions(
     let hasUnsupported = false;
 
     for (const [nextKey, nextValue] of Object.entries(params)) {
-      const result = collectClickHouseConditions(
+      const result = collectClickHouseConditions({
         field,
-        nextValue as string[] | Record<string, unknown>,
-        [...keys, nextKey], // Accumulate keys as we recurse
+        params: nextValue as string[] | Record<string, unknown>,
+        keys: [...keys, nextKey], // Accumulate keys as we recurse
         paramCounter,
         allParams,
         options,
-      );
+      });
 
       if (result.hasUnsupported) hasUnsupported = true;
       nestedConditions.push(...result.conditions);
@@ -524,14 +537,14 @@ export function generateClickHouseFilterConditions(
     }
 
     // Use recursive helper to handle any nesting depth
-    const result = collectClickHouseConditions(
-      filterField,
-      filterParams,
-      [], // Start with empty keys array
+    const result = collectClickHouseConditions({
+      field: filterField,
+      params: filterParams,
+      keys: [], // Start with empty keys array
       paramCounter,
       allParams,
       options,
-    );
+    });
 
     if (result.hasUnsupported) hasUnsupportedFilters = true;
     conditions.push(...result.conditions);

--- a/platform/app/src/server/filters/clickhouse/types.ts
+++ b/platform/app/src/server/filters/clickhouse/types.ts
@@ -64,13 +64,13 @@ export type SupportedClickHouseFilterDefinition = ClickHouseFilterDefinition & {
  * Each builder takes filter values and returns SQL + params for parameterized queries.
  * The paramId is used to create unique parameter names when multiple filters are combined.
  */
-export type FilterConditionBuilder = (
-  values: string[],
-  paramId: string,
-  key?: string,
-  subkey?: string,
-  options?: FilterConditionOptions,
-) => FilterConditionResult;
+export type FilterConditionBuilder = (params: {
+  values: string[];
+  paramId: string;
+  key?: string;
+  subkey?: string;
+  options?: FilterConditionOptions;
+}) => FilterConditionResult;
 
 /**
  * Cross-cutting options threaded to every condition builder.

--- a/platform/app/src/server/filters/precondition-matchers.ts
+++ b/platform/app/src/server/filters/precondition-matchers.ts
@@ -54,12 +54,12 @@ export type PreconditionField = FilterField | "input" | "output";
  * @param key - Optional key for nested filters (e.g., metadata key name)
  * @param subkey - Optional subkey for double-nested filters
  */
-export type PreconditionFieldMatcher = (
-  data: PreconditionTraceData,
-  value: string,
-  key?: string,
-  subkey?: string,
-) => string | string[] | null | undefined;
+export type PreconditionFieldMatcher = (params: {
+  data: PreconditionTraceData;
+  value: string;
+  key?: string;
+  subkey?: string;
+}) => string | string[] | null | undefined;
 
 // ---------------------------------------------------------------------------
 // Matcher registry — one matcher per PreconditionField
@@ -75,32 +75,33 @@ export const PRECONDITION_FIELD_MATCHERS: Record<
   PreconditionFieldMatcher | null
 > = {
   // Precondition-only fields
-  input: (data) => data.input,
-  output: (data) => data.output,
+  input: ({ data }) => data.input,
+  output: ({ data }) => data.output,
 
   // Trace fields
-  "traces.origin": (data) => data.origin ?? null,
-  "traces.error": (data) =>
+  "traces.origin": ({ data }) => data.origin ?? null,
+  "traces.error": ({ data }) =>
     data.hasError != null ? (data.hasError ? "true" : "false") : "false",
   "traces.name": null, // TraceName is a ClickHouse-only analytics dimension, not available at trace arrival time
 
   // Metadata fields
-  "metadata.user_id": (data) => data.userId,
-  "metadata.thread_id": (data) => data.threadId,
-  "metadata.customer_id": (data) => data.customerId,
-  "metadata.labels": (data) => data.labels,
-  "metadata.prompt_ids": (data) => data.promptIds,
+  "metadata.user_id": ({ data }) => data.userId,
+  "metadata.thread_id": ({ data }) => data.threadId,
+  "metadata.customer_id": ({ data }) => data.customerId,
+  "metadata.labels": ({ data }) => data.labels,
+  "metadata.prompt_ids": ({ data }) => data.promptIds,
   "metadata.key": null, // key selector — not matchable
-  "metadata.value": (data, _value, key) =>
+  "metadata.value": ({ data, key }) =>
     key ? (data.customMetadata?.[key] ?? null) : null,
 
   // Span fields
-  "spans.type": (data) => data.spanTypes,
-  "spans.model": (data) => data.spanModels,
+  "spans.type": ({ data }) => data.spanTypes,
+  "spans.model": ({ data }) => data.spanModels,
 
   // Topic fields
-  "topics.topics": (data) => (data.topicId ? [data.topicId] : null),
-  "topics.subtopics": (data) => (data.subTopicId ? [data.subTopicId] : null),
+  "topics.topics": ({ data }) => (data.topicId ? [data.topicId] : null),
+  "topics.subtopics": ({ data }) =>
+    data.subTopicId ? [data.subTopicId] : null,
 
   // Evaluation fields — not available at trace arrival time
   "evaluations.evaluator_id": null,
@@ -114,21 +115,22 @@ export const PRECONDITION_FIELD_MATCHERS: Record<
   "evaluations.label": null,
 
   // Event fields — fetched on demand when event preconditions exist
-  "events.event_type": (data) => data.events?.map((e) => e.event_type) ?? null,
-  "events.metrics.key": (data, _value, key) => {
+  "events.event_type": ({ data }) =>
+    data.events?.map((e) => e.event_type) ?? null,
+  "events.metrics.key": ({ data, key }) => {
     if (!key || !data.events) return null;
     const event = data.events.find((e) => e.event_type === key);
     return event?.metrics.map((m) => m.key) ?? null;
   },
   "events.metrics.value": null, // numeric range — matched in-memory via matchEventMetricRange in triggerFilter.matcher.ts, not through this string-based registry
-  "events.event_details.key": (data, _value, key) => {
+  "events.event_details.key": ({ data, key }) => {
     if (!key || !data.events) return null;
     const event = data.events.find((e) => e.event_type === key);
     return event?.event_details.map((d) => d.key) ?? null;
   },
 
   // Annotation fields
-  "annotations.hasAnnotation": (data) =>
+  "annotations.hasAnnotation": ({ data }) =>
     data.annotationIds != null
       ? data.annotationIds.length > 0
         ? "true"

--- a/platform/app/src/server/filters/triggerFilter.matcher.ts
+++ b/platform/app/src/server/filters/triggerFilter.matcher.ts
@@ -249,7 +249,7 @@ function matchField(
   // Simple array: resolve field and check if any value matches
   if (Array.isArray(filterValue)) {
     if (filterValue.length === 0) return true;
-    return matchSimpleArray(traceData, field, filterValue);
+    return matchSimpleArray({ traceData, field, filterValues: filterValue });
   }
 
   // Nested object: OR across keys (matches ClickHouse filter generation)
@@ -260,7 +260,7 @@ function matchField(
       // Record<string, string[]> — resolve with key
       if (subValue.length === 0) continue;
       hasActionableCondition = true;
-      if (matchSimpleArray(traceData, field, subValue, key)) {
+      if (matchSimpleArray({ traceData, field, filterValues: subValue, key })) {
         return true;
       }
     } else if (typeof subValue === "object" && subValue !== null) {
@@ -268,7 +268,15 @@ function matchField(
       for (const [subkey, values] of Object.entries(subValue)) {
         if (!Array.isArray(values) || values.length === 0) continue;
         hasActionableCondition = true;
-        if (matchSimpleArray(traceData, field, values, key, subkey)) {
+        if (
+          matchSimpleArray({
+            traceData,
+            field,
+            filterValues: values,
+            key,
+            subkey,
+          })
+        ) {
           return true;
         }
       }
@@ -282,20 +290,31 @@ function matchField(
  * Resolves a field value using the precondition matcher registry and
  * checks if any of the filter values match.
  */
-function matchSimpleArray(
-  traceData: PreconditionTraceData,
-  field: FilterField,
-  filterValues: string[],
-  key?: string,
-  subkey?: string,
-): boolean {
+function matchSimpleArray({
+  traceData,
+  field,
+  filterValues,
+  key,
+  subkey,
+}: {
+  traceData: PreconditionTraceData;
+  field: FilterField;
+  filterValues: string[];
+  key?: string;
+  subkey?: string;
+}): boolean {
   const matcher: PreconditionFieldMatcher | null | undefined =
     PRECONDITION_FIELD_MATCHERS[field];
 
   // Key-selector fields (metadata.key) and unavailable fields
   if (!matcher) return false;
 
-  const resolved = matcher(traceData, filterValues[0]!, key, subkey);
+  const resolved = matcher({
+    data: traceData,
+    value: filterValues[0]!,
+    key,
+    subkey,
+  });
 
   if (resolved == null) return false;
 

--- a/platform/app/src/server/gateway/__tests__/eligibleModelProviders.parity.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/eligibleModelProviders.parity.integration.test.ts
@@ -117,15 +117,20 @@ describe("eligible model providers - drawer / gateway parity on real PG", () => 
       data: { id: USER_ID, email: `${suffix}@elig.local`, name: "Elig" },
     });
 
-    const mp = (
-      id: string,
-      name: string,
+    const mp = ({
+      id,
+      name,
+      scopes,
+      overrides = {},
+    }: {
+      id: string;
+      name: string;
       scopes: Array<{
         scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
         scopeId: string;
-      }>,
-      overrides: { enabled?: boolean; disabledAt?: Date } = {},
-    ) =>
+      }>;
+      overrides?: { enabled?: boolean; disabledAt?: Date };
+    }) =>
       prisma.modelProvider.create({
         data: {
           id,
@@ -141,32 +146,42 @@ describe("eligible model providers - drawer / gateway parity on real PG", () => 
         },
       });
 
-    await mp(MP_ORG_ID, "Central OpenAI", [
-      { scopeType: "ORGANIZATION", scopeId: ORG_ID },
-    ]);
-    await mp(
-      MP_ORG_OFF_ID,
-      "Switched Off OpenAI",
-      [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
-      { enabled: false },
-    );
-    await mp(
-      MP_ORG_WITHDRAWN_ID,
-      "Withdrawn OpenAI",
-      [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
-      { disabledAt: new Date("2026-07-01T00:00:00Z") },
-    );
-    await mp(MP_PROJECT_ID, "Project OpenAI", [
-      { scopeType: "PROJECT", scopeId: PROJECT_ID },
-    ]);
-    await mp(MP_SIBLING_ID, "Sibling OpenAI", [
-      { scopeType: "PROJECT", scopeId: SIBLING_PROJECT_ID },
-    ]);
-    await mp(MP_MULTISCOPE_ID, "Everywhere OpenAI", [
-      { scopeType: "ORGANIZATION", scopeId: ORG_ID },
-      { scopeType: "TEAM", scopeId: TEAM_ID },
-      { scopeType: "PROJECT", scopeId: PROJECT_ID },
-    ]);
+    await mp({
+      id: MP_ORG_ID,
+      name: "Central OpenAI",
+      scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+    });
+    await mp({
+      id: MP_ORG_OFF_ID,
+      name: "Switched Off OpenAI",
+      scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+      overrides: { enabled: false },
+    });
+    await mp({
+      id: MP_ORG_WITHDRAWN_ID,
+      name: "Withdrawn OpenAI",
+      scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+      overrides: { disabledAt: new Date("2026-07-01T00:00:00Z") },
+    });
+    await mp({
+      id: MP_PROJECT_ID,
+      name: "Project OpenAI",
+      scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+    });
+    await mp({
+      id: MP_SIBLING_ID,
+      name: "Sibling OpenAI",
+      scopes: [{ scopeType: "PROJECT", scopeId: SIBLING_PROJECT_ID }],
+    });
+    await mp({
+      id: MP_MULTISCOPE_ID,
+      name: "Everywhere OpenAI",
+      scopes: [
+        { scopeType: "ORGANIZATION", scopeId: ORG_ID },
+        { scopeType: "TEAM", scopeId: TEAM_ID },
+        { scopeType: "PROJECT", scopeId: PROJECT_ID },
+      ],
+    });
 
     await prisma.virtualKey.create({
       data: {

--- a/platform/app/src/server/gateway/applicableBudgets.service.ts
+++ b/platform/app/src/server/gateway/applicableBudgets.service.ts
@@ -91,7 +91,7 @@ export async function resolveApplicableBudgetsForDraftKey(
 
   // Independent lookups on an interactive path: run them together.
   const [spentByBudgetId, labels, providerLabels] = await Promise.all([
-    loadSpend(prisma, draft, resolved, chRepo),
+    loadSpend({ prisma, draft, resolved, chRepo }),
     loadScopeLabels(prisma, resolved),
     resolveProviderLabels({
       prisma,
@@ -122,12 +122,17 @@ export async function resolveApplicableBudgetsForDraftKey(
   }));
 }
 
-async function loadSpend(
-  prisma: PrismaClient,
-  draft: DraftVirtualKey,
-  resolved: Awaited<ReturnType<typeof resolveApplicableBudgets>>,
-  chRepo?: GatewayBudgetClickHouseRepository,
-): Promise<Map<string, string>> {
+async function loadSpend({
+  prisma,
+  draft,
+  resolved,
+  chRepo,
+}: {
+  prisma: PrismaClient;
+  draft: DraftVirtualKey;
+  resolved: Awaited<ReturnType<typeof resolveApplicableBudgets>>;
+  chRepo?: GatewayBudgetClickHouseRepository;
+}): Promise<Map<string, string>> {
   if (!chRepo) return new Map();
   const projects = await prisma.project.findMany({
     where: { team: { organizationId: draft.organizationId } },

--- a/platform/app/src/server/gateway/budget.clickhouse.repository.ts
+++ b/platform/app/src/server/gateway/budget.clickhouse.repository.ts
@@ -347,12 +347,17 @@ function bucketQueryShape(args: {
  * both of them into each budget, reporting every budget at N times its
  * true spend for N budgets sharing the bucket.
  */
-function bucketMatchSql(
-  target: BudgetSpendTarget,
-  budgetIdParam: string,
-  scopeIdParam: string,
-  suffixParam: string,
-): string {
+function bucketMatchSql({
+  target,
+  budgetIdParam,
+  scopeIdParam,
+  suffixParam,
+}: {
+  target: BudgetSpendTarget;
+  budgetIdParam: string;
+  scopeIdParam: string;
+  suffixParam: string;
+}): string {
   const budget = `BudgetId = {${budgetIdParam}:String}`;
   if (target.match !== "prefix") {
     return `${budget} AND ScopeId = {${scopeIdParam}:String}`;
@@ -385,12 +390,12 @@ function flooredTargetSums(targets: BudgetSpendTarget[]): {
     if (t.match === "prefix" && t.bucketSuffix) {
       params[`fsuffix${i}`] = t.bucketSuffix;
     }
-    const bucket = bucketMatchSql(
-      t,
-      `fbudgetId${i}`,
-      `fscopeId${i}`,
-      `fsuffix${i}`,
-    );
+    const bucket = bucketMatchSql({
+      target: t,
+      budgetIdParam: `fbudgetId${i}`,
+      scopeIdParam: `fscopeId${i}`,
+      suffixParam: `fsuffix${i}`,
+    });
     return `toString(sumIf(AmountNanoUSD, Scope = {fscope${i}:String} AND ${bucket} AND Window = {fwindow${i}:String} AND OccurredAt >= fromUnixTimestamp64Milli({ffloor${i}:Int64}))) AS T${i}`;
   });
   return { sql: sums.join(",\n              "), params };
@@ -413,12 +418,12 @@ function rollupScopeFilter(targets: BudgetSpendTarget[]): {
     params[`scope${i}`] = scopeToClickHouse(t.scope);
     params[`scopeId${i}`] = t.scopeId;
     if (t.bucketSuffix) params[`suffix${i}`] = t.bucketSuffix;
-    const bucket = bucketMatchSql(
-      t,
-      `budgetId${i}`,
-      `scopeId${i}`,
-      `suffix${i}`,
-    );
+    const bucket = bucketMatchSql({
+      target: t,
+      budgetIdParam: `budgetId${i}`,
+      scopeIdParam: `scopeId${i}`,
+      suffixParam: `suffix${i}`,
+    });
     return `(Scope = {scope${i}:String} AND ${bucket})`;
   });
   return { sql: terms.join(" OR "), params };

--- a/platform/app/src/server/gateway/budget.service.ts
+++ b/platform/app/src/server/gateway/budget.service.ts
@@ -268,23 +268,38 @@ export type BudgetCheckResult = {
 };
 
 export class GatewayBudgetService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    private readonly changeEvents = new ChangeEventRepository(prisma),
-    private readonly auditLog = new GatewayAuditAdapter(prisma),
-    private readonly chRepo?: GatewayBudgetClickHouseRepository,
-  ) {}
+  private readonly prisma: PrismaClient;
+  private readonly changeEvents: ChangeEventRepository;
+  private readonly auditLog: GatewayAuditAdapter;
+  private readonly chRepo?: GatewayBudgetClickHouseRepository;
+
+  constructor({
+    prisma,
+    changeEvents = new ChangeEventRepository(prisma),
+    auditLog = new GatewayAuditAdapter(prisma),
+    chRepo,
+  }: {
+    prisma: PrismaClient;
+    changeEvents?: ChangeEventRepository;
+    auditLog?: GatewayAuditAdapter;
+    chRepo?: GatewayBudgetClickHouseRepository;
+  }) {
+    this.prisma = prisma;
+    this.changeEvents = changeEvents;
+    this.auditLog = auditLog;
+    this.chRepo = chRepo;
+  }
 
   static create(
     prisma: PrismaClient,
     chRepo?: GatewayBudgetClickHouseRepository,
   ): GatewayBudgetService {
-    return new GatewayBudgetService(
+    return new GatewayBudgetService({
       prisma,
-      new ChangeEventRepository(prisma),
-      new GatewayAuditAdapter(prisma),
+      changeEvents: new ChangeEventRepository(prisma),
+      auditLog: new GatewayAuditAdapter(prisma),
       chRepo,
-    );
+    });
   }
 
   async list(organizationId: string): Promise<GatewayBudgetWithSeats[]> {

--- a/platform/app/src/server/gateway/usage.service.ts
+++ b/platform/app/src/server/gateway/usage.service.ts
@@ -178,9 +178,24 @@ export class GatewayUsageService {
       totalUsd = totalUsd.plus(bucket.totalUsd);
       totalRequests += bucket.requests;
       blockedRequests += bucket.blockedRequests;
-      bumpBucket(byVk, bucket.virtualKeyId, bucket.totalUsd, bucket.requests);
-      bumpBucket(byModel, bucket.model, bucket.totalUsd, bucket.requests);
-      bumpBucket(byDay, bucket.day, bucket.totalUsd, bucket.requests);
+      bumpBucket({
+        map: byVk,
+        key: bucket.virtualKeyId,
+        amount: bucket.totalUsd,
+        requests: bucket.requests,
+      });
+      bumpBucket({
+        map: byModel,
+        key: bucket.model,
+        amount: bucket.totalUsd,
+        requests: bucket.requests,
+      });
+      bumpBucket({
+        map: byDay,
+        key: bucket.day,
+        amount: bucket.totalUsd,
+        requests: bucket.requests,
+      });
     }
 
     const vkMeta = await this.loadVirtualKeyMeta([...byVk.keys()]);
@@ -240,25 +255,8 @@ export class GatewayUsageService {
       }),
     ]);
 
-    const byModel = new Map<
-      string,
-      { totalUsd: Prisma.Decimal; requests: number }
-    >();
-    const byDay = new Map<
-      string,
-      { totalUsd: Prisma.Decimal; requests: number }
-    >();
-    let totalUsd = new Prisma.Decimal(0);
-    let totalRequests = 0;
-    let blockedRequests = 0;
-
-    for (const bucket of buckets) {
-      totalUsd = totalUsd.plus(bucket.totalUsd);
-      totalRequests += bucket.requests;
-      blockedRequests += bucket.blockedRequests;
-      bumpBucket(byModel, bucket.model, bucket.totalUsd, bucket.requests);
-      bumpBucket(byDay, bucket.day, bucket.totalUsd, bucket.requests);
-    }
+    const { byModel, byDay, totalUsd, totalRequests, blockedRequests } =
+      accumulateUsageBuckets(buckets);
 
     return {
       totalUsd: totalUsd.toFixed(6),
@@ -340,12 +338,63 @@ function sortedDays(
     }));
 }
 
-function bumpBucket(
-  map: Map<string, { totalUsd: Prisma.Decimal; requests: number }>,
-  key: string,
-  amount: Prisma.Decimal | string,
-  requests: number,
+/**
+ * Fold usage buckets into per-model and per-day maps plus grand totals —
+ * one pass, shared by the virtual-key summary.
+ */
+function accumulateUsageBuckets(
+  buckets: Array<{
+    model: string;
+    day: string;
+    totalUsd: Prisma.Decimal | string;
+    requests: number;
+    blockedRequests: number;
+  }>,
 ) {
+  const byModel = new Map<
+    string,
+    { totalUsd: Prisma.Decimal; requests: number }
+  >();
+  const byDay = new Map<
+    string,
+    { totalUsd: Prisma.Decimal; requests: number }
+  >();
+  let totalUsd = new Prisma.Decimal(0);
+  let totalRequests = 0;
+  let blockedRequests = 0;
+
+  for (const bucket of buckets) {
+    totalUsd = totalUsd.plus(bucket.totalUsd);
+    totalRequests += bucket.requests;
+    blockedRequests += bucket.blockedRequests;
+    bumpBucket({
+      map: byModel,
+      key: bucket.model,
+      amount: bucket.totalUsd,
+      requests: bucket.requests,
+    });
+    bumpBucket({
+      map: byDay,
+      key: bucket.day,
+      amount: bucket.totalUsd,
+      requests: bucket.requests,
+    });
+  }
+
+  return { byModel, byDay, totalUsd, totalRequests, blockedRequests };
+}
+
+function bumpBucket({
+  map,
+  key,
+  amount,
+  requests,
+}: {
+  map: Map<string, { totalUsd: Prisma.Decimal; requests: number }>;
+  key: string;
+  amount: Prisma.Decimal | string;
+  requests: number;
+}) {
   const existing = map.get(key);
   if (existing) {
     existing.totalUsd = existing.totalUsd.plus(amount);

--- a/platform/app/src/server/gateway/virtualKey.repository.ts
+++ b/platform/app/src/server/gateway/virtualKey.repository.ts
@@ -287,12 +287,17 @@ export class VirtualKeyRepository {
     });
   }
 
-  async updateConfig(
-    id: string,
-    organizationId: string,
-    config: Prisma.InputJsonValue,
-    tx?: Prisma.TransactionClient,
-  ): Promise<VirtualKeyWithScopes> {
+  async updateConfig({
+    id,
+    organizationId,
+    config,
+    tx,
+  }: {
+    id: string;
+    organizationId: string;
+    config: Prisma.InputJsonValue;
+    tx?: Prisma.TransactionClient;
+  }): Promise<VirtualKeyWithScopes> {
     const client = tx ?? this.prisma;
     return client.virtualKey.update({
       where: { id, organizationId },
@@ -329,12 +334,17 @@ export class VirtualKeyRepository {
     });
   }
 
-  async setRoutingPolicy(
-    id: string,
-    organizationId: string,
-    routingPolicyId: string | null,
-    tx?: Prisma.TransactionClient,
-  ): Promise<VirtualKeyWithScopes> {
+  async setRoutingPolicy({
+    id,
+    organizationId,
+    routingPolicyId,
+    tx,
+  }: {
+    id: string;
+    organizationId: string;
+    routingPolicyId: string | null;
+    tx?: Prisma.TransactionClient;
+  }): Promise<VirtualKeyWithScopes> {
     const client = tx ?? this.prisma;
     return client.virtualKey.update({
       where: { id, organizationId },
@@ -349,15 +359,23 @@ export class VirtualKeyRepository {
     });
   }
 
-  async rotateSecret(
-    id: string,
-    organizationId: string,
-    newHashedSecret: string,
-    newDisplayPrefix: string,
-    previousHashedSecret: string,
-    previousSecretValidUntil: Date,
-    tx?: Prisma.TransactionClient,
-  ): Promise<VirtualKeyWithScopes> {
+  async rotateSecret({
+    id,
+    organizationId,
+    newHashedSecret,
+    newDisplayPrefix,
+    previousHashedSecret,
+    previousSecretValidUntil,
+    tx,
+  }: {
+    id: string;
+    organizationId: string;
+    newHashedSecret: string;
+    newDisplayPrefix: string;
+    previousHashedSecret: string;
+    previousSecretValidUntil: Date;
+    tx?: Prisma.TransactionClient;
+  }): Promise<VirtualKeyWithScopes> {
     const client = tx ?? this.prisma;
     return client.virtualKey.update({
       where: { id, organizationId },
@@ -378,12 +396,17 @@ export class VirtualKeyRepository {
     });
   }
 
-  async revoke(
-    id: string,
-    organizationId: string,
-    revokedById: string,
-    tx?: Prisma.TransactionClient,
-  ): Promise<VirtualKeyWithScopes> {
+  async revoke({
+    id,
+    organizationId,
+    revokedById,
+    tx,
+  }: {
+    id: string;
+    organizationId: string;
+    revokedById: string;
+    tx?: Prisma.TransactionClient;
+  }): Promise<VirtualKeyWithScopes> {
     const client = tx ?? this.prisma;
     return client.virtualKey.update({
       where: { id, organizationId },

--- a/platform/app/src/server/gateway/virtualKey.service.ts
+++ b/platform/app/src/server/gateway/virtualKey.service.ts
@@ -196,20 +196,35 @@ export type CreatedVirtualKey = {
  * - RBAC is enforced by tRPC / Hono layers before reaching the service.
  */
 export class VirtualKeyService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    private readonly repository: VirtualKeyRepository,
-    private readonly changeEvents: ChangeEventRepository,
-    private readonly auditLog: GatewayAuditAdapter,
-  ) {}
+  private readonly prisma: PrismaClient;
+  private readonly repository: VirtualKeyRepository;
+  private readonly changeEvents: ChangeEventRepository;
+  private readonly auditLog: GatewayAuditAdapter;
+
+  constructor({
+    prisma,
+    repository,
+    changeEvents,
+    auditLog,
+  }: {
+    prisma: PrismaClient;
+    repository: VirtualKeyRepository;
+    changeEvents: ChangeEventRepository;
+    auditLog: GatewayAuditAdapter;
+  }) {
+    this.prisma = prisma;
+    this.repository = repository;
+    this.changeEvents = changeEvents;
+    this.auditLog = auditLog;
+  }
 
   static create(prisma: PrismaClient): VirtualKeyService {
-    return new VirtualKeyService(
+    return new VirtualKeyService({
       prisma,
-      new VirtualKeyRepository(prisma),
-      new ChangeEventRepository(prisma),
-      new GatewayAuditAdapter(prisma),
-    );
+      repository: new VirtualKeyRepository(prisma),
+      changeEvents: new ChangeEventRepository(prisma),
+      auditLog: new GatewayAuditAdapter(prisma),
+    });
   }
 
   async getAll(organizationId: string): Promise<VirtualKeyWithScopes[]> {
@@ -530,15 +545,15 @@ export class VirtualKeyService {
     const previousSecretValidUntil = new Date(Date.now() + ROTATION_GRACE_MS);
 
     const rotated = await this.prisma.$transaction(async (tx) => {
-      const vk = await this.repository.rotateSecret(
-        input.id,
-        input.organizationId,
+      const vk = await this.repository.rotateSecret({
+        id: input.id,
+        organizationId: input.organizationId,
         newHashedSecret,
         newDisplayPrefix,
-        existing.hashedSecret,
+        previousHashedSecret: existing.hashedSecret,
         previousSecretValidUntil,
         tx,
-      );
+      });
       await this.changeEvents.append(
         {
           organizationId: input.organizationId,
@@ -574,12 +589,12 @@ export class VirtualKeyService {
 
     return this.prisma
       .$transaction(async (tx) => {
-        const vk = await this.repository.revoke(
-          input.id,
-          input.organizationId,
-          input.actorUserId,
+        const vk = await this.repository.revoke({
+          id: input.id,
+          organizationId: input.organizationId,
+          revokedById: input.actorUserId,
           tx,
-        );
+        });
         // A dead key's cap is retired, not deleted: the ledger rows behind
         // it are the spend record, and an admin asking "what did this key
         // cost us before we killed it" needs the budget row to read them

--- a/platform/app/src/server/home/recent-items.service.ts
+++ b/platform/app/src/server/home/recent-items.service.ts
@@ -55,12 +55,12 @@ export class RecentItemsService {
     const entries = Array.from(entityMap.values()).slice(0, params.limit);
 
     for (const entry of entries) {
-      const item = await this.hydrateEntity(
-        entry.type,
-        entry.id,
-        entry.timestamp,
-        params.projectId,
-      );
+      const item = await this.hydrateEntity({
+        type: entry.type,
+        id: entry.id,
+        timestamp: entry.timestamp,
+        projectId: params.projectId,
+      });
       if (item) {
         recentItems.push(item);
       }
@@ -84,12 +84,17 @@ export class RecentItemsService {
   /**
    * Hydrate an entity with its details
    */
-  private async hydrateEntity(
-    type: RecentItemType,
-    id: string,
-    timestamp: Date,
-    projectId: string,
-  ): Promise<RecentItem | null> {
+  private async hydrateEntity({
+    type,
+    id,
+    timestamp,
+    projectId,
+  }: {
+    type: RecentItemType;
+    id: string;
+    timestamp: Date;
+    projectId: string;
+  }): Promise<RecentItem | null> {
     switch (type) {
       case "prompt": {
         const prompt = await this.repository.getPromptById(id, projectId);

--- a/platform/app/src/server/invites/__tests__/invite.service.unit.test.ts
+++ b/platform/app/src/server/invites/__tests__/invite.service.unit.test.ts
@@ -160,7 +160,11 @@ describe("InviteService", () => {
       getActivePlan: vi.fn(),
     };
 
-    service = new InviteService(mockPrisma, mockLicenseRepo, mockPlanProvider);
+    service = new InviteService({
+      prisma: mockPrisma,
+      licenseRepo: mockLicenseRepo,
+      planProvider: mockPlanProvider,
+    });
   });
 
   /**

--- a/platform/app/src/server/invites/invite.service.ts
+++ b/platform/app/src/server/invites/invite.service.ts
@@ -148,12 +148,27 @@ interface ApproveInviteInput {
  * Dependencies are injected to follow DIP and enable testability.
  */
 export class InviteService {
-  constructor(
-    private readonly prisma: PrismaClient | Prisma.TransactionClient,
-    private readonly licenseRepo: ILicenseEnforcementRepository,
-    private readonly planProvider: PlanProvider,
-    private readonly roleService?: RoleService,
-  ) {}
+  private readonly prisma: PrismaClient | Prisma.TransactionClient;
+  private readonly licenseRepo: ILicenseEnforcementRepository;
+  private readonly planProvider: PlanProvider;
+  private readonly roleService?: RoleService;
+
+  constructor({
+    prisma,
+    licenseRepo,
+    planProvider,
+    roleService,
+  }: {
+    prisma: PrismaClient | Prisma.TransactionClient;
+    licenseRepo: ILicenseEnforcementRepository;
+    planProvider: PlanProvider;
+    roleService?: RoleService;
+  }) {
+    this.prisma = prisma;
+    this.licenseRepo = licenseRepo;
+    this.planProvider = planProvider;
+    this.roleService = roleService;
+  }
 
   /**
    * Factory method for creating InviteService with default dependencies.
@@ -175,7 +190,12 @@ export class InviteService {
       getActivePlan: (params) => getApp().planProvider.getActivePlan(params),
     };
     const roleService = new RoleService(prisma);
-    return new InviteService(prisma, licenseRepo, provider, roleService);
+    return new InviteService({
+      prisma,
+      licenseRepo,
+      planProvider: provider,
+      roleService,
+    });
   }
 
   /**

--- a/platform/app/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
+++ b/platform/app/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
@@ -63,12 +63,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo();
       const limits = createLimits();
 
-      await assertMemberTypeLimitNotExceeded(
-        "no-change",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "no-change",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockRepo.getMemberCount).not.toHaveBeenCalled();
       expect(mockRepo.getMembersLiteCount).not.toHaveBeenCalled();
@@ -78,12 +78,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo();
       const limits = createLimits();
 
-      await assertMemberTypeLimitNotExceeded(
-        "no-change",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "no-change",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
     });
@@ -94,12 +94,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo();
       const limits = createLimits(5, 10, true);
 
-      await assertMemberTypeLimitNotExceeded(
-        "lite-to-full",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "lite-to-full",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockRepo.getMemberCount).not.toHaveBeenCalled();
       expect(mockRepo.getMembersLiteCount).not.toHaveBeenCalled();
@@ -109,12 +109,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo();
       const limits = createLimits(5, 10, true);
 
-      await assertMemberTypeLimitNotExceeded(
-        "lite-to-full",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "lite-to-full",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
     });
@@ -127,12 +127,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const limits = createLimits(5);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "lite-to-full",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "lite-to-full",
           organizationId,
-          mockRepo,
+          licenseRepo: mockRepo,
           limits,
-        ),
+        }),
       ).resolves.toBeUndefined();
 
       expect(mockRepo.getMemberCount).toHaveBeenCalledWith(organizationId);
@@ -142,12 +142,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(3);
       const limits = createLimits(5);
 
-      await assertMemberTypeLimitNotExceeded(
-        "lite-to-full",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "lite-to-full",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
     });
@@ -157,12 +157,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(5); // 5 members, limit is 5
       const limits = createLimits(5);
 
-      const error = await assertMemberTypeLimitNotExceeded(
-        "lite-to-full",
+      const error = await assertMemberTypeLimitNotExceeded({
+        changeType: "lite-to-full",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      ).catch((e) => e);
+      }).catch((e) => e);
 
       // The allowance travels as `meta` under a stable code, which is what lets
       // the client name which seats ran out. Asserting the code rather than the
@@ -182,12 +182,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(5);
       const limits = createLimits(5);
 
-      await assertMemberTypeLimitNotExceeded(
-        "lite-to-full",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "lite-to-full",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      ).catch(() => {});
+      }).catch(() => {});
 
       expect(mockNotifyResourceLimitReached).toHaveBeenCalledWith({
         organizationId,
@@ -202,12 +202,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const limits = createLimits(5);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "lite-to-full",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "lite-to-full",
           organizationId,
-          mockRepo,
+          licenseRepo: mockRepo,
           limits,
-        ),
+        }),
       ).rejects.toThrow(LimitExceededError);
     });
   });
@@ -218,12 +218,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const limits = createLimits(5, 10);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "full-to-lite",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "full-to-lite",
           organizationId,
-          mockRepo,
+          licenseRepo: mockRepo,
           limits,
-        ),
+        }),
       ).resolves.toBeUndefined();
 
       expect(mockRepo.getMembersLiteCount).toHaveBeenCalledWith(organizationId);
@@ -233,12 +233,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(0, 5);
       const limits = createLimits(5, 10);
 
-      await assertMemberTypeLimitNotExceeded(
-        "full-to-lite",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "full-to-lite",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      );
+      });
 
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
     });
@@ -247,12 +247,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(0, 10); // 10 lite members, limit is 10
       const limits = createLimits(5, 10);
 
-      const error = await assertMemberTypeLimitNotExceeded(
-        "full-to-lite",
+      const error = await assertMemberTypeLimitNotExceeded({
+        changeType: "full-to-lite",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      ).catch((e) => e);
+      }).catch((e) => e);
 
       expect(error).toMatchObject({
         code: "resource_limit_exceeded",
@@ -269,12 +269,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(0, 10);
       const limits = createLimits(5, 10);
 
-      await assertMemberTypeLimitNotExceeded(
-        "full-to-lite",
+      await assertMemberTypeLimitNotExceeded({
+        changeType: "full-to-lite",
         organizationId,
-        mockRepo,
+        licenseRepo: mockRepo,
         limits,
-      ).catch(() => {});
+      }).catch(() => {});
 
       expect(mockNotifyResourceLimitReached).toHaveBeenCalledWith({
         organizationId,
@@ -289,12 +289,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const limits = createLimits(5, 10);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "full-to-lite",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "full-to-lite",
           organizationId,
-          mockRepo,
+          licenseRepo: mockRepo,
           limits,
-        ),
+        }),
       ).rejects.toThrow(LimitExceededError);
     });
   });
@@ -312,12 +312,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(plan.maxMembers);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "lite-to-full",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "lite-to-full",
           organizationId,
-          mockRepo,
-          plan,
-        ),
+          licenseRepo: mockRepo,
+          limits: plan,
+        }),
       ).rejects.toMatchObject({
         code: "resource_limit_exceeded",
         meta: { limitType: "members" },
@@ -331,12 +331,12 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       const mockRepo = createMockRepo(plan.maxMembers - 1);
 
       await expect(
-        assertMemberTypeLimitNotExceeded(
-          "lite-to-full",
+        assertMemberTypeLimitNotExceeded({
+          changeType: "lite-to-full",
           organizationId,
-          mockRepo,
-          plan,
-        ),
+          licenseRepo: mockRepo,
+          limits: plan,
+        }),
       ).resolves.toBeUndefined();
     });
   });

--- a/platform/app/src/server/license-enforcement/__tests__/member-classification.unit.test.ts
+++ b/platform/app/src/server/license-enforcement/__tests__/member-classification.unit.test.ts
@@ -277,67 +277,67 @@ describe("getRoleChangeType", () => {
   describe("no-change scenarios", () => {
     it("returns no-change when both roles are Full Member (ADMIN to MEMBER)", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.ADMIN,
-          undefined,
-          OrganizationUserRole.MEMBER,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.ADMIN,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.MEMBER,
+          newPermissions: undefined,
+        }),
       ).toBe("no-change");
     });
 
     it("returns no-change when both roles are Full Member (MEMBER to ADMIN)", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.MEMBER,
-          undefined,
-          OrganizationUserRole.ADMIN,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.MEMBER,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.ADMIN,
+          newPermissions: undefined,
+        }),
       ).toBe("no-change");
     });
 
     it("returns no-change when both roles are Lite Member (EXTERNAL to EXTERNAL)", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-          OrganizationUserRole.EXTERNAL,
-          ["project:view"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:view"],
+        }),
       ).toBe("no-change");
     });
 
     it("returns no-change when EXTERNAL with non-view to MEMBER (both Full Member)", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:manage"],
-          OrganizationUserRole.MEMBER,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:manage"],
+          newRole: OrganizationUserRole.MEMBER,
+          newPermissions: undefined,
+        }),
       ).toBe("no-change");
     });
 
     it("returns no-change when custom role changes but stays view-only", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:view"],
-          OrganizationUserRole.EXTERNAL,
-          ["project:view", "analytics:view"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:view"],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:view", "analytics:view"],
+        }),
       ).toBe("no-change");
     });
 
     it("returns no-change when custom role changes but stays non-view", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:manage"],
-          OrganizationUserRole.EXTERNAL,
-          ["project:update"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:manage"],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:update"],
+        }),
       ).toBe("no-change");
     });
   });
@@ -345,56 +345,56 @@ describe("getRoleChangeType", () => {
   describe("lite-to-full scenarios", () => {
     it("returns lite-to-full when EXTERNAL upgraded to MEMBER", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-          OrganizationUserRole.MEMBER,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.MEMBER,
+          newPermissions: undefined,
+        }),
       ).toBe("lite-to-full");
     });
 
     it("returns lite-to-full when EXTERNAL upgraded to ADMIN", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-          OrganizationUserRole.ADMIN,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.ADMIN,
+          newPermissions: undefined,
+        }),
       ).toBe("lite-to-full");
     });
 
     it("returns lite-to-full when view-only custom role gets manage permission", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:view"],
-          OrganizationUserRole.EXTERNAL,
-          ["project:view", "project:manage"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:view"],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:view", "project:manage"],
+        }),
       ).toBe("lite-to-full");
     });
 
     it("returns lite-to-full when no permissions to non-view custom role", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-          OrganizationUserRole.EXTERNAL,
-          ["project:create"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:create"],
+        }),
       ).toBe("lite-to-full");
     });
 
     it("returns lite-to-full when empty permissions to non-view custom role", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          [],
-          OrganizationUserRole.EXTERNAL,
-          ["project:update"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: [],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:update"],
+        }),
       ).toBe("lite-to-full");
     });
   });
@@ -402,56 +402,56 @@ describe("getRoleChangeType", () => {
   describe("full-to-lite scenarios", () => {
     it("returns full-to-lite when MEMBER downgraded to EXTERNAL", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.MEMBER,
-          undefined,
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.MEMBER,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: undefined,
+        }),
       ).toBe("full-to-lite");
     });
 
     it("returns full-to-lite when ADMIN downgraded to EXTERNAL", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.ADMIN,
-          undefined,
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.ADMIN,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: undefined,
+        }),
       ).toBe("full-to-lite");
     });
 
     it("returns full-to-lite when MEMBER downgraded to EXTERNAL with view-only role", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.MEMBER,
-          undefined,
-          OrganizationUserRole.EXTERNAL,
-          ["project:view"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.MEMBER,
+          oldPermissions: undefined,
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:view"],
+        }),
       ).toBe("full-to-lite");
     });
 
     it("returns full-to-lite when non-view custom role changed to view-only", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:manage"],
-          OrganizationUserRole.EXTERNAL,
-          ["project:view"],
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:manage"],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: ["project:view"],
+        }),
       ).toBe("full-to-lite");
     });
 
     it("returns full-to-lite when non-view custom role removed", () => {
       expect(
-        getRoleChangeType(
-          OrganizationUserRole.EXTERNAL,
-          ["project:update"],
-          OrganizationUserRole.EXTERNAL,
-          undefined,
-        ),
+        getRoleChangeType({
+          oldRole: OrganizationUserRole.EXTERNAL,
+          oldPermissions: ["project:update"],
+          newRole: OrganizationUserRole.EXTERNAL,
+          newPermissions: undefined,
+        }),
       ).toBe("full-to-lite");
     });
   });

--- a/platform/app/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
+++ b/platform/app/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
@@ -56,12 +56,12 @@ describe("UsageStatsService", () => {
       getResolvedUsageUnit: vi.fn().mockResolvedValue("traces"),
     };
 
-    service = new UsageStatsService(
-      mockRepository,
-      mockTraceUsage,
-      mockPlanProvider,
-      mockUsageUnitResolver,
-    );
+    service = new UsageStatsService({
+      repository: mockRepository,
+      traceUsageService: mockTraceUsage,
+      planProvider: mockPlanProvider,
+      usageUnitResolver: mockUsageUnitResolver,
+    });
   });
 
   describe("getUsageStats", () => {

--- a/platform/app/src/server/license-enforcement/license-limit-guard.ts
+++ b/platform/app/src/server/license-enforcement/license-limit-guard.ts
@@ -39,12 +39,17 @@ export interface MemberTypeLimits {
  *
  * @throws LimitExceededError if the limit would be exceeded
  */
-export async function assertMemberTypeLimitNotExceeded(
-  changeType: RoleChangeType,
-  organizationId: string,
-  licenseRepo: ILicenseEnforcementRepository,
-  limits: MemberTypeLimits,
-): Promise<void> {
+export async function assertMemberTypeLimitNotExceeded({
+  changeType,
+  organizationId,
+  licenseRepo,
+  limits,
+}: {
+  changeType: RoleChangeType;
+  organizationId: string;
+  licenseRepo: ILicenseEnforcementRepository;
+  limits: MemberTypeLimits;
+}): Promise<void> {
   // No limit check needed if type unchanged or limits overridden
   if (changeType === "no-change" || limits.overrideAddingLimitations) {
     return;

--- a/platform/app/src/server/license-enforcement/member-classification.ts
+++ b/platform/app/src/server/license-enforcement/member-classification.ts
@@ -103,18 +103,23 @@ export type RoleChangeType =
  * Determines if a role change would change the member type.
  * Used for license limit validation when updating member roles.
  *
- * @param oldRole - Current organization user role
- * @param oldPermissions - Current custom role permissions (if any)
- * @param newRole - New organization user role
- * @param newPermissions - New custom role permissions (if any)
+ * @param params.oldRole - Current organization user role
+ * @param params.oldPermissions - Current custom role permissions (if any)
+ * @param params.newRole - New organization user role
+ * @param params.newPermissions - New custom role permissions (if any)
  * @returns RoleChangeType indicating if/how the member type would change
  */
-export function getRoleChangeType(
-  oldRole: OrganizationUserRole,
-  oldPermissions: string[] | undefined,
-  newRole: OrganizationUserRole,
-  newPermissions: string[] | undefined,
-): RoleChangeType {
+export function getRoleChangeType({
+  oldRole,
+  oldPermissions,
+  newRole,
+  newPermissions,
+}: {
+  oldRole: OrganizationUserRole;
+  oldPermissions: string[] | undefined;
+  newRole: OrganizationUserRole;
+  newPermissions: string[] | undefined;
+}): RoleChangeType {
   const wasFull = isFullMember(oldRole, oldPermissions);
   const willBeFull = isFullMember(newRole, newPermissions);
 

--- a/platform/app/src/server/license-enforcement/usage-stats.service.ts
+++ b/platform/app/src/server/license-enforcement/usage-stats.service.ts
@@ -128,12 +128,27 @@ export interface UsageStats {
  * manually wiring dependencies.
  */
 export class UsageStatsService {
-  constructor(
-    private readonly repository: ILicenseEnforcementRepository,
-    private readonly traceUsageService: ITraceUsageService,
-    private readonly planProvider: PlanProvider,
-    private readonly usageUnitResolver: IUsageUnitResolver,
-  ) {}
+  private readonly repository: ILicenseEnforcementRepository;
+  private readonly traceUsageService: ITraceUsageService;
+  private readonly planProvider: PlanProvider;
+  private readonly usageUnitResolver: IUsageUnitResolver;
+
+  constructor({
+    repository,
+    traceUsageService,
+    planProvider,
+    usageUnitResolver,
+  }: {
+    repository: ILicenseEnforcementRepository;
+    traceUsageService: ITraceUsageService;
+    planProvider: PlanProvider;
+    usageUnitResolver: IUsageUnitResolver;
+  }) {
+    this.repository = repository;
+    this.traceUsageService = traceUsageService;
+    this.planProvider = planProvider;
+    this.usageUnitResolver = usageUnitResolver;
+  }
 
   /**
    * Static factory method for creating UsageStatsService with proper DI.
@@ -141,12 +156,12 @@ export class UsageStatsService {
    */
   static create(prisma: PrismaClient): UsageStatsService {
     const repository = new LicenseEnforcementRepository(prisma);
-    return new UsageStatsService(
+    return new UsageStatsService({
       repository,
-      getApp().usage,
-      getApp().planProvider,
-      getApp().usage,
-    );
+      traceUsageService: getApp().usage,
+      planProvider: getApp().planProvider,
+      usageUnitResolver: getApp().usage,
+    });
   }
 
   /**

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.rowForModel.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.rowForModel.integration.test.ts
@@ -543,17 +543,21 @@ describe("Runtime provider-row selection follows the model (real DB)", () => {
 
     /** @scenario Evaluations accept a model served only by a wider-scope row */
     it("builds the evaluator env with the serving row's credentials instead of rejecting", async () => {
-      const env = await setupModelEnv(
-        `gemini/eval-custom-${ns}`,
-        false,
+      const env = await setupModelEnv({
+        model: `gemini/eval-custom-${ns}`,
+        embeddings: false,
         projectId,
-      );
+      });
       expect(env.X_LITELLM_api_key).toBe(`sk-gemini-org-${ns}`);
     });
 
     it("still rejects a model no accessible row serves", async () => {
       await expect(
-        setupModelEnv(`gemini/nonexistent-${ns}`, false, projectId),
+        setupModelEnv({
+          model: `gemini/nonexistent-${ns}`,
+          embeddings: false,
+          projectId,
+        }),
       ).rejects.toThrow(/not in the models list/);
     });
   });

--- a/platform/app/src/server/modelProviders/aiCallFailedError.ts
+++ b/platform/app/src/server/modelProviders/aiCallFailedError.ts
@@ -42,22 +42,33 @@ export class AiCallFailedError extends HandledError {
    */
   public readonly cause = AI_CALL_FAILED_CAUSE;
 
-  constructor(
-    public readonly featureKey: string,
-    public readonly role: ModelRole,
-    public readonly featureDisplayName: string,
-    /**
-     * The provider's / SDK's own sentence.
-     *
-     * SERVER-SIDE ONLY. It is a raw upstream string — deployment names,
-     * endpoint hosts, fragments of the response body, sometimes a credential
-     * echoed back — so it is deliberately absent from `message` (which the
-     * REST boundary ships verbatim), from `meta` (the client contract) and
-     * from {@link toResponseBody}. `wrapAiCall` logs it; that is where
-     * internals belong.
-     */
-    public readonly originalErrorMessage: string,
-  ) {
+  public readonly featureKey: string;
+  public readonly role: ModelRole;
+  public readonly featureDisplayName: string;
+
+  /**
+   * The provider's / SDK's own sentence.
+   *
+   * SERVER-SIDE ONLY. It is a raw upstream string — deployment names,
+   * endpoint hosts, fragments of the response body, sometimes a credential
+   * echoed back — so it is deliberately absent from `message` (which the
+   * REST boundary ships verbatim), from `meta` (the client contract) and
+   * from {@link toResponseBody}. `wrapAiCall` logs it; that is where
+   * internals belong.
+   */
+  public readonly originalErrorMessage: string;
+
+  constructor({
+    featureKey,
+    role,
+    featureDisplayName,
+    originalErrorMessage,
+  }: {
+    featureKey: string;
+    role: ModelRole;
+    featureDisplayName: string;
+    originalErrorMessage: string;
+  }) {
     super("ai_call_failed", `AI call failed for "${featureKey}".`, {
       httpStatus: 400,
       fault: "provider",
@@ -68,6 +79,10 @@ export class AiCallFailedError extends HandledError {
       meta: { featureKey, role, featureDisplayName },
     });
     this.name = "AiCallFailedError";
+    this.featureKey = featureKey;
+    this.role = role;
+    this.featureDisplayName = featureDisplayName;
+    this.originalErrorMessage = originalErrorMessage;
   }
 
   toResponseBody(): {
@@ -111,11 +126,11 @@ export async function wrapAiCall<T>(
     // `data.cause` sidecar until that block is retired, and a stack-laden
     // provider error should not be dragged along wholesale.
     const firstLine = message.split("\n")[0]!.slice(0, 200);
-    throw new AiCallFailedError(
-      feature.key,
-      feature.role,
-      feature.displayName,
-      firstLine,
-    );
+    throw new AiCallFailedError({
+      featureKey: feature.key,
+      role: feature.role,
+      featureDisplayName: feature.displayName,
+      originalErrorMessage: firstLine,
+    });
   }
 }

--- a/platform/app/src/server/modelProviders/modelNotConfiguredError.ts
+++ b/platform/app/src/server/modelProviders/modelNotConfiguredError.ts
@@ -46,12 +46,22 @@ export class ModelNotConfiguredError extends HandledError {
    */
   public readonly cause = MODEL_NOT_CONFIGURED_CAUSE;
 
-  constructor(
-    public readonly featureKey: string,
-    public readonly role: ModelRole,
-    public readonly featureDisplayName: string,
-    public readonly projectId: string,
-  ) {
+  public readonly featureKey: string;
+  public readonly role: ModelRole;
+  public readonly featureDisplayName: string;
+  public readonly projectId: string;
+
+  constructor({
+    featureKey,
+    role,
+    featureDisplayName,
+    projectId,
+  }: {
+    featureKey: string;
+    role: ModelRole;
+    featureDisplayName: string;
+    projectId: string;
+  }) {
     super(
       "model_not_configured",
       `No model configured for "${featureKey}" (role: ${role}, project: ${projectId}).`,
@@ -61,5 +71,9 @@ export class ModelNotConfiguredError extends HandledError {
       },
     );
     this.name = "ModelNotConfiguredError";
+    this.featureKey = featureKey;
+    this.role = role;
+    this.featureDisplayName = featureDisplayName;
+    this.projectId = projectId;
   }
 }

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -560,9 +560,9 @@ export class ModelProviderService {
       let result;
 
       if (existingProvider) {
-        result = await this.updateExisting(
+        result = await this.updateExisting({
           existingProvider,
-          {
+          data: {
             provider,
             enabled,
             name,
@@ -575,10 +575,10 @@ export class ModelProviderService {
           validatedKeys,
           customKeysProvided,
           tx,
-        );
+        });
       } else {
-        result = await this.createNew(
-          {
+        result = await this.createNew({
+          data: {
             provider,
             enabled,
             name: name ?? this.deriveDefaultName(provider),
@@ -591,7 +591,7 @@ export class ModelProviderService {
           validatedKeys,
           customKeysProvided,
           tx,
-        );
+        });
 
         // Onboarding seed: writes one role-level ModelDefault row per
         // role the provider can fulfill (DEFAULT / FAST / EMBEDDINGS),
@@ -1267,12 +1267,18 @@ export class ModelProviderService {
     return organizationId ?? null;
   }
 
-  private async updateExisting(
+  private async updateExisting({
+    existingProvider,
+    data,
+    validatedKeys,
+    customKeysProvided,
+    tx,
+  }: {
     existingProvider: {
       id: string;
       customKeys: unknown;
       extraHeaders: unknown;
-    },
+    };
     data: {
       provider: string;
       enabled: boolean;
@@ -1282,11 +1288,11 @@ export class ModelProviderService {
       customEmbeddingsModels: CustomModelsInput;
       extraHeaders: { key: string; value: string }[];
       advanced: AdvancedGatewayInput;
-    },
-    validatedKeys: Record<string, unknown> | null,
-    customKeysProvided: boolean,
-    tx: Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0],
-  ) {
+    };
+    validatedKeys: Record<string, unknown> | null;
+    customKeysProvided: boolean;
+    tx: Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0];
+  }) {
     let customKeysToSave: Record<string, unknown> | undefined;
 
     if (customKeysProvided) {
@@ -1319,7 +1325,12 @@ export class ModelProviderService {
     );
   }
 
-  private async createNew(
+  private async createNew({
+    data,
+    validatedKeys,
+    customKeysProvided,
+    tx,
+  }: {
     data: {
       name: string;
       provider: string;
@@ -1329,11 +1340,11 @@ export class ModelProviderService {
       extraHeaders: { key: string; value: string }[];
       scopes: ScopeInput[];
       advanced: AdvancedGatewayInput;
-    },
-    validatedKeys: Record<string, unknown> | null,
-    customKeysProvided: boolean,
-    tx: Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0],
-  ) {
+    };
+    validatedKeys: Record<string, unknown> | null;
+    customKeysProvided: boolean;
+    tx: Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0];
+  }) {
     return await this.repository.create(
       {
         name: data.name,

--- a/platform/app/src/server/modelProviders/modelProviderDisabledError.ts
+++ b/platform/app/src/server/modelProviders/modelProviderDisabledError.ts
@@ -61,16 +61,34 @@ export class ModelProviderDisabledError extends HandledError {
    */
   public readonly cause = MODEL_PROVIDER_DISABLED_CAUSE;
 
-  constructor(
-    public readonly featureKey: string,
-    public readonly featureDisplayName: string,
-    public readonly role: ModelRole,
-    public readonly projectId: string,
-    public readonly resolvedScope: Exclude<ResolutionScope, null>,
-    public readonly resolvedModel: string,
-    public readonly providerKey: string,
-    public readonly alternate: ResolvedAlternate | null,
-  ) {
+  public readonly featureKey: string;
+  public readonly featureDisplayName: string;
+  public readonly role: ModelRole;
+  public readonly projectId: string;
+  public readonly resolvedScope: Exclude<ResolutionScope, null>;
+  public readonly resolvedModel: string;
+  public readonly providerKey: string;
+  public readonly alternate: ResolvedAlternate | null;
+
+  constructor({
+    featureKey,
+    featureDisplayName,
+    role,
+    projectId,
+    resolvedScope,
+    resolvedModel,
+    providerKey,
+    alternate,
+  }: {
+    featureKey: string;
+    featureDisplayName: string;
+    role: ModelRole;
+    projectId: string;
+    resolvedScope: Exclude<ResolutionScope, null>;
+    resolvedModel: string;
+    providerKey: string;
+    alternate: ResolvedAlternate | null;
+  }) {
     super(
       "model_provider_disabled",
       `Model "${resolvedModel}" is configured at ${resolvedScope} scope for "${featureKey}", but its provider "${providerKey}" is currently disabled.`,
@@ -89,6 +107,14 @@ export class ModelProviderDisabledError extends HandledError {
       },
     );
     this.name = "ModelProviderDisabledError";
+    this.featureKey = featureKey;
+    this.featureDisplayName = featureDisplayName;
+    this.role = role;
+    this.projectId = projectId;
+    this.resolvedScope = resolvedScope;
+    this.resolvedModel = resolvedModel;
+    this.providerKey = providerKey;
+    this.alternate = alternate;
   }
 
   /**

--- a/platform/app/src/server/modelProviders/resolveModelForFeature.ts
+++ b/platform/app/src/server/modelProviders/resolveModelForFeature.ts
@@ -279,12 +279,12 @@ export async function resolveModelForFeature(
 
   // 2. Nothing in the cascade. AI features for this role are disabled
   // until the user configures a default.
-  throw new ModelNotConfiguredError(
-    feature.key,
-    feature.role,
-    feature.displayName,
-    ctx.projectId,
-  );
+  throw new ModelNotConfiguredError({
+    featureKey: feature.key,
+    role: feature.role,
+    featureDisplayName: feature.displayName,
+    projectId: ctx.projectId,
+  });
 }
 
 /**

--- a/platform/app/src/server/modelProviders/utils.ts
+++ b/platform/app/src/server/modelProviders/utils.ts
@@ -153,26 +153,27 @@ async function resolveModel({
     );
     const feature = featureByKey(featureKey);
     const alternateProviderKey = alternate?.model.split("/")[0] ?? null;
-    throw new ModelProviderDisabledError(
+    throw new ModelProviderDisabledError({
       featureKey,
-      feature?.displayName ?? featureKey,
-      resolved.feature.role,
+      featureDisplayName: feature?.displayName ?? featureKey,
+      role: resolved.feature.role,
       projectId,
-      resolved.scope,
-      resolved.model,
+      resolvedScope: resolved.scope,
+      resolvedModel: resolved.model,
       providerKey,
-      alternate && alternate.scope !== null && alternate.scope !== "project"
-        ? {
-            scope: alternate.scope,
-            model: alternate.model,
-            providerKey: alternateProviderKey ?? "",
-            providerEnabled: Boolean(
-              alternateProviderKey &&
-                modelProviders[alternateProviderKey]?.enabled,
-            ),
-          }
-        : null,
-    );
+      alternate:
+        alternate && alternate.scope !== null && alternate.scope !== "project"
+          ? {
+              scope: alternate.scope,
+              model: alternate.model,
+              providerKey: alternateProviderKey ?? "",
+              providerEnabled: Boolean(
+                alternateProviderKey &&
+                  modelProviders[alternateProviderKey]?.enabled,
+              ),
+            }
+          : null,
+    });
   } catch (err) {
     if (err instanceof ModelNotConfiguredError) throw err;
     if (err instanceof ModelProviderDisabledError) throw err;

--- a/platform/app/src/server/prompt-config/__tests__/prompt.service.test.ts
+++ b/platform/app/src/server/prompt-config/__tests__/prompt.service.test.ts
@@ -113,12 +113,12 @@ describe("PromptService", () => {
           data: updateData,
         });
 
-        expect(mockRepository.updateConfig).toHaveBeenCalledWith(
-          "test-prompt",
-          "project-1",
-          { handle: "updated-prompt", scope: undefined },
-          { tx: mockPrisma },
-        );
+        expect(mockRepository.updateConfig).toHaveBeenCalledWith({
+          idOrHandle: "test-prompt",
+          projectId: "project-1",
+          data: { handle: "updated-prompt", scope: undefined },
+          tx: mockPrisma,
+        });
       });
 
       it("updates scope if provided", async () => {
@@ -144,12 +144,12 @@ describe("PromptService", () => {
           data: updateData,
         });
 
-        expect(mockRepository.updateConfig).toHaveBeenCalledWith(
-          "test-prompt",
-          "project-1",
-          { handle: undefined, scope: "ORGANIZATION" },
-          { tx: mockPrisma },
-        );
+        expect(mockRepository.updateConfig).toHaveBeenCalledWith({
+          idOrHandle: "test-prompt",
+          projectId: "project-1",
+          data: { handle: undefined, scope: "ORGANIZATION" },
+          tx: mockPrisma,
+        });
       });
 
       it("creates new version with provided version data", async () => {

--- a/platform/app/src/server/prompt-config/prompt.service.ts
+++ b/platform/app/src/server/prompt-config/prompt.service.ts
@@ -58,6 +58,14 @@ type ConfigData = z.infer<
   ReturnType<typeof getLatestConfigVersionSchema>
 >["configData"];
 
+/** Message shape carried by prompt update payloads. */
+type UpdateMessages =
+  | Array<{
+      role: "user" | "assistant" | "system";
+      content: string;
+    }>
+  | undefined;
+
 /**
  * Full prompt shape that combines prompt config with version data.
  * This is the complete shape that should be returned to API consumers.
@@ -747,11 +755,11 @@ export class PromptService {
       projectId,
     });
 
-    const updatedConfig = await this.repository.updateConfig(
+    const updatedConfig = await this.repository.updateConfig({
       idOrHandle,
       projectId,
       data,
-    );
+    });
 
     // Get the latest version to return complete prompt
     const latestVersionRaw = await this.repository.versions.getLatestVersion(
@@ -841,27 +849,23 @@ export class PromptService {
     ) {
       const normalizedUpdate = this.normalizeSystemMessage(configDataUpdates);
       configDataUpdates.prompt = normalizedUpdate.prompt;
-      configDataUpdates.messages = normalizedUpdate.messages as unknown as
-        | Array<{
-            role: "user" | "assistant" | "system";
-            content: string;
-          }>
-        | undefined;
+      configDataUpdates.messages =
+        normalizedUpdate.messages as unknown as UpdateMessages;
     }
 
     // Handle in a transaction to ensure atomicity
     const result = await this.prisma.$transaction(
       async (tx: Prisma.TransactionClient) => {
         // Update the config metadata (handle/scope)
-        const updatedConfig = await this.repository.updateConfig(
+        const updatedConfig = await this.repository.updateConfig({
           idOrHandle,
           projectId,
-          {
+          data: {
             handle,
             scope,
           },
-          { tx },
-        );
+          tx,
+        });
 
         // Get the latest version
         // TODO: This should use the version service instead of accessing the repository directly

--- a/platform/app/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/platform/app/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -306,15 +306,17 @@ export class LlmConfigRepository {
   /**
    * Update an LLM config's metadata (name only)
    */
-  async updateConfig(
-    idOrHandle: string,
-    projectId: string,
-    data: Partial<CreateLlmConfigParams>,
-    options?: {
-      tx?: Prisma.TransactionClient;
-    },
-  ): Promise<LlmPromptConfig> {
-    const { tx } = options ?? {};
+  async updateConfig({
+    idOrHandle,
+    projectId,
+    data,
+    tx,
+  }: {
+    idOrHandle: string;
+    projectId: string;
+    data: Partial<CreateLlmConfigParams>;
+    tx?: Prisma.TransactionClient;
+  }): Promise<LlmPromptConfig> {
     const client = tx ?? this.prisma;
     // Get organizationId first using the proper approach
     const project = await client.project.findUnique({

--- a/platform/app/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
@@ -209,12 +209,12 @@ describe("legacy GET /api/trace/:id (singular)", () => {
       // with THREE args; it must pass { full: true } as the fourth arg.
       await makeRequest({ traceId: "trace-abc", query: { format: "json" } });
 
-      expect(mockGetById).toHaveBeenCalledWith(
-        "project-123",
-        "trace-abc",
-        expect.any(Object),
-        { full: true },
-      );
+      expect(mockGetById).toHaveBeenCalledWith({
+        projectId: "project-123",
+        traceId: "trace-abc",
+        protections: expect.any(Object),
+        opts: { full: true },
+      });
     });
 
     it("returns 200 with the trace json", async () => {

--- a/platform/app/src/server/routes/experiments-v3.ts
+++ b/platform/app/src/server/routes/experiments-v3.ts
@@ -251,17 +251,17 @@ secured.access(sessionAuth).post(
       );
     }
 
-    const dataResult = await loadExecutionData(
+    const dataResult = await loadExecutionData({
       projectId,
-      request.dataset,
-      request.targets,
-      request.evaluators,
-      {
+      dataset: request.dataset,
+      targets: request.targets,
+      evaluators: request.evaluators,
+      inputs: {
         data: request.data,
         datasetId: request.dataset_id,
         parameters: request.parameters,
       },
-    );
+    });
 
     if ("error" in dataResult) {
       return c.json(
@@ -588,17 +588,17 @@ secured.access(apiKeyAuthRun).post(
     }
     const runInputs = inputsParse.data;
 
-    const dataResult = await loadExecutionData(
-      project.id,
+    const dataResult = await loadExecutionData({
+      projectId: project.id,
       dataset,
-      workbenchState.targets,
-      workbenchState.evaluators,
-      {
+      targets: workbenchState.targets,
+      evaluators: workbenchState.evaluators,
+      inputs: {
         data: runInputs.data,
         datasetId: runInputs.dataset_id,
         parameters: runInputs.parameters,
       },
-    );
+    });
 
     if ("error" in dataResult) {
       return c.json(

--- a/platform/app/src/server/routes/gateway-internal.ts
+++ b/platform/app/src/server/routes/gateway-internal.ts
@@ -151,12 +151,17 @@ export function computeGatewaySignature(
  * logger. Includes the gateway node ID when present so multi-node
  * deployments can correlate which gateway sent the bad request.
  */
-function logAuthDecision(
-  c: Context,
-  code: string,
-  status: number,
-  detail?: Record<string, unknown>,
-): void {
+function logAuthDecision({
+  c,
+  code,
+  status,
+  detail,
+}: {
+  c: Context;
+  code: string;
+  status: number;
+  detail?: Record<string, unknown>;
+}): void {
   logger.warn(
     {
       code,
@@ -173,7 +178,11 @@ async function verifyGatewaySignature(c: Context, next: Next) {
   const secret =
     process.env.LW_GATEWAY_INTERNAL_SECRET ?? env.LW_GATEWAY_INTERNAL_SECRET;
   if (!secret) {
-    logAuthDecision(c, "gateway_internal_secret_missing", 500);
+    logAuthDecision({
+      c,
+      code: "gateway_internal_secret_missing",
+      status: 500,
+    });
     return c.json(
       {
         error: {
@@ -189,9 +198,14 @@ async function verifyGatewaySignature(c: Context, next: Next) {
   const presentedSig = c.req.header("X-LangWatch-Gateway-Signature");
   const presentedTs = c.req.header("X-LangWatch-Gateway-Timestamp");
   if (!presentedSig || !presentedTs) {
-    logAuthDecision(c, "missing_signature", 401, {
-      hasSignature: Boolean(presentedSig),
-      hasTimestamp: Boolean(presentedTs),
+    logAuthDecision({
+      c,
+      code: "missing_signature",
+      status: 401,
+      detail: {
+        hasSignature: Boolean(presentedSig),
+        hasTimestamp: Boolean(presentedTs),
+      },
     });
     return c.json(
       {
@@ -219,7 +233,7 @@ async function verifyGatewaySignature(c: Context, next: Next) {
   const a = Buffer.from(expected);
   const b = Buffer.from(presentedSig);
   if (a.length !== b.length || !timingSafeEqual(a, b)) {
-    logAuthDecision(c, "invalid_signature", 401);
+    logAuthDecision({ c, code: "invalid_signature", status: 401 });
     return c.json(
       {
         error: {
@@ -234,7 +248,12 @@ async function verifyGatewaySignature(c: Context, next: Next) {
 
   const ts = Number.parseInt(presentedTs, 10);
   if (!Number.isFinite(ts)) {
-    logAuthDecision(c, "invalid_timestamp", 401, { presentedTs });
+    logAuthDecision({
+      c,
+      code: "invalid_timestamp",
+      status: 401,
+      detail: { presentedTs },
+    });
     return c.json(
       {
         error: {
@@ -248,8 +267,11 @@ async function verifyGatewaySignature(c: Context, next: Next) {
   }
   const now = Math.floor(Date.now() / 1000);
   if (Math.abs(now - ts) > GATEWAY_SIGNATURE_WINDOW_SECONDS) {
-    logAuthDecision(c, "timestamp_out_of_window", 401, {
-      driftSeconds: now - ts,
+    logAuthDecision({
+      c,
+      code: "timestamp_out_of_window",
+      status: 401,
+      detail: { driftSeconds: now - ts },
     });
     return c.json(
       {
@@ -387,7 +409,11 @@ secured.access(gatewayPolicy()).post("/resolve-key", async (c) => {
 
   const parseRejection = virtualKeyParseRejection(presented);
   if (parseRejection) {
-    logAuthDecision(c, parseRejection.code, parseRejection.status);
+    logAuthDecision({
+      c,
+      code: parseRejection.code,
+      status: parseRejection.status,
+    });
     return c.json(rejectionBody(parseRejection), parseRejection.status);
   }
 
@@ -396,7 +422,7 @@ secured.access(gatewayPolicy()).post("/resolve-key", async (c) => {
     hashVirtualKeySecret(presented),
   );
   if (!vk) {
-    logAuthDecision(c, "virtual_key_not_found", 401);
+    logAuthDecision({ c, code: "virtual_key_not_found", status: 401 });
     return c.json(
       {
         error: {
@@ -410,8 +436,11 @@ secured.access(gatewayPolicy()).post("/resolve-key", async (c) => {
   }
   const statusRejection = virtualKeyStatusRejection(vk.status);
   if (statusRejection) {
-    logAuthDecision(c, statusRejection.code, statusRejection.status, {
-      vkId: vk.id,
+    logAuthDecision({
+      c,
+      code: statusRejection.code,
+      status: statusRejection.status,
+      detail: { vkId: vk.id },
     });
     return c.json(rejectionBody(statusRejection), statusRejection.status);
   }

--- a/platform/app/src/server/routes/github-langy.ts
+++ b/platform/app/src/server/routes/github-langy.ts
@@ -141,13 +141,18 @@ function popupHtml(
 }
 
 // Render the setup error path consistently across popup and redirect modes.
-function setupError(
+function setupError({
+  c,
+  state,
+  errorMessage,
+  status,
+}: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  c: any,
-  state: GithubOauthStatePayload | null,
-  errorMessage: string,
-  status: number,
-): Response {
+  c: any;
+  state: GithubOauthStatePayload | null;
+  errorMessage: string;
+  status: number;
+}): Response {
   if (state && state.mode === "redirect") {
     const returnTo = safeReturnTo(state.returnTo);
     return c.redirect(withGithubError(returnTo, errorMessage), 302);
@@ -262,7 +267,12 @@ secured
     const state = verifyState(c.req.query("state") ?? null);
     const installationId = c.req.query("installation_id");
     if (!state || !installationId) {
-      return setupError(c, state, "Invalid state or missing installation", 400);
+      return setupError({
+        c,
+        state,
+        errorMessage: "Invalid state or missing installation",
+        status: 400,
+      });
     }
 
     // Re-bind the session to the state's user.
@@ -270,14 +280,24 @@ secured
       req: c.req.raw as NextRequestShim,
     });
     if (!session?.user || session.user.id !== state.userId) {
-      return setupError(c, state, "Session changed mid-flow", 401);
+      return setupError({
+        c,
+        state,
+        errorMessage: "Session changed mid-flow",
+        status: 401,
+      });
     }
 
     // Burn the single-use nonce (skips when Redis was down at /install).
     if (state.nonceRegistered) {
       const consumed = await consumeGithubInstallNonce(state.nonce);
       if (consumed === false) {
-        return setupError(c, state, "Installation link already used", 401);
+        return setupError({
+          c,
+          state,
+          errorMessage: "Installation link already used",
+          status: 401,
+        });
       }
     }
 
@@ -288,7 +308,12 @@ secured
         organizationId: state.organizationId,
       }))
     ) {
-      return setupError(c, state, "Not a member of this organization", 403);
+      return setupError({
+        c,
+        state,
+        errorMessage: "Not a member of this organization",
+        status: 403,
+      });
     }
 
     // Re-check the connect permission too: the caller's role may have been
@@ -301,7 +326,7 @@ secured
         "langy:manage",
       ))
     ) {
-      return setupError(c, state, "Forbidden", 403);
+      return setupError({ c, state, errorMessage: "Forbidden", status: 403 });
     }
 
     // Re-check the Langy gate before persisting anything. The install may have
@@ -315,12 +340,12 @@ secured
         organizationId: state.organizationId,
       }))
     ) {
-      return setupError(
+      return setupError({
         c,
         state,
-        "The GitHub integration is not enabled for this account.",
-        404,
-      );
+        errorMessage: "The GitHub integration is not enabled for this account.",
+        status: 404,
+      });
     }
 
     const returnTo = safeReturnTo(state.returnTo);

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -335,24 +335,24 @@ secured
         const userId = `user_${nanoid()}`;
         const userInput = (await getInitialMessage()) ?? "";
 
-        const assistantResponse = await firstChatMessage(
+        const assistantResponse = await firstChatMessage({
           userInput,
           threadId,
           userId,
-          authToken as string,
-        );
+          authToken: authToken as string,
+        });
         const expectedUserResponse = await userResponse(
           userInput,
           assistantResponse ?? "",
         );
-        await secondChatMessage(
+        await secondChatMessage({
           userInput,
-          assistantResponse ?? "",
-          expectedUserResponse ?? "",
+          assistantResponse: assistantResponse ?? "",
+          expectedUserResponse: expectedUserResponse ?? "",
           threadId,
           userId,
-          authToken as string,
-        );
+          authToken: authToken as string,
+        });
 
         return c.json({ message: "Sent to LangWatch" });
       } catch (error: any) {
@@ -1620,15 +1620,23 @@ const processDSPyStep = async (project: Project, param: DSPyStepRESTParams) => {
 
 // --- Hotel bot helpers ---
 
-const langwatchAPI = async (
-  completion: any,
-  input: string,
-  authToken: string,
-  threadId: string,
-  userId: string,
-  type?: string,
-  contexts: string[] = [],
-) => {
+const langwatchAPI = async ({
+  completion,
+  input,
+  authToken,
+  threadId,
+  userId,
+  type,
+  contexts = [],
+}: {
+  completion: any;
+  input: string;
+  authToken: string;
+  threadId: string;
+  userId: string;
+  type?: string;
+  contexts?: string[];
+}) => {
   try {
     const contentPrefixId = Math.round(Math.random());
     const ragTime = Math.round(Math.random() * 300);
@@ -1764,24 +1772,29 @@ const ragMessage = async (authToken: string) => {
     )
   ).map((c) => c.choices[0]!.message.content ?? "");
 
-  await langwatchAPI(
+  await langwatchAPI({
     completion,
-    userInput,
+    input: userInput,
     authToken,
     threadId,
     userId,
-    "rag",
-    completions,
-  );
+    type: "rag",
+    contexts: completions,
+  });
   return completion.choices[0]!.message.content;
 };
 
-const firstChatMessage = async (
-  userInput: string,
-  threadId: string,
-  userId: string,
-  authToken: string,
-) => {
+const firstChatMessage = async ({
+  userInput,
+  threadId,
+  userId,
+  authToken,
+}: {
+  userInput: string;
+  threadId: string;
+  userId: string;
+  authToken: string;
+}) => {
   const completion = await hotelBotOpenai.chat.completions.create({
     messages: [
       { role: "system", content: HOTEL_SYSTEM_PROMPT },
@@ -1789,18 +1802,31 @@ const firstChatMessage = async (
     ],
     model: "gpt-3.5-turbo",
   });
-  await langwatchAPI(completion, userInput ?? "", authToken, threadId, userId);
+  await langwatchAPI({
+    completion,
+    input: userInput ?? "",
+    authToken,
+    threadId,
+    userId,
+  });
   return completion.choices[0]!.message.content;
 };
 
-const secondChatMessage = async (
-  userInput: string,
-  assistantResponse: string,
-  expectedUserResponse: string,
-  threadId: string,
-  userId: string,
-  authToken: string,
-) => {
+const secondChatMessage = async ({
+  userInput,
+  assistantResponse,
+  expectedUserResponse,
+  threadId,
+  userId,
+  authToken,
+}: {
+  userInput: string;
+  assistantResponse: string;
+  expectedUserResponse: string;
+  threadId: string;
+  userId: string;
+  authToken: string;
+}) => {
   const completion = await hotelBotOpenai.chat.completions.create({
     messages: [
       { role: "system", content: HOTEL_SYSTEM_PROMPT },
@@ -1810,13 +1836,13 @@ const secondChatMessage = async (
     ],
     model: "gpt-3.5-turbo",
   });
-  await langwatchAPI(
+  await langwatchAPI({
     completion,
-    expectedUserResponse ?? "",
+    input: expectedUserResponse ?? "",
     authToken,
     threadId,
     userId,
-  );
+  });
   return completion.choices[0]!.message.content;
 };
 

--- a/platform/app/src/server/routes/traces-legacy.ts
+++ b/platform/app/src/server/routes/traces-legacy.ts
@@ -128,8 +128,11 @@ secured.access(tracesViewAuth).get("/trace/:id", async (c) => {
       prisma,
       buildTraceBlobResolutionDeps(),
     );
-    const trace = await traceService.getById(project.id, traceId, protections, {
-      full: true,
+    const trace = await traceService.getById({
+      projectId: project.id,
+      traceId,
+      protections,
+      opts: { full: true },
     });
     if (!trace) {
       return c.json({ message: "Trace not found." }, 404);
@@ -347,12 +350,12 @@ secured.access(tracesViewAuth).get("/thread/:id", async (c) => {
     prisma,
     buildTraceBlobResolutionDeps(),
   );
-  const traces = await traceService.getTracesByThreadId(
-    project.id,
+  const traces = await traceService.getTracesByThreadId({
+    projectId: project.id,
     threadId,
     protections,
-    { full: true },
-  );
+    opts: { full: true },
+  });
 
   markUsed();
   return c.json({ traces });

--- a/platform/app/src/server/scenarios/adapters/http-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/adapters/http-agent.adapter.ts
@@ -101,12 +101,12 @@ export class HttpAgentAdapter extends AgentAdapter {
         input,
         templateContext,
       );
-      const responseData = await this.executeHttpRequest(
+      const responseData = await this.executeHttpRequest({
         url,
-        config.method,
+        method: config.method,
         headers,
         body,
-      );
+      });
       const result = this.extractResponseContent(
         responseData,
         config.outputPath,
@@ -197,12 +197,17 @@ export class HttpAgentAdapter extends AgentAdapter {
     Object.assign(headers, applyAuthentication(auth));
   }
 
-  private async executeHttpRequest(
-    url: string,
-    method: HttpComponentConfig["method"],
-    headers: Record<string, string>,
-    body: string,
-  ): Promise<unknown> {
+  private async executeHttpRequest({
+    url,
+    method,
+    headers,
+    body,
+  }: {
+    url: string;
+    method: HttpComponentConfig["method"];
+    headers: Record<string, string>;
+    body: string;
+  }): Promise<unknown> {
     logger.debug({ origin: safeOrigin(url), method }, "Making HTTP request");
 
     const response = await ssrfSafeFetch(url, {

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -463,12 +463,12 @@ async function fetchAgentData(
     );
   }
   if (target.type === "code") {
-    return fetchCodeAgentData(
+    return fetchCodeAgentData({
       projectId,
-      target.referenceId,
-      deps.agentFetcher,
-      deps.projectSecretsFetcher,
-    );
+      agentId: target.referenceId,
+      fetcher: deps.agentFetcher,
+      projectSecretsFetcher: deps.projectSecretsFetcher,
+    });
   }
   if (target.type === "workflow") {
     return fetchWorkflowAgentData({
@@ -581,12 +581,17 @@ const RawCodeAgentConfigSchema = z.object({
   scenarioOutputField: z.string().optional(),
 });
 
-async function fetchCodeAgentData(
-  projectId: string,
-  agentId: string,
-  fetcher: AgentFetcher,
-  projectSecretsFetcher: ProjectSecretsFetcher,
-): Promise<CodeAgentData | null> {
+async function fetchCodeAgentData({
+  projectId,
+  agentId,
+  fetcher,
+  projectSecretsFetcher,
+}: {
+  projectId: string;
+  agentId: string;
+  fetcher: AgentFetcher;
+  projectSecretsFetcher: ProjectSecretsFetcher;
+}): Promise<CodeAgentData | null> {
   const agent = await fetcher.findById({ projectId, id: agentId });
   if (agent?.type !== "code") return null;
 

--- a/platform/app/src/server/scenarios/execution/orchestrator.ts
+++ b/platform/app/src/server/scenarios/execution/orchestrator.ts
@@ -87,13 +87,16 @@ export class ScenarioExecutionOrchestrator {
 
       tracerHandle = this.createTracer(project.apiKey, scenario.id, context);
 
-      return await this.runScenario(
+      return await this.runScenario({
         scenario,
-        adapterResult.adapter,
-        modelParamsResult.params,
-        context.batchRunId,
-        { endpoint: this.deps.telemetryEndpoint, apiKey: project.apiKey },
-      );
+        adapter: adapterResult.adapter,
+        modelParams: modelParamsResult.params,
+        batchRunId: context.batchRunId,
+        telemetry: {
+          endpoint: this.deps.telemetryEndpoint,
+          apiKey: project.apiKey,
+        },
+      });
     } catch (error) {
       logger.error({ error, context }, "Scenario execution failed");
       return this.failure(
@@ -155,13 +158,19 @@ export class ScenarioExecutionOrchestrator {
     });
   }
 
-  private async runScenario(
-    scenario: ScenarioConfig,
-    adapter: Parameters<typeof this.deps.scenarioExecutor.run>[1],
-    modelParams: LiteLLMParams,
-    batchRunId: string,
-    telemetry: { endpoint: string; apiKey: string },
-  ) {
+  private async runScenario({
+    scenario,
+    adapter,
+    modelParams,
+    batchRunId,
+    telemetry,
+  }: {
+    scenario: ScenarioConfig;
+    adapter: Parameters<typeof this.deps.scenarioExecutor.run>[1];
+    modelParams: LiteLLMParams;
+    batchRunId: string;
+    telemetry: { endpoint: string; apiKey: string };
+  }) {
     return this.deps.scenarioExecutor.run(
       scenario,
       adapter,

--- a/platform/app/src/server/scenarios/scenario.processor.ts
+++ b/platform/app/src/server/scenarios/scenario.processor.ts
@@ -412,12 +412,12 @@ export async function executeScenarioRun(
     };
 
     const childStartTime = Date.now();
-    const result = await spawnScenarioChildProcess(
+    const result = await spawnScenarioChildProcess({
       jobData,
       childProcessData,
-      prefetchResult.telemetry,
+      telemetry: prefetchResult.telemetry,
       pool,
-    );
+    });
 
     const totalDurationMs = Date.now() - startTime;
     const childDurationMs = Date.now() - childStartTime;
@@ -451,12 +451,17 @@ export async function executeScenarioRun(
 /**
  * Spawn a child process to execute the scenario with isolated OTEL context.
  */
-async function spawnScenarioChildProcess(
-  jobData: ExecutionJobData,
-  childProcessData: ChildProcessJobData,
-  telemetry: { endpoint: string; apiKey: string },
-  pool: ScenarioExecutionPool,
-): Promise<ScenarioExecutionResult> {
+async function spawnScenarioChildProcess({
+  jobData,
+  childProcessData,
+  telemetry,
+  pool,
+}: {
+  jobData: ExecutionJobData;
+  childProcessData: ChildProcessJobData;
+  telemetry: { endpoint: string; apiKey: string };
+  pool: ScenarioExecutionPool;
+}): Promise<ScenarioExecutionResult> {
   return new Promise((resolve) => {
     const { scenarioId, projectId, batchRunId, setId } = jobData;
     const childLogger = logger.child({

--- a/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
@@ -97,12 +97,17 @@ function sha256Of(bytes: Buffer): string {
   return crypto.createHash("sha256").update(bytes).digest("hex");
 }
 
-async function waitForRow(
-  client: ClickHouseClient,
-  projectId: string,
-  id: string,
+async function waitForRow({
+  client,
+  projectId,
+  id,
   timeoutMs = 10_000,
-): Promise<boolean> {
+}: {
+  client: ClickHouseClient;
+  projectId: string;
+  id: string;
+  timeoutMs?: number;
+}): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const result = await client.query({
@@ -276,7 +281,9 @@ describe("StoredObjectsService against a real Azurite emulator", () => {
         bytes,
       });
 
-      expect(await waitForRow(ch, PROJECT, stored.id)).toBe(true);
+      expect(
+        await waitForRow({ client: ch, projectId: PROJECT, id: stored.id }),
+      ).toBe(true);
 
       const result = await service.getById({
         projectId: PROJECT,

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
@@ -137,12 +137,17 @@ function sha256Of(bytes: Buffer): string {
  * immediately but the data may not be visible to SELECT for a brief window.
  * Polling with a short backoff is the standard test pattern for this.
  */
-async function waitForRow(
-  client: ClickHouseClient,
-  projectId: string,
-  id: string,
+async function waitForRow({
+  client,
+  projectId,
+  id,
   timeoutMs = 10_000,
-): Promise<boolean> {
+}: {
+  client: ClickHouseClient;
+  projectId: string;
+  id: string;
+  timeoutMs?: number;
+}): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const result = await client.query({
@@ -256,7 +261,11 @@ describe("StoredObjectsService (ingest + read path)", () => {
           expect(result.id).toBeTruthy();
           expect(result.isDuplicate).toBe(false);
 
-          const found = await waitForRow(ch, PROJECT_A, result.id);
+          const found = await waitForRow({
+            client: ch,
+            projectId: PROJECT_A,
+            id: result.id,
+          });
           expect(found).toBe(true);
         });
       });
@@ -285,7 +294,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
           // deterministic UUID v5 of (project_id, sha256) — both inserts
           // produce the same row key and RMT collapses them. In this test
           // we want to observe the dedup-hit branch explicitly.
-          await waitForRow(ch, PROJECT_A, first.id);
+          await waitForRow({ client: ch, projectId: PROJECT_A, id: first.id });
 
           const second = await service.storeFromBytes({
             projectId: PROJECT_A,
@@ -300,7 +309,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
           expect(second.isDuplicate).toBe(true);
 
           // Only one row should exist for this sha256 + project
-          await waitForRow(ch, PROJECT_A, first.id);
+          await waitForRow({ client: ch, projectId: PROJECT_A, id: first.id });
           const result = await ch.query({
             query: `SELECT count() AS cnt FROM stored_objects WHERE project_id = {projectId:String} AND sha256 = {sha256:String}`,
             query_params: { projectId: PROJECT_A, sha256: sha256Of(bytes) },
@@ -346,8 +355,8 @@ describe("StoredObjectsService (ingest + read path)", () => {
           expect(resultB.isDuplicate).toBe(false);
 
           await Promise.all([
-            waitForRow(ch, PROJECT_A, resultA.id),
-            waitForRow(ch, PROJECT_B, resultB.id),
+            waitForRow({ client: ch, projectId: PROJECT_A, id: resultA.id }),
+            waitForRow({ client: ch, projectId: PROJECT_B, id: resultB.id }),
           ]);
 
           // Each row belongs to its respective project
@@ -388,7 +397,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
             bytes,
           });
 
-          await waitForRow(ch, PROJECT_A, id);
+          await waitForRow({ client: ch, projectId: PROJECT_A, id });
 
           const result = await service.getById({ projectId: PROJECT_A, id });
 
@@ -424,7 +433,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
             bytes,
           });
 
-          await waitForRow(ch, PROJECT_A, id);
+          await waitForRow({ client: ch, projectId: PROJECT_A, id });
 
           // Delete the file from storage so the next GET gets an ENOENT
           const sha256 = sha256Of(bytes);
@@ -478,7 +487,9 @@ describe("StoredObjectsService (ingest + read path)", () => {
           // Assert the row is visible before reading — a bare await would let
           // a CH async-insert timeout (waitForRow → false) pass silently and
           // flake the cross-tenant assertion below.
-          expect(await waitForRow(ch, PROJECT_A, id)).toBe(true);
+          expect(
+            await waitForRow({ client: ch, projectId: PROJECT_A, id }),
+          ).toBe(true);
 
           // Project B scoping the read by A's object id finds nothing: the CH
           // query is `WHERE project_id = B AND id = ...`, which prunes to B's
@@ -526,7 +537,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
           mediaType: "text/plain",
           bytes,
         });
-        await waitForRow(ch, PROJECT_A, stored.id);
+        await waitForRow({ client: ch, projectId: PROJECT_A, id: stored.id });
 
         // Read path: a span must be recorded
         await service.getById({ projectId: PROJECT_A, id: stored.id });
@@ -563,7 +574,7 @@ describe("StoredObjectsService (ingest + read path)", () => {
             bytes,
           });
 
-          await waitForRow(ch, PROJECT_A, id);
+          await waitForRow({ client: ch, projectId: PROJECT_A, id });
 
           const result = await ch.query({
             query: `SELECT project_id, storage_uri FROM stored_objects WHERE id = {id:String} LIMIT 1`,
@@ -612,8 +623,16 @@ describe("StoredObjectsService (ingest + read path)", () => {
             bytes: makeBytes(`cascade-bytes-2-${nanoid(6)}`),
           });
 
-          await waitForRow(ch, cascadeProj, stored1.id);
-          await waitForRow(ch, cascadeProj, stored2.id);
+          await waitForRow({
+            client: ch,
+            projectId: cascadeProj,
+            id: stored1.id,
+          });
+          await waitForRow({
+            client: ch,
+            projectId: cascadeProj,
+            id: stored2.id,
+          });
 
           // Sanity: both files are readable before the cascade runs.
           const before1 = await service.getById({

--- a/platform/app/src/server/stored-objects/azure-blob-driver.ts
+++ b/platform/app/src/server/stored-objects/azure-blob-driver.ts
@@ -120,12 +120,17 @@ function isPathStyleEndpoint(
  * rejects with a 403 AuthenticationFailed — no test hits this path unless
  * it asserts the actual signed bytes, not just the header's prefix.
  */
-function canonicalisedResource(
-  accountName: string,
-  container: string,
-  blobPath: string,
-  pathStyle: boolean,
-): string {
+function canonicalisedResource({
+  accountName,
+  container,
+  blobPath,
+  pathStyle,
+}: {
+  accountName: string;
+  container: string;
+  blobPath: string;
+  pathStyle: boolean;
+}): string {
   // A blank blobPath addresses the CONTAINER itself (e.g. container-create),
   // not a blob under it — omit the trailing "/" so the resource path reads
   // `/{account}/{container}`, not `/{account}/{container}/`.
@@ -221,7 +226,7 @@ function signRequest({
     "", // Range
     canonicalisedHeaders(xMsHeaders),
     withCanonicalisedQuery(
-      canonicalisedResource(accountName, container, blobPath, pathStyle),
+      canonicalisedResource({ accountName, container, blobPath, pathStyle }),
       queryParams,
     ),
   ].join("\n");

--- a/platform/app/src/server/stored-objects/value-media-extractor.ts
+++ b/platform/app/src/server/stored-objects/value-media-extractor.ts
@@ -163,12 +163,17 @@ function isBareDataUri(value: string): boolean {
   );
 }
 
-function collectCandidates(
-  value: unknown,
-  depth: number,
-  path: PathSeg[],
-  sites: CandidateSite[],
-): void {
+function collectCandidates({
+  value,
+  depth,
+  path,
+  sites,
+}: {
+  value: unknown;
+  depth: number;
+  path: PathSeg[];
+  sites: CandidateSite[];
+}): void {
   if (value == null || depth > MAX_MEDIA_WALK_DEPTH) return;
 
   if (typeof value === "string") {
@@ -190,13 +195,23 @@ function collectCandidates(
       return;
     }
     if (typeof parsed !== "object" || parsed === null) return;
-    collectCandidates(parsed, depth + 1, [...path, { json: true }], sites);
+    collectCandidates({
+      value: parsed,
+      depth: depth + 1,
+      path: [...path, { json: true }],
+      sites,
+    });
     return;
   }
 
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      collectCandidates(value[i], depth + 1, [...path, { index: i }], sites);
+      collectCandidates({
+        value: value[i],
+        depth: depth + 1,
+        path: [...path, { index: i }],
+        sites,
+      });
     }
     return;
   }
@@ -210,7 +225,12 @@ function collectCandidates(
     }
     const obj = value as Record<string, unknown>;
     for (const key of Object.keys(obj)) {
-      collectCandidates(obj[key], depth + 1, [...path, { key }], sites);
+      collectCandidates({
+        value: obj[key],
+        depth: depth + 1,
+        path: [...path, { key }],
+        sites,
+      });
     }
   }
 }
@@ -267,12 +287,17 @@ async function processSite(
   return { ...site, replacement: part };
 }
 
-async function storeCandidates(
-  sites: CandidateSite[],
-  params: WalkParams,
-  budget: ExtractionBudget,
-  refs: ExtractedRef[],
-): Promise<StoredSite[]> {
+async function storeCandidates({
+  sites,
+  params,
+  budget,
+  refs,
+}: {
+  sites: CandidateSite[];
+  params: WalkParams;
+  budget: ExtractionBudget;
+  refs: ExtractedRef[];
+}): Promise<StoredSite[]> {
   let takeable = sites;
   if (sites.length > budget.remainingParts) {
     budget.droppedByCap += sites.length - budget.remainingParts;
@@ -396,16 +421,16 @@ export async function extractInlineMediaFromValue({
   refs: ExtractedRef[];
 }> {
   const sites: CandidateSite[] = [];
-  collectCandidates(value, 0, [], sites);
+  collectCandidates({ value, depth: 0, path: [], sites });
   if (sites.length === 0) return { value, refs: [] };
 
   const refs: ExtractedRef[] = [];
-  const stored = await storeCandidates(
+  const stored = await storeCandidates({
     sites,
-    { projectId, purpose, ownerKind, ownerId, service },
-    budget ?? createExtractionBudget(),
+    params: { projectId, purpose, ownerKind, ownerId, service },
+    budget: budget ?? createExtractionBudget(),
     refs,
-  );
+  });
   if (stored.length === 0) return { value, refs };
 
   return { value: rebuild(value, stored, 0), refs };

--- a/platform/app/src/server/suites/__tests__/suite.service.unit.test.ts
+++ b/platform/app/src/server/suites/__tests__/suite.service.unit.test.ts
@@ -138,13 +138,13 @@ function createService(overrides?: {
   );
   const suiteRunService = createMockSuiteRunService();
 
-  const service = new SuiteService(
-    suiteRepo as unknown as SuiteRepository,
-    scenarioRepo as unknown as ScenarioRepository,
-    agentRepo as unknown as AgentRepository,
-    llmConfigRepo as unknown as LlmConfigRepository,
+  const service = new SuiteService({
+    repository: suiteRepo as unknown as SuiteRepository,
+    scenarioRepository: scenarioRepo as unknown as ScenarioRepository,
+    agentRepository: agentRepo as unknown as AgentRepository,
+    llmConfigRepository: llmConfigRepo as unknown as LlmConfigRepository,
     suiteRunService,
-  );
+  });
 
   return {
     service,

--- a/platform/app/src/server/suites/suite.service.ts
+++ b/platform/app/src/server/suites/suite.service.ts
@@ -58,13 +58,31 @@ type ResolvedTargetReferences = {
 };
 
 export class SuiteService {
-  constructor(
-    private readonly repository: SuiteRepository,
-    private readonly scenarioRepository: ScenarioRepository,
-    private readonly agentRepository: AgentRepository,
-    private readonly llmConfigRepository: LlmConfigRepository,
-    private readonly suiteRunService: SuiteRunService,
-  ) {}
+  private readonly repository: SuiteRepository;
+  private readonly scenarioRepository: ScenarioRepository;
+  private readonly agentRepository: AgentRepository;
+  private readonly llmConfigRepository: LlmConfigRepository;
+  private readonly suiteRunService: SuiteRunService;
+
+  constructor({
+    repository,
+    scenarioRepository,
+    agentRepository,
+    llmConfigRepository,
+    suiteRunService,
+  }: {
+    repository: SuiteRepository;
+    scenarioRepository: ScenarioRepository;
+    agentRepository: AgentRepository;
+    llmConfigRepository: LlmConfigRepository;
+    suiteRunService: SuiteRunService;
+  }) {
+    this.repository = repository;
+    this.scenarioRepository = scenarioRepository;
+    this.agentRepository = agentRepository;
+    this.llmConfigRepository = llmConfigRepository;
+    this.suiteRunService = suiteRunService;
+  }
 
   /**
    * Static factory method for creating a SuiteService with proper DI.
@@ -73,13 +91,13 @@ export class SuiteService {
     prisma: PrismaClient;
     suiteRunService: SuiteRunService;
   }): SuiteService {
-    return new SuiteService(
-      new SuiteRepository(params.prisma),
-      new ScenarioRepository(params.prisma),
-      new AgentRepository(params.prisma),
-      new LlmConfigRepository(params.prisma),
-      params.suiteRunService,
-    );
+    return new SuiteService({
+      repository: new SuiteRepository(params.prisma),
+      scenarioRepository: new ScenarioRepository(params.prisma),
+      agentRepository: new AgentRepository(params.prisma),
+      llmConfigRepository: new LlmConfigRepository(params.prisma),
+      suiteRunService: params.suiteRunService,
+    });
   }
 
   async create(

--- a/platform/app/src/server/teams/team.service.ts
+++ b/platform/app/src/server/teams/team.service.ts
@@ -91,12 +91,17 @@ async function computeEffectiveAdminUserIds(
   return userIds;
 }
 
-async function isUserAdminViaGroup(
-  tx: TxClient,
-  organizationId: string,
-  teamId: string,
-  userId: string,
-): Promise<boolean> {
+async function isUserAdminViaGroup({
+  tx,
+  organizationId,
+  teamId,
+  userId,
+}: {
+  tx: TxClient;
+  organizationId: string;
+  teamId: string;
+  userId: string;
+}): Promise<boolean> {
   const adminGroupBindings = await tx.roleBinding.findMany({
     where: {
       organizationId,
@@ -667,12 +672,12 @@ export class TeamService {
         // Project the post-removal admin set. Removing the target's direct
         // binding only changes things if they aren't also an admin via a
         // group membership on this team.
-        const targetStillAdminViaGroup = await isUserAdminViaGroup(
+        const targetStillAdminViaGroup = await isUserAdminViaGroup({
           tx,
-          team.organizationId,
+          organizationId: team.organizationId,
           teamId,
           userId,
-        );
+        });
         const projectedAdminUserIds = new Set(effectiveAdminUserIds);
         if (!targetStillAdminViaGroup) {
           projectedAdminUserIds.delete(userId);

--- a/platform/app/src/server/tracer/__tests__/tracesMapping.test.ts
+++ b/platform/app/src/server/tracer/__tests__/tracesMapping.test.ts
@@ -178,13 +178,21 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   };
 
   it("returns all spans when key is empty", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(mockTrace as any, "", "");
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "",
+      subkey: "",
+    });
 
     expect(result).toHaveLength(2);
   });
 
   it("returns all spans when key is * (any span wildcard)", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(mockTrace as any, "*", "");
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "*",
+      subkey: "",
+    });
 
     expect(result).toHaveLength(2);
     expect(result).toEqual(
@@ -196,11 +204,11 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 
   it("filters spans by specific name", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(
-      mockTrace as any,
-      "openai/gpt-4",
-      "",
-    );
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "openai/gpt-4",
+      subkey: "",
+    });
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(
@@ -209,7 +217,11 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 
   it("returns input field from all spans when key is * and subkey is input", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(mockTrace as any, "*", "input");
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "*",
+      subkey: "input",
+    });
 
     expect(result).toHaveLength(2);
     // input field is an object with { type, value }
@@ -220,7 +232,11 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 
   it("returns full span objects when key is * and subkey is * (full span object wildcard)", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(mockTrace as any, "*", "*");
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "*",
+      subkey: "*",
+    });
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual(
@@ -233,11 +249,11 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 
   it("returns specific field from specific span", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(
-      mockTrace as any,
-      "openai/gpt-4",
-      "output",
-    );
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "openai/gpt-4",
+      subkey: "output",
+    });
 
     expect(result).toHaveLength(1);
     // output field is an object with { type, value }
@@ -245,11 +261,11 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 
   it("returns full span object when key is specific and subkey is *", () => {
-    const result = TRACE_MAPPINGS.spans.mapping(
-      mockTrace as any,
-      "my-custom-span",
-      "*",
-    );
+    const result = TRACE_MAPPINGS.spans.mapping({
+      trace: mockTrace as any,
+      key: "my-custom-span",
+      subkey: "*",
+    });
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(
@@ -296,11 +312,11 @@ describe("mapTraceToDatasetEntry span expansion", () => {
   describe("when the all-spans expansion is enabled", () => {
     /** @scenario Expanding spans produces one dataset row per span */
     it("produces one dataset row per span", () => {
-      const rows = mapTraceToDatasetEntry(
-        threeSpanTrace as any,
-        spansMapping,
-        new Set(["spans.all.span_id"]) as any,
-      );
+      const rows = mapTraceToDatasetEntry({
+        trace: threeSpanTrace as any,
+        mapping: spansMapping,
+        expansions: new Set(["spans.all.span_id"]) as any,
+      });
 
       expect(rows).toHaveLength(3);
     });
@@ -309,11 +325,11 @@ describe("mapTraceToDatasetEntry span expansion", () => {
   describe("when no expansion is enabled", () => {
     /** @scenario Without the span expansion the trace stays a single row */
     it("produces a single row whose spans field holds all spans", () => {
-      const rows = mapTraceToDatasetEntry(
-        threeSpanTrace as any,
-        spansMapping,
-        new Set() as any,
-      );
+      const rows = mapTraceToDatasetEntry({
+        trace: threeSpanTrace as any,
+        mapping: spansMapping,
+        expansions: new Set() as any,
+      });
 
       expect(rows).toHaveLength(1);
       // The spans column is serialized as JSON; it should contain all 3 spans.
@@ -335,34 +351,46 @@ describe("TRACE_MAPPINGS.metadata.mapping", () => {
   };
 
   it("returns full metadata object when key is empty", () => {
-    const result = TRACE_MAPPINGS.metadata.mapping(mockTrace as any, "");
+    const result = TRACE_MAPPINGS.metadata.mapping({
+      trace: mockTrace as any,
+      key: "",
+    });
 
     expect(result).toBe(JSON.stringify(mockTrace.metadata));
   });
 
   it("returns full metadata object when key is * (any key wildcard)", () => {
-    const result = TRACE_MAPPINGS.metadata.mapping(mockTrace as any, "*");
+    const result = TRACE_MAPPINGS.metadata.mapping({
+      trace: mockTrace as any,
+      key: "*",
+    });
 
     expect(result).toEqual(mockTrace.metadata);
   });
 
   it("returns specific metadata field", () => {
-    const result = TRACE_MAPPINGS.metadata.mapping(mockTrace as any, "user_id");
+    const result = TRACE_MAPPINGS.metadata.mapping({
+      trace: mockTrace as any,
+      key: "user_id",
+    });
 
     expect(result).toBe("user-123");
   });
 
   it("returns labels array when key is labels", () => {
-    const result = TRACE_MAPPINGS.metadata.mapping(mockTrace as any, "labels");
+    const result = TRACE_MAPPINGS.metadata.mapping({
+      trace: mockTrace as any,
+      key: "labels",
+    });
 
     expect(result).toEqual(["label1", "label2"]);
   });
 
   it("returns undefined for non-existent key", () => {
-    const result = TRACE_MAPPINGS.metadata.mapping(
-      mockTrace as any,
-      "non_existent",
-    );
+    const result = TRACE_MAPPINGS.metadata.mapping({
+      trace: mockTrace as any,
+      key: "non_existent",
+    });
 
     expect(result).toBeUndefined();
   });
@@ -638,9 +666,14 @@ describe("TRACE_MAPPINGS.threads", () => {
         metadata: { thread_id: "other-thread" },
       });
 
-      const result = TRACE_MAPPINGS.threads.mapping(trace1 as any, "", "", {
-        allTraces: [trace1, trace2, unrelatedTrace] as any[],
-        selectedFields: ["thread_id"],
+      const result = TRACE_MAPPINGS.threads.mapping({
+        trace: trace1 as any,
+        key: "",
+        subkey: "",
+        data: {
+          allTraces: [trace1, trace2, unrelatedTrace] as any[],
+          selectedFields: ["thread_id"],
+        },
       });
 
       expect(result).toHaveLength(2);
@@ -655,9 +688,14 @@ describe("TRACE_MAPPINGS.threads", () => {
         input: { type: "text", value: "Second" },
       });
 
-      const result = TRACE_MAPPINGS.threads.mapping(trace1 as any, "", "", {
-        allTraces: [trace1, trace2] as any[],
-        selectedFields: ["input", "output"],
+      const result = TRACE_MAPPINGS.threads.mapping({
+        trace: trace1 as any,
+        key: "",
+        subkey: "",
+        data: {
+          allTraces: [trace1, trace2] as any[],
+          selectedFields: ["input", "output"],
+        },
       });
 
       expect(result).toHaveLength(2);
@@ -670,9 +708,14 @@ describe("TRACE_MAPPINGS.threads", () => {
     it("returns an empty array", () => {
       const trace = makeTrace();
 
-      const result = TRACE_MAPPINGS.threads.mapping(trace as any, "", "", {
-        allTraces: undefined,
-        selectedFields: ["thread_id"],
+      const result = TRACE_MAPPINGS.threads.mapping({
+        trace: trace as any,
+        key: "",
+        subkey: "",
+        data: {
+          allTraces: undefined,
+          selectedFields: ["thread_id"],
+        },
       });
 
       expect(result).toEqual([]);
@@ -683,9 +726,14 @@ describe("TRACE_MAPPINGS.threads", () => {
     it("returns an empty array", () => {
       const trace = makeTrace({ metadata: {} });
 
-      const result = TRACE_MAPPINGS.threads.mapping(trace as any, "", "", {
-        allTraces: [trace] as any[],
-        selectedFields: ["thread_id"],
+      const result = TRACE_MAPPINGS.threads.mapping({
+        trace: trace as any,
+        key: "",
+        subkey: "",
+        data: {
+          allTraces: [trace] as any[],
+          selectedFields: ["thread_id"],
+        },
       });
 
       expect(result).toEqual([]);
@@ -720,13 +768,12 @@ describe("mapTraceToDatasetEntry()", () => {
         },
       };
 
-      const result = mapTraceToDatasetEntry(
-        trace1 as any,
+      const result = mapTraceToDatasetEntry({
+        trace: trace1 as any,
         mapping,
-        new Set(),
-        undefined,
-        [trace1, trace2] as any[],
-      );
+        expansions: new Set(),
+        allTraces: [trace1, trace2] as any[],
+      });
 
       expect(result).toHaveLength(1);
       // The threads mapping returns an array of objects, which gets JSON.stringified
@@ -758,12 +805,17 @@ describe("TRACE_MAPPINGS keys for threads sub-field selection", () => {
 });
 
 describe("threads_until_current mapping", () => {
-  const makeTrace = (
-    traceId: string,
-    threadId: string,
-    startedAt: number,
-    input: string,
-  ) =>
+  const makeTrace = ({
+    traceId,
+    threadId,
+    startedAt,
+    input,
+  }: {
+    traceId: string;
+    threadId: string;
+    startedAt: number;
+    input: string;
+  }) =>
     ({
       trace_id: traceId,
       metadata: { thread_id: threadId },
@@ -774,68 +826,88 @@ describe("threads_until_current mapping", () => {
     }) as any;
 
   const allTraces = [
-    makeTrace("t1", "thread-A", 1000, "first"),
-    makeTrace("t2", "thread-A", 2000, "second"),
-    makeTrace("t3", "thread-A", 3000, "third"),
-    makeTrace("t4", "thread-B", 1500, "other-thread"),
+    makeTrace({
+      traceId: "t1",
+      threadId: "thread-A",
+      startedAt: 1000,
+      input: "first",
+    }),
+    makeTrace({
+      traceId: "t2",
+      threadId: "thread-A",
+      startedAt: 2000,
+      input: "second",
+    }),
+    makeTrace({
+      traceId: "t3",
+      threadId: "thread-A",
+      startedAt: 3000,
+      input: "third",
+    }),
+    makeTrace({
+      traceId: "t4",
+      threadId: "thread-B",
+      startedAt: 1500,
+      input: "other-thread",
+    }),
   ];
 
   it("returns only traces up to and including the current trace timestamp", () => {
     const currentTrace = allTraces[1]!; // t2, timestamp 2000
-    const result = TRACE_MAPPINGS.threads_until_current.mapping(
-      currentTrace,
-      "",
-      "",
-      { allTraces },
-    ) as any[];
+    const result = TRACE_MAPPINGS.threads_until_current.mapping({
+      trace: currentTrace,
+      key: "",
+      subkey: "",
+      data: { allTraces },
+    }) as any[];
 
     expect(result.map((t: any) => t.trace_id)).toEqual(["t1", "t2"]);
   });
 
   it("includes traces with equal timestamps", () => {
     const currentTrace = allTraces[2]!; // t3, timestamp 3000
-    const result = TRACE_MAPPINGS.threads_until_current.mapping(
-      currentTrace,
-      "",
-      "",
-      { allTraces },
-    ) as any[];
+    const result = TRACE_MAPPINGS.threads_until_current.mapping({
+      trace: currentTrace,
+      key: "",
+      subkey: "",
+      data: { allTraces },
+    }) as any[];
 
     expect(result.map((t: any) => t.trace_id)).toEqual(["t1", "t2", "t3"]);
   });
 
   it("excludes traces from other threads", () => {
     const currentTrace = allTraces[2]!; // t3, thread-A
-    const result = TRACE_MAPPINGS.threads_until_current.mapping(
-      currentTrace,
-      "",
-      "",
-      { allTraces },
-    ) as any[];
+    const result = TRACE_MAPPINGS.threads_until_current.mapping({
+      trace: currentTrace,
+      key: "",
+      subkey: "",
+      data: { allTraces },
+    }) as any[];
 
     expect(result.map((t: any) => t.trace_id)).not.toContain("t4");
   });
 
   it("extracts selectedFields from filtered traces", () => {
     const currentTrace = allTraces[1]!; // t2, timestamp 2000
-    const result = TRACE_MAPPINGS.threads_until_current.mapping(
-      currentTrace,
-      "",
-      "",
-      { allTraces, selectedFields: ["input"] },
-    ) as Record<string, unknown>[];
+    const result = TRACE_MAPPINGS.threads_until_current.mapping({
+      trace: currentTrace,
+      key: "",
+      subkey: "",
+      data: { allTraces, selectedFields: ["input"] },
+    }) as Record<string, unknown>[];
 
     expect(result).toEqual([{ input: "first" }, { input: "second" }]);
   });
 
   it("returns empty array when trace has no thread_id", () => {
     const noThreadTrace = { ...allTraces[0]!, metadata: {} } as any;
-    const result = TRACE_MAPPINGS.threads_until_current.mapping(
-      noThreadTrace,
-      "",
-      "",
-      { allTraces },
-    );
+    const result = TRACE_MAPPINGS.threads_until_current.mapping({
+      trace: noThreadTrace,
+      key: "",
+      subkey: "",
+      data: { allTraces },
+    });
 
     expect(result).toEqual([]);
   });

--- a/platform/app/src/server/tracer/tracesMapping.ts
+++ b/platform/app/src/server/tracer/tracesMapping.ts
@@ -142,7 +142,7 @@ function filterThreadTraces(
         const traceMapping =
           TRACE_MAPPINGS[field as keyof typeof TRACE_MAPPINGS];
         if (traceMapping) {
-          filteredTrace[field] = traceMapping.mapping(threadTrace, "", "", {});
+          filteredTrace[field] = traceMapping.mapping({ trace: threadTrace });
         } else {
           filteredTrace[field] =
             threadTrace[field as keyof TraceWithAnnotations];
@@ -157,26 +157,30 @@ function filterThreadTraces(
 
 export const TRACE_MAPPINGS = {
   trace_id: {
-    mapping: (trace: TraceWithAnnotations) => trace.trace_id,
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) => trace.trace_id,
   },
   thread_id: {
-    mapping: (trace: TraceWithAnnotations) => trace.metadata?.thread_id ?? "",
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.metadata?.thread_id ?? "",
   },
   timestamp: {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       new Date(trace.timestamps.started_at).toISOString(),
   },
   input: {
-    mapping: (trace: TraceWithAnnotations) => trace.input?.value ?? "",
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.input?.value ?? "",
   },
   output: {
-    mapping: (trace: TraceWithAnnotations) => trace.output?.value ?? "",
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.output?.value ?? "",
   },
   contexts: {
-    mapping: (trace: TraceWithAnnotations) => getRAGChunks(trace.spans ?? []),
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      getRAGChunks(trace.spans ?? []),
   },
   "contexts.string_list": {
-    mapping: (trace: TraceWithAnnotations) => {
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) => {
       try {
         return getRAGInfo(trace.spans ?? []).contexts ?? [];
       } catch {
@@ -185,24 +189,27 @@ export const TRACE_MAPPINGS = {
     },
   },
   "metrics.total_cost": {
-    mapping: (trace: TraceWithAnnotations) => trace.metrics?.total_cost ?? 0,
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.metrics?.total_cost ?? 0,
   },
   "metrics.first_token_ms": {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       trace.metrics?.first_token_ms ?? 0,
   },
   "metrics.total_time_ms": {
-    mapping: (trace: TraceWithAnnotations) => trace.metrics?.total_time_ms ?? 0,
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.metrics?.total_time_ms ?? 0,
   },
   "metrics.prompt_tokens": {
-    mapping: (trace: TraceWithAnnotations) => trace.metrics?.prompt_tokens ?? 0,
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
+      trace.metrics?.prompt_tokens ?? 0,
   },
   "metrics.completion_tokens": {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       trace.metrics?.completion_tokens ?? 0,
   },
   "metrics.total_tokens": {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       (trace.metrics?.prompt_tokens ?? 0) +
       (trace.metrics?.completion_tokens ?? 0),
   },
@@ -233,7 +240,15 @@ export const TRACE_MAPPINGS = {
           label: key,
         }));
     },
-    mapping: (trace: TraceWithAnnotations, key: string, subkey: string) => {
+    mapping: ({
+      trace,
+      key,
+      subkey,
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+    }) => {
       const traceSpans = esSpansToDatasetSpans(trace.spans ?? []);
       if (!key) {
         return traceSpans;
@@ -254,14 +269,14 @@ export const TRACE_MAPPINGS = {
     expandable_by: "spans.all.span_id",
   },
   "spans.llm.input": {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       trace.spans
         ?.filter((span) => span.type === "llm")
         ?.map((span) => span.input?.value) ?? [],
     expandable_by: "spans.llm.span_id",
   },
   "spans.llm.output": {
-    mapping: (trace: TraceWithAnnotations) =>
+    mapping: ({ trace }: { trace: TraceWithAnnotations }) =>
       trace.spans
         ?.filter((span) => span.type === "llm")
         ?.map((span) => span.output?.value) ?? [],
@@ -288,7 +303,13 @@ export const TRACE_MAPPINGS = {
         label: reservedKeys.includes(key) ? `${key}` : key,
       }));
     },
-    mapping: (trace: TraceWithAnnotations, key: string) => {
+    mapping: ({
+      trace,
+      key,
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+    }) => {
       // Handle * as wildcard - return full metadata object
       if (key === "*") {
         return trace.metadata;
@@ -331,7 +352,15 @@ export const TRACE_MAPPINGS = {
           label: key,
         }));
     },
-    mapping: (trace: TraceWithAnnotations, key: string, subkey: string) => {
+    mapping: ({
+      trace,
+      key,
+      subkey,
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+    }) => {
       if (!key) {
         return trace.evaluations ?? [];
       }
@@ -372,12 +401,17 @@ export const TRACE_MAPPINGS = {
         label: option.name,
       }));
     },
-    mapping: (
-      trace: TraceWithAnnotations,
-      key: string,
-      subkey: string,
-      data: { annotationScoreOptions?: AnnotationScore[] },
-    ) => {
+    mapping: ({
+      trace,
+      key,
+      subkey,
+      data = {},
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+      data?: { annotationScoreOptions?: AnnotationScore[] };
+    }) => {
       if (!key) {
         return trace.annotations ?? [];
       }
@@ -452,7 +486,15 @@ export const TRACE_MAPPINGS = {
         }),
       );
     },
-    mapping: (trace: TraceWithAnnotations, key: string, subkey: string) => {
+    mapping: ({
+      trace,
+      key,
+      subkey,
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+    }) => {
       if (!key) {
         return trace.events;
       }
@@ -478,26 +520,32 @@ export const TRACE_MAPPINGS = {
     expandable_by: "events.event_id",
   },
   threads: {
-    mapping: (
-      trace: TraceWithAnnotations,
-      _key: string,
-      _subkey: string,
-      data: {
+    mapping: ({
+      trace,
+      data = {},
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+      data?: {
         allTraces?: TraceWithAnnotations[];
         selectedFields?: string[];
-      } = {},
-    ) => filterThreadTraces(trace, data),
+      };
+    }) => filterThreadTraces(trace, data),
   },
   threads_until_current: {
-    mapping: (
-      trace: TraceWithAnnotations,
-      _key: string,
-      _subkey: string,
-      data: {
+    mapping: ({
+      trace,
+      data = {},
+    }: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+      data?: {
         allTraces?: TraceWithAnnotations[];
         selectedFields?: string[];
-      } = {},
-    ) =>
+      };
+    }) =>
       filterThreadTraces(trace, data, (t) => {
         return t.timestamps.started_at <= trace.timestamps.started_at;
       }),
@@ -514,25 +562,16 @@ export const TRACE_MAPPINGS = {
       key: string;
       label: string;
     }[];
-    mapping:
-      | ((
-          trace: TraceWithAnnotations,
-        ) => string | number | object | undefined | unknown[])
-      | ((
-          trace: TraceWithAnnotations,
-          key: string,
-        ) => string | number | object | undefined | unknown[])
-      | ((
-          trace: TraceWithAnnotations,
-          key: string,
-          subkey: string,
-        ) => string | number | object | undefined | unknown[])
-      | ((
-          trace: TraceWithAnnotations,
-          key: string,
-          subkey: string,
-          data: { annotationScoreOptions?: AnnotationScore[] },
-        ) => string | number | object | undefined | unknown[]);
+    mapping: (params: {
+      trace: TraceWithAnnotations;
+      key?: string;
+      subkey?: string;
+      data?: {
+        annotationScoreOptions?: AnnotationScore[];
+        allTraces?: TraceWithAnnotations[];
+        selectedFields?: string[];
+      };
+    }) => string | number | object | undefined | unknown[];
     expandable_by?: keyof typeof TRACE_EXPANSIONS;
   }
 >;
@@ -608,7 +647,7 @@ export const extractTracesFields = (
     for (const field of fields) {
       const traceMapping = TRACE_MAPPINGS[field];
       if (traceMapping) {
-        result[field] = traceMapping.mapping(trace as any, "", "", {});
+        result[field] = traceMapping.mapping({ trace: trace as any });
       }
     }
     return result;
@@ -818,8 +857,14 @@ const esSpansToDatasetSpans = (spans: Span[]): DatasetSpan[] => {
   }
 };
 
-export const mapTraceToDatasetEntry = (
-  trace: TraceWithAnnotations,
+export const mapTraceToDatasetEntry = ({
+  trace,
+  mapping,
+  expansions,
+  annotationScoreOptions,
+  allTraces,
+}: {
+  trace: TraceWithAnnotations;
   mapping: Record<
     string,
     {
@@ -828,11 +873,11 @@ export const mapTraceToDatasetEntry = (
       subkey?: string;
       selectedFields?: string[];
     }
-  >,
-  expansions: Set<keyof typeof TRACE_EXPANSIONS>,
-  annotationScoreOptions?: AnnotationScore[],
-  allTraces?: TraceWithAnnotations[],
-): Record<string, string | number>[] => {
+  >;
+  expansions: Set<keyof typeof TRACE_EXPANSIONS>;
+  annotationScoreOptions?: AnnotationScore[];
+  allTraces?: TraceWithAnnotations[];
+}): Record<string, string | number>[] => {
   let expandedTraces: TraceWithAnnotations[] = [trace];
 
   for (const expansion of expansions) {
@@ -852,10 +897,15 @@ export const mapTraceToDatasetEntry = (
               ? TRACE_MAPPINGS[source as keyof typeof TRACE_MAPPINGS]
               : undefined;
 
-          let value = source_?.mapping(trace, key!, subkey!, {
-            annotationScoreOptions,
-            allTraces,
-            selectedFields,
+          let value = source_?.mapping({
+            trace,
+            key,
+            subkey,
+            data: {
+              annotationScoreOptions,
+              allTraces,
+              selectedFields,
+            },
           });
 
           if (

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
@@ -404,11 +404,11 @@ describe("ClickHouse trace dedup (integration)", () => {
       });
 
       it("returns only the latest trace summary version", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceId],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceId],
+          protections: openProtections,
+        });
 
         expect(traces).not.toBeNull();
         expect(traces).toHaveLength(1);
@@ -419,11 +419,11 @@ describe("ClickHouse trace dedup (integration)", () => {
       });
 
       it("returns only the latest span version", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceId],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceId],
+          protections: openProtections,
+        });
 
         const trace = traces![0]!;
         expect(trace.spans).toHaveLength(1);
@@ -434,11 +434,11 @@ describe("ClickHouse trace dedup (integration)", () => {
       });
 
       it("preserves heavy SpanAttributes in the result", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceId],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceId],
+          protections: openProtections,
+        });
 
         const span = traces![0]!.spans[0]!;
         // SpanAttributes are mapped to params via unflattenDotNotation
@@ -452,11 +452,11 @@ describe("ClickHouse trace dedup (integration)", () => {
       });
 
       it("preserves heavy ComputedInput/ComputedOutput from the latest trace version", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceId],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceId],
+          protections: openProtections,
+        });
 
         const trace = traces![0]!;
 
@@ -477,12 +477,12 @@ describe("ClickHouse trace dedup (integration)", () => {
 
       describe("when an occurredAt window around the trace is supplied", () => {
         it("returns the same latest trace + span (partition hint is correctness-preserving)", async () => {
-          const traces = await service.getTracesWithSpans(
-            tenantId,
-            [traceId],
-            openProtections,
-            { from: now - 20000, to: now },
-          );
+          const traces = await service.getTracesWithSpans({
+            projectId: tenantId,
+            traceIds: [traceId],
+            protections: openProtections,
+            occurredAt: { from: now - 20000, to: now },
+          });
 
           expect(traces).toHaveLength(1);
           const trace = traces![0]!;
@@ -524,11 +524,11 @@ describe("ClickHouse trace dedup (integration)", () => {
           const { client, queries } = recordingClient();
           getClickHouseClientForProject.mockResolvedValue(client);
           try {
-            const traces = await service.getTracesWithSpans(
-              tenantId,
-              [traceId],
-              openProtections,
-            );
+            const traces = await service.getTracesWithSpans({
+              projectId: tenantId,
+              traceIds: [traceId],
+              protections: openProtections,
+            });
             // Correctness is unchanged: still the latest summary + span version.
             expect(traces).toHaveLength(1);
             expect(traces![0]!.trace_id).toBe(traceId);
@@ -555,11 +555,11 @@ describe("ClickHouse trace dedup (integration)", () => {
           const { client, queries } = recordingClient();
           getClickHouseClientForProject.mockResolvedValue(client);
           try {
-            const traces = await service.getTracesWithSpans(
-              tenantId,
-              [`missing-${nanoid()}`],
-              openProtections,
-            );
+            const traces = await service.getTracesWithSpans({
+              projectId: tenantId,
+              traceIds: [`missing-${nanoid()}`],
+              protections: openProtections,
+            });
             expect(traces ?? []).toHaveLength(0);
           } finally {
             getClickHouseClientForProject.mockResolvedValue(ch);
@@ -673,11 +673,11 @@ describe("ClickHouse trace dedup (integration)", () => {
       });
 
       it("deduplicates spans per trace correctly", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceX, traceY],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceX, traceY],
+          protections: openProtections,
+        });
 
         expect(traces).not.toBeNull();
         expect(traces).toHaveLength(2);

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
@@ -341,11 +341,11 @@ describe("ClickHouse field-name queries (integration)", () => {
 
       /** @scenario A trace with many spans exposes all of its spans */
       it("returns all spans of the trace, none dropped", async () => {
-        const traces = await service.getTracesWithSpans(
-          tenantId,
-          [traceId],
-          openProtections,
-        );
+        const traces = await service.getTracesWithSpans({
+          projectId: tenantId,
+          traceIds: [traceId],
+          protections: openProtections,
+        });
 
         expect(traces).not.toBeNull();
         expect(traces).toHaveLength(1);

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
@@ -205,11 +205,11 @@ describe("RAG contexts read path (integration)", () => {
     });
 
     it("returns the stored contexts on the RAG span", async () => {
-      const traces = await service.getTracesWithSpans(
-        tenantId,
-        [traceId],
-        openProtections,
-      );
+      const traces = await service.getTracesWithSpans({
+        projectId: tenantId,
+        traceIds: [traceId],
+        protections: openProtections,
+      });
 
       expect(traces).toHaveLength(1);
       const ragSpan = findRagSpan(traces?.[0]?.spans);
@@ -217,11 +217,11 @@ describe("RAG contexts read path (integration)", () => {
     });
 
     it("returns JSON-typed attributes as structured params, not strings", async () => {
-      const traces = await service.getTracesWithSpans(
-        tenantId,
-        [traceId],
-        openProtections,
-      );
+      const traces = await service.getTracesWithSpans({
+        projectId: tenantId,
+        traceIds: [traceId],
+        protections: openProtections,
+      });
 
       expect(traces).toHaveLength(1);
       const ragSpan = findRagSpan(traces?.[0]?.spans);

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -313,8 +313,11 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
         );
 
         await expect(
-          service.getTracesByThreadId(PROJECT_ID, "thread-1", protections, {
-            resolveBlobs: true,
+          service.getTracesByThreadId({
+            projectId: PROJECT_ID,
+            threadId: "thread-1",
+            protections,
+            opts: { resolveBlobs: true },
           }),
         ).rejects.toThrow(/returned 0 resolution\(s\) for 1 trace\(s\)/);
       });
@@ -359,13 +362,13 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
         );
 
         await expect(
-          service.getTracesWithSpans(
-            PROJECT_ID,
-            [TRACE_A, TRACE_B],
+          service.getTracesWithSpans({
+            projectId: PROJECT_ID,
+            traceIds: [TRACE_A, TRACE_B],
             protections,
-            { from: 0, to: Date.now() },
-            { resolveBlobs: true },
-          ),
+            occurredAt: { from: 0, to: Date.now() },
+            opts: { resolveBlobs: true },
+          }),
         ).rejects.toThrow(/resolutions must come back in input order/);
       });
 
@@ -406,13 +409,13 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
         );
 
         await expect(
-          service.getTracesWithSpans(
-            PROJECT_ID,
-            [TRACE_A, TRACE_B],
+          service.getTracesWithSpans({
+            projectId: PROJECT_ID,
+            traceIds: [TRACE_A, TRACE_B],
             protections,
-            { from: 0, to: Date.now() },
-            { resolveBlobs: true },
-          ),
+            occurredAt: { from: 0, to: Date.now() },
+            opts: { resolveBlobs: true },
+          }),
         ).rejects.toThrow(/resolutions must come back in input order/);
       });
     });
@@ -426,12 +429,12 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
           Promise.resolve(spans.map(passthrough)),
         );
 
-        const traces = await service.getTracesByThreadId(
-          PROJECT_ID,
-          "thread-1",
+        const traces = await service.getTracesByThreadId({
+          projectId: PROJECT_ID,
+          threadId: "thread-1",
           protections,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         expect(traces.map((t) => t.trace_id)).toEqual([TRACE_ID]);
       });
@@ -485,11 +488,11 @@ describe("ClickHouseTraceService.getTracesByThreadId — ordering contract", () 
         const { blobStore } = makeEventRefBlobStore();
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesByThreadId(
-          PROJECT_ID,
-          "thread-1",
+        const traces = await service.getTracesByThreadId({
+          projectId: PROJECT_ID,
+          threadId: "thread-1",
           protections,
-        );
+        });
 
         expect(traces.map((t) => t.trace_id)).toEqual([EARLY, LATE]);
       });
@@ -597,12 +600,12 @@ describe("ClickHouseTraceService.getTracesByThreadId — #4991 AC2 thread detail
         const { blobStore, getFromEventLog } = makeEventRefBlobStore();
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesByThreadId(
-          PROJECT_ID,
-          "thread-1",
+        const traces = await service.getTracesByThreadId({
+          projectId: PROJECT_ID,
+          threadId: "thread-1",
           protections,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         expect(getFromEventLog).toHaveBeenCalled();
         expect(traces![0]!.output?.value).toBe(FULL_OUTPUT);
@@ -615,11 +618,11 @@ describe("ClickHouseTraceService.getTracesByThreadId — #4991 AC2 thread detail
         const { blobStore, getFromEventLog } = makeEventRefBlobStore();
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesByThreadId(
-          PROJECT_ID,
-          "thread-1",
+        const traces = await service.getTracesByThreadId({
+          projectId: PROJECT_ID,
+          threadId: "thread-1",
           protections,
-        );
+        });
 
         expect(getFromEventLog).not.toHaveBeenCalled();
         // Falsifiable: exact preview, not merely "not the full value".

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
@@ -229,13 +229,12 @@ describe("ClickHouseTraceService — eventref resolution seam (ADR-022)", () => 
           );
 
           // Per-call gate (#4888): resolution fires only when resolveBlobs:true.
-          const traces = await service.getTracesWithSpans(
-            "proj-1",
-            ["trace-1"],
+          const traces = await service.getTracesWithSpans({
+            projectId: "proj-1",
+            traceIds: ["trace-1"],
             protections,
-            undefined,
-            { resolveBlobs: true },
-          );
+            opts: { resolveBlobs: true },
+          });
 
           const span = traces![0]!.spans[0];
           // The span's params should not contain any eventref key

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -1025,11 +1025,11 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        const traces = await service.getTracesWithSpans(
-          "proj_123",
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj_123",
           traceIds,
           protections,
-        );
+        });
 
         expect(traces).not.toBeNull();
         expect(traces!.map((t) => t.trace_id).sort()).toEqual(traceIds);
@@ -1080,11 +1080,11 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        const traces = await service.getTracesWithSpans(
-          "proj_123",
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj_123",
           traceIds,
           protections,
-        );
+        });
 
         expect(traces).toHaveLength(30);
         // call 0 = resolve, 1 = OOM full summary, 2 = summary batch1,
@@ -1105,7 +1105,11 @@ describe("ClickHouseTraceService", () => {
         } as never);
 
         await expect(
-          service.getTracesWithSpans("proj_123", ["trace-0"], protections),
+          service.getTracesWithSpans({
+            projectId: "proj_123",
+            traceIds: ["trace-0"],
+            protections,
+          }),
         ).rejects.toThrow();
         // The resolve fails open (call 1), then the summary's non-OOM error
         // propagates without per-batch retries (call 2) — no retry loop.
@@ -1129,9 +1133,14 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        await service.getTracesWithSpans("proj_123", ["trace-0"], protections, {
-          from: 1_000_000,
-          to: 2_000_000,
+        await service.getTracesWithSpans({
+          projectId: "proj_123",
+          traceIds: ["trace-0"],
+          protections,
+          occurredAt: {
+            from: 1_000_000,
+            to: 2_000_000,
+          },
         });
 
         const summaryCall = mockClickHouseQuery.mock.calls[0]![0];
@@ -1170,7 +1179,11 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        await service.getTracesWithSpans("proj_123", ["trace-0"], protections);
+        await service.getTracesWithSpans({
+          projectId: "proj_123",
+          traceIds: ["trace-0"],
+          protections,
+        });
 
         const resolveCall = mockClickHouseQuery.mock.calls[0]![0];
         expect(resolveCall.query).toContain("min(OccurredAt)");
@@ -1203,7 +1216,11 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        await service.getTracesWithSpans("proj_123", ["trace-0"], protections);
+        await service.getTracesWithSpans({
+          projectId: "proj_123",
+          traceIds: ["trace-0"],
+          protections,
+        });
 
         const summaryCall = mockClickHouseQuery.mock.calls[1]![0];
         // No OccurredAt predicate inlined at all, and no window params.
@@ -1228,11 +1245,11 @@ describe("ClickHouseTraceService", () => {
           project: { findUnique: mockPrismaFindUnique },
         } as never);
 
-        const traces = await service.getTracesWithSpans(
-          "proj_123",
-          ["trace-0"],
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj_123",
+          traceIds: ["trace-0"],
           protections,
-        );
+        });
 
         // The read still succeeds; the summary just stays unbounded (the
         // pre-optimization behaviour) rather than propagating the resolve error.

--- a/platform/app/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
@@ -205,8 +205,11 @@ describe("TraceService — AC1: getById with full=true resolves from event_log",
       it("calls BlobStore.getFromEventLog at least once (resolution runs)", async () => {
         setupGetTracesWithSpansMocks();
 
-        await service.getById(PROJECT_ID_A, TRACE_ID, protections, {
-          full: true,
+        await service.getById({
+          projectId: PROJECT_ID_A,
+          traceId: TRACE_ID,
+          protections,
+          opts: { full: true },
         });
 
         expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(1);
@@ -215,12 +218,12 @@ describe("TraceService — AC1: getById with full=true resolves from event_log",
       it("the resolved span attribute is defined", async () => {
         setupGetTracesWithSpansMocks();
 
-        const trace = await service.getById(
-          PROJECT_ID_A,
-          TRACE_ID,
+        const trace = await service.getById({
+          projectId: PROJECT_ID_A,
+          traceId: TRACE_ID,
           protections,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         const span = trace?.spans?.[0] as
           | { params?: { langwatch?: { output?: string } } }
@@ -231,12 +234,12 @@ describe("TraceService — AC1: getById with full=true resolves from event_log",
       it("the resolved span attribute byte length equals the full 400 KB value", async () => {
         setupGetTracesWithSpansMocks();
 
-        const trace = await service.getById(
-          PROJECT_ID_A,
-          TRACE_ID,
+        const trace = await service.getById({
+          projectId: PROJECT_ID_A,
+          traceId: TRACE_ID,
           protections,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         const span = trace?.spans?.[0] as
           | { params?: { langwatch?: { output?: string } } }
@@ -248,12 +251,12 @@ describe("TraceService — AC1: getById with full=true resolves from event_log",
       it("no langwatch.reserved.* key survives in the returned span (key-level check)", async () => {
         setupGetTracesWithSpansMocks();
 
-        const trace = await service.getById(
-          PROJECT_ID_A,
-          TRACE_ID,
+        const trace = await service.getById({
+          projectId: PROJECT_ID_A,
+          traceId: TRACE_ID,
           protections,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         const span = trace?.spans?.[0] as
           | { params?: { langwatch?: { reserved?: unknown } } }
@@ -273,12 +276,12 @@ describe("TraceService — AC1: getById with full=true resolves from event_log",
       it("the recomputed trace.output value equals the full 400 KB value", async () => {
         setupGetTracesWithSpansMocks();
 
-        const trace = await service.getById(
-          PROJECT_ID_A,
-          TRACE_ID,
+        const trace = await service.getById({
+          projectId: PROJECT_ID_A,
+          traceId: TRACE_ID,
           protections,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         expect(trace?.output?.value).toBe(FULL_OUTPUT);
       });
@@ -301,15 +304,14 @@ describe("TraceService — AC1: getTracesWithSpans with full=true resolves from 
       it("calls BlobStore.getFromEventLog at least once", async () => {
         setupGetTracesWithSpansMocks();
 
-        await service.getTracesWithSpans(
-          PROJECT_ID_A,
-          [TRACE_ID],
+        await service.getTracesWithSpans({
+          projectId: PROJECT_ID_A,
+          traceIds: [TRACE_ID],
           protections,
-          undefined,
-          {
+          opts: {
             full: true,
           },
-        );
+        });
 
         expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(1);
       });
@@ -317,13 +319,12 @@ describe("TraceService — AC1: getTracesWithSpans with full=true resolves from 
       it("the recomputed trace.output value equals the full 400 KB value", async () => {
         setupGetTracesWithSpansMocks();
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_A,
-          [TRACE_ID],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_A,
+          traceIds: [TRACE_ID],
           protections,
-          undefined,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         expect(traces[0]?.output?.value).toBe(FULL_OUTPUT);
       });
@@ -349,8 +350,11 @@ describe("TraceService — AC2: getById without full resolves nothing (preview)"
     it("BlobStore.getFromEventLog is called 0 times", async () => {
       setupGetTracesWithSpansMocks();
 
-      await service.getById(PROJECT_ID_A, TRACE_ID, protections, {
-        full: false,
+      await service.getById({
+        projectId: PROJECT_ID_A,
+        traceId: TRACE_ID,
+        protections,
+        opts: { full: false },
       });
 
       expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(0);
@@ -361,7 +365,11 @@ describe("TraceService — AC2: getById without full resolves nothing (preview)"
     it("BlobStore.getFromEventLog is called 0 times", async () => {
       setupGetTracesWithSpansMocks();
 
-      await service.getById(PROJECT_ID_A, TRACE_ID, protections);
+      await service.getById({
+        projectId: PROJECT_ID_A,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(0);
     });
@@ -369,7 +377,11 @@ describe("TraceService — AC2: getById without full resolves nothing (preview)"
     it("the returned trace.output is the ≤64 KB preview, not the full value", async () => {
       setupGetTracesWithSpansMocks();
 
-      const trace = await service.getById(PROJECT_ID_A, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID_A,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(trace?.output?.value).not.toBe(FULL_OUTPUT);
     });
@@ -390,7 +402,11 @@ describe("TraceService — AC2: getTracesWithSpans without full resolves nothing
     it("BlobStore.getFromEventLog is called 0 times", async () => {
       setupGetTracesWithSpansMocks();
 
-      await service.getTracesWithSpans(PROJECT_ID_A, [TRACE_ID], protections);
+      await service.getTracesWithSpans({
+        projectId: PROJECT_ID_A,
+        traceIds: [TRACE_ID],
+        protections,
+      });
 
       expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(0);
     });
@@ -400,15 +416,14 @@ describe("TraceService — AC2: getTracesWithSpans without full resolves nothing
     it("BlobStore.getFromEventLog is called 0 times", async () => {
       setupGetTracesWithSpansMocks();
 
-      await service.getTracesWithSpans(
-        PROJECT_ID_A,
-        [TRACE_ID],
+      await service.getTracesWithSpans({
+        projectId: PROJECT_ID_A,
+        traceIds: [TRACE_ID],
         protections,
-        undefined,
-        {
+        opts: {
           full: false,
         },
-      );
+      });
 
       expect(blobStore.getFromEventLog).toHaveBeenCalledTimes(0);
     });
@@ -426,13 +441,12 @@ describe("TraceService — AC2: a service constructed without blobResolutionDeps
         setupGetTracesWithSpansMocks();
         const listService = new TraceService({} as never);
 
-        const traces = await listService.getTracesWithSpans(
-          PROJECT_ID_A,
-          [TRACE_ID],
+        const traces = await listService.getTracesWithSpans({
+          projectId: PROJECT_ID_A,
+          traceIds: [TRACE_ID],
           protections,
-          undefined,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         // No resolver → preview kept, no full value.
         expect(traces[0]?.output?.value).not.toBe(FULL_OUTPUT);
@@ -459,8 +473,11 @@ describe("TraceService — AC7: cross-tenant event_log read denied, preview retu
         setupGetTracesWithSpansMocks();
         const serviceB = makeService(blobStore);
 
-        await serviceB.getById(PROJECT_ID_B, TRACE_ID, protections, {
-          full: true,
+        await serviceB.getById({
+          projectId: PROJECT_ID_B,
+          traceId: TRACE_ID,
+          protections,
+          opts: { full: true },
         });
 
         const callArgs = blobStore.getFromEventLog.mock.calls[0]?.[0] as
@@ -473,12 +490,12 @@ describe("TraceService — AC7: cross-tenant event_log read denied, preview retu
         setupGetTracesWithSpansMocks();
         const serviceB = makeService(blobStore);
 
-        const trace = await serviceB.getById(
-          PROJECT_ID_B,
-          TRACE_ID,
+        const trace = await serviceB.getById({
+          projectId: PROJECT_ID_B,
+          traceId: TRACE_ID,
           protections,
-          { full: true },
-        );
+          opts: { full: true },
+        });
 
         expect(trace?.output?.value).not.toBe(FULL_OUTPUT);
       });
@@ -488,7 +505,12 @@ describe("TraceService — AC7: cross-tenant event_log read denied, preview retu
         const serviceB = makeService(blobStore);
 
         await expect(
-          serviceB.getById(PROJECT_ID_B, TRACE_ID, protections, { full: true }),
+          serviceB.getById({
+            projectId: PROJECT_ID_B,
+            traceId: TRACE_ID,
+            protections,
+            opts: { full: true },
+          }),
         ).resolves.not.toThrow();
       });
     });
@@ -580,15 +602,14 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          {
+          opts: {
             resolveBlobs: true,
           },
-        );
+        });
 
         expect(getFromEventLogSpy).toHaveBeenCalledOnce();
       });
@@ -600,13 +621,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         const span = traces![0]!.spans[0] as unknown as {
           params?: { langwatch?: { output?: string } };
@@ -621,13 +641,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         const span = traces![0]!.spans[0] as unknown as {
           params?: { langwatch?: { output?: string } };
@@ -643,13 +662,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         const span = traces![0]!.spans[0] as unknown as {
           params?: { langwatch?: { output?: string } };
@@ -664,13 +682,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         const span = traces![0]!.spans[0] as unknown as {
           params?: { langwatch?: { reserved?: unknown } };
@@ -694,13 +711,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         expect(traces![0]!.output?.value).toBeDefined();
       });
@@ -712,13 +728,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         const outputVal = traces![0]!.output?.value as string | undefined;
         expect(Buffer.byteLength(outputVal!, "utf8")).toBeGreaterThan(
@@ -733,13 +748,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: true },
-        );
+          opts: { resolveBlobs: true },
+        });
 
         expect(traces![0]!.output?.value).toBe(FULL_OUTPUT);
       });
@@ -753,15 +767,14 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          {
+          opts: {
             resolveBlobs: false,
           },
-        );
+        });
 
         expect(getFromEventLogSpy).not.toHaveBeenCalled();
       });
@@ -773,13 +786,12 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
         });
         const service = buildService(blobStore);
 
-        const traces = await service.getTracesWithSpans(
-          PROJECT_ID_CH,
-          [TRACE_ID_CH],
+        const traces = await service.getTracesWithSpans({
+          projectId: PROJECT_ID_CH,
+          traceIds: [TRACE_ID_CH],
           protections,
-          undefined,
-          { resolveBlobs: false },
-        );
+          opts: { resolveBlobs: false },
+        });
 
         expect(traces![0]!.output?.value).not.toBe(FULL_OUTPUT);
       });

--- a/platform/app/src/server/traces/__tests__/trace-service-blob-resolution.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-blob-resolution.unit.test.ts
@@ -162,32 +162,32 @@ describe("TraceService.getTracesWithSpans() — ADR-022 blob resolution pipeline
       });
 
       it("returns the trace from ClickHouseTraceService", async () => {
-        const traces = await service.getTracesWithSpans(
-          "proj-1",
-          ["trace-1"],
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj-1",
+          traceIds: ["trace-1"],
           protections,
-        );
+        });
 
         expect(traces).toHaveLength(1);
         expect(traces[0]!.trace_id).toBe("trace-1");
       });
 
       it("delegates trace fetching to ClickHouseTraceService", async () => {
-        const traces = await service.getTracesWithSpans(
-          "proj-1",
-          ["trace-1"],
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj-1",
+          traceIds: ["trace-1"],
           protections,
-        );
+        });
 
         // #4888: TraceService forwards the per-call blob-resolution gate to CH.
         // No `full` was passed, so resolveBlobs is undefined (preview).
-        expect(mockGetTracesWithSpansCH).toHaveBeenCalledWith(
-          "proj-1",
-          ["trace-1"],
+        expect(mockGetTracesWithSpansCH).toHaveBeenCalledWith({
+          projectId: "proj-1",
+          traceIds: ["trace-1"],
           protections,
-          undefined,
-          { resolveBlobs: undefined },
-        );
+          occurredAt: undefined,
+          opts: { resolveBlobs: undefined },
+        });
         expect(traces[0]!.trace_id).toBe("trace-1");
       });
 
@@ -206,11 +206,11 @@ describe("TraceService.getTracesWithSpans() — ADR-022 blob resolution pipeline
       it("returns an empty array without errors", async () => {
         mockGetTracesWithSpansCH.mockResolvedValue([]);
 
-        const traces = await service.getTracesWithSpans(
-          "proj-1",
-          [],
+        const traces = await service.getTracesWithSpans({
+          projectId: "proj-1",
+          traceIds: [],
           protections,
-        );
+        });
 
         expect(traces).toEqual([]);
       });

--- a/platform/app/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
@@ -197,7 +197,11 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const trace = await service.getById(PROJECT_ID, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
       const span = trace?.spans?.[0];
 
       expect(span?.input).toEqual({
@@ -218,14 +222,18 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      await service.getById(PROJECT_ID, TRACE_ID, protections);
+      await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(getLogs).toHaveBeenCalledTimes(1);
-      expect(getLogs).toHaveBeenCalledWith(
-        PROJECT_ID,
-        TRACE_ID,
-        1_700_000_000_000,
-      );
+      expect(getLogs).toHaveBeenCalledWith({
+        tenantId: PROJECT_ID,
+        traceId: TRACE_ID,
+        occurredAtMs: 1_700_000_000_000,
+      });
     });
 
     it("preserves the span's real token metrics while overriding cost", async () => {
@@ -234,7 +242,11 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
       ]);
       const service = makeService(vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS));
 
-      const trace = await service.getById(PROJECT_ID, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(trace?.spans?.[0]?.metrics?.prompt_tokens).toBe(120);
       expect(trace?.spans?.[0]?.metrics?.completion_tokens).toBe(8);
@@ -249,7 +261,11 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const trace = await service.getById(PROJECT_ID, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(getLogs).not.toHaveBeenCalled();
       expect(trace?.spans?.[0]?.input ?? null).toBeNull();
@@ -264,7 +280,11 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
       ]);
       const service = makeService(vi.fn().mockResolvedValue([]));
 
-      const trace = await service.getById(PROJECT_ID, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(trace?.spans?.[0]?.input ?? null).toBeNull();
       expect(trace?.spans?.[0]?.metrics?.cost ?? null).toBeNull();
@@ -280,7 +300,11 @@ describe("TraceService.getById — Claude Code log content enrichment", () => {
         vi.fn().mockRejectedValue(new Error("clickhouse down")),
       );
 
-      const trace = await service.getById(PROJECT_ID, TRACE_ID, protections);
+      const trace = await service.getById({
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        protections,
+      });
 
       expect(trace?.spans?.[0]?.input ?? null).toBeNull();
     });
@@ -310,11 +334,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const traces = await service.getTracesWithSpans(
-        PROJECT_ID,
-        [TRACE_ID],
+      const traces = await service.getTracesWithSpans({
+        projectId: PROJECT_ID,
+        traceIds: [TRACE_ID],
         protections,
-      );
+      });
 
       expect(traces[0]?.spans?.[0]?.input).toEqual(enrichedInput);
       expect(traces[0]?.spans?.[0]?.output).toEqual(enrichedOutput);
@@ -329,11 +353,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const traces = await service.getTracesWithSpans(
-        PROJECT_ID,
-        [TRACE_ID],
+      const traces = await service.getTracesWithSpans({
+        projectId: PROJECT_ID,
+        traceIds: [TRACE_ID],
         protections,
-      );
+      });
 
       expect(getLogs).not.toHaveBeenCalled();
       expect(traces[0]?.spans?.[0]?.input ?? null).toBeNull();
@@ -348,11 +372,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const traces = await service.getTracesByThreadId(
-        PROJECT_ID,
-        "thread-1",
+      const traces = await service.getTracesByThreadId({
+        projectId: PROJECT_ID,
+        threadId: "thread-1",
         protections,
-      );
+      });
 
       expect(traces[0]?.spans?.[0]?.input).toEqual(enrichedInput);
       expect(traces[0]?.spans?.[0]?.metrics?.cost).toBe(0.0421);
@@ -365,7 +389,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      await service.getTracesByThreadId(PROJECT_ID, "thread-1", protections);
+      await service.getTracesByThreadId({
+        projectId: PROJECT_ID,
+        threadId: "thread-1",
+        protections,
+      });
 
       expect(getLogs).not.toHaveBeenCalled();
     });
@@ -462,11 +490,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      const traces = await service.getTracesWithSpansByThreadIds(
-        PROJECT_ID,
-        ["thread-1"],
+      const traces = await service.getTracesWithSpansByThreadIds({
+        projectId: PROJECT_ID,
+        threadIds: ["thread-1"],
         protections,
-      );
+      });
 
       // Only the coding-agent trace is enriched; only its log read happens.
       expect(traces[0]?.spans?.[0]?.input).toEqual(enrichedInput);
@@ -481,11 +509,11 @@ describe("TraceService — multi-trace read enrichment", () => {
       const getLogs = vi.fn().mockResolvedValue(CLAUDE_LOG_ROWS);
       const service = makeService(getLogs);
 
-      await service.getTracesWithSpansByThreadIds(
-        PROJECT_ID,
-        ["thread-1"],
+      await service.getTracesWithSpansByThreadIds({
+        projectId: PROJECT_ID,
+        threadIds: ["thread-1"],
         protections,
-      );
+      });
 
       expect(getLogs).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/traces/__tests__/trace-summary-anchored-span-window.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-summary-anchored-span-window.unit.test.ts
@@ -145,7 +145,11 @@ async function readTraces(traceIds: string[]) {
   const service = new ClickHouseTraceService({
     project: { findUnique: vi.fn() },
   } as never);
-  await service.getTracesWithSpans("proj-1", traceIds, protections);
+  await service.getTracesWithSpans({
+    projectId: "proj-1",
+    traceIds,
+    protections,
+  });
   const spanCall = mockClickHouseQuery.mock.calls.find(([args]) =>
     String(args.query).includes("FROM stored_spans AS t"),
   );

--- a/platform/app/src/server/traces/__tests__/trace.service.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace.service.unit.test.ts
@@ -119,7 +119,11 @@ describe("TraceService", () => {
       it("returns the trace without attempting prefix resolution", async () => {
         mockGetTracesWithSpansCH.mockResolvedValue([sampleTrace]);
 
-        const result = await service.getById(projectId, fullId, protections);
+        const result = await service.getById({
+          projectId,
+          traceId: fullId,
+          protections,
+        });
 
         expect(result).toBe(sampleTrace);
         expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();
@@ -133,7 +137,11 @@ describe("TraceService", () => {
           .mockResolvedValueOnce([sampleTrace]);
         mockResolveTraceIdByPrefixCH.mockResolvedValue([fullId]);
 
-        const result = await service.getById(projectId, prefix20, protections);
+        const result = await service.getById({
+          projectId,
+          traceId: prefix20,
+          protections,
+        });
 
         expect(result).toBe(sampleTrace);
         expect(mockResolveTraceIdByPrefixCH).toHaveBeenCalledWith(
@@ -148,14 +156,12 @@ describe("TraceService", () => {
           }),
         );
         // Second fetch uses the resolved full ID
-        expect(mockGetTracesWithSpansCH).toHaveBeenNthCalledWith(
-          2,
+        expect(mockGetTracesWithSpansCH).toHaveBeenNthCalledWith(2, {
           projectId,
-          [fullId],
+          traceIds: [fullId],
           protections,
-          undefined,
-          { resolveBlobs: undefined },
-        );
+          opts: { resolveBlobs: undefined },
+        });
       });
 
       it("throws AmbiguousTraceIdPrefixError when the prefix matches multiple traces", async () => {
@@ -166,7 +172,7 @@ describe("TraceService", () => {
         ]);
 
         await expect(
-          service.getById(projectId, prefix20, protections),
+          service.getById({ projectId, traceId: prefix20, protections }),
         ).rejects.toBeInstanceOf(AmbiguousTraceIdPrefixError);
       });
 
@@ -174,7 +180,11 @@ describe("TraceService", () => {
         mockGetTracesWithSpansCH.mockResolvedValue([]);
         mockResolveTraceIdByPrefixCH.mockResolvedValue([]);
 
-        const result = await service.getById(projectId, prefix20, protections);
+        const result = await service.getById({
+          projectId,
+          traceId: prefix20,
+          protections,
+        });
 
         expect(result).toBeUndefined();
       });
@@ -184,7 +194,11 @@ describe("TraceService", () => {
       it("returns undefined without querying by prefix", async () => {
         mockGetTracesWithSpansCH.mockResolvedValue([]);
 
-        const result = await service.getById(projectId, "abc", protections);
+        const result = await service.getById({
+          projectId,
+          traceId: "abc",
+          protections,
+        });
 
         expect(result).toBeUndefined();
         expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();
@@ -195,11 +209,11 @@ describe("TraceService", () => {
       it("skips prefix resolution and returns undefined", async () => {
         mockGetTracesWithSpansCH.mockResolvedValue([]);
 
-        const result = await service.getById(
+        const result = await service.getById({
           projectId,
-          "not-a-hex-id-zzzzzzzz",
+          traceId: "not-a-hex-id-zzzzzzzz",
           protections,
-        );
+        });
 
         expect(result).toBeUndefined();
         expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();

--- a/platform/app/src/server/traces/clickhouse-trace.service.ts
+++ b/platform/app/src/server/traces/clickhouse-trace.service.ts
@@ -422,13 +422,19 @@ export class ClickHouseTraceService {
    * @returns Array of Trace objects with spans
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
-  async getTracesWithSpans(
-    projectId: string,
-    traceIds: string[],
-    protections: Protections,
-    occurredAt?: OccurredAtRange,
-    opts?: { resolveBlobs?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesWithSpans({
+    projectId,
+    traceIds,
+    protections,
+    occurredAt,
+    opts,
+  }: {
+    projectId: string;
+    traceIds: string[];
+    protections: Protections;
+    occurredAt?: OccurredAtRange;
+    opts?: { resolveBlobs?: boolean };
+  }): Promise<Trace[]> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getTracesWithSpans",
       {
@@ -590,12 +596,17 @@ export class ClickHouseTraceService {
    *   clickhouse-trace.service-4991-bulk.unit.test.ts.
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
-  async getTracesByThreadId(
-    projectId: string,
-    threadId: string,
-    protections: Protections,
-    opts?: { resolveBlobs?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesByThreadId({
+    projectId,
+    threadId,
+    protections,
+    opts,
+  }: {
+    projectId: string;
+    threadId: string;
+    protections: Protections;
+    opts?: { resolveBlobs?: boolean };
+  }): Promise<Trace[]> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getTracesByThreadId",
       {
@@ -638,13 +649,12 @@ export class ClickHouseTraceService {
           // Fetch full traces with spans. Forward resolveBlobs so the
           // thread-detail read can resolve full IO (#4991); customer thread
           // views with no resolver wired stay on the preview.
-          const traces = await this.getTracesWithSpans(
+          const traces = await this.getTracesWithSpans({
             projectId,
             traceIds,
             protections,
-            undefined,
-            { resolveBlobs: opts?.resolveBlobs },
-          );
+            opts: { resolveBlobs: opts?.resolveBlobs },
+          });
 
           // Re-sort by timestamp — getTracesWithSpans returns in TraceId
           // order which doesn't match the chronological order we need.
@@ -687,12 +697,17 @@ export class ClickHouseTraceService {
    * @returns Array of Trace objects with spans
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
-  async getTracesWithSpansByThreadIds(
-    projectId: string,
-    threadIds: string[],
-    protections: Protections,
-    opts?: { resolveBlobs?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesWithSpansByThreadIds({
+    projectId,
+    threadIds,
+    protections,
+    opts,
+  }: {
+    projectId: string;
+    threadIds: string[];
+    protections: Protections;
+    opts?: { resolveBlobs?: boolean };
+  }): Promise<Trace[]> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getTracesWithSpansByThreadIds",
       {
@@ -742,13 +757,12 @@ export class ClickHouseTraceService {
           // Fetch full traces with spans. Forward resolveBlobs so the eval
           // path reads full thread IO (#4888); customer thread views pass
           // nothing and have no resolver, so they stay on the preview.
-          const traces = await this.getTracesWithSpans(
+          const traces = await this.getTracesWithSpans({
             projectId,
             traceIds,
             protections,
-            undefined,
-            { resolveBlobs: opts?.resolveBlobs },
-          );
+            opts: { resolveBlobs: opts?.resolveBlobs },
+          });
 
           // Re-sort by timestamp — getTracesWithSpans returns in TraceId
           // order which doesn't match the chronological order we need.
@@ -950,12 +964,12 @@ export class ClickHouseTraceService {
           const wantsFullIo = options.resolveBlobs === true;
 
           if ((wantsSpans || wantsFullIo) && traces.length > 0) {
-            const enriched = await this.enrichTracesWithSpans(
+            const enriched = await this.enrichTracesWithSpans({
               traces,
-              input.projectId,
+              projectId: input.projectId,
               protections,
-              wantsFullIo,
-            );
+              resolveBlobs: wantsFullIo,
+            });
 
             // A summary caller keeps the recomputed trace-level IO but not the
             // spans it never asked for — the payload shape stays exactly as it
@@ -2640,12 +2654,17 @@ export class ClickHouseTraceService {
    *
    * @internal
    */
-  private async enrichTracesWithSpans(
-    traces: Trace[],
-    projectId: string,
-    protections: Protections,
+  private async enrichTracesWithSpans({
+    traces,
+    projectId,
+    protections,
     resolveBlobs = false,
-  ): Promise<Trace[]> {
+  }: {
+    traces: Trace[];
+    projectId: string;
+    protections: Protections;
+    resolveBlobs?: boolean;
+  }): Promise<Trace[]> {
     const traceIds = traces.map((t) => t.trace_id);
     // The traces already carry their own timestamps, so derive the partition
     // window for free: this bounds the trace_summaries summary read to the

--- a/platform/app/src/server/traces/mappers/span.mapper.ts
+++ b/platform/app/src/server/traces/mappers/span.mapper.ts
@@ -437,12 +437,17 @@ function extractContexts(
  * statusMessage is often a short HTTP-status summary ("Bad Request") that
  * loses the actionable detail.
  */
-function extractError(
-  statusCode: NormalizedStatusCode | null,
-  statusMessage: string | null,
-  spanAttributes: NormalizedAttributes,
-  events: readonly { name: string; attributes: NormalizedAttributes }[],
-): ErrorCapture | null {
+function extractError({
+  statusCode,
+  statusMessage,
+  spanAttributes,
+  events,
+}: {
+  statusCode: NormalizedStatusCode | null;
+  statusMessage: string | null;
+  spanAttributes: NormalizedAttributes;
+  events: readonly { name: string; attributes: NormalizedAttributes }[];
+}): ErrorCapture | null {
   if (statusCode !== NormalizedStatusCode.ERROR) {
     return null;
   }
@@ -529,12 +534,12 @@ export function mapNormalizedSpanToSpan(normalizedSpan: NormalizedSpan): Span {
     name: normalizedSpan.name,
     input: extractInput(normalizedSpan.spanAttributes),
     output: extractOutput(normalizedSpan.spanAttributes),
-    error: extractError(
-      normalizedSpan.statusCode,
-      normalizedSpan.statusMessage,
-      normalizedSpan.spanAttributes,
-      normalizedSpan.events,
-    ),
+    error: extractError({
+      statusCode: normalizedSpan.statusCode,
+      statusMessage: normalizedSpan.statusMessage,
+      spanAttributes: normalizedSpan.spanAttributes,
+      events: normalizedSpan.events,
+    }),
     timestamps,
     metrics: extractMetrics(normalizedSpan.spanAttributes),
     params: unflattenDotNotation(normalizedSpan.spanAttributes),

--- a/platform/app/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/platform/app/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -108,13 +108,19 @@ async function forEachWithConcurrency<T>(
 }
 
 /** Logs a per-field resolution failure at warn level (no silent truncation). */
-function warnResolutionFailure(
-  logger: WarnLogger,
-  projectId: string,
-  span: NormalizedSpan,
-  attrKey: string,
-  error: unknown,
-): void {
+function warnResolutionFailure({
+  logger,
+  projectId,
+  span,
+  attrKey,
+  error,
+}: {
+  logger: WarnLogger;
+  projectId: string;
+  span: NormalizedSpan;
+  attrKey: string;
+  error: unknown;
+}): void {
   if (
     error instanceof BlobNotFoundError ||
     error instanceof BlobFieldNotFoundError
@@ -245,7 +251,13 @@ export async function resolveOffloadedTracesBatch({
           resolvedAttrs[attrKey] = result.value;
           anyResolved = true;
         } else if (result && !result.ok) {
-          warnResolutionFailure(logger, projectId, span, attrKey, result.error);
+          warnResolutionFailure({
+            logger,
+            projectId,
+            span,
+            attrKey,
+            error: result.error,
+          });
         }
       }
       return { ...span, spanAttributes: resolvedAttrs };

--- a/platform/app/src/server/traces/trace.service.ts
+++ b/platform/app/src/server/traces/trace.service.ts
@@ -172,7 +172,7 @@ class OffloadedSpanResolver {
  * @example
  * ```ts
  * const service = TraceService.create(prisma);
- * const traces = await service.getTracesWithSpans(projectId, traceIds, protections);
+ * const traces = await service.getTracesWithSpans({ projectId, traceIds, protections });
  * ```
  */
 export class TraceService {
@@ -253,23 +253,27 @@ export class TraceService {
    *   preview — identical to pre-#4888 behavior.
    * @returns The trace if found, undefined otherwise
    */
-  async getById(
-    projectId: string,
-    traceId: string,
-    protections: Protections,
-    opts?: { full?: boolean },
-  ): Promise<Trace | undefined> {
+  async getById({
+    projectId,
+    traceId,
+    protections,
+    opts,
+  }: {
+    projectId: string;
+    traceId: string;
+    protections: Protections;
+    opts?: { full?: boolean };
+  }): Promise<Trace | undefined> {
     return this.tracer.withActiveSpan(
       "TraceService.getById",
       { attributes: { "tenant.id": projectId, "trace.id": traceId } },
       async (span) => {
-        const traces = await this.clickHouseService.getTracesWithSpans(
+        const traces = await this.clickHouseService.getTracesWithSpans({
           projectId,
-          [traceId],
+          traceIds: [traceId],
           protections,
-          undefined,
-          { resolveBlobs: opts?.full },
-        );
+          opts: { resolveBlobs: opts?.full },
+        });
         if (traces[0]) {
           return this.enrichCodingAgentTrace(projectId, traces[0]);
         }
@@ -305,13 +309,12 @@ export class TraceService {
           }
 
           span.setAttribute("trace.id.prefix.resolved", candidates[0]!);
-          const resolved = await this.clickHouseService.getTracesWithSpans(
+          const resolved = await this.clickHouseService.getTracesWithSpans({
             projectId,
-            [candidates[0]!],
+            traceIds: [candidates[0]!],
             protections,
-            undefined,
-            { resolveBlobs: opts?.full },
-          );
+            opts: { resolveBlobs: opts?.full },
+          });
           return resolved[0]
             ? this.enrichCodingAgentTrace(projectId, resolved[0])
             : undefined;
@@ -403,26 +406,32 @@ export class TraceService {
    *   read back full (#4888). Default (undefined/false) returns previews.
    * @returns Array of Trace objects with spans
    */
-  async getTracesWithSpans(
-    projectId: string,
-    traceIds: string[],
-    protections: Protections,
-    occurredAt?: { from: number; to: number },
-    opts?: { full?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesWithSpans({
+    projectId,
+    traceIds,
+    protections,
+    occurredAt,
+    opts,
+  }: {
+    projectId: string;
+    traceIds: string[];
+    protections: Protections;
+    occurredAt?: { from: number; to: number };
+    opts?: { full?: boolean };
+  }): Promise<Trace[]> {
     return this.tracer.withActiveSpan(
       "TraceService.getTracesWithSpans",
       {
         attributes: { "tenant.id": projectId, "trace.count": traceIds.length },
       },
       async () => {
-        const traces = await this.clickHouseService.getTracesWithSpans(
+        const traces = await this.clickHouseService.getTracesWithSpans({
           projectId,
           traceIds,
           protections,
           occurredAt,
-          { resolveBlobs: opts?.full },
-        );
+          opts: { resolveBlobs: opts?.full },
+        });
         return this.enrichCodingAgentTraces(projectId, traces);
       },
     );
@@ -439,22 +448,27 @@ export class TraceService {
    *   Default (undefined/false) returns the ≤64 KB preview.
    * @returns Array of traces in the thread
    */
-  async getTracesByThreadId(
-    projectId: string,
-    threadId: string,
-    protections: Protections,
-    opts?: { full?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesByThreadId({
+    projectId,
+    threadId,
+    protections,
+    opts,
+  }: {
+    projectId: string;
+    threadId: string;
+    protections: Protections;
+    opts?: { full?: boolean };
+  }): Promise<Trace[]> {
     return this.tracer.withActiveSpan(
       "TraceService.getTracesByThreadId",
       { attributes: { "tenant.id": projectId, "thread.id": threadId } },
       async () => {
-        const traces = await this.clickHouseService.getTracesByThreadId(
+        const traces = await this.clickHouseService.getTracesByThreadId({
           projectId,
           threadId,
           protections,
-          { resolveBlobs: opts?.full },
-        );
+          opts: { resolveBlobs: opts?.full },
+        });
         return this.enrichCodingAgentTraces(projectId, traces);
       },
     );
@@ -580,12 +594,17 @@ export class TraceService {
    *   preview and issues zero event_log reads (#4888 / ADR-022).
    * @returns Array of traces
    */
-  async getTracesWithSpansByThreadIds(
-    projectId: string,
-    threadIds: string[],
-    protections: Protections,
-    opts?: { full?: boolean },
-  ): Promise<Trace[]> {
+  async getTracesWithSpansByThreadIds({
+    projectId,
+    threadIds,
+    protections,
+    opts,
+  }: {
+    projectId: string;
+    threadIds: string[];
+    protections: Protections;
+    opts?: { full?: boolean };
+  }): Promise<Trace[]> {
     return this.tracer.withActiveSpan(
       "TraceService.getTracesWithSpansByThreadIds",
       {
@@ -596,12 +615,12 @@ export class TraceService {
       },
       async () => {
         const traces =
-          await this.clickHouseService.getTracesWithSpansByThreadIds(
+          await this.clickHouseService.getTracesWithSpansByThreadIds({
             projectId,
             threadIds,
             protections,
-            { resolveBlobs: opts?.full },
-          );
+            opts: { resolveBlobs: opts?.full },
+          });
         return this.enrichCodingAgentTraces(projectId, traces);
       },
     );

--- a/platform/app/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/platform/app/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -8,6 +8,7 @@ const { mockRedisStore, mockRedis } = vi.hoisted(() => {
       mockRedisStore.set(key, { value, ttl });
     }),
     set: vi.fn(
+      // biome-ignore lint/complexity/useMaxParams: fake of ioredis's positional set(key, value, "EX", ttl, "NX")
       async (
         key: string,
         value: string,

--- a/platform/app/src/server/workflows/__tests__/materializeNodeLlmConfigs.unit.test.ts
+++ b/platform/app/src/server/workflows/__tests__/materializeNodeLlmConfigs.unit.test.ts
@@ -59,12 +59,12 @@ describe("materializeNodeLlmConfigs", () => {
 
   it("falls back to DEFAULT_MODEL when nothing is configured at any scope", async () => {
     vi.mocked(resolveModelForFeature).mockRejectedValue(
-      new ModelNotConfiguredError(
-        "workflows.create_default",
-        "DEFAULT",
-        "New workflow model",
-        "p1",
-      ),
+      new ModelNotConfiguredError({
+        featureKey: "workflows.create_default",
+        role: "DEFAULT",
+        featureDisplayName: "New workflow model",
+        projectId: "p1",
+      }),
     );
     const dsl = dslWith({ model: "", temperature: 0.2 });
 

--- a/platform/app/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
+++ b/platform/app/src/server/workflows/__tests__/runWorkflow.legacy-default-llm.integration.test.ts
@@ -220,7 +220,7 @@ describe("runWorkflow with a pre-1.5 published version", () => {
       json: async () => ({ result: {}, status: "success" }),
     });
 
-    await runWorkflow(workflowId, projectId, { input: "hello" });
+    await runWorkflow({ workflowId, projectId, inputs: { input: "hello" } });
 
     expect(nlpgoFetchMock).toHaveBeenCalledTimes(1);
     const dispatched = nlpgoFetchMock.mock.calls[0]![0] as {

--- a/platform/app/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
+++ b/platform/app/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
@@ -25,7 +25,11 @@ describe("runWorkflow()", () => {
       findUniqueMock.mockResolvedValue(null);
 
       await expect(
-        runWorkflow("nonexistent-workflow", "project_123", {}),
+        runWorkflow({
+          workflowId: "nonexistent-workflow",
+          projectId: "project_123",
+          inputs: {},
+        }),
       ).rejects.toBeInstanceOf(NotFoundError);
     });
   });
@@ -35,7 +39,11 @@ describe("runWorkflow()", () => {
       findUniqueMock.mockResolvedValue({ id: "wf_1", publishedId: null });
 
       await expect(
-        runWorkflow("wf_1", "project_123", {}),
+        runWorkflow({
+          workflowId: "wf_1",
+          projectId: "project_123",
+          inputs: {},
+        }),
       ).rejects.toBeInstanceOf(ValidationError);
     });
   });

--- a/platform/app/src/server/workflows/runWorkflow.ts
+++ b/platform/app/src/server/workflows/runWorkflow.ts
@@ -109,19 +109,26 @@ const checkForRequiredLLMKeys = (
   return true;
 };
 
-export async function runEvaluationWorkflow(
-  workflowId: string,
-  projectId: string,
-  inputs: Record<string, string>,
-  versionId?: string,
-  causalityDepth?: number,
-  parentTrace?: { traceId: string; parentSpanId: string },
-): Promise<{
+export async function runEvaluationWorkflow({
+  workflowId,
+  projectId,
+  inputs,
+  versionId,
+  causalityDepth,
+  parentTrace,
+}: {
+  workflowId: string;
+  projectId: string;
+  inputs: Record<string, string>;
+  versionId?: string;
+  causalityDepth?: number;
+  parentTrace?: { traceId: string; parentSpanId: string };
+}): Promise<{
   result: SingleEvaluationResult;
   status: ExecutionStatus;
 }> {
   try {
-    const data = await runWorkflow(
+    const data = await runWorkflow({
       workflowId,
       projectId,
       inputs,
@@ -136,15 +143,15 @@ export async function runEvaluationWorkflow(
       // execute_component) get a fresh trace_id and land as a
       // separate orphan trace. See the 2026-05-14 prod regression
       // reported by rchaves.
-      false, // do_not_trace
-      false, // run_evaluations - disable evaluators inside the workflow when running as an online evaluation
-      "evaluation",
+      do_not_trace: false,
+      run_evaluations: false, // disable evaluators inside the workflow when running as an online evaluation
+      origin: "evaluation",
       // Always pass a concrete depth (default 0) so the downstream
       // header gate in nlpgoFetch sees this as an evaluator-chain call
       // even when the parent had no depth attribute yet.
-      causalityDepth ?? 0,
+      causalityDepth: causalityDepth ?? 0,
       parentTrace,
-    );
+    });
 
     // Process the result
     if (data.result) {
@@ -180,17 +187,27 @@ export async function runEvaluationWorkflow(
   }
 }
 
-export async function runWorkflow(
-  workflowId: string,
-  projectId: string,
-  inputs: Record<string, string>,
-  versionId?: string,
-  do_not_trace?: boolean,
-  run_evaluations?: boolean,
-  origin: NLPOrigin = "workflow",
-  causalityDepth?: number,
-  parentTrace?: { traceId: string; parentSpanId: string },
-) {
+export async function runWorkflow({
+  workflowId,
+  projectId,
+  inputs,
+  versionId,
+  do_not_trace,
+  run_evaluations,
+  origin = "workflow",
+  causalityDepth,
+  parentTrace,
+}: {
+  workflowId: string;
+  projectId: string;
+  inputs: Record<string, string>;
+  versionId?: string;
+  do_not_trace?: boolean;
+  run_evaluations?: boolean;
+  origin?: NLPOrigin;
+  causalityDepth?: number;
+  parentTrace?: { traceId: string; parentSpanId: string };
+}) {
   const workflow = await prisma.workflow.findUnique({
     where: { id: workflowId, projectId },
   });

--- a/platform/app/src/server/workflows/workflowEvaluation.service.ts
+++ b/platform/app/src/server/workflows/workflowEvaluation.service.ts
@@ -187,13 +187,13 @@ export class WorkflowEvaluationService {
       }
     }
 
-    const dataResult = await loadExecutionData(
+    const dataResult = await loadExecutionData({
       projectId,
-      datasetRef,
-      [target],
-      [],
-      { data, datasetId: resolvedDatasetId, parameters },
-    );
+      dataset: datasetRef,
+      targets: [target],
+      evaluators: [],
+      inputs: { data, datasetId: resolvedDatasetId, parameters },
+    });
     if ("error" in dataResult) {
       throw new EvaluationInputError(dataResult.error, dataResult.status);
     }

--- a/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
+++ b/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
@@ -127,7 +127,7 @@ describe("modelProviderHelpers", () => {
         OPENAI_BASE_URL: "https://api.openai.com/v1",
       };
 
-      const result = buildCustomKeyState(displayKeyMap, storedKeys);
+      const result = buildCustomKeyState({ displayKeyMap, storedKeys });
 
       expect(result).toEqual({
         OPENAI_API_KEY: "sk-stored123",
@@ -140,11 +140,11 @@ describe("modelProviderHelpers", () => {
       const storedKeys = { OPENAI_API_KEY: "sk-old" };
       const previousKeys = { OPENAI_API_KEY: "sk-user-typing" };
 
-      const result = buildCustomKeyState(
+      const result = buildCustomKeyState({
         displayKeyMap,
         storedKeys,
         previousKeys,
-      );
+      });
 
       expect(result.OPENAI_API_KEY).toBe("sk-user-typing");
     });
@@ -154,11 +154,11 @@ describe("modelProviderHelpers", () => {
       const storedKeys = {};
       const previousKeys = { MANAGED: "true" };
 
-      const result = buildCustomKeyState(
+      const result = buildCustomKeyState({
         displayKeyMap,
         storedKeys,
         previousKeys,
-      );
+      });
 
       expect(result).toEqual({ MANAGED: "true" });
     });
@@ -168,12 +168,11 @@ describe("modelProviderHelpers", () => {
       const storedKeys = {};
       const options = { providerEnabledWithEnvVars: true };
 
-      const result = buildCustomKeyState(
+      const result = buildCustomKeyState({
         displayKeyMap,
         storedKeys,
-        undefined,
         options,
-      );
+      });
 
       expect(result.OPENAI_API_KEY).toBe(MASKED_KEY_PLACEHOLDER);
       expect(result.OPENAI_BASE_URL).toBe(""); // URL fields are not masked
@@ -183,7 +182,7 @@ describe("modelProviderHelpers", () => {
       const displayKeyMap = { OPENAI_API_KEY: {}, OPENAI_BASE_URL: {} };
       const storedKeys = {};
 
-      const result = buildCustomKeyState(displayKeyMap, storedKeys);
+      const result = buildCustomKeyState({ displayKeyMap, storedKeys });
 
       expect(result).toEqual({ OPENAI_API_KEY: "", OPENAI_BASE_URL: "" });
     });
@@ -193,18 +192,17 @@ describe("modelProviderHelpers", () => {
       const storedKeys = { OPENAI_API_KEY: "sk-actual-key" };
       const options = { providerEnabledWithEnvVars: true };
 
-      const result = buildCustomKeyState(
+      const result = buildCustomKeyState({
         displayKeyMap,
         storedKeys,
-        undefined,
         options,
-      );
+      });
 
       expect(result.OPENAI_API_KEY).toBe("sk-actual-key");
     });
 
     it("handles empty display key map", () => {
-      const result = buildCustomKeyState({}, {});
+      const result = buildCustomKeyState({ displayKeyMap: {}, storedKeys: {} });
       expect(result).toEqual({});
     });
   });

--- a/platform/app/src/utils/api.tsx
+++ b/platform/app/src/utils/api.tsx
@@ -191,6 +191,7 @@ function createQueryClientConfig() {
      * @see extractLimitExceededInfo in trpcError.ts
      */
     mutationCache: new MutationCache({
+      // biome-ignore lint/complexity/useMaxParams: TanStack Query's MutationCache onError callback contract is positional
       onError: (error, _variables, _context, _mutation) => {
         const limitInfo = extractLimitExceededInfo(error);
         if (limitInfo) {

--- a/platform/app/src/utils/gridPositions.ts
+++ b/platform/app/src/utils/gridPositions.ts
@@ -27,12 +27,17 @@ export const calculateGridPositions = <T extends GridItem>(
 
   const cellKey = (col: number, row: number) => `${col},${row}`;
 
-  const isAreaFree = (
-    col: number,
-    row: number,
-    colSpan: number,
-    rowSpan: number,
-  ) => {
+  const isAreaFree = ({
+    col,
+    row,
+    colSpan,
+    rowSpan,
+  }: {
+    col: number;
+    row: number;
+    colSpan: number;
+    rowSpan: number;
+  }) => {
     for (let c = col; c < col + colSpan; c++) {
       for (let r = row; r < row + rowSpan; r++) {
         if (c >= 2 || occupied.has(cellKey(c, r))) {
@@ -43,12 +48,17 @@ export const calculateGridPositions = <T extends GridItem>(
     return true;
   };
 
-  const occupyArea = (
-    col: number,
-    row: number,
-    colSpan: number,
-    rowSpan: number,
-  ) => {
+  const occupyArea = ({
+    col,
+    row,
+    colSpan,
+    rowSpan,
+  }: {
+    col: number;
+    row: number;
+    colSpan: number;
+    rowSpan: number;
+  }) => {
     for (let c = col; c < col + colSpan; c++) {
       for (let r = row; r < row + rowSpan; r++) {
         occupied.add(cellKey(c, r));
@@ -65,8 +75,8 @@ export const calculateGridPositions = <T extends GridItem>(
 
     while (!placed) {
       for (let col = 0; col <= 2 - colSpan; col++) {
-        if (isAreaFree(col, row, colSpan, rowSpan)) {
-          occupyArea(col, row, colSpan, rowSpan);
+        if (isAreaFree({ col, row, colSpan, rowSpan })) {
+          occupyArea({ col, row, colSpan, rowSpan });
           layouts.push({
             graphId: item.id,
             gridColumn: col,

--- a/platform/app/src/utils/modelProviderHelpers.ts
+++ b/platform/app/src/utils/modelProviderHelpers.ts
@@ -201,12 +201,17 @@ export function getDisplayKeysForProvider(
  * When provider is enabled but has no stored keys (using env vars),
  * API key fields will show MASKED_KEY_PLACEHOLDER.
  */
-export function buildCustomKeyState(
-  displayKeyMap: Record<string, unknown>,
-  storedKeys: Record<string, unknown>,
-  previousKeys?: Record<string, string>,
-  options?: { providerEnabledWithEnvVars?: boolean },
-): Record<string, string> {
+export function buildCustomKeyState({
+  displayKeyMap,
+  storedKeys,
+  previousKeys,
+  options,
+}: {
+  displayKeyMap: Record<string, unknown>;
+  storedKeys: Record<string, unknown>;
+  previousKeys?: Record<string, string>;
+  options?: { providerEnabledWithEnvVars?: boolean };
+}): Record<string, string> {
   if (previousKeys?.MANAGED) {
     return previousKeys;
   }

--- a/platform/app/src/utils/parsePythonInsideJson.ts
+++ b/platform/app/src/utils/parsePythonInsideJson.ts
@@ -39,6 +39,7 @@ const grammar = ohm.grammar(`
 const semantics = grammar.createSemantics().addOperation("toJSON", {
   Expression: (e) => e.toJSON(),
   ObjectExpr: (e) => e.toJSON(),
+  // biome-ignore lint/complexity/useMaxParams: ohm-js semantic actions receive one positional argument per grammar-rule child
   ClassExpr: (id, _1, args, _2) => {
     let argIndex = 0;
     const processedArgs = args.toJSON().map((arg: any) => {
@@ -60,6 +61,7 @@ const semantics = grammar.createSemantics().addOperation("toJSON", {
   Array: (_, elements, __) => elements.toJSON(),
   String: (q1, chars, q2) => chars.sourceString,
   Number: (n) => n.toJSON(),
+  // biome-ignore lint/complexity/useMaxParams: ohm-js semantic actions receive one positional argument per grammar-rule child
   float: function (neg, whole, dot, fract, e, eneg, exp) {
     return parseFloat(this.sourceString);
   },


### PR DESCRIPTION
Stacked on #6695.

## What

Converts every function past 3 positional parameters to a single named-object parameter (house style: `fn({ a, b })`), then promotes biome's `useMaxParams` from `warn` (delta-gated) to `error` (blocks everywhere).

- **307 sites across 192 files → 0**, with all callers updated repo-wide (440 files touched).
- Shared contracts converted uniformly with every implementation and call site: the `FilterConditionBuilder` registry (~24 entries), `TRACE_MAPPINGS` (~20 entries, unified on `{ trace, key, subkey, data }`), `DatasetTableContextValue.setCellValue` (both feature areas), the `onAddEdge` message-edge prop contract, and the event-sourcing error-class hierarchy.
- **10 library-imposed signatures** keep positional form under inline `biome-ignore` pragmas stating the imposing contract: React `<Profiler onRender>`, ioredis `set`/`eval` test fakes (×5), TanStack `MutationCache.onError`, ohm-js semantic actions (×2), an MCP SDK `tool()` fake.
- Fixes a collision the sweep introduced: `@langwatch/handled-error`'s **positional** `ValidationError` shares its name with the event-sourcing one; ten files' call sites were wrongly rewritten to the object shape, silently dropping `meta` (the ADR-045 wire channel). All reverted; `langy.turnErrors.unit.test.ts` covers it.
- Four functions the taller syntax pushed past the 60-line cap were trimmed back via small extractions — `noExcessiveLinesPerFunction` ends **one below** its pre-campaign baseline, so the reviewdog delta gate stays clean.

## Verification

- `pnpm lint` exits 0 with `useMaxParams` at `error`; full-tree scan shows zero diagnostics for the rule.
- ~25,000 unit tests run green across every touched subsystem (per-cluster scoped runs; behavior-identical conversions, no logic changes).
- Remaining warnings (3,407) are exclusively `noExcessiveLinesPerFunction` / `noExcessiveCognitiveComplexity` / `noMisplacedAssertion` — the first two are the next burn-down, the last is permanently `warn` (named assertion helpers are house style).