### PR TITLE
fix(scenarios): retry judge tool calls with reasoning off on provider rejection

### DIFF
--- a/platform/app/src/server/scenarios/execution/__tests__/judge-transport-tool-reasoning.integration.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/judge-transport-tool-reasoning.integration.test.ts
@@ -29,7 +29,6 @@
  * specs/scenarios/judge-transport-tool-reasoning.feature.
  */
 
-import { createServer, type Server } from "node:http";
 import { APICallError, generateText, tool } from "ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -38,6 +37,11 @@ import {
   createModelFromParams,
 } from "../model.factory";
 import type { LiteLLMParams } from "../types";
+import {
+  type StubEndpoint,
+  startEndpoint,
+  surfacedRejection,
+} from "./support/chat-completions-stub-endpoint";
 
 const JUDGE_PARAMS: LiteLLMParams = {
   api_key: "test-key",
@@ -58,184 +62,6 @@ const finishTest = tool({
     reasoning: z.string(),
   }),
 });
-
-type EndpointRule =
-  | "accept"
-  | "reject-tools-without-reasoning-off"
-  | "reject-reasoning-always"
-  | "reject-reasoning-without-remedy"
-  | "reject-unrelated"
-  | "reject-not-json";
-
-interface StubEndpoint {
-  url: string;
-  bodies: () => Array<Record<string, unknown>>;
-  close: () => Promise<void>;
-}
-
-const UNRELATED_REJECTION = {
-  error: {
-    type: "invalid_request_error",
-    message: "Unsupported value for parameter 'temperature'.",
-    param: "temperature",
-  },
-};
-
-/**
- * A rejection carrying the same structured `param` as the one the retry answers,
- * but asking for nothing: the provider refused the reasoning setting without
- * saying what it would accept. Keying the retry on `param` alone would answer
- * this by re-sending the request with a value nobody requested.
- */
-const UNSPECIFIC_REASONING_REJECTION = {
-  error: {
-    type: "invalid_request_error",
-    message: "Unsupported value for parameter 'reasoning_effort'.",
-    param: "reasoning_effort",
-  },
-};
-
-/** The upstream 400 verbatim, including the structured `param` the retry keys on. */
-function reasoningRejectionFor(model: unknown) {
-  return {
-    error: {
-      type: "invalid_request_error",
-      message: `Function tools with reasoning_effort are not supported for ${String(
-        model,
-      )} in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.`,
-      param: "reasoning_effort",
-    },
-  };
-}
-
-function completionFor(body: Record<string, unknown>, carriesTools: boolean) {
-  return {
-    id: "chatcmpl-stub",
-    object: "chat.completion",
-    created: 0,
-    model: body.model,
-    choices: [
-      {
-        index: 0,
-        message: carriesTools
-          ? {
-              role: "assistant",
-              content: null,
-              tool_calls: [
-                {
-                  id: "call_1",
-                  type: "function",
-                  function: {
-                    name: "finishTest",
-                    arguments: JSON.stringify({
-                      verdict: "success",
-                      reasoning: "criteria met",
-                    }),
-                  },
-                },
-              ],
-            }
-          : { role: "assistant", content: "plain answer" },
-        finish_reason: carriesTools ? "tool_calls" : "stop",
-      },
-    ],
-    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-  };
-}
-
-/** What the endpoint answers for one request under the given rule. */
-function responseFor(
-  rule: EndpointRule,
-  body: Record<string, unknown>,
-): { status: number; payload: unknown; raw?: string } {
-  const carriesTools =
-    Array.isArray(body.tools) && (body.tools as unknown[]).length > 0;
-
-  if (rule === "reject-unrelated") {
-    return { status: 400, payload: UNRELATED_REJECTION };
-  }
-  if (rule === "reject-reasoning-without-remedy") {
-    return { status: 400, payload: UNSPECIFIC_REASONING_REJECTION };
-  }
-  if (rule === "reject-not-json") {
-    return { status: 400, payload: undefined, raw: "Bad Request" };
-  }
-  if (rule === "reject-reasoning-always") {
-    return { status: 400, payload: reasoningRejectionFor(body.model) };
-  }
-  if (
-    rule === "reject-tools-without-reasoning-off" &&
-    carriesTools &&
-    body.reasoning_effort !== "none"
-  ) {
-    return { status: 400, payload: reasoningRejectionFor(body.model) };
-  }
-  return { status: 200, payload: completionFor(body, carriesTools) };
-}
-
-/**
- * Stands in for the chat-completions endpoint behind the gateway proxy.
- *
- * "reject-tools-without-reasoning-off" enforces the upstream rule.
- * "reject-reasoning-without-remedy" refuses the reasoning setting without
- * naming a value it would accept.
- * "reject-unrelated" answers a 400 that has nothing to do with reasoning.
- * "accept" takes anything and exists only to record the wire body.
- */
-async function startEndpoint(
-  rule: EndpointRule = "accept",
-): Promise<StubEndpoint> {
-  const bodies: Array<Record<string, unknown>> = [];
-
-  const server: Server = createServer((req, res) => {
-    let raw = "";
-    req.on("data", (chunk: Buffer) => (raw += chunk.toString()));
-    req.on("end", () => {
-      const body = JSON.parse(raw) as Record<string, unknown>;
-      bodies.push(body);
-      const { status, payload, raw: rawResponse } = responseFor(rule, body);
-      if (rawResponse !== undefined) {
-        res.writeHead(status, { "Content-Type": "text/plain" });
-        res.end(rawResponse);
-        return;
-      }
-      res.writeHead(status, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(payload));
-    });
-  });
-
-  await new Promise<void>((resolve) =>
-    server.listen(0, "127.0.0.1", () => resolve()),
-  );
-  const { port } = server.address() as { port: number };
-
-  return {
-    url: `http://127.0.0.1:${port}`,
-    bodies: () => bodies,
-    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
-  };
-}
-
-/**
- * The structured shape of a surfaced provider rejection. Asserting on
- * `statusCode` + `error.param` (not the message prose) keeps the tests immune
- * to upstream rewording.
- */
-async function surfacedRejection(
-  request: Promise<unknown>,
-): Promise<{ statusCode: number | undefined; param: unknown }> {
-  const failure = await request.then(
-    () => {
-      throw new Error("expected the request to be rejected");
-    },
-    (error: unknown) => error,
-  );
-  if (!APICallError.isInstance(failure)) throw failure;
-  const body = JSON.parse(failure.responseBody ?? "{}") as {
-    error?: { param?: unknown };
-  };
-  return { statusCode: failure.statusCode, param: body.error?.param };
-}
 
 let endpoint: StubEndpoint | undefined;
 

--- a/platform/app/src/server/scenarios/execution/__tests__/judge-transport-tool-reasoning.integration.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/judge-transport-tool-reasoning.integration.test.ts
@@ -33,12 +33,21 @@ import { createServer, type Server } from "node:http";
 import { APICallError, generateText, tool } from "ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import { createModelFromParams } from "../model.factory";
+import {
+  createJudgeModelFromParams,
+  createModelFromParams,
+} from "../model.factory";
 import type { LiteLLMParams } from "../types";
 
 const JUDGE_PARAMS: LiteLLMParams = {
   api_key: "test-key",
   model: "openai/gpt-5.6-sol",
+};
+
+/** A judge model NOT on #6620's known-incompatible list — no preemptive default. */
+const UNLISTED_JUDGE_PARAMS: LiteLLMParams = {
+  api_key: "test-key",
+  model: "openai/gpt-5.7-nova",
 };
 
 /** The finish_test tool the judge forces — shape mirrors the SDK's. */
@@ -53,8 +62,10 @@ const finishTest = tool({
 type EndpointRule =
   | "accept"
   | "reject-tools-without-reasoning-off"
+  | "reject-reasoning-always"
   | "reject-reasoning-without-remedy"
-  | "reject-unrelated";
+  | "reject-unrelated"
+  | "reject-not-json";
 
 interface StubEndpoint {
   url: string;
@@ -136,7 +147,7 @@ function completionFor(body: Record<string, unknown>, carriesTools: boolean) {
 function responseFor(
   rule: EndpointRule,
   body: Record<string, unknown>,
-): { status: number; payload: unknown } {
+): { status: number; payload: unknown; raw?: string } {
   const carriesTools =
     Array.isArray(body.tools) && (body.tools as unknown[]).length > 0;
 
@@ -145,6 +156,12 @@ function responseFor(
   }
   if (rule === "reject-reasoning-without-remedy") {
     return { status: 400, payload: UNSPECIFIC_REASONING_REJECTION };
+  }
+  if (rule === "reject-not-json") {
+    return { status: 400, payload: undefined, raw: "Bad Request" };
+  }
+  if (rule === "reject-reasoning-always") {
+    return { status: 400, payload: reasoningRejectionFor(body.model) };
   }
   if (
     rule === "reject-tools-without-reasoning-off" &&
@@ -176,7 +193,12 @@ async function startEndpoint(
     req.on("end", () => {
       const body = JSON.parse(raw) as Record<string, unknown>;
       bodies.push(body);
-      const { status, payload } = responseFor(rule, body);
+      const { status, payload, raw: rawResponse } = responseFor(rule, body);
+      if (rawResponse !== undefined) {
+        res.writeHead(status, { "Content-Type": "text/plain" });
+        res.end(rawResponse);
+        return;
+      }
       res.writeHead(status, { "Content-Type": "application/json" });
       res.end(JSON.stringify(payload));
     });
@@ -248,11 +270,44 @@ describe("judge transport: function tools and reasoning effort", () => {
       });
     });
 
-    describe("when the judge grades a conversation against its criteria", () => {
+    describe("when the judge grades with a model not on the known-incompatible list", () => {
       /** @scenario "A criteria-graded run reports the verdict its criteria produced" */
-      it("reaches a verdict instead of an infrastructure error", async () => {
+      it("reaches a verdict through the judge factory instead of an infrastructure error", async () => {
         endpoint = await startEndpoint("reject-tools-without-reasoning-off");
-        const model = createModelFromParams({
+        // The production judge path: no preemptive default applies to an
+        // unlisted model, so only the transport retry stands between the
+        // refusal and the verdict.
+        const model = createJudgeModelFromParams({
+          litellmParams: UNLISTED_JUDGE_PARAMS,
+          nlpServiceUrl: endpoint.url,
+        });
+
+        const result = await generateText({
+          model,
+          messages: [{ role: "user", content: "grade this" }],
+          tools: { finishTest },
+          toolChoice: "required",
+        });
+
+        const bodies = endpoint.bodies();
+        expect(bodies).toHaveLength(2);
+        expect(bodies[0]).not.toHaveProperty("reasoning_effort");
+        expect(bodies[1]?.reasoning_effort).toBe("none");
+        expect(result.toolCalls[0]?.input).toEqual({
+          verdict: "success",
+          reasoning: "criteria met",
+        });
+      });
+    });
+
+    describe("when the judge grades with a model on the known-incompatible list", () => {
+      /** @scenario "A judge model already known to need reasoning off asks only once" */
+      it("sends one request already declaring reasoning off and gets the verdict", async () => {
+        endpoint = await startEndpoint("reject-tools-without-reasoning-off");
+        // Composition of the two mechanisms: #6620's preemptive default puts
+        // reasoning off on the FIRST body for a listed model, which also makes
+        // the retry ineligible — one request, no wasted round-trip.
+        const model = createJudgeModelFromParams({
           litellmParams: JUDGE_PARAMS,
           nlpServiceUrl: endpoint.url,
         });
@@ -264,6 +319,9 @@ describe("judge transport: function tools and reasoning effort", () => {
           toolChoice: "required",
         });
 
+        const bodies = endpoint.bodies();
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0]?.reasoning_effort).toBe("none");
         expect(result.toolCalls[0]?.input).toEqual({
           verdict: "success",
           reasoning: "criteria met",
@@ -356,6 +414,94 @@ describe("judge transport: function tools and reasoning effort", () => {
         const bodies = endpoint.bodies();
         expect(bodies).toHaveLength(1);
         expect(bodies[0]).not.toHaveProperty("reasoning_effort");
+      });
+    });
+  });
+
+  describe("given an endpoint that refuses reasoning even when it is off", () => {
+    describe("when the request carries function tools", () => {
+      /** @scenario "A second refusal ends the exchange" */
+      it("stops after exactly two requests and surfaces the second refusal", async () => {
+        endpoint = await startEndpoint("reject-reasoning-always");
+        const model = createModelFromParams({
+          litellmParams: JUDGE_PARAMS,
+          nlpServiceUrl: endpoint.url,
+        });
+
+        const rejection = await surfacedRejection(
+          generateText({
+            model,
+            messages: [{ role: "user", content: "grade this" }],
+            tools: { finishTest },
+            toolChoice: "required",
+          }),
+        );
+        expect(rejection).toEqual({
+          statusCode: 400,
+          param: "reasoning_effort",
+        });
+
+        // The second body already declares reasoning off, so it is not
+        // retry-eligible — the exchange is bounded at two requests.
+        const bodies = endpoint.bodies();
+        expect(bodies).toHaveLength(2);
+        expect(bodies[1]?.reasoning_effort).toBe("none");
+      });
+    });
+
+    describe("when the request asks for no tools", () => {
+      /** @scenario "A request that asks for no tools is never retried" */
+      it("surfaces the rejection without a second request", async () => {
+        endpoint = await startEndpoint("reject-reasoning-always");
+        const model = createModelFromParams({
+          litellmParams: JUDGE_PARAMS,
+          nlpServiceUrl: endpoint.url,
+        });
+
+        const rejection = await surfacedRejection(
+          generateText({
+            model,
+            messages: [{ role: "user", content: "just answer" }],
+          }),
+        );
+        expect(rejection).toEqual({
+          statusCode: 400,
+          param: "reasoning_effort",
+        });
+
+        // The guard that keeps ordinary chat traffic from being rewritten:
+        // without tools the request is not retry-eligible at all.
+        expect(endpoint.bodies()).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given an endpoint whose rejection body is not JSON", () => {
+    describe("when the request carries function tools", () => {
+      /** @scenario "A rejection that is not JSON is surfaced untouched" */
+      it("surfaces the raw 400 without retrying", async () => {
+        endpoint = await startEndpoint("reject-not-json");
+        const model = createModelFromParams({
+          litellmParams: JUDGE_PARAMS,
+          nlpServiceUrl: endpoint.url,
+        });
+
+        const failure = await generateText({
+          model,
+          messages: [{ role: "user", content: "grade this" }],
+          tools: { finishTest },
+          toolChoice: "required",
+        }).then(
+          () => {
+            throw new Error("expected the request to be rejected");
+          },
+          (error: unknown) => error,
+        );
+
+        if (!APICallError.isInstance(failure)) throw failure;
+        expect(failure.statusCode).toBe(400);
+        expect(failure.responseBody).toBe("Bad Request");
+        expect(endpoint.bodies()).toHaveLength(1);
       });
     });
   });

--- a/platform/app/src/server/scenarios/execution/__tests__/support/chat-completions-stub-endpoint.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/support/chat-completions-stub-endpoint.ts
@@ -94,7 +94,6 @@ function completionFor(body: Record<string, unknown>, hasTools: boolean) {
   };
 }
 
-/** What the endpoint answers for one request under the given rule. */
 function responseFor(
   rule: EndpointRule,
   body: Record<string, unknown>,

--- a/platform/app/src/server/scenarios/execution/__tests__/support/chat-completions-stub-endpoint.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/support/chat-completions-stub-endpoint.ts
@@ -1,0 +1,197 @@
+/**
+ * Stub harness for judge-transport integration tests: a local HTTP server
+ * standing in for the chat-completions endpoint behind the gateway proxy,
+ * plus the provider-rejection fixtures and the surfaced-error reader.
+ *
+ * Support module only — imported by
+ * judge-transport-tool-reasoning.integration.test.ts.
+ */
+
+import { createServer, type Server } from "node:http";
+import { APICallError } from "ai";
+
+export type EndpointRule =
+  | "accept"
+  | "reject-tools-without-reasoning-off"
+  | "reject-reasoning-always"
+  | "reject-reasoning-without-remedy"
+  | "reject-unrelated"
+  | "reject-not-json";
+
+export interface StubEndpoint {
+  url: string;
+  bodies: () => Array<Record<string, unknown>>;
+  close: () => Promise<void>;
+}
+
+const UNRELATED_REJECTION = {
+  error: {
+    type: "invalid_request_error",
+    message: "Unsupported value for parameter 'temperature'.",
+    param: "temperature",
+  },
+};
+
+/**
+ * A rejection carrying the same structured `param` as the one the retry answers,
+ * but asking for nothing: the provider refused the reasoning setting without
+ * saying what it would accept. Keying the retry on `param` alone would answer
+ * this by re-sending the request with a value nobody requested.
+ */
+const UNSPECIFIC_REASONING_REJECTION = {
+  error: {
+    type: "invalid_request_error",
+    message: "Unsupported value for parameter 'reasoning_effort'.",
+    param: "reasoning_effort",
+  },
+};
+
+/** The upstream 400 verbatim, including the structured `param` the retry keys on. */
+function reasoningRejectionFor(model: unknown) {
+  return {
+    error: {
+      type: "invalid_request_error",
+      message: `Function tools with reasoning_effort are not supported for ${String(
+        model,
+      )} in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.`,
+      param: "reasoning_effort",
+    },
+  };
+}
+
+function completionFor(body: Record<string, unknown>, hasTools: boolean) {
+  return {
+    id: "chatcmpl-stub",
+    object: "chat.completion",
+    created: 0,
+    model: body.model,
+    choices: [
+      {
+        index: 0,
+        message: hasTools
+          ? {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "finishTest",
+                    arguments: JSON.stringify({
+                      verdict: "success",
+                      reasoning: "criteria met",
+                    }),
+                  },
+                },
+              ],
+            }
+          : { role: "assistant", content: "plain answer" },
+        finish_reason: hasTools ? "tool_calls" : "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+/** What the endpoint answers for one request under the given rule. */
+function responseFor(
+  rule: EndpointRule,
+  body: Record<string, unknown>,
+): { status: number; payload: unknown; raw?: string } {
+  const hasTools =
+    Array.isArray(body.tools) && (body.tools as unknown[]).length > 0;
+
+  if (rule === "reject-unrelated") {
+    return { status: 400, payload: UNRELATED_REJECTION };
+  }
+  if (rule === "reject-reasoning-without-remedy") {
+    return { status: 400, payload: UNSPECIFIC_REASONING_REJECTION };
+  }
+  if (rule === "reject-not-json") {
+    return { status: 400, payload: undefined, raw: "Bad Request" };
+  }
+  if (rule === "reject-reasoning-always") {
+    return { status: 400, payload: reasoningRejectionFor(body.model) };
+  }
+  if (
+    rule === "reject-tools-without-reasoning-off" &&
+    hasTools &&
+    body.reasoning_effort !== "none"
+  ) {
+    return { status: 400, payload: reasoningRejectionFor(body.model) };
+  }
+  return { status: 200, payload: completionFor(body, hasTools) };
+}
+
+/**
+ * Stands in for the chat-completions endpoint behind the gateway proxy.
+ *
+ * "reject-tools-without-reasoning-off" enforces the upstream rule.
+ * "reject-reasoning-always" refuses reasoning even when it is off.
+ * "reject-reasoning-without-remedy" refuses the reasoning setting without
+ * naming a value it would accept.
+ * "reject-unrelated" answers a 400 that has nothing to do with reasoning.
+ * "reject-not-json" answers a 400 whose body is not JSON.
+ * "accept" takes anything and exists only to record the wire body.
+ */
+export async function startEndpoint(
+  rule: EndpointRule = "accept",
+): Promise<StubEndpoint> {
+  const bodies: Array<Record<string, unknown>> = [];
+
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk: Buffer) => (raw += chunk.toString()));
+    req.on("end", () => {
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      bodies.push(body);
+      const { status, payload, raw: rawResponse } = responseFor(rule, body);
+      if (rawResponse !== undefined) {
+        res.writeHead(status, { "Content-Type": "text/plain" });
+        res.end(rawResponse);
+        return;
+      }
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+    });
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const { port } = server.address() as { port: number };
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    bodies: () => bodies,
+    close: () =>
+      new Promise<void>((resolve) => {
+        // close() alone only waits for existing connections to drain; drop
+        // undici/AI SDK keep-alive sockets so afterEach never waits on them.
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/**
+ * The structured shape of a surfaced provider rejection. Asserting on
+ * `statusCode` + `error.param` (not the message prose) keeps the tests immune
+ * to upstream rewording.
+ */
+export async function surfacedRejection(
+  request: Promise<unknown>,
+): Promise<{ statusCode: number | undefined; param: unknown }> {
+  const failure = await request.then(
+    () => {
+      throw new Error("expected the request to be rejected");
+    },
+    (error: unknown) => error,
+  );
+  if (!APICallError.isInstance(failure)) throw failure;
+  const body = JSON.parse(failure.responseBody ?? "{}") as {
+    error?: { param?: unknown };
+  };
+  return { statusCode: failure.statusCode, param: body.error?.param };
+}

--- a/platform/app/src/server/scenarios/execution/model.factory.ts
+++ b/platform/app/src/server/scenarios/execution/model.factory.ts
@@ -114,9 +114,9 @@ function retryEligibleRequestBody(
     return undefined;
   }
   if (typeof parsed !== "object" || parsed === null) return undefined;
-  const carriesTools =
+  const hasTools =
     Array.isArray(parsed.tools) && (parsed.tools as unknown[]).length > 0;
-  if (!carriesTools || parsed.reasoning_effort !== undefined) return undefined;
+  if (!hasTools || parsed.reasoning_effort !== undefined) return undefined;
   return parsed;
 }
 

--- a/specs/scenarios/judge-reasoning-tool-compatibility.feature
+++ b/specs/scenarios/judge-reasoning-tool-compatibility.feature
@@ -50,6 +50,11 @@ Feature: Scenario judge reasoning and tool compatibility
       | azure/gpt-5.6-sol        |
       | openai/gpt-5.5-sol       |
 
+  # Scoped to how the request is BUILT: no reasoning effort is injected up
+  # front. If the provider then refuses a tool-carrying request and names
+  # reasoning off as its remedy, the shared transport answers that refusal for
+  # any scenario model — the judge holds no monopoly on the retry. That rule
+  # and its bounds live in specs/scenarios/judge-transport-tool-reasoning.feature.
   @unit
   Scenario: The same model outside the judge is untouched
     Given a simulator or tested target uses "openai/gpt-5.6-sol"

--- a/specs/scenarios/judge-transport-tool-reasoning.feature
+++ b/specs/scenarios/judge-transport-tool-reasoning.feature
@@ -13,56 +13,85 @@ Feature: Scenario judge verdicts on reasoning models
   # A model already known to need its reasoning off is configured that way up
   # front — see specs/scenarios/judge-reasoning-tool-compatibility.feature.
   #
-  # The rule belongs to the transport rather than to the judge: anything that
-  # asks such a model for a structured answer meets it.
-
-  Background:
-    Given a scenario run dispatched to a worker
+  # The rule belongs to the transport rather than to the judge: every scenario
+  # model (judge, simulator, tested prompt agent) rides the same client, so
+  # anything that asks such a model for a structured answer meets it. The
+  # exchange is bounded at two requests: the configured one, and at most one
+  # answer to a refusal that named the value it would accept.
 
   @integration
   Scenario: A refusal that names reasoning is answered by asking again without it
-    Given a model that refuses a verdict while its reasoning is on, and says so
+    Given a model that refuses a tool-carrying request while its reasoning is on, naming the value it would accept
     When the judge grades a conversation against its criteria
-    Then the judge asks again with the model's reasoning switched off
-    And the second attempt is accepted
+    Then the second request declares reasoning off and returns the verdict tool call
 
   @integration
   Scenario: A criteria-graded run reports the verdict its criteria produced
-    Given a model that refuses a verdict while its reasoning is on, and says so
+    Given a judge model that is not on the known-incompatible list
+    And its provider refuses a tool-carrying request while reasoning is on, naming the value it would accept
     When the judge grades a conversation against its criteria
-    Then the run reports that verdict rather than an infrastructure error
+    Then the judge's own model client asks again and reports the verdict rather than an infrastructure error
+
+  @integration
+  Scenario: A judge model already known to need reasoning off asks only once
+    Given a judge model on the known-incompatible list
+    When the judge grades a conversation against its criteria
+    Then the first and only request already declares reasoning off
+    And the verdict tool call is returned
 
   @integration
   Scenario: A model that accepts the first attempt is never asked anything new
     Given a model that returns a verdict as the judge is configured
     When the judge grades a conversation against its criteria
     Then the model is asked exactly once
-    And the judge leaves the model's reasoning as configured
+    And the request carries no reasoning setting at all
 
   @integration
   Scenario: A model whose reasoning cannot be disabled is never asked to disable it
     Given a model that only works with its reasoning on
     When the judge grades a conversation against its criteria
-    Then the judge leaves the model's reasoning as configured
+    Then the model is asked exactly once
+    And the request carries no reasoning setting at all
+
+  @integration
+  Scenario: A second refusal ends the exchange
+    Given a model that refuses a tool-carrying request even with its reasoning off
+    When the judge grades a conversation against its criteria
+    Then exactly two requests are sent
+    And the caller receives the provider's own second refusal with its param unchanged
+
+  @integration
+  Scenario: A request that asks for no tools is never retried
+    Given a model that refuses any request while its reasoning is on, naming the value it would accept
+    When a request without tools is sent
+    Then the model is asked exactly once
+    And the caller receives the provider's own 400 with its param unchanged
 
   @integration
   Scenario: A reasoning refusal that names no remedy is surfaced, not retried
-    Given a model that refuses the reasoning it was given without naming one it accepts
+    Given a model that refuses the reasoning it was given, naming the parameter but no value it would accept
     When the judge grades a conversation against its criteria
-    Then the refusal is reported as it stands
-    And the judge does not ask again
+    Then the model is asked exactly once
+    And the caller receives the provider's own 400 with its param unchanged
 
   @integration
   Scenario: An unrelated rejection is surfaced, not retried
     Given a model that refuses the request for a reason unrelated to reasoning
     When the judge grades a conversation against its criteria
-    Then the refusal is reported as it stands
-    And the judge does not ask again
+    Then the model is asked exactly once
+    And the caller receives the provider's own 400 with its param unchanged
+
+  @integration
+  Scenario: A rejection that is not JSON is surfaced untouched
+    Given a model that refuses a tool-carrying request with a body that is not JSON
+    When the judge grades a conversation against its criteria
+    Then the model is asked exactly once
+    And the caller receives the provider's own 400 as it stands
 
   @integration
   Scenario: A run that pins the judge's reasoning keeps it
     Given a run that has pinned how hard the judge should think
     And a model that refuses a verdict while its reasoning is on
     When the judge grades a conversation against its criteria
-    Then the refusal is reported as it stands
-    And the pinned setting is left as the run asked for it
+    Then the model is asked exactly once
+    And the request carries the effort the run pinned, unchanged


### PR DESCRIPTION
# Related Issue

- Resolves #6369

## Status after the 2026-08-10 rebase — read this first

Epic PR #6607 merged to `main` at `964fe4f`, and it carried the runtime fix. Rebasing this branch dropped two of its five commits as already upstream:

- `c575c685b` (failing test) and `cdeb1f8ab` (`withReasoningOffRetry` + guards) — **now on `main`**, patch-identical.
- What remains here is the **review remainder**: 4 extra spec scenarios (7 → 11), the `chat-completions-stub-endpoint.ts` test harness, a `carriesTools` → `hasTools` rename, and a scoping comment on the sibling spec.

So #6369 is **not** fixed by merging this PR — it is already fixed on `main`. This PR hardens the contract around that fix. The sections below describe the original slice; they are kept as the design record for the code that shipped in #6607.

## Reviewer cockpit

- **Scariest thing:** nothing runtime-facing is left in this diff. The fetch wrapper in `model.factory.ts` — the thing worth fearing — is already on `main`; the only source edit remaining is a local variable rename inside `retryEligibleRequestBody`.
- **Start here:** `specs/scenarios/judge-transport-tool-reasoning.feature` — the eleven scenarios are the contract; the integration test binds all eleven. The 4 new ones (see *AC-review triage*) are the point of this PR.

## Why

Closes #6369. Every criteria-graded platform scenario run on a judge resolving to `gpt-5.6-sol` died with `scenario_infra_error` before any verdict: the JudgeAgent forces a `finish_test`/`continue_test` function tool, these Chat Completions models **enable reasoning by default**, and the endpoint rejects function tools + active reasoning. We never send `reasoning_effort` — the conflict is the model's own default meeting the judge's forced tool.

## The two fixes the error names — chosen deliberately

The provider's error offers `/v1/responses` or `reasoning_effort: 'none'`. **Chosen: `'none'`, applied by retry-on-rejection.**

- **Not `/v1/responses`** → the judge's requests go through `createOpenAICompatible` → `nlpgo /go/proxy/v1`, a Chat Completions transport shared by every provider (OpenAI, Azure, Gemini, custom). A Responses-API migration is an OpenAI-specific transport rewrite across the proxy and does nothing for the same error class on other providers (langwatch/scenario#864).
- **Not blanket `'none'`** → falsified in CI: Gemini 2.5 Pro rejects reasoning off ("Budget 0 is invalid. This model only works in thinking mode."). "Supports reasoning_effort" ≠ "accepts reasoning off"; only the provider answers the second.
- **Not a hardcoded model list** → #6620 (merged) already defaults reasoning off for the three *observed* gpt-5.6 models; that shape breaks on the next model tier. It stays as a fast-path default; this retry is the model-agnostic net.

## What changed

- **`withReasoningOffRetry` fetch wrapper on the scenario worker's model client** → alternative: a capability registry / Go request rewriter (the shape #6620 replaced) → the request goes out exactly as configured and is re-sent once with `reasoning_effort: "none"` only when the provider's 400 both names `reasoning_effort` and quotes `'none'` as the remedy. A caller-pinned effort is never rewritten; unrelated 400s and remedy-less reasoning rejections surface untouched.
- **`specs/scenarios/judge-transport-tool-reasoning.feature` (11 scenarios, all `@integration`-bound)** + `judge-transport-tool-reasoning.integration.test.ts` driving the real `createModelFromParams` model + real AI SDK against a local stand-in endpoint.
- ~~This is the judge-transport slice of open epic PR #6607, extracted so the P0 lands independently; #6607 rebases to identical code.~~ **Superseded 2026-08-10:** #6607 merged first, so the fix landed through it. This branch was rebased onto that `main`; the two commits above are gone from the diff and only the spec/test hardening remains.

## How it works

```
model.factory.ts
├── createModelFromParams        — now installs withReasoningOffRetry as the provider fetch
│   ├── retryEligibleRequestBody — only tool-carrying JSON bodies with no caller reasoning_effort
│   └── rejectionAsksForReasoningOff — 400 must name the param AND quote 'none'
└── createJudgeModelFromParams   — unchanged (#6620's preemptive default for known models)
```

## Human verification

1. Check out commit `c575c685b` (test only): `pnpm test:integration run src/server/scenarios/execution/__tests__/judge-transport-tool-reasoning.integration.test.ts --watch=false` → 2 failures with the exact filed `AI_APICallError`.
2. Check out `HEAD`: same command → 7/7 pass.
3. Original repro (project on `gpt-5.6-sol`, run a criteria-graded suite) no longer ends `ERROR` — note the judge for that exact model is already fixed on main by #6620's default; this PR is what covers the next unlisted model.

## How I can prove I was successful

- **proven** — falsifiability: fix reverted to base → 2 red reproducing the filed error verbatim; fix restored → 7/7 green. Terminal capture:

  ![red/green falsifiability](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/issue-6369/falsifiability-red-green.png)

- **proven** — commit order is the audit trail: failing-test commit `c575c685b` precedes fix commit `cdeb1f8ab`.
- **proven** — `pnpm typecheck:all` exit 0 (pipefail-checked); biome clean on touched files; `check:feature-parity` reports 11/11 scenarios bound (sibling spec still 5/5).
- **proven** — existing `model.factory.unit.test.ts` (8 tests, #6620's coverage) still green — the preemptive default and the retry compose.
- **claimed** — full CI matrix on this head (draft just opened; driving to terminal below).
- Live-endpoint behaviour was verified in the parent lane: a probe at api.openai.com with `gpt-5.6-sol` reproduced the 400 verbatim and returned 200 + a `finish_test` tool call with reasoning off (see #6607's body).

## AC-review triage (third commit)

A post-hoc ac-reviewer pass found the original binding tests never exercised `createJudgeModelFromParams` — the production judge path — and left guard branches unpinned. Commit `976c3e56d` grew the spec 7 → 11 scenarios: judge-factory retry with an unlisted model, the two-mechanism composition on a listed model (one request, reasoning already off), the no-tools guard, the two-request bound, and a non-JSON rejection body; the sibling compatibility spec's "untouched outside the judge" scenario is now scoped to build time instead of contradicting the transport retry. Full triage on the issue: https://github.com/langwatch/langwatch/issues/6369#issuecomment-5221186030. Retry-trigger prose fragility is tracked separately as #6715.

## Anything surprising?

- The affected model never *received* a `reasoning_effort` from us — the bug is a provider-side default, which is why "stop sending the parameter" was never available as a fix.
- `@ai-sdk/openai-compatible` overwrites a snake_case `reasoning_effort` passthrough with its first-class option even when undefined, which is why the retry lives at the fetch layer rather than in provider options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for tool-enabled requests when providers reject unsupported reasoning settings.
  * Retries eligible requests once with reasoning disabled and avoids retries for unrelated errors, non-tool requests, repeated refusals, and non-JSON responses.
  * Preserves explicit run settings and surfaces clear provider errors when compatibility cannot be established.

* **Tests**
  * Expanded coverage for judge and scenario-model reasoning compatibility, retry limits, initial request handling, and provider error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
