### PR TITLE
fix(annotations): mark comment and isThumbsUp as required in PATCH OpenAPI spec (#946)

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -245,6 +245,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": ["comment", "isThumbsUp"],
                 "properties": {
                   "comment": {
                     "type": "string"

--- a/langwatch/src/app/api/openapiLangWatch.json
+++ b/langwatch/src/app/api/openapiLangWatch.json
@@ -245,6 +245,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": ["comment", "isThumbsUp"],
                 "properties": {
                   "comment": {
                     "type": "string"


### PR DESCRIPTION
OpenAPI spec correction only, fixes #946

## Why

The `PATCH /api/annotations/{id}` route validates both `comment` and
`isThumbsUp` as required and returns a 400 error if either is missing.
The OpenAPI spec had no `required` array, making both fields appear
optional to API consumers and SDK generators — a misleading contract.

Closes #946

## What changed

Added `"required": ["comment", "isThumbsUp"]` to the `requestBody`
schema for `PATCH /api/annotations/{id}` in:
- `langwatch/src/app/api/openapiLangWatch.json`
- `docs/api-reference/openapiLangWatch.json`

## Test plan

- Verified against route source (`src/server/routes/annotations.ts`
  lines 157–175) which confirms both fields are runtime-required
- Two-line change, no logic affected
