### PR TITLE
fix(annotations): read the dataset annotations column as the text it is

### DIFF
--- a/platform/app/src/server/api/routers/__tests__/annotation.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.integration.test.ts
@@ -873,9 +873,12 @@ describe("Annotation CRUD", () => {
         expect(
           (JSON.parse(row!.comments as string) as string[]).sort(),
         ).toEqual(everyComment);
-        const readable = JSON.parse(row!.readable as string) as string[];
+        // The readable column is one text with a rule between reviews, not a
+        // list to parse: it is written to be read, by a person or a judge.
+        const readable = (row!.readable as string).split("\n---\n");
+        expect(readable).toHaveLength(everyComment.length);
         expect(
-          readable.filter((line) => line.includes("(on Span span-")),
+          readable.filter((line) => line.includes("(on span (span-")),
         ).toHaveLength(3);
       });
 


### PR DESCRIPTION
## What was wrong

`test-integration (6)` is red on `main`, and therefore on every open PR whose merge commit picks main up:

```
FAIL src/server/api/routers/__tests__/annotation.integration.test.ts
  > fills a dataset annotations column with all four comments
SyntaxError: Unexpected token 'T', "Test User:"... is not valid JSON
```

## Why

The `ai_readable` dataset column is deliberately **one text**, with `\n---\n` between reviews, so that whoever reads the column reads the review rather than JSON. `tracesMapping.ts` says so in as many words, and its own unit tests pin the joined form.

This assertion never caught up. It still `JSON.parse`d the column, and it still looked for the older anchor wording `(on Span span-1)`, where the line reads `(on span (span-1))` today.

## The fix

Split on the rule, check there is one entry per comment, and look for the anchor as it actually reads. Nothing in the product changes; the test now describes the column the product writes.

Run locally against the real database, `48 passed (48)`, red before and green after on the same command:

```
pnpm test:integration src/server/api/routers/__tests__/annotation.integration.test.ts --watch=false
```

Found while driving #6730, whose CI inherited this failure through its merge commit.
