### PR TITLE
docs(sdk): say which API key family the org-anchored services take

### DIFF
--- a/sdks/typescript/src/client-sdk/services/spend-events/spend-events-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/spend-events/spend-events-api.service.ts
@@ -169,6 +169,14 @@ export class SpendEventsApiError extends Error {
  * query filter rather than scoping on a header, so the project belongs to the
  * call, not to the client.
  *
+ * The key MUST be an organization API key (`sk-lw-{id}_{secret}`, from
+ * Settings > API Keys). A project API key is refused before any permission is
+ * consulted, with `credential_class_mismatch`, and no header makes it work:
+ * these are organization-scoped routes and a project key names one project.
+ * The same organization key also reaches the project-scoped surfaces when
+ * given `X-Project-Id`, so one key covers both families and a project key
+ * covers only one.
+ *
  * Neither collection on this service offers an eager whole-set read. The
  * ledger is unbounded, and materialising a window of it is the very
  * under-counting and out-of-memory footgun the page docstrings warn about:

--- a/sdks/typescript/src/client-sdk/services/webhooks/webhooks-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/webhooks/webhooks-api.service.ts
@@ -139,6 +139,13 @@ export class WebhooksApiError extends Error {
  * rejected by the server. The surface is anchored on the organization alone,
  * so there is no project id to give this client.
  *
+ * The key MUST be an organization API key (`sk-lw-{id}_{secret}`, from
+ * Settings > API Keys). A project API key is refused with
+ * `credential_class_mismatch` before any permission is consulted, and no
+ * header makes it work. The same organization key also reaches the
+ * project-scoped surfaces when given `X-Project-Id`, so one key covers both
+ * families and a project key covers only one.
+ *
  * The endpoint entity and the create/update bodies mirror the wire verbatim,
  * so their fields are lowercase snake_case: virtual keys and gateway budgets
  * already take the wire body as it is, and translating field by field here


### PR DESCRIPTION
Split out of [langwatch#6647](https://github.com/langwatch/langwatch/pull/6647) so the breaking change there stays inside one release component. `release-please` applies a whole commit message to every component a change touched, and these two doc comments were the only files that PR had under `sdks/typescript`, so a paragraph of prose would have taken the published SDK to 2.0.0. Nothing here is breaking, and nothing here is code.

## What it says

`SpendEventsApiService` and `WebhooksApiService` both said "ORGANIZATION API key (sk-lw-*)" and left the rest to be found out from a 401. Neither said what a project key actually gets back, that the refusal lands before any permission is consulted, or that no header rescues it. The natural next move on that error is to go hunting for a scoping header that does not exist.

They now also say the direction that does work: the same organization key reaches the project-scoped surfaces when given `X-Project-Id`, so one key covers both families and a project key covers only one.

## Test plan

Doc comments only, no runtime change and no exported type touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API key format requirements for organization-scoped requests.
  * Documented that project keys are rejected for organization-level operations.
  * Added guidance for using `X-Project-Id` with project-scoped routes.
  * Clarified permission-check behavior and organization-key requirements for webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->