### PR TITLE
feat(cli): keep the LangWatch Claude Code plugin up to date from every wrapped run

### DIFF
--- a/sdks/typescript/src/cli/utils/__tests__/compare-versions.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/compare-versions.unit.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The version ordering two callers depend on: the copilot version gate, which
+ * warns below a floor, and the Claude Code plugin update, which only moves an
+ * installed copy forward. Both read the SIGN, so the cases that matter are the
+ * ones where a naive string comparison would disagree with a numeric one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { compareVersions } from "../compare-versions";
+
+describe("compareVersions", () => {
+  describe("given two ordinary releases", () => {
+    it("orders them oldest first", () => {
+      expect(compareVersions("0.1.0", "0.2.0")).toBeLessThan(0);
+      expect(compareVersions("0.2.0", "0.1.0")).toBeGreaterThan(0);
+      expect(compareVersions("0.2.0", "0.2.0")).toBe(0);
+    });
+
+    it("compares components numerically rather than as text", () => {
+      // "0.10.0" < "0.9.0" as strings, which would read a release as older
+      // than the one it followed and update nothing for the rest of the 0.x.
+      expect(compareVersions("0.9.0", "0.10.0")).toBeLessThan(0);
+      expect(compareVersions("1.0.0", "0.99.99")).toBeGreaterThan(0);
+    });
+  });
+
+  describe("given a version that is not a plain triple", () => {
+    it("reads a missing component as zero", () => {
+      expect(compareVersions("1.2", "1.2.0")).toBe(0);
+      expect(compareVersions("1.2", "1.2.1")).toBeLessThan(0);
+    });
+
+    it("reads a suffixed component as its leading digits", () => {
+      expect(compareVersions("2.0.0-rc.1", "2.0.0")).toBe(0);
+      expect(compareVersions("2.0.0-rc.1", "1.9.9")).toBeGreaterThan(0);
+    });
+
+    it("reads a component that is not a number at all as zero", () => {
+      expect(compareVersions("main", "0.0.0")).toBe(0);
+    });
+  });
+});

--- a/sdks/typescript/src/cli/utils/__tests__/compare-versions.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/compare-versions.unit.test.ts
@@ -12,32 +12,32 @@ import { compareVersions } from "../compare-versions";
 describe("compareVersions", () => {
   describe("given two ordinary releases", () => {
     it("orders them oldest first", () => {
-      expect(compareVersions("0.1.0", "0.2.0")).toBeLessThan(0);
-      expect(compareVersions("0.2.0", "0.1.0")).toBeGreaterThan(0);
-      expect(compareVersions("0.2.0", "0.2.0")).toBe(0);
+      expect(compareVersions({ version: "0.1.0", against: "0.2.0" })).toBeLessThan(0);
+      expect(compareVersions({ version: "0.2.0", against: "0.1.0" })).toBeGreaterThan(0);
+      expect(compareVersions({ version: "0.2.0", against: "0.2.0" })).toBe(0);
     });
 
     it("compares components numerically rather than as text", () => {
       // "0.10.0" < "0.9.0" as strings, which would read a release as older
       // than the one it followed and update nothing for the rest of the 0.x.
-      expect(compareVersions("0.9.0", "0.10.0")).toBeLessThan(0);
-      expect(compareVersions("1.0.0", "0.99.99")).toBeGreaterThan(0);
+      expect(compareVersions({ version: "0.9.0", against: "0.10.0" })).toBeLessThan(0);
+      expect(compareVersions({ version: "1.0.0", against: "0.99.99" })).toBeGreaterThan(0);
     });
   });
 
   describe("given a version that is not a plain triple", () => {
     it("reads a missing component as zero", () => {
-      expect(compareVersions("1.2", "1.2.0")).toBe(0);
-      expect(compareVersions("1.2", "1.2.1")).toBeLessThan(0);
+      expect(compareVersions({ version: "1.2", against: "1.2.0" })).toBe(0);
+      expect(compareVersions({ version: "1.2", against: "1.2.1" })).toBeLessThan(0);
     });
 
     it("reads a suffixed component as its leading digits", () => {
-      expect(compareVersions("2.0.0-rc.1", "2.0.0")).toBe(0);
-      expect(compareVersions("2.0.0-rc.1", "1.9.9")).toBeGreaterThan(0);
+      expect(compareVersions({ version: "2.0.0-rc.1", against: "2.0.0" })).toBe(0);
+      expect(compareVersions({ version: "2.0.0-rc.1", against: "1.9.9" })).toBeGreaterThan(0);
     });
 
     it("reads a component that is not a number at all as zero", () => {
-      expect(compareVersions("main", "0.0.0")).toBe(0);
+      expect(compareVersions({ version: "main", against: "0.0.0" })).toBe(0);
     });
   });
 });

--- a/sdks/typescript/src/cli/utils/compare-versions.ts
+++ b/sdks/typescript/src/cli/utils/compare-versions.ts
@@ -1,0 +1,27 @@
+/**
+ * Compare two dotted version strings, oldest first: negative when `a` is older
+ * than `b`, zero when they name the same release, positive when `a` is newer.
+ *
+ * A numeric triple comparison, which is what both callers need and no more. The
+ * versions come from our own release tags and from a tool's `--version` output,
+ * and both are plain `MAJOR.MINOR.PATCH`. A component that is absent reads as
+ * zero, so `1.2` and `1.2.0` are the same release, and a component with a
+ * suffix reads as its leading digits, so `2.0.0-rc.1` sorts with `2.0.0` rather
+ * than before every release ever cut. Callers that must reject a version they
+ * cannot understand check its shape before comparing; this returns an ordering
+ * for whatever it is given.
+ */
+export function compareVersions(a: string, b: string): number {
+  const left = a.split(".");
+  const right = b.split(".");
+  for (let index = 0; index < 3; index++) {
+    const difference = component(left[index]) - component(right[index]);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function component(raw: string | undefined): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/sdks/typescript/src/cli/utils/compare-versions.ts
+++ b/sdks/typescript/src/cli/utils/compare-versions.ts
@@ -1,6 +1,6 @@
 /**
- * Compare two dotted version strings, oldest first: negative when `a` is older
- * than `b`, zero when they name the same release, positive when `a` is newer.
+ * Compare two dotted version strings: negative when `version` is older than
+ * `against`, zero when they name the same release, positive when it is newer.
  *
  * A numeric triple comparison, which is what both callers need and no more. The
  * versions come from our own release tags and from a tool's `--version` output,
@@ -11,9 +11,15 @@
  * cannot understand check its shape before comparing; this returns an ordering
  * for whatever it is given.
  */
-export function compareVersions(a: string, b: string): number {
-  const left = a.split(".");
-  const right = b.split(".");
+export function compareVersions({
+  version,
+  against,
+}: {
+  version: string;
+  against: string;
+}): number {
+  const left = version.split(".");
+  const right = against.split(".");
   for (let index = 0; index < 3; index++) {
     const difference = component(left[index]) - component(right[index]);
     if (difference !== 0) return difference;

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-state.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-state.unit.test.ts
@@ -180,6 +180,57 @@ describe("readClaudePluginState", () => {
       expect(readClaudePluginState().marketplaceOwnedByLangwatch).toBe(false);
     });
 
+    /** @scenario "A source built to read like ours is not ours" */
+    it("disclaims the addresses built to read like our repository", async () => {
+      // Each of these contains our repository name and belongs to somebody
+      // else. Ownership decides what logout may deregister and what a wrapped
+      // run may pull new plugin code from, so a lookalike that passes here
+      // gets both.
+      const lookalikes = [
+        "https://github.com/langwatch/agent-plugin.evil",
+        "https://evil.example/?repo=langwatch/agent-plugin",
+        "https://evil.example/langwatch/agent-plugin",
+        "https://github.com.evil.example/langwatch/agent-plugin",
+        "https://github.com/langwatch/agent-plugin#/../evil",
+        "/home/someone/checkouts/langwatch/agent-plugin",
+        "file:///home/someone/checkouts/langwatch/agent-plugin",
+        "git@evil.example:langwatch/agent-plugin.git",
+      ];
+
+      for (const url of lookalikes) {
+        writeJson({
+          segments: ["plugins", "known_marketplaces.json"],
+          value: { langwatch: { source: { source: "git", url } } },
+        });
+        const { readClaudePluginState } = await loadModule();
+        expect(
+          readClaudePluginState().marketplaceOwnedByLangwatch,
+          `${url} must not read as ours`,
+        ).toBe(false);
+      }
+    });
+
+    it("claims ownership of the canonical addresses of our repository", async () => {
+      const ours = [
+        "https://github.com/langwatch/agent-plugin",
+        "https://github.com/langwatch/agent-plugin.git",
+        "https://GitHub.com/LangWatch/Agent-Plugin.git",
+        "git@github.com:langwatch/agent-plugin.git",
+      ];
+
+      for (const url of ours) {
+        writeJson({
+          segments: ["plugins", "known_marketplaces.json"],
+          value: { langwatch: { source: { source: "git", url } } },
+        });
+        const { readClaudePluginState } = await loadModule();
+        expect(
+          readClaudePluginState().marketplaceOwnedByLangwatch,
+          `${url} is ours`,
+        ).toBe(true);
+      }
+    });
+
     /** @scenario "A marketplace that only mentions our repository is not ours" */
     it("disclaims a source that only mentions us outside its identifying fields", async () => {
       writeJson({

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-test-helpers.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-test-helpers.ts
@@ -41,45 +41,80 @@ export const writeClaudeJson = ({
 };
 
 /**
- * `installed_plugins.json` with the LangWatch plugin recorded at user scope,
- * carrying the bookkeeping fields Claude Code writes beside the scope.
+ * `installed_plugins.json` with the LangWatch plugin recorded, carrying the
+ * bookkeeping fields Claude Code writes beside the scope. `scope` is settable
+ * because the update path only manages the user-scope record.
  */
-export const seedInstalledPlugin = ({ home }: { home: string }): void =>
+export const seedInstalledPlugin = ({
+	home,
+	version = "0.1.0",
+	scope = "user",
+}: {
+	home: string;
+	version?: string;
+	scope?: string;
+}): void =>
 	writeClaudeJson({
 		home,
 		segments: ["plugins", "installed_plugins.json"],
 		value: {
 			version: 2,
 			plugins: {
-				"langwatch@langwatch": [
-					{ scope: "user", installPath: "/somewhere", version: "0.1.0" },
-				],
+				"langwatch@langwatch": [{ scope, installPath: "/somewhere", version }],
 			},
 		},
 	});
 
 /**
  * `known_marketplaces.json` with a marketplace named `langwatch` sourced from
- * `repo`. The default is the one we publish; pass another to stand in for
- * somebody else's registration under the same name.
+ * `repo`, and the clone it points at. The default repo is the one we publish;
+ * pass another to stand in for somebody else's registration under the same
+ * name.
+ *
+ * `publishedVersion` writes the plugin manifest inside that clone, which is
+ * what the update path compares the installed version against. Leaving it out
+ * gives a listing whose manifest cannot be read, which is a case of its own.
  */
 export const seedMarketplace = ({
 	home,
 	repo = OWNED_MARKETPLACE_REPO,
+	publishedVersion,
 }: {
 	home: string;
 	repo?: string;
-}): void =>
+	publishedVersion?: string;
+}): void => {
+	const installLocation = path.join(
+		home,
+		".claude",
+		"plugins",
+		"marketplaces",
+		"langwatch",
+	);
+	if (publishedVersion !== undefined) {
+		writeClaudeJson({
+			home,
+			segments: [
+				"plugins",
+				"marketplaces",
+				"langwatch",
+				".claude-plugin",
+				"plugin.json",
+			],
+			value: { name: "langwatch", version: publishedVersion },
+		});
+	}
 	writeClaudeJson({
 		home,
 		segments: ["plugins", "known_marketplaces.json"],
 		value: {
 			langwatch: {
 				source: { source: "github", repo },
-				installLocation: "/somewhere",
+				installLocation,
 			},
 		},
 	});
+};
 
 export type ClaudePluginModule = typeof ClaudePluginModuleType;
 
@@ -87,7 +122,9 @@ export type ClaudePluginModule = typeof ClaudePluginModuleType;
 export interface ClaudeAnswers {
 	pluginHelp?: number;
 	marketplaceAdd?: number;
+	marketplaceUpdate?: number;
 	install?: number;
+	update?: number;
 	uninstall?: number;
 	marketplaceRemove?: number;
 }
@@ -99,8 +136,11 @@ export interface ClaudePluginHarness {
 	pluginsDir: () => string;
 	writeJson: (args: { segments: string[]; value: unknown }) => void;
 	readSettings: <T>() => T;
-	seedInstalledPlugin: () => void;
-	seedMarketplace: (args?: { repo?: string }) => void;
+	seedInstalledPlugin: (args?: { version?: string; scope?: string }) => void;
+	seedMarketplace: (args?: {
+		repo?: string;
+		publishedVersion?: string;
+	}) => void;
 	/** Program the `claude` binary's answers. Anything unset succeeds. */
 	answerClaude: (answers: ClaudeAnswers) => void;
 	commandsRun: () => string[];
@@ -118,7 +158,9 @@ function claudeAnswerer(spawnSyncMock: Mock) {
 	return ({
 		pluginHelp = 0,
 		marketplaceAdd = 0,
+		marketplaceUpdate = 0,
 		install = 0,
+		update = 0,
 		uninstall = 0,
 		marketplaceRemove = 0,
 	}: ClaudeAnswers): void => {
@@ -139,8 +181,14 @@ function claudeAnswerer(spawnSyncMock: Mock) {
 			if (joined.startsWith("plugin marketplace remove")) {
 				return { ...OK, status: marketplaceRemove };
 			}
+			if (joined.startsWith("plugin marketplace update")) {
+				return answer(marketplaceUpdate, "listing refresh rejected");
+			}
 			if (joined.startsWith("plugin install")) {
 				return answer(install, "install rejected");
+			}
+			if (joined.startsWith("plugin update")) {
+				return answer(update, "update rejected");
 			}
 			if (joined.startsWith("plugin uninstall")) {
 				return answer(uninstall, "uninstall rejected");
@@ -262,9 +310,16 @@ export function installClaudePluginHarness({
 			writeClaudeJson({ home: state.home, segments, value }),
 		readSettings: <T,>() =>
 			JSON.parse(fs.readFileSync(settingsPath(), "utf8")) as T,
-		seedInstalledPlugin: () => seedInstalledPlugin({ home: state.home }),
-		seedMarketplace: ({ repo }: { repo?: string } = {}) =>
-			seedMarketplace({ home: state.home, repo }),
+		seedInstalledPlugin: ({
+			version,
+			scope,
+		}: { version?: string; scope?: string } = {}) =>
+			seedInstalledPlugin({ home: state.home, version, scope }),
+		seedMarketplace: ({
+			repo,
+			publishedVersion,
+		}: { repo?: string; publishedVersion?: string } = {}) =>
+			seedMarketplace({ home: state.home, repo, publishedVersion }),
 		answerClaude,
 		commandsRun,
 		lastSpawnOptions,

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Keeping the installed LangWatch plugin up to date: when a wrapped run spends
+ * a subprocess looking, what it does with what it finds, and what it costs on
+ * the runs in between.
+ *
+ * `node:child_process` is the only thing mocked. The install record, the
+ * marketplace listing and its plugin manifest are real files under a temp HOME,
+ * because the version comparison reads them the way Claude Code writes them and
+ * a hand-stubbed reader would prove nothing about that.
+ *
+ * Feature: specs/ai-governance/cli-wrappers/claude-plugin-update.feature
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import type * as ChildProcessModule from "node:child_process";
+
+import { installClaudePluginHarness } from "./claude-plugin-test-helpers";
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof ChildProcessModule>("node:child_process");
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+const {
+  answerClaude,
+  commandsRun,
+  loadModule,
+  readConfig,
+  seedInstalledPlugin,
+  seedMarketplace,
+  writeConfig,
+  writeJson,
+} = installClaudePluginHarness({
+  spawnSyncMock,
+  prefix: "lw-claude-plugin-update-",
+});
+
+const OK = { status: 0, stdout: "", stderr: "" };
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const secondsAgo = (ms: number): number => Math.floor((Date.now() - ms) / 1000);
+
+/**
+ * A `claude` whose `plugin update` does what a real one does: moves the version
+ * in the install record. Nothing else about the outcome is observable, and a
+ * mock that only reported success would let a no-op update pass as an applied
+ * one.
+ */
+const claudeThatUpdatesTo = (version: string): void => {
+  spawnSyncMock.mockImplementation((_bin: string, args: string[]) => {
+    if (args.join(" ").startsWith("plugin update")) {
+      seedInstalledPlugin({ version });
+    }
+    return OK;
+  });
+};
+
+/** The common starting point: an install one release behind the listing. */
+const seedOutdatedInstall = (): void => {
+  seedInstalledPlugin({ version: "0.1.0" });
+  seedMarketplace({ publishedVersion: "0.2.0" });
+};
+
+describe("updateLangwatchClaudePlugin", () => {
+  describe("given a plugin the marketplace has moved past", () => {
+    /** @scenario "A plugin the marketplace has moved past is updated before the tool starts" */
+    it("refreshes the listing, then updates the plugin", async () => {
+      seedOutdatedInstall();
+      claudeThatUpdatesTo("0.2.0");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      const result = updateLangwatchClaudePlugin();
+
+      expect(result).toEqual({ action: "updated", from: "0.1.0", to: "0.2.0" });
+      expect(commandsRun()).toEqual([
+        "plugin --help",
+        "plugin marketplace update langwatch",
+        "plugin update langwatch@langwatch --scope user",
+      ]);
+    });
+
+    /** @scenario "The plugin is kept current from a machine that wraps another tool" */
+    it("updates on a machine that only ever wraps codex", async () => {
+      writeConfig({ tool_mode: { codex: "ingestion" } });
+      seedOutdatedInstall();
+      claudeThatUpdatesTo("0.2.0");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("updated");
+    });
+
+    /** @scenario "An update that will not apply warns" */
+    it("reports the failure with the version it was reaching for", async () => {
+      seedOutdatedInstall();
+      answerClaude({ update: 1 });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      const result = updateLangwatchClaudePlugin();
+
+      expect(result.action).toBe("failed");
+      expect(result.reason).toContain("0.2.0");
+      expect(result.reason).toContain("update rejected");
+    });
+
+    /** @scenario "A claude that cannot manage plugins is left alone" */
+    it("does not try to update through a claude with no plugin subcommand", async () => {
+      seedOutdatedInstall();
+      answerClaude({ pluginHelp: 1 });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("unavailable");
+      expect(commandsRun()).toEqual(["plugin --help"]);
+    });
+  });
+
+  describe("given a plugin already at the published version", () => {
+    /** @scenario "A plugin already at the published version is left alone" */
+    it("refreshes the listing and stops there", async () => {
+      seedInstalledPlugin({ version: "0.2.0" });
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin()).toEqual({
+        action: "up_to_date",
+        from: "0.2.0",
+      });
+      expect(commandsRun()).not.toContain(
+        "plugin update langwatch@langwatch --scope user",
+      );
+    });
+
+    it("leaves an install ahead of the listing where it is", async () => {
+      seedInstalledPlugin({ version: "0.9.0" });
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("up_to_date");
+    });
+  });
+
+  describe("given nothing of ours to keep current", () => {
+    /** @scenario "A machine without the plugin is not asked about it" */
+    it("spends no subprocess when the plugin is not installed", async () => {
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin()).toEqual({ action: "absent" });
+      expect(commandsRun()).toEqual([]);
+    });
+
+    /** @scenario "A marketplace of our name that somebody else registered is left alone" */
+    it("does not update through a marketplace pointing somewhere else", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace({ repo: "someone-else/plugins", publishedVersion: "0.2.0" });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("unavailable");
+      expect(commandsRun()).toEqual([]);
+    });
+
+    it("leaves a plugin installed only for a project alone", async () => {
+      seedInstalledPlugin({ version: "0.1.0", scope: "project" });
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("unknown_version");
+    });
+
+    /** @scenario "A version that cannot be read is left alone rather than blindly updated" */
+    it("does not update against a listing whose manifest cannot be read", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace();
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      const result = updateLangwatchClaudePlugin();
+
+      expect(result.action).toBe("unknown_version");
+      expect(commandsRun()).not.toContain(
+        "plugin update langwatch@langwatch --scope user",
+      );
+    });
+
+    it("does not update against a version it cannot make sense of", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace();
+      writeJson({
+        segments: [
+          "plugins",
+          "marketplaces",
+          "langwatch",
+          ".claude-plugin",
+          "plugin.json",
+        ],
+        value: { name: "langwatch", version: "main" },
+      });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("unknown_version");
+    });
+  });
+
+  describe("given a check that already ran", () => {
+    /** @scenario "A plugin checked today is not checked again" */
+    it("spends no subprocess an hour later", async () => {
+      seedOutdatedInstall();
+      writeConfig({ claude_plugin_last_update_check: secondsAgo(HOUR_MS) });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin()).toEqual({
+        action: "checked_recently",
+      });
+      expect(commandsRun()).toEqual([]);
+    });
+
+    /** @scenario "A day after the last check the plugin is checked again" */
+    it("checks again two days later", async () => {
+      seedOutdatedInstall();
+      writeConfig({
+        claude_plugin_last_update_check: secondsAgo(48 * HOUR_MS),
+      });
+      claudeThatUpdatesTo("0.2.0");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("updated");
+      expect(commandsRun()).toContain("plugin marketplace update langwatch");
+    });
+
+    /** @scenario "A check stamped in the future does not suppress the next one" */
+    it("checks rather than waiting for the clock to catch up", async () => {
+      seedOutdatedInstall();
+      writeConfig({
+        claude_plugin_last_update_check: secondsAgo(-365 * 24 * HOUR_MS),
+      });
+      claudeThatUpdatesTo("0.2.0");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("updated");
+    });
+  });
+
+  describe("given a marketplace listing that will not refresh", () => {
+    /** @scenario "A marketplace listing that will not refresh warns and gives up for the day" */
+    it("reports the failure rather than claiming the stale listing is current", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace({ publishedVersion: "0.1.0" });
+      answerClaude({ marketplaceUpdate: 1 });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      const result = updateLangwatchClaudePlugin();
+
+      expect(result.action).toBe("failed");
+      expect(result.reason).toContain("listing refresh rejected");
+    });
+
+    it("stamps the check so the next run does not repeat it", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace({ publishedVersion: "0.1.0" });
+      answerClaude({ marketplaceUpdate: 1 });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+      updateLangwatchClaudePlugin();
+
+      expect(readConfig().claude_plugin_last_update_check).toBeTypeOf("number");
+
+      spawnSyncMock.mockClear();
+      const next = await loadModule();
+      expect(next.updateLangwatchClaudePlugin().action).toBe("checked_recently");
+      expect(commandsRun()).toEqual([]);
+    });
+
+    it("still applies an update the stale listing already knows about", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      spawnSyncMock.mockImplementation((_bin: string, args: string[]) => {
+        const joined = args.join(" ");
+        if (joined.startsWith("plugin marketplace update")) {
+          return { ...OK, status: 1, stderr: "offline" };
+        }
+        if (joined.startsWith("plugin update")) {
+          seedInstalledPlugin({ version: "0.2.0" });
+        }
+        return OK;
+      });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin().action).toBe("updated");
+    });
+  });
+
+  describe("given a subprocess that throws", () => {
+    it("returns a failure rather than taking the launch down with it", async () => {
+      seedOutdatedInstall();
+      spawnSyncMock.mockImplementation((_bin: string, args: string[]) => {
+        if (args.join(" ") === "plugin --help") return OK;
+        throw new Error("spawn exploded");
+      });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      const result = updateLangwatchClaudePlugin();
+
+      expect(result.action).toBe("failed");
+      expect(result.reason).toContain("spawn exploded");
+    });
+  });
+});

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -201,7 +201,7 @@ describe("updateLangwatchClaudePlugin", () => {
       const lookalikes = [
         { source: "github", repo: "langwatch/agent-plugin.evil" },
         { source: "git", url: "https://github.com/langwatch/agent-plugin.evil" },
-      ];
+      ] as const;
 
       for (const source of lookalikes) {
         // Each shape starts from an unchecked machine: the pass before it

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -195,30 +195,42 @@ describe("updateLangwatchClaudePlugin", () => {
 
     /** @scenario "A marketplace whose address only looks like ours is never updated from" */
     it("does not update through an address built to look like ours", async () => {
-      seedInstalledPlugin({ version: "0.1.0" });
-      // The listing is real and it publishes something newer, so the only
-      // thing standing between it and the user's agent is the address.
-      seedMarketplace({ publishedVersion: "0.2.0" });
-      writeJson({
-        segments: ["plugins", "known_marketplaces.json"],
-        value: {
-          langwatch: {
-            source: {
-              source: "git",
-              url: "https://github.com/langwatch/agent-plugin.evil",
-            },
-            installLocation: `${home()}/.claude/plugins/marketplaces/langwatch`,
-          },
-        },
-      });
-      const onCheckStart = vi.fn();
-      const { updateLangwatchClaudePlugin } = await loadModule();
+      // Both shapes a real `claude` writes: `marketplace add <owner>/<repo>`
+      // records the shorthand, `marketplace add <url>` records
+      // `{ source: "git", url }`. A lookalike can arrive as either.
+      const lookalikes = [
+        { source: "github", repo: "langwatch/agent-plugin.evil" },
+        { source: "git", url: "https://github.com/langwatch/agent-plugin.evil" },
+      ];
 
-      expect(updateLangwatchClaudePlugin({ onCheckStart }).action).toBe(
-        "unavailable",
-      );
-      expect(commandsRun()).toEqual([]);
-      expect(onCheckStart).not.toHaveBeenCalled();
+      for (const source of lookalikes) {
+        // Each shape starts from an unchecked machine: the pass before it
+        // stamped the check on its way out, which would throttle this one.
+        writeConfig();
+        seedInstalledPlugin({ version: "0.1.0" });
+        // The listing is real and publishes something newer, so the only thing
+        // standing between it and the user's agent is the address.
+        seedMarketplace({ publishedVersion: "0.2.0" });
+        writeJson({
+          segments: ["plugins", "known_marketplaces.json"],
+          value: {
+            langwatch: {
+              source,
+              installLocation: `${home()}/.claude/plugins/marketplaces/langwatch`,
+            },
+          },
+        });
+        const onCheckStart = vi.fn();
+        const { updateLangwatchClaudePlugin } = await loadModule();
+
+        expect(
+          updateLangwatchClaudePlugin({ onCheckStart }).action,
+          `${JSON.stringify(source)} must not be updated from`,
+        ).toBe("unavailable");
+        expect(commandsRun()).toEqual([]);
+        expect(onCheckStart).not.toHaveBeenCalled();
+        spawnSyncMock.mockClear();
+      }
     });
 
     /** @scenario "A machine that cannot remember the check does not repeat it every launch" */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -11,7 +11,7 @@
  * Feature: specs/ai-governance/cli-wrappers/claude-plugin-update.feature
  */
 
-import { writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -70,7 +70,7 @@ const seedOutdatedInstall = (): void => {
 
 describe("updateLangwatchClaudePlugin", () => {
   describe("given a plugin the marketplace has moved past", () => {
-    /** @scenario "A plugin the marketplace has moved past is updated before the tool starts" */
+    /** @scenario "A plugin the marketplace has moved past is brought up to date" */
     it("refreshes the listing, then updates the plugin", async () => {
       seedOutdatedInstall();
       claudeThatUpdatesTo("0.2.0");
@@ -136,7 +136,7 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(spawnsWhenAnnounced).toEqual([1]);
     });
 
-    /** @scenario "A claude that cannot manage plugins is left alone" */
+    /** @scenario "A claude that cannot manage plugins leaves the plugin as it is" */
     it("does not try to update through a claude with no plugin subcommand", async () => {
       seedOutdatedInstall();
       answerClaude({ pluginHelp: 1 });
@@ -173,7 +173,7 @@ describe("updateLangwatchClaudePlugin", () => {
   });
 
   describe("given nothing of ours to keep current", () => {
-    /** @scenario "A machine without the plugin is not asked about it" */
+    /** @scenario "A machine without the plugin is not held up by it" */
     it("spends no subprocess when the plugin is not installed", async () => {
       seedMarketplace({ publishedVersion: "0.2.0" });
       const { updateLangwatchClaudePlugin } = await loadModule();
@@ -192,27 +192,36 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(commandsRun()).toEqual([]);
     });
 
-    /** @scenario "A config that cannot be read stops the check rather than repeating it" */
-    it("does not check at all when the config will not parse", async () => {
+    /** @scenario "A machine that cannot remember the check does not repeat it every launch" */
+    it("does not check at all when the check cannot be recorded", async () => {
       seedOutdatedInstall();
-      writeFileSync(process.env.LANGWATCH_CLI_CONFIG!, "{ not json");
+      // The config still reads. What fails is saving it: `saveConfig` writes a
+      // sibling `.tmp` and renames it, so a DIRECTORY sitting on that name
+      // fails the write for any user, root included, which a read-only file
+      // would not.
+      mkdirSync(`${process.env.LANGWATCH_CLI_CONFIG!}.tmp`, { recursive: true });
       const { updateLangwatchClaudePlugin } = await loadModule();
 
-      // A stamp that cannot be written is a check that would otherwise repeat
-      // on every single launch, forever.
+      // A stamp that cannot land is a check with no memory, and a check with
+      // no memory would run on every single launch, forever.
       expect(updateLangwatchClaudePlugin().action).toBe("unavailable");
       expect(commandsRun()).toEqual([]);
     });
 
+    /** @scenario "A plugin somebody installed for one repository only is not touched" */
     it("leaves a plugin installed only for a project alone", async () => {
       seedInstalledPlugin({ version: "0.1.0", scope: "project" });
       seedMarketplace({ publishedVersion: "0.2.0" });
       const { updateLangwatchClaudePlugin } = await loadModule();
 
-      expect(updateLangwatchClaudePlugin().action).toBe("unknown_version");
+      // Not ours to move, and cheap to learn: no probe, no fetch, and no stamp
+      // that would hold up a real user-scope install later the same day.
+      expect(updateLangwatchClaudePlugin()).toEqual({ action: "absent" });
+      expect(commandsRun()).toEqual([]);
+      expect(readConfig().claude_plugin_last_update_check).toBeUndefined();
     });
 
-    /** @scenario "A version that cannot be read is left alone rather than blindly updated" */
+    /** @scenario "A version that cannot be read leaves the plugin alone rather than replacing it blindly" */
     it("does not update against a listing whose manifest cannot be read", async () => {
       seedInstalledPlugin({ version: "0.1.0" });
       seedMarketplace();
@@ -246,7 +255,7 @@ describe("updateLangwatchClaudePlugin", () => {
   });
 
   describe("given a check that already ran", () => {
-    /** @scenario "A plugin checked today is not checked again" */
+    /** @scenario "A plugin looked at today is not looked at again" */
     it("spends no subprocess an hour later", async () => {
       seedOutdatedInstall();
       writeConfig({ claude_plugin_last_update_check: secondsAgo(HOUR_MS) });
@@ -258,7 +267,7 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(commandsRun()).toEqual([]);
     });
 
-    /** @scenario "A run that answers from disk says nothing at all" */
+    /** @scenario "A plugin looked at today is not looked at again" */
     it("announces nothing on a run that does no work", async () => {
       seedOutdatedInstall();
       writeConfig({ claude_plugin_last_update_check: secondsAgo(HOUR_MS) });
@@ -270,7 +279,7 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(onCheckStart).not.toHaveBeenCalled();
     });
 
-    /** @scenario "A day after the last check the plugin is checked again" */
+    /** @scenario "A day after the last check the plugin is looked at again" */
     it("checks again two days later", async () => {
       seedOutdatedInstall();
       writeConfig({

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -11,6 +11,8 @@
  * Feature: specs/ai-governance/cli-wrappers/claude-plugin-update.feature
  */
 
+import { writeFileSync } from "node:fs";
+
 import { describe, expect, it, vi } from "vitest";
 
 import type * as ChildProcessModule from "node:child_process";
@@ -107,6 +109,33 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(result.reason).toContain("update rejected");
     });
 
+    it("claims no new version when the update did not apply", async () => {
+      seedOutdatedInstall();
+      answerClaude({ update: 1 });
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      // `to` means "the version now installed", and nothing was installed.
+      expect(updateLangwatchClaudePlugin().to).toBeUndefined();
+    });
+
+    /** @scenario "A run that waits on the network says what it is waiting for" */
+    it("announces the check before the first subprocess", async () => {
+      seedOutdatedInstall();
+      const spawnsWhenAnnounced: number[] = [];
+      claudeThatUpdatesTo("0.2.0");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      updateLangwatchClaudePlugin({
+        onCheckStart: () =>
+          spawnsWhenAnnounced.push(spawnSyncMock.mock.calls.length),
+      });
+
+      // Announced once, and before anything reached the network. The probe is
+      // the only spawn allowed to precede it: it decides whether there is a
+      // check to announce at all.
+      expect(spawnsWhenAnnounced).toEqual([1]);
+    });
+
     /** @scenario "A claude that cannot manage plugins is left alone" */
     it("does not try to update through a claude with no plugin subcommand", async () => {
       seedOutdatedInstall();
@@ -163,6 +192,18 @@ describe("updateLangwatchClaudePlugin", () => {
       expect(commandsRun()).toEqual([]);
     });
 
+    /** @scenario "A config that cannot be read stops the check rather than repeating it" */
+    it("does not check at all when the config will not parse", async () => {
+      seedOutdatedInstall();
+      writeFileSync(process.env.LANGWATCH_CLI_CONFIG!, "{ not json");
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      // A stamp that cannot be written is a check that would otherwise repeat
+      // on every single launch, forever.
+      expect(updateLangwatchClaudePlugin().action).toBe("unavailable");
+      expect(commandsRun()).toEqual([]);
+    });
+
     it("leaves a plugin installed only for a project alone", async () => {
       seedInstalledPlugin({ version: "0.1.0", scope: "project" });
       seedMarketplace({ publishedVersion: "0.2.0" });
@@ -215,6 +256,18 @@ describe("updateLangwatchClaudePlugin", () => {
         action: "checked_recently",
       });
       expect(commandsRun()).toEqual([]);
+    });
+
+    /** @scenario "A run that answers from disk says nothing at all" */
+    it("announces nothing on a run that does no work", async () => {
+      seedOutdatedInstall();
+      writeConfig({ claude_plugin_last_update_check: secondsAgo(HOUR_MS) });
+      const onCheckStart = vi.fn();
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      updateLangwatchClaudePlugin({ onCheckStart });
+
+      expect(onCheckStart).not.toHaveBeenCalled();
     });
 
     /** @scenario "A day after the last check the plugin is checked again" */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/claude-plugin-update.unit.test.ts
@@ -30,6 +30,7 @@ vi.mock("node:child_process", async () => {
 const {
   answerClaude,
   commandsRun,
+  home,
   loadModule,
   readConfig,
   seedInstalledPlugin,
@@ -190,6 +191,34 @@ describe("updateLangwatchClaudePlugin", () => {
 
       expect(updateLangwatchClaudePlugin().action).toBe("unavailable");
       expect(commandsRun()).toEqual([]);
+    });
+
+    /** @scenario "A marketplace whose address only looks like ours is never updated from" */
+    it("does not update through an address built to look like ours", async () => {
+      seedInstalledPlugin({ version: "0.1.0" });
+      // The listing is real and it publishes something newer, so the only
+      // thing standing between it and the user's agent is the address.
+      seedMarketplace({ publishedVersion: "0.2.0" });
+      writeJson({
+        segments: ["plugins", "known_marketplaces.json"],
+        value: {
+          langwatch: {
+            source: {
+              source: "git",
+              url: "https://github.com/langwatch/agent-plugin.evil",
+            },
+            installLocation: `${home()}/.claude/plugins/marketplaces/langwatch`,
+          },
+        },
+      });
+      const onCheckStart = vi.fn();
+      const { updateLangwatchClaudePlugin } = await loadModule();
+
+      expect(updateLangwatchClaudePlugin({ onCheckStart }).action).toBe(
+        "unavailable",
+      );
+      expect(commandsRun()).toEqual([]);
+      expect(onCheckStart).not.toHaveBeenCalled();
     });
 
     /** @scenario "A machine that cannot remember the check does not repeat it every launch" */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/telemetry-targets.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/telemetry-targets.unit.test.ts
@@ -61,8 +61,16 @@ const origUserprofile = process.env.USERPROFILE;
 const origCodexHome = process.env.CODEX_HOME;
 const origXdgConfigHome = process.env.XDG_CONFIG_HOME;
 
+// The directory the scan treats as "this directory". A scratch one by
+// default: the targets a scan returns can REMOVE real files, and a suite that
+// let that resolve to the checkout it runs in would delete the project pin of
+// any developer who had run `langwatch claude` there.
+let scanCwd: string;
+
+const scan = () => scanTelemetryTargets({ cwd: scanCwd });
+
 const presentLabels = (): string[] =>
-	scanTelemetryTargets()
+	scan()
 		.filter((t) => t.present)
 		.map((t) => t.label);
 
@@ -87,6 +95,8 @@ const seedMarketplace = (repo = OWNED_MARKETPLACE_REPO): void =>
 
 beforeEach(() => {
 	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "lw-telemetry-targets-"));
+	scanCwd = path.join(tmpHome, "cwd");
+	fs.mkdirSync(scanCwd, { recursive: true });
 	process.env.HOME = tmpHome;
 	process.env.USERPROFILE = tmpHome;
 	spawnSyncMock.mockReset();
@@ -157,7 +167,7 @@ describe("scanTelemetryTargets", () => {
 		});
 
 		it("removes every present target, and a re-scan finds nothing", () => {
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 			expect(presentLabels()).toEqual([]);
@@ -171,7 +181,7 @@ describe("scanTelemetryTargets", () => {
 			settings.model = "claude-sonnet-5";
 			fs.writeFileSync(claude.path, JSON.stringify(settings, null, 2));
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				t.remove();
 			}
 
@@ -203,7 +213,7 @@ describe("scanTelemetryTargets", () => {
 				presentLabels().some((l) => l.startsWith("code shell function")),
 			).toBe(true);
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 
@@ -230,7 +240,7 @@ describe("scanTelemetryTargets", () => {
 				presentLabels().some((l) => l.startsWith("claude session hooks")),
 			).toBe(true);
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 
@@ -257,7 +267,7 @@ describe("scanTelemetryTargets", () => {
 				true,
 			);
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 
@@ -275,7 +285,7 @@ describe("scanTelemetryTargets", () => {
 				presentLabels().some((l) => l.startsWith("opencode session plugin")),
 			).toBe(false);
 
-			for (const t of scanTelemetryTargets()) t.remove();
+			for (const t of scan()) t.remove();
 
 			expect(fs.readFileSync(target.path, "utf8")).toBe(
 				"export const Mine = async () => ({});\n",
@@ -301,7 +311,7 @@ describe("scanTelemetryTargets", () => {
 
 		/** @scenario "Logout uninstalls the plugin and removes the marketplace" */
 		it("uninstalls the plugin at user scope and removes the marketplace", () => {
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 
@@ -331,7 +341,7 @@ describe("scanTelemetryTargets", () => {
 					: { status: 0, stdout: "", stderr: "" },
 			);
 
-			const target = scanTelemetryTargets().find((t) =>
+			const target = scan().find((t) =>
 				t.label.startsWith("claude langwatch plugin ("),
 			)!;
 			expect(target.present).toBe(true);
@@ -356,7 +366,7 @@ describe("scanTelemetryTargets", () => {
 				),
 			).toBe(false);
 
-			const target = scanTelemetryTargets().find((t) =>
+			const target = scan().find((t) =>
 				t.label.startsWith("claude langwatch plugin marketplace"),
 			)!;
 			expect(target.remove()).toBe(false);
@@ -375,7 +385,7 @@ describe("scanTelemetryTargets", () => {
 				labels.some((l) => l.startsWith("codex langwatch profile file")),
 			).toBe(true);
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				t.remove();
 			}
 			expect(presentLabels()).toEqual([]);
@@ -383,23 +393,14 @@ describe("scanTelemetryTargets", () => {
 	});
 
 	describe("when the working directory carries a claude project pin", () => {
-		let cwdSpy: ReturnType<typeof vi.spyOn>;
-
 		beforeEach(() => {
-			const projectDir = path.join(tmpHome, "project");
-			fs.mkdirSync(projectDir, { recursive: true });
-			cwdSpy = vi
-				.spyOn(process, "cwd")
-				.mockReturnValue(projectDir) as ReturnType<typeof vi.spyOn>;
-			installAppEnv(claudeProjectSettingsTarget(projectDir), {
+			scanCwd = path.join(tmpHome, "project");
+			fs.mkdirSync(scanCwd, { recursive: true });
+			installAppEnv(claudeProjectSettingsTarget(scanCwd), {
 				OTEL_EXPORTER_OTLP_ENDPOINT: "http://app/api/otel",
 				OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Bearer ik-lw-x_y",
 				CLAUDE_CODE_ENABLE_TELEMETRY: "1",
 			});
-		});
-
-		afterEach(() => {
-			cwdSpy.mockRestore();
 		});
 
 		it("reports the pin as present and removes it on logout", () => {
@@ -409,7 +410,7 @@ describe("scanTelemetryTargets", () => {
 				),
 			).toBe(true);
 
-			for (const t of scanTelemetryTargets().filter((t) => t.present)) {
+			for (const t of scan().filter((t) => t.present)) {
 				expect(t.remove()).toBe(true);
 			}
 
@@ -440,7 +441,7 @@ describe("scanTelemetryTargets", () => {
 				presentLabels().some((l) => l.startsWith("claude telemetry env")),
 			).toBe(false);
 
-			const target = scanTelemetryTargets().find((t) =>
+			const target = scan().find((t) =>
 				t.label.startsWith("claude telemetry env"),
 			)!;
 			expect(target.remove()).toBe(false);
@@ -481,7 +482,7 @@ describe("scanTelemetryTargets", () => {
 				),
 			).toBe(false);
 
-			const target = scanTelemetryTargets().find((t) =>
+			const target = scan().find((t) =>
 				t.label.startsWith("claude project telemetry pin"),
 			)!;
 			expect(target.remove()).toBe(false);
@@ -507,7 +508,7 @@ describe("scanTelemetryTargets", () => {
 				),
 			).toBe(false);
 
-			const target = scanTelemetryTargets().find((t) =>
+			const target = scan().find((t) =>
 				t.label.startsWith("codex langwatch profile file"),
 			)!;
 			expect(target.remove()).toBe(false);

--- a/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
+++ b/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
@@ -20,19 +20,28 @@
  * else, and a plugin cannot set a session's environment, so the env block stays
  * CLI-managed (see app-settings.ts) whichever seam carries the hooks.
  *
+ * Shipping the hook inside the plugin only solves the drift it was built to
+ * solve while the installed copy keeps up with what we publish, and Claude Code
+ * will not see to that: it auto-updates its own marketplaces and leaves
+ * third-party ones like ours switched off by default. So the plugin is also
+ * updated from here, once a day, from whichever wrapped run comes first.
+ *
  * Everything in this file is best-effort by construction. A `claude` too old to
  * take a plugin, a network that is down, a marketplace that will not clone: none
  * of them may fail the coding session the user actually asked for. Every entry
  * point reports what happened and leaves the caller free to fall back to the raw
  * hook entries in session-context-hooks.ts.
  *
- * Spec: specs/ai-governance/cli-wrappers/claude-plugin-install.feature
+ * Specs:
+ *   specs/ai-governance/cli-wrappers/claude-plugin-install.feature
+ *   specs/ai-governance/cli-wrappers/claude-plugin-update.feature
  */
 
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { compareVersions } from "../compare-versions";
 import {
   appSettingsTargetFor,
   readAppSettingsFileForUpdate,
@@ -79,6 +88,29 @@ const INSTALL_TIMEOUT_MS = 120_000;
  * subprocess and a clone each time to learn it again.
  */
 const RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How long a completed update check suppresses the next one. The plugin moves
+ * when we cut a release, which is nowhere near often enough to be worth a
+ * repository fetch per wrapped launch, and a day is short enough that a fix
+ * reaches a machine the day after it ships.
+ */
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Refreshing the listing and applying an update are each a fetch of a small
+ * repository. Well clear of a slow network, and far below the install timeout,
+ * because unlike an install this can happen on a run the user never asked to
+ * involve Claude Code at all.
+ */
+const UPDATE_TIMEOUT_MS = 60_000;
+
+/**
+ * A version we are willing to reason about. Anything else (absent, a git sha, a
+ * shape we do not recognise) means we do not know what is installed, and the
+ * safe answer to that is to leave it alone rather than update it blindly.
+ */
+const VERSION_PATTERN = /^\d+\.\d+\.\d+/;
 
 /**
  * `DEBUG=langwatch:claude-plugin` (or any DEBUG containing "langwatch") turns
@@ -144,8 +176,8 @@ function claudeSettingsPath(): string {
 }
 
 /** Where Claude Code keeps its plugin bookkeeping, beside the settings file. */
-function claudeHomeDir(): string {
-  return path.dirname(claudeSettingsPath());
+function claudePluginsDir(): string {
+  return path.join(path.dirname(claudeSettingsPath()), "plugins");
 }
 
 /**
@@ -155,7 +187,7 @@ function claudeHomeDir(): string {
  * coding session.
  */
 export function readClaudePluginState(): ClaudePluginState {
-  const pluginsDir = path.join(claudeHomeDir(), "plugins");
+  const pluginsDir = claudePluginsDir();
   const installed = readJsonObject(path.join(pluginsDir, "installed_plugins.json"));
   const marketplaces = readJsonObject(path.join(pluginsDir, "known_marketplaces.json"));
   const settings = readJsonObject(claudeSettingsPath());
@@ -304,6 +336,219 @@ export function ensureLangwatchClaudePlugin({
     return { action: "installed" };
   } catch (err) {
     return recordFailure((err as Error).message);
+  }
+}
+
+export type ClaudePluginUpdateAction =
+  /** The installed copy was behind the listing and has been moved forward. */
+  | "updated"
+  /** The installed copy is the published one. */
+  | "up_to_date"
+  /** Nothing of ours is installed, so there is nothing to keep current. */
+  | "absent"
+  /** A check inside the last day already answered this. */
+  | "checked_recently"
+  /** This `claude` cannot manage plugins, or the marketplace is not ours. */
+  | "unavailable"
+  /** One of the two versions could not be read, so neither is trusted. */
+  | "unknown_version"
+  /** The listing could not be refreshed, or the update would not apply. */
+  | "failed";
+
+export interface ClaudePluginUpdateResult {
+  action: ClaudePluginUpdateAction;
+  /** The version that was installed before this ran. */
+  from?: string;
+  /** The version now installed, on an update. */
+  to?: string;
+  /** What went wrong, for the caller's warning. */
+  reason?: string;
+}
+
+/**
+ * Bring the installed plugin up to the version the marketplace publishes, at
+ * most once a day. Never throws: this runs on the way into a coding session
+ * that has nothing to do with plugin housekeeping, so every failure here is a
+ * warning the caller prints and then gets on with the launch.
+ *
+ * Ordered so the cheap answers come first. A machine without the plugin and a
+ * machine already checked today both return without spawning anything, which is
+ * what the overwhelming majority of wrapped runs do.
+ *
+ * The check is stamped BEFORE the work rather than after it, so a fetch that
+ * hangs until the timeout, or a process killed in the middle of one, costs the
+ * next launch nothing. The price is that a transient failure waits a day for
+ * its retry, which is the right trade for housekeeping: the plugin that is
+ * installed keeps working, it is only a version behind.
+ */
+export function updateLangwatchClaudePlugin(): ClaudePluginUpdateResult {
+  try {
+    const state = readClaudePluginState();
+    if (!state.pluginInstalled) return { action: "absent" };
+    if (checkedRecently()) return { action: "checked_recently" };
+
+    // A marketplace of our name that points somewhere else is somebody else's
+    // registration, and updating what it serves is not ours to do.
+    if (!state.marketplaceOwnedByLangwatch) {
+      stampUpdateCheck();
+      return {
+        action: "unavailable",
+        reason: "the langwatch marketplace on this machine is not ours",
+      };
+    }
+    if (!claudePluginCliAvailable()) {
+      stampUpdateCheck();
+      return { action: "unavailable", reason: "this claude has no plugin subcommand" };
+    }
+
+    stampUpdateCheck();
+
+    // The listing on disk is a clone, and it is as old as the last time
+    // something refreshed it. Refresh first so the version we compare against
+    // is what we publish today rather than what we published when the user
+    // installed.
+    const refresh = runClaude({
+      args: ["plugin", "marketplace", "update", CLAUDE_PLUGIN_MARKETPLACE],
+      timeoutMs: UPDATE_TIMEOUT_MS,
+    });
+    const refreshFailure =
+      refresh.status === 0 ? null : `the marketplace listing could not be refreshed: ${refresh.detail}`;
+    if (refreshFailure) debugLog(refreshFailure);
+
+    const installed = readInstalledPluginVersion();
+    const published = readPublishedPluginVersion();
+    if (!installed || !published) {
+      // Not a failed operation, so it stays off the user's terminal: there is
+      // no action for them in it, and a daily line about a state they cannot
+      // influence is noise. It is the shape a Claude Code layout change would
+      // take, though, so make it findable.
+      debugLog(
+        `left the plugin alone, versions unread (installed=${installed ?? "?"}, published=${published ?? "?"})`,
+      );
+      return {
+        action: "unknown_version",
+        reason: refreshFailure ?? undefined,
+        from: installed ?? undefined,
+      };
+    }
+
+    // Equal is the common case. Ahead of the listing happens on a machine that
+    // installed from a local checkout, and dragging that backwards to what we
+    // published would undo somebody's testing.
+    if (compareVersions(installed, published) >= 0) {
+      // A refresh that failed leaves this unproven: the listing we just
+      // compared against is whatever was already on disk, which may be older
+      // than the release we are trying to deliver.
+      return refreshFailure
+        ? { action: "failed", from: installed, reason: refreshFailure }
+        : { action: "up_to_date", from: installed };
+    }
+
+    const update = runClaude({
+      args: ["plugin", "update", CLAUDE_PLUGIN_REF, "--scope", "user"],
+      timeoutMs: UPDATE_TIMEOUT_MS,
+    });
+    // What is on disk afterwards decides, not the exit status: a non-zero exit
+    // that still moved the version did the job, and a zero exit that moved
+    // nothing did not.
+    const after = readInstalledPluginVersion();
+    if (!after || compareVersions(after, installed) <= 0) {
+      return {
+        action: "failed",
+        from: installed,
+        to: published,
+        reason: `the update to ${published} could not be applied: ${update.detail}`,
+      };
+    }
+    return { action: "updated", from: installed, to: after };
+  } catch (err) {
+    return { action: "failed", reason: (err as Error).message };
+  }
+}
+
+/**
+ * The version of the user-scope install record, which is the one this CLI put
+ * there. A project or local record belongs to a checkout somebody else pinned
+ * and is not ours to move, so a machine carrying only those reads as unknown
+ * and is left alone.
+ */
+function readInstalledPluginVersion(): string | null {
+  const document = readJsonObject(
+    path.join(claudePluginsDir(), "installed_plugins.json"),
+  );
+  const plugins = isPlainObject(document.plugins) ? document.plugins : document;
+  const records = plugins[CLAUDE_PLUGIN_REF];
+  if (!Array.isArray(records)) return null;
+  const userScoped = records.find(
+    (record) => isPlainObject(record) && record.scope === "user",
+  );
+  return isPlainObject(userScoped) ? versionOf(userScoped) : null;
+}
+
+/**
+ * The version the marketplace listing on disk publishes. Both manifests are
+ * read because both ship and the publish workflow refuses to release them
+ * disagreeing: whichever one this Claude Code wrote into its clone answers.
+ */
+function readPublishedPluginVersion(): string | null {
+  const listing = marketplaceListingDir();
+  for (const manifest of [
+    path.join(listing, ".claude-plugin", "plugin.json"),
+    path.join(listing, "plugin.json"),
+  ]) {
+    const version = versionOf(readJsonObject(manifest));
+    if (version) return version;
+  }
+  return null;
+}
+
+/**
+ * Where Claude Code cloned the listing. It records the location itself, so read
+ * that; the conventional path is the fallback for an entry that does not carry
+ * one, and a wrong guess only costs an unreadable manifest.
+ */
+function marketplaceListingDir(): string {
+  const marketplaces = readJsonObject(
+    path.join(claudePluginsDir(), "known_marketplaces.json"),
+  );
+  const entry = marketplaces[CLAUDE_PLUGIN_MARKETPLACE];
+  if (isPlainObject(entry) && typeof entry.installLocation === "string" && entry.installLocation) {
+    return entry.installLocation;
+  }
+  return path.join(claudePluginsDir(), "marketplaces", CLAUDE_PLUGIN_MARKETPLACE);
+}
+
+function versionOf(document: Record<string, unknown>): string | null {
+  const version = document.version;
+  return typeof version === "string" && VERSION_PATTERN.test(version) ? version : null;
+}
+
+/**
+ * Whether a check inside the last day already answered this. Bounded at both
+ * ends for the same reason the install suppression is: a stamp in the future is
+ * a clock that went backwards or a config copied from another machine, and
+ * reading it as recent would suppress every check until time caught up.
+ */
+function checkedRecently(): boolean {
+  try {
+    const checkedAt = loadConfig().claude_plugin_last_update_check;
+    if (typeof checkedAt !== "number") return false;
+    const sinceCheck = Date.now() - checkedAt * 1000;
+    return sinceCheck >= 0 && sinceCheck < UPDATE_CHECK_INTERVAL_MS;
+  } catch {
+    // A config we cannot read is a check we have no record of.
+    return false;
+  }
+}
+
+/** Best-effort: a stamp that does not land only costs an extra check. */
+function stampUpdateCheck(): void {
+  try {
+    const cfg = loadConfig();
+    cfg.claude_plugin_last_update_check = Math.floor(Date.now() / 1000);
+    saveConfig(cfg);
+  } catch {
+    // The check still ran; only its suppression window went unwritten.
   }
 }
 

--- a/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
+++ b/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
@@ -232,15 +232,26 @@ function hasInstallRecord(document: Record<string, unknown>): boolean {
  * `langwatch`, and removing theirs on our logout would be taking something that
  * is not ours.
  *
- * Read liberally, because Claude Code records a source several ways: github
- * shorthand (`{ source: "github", repo: "langwatch/agent-plugin" }`), a git URL,
- * or a local path. Any of them naming the repository is ours. The boundaries
- * matter, though: `evil-langwatch/agent-plugin` and `langwatch/agent-plugin-fork`
- * both contain the name and belong to somebody else.
+ * Claude Code records a source several ways: github shorthand
+ * (`{ source: "github", repo: "langwatch/agent-plugin" }`), a git URL, or a
+ * local path. Only an exact, canonical GitHub identity counts. Everything else
+ * belongs to whoever registered it, including the near misses built to read
+ * like us: `evil-langwatch/agent-plugin`, `langwatch/agent-plugin-fork`,
+ * `github.com/langwatch/agent-plugin.evil`, and any host that is not GitHub.
  */
-const OWNED_REPO_PATTERN = new RegExp(
-  `(?<![\\w-])${CLAUDE_PLUGIN_MARKETPLACE_REPO.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\w-])`,
-);
+/**
+ * The hosts a canonical registration can name. Nothing else qualifies: the
+ * plugin is published to GitHub and only to GitHub, so a source anywhere else
+ * is by definition not the one we publish, whatever it is called.
+ */
+const OWNED_HOSTS = new Set(["github.com", "www.github.com"]);
+
+/**
+ * The protocols git registrations use. A `file:` source is deliberately absent:
+ * a local checkout is somebody's working copy, and it is not something we
+ * should be pulling new code into a user's agent from on a timer.
+ */
+const OWNED_PROTOCOLS = new Set(["https:", "http:", "ssh:", "git:"]);
 
 /**
  * The fields that say WHERE a marketplace comes from, across the shapes Claude
@@ -251,8 +262,52 @@ const OWNED_REPO_PATTERN = new RegExp(
  */
 const SOURCE_IDENTITY_KEYS = ["source", "repo", "url", "path"] as const;
 
+/**
+ * Whether one source field names the repository we publish from, and names it
+ * exactly. Parsed rather than pattern-matched, because the interesting inputs
+ * are the ones built to look right: `github.com/langwatch/agent-plugin.evil`,
+ * `evil.example/?repo=langwatch/agent-plugin` and a local directory that
+ * happens to sit at that path all contain our repository name and none of them
+ * are us.
+ *
+ * The stakes are what make exactness worth the parser. This gate decides both
+ * what logout may deregister and, now, what a wrapped run may pull new code
+ * into the user's agent from without asking.
+ */
 function pointsAtOwnedRepo(value: unknown): boolean {
-  return typeof value === "string" && OWNED_REPO_PATTERN.test(value.toLowerCase());
+  if (typeof value !== "string") return false;
+  const raw = value.trim();
+  if (raw === "") return false;
+  const lowered = raw.toLowerCase();
+
+  // The shorthand `claude plugin marketplace add` takes, which is how the CLI
+  // registers it and therefore the case that matters most.
+  if (lowered === CLAUDE_PLUGIN_MARKETPLACE_REPO) return true;
+
+  const scp = /^git@([^:]+):(.+)$/.exec(lowered);
+  if (scp) {
+    return (
+      OWNED_HOSTS.has(scp[1]!) && stripRepoPath(scp[2]!) === CLAUDE_PLUGIN_MARKETPLACE_REPO
+    );
+  }
+
+  try {
+    const url = new URL(raw);
+    if (!OWNED_PROTOCOLS.has(url.protocol)) return false;
+    if (!OWNED_HOSTS.has(url.hostname.toLowerCase())) return false;
+    // A query or a fragment means the path is not the whole address, and we do
+    // not know what the rest of it does.
+    if (url.search !== "" || url.hash !== "") return false;
+    return stripRepoPath(url.pathname.toLowerCase()) === CLAUDE_PLUGIN_MARKETPLACE_REPO;
+  } catch {
+    // Not a URL. A bare path is a local checkout, which is never ours.
+    return false;
+  }
+}
+
+/** `/langwatch/agent-plugin.git/` and friends down to `langwatch/agent-plugin`. */
+function stripRepoPath(value: string): string {
+  return value.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/, "");
 }
 
 function sourcePointsAtLangwatch(source: unknown): boolean {
@@ -399,7 +454,6 @@ export function updateLangwatchClaudePlugin({
     const ineligible = updateEligibility();
     if (ineligible) return ineligible;
 
-    stampUpdateCheck();
     onCheckStart?.();
 
     // The listing on disk is a clone, and it is as old as the last time
@@ -460,29 +514,32 @@ export function updateLangwatchClaudePlugin({
  * the same thing.
  */
 function updateEligibility(): ClaudePluginUpdateResult | null {
-  const state = readClaudePluginState();
-  if (!state.pluginInstalled) return { action: "absent" };
+  // The user scope is the one this CLI installs into and the only one it may
+  // move: a project or local record is a pin somebody chose for a checkout.
+  // Reading it here rather than `pluginInstalled` keeps a project-only machine
+  // from spending a probe and a fetch every day to reach the same conclusion.
+  if (!readUserScopeInstall()) return { action: "absent" };
 
-  const stamp = readCheckStamp();
-  // A config that cannot be read is a stamp that cannot be written, and a
-  // check that cannot be recorded would repeat on every single launch forever.
-  // Unreadable therefore reads as "checked", not as "never checked".
-  if (!stamp.readable) {
-    return { action: "unavailable", reason: "the CLI config could not be read" };
+  if (checkedRecently(lastCheckedAt())) return { action: "checked_recently" };
+
+  // Record the check BEFORE running it, and give up when that cannot be done.
+  // A stamp that does not land is a check with no memory, and a check with no
+  // memory runs on every launch for as long as the machine stays that way. It
+  // also means a fetch that hangs to its timeout, or a Ctrl-C in the middle of
+  // one, costs the next launch nothing.
+  if (!stampUpdateCheck()) {
+    return { action: "unavailable", reason: "the check could not be recorded" };
   }
-  if (checkedRecently(stamp.at)) return { action: "checked_recently" };
 
   // A marketplace of our name that points somewhere else is somebody else's
   // registration, and updating what it serves is not ours to do.
-  if (!state.marketplaceOwnedByLangwatch) {
-    stampUpdateCheck();
+  if (!readClaudePluginState().marketplaceOwnedByLangwatch) {
     return {
       action: "unavailable",
       reason: "the langwatch marketplace on this machine is not ours",
     };
   }
   if (!claudePluginCliAvailable()) {
-    stampUpdateCheck();
     return { action: "unavailable", reason: "this claude has no plugin subcommand" };
   }
   return null;
@@ -520,12 +577,12 @@ function applyUpdate({
 }
 
 /**
- * The version of the user-scope install record, which is the one this CLI put
- * there. A project or local record belongs to a checkout somebody else pinned
- * and is not ours to move, so a machine carrying only those reads as unknown
- * and is left alone.
+ * The install record this CLI put there, or null when the machine has none.
+ * Only the user scope qualifies: a project or local record belongs to a
+ * checkout somebody else pinned, and moving it would be taking that decision
+ * off them.
  */
-function readInstalledPluginVersion(): string | null {
+function readUserScopeInstall(): Record<string, unknown> | null {
   const document = readJsonObject(
     path.join(claudePluginsDir(), "installed_plugins.json"),
   );
@@ -535,7 +592,13 @@ function readInstalledPluginVersion(): string | null {
   const userScoped = records.find(
     (record) => isPlainObject(record) && record.scope === "user",
   );
-  return isPlainObject(userScoped) ? versionOf(userScoped) : null;
+  return isPlainObject(userScoped) ? userScoped : null;
+}
+
+/** The version of that record, when it carries one we can reason about. */
+function readInstalledPluginVersion(): string | null {
+  const record = readUserScopeInstall();
+  return record ? versionOf(record) : null;
 }
 
 /**
@@ -577,19 +640,16 @@ function versionOf(document: Record<string, unknown>): string | null {
 }
 
 /**
- * When the last check ran, and whether that question could be answered at all.
- * The two are different: a config with no stamp has never been checked, and a
- * config that will not parse cannot record that a check happened either.
+ * When the last check ran, as far as the config knows. A config we cannot read
+ * answers "never", which is safe here because the write that follows reads it
+ * too and stops the run when it cannot.
  */
-function readCheckStamp(): { readable: boolean; at?: number } {
+function lastCheckedAt(): number | undefined {
   try {
     const checkedAt = loadConfig().claude_plugin_last_update_check;
-    return {
-      readable: true,
-      at: typeof checkedAt === "number" ? checkedAt : undefined,
-    };
+    return typeof checkedAt === "number" ? checkedAt : undefined;
   } catch {
-    return { readable: false };
+    return undefined;
   }
 }
 
@@ -605,14 +665,20 @@ function checkedRecently(checkedAt: number | undefined): boolean {
   return sinceCheck >= 0 && sinceCheck < UPDATE_CHECK_INTERVAL_MS;
 }
 
-/** Best-effort: a stamp that does not land only costs an extra check. */
-function stampUpdateCheck(): void {
+/**
+ * Record that the check is happening. Reports whether it landed, because the
+ * caller uses that to decide whether to check at all: this is the one thing
+ * here that is not best-effort.
+ */
+function stampUpdateCheck(): boolean {
   try {
     const cfg = loadConfig();
     cfg.claude_plugin_last_update_check = Math.floor(Date.now() / 1000);
     saveConfig(cfg);
-  } catch {
-    // The check still ran; only its suppression window went unwritten.
+    return true;
+  } catch (err) {
+    debugLog(`the update check could not be recorded: ${(err as Error).message}`);
+    return false;
   }
 }
 

--- a/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
+++ b/sdks/typescript/src/cli/utils/governance/claude-plugin.ts
@@ -99,11 +99,14 @@ const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Refreshing the listing and applying an update are each a fetch of a small
- * repository. Well clear of a slow network, and far below the install timeout,
- * because unlike an install this can happen on a run the user never asked to
- * involve Claude Code at all.
+ * repository, so this is generous for the work and deliberately far below the
+ * install timeout. Both can run on the way into a launch the user never asked
+ * to involve Claude Code in, and they run back to back, so the number that
+ * matters is the two of them plus the probe: a wrapped run waits at most a
+ * bit over a minute on a network that has stopped answering, having said so
+ * first, rather than the two minutes a matching install timeout would cost.
  */
-const UPDATE_TIMEOUT_MS = 60_000;
+const UPDATE_TIMEOUT_MS = 30_000;
 
 /**
  * A version we are willing to reason about. Anything else (absent, a git sha, a
@@ -381,27 +384,23 @@ export interface ClaudePluginUpdateResult {
  * its retry, which is the right trade for housekeeping: the plugin that is
  * installed keeps working, it is only a version behind.
  */
-export function updateLangwatchClaudePlugin(): ClaudePluginUpdateResult {
+export function updateLangwatchClaudePlugin({
+  onCheckStart,
+}: {
+  /**
+   * Called once, immediately before the first subprocess, and not at all on
+   * the runs that answer from disk. The work behind it is a network fetch on
+   * somebody's way into a coding session, so the caller gets the chance to say
+   * what the pause is for rather than leaving a silent terminal.
+   */
+  onCheckStart?: () => void;
+} = {}): ClaudePluginUpdateResult {
   try {
-    const state = readClaudePluginState();
-    if (!state.pluginInstalled) return { action: "absent" };
-    if (checkedRecently()) return { action: "checked_recently" };
-
-    // A marketplace of our name that points somewhere else is somebody else's
-    // registration, and updating what it serves is not ours to do.
-    if (!state.marketplaceOwnedByLangwatch) {
-      stampUpdateCheck();
-      return {
-        action: "unavailable",
-        reason: "the langwatch marketplace on this machine is not ours",
-      };
-    }
-    if (!claudePluginCliAvailable()) {
-      stampUpdateCheck();
-      return { action: "unavailable", reason: "this claude has no plugin subcommand" };
-    }
+    const ineligible = updateEligibility();
+    if (ineligible) return ineligible;
 
     stampUpdateCheck();
+    onCheckStart?.();
 
     // The listing on disk is a clone, and it is as old as the last time
     // something refreshed it. Refresh first so the version we compare against
@@ -435,7 +434,7 @@ export function updateLangwatchClaudePlugin(): ClaudePluginUpdateResult {
     // Equal is the common case. Ahead of the listing happens on a machine that
     // installed from a local checkout, and dragging that backwards to what we
     // published would undo somebody's testing.
-    if (compareVersions(installed, published) >= 0) {
+    if (compareVersions({ version: installed, against: published }) >= 0) {
       // A refresh that failed leaves this unproven: the listing we just
       // compared against is whatever was already on disk, which may be older
       // than the release we are trying to deliver.
@@ -444,26 +443,80 @@ export function updateLangwatchClaudePlugin(): ClaudePluginUpdateResult {
         : { action: "up_to_date", from: installed };
     }
 
-    const update = runClaude({
-      args: ["plugin", "update", CLAUDE_PLUGIN_REF, "--scope", "user"],
-      timeoutMs: UPDATE_TIMEOUT_MS,
-    });
-    // What is on disk afterwards decides, not the exit status: a non-zero exit
-    // that still moved the version did the job, and a zero exit that moved
-    // nothing did not.
-    const after = readInstalledPluginVersion();
-    if (!after || compareVersions(after, installed) <= 0) {
-      return {
-        action: "failed",
-        from: installed,
-        to: published,
-        reason: `the update to ${published} could not be applied: ${update.detail}`,
-      };
-    }
-    return { action: "updated", from: installed, to: after };
+    return applyUpdate({ installed, published });
   } catch (err) {
     return { action: "failed", reason: (err as Error).message };
   }
+}
+
+/**
+ * Why this run should not go looking, or null when it should. Everything here
+ * answers from disk, which is what keeps the runs that have nothing to do from
+ * costing a subprocess.
+ *
+ * The paths that DID reach a conclusion about this machine stamp the check on
+ * their way out. A `claude` that cannot manage plugins will not learn to before
+ * tomorrow, and asking it again on every launch spends a subprocess to be told
+ * the same thing.
+ */
+function updateEligibility(): ClaudePluginUpdateResult | null {
+  const state = readClaudePluginState();
+  if (!state.pluginInstalled) return { action: "absent" };
+
+  const stamp = readCheckStamp();
+  // A config that cannot be read is a stamp that cannot be written, and a
+  // check that cannot be recorded would repeat on every single launch forever.
+  // Unreadable therefore reads as "checked", not as "never checked".
+  if (!stamp.readable) {
+    return { action: "unavailable", reason: "the CLI config could not be read" };
+  }
+  if (checkedRecently(stamp.at)) return { action: "checked_recently" };
+
+  // A marketplace of our name that points somewhere else is somebody else's
+  // registration, and updating what it serves is not ours to do.
+  if (!state.marketplaceOwnedByLangwatch) {
+    stampUpdateCheck();
+    return {
+      action: "unavailable",
+      reason: "the langwatch marketplace on this machine is not ours",
+    };
+  }
+  if (!claudePluginCliAvailable()) {
+    stampUpdateCheck();
+    return { action: "unavailable", reason: "this claude has no plugin subcommand" };
+  }
+  return null;
+}
+
+/**
+ * Move the installed copy to what the listing publishes, and report on what is
+ * on disk afterwards rather than on the exit status: a non-zero exit that still
+ * moved the version did the job, and a zero exit that moved nothing did not.
+ *
+ * A failure carries no `to`, because nothing was installed. The version it was
+ * reaching for is in the reason, where it reads as an intention rather than as
+ * a version the machine has.
+ */
+function applyUpdate({
+  installed,
+  published,
+}: {
+  installed: string;
+  published: string;
+}): ClaudePluginUpdateResult {
+  const update = runClaude({
+    args: ["plugin", "update", CLAUDE_PLUGIN_REF, "--scope", "user"],
+    timeoutMs: UPDATE_TIMEOUT_MS,
+  });
+  const after = readInstalledPluginVersion();
+  if (!after || compareVersions({ version: after, against: installed }) <= 0) {
+    return {
+      action: "failed",
+      from: installed,
+      reason: `the update to ${published} could not be applied: ${update.detail}`,
+    };
+  }
+  return { action: "updated", from: installed, to: after };
 }
 
 /**
@@ -524,21 +577,32 @@ function versionOf(document: Record<string, unknown>): string | null {
 }
 
 /**
+ * When the last check ran, and whether that question could be answered at all.
+ * The two are different: a config with no stamp has never been checked, and a
+ * config that will not parse cannot record that a check happened either.
+ */
+function readCheckStamp(): { readable: boolean; at?: number } {
+  try {
+    const checkedAt = loadConfig().claude_plugin_last_update_check;
+    return {
+      readable: true,
+      at: typeof checkedAt === "number" ? checkedAt : undefined,
+    };
+  } catch {
+    return { readable: false };
+  }
+}
+
+/**
  * Whether a check inside the last day already answered this. Bounded at both
  * ends for the same reason the install suppression is: a stamp in the future is
  * a clock that went backwards or a config copied from another machine, and
  * reading it as recent would suppress every check until time caught up.
  */
-function checkedRecently(): boolean {
-  try {
-    const checkedAt = loadConfig().claude_plugin_last_update_check;
-    if (typeof checkedAt !== "number") return false;
-    const sinceCheck = Date.now() - checkedAt * 1000;
-    return sinceCheck >= 0 && sinceCheck < UPDATE_CHECK_INTERVAL_MS;
-  } catch {
-    // A config we cannot read is a check we have no record of.
-    return false;
-  }
+function checkedRecently(checkedAt: number | undefined): boolean {
+  if (checkedAt === undefined) return false;
+  const sinceCheck = Date.now() - checkedAt * 1000;
+  return sinceCheck >= 0 && sinceCheck < UPDATE_CHECK_INTERVAL_MS;
 }
 
 /** Best-effort: a stamp that does not land only costs an extra check. */

--- a/sdks/typescript/src/cli/utils/governance/config.ts
+++ b/sdks/typescript/src/cli/utils/governance/config.ts
@@ -93,6 +93,17 @@ export interface GovernanceConfig {
   claude_plugin_last_failure?: number;
 
   /**
+   * Unix epoch (seconds) of the last time a wrapped run checked whether the
+   * installed LangWatch Claude Code plugin is still the published version.
+   * Claude Code leaves auto-update off for third-party marketplaces, so the
+   * wrapper does the checking, and it holds the check to once a day: every run
+   * in between reads this field and stops, which is what keeps a launch from
+   * paying for a repository fetch it almost never needs. Stamped whether the
+   * check found an update or not. Absent = never checked.
+   */
+  claude_plugin_last_update_check?: number;
+
+  /**
    * Per-wrapped-tool routing mode answer.
    *
    *   "gateway"   — Path A: route the tool's HTTP calls through

--- a/sdks/typescript/src/cli/utils/governance/copilot-prespawn.ts
+++ b/sdks/typescript/src/cli/utils/governance/copilot-prespawn.ts
@@ -33,6 +33,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { compareVersions } from "../compare-versions";
 import { lwTag } from "./brand";
 
 /** First copilot version whose OTel attribute set matches the extractor. */
@@ -122,17 +123,6 @@ export function parseCopilotVersion(raw: string | null): string | null {
   if (!raw) return null;
   const match = /(\d+)\.(\d+)\.(\d+)/.exec(raw);
   return match ? match[0] : null;
-}
-
-/** Simple semver-triple comparison: negative when a < b. */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
-    if (d !== 0) return d;
-  }
-  return 0;
 }
 
 /** Run `copilot --version` (2s cap). Null on any failure — never block. */

--- a/sdks/typescript/src/cli/utils/governance/copilot-prespawn.ts
+++ b/sdks/typescript/src/cli/utils/governance/copilot-prespawn.ts
@@ -163,7 +163,10 @@ export function copilotPrespawnWarnings(
   }
 
   const version = (opts.readVersionImpl ?? readInstalledVersion)();
-  if (version && compareVersions(version, COPILOT_MIN_OTEL_VERSION) < 0) {
+  if (
+    version &&
+    compareVersions({ version, against: COPILOT_MIN_OTEL_VERSION }) < 0
+  ) {
     warnings.push(
       `${lwTag()} copilot ${version} exports incomplete telemetry attributes; upgrade to ${COPILOT_MIN_OTEL_VERSION}+ (\`copilot update\`) for full capture.`,
     );

--- a/sdks/typescript/src/cli/utils/governance/telemetry-targets.ts
+++ b/sdks/typescript/src/cli/utils/governance/telemetry-targets.ts
@@ -107,7 +107,19 @@ const SHELLS: DetectedShell[] = ["zsh", "bash", "fish"];
  * Enumerate every telemetry-persist target with a present flag and a
  * remover. Callers filter to `present` targets for display + removal.
  */
-export function scanTelemetryTargets(): TelemetryTarget[] {
+export function scanTelemetryTargets({
+  cwd = process.cwd(),
+}: {
+  /**
+   * The directory whose project pin counts as "this directory". Defaults to
+   * the process's own, which is what logout means by it. Passed explicitly by
+   * the tests, so a suite that scans and REMOVES project pins cannot reach the
+   * checkout it is running inside: `remove()` here deletes real files, and a
+   * developer who had run `langwatch claude` in that directory would find the
+   * pin gone after a test run.
+   */
+  cwd?: string;
+} = {}): TelemetryTarget[] {
 	const targets: TelemetryTarget[] = [];
 
 	// claude — OTEL keys inside ~/.claude/settings.json's `env` object.
@@ -177,7 +189,6 @@ export function scanTelemetryTargets(): TelemetryTarget[] {
 	// requirement as the global target above: `remove()` already gates on
 	// it (removeClaudeProjectTelemetryPin), so `present` must match or the
 	// confirm list would offer a target whose removal silently no-ops.
-	const cwd = process.cwd();
 	const claudePin = claudeProjectSettingsTarget(cwd);
 	targets.push({
 		label: `claude project telemetry pin (${claudePin.displayPath} in this directory)`,

--- a/sdks/typescript/src/cli/utils/governance/wrapper.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper.ts
@@ -22,6 +22,7 @@ import { getCliBootstrap } from "./cli-api";
 import { createCodexIOStreamer } from "./codex-rollout-otlp";
 import type { GovernanceConfig } from "./config";
 import { isLoggedIn, loadConfig, saveConfig } from "./config";
+import { updateLangwatchClaudePlugin } from "./claude-plugin";
 import {
 	copilotGatewayModelPreflight,
 	copilotPrespawnWarnings,
@@ -564,6 +565,26 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 			tool,
 			vars: modeResult.vars,
 		});
+	}
+
+	// Keep the installed plugin current, whichever tool this run wraps. The
+	// plugin is installed once per machine, not once per tool, so tying its
+	// upkeep to `langwatch claude` would leave it to rot on a machine whose
+	// owner mostly wraps something else. It is stamped to once a day, so nearly
+	// every run reads one config field and moves on, and it runs BEFORE the
+	// spawn so a new version reaches the session this launch is about to start
+	// rather than the one after it. Housekeeping, so it warns and continues.
+	const pluginUpdate = updateLangwatchClaudePlugin();
+	if (pluginUpdate.action === "updated") {
+		process.stderr.write(
+			`${lwTag()} updated the LangWatch plugin for Claude Code, ` +
+				`${pluginUpdate.from} to ${pluginUpdate.to}.\n`,
+		);
+	} else if (pluginUpdate.action === "failed") {
+		process.stderr.write(
+			`${lwTag()} couldn't update the LangWatch plugin for Claude Code ` +
+				`(best-effort, continuing): ${pluginUpdate.reason}\n`,
+		);
 	}
 
 	// Scrub conflicting twins from the inherited parent env BEFORE merging

--- a/sdks/typescript/src/cli/utils/governance/wrapper.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper.ts
@@ -574,7 +574,16 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 	// every run reads one config field and moves on, and it runs BEFORE the
 	// spawn so a new version reaches the session this launch is about to start
 	// rather than the one after it. Housekeeping, so it warns and continues.
-	const pluginUpdate = updateLangwatchClaudePlugin();
+	const pluginUpdate = updateLangwatchClaudePlugin({
+		// Said before the work, not after it: the check fetches from a network
+		// that may be slow or half-open, and a launch that pauses without
+		// explanation reads as the wrapper having hung.
+		onCheckStart: () =>
+			process.stderr.write(
+				`${lwTag()} checking whether the LangWatch plugin for Claude Code ` +
+					`is up to date (once a day).\n`,
+			),
+	});
 	if (pluginUpdate.action === "updated") {
 		process.stderr.write(
 			`${lwTag()} updated the LangWatch plugin for Claude Code, ` +

--- a/specs/ai-governance/cli-wrappers/claude-plugin-install.feature
+++ b/specs/ai-governance/cli-wrappers/claude-plugin-install.feature
@@ -203,3 +203,9 @@ Rule: Plugin state is read defensively
     Given a marketplace of the same name published by somebody else, mentioning our repository in its notes
     When the plugin state is read
     Then the marketplace is not claimed as ours
+
+  @unit
+  Scenario: A source built to read like ours is not ours
+    Given a marketplace of the same name whose address is built to look like our repository
+    When the plugin state is read
+    Then the marketplace is not claimed as ours

--- a/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
+++ b/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
@@ -1,0 +1,120 @@
+# Keeping the installed LangWatch plugin current
+#
+# Implementation:
+#   sdks/typescript/src/cli/utils/governance/claude-plugin.ts   (the version check and the update)
+#   sdks/typescript/src/cli/utils/governance/wrapper.ts         (the wrapped-run seam that calls it)
+#   sdks/typescript/src/cli/utils/compare-versions.ts           (the version comparison)
+#
+# Related specs:
+#   specs/ai-governance/cli-wrappers/claude-plugin-install.feature , how the plugin gets there
+#   specs/ai-governance/cli-wrappers/session-context-hook.feature , what its hooks report
+#
+# Motivation: the plugin carries the hook script, so the code that records a
+# session's repository and branch now ships inside a versioned artifact rather
+# than resolving against whatever `langwatch` is on PATH. That solves the drift
+# it was built to solve only while the installed copy keeps up with what we
+# publish, and Claude Code will not do that on its own: it auto-updates its own
+# marketplaces by default and leaves third-party ones like ours switched off, so
+# a plugin installed once stays at that version forever unless somebody finds
+# the toggle.
+#
+# The wrapper is the natural place to fix that. It already runs before every
+# `langwatch <tool>` launch, it already re-syncs the telemetry wiring there, and
+# an update applied before the spawn is picked up by the session about to start
+# rather than the one after it.
+#
+# Two properties this must keep. It cannot become a tax on startup, so the check
+# is stamped and runs at most once a day; every run in between reads one config
+# field and stops. And it cannot fail a launch, because a coding session the
+# user asked for must not depend on our housekeeping: a `claude` that cannot be
+# reached, a marketplace that will not refresh and an update that will not apply
+# all warn and get out of the way.
+
+Feature: Keeping the LangWatch Claude Code plugin up to date
+
+Rule: A wrapped run brings the installed plugin up to the published version
+
+  @unit
+  Scenario: A plugin the marketplace has moved past is updated before the tool starts
+    Given the LangWatch plugin is installed at an older version than the marketplace publishes
+    When the user runs a wrapped tool
+    Then the marketplace listing is refreshed
+    And the plugin is updated
+    And the user is told which version it moved to
+
+  @unit
+  Scenario: A plugin already at the published version is left alone
+    Given the LangWatch plugin is installed at the version the marketplace publishes
+    When the user runs a wrapped tool
+    Then the plugin is not updated
+    And nothing is reported to the user
+
+  @unit
+  Scenario: The plugin is kept current from a machine that wraps another tool
+    Given the LangWatch plugin is installed at an older version than the marketplace publishes
+    And a machine whose only wrapped tool is codex
+    When the user runs a wrapped tool
+    Then the plugin is updated
+
+  @unit
+  Scenario: A marketplace of our name that somebody else registered is left alone
+    Given a marketplace named langwatch that points at another repository
+    And the LangWatch plugin is installed
+    When the user runs a wrapped tool
+    Then the plugin is not updated
+
+Rule: A check that has nothing to do costs nothing
+
+  @unit
+  Scenario: A machine without the plugin is not asked about it
+    Given the LangWatch plugin is not installed
+    When the user runs a wrapped tool
+    Then no claude subprocess runs
+
+  @unit
+  Scenario: A plugin checked today is not checked again
+    Given the plugin was checked for updates an hour ago
+    When the user runs a wrapped tool
+    Then no claude subprocess runs
+
+  @unit
+  Scenario: A day after the last check the plugin is checked again
+    Given the plugin was checked for updates two days ago
+    When the user runs a wrapped tool
+    Then the marketplace listing is refreshed
+
+  @unit
+  Scenario: A check stamped in the future does not suppress the next one
+    Given the plugin was checked for updates at a time in the future
+    When the user runs a wrapped tool
+    Then the marketplace listing is refreshed
+
+  @unit
+  Scenario: A claude that cannot manage plugins is left alone
+    Given a claude binary with no plugin subcommand
+    And the LangWatch plugin is installed at an older version than the marketplace publishes
+    Then the plugin is not updated
+
+Rule: Nothing here may stop the session the user asked for
+
+  @unit
+  Scenario: A marketplace listing that will not refresh warns and gives up for the day
+    Given a claude binary whose marketplace update reports failure
+    And the LangWatch plugin is installed at the version its stale listing publishes
+    When the user runs a wrapped tool
+    Then the user is warned that the plugin could not be checked
+    And the check is not attempted again until tomorrow
+
+  @unit
+  Scenario: An update that will not apply warns
+    Given the LangWatch plugin is installed at an older version than the marketplace publishes
+    And a claude binary whose plugin update reports failure
+    When the user runs a wrapped tool
+    Then the user is warned that the plugin could not be updated
+
+  @unit
+  Scenario: A version that cannot be read is left alone rather than blindly updated
+    Given a marketplace listing whose plugin manifest cannot be read
+    And the LangWatch plugin is installed
+    When the user runs a wrapped tool
+    Then the plugin is not updated

--- a/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
+++ b/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
@@ -93,9 +93,29 @@ Rule: A check that has nothing to do costs nothing
   Scenario: A claude that cannot manage plugins is left alone
     Given a claude binary with no plugin subcommand
     And the LangWatch plugin is installed at an older version than the marketplace publishes
+    When the user runs a wrapped tool
     Then the plugin is not updated
 
+  @unit
+  Scenario: A config that cannot be read stops the check rather than repeating it
+    Given a CLI config file that cannot be parsed
+    And the LangWatch plugin is installed
+    When the user runs a wrapped tool
+    Then no claude subprocess runs
+
 Rule: Nothing here may stop the session the user asked for
+
+  @unit
+  Scenario: A run that waits on the network says what it is waiting for
+    Given the LangWatch plugin is installed at an older version than the marketplace publishes
+    When the user runs a wrapped tool
+    Then the user is told the check is running before it reaches the network
+
+  @unit
+  Scenario: A run that answers from disk says nothing at all
+    Given the plugin was checked for updates an hour ago
+    When the user runs a wrapped tool
+    Then the user is told nothing about the check
 
   @unit
   Scenario: A marketplace listing that will not refresh warns and gives up for the day

--- a/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
+++ b/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
@@ -140,3 +140,11 @@ Rule: Nothing here may cost the user the session they asked for
     And the LangWatch plugin is installed
     When the user runs a wrapped tool
     Then the plugin on the machine is left as it is
+
+  @unit
+  Scenario: A marketplace whose address only looks like ours is never updated from
+    Given a marketplace named langwatch whose address is built to look like our repository
+    And the LangWatch plugin is installed at an older version than that marketplace publishes
+    When the user runs a wrapped tool
+    Then the plugin on the machine is left as it is
+    And the user is told nothing about the plugin

--- a/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
+++ b/specs/ai-governance/cli-wrappers/claude-plugin-update.feature
@@ -23,99 +23,93 @@
 # an update applied before the spawn is picked up by the session about to start
 # rather than the one after it.
 #
-# Two properties this must keep. It cannot become a tax on startup, so the check
-# is stamped and runs at most once a day; every run in between reads one config
-# field and stops. And it cannot fail a launch, because a coding session the
-# user asked for must not depend on our housekeeping: a `claude` that cannot be
-# reached, a marketplace that will not refresh and an update that will not apply
-# all warn and get out of the way.
+# Two properties this must keep. It cannot become a tax on startup, so it looks
+# at most once a day and every launch in between starts the tool immediately.
+# And it cannot cost anyone the session they asked for, so every way it can go
+# wrong ends with the tool starting anyway.
 
 Feature: Keeping the LangWatch Claude Code plugin up to date
 
 Rule: A wrapped run brings the installed plugin up to the published version
 
   @unit
-  Scenario: A plugin the marketplace has moved past is updated before the tool starts
+  Scenario: A plugin the marketplace has moved past is brought up to date
     Given the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then the marketplace listing is refreshed
-    And the plugin is updated
+    Then the plugin on the machine is the version the marketplace publishes
     And the user is told which version it moved to
 
   @unit
   Scenario: A plugin already at the published version is left alone
     Given the LangWatch plugin is installed at the version the marketplace publishes
     When the user runs a wrapped tool
-    Then the plugin is not updated
-    And nothing is reported to the user
+    Then the plugin on the machine is left as it is
+    And the user is told nothing about the plugin
 
   @unit
   Scenario: The plugin is kept current from a machine that wraps another tool
     Given the LangWatch plugin is installed at an older version than the marketplace publishes
     And a machine whose only wrapped tool is codex
     When the user runs a wrapped tool
-    Then the plugin is updated
+    Then the plugin on the machine is the version the marketplace publishes
+
+Rule: A launch with nothing to keep current starts the tool immediately
 
   @unit
-  Scenario: A marketplace of our name that somebody else registered is left alone
-    Given a marketplace named langwatch that points at another repository
-    And the LangWatch plugin is installed
-    When the user runs a wrapped tool
-    Then the plugin is not updated
-
-Rule: A check that has nothing to do costs nothing
-
-  @unit
-  Scenario: A machine without the plugin is not asked about it
+  Scenario: A machine without the plugin is not held up by it
     Given the LangWatch plugin is not installed
     When the user runs a wrapped tool
-    Then no claude subprocess runs
+    Then the tool starts without looking for a plugin update
 
   @unit
-  Scenario: A plugin checked today is not checked again
+  Scenario: A plugin somebody installed for one repository only is not touched
+    Given the LangWatch plugin is installed for a single repository rather than for the user
+    When the user runs a wrapped tool
+    Then the tool starts without looking for a plugin update
+
+  @unit
+  Scenario: A plugin looked at today is not looked at again
     Given the plugin was checked for updates an hour ago
     When the user runs a wrapped tool
-    Then no claude subprocess runs
+    Then the tool starts without looking for a plugin update
+    And the user is told nothing about the plugin
 
   @unit
-  Scenario: A day after the last check the plugin is checked again
+  Scenario: A day after the last check the plugin is looked at again
     Given the plugin was checked for updates two days ago
+    And the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then the marketplace listing is refreshed
+    Then the plugin on the machine is the version the marketplace publishes
 
   @unit
   Scenario: A check stamped in the future does not suppress the next one
     Given the plugin was checked for updates at a time in the future
-    When the user runs a wrapped tool
-    Then the marketplace listing is refreshed
-
-  @unit
-  Scenario: A claude that cannot manage plugins is left alone
-    Given a claude binary with no plugin subcommand
     And the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then the plugin is not updated
+    Then the plugin on the machine is the version the marketplace publishes
 
   @unit
-  Scenario: A config that cannot be read stops the check rather than repeating it
-    Given a CLI config file that cannot be parsed
-    And the LangWatch plugin is installed
+  Scenario: A machine that cannot remember the check does not repeat it every launch
+    Given a machine whose LangWatch settings cannot be saved
+    And the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then no claude subprocess runs
+    Then the tool starts without looking for a plugin update
 
-Rule: Nothing here may stop the session the user asked for
+Rule: Nothing here may cost the user the session they asked for
 
   @unit
   Scenario: A run that waits on the network says what it is waiting for
     Given the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then the user is told the check is running before it reaches the network
+    Then the user is told the plugin is being checked before the waiting starts
 
   @unit
-  Scenario: A run that answers from disk says nothing at all
-    Given the plugin was checked for updates an hour ago
+  Scenario: A claude that cannot manage plugins leaves the plugin as it is
+    Given a claude binary with no plugin subcommand
+    And the LangWatch plugin is installed at an older version than the marketplace publishes
     When the user runs a wrapped tool
-    Then the user is told nothing about the check
+    Then the plugin on the machine is left as it is
+    And the tool starts
 
   @unit
   Scenario: A marketplace listing that will not refresh warns and gives up for the day
@@ -123,7 +117,7 @@ Rule: Nothing here may stop the session the user asked for
     And the LangWatch plugin is installed at the version its stale listing publishes
     When the user runs a wrapped tool
     Then the user is warned that the plugin could not be checked
-    And the check is not attempted again until tomorrow
+    And the plugin is not checked again until tomorrow
 
   @unit
   Scenario: An update that will not apply warns
@@ -131,10 +125,18 @@ Rule: Nothing here may stop the session the user asked for
     And a claude binary whose plugin update reports failure
     When the user runs a wrapped tool
     Then the user is warned that the plugin could not be updated
+    And the user is not told a version they do not have
 
   @unit
-  Scenario: A version that cannot be read is left alone rather than blindly updated
-    Given a marketplace listing whose plugin manifest cannot be read
+  Scenario: A version that cannot be read leaves the plugin alone rather than replacing it blindly
+    Given a marketplace listing that does not say which version it publishes
     And the LangWatch plugin is installed
     When the user runs a wrapped tool
-    Then the plugin is not updated
+    Then the plugin on the machine is left as it is
+
+  @unit
+  Scenario: A marketplace of our name that somebody else registered is left alone
+    Given a marketplace named langwatch that points at another repository
+    And the LangWatch plugin is installed
+    When the user runs a wrapped tool
+    Then the plugin on the machine is left as it is


### PR DESCRIPTION
Follow-up to #6747. The plugin shipped, but nothing keeps it current on a user's machine.

## Why

Claude Code does have automatic plugin updates, and it enables them by default only for Anthropic's own marketplaces. Third-party ones, which is what `langwatch/agent-plugin` is, are switched off unless the user finds the toggle in `/plugin` or an admin forces it through managed settings.

For a skills-only plugin that would be cosmetic. Ours carries the session context hook, so an un-updated copy is stale capture code, which is the exact drift class that moving the hook off the global CLI and into a versioned plugin was meant to end. Publishing a fix would leave every existing install on the old one indefinitely.

## What this does

Every `langwatch <tool>` run now keeps the installed plugin current:

1. Reads the version in Claude Code's own install record.
2. Refreshes the marketplace listing and reads the version it publishes.
3. Runs `claude plugin update langwatch@langwatch --scope user` when the installed copy is behind.

Three properties worth calling out:

**It is not tied to the claude wrapper.** The plugin is installed once per machine, not once per tool, so a user who mostly runs `langwatch codex` would otherwise never pick up a new hook. The check runs on any wrapped tool and no-ops in microseconds on a machine that has no plugin installed.

**It runs before the spawn.** Claude Code reports "restart required to apply" for a plugin update, and the wrapper is the one place that is about to start a fresh session anyway, so the new version lands in the session this launch creates rather than the one after it.

**It cannot fail a launch.** Requested explicitly, and it is also how the rest of this file already behaves. A `claude` with no plugin subcommand, a listing that will not refresh, an update that will not apply and a manifest that cannot be read each either warn on stderr and continue, or stay quiet when there is no action for the user in it. The one user-visible line on success names the versions.

**It is stamped to once a day.** A launch is not the place to pay for a repository fetch that almost never has anything to deliver, so the check writes `claude_plugin_last_update_check` and every run in between reads one config field and stops. The stamp is written before the network work, so a fetch that hangs to its timeout costs the next launch nothing.

Two smaller decisions in here: the update only manages the **user-scope** record, because a project or local record is a pin somebody else chose; and it refuses to act through a marketplace named `langwatch` whose source is not our repository, the same ownership check logout already uses.

## Verification

Unit tests cover the paths (12 scenarios, all bound). The end-to-end proof used a real `claude` 2.1.226, a real git marketplace and the real built CLI, in an isolated HOME:

| What was exercised | Result |
|---|---|
| `langwatch claude` against a marketplace that published 0.2.0 | `updated the LangWatch plugin for Claude Code, 0.1.0 to 0.2.0`, install record and cache directory both moved |
| A second run the same day | silent, no subprocess spawned |
| `langwatch codex` against a marketplace that published 0.3.0 | updated 0.2.0 to 0.3.0, proving the upkeep is not tied to the claude path |
| An update that exits 0 without moving anything | reported as a failure, warned, and `claude --version` still ran |

That last row was an accident of an early run and worth keeping: the code decides on what is on disk afterwards rather than on the exit status, so an update that claims success and changes nothing is not reported as an update.

Also in here: `compareVersions` moved out of `copilot-prespawn.ts` into `cli/utils/compare-versions.ts` so both callers share one implementation instead of two.

## Follow-up not in this PR

Enabling Claude Code's own per-marketplace auto-update from our install path would let it keep the plugin fresh between wrapped runs too. The docs only describe that field for managed settings, so it needs verifying at user scope before we rely on it. This PR covers the path we control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic daily updates for the LangWatch Claude Code plugin during wrapped tool runs.
  - Updates compare versions, validate marketplace ownership, and apply user-scoped updates when available.
  - Added clear outcomes and notifications for skipped, unavailable, invalid, failed, up-to-date, and successful checks.
  - Update failures no longer prevent wrapped tool execution.

- **Bug Fixes**
  - Improved version comparison and rejected lookalike marketplace repositories.
  - Improved telemetry target scanning in specified project directories.

- **Tests**
  - Added comprehensive coverage for update flows, failures, throttling, version handling, and marketplace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->