### PR TITLE
fix(tests): read the annotations column as the text it is, and stop the queue overlap test racing its holder

### DIFF
--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -33,14 +33,26 @@ const QUEUE_SCRIPT = path.join(REPO_ROOT, "dev/scripts/check-queue.mjs");
  * The command the wrapper runs. Appends `start` on boot and `end` after
  * `holdMs`, so the log is enough to reconstruct who ran when and how many ran
  * at once.
+ *
+ * A test that kills the wrapper mid-hold cannot signal this process, which the
+ * kernel hands to init instead. Watching for that reparenting is what stops a
+ * long hold from outliving the suite as a sleeping process.
  */
 const FAKE_COMMAND = `
 const fs = require("node:fs");
 const [log, tag, holdMs] = process.argv.slice(2);
 const write = (event) =>
   fs.appendFileSync(log, JSON.stringify({ event, tag, at: Date.now() }) + "\\n");
+const wrapper = process.ppid;
+const orphaned = setInterval(() => {
+  if (process.ppid !== wrapper) process.exit(0);
+}, 50);
+orphaned.unref();
 write("start");
-setTimeout(() => write("end"), Number(holdMs));
+setTimeout(() => {
+  write("end");
+  clearInterval(orphaned);
+}, Number(holdMs));
 `;
 
 type Event = { event: "start" | "end"; tag: string; at: number };
@@ -349,7 +361,13 @@ describe("check queue", () => {
 
     /** @scenario "A run that waits too long runs anyway" */
     it("starts without a slot rather than hanging forever", async () => {
-      const holder = startRun("holder", { holdMs: 3000 });
+      // The overlap below is only observable while the holder is still inside
+      // the command, and the impatient run reaches it only after two node
+      // boots and its own maximum wait. The holder is killed as soon as the
+      // overlap has been read, so holding far longer than that costs the suite
+      // nothing and keeps a loaded machine from ending the holder first, which
+      // reads as the queue having serialized the two runs.
+      const holder = startRun("holder", { holdMs: 60_000 });
       await waitForHolder();
       const impatient = startRun("impatient", {
         env: { CHECK_QUEUE_MAX_WAIT_MS: "200" },

--- a/platform/app/src/server/api/routers/__tests__/annotation.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.integration.test.ts
@@ -873,10 +873,15 @@ describe("Annotation CRUD", () => {
         expect(
           (JSON.parse(row!.comments as string) as string[]).sort(),
         ).toEqual(everyComment);
-        const readable = JSON.parse(row!.readable as string) as string[];
+        // The readable column is one text a reader reads straight through, one
+        // review per line with a rule between them, not a list to parse. A
+        // dataset row leaves the product, so each anchored review names its
+        // span by id as well.
+        const readable = (row!.readable as string).split("\n---\n");
+        expect(readable).toHaveLength(everyComment.length);
         expect(
-          readable.filter((line) => line.includes("(on Span span-")),
-        ).toHaveLength(3);
+          readable.filter((line) => line.includes("(on span (span-")),
+        ).toHaveLength(spanIds.length);
       });
 
       it("still narrows to the trace's own comments when a caller asks", async () => {


### PR DESCRIPTION
## What

Two test-only fixes for failures that come from main, not from the PRs that are hitting them.

### The annotations column is one text, and the test still parsed it as JSON

`33d55ee3b6` (#6565) made the dataset `ai_readable` column one text a reader reads straight through, one review per line with a `---` rule between them, deliberately so that a person or a judge reads the review instead of reading JSON first. The same commit left `annotation.integration.test.ts` calling `JSON.parse` on that column, so the test throws:

```
SyntaxError: Unexpected token 'T', "Test User:"... is not valid JSON
 ❯ src/server/api/routers/__tests__/annotation.integration.test.ts:876:31
```

The joined-text shape is the intended one and is already pinned by `specs/datasets/dataset-annotations-mapping.feature` and by unit tests that assert the column does not contain `["`. The integration test is the stale side, so it now splits on the rule.

It also expected the on-screen anchor wording, `(on Span span-1)`. A dataset row leaves the product, so `mapTraceToDatasetEntry` names anchors with ids, `(on span (span-1))`. The test now matches what a dataset row actually carries.

#6565 merged with `test-integration (6)` already red, which is how this reached main.

### The check queue's give-up test raced its own holder

`starts without a slot rather than hanging forever` starts a holder, then a run that gives up waiting after 200ms, then asserts both were inside the command at once. That overlap is only observable while the holder still runs, and the holder was given three seconds. The impatient run needs two node boots plus its own wait to get there, so on a loaded runner the holder finishes first and the queue looks like it serialized the two runs:

```
AssertionError: expected 1 to be 2
 ❯ scripts/__tests__/check-queue.unit.test.ts:362:40
```

The holder is killed as soon as the overlap has been read, so holding far longer costs the suite nothing. The fake command now also exits when the kernel reparents it, so a long hold cannot outlive the suite as a sleeping process.

## Verification

Reproduced on plain main before the fix, and the queue race was reproduced deterministically by shortening the holder's hold to 350ms, which yields the same `expected 1 to be 2`.

| Suite | Result |
|---|---|
| `annotation.integration.test.ts` | 48 passed |
| `annotation.integration.test.ts` + `TracesMapping.annotations.integration.test.tsx` | 52 passed |
| `tracesMapping.test.ts` + `buildReadableAnnotation.test.ts` | 96 passed |
| `check-queue.unit.test.ts`, three consecutive runs | 15 passed each, no stray processes |
| `pnpm typecheck:tests` | clean |

## Unblocks

`test-integration` shard 6 was red on main itself and on every PR that ran it: #6656, #6737 and #6759. #6737 also hit the check queue race on `test-unit` shard 3.

One failure in this set is not from main and is not fixed here: #6759's `test-integration` shard 1 never reached the tests. It failed in `setup-pnpm-node` building `node-pty`, a transient native build failure. Shard 6 of the same run installed fine, so a rerun clears it.
