### PR TITLE
fix(ci): the release-scope guard recognizes its own pin remediation

### DIFF
--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -1,15 +1,32 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
 
 import {
   bumpedComponents,
   carriesBreakingChange,
+  componentPins,
+  releaseAsVersions,
   releaseComponents,
+  shimPath,
+  shimVersion,
 } from "./guard-breaking-change-scope.ts";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
+const scriptPath = resolve(
+  import.meta.dirname,
+  "guard-breaking-change-scope.ts",
+);
 
 const liveComponents = () =>
   releaseComponents(
@@ -25,6 +42,95 @@ const names = (files: string[]): string[] =>
   bumpedComponents(files, liveComponents())
     .map((component) => component.name)
     .sort();
+
+const temporaryRoots: string[] = [];
+
+after(() => {
+  for (const root of temporaryRoots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A checkout shaped the way the workflow hands one to the guard: the live
+ * release-please config and manifest, the shim contents at the pull request
+ * head, and the two input files the collect step writes.
+ */
+const checkout = ({
+  files,
+  messages,
+  shims = {},
+}: {
+  files: string[];
+  messages: string[];
+  shims?: Record<string, string>;
+}): string => {
+  const root = mkdtempSync(join(tmpdir(), "release-scope-guard-"));
+  temporaryRoots.push(root);
+
+  mkdirSync(join(root, ".github"));
+  for (const file of [
+    ".github/release-please-config.json",
+    ".github/.release-please-manifest.json",
+  ]) {
+    copyFileSync(resolve(repoRoot, file), join(root, file));
+  }
+  for (const [path, content] of Object.entries(shims)) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), `${content}\n`);
+  }
+
+  writeFileSync(join(root, "changed-files.txt"), `${files.join("\n")}\n`);
+  writeFileSync(
+    join(root, "commit-messages.txt"),
+    `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
+  );
+  return root;
+};
+
+const runGuard = (
+  root: string,
+): { status: number; stdout: string; stderr: string } => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      scriptPath,
+      root,
+      join(root, "changed-files.txt"),
+      join(root, "commit-messages.txt"),
+    ],
+    { encoding: "utf8" },
+  );
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const shimSaying = (version: string): string =>
+  `release-please shadow marker (v9), next: ${version}`;
+
+const pinCommit = (component: string, version: string): string =>
+  [
+    `chore(release): pin ${component} at ${version}`,
+    "",
+    `Release-As: ${version}`,
+  ].join("\n");
+
+const breakingCommit = "feat(gateway)!: a key must say where its traces land";
+
+/** One ordinary file per component, so three components come up bumped. */
+const threeComponents = [
+  "platform/app/src/server/gateway/spendFilters.ts",
+  "sdks/python/src/langwatch/spend_events.py",
+  "sdks/typescript/src/index.ts",
+];
+
+const rootShim = ".release-please-shim";
+const pythonShim = "sdks/python/.release-please-shim";
+const typescriptShim = "sdks/typescript/.release-please-shim";
 
 describe("breaking-change scope guard", () => {
   describe("when reading the markers release-please reads", () => {
@@ -180,6 +286,390 @@ describe("breaking-change scope guard", () => {
         packages: { ".": { component: "root", "exclude-paths": ["/skills/"] } },
       });
       assert.deepEqual(component?.excludePaths, ["skills"]);
+    });
+  });
+
+  describe("when reading the two halves of a pin", () => {
+    it("collects every `Release-As:` footer, and nothing that only reads like one", () => {
+      assert.deepEqual(
+        releaseAsVersions([
+          "chore(release): pin the SDK\n\nRelease-As: 1.5.0",
+          "chore(release): pin the product\n\nrelease-as: 3.11.0",
+          "docs: explain that Release-As: beats every other signal",
+          "feat: something else entirely",
+        ]),
+        ["1.5.0", "3.11.0"],
+      );
+    });
+
+    it("reads the version out of every shim this repository ships", () => {
+      for (const component of liveComponents()) {
+        const shim = shimPath(component);
+        const version = shimVersion(
+          readFileSync(resolve(repoRoot, shim), "utf8"),
+        );
+        assert.match(
+          version ?? "",
+          /^\d+\.\d+\.\d+$/,
+          `${shim} has to record a version the guard can match a footer to`,
+        );
+      }
+    });
+
+    it("takes a component as pinned only with the shim edit and the footer", () => {
+      const [component] = releaseComponents({
+        packages: { "sdks/typescript": { component: "typescript-sdk" } },
+      });
+      assert.ok(component);
+      const pinFor = ({
+        files,
+        footerVersions,
+      }: {
+        files: string[];
+        footerVersions: string[];
+      }) =>
+        componentPins({
+          components: [component],
+          files,
+          footerVersions,
+          readShim: () => shimSaying("1.5.0"),
+        })[0];
+
+      assert.equal(
+        pinFor({ files: [typescriptShim], footerVersions: ["1.5.0"] })?.pinned,
+        "1.5.0",
+      );
+      assert.equal(
+        pinFor({ files: [typescriptShim], footerVersions: [] })?.pinned,
+        undefined,
+      );
+      assert.equal(
+        pinFor({ files: [typescriptShim], footerVersions: ["1.4.1"] })?.pinned,
+        undefined,
+      );
+      assert.equal(
+        pinFor({
+          files: ["sdks/typescript/src/index.ts"],
+          footerVersions: ["1.5.0"],
+        })?.pinned,
+        undefined,
+      );
+    });
+  });
+
+  describe("when the pull request pins the components it must not major", () => {
+    it("passes once every bumped component is pinned", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, rootShim, pythonShim, typescriptShim],
+          messages: [
+            breakingCommit,
+            pinCommit("typescript-sdk", "1.5.0"),
+            pinCommit("python-sdk", "1.2.1"),
+            pinCommit("langwatch", "3.11.0"),
+          ],
+          shims: {
+            [rootShim]: shimSaying("3.11.0"),
+            [pythonShim]: shimSaying("1.2.1"),
+            [typescriptShim]: shimSaying("1.5.0"),
+          },
+        }),
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes(
+          `typescript-sdk pinned to 1.5.0 by ${typescriptShim}`,
+        ),
+        result.stdout,
+      );
+      assert.ok(
+        result.stdout.includes(`python-sdk pinned to 1.2.1 by ${pythonShim}`),
+        result.stdout,
+      );
+      assert.ok(
+        result.stdout.includes(`langwatch pinned to 3.11.0 by ${rootShim}`),
+        result.stdout,
+      );
+    });
+
+    it("passes with one component left unpinned, the one taking the major", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, pythonShim, typescriptShim],
+          messages: [
+            breakingCommit,
+            pinCommit("typescript-sdk", "1.5.0"),
+            pinCommit("python-sdk", "1.2.1"),
+          ],
+          shims: {
+            [pythonShim]: shimSaying("1.2.1"),
+            [typescriptShim]: shimSaying("1.5.0"),
+          },
+        }),
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes("breaking change scoped to langwatch"),
+        result.stdout,
+      );
+    });
+
+    it("fails while more than one bumped component is still unpinned", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, typescriptShim],
+          messages: [breakingCommit, pinCommit("typescript-sdk", "1.5.0")],
+          shims: { [typescriptShim]: shimSaying("1.5.0") },
+        }),
+      );
+
+      assert.equal(result.status, 1);
+      assert.ok(
+        result.stderr.includes(
+          "- typescript-sdk (sdks/typescript), now 1.4.0, pinned to 1.5.0",
+        ),
+        result.stderr,
+      );
+      assert.ok(result.stderr.includes("- python-sdk (sdks/python)"));
+      assert.ok(result.stderr.includes("- langwatch (.)"));
+    });
+
+    it("fails naming the shim whose footer never arrived", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, typescriptShim],
+          messages: [breakingCommit],
+          shims: { [typescriptShim]: shimSaying("1.5.0") },
+        }),
+      );
+
+      assert.equal(result.status, 1);
+      assert.ok(
+        result.stderr.includes(`- ${typescriptShim} records next: 1.5.0,`),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("and no commit carries `Release-As: 1.5.0`."),
+        result.stderr,
+      );
+    });
+
+    it("fails naming the mismatch when the footer version drifted from the shim", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, typescriptShim],
+          messages: [breakingCommit, pinCommit("typescript-sdk", "1.4.1")],
+          shims: { [typescriptShim]: shimSaying("1.5.0") },
+        }),
+      );
+
+      assert.equal(result.status, 1);
+      assert.ok(
+        result.stderr.includes(`- ${typescriptShim} records next: 1.5.0,`),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("and no commit carries `Release-As: 1.5.0`."),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("Footers on this pull request: 1.4.1."),
+        result.stderr,
+      );
+    });
+
+    it("fails naming the shim that records no version to match", () => {
+      const result = runGuard(
+        checkout({
+          files: [...threeComponents, typescriptShim],
+          messages: [breakingCommit, pinCommit("typescript-sdk", "1.5.0")],
+          shims: { [typescriptShim]: "release-please shadow marker (v9)" },
+        }),
+      );
+
+      assert.equal(result.status, 1);
+      assert.ok(
+        result.stderr.includes(`- ${typescriptShim} changed but records no`),
+        result.stderr,
+      );
+    });
+
+    it("fails when a footer arrives with no shim edit to route it", () => {
+      const result = runGuard(
+        checkout({
+          files: threeComponents,
+          messages: [breakingCommit, pinCommit("typescript-sdk", "1.5.0")],
+        }),
+      );
+
+      assert.equal(result.status, 1);
+      assert.ok(
+        result.stderr.includes("but changes no shim, so nothing routes them"),
+        result.stderr,
+      );
+    });
+
+    it("keeps a breaking change inside one component passing, pins or not", () => {
+      const result = runGuard(
+        checkout({
+          files: ["sdks/typescript/src/index.ts"],
+          messages: [breakingCommit],
+        }),
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes("breaking change scoped to typescript-sdk"),
+        result.stdout,
+      );
+    });
+
+    it("leaves the label override where it lives, ahead of the script", () => {
+      const workflow = readFileSync(
+        resolve(repoRoot, ".github/workflows/release-scope-guard.yml"),
+        "utf8",
+      );
+      const label = workflow.indexOf(
+        "contains(github.event.pull_request.labels.*.name, 'multi-component-major')",
+      );
+      const shortCircuit = workflow.indexOf(
+        'if [ "$ACKNOWLEDGED" = "true" ]; then',
+      );
+      const guardRun = workflow.lastIndexOf(
+        ".github/scripts/guard-breaking-change-scope.ts",
+      );
+
+      assert.ok(label > -1, "the label still reaches the job");
+      assert.ok(
+        shortCircuit > label && shortCircuit < guardRun,
+        "the label still exits before the guard runs at all",
+      );
+      assert.ok(
+        workflow.indexOf("exit 0", shortCircuit) < guardRun,
+        "the label short circuit still exits 0",
+      );
+    });
+  });
+
+  describe("when replaying the pull request that motivated pin detection", () => {
+    // #6656: a stacked branch that inherited a `!` commit from its base, bumped
+    // three components, and pinned all three the way this guard's own
+    // remediation says to. The file list and the commits are the ones the
+    // workflow collects from the API, reduced to the messages that carry a
+    // marker or a footer, and the shim contents are the ones at its head. The
+    // guard failed it anyway, so the only unblock was the
+    // `multi-component-major` label, which asserted three majors nobody wanted.
+    const files = [
+      ".github/workflows/gateway-matrix.yaml",
+      ".release-please-shim",
+      "docs/ai-gateway/api/errors.mdx",
+      "docs/ai-gateway/billing-events.mdx",
+      "docs/ai-gateway/cookbooks/metering-and-rebilling.mdx",
+      "docs/api-reference/openapiLangWatch.json",
+      "docs/llms-full.txt",
+      "platform/app/src/app/api/gateway-spend/[[...route]]/app.ts",
+      "platform/app/src/app/api/gateway-spend/[[...route]]/contract.ts",
+      "platform/app/src/app/api/gateway-spend/__tests__/gateway-spend-rest-api.integration.test.ts",
+      "platform/app/src/app/api/gateway-spend/__tests__/spendFilterParity.unit.test.ts",
+      "platform/app/src/app/api/openapiLangWatch.json",
+      "platform/app/src/features/errors/logic/codes.ts",
+      "platform/app/src/features/errors/logic/presentation.ts",
+      "platform/app/src/pages/settings/gateway/__tests__/billing-events.integration.test.tsx",
+      "platform/app/src/pages/settings/gateway/billing-events.tsx",
+      "platform/app/src/server/api/routers/__tests__/gatewaySpendEvents.unit.test.ts",
+      "platform/app/src/server/api/routers/gatewaySpendEvents.ts",
+      "platform/app/src/server/clickhouse/migrations/00076_gateway_spend_filter_indices.sql",
+      "platform/app/src/server/gateway/__tests__/spendEventsCursor.unit.test.ts",
+      "platform/app/src/server/gateway/__tests__/spendFiltering.integration.test.ts",
+      "platform/app/src/server/gateway/__tests__/spendFilters.unit.test.ts",
+      "platform/app/src/server/gateway/__tests__/spendGrouping.unit.test.ts",
+      "platform/app/src/server/gateway/errors.ts",
+      "platform/app/src/server/gateway/spendEvents.clickhouse.repository.ts",
+      "platform/app/src/server/gateway/spendFilters.ts",
+      "platform/app/src/server/gateway/spendGrouping.ts",
+      "platform/app/src/server/gateway/spendScope.ts",
+      "sdks/python/.release-please-shim",
+      "sdks/python/src/langwatch/spend_events.py",
+      "sdks/python/tests/test_webhooks_and_spend_facades.py",
+      "sdks/typescript/.release-please-shim",
+      "sdks/typescript/src/cli/commands/spend-events/summary.ts",
+      "sdks/typescript/src/cli/program.ts",
+      "sdks/typescript/src/client-sdk/services/spend-events/__tests__/spend-events-api.paging.unit.test.ts",
+      "sdks/typescript/src/client-sdk/services/spend-events/spend-events-api.service.ts",
+      "sdks/typescript/src/index.ts",
+      "sdks/typescript/src/internal/generated/openapi/api-client.ts",
+      "services/aigateway/adapters/gatewaymetrics/docs_contract_test.go",
+      "specs/ai-gateway/gateway-spend-rest.feature",
+    ];
+
+    const shims = {
+      ".release-please-shim": "release-please shadow marker (v5), next: 3.11.0",
+      "sdks/python/.release-please-shim":
+        "release-please shadow marker (v4), next: 1.2.1",
+      "sdks/typescript/.release-please-shim":
+        "release-please shadow marker (v6), next: 1.5.0",
+    };
+
+    const inheritedBreak =
+      "feat(gateway)!: a key must say where its traces land, instead of having it guessed";
+
+    const pins = [
+      "chore(release): pin typescript-sdk at 1.5.0 under the inherited breaking marker\n\nRelease-As: 1.5.0",
+      "chore(release): pin python-sdk at 1.2.1 under the inherited breaking marker\n\nRelease-As: 1.2.1",
+      "chore(release): pin langwatch at 3.11.0 under the inherited breaking marker\n\nRelease-As: 3.11.0",
+    ];
+
+    // The workflow appends the pull request title, since a squash merge puts it
+    // in the subject line.
+    const title =
+      "feat(spend): one filter vocabulary on both reads, and a grouping that refuses to lie";
+
+    it("accepts it, with all three components pinned and none going major", () => {
+      const result = runGuard(
+        checkout({
+          files,
+          messages: [inheritedBreak, ...pins, title],
+          shims,
+        }),
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes(
+          "typescript-sdk pinned to 1.5.0 by sdks/typescript/.release-please-shim",
+        ),
+        result.stdout,
+      );
+      assert.ok(
+        result.stdout.includes(
+          "python-sdk pinned to 1.2.1 by sdks/python/.release-please-shim",
+        ),
+        result.stdout,
+      );
+      assert.ok(
+        result.stdout.includes(
+          "langwatch pinned to 3.11.0 by .release-please-shim",
+        ),
+        result.stdout,
+      );
+    });
+
+    it("still refuses it with the pin commits dropped, shims and all", () => {
+      const result = runGuard(
+        checkout({ files, messages: [inheritedBreak, title], shims }),
+      );
+
+      assert.equal(result.status, 1);
+      for (const [shim, content] of Object.entries(shims)) {
+        assert.ok(
+          result.stderr.includes(
+            `- ${shim} records next: ${shimVersion(content)},`,
+          ),
+          result.stderr,
+        );
+      }
     });
   });
 });

--- a/.github/scripts/guard-breaking-change-scope.ts
+++ b/.github/scripts/guard-breaking-change-scope.ts
@@ -15,6 +15,15 @@ const rootPath = ".";
 const breakingHeaderPattern = /^(?:[*-]\s+)?[a-zA-Z]+(?:\([^)]*\))?!:/m;
 const breakingFooterPattern = /^BREAKING[ -]CHANGE:/m;
 
+// A pin is the remediation this guard prints: one commit per component that
+// edits only that component's shim and carries one `Release-As:` footer.
+// release-please reads the footer per commit and routes it by the paths that
+// commit touched, so the shim edit and the footer are one mechanism. The guard
+// sees files per pull request rather than per commit, so it binds the two by
+// version: the footer has to name the version the shim records.
+const releaseAsPattern = /^[ \t]*Release-As:[ \t]*v?(\S+)[ \t]*$/gim;
+const shimNextPattern = /next:[ \t]*v?(\S+)/i;
+
 export type ReleaseComponent = {
   /** Package path as release-please keys it, e.g. `sdks/typescript` or `.`. */
   path: string;
@@ -96,10 +105,65 @@ export const bumpedComponents = (
   });
 };
 
-const shimPath = (component: ReleaseComponent): string =>
+export const shimPath = (component: ReleaseComponent): string =>
   component.path === rootPath
     ? ".release-please-shim"
     : `${component.path}/.release-please-shim`;
+
+/** Every `Release-As:` footer version the pull request carries, in order. */
+export const releaseAsVersions = (messages: string[]): string[] =>
+  messages.flatMap((message) =>
+    [...message.matchAll(releaseAsPattern)]
+      .map((match) => match[1])
+      .filter((version): version is string => version !== undefined),
+  );
+
+/** The version a shim records for its component, written as `next: <x.y.z>`. */
+export const shimVersion = (content: string): string | undefined =>
+  shimNextPattern.exec(content)?.[1];
+
+export type ComponentPin = {
+  component: ReleaseComponent;
+  /** The one file a pin for this component has to touch. */
+  shim: string;
+  /** Whether the pull request changes that shim. */
+  shimChanged: boolean;
+  /** Version the shim records at the pull request head, when it is readable. */
+  recorded?: string;
+  /** Version a footer confirms, which is what exempts the component. */
+  pinned?: string;
+};
+
+/**
+ * A component counts as pinned only with both halves in place. A shim edit
+ * alone moves nothing, since release-please reads the version off the footer;
+ * a footer alone cannot be attributed to a component, since only the paths a
+ * commit touched route it. The version recorded in the shim binds them.
+ */
+export const componentPins = ({
+  components,
+  files,
+  footerVersions,
+  readShim,
+}: {
+  components: ReleaseComponent[];
+  files: string[];
+  footerVersions: string[];
+  readShim: (path: string) => string | undefined;
+}): ComponentPin[] =>
+  components.map((component) => {
+    const shim = shimPath(component);
+    if (!files.includes(shim)) {
+      return { component, shim, shimChanged: false };
+    }
+
+    const recorded = shimVersion(readShim(shim) ?? "");
+    const pinned =
+      recorded !== undefined && footerVersions.includes(recorded)
+        ? recorded
+        : undefined;
+    return { component, shim, shimChanged: true, recorded, pinned };
+  });
 
 const readLines = (path: string): string[] =>
   readFileSync(path, "utf8")
@@ -110,22 +174,111 @@ const readLines = (path: string): string[] =>
 const readJson = <T>(path: string): T =>
   JSON.parse(readFileSync(path, "utf8")) as T;
 
-const report = (
-  bumped: ReleaseComponent[],
-  versions: Record<string, string>,
-): void => {
+/**
+ * A shim the pull request deletes, or one under a path this checkout does not
+ * have, reads as no pin rather than as a crash.
+ */
+const readShimFile = (path: string): string | undefined => {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+};
+
+const unique = (values: string[]): string[] => [...new Set(values)];
+
+/**
+ * Says which components the guard let past and at which version, so a passing
+ * run still shows what it accepted.
+ */
+const reportAcceptedPins = (pins: ComponentPin[]): void => {
+  for (const pin of pins) {
+    if (pin.pinned === undefined) continue;
+    console.log(
+      `${pin.component.name} pinned to ${pin.pinned} by ${pin.shim}`,
+    );
+  }
+};
+
+/**
+ * Names the half of a pin that is missing. A shim edit without its footer is
+ * the likeliest way to follow the procedure and still not pin anything, and a
+ * footer whose version drifted from the shim looks identical from here.
+ */
+const reportHalfDonePins = ({
+  pins,
+  footerVersions,
+}: {
+  pins: ComponentPin[];
+  footerVersions: string[];
+}): void => {
+  const halfDone = pins.filter(
+    (pin) => pin.pinned === undefined && pin.shimChanged,
+  );
+
+  if (halfDone.length > 0) {
+    console.error("A pin takes both halves: the shim edit, which is what");
+    console.error("routes the footer to one component, and a `Release-As:`");
+    console.error("footer naming the version that shim records. These have");
+    console.error("the shim edit and no footer to go with it:");
+    console.error("");
+    for (const pin of halfDone) {
+      if (pin.recorded === undefined) {
+        console.error(`- ${pin.shim} changed but records no`);
+        console.error("  `next: <x.y.z>` version, so no footer can bind to it.");
+        continue;
+      }
+      console.error(`- ${pin.shim} records next: ${pin.recorded},`);
+      console.error(`  and no commit carries \`Release-As: ${pin.recorded}\`.`);
+    }
+    if (footerVersions.length > 0) {
+      console.error("");
+      console.error(
+        `Footers on this pull request: ${unique(footerVersions).join(", ")}.`,
+      );
+    }
+    console.error("");
+    return;
+  }
+
+  if (footerVersions.length > 0 && !pins.some((pin) => pin.shimChanged)) {
+    console.error(
+      `This pull request carries \`Release-As:\` footers (${unique(footerVersions).join(", ")})`,
+    );
+    console.error("but changes no shim, so nothing routes them to a");
+    console.error("component and every one of them reaches all of them.");
+    console.error("");
+  }
+};
+
+const report = ({
+  pins,
+  versions,
+  footerVersions,
+}: {
+  pins: ComponentPin[];
+  /** Current version per component path, from the release-please manifest. */
+  versions: Record<string, string>;
+  footerVersions: string[];
+}): void => {
   console.error(
     "This pull request carries a breaking-change marker and touches more than",
   );
   console.error("one release component. release-please splits commits by path");
   console.error("but applies the whole commit message to every component the");
-  console.error("commit touched, so all of these go to a major:");
+  console.error("commit touched, so every one of these that is not pinned");
+  console.error("goes to a major:");
   console.error("");
-  for (const component of bumped) {
-    const current = versions[component.path] ?? "unknown";
-    console.error(`- ${component.name} (${component.path}), now ${current}`);
+  for (const pin of pins) {
+    const current = versions[pin.component.path] ?? "unknown";
+    const pinned = pin.pinned === undefined ? "" : `, pinned to ${pin.pinned}`;
+    console.error(
+      `- ${pin.component.name} (${pin.component.path}), now ${current}${pinned}`,
+    );
   }
   console.error("");
+  reportHalfDonePins({ pins, footerVersions });
   console.error("If the break really does apply to all of them, add the");
   console.error(`\`${acknowledgementLabel}\` label and this check passes.`);
   console.error("");
@@ -135,10 +288,14 @@ const report = (
   console.error("   component, which is the cheaper fix before merge.");
   console.error("2. Keep it together and pin the components that must not go");
   console.error("   major. Add a follow-up commit per component that edits");
-  console.error("   only that component's shim and carries one footer:");
+  console.error("   only that component's shim and carries one footer naming");
+  console.error("   the version that shim records. This check passes once at");
+  console.error("   most one bumped component is left unpinned:");
   console.error("");
-  for (const component of bumped) {
-    console.error(`   ${shimPath(component)}   +   Release-As: <x.y.z>`);
+  for (const pin of pins) {
+    if (pin.pinned !== undefined) continue;
+    const version = pin.recorded ?? "<x.y.z>";
+    console.error(`   ${pin.shim}   +   Release-As: ${version}`);
   }
   console.error("");
   console.error("See dev/docs/RELEASES.md for the whole procedure.");
@@ -174,10 +331,33 @@ const main = (): number => {
     return 0;
   }
 
+  const footerVersions = releaseAsVersions(messages);
+  const pins = componentPins({
+    components: bumped,
+    files,
+    footerVersions,
+    readShim: (path) => readShimFile(resolve(repoRoot, path)),
+  });
+  const unpinned = pins.filter((pin) => pin.pinned === undefined);
+  const halfDone = unpinned.filter((pin) => pin.shimChanged);
+
+  // A half-done pin fails even when the count alone would pass: the author meant
+  // to pin that component, and it is going major anyway.
+  if (halfDone.length === 0 && unpinned.length <= 1) {
+    reportAcceptedPins(pins);
+    const scope = unpinned[0]?.component.name;
+    console.log(
+      scope === undefined
+        ? "every bumped component is pinned, so none takes an implicit major"
+        : `breaking change scoped to ${scope}, every other component pinned`,
+    );
+    return 0;
+  }
+
   const versions = readJson<Record<string, string>>(
     resolve(repoRoot, manifestFile),
   );
-  report(bumped, versions);
+  report({ pins, versions, footerVersions });
   return 1;
 };
 

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -42,8 +42,11 @@ the components that should not go major, below.
 
 `release-scope-guard` enforces this on every PR. It fails when the PR title or any
 of its commits carries a breaking marker and the changed files span more than one
-component. If the break really does apply to all of them, add the
-**`multi-component-major`** label and the check passes.
+component, unless the extra components are pinned. It reads the pins described
+below and passes once at most one bumped component is left unpinned. If the break
+really does apply to all of them, add the **`multi-component-major`** label and the
+check passes. Reach for that label only when every one of those majors is wanted:
+it asserts intent, while a pin is what says a component is not going major.
 
 It reads the title and the commits because a squash merge builds the commit from
 exactly those two. It deliberately does not read the PR description, which never
@@ -73,6 +76,18 @@ component a file to touch.
 To pin several components, use one commit per component, each touching only its own
 shim and carrying only its own footer. A commit with two footers, or one that
 touches two shims, is what caused the problem in the first place.
+
+`release-scope-guard` reads pins done this way, so a breaking PR that pins its
+extra components passes without the label. It requires both halves and binds them
+by version: the component's shim has to be among the changed files, and some
+commit has to carry a `Release-As:` footer naming the version that shim records
+after `next:`. A shim edit alone moves nothing, since release-please takes the
+version from the footer, and a footer alone reaches every component the PR
+touched, since only paths route it. The guard sees one file list per PR rather
+than one per commit, so the recorded version is what attributes a footer to a
+component. A changed shim with no footer naming its version fails the check by
+name, which catches a pin that would have done nothing before merge rather than
+after the release PR regenerates.
 
 Worked examples: #6704 pinned the root package to 3.10.0, #6734 pinned the
 typescript SDK to 1.3.0, and #3627 pinned six components at once.


### PR DESCRIPTION
The guard that keeps a breaking change inside one release component prints a
remediation it cannot read. Option 2 tells the author to pin the components that
must not go major, one commit per component editing only that component's
`.release-please-shim` and carrying one `Release-As:` footer. Do exactly that and
the check stays red, because the script only ever counted bumped components. The
only unblock left was the `multi-component-major` label, which asserts that every
one of those majors is intended. On the pull request that motivated this, all
three components were pinned to a minor and a patch, and the label went on anyway,
saying the opposite of what the pins said.

## The rule

A bumped component is exempt when it is explicitly pinned, which takes both
halves:

1. its shim is among the pull request's changed files, and
2. some commit carries a `Release-As:` footer whose version equals the version
   that shim records after `next:` at the pull request head.

Both are required. A shim edit alone moves nothing, since release-please takes the
version from the footer. A footer alone reaches every component the pull request
touched, since only the paths a commit walks route it. The guard sees one file
list per pull request rather than one per commit, so the recorded version is what
attributes a footer to a component. The pinned version can be anything, a major
included: a pin is an explicit choice, and this guard exists to stop implicit
majors.

After exemptions the check passes when at most one bumped component is left
unpinned, and logs which ones it accepted and at what version. A shim that moved
with no footer naming its version fails by name, so a pin that would have done
nothing is caught before merge instead of after the release PR regenerates. The
label path is untouched and still short circuits in the workflow.

`report()` option 2 now says the check passes once the pins are in place, and
prefills each line with the version the shim already records. `dev/docs/RELEASES.md`
says the same thing.

## Proof on the case that motivated it

The tests replay #6656 as the workflow collects it: its 40 changed files from the
files API, the commits that carry a marker or a footer plus the title, and the
three shim contents at its head (3.11.0, 1.2.1, 1.5.0). Against that fixture the
script on `main` exits 1 and this one exits 0, naming all three pins. Dropping the
three pin commits from the same fixture puts it back to exit 1, now naming each
shim that moved without its footer.

Tests cover pinned-all, pinned-all-but-one, pinned-some, shim without footer,
footer version drifted from the shim, shim recording no version, footer with no
shim edit, a single-component break, and the label short circuit still sitting
ahead of the script. 28 pass, and the workflow's push trigger self-tests this
change.
