### PR TITLE
fix(model-providers): an extra header no longer deletes the stored Azure credentials

### DIFF
--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -137,6 +137,7 @@ export const APP_ERROR_CODES = [
   "missing_slack_webhook",
   "model_not_configured",
   "model_provider_anchor_required",
+  "model_provider_credentials_would_be_dropped",
   "model_provider_deprecated",
   "model_provider_disabled",
   "model_provider_not_found",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -489,6 +489,11 @@ const presentations = {
     describe: () =>
       "A provider added outside a project needs at least one scope, so pick the teams or projects it covers.",
   },
+  model_provider_credentials_would_be_dropped: {
+    title: "That save would delete the stored credentials",
+    describe: () =>
+      "The request carried no credential for this provider, and applying it would remove the ones on file. Send the credentials with it, or leave them out of the request to keep what is stored.",
+  },
   missing_provider: {
     // fault: customer — a configuration choice they can change, so the copy
     // names it rather than apologising.

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -492,7 +492,7 @@ const presentations = {
   model_provider_credentials_would_be_dropped: {
     title: "That save would delete the stored credentials",
     describe: () =>
-      "The request carried no credential for this provider, and applying it would remove the ones on file. Send the credentials with it, or leave them out of the request to keep what is stored.",
+      "Saving this would remove the API key and endpoint already stored for this provider. Leave the credential fields as they are to keep them, or empty them yourself if removing them is what you want.",
   },
   missing_provider: {
     // fault: customer — a configuration choice they can change, so the copy

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -492,7 +492,7 @@ const presentations = {
   model_provider_credentials_would_be_dropped: {
     title: "That save would delete the stored credentials",
     describe: () =>
-      "Saving this would remove the API key and endpoint already stored for this provider. Leave the credential fields as they are to keep them, or empty them yourself if removing them is what you want.",
+      "Saving this would remove the credentials already stored for this provider. Leave the credential fields as they are to keep them, or empty them yourself if removing them is what you want.",
   },
   missing_provider: {
     // fault: customer — a configuration choice they can change, so the copy

--- a/platform/app/src/hooks/__tests__/useModelProviderForm.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useModelProviderForm.integration.test.tsx
@@ -294,12 +294,11 @@ describe("useModelProviderForm()", () => {
   // provider holding a header read as dirty the moment its drawer opened, so
   // Save was live over a form nobody had touched, and clicking it sent a save
   // the customer never asked for.
-  describe("isDirty with a stored extra header", () => {
-    // A saved provider, so the scope set matches what is on file and the only
-    // thing under test is the header comparison.
+  describe("given a saved provider that already holds an extra header", () => {
     // Built once per test, never inside the render callback: the hook's reset
     // effect keys on `provider.customKeys` and `provider.extraHeaders`, so a
-    // fresh object each render re-fires it forever.
+    // fresh object each render re-fires it forever. Scopes are set so the row
+    // reads as saved and the header comparison is the only thing under test.
     const openForm = (headers: { key: string; value: string }[]) => {
       const provider = createOpenAIProvider({
         name: "OpenAI",
@@ -314,49 +313,51 @@ describe("useModelProviderForm()", () => {
         }),
       );
     };
+    const withHeader = () =>
+      openForm([{ key: "api-key", value: MASKED_KEY_PLACEHOLDER }]);
 
-    it("is false on open for a saved provider with no headers (control)", () => {
-      expect(openForm([]).result.current[0].isDirty).toBe(false);
-    });
-
-    /** @scenario A stored extra header does not make the form dirty on open */
-    it("is false when the drawer just opened on a provider that has a header", () => {
-      const { result } = openForm([
-        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
-      ]);
-
-      expect(result.current[0].isDirty).toBe(false);
-    });
-
-    it("is true once that header's value is edited", () => {
-      const { result } = openForm([
-        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
-      ]);
-
-      act(() => {
-        result.current[1].setExtraHeaderValue(0, "a-new-value");
+    describe("when the drawer has just opened and nothing was touched", () => {
+      /** @scenario A stored extra header does not make the form dirty on open */
+      it("leaves the form clean, so Save stays disabled", () => {
+        expect(withHeader().result.current[0].isDirty).toBe(false);
       });
-
-      expect(result.current[0].isDirty).toBe(true);
     });
 
-    it("is true once a header is added", () => {
-      const { result } = openForm([
-        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
-      ]);
-
-      act(() => {
-        result.current[1].addExtraHeader();
+    describe("when the same provider holds no headers at all", () => {
+      it("also leaves the form clean, which is the control for the case above", () => {
+        expect(openForm([]).result.current[0].isDirty).toBe(false);
       });
+    });
 
-      expect(result.current[0].isDirty).toBe(true);
+    describe("when the header's value is edited", () => {
+      it("marks the form dirty", () => {
+        const { result } = withHeader();
+
+        act(() => {
+          result.current[1].setExtraHeaderValue(0, "a-new-value");
+        });
+
+        expect(result.current[0].isDirty).toBe(true);
+      });
+    });
+
+    describe("when another header is added", () => {
+      it("marks the form dirty", () => {
+        const { result } = withHeader();
+
+        act(() => {
+          result.current[1].addExtraHeader();
+        });
+
+        expect(result.current[0].isDirty).toBe(true);
+      });
     });
   });
 
   // Emptying a credential is an edit like any other. Dirty detection used to
   // ask only whether a new key had been typed, so Save stayed disabled over a
   // cleared field and a credential could not be removed at all.
-  describe("isDirty when a credential is emptied", () => {
+  describe("given a saved provider whose API key is already on file", () => {
     // Same rule as above: one provider object per test, held stable across
     // renders so the hook's reset effect fires once.
     const openForm = () => {
@@ -375,29 +376,35 @@ describe("useModelProviderForm()", () => {
       );
     };
 
-    it("is false on open (control)", () => {
-      expect(openForm().result.current[0].isDirty).toBe(false);
+    describe("when the drawer has just opened and nothing was touched", () => {
+      it("leaves the form clean, which is the control for the cases below", () => {
+        expect(openForm().result.current[0].isDirty).toBe(false);
+      });
     });
 
-    /** @scenario Clearing a stored API key enables Save */
-    it("is true once the stored API key is cleared", () => {
-      const { result } = openForm();
+    describe("when the key field is cleared", () => {
+      /** @scenario Clearing a stored API key enables Save */
+      it("marks the form dirty, so the credential can be removed", () => {
+        const { result } = openForm();
 
-      act(() => {
-        result.current[1].setCustomKey("OPENAI_API_KEY", "");
+        act(() => {
+          result.current[1].setCustomKey("OPENAI_API_KEY", "");
+        });
+
+        expect(result.current[0].isDirty).toBe(true);
       });
-
-      expect(result.current[0].isDirty).toBe(true);
     });
 
-    it("is true once a new API key is typed", () => {
-      const { result } = openForm();
+    describe("when a new key is typed", () => {
+      it("marks the form dirty", () => {
+        const { result } = openForm();
 
-      act(() => {
-        result.current[1].setCustomKey("OPENAI_API_KEY", "sk-freshly-typed");
+        act(() => {
+          result.current[1].setCustomKey("OPENAI_API_KEY", "sk-freshly-typed");
+        });
+
+        expect(result.current[0].isDirty).toBe(true);
       });
-
-      expect(result.current[0].isDirty).toBe(true);
     });
   });
 

--- a/platform/app/src/hooks/__tests__/useModelProviderForm.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useModelProviderForm.integration.test.tsx
@@ -289,6 +289,118 @@ describe("useModelProviderForm()", () => {
     });
   });
 
+  // A stored header arrives masked and the form wraps it with a `concealed`
+  // flag for the show/hide eye. Comparing the objects whole made every
+  // provider holding a header read as dirty the moment its drawer opened, so
+  // Save was live over a form nobody had touched, and clicking it sent a save
+  // the customer never asked for.
+  describe("isDirty with a stored extra header", () => {
+    // A saved provider, so the scope set matches what is on file and the only
+    // thing under test is the header comparison.
+    // Built once per test, never inside the render callback: the hook's reset
+    // effect keys on `provider.customKeys` and `provider.extraHeaders`, so a
+    // fresh object each render re-fires it forever.
+    const openForm = (headers: { key: string; value: string }[]) => {
+      const provider = createOpenAIProvider({
+        name: "OpenAI",
+        scopes: [{ scopeType: "PROJECT", scopeId: "test-project-id" }],
+        extraHeaders: headers,
+      } as Partial<MaybeStoredModelProvider>);
+      return renderHook(() =>
+        useModelProviderForm({
+          provider,
+          projectId: "test-project-id",
+          enabledProvidersCount: 2,
+        }),
+      );
+    };
+
+    it("is false on open for a saved provider with no headers (control)", () => {
+      expect(openForm([]).result.current[0].isDirty).toBe(false);
+    });
+
+    /** @scenario A stored extra header does not make the form dirty on open */
+    it("is false when the drawer just opened on a provider that has a header", () => {
+      const { result } = openForm([
+        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(result.current[0].isDirty).toBe(false);
+    });
+
+    it("is true once that header's value is edited", () => {
+      const { result } = openForm([
+        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      act(() => {
+        result.current[1].setExtraHeaderValue(0, "a-new-value");
+      });
+
+      expect(result.current[0].isDirty).toBe(true);
+    });
+
+    it("is true once a header is added", () => {
+      const { result } = openForm([
+        { key: "api-key", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      act(() => {
+        result.current[1].addExtraHeader();
+      });
+
+      expect(result.current[0].isDirty).toBe(true);
+    });
+  });
+
+  // Emptying a credential is an edit like any other. Dirty detection used to
+  // ask only whether a new key had been typed, so Save stayed disabled over a
+  // cleared field and a credential could not be removed at all.
+  describe("isDirty when a credential is emptied", () => {
+    // Same rule as above: one provider object per test, held stable across
+    // renders so the hook's reset effect fires once.
+    const openForm = () => {
+      const provider = createOpenAIProvider({
+        name: "OpenAI",
+        enabled: true,
+        scopes: [{ scopeType: "PROJECT", scopeId: "test-project-id" }],
+        customKeys: { OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER },
+      } as Partial<MaybeStoredModelProvider>);
+      return renderHook(() =>
+        useModelProviderForm({
+          provider,
+          projectId: "test-project-id",
+          enabledProvidersCount: 2,
+        }),
+      );
+    };
+
+    it("is false on open (control)", () => {
+      expect(openForm().result.current[0].isDirty).toBe(false);
+    });
+
+    /** @scenario Clearing a stored API key enables Save */
+    it("is true once the stored API key is cleared", () => {
+      const { result } = openForm();
+
+      act(() => {
+        result.current[1].setCustomKey("OPENAI_API_KEY", "");
+      });
+
+      expect(result.current[0].isDirty).toBe(true);
+    });
+
+    it("is true once a new API key is typed", () => {
+      const { result } = openForm();
+
+      act(() => {
+        result.current[1].setCustomKey("OPENAI_API_KEY", "sk-freshly-typed");
+      });
+
+      expect(result.current[0].isDirty).toBe(true);
+    });
+  });
+
   describe("Extra Headers", () => {
     it("initializes with existing extra headers", () => {
       const provider = createOpenAIProvider({

--- a/platform/app/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
@@ -561,6 +561,72 @@ describe("useProviderFormSubmit()", () => {
         });
       });
     });
+
+    // Headers used to be folded into customKeys for Azure. When no credential
+    // had changed the credential branch had already settled on `undefined`,
+    // and the fold turned that into an object holding only the headers, which
+    // the server then wrote over the stored credentials.
+    describe("when an extra header is added and no credential was touched", () => {
+      /** @scenario Adding an extra header keeps the stored Azure credentials */
+      it("still sends customKeys undefined rather than a header-only object", async () => {
+        const snapshot = buildSnapshot({
+          isUsingEnvVars: false,
+          useAsDefaultProvider: false,
+          providerKeysSchema: passthroughSchema,
+          customKeys: {
+            AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            AZURE_OPENAI_ENDPOINT: MASKED_KEY_PLACEHOLDER,
+          },
+          initialKeys: {
+            AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            AZURE_OPENAI_ENDPOINT: MASKED_KEY_PLACEHOLDER,
+          },
+          extraHeaders: [{ key: "api-key", value: "header-secret" }],
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        const payload = mockUpdateMutateAsync.mock.calls[0]?.[0];
+        expect(payload?.customKeys).toBeUndefined();
+        expect(payload?.extraHeaders).toEqual([
+          { key: "api-key", value: "header-secret" },
+        ]);
+      });
+    });
+
+    describe("when a header is present and a credential was genuinely edited", () => {
+      it("sends the credentials only, with no header folded in", async () => {
+        const snapshot = buildSnapshot({
+          isUsingEnvVars: false,
+          useAsDefaultProvider: false,
+          providerKeysSchema: passthroughSchema,
+          customKeys: {
+            AZURE_OPENAI_API_KEY: "sk-newly-typed",
+            AZURE_OPENAI_ENDPOINT: MASKED_KEY_PLACEHOLDER,
+          },
+          initialKeys: {
+            AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            AZURE_OPENAI_ENDPOINT: MASKED_KEY_PLACEHOLDER,
+          },
+          extraHeaders: [{ key: "api-key", value: "header-secret" }],
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        const payload = mockUpdateMutateAsync.mock.calls[0]?.[0];
+        expect(payload?.customKeys).toEqual({
+          AZURE_OPENAI_API_KEY: "sk-newly-typed",
+          AZURE_OPENAI_ENDPOINT: MASKED_KEY_PLACEHOLDER,
+        });
+        expect(payload?.customKeys).not.toHaveProperty("api-key");
+      });
+    });
   });
 
   describe("given the parent form opts out of the advanced payload (FF off)", () => {

--- a/platform/app/src/hooks/useModelProviderForm.ts
+++ b/platform/app/src/hooks/useModelProviderForm.ts
@@ -5,8 +5,8 @@ import {
   modelProviders as modelProvidersRegistry,
 } from "../server/modelProviders/registry";
 import {
-  hasUserEnteredNewApiKey,
-  hasUserModifiedNonApiKeyFields,
+  hasUserModifiedAnyCredential,
+  headerSignature,
 } from "../utils/modelProviderHelpers";
 
 // Mirrors the server's deriveDefaultName. Kept here so the drawer can
@@ -295,15 +295,19 @@ export function useModelProviderForm(
       humanizeProviderName(provider.provider);
     if (name.trim() !== initialName.trim()) return true;
 
-    if (hasUserEnteredNewApiKey(credentialKeysHook.customKeys)) return true;
+    // The same helper the submit path uses to decide whether to send
+    // credentials at all, so the button and the payload cannot disagree.
+    // Reading only "a new api key was typed" plus "a non-key field changed"
+    // left one edit invisible: emptying a key field is a change, and with
+    // Save disabled there was no way to remove a credential at all.
     if (
-      hasUserModifiedNonApiKeyFields(
-        credentialKeysHook.customKeys,
-        credentialKeysHook.originalStoredKeysRef.current as Record<
+      hasUserModifiedAnyCredential({
+        customKeys: credentialKeysHook.customKeys,
+        initialKeys: credentialKeysHook.originalStoredKeysRef.current as Record<
           string,
           unknown
         >,
-      )
+      })
     ) {
       return true;
     }
@@ -332,9 +336,14 @@ export function useModelProviderForm(
     // Headers and models: order-sensitive JSON compare. Reordering a list
     // counts as dirty here, which matches user intent (the user dragged
     // them on purpose).
+    //
+    // Headers are compared on key and value only. The form carries a
+    // `concealed` flag the stored header has no idea about, so comparing the
+    // objects whole made every provider that holds a header read as dirty the
+    // moment its drawer opened, with Save enabled over an untouched form.
     if (
-      JSON.stringify(extraHeadersHook.extraHeaders) !==
-      JSON.stringify(provider.extraHeaders ?? [])
+      headerSignature(extraHeadersHook.extraHeaders) !==
+      headerSignature(provider.extraHeaders)
     ) {
       return true;
     }

--- a/platform/app/src/hooks/useProviderFormSubmit.ts
+++ b/platform/app/src/hooks/useProviderFormSubmit.ts
@@ -269,24 +269,18 @@ export function useProviderFormSubmit({
         customKeysToSend = undefined;
       }
 
-      // Merge azure headers when applicable
-      if (!isUsingEnvVars && provider.provider === "azure") {
-        const headerMap: Record<string, string> = {};
-        (extraHeaders ?? []).forEach((header) => {
-          if (header.key.trim() && header.value.trim()) {
-            const sanitizedKey = header.key
-              .trim()
-              .replace(/[^a-zA-Z0-9_-]/g, "_");
-            if (sanitizedKey) headerMap[sanitizedKey] = header.value.trim();
-          }
-        });
-        customKeysToSend = { ...customKeysToSend, ...headerMap };
-      }
+      // Headers are not credentials. They have their own column, their own
+      // masked-placeholder merge (`mergeExtraHeaders`), and both readers take
+      // them from there: `prepareLitellmParams` builds `extra_headers` from
+      // `modelProvider.extraHeaders`, and the gateway materialiser reads
+      // `mp.extraHeaders`. Nothing reads a header out of `customKeys`, so
+      // folding them in wrote a value no one consumed and, when no credential
+      // had changed, replaced the whole credential bag with the headers.
 
-      // Safety net: if the steps above (placeholder stripping, azure-header
-      // merge) leave an empty customKeys object, send `undefined` so the
-      // server treats it as "no key change" and preserves the stored key,
-      // rather than validating `{}` against the provider's keysSchema.
+      // Safety net: if placeholder stripping leaves an empty customKeys
+      // object, send `undefined` so the server treats it as "no key change"
+      // and preserves the stored key, rather than validating `{}` against the
+      // provider's keysSchema.
       if (
         customKeysToSend !== undefined &&
         Object.keys(customKeysToSend).length === 0

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
@@ -4,12 +4,12 @@
  * Real-Postgres coverage for the credential a customer never retyped.
  *
  * The drawer shows a stored API key masked, so every save of an unrelated
- * field carries that placeholder back. The service is supposed to swap it
- * for the credential already on file. The sibling unit test asserts that
- * rule against a copy of the merge function, which is exactly why it stayed
- * green while a base-URL edit through the real path wrote the row without
- * any key at all: the credential the customer never touched was gone, and
- * the provider stopped working with no visible cause.
+ * field carries that placeholder back, and the service swaps it for the
+ * credential already on file. A write that leaves the key out entirely gets
+ * the same protection, since a masked value is one nobody can retype. Both
+ * rules are asserted here, against the row the service actually wrote: the
+ * credential a customer never touched has gone missing twice, each time
+ * leaving a provider that had stopped working with nothing to explain why.
  *
  * Covers @integration scenarios from
  * specs/model-providers/provider-configuration.feature.
@@ -363,6 +363,97 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
 
           expect(await keysById(created.id)).toEqual({
             "api-key": "header-secret",
+          });
+        });
+      });
+
+      // A write that names some credentials passes the guard above, and then
+      // the merge decides what happens to the ones it did not name. A secret
+      // is masked on read, so nobody can resend one they did not type: leaving
+      // it out is not a request to delete it. The visible fields are a
+      // different matter, and the API gateway option depends on that.
+      describe("when the payload names only some of the stored credentials", () => {
+        /** @scenario A save that names one credential keeps the ones it leaves out */
+        it("keeps the API key it never mentioned and updates the endpoint", async () => {
+          const created = await createAzureProvider();
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: {
+                AZURE_OPENAI_ENDPOINT: "https://acme3.openai.azure.com",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_OPENAI_API_KEY: STORED_KEY,
+            AZURE_OPENAI_ENDPOINT: "https://acme3.openai.azure.com",
+          });
+        });
+
+        // The REST upsert is the entry a script uses, and a script sends the
+        // one field it means to change. It reaches the same merge through a
+        // different door, so it is worth its own case.
+        /** @scenario A save that names one credential keeps the ones it leaves out */
+        it("keeps it through the REST upsert entry as well", async () => {
+          const created = await service().updateModelProvider(
+            {
+              projectId,
+              provider: "bedrock",
+              enabled: true,
+              customKeys: {
+                AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+                AWS_SECRET_ACCESS_KEY: STORED_KEY,
+                AWS_REGION_NAME: "us-east-1",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          await service().upsertByProviderKey({
+            projectId,
+            provider: "bedrock",
+            enabled: true,
+            customKeys: { AWS_REGION_NAME: "eu-west-1" },
+          });
+
+          expect(await keysById(created.id)).toEqual({
+            AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+            AWS_SECRET_ACCESS_KEY: STORED_KEY,
+            AWS_REGION_NAME: "eu-west-1",
+          });
+        });
+
+        /** @scenario Switching Azure to its API gateway keeps the key and drops the direct endpoint */
+        it("drops the direct endpoint when the gateway fields take over, and keeps the key", async () => {
+          const created = await createAzureProvider();
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: {
+                AZURE_API_GATEWAY_BASE_URL: "https://apim.acme.com",
+                AZURE_API_GATEWAY_VERSION: "2024-05-01-preview",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_API_GATEWAY_BASE_URL: "https://apim.acme.com",
+            AZURE_API_GATEWAY_VERSION: "2024-05-01-preview",
+            AZURE_OPENAI_API_KEY: STORED_KEY,
           });
         });
       });

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
@@ -366,6 +366,68 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
           });
         });
       });
+
+      // The guard reads the provider's own schema rather than a list of
+      // provider names, so it has to hold for the other two providers whose
+      // drawer offers extra headers.
+      //
+      // Which layer says no depends on how strict the provider's schema is,
+      // and both answers are right. `custom` accepts the payload and strips
+      // the unknown key, so the guard is what catches it. `azure_safety`
+      // demands a URL and a non-empty key, so validation rejects it one layer
+      // earlier. That difference is the point: the guard exists precisely
+      // because a loose schema, which is what Azure has, never objects.
+      describe("when the same shape reaches a provider other than azure", () => {
+        it.each([
+          {
+            provider: "custom",
+            stored: {
+              CUSTOM_API_KEY: "custom-secret",
+              CUSTOM_BASE_URL: "https://proxy.acme.internal/v1",
+            },
+            rejectedWith: /would delete the credentials/i,
+          },
+          {
+            provider: "azure_safety",
+            stored: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "https://safety.acme.internal",
+              AZURE_CONTENT_SAFETY_KEY: "safety-secret",
+            },
+            rejectedWith: /invalid api key configuration/i,
+          },
+        ])("refuses it for $provider and keeps the stored credentials", async ({
+          provider,
+          stored,
+          rejectedWith,
+        }) => {
+          const created = await service().updateModelProvider(
+            {
+              projectId,
+              provider,
+              enabled: true,
+              customKeys: stored,
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          await expect(
+            service().updateModelProvider(
+              {
+                projectId,
+                id: created.id,
+                provider,
+                enabled: true,
+                customKeys: { "x-tenant": "acme" },
+                scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+              },
+              ctx(),
+            ),
+          ).rejects.toThrow(rejectedWith);
+
+          expect(await keysById(created.id)).toEqual(stored);
+        });
+      });
     });
   },
 );

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
@@ -25,6 +25,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cleanupTestRows } from "../../../test-utils/cleanupTestRows";
 import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
 import { prisma } from "../../db";
+import { ModelProviderRepository } from "../modelProvider.repository";
 import { ModelProviderService } from "../modelProvider.service";
 
 // Postgres and an encryption key are all this needs (the setup files
@@ -196,6 +197,172 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
           expect(await storedKeysOf(created.id)).toEqual({
             ANTHROPIC_API_KEY: "",
             ANTHROPIC_BASE_URL: SELF_HOSTED,
+          });
+        });
+      });
+    });
+
+    // A payload that names none of the provider's credential fields cannot be
+    // a credential edit, and applying it would drop every stored one. Azure's
+    // schema is `.passthrough()` with everything optional, so it accepted such
+    // a payload without a word and the row came back holding only a header.
+    describe("given a payload that would drop every stored credential", () => {
+      // Reads the row by id rather than through the collapsed per-provider
+      // record `storedKeysOf` uses: these cases create several azure rows in
+      // one project, and only one of them wins that collapse.
+      async function keysById(id: string) {
+        const row = await new ModelProviderRepository(
+          prisma,
+        ).findByIdWithDecryptedKeys(id);
+        return row?.customKeys;
+      }
+
+      async function createAzureProvider() {
+        return await service().updateModelProvider(
+          {
+            projectId,
+            provider: "azure",
+            enabled: true,
+            customKeys: {
+              AZURE_OPENAI_API_KEY: STORED_KEY,
+              AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+            },
+            scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+          },
+          ctx(),
+        );
+      }
+
+      describe("when the payload carries only an extra header", () => {
+        /** @scenario A header-only payload is refused instead of dropping credentials */
+        it("is refused and the stored credentials survive", async () => {
+          const created = await createAzureProvider();
+
+          await expect(
+            service().updateModelProvider(
+              {
+                projectId,
+                id: created.id,
+                provider: "azure",
+                enabled: true,
+                customKeys: { "api-key": "header-secret" },
+                scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+              },
+              ctx(),
+            ),
+          ).rejects.toThrow(/would delete the credentials/i);
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_OPENAI_API_KEY: STORED_KEY,
+            AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+          });
+        });
+      });
+
+      describe("when the payload is an empty object", () => {
+        it("is refused rather than emptying the credential bag", async () => {
+          const created = await createAzureProvider();
+
+          await expect(
+            service().updateModelProvider(
+              {
+                projectId,
+                id: created.id,
+                provider: "azure",
+                enabled: true,
+                customKeys: {},
+                scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+              },
+              ctx(),
+            ),
+          ).rejects.toThrow(/would delete the credentials/i);
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_OPENAI_API_KEY: STORED_KEY,
+            AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+          });
+        });
+      });
+
+      describe("when the payload names a credential field", () => {
+        it("still goes through, and an unrelated key rides along", async () => {
+          const created = await createAzureProvider();
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: {
+                AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+                AZURE_OPENAI_ENDPOINT: "https://acme2.openai.azure.com",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_OPENAI_API_KEY: STORED_KEY,
+            AZURE_OPENAI_ENDPOINT: "https://acme2.openai.azure.com",
+          });
+        });
+      });
+
+      describe("when the customer clears every credential on purpose", () => {
+        it("still clears them, because the fields are sent empty rather than left out", async () => {
+          const created = await createAzureProvider();
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: {
+                AZURE_OPENAI_API_KEY: "",
+                AZURE_OPENAI_ENDPOINT: "",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          expect(await keysById(created.id)).toEqual({
+            AZURE_OPENAI_API_KEY: "",
+            AZURE_OPENAI_ENDPOINT: "",
+          });
+        });
+      });
+
+      describe("when the row has no credentials stored yet", () => {
+        it("accepts the payload, since there is nothing to lose", async () => {
+          const created = await service().updateModelProvider(
+            {
+              projectId,
+              provider: "azure",
+              enabled: true,
+              customKeys: { AZURE_OPENAI_API_KEY: "" },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: { "api-key": "header-secret" },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          expect(await keysById(created.id)).toEqual({
+            "api-key": "header-secret",
           });
         });
       });

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
@@ -1,28 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { mergeStoredCustomKeys } from "../credentialMerge";
 
 /**
  * Unit tests for ModelProviderService business logic.
  * These test the pure transformation functions and business rules.
  */
-
-// Test the key merging logic (extracted for testing)
-function mergeCustomKeys(
-  validatedKeys: Record<string, unknown> | null,
-  existingKeys: Record<string, unknown> | null,
-): Record<string, unknown> {
-  if (!validatedKeys) return {};
-  if (!existingKeys) return validatedKeys;
-
-  return {
-    ...validatedKeys,
-    ...Object.fromEntries(
-      Object.entries(existingKeys)
-        .filter(([key]) => validatedKeys[key] === MASKED_KEY_PLACEHOLDER)
-        .map(([key, value]) => [key, value]),
-    ),
-  };
-}
 
 // Test the key masking logic (extracted for testing)
 function maskApiKeys(
@@ -64,85 +47,146 @@ function shouldKeepModelProvider(
 }
 
 describe("ModelProviderService business logic", () => {
-  describe("mergeCustomKeys", () => {
-    it("returns empty object when validatedKeys is null", () => {
-      const result = mergeCustomKeys(null, { existing: "value" });
-      expect(result).toEqual({});
+  describe("mergeStoredCustomKeys", () => {
+    describe("given a row with nothing worth keeping", () => {
+      it("returns an empty bag when the write carries no credentials", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: null,
+          stored: { existing: "value" },
+        });
+        expect(result).toEqual({});
+      });
+
+      it("returns the write untouched when the row is empty", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { OPENAI_API_KEY: "new-key" },
+          stored: null,
+        });
+        expect(result).toEqual({ OPENAI_API_KEY: "new-key" });
+      });
     });
 
-    it("returns validatedKeys when existingKeys is null", () => {
-      const validatedKeys = { OPENAI_API_KEY: "new-key" };
-      const result = mergeCustomKeys(validatedKeys, null);
-      expect(result).toEqual({ OPENAI_API_KEY: "new-key" });
+    describe("when a field comes back masked", () => {
+      it("restores the stored value and takes the edited one", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            OPENAI_BASE_URL: "https://new-url.com",
+          },
+          stored: {
+            OPENAI_API_KEY: "sk-actual-secret",
+            OPENAI_BASE_URL: "https://old-url.com",
+          },
+        });
+
+        expect(result.OPENAI_API_KEY).toBe("sk-actual-secret");
+        expect(result.OPENAI_BASE_URL).toBe("https://new-url.com");
+      });
+
+      /** @scenario Preserve original subscription key when saving with masked placeholder */
+      it("restores every masked field at once", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: {
+            AWS_ACCESS_KEY_ID: MASKED_KEY_PLACEHOLDER,
+            AWS_SECRET_ACCESS_KEY: MASKED_KEY_PLACEHOLDER,
+            AWS_REGION_NAME: "eu-west-1",
+          },
+          stored: {
+            AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+            AWS_SECRET_ACCESS_KEY: "secretkey123",
+            AWS_REGION_NAME: "us-east-1",
+          },
+        });
+
+        expect(result.AWS_ACCESS_KEY_ID).toBe("AKIAEXAMPLE");
+        expect(result.AWS_SECRET_ACCESS_KEY).toBe("secretkey123");
+        expect(result.AWS_REGION_NAME).toBe("eu-west-1");
+      });
+
+      it("carries along a field the row never held", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            NEW_KEY: "new-value",
+          },
+          stored: { OPENAI_API_KEY: "sk-stored" },
+        });
+
+        expect(result.OPENAI_API_KEY).toBe("sk-stored");
+        expect(result.NEW_KEY).toBe("new-value");
+      });
     });
 
-    // Shape check against a copy of the rule. The scenario it belongs to is
-    // bound where the real path runs, in
-    // modelProvider.credentialPreservation.integration.test.ts and
-    // ModelProviderForm.credential-rules.integration.test.tsx: a copy stayed
-    // green while the credential was being dropped end to end.
-    it("preserves existing key when new value is masked placeholder", () => {
-      const validatedKeys = {
-        OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
-        OPENAI_BASE_URL: "https://new-url.com",
-      };
-      const existingKeys = {
-        OPENAI_API_KEY: "sk-actual-secret",
-        OPENAI_BASE_URL: "https://old-url.com",
-      };
+    describe("when a field is named with a value", () => {
+      it("takes the new value over the stored one", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { OPENAI_API_KEY: "sk-new-key" },
+          stored: { OPENAI_API_KEY: "sk-old-key" },
+        });
 
-      const result = mergeCustomKeys(validatedKeys, existingKeys);
+        expect(result.OPENAI_API_KEY).toBe("sk-new-key");
+      });
 
-      expect(result.OPENAI_API_KEY).toBe("sk-actual-secret");
-      expect(result.OPENAI_BASE_URL).toBe("https://new-url.com");
+      it("clears the stored secret when the value is empty", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { OPENAI_API_KEY: "" },
+          stored: { OPENAI_API_KEY: "sk-old-key" },
+        });
+
+        expect(result.OPENAI_API_KEY).toBe("");
+      });
     });
 
-    it("replaces key when new value is not masked placeholder", () => {
-      const validatedKeys = {
-        OPENAI_API_KEY: "sk-new-key",
-      };
-      const existingKeys = {
-        OPENAI_API_KEY: "sk-old-key",
-      };
+    // Secrets are masked on read, so no caller can resend one it did not type,
+    // and leaving one out cannot mean "delete it". Everything else is visible,
+    // so a write states it in full.
+    describe("when a field is left out of the write", () => {
+      /** @scenario A save that names one credential keeps the ones it leaves out */
+      it("keeps a stored secret", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { AZURE_OPENAI_ENDPOINT: "https://acme2.openai.azure.com" },
+          stored: {
+            AZURE_OPENAI_API_KEY: "sk-stored",
+            AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+          },
+        });
 
-      const result = mergeCustomKeys(validatedKeys, existingKeys);
+        expect(result).toEqual({
+          AZURE_OPENAI_API_KEY: "sk-stored",
+          AZURE_OPENAI_ENDPOINT: "https://acme2.openai.azure.com",
+        });
+      });
 
-      expect(result.OPENAI_API_KEY).toBe("sk-new-key");
-    });
+      it("does not resurrect a secret the customer had already cleared", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com" },
+          stored: { AZURE_OPENAI_API_KEY: "" },
+        });
 
-    /** @scenario Preserve original subscription key when saving with masked placeholder */
-    it("preserves multiple masked keys", () => {
-      const validatedKeys = {
-        AWS_ACCESS_KEY_ID: MASKED_KEY_PLACEHOLDER,
-        AWS_SECRET_ACCESS_KEY: MASKED_KEY_PLACEHOLDER,
-        AWS_REGION_NAME: "eu-west-1",
-      };
-      const existingKeys = {
-        AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
-        AWS_SECRET_ACCESS_KEY: "secretkey123",
-        AWS_REGION_NAME: "us-east-1",
-      };
+        expect(result).toEqual({
+          AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+        });
+      });
 
-      const result = mergeCustomKeys(validatedKeys, existingKeys);
+      /** @scenario Switching Azure to its API gateway keeps the key and drops the direct endpoint */
+      it("drops a stored field that is not a secret", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: {
+            AZURE_API_GATEWAY_BASE_URL: "https://apim.acme.com",
+            AZURE_API_GATEWAY_VERSION: "2024-05-01-preview",
+          },
+          stored: {
+            AZURE_OPENAI_API_KEY: "sk-stored",
+            AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+          },
+        });
 
-      expect(result.AWS_ACCESS_KEY_ID).toBe("AKIAEXAMPLE");
-      expect(result.AWS_SECRET_ACCESS_KEY).toBe("secretkey123");
-      expect(result.AWS_REGION_NAME).toBe("eu-west-1");
-    });
-
-    it("handles new key not in existing", () => {
-      const validatedKeys = {
-        OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
-        NEW_KEY: "new-value",
-      };
-      const existingKeys = {
-        OPENAI_API_KEY: "sk-stored",
-      };
-
-      const result = mergeCustomKeys(validatedKeys, existingKeys);
-
-      expect(result.OPENAI_API_KEY).toBe("sk-stored");
-      expect(result.NEW_KEY).toBe("new-value");
+        expect(result).toEqual({
+          AZURE_API_GATEWAY_BASE_URL: "https://apim.acme.com",
+          AZURE_API_GATEWAY_VERSION: "2024-05-01-preview",
+          AZURE_OPENAI_API_KEY: "sk-stored",
+        });
+      });
     });
   });
 

--- a/platform/app/src/server/modelProviders/credentialMerge.ts
+++ b/platform/app/src/server/modelProviders/credentialMerge.ts
@@ -1,0 +1,52 @@
+import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+
+/**
+ * Whether a credential field holds a secret, by the same test the read path
+ * masks with. That shared test is the point: a value the server never shows
+ * back is one no caller can resend.
+ */
+export function isSecretCredential(key: string): boolean {
+  return KEY_CHECK.some((marker) => key.includes(marker));
+}
+
+/**
+ * The credential bag to store, given what a write carries and what the row
+ * already holds.
+ *
+ * Three rules, and the read path is what separates them:
+ *
+ * - A field carrying the masked placeholder is one the drawer displayed and
+ *   the customer left alone, so the stored value comes back.
+ * - A **secret** the write leaves out is kept. Secrets are masked on read, so
+ *   no caller can resend one it did not type, and leaving one out therefore
+ *   cannot mean "delete it" — it means "I am not editing that". Without this,
+ *   a write that names one field of a multi-field provider (rotating an Azure
+ *   endpoint, say) deletes the API key it never mentioned, and the provider
+ *   stops working with nothing on screen to explain why.
+ * - Anything else left out is dropped, because a write states the visible
+ *   configuration in full. Azure's API-Gateway toggle is exactly that: it
+ *   saves the two gateway fields and leaves the direct ones out, and the
+ *   presence of `AZURE_API_GATEWAY_BASE_URL` is what routes through the
+ *   gateway. Preserving those would make the toggle unable to switch back.
+ *
+ * Clearing a secret on purpose still works: the field is sent empty, which
+ * names it, and an empty value replaces the stored one.
+ */
+export function mergeStoredCustomKeys({
+  incoming,
+  stored,
+}: {
+  incoming: Record<string, unknown> | null;
+  stored: Record<string, unknown> | null;
+}): Record<string, unknown> {
+  if (!stored) return incoming ?? {};
+
+  const preserved = Object.entries(stored).filter(([key, value]) => {
+    if (incoming && key in incoming) {
+      return incoming[key] === MASKED_KEY_PLACEHOLDER;
+    }
+    return isSecretCredential(key) && value !== "" && value != null;
+  });
+
+  return { ...(incoming ?? {}), ...Object.fromEntries(preserved) };
+}

--- a/platform/app/src/server/modelProviders/errors.ts
+++ b/platform/app/src/server/modelProviders/errors.ts
@@ -192,3 +192,37 @@ export class ModelProviderTestRateLimitedError extends HandledError {
     this.name = "ModelProviderTestRateLimitedError";
   }
 }
+
+/**
+ * A write carried credentials, but none of the ones this provider declares,
+ * while the row on file holds some. Applying it would leave the provider with
+ * no credential at all.
+ *
+ * The merge keeps a stored value when the payload sends the masked
+ * placeholder for it. A key the payload never mentions has no such signal, so
+ * it is dropped, and a payload naming no credential at all drops every one of
+ * them. That is never what a caller means: clearing a credential is sending it
+ * empty, not leaving it out.
+ *
+ * Refusing rather than repairing, because the payload does not say what was
+ * intended and a guess would be silently wrong in the other direction. The
+ * check exists because the same silent loss has now arrived twice by different
+ * routes, and both times the provider's schema was loose enough to accept the
+ * short payload without complaint.
+ */
+export class ModelProviderCredentialsWouldBeDroppedError extends HandledError {
+  declare readonly code: "model_provider_credentials_would_be_dropped";
+
+  constructor({ provider }: { provider: string }) {
+    super(
+      "model_provider_credentials_would_be_dropped",
+      "This save would delete the credentials already stored for this provider. Send the credentials with it, or leave them out of the request entirely to keep them.",
+      {
+        meta: { provider },
+        httpStatus: 400,
+        fault: "customer",
+      },
+    );
+    this.name = "ModelProviderCredentialsWouldBeDroppedError";
+  }
+}

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -3,9 +3,10 @@ import { z } from "zod";
 import { env } from "~/env.mjs";
 import type { Session } from "~/server/auth";
 import { isManagedProvider } from "../../../ee/managed-providers/managedBedrockConfig";
-import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
 import { getSchemaShape } from "../../utils/modelProviderHelpers";
 import { rateLimit } from "../rateLimit";
+import { isSecretCredential, mergeStoredCustomKeys } from "./credentialMerge";
 import type { CustomModelsInput } from "./customModel.schema";
 import { toLegacyCompatibleCustomModels } from "./customModel.schema";
 import {
@@ -1135,7 +1136,9 @@ export class ModelProviderService {
   }
 
   /** Mask key-bearing fields of a row's customKeys for frontend display,
-   * leaving URLs and other non-secret values visible. */
+   * leaving URLs and other non-secret values visible. The same test decides
+   * what `mergeStoredCustomKeys` keeps on a write that leaves a field out:
+   * what we never show back is what a caller cannot resend. */
   private maskRowCustomKeys(
     customKeys: unknown,
   ): MaybeStoredModelProvider["customKeys"] {
@@ -1144,9 +1147,7 @@ export class ModelProviderService {
       Object.entries(customKeys as Record<string, unknown>).map(
         ([key, value]) => [
           key,
-          KEY_CHECK.some((k) => key.includes(k))
-            ? MASKED_KEY_PLACEHOLDER
-            : value,
+          isSecretCredential(key) ? MASKED_KEY_PLACEHOLDER : value,
         ],
       ),
     ) as MaybeStoredModelProvider["customKeys"];
@@ -1490,7 +1491,10 @@ export class ModelProviderService {
         validatedKeys,
         existingKeys,
       });
-      customKeysToSave = this.mergeCustomKeys(validatedKeys, existingKeys);
+      customKeysToSave = mergeStoredCustomKeys({
+        incoming: validatedKeys,
+        stored: existingKeys,
+      });
     }
 
     return await this.repository.update(
@@ -1551,15 +1555,16 @@ export class ModelProviderService {
   }
 
   /**
-   * Refuses a write whose credential payload would leave the provider with no
-   * credential at all.
+   * Refuses a write whose credential payload names none of the provider's
+   * credential fields.
    *
-   * `mergeCustomKeys` restores a stored value only where the payload sends the
-   * masked placeholder for that key. A key the payload omits is dropped, so a
-   * payload that names none of the provider's credential fields silently
-   * deletes every one of them. Providers whose schema is loose (Azure is
-   * `.passthrough()` with every field optional) accept such a payload without
-   * a murmur, which is what turned a UI slip into lost credentials.
+   * Such a payload cannot be a credential edit — it would replace the whole
+   * bag with something that is not a credential — and it is how a UI slip
+   * arrived here: a header-only object, which Azure's loose schema
+   * (`.passthrough()`, every field optional) accepted without a murmur.
+   * `mergeStoredCustomKeys` keeps the secrets it leaves out, so what is left
+   * to lose is the visible configuration, and losing that silently is still
+   * not something to do on a write that asked for nothing.
    *
    * Omission is the signal this reads, not emptiness: clearing a credential on
    * purpose sends the field with an empty value, and that still goes through.
@@ -1603,32 +1608,7 @@ export class ModelProviderService {
   }
 
   /**
-   * Smart merging: preserves original keys when masked placeholder is sent.
-   *
-   * Business rules:
-   * - Start with new validated keys
-   * - For any key with MASKED_KEY_PLACEHOLDER value, use existing value
-   */
-  private mergeCustomKeys(
-    validatedKeys: Record<string, unknown> | null,
-    existingKeys: Record<string, unknown> | null,
-  ): Record<string, unknown> {
-    if (!validatedKeys) return {};
-
-    if (!existingKeys) return validatedKeys;
-
-    return {
-      ...validatedKeys,
-      ...Object.fromEntries(
-        Object.entries(existingKeys)
-          .filter(([key]) => validatedKeys[key] === MASKED_KEY_PLACEHOLDER)
-          .map(([key, value]) => [key, value]),
-      ),
-    };
-  }
-
-  /**
-   * Header counterpart of `mergeCustomKeys`: the frontend receives header
+   * Header counterpart of `mergeStoredCustomKeys`: the frontend receives header
    * values as the masked placeholder, so an untouched header comes back
    * masked on save and must be restored from the stored row. Restore by
    * header key first; when the key was renamed in place, fall back to the

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -4,11 +4,13 @@ import { env } from "~/env.mjs";
 import type { Session } from "~/server/auth";
 import { isManagedProvider } from "../../../ee/managed-providers/managedBedrockConfig";
 import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+import { getSchemaShape } from "../../utils/modelProviderHelpers";
 import { rateLimit } from "../rateLimit";
 import type { CustomModelsInput } from "./customModel.schema";
 import { toLegacyCompatibleCustomModels } from "./customModel.schema";
 import {
   ModelProviderAnchorRequiredError,
+  ModelProviderCredentialsWouldBeDroppedError,
   ModelProviderDeprecatedError,
   ModelProviderNotFoundError,
   ModelProviderScopesRequiredError,
@@ -1479,10 +1481,16 @@ export class ModelProviderService {
     let customKeysToSave: Record<string, unknown> | undefined;
 
     if (customKeysProvided) {
-      customKeysToSave = this.mergeCustomKeys(
+      const existingKeys = existingProvider.customKeys as Record<
+        string,
+        unknown
+      > | null;
+      this.assertKeepsStoredCredentials({
+        provider: data.provider,
         validatedKeys,
-        existingProvider.customKeys as Record<string, unknown> | null,
-      );
+        existingKeys,
+      });
+      customKeysToSave = this.mergeCustomKeys(validatedKeys, existingKeys);
     }
 
     return await this.repository.update(
@@ -1540,6 +1548,58 @@ export class ModelProviderService {
       },
       tx,
     );
+  }
+
+  /**
+   * Refuses a write whose credential payload would leave the provider with no
+   * credential at all.
+   *
+   * `mergeCustomKeys` restores a stored value only where the payload sends the
+   * masked placeholder for that key. A key the payload omits is dropped, so a
+   * payload that names none of the provider's credential fields silently
+   * deletes every one of them. Providers whose schema is loose (Azure is
+   * `.passthrough()` with every field optional) accept such a payload without
+   * a murmur, which is what turned a UI slip into lost credentials.
+   *
+   * Omission is the signal this reads, not emptiness: clearing a credential on
+   * purpose sends the field with an empty value, and that still goes through.
+   * `MANAGED` rows carry their own single key rather than the schema's, so they
+   * are recognised too.
+   */
+  private assertKeepsStoredCredentials({
+    provider,
+    validatedKeys,
+    existingKeys,
+  }: {
+    provider: string;
+    validatedKeys: Record<string, unknown> | null;
+    existingKeys: Record<string, unknown> | null;
+  }): void {
+    if (!existingKeys) return;
+
+    const definition =
+      modelProviders[provider as keyof typeof modelProviders] ?? undefined;
+    const schemaKeys = new Set([
+      ...Object.keys(getSchemaShape(definition?.keysSchema)),
+      "MANAGED",
+    ]);
+    if (schemaKeys.size === 1) return; // unknown provider: nothing to judge against
+
+    // Only a credential that actually holds something is worth protecting. A
+    // field already sitting empty has nothing to lose, and counting it would
+    // block the save right after a customer cleared one on purpose.
+    const storedCredentials = Object.entries(existingKeys).filter(
+      ([key, value]) =>
+        schemaKeys.has(key) && typeof value === "string" && value !== "",
+    );
+    if (storedCredentials.length === 0) return;
+
+    const incomingCredentials = Object.keys(validatedKeys ?? {}).filter((key) =>
+      schemaKeys.has(key),
+    );
+    if (incomingCredentials.length > 0) return;
+
+    throw new ModelProviderCredentialsWouldBeDroppedError({ provider });
   }
 
   /**

--- a/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
+++ b/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
@@ -7,6 +7,7 @@ import {
   getProviderFromModel,
   getSchemaShape,
   hasUserEnteredNewApiKey,
+  headerSignature,
   shouldAutoEnableAsDefault,
 } from "../modelProviderHelpers";
 
@@ -292,6 +293,53 @@ describe("modelProviderHelpers", () => {
         expect(shouldAutoEnableAsDefault({ enabledProvidersCount: 2 })).toBe(
           false,
         );
+      });
+    });
+  });
+
+  describe("headerSignature()", () => {
+    describe("given a form header list and the stored list it came from", () => {
+      it("reads them as equal even though only the form list is concealed", () => {
+        const stored = [{ key: "api-key", value: MASKED_KEY_PLACEHOLDER }];
+        const asShownInTheForm = [
+          { key: "api-key", value: MASKED_KEY_PLACEHOLDER, concealed: true },
+        ];
+
+        expect(headerSignature(asShownInTheForm)).toBe(headerSignature(stored));
+      });
+    });
+
+    describe("given a header the customer actually changed", () => {
+      it("reads a renamed key as different", () => {
+        expect(headerSignature([{ key: "api-key", value: "v" }])).not.toBe(
+          headerSignature([{ key: "x-api-key", value: "v" }]),
+        );
+      });
+
+      it("reads a new value as different", () => {
+        expect(headerSignature([{ key: "api-key", value: "v" }])).not.toBe(
+          headerSignature([{ key: "api-key", value: "w" }]),
+        );
+      });
+
+      it("reads a reorder as different, because dragging is a real edit", () => {
+        const a = [
+          { key: "one", value: "1" },
+          { key: "two", value: "2" },
+        ];
+        const b = [
+          { key: "two", value: "2" },
+          { key: "one", value: "1" },
+        ];
+
+        expect(headerSignature(a)).not.toBe(headerSignature(b));
+      });
+    });
+
+    describe("given no headers at all", () => {
+      it("treats null, undefined and the empty list the same", () => {
+        expect(headerSignature(null)).toBe(headerSignature([]));
+        expect(headerSignature(undefined)).toBe(headerSignature([]));
       });
     });
   });

--- a/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
+++ b/platform/app/src/utils/__tests__/modelProviderHelpers.unit.test.ts
@@ -297,9 +297,9 @@ describe("modelProviderHelpers", () => {
     });
   });
 
-  describe("headerSignature()", () => {
-    describe("given a form header list and the stored list it came from", () => {
-      it("reads them as equal even though only the form list is concealed", () => {
+  describe("given headerSignature() compares a form header list with the stored one", () => {
+    describe("when only the form list carries the display-only concealed flag", () => {
+      it("reads the two lists as equal", () => {
         const stored = [{ key: "api-key", value: MASKED_KEY_PLACEHOLDER }];
         const asShownInTheForm = [
           { key: "api-key", value: MASKED_KEY_PLACEHOLDER, concealed: true },
@@ -309,20 +309,24 @@ describe("modelProviderHelpers", () => {
       });
     });
 
-    describe("given a header the customer actually changed", () => {
-      it("reads a renamed key as different", () => {
+    describe("when a header key was renamed", () => {
+      it("reads the lists as different", () => {
         expect(headerSignature([{ key: "api-key", value: "v" }])).not.toBe(
           headerSignature([{ key: "x-api-key", value: "v" }]),
         );
       });
+    });
 
-      it("reads a new value as different", () => {
+    describe("when a header value was edited", () => {
+      it("reads the lists as different", () => {
         expect(headerSignature([{ key: "api-key", value: "v" }])).not.toBe(
           headerSignature([{ key: "api-key", value: "w" }]),
         );
       });
+    });
 
-      it("reads a reorder as different, because dragging is a real edit", () => {
+    describe("when the headers were dragged into a new order", () => {
+      it("reads the lists as different, because reordering is a real edit", () => {
         const a = [
           { key: "one", value: "1" },
           { key: "two", value: "2" },
@@ -336,7 +340,7 @@ describe("modelProviderHelpers", () => {
       });
     });
 
-    describe("given no headers at all", () => {
+    describe("when there are no headers at all", () => {
       it("treats null, undefined and the empty list the same", () => {
         expect(headerSignature(null)).toBe(headerSignature([]));
         expect(headerSignature(undefined)).toBe(headerSignature([]));

--- a/platform/app/src/utils/modelProviderHelpers.ts
+++ b/platform/app/src/utils/modelProviderHelpers.ts
@@ -319,6 +319,22 @@ export function hasUserModifiedAnyCredential({
 }
 
 /**
+ * An extra-header list reduced to what the customer can actually change:
+ * the ordered key and value pairs.
+ *
+ * The form's own header objects carry a `concealed` flag that drives the
+ * show/hide eye and never leaves the browser, so a whole-object compare
+ * against the stored list always differs and reports a dirty form over an
+ * untouched one. Order is kept, because dragging headers into a new order is
+ * a real edit.
+ */
+export function headerSignature(
+  headers: { key: string; value: string }[] | null | undefined,
+): string {
+  return JSON.stringify((headers ?? []).map(({ key, value }) => [key, value]));
+}
+
+/**
  * Filters customKeys to remove masked API keys before sending to backend.
  * Used when env var provider has modified URL fields.
  *

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -112,6 +112,47 @@ Feature: Model Provider Configuration
     Then the original API key "sk-actual123" is preserved
     And the base URL is updated to "https://custom.openai.com/v1"
 
+  # Headers live in their own column and are read from there. Folding them into
+  # the credential bag replaced it, and an Azure provider came back holding the
+  # header and nothing else.
+  @integration
+  Scenario: Adding an extra header keeps the stored Azure credentials
+    Given I have "azure" provider configured with an API key and an endpoint
+    When I open the model provider configuration drawer for "azure"
+    And I leave every credential field untouched
+    And I add an extra header "api-key" with a value
+    And I click "Save"
+    Then no credentials are sent with the save
+    And the stored API key and endpoint are preserved
+
+  # A stored header comes back masked and the form wraps it with a display-only
+  # concealed flag, so comparing the objects whole reported a dirty form over an
+  # untouched one and left Save live.
+  @integration
+  Scenario: A stored extra header does not make the form dirty on open
+    Given I have "azure" provider configured with an extra header
+    When I open the model provider configuration drawer for "azure"
+    And I change nothing
+    Then the Save button is disabled
+
+  # Emptying a field is an edit. Without this there was no way to remove a
+  # credential at all, because Save never enabled over a cleared field.
+  @integration
+  Scenario: Clearing a stored API key enables Save
+    Given I have "openai" provider configured with API key "sk-actual123"
+    When I open the model provider configuration drawer for "openai"
+    And I clear the API key field
+    Then the Save button is enabled
+
+  # The Azure schema accepts anything, so the loss was silent. The server now
+  # says no rather than trusting every provider schema to be strict.
+  @integration
+  Scenario: A header-only payload is refused instead of dropping credentials
+    Given I have "azure" provider configured with an API key and an endpoint
+    When a write sends credentials naming none of the provider's fields
+    Then the write is rejected
+    And the stored API key and endpoint are preserved
+
   @integration @unimplemented
   Scenario: Configure API keys from environment variables
     Given I have "openai" provider enabled via environment variable "OPENAI_API_KEY"

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -148,6 +148,25 @@ Feature: Model Provider Configuration
     Then the save is rejected with an error the customer can act on
     And the stored API key and endpoint are preserved
 
+  # A save that names one credential is editing that one. An API key is never
+  # shown back, so nobody can send one they did not type, and leaving it out
+  # asks for nothing rather than asking for its removal.
+  @integration
+  Scenario: A save that names one credential keeps the ones it leaves out
+    Given I have "azure" provider configured with an API key and an endpoint
+    When a save carries a new endpoint and no API key
+    Then the endpoint is updated
+    And the stored API key is preserved
+
+  # Everything else is on screen, so a save states it in full. That is how the
+  # API gateway option switches over, and it must not take the key with it.
+  @integration
+  Scenario: Switching Azure to its API gateway keeps the key and drops the direct endpoint
+    Given I have "azure" provider configured with an API key and an endpoint
+    When I switch the provider to its API gateway and save
+    Then the direct endpoint gives way to the gateway address
+    And the stored API key is preserved
+
   @integration @unimplemented
   Scenario: Configure API keys from environment variables
     Given I have "openai" provider enabled via environment variable "OPENAI_API_KEY"

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -112,9 +112,7 @@ Feature: Model Provider Configuration
     Then the original API key "sk-actual123" is preserved
     And the base URL is updated to "https://custom.openai.com/v1"
 
-  # Headers live in their own column and are read from there. Folding them into
-  # the credential bag replaced it, and an Azure provider came back holding the
-  # header and nothing else.
+  # Editing headers changes headers. It must never touch the credentials.
   @integration
   Scenario: Adding an extra header keeps the stored Azure credentials
     Given I have "azure" provider configured with an API key and an endpoint
@@ -122,12 +120,10 @@ Feature: Model Provider Configuration
     And I leave every credential field untouched
     And I add an extra header "api-key" with a value
     And I click "Save"
-    Then no credentials are sent with the save
+    Then the extra header is saved
     And the stored API key and endpoint are preserved
 
-  # A stored header comes back masked and the form wraps it with a display-only
-  # concealed flag, so comparing the objects whole reported a dirty form over an
-  # untouched one and left Save live.
+  # Opening a provider and changing nothing is not an edit, whatever it holds.
   @integration
   Scenario: A stored extra header does not make the form dirty on open
     Given I have "azure" provider configured with an extra header
@@ -135,8 +131,7 @@ Feature: Model Provider Configuration
     And I change nothing
     Then the Save button is disabled
 
-  # Emptying a field is an edit. Without this there was no way to remove a
-  # credential at all, because Save never enabled over a cleared field.
+  # Emptying a field is an edit, so a credential can actually be removed.
   @integration
   Scenario: Clearing a stored API key enables Save
     Given I have "openai" provider configured with API key "sk-actual123"
@@ -144,13 +139,13 @@ Feature: Model Provider Configuration
     And I clear the API key field
     Then the Save button is enabled
 
-  # The Azure schema accepts anything, so the loss was silent. The server now
-  # says no rather than trusting every provider schema to be strict.
+  # A save that would leave a provider with no credential fails loudly rather
+  # than quietly removing the one on file.
   @integration
   Scenario: A header-only payload is refused instead of dropping credentials
     Given I have "azure" provider configured with an API key and an endpoint
-    When a write sends credentials naming none of the provider's fields
-    Then the write is rejected
+    When a save carries no credential for the provider
+    Then the save is rejected with an error the customer can act on
     And the stored API key and endpoint are preserved
 
   @integration @unimplemented


### PR DESCRIPTION
Closes #6723

## What was wrong

An Azure OpenAI provider that already holds an API key loses it, and its endpoint, the moment an extra header is saved. The row comes back holding only the header. There is no warning and no undo, and the credential is destroyed rather than hidden.

It also fires without anyone adding a header. A provider that already holds one sends that header back on the next save, so renaming the provider or changing its scopes was enough to wipe the key.

## Why

Three things stacked up.

**Headers were folded into `customKeys`.** When no credential had changed, the credential branch in `useProviderFormSubmit.ts` correctly settled on `undefined`, which tells the server to leave the stored keys alone. The Azure header merge just below spread that `undefined` into an object holding only the headers, and the "send nothing" intent was lost. The empty-object safety net below it did not catch that, because the object was not empty.

**The server dropped what the payload did not mention.** `mergeCustomKeys` restores a stored value only where the payload carries the masked placeholder for that key. A key the payload omits has no such signal, so it is dropped, and a payload naming no credential at all drops every one of them.

**Nothing complained.** The Azure `keysSchema` is `.passthrough()` with every field optional, so `{"api-key": "..."}` validated cleanly. A stricter provider would have thrown a visible error instead of quietly losing data.

## The fix

**Headers are not credentials, so stop folding them in.** They have their own column, their own masked-placeholder merge in `mergeExtraHeaders`, and both readers already take them from there: `prepareLitellmParams` builds `extra_headers` from `modelProvider.extraHeaders`, and the gateway materialiser reads `mp.extraHeaders`. The only generic scan over `customKeys` matches `/_API_KEY$/`, which no header name hits. The fold wrote a value nothing consumed and replaced the credential bag doing it, so it is removed rather than patched.

**Dirty detection compares headers on key and value only.** Stored header values come back to the drawer masked, and the form wraps each one with a `concealed` flag the stored copy lacks. Comparing the objects whole made every Azure provider holding a header read as dirty the moment its drawer opened, so Save was live over an untouched form. That is the second trigger above, and it is settled by running it, not by reading it: Save was enabled with no edit before, and is disabled after.

**Dirty detection now uses the same helper as the submit path.** Widening the header comparison exposed a second gap: emptying a credential field was invisible to dirty detection, so Save stayed disabled and a credential could not be removed at all. That was already true on `main` for any provider without a header, and the header bug had been accidentally papering over it. `isDirty` now calls `hasUserModifiedAnyCredential`, the same function the submit path uses to decide whether to send credentials, so the button and the payload cannot disagree.

**The server refuses a payload that would drop every stored credential.** A write naming none of the provider's credential fields cannot be a credential edit, and applying it would delete the lot. This is the layer that would have made this loud instead of silent, and the same silent loss has now arrived twice by different routes, so a backstop is worth having rather than relying on every provider schema being strict.

**A save keeps the secrets it leaves out.** That guard only refused a payload naming nothing at all. A payload naming one field of several passed it, and the merge then dropped every field it had not mentioned, so a caller rotating an Azure endpoint deleted the API key it never sent. The REST upsert is where that shape arrives, since a script sends the one field it means to change.

A secret is masked on read, so no caller can resend one it did not type, and leaving one out cannot be a request to delete it. Leaving out anything else still drops it, because the visible configuration is stated in full on every save, and that is how the Azure API-Gateway toggle switches over: it saves the two gateway fields, the direct endpoint gives way, and the key stays. `mergeStoredCustomKeys` is now the single place that says this, called by the unit test instead of restated in it, since the copy that used to live there stayed green through both rounds of this bug.

Clearing a credential on purpose still works, by sending the field empty. A row with nothing stored yet is unaffected. `MANAGED` rows are recognised. This also closes an empty-object payload on the REST upsert that emptied the bag the same way.

## Scope, and the neighbours

Azure only. `ExtraHeadersSection` renders headers for `azure`, `custom` and `azure_safety`, but the fold was guarded by `provider.provider === "azure"`, so the other two were never affected. Both are covered below anyway, as regression guards.

That asymmetry was the bug rather than a design: no provider needs headers in `customKeys`, so removing it for Azure leaves all three consistent instead of two out of three.

## Proof, by driving the product

Real dev server, real browser, real Azure credentials, and the decrypted `ModelProvider.customKeys` column read straight out of postgres after every save. Secrets are fingerprinted, never printed. The same script ran before and after the change.

Before: 7 of 11 checks passed. After: 14 of 14.

| Scenario | Before | After |
| --- | --- | --- |
| Add a header to a keyed Azure provider, key survives | fail, key and endpoint gone | pass |
| Save an Azure provider that already has a header, changing only its name | fail, payload carried headers only | pass |
| Save is disabled on open for a provider holding a header | fail, Save was live | pass |
| A newly typed key is written | pass | pass |
| Clearing a credential on purpose clears it | pass, but only via the dirty bug | pass |
| `custom` keeps its credentials when a header is added | pass | pass |
| `azure_safety` keeps its credentials when a header is added | not covered | pass |

The captured payload tells the story on its own. Before, adding a header sent `customKeys: {"x-tenant":"acme"}`. After, it sends `customKeys` omitted, which is what tells the server to keep what is on file.

### Saving a header, in the drawer

A real Azure OpenAI provider holding a real key and endpoint. Adding `x-tenant: acme` and saving is the exact move that used to destroy the credential.

<img src="https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6730/header-save/01-adding-a-header.png" width="900" />

Reopened after the save: the key is still on file and masked, the endpoint is untouched, the header is there with its value masked, and Save is greyed out because nothing has been edited yet.

<img src="https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6730/header-save/02-reopened-key-header-intact-save-disabled.png" width="900" />

The row behind those two screens, read decrypted out of postgres and fingerprinted:

```
AZURE_OPENAI_API_KEY: 32 chars, sha256:97f51d1756f4   (unchanged)
AZURE_OPENAI_ENDPOINT: "https://langwatchopenaisweden.openai.azure.com/"
extraHeaders: [{"key":"x-tenant","value":"acme"}]
```

### A partial save, through the REST API

`PUT /api/model-providers/azure` with `customKeys: {"AZURE_OPENAI_ENDPOINT": ".../v2/"}` against a row holding a key and an endpoint. Same request, same row, the preservation rule off and then on.

Before, the endpoint is updated and the API key is gone:

<img src="https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6730/partial-update/01-before-key-deleted.png" width="900" />

After, the endpoint is updated and the key the request never mentioned is still there:

<img src="https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6730/partial-update/02-after-key-kept.png" width="900" />

```
before  AZURE_OPENAI_ENDPOINT: ".../v2/"                          (key row absent)
after   AZURE_OPENAI_ENDPOINT: ".../v2/"
        AZURE_OPENAI_API_KEY: 32 chars, sha256:97f51d1756f4       (unchanged)
```

## Tests

Extended the existing files rather than adding new ones.

- `modelProviderHelpers.unit.test.ts`: `headerSignature` ignores the UI-only `concealed` flag, still sees a renamed key, a new value and a reorder.
- `useProviderFormSubmit.integration.test.tsx`: adding a header with no credential touched sends `customKeys` undefined, not a header-only object; a genuine credential edit alongside a header sends the credentials with no header folded in.
- `useModelProviderForm.integration.test.tsx`: `isDirty` is false on open for a provider holding a header, true once a header is edited or added, true once a credential is cleared or typed, with a headerless control either side.
- `modelProvider.credentialPreservation.integration.test.ts`, against a real database: a header-only payload is refused and the stored credentials survive, an empty-object payload is refused, a payload naming a credential still goes through, clearing on purpose still clears, and a row with nothing stored is accepted. Also parameterised over `custom` and `azure_safety`, since the guard reads the provider's own schema rather than a list of names.

That last case is worth reading. Which layer says no depends on how strict the provider's schema is, and both answers are right: `custom` accepts the payload and strips the unknown key, so the guard is what catches it, while `azure_safety` demands a URL and a non-empty key, so validation rejects it one layer earlier. Both keep their credentials. That spread is the argument for the guard, because Azure sits at the loose end and never objects at all.

For the partial save, three more against the real database and three on the merge rule itself:

- `modelProvider.credentialPreservation.integration.test.ts`: a write naming only the Azure endpoint keeps the API key and updates the endpoint; the same holds through `upsertByProviderKey`, the entry the REST route uses, with a bedrock row whose region changes and whose two secrets stay; and a write carrying the Azure gateway fields drops the direct endpoint while keeping the key, which is the toggle behaving as designed.
- `modelProvider.service.unit.test.ts` now calls `mergeStoredCustomKeys` rather than a copy of it, and covers the three outcomes of leaving a field out: a stored secret is kept, a secret the customer had already cleared is not resurrected, and a stored field that is not a secret gives way.

All ten new behaviour tests were confirmed red against the unfixed code before being made green, so they pin the bug rather than the implementation.

`pnpm typecheck:all` clean. `pnpm lint` clean of errors. `pnpm test:unit src/utils src/hooks` is 1193 passing, `src/server/modelProviders src/features/errors` is 732 passing. `pnpm test:integration src/hooks src/server/modelProviders` is 270 passing, with two pre-existing failures in `modelIdBoundary.integration.test.ts`, which calls the live Anthropic API and gets a 404 for two retired model ids. Those fail identically on `main` with this change stashed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saved model provider credentials from being unintentionally removed during updates.
  * Improved form change detection for credentials and extra headers, including cleared or newly entered values.
  * Preserved extra headers separately from credential data during submission.
  * Added a clear warning when saving could remove stored credentials, with guidance for preserving them.

* **Tests**
  * Added coverage for credential preservation, header handling, and form dirty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
