### PR TITLE
fix(cli): drop billing and cadence wording from wrapper prompts

### DIFF
--- a/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-path-choice.unit.test.ts
@@ -219,7 +219,7 @@ describe("resolveWrapperPath", () => {
           "keep your own plan, send only telemetry to LangWatch",
         );
         expect(promptArg.choices[1]!.description).toBe(
-          "route calls through LangWatch with a virtual key, billed per token",
+          "route calls through LangWatch with a virtual key",
         );
         // Remembered for next time.
         expect(save).toHaveBeenCalledTimes(1);
@@ -398,11 +398,14 @@ describe("resolveWrapperPath", () => {
       });
       const promptArg = (prompt as unknown as ReturnType<typeof vi.fn>).mock
         .calls[0]![0] as {
-        choices: Array<{ value: string }>;
+        choices: Array<{ value: string; description: string }>;
         initial: number;
       };
       const values = promptArg.choices.map((c) => c.value);
       expect(values[promptArg.initial]).toBe("ingestion");
+      expect(promptArg.choices[values.indexOf("gateway")]!.description).toBe(
+        "route calls through LangWatch with a virtual key",
+      );
     });
 
     /** @scenario An explicit --tool-mode=gateway flag routes copilot through the gateway */
@@ -586,7 +589,9 @@ describe("resolveWrapperPath", () => {
         "keep your own plan, send only telemetry to LangWatch",
       );
       expect(gatewayChoiceTitle()).toBe("Using an API key");
-      expect(gatewayChoiceDescription()).toContain("billed per token");
+      expect(gatewayChoiceDescription()).toBe(
+        "route calls through LangWatch with a virtual key",
+      );
     });
 
     it("names the right subscription per tool, with a neutral fallback", () => {

--- a/sdks/typescript/src/cli/utils/governance/wrapper-path-choice.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper-path-choice.ts
@@ -185,7 +185,7 @@ export function gatewayChoiceTitle(): string {
 }
 
 export function gatewayChoiceDescription(): string {
-  return "route calls through LangWatch with a virtual key, billed per token";
+  return "route calls through LangWatch with a virtual key";
 }
 
 /**

--- a/sdks/typescript/src/cli/utils/governance/wrapper.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper.ts
@@ -18,11 +18,11 @@ import { spawn } from "node:child_process";
 import { normalizeEndpoint } from "../../../internal/endpoint";
 import { lwTag } from "./brand";
 import { checkBudget, renderBudgetExceeded } from "./budget";
+import { updateLangwatchClaudePlugin } from "./claude-plugin";
 import { getCliBootstrap } from "./cli-api";
 import { createCodexIOStreamer } from "./codex-rollout-otlp";
 import type { GovernanceConfig } from "./config";
 import { isLoggedIn, loadConfig, saveConfig } from "./config";
-import { updateLangwatchClaudePlugin } from "./claude-plugin";
 import {
 	copilotGatewayModelPreflight,
 	copilotPrespawnWarnings,
@@ -581,7 +581,7 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 		onCheckStart: () =>
 			process.stderr.write(
 				`${lwTag()} checking whether the LangWatch plugin for Claude Code ` +
-					`is up to date (once a day).\n`,
+					`is up to date.\n`,
 			),
 	});
 	if (pluginUpdate.action === "updated") {

--- a/specs/ai-governance/cli-wrappers/copilot-path-defaults.feature
+++ b/specs/ai-governance/cli-wrappers/copilot-path-defaults.feature
@@ -39,7 +39,7 @@ Feature: `langwatch copilot` defaults to direct OTLP so Copilot seat billing is 
       And stdin and stdout are a TTY
       When the user runs `langwatch copilot`
       Then the select prompt's pre-selected choice is "Direct OTLP"
-      And the gateway choice explains that LLM usage is billed per token
+      And the gateway choice explains that calls route through LangWatch on a virtual key
 
   Rule: explicit choices win over the copilot exception
 


### PR DESCRIPTION
Two lines of wrapper copy, no behavior change.

### The API-key option said LangWatch bills per token

```
? How should `langwatch claude` run?
    Using a Claude subscription - keep your own plan, send only telemetry to LangWatch
❯   Using an API key - route calls through LangWatch with a virtual key, billed per token
```

"billed per token" sits right after "through LangWatch", so it reads as if LangWatch charges per token for the privilege of proxying. It does not. The virtual key routes to the org's own provider keys, and the provider bills the tokens. The clause is dropped rather than reworded: the option is already titled "Using an API key", which is the part the user is choosing between.

### The plugin update check announced its own schedule

```
✦ langwatch checking whether the LangWatch plugin for Claude Code is up to date (once a day).
```

The once-a-day stamp is how the check avoids becoming a tax on startup. It is not something the user does anything with, and naming it invites the question this line was meant to avoid. The message now says only what it is doing while it waits.

### Spec

`copilot-path-defaults.feature` asserted the old billing wording in a step no test covered, so the sentence was free to drift from the code. It now names the copy that ships, and the copilot prompt test asserts the gateway option's description alongside the pre-selection it already checked.

### Verification

`pnpm test:unit` on the wrapper path-choice suite (81 passing) and `pnpm typecheck`, both clean in `sdks/typescript`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gateway selection prompts with clearer, neutral descriptions.
  * Removed token-billing wording from gateway guidance.
  * Clarified that Copilot requests are routed through LangWatch using a virtual key.
  * Simplified the plugin update status message by removing the daily-update qualifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->