### PR TITLE
chore(release): single-footer shadow Release-As 1.3.0 for the typescript SDK

### DIFF
--- a/sdks/typescript/.release-please-shim
+++ b/sdks/typescript/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v4), next: 1.0.0
+release-please shadow marker (v5), next: 1.3.0


### PR DESCRIPTION
## What

Pins the next `typescript-sdk` release to **1.3.0**. Release PR #6722 currently proposes **2.0.0**.

## Why

Squash commit `ef9ea90` (#6600, remove the legacy Ragas evaluators) carries a `BREAKING CHANGE:` footer. That footer is correct for the product. The commit also touched three release components at once:

| component | files in `ef9ea90` |
| --- | --- |
| `services/langevals` | 57 |
| root (`.` / langwatch) | 46 |
| `sdks/typescript` | 2 |

release-please splits commits by path but applies the **whole message**, footer included, to every component the commit touched. So all three were proposed as majors.

The two files `sdks/typescript` actually received were:

- `src/cli/commands/evaluators/catalog.ts`, a doc comment only
- `src/cli/commands/evaluators/__tests__/catalog.unit.test.ts`, a unit test

No exported symbol changed. No behaviour changed. Publishing `langwatch@2.0.0` to npm over a doc comment tells every consumer to plan a migration that does not exist, and npm majors cannot be taken back.

The only other commit in the range since `typescript-sdk@v1.2.0` is #6435, a feature. Feature plus nothing breaking is a minor, so 1.3.0.

## How

Same mechanism as `d0842fab` (#6704), which pinned the root package to 3.10.0, and as #3627 before it. `Release-As` beats every other signal in release-please's default versioning strategy, and it is read per commit, so the same path-splitting that caused the problem also routes the override. A commit that touches exactly one component's paths reaches exactly that component.

This PR is one file under `sdks/typescript/`, so the footer cannot leak anywhere else.

> [!IMPORTANT]
> **Squash and merge, and keep the commit message body.** The `Release-As: 1.3.0` footer has to reach `main` inside the commit message or release-please will not see it. The PR has a single commit, so GitHub's default squash body is already correct. Do not replace it with the PR description.

## Verification

After merge, `release-please-sdks` regenerates #6722. Expected: title `chore(main): release typescript-sdk 1.3.0`, and `sdks/typescript/package.json` at `1.3.0`.

## Not changed

- **#6710 `langwatch 4.0.0`** stays. Removing evaluators genuinely breaks monitors, evaluations and experiments that reference them, so a major on the product is right.
- **#3626 `langevals 3.0.0`** stays. That component really did delete the `evaluators/legacy` package.
- **`sdks/python`** was never affected. Zero commits touch it since `python-sdk@v1.2.0` and no 2.x tag exists.

## Follow-up

The prevention side is a separate PR, since a durable fix touches root paths and cannot share a commit with a `Release-As` footer.
