### PR TITLE
fix(traces): default the oversized-span S3 spool on so configured storage means no truncation

### DIFF
--- a/dev/docs/adr/022-event-log-source-of-truth.md
+++ b/dev/docs/adr/022-event-log-source-of-truth.md
@@ -147,8 +147,8 @@ LEAN BOUNDARIES  (what stays small at each hop)
 ## On-prem / no-object-storage deployments
 
 - **Reads are object-storage-independent.** Full content lives in `event_log` (ClickHouse). `BlobStore.getFromEventLog` (`blob-store.service.ts:85-158`) issues a CH SELECT and parses `EventPayload`; it never calls `resolveS3Client`. "Show full" and online-eval work with no object storage present.
-- **The edge spool is flag-gated and fail-open.** `release_trace_blob_offload` off → edge spool code never runs → pre-ADR-022 behavior (worker-side `capOversizedAttributes` bounds the payload). Flag on but storage absent → edge PUT fails open (full inline payload forwarded, `warn` logged) — ingestion is never blocked.
-- **"No S3 equivalent" means no object storage at all.** S3-compatible stores (MinIO, Ceph RGW) satisfy the AWS S3 client; they are equivalent. Deployments with no object storage should leave `release_trace_blob_offload` off; they lose only the edge Redis-queue oversize protection, not any read-path capability.
+- **The edge spool is on by default and fail-open.** `release_trace_blob_offload` defaults to on, so a deployment that has object storage configured keeps oversized content intact without setting anything; the flag stays the kill switch and the per-project opt-out. Flag off → edge spool code never runs → pre-ADR-022 behavior (worker-side `capOversizedAttributes` bounds the payload). Flag on but storage absent → edge PUT fails open (full inline payload forwarded, `warn` logged), ingestion is never blocked.
+- **"No S3 equivalent" means no object storage at all.** S3-compatible stores (MinIO, Ceph RGW) satisfy the AWS S3 client; they are equivalent. Deployments with no object storage keep ingesting with the flag on: every over-threshold span fails open to the inline path, costing a `warn` per span and the edge Redis-queue oversize protection, not any read-path capability. Switching `release_trace_blob_offload` off there silences the warn and changes nothing else.
 
 ## Rules
 

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1273,15 +1273,19 @@ export function initializeDefaultApp(options?: {
     new TraceRequestCollectionService({
       dedup: spanDedup,
       recordSpan: commands.traces.recordSpan,
-      // ADR-022: Edge size-check + transient S3 spool, flag-gated per project.
-      // projectId === tenantId (routes/otel.ts passes project.id). processCommandData
-      // runs PER SPAN (not once per OTLP request/batch); the flag is read per span and
-      // the 5s-cached flag store keeps that per-span read cheap.
+      // ADR-022: Edge size-check + transient S3 spool, on by default and
+      // switchable off per project. projectId === tenantId (routes/otel.ts
+      // passes project.id). processCommandData runs PER SPAN (not once per OTLP
+      // request/batch); the flag is resolved per span against the operator
+      // store, falling back to the registry default rather than PostHog, and
+      // the 5s-cached store keeps that per-span read cheap.
       //
       // FAIL-OPEN: any error from the flag store (Postgres/network blip) or
       // from maybeSpool (S3 outage, BlobStore.putSpool throws) is caught here.
       // We log at warn level and return the original commandData unchanged so
-      // that ingestion is never blocked by the spool path. ADR-022.
+      // that ingestion is never blocked by the spool path. The span then takes
+      // the inline route, where capOversizedAttributes bounds each attribute
+      // value at 256 KB. ADR-022.
       processCommandData: async (data) => {
         // Media extraction runs FIRST: externalizing inline media parts to
         // the content-addressed stored-objects store usually brings the
@@ -1298,11 +1302,11 @@ export function initializeDefaultApp(options?: {
         // reason label (flag_store vs spool/S3) for alerting (GtVrL).
         let stage: "flag_store" | "spool" = "flag_store";
         try {
-          const enabled = await getFeatureFlagStore().get(
+          const enabled = await getFeatureFlagStore().getOrRegistryDefault(
             "release_trace_blob_offload",
             { projectId: data.tenantId },
           );
-          if (enabled !== true) return data;
+          if (!enabled) return data;
           stage = "spool";
           return await maybeSpool({
             data,
@@ -1319,7 +1323,7 @@ export function initializeDefaultApp(options?: {
               reason: stage,
               error: err instanceof Error ? err.message : String(err),
             },
-            "Edge spool failed — falling back to unmodified command data (fail-open)",
+            "Edge spool unavailable, ingesting this oversized span inline (fail-open). Attribute values above 256 KB will be truncated on this span; configure S3-compatible object storage to keep them intact.",
           );
           return data;
         }

--- a/platform/app/src/server/app-layer/traces/__tests__/edge-offload.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/edge-offload.unit.test.ts
@@ -6,7 +6,10 @@
  *   - payload > 256 KB + PUT succeeds → oversized command with spoolRef only; payload NOT in command
  *   - payload > 256 KB + PUT fails → fail-open: regular command with full inline; warn log emitted
  *   - warn message contains "oversize protection skipped"
- *   - fail-open payload is then bounded by capOversizedAttributes(256 KB)
+ *
+ * What the fail-open payload then costs the deployment is pinned where the
+ * cap actually runs: recordSpanCommand.oversized.unit.test.ts drives the
+ * command worker over the command this module hands back.
  *
  * BDD structure: describe("given X") → describe("when Y") → it("…").
  * No "should" in it() names (project convention).
@@ -14,10 +17,6 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { RecordSpanCommandData } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
-import {
-  capOversizedAttributes,
-  DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
-} from "~/server/event-sourcing/pipelines/trace-processing/utils/capOversizedAttributes";
 import type { BlobStore } from "../blob-store.service";
 import { maybeSpool, type SpoolLogger } from "../edge-spool";
 import { COMMAND_INLINE_THRESHOLD } from "../lean-for-projection";
@@ -189,31 +188,6 @@ describe("given a command payload > COMMAND_INLINE_THRESHOLD and the S3 spool PU
       const warnArg: unknown = logger.warn.mock.calls[0]?.[0];
       expect(typeof warnArg === "string" ? warnArg : "").toContain(
         "oversize protection skipped",
-      );
-    });
-  });
-
-  // What the deployment actually loses when the spool is unavailable: the
-  // span keeps flowing, and the value it carries is bounded downstream by
-  // the same cap that existed before ADR-022. This is the consequence the
-  // fail-open warn tells operators about, exercised rather than described.
-  describe("when the fallen-back command reaches the command worker", () => {
-    /** @scenario When edge S3 spool PUT fails, ingestion falls back to inline (fail-open) */
-    it("has its oversized attribute value replaced by the 256 KB cap's truncation marker", async () => {
-      const data = makeCommandData({ outputSize: 300 * 1024 });
-      const blobStore = makeBlobStore({ putSpoolResult: "fail" });
-      const logger = makeLogger();
-
-      const result = await maybeSpool({ data, blobStore, logger });
-      const capped = capOversizedAttributes(result.span, result.resource);
-
-      expect(capped).toBe(1);
-      const outputValue = result.span.attributes?.find(
-        (a) => a.key === "langwatch.output",
-      )?.value?.stringValue;
-      expect(outputValue).toContain("[truncated:");
-      expect(Buffer.byteLength(outputValue ?? "", "utf-8")).toBeLessThanOrEqual(
-        DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
       );
     });
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/edge-offload.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/edge-offload.unit.test.ts
@@ -6,9 +6,7 @@
  *   - payload > 256 KB + PUT succeeds → oversized command with spoolRef only; payload NOT in command
  *   - payload > 256 KB + PUT fails → fail-open: regular command with full inline; warn log emitted
  *   - warn message contains "oversize protection skipped"
- *
- * These tests FAIL at unit runtime because `maybeSpool` throws "not implemented".
- * They pass typecheck, serving as the TDD contract.
+ *   - fail-open payload is then bounded by capOversizedAttributes(256 KB)
  *
  * BDD structure: describe("given X") → describe("when Y") → it("…").
  * No "should" in it() names (project convention).
@@ -16,6 +14,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { RecordSpanCommandData } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
+import {
+  capOversizedAttributes,
+  DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
+} from "~/server/event-sourcing/pipelines/trace-processing/utils/capOversizedAttributes";
 import type { BlobStore } from "../blob-store.service";
 import { maybeSpool, type SpoolLogger } from "../edge-spool";
 import { COMMAND_INLINE_THRESHOLD } from "../lean-for-projection";
@@ -156,6 +158,7 @@ describe("given a command payload > COMMAND_INLINE_THRESHOLD (256 KB) and the S3
 
 describe("given a command payload > COMMAND_INLINE_THRESHOLD and the S3 spool PUT fails", () => {
   describe("when maybeSpool is called", () => {
+    /** @scenario When edge S3 spool PUT fails, ingestion falls back to inline (fail-open) */
     it("returns the regular command with full inline payload (fail-open, no spoolRef)", async () => {
       const data = makeCommandData({ outputSize: 300 * 1024 });
       const blobStore = makeBlobStore({ putSpoolResult: "fail" });
@@ -186,6 +189,31 @@ describe("given a command payload > COMMAND_INLINE_THRESHOLD and the S3 spool PU
       const warnArg: unknown = logger.warn.mock.calls[0]?.[0];
       expect(typeof warnArg === "string" ? warnArg : "").toContain(
         "oversize protection skipped",
+      );
+    });
+  });
+
+  // What the deployment actually loses when the spool is unavailable: the
+  // span keeps flowing, and the value it carries is bounded downstream by
+  // the same cap that existed before ADR-022. This is the consequence the
+  // fail-open warn tells operators about, exercised rather than described.
+  describe("when the fallen-back command reaches the command worker", () => {
+    /** @scenario When edge S3 spool PUT fails, ingestion falls back to inline (fail-open) */
+    it("has its oversized attribute value replaced by the 256 KB cap's truncation marker", async () => {
+      const data = makeCommandData({ outputSize: 300 * 1024 });
+      const blobStore = makeBlobStore({ putSpoolResult: "fail" });
+      const logger = makeLogger();
+
+      const result = await maybeSpool({ data, blobStore, logger });
+      const capped = capOversizedAttributes(result.span, result.resource);
+
+      expect(capped).toBe(1);
+      const outputValue = result.span.attributes?.find(
+        (a) => a.key === "langwatch.output",
+      )?.value?.stringValue;
+      expect(outputValue).toContain("[truncated:");
+      expect(Buffer.byteLength(outputValue ?? "", "utf-8")).toBeLessThanOrEqual(
+        DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
       );
     });
   });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
@@ -6,9 +6,9 @@
  *   2. Reconstitute the full span and process it normally.
  *   3. After event_log INSERT succeeds, best-effort delete the spool.
  *
- * These tests FAIL at unit runtime because RecordSpanCommand does not yet
- * fetch from spool or call deleteSpool (Step 5). They pass typecheck,
- * serving as the TDD contract.
+ * And the other side of that branch: when no `spoolRef` is present, because
+ * the payload fit inline or because the edge spool failed open, the worker
+ * caps oversized attribute values before the span becomes an event.
  *
  * BDD structure: describe("given X") → describe("when Y") → it("…").
  * No "should" in it() names (project convention).
@@ -16,9 +16,11 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import { maybeSpool } from "~/server/app-layer/traces/edge-spool";
 import { type Command, createTenantId } from "../../../../";
 import type { RecordSpanCommandData } from "../../schemas/commands";
 import { RECORD_SPAN_COMMAND_TYPE } from "../../schemas/constants";
+import { DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES } from "../../utils/capOversizedAttributes";
 import {
   RecordSpanCommand,
   type RecordSpanCommandDependencies,
@@ -317,6 +319,98 @@ describe("given a RecordSpanCommand that carries a spoolRef (oversized path)", (
       expect(
         Buffer.byteLength(outputAttr?.value?.stringValue ?? "", "utf-8"),
       ).toBe(300 * 1024);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-open consequence: what the worker does with the command the edge hands
+// back when the spool is unavailable
+// ---------------------------------------------------------------------------
+
+/**
+ * Starts from the real edge decision rather than a hand-built command: a
+ * failing spool PUT is what produces the inline command, and the worker is
+ * what applies the cap. Asserting the cap helper directly would stay green if
+ * the worker stopped calling it, applied it before spool rehydration, or
+ * skipped it on the inline path.
+ */
+describe("given the edge spool PUT failed and the command fell back to inline", () => {
+  const OVERSIZED_BYTES = 300 * 1024;
+
+  function makeFailingBlobStore(): BlobStore {
+    return {
+      putSpool: vi.fn().mockRejectedValue(new Error("S3 PUT failed")),
+      getSpool: vi.fn(),
+      deleteSpool: vi.fn(),
+    } as unknown as BlobStore;
+  }
+
+  /** The command the edge actually forwards after its spool attempt fails. */
+  async function inlineCommandAfterFailedSpool(): Promise<
+    Command<RecordSpanCommandData>
+  > {
+    const blobStore = makeFailingBlobStore();
+    const data = await maybeSpool({
+      data: {
+        tenantId: TENANT_ID,
+        occurredAt: 1700000000000,
+        span: {
+          traceId: TRACE_ID,
+          spanId: SPAN_ID,
+          name: "test-span",
+          kind: 1,
+          startTimeUnixNano: { low: 0, high: 0 },
+          endTimeUnixNano: { low: 1000000, high: 0 },
+          attributes: [
+            {
+              key: "langwatch.output",
+              value: { stringValue: "z".repeat(OVERSIZED_BYTES) },
+            },
+          ],
+          events: [],
+          links: [],
+          status: {},
+          droppedAttributesCount: 0,
+          droppedEventsCount: 0,
+          droppedLinksCount: 0,
+        },
+        resource: null,
+        instrumentationScope: null,
+      },
+      blobStore,
+      logger: { warn: vi.fn() },
+    });
+
+    return {
+      type: RECORD_SPAN_COMMAND_TYPE,
+      aggregateId: TRACE_ID,
+      tenantId: createTenantId(TENANT_ID),
+      data,
+    };
+  }
+
+  describe("when the command worker handles that command", () => {
+    /** @scenario When edge S3 spool PUT fails, ingestion falls back to inline (fail-open) */
+    it("emits a span whose oversized value carries the truncation marker and fits the cap", async () => {
+      const handler = new RecordSpanCommand({
+        ...makeDeps(),
+        blobStore: makeFailingBlobStore(),
+      });
+      const command = await inlineCommandAfterFailedSpool();
+
+      // Fail-open contract: the edge forwarded the full payload inline.
+      expect(command.data.spoolRef).toBeUndefined();
+
+      const events = await handler.handle(command);
+
+      const outputValue = events[0]?.data.span?.attributes?.find(
+        (a: { key: string }) => a.key === "langwatch.output",
+      )?.value?.stringValue;
+      expect(outputValue).toContain("[truncated:");
+      expect(Buffer.byteLength(outputValue ?? "", "utf-8")).toBeLessThanOrEqual(
+        DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
+      );
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.oversized.unit.test.ts
@@ -9,9 +9,6 @@
  * And the other side of that branch: when no `spoolRef` is present, because
  * the payload fit inline or because the edge spool failed open, the worker
  * caps oversized attribute values before the span becomes an event.
- *
- * BDD structure: describe("given X") → describe("when Y") → it("…").
- * No "should" in it() names (project convention).
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -346,7 +343,6 @@ describe("given the edge spool PUT failed and the command fell back to inline", 
     } as unknown as BlobStore;
   }
 
-  /** The command the edge actually forwards after its spool attempt fails. */
   async function inlineCommandAfterFailedSpool(): Promise<
     Command<RecordSpanCommandData>
   > {

--- a/platform/app/src/server/featureFlag/__tests__/featureFlagStore.postgres.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/featureFlagStore.postgres.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment node
+ *
+ * Store-level resolution of a registered flag, with postgres as the only
+ * mocked hop.
+ *
+ * `get` keeps "no row" as a distinct `null` so the service layer can decide
+ * whether a PRODUCT flag still falls through to PostHog. Per-span ingestion
+ * cannot afford that fall-through, so the edge calls `getOrRegistryDefault`
+ * instead. That makes the registry default the thing an unconfigured
+ * deployment actually gets, which is what these tests pin: reading the
+ * registry object alone would prove nothing about the path the edge takes.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+
+const { findUnique } = vi.hoisted(() => ({ findUnique: vi.fn() }));
+
+vi.mock("../../db", () => ({
+  prisma: { featureFlag: { findUnique } },
+}));
+
+const BLOB_OFFLOAD = "release_trace_blob_offload";
+const PROJECT_ID = "project-abc";
+
+beforeEach(() => {
+  findUnique.mockReset();
+});
+
+describe("given no operator row exists for the trace blob offload flag", () => {
+  describe("when the ingestion edge resolves the flag for a project", () => {
+    /** @scenario A deployment that configured object storage spools oversized spans with no flag setup */
+    it("resolves to the registry default of on", async () => {
+      findUnique.mockResolvedValue(null);
+      const store = new FeatureFlagStorePostgres();
+
+      const enabled = await store.getOrRegistryDefault(BLOB_OFFLOAD, {
+        projectId: PROJECT_ID,
+      });
+
+      expect(enabled).toBe(true);
+      // Proves postgres was actually consulted, so the `true` above is the
+      // registry default filling an absent row rather than a stubbed hit.
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { key: BLOB_OFFLOAD },
+        select: { enabled: true, rules: true },
+      });
+    });
+
+    it("still reports the raw absence as null through get, which the service layer needs", async () => {
+      findUnique.mockResolvedValue(null);
+      const store = new FeatureFlagStorePostgres();
+
+      await expect(
+        store.get(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
+      ).resolves.toBeNull();
+    });
+  });
+});
+
+describe("given an operator switched the trace blob offload flag off fleet-wide", () => {
+  describe("when the ingestion edge resolves the flag", () => {
+    it("returns false, so the row keeps working as a kill switch over the default", async () => {
+      findUnique.mockResolvedValue({ enabled: false, rules: [] });
+      const store = new FeatureFlagStorePostgres();
+
+      await expect(
+        store.getOrRegistryDefault(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
+      ).resolves.toBe(false);
+    });
+  });
+});
+
+describe("given an operator opted a single project out of the trace blob offload", () => {
+  const row = {
+    enabled: true,
+    rules: [{ match: { projectId: "project-opted-out" }, enabled: false }],
+  };
+
+  describe("when the ingestion edge resolves the flag for the opted-out project", () => {
+    /** @scenario A deployment that configured object storage spools oversized spans with no flag setup */
+    it("returns false for that project", async () => {
+      findUnique.mockResolvedValue(row);
+      const store = new FeatureFlagStorePostgres();
+
+      await expect(
+        store.getOrRegistryDefault(BLOB_OFFLOAD, {
+          projectId: "project-opted-out",
+        }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("when the ingestion edge resolves the flag for any other project", () => {
+    it("returns true", async () => {
+      findUnique.mockResolvedValue(row);
+      const store = new FeatureFlagStorePostgres();
+
+      await expect(
+        store.getOrRegistryDefault(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
+      ).resolves.toBe(true);
+    });
+  });
+});
+
+describe("given the postgres read fails", () => {
+  describe("when the ingestion edge resolves the flag", () => {
+    it("falls back to the registry default rather than propagating the error", async () => {
+      findUnique.mockRejectedValue(new Error("connection terminated"));
+      const store = new FeatureFlagStorePostgres();
+
+      await expect(
+        store.getOrRegistryDefault(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
+      ).resolves.toBe(true);
+    });
+  });
+});

--- a/platform/app/src/server/featureFlag/__tests__/featureFlagStore.postgres.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/featureFlagStore.postgres.unit.test.ts
@@ -2,7 +2,9 @@
  * @vitest-environment node
  *
  * Store-level resolution of a registered flag, with postgres as the only
- * mocked hop.
+ * faked hop. The fake is a real table (a Map behind `findUnique` / `upsert`),
+ * so an operator write and the read that follows it round-trip through the
+ * store's own code rather than through an assertion on call arguments.
  *
  * `get` keeps "no row" as a distinct `null` so the service layer can decide
  * whether a PRODUCT flag still falls through to PostHog. Per-span ingestion
@@ -14,24 +16,53 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
 
-const { findUnique } = vi.hoisted(() => ({ findUnique: vi.fn() }));
+type FakeRow = { key: string; enabled: boolean; rules: unknown };
+
+const { table, findUnique, upsert } = vi.hoisted(() => {
+  const table = new Map<string, FakeRow>();
+  return {
+    table,
+    findUnique: vi.fn(
+      async ({ where }: { where: { key: string } }) =>
+        table.get(where.key) ?? null,
+    ),
+    upsert: vi.fn(
+      async ({
+        where,
+        create,
+        update,
+      }: {
+        where: { key: string };
+        create: FakeRow;
+        update: Partial<FakeRow>;
+      }) => {
+        const existing = table.get(where.key);
+        const row = existing ? { ...existing, ...update } : { ...create };
+        table.set(where.key, row);
+        return row;
+      },
+    ),
+  };
+});
 
 vi.mock("../../db", () => ({
-  prisma: { featureFlag: { findUnique } },
+  prisma: { featureFlag: { findUnique, upsert } },
 }));
 
 const BLOB_OFFLOAD = "release_trace_blob_offload";
 const PROJECT_ID = "project-abc";
+const OPTED_OUT_PROJECT_ID = "project-opted-out";
 
 beforeEach(() => {
-  findUnique.mockReset();
+  table.clear();
+  findUnique.mockClear();
+  upsert.mockClear();
 });
 
 describe("given no operator row exists for the trace blob offload flag", () => {
   describe("when the ingestion edge resolves the flag for a project", () => {
-    /** @scenario A deployment that configured object storage spools oversized spans with no flag setup */
+    /** @scenario Oversized span content survives ingestion wherever storage is available */
     it("resolves to the registry default of on", async () => {
-      findUnique.mockResolvedValue(null);
       const store = new FeatureFlagStorePostgres();
 
       const enabled = await store.getOrRegistryDefault(BLOB_OFFLOAD, {
@@ -48,7 +79,6 @@ describe("given no operator row exists for the trace blob offload flag", () => {
     });
 
     it("still reports the raw absence as null through get, which the service layer needs", async () => {
-      findUnique.mockResolvedValue(null);
       const store = new FeatureFlagStorePostgres();
 
       await expect(
@@ -61,8 +91,8 @@ describe("given no operator row exists for the trace blob offload flag", () => {
 describe("given an operator switched the trace blob offload flag off fleet-wide", () => {
   describe("when the ingestion edge resolves the flag", () => {
     it("returns false, so the row keeps working as a kill switch over the default", async () => {
-      findUnique.mockResolvedValue({ enabled: false, rules: [] });
       const store = new FeatureFlagStorePostgres();
+      await store.set(BLOB_OFFLOAD, false, "operator-1");
 
       await expect(
         store.getOrRegistryDefault(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
@@ -71,34 +101,64 @@ describe("given an operator switched the trace blob offload flag off fleet-wide"
   });
 });
 
-describe("given an operator opted a single project out of the trace blob offload", () => {
-  const row = {
-    enabled: true,
-    rules: [{ match: { projectId: "project-opted-out" }, enabled: false }],
-  };
+describe("given an operator wrote a single per-project opt-out rule and no row existed before", () => {
+  async function writeOptOutRule(store: FeatureFlagStorePostgres) {
+    await store.setRules(
+      BLOB_OFFLOAD,
+      [{ match: { projectId: OPTED_OUT_PROJECT_ID }, enabled: false }],
+      "operator-1",
+    );
+  }
 
-  describe("when the ingestion edge resolves the flag for the opted-out project", () => {
-    /** @scenario A deployment that configured object storage spools oversized spans with no flag setup */
+  describe("when the ingestion edge resolves the flag for the targeted project", () => {
+    /** @scenario Oversized span content survives ingestion wherever storage is available */
     it("returns false for that project", async () => {
-      findUnique.mockResolvedValue(row);
       const store = new FeatureFlagStorePostgres();
+      await writeOptOutRule(store);
 
       await expect(
         store.getOrRegistryDefault(BLOB_OFFLOAD, {
-          projectId: "project-opted-out",
+          projectId: OPTED_OUT_PROJECT_ID,
         }),
       ).resolves.toBe(false);
     });
   });
 
-  describe("when the ingestion edge resolves the flag for any other project", () => {
-    it("returns true", async () => {
-      findUnique.mockResolvedValue(row);
+  describe("when the ingestion edge resolves the flag for a project the rule does not name", () => {
+    /** @scenario Oversized span content survives ingestion wherever storage is available */
+    it("stays enabled, so one project's opt-out never turns the fleet off", async () => {
       const store = new FeatureFlagStorePostgres();
+      await writeOptOutRule(store);
 
       await expect(
         store.getOrRegistryDefault(BLOB_OFFLOAD, { projectId: PROJECT_ID }),
       ).resolves.toBe(true);
+    });
+
+    it("seeds the created row's fallback from the registry default rather than false", async () => {
+      const store = new FeatureFlagStorePostgres();
+      await writeOptOutRule(store);
+
+      expect(table.get(BLOB_OFFLOAD)?.enabled).toBe(true);
+    });
+  });
+});
+
+describe("given a rule-only write for a flag whose registry default is off", () => {
+  describe("when the ingestion edge resolves the flag for an unnamed project", () => {
+    it("stays off, so an org-scoped enable cannot flip the flag on fleet-wide", async () => {
+      const store = new FeatureFlagStorePostgres();
+      await store.setRules(
+        "release_trace_media_extraction",
+        [{ match: { organizationId: "org-early-access" }, enabled: true }],
+        "operator-1",
+      );
+
+      await expect(
+        store.getOrRegistryDefault("release_trace_media_extraction", {
+          projectId: PROJECT_ID,
+        }),
+      ).resolves.toBe(false);
     });
   });
 });
@@ -106,7 +166,7 @@ describe("given an operator opted a single project out of the trace blob offload
 describe("given the postgres read fails", () => {
   describe("when the ingestion edge resolves the flag", () => {
     it("falls back to the registry default rather than propagating the error", async () => {
-      findUnique.mockRejectedValue(new Error("connection terminated"));
+      findUnique.mockRejectedValueOnce(new Error("connection terminated"));
       const store = new FeatureFlagStorePostgres();
 
       await expect(

--- a/platform/app/src/server/featureFlag/featureFlagStore.postgres.ts
+++ b/platform/app/src/server/featureFlag/featureFlagStore.postgres.ts
@@ -166,10 +166,19 @@ export class FeatureFlagStorePostgres {
   }
 
   /**
-   * Operator write of the targeting rules for a flag. Creates a row
-   * with rule-only semantics (no row-level true) when one doesn't
-   * already exist so an org-scoped enable doesn't accidentally flip
-   * the flag on cluster-wide.
+   * Operator write of the targeting rules for a flag.
+   *
+   * A rule is an override for the targets it names, and for nobody else.
+   * When no row exists yet, the row this creates seeds its row-level
+   * `enabled` from the registry default so unmatched callers keep resolving
+   * to exactly what they resolved to before the rule was written. Seeding
+   * `false` unconditionally would make a single per-project opt-out rule
+   * switch a default-on flag off for the whole fleet, since the new row
+   * shadows the registry default for every non-matching context.
+   *
+   * For a default-off flag the seed is `false`, so an org-scoped enable
+   * still cannot flip the flag on cluster-wide. Unregistered keys seed
+   * `false` for the same reason.
    */
   async setRules(
     key: string,
@@ -180,7 +189,7 @@ export class FeatureFlagStorePostgres {
       where: { key },
       create: {
         key,
-        enabled: false,
+        enabled: resolveFlagDefinition(key)?.defaultValue ?? false,
         rules: rules as unknown as object,
         lastEditedBy,
       },

--- a/platform/app/src/server/featureFlag/featureFlagStore.postgres.ts
+++ b/platform/app/src/server/featureFlag/featureFlagStore.postgres.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@langwatch/observability";
 import { prisma } from "../db";
 import { TtlCache } from "../utils/ttlCache";
 import { KILL_SWITCH_CACHE_TTL_MS } from "./constants";
+import { type FeatureFlagKey, resolveFlagDefinition } from "./registry";
 import {
   evaluateRules,
   type FeatureFlagRules,
@@ -68,6 +69,28 @@ export class FeatureFlagStorePostgres {
     if (row === null) return null;
     const ruleHit = evaluateRules(row.rules, ctx);
     return ruleHit ?? row.enabled;
+  }
+
+  /**
+   * Same resolution as `get`, but an absent row resolves to the flag's
+   * registry default instead of `null`.
+   *
+   * For hot-path callers that must decide without the service layer: the
+   * PRODUCT branch of `FeatureFlagService` falls through to PostHog when no
+   * row exists, which per-span ingestion cannot afford. Reading `get`
+   * directly instead makes an absent row read as "off" and silently strands
+   * the registry default, so a flag that ships on by default would never
+   * reach a deployment that has not written an operator row. This method is
+   * the resolution those callers actually want: operator row (with its
+   * targeting rules) first, registry default second, PostHog never.
+   */
+  async getOrRegistryDefault(
+    key: FeatureFlagKey,
+    ctx: RuleEvaluationContext = {},
+  ): Promise<boolean> {
+    const stored = await this.get(key, ctx);
+    if (stored !== null) return stored;
+    return resolveFlagDefinition(key)?.defaultValue ?? false;
   }
 
   /**

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -142,17 +142,25 @@ export const FEATURE_FLAGS = [
     description:
       "Surfaces the AI Gateway menu in the project sidebar. Default flipped to on: operators can hide the surface per project via a PostHog rule or operator-store row.",
   },
-  // Per-project gate for trace blob offload (#4215 / ADR-022). Checked ONCE per
-  // ingestion request (not per span) via the postgres-cached store, so the
-  // hot-path cost is one cached lookup. When on, over-threshold spans get
-  // routed via the transient S3 spool at the edge (ADR-022). Off = today's
-  // behavior — the existing capOversizedAttributes(256 KB) is the only cap.
+  // Per-project gate for the transient S3 spool at the ingestion edge
+  // (#4215 / ADR-022). ON by default, so a deployment with object storage
+  // configured keeps oversized span content intact with no flag setup: a span
+  // whose serialized command exceeds 256 KB is written to the spool and the
+  // queued command carries only a spool ref. Resolved per span against the
+  // postgres-cached store, so the hot-path cost is one cached lookup.
+  //
+  // The flag stays the kill switch and the per-project opt-out: an operator
+  // row in /ops/feature-flags turns the spool off fleet-wide or for a single
+  // project. When the spool cannot run at all (no reachable object storage,
+  // or an Azure-only install where the S3 client refuses to build) the edge
+  // fails open: ingestion proceeds inline and capOversizedAttributes truncates
+  // each attribute value at 256 KB.
   {
     key: "release_trace_blob_offload",
     scope: "PRODUCT",
-    defaultValue: false,
+    defaultValue: true,
     description:
-      "Routes over-threshold OTLP spans via a transient S3 spool at the ingestion edge (ADR-022). Off = current behavior (full value flows through the command queue; capOversizedAttributes(256 KB) is the only cap).",
+      "Routes over-threshold OTLP spans through a transient S3 spool at the ingestion edge so oversized attribute values reach the trace intact (ADR-022). On by default; switch it off fleet-wide or per project to keep spans inline, where the 256 KB per-value cap applies. Deployments with no reachable object storage keep ingesting either way: the edge falls back inline and the same 256 KB cap applies.",
   },
   // Externalizes inline media (base64 audio turns, data-URI images, file
   // attachments) from span attributes into the content-addressed

--- a/specs/event-sourcing/large-trace-blob-offload.feature
+++ b/specs/event-sourcing/large-trace-blob-offload.feature
@@ -148,8 +148,27 @@ Feature: Large trace payloads — event_log as single source of truth · transie
     And the event is written to event_log with the full content as EventPayload
     And after event_log INSERT succeeds the S3 spool object is best-effort DELETEd
 
-  @integration @track2 @unimplemented
-  # Bound by edge-offload.unit.test.ts written in Step 4.
+  @unit @track2
+  # The spool is on by default, so a deployment that already has object
+  # storage keeps oversized content intact without configuring anything.
+  # The edge resolves the flag against the operator store and falls back to
+  # the registry default (never PostHog, which per-span ingestion cannot
+  # afford), so the default only lands if it flows through that lookup.
+  # Bound by featureFlagStore.postgres.unit.test.ts.
+  Scenario: A deployment that configured object storage spools oversized spans with no flag setup
+    Given a deployment with object storage configured
+    And no operator row or targeting rule exists for "release_trace_blob_offload"
+    When the ingestion edge resolves the flag for a project
+    Then the flag resolves to enabled from the registry default
+    And a span whose serialized command exceeds 256 KB is spooled rather than
+        truncated at the 256 KB per-value cap
+    And an operator row switching the flag off still wins, fleet-wide or for
+        a single project
+
+  @unit @track2
+  # Bound by edge-offload.unit.test.ts, which also pins what the span loses
+  # on this path: capOversizedAttributes replaces the over-cap value with a
+  # truncation marker once the command reaches the worker.
   Scenario: When edge S3 spool PUT fails, ingestion falls back to inline (fail-open)
     Given a span whose serialized command payload exceeds 256 KB
     And the S3 spool PUT fails at the edge

--- a/specs/event-sourcing/large-trace-blob-offload.feature
+++ b/specs/event-sourcing/large-trace-blob-offload.feature
@@ -149,26 +149,22 @@ Feature: Large trace payloads — event_log as single source of truth · transie
     And after event_log INSERT succeeds the S3 spool object is best-effort DELETEd
 
   @unit @track2
-  # The spool is on by default, so a deployment that already has object
-  # storage keeps oversized content intact without configuring anything.
-  # The edge resolves the flag against the operator store and falls back to
-  # the registry default (never PostHog, which per-span ingestion cannot
-  # afford), so the default only lands if it flows through that lookup.
-  # Bound by featureFlagStore.postgres.unit.test.ts.
-  Scenario: A deployment that configured object storage spools oversized spans with no flag setup
-    Given a deployment with object storage configured
-    And no operator row or targeting rule exists for "release_trace_blob_offload"
-    When the ingestion edge resolves the flag for a project
-    Then the flag resolves to enabled from the registry default
-    And a span whose serialized command exceeds 256 KB is spooled rather than
-        truncated at the 256 KB per-value cap
-    And an operator row switching the flag off still wins, fleet-wide or for
-        a single project
+  # Preservation is the default, so nobody has to discover a setting to get
+  # it. Turning it off is the deliberate act, and it reaches only what the
+  # operator aimed at. Bound by featureFlagStore.postgres.unit.test.ts.
+  Scenario: Oversized span content survives ingestion wherever storage is available
+    Given a deployment whose object storage is reachable
+    And nobody has configured anything about oversized content
+    When a trace arrives carrying far more content than a span field holds
+    Then the whole value is preserved on the trace
+    When an operator turns preservation off for one project
+    Then that project's oversized content is no longer preserved
+    And every other project keeps its content preserved
 
   @unit @track2
-  # Bound by edge-offload.unit.test.ts, which also pins what the span loses
-  # on this path: capOversizedAttributes replaces the over-cap value with a
-  # truncation marker once the command reaches the worker.
+  # Bound by edge-offload.unit.test.ts for the edge decision, and by
+  # recordSpanCommand.oversized.unit.test.ts for what the worker then does
+  # with the command the edge handed back.
   Scenario: When edge S3 spool PUT fails, ingestion falls back to inline (fail-open)
     Given a span whose serialized command payload exceeds 256 KB
     And the S3 spool PUT fails at the edge


### PR DESCRIPTION
## What

Makes the ADR-022 transient S3 spool the default. `release_trace_blob_offload` flips to `defaultValue: true`, and the ingestion edge now resolves it through `FeatureFlagStorePostgres.getOrRegistryDefault` instead of the raw `get`.

The second half is load-bearing. `get` returns `null` for an absent row on purpose, so the service layer can decide whether a PRODUCT flag still falls through to PostHog. The edge reads the store directly (per-span ingestion cannot afford a PostHog hop), which meant an absent row read as "off" and the registry default never landed. Flipping the registry alone would have changed nothing.

## What changes where

- **Cloud**: nothing. Prod already runs this flag on with a match-all operator rule, and an operator row still wins over the default.
- **Self-hosted with S3 (or MinIO / Ceph RGW) configured**: oversized span attribute values stop being truncated at 256 KB with no flag setup at all. A span whose serialized command exceeds 256 KB goes to the spool and the full content reaches `event_log`.
- **Deployments with no object storage**: identical behavior. The edge already fails open, increments `langwatch_edge_spool_fail_open_total{reason="spool"}` and proceeds inline, where `capOversizedAttributes` caps each value at 256 KB. The warn now names the consequence and the fix instead of saying "edge spool failed".
- **Azure-only installs** (`STORED_OBJECTS_BACKEND=azure`, no `S3_BUCKET_NAME`): `createS3Client` throws by design, so the spool is unavailable until the Azure storage work lands. Fail-open catches it, ingestion is never blocked, and the 256 KB cap applies.

The flag keeps both of its jobs: fleet-wide kill switch, and per-project opt-out via a targeting rule in /ops/feature-flags.

## Tests

- `featureFlagStore.postgres.unit.test.ts` (new): pins that the store resolves to `true` when postgres has no row, that `get` still reports the raw absence as `null`, that a fleet-wide off row and a per-project opt-out rule both beat the default, and that a failed postgres read degrades to the default. Postgres is the only mocked hop, so the pin exercises the fallback rather than re-reading the registry object.
- `edge-offload.unit.test.ts`: extended with the fail-open consequence, running `capOversizedAttributes` over the command that fell back inline and asserting the truncation marker. Also binds the fail-open scenario, which was tagged `@unimplemented` while already implemented.
- `specs/event-sourcing/large-trace-blob-offload.feature`: new `@unit` scenario for the default, bound and passing `pnpm check:feature-parity`.
- ADR-022's on-prem section no longer tells operators to leave the flag off.

## Verification

`pnpm test:unit run` on the touched suites (11 passed), the wider `src/server/featureFlag` + oversized-command suites (75 passed), `pnpm typecheck:all` clean, `pnpm check:feature-parity` OK, and the Biome added-violations gate against `origin/main` reports 0 new violations.

## Deployment Impact

No migration, no config, no rollout step. On deploy, any project with no operator row starts spooling over-threshold spans to the bucket the deployment already uses for stored objects. Cloud is unaffected because its match-all rule already resolves ahead of the default. Watch `langwatch_edge_spool_fail_open_total` after the rollout: a sustained `reason="spool"` rate means object storage is unreachable and those spans are taking the 256 KB inline cap. The rollback is an operator row in /ops/feature-flags setting `release_trace_blob_offload` to off, fleet-wide or per project, with no redeploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace blob offloading is now enabled by default.
  * Oversized spans are spooled to object storage when available.
  * Operators can disable offloading fleet-wide or for specific projects.
  * If object storage is unavailable, ingestion continues inline with attribute values capped at 256 KB.

* **Bug Fixes**
  * Improved fallback behavior when feature-flag settings are missing or unavailable.

* **Tests**
  * Added coverage for default settings, overrides, storage failures, and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->