### PR TITLE
fix(charts): unpin the clickhouse-serverless subchart and resync the lock

### DIFF
--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -12,12 +12,18 @@ name: release-please-chart-lock-sync
 # with `can't get a valid version for dependency langwatch-gateway` /
 # `the lock file (Chart.lock) is out of sync with the dependencies file`.
 #
-# This workflow watches release-please's umbrella PR, runs
-# `helm dependency update`, and pushes the regenerated Chart.lock back to the
-# PR branch so the lock stays meaningful end-to-end. We push with a PAT
-# (RELEASE_PLEASE_TOKEN — same one release-please-sdks.yml uses) so the new
-# commit re-triggers the chart CI; pushes authored by the default GITHUB_TOKEN
-# do NOT trigger downstream workflows.
+# clickhouse-serverless reaches the same lock from its own release PR rather
+# than the umbrella one, because it versions independently. Its release only
+# touches charts/clickhouse-serverless, so without the branch and path below
+# the umbrella lock keeps the superseded version and every chart job fails
+# the same way, which is what happened on 0.2.0 and again on 0.3.0.
+#
+# This workflow watches those release PRs, runs `helm dependency update`, and
+# pushes the regenerated Chart.lock back to the PR branch so the lock stays
+# meaningful end-to-end. We push with a PAT (RELEASE_PLEASE_TOKEN — same one
+# release-please-sdks.yml uses) so the new commit re-triggers the chart CI;
+# pushes authored by the default GITHUB_TOKEN do NOT trigger downstream
+# workflows.
 
 on:
   pull_request_target:
@@ -25,6 +31,7 @@ on:
     paths:
       - "charts/gateway/Chart.yaml"
       - "charts/langwatch/Chart.yaml"
+      - "charts/clickhouse-serverless/Chart.yaml"
 
 permissions:
   contents: write
@@ -39,7 +46,8 @@ jobs:
     # the upstream repo, so this is the right tightening.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.head_ref, 'release-please--branches--main--components--langwatch')
+      (startsWith(github.head_ref, 'release-please--branches--main--components--langwatch') ||
+       startsWith(github.head_ref, 'release-please--branches--main--components--clickhouse-serverless'))
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/charts/langwatch/Chart.lock
+++ b/charts/langwatch/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 25.27.0
 - name: clickhouse-serverless
   repository: file://../clickhouse-serverless
-  version: 0.2.0
+  version: 0.3.0
 - name: langwatch-gateway
   repository: file://../gateway
   version: 3.10.0
 - name: langwatch-langyagent
   repository: file://../langyagent
   version: 3.10.0
-digest: sha256:f5d47f1b94e190ed0518a0f4a204d4c943569d2703bb75d9a1569b05bb833237
-generated: "2026-08-07T15:01:34.716035229Z"
+digest: sha256:e205df62e67936c2def5167e931589e9de0511702933204091fd4cec0c4d616a
+generated: "2026-08-08T11:37:59.405592+02:00"

--- a/charts/langwatch/Chart.yaml
+++ b/charts/langwatch/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     condition: prometheus.chartManaged
   - name: clickhouse-serverless
     alias: clickhouse
-    version: 0.2.0
+    version: '>= 0.0.0'
     repository: file://../clickhouse-serverless
     condition: clickhouse.chartManaged
   - name: langwatch-gateway


### PR DESCRIPTION
## What broke

Every helm job, on every PR, since `clickhouse-serverless 0.3.0` landed in #3622 (2026-08-07 18:55).

```
Error: can't get a valid version for 1 subchart(s): "clickhouse-serverless"
(repository "file://../clickhouse-serverless", version "0.2.0").
Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml
```

`charts/langwatch/Chart.yaml` pinned the dependency at exactly `0.2.0`. The release bumped `charts/clickhouse-serverless/Chart.yaml` to `0.3.0`. Nothing bumps the pin, so no version satisfies it any more.

Blast radius, all failing on the same line: the whole `langwatch-chart` template matrix, `langwatch-chart / langevals sizing`, `sso providers`, `email gateway`, `go-services / helm`, and `release-please-chart-lock-sync / sync-chart-lock`. Not just release PRs, `dependabot/npm_and_yarn/nanoid-6.0.0` was failing on it too.

## Fix, part 1: the pin

An exact pin on a `file://` dependency cannot do anything useful. The only version available is whatever is in the working tree, so the pin can never select a different chart, it can only fail to match one. The two sibling local dependencies already use `'>= 0.0.0'`:

| dependency | repository | constraint |
| --- | --- | --- |
| `langwatch-gateway` | `file://../gateway` | `>= 0.0.0` |
| `langwatch-langyagent` | `file://../langyagent` | `>= 0.0.0` |
| `clickhouse-serverless` | `file://../clickhouse-serverless` | ~~`0.2.0`~~ → `>= 0.0.0` |

`Chart.lock` is regenerated, which is where the resolved version actually belongs. It now records `0.3.0`.

## Fix, part 2: stopping the recurrence

The constraint alone does **not** prevent this. `helm dependency build` resolves against the **lock**, not the constraint. I verified it: with the floating constraint in place, bumping the local chart to `0.4.0` produces the identical error, because the lock still names `0.3.0`.

`release-please-chart-lock-sync` already exists to solve exactly this, and its own header comment describes this failure mode for `gateway`. It only watched the umbrella `langwatch` release PR. `clickhouse-serverless` versions independently and its release touches only its own chart, so the umbrella lock was never regenerated. The workflow now also watches `charts/clickhouse-serverless/Chart.yaml` and the `...components--clickhouse-serverless` branch.

Part 1 is what makes part 2 able to work: with the old exact pin, the sync job's `helm dependency update` step failed on the same error it was meant to repair. That is why `sync-chart-lock` is red rather than self-healing.

This is the second time this has bitten. It happened on `0.2.0` too and was fixed by hand in #3026.

## Verification

Locally with **helm 3.12.0**, the version CI pins, not my system 3.18:

- `helm dependency build` passes
- all **12** template matrix presets pass: `default`, `dev+nodeport`, `minimal+nodeport`, `prod+ingress`, `ha+ingress+replicated`, `langy-gvisor`, `langy-disabled`, `prod+external-ch`, `prod+ext-pg+ext-redis`, `local`, `hosted-prod`, `scalable-prod`
- `tests/langevals-sizing.sh`, `tests/sso-providers.sh`, `tests/email-gateway.sh` all pass
- the regenerated `Chart.lock` digest is byte-identical under helm 3.12.0 and 3.18.3, so the lock is safe for the pinned CI version

## Note

#6710 (`langwatch 3.11.0`) is red on these same jobs. Once this merges, release-please regenerates that branch off main and picks the fix up, and `sync-chart-lock` will then be able to bump the gateway and langyagent entries to 3.11.0 as designed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release automation support for the ClickHouse Serverless chart.
  * Documented the independent release process for this chart.

* **Maintenance**
  * Updated the ClickHouse Serverless chart dependency constraint to support compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->