### PR TITLE
chore(release): pin python-sdk at 1.2.1

### DIFF
--- a/sdks/python/.release-please-shim
+++ b/sdks/python/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v4), next: 1.2.1
+release-please shadow marker (v5), next: 1.2.1


### PR DESCRIPTION
Same repair as the typescript pin: #6765 proposes 2.0.0 for tests and docstring constraints, a patch. Single commit touching only the python shim, footer as the last body line. Squash keeping the default message body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release metadata to prepare the next version, which remains 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->