### PR TITLE
feat(evaluators): add BDD spec for judge quality analysis (#3945)

### DIFF
--- a/specs/evaluators/judge-quality-analysis.feature
+++ b/specs/evaluators/judge-quality-analysis.feature
@@ -1,0 +1,105 @@
+@unit
+Feature: Judge Quality Analysis
+  As a user of LangWatch who uses LLM-as-judge evaluators
+  I want to measure the reliability of my evaluators against human annotations
+  So that I can know whether to trust my evaluation scores
+
+  Background:
+    Given I have a project with evaluator "Answer Correctness"
+    And at least 10 traces have both a judge score and a human annotation score
+    for evaluator "Answer Correctness"
+
+  # ============================================================================
+  # Access
+  # ============================================================================
+
+  Scenario: Judge Quality tab appears on evaluator detail page
+    Given evaluator "Answer Correctness" has 10 or more annotated traces
+    When I open evaluator "Answer Correctness"
+    Then I see a "Judge Quality" tab alongside the configuration tab
+
+  Scenario: Judge Quality tab is hidden when insufficient annotations exist
+    Given evaluator "Answer Correctness" has fewer than 10 annotated traces
+    When I open evaluator "Answer Correctness"
+    Then I do not see a "Judge Quality" tab
+    And I see a prompt: "Annotate at least 10 traces to unlock judge quality analysis"
+
+  # ============================================================================
+  # Confusion Matrix
+  # ============================================================================
+
+  Scenario: Confusion matrix is displayed
+    When I open the "Judge Quality" tab for evaluator "Answer Correctness"
+    Then I see a 2x2 confusion matrix with cells:
+      | cell           | description                                |
+      | True Positive  | Judge passed, human annotated pass         |
+      | False Positive | Judge passed, human annotated fail         |
+      | False Negative | Judge failed, human annotated pass         |
+      | True Negative  | Judge failed, human annotated fail         |
+    And each cell shows a count of matching traces
+
+  Scenario: Clicking a confusion matrix cell shows matching traces
+    Given the confusion matrix shows 4 False Positives
+    When I click the "False Positive" cell
+    Then I see a list of the 4 traces where the judge passed but human annotated fail
+    And each trace links to its trace detail view
+
+  # ============================================================================
+  # Reliability Metrics
+  # ============================================================================
+
+  Scenario: Reliability metrics are computed from the confusion matrix
+    When I open the "Judge Quality" tab
+    Then I see the following metrics:
+      | metric         | description                                              |
+      | Precision      | TP / (TP + FP) — of judge passes, how many were correct  |
+      | Recall         | TP / (TP + FN) — of actual passes, how many did judge catch |
+      | F1 Score       | Harmonic mean of Precision and Recall                    |
+      | Accuracy       | (TP + TN) / total — overall correct predictions          |
+      | Agreement Rate | % of traces where judge and human reached the same verdict |
+
+  Scenario: Metrics update when new annotations are added
+    Given the Judge Quality tab shows Precision of 0.80
+    When a new annotation is added that contradicts a judge pass
+    Then the Precision value updates to reflect the new annotation
+
+  # ============================================================================
+  # Coverage Indicator
+  # ============================================================================
+
+  Scenario: Coverage indicator shows annotation completeness
+    Given evaluator "Answer Correctness" has scored 200 traces
+    And 25 of those traces have human annotations
+    When I open the "Judge Quality" tab
+    Then I see "25 / 200 traces annotated (12.5% coverage)"
+
+  # ============================================================================
+  # Performance Over Time
+  # ============================================================================
+
+  Scenario: Metrics trend chart is shown when multiple evaluation runs exist
+    Given evaluator "Answer Correctness" has run across 3 different date ranges
+    When I open the "Judge Quality" tab
+    Then I see a timeseries chart showing Precision, Recall, and F1 over time
+    And I can identify whether a recent prompt change improved or degraded reliability
+
+  Scenario: No trend chart when only one evaluation run exists
+    Given evaluator "Answer Correctness" has only one evaluation run
+    When I open the "Judge Quality" tab
+    Then I do not see a timeseries chart
+    And I see a message: "Run more evaluations over time to see performance trends"
+
+  # ============================================================================
+  # Data scoping
+  # ============================================================================
+
+  Scenario: Analysis is scoped to the current project
+    Given I am in project "Project A"
+    And project "Project B" has annotations for the same evaluator slug
+    When I open the "Judge Quality" tab
+    Then I only see annotations from "Project A"
+
+  Scenario: Analysis compares judge score pass/fail against annotation thumbs up/down
+    Given a trace where the judge scored 0.8 with a pass threshold of 0.5
+    And the same trace has a human annotation of thumbs down
+    Then this trace is counted as a False Positive in the confusion matrix

--- a/specs/evaluators/judge-quality-analysis.feature
+++ b/specs/evaluators/judge-quality-analysis.feature
@@ -100,6 +100,7 @@ Feature: Judge Quality Analysis
     And project "Project B" has annotations for the same evaluator
     When I open the "Judge Quality" tab
     Then I only see annotations from "Project A"
+    And Project B data does not affect the confusion matrix counts, coverage, or trend chart
 
   Scenario: Analysis compares judge score pass/fail against annotation thumbs up/down
     Given a trace where the judge classified the result as pass

--- a/specs/evaluators/judge-quality-analysis.feature
+++ b/specs/evaluators/judge-quality-analysis.feature
@@ -79,8 +79,10 @@ Feature: Judge Quality Analysis
 
   Scenario: Metrics trend chart is shown when multiple evaluation runs exist
     Given evaluator "Answer Correctness" has run across 3 different date ranges
+    And some runs used different evaluator versions
     When I open the "Judge Quality" tab
     Then I see a timeseries chart showing Precision, Recall, and F1 over time
+    And each data point is labelled with its evaluator version
     And I can identify whether a recent prompt change improved or degraded reliability
 
   Scenario: No trend chart when only one evaluation run exists
@@ -95,11 +97,11 @@ Feature: Judge Quality Analysis
 
   Scenario: Analysis is scoped to the current project
     Given I am in project "Project A"
-    And project "Project B" has annotations for the same evaluator slug
+    And project "Project B" has annotations for the same evaluator
     When I open the "Judge Quality" tab
     Then I only see annotations from "Project A"
 
   Scenario: Analysis compares judge score pass/fail against annotation thumbs up/down
-    Given a trace where the judge scored 0.8 with a pass threshold of 0.5
+    Given a trace where the judge classified the result as pass
     And the same trace has a human annotation of thumbs down
     Then this trace is counted as a False Positive in the confusion matrix


### PR DESCRIPTION
**NO CODE CHANGE** — BDD spec only for feature #3945

## Why

LangWatch's LLM-as-judge evaluators have no way to measure their own reliability.
Every evaluation score assumes the judge is correct — when it isn't, teams make
prompt and model decisions based on bad signal.

This spec defines acceptance criteria for Judge Quality Analysis: using existing
annotation data as ground truth to compute Precision, Recall, F1, and Accuracy
for any LLM judge. No new data collection needed — the data is already there.

Closes #3945

## What changed

Added `specs/evaluators/judge-quality-analysis.feature` covering:

- **Confusion matrix** — TP/TN/FP/FN comparing judge scores vs. human annotations, with drill-down to individual traces
- **Reliability metrics** — Precision, Recall, F1, Accuracy, Human-AI Agreement Rate
- **Coverage indicator** — annotated vs. total evaluated trace count
- **Performance trend chart** — metrics over time across evaluation runs
- **Minimum threshold** — tab hidden until ≥10 annotated traces exist
- **Project scoping** — analysis isolated to current project

## How it works

Judge scores live in ClickHouse `evaluation_runs`. Human scores live in the
annotation system. Both are keyed on `traceId + projectId`. The confusion matrix
is a join on matching traces — making this a read-only analytics layer with zero
schema or pipeline changes.

## Test plan

- Follows `.feature` conventions in `specs/evaluators/`
- Action-based scenario descriptions, no "should"
- Edge cases covered: sub-threshold annotations, single run, real-time metric updates

## Anything surprising?

Annotation thumbs-up/down maps to binary pass/fail ground truth. Kept simple
intentionally — numeric annotation scores can be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive feature specifications for Judge Quality Analysis.
  * Covered access gating based on annotation counts and project-level scoping.
  * Added validation for confusion matrices, reliability metrics, annotation coverage, and performance trends.
  * Verified judge-pass and human-thumbs-down classifications, including pass/fail outcomes across supported analysis views.
  * Confirmed behavior across eligible and ineligible project configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->