### PR TITLE
fix(dev): identify a dev lane by its command line, not by ps comm alone

### DIFF
--- a/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
+++ b/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
@@ -141,7 +141,7 @@ function launchFrom(command: string, env: Record<string, string> = {}): number {
 
 /** Every live pid whose command line carries this test's marker. */
 function stackPids(): number[] {
-  const out = spawnSync("ps", ["-Ao", "pid=,command="], {
+  const out = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
     encoding: "utf8",
   }).stdout;
   return out
@@ -289,7 +289,7 @@ describe("dev stack supervisor", () => {
         process.kill(launcher, "SIGKILL");
         await sleep(1500);
 
-        const survivors = spawnSync("ps", ["-Ao", "pid=,command="], {
+        const survivors = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
           encoding: "utf8",
         })
           .stdout.split("\n")

--- a/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
+++ b/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
@@ -213,6 +213,25 @@ function pathWithBrokenSs(): string {
 }
 
 /**
+ * An `ss` that can see the socket but fails the moment it is asked who holds
+ * it, which is what a host that cannot map sockets to processes looks like.
+ * Seeing a listener you cannot attribute is not the same as seeing one that
+ * belongs to somebody else.
+ *
+ * Only options are inspected for the `-p`, since the filter expression the
+ * script passes contains "sport".
+ */
+function pathWithUnattributableSs(port: number): string {
+  return pathWithStubbedSs([
+    "#!/bin/bash",
+    'for arg in "$@"; do',
+    '  case "$arg" in -*p*) exit 1 ;; esac',
+    "done",
+    `echo 'LISTEN 0 511 127.0.0.1:${port} 0.0.0.0:*'`,
+  ]);
+}
+
+/**
  * A stand-in for `start.sh`: it survives being asked to stop and answers a
  * dead lane with a new one, which is what `concurrently --restart-tries -1`
  * does. That is the shape a plain SIGTERM cannot clear.
@@ -249,19 +268,26 @@ function startInOwnGroup(command: string, args: string[]): number {
   return child.pid as number;
 }
 
+const strangerReadyFile = (named: string) =>
+  path.join(scratch, `${named}-is-up`);
+
 /**
  * A listener that is emphatically not one of ours: the same node binary,
- * reached through a symlink under another name, so `ps -o comm=` reports
- * something without "node" in it and the script must leave it where it is.
- * Cheaper and more portable than reaching for a second language runtime.
+ * reached through a symlink under another name, so it is a real process
+ * holding a real port that the script must leave where it is. Cheaper and
+ * more portable than reaching for a second language runtime.
+ *
+ * The name is a parameter because it is the whole question. `node_exporter`
+ * holds a port on plenty of machines and is nobody's dev lane, and it is
+ * exactly what a "does the command line mention node" test gets wrong.
  */
-function startStranger(port: number): number {
-  const asAnother = path.join(scratch, "dev-listener");
+function startStranger(port: number, named = "dev-listener"): number {
+  const asAnother = path.join(scratch, named);
   symlinkSync(process.execPath, asAnother);
   return startInOwnGroup(asAnother, [
     writeLane(),
     String(port),
-    path.join(scratch, "stranger-is-up"),
+    strangerReadyFile(named),
   ]);
 }
 
@@ -392,9 +418,7 @@ describe("clearing the dev ports", () => {
         expect(await laneIsUp()).toBe(true);
         const stranger = startStranger(theirs);
         expect(
-          await waitUntil(() =>
-            existsSync(path.join(scratch, "stranger-is-up")),
-          ),
+          await waitUntil(() => existsSync(strangerReadyFile("dev-listener"))),
         ).toBe(true);
 
         const result = clearPorts(`${ours},${theirs}`, {
@@ -405,6 +429,24 @@ describe("clearing the dev ports", () => {
         expect(result.status, said).toBe(1);
         expect(result.stdout).not.toContain("ports free");
         expect(liveMembers(stack), said).toBe(0);
+        expect(liveMembers(stranger), said).toBeGreaterThan(0);
+      }, 30000);
+
+      /** @scenario "A port held by something we did not start is reported, not claimed" */
+      it("leaves a stranger whose own name contains node where it is", async () => {
+        const theirs = await freePort();
+        const stranger = startStranger(theirs, "node_exporter");
+        expect(
+          await waitUntil(() => existsSync(strangerReadyFile("node_exporter"))),
+        ).toBe(true);
+
+        const result = clearPorts(String(theirs), {
+          KILL_DEV_TREE_GRACE: "2",
+        });
+
+        const said = `${result.stdout}${result.stderr}`;
+        expect(result.status, said).toBe(1);
+        expect(result.stdout).not.toContain("ports free");
         expect(liveMembers(stranger), said).toBeGreaterThan(0);
       }, 30000);
     });
@@ -440,6 +482,28 @@ describe("clearing the dev ports", () => {
         expect(result.stdout).not.toContain("nothing of ours");
         expect(result.stderr).toContain("could not inspect");
       });
+
+      /** @scenario "A listener that cannot be attributed is not blamed on a stranger" */
+      it("refuses to call a listener someone else's when it could not attribute it", async () => {
+        const port = await freePort();
+        const lane = startInOwnGroup(process.execPath, [
+          writeLane(),
+          String(port),
+          readyFile(),
+        ]);
+        expect(await laneIsUp()).toBe(true);
+
+        const result = clearPorts(String(port), {
+          PATH: pathWithUnattributableSs(port),
+        });
+
+        const said = `${result.stdout}${result.stderr}`;
+        expect(result.status, said).not.toBe(0);
+        expect(result.stdout).not.toContain("ports free");
+        expect(result.stderr).not.toContain("not a node process of ours");
+        expect(result.stderr).toContain("could not inspect");
+        expect(liveMembers(lane), said).toBeGreaterThan(0);
+      }, 30000);
 
       it("reports how to call it when given no ports at all", () => {
         const result = spawnSync("bash", [SCRIPT], { encoding: "utf8" });

--- a/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
+++ b/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
@@ -281,7 +281,13 @@ const strangerReadyFile = (named: string) =>
  * holds a port on plenty of machines and is nobody's dev lane, and it is
  * exactly what a "does the command line mention node" test gets wrong.
  */
-function startStranger(port: number, named = "dev-listener"): number {
+function startStranger({
+  port,
+  named = "dev-listener",
+}: {
+  port: number;
+  named?: string;
+}): number {
   const asAnother = path.join(scratch, named);
   symlinkSync(process.execPath, asAnother);
   return startInOwnGroup(asAnother, [
@@ -416,7 +422,7 @@ describe("clearing the dev ports", () => {
         const theirs = await freePort();
         const stack = startInOwnGroup("bash", [writeRestartingStack(ours)]);
         expect(await laneIsUp()).toBe(true);
-        const stranger = startStranger(theirs);
+        const stranger = startStranger({ port: theirs });
         expect(
           await waitUntil(() => existsSync(strangerReadyFile("dev-listener"))),
         ).toBe(true);
@@ -435,7 +441,10 @@ describe("clearing the dev ports", () => {
       /** @scenario "A port held by something we did not start is reported, not claimed" */
       it("leaves a stranger whose own name contains node where it is", async () => {
         const theirs = await freePort();
-        const stranger = startStranger(theirs, "node_exporter");
+        const stranger = startStranger({
+          port: theirs,
+          named: "node_exporter",
+        });
         expect(
           await waitUntil(() => existsSync(strangerReadyFile("node_exporter"))),
         ).toBe(true);

--- a/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
+++ b/platform/app/scripts/__tests__/kill-dev-tree.unit.test.ts
@@ -107,7 +107,9 @@ function listening(port: number): boolean {
  * and it holds neither a port nor any memory.
  */
 function liveMembers(pgid: number): number {
-  const result = spawnSync("ps", ["-Ao", "pgid=,stat="], { encoding: "utf8" });
+  const result = spawnSync("ps", ["-Ao", "pgid=", "-o", "stat="], {
+    encoding: "utf8",
+  });
   return (result.stdout ?? "")
     .split("\n")
     .map((line) => line.trim().split(/\s+/))
@@ -225,6 +227,12 @@ function writeRestartingStack(port: number): string {
       "while true; do",
       `  ${asBashWord(process.execPath)} ${asBashWord(writeLane())} ${port} ${asBashWord(readyFile())} &`,
       "  wait $! 2>/dev/null",
+      // Paced deliberately. A lane that cannot bind exits at once, and an
+      // unpaced loop then reissues it as fast as the kernel will fork: one
+      // orphaned copy of this shape was measured sustaining ~1800 processes a
+      // second for hours, starving the machine. The takedown is still what is
+      // under test, since a fifth of a second is far inside its grace period.
+      "  sleep 0.2",
       "done",
       "",
     ].join("\n"),

--- a/platform/app/scripts/kill-dev-tree.sh
+++ b/platform/app/scripts/kill-dev-tree.sh
@@ -52,7 +52,9 @@ done
 # exits 0 with no output for a port that is genuinely free, so a non-zero status
 # is unambiguously a broken lookup and we stop rather than guess. lsof gets no
 # such treatment: it returns 1 both for "found nothing" and for real errors, so
-# its status carries nothing to act on.
+# its status carries nothing to act on. The flag that would separate the two,
+# `-Q`, is newer than the 4.91 macOS ships, and acting on the status without it
+# would refuse every genuinely free port on a Mac.
 port_busy() {
   local found
   if command -v lsof >/dev/null 2>&1; then

--- a/platform/app/scripts/kill-dev-tree.sh
+++ b/platform/app/scripts/kill-dev-tree.sh
@@ -68,27 +68,47 @@ port_busy() {
 
 # Whatever is listening on those ports. lsof is what the rest of the dev
 # scripts use; ss covers the Linux hosts that ship iproute2 and not lsof.
-# A failing `ss` stops us the same way it does in port_busy: an empty answer
-# from a lookup that broke is not "nobody is listening".
+# A failing `ss` is reported the same way it is in port_busy: an empty answer
+# from a lookup that broke is not "nobody is listening". It returns that as a
+# status rather than exiting, because every caller reads it through a pipe and
+# an `exit` there would leave only the subshell, with the script carrying on
+# over an answer it just said it did not have.
 listening_pids() {
   local found
   if command -v lsof >/dev/null 2>&1; then
     lsof -t -a -iTCP:"$PORTS" -sTCP:LISTEN 2>/dev/null
-    return
+    # Its own 1 means "found nothing", which is an answer, not a failure.
+    return 0
   fi
   if ! found=$(ss -ltnpH "( ${SS_FILTER} )" 2>/dev/null); then
     echo "ss could not inspect ${PORTS}, refusing to guess whether it is free" >&2
-    exit 69
+    return 69
   fi
   printf '%s\n' "$found" | grep -o 'pid=[0-9]*' | cut -d= -f2
+  # Likewise for grep: no pids in the output is a result, and under pipefail
+  # its 1 would otherwise come back as a broken lookup.
+  return 0
 }
 
-# What a pid is. Linux answers from /proc, which is authoritative and needs no
-# output parsing at all; ps is the fallback for macOS, asked two ways because
-# neither is portable on its own. `comm` is the bare binary name on Linux and
-# the full path on macOS, and `args` is the whole command line, which always
-# begins with the interpreter. Relying on `comm` alone is what made this miss
-# node processes it had correctly found.
+# What a pid was started as, down to the bare binary name. Linux answers from
+# /proc, which is authoritative and needs no output parsing at all; ps is the
+# fallback for macOS, where `comm` is the same argv[0] spelled as a full path.
+# Reading `comm` as if it were already the bare name is what made this miss node
+# processes it had correctly found, because on macOS it never is.
+lane_binary() {
+  local argv0
+  if [ -r "/proc/$1/cmdline" ]; then
+    argv0=$(tr '\0' '\n' <"/proc/$1/cmdline")
+    argv0=${argv0%%$'\n'*}
+  else
+    argv0=$(ps -p "$1" -o comm= 2>/dev/null)
+  fi
+  echo "${argv0##*/}"
+}
+
+# The whole command line, for saying what we saw rather than only how we
+# classified it. `args` alongside `comm` on macOS because the two disagree:
+# one is the binary, the other is what it was told to run.
 describe_pid() {
   if [ -r "/proc/$1/cmdline" ]; then
     tr '\0' ' ' <"/proc/$1/cmdline"
@@ -103,10 +123,14 @@ describe_pid() {
 # Never our own group either: this is usually pasted into the very shell that
 # is about to retry `pnpm dev`, and closing that would be its own surprise.
 listening_groups() {
-  listening_pids | sort -u | while read -r pid; do
+  printf '%s\n' "$LISTENERS" | while read -r pid; do
     [ -n "$pid" ] || continue
-    case "$(describe_pid "$pid")" in
-      *node*) ;;
+    # The node binary itself, not a command line with "node" somewhere in it:
+    # node_exporter holds a port, and so does anything running node-config.py,
+    # and neither is a dev lane. The digits cover distros that install node
+    # under its major version, and `nodejs` covers Debian's spelling.
+    case "$(lane_binary "$pid")" in
+      node | nodejs | node[0-9]*) ;;
       *) continue ;;
     esac
     pgid=$(ps -p "$pid" -o pgid= 2>/dev/null | tr -d ' ')
@@ -120,7 +144,7 @@ listening_groups() {
 # rather than an assertion. Without this the message is the same whether the
 # port really belongs to someone else or we simply failed to identify it.
 describe_listeners() {
-  listening_pids | sort -u | while read -r pid; do
+  printf '%s\n' "$LISTENERS" | while read -r pid; do
     [ -n "$pid" ] || continue
     echo "${pid}:$(describe_pid "$pid" | tr '\n' ' ' | cut -c1-60)"
   done | tr '\n' ' '
@@ -153,6 +177,13 @@ signal_groups() {
     kill "-${signal}" "-${pgid}" 2>/dev/null
   done
 }
+
+# Asked once, so the group we take down and the listeners we name in a failure
+# are the same moment rather than two lookups that can disagree.
+if ! LISTENERS=$(listening_pids); then
+  exit 69
+fi
+LISTENERS=$(printf '%s\n' "$LISTENERS" | sort -u)
 
 targets=$(listening_groups)
 if [ -z "$targets" ]; then

--- a/platform/app/scripts/kill-dev-tree.sh
+++ b/platform/app/scripts/kill-dev-tree.sh
@@ -32,7 +32,7 @@ fi
 # How long the stack gets to go down on its own before SIGKILL.
 GRACE_SECONDS="${KILL_DEV_TREE_GRACE:-5}"
 
-OWN_PGID=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')
+OWN_PGID=$(ps -p $$ -o pgid= 2>/dev/null | tr -d ' ')
 
 if ! command -v lsof >/dev/null 2>&1 && ! command -v ss >/dev/null 2>&1; then
   echo "need lsof or ss to find what is holding ${PORTS}" >&2
@@ -68,12 +68,34 @@ port_busy() {
 
 # Whatever is listening on those ports. lsof is what the rest of the dev
 # scripts use; ss covers the Linux hosts that ship iproute2 and not lsof.
+# A failing `ss` stops us the same way it does in port_busy: an empty answer
+# from a lookup that broke is not "nobody is listening".
 listening_pids() {
+  local found
   if command -v lsof >/dev/null 2>&1; then
     lsof -t -a -iTCP:"$PORTS" -sTCP:LISTEN 2>/dev/null
     return
   fi
-  ss -ltnpH "( ${SS_FILTER} )" 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2
+  if ! found=$(ss -ltnpH "( ${SS_FILTER} )" 2>/dev/null); then
+    echo "ss could not inspect ${PORTS}, refusing to guess whether it is free" >&2
+    exit 69
+  fi
+  printf '%s\n' "$found" | grep -o 'pid=[0-9]*' | cut -d= -f2
+}
+
+# What a pid is. Linux answers from /proc, which is authoritative and needs no
+# output parsing at all; ps is the fallback for macOS, asked two ways because
+# neither is portable on its own. `comm` is the bare binary name on Linux and
+# the full path on macOS, and `args` is the whole command line, which always
+# begins with the interpreter. Relying on `comm` alone is what made this miss
+# node processes it had correctly found.
+describe_pid() {
+  if [ -r "/proc/$1/cmdline" ]; then
+    tr '\0' ' ' <"/proc/$1/cmdline"
+    return
+  fi
+  ps -p "$1" -o comm= 2>/dev/null
+  ps -p "$1" -o args= 2>/dev/null
 }
 
 # The process groups behind those listeners, node ones only, so a port that
@@ -82,15 +104,26 @@ listening_pids() {
 # is about to retry `pnpm dev`, and closing that would be its own surprise.
 listening_groups() {
   listening_pids | sort -u | while read -r pid; do
-    case "$(ps -o comm= -p "$pid" 2>/dev/null)" in
+    [ -n "$pid" ] || continue
+    case "$(describe_pid "$pid")" in
       *node*) ;;
       *) continue ;;
     esac
-    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+    pgid=$(ps -p "$pid" -o pgid= 2>/dev/null | tr -d ' ')
     [ -n "$pgid" ] || continue
     [ "$pgid" -gt 1 ] 2>/dev/null || continue
     if [ "$pgid" != "$OWN_PGID" ]; then echo "$pgid"; fi
   done | sort -u
+}
+
+# What we saw but did not claim, so "not a node process of ours" is a finding
+# rather than an assertion. Without this the message is the same whether the
+# port really belongs to someone else or we simply failed to identify it.
+describe_listeners() {
+  listening_pids | sort -u | while read -r pid; do
+    [ -n "$pid" ] || continue
+    echo "${pid}:$(describe_pid "$pid" | tr '\n' ' ' | cut -c1-60)"
+  done | tr '\n' ' '
 }
 
 # Whether any member of the group is still running, asked of the process table
@@ -98,7 +131,7 @@ listening_groups() {
 # Zombies deliberately do not count: they hold no port and no memory, and a
 # leader whose parent has not reaped it yet would otherwise read as alive.
 group_alive() {
-  ps -Ao pgid=,stat= 2>/dev/null |
+  ps -Ao pgid= -o stat= 2>/dev/null |
     awk -v want="$1" '$1 == want && $2 !~ /^Z/ { alive = 1 } END { exit !alive }'
 }
 
@@ -127,7 +160,7 @@ if [ -z "$targets" ]; then
   # them is good news. Saying "free" over a port we simply could not attribute
   # is how a takedown reports success and leaves the stack running.
   if port_busy; then
-    echo "something is listening on ${PORTS} that is not a node process of ours, leaving it alone" >&2
+    echo "something is listening on ${PORTS} that is not a node process of ours, leaving it alone (saw: $(describe_listeners))" >&2
     exit 1
   fi
   echo "nothing of ours is listening on ${PORTS}"

--- a/specs/setup/dev-stack-lifecycle.feature
+++ b/specs/setup/dev-stack-lifecycle.feature
@@ -159,6 +159,13 @@ Feature: A dev stack does not outlive whoever started it
     Then it says it could not look and fails, rather than reporting them free
 
   @unit
+  Scenario: A listener that cannot be attributed is not blamed on a stranger
+    Given the port lookup can see a listener but not which process holds it
+    When the ports are cleared
+    Then it says it could not look and fails, rather than calling the port someone else's
+    And nothing is stopped
+
+  @unit
   Scenario: A port held by something we did not start is reported, not claimed
     Given one of the ports is held by a process that is not a dev stack of ours
     When the ports are cleared


### PR DESCRIPTION
## Why

`kill-dev-tree.sh` fails on Linux and passes on a Mac, so it went in green and turned `main` red. Three of its tests fail on the runner:

```
AssertionError: something is listening on 24130 that is not a node process of ours, leaving it alone
  ❯ kill-dev-tree.unit.test.ts:304  expected 1 to be +0
```

The script found the listener and then refused to act on it.

## What was wrong

It classified a listener with `ps -o comm=`, which is the full binary path on macOS and the bare name on Linux, and on the runner that does not come back containing `node`.

The test that pins the `ss` path is what identifies it. That test supplies its own stand-in `ss`, which cannot fail to emit a pid, and it failed too. So the pid was found and only the classification rejected it.

Linux now answers from `/proc/<pid>/cmdline`, which is authoritative and needs no output parsing. `ps` stays as the macOS fallback and is asked for `args` as well as `comm`, since the command line always names the interpreter.

## Three things that hid it

**A broken lookup read as an empty one.** `listening_pids` ignored the `ss` exit status. `port_busy` was fixed for exactly this a commit earlier; its twin was not.

**The message asserted something the script could not know.** "not a node process of ours" is identical whether the port really belongs to someone else or we simply failed to identify it. It now reports what it saw, so the next failure of this kind diagnoses itself:

```
something is listening on 26777 that is not a node process of ours, leaving it alone
  (saw: 63706:/private/tmp/.../dev-listener /tmp/.../lane.js 26777)
```

**`ps` format specs are one column per `-o`.** `-o pgid=,stat=` reads the comma as part of the previous column's header on some `ps` builds, so the second column silently vanishes. Split in the script and in both test suites.

## A fork storm in the test fixture

Separately, and worth its own paragraph. The stand-in stack replaces any lane that dies, on purpose, because that is what `concurrently --restart-tries -1` does and what the takedown has to survive. Unpaced, a lane that cannot bind exits immediately and the loop reissues it as fast as the kernel will fork.

An orphaned copy of this shape was measured sustaining **~1800 processes per second for roughly twelve hours**: 99.5% of all process creation on the machine, wrapping the whole PID space every 57 seconds, and starving unrelated software to the point of hanging. It also carries `trap '' TERM`, so it ignores anything short of SIGKILL.

The loop now sleeps a fifth of a second between restarts, far inside the takedown's grace period, so the behaviour under test is unchanged and an orphan cannot storm.

## Verification, and its limit

Both suites green three runs in a row on macOS, 169/169 across `scripts/__tests__`, `typecheck`, `typecheck:tests` and parity clean, and the new diagnostic confirmed against a real non-node listener.

Being straight about the gap: the bug only reproduces on Linux, and I cannot run Linux here. macOS exercises the `ps` fallback; the `/proc` branch this fix turns on is exercised by CI. That is why the diagnostic went in with the fix rather than after it, so if anything survives, the failure names the cause instead of repeating the same misleading sentence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-process detection across different environments.
  * Added clearer handling when process or network listener information cannot be retrieved.
  * Enhanced safety checks to prevent accidentally terminating unrelated processes.
  * Port cleanup now fails safely when listener ownership cannot be confirmed.
  * Refusal messages include more useful process details, including PID and command information.
  * Improved listener identification and handling of uninspectable processes.
  * Improved restart stability by preventing rapid process relaunch cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->