### PR TITLE
fix(billing): say which limit was hit in the plan limit slack alert

### DIFF
--- a/platform/app/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/notification.service.unit.test.ts
@@ -156,16 +156,16 @@ describe("NotificationService", () => {
           expected:
             "Plan limit reached: Acme, jane@acme.com, Plan: Free, Monthly Events: 12000/10000",
         },
-      ])(
-        "names the $limitType cap and the numbers behind it",
-        async ({ limitType, expected }) => {
-          config.slackPlanLimitChannel = "https://hooks.slack.com/test";
+      ])("names the $limitType cap and the numbers behind it", async ({
+        limitType,
+        expected,
+      }) => {
+        config.slackPlanLimitChannel = "https://hooks.slack.com/test";
 
-          await service.sendSlackPlanLimitAlert({ ...context, limitType });
+        await service.sendSlackPlanLimitAlert({ ...context, limitType });
 
-          expect(mockSlackSend).toHaveBeenCalledWith({ text: expected });
-        },
-      );
+        expect(mockSlackSend).toHaveBeenCalledWith({ text: expected });
+      });
 
       /** @scenario "Plan limit alert still sends when the organization has no admin email" */
       it("falls back to unknown when the org has no admin email", async () => {

--- a/platform/app/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/notification.service.unit.test.ts
@@ -126,7 +126,10 @@ describe("NotificationService", () => {
       organizationName: "Acme",
       adminName: "Jane",
       adminEmail: "jane@acme.com",
-      planName: "free",
+      planName: "Free",
+      limitType: "Monthly Traces",
+      current: 12000,
+      max: 10000,
     };
 
     describe("when SLACK_PLAN_LIMIT_CHANNEL is not set", () => {
@@ -140,14 +143,64 @@ describe("NotificationService", () => {
     });
 
     describe("when SLACK_PLAN_LIMIT_CHANNEL is set", () => {
-      it("sends a Slack message with plan limit info", async () => {
+      /** @scenario "Plan limit alert names the monthly trace cap and the numbers" */
+      /** @scenario "Plan limit alert names the monthly event cap and the numbers" */
+      it.each([
+        {
+          limitType: "Monthly Traces",
+          expected:
+            "Plan limit reached: Acme, jane@acme.com, Plan: Free, Monthly Traces: 12000/10000",
+        },
+        {
+          limitType: "Monthly Events",
+          expected:
+            "Plan limit reached: Acme, jane@acme.com, Plan: Free, Monthly Events: 12000/10000",
+        },
+      ])(
+        "names the $limitType cap and the numbers behind it",
+        async ({ limitType, expected }) => {
+          config.slackPlanLimitChannel = "https://hooks.slack.com/test";
+
+          await service.sendSlackPlanLimitAlert({ ...context, limitType });
+
+          expect(mockSlackSend).toHaveBeenCalledWith({ text: expected });
+        },
+      );
+
+      /** @scenario "Plan limit alert still sends when the organization has no admin email" */
+      it("falls back to unknown when the org has no admin email", async () => {
+        config.slackPlanLimitChannel = "https://hooks.slack.com/test";
+
+        await service.sendSlackPlanLimitAlert({
+          ...context,
+          adminEmail: undefined,
+        });
+
+        expect(mockSlackSend).toHaveBeenCalledWith({
+          text: "Plan limit reached: Acme, unknown, Plan: Free, Monthly Traces: 12000/10000",
+        });
+      });
+
+      /** @scenario "Plan limit alert reads the same way as the resource limit alert" */
+      it("keeps the same field order as the resource limit alert", async () => {
         config.slackPlanLimitChannel = "https://hooks.slack.com/test";
 
         await service.sendSlackPlanLimitAlert(context);
-
-        expect(mockSlackSend).toHaveBeenCalledWith({
-          text: expect.stringContaining("Plan limit reached: Acme"),
+        await service.sendSlackResourceLimitAlert({
+          ...context,
+          limitType: "Team Members",
+          current: 2,
+          max: 2,
         });
+
+        const sentTexts = mockSlackSend.mock.calls.map(
+          (args: unknown[]) => (args[0] as { text: string }).text,
+        );
+
+        expect(sentTexts).toEqual([
+          "Plan limit reached: Acme, jane@acme.com, Plan: Free, Monthly Traces: 12000/10000",
+          "Resource limit reached: Acme, jane@acme.com, Plan: Free, Team Members: 2/2",
+        ]);
       });
     });
 
@@ -463,6 +516,9 @@ describe("NotificationService", () => {
       adminName: "Jane",
       adminEmail: "jane@acme.com",
       planName: "free",
+      limitType: "Monthly Traces",
+      current: 12000,
+      max: 10000,
     };
 
     describe("when HubSpot env vars are not set", () => {

--- a/platform/app/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -46,6 +46,7 @@ import {
   resourceLimitCooldown,
   UsageLimitService,
 } from "../notifications/usage-limit.service";
+import type { PlanLimitNotifierInput } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -123,6 +124,14 @@ function createService({
   };
 }
 
+const PLAN_LIMIT_INPUT = {
+  organizationId: "org_1",
+  planName: "free",
+  usageUnit: "traces",
+  current: 12000,
+  max: 10000,
+} satisfies PlanLimitNotifierInput;
+
 const ORG_WITH_ADMIN = {
   id: "org_1",
   name: "Acme Corp",
@@ -176,8 +185,7 @@ describe("UsageLimitService", () => {
         const { service, organizationService } = createService();
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
 
         expect(organizationService.findWithAdmins).not.toHaveBeenCalled();
@@ -193,8 +201,8 @@ describe("UsageLimitService", () => {
         ).mockResolvedValue(null);
 
         await service.notifyPlanLimitReached({
+          ...PLAN_LIMIT_INPUT,
           organizationId: "org_missing",
-          planName: "free",
         });
 
         expect(
@@ -218,8 +226,7 @@ describe("UsageLimitService", () => {
         });
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
 
         expect(
@@ -237,8 +244,7 @@ describe("UsageLimitService", () => {
         ).mockResolvedValue(ORG_WITH_ADMIN);
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
 
         expect(
@@ -250,6 +256,9 @@ describe("UsageLimitService", () => {
             adminName: "Jane Admin",
             adminEmail: "jane@example.com",
             planName: "free",
+            limitType: "Monthly Traces",
+            current: 12000,
+            max: 10000,
           }),
         );
         expect(
@@ -265,6 +274,37 @@ describe("UsageLimitService", () => {
       });
     });
 
+    describe("for each usage unit a plan cap can be metered in", () => {
+      it.each([
+        { usageUnit: "traces" as const, limitType: "Monthly Traces" },
+        { usageUnit: "events" as const, limitType: "Monthly Events" },
+      ])("labels a $usageUnit cap as $limitType", async ({
+        usageUnit,
+        limitType,
+      }) => {
+        const { service, organizationService, notificationService } =
+          createService();
+        (
+          organizationService.findWithAdmins as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(ORG_WITH_ADMIN);
+
+        await service.notifyPlanLimitReached({
+          ...PLAN_LIMIT_INPUT,
+          usageUnit,
+        });
+
+        expect(
+          notificationService.sendSlackPlanLimitAlert,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            limitType,
+            current: 12000,
+            max: 10000,
+          }),
+        );
+      });
+    });
+
     describe("when alert was sent more than 30 days ago", () => {
       it("sends notifications again", async () => {
         const { service, organizationService, notificationService } =
@@ -277,8 +317,7 @@ describe("UsageLimitService", () => {
         });
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
 
         expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalled();
@@ -295,24 +334,19 @@ describe("UsageLimitService", () => {
 
         await Promise.all([
           service.notifyPlanLimitReached({
-            organizationId: "org_1",
-            planName: "free",
+            ...PLAN_LIMIT_INPUT,
           }),
           service.notifyPlanLimitReached({
-            organizationId: "org_1",
-            planName: "free",
+            ...PLAN_LIMIT_INPUT,
           }),
           service.notifyPlanLimitReached({
-            organizationId: "org_1",
-            planName: "free",
+            ...PLAN_LIMIT_INPUT,
           }),
           service.notifyPlanLimitReached({
-            organizationId: "org_1",
-            planName: "free",
+            ...PLAN_LIMIT_INPUT,
           }),
           service.notifyPlanLimitReached({
-            organizationId: "org_1",
-            planName: "free",
+            ...PLAN_LIMIT_INPUT,
           }),
         ]);
 
@@ -331,8 +365,7 @@ describe("UsageLimitService", () => {
         ).mockResolvedValue(ORG_WITH_ADMIN);
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
         expect(
           notificationService.sendSlackPlanLimitAlert,
@@ -348,8 +381,7 @@ describe("UsageLimitService", () => {
         ).mockClear();
 
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
         expect(
           notificationService.sendSlackPlanLimitAlert,
@@ -372,8 +404,7 @@ describe("UsageLimitService", () => {
 
         // Should not throw — allSettled absorbs the rejection
         await service.notifyPlanLimitReached({
-          organizationId: "org_1",
-          planName: "free",
+          ...PLAN_LIMIT_INPUT,
         });
 
         expect(

--- a/platform/app/ee/billing/notifications/notification.service.ts
+++ b/platform/app/ee/billing/notifications/notification.service.ts
@@ -391,7 +391,7 @@ export class NotificationService {
     await this.sendSlackMessage({
       channelUrl: this.config.slackPlanLimitChannel,
       body: {
-        text: `Plan limit reached: ${context.organizationName}, ${context.adminEmail ?? "unknown"}, Plan: ${context.planName}`,
+        text: `Plan limit reached: ${context.organizationName}, ${context.adminEmail ?? "unknown"}, Plan: ${context.planName}, ${context.limitType}: ${context.current}/${context.max}`,
       },
       errorLog: "Failed to send Slack plan-limit notification",
     });

--- a/platform/app/ee/billing/notifications/usage-limit.service.ts
+++ b/platform/app/ee/billing/notifications/usage-limit.service.ts
@@ -3,6 +3,7 @@ import { env } from "../../../src/env.mjs";
 import type { OrganizationService } from "../../../src/server/app-layer/organizations/organization.service";
 import type { PlanProvider } from "../../../src/server/app-layer/subscription/plan-provider";
 import type { UsageService } from "../../../src/server/app-layer/usage/usage.service";
+import { USAGE_UNIT_DISPLAY_LABELS } from "../../../src/server/app-layer/usage/usage-meter-policy";
 import { LIMIT_TYPE_DISPLAY_LABELS } from "../../../src/server/license-enforcement/constants";
 import { USAGE_UNKNOWN } from "../../../src/server/traces/usage-count";
 import { getCurrentMonthStart } from "../../../src/server/utils/dateUtils";
@@ -155,6 +156,9 @@ export class UsageLimitService {
   async notifyPlanLimitReached({
     organizationId,
     planName,
+    usageUnit,
+    current,
+    max,
   }: PlanLimitNotifierInput): Promise<void> {
     if (!env.IS_SAAS) {
       return;
@@ -203,6 +207,9 @@ export class UsageLimitService {
         adminName: admin?.name ?? undefined,
         adminEmail: admin?.email ?? undefined,
         planName,
+        limitType: USAGE_UNIT_DISPLAY_LABELS[usageUnit],
+        current,
+        max,
       };
 
       // Both sends are fire-and-forget (errors swallowed internally),

--- a/platform/app/ee/billing/types.ts
+++ b/platform/app/ee/billing/types.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { UsageUnit } from "../../src/server/app-layer/usage/usage-meter-policy";
 import type { LimitType } from "../../src/server/license-enforcement/types";
 import type { signUpDataSchema } from "../../src/server/schemas/sign-up-data.schema";
 import type { PlanInfo } from "../licensing/planInfo";
@@ -21,6 +22,12 @@ export type BillingPlanProvider = {
 export type PlanLimitNotifierInput = {
   organizationId: string;
   planName: string;
+  /** Counting unit the plan cap is measured in. */
+  usageUnit: UsageUnit;
+  /** Usage counted so far this month, in `usageUnit`. */
+  current: number;
+  /** Monthly cap allowed by the plan, in `usageUnit`. */
+  max: number;
 };
 
 export type PlanLimitNotificationContext = {
@@ -29,6 +36,10 @@ export type PlanLimitNotificationContext = {
   adminName?: string;
   adminEmail?: string;
   planName: string;
+  /** Display label for the cap that was hit, for example "Monthly Traces". */
+  limitType: string;
+  current: number;
+  max: number;
 };
 
 type SubscriptionPlan = PlanTypes | (string & {});

--- a/platform/app/src/app/api/middleware/trace-limit.ts
+++ b/platform/app/src/app/api/middleware/trace-limit.ts
@@ -31,6 +31,9 @@ export const blockTraceUsageExceededMiddleware: MiddlewareHandler = async (
         await getApp().usageLimits.notifyPlanLimitReached({
           organizationId: team.organizationId,
           planName: activePlan.name ?? "free",
+          usageUnit: result.usageUnit,
+          current: result.count,
+          max: result.maxMessagesPerMonth,
         });
       }
     } catch (error) {

--- a/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -278,6 +278,13 @@ describe("UsageService", () => {
           "upgrade your plan at https://app.langwatch.ai/settings/subscription",
         );
       });
+
+      it("reports the unit the cap is metered in", async () => {
+        const result = await service.checkLimit({ teamId: "team-123" });
+
+        assertExceeded(result);
+        expect(result.usageUnit).toBe("traces");
+      });
     });
 
     describe("when paid TIERED org exceeds limit on self-hosted", () => {
@@ -333,6 +340,13 @@ describe("UsageService", () => {
         expect(result.count).toBe(1000);
         expect(result.maxMessagesPerMonth).toBe(1000);
         expect(result.planName).toBe("Free");
+      });
+
+      it("reports the unit the cap is metered in", async () => {
+        const result = await service.checkLimit({ teamId: "team-123" });
+
+        assertExceeded(result);
+        expect(result.usageUnit).toBe("events");
       });
 
       it("calls planResolver with organizationId", async () => {

--- a/platform/app/src/server/app-layer/usage/usage-meter-policy.ts
+++ b/platform/app/src/server/app-layer/usage/usage-meter-policy.ts
@@ -2,6 +2,16 @@ import { PricingModel } from "@prisma/client";
 
 export type UsageUnit = "traces" | "events";
 
+/**
+ * Display labels for each usage unit (title case, for use as a label in
+ * internal alerts). Mirrors LIMIT_TYPE_DISPLAY_LABELS for resource limits so
+ * plan-limit and resource-limit alerts read the same way.
+ */
+export const USAGE_UNIT_DISPLAY_LABELS: Record<UsageUnit, string> = {
+  traces: "Monthly Traces",
+  events: "Monthly Events",
+} as const;
+
 export interface MeterDecision {
   usageUnit: UsageUnit;
   reason: string;

--- a/platform/app/src/server/app-layer/usage/usage.service.ts
+++ b/platform/app/src/server/app-layer/usage/usage.service.ts
@@ -33,6 +33,7 @@ export type UsageLimitResult =
       count: number;
       maxMessagesPerMonth: number;
       planName: string;
+      usageUnit: UsageUnit;
     };
 
 /**
@@ -109,6 +110,7 @@ export class UsageService {
         count,
         maxMessagesPerMonth: plan.maxMessagesPerMonth,
         planName: plan.name,
+        usageUnit: decision.usageUnit,
       };
     }
     return { exceeded: false };

--- a/platform/app/src/server/routes/__tests__/collector.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector.unit.test.ts
@@ -6,14 +6,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockIngestNormalizedSpan = vi.fn();
 const mockReportEvaluation = vi.fn();
 const mockCheckLimit = vi.fn();
+const mockNotifyPlanLimitReached = vi.fn();
 
 vi.mock("~/server/app-layer/app", () => ({
   getApp: vi.fn(() => ({
     usage: { checkLimit: mockCheckLimit },
     traces: { collection: { ingestNormalizedSpan: mockIngestNormalizedSpan } },
     evaluations: { reportEvaluation: mockReportEvaluation },
-    planProvider: { getActivePlan: vi.fn() },
-    usageLimits: { notifyPlanLimitReached: vi.fn() },
+    planProvider: { getActivePlan: vi.fn(async () => ({ name: "free" })) },
+    usageLimits: { notifyPlanLimitReached: mockNotifyPlanLimitReached },
   })),
 }));
 
@@ -202,6 +203,7 @@ describe("POST /api/collector", () => {
           planName: "free",
           count: 10,
           maxMessagesPerMonth: 10,
+          usageUnit: "traces",
         });
 
         const res = await postCollector({
@@ -219,6 +221,28 @@ describe("POST /api/collector", () => {
           activePlanName: "free",
         });
         expect(mockIngestNormalizedSpan).not.toHaveBeenCalled();
+      });
+
+      it("tells the plan limit notifier which cap was hit", async () => {
+        mockCheckLimit.mockResolvedValue({
+          exceeded: true,
+          message: "monthly limit reached",
+          planName: "free",
+          count: 12000,
+          maxMessagesPerMonth: 10000,
+          usageUnit: "traces",
+        });
+
+        await postCollector({ trace_id: "trace-1", spans: [makeSpan(1)] });
+
+        expect(mockNotifyPlanLimitReached).toHaveBeenCalledWith(
+          expect.objectContaining({
+            planName: "free",
+            usageUnit: "traces",
+            current: 12000,
+            max: 10000,
+          }),
+        );
       });
     });
   });

--- a/platform/app/src/server/routes/__tests__/otel.logs.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.logs.unit.test.ts
@@ -173,6 +173,7 @@ describe("POST /api/otel/v1/logs", () => {
         planName: "free",
         count: 10,
         maxMessagesPerMonth: 10,
+        usageUnit: "traces",
       });
 
       const response = await postLogs();

--- a/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.metrics.unit.test.ts
@@ -118,6 +118,7 @@ describe("POST /api/otel/v1/metrics", () => {
       planName: "free",
       count: 10,
       maxMessagesPerMonth: 10,
+      usageUnit: "traces",
     });
 
     const response = await postMetrics();
@@ -132,6 +133,28 @@ describe("POST /api/otel/v1/metrics", () => {
       activePlanName: "free",
     });
     expect(mockHandleMetrics).not.toHaveBeenCalled();
+  });
+
+  it("tells the plan limit notifier which cap was hit", async () => {
+    mockCheckLimit.mockResolvedValue({
+      exceeded: true,
+      message: "monthly limit reached",
+      planName: "free",
+      count: 12000,
+      maxMessagesPerMonth: 10000,
+      usageUnit: "events",
+    });
+
+    await postMetrics();
+
+    expect(mockNotifyPlanLimitReached).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planName: "free",
+        usageUnit: "events",
+        current: 12000,
+        max: 10000,
+      }),
+    );
   });
 
   it("returns OTLP partial success when some data points are rejected", async () => {

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -177,6 +177,9 @@ secured
           await getApp().usageLimits.notifyPlanLimitReached({
             organizationId: project.team.organizationId,
             planName: activePlan.name ?? "free",
+            usageUnit: limitResult.usageUnit,
+            current: limitResult.count,
+            max: limitResult.maxMessagesPerMonth,
           });
         } catch (error) {
           logger.error(

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -224,6 +224,9 @@ async function enforcePlanLimit({
       .usageLimits.notifyPlanLimitReached({
         organizationId: project.team.organizationId,
         planName: activePlan.name ?? "free",
+        usageUnit: limitResult.usageUnit,
+        current: limitResult.count,
+        max: limitResult.maxMessagesPerMonth,
       })
       .catch((error: unknown) => {
         logger.error(

--- a/specs/licensing/plan-limit-notifications.feature
+++ b/specs/licensing/plan-limit-notifications.feature
@@ -1,0 +1,33 @@
+Feature: Internal Slack Notifications for Plan Limit Reached
+
+  As a LangWatch ops team member
+  I want the plan limit alert to say which cap was hit and how far over it is
+  So that I can act on it without opening the admin panel first
+
+  Background:
+    Given an organization "Acme" whose admin is "someone@acme.com"
+    And the internal plan limit Slack channel is configured
+
+  @unit
+  Scenario: Plan limit alert names the monthly trace cap and the numbers
+    Given the organization is on the "Free" plan metered in traces
+    When the organization goes over 10000 traces for the month
+    Then the Slack alert reads "Plan limit reached: Acme, someone@acme.com, Plan: Free, Monthly Traces: 12000/10000"
+
+  @unit
+  Scenario: Plan limit alert names the monthly event cap and the numbers
+    Given the organization is on the "Free" plan metered in events
+    When the organization goes over 10000 events for the month
+    Then the Slack alert reads "Plan limit reached: Acme, someone@acme.com, Plan: Free, Monthly Events: 12000/10000"
+
+  @unit
+  Scenario: Plan limit alert reads the same way as the resource limit alert
+    Given the organization has gone over its monthly trace cap
+    And the organization has also filled every team member seat
+    Then both Slack alerts list the organization, the admin, the plan, and the limit with its current and maximum
+
+  @unit
+  Scenario: Plan limit alert still sends when the organization has no admin email
+    Given the organization has no admin email on record
+    When the organization goes over its monthly cap
+    Then the Slack alert reads "unknown" in place of the admin email and still carries the limit and the numbers


### PR DESCRIPTION
## What

The internal Slack alert for a plan limit now says which limit was hit and the numbers behind it, the same way the resource limit alert already does.

Before:

```
Plan limit reached: ACME, someone@acme.com, Plan: Free
```

After:

```
Plan limit reached: ACME, someone@acme.com, Plan: Free, Monthly Traces: 12000/10000
```

The resource limit alert is unchanged and still reads:

```
Resource limit reached: ACME, someone@acme.com, Plan: Free, Team Members: 2/2
```

## Why

Half the messages in the internal alert channel carried no reason at all. Whoever reads the channel could see that an org hit something, but not what, and not how far past it they were, so every alert meant opening the admin panel before you could act on it.

## How

A plan limit is the monthly volume cap, and that cap is metered in either traces or events depending on the plan. `UsageService.checkLimit` already resolves that unit to build the 402 message, so nothing new is fetched:

- `UsageLimitResult` now carries `usageUnit` next to `count` and `maxMessagesPerMonth`.
- The three ingestion call sites that report a plan limit (collector, OTLP, and the trace limit middleware) pass the unit and the two numbers to `notifyPlanLimitReached`.
- `UsageLimitService` maps the unit to a display label through `USAGE_UNIT_DISPLAY_LABELS`, mirroring how the resource limit path uses `LIMIT_TYPE_DISPLAY_LABELS`.
- `NotificationService` renders it in the same field order as the resource limit alert, so the channel stays greppable.

Message shape, prefix and channel are unchanged. No emoji, no Block Kit.

## Tests

`platform/app/ee/billing/__tests__/notification.service.unit.test.ts`

- asserts the full rendered string for each unit a plan cap can be metered in (Monthly Traces, Monthly Events)
- asserts the fallback to `unknown` when the org has no admin email
- asserts the plan alert and the resource alert list their fields in the same order

`platform/app/ee/billing/__tests__/usage-limit.service.unit.test.ts`

- asserts each usage unit maps to the right display label and that the counts reach the notifier

`platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts`

- asserts `checkLimit` reports the unit for both a free (events) and a paid volume (traces) plan

`platform/app/src/server/routes/__tests__/collector.unit.test.ts` and `otel.metrics.unit.test.ts`

- assert the route hands the unit and the numbers to the notifier

New spec `specs/licensing/plan-limit-notifications.feature`, four scenarios, all bound. `pnpm check:feature-parity` passes.

## Issue

Closes langwatch/langwatch-saas#316 Alert us on slack also when people reach other kinds of limits (prompts evals etc)

GitHub closing keywords do not work across repositories, so that issue needs a manual close once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan-limit notifications now identify the exceeded usage type and show current usage alongside the monthly maximum.
  * Alerts support both trace- and event-based limits with clearer display labels.
  * Notifications use an “unknown” fallback when administrator contact details are unavailable.

* **Tests**
  * Expanded coverage verifies notification content, usage-limit reporting, and alert consistency across supported usage types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->