### PR TITLE
fix(observability): default ClickHouse backup metrics ON, opt out where there are no backups

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -747,16 +747,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: CLICKHOUSE_COLD_STORAGE_DEFAULT_TTL_DAYS
   value: {{ $chCold.defaultTtlDays | default "49" | quote }}
 {{- end }}
-{{/* Backup-status gauges (system.backup_log) are opt-in — the app/worker only
-     queries the backup log when CLICKHOUSE_BACKUP_METRICS_ENABLED=true. Couple
-     that to the backup config so the "Backup Reporting Absent" signal can never
-     drift from whether backups actually run: on whenever chart-managed backups
-     are enabled, or when an operator forces it for out-of-band backups. */}}
+{{/* Backup-status gauges (system.backup_log) are opt-OUT in the app/worker: an
+     unset CLICKHOUSE_BACKUP_METRICS_ENABLED collects, so no deployment can lose
+     the "Backup Reporting Absent" signal just by not knowing about the flag.
+     The chart states it explicitly in both directions, coupled to the backup
+     config: "true" wherever chart-managed backups run (or an operator forces it
+     for out-of-band backups), "false" where this chart knows there are no
+     backups and system.backup_log would not exist. */}}
 {{- $chBackup := (.Values.clickhouse).backup }}
-{{- if or ($chBackup).enabled ($chBackup).metricsEnabled }}
 - name: CLICKHOUSE_BACKUP_METRICS_ENABLED
-  value: "true"
-{{- end }}
+  value: {{ if or ($chBackup).enabled ($chBackup).metricsEnabled }}"true"{{ else }}"false"{{ end }}
 
 # Credentials encryption key
 {{- if .Values.app.credentialsEncryptionKey.secretKeyRef.name }}

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -488,11 +488,16 @@ test_backup_metrics_gate() {
 
   local backup_flags="--set autogen.enabled=true --set clickhouse.objectStorage.bucket=b --set clickhouse.objectStorage.region=us-east-1"
 
-  # Off by default: no backups configured -> no backup-log querying.
+  # No backups configured -> the chart opts OUT explicitly. The app defaults to
+  # collecting (an unset var must never disarm production monitoring), so the
+  # chart has to say "false" to stop the workers querying a table that this
+  # deployment does not have.
   local off
-  off=$(tmpl_only "templates/workers/deployment.yaml" --set autogen.enabled=true)
-  assert_not_contains "default: workers do not set backup metrics" \
-    "$off" "CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  off=$(tmpl_only "templates/workers/deployment.yaml" --set autogen.enabled=true \
+    | grep -A1 "name: CLICKHOUSE_BACKUP_METRICS_ENABLED")
+  assert_contains "default: workers opt out of backup metrics" \
+    "$off" "name: CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  assert_contains "default: backup metrics value false" "$off" '"false"'
 
   # Chart-managed backups on -> metrics auto-enabled on the workers (which emit
   # the gauges), so the alert never fires spuriously against a live backup setup.
@@ -512,6 +517,7 @@ test_backup_metrics_gate() {
     | grep -A1 "name: CLICKHOUSE_BACKUP_METRICS_ENABLED")
   assert_contains "metricsEnabled override: workers set backup metrics" \
     "$forced" "name: CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  assert_contains "metricsEnabled override: backup metrics value true" "$forced" '"true"'
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -5,6 +5,12 @@ services:
       SKIP_ENV_VALIDATION: true
       DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
       CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
+      # This compose stack runs a plain ClickHouse with no backups, so
+      # system.backup_log does not exist here. Backup-status collection is on by
+      # default (an unset flag must not disarm the alerts that read those gauges
+      # in deployments that do have backups), so opt out explicitly rather than
+      # failing the query on every stats tick.
+      CLICKHOUSE_BACKUP_METRICS_ENABLED: "false"
       REDIS_URL: redis://redis:6379
       LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
       LANGEVALS_ENDPOINT: http://langevals:5562
@@ -32,6 +38,12 @@ services:
       SKIP_ENV_VALIDATION: true
       DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
       CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
+      # This compose stack runs a plain ClickHouse with no backups, so
+      # system.backup_log does not exist here. Backup-status collection is on by
+      # default (an unset flag must not disarm the alerts that read those gauges
+      # in deployments that do have backups), so opt out explicitly rather than
+      # failing the query on every stats tick.
+      CLICKHOUSE_BACKUP_METRICS_ENABLED: "false"
       REDIS_URL: redis://redis:6379
       LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
       LANGEVALS_ENDPOINT: http://langevals:5562

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -140,13 +140,16 @@ DATABASE_URL="postgresql://postgres@localhost:5432/langwatch_db?schema=langwatch
 
 # ClickHouse for analytics, trace indexing, and time-series data
 CLICKHOUSE_URL="http://localhost:8123/langwatch"
-# Opt in to backup-status gauges (queries system.backup_log every stats tick).
-# Only set this on deployments where ClickHouse backups are actually configured
-# (see charts/clickhouse-serverless) — everywhere else the table doesn't exist.
-# The langwatch Helm chart wires this automatically from clickhouse.backup.enabled
-# (override: clickhouse.backup.metricsEnabled), so operators using the chart never
-# set it by hand — this var is for non-chart deployments.
-#CLICKHOUSE_BACKUP_METRICS_ENABLED=true
+# Backup-status gauges (queries system.backup_log every stats tick) are ON by
+# default: production alerts read those gauges from deployments that set nothing,
+# so an unset value must never disarm them. Set this to false where ClickHouse
+# backups are NOT configured (local dev, CI, self-hosted without backups) — the
+# table doesn't exist there and the query fails on every tick for nothing.
+# Accepted opt-out values: false/0/no/off; anything else collects.
+# The langwatch Helm chart sets this in both directions from clickhouse.backup.enabled
+# (override: clickhouse.backup.metricsEnabled), and haven sets false for local
+# worktrees, so this var is for hand-rolled deployments.
+#CLICKHOUSE_BACKUP_METRICS_ENABLED=false
 
 # Redis for queues
 REDIS_URL=""

--- a/platform/app/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -527,11 +527,37 @@ describe("ClickHouse metrics", () => {
       });
     });
 
-    describe("when backup metrics are not enabled (the default)", () => {
-      // system.backup_log only exists where backups are configured, so anywhere
-      // that hasn't opted in the collector must skip it entirely, leaving only
-      // parts + disks.
+    describe("when CLICKHOUSE_BACKUP_METRICS_ENABLED is unset (the default)", () => {
+      // Production workers never set this variable and live Grafana alerts read
+      // the gauges it feeds, so the default MUST keep collecting. A default-off
+      // flag silently disarms backup monitoring on the next deploy.
+      beforeEach(() => {
+        delete process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+      });
+
+      it("still queries system.backup_log", async () => {
+        const client = buildMockClient(() => false);
+
+        await metrics.collectStorageStats(client);
+
+        expect(client.query).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.stringContaining("system.backup_log"),
+          }),
+        );
+      });
+    });
+
+    describe("when backup metrics are explicitly disabled", () => {
+      // system.backup_log only exists where backups are configured, so the
+      // environments without them (local dev, CI, self-hosted) opt out and the
+      // collector skips it entirely, leaving only parts + disks.
+      afterEach(() => {
+        delete process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+      });
+
       it("skips the system.backup_log query entirely", async () => {
+        process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED = "false";
         const client = buildMockClient(() => false);
 
         await metrics.collectStorageStats(client);
@@ -542,6 +568,42 @@ describe("ClickHouse metrics", () => {
           }),
         );
       });
+    });
+  });
+
+  describe("shouldCollectBackupMetrics", () => {
+    // The whole point of the inversion: absence of configuration means the
+    // existing (collecting) behaviour, never a silent opt-out.
+    const collectingCases: [string, NodeJS.ProcessEnv][] = [
+      ["unset", {}],
+      ["empty", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "" }],
+      ["whitespace", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "   " }],
+      ["true", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "true" }],
+      ["TRUE", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "TRUE" }],
+      ["padded true", { CLICKHOUSE_BACKUP_METRICS_ENABLED: " true " }],
+      ["1", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "1" }],
+      ["unparseable", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "banana" }],
+    ];
+
+    it.each(collectingCases)("collects when %s", (_label, env) => {
+      expect(metrics.shouldCollectBackupMetrics(env)).toBe(true);
+    });
+
+    const optedOutValues: string[] = [
+      "false",
+      "FALSE",
+      "  false  ",
+      "0",
+      "no",
+      "off",
+    ];
+
+    it.each(optedOutValues)("skips when explicitly %s", (value) => {
+      expect(
+        metrics.shouldCollectBackupMetrics({
+          CLICKHOUSE_BACKUP_METRICS_ENABLED: value,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/platform/app/src/server/clickhouse/metrics.ts
+++ b/platform/app/src/server/clickhouse/metrics.ts
@@ -377,10 +377,41 @@ const MONITORED_TABLES = [
   "stored_objects",
 ];
 
+/** Values of CLICKHOUSE_BACKUP_METRICS_ENABLED that turn backup collection off. */
+const BACKUP_METRICS_OFF_VALUES = new Set(["false", "0", "no", "off"]);
+
+/**
+ * Whether this deployment should collect backup-status gauges from
+ * system.backup_log.
+ *
+ * Collection is ON unless explicitly disabled. The gauges predate this flag and
+ * production alerts (clickhouse_backup_last_success_timestamp_seconds,
+ * clickhouse_backup_status_total, and the "Backup Reporting Absent" rule built on
+ * them) already depend on them, while the deployments that emit them do not set
+ * the variable. Defaulting to off silently disarms live backup monitoring on the
+ * next deploy, so an unset, or unparseable, value keeps the existing behaviour and
+ * only a deliberate opt-OUT stops collection.
+ *
+ * Opting out is for environments where backups genuinely do not exist (local dev
+ * under haven, CI, self-hosted installs without backups), where the table is
+ * missing and the query would fail on every 15s tick for nothing.
+ *
+ * See specs/ops/clickhouse-backup-metrics.feature.
+ */
+export function shouldCollectBackupMetrics(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+  if (typeof raw !== "string") return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "") return true;
+  return !BACKUP_METRICS_OFF_VALUES.has(normalized);
+}
+
 /**
  * Collects ClickHouse backup status from system.backup_log into the backup gauges.
- * Extracted so collectStorageStats can gate it behind the explicit opt-in (see the
- * call site).
+ * Extracted so collectStorageStats can gate it behind the opt-out (see the call
+ * site).
  *
  * We deliberately query system.backup_log instead of system.backups: system.backups
  * is an in-memory table that gets wiped on CH restart, which happens on every app
@@ -507,12 +538,13 @@ export async function collectStorageStats(
     // Backup status only exists where backups are configured (the production
     // cluster, via clickhouse-serverless's backup cronjobs) — everywhere else this
     // query just fails on every 15s tick for nothing, and NODE_ENV can't tell
-    // "has backups" from "staging/self-hosted production build". So the deployment
-    // that has backups opts in explicitly (set on the worker alongside the backup
-    // cronjobs). Gating here (not at one call site) covers both the app under
+    // "has backups" from "staging/self-hosted production build". So the
+    // deployments WITHOUT backups opt out explicitly; unset stays on, because
+    // production already emits these gauges and alerts on them without setting
+    // anything. Gating here (not at one call site) covers both the app under
     // haven's in-process workers and the standalone worker.
     // See specs/ops/clickhouse-backup-metrics.feature.
-    if (process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED === "true") {
+    if (shouldCollectBackupMetrics()) {
       await collectBackupStats(client);
     }
 

--- a/specs/ops/clickhouse-backup-metrics.feature
+++ b/specs/ops/clickhouse-backup-metrics.feature
@@ -1,22 +1,40 @@
-Feature: ClickHouse backup status metrics are opt-in
+Feature: ClickHouse backup status metrics are opt-out
   Backup monitoring only makes sense where ClickHouse backups are actually
   configured (the production cluster, backed by the clickhouse-serverless
   chart's backup cronjobs). Everywhere else — local dev, CI, self-hosted
   installs without backups — querying system.backup_log would fail on every
   collection tick for nothing. NODE_ENV is not a reliable signal for "backups
   exist here" (staging and self-hosted also run production builds), so the
-  deployment that has backups opts in explicitly.
+  environments WITHOUT backups say so explicitly.
 
-  Scenario: deployment with backups opts in to backup monitoring
+  The gate defaults to ON, not off. The gauges predate the flag and live Grafana
+  alerts (clickhouse_backup_last_success_timestamp_seconds,
+  clickhouse_backup_status_total, and the "Backup Reporting Absent" rule built on
+  them) already read them from deployments that set nothing. A default-off flag
+  would silently disarm production backup monitoring the moment it shipped, so
+  absence of configuration keeps the existing behaviour and only a deliberate
+  opt-out stops collection.
+
+  Scenario: a deployment that says nothing keeps collecting backup status
+    Given CLICKHOUSE_BACKUP_METRICS_ENABLED is not set
+    When the storage stats collector ticks
+    Then backup status is collected from the ClickHouse backup log
+
+  Scenario: a deployment with backups collects backup status
     Given backup metrics collection is enabled for the deployment
     When the storage stats collector ticks
     Then backup status is collected from the ClickHouse backup log
 
-  Scenario: deployment without backups never queries the backup log
-    Given backup metrics collection is not enabled
+  Scenario: a deployment without backups opts out of the backup log query
+    Given backup metrics collection is explicitly disabled
     When the storage stats collector ticks
     Then the ClickHouse backup log is never queried
     And table and disk storage stats are still collected
+
+  Scenario: an unrecognised value is treated as enabled
+    Given CLICKHOUSE_BACKUP_METRICS_ENABLED is set to an unparseable value
+    When the storage stats collector ticks
+    Then backup status is collected from the ClickHouse backup log
 
   Scenario: transient backup-log failure warns once until recovery
     Given backup metrics collection is enabled
@@ -24,9 +42,8 @@ Feature: ClickHouse backup status metrics are opt-in
     Then a single warning is logged for the failure streak
     And a recovery is logged once collection succeeds again
 
-  # The opt-in must not let production silently stop emitting the gauges the
-  # "Backup Reporting Absent" alert depends on. The Helm chart couples the toggle
-  # to the backup config so the signal can never drift from whether backups run.
+  # The Helm chart states the toggle explicitly in both directions, coupled to
+  # the backup config, so a chart deployment never depends on the app's default.
   Scenario: the Helm chart enables backup metrics wherever it runs backups
     Given the langwatch chart is deployed with clickhouse.backup.enabled true
     When the app and worker deployments are rendered
@@ -37,3 +54,13 @@ Feature: ClickHouse backup status metrics are opt-in
     And chart-managed backups are disabled
     When the app and worker deployments are rendered
     Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to true on them
+
+  Scenario: the Helm chart opts out where it knows there are no backups
+    Given the langwatch chart is deployed with clickhouse backups disabled
+    When the app and worker deployments are rendered
+    Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to false on them
+
+  Scenario: haven opts local worktrees out
+    Given a haven stack manages its own ClickHouse
+    When the portless overlay is rendered
+    Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to false in it

--- a/tools/thuishaven/domain/domain_test.go
+++ b/tools/thuishaven/domain/domain_test.go
@@ -163,6 +163,25 @@ func TestOverlayDisablesGoogleDLPWhenAsked(t *testing.T) {
 	}
 }
 
+// The app collects ClickHouse backup-status gauges by default (an unset flag must
+// not disarm the production alerts that read them), so haven's own container,
+// which has no backups and therefore no system.backup_log, has to opt out, or
+// every 15s stats tick fails on a missing table.
+func TestOverlayOptsOutOfBackupMetricsWhenManagingClickHouse(t *testing.T) {
+	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
+		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},
+	}}
+	if hasKey(base.OverlayEnv(), "CLICKHOUSE_BACKUP_METRICS_ENABLED") {
+		t.Fatalf("unmanaged stack must leave backup metrics to the worktree's own .env")
+	}
+	managed := base
+	managed.ClickHouseHTTPPort = 18123
+	managed.ClickHouseDatabase = "lw_brave_otter"
+	if got := valueOf(managed.OverlayEnv(), "CLICKHOUSE_BACKUP_METRICS_ENABLED"); got != "false" {
+		t.Errorf("CLICKHOUSE_BACKUP_METRICS_ENABLED = %q, want %q", got, "false")
+	}
+}
+
 func TestOverlayEmitsPostgresURLOnlyWhenManaged(t *testing.T) {
 	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
 		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -150,6 +150,12 @@ func (s Stack) OverlayEnv() []string {
 	if s.ClickHouseHTTPPort != 0 && s.ClickHouseDatabase != "" {
 		env = append(env, fmt.Sprintf("CLICKHOUSE_URL=http://%s:%s@127.0.0.1:%d/%s",
 			ClickHouseUser, ClickHousePassword, s.ClickHouseHTTPPort, s.ClickHouseDatabase))
+		// Backup-status gauges query system.backup_log, which only exists once
+		// backups are configured, a production concern. The app collects them by
+		// default (unset must not disarm the production alerts that read them), so
+		// haven's container, which has no backups, opts out explicitly. Otherwise
+		// every 15s stats tick would fail on a missing table for nothing.
+		env = append(env, "CLICKHOUSE_BACKUP_METRICS_ENABLED=false")
 	}
 	// Same story for Postgres: one shared brew-managed server, a database per
 	// slug, connected straight to loopback.


### PR DESCRIPTION
## What broke

`clickhouse_backup_last_success_timestamp_seconds` stopped reporting in production on **2026-07-16 at about 09:30 UTC**, and nobody noticed for three weeks.

The cause is a gate added the day before, in #5814:

```ts
if (process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED === "true") {
  await collectBackupStats(client);
}
```

Before that, collection was unconditional. Nothing sets that variable. It appears nowhere in `langwatch-saas`, not in the worker deployment, not anywhere in that repo's git history. So the gate shipped, prod didn't opt in, and the gauge went away.

Verified in Prometheus: the series is present up to 2026-07-16 09:29 UTC and absent from then to today.

## What that did to the alerts

Two live Grafana rules read those gauges, and they failed in opposite directions, which is why only one was visible:

| rule | expression | behaviour once the gauge vanished |
|---|---|---|
| `ClickHouse Backup Missing` | `time() - max(gauge > 0)` | empty vector, `noDataState: OK` keeps it quiet. Reads green. Silent coverage of nothing. |
| `ClickHouse Backup Reporting Absent` | `absent_over_time(gauge[30m])` | returns **1**. `noDataState` never applies, because there is data. Fired continuously for three weeks. |

Both were paging, or silently not paging, against a healthy cluster. They are paused in the workspace right now (langwatch-saas#993) precisely because this gauge is dead. Merging this un-deads them.

## The fix

This is Alex's `38b2329211` from 2026-07-19, rewritten against current `main`. That commit was never merged: it sits on `otel-and-haven-improvements`, the paths have since moved (`langwatch/src` to `platform/app/src`), and it bundles unrelated clog and pretty-logging work. Only the backup-metrics half is here. The reasoning and wording are his.

Collection is ON unless a deployment explicitly turns it off:

- `shouldCollectBackupMetrics()` treats unset, empty, whitespace and unrecognised values as "collect". Only `false` / `0` / `no` / `off`, trimmed and case-insensitive, opt out.
- The deployments that genuinely have no `system.backup_log` now say so, instead of getting it by accident from a default: the Helm chart renders the flag in **both** directions from `clickhouse.backup.enabled` (override `clickhouse.backup.metricsEnabled`), haven's overlay sets `false` for local worktrees, and `infra/compose.yml` opts its plain ClickHouse out.

The asymmetry is the point. An unset variable can only ever mean "keep monitoring". Turning monitoring off requires someone to write it down.

## Why not just use kube-state-metrics

We do, and those four rules were fixed separately this week (langwatch-saas#992). They are not a substitute.

- kube-state-metrics answers: **did the Job exit 0?**
- These gauges answer: **did ClickHouse record `BACKUP_CREATED` in `system.backup_log`, and how many bytes?**

A job can exit 0 and produce a useless backup. That is not hypothetical: the cross-region DR sync exited 0 for over a week while copying 3% of the bytes, and every job-level check passed the whole time. The size gauge here is the signal that would have caught it on day one.

## Verification

- `platform/app` unit tests: **47 passed**, up from 32 on this branch's base. The new ones cover the full parse table plus an end-to-end "unset still queries `system.backup_log`" case through `collectStorageStats`.
- `tools/thuishaven` Go tests pass, including a new one asserting haven's overlay emits `CLICKHOUSE_BACKUP_METRICS_ENABLED=false` only when it manages ClickHouse.
- `helm template` on all three chart paths, rendered directly rather than trusting the assertions:
  - no backups configured, renders `"false"` (previously the variable was absent)
  - `clickhouse.backup.enabled=true`, renders `"true"`
  - `clickhouse.backup.metricsEnabled=true` override, renders `"true"`
- `infra/compose.yml` parses and both `app` and `workers` carry the opt-out.
- `tsc --noEmit` clean on the changed files, `go vet` clean, `gofmt` clean.

The chart e2e suite (`charts/langwatch/tests/e2e-overlays.sh`) needs a kind cluster, so I ran the three `helm template` cases from `test_backup_metrics_gate` by hand instead. The assertions in that function are updated to match the new behaviour and will run in CI.

## After this merges

Unpause the two rules in Grafana. They become real coverage again rather than the misleading pair they are today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup metrics are now collected by default.
  * Explicitly disable collection using `false`, `0`, `no`, or `off`.
  * Deployment configurations now clearly expose the backup metrics setting.

* **Bug Fixes**
  * Ensured backup metrics are consistently enabled or disabled across Helm, Compose, and Haven deployments.

* **Tests**
  * Added coverage for default behavior, explicit opt-outs, and deployment-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->