### PR TITLE
fix(cli): survive orphaned member rows when resolving the bootstrap admin email

### DIFF
--- a/platform/app/ee/governance/services/__tests__/cliBootstrap.orphanedAdmin.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/cliBootstrap.orphanedAdmin.integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration coverage for the admin-email leg of CliBootstrapService.
+ * Hits real PG, no mocks.
+ *
+ * `OrganizationUser.user` is backed by no database foreign key (the schema
+ * runs `relationMode = "prisma"`), so a membership row outlives the account
+ * it points at. Joining that required relation made one dangling ADMIN row
+ * reject the whole read with "Inconsistent query result: Field user is
+ * required to return data, got null instead", which surfaced as a 500 on
+ * `/api/auth/cli/bootstrap`. The CLI then cached nothing, so the wrapper
+ * had no `tool_policies` left to enforce, hence the toolPolicies
+ * assertions below alongside the admin email itself.
+ *
+ * Spec: specs/ai-gateway/governance/cli-login.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+
+import { CliBootstrapService } from "../cliBootstrap.service";
+import { PLATFORM_TOOL_SLUGS } from "../platformToolPolicy.service";
+
+const suffix = nanoid(8);
+const MIXED_ORG_ID = `org-cbo-${suffix}`;
+const ORPHAN_ONLY_ORG_ID = `org-cbo-only-${suffix}`;
+const CALLER_USER_ID = `usr-cbo-${suffix}`;
+const HEALTHY_ADMIN_ID = `usr-cbo-admin-${suffix}`;
+const HEALTHY_ADMIN_EMAIL = `cbo-admin-${suffix}@example.com`;
+/** Never inserted into User, so this membership dangles. */
+const DELETED_ADMIN_ID = `usr-cbo-deleted-${suffix}`;
+
+/** The orphan is the earliest membership, so ordering hands it over first. */
+const ORPHAN_CREATED_AT = new Date("2020-01-01T00:00:00.000Z");
+const HEALTHY_CREATED_AT = new Date("2021-01-01T00:00:00.000Z");
+
+describe("CliBootstrapService admin email with orphaned member rows", () => {
+  const service = CliBootstrapService.create({
+    prisma,
+    budgetRepository: undefined,
+  });
+
+  beforeAll(async () => {
+    await startTestContainers();
+
+    await prisma.organization.createMany({
+      data: [
+        { id: MIXED_ORG_ID, name: `CBO Org ${suffix}`, slug: `cbo-${suffix}` },
+        {
+          id: ORPHAN_ONLY_ORG_ID,
+          name: `CBO Orphan Org ${suffix}`,
+          slug: `cbo-only-${suffix}`,
+        },
+      ],
+    });
+    await prisma.user.createMany({
+      data: [
+        {
+          id: CALLER_USER_ID,
+          email: `cbo-${suffix}@example.com`,
+          name: "CBO Caller",
+        },
+        {
+          id: HEALTHY_ADMIN_ID,
+          email: HEALTHY_ADMIN_EMAIL,
+          name: "CBO Admin",
+        },
+      ],
+    });
+    await prisma.organizationUser.createMany({
+      data: [
+        {
+          organizationId: MIXED_ORG_ID,
+          userId: DELETED_ADMIN_ID,
+          role: "ADMIN",
+          createdAt: ORPHAN_CREATED_AT,
+        },
+        {
+          organizationId: MIXED_ORG_ID,
+          userId: HEALTHY_ADMIN_ID,
+          role: "ADMIN",
+          createdAt: HEALTHY_CREATED_AT,
+        },
+        {
+          organizationId: MIXED_ORG_ID,
+          userId: CALLER_USER_ID,
+          role: "MEMBER",
+        },
+        {
+          organizationId: ORPHAN_ONLY_ORG_ID,
+          userId: DELETED_ADMIN_ID,
+          role: "ADMIN",
+          createdAt: ORPHAN_CREATED_AT,
+        },
+        {
+          organizationId: ORPHAN_ONLY_ORG_ID,
+          userId: CALLER_USER_ID,
+          role: "MEMBER",
+        },
+      ],
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    const organizationIds = [MIXED_ORG_ID, ORPHAN_ONLY_ORG_ID];
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: { in: organizationIds } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [CALLER_USER_ID, HEALTHY_ADMIN_ID] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: organizationIds } },
+    });
+    await stopTestContainers();
+  }, 60_000);
+
+  describe("when the earliest admin membership outlived its user", () => {
+    /** @scenario Login completes when the earliest admin account is gone */
+    it("skips the orphan and reports the surviving admin's email", async () => {
+      const result = await service.resolve({
+        userId: CALLER_USER_ID,
+        organizationId: MIXED_ORG_ID,
+      });
+
+      expect(result.adminEmail).toBe(HEALTHY_ADMIN_EMAIL);
+    });
+
+    /** @scenario Login completes when the earliest admin account is gone */
+    it("still returns a complete per-tool policy map for the CLI to cache", async () => {
+      const result = await service.resolve({
+        userId: CALLER_USER_ID,
+        organizationId: MIXED_ORG_ID,
+      });
+
+      expect(Object.keys(result.toolPolicies).sort()).toEqual(
+        [...PLATFORM_TOOL_SLUGS].sort(),
+      );
+      expect(result.toolPolicies.cursor).toEqual({
+        allowVk: true,
+        allowOtelDirect: false,
+      });
+    });
+  });
+
+  describe("when every admin membership in the organization is orphaned", () => {
+    /** @scenario Login completes when every admin account is gone */
+    it("reports no admin email rather than failing the bootstrap", async () => {
+      const result = await service.resolve({
+        userId: CALLER_USER_ID,
+        organizationId: ORPHAN_ONLY_ORG_ID,
+      });
+
+      expect(result.adminEmail).toBeNull();
+      expect(Object.keys(result.toolPolicies).sort()).toEqual(
+        [...PLATFORM_TOOL_SLUGS].sort(),
+      );
+    });
+  });
+});

--- a/platform/app/ee/governance/services/cliBootstrap.service.ts
+++ b/platform/app/ee/governance/services/cliBootstrap.service.ts
@@ -25,6 +25,7 @@ import type { PrismaClient } from "@prisma/client";
 import { env } from "~/env.mjs";
 import type { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { GatewayBudgetService } from "~/server/gateway/budget.service";
+import { resolveOrgAdminEmail } from "~/server/organizations/resolveOrgAdminEmail";
 import { AiToolEntryService } from "./aiToolEntry.service";
 import { resolveGatewayBaseUrl } from "./gatewayUrl";
 import { PersonalVirtualKeyService } from "./personalVirtualKey.service";
@@ -86,9 +87,9 @@ export interface CliBootstrapResult {
   /**
    * Mailto target the CLI can render when preflight fails (gateway
    * down, no provider configured, no personal VK). First org admin by
-   * createdAt, same selection used by the budget-exceeded payload so
-   * the user sees a consistent "ask this person" address across
-   * surfaces. Null when the org has no admin row yet.
+   * createdAt, resolved through {@link resolveOrgAdminEmail} so the
+   * budget-exceeded payload and this one name the same person. Null when
+   * the org has no admin the CLI can reach.
    */
   adminEmail: string | null;
   /**
@@ -174,7 +175,10 @@ export class CliBootstrapService {
       displayName: p.displayName,
       configured: p.configured,
     }));
-    const adminEmail = await this.resolveAdminEmail(input.organizationId);
+    const adminEmail = await resolveOrgAdminEmail({
+      prisma: this.prisma,
+      organizationId: input.organizationId,
+    });
 
     const workspaceService = new PersonalWorkspaceService(this.prisma);
     const workspace = await workspaceService.findExisting({
@@ -226,17 +230,6 @@ export class CliBootstrapService {
       map[slug] = overrides[slug] ?? { ...PLATFORM_TOOL_POLICY_DEFAULTS[slug] };
     }
     return map;
-  }
-
-  private async resolveAdminEmail(
-    organizationId: string,
-  ): Promise<string | null> {
-    const admin = await this.prisma.organizationUser.findFirst({
-      where: { organizationId, role: "ADMIN" },
-      include: { user: { select: { email: true } } },
-      orderBy: { createdAt: "asc" },
-    });
-    return admin?.user.email ?? null;
   }
 
   private async resolveBudget(input: {

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -250,7 +250,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-gateway/governance/cli-402-license-gate.feature",
   "specs/ai-gateway/governance/cli-deep-links.feature",
   "specs/ai-gateway/governance/cli-ingest-debug.feature",
-  "specs/ai-gateway/governance/cli-login.feature",
   "specs/ai-gateway/governance/cli-tool-mode-policy.feature",
   "specs/ai-gateway/governance/compliance-baseline.feature",
   "specs/ai-gateway/governance/event-log-durability.feature",

--- a/platform/app/src/server/organizations/resolveOrgAdminEmail.ts
+++ b/platform/app/src/server/organizations/resolveOrgAdminEmail.ts
@@ -5,6 +5,18 @@ import type { PrismaClient } from "@prisma/client";
  * — used as the recipient when we need to actually SEND email (eg.
  * budget-increase requests). Distinct from [[resolveSupportContact]]
  * which may return a URL or free text intended for user display.
+ *
+ * Membership rows and users are read separately on purpose. The `user`
+ * relation is backed by no database foreign key (the schema runs
+ * `relationMode = "prisma"`), so an `OrganizationUser` can outlive the
+ * `User` it points at. Asking Prisma to join a required relation makes a
+ * single dangling row reject the whole read with "Inconsistent query
+ * result: Field user is required to return data, got null instead".
+ * Orphaned memberships are skipped instead, and the first admin that
+ * still resolves to a user with an email wins.
+ *
+ * Returns null when the org has no admin membership, or when every admin
+ * membership is orphaned.
  */
 export async function resolveOrgAdminEmail({
   prisma,
@@ -13,10 +25,22 @@ export async function resolveOrgAdminEmail({
   prisma: PrismaClient;
   organizationId: string;
 }): Promise<string | null> {
-  const admin = await prisma.organizationUser.findFirst({
+  const admins = await prisma.organizationUser.findMany({
     where: { organizationId, role: "ADMIN" },
-    include: { user: { select: { email: true } } },
+    select: { userId: true },
     orderBy: { createdAt: "asc" },
   });
-  return admin?.user.email ?? null;
+  if (admins.length === 0) return null;
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: admins.map((admin) => admin.userId) } },
+    select: { id: true, email: true },
+  });
+  const emailByUserId = new Map(users.map((user) => [user.id, user.email]));
+
+  for (const admin of admins) {
+    const email = emailByUserId.get(admin.userId);
+    if (email) return email;
+  }
+  return null;
 }

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -151,6 +151,32 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     And the CLI prints "Logged out"
 
   # ---------------------------------------------------------------------------
+  # Login completion when the organization carries deleted accounts
+  # ---------------------------------------------------------------------------
+  # Membership rows survive the deletion of the account behind them, so an org
+  # can list an admin nobody can email. Login completion must still hand the
+  # CLI its policy map, otherwise the wrapper caches nothing and enforces
+  # nothing.
+
+  @integration @cli @bootstrap
+  Scenario: Login completes when the earliest admin account is gone
+    Given organization "acme" lists two admins
+    And the account behind the admin who joined first has been deleted
+    When Jane completes login and the CLI asks for its bootstrap data
+    Then login completion succeeds
+    And the "contact your admin" address is the remaining admin's email
+    And the CLI receives a policy entry for every tool it can run
+
+  @integration @cli @bootstrap
+  Scenario: Login completes when every admin account is gone
+    Given organization "acme" lists one admin
+    And the account behind that admin has been deleted
+    When Jane completes login and the CLI asks for its bootstrap data
+    Then login completion succeeds
+    And no "contact your admin" address is offered
+    And the CLI receives a policy entry for every tool it can run
+
+  # ---------------------------------------------------------------------------
   # Multi-org user (out of scope this iteration but pinned for design clarity)
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The failure

`GET /api/auth/cli/bootstrap` returned 500 for any organization holding an ADMIN
`OrganizationUser` row whose `User` no longer exists:

```
Inconsistent query result: Field user is required to return data, got `null` instead.
```

Found in a live dogfood. The admin lookup joined the required `user` relation, so
one dangling row rejected the entire read.

## Why orphans are expected here

The schema runs `relationMode = "prisma"`. There are no database foreign keys by
design, integrity is enforced at the app layer, so a membership row outliving the
account it points at is a reality the read path has to tolerate, not a corruption
to be prevented by the database.

## The silent consequence

The 500 meant the CLI got no bootstrap response, so it persisted no
`tool_policies` at all. Wrapper policy enforcement (`allowOtelDirect`, `allowVk`,
gateway preflight) then had nothing to gate on and silently allowed everything.

## The fix

Memberships and users are read separately, orphaned rows are skipped, and the
first admin that still resolves to a user with an email wins. An org where every
admin is orphaned keeps the existing no-admin behavior and reports `null`, no new
error was invented.

`CliBootstrapService` carried a byte-identical private copy of
`resolveOrgAdminEmail`, so it now calls the shared helper instead of forking a
second implementation. That keeps the CLI ceremony, the budget-exceeded payload
and the "contact your admin" copy on one code path.

## The tests

`cliBootstrap.orphanedAdmin.integration.test.ts`, real Postgres, no mocks. Seeds
one org with an orphaned ADMIN membership created before a healthy admin, and a
second org whose only admin is orphaned. Verified red on `main` (all three cases
fail with the verbatim Prisma error above) and green with the fix. Asserts the
surviving admin's email, the null no-admin path, and the complete per-tool policy
map so the cached-policy consequence is pinned too.

Both scenarios are written into `specs/ai-gateway/governance/cli-login.feature`,
tagged `@integration` and bound via `@scenario`. That file was in `LEGACY_INERT`
(enforcing nothing); the entry is removed and it now reports `2/2 scenarios bound`.

## Follow-up: the same shape elsewhere

Scanned for the same crash shape, a join onto the required `user` relation of an
`OrganizationUser` / `TeamUser` row. Left out to keep this PR scoped to the
reported 500, listed here so the pattern is tracked:

- `ee/governance/services/activity-monitor/activityMonitor.service.ts:670` org-wide
  `findMany` with nested `user`, so one orphan breaks department spend attribution
- `ee/scim/scim.service.ts:249` `include: { user: true }`, SCIM user GET 500s
  instead of 404s
- `src/server/api-key/api-key.repository.ts:443` `findOrgMembers`, org-wide
- `src/server/organizations/resolveCallerProjectScope.ts:148` same shape on `TeamUser`
- `src/server/invites/invite.service.ts:226` also filters on `user.email`, so lower
  risk, but the projection is still non-null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI login and bootstrap behavior when organization admin accounts have been deleted.
  * Selects the remaining administrator’s email when available, or omits the contact address when none remain.
  * Preserves complete tool-policy results during bootstrap.

* **Tests**
  * Added integration coverage for mixed and fully orphaned administrator membership scenarios.
  * Added feature scenarios verifying successful login completion and correct policy delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->