### PR TITLE
ci(release): keep a breaking change inside one release component

### DIFF
--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -65,6 +65,28 @@ describe("breaking-change scope guard", () => {
       );
       assert.equal(carriesBreakingChange(["feat(api): add a v2 endpoint"]), false);
     });
+
+    it("ignores a release-please changelog that reports past breaks", () => {
+      // A release PR restates every breaking change it ships. Reading it as a
+      // marker would fail release-please's own pull requests, which touch the
+      // manifest, the changelogs and the charts at once.
+      assert.equal(
+        carriesBreakingChange([
+          [
+            "chore(main): release langwatch 4.0.0",
+            "",
+            "### ⚠ BREAKING CHANGES",
+            "",
+            "* **evaluators:** evaluations referencing a legacy/ragas_* type stop working.",
+            "",
+            "### Features",
+            "",
+            "* **model-providers:** test a credential you have already saved",
+          ].join("\n"),
+        ]),
+        false,
+      );
+    });
   });
 
   describe("when mapping changed files onto release components", () => {

--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  bumpedComponents,
+  carriesBreakingChange,
+  releaseComponents,
+} from "./guard-breaking-change-scope.ts";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+const liveComponents = () =>
+  releaseComponents(
+    JSON.parse(
+      readFileSync(
+        resolve(repoRoot, ".github/release-please-config.json"),
+        "utf8",
+      ),
+    ),
+  );
+
+const names = (files: string[]): string[] =>
+  bumpedComponents(files, liveComponents())
+    .map((component) => component.name)
+    .sort();
+
+describe("breaking-change scope guard", () => {
+  describe("when reading the markers release-please reads", () => {
+    it("finds the `!` marker in a header, scoped or not", () => {
+      assert.equal(carriesBreakingChange(["feat!: drop the v1 endpoint"]), true);
+      assert.equal(
+        carriesBreakingChange(["feat(evaluators)!: remove the legacy ones"]),
+        true,
+      );
+    });
+
+    it("finds a header that arrives as a squash-body bullet", () => {
+      assert.equal(
+        carriesBreakingChange([
+          "chore: merge branch\n\n* feat(evaluators)!: remove the legacy ones\n",
+        ]),
+        true,
+      );
+    });
+
+    it("finds both spellings of the footer", () => {
+      assert.equal(
+        carriesBreakingChange(["feat: x\n\nBREAKING CHANGE: the v1 endpoint"]),
+        true,
+      );
+      assert.equal(
+        carriesBreakingChange(["feat: x\n\nBREAKING-CHANGE: the v1 endpoint"]),
+        true,
+      );
+    });
+
+    it("ignores prose that only talks about breaking changes", () => {
+      assert.equal(
+        carriesBreakingChange([
+          "fix(api): keep the v1 endpoint alive\n\nThis is not a BREAKING CHANGE, the shim stays.",
+        ]),
+        false,
+      );
+      assert.equal(carriesBreakingChange(["feat(api): add a v2 endpoint"]), false);
+    });
+  });
+
+  describe("when mapping changed files onto release components", () => {
+    it("charges a file to its own package and not to a sibling", () => {
+      assert.deepEqual(names(["sdks/typescript/src/index.ts"]), [
+        "typescript-sdk",
+      ]);
+    });
+
+    it("charges a nested package over the parent that contains it", () => {
+      const components = releaseComponents({
+        packages: {
+          "sdks": { component: "sdks" },
+          "sdks/typescript": { component: "typescript-sdk" },
+        },
+      });
+      assert.deepEqual(
+        bumpedComponents(["sdks/typescript/src/index.ts"], components).map(
+          (component) => component.name,
+        ),
+        ["typescript-sdk"],
+      );
+    });
+
+    it("charges a top-level file to the root package alone", () => {
+      assert.deepEqual(names(["SECURITY.md"]), ["langwatch"]);
+    });
+
+    it("spares the root package when every file sits in an excluded path", () => {
+      assert.deepEqual(names(["mcp/typescript/src/server.ts"]), ["mcp-server"]);
+    });
+
+    it("charges the root package when one file escapes the excluded paths", () => {
+      // The shape of #6641: fifteen files under mcp/typescript, plus SECURITY.md.
+      assert.deepEqual(
+        names(["mcp/typescript/src/server.ts", "SECURITY.md"]),
+        ["langwatch", "mcp-server"],
+      );
+    });
+
+    it("reproduces the three components #6600 bumped at once", () => {
+      assert.deepEqual(
+        names([
+          "sdks/typescript/src/cli/commands/evaluators/catalog.ts",
+          "services/langevals/pyproject.toml",
+          "platform/app/src/server/evaluations/evaluators.generated.ts",
+        ]),
+        ["langevals", "langwatch", "typescript-sdk"],
+      );
+    });
+
+    it("spares a package whose every touched file is excluded", () => {
+      const components = releaseComponents({
+        packages: {
+          "sdks/typescript": {
+            component: "typescript-sdk",
+            "exclude-paths": ["sdks/typescript/docs"],
+          },
+        },
+      });
+      assert.deepEqual(
+        bumpedComponents(["sdks/typescript/docs/readme.md"], components),
+        [],
+      );
+      assert.deepEqual(
+        bumpedComponents(
+          ["sdks/typescript/docs/readme.md", "sdks/typescript/src/index.ts"],
+          components,
+        ).map((component) => component.name),
+        ["typescript-sdk"],
+      );
+    });
+  });
+
+  describe("when reading the release-please config", () => {
+    it("keeps every configured package, named by its component", () => {
+      const configured = liveComponents();
+      const byPath = new Map(
+        configured.map((component) => [component.path, component]),
+      );
+      assert.equal(byPath.get("sdks/typescript")?.name, "typescript-sdk");
+      assert.equal(byPath.get(".")?.name, "langwatch");
+      assert.ok(
+        byPath.get(".")?.excludePaths.includes("sdks/typescript"),
+        "the root package must keep excluding the typescript SDK",
+      );
+    });
+
+    it("trims surrounding slashes the way release-please normalizes them", () => {
+      const [component] = releaseComponents({
+        packages: { ".": { component: "root", "exclude-paths": ["/skills/"] } },
+      });
+      assert.deepEqual(component?.excludePaths, ["skills"]);
+    });
+  });
+});

--- a/.github/scripts/guard-breaking-change-scope.ts
+++ b/.github/scripts/guard-breaking-change-scope.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const defaultRepoRoot = ".";
+const configFile = ".github/release-please-config.json";
+const manifestFile = ".github/.release-please-manifest.json";
+const acknowledgementLabel = "multi-component-major";
+const rootPath = ".";
+
+// A conventional-commit header marks a break with `!` before the colon; a body
+// marks one with a `BREAKING CHANGE:`/`BREAKING-CHANGE:` footer. Squash bodies
+// list the branch commits as bullets, so a header can arrive list-prefixed.
+const breakingHeaderPattern = /^(?:[*-]\s+)?[a-zA-Z]+(?:\([^)]*\))?!:/m;
+const breakingFooterPattern = /^BREAKING[ -]CHANGE:/m;
+
+export type ReleaseComponent = {
+  /** Package path as release-please keys it, e.g. `sdks/typescript` or `.`. */
+  path: string;
+  /** Component name that ends up in the tag and the release PR title. */
+  name: string;
+  excludePaths: string[];
+};
+
+type ReleasePleaseConfig = {
+  packages?: Record<
+    string,
+    { component?: string; "exclude-paths"?: string[] } | undefined
+  >;
+};
+
+/**
+ * release-please matches a file against a package path by directory prefix
+ * only, in `util/commit-exclude.ts` and `util/commit-split.ts` alike. The root
+ * package is relevant to every file.
+ */
+const isUnder = (file: string, path: string): boolean =>
+  path === rootPath || file.indexOf(`${path}/`) === 0;
+
+export const releaseComponents = (
+  config: ReleasePleaseConfig,
+): ReleaseComponent[] =>
+  Object.entries(config.packages ?? {}).map(([path, packageConfig]) => ({
+    path,
+    name: packageConfig?.component ?? path,
+    excludePaths: (packageConfig?.["exclude-paths"] ?? []).map((excluded) =>
+      excluded.replace(/^\/+|\/+$/g, ""),
+    ),
+  }));
+
+export const carriesBreakingChange = (messages: string[]): boolean =>
+  messages.some(
+    (message) =>
+      breakingHeaderPattern.test(message) || breakingFooterPattern.test(message),
+  );
+
+/**
+ * A component is bumped when the change touches at least one of its files that
+ * no `exclude-paths` entry covers. release-please drops a commit from a
+ * component only when *every* touched file of that component is excluded.
+ */
+const isBumped = (component: ReleaseComponent, files: string[]): boolean => {
+  const owned = files.filter((file) => isUnder(file, component.path));
+  return (
+    owned.length > 0 &&
+    !owned.every((file) =>
+      component.excludePaths.some((excluded) => isUnder(file, excluded)),
+    )
+  );
+};
+
+/**
+ * Non-root packages are matched longest path first so that a nested package
+ * wins over its parent, and a file owned by one never counts for another.
+ */
+export const bumpedComponents = (
+  files: string[],
+  components: ReleaseComponent[],
+): ReleaseComponent[] => {
+  const nested = components
+    .filter((component) => component.path !== rootPath)
+    .sort((a, b) => b.path.length - a.path.length);
+
+  return components.filter((component) => {
+    if (component.path === rootPath) {
+      return isBumped(component, files);
+    }
+
+    const owned = files.filter(
+      (file) =>
+        nested.find((candidate) => isUnder(file, candidate.path))?.path ===
+        component.path,
+    );
+    return isBumped(component, owned);
+  });
+};
+
+const shimPath = (component: ReleaseComponent): string =>
+  component.path === rootPath
+    ? ".release-please-shim"
+    : `${component.path}/.release-please-shim`;
+
+const readLines = (path: string): string[] =>
+  readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+const readJson = <T>(path: string): T =>
+  JSON.parse(readFileSync(path, "utf8")) as T;
+
+const report = (
+  bumped: ReleaseComponent[],
+  versions: Record<string, string>,
+): void => {
+  console.error(
+    "This pull request carries a breaking-change marker and touches more than",
+  );
+  console.error("one release component. release-please splits commits by path");
+  console.error("but applies the whole commit message to every component the");
+  console.error("commit touched, so all of these go to a major:");
+  console.error("");
+  for (const component of bumped) {
+    const current = versions[component.path] ?? "unknown";
+    console.error(`- ${component.name} (${component.path}), now ${current}`);
+  }
+  console.error("");
+  console.error("If the break really does apply to all of them, add the");
+  console.error(`\`${acknowledgementLabel}\` label and this check passes.`);
+  console.error("");
+  console.error("Otherwise pick one:");
+  console.error("");
+  console.error("1. Split the change so the breaking commit touches one");
+  console.error("   component, which is the cheaper fix before merge.");
+  console.error("2. Keep it together and pin the components that must not go");
+  console.error("   major. Add a follow-up commit per component that edits");
+  console.error("   only that component's shim and carries one footer:");
+  console.error("");
+  for (const component of bumped) {
+    console.error(`   ${shimPath(component)}   +   Release-As: <x.y.z>`);
+  }
+  console.error("");
+  console.error("See dev/docs/RELEASES.md for the whole procedure.");
+};
+
+const main = (): number => {
+  const [repoRootArg, filesArg, messagesArg] = process.argv.slice(2);
+  const repoRoot = repoRootArg ?? defaultRepoRoot;
+  if (!filesArg || !messagesArg) {
+    console.error(
+      "usage: guard-breaking-change-scope.ts <repo-root> <changed-files> <commit-messages>",
+    );
+    return 2;
+  }
+
+  const messages = readLines(messagesArg).map(
+    (line) => JSON.parse(line) as string,
+  );
+  if (!carriesBreakingChange(messages)) {
+    console.log("no breaking-change marker, release scope check skipped");
+    return 0;
+  }
+
+  const files = readLines(filesArg);
+  const components = releaseComponents(
+    readJson<ReleasePleaseConfig>(resolve(repoRoot, configFile)),
+  );
+  const bumped = bumpedComponents(files, components);
+
+  if (bumped.length <= 1) {
+    const scope = bumped[0]?.name ?? "no release component";
+    console.log(`breaking change scoped to ${scope}`);
+    return 0;
+  }
+
+  const versions = readJson<Record<string, string>>(
+    resolve(repoRoot, manifestFile),
+  );
+  report(bumped, versions);
+  return 1;
+};
+
+const isEntrypoint = (): boolean =>
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isEntrypoint()) {
+  process.exitCode = main();
+}

--- a/.github/workflows/release-scope-guard.yml
+++ b/.github/workflows/release-scope-guard.yml
@@ -1,0 +1,65 @@
+name: release-scope-guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/scripts/guard-breaking-change-scope*.ts"
+      - ".github/release-please-config.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  breaking-change-scope:
+    name: breaking change stays in one component
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 24
+
+      - name: Check guard tests
+        run: node --test --experimental-strip-types .github/scripts/guard-breaking-change-scope.test.ts
+
+      # A squash merge puts the pull request title in the subject and the branch
+      # commit messages in the body, so those are the two places a breaking
+      # marker can reach main from. Both arrive as JSON strings, one per line,
+      # so a crafted title cannot escape into the shell or into the guard input.
+      - name: Collect the pull request title, commits and files
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' > changed-files.txt
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[].commit.message | @json' > commit-messages.txt
+          jq -Rn 'env.PR_TITLE' >> commit-messages.txt
+
+      - name: Check the breaking change stays in one release component
+        if: github.event_name == 'pull_request'
+        env:
+          ACKNOWLEDGED: ${{ contains(github.event.pull_request.labels.*.name, 'multi-component-major') }}
+        run: |
+          if [ "$ACKNOWLEDGED" = "true" ]; then
+            echo "multi-component-major label present, a major on every touched component is intended"
+            exit 0
+          fi
+          node --experimental-strip-types \
+            .github/scripts/guard-breaking-change-scope.ts \
+            . changed-files.txt commit-messages.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,12 @@ See `tests/agentic-e2e/README.md` for details on writing new tests.
 
 We follow the [Conventional Commits](https://www.conventionalcommits.org) specification for our commit messages and PR titles. This helps us automate versioning and generate changelogs.
 
+### Breaking Changes
+
+The repo publishes eight independently versioned components: the product itself, the four SDKs, the MCP server, langevals and the skills package. release-please decides which of them a commit affects by path, then applies the whole commit message to every one of them. A `!` marker or a `BREAKING CHANGE:` footer on a commit that touches three components therefore releases three majors, whether or not the break means anything to all three.
+
+So keep a breaking change inside one component. If the work has to touch another one, land the incidental part as a separate non-breaking PR. The `release-scope-guard` check fails a PR that breaks this rule, and tells you what to do about it. See [dev/docs/RELEASES.md](./dev/docs/RELEASES.md) for the full procedure, including how to pin a version release-please got wrong.
+
 ## Additional Notes
 
 Please don't use the issue tracker for support questions. Check whether the [Docs](https://docs.langwatch.ai/) offer any help with your problem.

--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -6,6 +6,7 @@ Cross-cutting principles that apply everywhere:
 
 - **CODING_STANDARDS.md** - Clean code, SOLID, readability
 - **TESTING_PHILOSOPHY.md** - Test hierarchy, BDD workflow
+- **RELEASES.md** - release-please components, breaking-change scope, version pinning
 
 ## Language & Framework Specific
 

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -44,6 +44,11 @@ of its commits carries a breaking marker and the changed files span more than on
 component. If the break really does apply to all of them, add the
 **`multi-component-major`** label and the check passes.
 
+It reads the title and the commits because a squash merge builds the commit from
+exactly those two. It deliberately does not read the PR description, which never
+reaches `main` on its own and which a release PR fills with a changelog restating
+every break it ships.
+
 ## Pinning a version release-please got wrong
 
 `Release-As:` beats every other signal. release-please reads it per commit, so the

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -1,0 +1,83 @@
+# Releases
+
+Releases are cut by [release-please](https://github.com/googleapis/release-please) from
+conventional commits on `main`. Config lives in `.github/release-please-config.json`,
+current versions in `.github/.release-please-manifest.json`.
+
+This repo publishes eight independently versioned components:
+
+| component | path | shim |
+| --- | --- | --- |
+| `langwatch` (the product, charts and app) | `.` | `.release-please-shim` |
+| `typescript-sdk` | `sdks/typescript` | `sdks/typescript/.release-please-shim` |
+| `python-sdk` | `sdks/python` | `sdks/python/.release-please-shim` |
+| `sdk-go` | `sdks/go` | `sdks/go/.release-please-shim` |
+| `mcp-server` | `mcp/typescript` | `mcp/typescript/.release-please-shim` |
+| `langevals` | `services/langevals` | `services/langevals/.release-please-shim` |
+| `clickhouse-serverless` | `charts/clickhouse-serverless` | `charts/clickhouse-serverless/.release-please-shim` |
+| `skills` | `skills` | `skills/.release-please-shim` |
+
+Each gets its own release PR, its own tag and its own changelog.
+
+## A breaking change belongs to one component
+
+release-please decides which components a commit affects **by path**, then applies
+the **whole commit message** to every one of them. It has no way to say "this break
+is only about the SDK". So a single commit that carries a `!` marker or a
+`BREAKING CHANGE:` footer and touches three components proposes three majors.
+
+That has happened repeatedly:
+
+- #6600 removed the legacy Ragas evaluators. Breaking for the product, correctly.
+  It also touched two files under `sdks/typescript`, a doc comment and a unit test,
+  and 57 under `services/langevals`. All three were proposed as majors.
+- #6641 changed MCP server auth. It touched fifteen files under `mcp/typescript`
+  and one at the root, `SECURITY.md`. That one root file pulled the break into the
+  product changelog.
+
+**So: keep a breaking change inside one component.** If the same work has to touch
+another component, land the incidental part in a separate non-breaking PR, or pin
+the components that should not go major, below.
+
+`release-scope-guard` enforces this on every PR. It fails when the PR title or any
+of its commits carries a breaking marker and the changed files span more than one
+component. If the break really does apply to all of them, add the
+**`multi-component-major`** label and the check passes.
+
+## Pinning a version release-please got wrong
+
+`Release-As:` beats every other signal. release-please reads it per commit, so the
+same path splitting that spreads a breaking marker also routes the override. A
+commit that touches exactly one component's paths reaches exactly that component.
+
+That is what the `.release-please-shim` files are for. They exist only to give each
+component a file to touch.
+
+1. Branch from latest `main`.
+2. Edit **one** shim, the one belonging to the component you are pinning. Bump its
+   marker number and record the version you are aiming at.
+3. Commit that one file. Put `Release-As: <x.y.z>` as the last line of the message,
+   and put **exactly one** such footer in it.
+4. Open the PR, then **squash and merge it keeping the commit message body**. The
+   footer has to reach `main` inside the commit message. A single-commit PR already
+   squashes to the right body. Replacing that body with the PR description drops
+   the footer and the override silently does nothing.
+5. Confirm the release PR regenerated to the version you asked for. Do not assume it.
+
+To pin several components, use one commit per component, each touching only its own
+shim and carrying only its own footer. A commit with two footers, or one that
+touches two shims, is what caused the problem in the first place.
+
+Worked examples: #6704 pinned the root package to 3.10.0, #6734 pinned the
+typescript SDK to 1.3.0, and #3627 pinned six components at once.
+
+## Why not just configure it away
+
+`exclude-paths` cannot express this. release-please matches it by directory prefix
+only, with no globs, and drops a commit from a component only when *every* touched
+file of that component is excluded. Excluding "tests" or "internal CLI code" is not
+expressible, and would not have helped #6600 anyway: the file that dragged the SDK
+to a major was ordinary SDK source.
+
+Per-package `versioning: always-bump-minor` would cap majors, including deliberate
+ones, so a genuine break would ship silently mis-versioned. Worse than the problem.


### PR DESCRIPTION
## The problem

release-please decides which components a commit affects **by path**, then applies the **whole commit message** to every one of them. There is no way to express "this break is only about the SDK". So one commit carrying a `!` marker or a `BREAKING CHANGE:` footer, touching three components, proposes three majors.

Twice in the last 400 commits on `main`:

| commit | what it was | what it hit |
| --- | --- | --- |
| `ef9ea90` (#6600) | remove the legacy Ragas evaluators, correctly breaking for the product | `langwatch` **and** `typescript-sdk` **and** `langevals`. The SDK's share of that commit was one doc comment and one unit test, and it produced #6722 proposing `typescript-sdk 2.0.0` |
| `af324de` (#6641) | MCP server auth change | `mcp-server` **and** `langwatch`, via **one file**, `SECURITY.md`. Fifteen of its sixteen files were under `mcp/typescript` |

That second one is worth dwelling on. **#6710 `langwatch 4.0.0` is correct, but partly for the wrong reason.** It lists two breaking changes. The evaluator removal genuinely breaks the product, so the major stands and this PR does not touch it. The MCP auth one reached the product changelog only because a sixteenth file happened to be at the repo root. A single incidental edit is enough. That is the strongest argument for this guard existing.

The remedy so far has been to notice afterwards and pin the version by hand: #3627 for six components at once, #6704 for the root package, #6734 for the typescript SDK yesterday. That is three cleanup PRs for something detectable before merge.

## The guard

`release-scope-guard` fails a PR whose title or commits carry a breaking marker when its changed files span more than one release component.

It reimplements release-please's own path rules rather than approximating them:

- longest package prefix wins, so a file counts for exactly one non-root component (`util/commit-split.ts`)
- top-level files belong to the root package only, which is precisely the `SECURITY.md` case
- a component is spared only when **every** file it owns sits under one of its `exclude-paths` (`util/commit-exclude.ts` uses `.every()`)

Squash merge puts the PR title in the subject and the branch commit messages in the body, so those are the two places a marker can reach `main` from, and those are what it reads. Both arrive as JSON strings, one per line, so a crafted title cannot escape into the shell or into the guard input.

The failure message names the components, their current versions from the manifest, and the two ways out, because a check that only says "blocked" gets escape-hatched by reflex:

```
- typescript-sdk (sdks/typescript), now 1.2.0
- langevals (services/langevals), now 2.2.0
- langwatch (.), now 3.10.0

If the break really does apply to all of them, add the
`multi-component-major` label and this check passes.

Otherwise pick one:

1. Split the change so the breaking commit touches one
   component, which is the cheaper fix before merge.
2. Keep it together and pin the components that must not go
   major. Add a follow-up commit per component that edits
   only that component's shim and carries one footer:

   sdks/typescript/.release-please-shim   +   Release-As: <x.y.z>
   ...
```

`multi-component-major` is the deliberate override, for a break that really does apply everywhere it landed.

## Evidence

Replayed over the **last 400 commits on `main`**. Four carry a breaking marker. The guard fires on **exactly two**, `ef9ea90` and `af324de`, and names precisely the components that really were bumped in each case. **Zero false positives.** The other two breaking commits, `60d98f9` and `75ae272`, it correctly passes as single-component.

The full workflow pipeline was also run end to end against the live API for #6600 as it looked at review time, with its fifteen individual commits rather than the squashed message. It fails and names all three components, so the guard would have caught this before the bad majors were ever proposed.

It also has to not fire on release-please's own PRs, which touch the manifest, every changelog and the charts at once. Ran against all four open ones, #6710, #6722, #3626 and #4025: all pass. The reason is deliberate. The guard reads the **title and the commits**, which is what a squash merge actually builds the commit from, and **not the PR description**, which never reaches `main` on its own and which a release PR fills with a changelog restating every break it ships. A unit test pins that.


Plus 14 unit tests, colocated and run by the workflow, following `guard-pull-request-target.ts` and its test file.

## Why not configure it away

**`exclude-paths`** cannot express this. release-please matches it by directory prefix with no globs, so "tests" and "internal CLI code" are not sayable. And it would not have caught #6600 anyway: the file that dragged the SDK to a major was `src/cli/commands/evaluators/catalog.ts`, ordinary SDK source. Excluding `sdks/typescript/src/cli` wholesale would then swallow genuine CLI releases.

**A native component-scoped breaking change does not exist.** `commit.ts` derives `commit.breaking` purely from the message text. There is no path or component dimension anywhere in that derivation.

**Per-package `versioning: always-bump-minor`** would cap majors permanently, including deliberate ones, so a genuine SDK break would ship silently mis-versioned. Worse than the problem.

That leaves prevention at PR time, which is this.

## Docs

`dev/docs/RELEASES.md` is new. It documents the component map, this rule, and the shim plus `Release-As` procedure for pinning a version release-please got wrong, including the trap that sank an earlier attempt: the footer must survive the squash, so keeping the commit message body matters. Until now that procedure was only recoverable by reading the history of #3627 and #6704. `CONTRIBUTING.md` gains a Breaking Changes subsection under the existing commit conventions and links to it.

## Cost

One job per PR, checkout plus node, no build. It has to run on every PR because any PR can carry a marker.
