### PR TITLE
fix(langevals): restore the ragas evaluators and close 17 alerts

### DIFF
--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -146,8 +146,24 @@ jobs:
         # tests/` runs on the secret-bearing step by default, which forks skip,
         # so a contributor could otherwise break the request shape and see CI
         # stay green.
+        #
+        # The two ragas files are named individually for the same reason. The
+        # step above ignores `evaluators/ragas/` wholesale because the evaluator
+        # tests there are LLM-judged, and that is how two import-time breaks
+        # reached main without CI noticing: the litellm client losing the shape
+        # langchain-openai calls it with, and a notebooks dependency that could
+        # not be imported on this Python taking the whole suite's collection
+        # down. Neither needs a provider. These two files stub every call, so
+        # they pin the client shape and the token accounting that prices each
+        # evaluation, and they fail loudly at import if that surface moves again.
         working-directory: services/langevals
-        run: uv run pytest -x -v evaluators/langevals/tests/test_llm_answer_match_threading.py tests/deterministic/ langevals_core/tests/
+        run: |
+          uv run pytest -x -v \
+            evaluators/langevals/tests/test_llm_answer_match_threading.py \
+            evaluators/ragas/tests/test_model_to_langchain.py \
+            evaluators/ragas/tests/test_token_usage.py \
+            tests/deterministic/ \
+            langevals_core/tests/
 
   docker-build:
     needs: changes

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/common.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/common.py
@@ -12,7 +12,7 @@ from langevals_core.base_evaluator import (
 )
 from pydantic import Field
 from ragas.llms import LangchainLLMWrapper
-from langchain_community.callbacks import get_openai_callback
+from langevals_ragas.lib.token_usage import get_token_usage_callback
 
 from langevals_ragas.lib.model_to_langchain import (
     embeddings_model_to_langchain,
@@ -110,7 +110,7 @@ def check_max_tokens(
 
 @contextmanager
 def capture_cost(llm: LangchainLLMWrapper):
-    with get_openai_callback() as cb:
+    with get_token_usage_callback() as cb:
         money = Money(amount=0, currency="USD")
         yield money
 

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
@@ -10,6 +10,39 @@ from langchain_core.language_models.chat_models import (
 import litellm
 
 
+class RawCompletion:
+    """The `.parse()` / `.headers` shape ChatOpenAI expects back from a raw call.
+
+    langchain-openai 0.3 routes the non-streaming path through
+    `client.with_raw_response.create(...)` and then calls `.parse()` on what
+    comes back. litellm returns the parsed response directly, so the two are
+    bridged here rather than by pinning langchain-openai below 0.3.
+    """
+
+    def __init__(self, response):
+        self._response = response
+        self.headers: dict = {}
+
+    def parse(self):
+        return self._response
+
+
+class RawCompletionProxy:
+    def __init__(self, client: "LitellmCompletion"):
+        self._client = client
+
+    def create(self, *args, **kwargs):
+        return RawCompletion(self._client.create(*args, **kwargs))
+
+
+class AsyncRawCompletionProxy:
+    def __init__(self, client: "AsyncLitellmCompletion"):
+        self._client = client
+
+    async def create(self, *args, **kwargs):
+        return RawCompletion(await self._client.create(*args, **kwargs))
+
+
 class LitellmCompletion:
     exception: Optional[Exception] = None
     temperature: float = 0
@@ -36,10 +69,18 @@ class LitellmCompletion:
             self.exception = e
             raise e
 
+    @property
+    def with_raw_response(self):
+        return RawCompletionProxy(self)
+
 
 class AsyncLitellmCompletion(LitellmCompletion):
     async def create(self, *args, **kwargs):
         return super().create(*args, **kwargs)
+
+    @property
+    def with_raw_response(self):
+        return AsyncRawCompletionProxy(self)
 
 
 def model_to_langchain(

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
@@ -13,10 +13,10 @@ import litellm
 class RawCompletion:
     """The `.parse()` / `.headers` shape ChatOpenAI expects back from a raw call.
 
-    langchain-openai 0.3 routes the non-streaming path through
+    langchain-openai routes the non-streaming path through
     `client.with_raw_response.create(...)` and then calls `.parse()` on what
     comes back. litellm returns the parsed response directly, so the two are
-    bridged here rather than by pinning langchain-openai below 0.3.
+    bridged here.
     """
 
     def __init__(self, response):

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/token_usage.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/token_usage.py
@@ -1,0 +1,95 @@
+"""Token accounting for a block of langchain LLM calls.
+
+langchain-community's `get_openai_callback` is the usual way to do this, but
+importing it drags in `langchain_core.tracers.langchain_v1`, which langchain-core
+1.x removed, so it cannot be used on the 1.x line. Only the prompt and completion
+counters are needed here (cost is priced by litellm afterwards), so the handler is
+built directly on the langchain-core callback surface instead.
+"""
+
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Generator, Optional
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+from langchain_core.tracers.context import register_configure_hook
+
+
+class TokenUsageCallbackHandler(BaseCallbackHandler):
+    """Sums prompt and completion tokens across every LLM call in a block."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.total_tokens = 0
+        self.successful_requests = 0
+
+    def __repr__(self) -> str:
+        return (
+            f"Prompt tokens: {self.prompt_tokens}\n"
+            f"Completion tokens: {self.completion_tokens}\n"
+            f"Total tokens: {self.total_tokens}\n"
+            f"Successful requests: {self.successful_requests}"
+        )
+
+    @property
+    def always_verbose(self) -> bool:
+        return True
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        prompt_tokens, completion_tokens = self._extract_usage(response)
+
+        with self._lock:
+            self.successful_requests += 1
+            self.prompt_tokens += prompt_tokens
+            self.completion_tokens += completion_tokens
+            self.total_tokens += prompt_tokens + completion_tokens
+
+    @staticmethod
+    def _extract_usage(response: LLMResult) -> tuple[int, int]:
+        """Read usage off a chat message, falling back to the llm_output block.
+
+        Chat models report usage on the AIMessage; completion models and any
+        provider that skips `usage_metadata` report it under
+        `llm_output["token_usage"]`.
+        """
+        try:
+            generation = response.generations[0][0]
+        except IndexError:
+            generation = None
+
+        if isinstance(generation, ChatGeneration):
+            message = generation.message
+            if isinstance(message, AIMessage) and message.usage_metadata:
+                usage = message.usage_metadata
+                return usage.get("input_tokens", 0), usage.get("output_tokens", 0)
+
+        token_usage = (response.llm_output or {}).get("token_usage")
+        if not token_usage:
+            return 0, 0
+        return (
+            token_usage.get("prompt_tokens", 0),
+            token_usage.get("completion_tokens", 0),
+        )
+
+
+token_usage_callback_var: ContextVar[Optional[TokenUsageCallbackHandler]] = ContextVar(
+    "token_usage_callback", default=None
+)
+register_configure_hook(token_usage_callback_var, True)
+
+
+@contextmanager
+def get_token_usage_callback() -> Generator[TokenUsageCallbackHandler, None, None]:
+    """Attach a token counter to every langchain call made inside the block."""
+    handler = TokenUsageCallbackHandler()
+    token_usage_callback_var.set(handler)
+    try:
+        yield handler
+    finally:
+        token_usage_callback_var.set(None)

--- a/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
@@ -1,0 +1,63 @@
+"""The litellm client has to satisfy the shape langchain-openai calls it with.
+
+langchain-openai 0.3 routes the non-streaming path through
+`client.with_raw_response.create(...)` followed by `.parse()`, rather than
+calling `client.create(...)` directly as 0.2 did. These tests pin that shape so
+a future bump cannot quietly reintroduce the AttributeError.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from litellm.types.utils import Choices, Message, ModelResponse
+
+from langevals_ragas.lib.model_to_langchain import model_to_langchain
+
+
+def _canned_response(content: str = "pong") -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(role="assistant", content=content),
+            )
+        ],
+    )
+
+
+def test_client_exposes_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    assert hasattr(llm.client, "with_raw_response")
+    assert hasattr(llm.async_client, "with_raw_response")
+
+
+def test_invoke_routes_through_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    with patch("litellm.completion", return_value=_canned_response()) as completion:
+        result = llm.invoke("ping")
+    assert result.content == "pong"
+    assert completion.call_count == 1
+
+
+def test_ainvoke_routes_through_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+
+    async def go():
+        with patch("litellm.completion", return_value=_canned_response("async pong")):
+            return await llm.ainvoke("ping")
+
+    assert asyncio.run(go()).content == "async pong"
+
+
+def test_raw_response_parse_returns_the_litellm_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    canned = _canned_response()
+    with patch("litellm.completion", return_value=canned):
+        raw = llm.client.with_raw_response.create(model="gpt-4o-mini", messages=[])
+    assert raw.parse() is canned
+    assert raw.headers == {}

--- a/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
@@ -1,9 +1,8 @@
 """The litellm client has to satisfy the shape langchain-openai calls it with.
 
-langchain-openai 0.3 routes the non-streaming path through
-`client.with_raw_response.create(...)` followed by `.parse()`, rather than
-calling `client.create(...)` directly as 0.2 did. These tests pin that shape so
-a future bump cannot quietly reintroduce the AttributeError.
+langchain-openai routes the non-streaming path through
+`client.with_raw_response.create(...)` followed by `.parse()`. These tests pin
+that shape so a future bump cannot quietly reintroduce the AttributeError.
 """
 
 import asyncio

--- a/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/tests/test_model_to_langchain.py
@@ -1,11 +1,38 @@
+"""The litellm client has to satisfy the shape langchain-openai calls it with.
+
+langchain-openai routes the non-streaming path through
+`client.with_raw_response.create(...)` followed by `.parse()`, rather than
+calling `client.create(...)` directly as it once did. These tests pin that shape
+so a future bump cannot quietly reintroduce the AttributeError.
+"""
+
 import asyncio
+from unittest.mock import patch
 
 import litellm
+from litellm.types.utils import Choices, Message, ModelResponse
 
 from langevals_ragas.lib.model_to_langchain import (
     AsyncLitellmCompletion,
     LitellmCompletion,
+    model_to_langchain,
 )
+
+
+def _canned_response(content: str = "pong") -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(role="assistant", content=content),
+            )
+        ],
+    )
 
 
 def test_with_raw_response_wraps_the_completion(monkeypatch):
@@ -35,3 +62,36 @@ def test_async_with_raw_response_wraps_the_completion(monkeypatch):
 
     assert raw.headers == {}
     assert raw.parse()["kw"]["api_version"] == "2024-06-01"
+
+
+def test_client_exposes_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    assert hasattr(llm.client, "with_raw_response")
+    assert hasattr(llm.async_client, "with_raw_response")
+
+
+def test_invoke_routes_through_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    with patch("litellm.completion", return_value=_canned_response()) as completion:
+        result = llm.invoke("ping")
+    assert result.content == "pong"
+    assert completion.call_count == 1
+
+
+def test_ainvoke_routes_through_with_raw_response():
+    llm = model_to_langchain("gpt-4o-mini")
+
+    async def go():
+        with patch("litellm.completion", return_value=_canned_response("async pong")):
+            return await llm.ainvoke("ping")
+
+    assert asyncio.run(go()).content == "async pong"
+
+
+def test_raw_response_parse_returns_the_litellm_response():
+    llm = model_to_langchain("gpt-4o-mini")
+    canned = _canned_response()
+    with patch("litellm.completion", return_value=canned):
+        raw = llm.client.with_raw_response.create(model="gpt-4o-mini", messages=[])
+    assert raw.parse() is canned
+    assert raw.headers == {}

--- a/services/langevals/evaluators/ragas/tests/test_token_usage.py
+++ b/services/langevals/evaluators/ragas/tests/test_token_usage.py
@@ -1,0 +1,122 @@
+"""Token accounting has to keep working without langchain-community.
+
+`capture_cost` prices an evaluation from the prompt and completion token counts
+gathered across a block of LLM calls. These tests pin the two shapes langchain
+reports usage in, so the counters cannot silently go to zero and price every
+evaluation at nothing.
+"""
+
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, Generation, LLMResult
+
+from langevals_ragas.lib.token_usage import (
+    TokenUsageCallbackHandler,
+    get_token_usage_callback,
+    token_usage_callback_var,
+)
+
+
+def _chat_result(input_tokens: int, output_tokens: int) -> LLMResult:
+    message = AIMessage(
+        content="hello",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    )
+    return LLMResult(generations=[[ChatGeneration(message=message)]])
+
+
+def _llm_output_result(prompt_tokens: int, completion_tokens: int) -> LLMResult:
+    return LLMResult(
+        generations=[[Generation(text="hello")]],
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+            },
+            "model_name": "gpt-4o-mini",
+        },
+    )
+
+
+def test_counts_usage_metadata_from_a_chat_message():
+    handler = TokenUsageCallbackHandler()
+    handler.on_llm_end(_chat_result(11, 5))
+
+    assert handler.prompt_tokens == 11
+    assert handler.completion_tokens == 5
+    assert handler.total_tokens == 16
+    assert handler.successful_requests == 1
+
+
+def test_falls_back_to_the_llm_output_token_usage_block():
+    handler = TokenUsageCallbackHandler()
+    handler.on_llm_end(_llm_output_result(7, 3))
+
+    assert handler.prompt_tokens == 7
+    assert handler.completion_tokens == 3
+    assert handler.total_tokens == 10
+
+
+def test_sums_across_every_call_in_the_block():
+    handler = TokenUsageCallbackHandler()
+    handler.on_llm_end(_chat_result(10, 2))
+    handler.on_llm_end(_llm_output_result(5, 1))
+
+    assert handler.prompt_tokens == 15
+    assert handler.completion_tokens == 3
+    assert handler.successful_requests == 2
+
+
+def test_a_response_without_usage_does_not_raise():
+    handler = TokenUsageCallbackHandler()
+    handler.on_llm_end(LLMResult(generations=[[Generation(text="hello")]]))
+
+    assert handler.prompt_tokens == 0
+    assert handler.completion_tokens == 0
+    assert handler.successful_requests == 1
+
+
+def test_the_context_manager_exposes_the_handler_and_clears_it_afterwards():
+    with get_token_usage_callback() as cb:
+        assert token_usage_callback_var.get() is cb
+        cb.on_llm_end(_chat_result(4, 6))
+        assert cb.prompt_tokens == 4
+        assert cb.completion_tokens == 6
+
+    assert token_usage_callback_var.get() is None
+
+
+def test_the_context_var_is_cleared_even_when_the_block_raises():
+    try:
+        with get_token_usage_callback():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+
+    assert token_usage_callback_var.get() is None
+
+
+def test_the_handler_attaches_itself_to_langchain_calls_in_the_block():
+    """The counters are never passed to the model explicitly.
+
+    `capture_cost` wraps evaluator code that calls the LLM through ragas, so the
+    handler has to attach itself through the langchain callback configure hook.
+    """
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+    reply = AIMessage(
+        content="pong",
+        usage_metadata={"input_tokens": 12, "output_tokens": 4, "total_tokens": 16},
+    )
+    llm = GenericFakeChatModel(messages=iter([reply, reply]))
+
+    with get_token_usage_callback() as cb:
+        llm.invoke("ping")
+        llm.invoke("ping")
+
+    assert cb.successful_requests == 2
+    assert cb.prompt_tokens == 24
+    assert cb.completion_tokens == 8

--- a/services/langevals/notebooks/pyproject.toml
+++ b/services/langevals/notebooks/pyproject.toml
@@ -8,7 +8,14 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "pytest>=8.1.2",
     "fastapi>=0.115.11",
-    "arize-phoenix>=4.9.0",
+    # Capped below 19.18.0: from that release phoenix declares a dataclass with
+    # a mappingproxy default, which Python 3.11 rejects at import
+    # ("mutable default <class 'mappingproxy'> ... use default_factory"). Its
+    # metadata still claims >=3.10, and this project is on 3.11 per
+    # .python-version, so the bad versions resolve happily and then break
+    # collection for the whole suite via phoenix's pytest plugin. Lift the cap
+    # once phoenix fixes that or langevals moves to 3.12.
+    "arize-phoenix>=4.9.0,<19.18.0",
     "openinference-instrumentation-dspy>=0.1.9",
     "opentelemetry-exporter-otlp>=1.25.0",
     "hypercorn>=0.16.0",

--- a/services/langevals/pyproject.toml
+++ b/services/langevals/pyproject.toml
@@ -82,9 +82,8 @@ override-dependencies = [
     # server-side file read; patched in 0.8.18.
     "langsmith>=0.8.18",
     # Force a patched strawberry-graphql (GHSA-fr49-mhgj-crfc, GHSA-qfwv-87qj-98xq,
-    # GHSA-x97m-qp5c-w9xj). arize-phoenix 14.6.0 pins it to 0.314.3; the patched
-    # 0.316.0 is API-compatible with Phoenix and is the version Phoenix itself moved
-    # to in 16.4.0.
+    # GHSA-x97m-qp5c-w9xj, all of which top out at 0.315.6). arize-phoenix pins
+    # strawberry exactly, so without this the pin decides the version.
     "strawberry-graphql>=0.316.0",
     "pydantic-settings>=2.14.2",  # security: pydantic-settings advisory (#1517)
     # security: GHSA circular JSON Schema $ref unbounded-CPU DoS; patched in 0.60.1.

--- a/services/langevals/pyproject.toml
+++ b/services/langevals/pyproject.toml
@@ -67,17 +67,19 @@ packages = ["langevals"]
 [tool.uv]
 exclude-newer = "7 days"
 override-dependencies = [
-    # Upper bounds are load-bearing, not tidiness. This was an unbounded
-    # `langchain>=0.3.30`, so re-locking for the security floors below silently
-    # took langchain to 1.3.15 and langchain-core to 1.5.4. langchain-community
-    # is not on that line and still imports langchain_core.tracers.langchain_v1,
-    # which 1.x removed, so every evaluator load crashed at import. Keeping the
-    # family on 0.x is what makes this a security-floor change and nothing else;
-    # moving to 1.x is a deliberate migration with its own PR.
-    "langchain>=0.3.30,<1",
-    "langchain-core>=0.3.86,<1",
-    "langchain-openai>=0.2.14,<1",
-    "langchain-text-splitters>=0.3.11,<1",
+    # The langchain family is on the 1.x line, where the advisories affecting it
+    # are fixed. Each floor is the highest first-patched version across the
+    # advisories for that package.
+    "langchain>=1.3.9",
+    "langchain-core>=1.2.22",
+    "langchain-openai>=1.1.14",
+    "langchain-text-splitters>=1.1.2",
+    # langchain-community stays on 0.3.x, which is compatible with core 1.x by
+    # declaration and in practice. It is capped below 0.4 because ragas imports
+    # `langchain_community.chat_models.vertexai` at module level and 0.4.0 moved
+    # the vertexai integrations out, so 0.4.x makes every ragas import fail.
+    # No advisory currently affects this package.
+    "langchain-community>=0.3.31,<0.4",
     # security: GHSA-f4xh-w4cj-qxq8 — LangSmith SDK TracingMiddleware arbitrary
     # server-side file read; patched in 0.8.18.
     "langsmith>=0.8.18",
@@ -115,11 +117,7 @@ override-dependencies = [
     "torch>=2.13.0",
     #
     # NOT fixed here, deliberately:
-    #   langchain / langchain-core / langchain-openai / langchain-text-splitters
-    #     — this workspace is on the 0.3.x line and every patched version is on
-    #       1.x, so clearing those four alerts is a breaking major upgrade of the
-    #       evaluator surface, not a floor bump. Tracked separately.
-    #   ragas, diskcache — no patched release exists upstream yet.
+    #   ragas, diskcache: no patched release exists upstream yet.
 ]
 
 [tool.uv.workspace]

--- a/services/langevals/pyproject.toml
+++ b/services/langevals/pyproject.toml
@@ -67,24 +67,25 @@ packages = ["langevals"]
 [tool.uv]
 exclude-newer = "7 days"
 override-dependencies = [
-    # Upper bounds are load-bearing, not tidiness. This was an unbounded
-    # `langchain>=0.3.30`, so re-locking for the security floors below silently
-    # took langchain to 1.3.15 and langchain-core to 1.5.4. langchain-community
-    # is not on that line and still imports langchain_core.tracers.langchain_v1,
-    # which 1.x removed, so every evaluator load crashed at import. Keeping the
-    # family on 0.x is what makes this a security-floor change and nothing else;
-    # moving to 1.x is a deliberate migration with its own PR.
-    "langchain>=0.3.30,<1",
-    "langchain-core>=0.3.86,<1",
-    "langchain-openai>=0.2.14,<1",
-    "langchain-text-splitters>=0.3.11,<1",
+    # The langchain family is on the 1.x line, where the advisories affecting it
+    # are fixed. Each floor is the highest first-patched version across the
+    # advisories for that package.
+    "langchain>=1.3.9",
+    "langchain-core>=1.2.22",
+    "langchain-openai>=1.1.14",
+    "langchain-text-splitters>=1.1.2",
+    # langchain-community stays on 0.3.x, which is compatible with core 1.x by
+    # declaration and in practice. It is capped below 0.4 because ragas imports
+    # `langchain_community.chat_models.vertexai` at module level and 0.4.0 moved
+    # the vertexai integrations out, so 0.4.x makes every ragas import fail.
+    # No advisory currently affects this package.
+    "langchain-community>=0.3.31,<0.4",
     # security: GHSA-f4xh-w4cj-qxq8 — LangSmith SDK TracingMiddleware arbitrary
     # server-side file read; patched in 0.8.18.
     "langsmith>=0.8.18",
     # Force a patched strawberry-graphql (GHSA-fr49-mhgj-crfc, GHSA-qfwv-87qj-98xq,
-    # GHSA-x97m-qp5c-w9xj). arize-phoenix 14.6.0 pins it to 0.314.3; the patched
-    # 0.316.0 is API-compatible with Phoenix and is the version Phoenix itself moved
-    # to in 16.4.0.
+    # GHSA-x97m-qp5c-w9xj, all of which top out at 0.315.6). arize-phoenix pins
+    # strawberry exactly, so without this the pin decides the version.
     "strawberry-graphql>=0.316.0",
     "pydantic-settings>=2.14.2",  # security: pydantic-settings advisory (#1517)
     # security: GHSA circular JSON Schema $ref unbounded-CPU DoS; patched in 0.60.1.
@@ -100,8 +101,9 @@ override-dependencies = [
     "litellm>=1.84.0",
     # Pillow: heap overflow / DoS across several decoders.
     "pillow>=12.3.0",
-    # nltk unsafe deserialization in the pickle loader path.
-    "nltk>=3.10.0",
+    # nltk unsafe deserialization in the pickle loader path, plus the advisories
+    # closed in 3.10.1 and 3.10.3.
+    "nltk>=3.10.3",
     # pyasn1 decoder DoS on crafted BER/DER input.
     "pyasn1>=0.6.4",
     # aiohttp request smuggling and header-parsing advisories.
@@ -114,13 +116,11 @@ override-dependencies = [
     "setuptools>=83.0.0",
     # torch: deserialization advisory in torch.load.
     "torch>=2.13.0",
+    # tornado: HTTP header and multipart parsing advisories.
+    "tornado>=6.5.8",
     #
     # NOT fixed here, deliberately:
-    #   langchain / langchain-core / langchain-openai / langchain-text-splitters
-    #     — this workspace is on the 0.3.x line and every patched version is on
-    #       1.x, so clearing those four alerts is a breaking major upgrade of the
-    #       evaluator surface, not a floor bump. Tracked separately.
-    #   ragas, diskcache — no patched release exists upstream yet.
+    #   ragas, diskcache: no patched release exists upstream yet.
 ]
 
 [tool.uv.workspace]

--- a/services/langevals/uv.lock
+++ b/services/langevals/uv.lock
@@ -35,10 +35,11 @@ overrides = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "h2", specifier = ">=4.4.1" },
     { name = "json-repair", specifier = ">=0.60.1" },
-    { name = "langchain", specifier = ">=0.3.30,<1" },
-    { name = "langchain-core", specifier = ">=0.3.86,<1" },
-    { name = "langchain-openai", specifier = ">=0.2.14,<1" },
-    { name = "langchain-text-splitters", specifier = ">=0.3.11,<1" },
+    { name = "langchain", specifier = ">=1.3.9" },
+    { name = "langchain-community", specifier = ">=0.3.31,<0.4" },
+    { name = "langchain-core", specifier = ">=1.2.22" },
+    { name = "langchain-openai", specifier = ">=1.1.14" },
+    { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "nltk", specifier = ">=3.10.0" },
@@ -2299,20 +2300,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.30"
+version = "1.3.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
-    { name = "langchain-text-splitters" },
-    { name = "langsmith" },
+    { name = "langgraph" },
     { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/f8/9d262e12d95ac940948847e0ed844eff430fc0660f73a704367c7c47a3ce/langchain-0.3.30.tar.gz", hash = "sha256:06599ec90fb550e0118b0ceab737667d2c0891fcc62ffce2058d21c945844448", size = 10243710, upload-time = "2026-05-07T15:48:12.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1c/b84579174a8e82ed79f4c3e0cd5a7f2323facc5ccd4d1b8390e7d175b663/langchain-1.3.15.tar.gz", hash = "sha256:ab4b775b9703f7e37babe0b325dbbaef25573bda60ecf79f7850bc875f252795", size = 665047, upload-time = "2026-08-11T19:10:52.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/54/c0775c29bf9ae27c8cbf8484ad600edd2e787a0eacf3a374cb6561613de9/langchain-0.3.30-py3-none-any.whl", hash = "sha256:37e6fcce92faf70cc7bac23739d13d6c3b9a3282da4dbcc06cb7e78330ed406a", size = 1025603, upload-time = "2026-05-07T15:48:10.607Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8d/ae721f4d68ff79a17110cabc9cb39b4568b0e3f1fe0a379b926c3f81d175/langchain-1.3.15-py3-none-any.whl", hash = "sha256:c0d2d0d51ed7da249e8ab7487173872059a9dd46fb071d905957485b7334f987", size = 147001, upload-time = "2026-08-11T19:10:50.846Z" },
 ]
 
 [[package]]
@@ -2340,10 +2337,12 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.86"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2352,35 +2351,36 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8d/d54586b8f65c6fc209db93916ff9e919e1cc14bad8fe66880ea4d7ea9d6c/langchain_core-0.3.86.tar.gz", hash = "sha256:671cbc96a325fe47f7dbab421236ada2d437bc4bfad0038102264885d0b462e2", size = 603154, upload-time = "2026-05-07T16:48:08.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/c1/c226367fdf92a173c8b520d0b3583a0aaf4c3fe4952010f680e49d88589d/langchain_core-1.5.5.tar.gz", hash = "sha256:c08d78176113867e9a76acc1007d641cd68fa5682e9e0018980d062b4ae0777e", size = 983166, upload-time = "2026-08-14T18:56:24.364Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/93/ba19ca54701c6118e68f8785949b6c0eab1df3a5cfa5310508cc86877994/langchain_core-0.3.86-py3-none-any.whl", hash = "sha256:7d2a1c50d2d2a139dbc6465cd339f32d14aa43db5ac9bd232e5b567a238709e8", size = 461306, upload-time = "2026-05-07T16:48:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/9f29e62e99118865d092acda6143a1ba6ce1893e3dcb72388a75b798e37d/langchain_core-1.5.5-py3-none-any.whl", hash = "sha256:537037fd44ead7c1ffb9621011029ad2e347e051519d17f112d7bf7be12f4365", size = 565884, upload-time = "2026-08-14T18:56:23.051Z" },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.35"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/96/06d0d25a37e05a0ff2d918f0a4b0bf0732aed6a43b472b0b68426ce04ef8/langchain_openai-0.3.35.tar.gz", hash = "sha256:fa985fd041c3809da256a040c98e8a43e91c6d165b96dcfeb770d8bd457bf76f", size = 786635, upload-time = "2025-10-06T15:09:28.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/ed/8dea294b76f7cbda7baa8fcee10f6f448a2157c81c905ea8893ddf9ede19/langchain_openai-1.5.1.tar.gz", hash = "sha256:e7100c89a6180e3fdf8d02b29a0f2b6c532da91428fc1b57aa93ebbc8acc0ce9", size = 3286615, upload-time = "2026-08-14T15:47:30.765Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/d5/c90c5478215c20ee71d8feaf676f7ffd78d0568f8c98bd83f81ce7562ed7/langchain_openai-0.3.35-py3-none-any.whl", hash = "sha256:76d5707e6e81fd461d33964ad618bd326cb661a1975cef7c1cb0703576bdada5", size = 75952, upload-time = "2025-10-06T15:09:27.137Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3b/cf0811ade95747439a43e3537452fefca88dddadb9f2b6e862ec8961620c/langchain_openai-1.5.1-py3-none-any.whl", hash = "sha256:a4da6e507d2e867127f0d622797bca4b7e7e98f08b3bbdc8db46f0a0695d69cb", size = 123733, upload-time = "2026-08-14T15:47:29.674Z" },
 ]
 
 [[package]]
-name = "langchain-text-splitters"
-version = "0.3.11"
+name = "langchain-protocol"
+version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]
@@ -2883,6 +2883,65 @@ test = [
     { name = "pytest", specifier = ">=7.4.2" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/089c4c9e0a2fec7f883f82ae8e6a727138d50074cfeb6644bc2d13b1019b/langgraph_checkpoint-4.2.0.tar.gz", hash = "sha256:51a593b6bee684b0818e5d6e58e28ab340c6db7794575056ce7bd1b746a84ed7", size = 180239, upload-time = "2026-08-07T20:05:03.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/71/3b475f09bd57d3a5649792c66353312b4432afd843f301739dfcebd157f0/langgraph_checkpoint-4.2.0-py3-none-any.whl", hash = "sha256:0547fd228935a0b758865de3a3d6d7a2537c308895d0f9ab092ce9151b5da942", size = 56833, upload-time = "2026-08-07T20:05:02.655Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]
@@ -3804,6 +3863,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/e4/15ecc67edb3ddb3e2f46ae04475f2d294e8b60c1825fbe28a428b93b3fbd/orjson-3.11.7-cp312-cp312-win32.whl", hash = "sha256:f4f7c956b5215d949a1f65334cf9d7612dde38f20a95f2315deef167def91a6f", size = 127923, upload-time = "2026-02-02T15:38:02.75Z" },
     { url = "https://files.pythonhosted.org/packages/34/70/2e0855361f76198a3965273048c8e50a9695d88cd75811a5b46444895845/orjson-3.11.7-cp312-cp312-win_amd64.whl", hash = "sha256:bf742e149121dc5648ba0a08ea0871e87b660467ef168a3a5e53bc1fbd64bb74", size = 125007, upload-time = "2026-02-02T15:38:04.032Z" },
     { url = "https://files.pythonhosted.org/packages/68/40/c2051bd19fc467610fed469dc29e43ac65891571138f476834ca192bc290/orjson-3.11.7-cp312-cp312-win_arm64.whl", hash = "sha256:26c3b9132f783b7d7903bf1efb095fed8d4a3a85ec0d334ee8beff3d7a4749d5", size = 126089, upload-time = "2026-02-02T15:38:05.297Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
 ]
 
 [[package]]

--- a/services/langevals/uv.lock
+++ b/services/langevals/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "arize-phoenix"
-version = "20.0.0"
+version = "19.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioitertools" },
@@ -258,7 +258,6 @@ dependencies = [
     { name = "arize-phoenix-client" },
     { name = "arize-phoenix-evals" },
     { name = "arize-phoenix-otel" },
-    { name = "arize-phoenix-sqlean" },
     { name = "authlib" },
     { name = "bashkit" },
     { name = "cachetools" },
@@ -296,6 +295,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlean-py" },
     { name = "starlette" },
     { name = "strawberry-graphql" },
     { name = "tqdm" },
@@ -303,9 +303,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/80/051bed5503ed6fb8505bd90c4b035a319ba4e12b389b3ce4c94abfb4ddca/arize_phoenix-20.0.0.tar.gz", hash = "sha256:0ad4ef878e0e86b5be9c61b5b3893c846273919c1e17a68cd2bdaa1beba1da6b", size = 7253720, upload-time = "2026-08-11T18:52:23.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/d2/e3294b88f41f74b660ee30c90918b562829f605c84acf43c0944aaf3ebef/arize_phoenix-19.17.0.tar.gz", hash = "sha256:c1a847dbf1804e0a25df4b121ca452c655d62a987e2acb59af05028809bcb63b", size = 7392602, upload-time = "2026-08-04T22:10:41.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e5/9f37e001b1b1add2a47ddee788fde32b90cfb1bb8a3a8658a3937ef4e72f/arize_phoenix-20.0.0-py3-none-any.whl", hash = "sha256:0e852bb00164a1770f591013d16526cf0d6da76a36745107b731b11d46aa3367", size = 7659656, upload-time = "2026-08-11T18:52:20.573Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6f/8088659bb17baec6f9aff3b2892db7126d576665064d9e4a705963e65681/arize_phoenix-19.17.0-py3-none-any.whl", hash = "sha256:6a8b7a3e5da9b2977d15965d82317569947b1f79ee8a50e8675575661bd889e7", size = 7782453, upload-time = "2026-08-04T22:10:38.944Z" },
 ]
 
 [[package]]
@@ -363,26 +363,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/c8/665028fbbb1638f01a1d0e6c7738a44e95c826e4784d2411a36f9c08e437/arize_phoenix_otel-0.17.1.tar.gz", hash = "sha256:63baec1128a036895dd49fa50222b9deac2cdeababbcca3d0f1f9b96e615fd6b", size = 28498, upload-time = "2026-08-10T17:36:29.629Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/16/6027af2a69a5a150f7e2242cdc96127c912755b86c1395752582e96572bf/arize_phoenix_otel-0.17.1-py3-none-any.whl", hash = "sha256:ef2468290e73d3149729c72715267e547f5ad9a6700331dd2ca53b1a192d2a24", size = 22334, upload-time = "2026-08-10T17:36:28.038Z" },
-]
-
-[[package]]
-name = "arize-phoenix-sqlean"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/9d/57f4a702fc81329db31d3fb3db64fa01514a71d044311bf80f0438185728/arize_phoenix_sqlean-0.1.0.tar.gz", hash = "sha256:a7248b8530c44d1d3861c580b610bf0312eb6f675883cf4de18c35b2d9acdc98", size = 3529126, upload-time = "2026-08-06T00:13:44.109Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6f/537231578570d138d0375d72f167e9e65e8d2fca19591cb13e65ad616278/arize_phoenix_sqlean-0.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:fc04fe2b983e4588eacea7c0b4d4c55447f93a924c046b0ae5d6a6c1d81ce59f", size = 1196338, upload-time = "2026-08-06T00:13:00.828Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/b8/fb4c6244835a830a3d4e5de1f77b4629f5cf8dcc900abfe5f129edf9e1de/arize_phoenix_sqlean-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e93efc2f7d60a22379bac683e873743598fde0da5f1708a517ddcea78cbf729f", size = 1122150, upload-time = "2026-08-06T00:13:02.362Z" },
-    { url = "https://files.pythonhosted.org/packages/06/4b/71a0857a4857b21afe7c8b593f60f95aae86ba210f0af105c17b94c991cb/arize_phoenix_sqlean-0.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4e42b4e79e6819894d65ff0a282d8ddb3f80e720d6165480e3acf9f90e55d45c", size = 3252098, upload-time = "2026-08-06T00:13:04.209Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/1b/2fcd33328f25dfc0450438594faa3bee411bd48cd684a1829b23985ffa66/arize_phoenix_sqlean-0.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d6aef263f56316227f1f882a046600bf44003fb498ea2114128387a330e77cb2", size = 3236282, upload-time = "2026-08-06T00:13:05.98Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/24/7928c028eb6ab4be7bca2cd103fa26c2d758727640242b9063e937298db3/arize_phoenix_sqlean-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:df54afc5b29aa10645ba50424ea2e56bac564e34d85a1c1f50834d401021a232", size = 920139, upload-time = "2026-08-06T00:13:07.566Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fc/acb50b0bfd6d387c1f02468f612e59456280512ac3ff01060d8420fbd65e/arize_phoenix_sqlean-0.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:c32eb9262a9e6d5783e59c5a807505a1c88d62b0ff1aa0a3b6977f1e1e76d5f6", size = 853790, upload-time = "2026-08-06T00:13:09.908Z" },
-    { url = "https://files.pythonhosted.org/packages/02/51/ed8cbb6457c060c8e329f13aa855da7c3d66f99fc671342667ad8d6d5e23/arize_phoenix_sqlean-0.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:bb838dd848841cabd2ca055aaf2625e353fd90324e560b6ac4125a9edd593d7f", size = 1197119, upload-time = "2026-08-06T00:13:11.706Z" },
-    { url = "https://files.pythonhosted.org/packages/10/28/737f96dccadddea710d05139f4e6e313a3f89982874773e43a978b7319f5/arize_phoenix_sqlean-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6586d84b78c990ced9c336147cfe082c6e12647824bb868af9e9b03ae52b48e", size = 1122765, upload-time = "2026-08-06T00:13:13.382Z" },
-    { url = "https://files.pythonhosted.org/packages/79/7c/0af4ac52dbb56568be10df5cec2ad824281a3b8f69f26a8171e2f322bfd0/arize_phoenix_sqlean-0.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c5d735a38d6d89cce57e70b1d0deff3693591d44fd71648c719424fd44c81da9", size = 3260397, upload-time = "2026-08-06T00:13:15.547Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/1e/621a84ac2991437b5a7fa1a0c4d90e1b0435deec6eb202ab5bf197146654/arize_phoenix_sqlean-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f9a6853475fd0c52d162d0214b99557532e8c42ce6fb5eb1aefd53238cafad97", size = 3245670, upload-time = "2026-08-06T00:13:17.494Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/64/1f460ba9f8219f3d3db497dd8ee51dde798c11c8760ebf47310450d5c177/arize_phoenix_sqlean-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:dce5fa4bb09842aa4dca700bbc28aabd3f6c8c8be78030151e54c98ec0e0f3fe", size = 921509, upload-time = "2026-08-06T00:13:19.127Z" },
-    { url = "https://files.pythonhosted.org/packages/51/1c/f2aaa88d227b927890be93d17dd2ea1c6d6b61e8f113d22358895b6c481e/arize_phoenix_sqlean-0.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:1cce6ef53c9cdc5e8f177ca3592075c315750fd01c3d0bedcad097d5f9ce4238", size = 854438, upload-time = "2026-08-06T00:13:20.966Z" },
 ]
 
 [[package]]
@@ -807,7 +787,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -834,43 +814,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1755,8 +1735,8 @@ name = "httpcore2"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -2703,7 +2683,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arize-phoenix", specifier = ">=4.9.0" },
+    { name = "arize-phoenix", specifier = ">=4.9.0,<19.18.0" },
     { name = "dspy", specifier = ">=2.5.43" },
     { name = "faiss-cpu", specifier = "==1.15.0" },
     { name = "fastapi", specifier = ">=0.115.11" },
@@ -3423,7 +3403,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3462,7 +3442,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3474,7 +3454,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3504,9 +3484,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3518,7 +3498,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3888,7 +3868,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5083,8 +5063,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5249,6 +5229,26 @@ asyncio = [
 ]
 
 [[package]]
+name = "sqlean-py"
+version = "3.49.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/eb/ac95fab0bc4658124b4ec8fbc31fc494165ab4544606ae91b9a489907dad/sqlean_py-3.49.1.tar.gz", hash = "sha256:210d89989226b988d7d6391f837387d3b81e8cd608c997e0bd37826e395970e7", size = 3319012, upload-time = "2025-05-02T11:58:24.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/0e/5abd9f12008918dfbce0add356eee8a6f076c3cb24af4a5d2694a8b9f009/sqlean_py-3.49.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9858cd066c7105145d56aae2d9c0a6c8baf343b642e41c9a96a83ff3033e5395", size = 1128201, upload-time = "2025-05-02T11:57:44.744Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/f39ee0b16050b79fb86507e0affd623f6f7fba04f3d3b1dc7e41b93ada7d/sqlean_py-3.49.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b034fd390fccbb62198e0163e885111de86f2a20767a2f31d38313008cb57442", size = 1053419, upload-time = "2025-05-02T11:57:46.545Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/10/2f2bd23d2ec66662bebed7d83fcc912af97dd12be739fd5bd3c08444a55c/sqlean_py-3.49.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09d7b002f490fd0dad98e884a6e05f062d02ca6520c1910b486fb9e19c5e61ab", size = 2995449, upload-time = "2025-05-02T11:57:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d7/c9970eedb0876f3bcf3f0e230ef68f41fa4bb1c88a67f437f88f0cb0d62b/sqlean_py-3.49.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8738695e3ca05cd47b16808d8ad8cd973f1eb6e32497364512a26cb4e61ad63", size = 3000141, upload-time = "2025-05-02T11:57:49.388Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ce/a41b35ecaf7825fbf63cedabfe3ee89f26b75556432ab547476c0f039650/sqlean_py-3.49.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bf2e118ea3c5c16c6a0be4b80d31c9392ffee231e61f08464cc8f892e40c628", size = 803486, upload-time = "2025-05-02T11:57:50.872Z" },
+    { url = "https://files.pythonhosted.org/packages/09/dd/6dbcda7d883701eb8a6f55fc5636919b04f84ad9c9be33b3309199150dd4/sqlean_py-3.49.1-cp311-cp311-win_arm64.whl", hash = "sha256:ff575bb11a3013963e4b2edb0eaafc771e8dbe193f22151ee2c3ecc694f25eee", size = 739176, upload-time = "2025-05-02T11:57:52.08Z" },
+    { url = "https://files.pythonhosted.org/packages/23/0e/95379c801907f8da939be30c61b63ef881eb18cc0a90713cc74002deaf16/sqlean_py-3.49.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:b43397ac27312a20fef8f5db0d011d3676fddea04850d6c35ad1d7644d146f71", size = 1129522, upload-time = "2025-05-02T11:57:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/b4c5d0ff47f179a0729dc71832558f63a1605e931f773b6d435a767baca9/sqlean_py-3.49.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:56a3388f4fe08e1332af424eaaf378eb9e258165885a4e284c5238e4837b2232", size = 1053757, upload-time = "2025-05-02T11:57:54.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/11/f8a5c0f7fb889cabbd8c7f887f9e261b65bf45fa1d33a245490855bff53e/sqlean_py-3.49.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9bbc00d57f68dbb3f5dea20380bdad7fa9299b3c2a8d8b3798c2bf315146be9", size = 3003708, upload-time = "2025-05-02T11:57:57.035Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/065a21e9a578ef13d9749c2bf3c382f7e50a1644af7d7a109924fbc6faee/sqlean_py-3.49.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae92413470409b3b3678c797db82c1d247b6ed2198017b5e893d9fc0606e061f", size = 3008238, upload-time = "2025-05-02T11:57:58.927Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e5/d980bf0c5e67cfd4486b5e6d8daea6815fdac57b3d0899c23127a30283b5/sqlean_py-3.49.1-cp312-cp312-win_amd64.whl", hash = "sha256:b45ed4adb8442299019988d5e90aa1474f3ef8c71f6e8921a70705b9d971c590", size = 804506, upload-time = "2025-05-02T11:58:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d1/8828ec685022e2b86ebd717743359dd5e8eab70a9c1ebff78aa733848216/sqlean_py-3.49.1-cp312-cp312-win_arm64.whl", hash = "sha256:c2537f69879adaed22b16e840d494c440ece5b49d28a5a51094e6c8ca6a2b0a5", size = 739690, upload-time = "2025-05-02T11:58:02.262Z" },
+]
+
+[[package]]
 name = "sqlglot"
 version = "28.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5357,7 +5357,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.316.0"
+version = "0.320.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -5366,9 +5366,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/09/f189fd3c70544322eeba0398ccaa980d17857894c0a66d447aa0b5704686/strawberry_graphql-0.316.0.tar.gz", hash = "sha256:bee5ce0e20d522325bd1ed2db186c812c03c2ea7db29f997b35e7d694649820c", size = 223985, upload-time = "2026-05-19T17:06:10.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/6b3f0ce8d1f77f89446aff8ccaa3f875b23a082111b903a7adc261f99645/strawberry_graphql-0.320.4.tar.gz", hash = "sha256:cd02eb963c63b84a89007c2784704327924d826ca8f4f172e8386701f839416b", size = 229798, upload-time = "2026-07-09T09:29:57.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/dd/b2cf54803cbd0d37e3ce73c7274bdb144ba83743bc83351b5790eb2a5fad/strawberry_graphql-0.316.0-py3-none-any.whl", hash = "sha256:222e16fbbf953f5a1fa75f62bf9a8e95f274180f928f70bec459b566053aa2cb", size = 326530, upload-time = "2026-05-19T17:06:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ba/ab8323bed6ddc12c218c0e38d9bee02b10fbc6f03da6a05b5af1cf250572/strawberry_graphql-0.320.4-py3-none-any.whl", hash = "sha256:79a0172ecb372cd1855a199b78668629dc7c6e54276554d459ff51678385e389", size = 332789, upload-time = "2026-07-09T09:29:56.186Z" },
 ]
 
 [[package]]

--- a/services/langevals/uv.lock
+++ b/services/langevals/uv.lock
@@ -35,19 +35,21 @@ overrides = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "h2", specifier = ">=4.4.1" },
     { name = "json-repair", specifier = ">=0.60.1" },
-    { name = "langchain", specifier = ">=0.3.30,<1" },
-    { name = "langchain-core", specifier = ">=0.3.86,<1" },
-    { name = "langchain-openai", specifier = ">=0.2.14,<1" },
-    { name = "langchain-text-splitters", specifier = ">=0.3.11,<1" },
+    { name = "langchain", specifier = ">=1.3.9" },
+    { name = "langchain-community", specifier = ">=0.3.31,<0.4" },
+    { name = "langchain-core", specifier = ">=1.2.22" },
+    { name = "langchain-openai", specifier = ">=1.1.14" },
+    { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "litellm", specifier = ">=1.84.0" },
-    { name = "nltk", specifier = ">=3.10.0" },
+    { name = "nltk", specifier = ">=3.10.3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "setuptools", specifier = ">=83.0.0" },
     { name = "strawberry-graphql", specifier = ">=0.316.0" },
     { name = "torch", specifier = ">=2.13.0" },
+    { name = "tornado", specifier = ">=6.5.8" },
 ]
 
 [[package]]
@@ -249,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "arize-phoenix"
-version = "20.0.0"
+version = "19.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioitertools" },
@@ -258,7 +260,6 @@ dependencies = [
     { name = "arize-phoenix-client" },
     { name = "arize-phoenix-evals" },
     { name = "arize-phoenix-otel" },
-    { name = "arize-phoenix-sqlean" },
     { name = "authlib" },
     { name = "bashkit" },
     { name = "cachetools" },
@@ -296,6 +297,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlean-py" },
     { name = "starlette" },
     { name = "strawberry-graphql" },
     { name = "tqdm" },
@@ -303,9 +305,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/80/051bed5503ed6fb8505bd90c4b035a319ba4e12b389b3ce4c94abfb4ddca/arize_phoenix-20.0.0.tar.gz", hash = "sha256:0ad4ef878e0e86b5be9c61b5b3893c846273919c1e17a68cd2bdaa1beba1da6b", size = 7253720, upload-time = "2026-08-11T18:52:23.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/d2/e3294b88f41f74b660ee30c90918b562829f605c84acf43c0944aaf3ebef/arize_phoenix-19.17.0.tar.gz", hash = "sha256:c1a847dbf1804e0a25df4b121ca452c655d62a987e2acb59af05028809bcb63b", size = 7392602, upload-time = "2026-08-04T22:10:41.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e5/9f37e001b1b1add2a47ddee788fde32b90cfb1bb8a3a8658a3937ef4e72f/arize_phoenix-20.0.0-py3-none-any.whl", hash = "sha256:0e852bb00164a1770f591013d16526cf0d6da76a36745107b731b11d46aa3367", size = 7659656, upload-time = "2026-08-11T18:52:20.573Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6f/8088659bb17baec6f9aff3b2892db7126d576665064d9e4a705963e65681/arize_phoenix-19.17.0-py3-none-any.whl", hash = "sha256:6a8b7a3e5da9b2977d15965d82317569947b1f79ee8a50e8675575661bd889e7", size = 7782453, upload-time = "2026-08-04T22:10:38.944Z" },
 ]
 
 [[package]]
@@ -363,26 +365,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/c8/665028fbbb1638f01a1d0e6c7738a44e95c826e4784d2411a36f9c08e437/arize_phoenix_otel-0.17.1.tar.gz", hash = "sha256:63baec1128a036895dd49fa50222b9deac2cdeababbcca3d0f1f9b96e615fd6b", size = 28498, upload-time = "2026-08-10T17:36:29.629Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/16/6027af2a69a5a150f7e2242cdc96127c912755b86c1395752582e96572bf/arize_phoenix_otel-0.17.1-py3-none-any.whl", hash = "sha256:ef2468290e73d3149729c72715267e547f5ad9a6700331dd2ca53b1a192d2a24", size = 22334, upload-time = "2026-08-10T17:36:28.038Z" },
-]
-
-[[package]]
-name = "arize-phoenix-sqlean"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/9d/57f4a702fc81329db31d3fb3db64fa01514a71d044311bf80f0438185728/arize_phoenix_sqlean-0.1.0.tar.gz", hash = "sha256:a7248b8530c44d1d3861c580b610bf0312eb6f675883cf4de18c35b2d9acdc98", size = 3529126, upload-time = "2026-08-06T00:13:44.109Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6f/537231578570d138d0375d72f167e9e65e8d2fca19591cb13e65ad616278/arize_phoenix_sqlean-0.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:fc04fe2b983e4588eacea7c0b4d4c55447f93a924c046b0ae5d6a6c1d81ce59f", size = 1196338, upload-time = "2026-08-06T00:13:00.828Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/b8/fb4c6244835a830a3d4e5de1f77b4629f5cf8dcc900abfe5f129edf9e1de/arize_phoenix_sqlean-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e93efc2f7d60a22379bac683e873743598fde0da5f1708a517ddcea78cbf729f", size = 1122150, upload-time = "2026-08-06T00:13:02.362Z" },
-    { url = "https://files.pythonhosted.org/packages/06/4b/71a0857a4857b21afe7c8b593f60f95aae86ba210f0af105c17b94c991cb/arize_phoenix_sqlean-0.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4e42b4e79e6819894d65ff0a282d8ddb3f80e720d6165480e3acf9f90e55d45c", size = 3252098, upload-time = "2026-08-06T00:13:04.209Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/1b/2fcd33328f25dfc0450438594faa3bee411bd48cd684a1829b23985ffa66/arize_phoenix_sqlean-0.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d6aef263f56316227f1f882a046600bf44003fb498ea2114128387a330e77cb2", size = 3236282, upload-time = "2026-08-06T00:13:05.98Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/24/7928c028eb6ab4be7bca2cd103fa26c2d758727640242b9063e937298db3/arize_phoenix_sqlean-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:df54afc5b29aa10645ba50424ea2e56bac564e34d85a1c1f50834d401021a232", size = 920139, upload-time = "2026-08-06T00:13:07.566Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fc/acb50b0bfd6d387c1f02468f612e59456280512ac3ff01060d8420fbd65e/arize_phoenix_sqlean-0.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:c32eb9262a9e6d5783e59c5a807505a1c88d62b0ff1aa0a3b6977f1e1e76d5f6", size = 853790, upload-time = "2026-08-06T00:13:09.908Z" },
-    { url = "https://files.pythonhosted.org/packages/02/51/ed8cbb6457c060c8e329f13aa855da7c3d66f99fc671342667ad8d6d5e23/arize_phoenix_sqlean-0.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:bb838dd848841cabd2ca055aaf2625e353fd90324e560b6ac4125a9edd593d7f", size = 1197119, upload-time = "2026-08-06T00:13:11.706Z" },
-    { url = "https://files.pythonhosted.org/packages/10/28/737f96dccadddea710d05139f4e6e313a3f89982874773e43a978b7319f5/arize_phoenix_sqlean-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6586d84b78c990ced9c336147cfe082c6e12647824bb868af9e9b03ae52b48e", size = 1122765, upload-time = "2026-08-06T00:13:13.382Z" },
-    { url = "https://files.pythonhosted.org/packages/79/7c/0af4ac52dbb56568be10df5cec2ad824281a3b8f69f26a8171e2f322bfd0/arize_phoenix_sqlean-0.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c5d735a38d6d89cce57e70b1d0deff3693591d44fd71648c719424fd44c81da9", size = 3260397, upload-time = "2026-08-06T00:13:15.547Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/1e/621a84ac2991437b5a7fa1a0c4d90e1b0435deec6eb202ab5bf197146654/arize_phoenix_sqlean-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f9a6853475fd0c52d162d0214b99557532e8c42ce6fb5eb1aefd53238cafad97", size = 3245670, upload-time = "2026-08-06T00:13:17.494Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/64/1f460ba9f8219f3d3db497dd8ee51dde798c11c8760ebf47310450d5c177/arize_phoenix_sqlean-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:dce5fa4bb09842aa4dca700bbc28aabd3f6c8c8be78030151e54c98ec0e0f3fe", size = 921509, upload-time = "2026-08-06T00:13:19.127Z" },
-    { url = "https://files.pythonhosted.org/packages/51/1c/f2aaa88d227b927890be93d17dd2ea1c6d6b61e8f113d22358895b6c481e/arize_phoenix_sqlean-0.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:1cce6ef53c9cdc5e8f177ca3592075c315750fd01c3d0bedcad097d5f9ce4238", size = 854438, upload-time = "2026-08-06T00:13:20.966Z" },
 ]
 
 [[package]]
@@ -807,7 +789,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -834,43 +816,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1755,8 +1737,8 @@ name = "httpcore2"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -2319,20 +2301,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.30"
+version = "1.3.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
-    { name = "langchain-text-splitters" },
-    { name = "langsmith" },
+    { name = "langgraph" },
     { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/f8/9d262e12d95ac940948847e0ed844eff430fc0660f73a704367c7c47a3ce/langchain-0.3.30.tar.gz", hash = "sha256:06599ec90fb550e0118b0ceab737667d2c0891fcc62ffce2058d21c945844448", size = 10243710, upload-time = "2026-05-07T15:48:12.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1c/b84579174a8e82ed79f4c3e0cd5a7f2323facc5ccd4d1b8390e7d175b663/langchain-1.3.15.tar.gz", hash = "sha256:ab4b775b9703f7e37babe0b325dbbaef25573bda60ecf79f7850bc875f252795", size = 665047, upload-time = "2026-08-11T19:10:52.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/54/c0775c29bf9ae27c8cbf8484ad600edd2e787a0eacf3a374cb6561613de9/langchain-0.3.30-py3-none-any.whl", hash = "sha256:37e6fcce92faf70cc7bac23739d13d6c3b9a3282da4dbcc06cb7e78330ed406a", size = 1025603, upload-time = "2026-05-07T15:48:10.607Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8d/ae721f4d68ff79a17110cabc9cb39b4568b0e3f1fe0a379b926c3f81d175/langchain-1.3.15-py3-none-any.whl", hash = "sha256:c0d2d0d51ed7da249e8ab7487173872059a9dd46fb071d905957485b7334f987", size = 147001, upload-time = "2026-08-11T19:10:50.846Z" },
 ]
 
 [[package]]
@@ -2360,10 +2338,12 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.86"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2372,35 +2352,36 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8d/d54586b8f65c6fc209db93916ff9e919e1cc14bad8fe66880ea4d7ea9d6c/langchain_core-0.3.86.tar.gz", hash = "sha256:671cbc96a325fe47f7dbab421236ada2d437bc4bfad0038102264885d0b462e2", size = 603154, upload-time = "2026-05-07T16:48:08.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/c1/c226367fdf92a173c8b520d0b3583a0aaf4c3fe4952010f680e49d88589d/langchain_core-1.5.5.tar.gz", hash = "sha256:c08d78176113867e9a76acc1007d641cd68fa5682e9e0018980d062b4ae0777e", size = 983166, upload-time = "2026-08-14T18:56:24.364Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/93/ba19ca54701c6118e68f8785949b6c0eab1df3a5cfa5310508cc86877994/langchain_core-0.3.86-py3-none-any.whl", hash = "sha256:7d2a1c50d2d2a139dbc6465cd339f32d14aa43db5ac9bd232e5b567a238709e8", size = 461306, upload-time = "2026-05-07T16:48:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/9f29e62e99118865d092acda6143a1ba6ce1893e3dcb72388a75b798e37d/langchain_core-1.5.5-py3-none-any.whl", hash = "sha256:537037fd44ead7c1ffb9621011029ad2e347e051519d17f112d7bf7be12f4365", size = 565884, upload-time = "2026-08-14T18:56:23.051Z" },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.35"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/96/06d0d25a37e05a0ff2d918f0a4b0bf0732aed6a43b472b0b68426ce04ef8/langchain_openai-0.3.35.tar.gz", hash = "sha256:fa985fd041c3809da256a040c98e8a43e91c6d165b96dcfeb770d8bd457bf76f", size = 786635, upload-time = "2025-10-06T15:09:28.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/ed/8dea294b76f7cbda7baa8fcee10f6f448a2157c81c905ea8893ddf9ede19/langchain_openai-1.5.1.tar.gz", hash = "sha256:e7100c89a6180e3fdf8d02b29a0f2b6c532da91428fc1b57aa93ebbc8acc0ce9", size = 3286615, upload-time = "2026-08-14T15:47:30.765Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/d5/c90c5478215c20ee71d8feaf676f7ffd78d0568f8c98bd83f81ce7562ed7/langchain_openai-0.3.35-py3-none-any.whl", hash = "sha256:76d5707e6e81fd461d33964ad618bd326cb661a1975cef7c1cb0703576bdada5", size = 75952, upload-time = "2025-10-06T15:09:27.137Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3b/cf0811ade95747439a43e3537452fefca88dddadb9f2b6e862ec8961620c/langchain_openai-1.5.1-py3-none-any.whl", hash = "sha256:a4da6e507d2e867127f0d622797bca4b7e7e98f08b3bbdc8db46f0a0695d69cb", size = 123733, upload-time = "2026-08-14T15:47:29.674Z" },
 ]
 
 [[package]]
-name = "langchain-text-splitters"
-version = "0.3.11"
+name = "langchain-protocol"
+version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]
@@ -2703,7 +2684,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arize-phoenix", specifier = ">=4.9.0" },
+    { name = "arize-phoenix", specifier = ">=4.9.0,<19.18.0" },
     { name = "dspy", specifier = ">=2.5.43" },
     { name = "faiss-cpu", specifier = "==1.15.0" },
     { name = "fastapi", specifier = ">=0.115.11" },
@@ -2903,6 +2884,65 @@ test = [
     { name = "pytest", specifier = ">=7.4.2" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/089c4c9e0a2fec7f883f82ae8e6a727138d50074cfeb6644bc2d13b1019b/langgraph_checkpoint-4.2.0.tar.gz", hash = "sha256:51a593b6bee684b0818e5d6e58e28ab340c6db7794575056ce7bd1b746a84ed7", size = 180239, upload-time = "2026-08-07T20:05:03.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/71/3b475f09bd57d3a5649792c66353312b4432afd843f301739dfcebd157f0/langgraph_checkpoint-4.2.0-py3-none-any.whl", hash = "sha256:0547fd228935a0b758865de3a3d6d7a2537c308895d0f9ab092ce9151b5da942", size = 56833, upload-time = "2026-08-07T20:05:02.655Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]
@@ -3380,7 +3420,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3389,9 +3429,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/16/24d639531e73cbc6884fb251d116dfe469df9c595e0dcf24668c54d0e8d3/nltk-3.10.2.tar.gz", hash = "sha256:fcfd80fb77931868cea8357573c79838b8abc609942ef9914d1c9f6070d4645c", size = 3101716, upload-time = "2026-08-05T09:56:20.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/2b/bf677eb32ca6684b270c0d19ab133c2271e9f3375997e5a8dd2b08e3152d/nltk-3.10.2-py3-none-any.whl", hash = "sha256:2c7ccacb765c5e26b0cb60fb1b57080af522c6924d12a714a243305ba3637412", size = 1725815, upload-time = "2026-08-05T09:56:09.657Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -3423,7 +3463,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3462,7 +3502,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3474,7 +3514,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3504,9 +3544,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3518,7 +3558,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3827,6 +3867,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3888,7 +3954,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5083,8 +5149,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5249,6 +5315,26 @@ asyncio = [
 ]
 
 [[package]]
+name = "sqlean-py"
+version = "3.49.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/eb/ac95fab0bc4658124b4ec8fbc31fc494165ab4544606ae91b9a489907dad/sqlean_py-3.49.1.tar.gz", hash = "sha256:210d89989226b988d7d6391f837387d3b81e8cd608c997e0bd37826e395970e7", size = 3319012, upload-time = "2025-05-02T11:58:24.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/0e/5abd9f12008918dfbce0add356eee8a6f076c3cb24af4a5d2694a8b9f009/sqlean_py-3.49.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9858cd066c7105145d56aae2d9c0a6c8baf343b642e41c9a96a83ff3033e5395", size = 1128201, upload-time = "2025-05-02T11:57:44.744Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/f39ee0b16050b79fb86507e0affd623f6f7fba04f3d3b1dc7e41b93ada7d/sqlean_py-3.49.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b034fd390fccbb62198e0163e885111de86f2a20767a2f31d38313008cb57442", size = 1053419, upload-time = "2025-05-02T11:57:46.545Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/10/2f2bd23d2ec66662bebed7d83fcc912af97dd12be739fd5bd3c08444a55c/sqlean_py-3.49.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09d7b002f490fd0dad98e884a6e05f062d02ca6520c1910b486fb9e19c5e61ab", size = 2995449, upload-time = "2025-05-02T11:57:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d7/c9970eedb0876f3bcf3f0e230ef68f41fa4bb1c88a67f437f88f0cb0d62b/sqlean_py-3.49.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8738695e3ca05cd47b16808d8ad8cd973f1eb6e32497364512a26cb4e61ad63", size = 3000141, upload-time = "2025-05-02T11:57:49.388Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ce/a41b35ecaf7825fbf63cedabfe3ee89f26b75556432ab547476c0f039650/sqlean_py-3.49.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bf2e118ea3c5c16c6a0be4b80d31c9392ffee231e61f08464cc8f892e40c628", size = 803486, upload-time = "2025-05-02T11:57:50.872Z" },
+    { url = "https://files.pythonhosted.org/packages/09/dd/6dbcda7d883701eb8a6f55fc5636919b04f84ad9c9be33b3309199150dd4/sqlean_py-3.49.1-cp311-cp311-win_arm64.whl", hash = "sha256:ff575bb11a3013963e4b2edb0eaafc771e8dbe193f22151ee2c3ecc694f25eee", size = 739176, upload-time = "2025-05-02T11:57:52.08Z" },
+    { url = "https://files.pythonhosted.org/packages/23/0e/95379c801907f8da939be30c61b63ef881eb18cc0a90713cc74002deaf16/sqlean_py-3.49.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:b43397ac27312a20fef8f5db0d011d3676fddea04850d6c35ad1d7644d146f71", size = 1129522, upload-time = "2025-05-02T11:57:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/b4c5d0ff47f179a0729dc71832558f63a1605e931f773b6d435a767baca9/sqlean_py-3.49.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:56a3388f4fe08e1332af424eaaf378eb9e258165885a4e284c5238e4837b2232", size = 1053757, upload-time = "2025-05-02T11:57:54.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/11/f8a5c0f7fb889cabbd8c7f887f9e261b65bf45fa1d33a245490855bff53e/sqlean_py-3.49.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9bbc00d57f68dbb3f5dea20380bdad7fa9299b3c2a8d8b3798c2bf315146be9", size = 3003708, upload-time = "2025-05-02T11:57:57.035Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/065a21e9a578ef13d9749c2bf3c382f7e50a1644af7d7a109924fbc6faee/sqlean_py-3.49.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae92413470409b3b3678c797db82c1d247b6ed2198017b5e893d9fc0606e061f", size = 3008238, upload-time = "2025-05-02T11:57:58.927Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e5/d980bf0c5e67cfd4486b5e6d8daea6815fdac57b3d0899c23127a30283b5/sqlean_py-3.49.1-cp312-cp312-win_amd64.whl", hash = "sha256:b45ed4adb8442299019988d5e90aa1474f3ef8c71f6e8921a70705b9d971c590", size = 804506, upload-time = "2025-05-02T11:58:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d1/8828ec685022e2b86ebd717743359dd5e8eab70a9c1ebff78aa733848216/sqlean_py-3.49.1-cp312-cp312-win_arm64.whl", hash = "sha256:c2537f69879adaed22b16e840d494c440ece5b49d28a5a51094e6c8ca6a2b0a5", size = 739690, upload-time = "2025-05-02T11:58:02.262Z" },
+]
+
+[[package]]
 name = "sqlglot"
 version = "28.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5357,7 +5443,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.316.0"
+version = "0.320.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -5366,9 +5452,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/09/f189fd3c70544322eeba0398ccaa980d17857894c0a66d447aa0b5704686/strawberry_graphql-0.316.0.tar.gz", hash = "sha256:bee5ce0e20d522325bd1ed2db186c812c03c2ea7db29f997b35e7d694649820c", size = 223985, upload-time = "2026-05-19T17:06:10.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/6b3f0ce8d1f77f89446aff8ccaa3f875b23a082111b903a7adc261f99645/strawberry_graphql-0.320.4.tar.gz", hash = "sha256:cd02eb963c63b84a89007c2784704327924d826ca8f4f172e8386701f839416b", size = 229798, upload-time = "2026-07-09T09:29:57.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/dd/b2cf54803cbd0d37e3ce73c7274bdb144ba83743bc83351b5790eb2a5fad/strawberry_graphql-0.316.0-py3-none-any.whl", hash = "sha256:222e16fbbf953f5a1fa75f62bf9a8e95f274180f928f70bec459b566053aa2cb", size = 326530, upload-time = "2026-05-19T17:06:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ba/ab8323bed6ddc12c218c0e38d9bee02b10fbc6f03da6a05b5af1cf250572/strawberry_graphql-0.320.4-py3-none-any.whl", hash = "sha256:79a0172ecb372cd1855a199b78668629dc7c6e54276554d459ff51678385e389", size = 332789, upload-time = "2026-07-09T09:29:56.186Z" },
 ]
 
 [[package]]
@@ -5569,19 +5655,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.7"
+version = "6.5.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
-    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
-    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58", size = 450707, upload-time = "2026-08-07T02:12:31.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/20efeee9a01c141e9ac47c397f81679dfda24b32768fc4fff24e76d36c2c/tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808", size = 451677, upload-time = "2026-08-07T02:12:33.512Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/a96ccb8ccf0de2b7bc2c5fa1608a4803735018242e90c4882365a9fd418f/tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22", size = 451510, upload-time = "2026-08-07T02:12:35.346Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/93185859245ad3f00e62175f29607346788b696369347f0146e0421286bb/tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195", size = 450917, upload-time = "2026-08-07T02:12:36.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/fe33cf062834487d34d1559746a4a12521033c22645b6d74d4bca702e018/tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836", size = 451952, upload-time = "2026-08-07T02:12:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/468ad54333e92ccb62627e62cb88e5fc14a2171daa67ed47b1b8542d5b86/tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee", size = 452391, upload-time = "2026-08-07T02:12:39.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3e/cd5e4f06e34cde33b8ef66cf36aa2b5ad46354cc1af7d2136bbe365fee1d/tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26", size = 451411, upload-time = "2026-08-07T02:12:41.469Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Closes **17 of the 21** open alerts on `services/langevals` (1 CRITICAL, 4 HIGH), restores the ragas evaluators after two import-time breaks reached main, and closes the CI hole that let both through with a green tick.

| package | from | to | alerts |
|---|---|---|---|
| nltk | 3.10.2 | 3.10.3 | #2158 (CRITICAL), #2156 (HIGH), #2218 (HIGH), #2205, #2207, #2209, #2213, #2215, #2264 |
| langchain-core | 0.3.86 | 1.5.5 | #2012 (HIGH), #2010 |
| tornado | 6.5.7 | 6.5.8 | #2263 (HIGH), #2203, #2160 |
| langchain | 0.3.30 | 1.3.15 | #2021 |
| langchain-openai | 0.3.35 | 1.5.1 | #2017 |
| langchain-text-splitters | 0.3.11 | folded into langchain 1.x | #2016 |

## The langchain cap was ours, not ragas'

The family was pinned below 1.0 with a note saying ragas could not take core 1.x. That was not the blocker. The blocker was our own import of `get_openai_callback`, which pulls in `langchain_core.tracers.langchain_v1` — a module core 1.x removed. ragas imports fine on core 1.x, checked symbol by symbol.

Only the prompt and completion counters were ever used from that callback (cost is priced by litellm afterwards), so `lib/token_usage.py` builds the handler directly on the langchain-core callback surface and the cap comes off. `register_configure_hook` attaches it to every langchain call inside the block, exactly as the community version did, and a test drives that end to end against a fake chat model rather than asserting on the handler in isolation.

`langchain-community` stays on 0.3.x, capped below 0.4. ragas imports `langchain_community.chat_models.vertexai` at module level and 0.4.0 moved the vertexai integrations out, so 0.4.x makes every ragas import fail. No advisory currently affects that package.

## arize-phoenix is capped below 19.18.0, and that is a repair

The lock moves phoenix from main's 20.0.0 down to 19.17.0. That looks like a regression and is the opposite: **main is currently broken for this workspace**.

From 19.18.0, phoenix declares a dataclass with a `mappingproxy` default. Python 3.11 rejects it at import:

```
ValueError: mutable default <class 'mappingproxy'> for field boolean_names
            is not allowed: use default_factory
```

Phoenix's metadata still claims `>=3.10`, and this workspace is on 3.11 per `.python-version`, so the bad versions resolve happily and then take down collection for the whole suite through phoenix's pytest plugin. Checked against each published wheel rather than inferred:

| version | `import phoenix.trace.dsl.filter` on 3.11 |
|---|---|
| 19.17.0 | OK |
| 19.18.0 | ValueError |
| 20.0.0 | ValueError |
| 20.8.0 (current latest) | ValueError |

The cap lifts once phoenix fixes that or langevals moves to 3.12.

## The CI hole

`evaluators/ragas/` is excluded wholesale from the secret-bearing test step (`--ignore=evaluators/ragas/`), because the evaluator tests there are LLM-judged. A green `langevals-complete` therefore proved nothing about that directory, which is how two import-time breaks reached main.

The two new test files need no provider at all. They stub every call, pin the shape langchain-openai calls the litellm client with, and pin the token accounting that prices each evaluation. Both are named individually in the provider-free step so they fail loudly at import if that surface moves again.

## Four alerts stay open, and none of them has a fix to take

**nltk (#2211)**, **diskcache (#2011)** and **ragas (#2018 on the lock, #2009 on the ragas pyproject, the same advisory raised against both)** have no patched release published upstream in any line. There is nothing to bump to. They are called out in the pyproject rather than left to look like an oversight.

This count was 18-and-3 when this PR was first written. The miscount was mine: my closure check scored a manifest it cannot read (`evaluators/ragas/pyproject.toml` is not a lockfile, so it has no resolved versions to interval-test) as *closed* rather than as *unknown*, which quietly hid #2009. The check now reports that case separately, and the corrected split is what stands above.

## Deployment Impact

The langevals service image changes what it installs, and one module inside it is new. No configuration changes.

- **No new or changed environment variables**, helm values, secrets, ports or migrations. Nothing in `charts/` is touched.
- **The image resolves a different dependency set.** The langchain family moves from the 0.3 line to 1.x, `langchain-text-splitters` disappears (folded into `langchain` 1.x), and `langgraph` and its checkpoint/prebuilt/sdk packages arrive as new transitives of langchain 1.x. Image size moves accordingly; nothing is pinned to a version that needs a wheel this base image cannot build.
- **arize-phoenix resolves 19.17.0 rather than 20.0.0.** That is a repair, not a downgrade in capability: 19.18.0 and above cannot be imported at all on the Python this service runs, so the currently-deployed resolution is one where phoenix's import raises. Nothing in the served evaluator path imports phoenix; it is a notebooks dependency, and the failure surfaced through pytest collection.
- **Token accounting for ragas evaluators changes implementation, not output.** `get_openai_callback` is replaced by a handler on the same langchain-core callback surface, summing the same two counters. Cost is still priced by litellm downstream from the same numbers, so the cost figures the service reports are unchanged.
- **Rollback is a plain revert.** No state is written, no schema moves, and an older image resolves its own lock.

## Verified

- `uv sync --all-extras --all-packages` exit 0
- the provider-free CI step this PR defines: **225 passed**, 0 failed (it collected 98 items before the ragas files were named)
- every phoenix version in the table above imported directly against its published wheel on Python 3.11
- closure re-checked against each advisory's `vulnerableVersionRange` rather than its `firstPatchedVersion`: 17 of 21 closed, 4 with no fix published
- every resolved version this change moves audited against every published advisory for its package, not only the ones raised against this repo: the only hits are the two nltk advisories that have no patched release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SsqT8ApEch8zUo7Aqc3y7

