### PR TITLE
chore(release): single-footer shadow Release-As 3.11.0

### DIFF
--- a/.release-please-shim
+++ b/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v3), next: 3.10.0
+release-please shadow marker (v4), next: 3.11.0


### PR DESCRIPTION
## What

Pins the next `langwatch` release to **3.11.0**. Release PR #6710 currently proposes **4.0.0**.

## Why

#6710 lists two breaking changes. Neither earns a major on the product.

**1. The legacy Ragas evaluator removal (#6600).** Real footer, real removal, but the evaluators had been failing *every* call for roughly two months: 30,258 invocations against 30,258 errors over seven days. Nothing that worked stopped working. Four of the seven retired slugs migrate forward to their current equivalents through the new forward migration. The remaining three had no successor to move to, and they now fall through to the evaluator picker with the saved slug named, instead of throwing on render and leaving the monitor page unreachable. That is strictly better than the state those rows were already in.

**2. The MCP server auth change (#6641).** This one reached the product component by accident:

| | |
| --- | --- |
| files under `mcp/typescript` | 15 |
| files at the repo root | 1, `SECURITY.md` |

The root package excludes `mcp/typescript`, so those fifteen count for nothing here. The single `SECURITY.md` edit is enough to pull the entire commit message, footer included, into the product's range. `mcp-server` already shipped that break as its own `mcp-server@v2.0.0`, which is where it belongs. The product does not need to restate it as a major.

Everything else in the range is features and fixes, so the range is a minor: **3.11.0**.

## How

Same mechanism as `d0842fab` (#6704), which pinned this same component to 3.10.0, and #6734 for the typescript SDK earlier today. `Release-As` beats every other signal in release-please's default versioning strategy, and it is read per commit, so the same path splitting that spreads a breaking marker also routes the override.

This PR is one file, the root `.release-please-shim`. It is a top-level file, so no sub-package claims it, and no exclude path covers it. It reaches the root component and nothing else.

> [!IMPORTANT]
> **Squash and merge, and keep the commit message body.** The `Release-As: 3.11.0` footer has to reach `main` inside the commit message or release-please will not see it. Single commit, so GitHub's default squash body is already correct. Do not replace it with this description.

## Verification

After merge, `release-please-sdks` regenerates #6710. Expected: title `chore(main): release langwatch 3.11.0`, with `platform/app/package.json`, the root `package.json` and the three chart `Chart.yaml` version/appVersion pairs all at `3.11.0`. I will confirm it actually regenerates rather than assume it.

## Note

The generated changelog will still carry a `⚠ BREAKING CHANGES` heading under 3.11.0. `Release-As` overrides the version but release-please still collects the note text from the commits. The 3.10.0 entry from #6704 has the same artifact. Removing it is a separate follow-up commit after the release PR merges, since the changelog updater only ever prepends above the newest entry and never rewrites earlier ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release metadata to target version 3.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->