### PR TITLE
fix(helm): bump the clickhouse-serverless dependency so the langwatch chart builds again

### DIFF
--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -2,22 +2,30 @@ name: release-please-chart-lock-sync
 
 # Keep charts/langwatch/Chart.lock honest on release-please PRs.
 #
-# release-please bumps charts/gateway/Chart.yaml `$.version` and `$.appVersion`
-# in lockstep with the umbrella `langwatch` package on every release (per
-# release-please-config.json `.` extra-files), but it cannot recompute the
-# sha256 digest in Chart.lock. helm 3.12's `dependency build` hashes both the
-# Chart.yaml dependencies AND the Chart.lock resolved versions together — so
-# the freshly-bumped sub-chart version invalidates the digest, and every
-# downstream chart workflow (template CI, e2e, release-langwatch-chart) fails
-# with `can't get a valid version for dependency langwatch-gateway` /
-# `the lock file (Chart.lock) is out of sync with the dependencies file`.
+# release-please bumps a sub-chart's Chart.yaml `$.version` on release, but it
+# cannot recompute the resolved versions in charts/langwatch/Chart.lock. helm
+# resolves a local `file://` dependency against the version recorded in the
+# lock, so a sub-chart released past that version makes `dependency build` fail
+# with `can't get a valid version for dependency <name>`, taking every
+# downstream chart workflow (template CI, e2e, release-langwatch-chart) with it.
 #
-# This workflow watches release-please's umbrella PR, runs
-# `helm dependency update`, and pushes the regenerated Chart.lock back to the
-# PR branch so the lock stays meaningful end-to-end. We push with a PAT
-# (RELEASE_PLEASE_TOKEN — same one release-please-sdks.yml uses) so the new
-# commit re-triggers the chart CI; pushes authored by the default GITHUB_TOKEN
-# do NOT trigger downstream workflows.
+# Two release shapes reach the lock, and both need the sync:
+#   - `langwatch`, the umbrella, which bumps charts/gateway and
+#     charts/langyagent in lockstep with itself (release-please-config.json `.`
+#     extra-files).
+#   - `clickhouse-serverless`, which is its own release-please component and
+#     moves on its own cadence.
+#
+# This workflow watches those PRs, runs `helm dependency update`, and pushes the
+# regenerated Chart.lock back to the PR branch so the lock stays meaningful
+# end-to-end. We push with a PAT (RELEASE_PLEASE_TOKEN, the same one
+# release-please-sdks.yml uses) so the new commit re-triggers the chart CI;
+# pushes authored by the default GITHUB_TOKEN do NOT trigger downstream
+# workflows.
+#
+# The sync only works because charts/langwatch/Chart.yaml constrains its local
+# sub-charts with a `>= 0.0.0` range. An exact pin fails `dependency update`
+# itself once the sub-chart moves past it, so there would be no lock to push.
 
 on:
   pull_request_target:
@@ -25,6 +33,7 @@ on:
     paths:
       - "charts/gateway/Chart.yaml"
       - "charts/langwatch/Chart.yaml"
+      - "charts/clickhouse-serverless/Chart.yaml"
 
 permissions:
   contents: write
@@ -39,7 +48,8 @@ jobs:
     # the upstream repo, so this is the right tightening.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.head_ref, 'release-please--branches--main--components--langwatch')
+      (startsWith(github.head_ref, 'release-please--branches--main--components--langwatch') ||
+       startsWith(github.head_ref, 'release-please--branches--main--components--clickhouse-serverless'))
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/charts/langwatch/Chart.lock
+++ b/charts/langwatch/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 25.27.0
 - name: clickhouse-serverless
   repository: file://../clickhouse-serverless
-  version: 0.2.0
+  version: 0.3.0
 - name: langwatch-gateway
   repository: file://../gateway
   version: 3.10.0
 - name: langwatch-langyagent
   repository: file://../langyagent
   version: 3.10.0
-digest: sha256:f5d47f1b94e190ed0518a0f4a204d4c943569d2703bb75d9a1569b05bb833237
-generated: "2026-08-07T15:01:34.716035229Z"
+digest: sha256:e205df62e67936c2def5167e931589e9de0511702933204091fd4cec0c4d616a
+generated: "2026-08-07T22:55:40.957374+02:00"

--- a/charts/langwatch/Chart.yaml
+++ b/charts/langwatch/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     condition: prometheus.chartManaged
   - name: clickhouse-serverless
     alias: clickhouse
-    version: 0.2.0
+    version: '>= 0.0.0'
     repository: file://../clickhouse-serverless
     condition: clickhouse.chartManaged
   - name: langwatch-gateway


### PR DESCRIPTION
## Root cause

`chore(main): release clickhouse-serverless 0.3.0` (3c6c025212) bumped `charts/clickhouse-serverless/Chart.yaml` to 0.3.0, but `charts/langwatch` still pinned the dependency at an exact `0.2.0` in both `Chart.yaml` and `Chart.lock`. Every `helm dependency build charts/langwatch` has died since with `can't get a valid version for dependency clickhouse-serverless`, which is why `langwatch-chart` and `prerelease-charts-oci` are red on main and every open PR touching `charts/` inherits it.

## What changed

- `charts/langwatch/Chart.yaml`: the `clickhouse-serverless` constraint becomes `>= 0.0.0`, which is what the other two local sub-charts (`gateway`, `langyagent`) already use, and is exactly why they never went stale on their own release bumps.
- `charts/langwatch/Chart.lock`: regenerated, resolving to 0.3.0.
- `.github/workflows/release-please-chart-lock-sync.yml`: path filter and `head_ref` guard extended to the `clickhouse-serverless` component.

That last one is the part that keeps it fixed. The range alone is not durable: the lock still records a concrete version, so I confirmed by simulating a 0.4.0 release that `dependency build` strands again exactly the same way. The lock-sync workflow exists for this, but it only watched the `langwatch` umbrella component, so an independently released sub-chart never reached it. Both halves are required, since an exact stale pin also fails `helm dependency update` itself ("Try changing the version constraint in Chart.yaml"), leaving that workflow with no lock to push.

## Verified locally

Against helm **v3.12.0**, the exact version CI pins:

- reproduced the failure on `origin/main`, then confirmed `helm dependency build` passes after the fix
- all 12 `helm template` matrix entries from `langwatch-chart.yml` render
- `tests/langevals-sizing.sh`, `tests/email-gateway.sh`, `tests/sso-providers.sh` all pass
- `helm lint`: 0 charts failed
- `helm package` succeeds and vendors `clickhouse-serverless 0.3.0` into the tgz, so the range never reaches consumers (covers the `prerelease-charts-oci` publish step)
- lock also accepted by helm 3.18.3, and `actionlint` is clean on the workflow

The chart `e2e` jobs need kind and Docker and were not run locally.

## Deployment Impact

No env vars added or changed, and no helm values added, renamed or removed. The only chart change is the dependency constraint on the bundled `clickhouse-serverless` sub-chart plus its regenerated lock entry.

A vanilla `helm install` with no overrides is unaffected in rendered output: the sub-chart is vendored into the packaged tgz at 0.3.0, so consumers resolve nothing at install time and the `>= 0.0.0` range never reaches them. Verified by packaging the chart and reading back the bundled `Chart.yaml`. The practical change is that packaging succeeds again at all, since it currently fails.

BYOC dataplane: no impact. Nothing in the templates, images or values changed, so an existing release upgraded to this chart renders the same manifests.

## Note

The regenerated lock digest is byte-identical to the one #6720 produced independently. #6720 and #6486 both carry this same lock/pin change incidentally, but both are conflicted feature PRs, so neither unblocks main. They can drop their chart hunks once this lands.

release-please config needs no change: it cannot recompute a helm lock, which is why the sync workflow is the right mechanism.
