### PR TITLE
chore(release): pin typescript-sdk at 1.5.0

### DIFF
--- a/sdks/typescript/.release-please-shim
+++ b/sdks/typescript/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v6), next: 1.5.0
+release-please shadow marker (v7), next: 1.5.0


### PR DESCRIPTION
Repairs the lost pin from #6656: the squash folded three Release-As footers into one body and only the last parsed, so #6758 proposes 2.0.0 for additive filter surface. Single commit touching only the typescript shim, footer as the last body line. Squash keeping the default message body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release metadata for the upcoming version 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->