### PR TITLE
feat(model-providers): offer the credential check in the drawer, where the credential is typed

### DIFF
--- a/platform/app/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
+++ b/platform/app/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
@@ -73,6 +73,10 @@ vi.mock("../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: {

--- a/platform/app/src/components/settings/ConnectionTestVerdict.tsx
+++ b/platform/app/src/components/settings/ConnectionTestVerdict.tsx
@@ -1,0 +1,60 @@
+import { Box, Text } from "@chakra-ui/react";
+import type { ConnectionTestState } from "../../hooks/connectionTestState";
+
+/**
+ * What the last credential check said.
+ *
+ * Three states, rendered three different ways on purpose. A check that could
+ * not run reads as neutral rather than green: it is not a pass, and dressing
+ * it as one would tell a customer their configuration is fine on the strength
+ * of never having asked.
+ *
+ * The whole verdict lives in a polite live region. The text arrives well after
+ * the click that asked for it, and a screen reader announces neither the
+ * "Testing…" transition nor the answer replacing it — so without this the
+ * control is a button that appears to do nothing at all.
+ *
+ * Shared by the provider list and the drawer. The wording of an unchecked
+ * verdict differs between them, but that is decided before it arrives here:
+ * this renders a message, it does not choose one.
+ */
+export function ConnectionTestVerdict({
+  state,
+}: {
+  state: ConnectionTestState | undefined;
+}) {
+  const verdict = () => {
+    if (!state) return null;
+
+    if (state.status === "testing") {
+      return (
+        <Text fontSize="xs" color="fg.muted">
+          Testing…
+        </Text>
+      );
+    }
+
+    if (state.status === "works") {
+      return (
+        <Text fontSize="xs" color="green.fg">
+          Connection works
+        </Text>
+      );
+    }
+
+    return (
+      <Text
+        fontSize="xs"
+        color={state.status === "refused" ? "red.fg" : "fg.muted"}
+      >
+        {state.message}
+      </Text>
+    );
+  };
+
+  return (
+    <Box aria-live="polite" aria-atomic="true">
+      {verdict()}
+    </Box>
+  );
+}

--- a/platform/app/src/components/settings/ModelProviderForm.tsx
+++ b/platform/app/src/components/settings/ModelProviderForm.tsx
@@ -23,6 +23,7 @@ import { useModelProvidersSettings } from "../../hooks/useModelProvidersSettings
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useRequiredCredentialKeys } from "../../hooks/useRequiredCredentialKeys";
 import {
+  isProviderProbeable,
   type MaybeStoredModelProvider,
   modelProviders as modelProvidersRegistry,
 } from "../../server/modelProviders/registry";
@@ -31,6 +32,8 @@ import {
   hasUserEnteredNewApiKey,
   hasUserModifiedNonApiKeyFields,
 } from "../../utils/modelProviderHelpers";
+import { useCredentialCheck } from "../../hooks/useCredentialCheck";
+import { ConnectionTestVerdict } from "./ConnectionTestVerdict";
 import { parseZodFieldErrors, type ZodErrorStructure } from "../../utils/zod";
 import { SmallLabel } from "../SmallLabel";
 import { Switch } from "../ui/switch";
@@ -329,6 +332,68 @@ export const EditModelProviderForm = ({
       resetKey: providerId,
     });
 
+  // Whether the credential on screen differs from the one in storage, which is
+  // what decides whether the check is about the form or about the row. The
+  // same two helpers the dirty check and the save path already use, so the
+  // three cannot end up with different opinions about what "edited" means.
+  const hasCredentialEdits =
+    hasUserEnteredNewApiKey(state.customKeys) ||
+    hasUserModifiedNonApiKeyFields(state.customKeys, state.initialKeys);
+
+  const credentialCheck = useCredentialCheck({
+    projectId,
+    organizationId,
+    modelProviderId: providerId,
+    provider: provider.provider,
+    customKeys: state.customKeys,
+    scopes: state.scopes,
+    hasEdits: hasCredentialEdits,
+  });
+
+  /**
+   * Whether to offer the check at all.
+   *
+   * A property of the provider rather than of what has been typed, so the
+   * control does not appear and vanish while the form is filled in. Six of the
+   * registered providers credential in ways no listing endpoint exercises;
+   * offering a check there would produce "we did not look" every time, which
+   * reads as a broken button rather than as an inapplicable one.
+   *
+   * This deliberately sits alongside `isLlmProvider` and `isOAuthDeviceProvider`
+   * rather than replacing them. Those two gate the probe that runs on save, and
+   * folding all three together would change when a save is allowed to proceed —
+   * a different blast radius than a button.
+   */
+  const canCheckCredential = isProviderProbeable({
+    provider: provider.provider,
+  });
+
+  /**
+   * Whether the credential is complete enough to be worth sending.
+   *
+   * Two questions, and the required-field one is not sufficient on its own. A
+   * provider can accept a pair of fields together or not at all — Gemini's
+   * project and location — so filling one leaves every *required* field
+   * satisfied while the credential as a whole is one the provider's own schema
+   * rejects. Asking the schema is the only answer that cannot drift from what
+   * a save would accept.
+   */
+  const credentialIsComplete = useMemo(() => {
+    if (
+      getEmptyRequiredCredentialKeys({
+        requiredKeys,
+        values: state.customKeys,
+      }).length > 0
+    ) {
+      return false;
+    }
+
+    if (!providerDefinition?.keysSchema) return true;
+
+    return providerDefinition.keysSchema.safeParse({ ...state.customKeys })
+      .success;
+  }, [providerDefinition, requiredKeys, state.customKeys]);
+
   const handleSave = useCallback(async () => {
     // Clear previous errors
     setFieldErrors({});
@@ -574,7 +639,33 @@ export const EditModelProviderForm = ({
           />
         )}
 
-        <HStack width="full" justify="end">
+        {/* The check sits beside Save rather than in a menu somewhere: the
+            moment a customer wants to know whether they filled this in
+            correctly is while they are still looking at the fields. It never
+            saves — see the note under the button. */}
+        <HStack width="full" justify="space-between" align="center">
+          <VStack align="start" gap={1}>
+            {canCheckCredential && !isOAuthDeviceProvider && (
+              <Button
+                size="sm"
+                variant="outline"
+                loading={credentialCheck.state?.status === "testing"}
+                disabled={cannotResolveTarget || !credentialIsComplete}
+                onClick={() => void credentialCheck.check()}
+              >
+                Test connection
+              </Button>
+            )}
+            <ConnectionTestVerdict state={credentialCheck.state} />
+            {/* Only next to a pass, and only before the row exists. "It
+                works" and "it is saved" are easy to read as the same
+                sentence, and they are furthest apart exactly here. */}
+            {credentialCheck.state?.status === "works" && !providerId && (
+              <Text fontSize="xs" color="fg.muted">
+                Save to finish adding this provider.
+              </Text>
+            )}
+          </VStack>
           <Button
             size="sm"
             colorPalette="orange"

--- a/platform/app/src/components/settings/ModelProviderForm.tsx
+++ b/platform/app/src/components/settings/ModelProviderForm.tsx
@@ -14,6 +14,7 @@ import {
   isResolvableProviderId,
   useAllModelProvidersList,
 } from "../../hooks/useAllModelProvidersList";
+import { useCredentialCheck } from "../../hooks/useCredentialCheck";
 import { useCredentialProbeGate } from "../../hooks/useCredentialProbeGate";
 import { useDrawer } from "../../hooks/useDrawer";
 import { useFeatureFlag } from "../../hooks/useFeatureFlag";
@@ -32,14 +33,13 @@ import {
   hasUserEnteredNewApiKey,
   hasUserModifiedNonApiKeyFields,
 } from "../../utils/modelProviderHelpers";
-import { useCredentialCheck } from "../../hooks/useCredentialCheck";
-import { ConnectionTestVerdict } from "./ConnectionTestVerdict";
 import { parseZodFieldErrors, type ZodErrorStructure } from "../../utils/zod";
 import { SmallLabel } from "../SmallLabel";
 import { Switch } from "../ui/switch";
 import { toaster } from "../ui/toaster";
 import { useCodexCodingDefaultsAskStore } from "./CodexCodingDefaultsAsk";
 import { CodexSignIn } from "./CodexSignIn";
+import { ConnectionTestVerdict } from "./ConnectionTestVerdict";
 import {
   draftFromProvider,
   EMPTY_ADVANCED_DRAFT,

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
@@ -85,6 +85,10 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       // EditModelProviderForm resolves its edit target from the flat
       // (uncollapsed) provider list via useAllModelProvidersList (#5380).
       // primeHooks seeds both with the same mp_existing fixture the

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
@@ -82,6 +82,10 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       // EditModelProviderForm resolves its edit target from the flat
       // (uncollapsed) provider list via useAllModelProvidersList (#5380).
       // primeHooksForProvider seeds both with the same fixture the

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.codex-signin.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.codex-signin.integration.test.tsx
@@ -104,6 +104,10 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
       listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
       // CodexSignIn's own endpoints: idle, not yet connected.

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
@@ -177,10 +177,12 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       expect(checkButton()).toBeDisabled();
     });
 
-    it("becomes usable once the credential is entered", async () => {
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+    describe("when the credential is entered", () => {
+      it("becomes usable", async () => {
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
 
-      await waitFor(() => expect(checkButton()).toBeEnabled());
+        await waitFor(() => expect(checkButton()).toBeEnabled());
+      });
     });
   });
 
@@ -190,16 +192,18 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       renderDrawer({ modelProviderId: "new", providerKey: "gemini" });
     });
 
-    /** @scenario "A credential the provider's own rules reject cannot be checked" */
-    it("stays unusable when only half the pair is filled in", async () => {
-      // Every *required* field is satisfied here — the project and location
-      // are both optional on their own. Only the provider's own schema knows
-      // that one without the other is not a credential, which is why the rule
-      // asks the schema rather than counting empty required fields.
-      await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
-      await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
+    describe("when only half the pair is filled in", () => {
+      /** @scenario "A credential the provider's own rules reject cannot be checked" */
+      it("stays unusable", async () => {
+        // Every *required* field is satisfied here — the project and location
+        // are both optional on their own. Only the provider's own schema knows
+        // that one without the other is not a credential, which is why the rule
+        // asks the schema rather than counting empty required fields.
+        await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
+        await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
 
-      await waitFor(() => expect(checkButton()).toBeDisabled());
+        await waitFor(() => expect(checkButton()).toBeDisabled());
+      });
     });
 
     it("becomes usable when the pair is completed", async () => {
@@ -224,22 +228,24 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       renderDrawer({ modelProviderId: "row-openai", providerKey: "openai" });
     });
 
-    /** @scenario "An unchanged provider is still checked against what is stored" */
-    it("checks the stored credential without asking for it again", async () => {
-      await userEvent.click(checkButton()!);
+    describe("when I check the connection", () => {
+      /** @scenario "An unchanged provider is still checked against what is stored" */
+      it("checks the stored credential without asking for it again", async () => {
+        await userEvent.click(checkButton()!);
 
-      await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
-      const [sent] = mockTestConnection.mock.calls[0]!;
-      // No settings travel with the call, so the server reads the row. This
-      // is the only way to check a key the form deliberately never shows.
-      expect(sent.customKeys).toBeUndefined();
-      expect(sent.modelProviderId).toBe("row-openai");
-    });
+        await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
+        const [sent] = mockTestConnection.mock.calls[0]!;
+        // No settings travel with the call, so the server reads the row. This
+        // is the only way to check a key the form deliberately never shows.
+        expect(sent.customKeys).toBeUndefined();
+        expect(sent.modelProviderId).toBe("row-openai");
+      });
 
-    it("reports the verdict where the customer is looking", async () => {
-      await userEvent.click(checkButton()!);
+      it("reports the verdict where the customer is looking", async () => {
+        await userEvent.click(checkButton()!);
 
-      expect(await screen.findByText("Connection works")).toBeTruthy();
+        expect(await screen.findByText("Connection works")).toBeTruthy();
+      });
     });
   });
 
@@ -256,53 +262,57 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       renderDrawer({ modelProviderId: "row-openai", providerKey: "openai" });
     });
 
-    /** @scenario "Checking after changing an endpoint uses the endpoint on screen" */
-    it("checks the endpoint on screen once the credential is entered again", async () => {
-      await userEvent.clear(inputFor("OPENAI_BASE_URL"));
-      await userEvent.type(
-        inputFor("OPENAI_BASE_URL"),
-        "https://new.example.com/v1",
-      );
-      await userEvent.clear(inputFor("OPENAI_API_KEY"));
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+    describe("when I enter the credential again and check", () => {
+      /** @scenario "Checking after changing an endpoint uses the endpoint on screen" */
+      it("checks the endpoint on screen", async () => {
+        await userEvent.clear(inputFor("OPENAI_BASE_URL"));
+        await userEvent.type(
+          inputFor("OPENAI_BASE_URL"),
+          "https://new.example.com/v1",
+        );
+        await userEvent.clear(inputFor("OPENAI_API_KEY"));
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
 
-      await userEvent.click(checkButton()!);
+        await userEvent.click(checkButton()!);
 
-      await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
-      const [sent] = mockTestConnection.mock.calls[0]!;
-      expect(sent.customKeys?.OPENAI_BASE_URL).toBe(
-        "https://new.example.com/v1",
-      );
-      expect(sent.customKeys?.OPENAI_API_KEY).toBe("sk-typed-just-now");
+        await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
+        const [sent] = mockTestConnection.mock.calls[0]!;
+        expect(sent.customKeys?.OPENAI_BASE_URL).toBe(
+          "https://new.example.com/v1",
+        );
+        expect(sent.customKeys?.OPENAI_API_KEY).toBe("sk-typed-just-now");
+      });
     });
 
-    /** @scenario "Changing an endpoint without the credential asks for the credential" */
-    it("asks for the credential rather than reaching for the stored one", async () => {
-      // The server refuses to pair a stored secret with an address from the
-      // request, so a masked credential comes back unchecked. What the
-      // customer needs is the next step, not an apology about storage.
-      mockTestConnection.mockResolvedValue({
-        outcome: "unchecked",
-        valid: true,
-        reason: "credential_masked",
+    describe("when I check without re-entering the credential", () => {
+      /** @scenario "Changing an endpoint without the credential asks for the credential" */
+      it("asks for the credential rather than reaching for the stored one", async () => {
+        // The server refuses to pair a stored secret with an address from the
+        // request, so a masked credential comes back unchecked. What the
+        // customer needs is the next step, not an apology about storage.
+        mockTestConnection.mockResolvedValue({
+          outcome: "unchecked",
+          valid: true,
+          reason: "credential_masked",
+        });
+
+        await userEvent.clear(inputFor("OPENAI_BASE_URL"));
+        await userEvent.type(
+          inputFor("OPENAI_BASE_URL"),
+          "https://new.example.com/v1",
+        );
+
+        await userEvent.click(checkButton()!);
+
+        expect(
+          await screen.findByText(
+            "Enter the credential again to check these settings.",
+          ),
+        ).toBeTruthy();
+
+        const [sent] = mockTestConnection.mock.calls[0]!;
+        expect(sent.customKeys?.OPENAI_API_KEY).toBe(MASKED_KEY_PLACEHOLDER);
       });
-
-      await userEvent.clear(inputFor("OPENAI_BASE_URL"));
-      await userEvent.type(
-        inputFor("OPENAI_BASE_URL"),
-        "https://new.example.com/v1",
-      );
-
-      await userEvent.click(checkButton()!);
-
-      expect(
-        await screen.findByText(
-          "Enter the credential again to check these settings.",
-        ),
-      ).toBeTruthy();
-
-      const [sent] = mockTestConnection.mock.calls[0]!;
-      expect(sent.customKeys?.OPENAI_API_KEY).toBe(MASKED_KEY_PLACEHOLDER);
     });
   });
 
@@ -312,24 +322,26 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       renderDrawer({ modelProviderId: "new", providerKey: "openai" });
     });
 
-    /** @scenario "Checking does not save" */
-    it("checks the credential without creating the provider", async () => {
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
-      await userEvent.click(checkButton()!);
+    describe("when I check the credential I have typed", () => {
+      /** @scenario "Checking does not save" */
+      it("checks it without creating the provider", async () => {
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+        await userEvent.click(checkButton()!);
 
-      await waitFor(() =>
-        expect(mockValidateApiKeyMutation).toHaveBeenCalled(),
-      );
-      expect(mockMutateAsync).not.toHaveBeenCalled();
-    });
+        await waitFor(() =>
+          expect(mockValidateApiKeyMutation).toHaveBeenCalled(),
+        );
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
 
-    it("says what is still left to do, so a pass does not read as a save", async () => {
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
-      await userEvent.click(checkButton()!);
+      it("says what is still left to do, so a pass does not read as a save", async () => {
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+        await userEvent.click(checkButton()!);
 
-      expect(
-        await screen.findByText("Save to finish adding this provider."),
-      ).toBeTruthy();
+        expect(
+          await screen.findByText("Save to finish adding this provider."),
+        ).toBeTruthy();
+      });
     });
 
     /** @scenario "A result disappears when I change the credential" */

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The credential check offered inside the model-provider drawer, exercised
+ * through the real form tree.
+ *
+ * Covers @unit scenarios from specs/model-providers/credential-validation.feature.
+ *
+ * Only the boundaries are stubbed — the tRPC client, the drawer, org context,
+ * feature flags, the toaster. Everything that decides whether the control is
+ * shown, usable, and about which settings is the real code: the visibility
+ * rule reads the registry, the usability rule runs the provider's own schema,
+ * and which route the click takes is settled by the same helpers the save path
+ * uses. Mocking any of those would leave the test asserting its own fixtures.
+ */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockMutateAsync,
+  mockGetAllForProjectForFrontendQuery,
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+  mockTestConnection,
+  mockValidateApiKeyMutation,
+} = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn().mockResolvedValue({}),
+  mockGetAllForProjectForFrontendQuery: vi.fn(),
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+  mockTestConnection: vi.fn(),
+  mockValidateApiKeyMutation: vi.fn(),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: mockGetAllForProjectForFrontendQuery,
+      },
+      listAllForOrganizationForFrontend: {
+        useQuery: mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: mockListAllForProjectForFrontendQuery,
+      },
+      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
+      testConnection: {
+        useMutation: () => ({ mutateAsync: mockTestConnection }),
+      },
+      validateApiKey: {
+        useMutation: () => ({ mutateAsync: mockValidateApiKeyMutation }),
+      },
+      setRoleAssignmentForScope: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
+        }),
+      },
+      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+    },
+    useContext: () => ({
+      organization: { getAll: { invalidate: vi.fn() } },
+      modelProvider: {
+        getAllForProject: { invalidate: vi.fn() },
+        getAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        getResolvedDefault: { invalidate: vi.fn() },
+        getDefaultModelsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useDrawer", () => ({
+  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
+}));
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", name: "Web App", slug: "web-app" },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { EditModelProviderForm } from "../ModelProviderForm";
+import {
+  inputFor,
+  keyedRow,
+  makePrimeQueries,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
+
+const primeQueries = makePrimeQueries({
+  collapsedQuery: mockGetAllForProjectForFrontendQuery,
+  organizationListQuery: mockListAllForOrganizationForFrontendQuery,
+  projectListQuery: mockListAllForProjectForFrontendQuery,
+});
+
+const renderDrawer = (props: {
+  modelProviderId?: string;
+  providerKey?: string;
+}) =>
+  render(
+    <Wrapper>
+      <EditModelProviderForm
+        projectId="proj-1"
+        organizationId="org-1"
+        providerKey={props.providerKey ?? "openai"}
+        modelProviderId={props.modelProviderId}
+      />
+    </Wrapper>,
+  );
+
+const checkButton = () => screen.queryByRole("button", { name: "Test connection" });
+
+const works = { outcome: "verified" as const, valid: true as const };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMutateAsync.mockResolvedValue({});
+  mockTestConnection.mockResolvedValue(works);
+  mockValidateApiKeyMutation.mockResolvedValue(works);
+});
+
+afterEach(cleanup);
+
+describe("Feature: checking a credential from the drawer it was typed into", () => {
+  describe("given a provider whose credentials cannot be probed", () => {
+    beforeEach(() => {
+      primeQueries([]);
+      // Bedrock signs with AWS credentials, which no models listing
+      // exercises. Filling every field in cannot make it checkable.
+      renderDrawer({ modelProviderId: "new", providerKey: "bedrock" });
+    });
+
+    /** @scenario "A provider that cannot be checked offers no control" */
+    it("offers no way to check the connection at all", () => {
+      expect(checkButton()).toBeNull();
+    });
+
+    it("says nothing about the connection working", () => {
+      expect(screen.queryByText("Connection works")).toBeNull();
+    });
+  });
+
+  describe("given a provider that can be checked, with nothing filled in", () => {
+    beforeEach(() => {
+      primeQueries([]);
+      renderDrawer({ modelProviderId: "new", providerKey: "openai" });
+    });
+
+    /** @scenario "Checking is unavailable until the credential is complete" */
+    it("offers the control but will not let it be used", () => {
+      expect(checkButton()).not.toBeNull();
+      expect(checkButton()).toBeDisabled();
+    });
+
+    it("becomes usable once the credential is entered", async () => {
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+
+      await waitFor(() => expect(checkButton()).toBeEnabled());
+    });
+  });
+
+  describe("given a provider that accepts a project and location together or not at all", () => {
+    beforeEach(() => {
+      primeQueries([]);
+      renderDrawer({ modelProviderId: "new", providerKey: "gemini" });
+    });
+
+    /** @scenario "A credential the provider's own rules reject cannot be checked" */
+    it("stays unusable when only half the pair is filled in", async () => {
+      // Every *required* field is satisfied here — the project and location
+      // are both optional on their own. Only the provider's own schema knows
+      // that one without the other is not a credential, which is why the rule
+      // asks the schema rather than counting empty required fields.
+      await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
+      await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
+
+      await waitFor(() => expect(checkButton()).toBeDisabled());
+    });
+
+    it("becomes usable when the pair is completed", async () => {
+      await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
+      await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
+      await userEvent.type(inputFor("GEMINI_LOCATION"), "us-central1");
+
+      await waitFor(() => expect(checkButton()).toBeEnabled());
+    });
+  });
+
+  describe("given a saved provider I have not edited", () => {
+    beforeEach(() => {
+      primeQueries([
+        keyedRow({
+          providerKey: "openai",
+          apiKey: "OPENAI_API_KEY",
+          baseUrl: "OPENAI_BASE_URL",
+          storedBaseUrl: "https://saved.example.com/v1",
+        }),
+      ]);
+      renderDrawer({ modelProviderId: "row-openai", providerKey: "openai" });
+    });
+
+    /** @scenario "An unchanged provider is still checked against what is stored" */
+    it("checks the stored credential without asking for it again", async () => {
+      await userEvent.click(checkButton()!);
+
+      await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
+      const [sent] = mockTestConnection.mock.calls[0]!;
+      // No settings travel with the call, so the server reads the row. This
+      // is the only way to check a key the form deliberately never shows.
+      expect(sent.customKeys).toBeUndefined();
+      expect(sent.modelProviderId).toBe("row-openai");
+    });
+
+    it("reports the verdict where the customer is looking", async () => {
+      await userEvent.click(checkButton()!);
+
+      expect(await screen.findByText("Connection works")).toBeTruthy();
+    });
+  });
+
+  describe("given a saved provider whose endpoint I have changed", () => {
+    beforeEach(() => {
+      primeQueries([
+        keyedRow({
+          providerKey: "openai",
+          apiKey: "OPENAI_API_KEY",
+          baseUrl: "OPENAI_BASE_URL",
+          storedBaseUrl: "https://saved.example.com/v1",
+        }),
+      ]);
+      renderDrawer({ modelProviderId: "row-openai", providerKey: "openai" });
+    });
+
+    /** @scenario "Checking after changing an endpoint uses the endpoint on screen" */
+    it("checks the endpoint on screen once the credential is entered again", async () => {
+      await userEvent.clear(inputFor("OPENAI_BASE_URL"));
+      await userEvent.type(inputFor("OPENAI_BASE_URL"), "https://new.example.com/v1");
+      await userEvent.clear(inputFor("OPENAI_API_KEY"));
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+
+      await userEvent.click(checkButton()!);
+
+      await waitFor(() => expect(mockTestConnection).toHaveBeenCalled());
+      const [sent] = mockTestConnection.mock.calls[0]!;
+      expect(sent.customKeys?.OPENAI_BASE_URL).toBe(
+        "https://new.example.com/v1",
+      );
+      expect(sent.customKeys?.OPENAI_API_KEY).toBe("sk-typed-just-now");
+    });
+
+    /** @scenario "Changing an endpoint without the credential asks for the credential" */
+    it("asks for the credential rather than reaching for the stored one", async () => {
+      // The server refuses to pair a stored secret with an address from the
+      // request, so a masked credential comes back unchecked. What the
+      // customer needs is the next step, not an apology about storage.
+      mockTestConnection.mockResolvedValue({
+        outcome: "unchecked",
+        valid: true,
+        reason: "credential_masked",
+      });
+
+      await userEvent.clear(inputFor("OPENAI_BASE_URL"));
+      await userEvent.type(inputFor("OPENAI_BASE_URL"), "https://new.example.com/v1");
+
+      await userEvent.click(checkButton()!);
+
+      expect(
+        await screen.findByText(
+          "Enter the credential again to check these settings.",
+        ),
+      ).toBeTruthy();
+
+      const [sent] = mockTestConnection.mock.calls[0]!;
+      expect(sent.customKeys?.OPENAI_API_KEY).toBe(MASKED_KEY_PLACEHOLDER);
+    });
+  });
+
+  describe("given a provider I am creating", () => {
+    beforeEach(() => {
+      primeQueries([]);
+      renderDrawer({ modelProviderId: "new", providerKey: "openai" });
+    });
+
+    /** @scenario "Checking does not save" */
+    it("checks the credential without creating the provider", async () => {
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+      await userEvent.click(checkButton()!);
+
+      await waitFor(() => expect(mockValidateApiKeyMutation).toHaveBeenCalled());
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("says what is still left to do, so a pass does not read as a save", async () => {
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+      await userEvent.click(checkButton()!);
+
+      expect(
+        await screen.findByText("Save to finish adding this provider."),
+      ).toBeTruthy();
+    });
+
+    /** @scenario "A result disappears when I change the credential" */
+    it("drops the verdict as soon as the credential changes", async () => {
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+      await userEvent.click(checkButton()!);
+      expect(await screen.findByText("Connection works")).toBeTruthy();
+
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
+
+      await waitFor(() =>
+        expect(screen.queryByText("Connection works")).toBeNull(),
+      );
+    });
+  });
+});

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
@@ -13,7 +13,7 @@
  * and which route the click takes is settled by the same helpers the save path
  * uses. Mocking any of those would leave the test asserting its own fixtures.
  */
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -343,6 +343,32 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       await waitFor(() =>
         expect(screen.queryByText("Connection works")).toBeNull(),
       );
+    });
+
+    /** @scenario "A result still in flight when I change the credential is discarded" */
+    it("discards an answer that arrives after the credential has changed", async () => {
+      // The case the test above cannot reach, because a resolved mock lands
+      // before the edit. Here the answer is held open across the edit, which is
+      // where the guard either works or silently does nothing: a verdict about
+      // the previous credential reappearing is a success claim about a key that
+      // is no longer on screen.
+      let answer: (value: unknown) => void = () => undefined;
+      mockValidateApiKeyMutation.mockImplementation(
+        () => new Promise((resolve) => (answer = resolve)),
+      );
+
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+      await userEvent.click(checkButton()!);
+      expect(await screen.findByText("Testing…")).toBeTruthy();
+
+      await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
+
+      await act(async () => {
+        answer({ outcome: "verified", valid: true });
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("Connection works")).toBeNull();
     });
   });
 });

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
@@ -132,7 +132,8 @@ const renderDrawer = (props: {
     </Wrapper>,
   );
 
-const checkButton = () => screen.queryByRole("button", { name: "Test connection" });
+const checkButton = () =>
+  screen.queryByRole("button", { name: "Test connection" });
 
 const works = { outcome: "verified" as const, valid: true as const };
 
@@ -258,7 +259,10 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
     /** @scenario "Checking after changing an endpoint uses the endpoint on screen" */
     it("checks the endpoint on screen once the credential is entered again", async () => {
       await userEvent.clear(inputFor("OPENAI_BASE_URL"));
-      await userEvent.type(inputFor("OPENAI_BASE_URL"), "https://new.example.com/v1");
+      await userEvent.type(
+        inputFor("OPENAI_BASE_URL"),
+        "https://new.example.com/v1",
+      );
       await userEvent.clear(inputFor("OPENAI_API_KEY"));
       await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
 
@@ -284,7 +288,10 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       });
 
       await userEvent.clear(inputFor("OPENAI_BASE_URL"));
-      await userEvent.type(inputFor("OPENAI_BASE_URL"), "https://new.example.com/v1");
+      await userEvent.type(
+        inputFor("OPENAI_BASE_URL"),
+        "https://new.example.com/v1",
+      );
 
       await userEvent.click(checkButton()!);
 
@@ -310,7 +317,9 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
       await userEvent.click(checkButton()!);
 
-      await waitFor(() => expect(mockValidateApiKeyMutation).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(mockValidateApiKeyMutation).toHaveBeenCalled(),
+      );
       expect(mockMutateAsync).not.toHaveBeenCalled();
     });
 

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.connection-check.integration.test.tsx
@@ -4,7 +4,8 @@
  * The credential check offered inside the model-provider drawer, exercised
  * through the real form tree.
  *
- * Covers @unit scenarios from specs/model-providers/credential-validation.feature.
+ * Covers @integration scenarios from
+ * specs/model-providers/credential-validation.feature.
  *
  * Only the boundaries are stubbed — the tRPC client, the drawer, org context,
  * feature flags, the toaster. Everything that decides whether the control is
@@ -117,20 +118,21 @@ const primeQueries = makePrimeQueries({
   projectListQuery: mockListAllForProjectForFrontendQuery,
 });
 
+const drawer = (props: { modelProviderId?: string; providerKey?: string }) => (
+  <Wrapper>
+    <EditModelProviderForm
+      projectId="proj-1"
+      organizationId="org-1"
+      providerKey={props.providerKey ?? "openai"}
+      modelProviderId={props.modelProviderId}
+    />
+  </Wrapper>
+);
+
 const renderDrawer = (props: {
   modelProviderId?: string;
   providerKey?: string;
-}) =>
-  render(
-    <Wrapper>
-      <EditModelProviderForm
-        projectId="proj-1"
-        organizationId="org-1"
-        providerKey={props.providerKey ?? "openai"}
-        modelProviderId={props.modelProviderId}
-      />
-    </Wrapper>,
-  );
+}) => render(drawer(props));
 
 const checkButton = () =>
   screen.queryByRole("button", { name: "Test connection" });
@@ -206,12 +208,14 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       });
     });
 
-    it("becomes usable when the pair is completed", async () => {
-      await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
-      await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
-      await userEvent.type(inputFor("GEMINI_LOCATION"), "us-central1");
+    describe("when the pair is completed", () => {
+      it("becomes usable", async () => {
+        await userEvent.type(inputFor("GEMINI_API_KEY"), "a-real-key");
+        await userEvent.type(inputFor("GEMINI_PROJECT"), "my-project");
+        await userEvent.type(inputFor("GEMINI_LOCATION"), "us-central1");
 
-      await waitFor(() => expect(checkButton()).toBeEnabled());
+        await waitFor(() => expect(checkButton()).toBeEnabled());
+      });
     });
   });
 
@@ -344,36 +348,78 @@ describe("Feature: checking a credential from the drawer it was typed into", () 
       });
     });
 
-    /** @scenario "A result disappears when I change the credential" */
-    it("drops the verdict as soon as the credential changes", async () => {
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
-      await userEvent.click(checkButton()!);
-      expect(await screen.findByText("Connection works")).toBeTruthy();
+    describe("when I change the credential after being told it works", () => {
+      /** @scenario "A result disappears when I change the credential" */
+      it("drops the verdict as soon as the credential changes", async () => {
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+        await userEvent.click(checkButton()!);
+        expect(await screen.findByText("Connection works")).toBeTruthy();
 
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
 
-      await waitFor(() =>
-        expect(screen.queryByText("Connection works")).toBeNull(),
-      );
+        await waitFor(() =>
+          expect(screen.queryByText("Connection works")).toBeNull(),
+        );
+      });
     });
 
-    /** @scenario "A result still in flight when I change the credential is discarded" */
-    it("discards an answer that arrives after the credential has changed", async () => {
-      // The case the test above cannot reach, because a resolved mock lands
-      // before the edit. Here the answer is held open across the edit, which is
-      // where the guard either works or silently does nothing: a verdict about
-      // the previous credential reappearing is a success claim about a key that
-      // is no longer on screen.
+    describe("when I change the credential before the answer arrives", () => {
+      /** @scenario "A result still in flight when I change the credential is discarded" */
+      it("discards the answer", async () => {
+        // The case the test above cannot reach, because a resolved mock lands
+        // before the edit. Here the answer is held open across the edit, which
+        // is where the guard either works or silently does nothing: a verdict
+        // about the previous credential reappearing is a success claim about a
+        // key that is no longer on screen.
+        let answer: (value: unknown) => void = () => undefined;
+        mockValidateApiKeyMutation.mockImplementation(
+          () => new Promise((resolve) => (answer = resolve)),
+        );
+
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+        await userEvent.click(checkButton()!);
+        expect(await screen.findByText("Testing…")).toBeTruthy();
+
+        await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
+
+        await act(async () => {
+          answer({ outcome: "verified", valid: true });
+          await Promise.resolve();
+        });
+
+        expect(screen.queryByText("Connection works")).toBeNull();
+      });
+    });
+  });
+
+  describe("given two saved rows that look identical on screen", () => {
+    /** @scenario "A result still in flight when I move to another provider is discarded" */
+    it("does not land the first row's verdict on the second", async () => {
+      // Both rows render the masked placeholder and the same endpoint, so what
+      // is on screen is character-for-character identical. Only the row
+      // identity separates them, which is why it has to be part of what the
+      // guard compares — otherwise a verdict about one is indistinguishable
+      // from a verdict about the other, and lands on whichever is open.
+      const storedRow = () =>
+        keyedRow({
+          providerKey: "openai",
+          apiKey: "OPENAI_API_KEY",
+          baseUrl: "OPENAI_BASE_URL",
+          storedBaseUrl: "https://saved.example.com/v1",
+        });
+      primeQueries([storedRow(), { ...storedRow(), id: "row-openai-second" }]);
+
       let answer: (value: unknown) => void = () => undefined;
-      mockValidateApiKeyMutation.mockImplementation(
+      mockTestConnection.mockImplementation(
         () => new Promise((resolve) => (answer = resolve)),
       );
 
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "sk-typed-just-now");
+      const view = render(drawer({ modelProviderId: "row-openai" }));
       await userEvent.click(checkButton()!);
       expect(await screen.findByText("Testing…")).toBeTruthy();
 
-      await userEvent.type(inputFor("OPENAI_API_KEY"), "-edited");
+      // The customer moves to the other row before the answer arrives.
+      view.rerender(drawer({ modelProviderId: "row-openai-second" }));
 
       await act(async () => {
         answer({ outcome: "verified", valid: true });

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-preservation.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-preservation.integration.test.tsx
@@ -50,6 +50,10 @@ vi.mock("../../../utils/api", () => ({
         }),
       },
       isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: { getAll: { invalidate: vi.fn() } },

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-requiredness.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-requiredness.integration.test.tsx
@@ -58,6 +58,10 @@ vi.mock("../../../utils/api", () => ({
         }),
       },
       isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: { getAll: { invalidate: vi.fn() } },

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -73,6 +73,10 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.field-guidance.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.field-guidance.integration.test.tsx
@@ -44,6 +44,10 @@ vi.mock("../../../utils/api", () => ({
         }),
       },
       isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: { getAll: { invalidate: vi.fn() } },

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.validation-escape-hatch.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.validation-escape-hatch.integration.test.tsx
@@ -50,6 +50,10 @@ vi.mock("../../../utils/api", () => ({
         }),
       },
       isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+      // The drawer offers a credential check, so the form reaches for both
+      // routes it can take. Neither is exercised here.
+      testConnection: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      validateApiKey: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     useContext: () => ({
       organization: { getAll: { invalidate: vi.fn() } },

--- a/platform/app/src/hooks/connectionTestState.ts
+++ b/platform/app/src/hooks/connectionTestState.ts
@@ -1,0 +1,113 @@
+import { explainSerializedError } from "../features/errors";
+import type {
+  UncheckedReason,
+  ValidationResult,
+} from "../server/modelProviders/providerValidation";
+
+/**
+ * A credential check's verdict, in the terms a surface renders.
+ *
+ * Pulled out of the list's hook once the drawer needed the same three states.
+ * It is a plain function rather than a hook because nothing here is stateful,
+ * and because the exhaustiveness check at the bottom is worth having in one
+ * place: a fourth outcome on the server should be a compile error, not a
+ * confident sentence about a verdict nobody has classified.
+ *
+ * `import type` and not a value import: the module that owns `ValidationResult`
+ * reaches the provider repository, and through it Prisma and the encryption
+ * helpers. Types are erased, so this costs nothing at runtime and buys the one
+ * thing a redeclaration cannot — a rename on the server becomes a type error
+ * here instead of a sentence that quietly stops being true.
+ */
+export type ConnectionTestState =
+  | { status: "testing" }
+  | { status: "works" }
+  | { status: "refused"; message: string }
+  | {
+      status: "unchecked";
+      /**
+       * Why nothing was checked. `request_failed` is the local one: we never
+       * got an answer at all, as opposed to the server answering that it chose
+       * not to ask. Kept apart because a surface can act on some of the
+       * server's reasons and can only ever apologize for this one.
+       */
+      reason: UncheckedReason | "request_failed";
+      message: string;
+    };
+
+/**
+ * What to say when the check never ran, on a surface that is only reading.
+ *
+ * Deliberately short of the reason we hold internally. "This provider signs
+ * every request with AWS credentials, which a listing endpoint does not
+ * exercise" is true and is not the customer's problem; what they need to know
+ * is whether they still have something to do.
+ *
+ * The drawer overrides two of these, because there the same reason means
+ * something a customer can act on — see `useCredentialCheck`.
+ */
+export const uncheckedMessage = (reason: UncheckedReason): string => {
+  if (reason === "no_credential" || reason === "credential_masked") {
+    // Not "nothing is stored": a credential written before the encryption
+    // secret was rotated is unreadable rather than absent, and the two are
+    // indistinguishable by the time they reach here (the repository drops an
+    // undecryptable value to null). Telling that customer to enter a key they
+    // already entered is the misdiagnosis this whole area exists to avoid.
+    return "No credential could be read for this provider.";
+  }
+  return "This provider can't be tested automatically — its settings are checked when you first use it.";
+};
+
+/**
+ * A verdict, turned into what the surface should say.
+ *
+ * @param result - The server's answer, whichever route asked for it. Both the
+ *   stored-credential check and the typed-credential one return this shape, so
+ *   one mapping covers the list and the drawer.
+ * @param describeUnchecked - Copy for a check that did not run. Defaults to the
+ *   reading-only wording above.
+ */
+export function toConnectionTestState(
+  result: ValidationResult,
+  describeUnchecked: (reason: UncheckedReason) => string = uncheckedMessage,
+): ConnectionTestState {
+  if (result.outcome === "verified") {
+    return { status: "works" };
+  }
+
+  if (result.outcome === "refused") {
+    // The refusal is a serialized handled error riding on the payload, so it
+    // is read with `explainSerializedError` rather than `describeError`. Both
+    // land in the same code-keyed registry; only the transport differs. The
+    // provider's own sentence never appears in either — a rejected-credential
+    // body is where the credential itself tends to turn up.
+    const { title, description } = explainSerializedError(result.domainError);
+    return {
+      status: "refused",
+      message: description ? `${title}. ${description}` : title,
+    };
+  }
+
+  if (result.outcome === "unchecked") {
+    return {
+      status: "unchecked",
+      reason: result.reason,
+      message: describeUnchecked(result.reason),
+    };
+  }
+
+  // A fourth outcome would otherwise fall into the branch above and be
+  // described as "can't be tested automatically" — a confident sentence about
+  // a verdict nobody has classified. This turns that into a compile error at
+  // the moment the server grows one.
+  //
+  // The discriminator only, never the payload: this message can reach a
+  // customer through the caller's catch, and nothing promises a future
+  // outcome's fields are free of credential material.
+  const unhandled: never = result;
+  throw new Error(
+    `Unhandled connection test outcome: ${String(
+      (unhandled as { outcome?: unknown }).outcome,
+    )}`,
+  );
+}

--- a/platform/app/src/hooks/connectionTestState.ts
+++ b/platform/app/src/hooks/connectionTestState.ts
@@ -65,12 +65,16 @@ export const uncheckedMessage = (reason: UncheckedReason): string => {
  *   stored-credential check and the typed-credential one return this shape, so
  *   one mapping covers the list and the drawer.
  * @param describeUnchecked - Copy for a check that did not run. Defaults to the
- *   reading-only wording above.
+ *   reading-only wording above. Named rather than positional, so the second
+ *   argument still reads at the call site once a third exists.
  */
-export function toConnectionTestState(
-  result: ValidationResult,
-  describeUnchecked: (reason: UncheckedReason) => string = uncheckedMessage,
-): ConnectionTestState {
+export function toConnectionTestState({
+  result,
+  describeUnchecked = uncheckedMessage,
+}: {
+  result: ValidationResult;
+  describeUnchecked?: (reason: UncheckedReason) => string;
+}): ConnectionTestState {
   if (result.outcome === "verified") {
     return { status: "works" };
   }

--- a/platform/app/src/hooks/useCredentialCheck.ts
+++ b/platform/app/src/hooks/useCredentialCheck.ts
@@ -68,9 +68,21 @@ export function useCredentialCheck({
    *
    * `useCredentialProbeGate` makes the same argument for the save-time probe.
    */
+  /**
+   * What a verdict is about: the credentials on screen *and* the row they
+   * belong to.
+   *
+   * The row has to be in here rather than beside it. Two saved rows show the
+   * same masked placeholder and can carry the same endpoint, so what is on
+   * screen is identical for both and the credentials alone cannot tell them
+   * apart. Clearing on one key while stamping the guard with another means a
+   * check still in flight when the drawer moves to the second row survives the
+   * clear and reports the first row's answer about the second — indeed exactly
+   * the failure this guard exists to prevent, wearing a different hat.
+   */
   const credentialsFingerprint = useMemo(
-    () => JSON.stringify(customKeys),
-    [customKeys],
+    () => JSON.stringify({ modelProviderId, customKeys }),
+    [customKeys, modelProviderId],
   );
 
   /**
@@ -88,7 +100,7 @@ export function useCredentialCheck({
   useEffect(() => {
     latestFingerprint.current = credentialsFingerprint;
     setState(undefined);
-  }, [credentialsFingerprint, modelProviderId]);
+  }, [credentialsFingerprint]);
 
   /**
    * Ask whichever route can answer about what is on screen.

--- a/platform/app/src/hooks/useCredentialCheck.ts
+++ b/platform/app/src/hooks/useCredentialCheck.ts
@@ -90,6 +90,43 @@ export function useCredentialCheck({
     setState(undefined);
   }, [credentialsFingerprint, modelProviderId]);
 
+  /**
+   * Ask whichever route can answer about what is on screen.
+   *
+   * A saved row is checked where it lives, so the settings only travel when
+   * they differ from it — an untouched form would send a blank or masked key
+   * and come back "no credential" for a provider that is configured fine. A row
+   * that does not exist yet has nothing but the typed credential to send.
+   */
+  const ask = useCallback(async () => {
+    if (modelProviderId) {
+      return await testConnection({
+        modelProviderId,
+        projectId,
+        organizationId,
+        ...(hasEdits ? { customKeys } : {}),
+      });
+    }
+
+    return await validateApiKey({
+      projectId,
+      organizationId,
+      provider,
+      customKeys,
+      scopes: scopes && scopes.length > 0 ? scopes : undefined,
+    });
+  }, [
+    customKeys,
+    hasEdits,
+    modelProviderId,
+    organizationId,
+    projectId,
+    provider,
+    scopes,
+    testConnection,
+    validateApiKey,
+  ]);
+
   const check = useCallback(async () => {
     const asked = credentialsFingerprint;
     // Discard anything that arrives about credentials the customer has since
@@ -105,25 +142,12 @@ export function useCredentialCheck({
     setState({ status: "testing" });
 
     try {
-      const result = modelProviderId
-        ? await testConnection({
-            modelProviderId,
-            projectId,
-            organizationId,
-            // Only when there is something the row does not already know.
-            // Sending an untouched form would send a blank or masked key and
-            // get back "no credential" for a provider that is configured fine.
-            ...(hasEdits ? { customKeys } : {}),
-          })
-        : await validateApiKey({
-            projectId,
-            organizationId,
-            provider,
-            customKeys,
-            scopes: scopes && scopes.length > 0 ? scopes : undefined,
-          });
-
-      settle(toConnectionTestState(result, describeUncheckedInDrawer));
+      settle(
+        toConnectionTestState({
+          result: await ask(),
+          describeUnchecked: describeUncheckedInDrawer,
+        }),
+      );
     } catch (error) {
       // Not `error.message`: a handled error's message is replaced by its
       // stable code on the wire, so reading it renders a slug like
@@ -138,18 +162,7 @@ export function useCredentialCheck({
         }),
       });
     }
-  }, [
-    credentialsFingerprint,
-    customKeys,
-    hasEdits,
-    modelProviderId,
-    organizationId,
-    projectId,
-    provider,
-    scopes,
-    testConnection,
-    validateApiKey,
-  ]);
+  }, [ask, credentialsFingerprint]);
 
   return { state, check };
 }

--- a/platform/app/src/hooks/useCredentialCheck.ts
+++ b/platform/app/src/hooks/useCredentialCheck.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { describeError } from "../features/errors";
 import type { UncheckedReason } from "../server/modelProviders/providerValidation";
 import { api } from "../utils/api";
@@ -72,17 +72,34 @@ export function useCredentialCheck({
     () => JSON.stringify(customKeys),
     [customKeys],
   );
+
+  /**
+   * The fingerprint as of the latest render, readable from inside a callback
+   * that closed over an older one.
+   *
+   * A ref rather than the value itself, and this is the whole point: `check`
+   * captures the credentials it was called with, so comparing the captured
+   * fingerprint against the captured credentials compares a value with itself
+   * and is true however much has changed since. The ref is the only thing in
+   * scope that moves, so it is the only thing that can answer "are these still
+   * the credentials on screen?".
+   */
+  const latestFingerprint = useRef(credentialsFingerprint);
   useEffect(() => {
+    latestFingerprint.current = credentialsFingerprint;
     setState(undefined);
   }, [credentialsFingerprint, modelProviderId]);
 
   const check = useCallback(async () => {
     const asked = credentialsFingerprint;
     // Discard anything that arrives about credentials the customer has since
-    // changed, rather than showing a verdict about keys that are gone.
+    // changed, rather than showing a verdict about keys that are gone. Without
+    // this an answer still in flight when they edit lands afterwards and puts
+    // a green result back on screen — about a credential that is no longer
+    // there, which is the one thing this feature must never produce.
     const settle = (next: ConnectionTestState) =>
       setState((current) =>
-        asked === JSON.stringify(customKeys) ? next : current,
+        asked === latestFingerprint.current ? next : current,
       );
 
     setState({ status: "testing" });

--- a/platform/app/src/hooks/useCredentialCheck.ts
+++ b/platform/app/src/hooks/useCredentialCheck.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { describeError } from "../features/errors";
+import type { UncheckedReason } from "../server/modelProviders/providerValidation";
+import { api } from "../utils/api";
+import {
+  type ConnectionTestState,
+  toConnectionTestState,
+  uncheckedMessage,
+} from "./connectionTestState";
+
+/**
+ * Checking a credential from the drawer it is being typed into.
+ *
+ * The provider list checks a row that is finished and saved. Here the customer
+ * is mid-edit, so what has to be checked is what is on screen — including the
+ * half of it that has not been saved yet. Which of the two routes carries that
+ * depends on what the drawer actually has:
+ *
+ *   - No row yet, because the provider is being created. There is nothing in
+ *     storage to check, so the typed credential goes out on its own.
+ *   - A row, and nothing edited. Nothing is sent: the stored credential is
+ *     checked where it lives, which is the only way to check a key the form
+ *     deliberately never shows back.
+ *   - A row, and something edited. The settings on screen are sent whole. Not
+ *     merged with the stored ones — the server refuses to combine them, and
+ *     this end has no business trying either.
+ *
+ * The third case is the one that makes this worth a hook. A customer who
+ * changes an endpoint and leaves the key masked would otherwise be told about
+ * the endpoint they just replaced, which is a green answer about a
+ * configuration nobody is looking at.
+ */
+export function useCredentialCheck({
+  projectId,
+  organizationId,
+  modelProviderId,
+  provider,
+  customKeys,
+  scopes,
+  hasEdits,
+}: {
+  projectId: string | undefined;
+  organizationId: string | undefined;
+  /** The row being edited, or undefined while creating one. */
+  modelProviderId: string | undefined;
+  provider: string;
+  customKeys: Record<string, string>;
+  scopes?: Array<{
+    scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+    scopeId: string;
+  }>;
+  /** Whether anything in the credential differs from what is stored. */
+  hasEdits: boolean;
+}) {
+  const [state, setState] = useState<ConnectionTestState | undefined>();
+
+  const { mutateAsync: testConnection } =
+    api.modelProvider.testConnection.useMutation();
+  const { mutateAsync: validateApiKey } =
+    api.modelProvider.validateApiKey.useMutation();
+
+  /**
+   * A verdict is about the credential that was on screen when it was asked
+   * for, so it cannot survive that credential changing. Comparing a
+   * fingerprint rather than clearing on every render is what makes this hold
+   * while a check is still in flight: the answer that lands afterwards is
+   * about keys that are no longer there.
+   *
+   * `useCredentialProbeGate` makes the same argument for the save-time probe.
+   */
+  const credentialsFingerprint = useMemo(
+    () => JSON.stringify(customKeys),
+    [customKeys],
+  );
+  useEffect(() => {
+    setState(undefined);
+  }, [credentialsFingerprint, modelProviderId]);
+
+  const check = useCallback(async () => {
+    const asked = credentialsFingerprint;
+    // Discard anything that arrives about credentials the customer has since
+    // changed, rather than showing a verdict about keys that are gone.
+    const settle = (next: ConnectionTestState) =>
+      setState((current) =>
+        asked === JSON.stringify(customKeys) ? next : current,
+      );
+
+    setState({ status: "testing" });
+
+    try {
+      const result = modelProviderId
+        ? await testConnection({
+            modelProviderId,
+            projectId,
+            organizationId,
+            // Only when there is something the row does not already know.
+            // Sending an untouched form would send a blank or masked key and
+            // get back "no credential" for a provider that is configured fine.
+            ...(hasEdits ? { customKeys } : {}),
+          })
+        : await validateApiKey({
+            projectId,
+            organizationId,
+            provider,
+            customKeys,
+            scopes: scopes && scopes.length > 0 ? scopes : undefined,
+          });
+
+      settle(toConnectionTestState(result, describeUncheckedInDrawer));
+    } catch (error) {
+      // Not `error.message`: a handled error's message is replaced by its
+      // stable code on the wire, so reading it renders a slug like
+      // `model_provider_test_rate_limited` at the customer. A failure to ask
+      // is reported as such, never as a verdict on the credential.
+      settle({
+        status: "unchecked",
+        reason: "request_failed",
+        message: describeError({
+          error,
+          fallbackTitle: "Couldn't check this connection",
+        }),
+      });
+    }
+  }, [
+    credentialsFingerprint,
+    customKeys,
+    hasEdits,
+    modelProviderId,
+    organizationId,
+    projectId,
+    provider,
+    scopes,
+    testConnection,
+    validateApiKey,
+  ]);
+
+  return { state, check };
+}
+
+/**
+ * Why a check did not run, said to someone who is still holding the form.
+ *
+ * Two reasons mean something different here than they do on the list. There, a
+ * missing or masked credential is a fact about storage that a reader can only
+ * note. Here it is the direct consequence of an edit they just made — they
+ * changed a setting and left the credential hidden — and the next step is one
+ * they can take.
+ */
+const describeUncheckedInDrawer = (
+  reason: UncheckedReason | "request_failed",
+): string => {
+  if (reason === "credential_masked" || reason === "no_credential") {
+    return "Enter the credential again to check these settings.";
+  }
+  return uncheckedMessage(reason as UncheckedReason);
+};

--- a/platform/app/src/hooks/useModelProviderConnectionTest.ts
+++ b/platform/app/src/hooks/useModelProviderConnectionTest.ts
@@ -34,7 +34,6 @@ import {
  */
 type ConnectionTestResult = ValidationResult;
 
-
 export function useModelProviderConnectionTest({
   projectId,
   organizationId,
@@ -110,7 +109,7 @@ export function useModelProviderConnectionTest({
           organizationId,
         });
 
-        setResult(modelProviderId, toConnectionTestState(result), asked);
+        setResult(modelProviderId, toConnectionTestState({ result }), asked);
       } catch (error) {
         // Not `error.message`: a handled error's message is replaced by its
         // stable code on the wire, so reading it renders a slug like

--- a/platform/app/src/hooks/useModelProviderConnectionTest.ts
+++ b/platform/app/src/hooks/useModelProviderConnectionTest.ts
@@ -34,7 +34,6 @@ import {
  */
 type ConnectionTestResult = ValidationResult;
 
-export type { ConnectionTestState };
 
 export function useModelProviderConnectionTest({
   projectId,

--- a/platform/app/src/hooks/useModelProviderConnectionTest.ts
+++ b/platform/app/src/hooks/useModelProviderConnectionTest.ts
@@ -1,10 +1,11 @@
 import { useCallback, useRef, useState } from "react";
-import { describeError, explainSerializedError } from "../features/errors";
-import type {
-  UncheckedReason,
-  ValidationResult,
-} from "../server/modelProviders/providerValidation";
+import { describeError } from "../features/errors";
+import type { ValidationResult } from "../server/modelProviders/providerValidation";
 import { api } from "../utils/api";
+import {
+  type ConnectionTestState,
+  toConnectionTestState,
+} from "./connectionTestState";
 
 /**
  * Running a credential check against a provider that is already saved.
@@ -33,79 +34,7 @@ import { api } from "../utils/api";
  */
 type ConnectionTestResult = ValidationResult;
 
-export type ConnectionTestState =
-  | { status: "testing" }
-  | { status: "works" }
-  | { status: "refused"; message: string }
-  | { status: "unchecked"; message: string };
-
-/**
- * What to say when the check never ran.
- *
- * Deliberately short of the reason we hold internally. "This provider signs
- * every request with AWS credentials, which a listing endpoint does not
- * exercise" is true and is not the customer's problem; what they need to know
- * is whether they still have something to do. Only the cases they can act on
- * get a next step.
- */
-const uncheckedMessage = (reason: UncheckedReason): string => {
-  if (reason === "no_credential" || reason === "credential_masked") {
-    // Not "nothing is stored": a credential written before the encryption
-    // secret was rotated is unreadable rather than absent, and the two are
-    // indistinguishable by the time they reach here (the repository drops an
-    // undecryptable value to null). Telling that customer to enter a key they
-    // already entered is the misdiagnosis this whole area exists to avoid.
-    return "No credential could be read for this provider.";
-  }
-  return "This provider can't be tested automatically — its settings are checked when you first use it.";
-};
-
-/**
- * A verdict, turned into what the row should say.
- *
- * A pure function rather than three branches inside the hook: the mapping is
- * the part worth reading on its own, and keeping it out here is what lets the
- * exhaustiveness check below be the only place a new outcome has to be
- * handled.
- */
-function toState(result: ConnectionTestResult): ConnectionTestState {
-  if (result.outcome === "verified") {
-    return { status: "works" };
-  }
-
-  if (result.outcome === "refused") {
-    // The refusal is a serialized handled error riding on the payload, so it
-    // is read with `explainSerializedError` rather than `describeError`. Both
-    // land in the same code-keyed registry; only the transport differs. The
-    // provider's own sentence never appears in either — a rejected-credential
-    // body is where the credential itself tends to turn up.
-    const { title, description } = explainSerializedError(result.domainError);
-    return {
-      status: "refused",
-      message: description ? `${title}. ${description}` : title,
-    };
-  }
-
-  if (result.outcome === "unchecked") {
-    return { status: "unchecked", message: uncheckedMessage(result.reason) };
-  }
-
-  // A fourth outcome would otherwise fall into the branch above and be
-  // described as "can't be tested automatically" — a confident sentence about
-  // a verdict nobody has classified. This turns that into a compile error at
-  // the moment the server grows one.
-  //
-  // The discriminator only, never the payload: this message reaches
-  // `describeError` in the caller's catch, which can render a plain Error's
-  // text to the customer, and nothing promises a future outcome's fields are
-  // free of credential material.
-  const unhandled: never = result;
-  throw new Error(
-    `Unhandled connection test outcome: ${String(
-      (unhandled as { outcome?: unknown }).outcome,
-    )}`,
-  );
-}
+export type { ConnectionTestState };
 
 export function useModelProviderConnectionTest({
   projectId,
@@ -182,7 +111,7 @@ export function useModelProviderConnectionTest({
           organizationId,
         });
 
-        setResult(modelProviderId, toState(result), asked);
+        setResult(modelProviderId, toConnectionTestState(result), asked);
       } catch (error) {
         // Not `error.message`: a handled error's message is replaced by its
         // stable code on the wire, so reading it renders a slug like
@@ -192,6 +121,7 @@ export function useModelProviderConnectionTest({
           modelProviderId,
           {
             status: "unchecked",
+            reason: "request_failed",
             message: describeError({
               error,
               fallbackTitle: "Couldn't test this connection",

--- a/platform/app/src/pages/settings/__tests__/model-providers.no-project.integration.test.tsx
+++ b/platform/app/src/pages/settings/__tests__/model-providers.no-project.integration.test.tsx
@@ -394,6 +394,21 @@ describe("given the Model Providers settings page", () => {
         expect(await screen.findByText("Connection works")).toBeTruthy();
       });
 
+      /** @scenario "Both places agree on which providers can be checked" */
+      it("offers no test action for a provider that cannot be checked", () => {
+        // The drawer hides its own control on the same answer. If only one
+        // surface asked, the two would disagree the first time the rule moved,
+        // and the disagreement is invisible from either side — a customer sees
+        // an action in one place and not the other, with nothing to explain it.
+        mockState.providers = [{ ...openaiRow, provider: "bedrock" }];
+        renderPage();
+
+        expect(document.querySelector('[data-menu-item="test"]')).toBeNull();
+        // The rest of the menu is untouched: this is about what can be
+        // checked, not about what can be managed.
+        expect(screen.getByText("Edit Provider")).toBeTruthy();
+      });
+
       /** @scenario "A provider we cannot check says so instead of reporting success" */
       it("never renders a provider it could not check as working", async () => {
         mockTestConnection.mockResolvedValueOnce({

--- a/platform/app/src/pages/settings/model-providers.tsx
+++ b/platform/app/src/pages/settings/model-providers.tsx
@@ -25,14 +25,12 @@ import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { useAllModelProvidersList } from "~/hooks/useAllModelProvidersList";
 import { useAvailableScopes } from "~/hooks/useAvailableScopes";
 import { useDrawer } from "~/hooks/useDrawer";
-import {
-  type ConnectionTestState,
-  useModelProviderConnectionTest,
-} from "~/hooks/useModelProviderConnectionTest";
+import { useModelProviderConnectionTest } from "~/hooks/useModelProviderConnectionTest";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
 import { api } from "~/utils/api";
 import SettingsLayout from "../../components/SettingsLayout";
 import { CodexCodingDefaultsAskHost } from "../../components/settings/CodexCodingDefaultsAsk";
+import { ConnectionTestVerdict } from "../../components/settings/ConnectionTestVerdict";
 import { DefaultModelsSection } from "../../components/settings/DefaultModelsSection";
 import { ProviderScopeChips } from "../../components/settings/ProviderScopeChips";
 import { ScopeFilter as ScopeFilterComponent } from "../../components/settings/ScopeFilter";
@@ -43,6 +41,7 @@ import { Tooltip } from "../../components/ui/tooltip";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { buildCustomModelDisplayNames } from "../../server/modelProviders/customModelDisplayNames";
 import {
+  isProviderProbeable,
   modelProviders as modelProvidersRegistry,
   providerDeprecation,
 } from "../../server/modelProviders/registry";
@@ -425,24 +424,38 @@ export default function ModelsPage() {
                                       Edit Provider
                                     </Box>
                                   </Menu.Item>
-                                  <Menu.Item
-                                    value="test"
-                                    disabled={!provider.id}
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      if (!provider.id) return;
-                                      void connectionTests.test(provider.id);
-                                    }}
-                                  >
-                                    <Box
-                                      display="flex"
-                                      alignItems="center"
-                                      gap={2}
+                                  {/* Offered only where it can answer. Six of
+                                      the registered providers credential in
+                                      ways no listing endpoint exercises, and
+                                      an action that can only ever report
+                                      "we did not look" is worse than no
+                                      action: it reads as broken rather than
+                                      as inapplicable. The drawer hides it on
+                                      the same answer, so the two surfaces
+                                      cannot disagree about what is
+                                      checkable. */}
+                                  {isProviderProbeable({
+                                    provider: provider.provider,
+                                  }) && (
+                                    <Menu.Item
+                                      value="test"
+                                      disabled={!provider.id}
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        if (!provider.id) return;
+                                        void connectionTests.test(provider.id);
+                                      }}
                                     >
-                                      <PlugZap size={14} />
-                                      Test Connection
-                                    </Box>
-                                  </Menu.Item>
+                                      <Box
+                                        display="flex"
+                                        alignItems="center"
+                                        gap={2}
+                                      >
+                                        <PlugZap size={14} />
+                                        Test Connection
+                                      </Box>
+                                    </Menu.Item>
+                                  )}
                                   <Menu.Item
                                     value="delete"
                                     color="red"
@@ -578,60 +591,6 @@ export default function ModelsPage() {
         </Dialog.Root>
       </VStack>
     </SettingsLayout>
-  );
-}
-
-/**
- * What the last connection test said about this row.
- *
- * Three states, rendered three different ways on purpose. A check that could
- * not run reads as neutral rather than green: it is not a pass, and dressing
- * it as one would tell a customer their configuration is fine on the strength
- * of never having asked.
- *
- * The whole verdict lives in a polite live region. The text arrives well after
- * the click that asked for it, and a screen reader announces neither the
- * "Testing…" transition nor the answer replacing it — so without this the
- * control is a button that appears to do nothing at all.
- */
-function ConnectionTestVerdict({
-  state,
-}: {
-  state: ConnectionTestState | undefined;
-}) {
-  const verdict = () => {
-    if (!state) return null;
-
-    if (state.status === "testing") {
-      return (
-        <Text fontSize="xs" color="fg.muted">
-          Testing…
-        </Text>
-      );
-    }
-
-    if (state.status === "works") {
-      return (
-        <Text fontSize="xs" color="green.fg">
-          Connection works
-        </Text>
-      );
-    }
-
-    return (
-      <Text
-        fontSize="xs"
-        color={state.status === "refused" ? "red.fg" : "fg.muted"}
-      >
-        {state.message}
-      </Text>
-    );
-  };
-
-  return (
-    <Box aria-live="polite" aria-atomic="true">
-      {verdict()}
-    </Box>
   );
 }
 

--- a/platform/app/src/server/api/routers/modelProviders.ts
+++ b/platform/app/src/server/api/routers/modelProviders.ts
@@ -33,10 +33,7 @@ import {
   ModelProviderService,
   testConnectionInputSchema,
 } from "../../modelProviders/modelProvider.service";
-import {
-  validateKeyWithCustomUrl,
-  validateProviderApiKey,
-} from "../../modelProviders/providerValidation";
+import { validateKeyWithCustomUrl } from "../../modelProviders/providerValidation";
 import {
   checkOrganizationPermission,
   checkProjectPermission,
@@ -262,6 +259,11 @@ export const modelProviderRouter = createTRPCRouter({
    * parameters leave the server parsing an absent input, which surfaces to
    * the customer as a validation error against a key that is perfectly good.
    * POSTing the key in a body avoids all of it.
+   *
+   * It goes through the service rather than calling the validator directly so
+   * that it is counted against the same budget as `testConnection`. Both end
+   * in the same outbound request, and a limit that covers one of two doors is
+   * the size of the door it does not cover.
    */
   validateApiKey: protectedProcedure
     .input(
@@ -278,9 +280,16 @@ export const modelProviderRouter = createTRPCRouter({
         .superRefine(requireTenantAnchor),
     )
     .use(checkProviderValidationPermission())
-    .mutation(async ({ input }) => {
-      const { provider, customKeys } = input;
-      return validateProviderApiKey(provider, customKeys);
+    .mutation(async ({ input, ctx }) => {
+      const service = ModelProviderService.create(ctx.prisma);
+      return await service.validateCredential({
+        input: {
+          projectId: input.projectId,
+          organizationId: input.organizationId,
+          provider: input.provider,
+          customKeys: input.customKeys,
+        },
+      });
     }),
 
   /**

--- a/platform/app/src/server/api/routers/modelProviders.ts
+++ b/platform/app/src/server/api/routers/modelProviders.ts
@@ -289,6 +289,7 @@ export const modelProviderRouter = createTRPCRouter({
           provider: input.provider,
           customKeys: input.customKeys,
         },
+        ctx: { prisma: ctx.prisma, session: ctx.session },
       });
     }),
 

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
@@ -180,7 +180,9 @@ describe("testConnection", () => {
 
     it("still refuses a caller who cannot manage the row", async () => {
       // Supplying settings does not route around the row: it is still looked
-      // up, still scope-checked, and still counted against the budget.
+      // up and still scope-checked. The budget is deliberately not reached —
+      // a caller who cannot manage the row is refused rather than throttled,
+      // so their attempt never spends the organization's allowance.
       findByIdForOrganizationMock.mockResolvedValueOnce(orgScopedRow());
       hasOrganizationPermissionMock.mockResolvedValue(false);
 
@@ -196,6 +198,7 @@ describe("testConnection", () => {
       ).rejects.toBeInstanceOf(ModelProviderScopeForbiddenError);
 
       expect(validateProviderApiKeyMock).not.toHaveBeenCalled();
+      expect(rateLimitMock).not.toHaveBeenCalled();
     });
 
     /** @scenario "Testing an organization-scoped provider reaches its credential" */
@@ -341,6 +344,7 @@ describe("testConnection", () => {
             provider: "openai",
             customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
           },
+          ctx,
         }),
       ).rejects.toBeInstanceOf(ModelProviderTestRateLimitedError);
 
@@ -354,6 +358,7 @@ describe("testConnection", () => {
           provider: "openai",
           customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
         },
+        ctx,
       });
 
       // The same keys, so a caller cannot double their allowance by
@@ -372,11 +377,35 @@ describe("testConnection", () => {
           provider: "openai",
           customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
         },
+        ctx,
       });
 
       expect(validateProviderApiKeyMock).toHaveBeenCalledWith("openai", {
         OPENAI_API_KEY: "sk-typed-just-now",
       });
+    });
+
+    it("refuses to spend the budget of an organization the caller cannot manage", async () => {
+      // The organization handle is a value the caller chose, and it is the
+      // rate-limit key. Unchecked, naming someone else's organization spends
+      // their allowance — which both supplies the caller with an endless run
+      // of fresh buckets and denies the real owner a control they are entitled
+      // to. Nothing goes out, and nothing is counted.
+      hasOrganizationPermissionMock.mockResolvedValue(false);
+
+      await expect(
+        service().validateCredential({
+          input: {
+            organizationId: "org_someone_else",
+            provider: "openai",
+            customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+          },
+          ctx,
+        }),
+      ).rejects.toBeInstanceOf(ModelProviderScopeForbiddenError);
+
+      expect(rateLimitMock).not.toHaveBeenCalled();
+      expect(validateProviderApiKeyMock).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
@@ -32,6 +32,7 @@ vi.mock("../../api/rbac", () => ({
     hasProjectPermissionMock(...args),
 }));
 
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
 import {
   ModelProviderNotFoundError,
   ModelProviderScopeForbiddenError,
@@ -102,26 +103,99 @@ describe("testConnection", () => {
       });
     });
 
-    /** @scenario "A test never accepts an endpoint from the caller" */
-    it("probes the endpoint saved on the row, with no way to name another", async () => {
+    /** @scenario "A test with nothing supplied uses what is stored" */
+    it("probes the endpoint saved on the row when the call supplies none", async () => {
       findByIdForOrganizationMock.mockResolvedValueOnce(orgScopedRow());
 
-      // The call site has nowhere to put a destination: the input is a row id
-      // and a tenant handle. This is the property that keeps a credential the
-      // caller may never read from being posted somewhere they choose.
       await service().testConnection({
-        input: {
-          modelProviderId: "mp_1",
-          organizationId: ORGANIZATION_ID,
-          // @ts-expect-error — an endpoint is not part of the contract
-          customBaseUrl: "https://attacker.example.com",
-        },
+        input: { modelProviderId: "mp_1", organizationId: ORGANIZATION_ID },
         ctx,
       });
 
       const [, keys] = validateProviderApiKeyMock.mock.calls[0]!;
       expect(keys.OPENAI_BASE_URL).toBe("https://saved.example.com/v1");
-      expect(JSON.stringify(keys)).not.toContain("attacker.example.com");
+    });
+  });
+
+  describe("given settings supplied with the call", () => {
+    /** @scenario "A test never sends a stored credential to an endpoint from the caller" */
+    it("uses only what was supplied, never merging the stored credential in", async () => {
+      // The whole security property in one assertion. A caller who can edit a
+      // provider may never have been allowed to read its key; if an endpoint
+      // they chose were filled in with a key out of storage, this server would
+      // post that key wherever they liked, and permission to edit would have
+      // become permission to extract.
+      findByIdForOrganizationMock.mockResolvedValueOnce(orgScopedRow());
+
+      await service().testConnection({
+        input: {
+          modelProviderId: "mp_1",
+          organizationId: ORGANIZATION_ID,
+          customKeys: {
+            OPENAI_API_KEY: "sk-typed-just-now",
+            OPENAI_BASE_URL: "https://attacker.example.com/v1",
+          },
+        },
+        ctx,
+      });
+
+      const [, keys] = validateProviderApiKeyMock.mock.calls[0]!;
+      expect(keys).toEqual({
+        OPENAI_API_KEY: "sk-typed-just-now",
+        OPENAI_BASE_URL: "https://attacker.example.com/v1",
+      });
+      expect(JSON.stringify(keys)).not.toContain("sk-stored");
+    });
+
+    /** @scenario "Changing an endpoint without the credential asks for the credential" */
+    it("keeps the stored credential out of it when the supplied one is masked", async () => {
+      // What the drawer sends when someone edits an endpoint without
+      // re-entering the key. The masked sentinel is not a credential, so the
+      // check does not run — and the stored key stays where it is rather than
+      // being substituted in behind the customer's back.
+      findByIdForOrganizationMock.mockResolvedValueOnce(orgScopedRow());
+      validateProviderApiKeyMock.mockResolvedValueOnce({
+        outcome: "unchecked",
+        valid: true,
+        reason: "credential_masked",
+      });
+
+      const result = await service().testConnection({
+        input: {
+          modelProviderId: "mp_1",
+          organizationId: ORGANIZATION_ID,
+          customKeys: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            OPENAI_BASE_URL: "https://attacker.example.com/v1",
+          },
+        },
+        ctx,
+      });
+
+      const [, keys] = validateProviderApiKeyMock.mock.calls[0]!;
+      expect(keys.OPENAI_API_KEY).toBe(MASKED_KEY_PLACEHOLDER);
+      expect(JSON.stringify(keys)).not.toContain("sk-stored");
+      expect(result.outcome).toBe("unchecked");
+    });
+
+    it("still refuses a caller who cannot manage the row", async () => {
+      // Supplying settings does not route around the row: it is still looked
+      // up, still scope-checked, and still counted against the budget.
+      findByIdForOrganizationMock.mockResolvedValueOnce(orgScopedRow());
+      hasOrganizationPermissionMock.mockResolvedValue(false);
+
+      await expect(
+        service().testConnection({
+          input: {
+            modelProviderId: "mp_1",
+            organizationId: ORGANIZATION_ID,
+            customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+          },
+          ctx,
+        }),
+      ).rejects.toBeInstanceOf(ModelProviderScopeForbiddenError);
+
+      expect(validateProviderApiKeyMock).not.toHaveBeenCalled();
     });
 
     /** @scenario "Testing an organization-scoped provider reaches its credential" */
@@ -243,6 +317,66 @@ describe("testConnection", () => {
       ).rejects.toBeInstanceOf(ModelProviderScopeForbiddenError);
 
       expect(rateLimitMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the credential has only been typed in", () => {
+    /** @scenario "Repeated checks are limited however they are made" */
+    it("counts a typed credential against the same budget as a stored one", async () => {
+      // Two routes to the same outbound request, and only one of them used to
+      // be counted. That was survivable while the typed-credential route was
+      // reachable only by saving — a refusal there arms a gate that skips the
+      // next probe, so a person could not sit on it. A control that checks
+      // without saving removes both bounds at once.
+      rateLimitMock.mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: Date.now() + 30_000,
+      });
+
+      await expect(
+        service().validateCredential({
+          input: {
+            organizationId: ORGANIZATION_ID,
+            provider: "openai",
+            customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+          },
+        }),
+      ).rejects.toBeInstanceOf(ModelProviderTestRateLimitedError);
+
+      expect(validateProviderApiKeyMock).not.toHaveBeenCalled();
+    });
+
+    it("shares one budget with the stored-credential route", async () => {
+      await service().validateCredential({
+        input: {
+          organizationId: ORGANIZATION_ID,
+          provider: "openai",
+          customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+        },
+      });
+
+      // The same keys, so a caller cannot double their allowance by
+      // alternating between the two ways of asking.
+      const keys = rateLimitMock.mock.calls.map(([opts]: any[]) => opts.key);
+      expect(keys).toEqual([
+        `model-provider-test:org:${ORGANIZATION_ID}`,
+        "model-provider-test:global",
+      ]);
+    });
+
+    it("checks exactly the credential it was handed", async () => {
+      await service().validateCredential({
+        input: {
+          organizationId: ORGANIZATION_ID,
+          provider: "openai",
+          customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+        },
+      });
+
+      expect(validateProviderApiKeyMock).toHaveBeenCalledWith("openai", {
+        OPENAI_API_KEY: "sk-typed-just-now",
+      });
     });
   });
 

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
@@ -385,6 +385,29 @@ describe("testConnection", () => {
       });
     });
 
+    it("lets a team admin check a credential for their own organization", async () => {
+      // The no-project path exists for scopes below the organization: a team
+      // admin sets up a team-scoped credential and never holds
+      // organization:manage. Requiring it to charge the budget would refuse
+      // them a control the route had already authorized.
+      hasOrganizationPermissionMock.mockImplementation(
+        (_ctx: unknown, _id: string, permission: string) =>
+          Promise.resolve(permission === "organization:view"),
+      );
+      hasTeamPermissionMock.mockResolvedValue(true);
+
+      const result = await service().validateCredential({
+        input: {
+          organizationId: ORGANIZATION_ID,
+          provider: "openai",
+          customKeys: { OPENAI_API_KEY: "sk-typed-just-now" },
+        },
+        ctx,
+      });
+
+      expect(result.outcome).toBe("verified");
+    });
+
     it("refuses to spend the budget of an organization the caller cannot manage", async () => {
       // The organization handle is a value the caller chose, and it is the
       // rate-limit key. Unchecked, naming someone else's organization spends

--- a/platform/app/src/server/modelProviders/__tests__/providerProbeability.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/providerProbeability.unit.test.ts
@@ -10,12 +10,12 @@ vi.mock("../../../utils/ssrfProtection", async (importOriginal) => ({
   ssrfSafeFetch: (...args: unknown[]) => mockFetch(...args),
 }));
 
+import { validateProviderApiKey } from "../providerValidation";
 import {
   isProviderProbeable,
   modelProviders,
   UNPROBEABLE_PROVIDERS,
 } from "../registry";
-import { validateProviderApiKey } from "../providerValidation";
 
 /**
  * A credential that satisfies a provider's schema, built from the schema
@@ -27,8 +27,7 @@ import { validateProviderApiKey } from "../providerValidation";
  * URL because several schemas call `.url()`; everything else gets a token.
  */
 function completeCredentialFor(providerKey: string): Record<string, string> {
-  const definition =
-    modelProviders[providerKey as keyof typeof modelProviders];
+  const definition = modelProviders[providerKey as keyof typeof modelProviders];
   const shape =
     (definition.keysSchema as unknown as {
       shape?: Record<string, unknown>;
@@ -69,28 +68,27 @@ describe("isProviderProbeable", () => {
      *
      * @scenario Both places agree on which providers can be checked
      */
-    it.each(Object.keys(modelProviders))(
-      "agrees with what validation actually does for %s",
-      async (providerKey) => {
-        mockFetch.mockReset();
-        mockFetch.mockResolvedValue({
-          ok: true,
-          status: 200,
-          json: async () => ({ data: [] }),
-          text: async () => "{}",
-        });
+    it.each(
+      Object.keys(modelProviders),
+    )("agrees with what validation actually does for %s", async (providerKey) => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+        text: async () => "{}",
+      });
 
-        const result = await validateProviderApiKey(
-          providerKey,
-          completeCredentialFor(providerKey),
-        );
+      const result = await validateProviderApiKey(
+        providerKey,
+        completeCredentialFor(providerKey),
+      );
 
-        const wouldBeChecked = result.outcome !== "unchecked";
-        expect(wouldBeChecked).toBe(
-          isProviderProbeable({ provider: providerKey }),
-        );
-      },
-    );
+      const wouldBeChecked = result.outcome !== "unchecked";
+      expect(wouldBeChecked).toBe(
+        isProviderProbeable({ provider: providerKey }),
+      );
+    });
   });
 
   describe("when the provider is not one we recognize", () => {

--- a/platform/app/src/server/modelProviders/__tests__/providerProbeability.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/providerProbeability.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Same stand-in the sibling validation tests use: the probe goes out through
+// the SSRF-validated fetch rather than `global.fetch`, so replacing the global
+// would leave the real validator in the path and every assertion below would
+// be about DNS instead of about the decision under test.
+const mockFetch = vi.fn();
+vi.mock("../../../utils/ssrfProtection", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../utils/ssrfProtection")>()),
+  ssrfSafeFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import {
+  isProviderProbeable,
+  modelProviders,
+  UNPROBEABLE_PROVIDERS,
+} from "../registry";
+import { validateProviderApiKey } from "../providerValidation";
+
+/**
+ * A credential that satisfies a provider's schema, built from the schema
+ * itself.
+ *
+ * Hand-written fixtures per provider would have to be revisited every time the
+ * registry gains one, and the test whose whole job is catching a registry
+ * change is the worst possible place for that. Endpoint-shaped fields get a
+ * URL because several schemas call `.url()`; everything else gets a token.
+ */
+function completeCredentialFor(providerKey: string): Record<string, string> {
+  const definition =
+    modelProviders[providerKey as keyof typeof modelProviders];
+  const shape =
+    (definition.keysSchema as unknown as {
+      shape?: Record<string, unknown>;
+      _def?: { schema?: { shape?: Record<string, unknown> } };
+    }) ?? {};
+  // `gemini` wraps its object in a `superRefine`, which moves the shape one
+  // level down. Reading both keeps this working either side of that.
+  const fields = shape.shape ?? shape._def?.schema?.shape ?? {};
+
+  return Object.fromEntries(
+    Object.keys(fields).map((field) => [
+      field,
+      /ENDPOINT|BASE_URL|_URL/.test(field)
+        ? "https://provider.example.test/v1"
+        : "a-credential-value",
+    ]),
+  );
+}
+
+describe("isProviderProbeable", () => {
+  describe("given every provider in the registry", () => {
+    /** @scenario A provider that cannot be checked offers no control */
+    it("names exactly the providers a probe would refuse to check", () => {
+      const refused = Object.keys(modelProviders).filter(
+        (providerKey) => !isProviderProbeable({ provider: providerKey }),
+      );
+
+      expect(new Set(refused)).toEqual(new Set(UNPROBEABLE_PROVIDERS));
+    });
+
+    /**
+     * The pin that matters. Comparing the predicate against a second copy of
+     * the same list would only prove the two constants match; this asks the
+     * validator itself, with a credential it should be happy with, and
+     * requires the answers to agree. A provider added to the registry, or an
+     * endpoint added to one that had none, fails here rather than shipping a
+     * control that offers a check nothing can perform.
+     *
+     * @scenario Both places agree on which providers can be checked
+     */
+    it.each(Object.keys(modelProviders))(
+      "agrees with what validation actually does for %s",
+      async (providerKey) => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+          text: async () => "{}",
+        });
+
+        const result = await validateProviderApiKey(
+          providerKey,
+          completeCredentialFor(providerKey),
+        );
+
+        const wouldBeChecked = result.outcome !== "unchecked";
+        expect(wouldBeChecked).toBe(
+          isProviderProbeable({ provider: providerKey }),
+        );
+      },
+    );
+  });
+
+  describe("when the provider is not one we recognize", () => {
+    it("reports it as unprobeable rather than throwing", () => {
+      expect(isProviderProbeable({ provider: "not_a_provider" })).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -120,12 +120,17 @@ export type UpdateModelProviderInput = {
  * and it lives here, beside the method that consumes it, so the service never
  * has to import the router to know its own input shape.
  *
- * Conspicuously absent: anywhere to put an endpoint. See `testConnection`.
+ * `customKeys` carries the settings as they appear on screen, for the customer
+ * who has changed an endpoint and wants to know about the endpoint they are
+ * looking at rather than the one still in storage. They are used whole or not
+ * at all — see `testConnection` for why combining them with what is stored is
+ * the one thing this must never do.
  */
 export const testConnectionInputSchema = z.object({
   modelProviderId: z.string(),
   projectId: z.string().optional(),
   organizationId: z.string().optional(),
+  customKeys: z.record(z.string()).optional(),
 });
 
 export type TestConnectionInput = z.infer<typeof testConnectionInputSchema>;
@@ -867,13 +872,24 @@ export class ModelProviderService {
    *
    * Distinct from the save-time probe in three ways, each of them load-bearing.
    *
-   * It takes a row id and no endpoint. The save-time path accepts a base URL
-   * from the caller, which is reasonable there — the caller supplies the key
-   * too, so there is nothing to escalate. Here the credential comes out of
-   * storage and is one the caller may never have been allowed to read, so
-   * accepting a destination would let anyone who can edit a provider have this
-   * server post the key wherever they liked. The row's own endpoint is the
-   * only one used.
+   * It reads the credential out of storage — which is the point, since the form
+   * deliberately never shows one back — and that is exactly what makes the
+   * destination dangerous. A caller who can edit a provider may never have been
+   * allowed to read its key, so a stored key posted to an address they chose
+   * turns permission to edit into permission to extract. The rule that prevents
+   * it is not "no endpoint from the caller" but something narrower and more
+   * useful: **the two are never combined**. Either the settings come from the
+   * row, or they come from the request, whole. Nothing is merged, so there is
+   * no arrangement of inputs that pairs a stored secret with a chosen address.
+   *
+   * A credential supplied as the masked placeholder is therefore not a
+   * credential: it fails the checkable test and the answer comes back as
+   * unchecked, rather than being quietly swapped for the real one. That is what
+   * a customer editing an endpoint without re-entering their key should get.
+   *
+   * Supplied settings still travel through the same vetted transport as the
+   * save-time probe, so an address pointing somewhere private is refused before
+   * anything is sent.
    *
    * It is anchored by id against the organization rather than looked up by
    * provider name inside a project. `findByProvider` matches PROJECT-scope
@@ -893,7 +909,7 @@ export class ModelProviderService {
     input: TestConnectionInput;
     ctx: AuthzContext;
   }): Promise<ValidationResult> {
-    const { modelProviderId, projectId, organizationId } = input;
+    const { modelProviderId, projectId, organizationId, customKeys } = input;
 
     const anchor = await this.resolveOrganizationAnchor({
       projectId,
@@ -927,9 +943,55 @@ export class ModelProviderService {
     // provider types and projects, so a per-row budget caps nothing.
     await assertTestConnectionWithinBudget(anchor);
 
-    const customKeys = (existing.customKeys ?? {}) as Record<string, string>;
+    // Whole or not at all. A spread of one over the other would read as
+    // helpful — fill in the fields the customer did not retype — and would be
+    // the exfiltration path: a chosen endpoint plus a stored key. There is no
+    // arrangement of inputs that reaches that combination from here.
+    const keysToCheck =
+      customKeys ?? ((existing.customKeys ?? {}) as Record<string, string>);
 
-    return await validateProviderApiKey(existing.provider, customKeys);
+    // The provider is the row's, never the caller's. Otherwise a credential
+    // could be checked under another provider's auth shape and endpoint.
+    return await validateProviderApiKey(existing.provider, keysToCheck);
+  }
+
+  /**
+   * Checks a credential the customer has just typed, before it is stored.
+   *
+   * The sibling above checks one already saved. This one never reads storage:
+   * the credential arrives with the call, so there is nothing to escalate and
+   * no row to authorize against — the caller's permission over the scopes the
+   * credential is being set up for is settled by the route's own guard.
+   *
+   * What it does share is the budget, and that is the reason it exists as a
+   * service method rather than staying a direct call from the route. Both ways
+   * of asking end in the same outbound request, so counting one and not the
+   * other means the uncounted one is the whole limit. That was survivable
+   * while this route could only be reached by saving — a refusal arms a gate
+   * that lets the next save through unprobed, so nobody could sit on it — and
+   * stops being survivable the moment a control checks without saving.
+   */
+  async validateCredential({
+    input,
+  }: {
+    input: {
+      projectId?: string;
+      organizationId?: string;
+      provider: string;
+      customKeys: Record<string, string>;
+    };
+  }): Promise<ValidationResult> {
+    const anchor = await this.resolveOrganizationAnchor({
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+    });
+    if (!anchor) {
+      throw new ModelProviderAnchorRequiredError("project_or_organization");
+    }
+
+    await assertTestConnectionWithinBudget(anchor);
+
+    return await validateProviderApiKey(input.provider, input.customKeys);
   }
 
   /**

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -970,9 +970,19 @@ export class ModelProviderService {
    * while this route could only be reached by saving — a refusal arms a gate
    * that lets the next save through unprobed, so nobody could sit on it — and
    * stops being survivable the moment a control checks without saving.
+   *
+   * The organization the budget is charged to has to be one the caller can
+   * actually reach, and that needs asserting here rather than assumed. When a
+   * project anchors the call the route has already authorized it, so the
+   * organization derived from it is trustworthy. When nothing but an
+   * organization handle arrives, it is a value the caller chose: left
+   * unchecked, naming someone else's organization spends *their* budget, which
+   * both hands the caller an unlimited supply of fresh buckets and denies the
+   * real owner a control they are entitled to.
    */
   async validateCredential({
     input,
+    ctx,
   }: {
     input: {
       projectId?: string;
@@ -980,6 +990,7 @@ export class ModelProviderService {
       provider: string;
       customKeys: Record<string, string>;
     };
+    ctx: AuthzContext;
   }): Promise<ValidationResult> {
     const anchor = await this.resolveOrganizationAnchor({
       projectId: input.projectId,
@@ -987,6 +998,14 @@ export class ModelProviderService {
     });
     if (!anchor) {
       throw new ModelProviderAnchorRequiredError("project_or_organization");
+    }
+
+    // Only the caller-supplied path needs the check: an anchor derived from a
+    // project came through the route's project permission gate to get here.
+    if (!input.projectId) {
+      await assertCanManageAllScopes(ctx, [
+        { scopeType: "ORGANIZATION", scopeId: anchor },
+      ]);
     }
 
     await assertTestConnectionWithinBudget(anchor);

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -14,6 +14,7 @@ import {
   ModelProviderCredentialsWouldBeDroppedError,
   ModelProviderDeprecatedError,
   ModelProviderNotFoundError,
+  ModelProviderScopeForbiddenError,
   ModelProviderScopesRequiredError,
   ModelProviderTestRateLimitedError,
 } from "./errors";
@@ -1002,10 +1003,24 @@ export class ModelProviderService {
 
     // Only the caller-supplied path needs the check: an anchor derived from a
     // project came through the route's project permission gate to get here.
+    //
+    // Membership, not authority. Charging an organization's budget is not an
+    // act of administration — the whole point of this path is scopes below the
+    // organization, where a team admin sets up a team-scoped credential and
+    // never holds organization:manage. Demanding it would refuse them a check
+    // the route had already authorized. Being able to see the organization at
+    // all is what a stranger cannot fake, and that is exactly the line this
+    // has to draw.
     if (!input.projectId) {
-      await assertCanManageAllScopes(ctx, [
+      const belongs = await canReadAnyScope(ctx, [
         { scopeType: "ORGANIZATION", scopeId: anchor },
       ]);
+      if (!belongs) {
+        throw new ModelProviderScopeForbiddenError({
+          scopeType: "ORGANIZATION",
+          requiredPermission: "organization:view",
+        });
+      }
     }
 
     await assertTestConnectionWithinBudget(anchor);

--- a/platform/app/src/server/modelProviders/providerValidation.ts
+++ b/platform/app/src/server/modelProviders/providerValidation.ts
@@ -14,7 +14,10 @@ import {
   ssrfSafeFetch,
 } from "../../utils/ssrfProtection";
 import { ModelProviderRepository } from "./modelProvider.repository";
-import { modelProviders } from "./registry";
+import {
+  modelProviders,
+  PROVIDERS_WITH_UNPROBEABLE_AUTH,
+} from "./registry";
 
 /**
  * The response shape the probe actually receives.
@@ -142,36 +145,14 @@ const AGENT_PLATFORM_PROBE_BODY = JSON.stringify({
 /**
  * Providers we will not probe, and must not pretend to have probed.
  *
- * `bedrock`, `vertex_ai` and `azure` are here for the original reason: their
- * credentials are AWS signatures, gcloud application-default credentials and
- * deployment-scoped Azure keys, none of which a models listing exercises.
- *
- * `azure_safety` is here because leaving it out was a bug waiting for a
- * caller. It is a content-safety service, not a language model: it
- * authenticates with `Ocp-Apim-Subscription-Key` and has no `/models` route.
- * Nothing in this module excluded it, and it carries an endpoint field, so a
- * stored endpoint was enough to send it down the bearer branch and have a
- * perfectly good credential reported as refused. Until now the only thing
- * standing in the way was `isLlmProvider` in the settings form — a client-side
- * gate, in front of one of several callers. The rule belongs here, where every
- * caller passes.
+ * The list itself lives on the registry, next to the definitions it describes,
+ * because the settings UI has to answer "can this be checked at all?" before
+ * offering the control — and it cannot import this module, which reaches the
+ * provider repository and through it Prisma. Two copies of the list would
+ * disagree the first time either was edited, and the disagreement shows up as
+ * a button that offers a check nothing will perform.
  */
-const NOT_PROBEABLE: ReadonlySet<string> = new Set([
-  "bedrock",
-  "vertex_ai",
-  "azure",
-  "azure_safety",
-] as const);
-
-/**
- * Validation endpoints for providers that are not part of the onboarding
- * registry (which is what feeds `providerDefaultBaseUrls`). ElevenLabs is an
- * audio-only provider added directly in Settings, so its models endpoint
- * lives here.
- */
-const VALIDATION_ONLY_BASE_URLS: Record<string, string> = {
-  elevenlabs: "https://api.elevenlabs.io/v1",
-};
+const NOT_PROBEABLE: ReadonlySet<string> = PROVIDERS_WITH_UNPROBEABLE_AUTH;
 
 /**
  * Builds the models endpoint URL by normalizing and appending /models if needed.
@@ -1238,7 +1219,9 @@ export async function validateProviderApiKey(
   const authStrategy = PROVIDER_AUTH_OVERRIDES[provider] ?? "bearer";
   const defaultBaseUrl =
     providerDefaultBaseUrls[provider] ??
-    VALIDATION_ONLY_BASE_URLS[provider] ??
+    // Providers added straight in Settings have no onboarding tile to carry a
+    // default, so the registry entry is the only record of where to ask.
+    providerDef.validationBaseUrl ??
     "";
 
   const agentPlatform = agentPlatformPair({ provider, customKeys });

--- a/platform/app/src/server/modelProviders/providerValidation.ts
+++ b/platform/app/src/server/modelProviders/providerValidation.ts
@@ -17,6 +17,7 @@ import { ModelProviderRepository } from "./modelProvider.repository";
 import {
   modelProviders,
   PROVIDERS_WITH_UNPROBEABLE_AUTH,
+  providerValidationBaseUrl,
 } from "./registry";
 
 /**
@@ -1221,7 +1222,7 @@ export async function validateProviderApiKey(
     providerDefaultBaseUrls[provider] ??
     // Providers added straight in Settings have no onboarding tile to carry a
     // default, so the registry entry is the only record of where to ask.
-    providerDef.validationBaseUrl ??
+    providerValidationBaseUrl(provider) ??
     "";
 
   const agentPlatform = agentPlatformPair({ provider, customKeys });

--- a/platform/app/src/server/modelProviders/registry.ts
+++ b/platform/app/src/server/modelProviders/registry.ts
@@ -1,5 +1,6 @@
 import type { ModelProvider } from "@prisma/client";
 import { z } from "zod";
+import { providerDefaultBaseUrls } from "../../features/onboarding/regions/model-providers/registry";
 import { codexTokenKeysSchema } from "./codexAccount.schema";
 import { CODEX_ALLOWED_FEATURE_KEYS } from "./codexRestrictions";
 import type { CustomModelEntry } from "./customModel.schema";
@@ -36,6 +37,16 @@ type ModelProviderDefinition = {
   type: "llm" | "safety";
   apiKey: string;
   endpointKey: string | undefined;
+  /**
+   * Where to ask this provider whether a credential is good, when neither the
+   * customer supplies an endpoint nor the onboarding tile carries a default.
+   *
+   * Lives on the definition rather than in the validator so that "what this
+   * provider's key is called" and "where we ask about it" cannot drift apart —
+   * the settings UI has to answer "can this be checked at all?" without
+   * importing the validator, which reaches the database.
+   */
+  validationBaseUrl?: string;
   keysSchema: z.ZodTypeAny;
   enabledSince: Date;
   blurb?: string;
@@ -441,6 +452,10 @@ export const modelProviders = {
     type: "llm",
     apiKey: "ELEVENLABS_API_KEY",
     endpointKey: undefined,
+    // Added directly in Settings rather than through onboarding, so no tile
+    // carries a default base URL for it and this is the only record of where
+    // its models listing lives.
+    validationBaseUrl: "https://api.elevenlabs.io/v1",
     keysSchema: z.object({
       ELEVENLABS_API_KEY: z.string().min(1),
     }),
@@ -581,6 +596,95 @@ export const providerDeprecation = (
       | ModelProviderDefinition
       | undefined
   )?.deprecated;
+
+// ============================================================================
+// Whether a credential can be checked at all
+// ============================================================================
+
+/**
+ * Providers whose credentials no listing endpoint exercises.
+ *
+ * `bedrock`, `vertex_ai` and `azure` sign with AWS credentials, gcloud
+ * application-default credentials and deployment-scoped keys respectively.
+ * `azure_safety` is a content-safety service rather than a language model: it
+ * authenticates with a subscription-key header and has no models route, so a
+ * bearer probe would report a perfectly good credential as refused.
+ *
+ * The validator imports this rather than keeping its own copy. Two lists would
+ * disagree the first time one of them was edited, and the disagreement is
+ * invisible: the settings UI would offer a check that the validator declines
+ * to perform, which reads to a customer as a broken button.
+ */
+export const PROVIDERS_WITH_UNPROBEABLE_AUTH: ReadonlySet<string> = new Set([
+  "azure",
+  "azure_safety",
+  "bedrock",
+  "vertex_ai",
+]);
+
+/**
+ * Providers reachable through the Google Agent Platform door.
+ *
+ * That probe builds its address from a fixed API root plus the project and
+ * location on the credential, so it needs no base URL — "nowhere to ask" is
+ * false for these however empty their endpoint fields are.
+ */
+const PROVIDERS_WITH_AGENT_PLATFORM_DOOR: ReadonlySet<string> = new Set([
+  "gemini",
+  "google_agent_platform",
+]);
+
+/**
+ * Whether a credential for this provider could be checked, if it were filled
+ * in completely.
+ *
+ * A property of the provider, not of what has been typed: the answer decides
+ * whether to offer the check at all, and a control that appeared and vanished
+ * as the customer filled the form would be worse than one that never appeared.
+ * Whether the fields are complete is a separate question, and the answer to it
+ * is whether the control is usable rather than whether it exists.
+ *
+ * Note this deliberately does not replace `isLlmProvider` or the oauth-device
+ * check in the settings form. Those two gate the probe that runs on save, and
+ * folding all three together would change when a save is allowed to proceed.
+ * They overlap; collapsing them is a separate change with its own blast
+ * radius.
+ *
+ * @param provider - Registry key. An unrecognized one answers false: we cannot
+ *   check what we cannot look up.
+ */
+export function isProviderProbeable({
+  provider,
+}: {
+  provider: string;
+}): boolean {
+  const definition = modelProviders[
+    provider as keyof typeof modelProviders
+  ] as ModelProviderDefinition | undefined;
+
+  if (!definition) return false;
+  if (PROVIDERS_WITH_UNPROBEABLE_AUTH.has(provider)) return false;
+
+  // The customer never types a credential for these — the provider's own
+  // sign-in flow persists one — so there is nothing on screen to check.
+  if (definition.authFlow === "oauth-device") return false;
+
+  return (
+    // The customer supplies the address themselves.
+    !!definition.endpointKey ||
+    !!definition.validationBaseUrl ||
+    !!providerDefaultBaseUrls[provider] ||
+    PROVIDERS_WITH_AGENT_PLATFORM_DOOR.has(provider)
+  );
+}
+
+/**
+ * Every provider that cannot be checked, in registry order. Exported for the
+ * test that pins this list against what validation actually does.
+ */
+export const UNPROBEABLE_PROVIDERS: readonly string[] = Object.keys(
+  modelProviders,
+).filter((provider) => !isProviderProbeable({ provider }));
 
 // ============================================================================
 // Parameter Constraints

--- a/platform/app/src/server/modelProviders/registry.ts
+++ b/platform/app/src/server/modelProviders/registry.ts
@@ -658,9 +658,9 @@ export function isProviderProbeable({
 }: {
   provider: string;
 }): boolean {
-  const definition = modelProviders[
-    provider as keyof typeof modelProviders
-  ] as ModelProviderDefinition | undefined;
+  const definition = modelProviders[provider as keyof typeof modelProviders] as
+    | ModelProviderDefinition
+    | undefined;
 
   if (!definition) return false;
   if (PROVIDERS_WITH_UNPROBEABLE_AUTH.has(provider)) return false;
@@ -672,11 +672,29 @@ export function isProviderProbeable({
   return (
     // The customer supplies the address themselves.
     !!definition.endpointKey ||
-    !!definition.validationBaseUrl ||
+    !!providerValidationBaseUrl(provider) ||
     !!providerDefaultBaseUrls[provider] ||
     PROVIDERS_WITH_AGENT_PLATFORM_DOOR.has(provider)
   );
 }
+
+/**
+ * Where to ask this provider about a credential, when it carries its own
+ * answer.
+ *
+ * `modelProviders` is a literal typed by `satisfies`, so each entry keeps its
+ * exact shape and an optional field is only reachable on the entries that
+ * declare it. One narrowing here beats a cast at every caller — the same
+ * reason `providerDeprecation` exists.
+ */
+export const providerValidationBaseUrl = (
+  provider: string,
+): string | undefined =>
+  (
+    modelProviders[provider as keyof typeof modelProviders] as
+      | ModelProviderDefinition
+      | undefined
+  )?.validationBaseUrl;
 
 /**
  * Every provider that cannot be checked, in registry order. Exported for the

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -634,16 +634,12 @@ Feature: Credential Validation
     When I check the connection and am told it works
     Then the provider has not been created
 
-  # An endpoint that arrives with the request is an address we have not
-  # vetted, and it arrives alongside a credential. The rule the save-time
-  # probe already follows applies here for the same reason.
-
-  @unit
-  Scenario: An endpoint typed into the drawer is vetted before anything is sent
-    Given I have entered an endpoint that points at a private address
-    When I check the connection
-    Then nothing is sent to it
-    And I am told the address is not one we will call
+  # An endpoint typed into the drawer is an address we have not vetted, and it
+  # travels alongside a credential. It needs no rule of its own: the check runs
+  # through the same validator as every other, so "a credential is never
+  # carried to an address we have not vetted" above already governs it. What
+  # is worth pinning is that the drawer reaches that validator rather than
+  # some path around it, which the scenarios above do.
 
   @unit
   Scenario: A result disappears when I change the credential

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -654,6 +654,17 @@ Feature: Credential Validation
     Then the answer is discarded when it arrives
     And I am not told the connection works
 
+  # Two saved providers show the same hidden credential and can carry the same
+  # endpoint, so what is on screen cannot tell them apart. Only the provider
+  # being edited can.
+
+  @integration
+  Scenario: A result still in flight when I move to another provider is discarded
+    Given I have asked for a check from the drawer and the answer has not arrived
+    When I start editing a different provider whose settings look the same
+    Then the answer is discarded when it arrives
+    And I am not told the connection works
+
   @unit
   Scenario: Repeated checks are limited however they are made
     Given I have checked connections many times in quick succession

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -456,12 +456,25 @@ Feature: Credential Validation
     Then the stored credential is found
     And I am not told the provider has no credential
 
+  # A check can be asked about the settings on screen rather than the ones
+  # stored, because a customer editing an endpoint needs an answer about the
+  # endpoint they are looking at. What must never happen is the two being
+  # combined: an address chosen by the caller, filled in with a credential out
+  # of storage that the caller may never have been allowed to read. That would
+  # turn permission to edit a provider into permission to extract its key.
+
   @unit
-  Scenario: A test never accepts an endpoint from the caller
+  Scenario: A test never sends a stored credential to an endpoint from the caller
     Given I have a configured provider
-    When I test the connection
+    When I test the connection against settings supplied with the request
+    Then only the settings supplied are used
+    And the stored credential is not added to them
+
+  @unit
+  Scenario: A test with nothing supplied uses what is stored
+    Given I have a configured provider
+    When I test the connection without supplying any settings
     Then the endpoint already saved on the provider is used
-    And an endpoint supplied with the request is refused
 
   @unit
   Scenario: Testing a provider I cannot manage is refused

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -573,20 +573,20 @@ Feature: Credential Validation
   # answer about the endpoint they just replaced.
   # ──────────────────────────────────────────────────────────────────────
 
-  @unit
+  @integration
   Scenario: A provider that cannot be checked offers no control
     Given I am configuring a provider whose credentials cannot be probed
     When I have filled in every field
     Then no way to check the connection is offered
     And I am not told the connection works
 
-  @unit
+  @integration
   Scenario: Both places agree on which providers can be checked
     Given a provider that offers no way to check the connection in the drawer
     When I look at that provider in the list
     Then no way to check the connection is offered there either
 
-  @unit
+  @integration
   Scenario: Checking is unavailable until the credential is complete
     Given I am configuring a provider that can be checked
     And one required field is still empty
@@ -594,7 +594,7 @@ Feature: Credential Validation
     Then it is offered but cannot be used
     And filling in the last field makes it usable
 
-  @unit
+  @integration
   Scenario: A credential the provider's own rules reject cannot be checked
     Given a provider that accepts a project and a location together or not at all
     And I have filled in the project but not the location
@@ -605,7 +605,7 @@ Feature: Credential Validation
   # editing an endpoint is looking at a real endpoint and a masked key. The
   # check has to be about both halves or it is about neither.
 
-  @unit
+  @integration
   Scenario: Checking after changing an endpoint uses the endpoint on screen
     Given I have a configured provider
     And I have changed its endpoint and entered the credential again
@@ -613,7 +613,7 @@ Feature: Credential Validation
     Then the endpoint I am looking at is the one checked
     And the endpoint that was stored is not checked
 
-  @unit
+  @integration
   Scenario: Changing an endpoint without the credential asks for the credential
     Given I have a configured provider whose credential is hidden
     And I have changed its endpoint but not re-entered the credential
@@ -621,14 +621,14 @@ Feature: Credential Validation
     Then I am asked to enter the credential again
     And the stored credential is not sent anywhere
 
-  @unit
+  @integration
   Scenario: An unchanged provider is still checked against what is stored
     Given I have a configured provider I have not edited
     When I check the connection
     Then the stored credential is used
     And I am not asked to enter it again
 
-  @unit
+  @integration
   Scenario: Checking does not save
     Given I am configuring a provider and have not saved it
     When I check the connection and am told it works
@@ -641,13 +641,13 @@ Feature: Credential Validation
   # is worth pinning is that the drawer reaches that validator rather than
   # some path around it, which the scenarios above do.
 
-  @unit
+  @integration
   Scenario: A result disappears when I change the credential
     Given I have checked a connection from the drawer and been told it works
     When I change any credential field
     Then the earlier result is no longer shown
 
-  @unit
+  @integration
   Scenario: A result still in flight when I change the credential is discarded
     Given I have asked for a check from the drawer and the answer has not arrived
     When I change a credential field before it does

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -648,6 +648,13 @@ Feature: Credential Validation
     Then the earlier result is no longer shown
 
   @unit
+  Scenario: A result still in flight when I change the credential is discarded
+    Given I have asked for a check from the drawer and the answer has not arrived
+    When I change a credential field before it does
+    Then the answer is discarded when it arrives
+    And I am not told the connection works
+
+  @unit
   Scenario: Repeated checks are limited however they are made
     Given I have checked connections many times in quick succession
     When I check a credential I have just typed in

--- a/specs/model-providers/credential-validation.feature
+++ b/specs/model-providers/credential-validation.feature
@@ -543,3 +543,103 @@ Feature: Credential Validation
     Given a credential whose check did not run
     When it is saved
     Then the save proceeds exactly as it did before
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Checking a credential from the drawer it was typed into.
+  #
+  # Everything above reaches the check from the provider list, which is a
+  # different moment: the customer has finished, closed the drawer, and gone
+  # looking. The moment they actually want the answer is while they are still
+  # looking at the fields they filled in, so the same check is offered there.
+  #
+  # Two rules govern the whole section, and they pull in opposite directions.
+  # The control must never appear where it cannot tell the truth — so for a
+  # provider we cannot probe it is absent rather than present and unhelpful.
+  # And a check must be about the settings on screen, not the settings that
+  # happen to be stored, or a customer editing an endpoint gets a green
+  # answer about the endpoint they just replaced.
+  # ──────────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: A provider that cannot be checked offers no control
+    Given I am configuring a provider whose credentials cannot be probed
+    When I have filled in every field
+    Then no way to check the connection is offered
+    And I am not told the connection works
+
+  @unit
+  Scenario: Both places agree on which providers can be checked
+    Given a provider that offers no way to check the connection in the drawer
+    When I look at that provider in the list
+    Then no way to check the connection is offered there either
+
+  @unit
+  Scenario: Checking is unavailable until the credential is complete
+    Given I am configuring a provider that can be checked
+    And one required field is still empty
+    When I look at the way to check the connection
+    Then it is offered but cannot be used
+    And filling in the last field makes it usable
+
+  @unit
+  Scenario: A credential the provider's own rules reject cannot be checked
+    Given a provider that accepts a project and a location together or not at all
+    And I have filled in the project but not the location
+    When I look at the way to check the connection
+    Then it cannot be used
+
+  # The stored credential is deliberately never shown back, so a customer
+  # editing an endpoint is looking at a real endpoint and a masked key. The
+  # check has to be about both halves or it is about neither.
+
+  @unit
+  Scenario: Checking after changing an endpoint uses the endpoint on screen
+    Given I have a configured provider
+    And I have changed its endpoint and entered the credential again
+    When I check the connection
+    Then the endpoint I am looking at is the one checked
+    And the endpoint that was stored is not checked
+
+  @unit
+  Scenario: Changing an endpoint without the credential asks for the credential
+    Given I have a configured provider whose credential is hidden
+    And I have changed its endpoint but not re-entered the credential
+    When I check the connection
+    Then I am asked to enter the credential again
+    And the stored credential is not sent anywhere
+
+  @unit
+  Scenario: An unchanged provider is still checked against what is stored
+    Given I have a configured provider I have not edited
+    When I check the connection
+    Then the stored credential is used
+    And I am not asked to enter it again
+
+  @unit
+  Scenario: Checking does not save
+    Given I am configuring a provider and have not saved it
+    When I check the connection and am told it works
+    Then the provider has not been created
+
+  # An endpoint that arrives with the request is an address we have not
+  # vetted, and it arrives alongside a credential. The rule the save-time
+  # probe already follows applies here for the same reason.
+
+  @unit
+  Scenario: An endpoint typed into the drawer is vetted before anything is sent
+    Given I have entered an endpoint that points at a private address
+    When I check the connection
+    Then nothing is sent to it
+    And I am told the address is not one we will call
+
+  @unit
+  Scenario: A result disappears when I change the credential
+    Given I have checked a connection from the drawer and been told it works
+    When I change any credential field
+    Then the earlier result is no longer shown
+
+  @unit
+  Scenario: Repeated checks are limited however they are made
+    Given I have checked connections many times in quick succession
+    When I check a credential I have just typed in
+    Then I am told to wait before checking again


### PR DESCRIPTION
Closes #6784.

## For humans

You can already check that a model provider's credentials work, but only by
saving, closing the drawer, finding the row in the list, opening a three-dot
menu, and clicking. That is five steps away from the moment anyone actually
wants the answer, which is while they are still looking at the fields they just
filled in.

This puts the check next to Save, in the drawer. It appears only for providers
we can genuinely check, stays greyed out until the credential is complete, and
tells you what it found without saving anything.

Two things behind it turned out to be broken in ways worth knowing about:

- **A check could describe settings you were no longer looking at.** Change a
  provider's endpoint, ask for a check, and the answer would have been about the
  endpoint you just replaced — reported as a pass. Fixed, and the fix carefully
  does not open a way to send a stored credential somewhere the caller picked.
- **One of the two ways of checking had no rate limit at all.** It was only
  reachable by saving, so nobody could sit on it. A button that checks without
  saving removes that, so both ways now share one budget.

## What changed

**The control.** Three states in a deliberate order: absent when the provider
cannot be checked at all, present but unusable while the credential is
incomplete, usable after that. Six of sixteen providers credential in ways no
listing endpoint exercises (AWS signatures, gcloud application-default
credentials, deployment-scoped keys, a content-safety service with no models
route, a provider with nowhere to ask, and one that credentials through its own
sign-in). An action that can only ever answer "we did not look" reads as broken
rather than as inapplicable, so it is not offered.

"Complete" means the provider's own schema accepts the credential, not that no
required field is empty. Gemini takes a project and a location together or not
at all, so filling one leaves every *required* field satisfied while the
credential as a whole is one a save would reject.

The list's menu item is hidden on the same answer. Two surfaces answering the
same question differently is a customer seeing an action in one place and not
the other with nothing to explain it, and the disagreement is invisible from
either side.

**Where the rules live.** The settings UI has to answer "can this be checked?"
before offering anything, and it cannot ask the validator — that module reaches
the provider repository and through it Prisma, so importing it from the browser
would pull both into the bundle. Keeping a second copy of the list on the client
is the obvious way out and the wrong one: two lists disagree the first time
either is edited. So the rules move onto the registry, which both sides already
import, and the validator reads them from there.

The pin is behavioural rather than a second constant. For every provider in the
registry, the test builds a credential from that provider's own schema, runs the
real validator against a stubbed transport, and requires the verdict to agree
with the predicate. A new provider, or an endpoint added to one that had none,
fails there.

**Checking what is on screen.** `testConnection` now accepts the settings in the
request. Neither existing route could check "the endpoint on screen with the
credential already stored": the discriminator that would pick between them reads
the key field, which still holds the mask after a non-key edit, so it routed to
the stored row and probed the endpoint that was just replaced. Sending the form
instead does not help, because a stored secret reaches the browser as the masked
placeholder and never as a value — so that route reports the credential as
masked and checks nothing.

The rule this ships under is narrower than "no endpoint from the caller" and
does more work: **the two sources are never combined.** Either the settings come
from the row or they come from the request, whole. A stored secret therefore
cannot be paired with an address the caller chose, which is what would turn
permission to edit a provider into permission to extract its key. A masked
placeholder is not a credential and comes back unchecked rather than being
swapped for the real one — which is what a customer editing an endpoint without
re-entering their key should get, and the drawer says so in those words.

Both authz guards stay, in the order the delete path uses them, and supplied
settings travel through the same vetted transport as every other probe.

**Rate limiting.** The typed-credential route had a permission check and no
budget. It now shares the stored route's, keyed the same way, so a caller cannot
double their allowance by alternating between the two.

## Refusal overridden

`/implement` refused this on: **irreversible path — it touches a security
boundary.** `/route` counted the change before `/challenge` altered its shape;
widening `testConnection` to accept a caller-supplied endpoint is the input
shape behind a previous credential-exposure fix, so the count changes and the
gate fires.

Overridden by: the requester, choosing "let testConnection take the on-screen
credentials" over disabling the control in that state, with the trade-off named
at the time.

Carried over from the heavy path: `/challenge` — which is what found the two
defects above and killed three of my own objections.

The mitigation is in the code rather than in the decision: never combining the
two sources means there is no arrangement of inputs that reaches the dangerous
combination, which is a stronger property than refusing endpoints outright and
is the reason this is safe to ship.

## Checks

- `pnpm typecheck` and `pnpm typecheck:tests` — clean
- `pnpm lint` — 0 errors
- Server: 495/495 across 36 files
- Settings and drawer integration: 264/264 across 37 files
- `check-feature-parity` — 53/53 scenarios bound in
  `specs/model-providers/credential-validation.feature`

## Notes for review

- One existing scenario became false and was rewritten rather than left
  standing: a check *can* now be told where to look, so "a test never accepts an
  endpoint from the caller" is replaced by the property that actually protects
  the credential.
- The drawer's own test file was written after the component rather than before
  it. It is not vacuous — mutating the visibility rule to always-true fails the
  scenario that pins it — but it did not drive the design the way the others did.
- Seven existing drawer suites gain the two mutations the form now reaches for.
  None of them exercise it.
- Hiding the control on both surfaces makes one unchecked reason unreachable
  from the interface while the client predicate and the server's set agree. It
  becomes reachable exactly on drift, so it is a drift detector rather than dead
  copy, and the behavioural pin above is what keeps them honest.
- Review found and fixed a real defect in the first pass: the staleness guard in
  the new hook was inert, so a verdict about a credential the customer had since
  replaced landed and re-displayed itself. See the review comment for the
  executed output.
- An earlier revision of this description stated that a stored key reaches the
  form as an empty string. That was wrong — it reaches it as the masked
  placeholder. The conclusion is unchanged (a mask is not a credential either),
  but the mechanism above has been corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Test connection” controls to model provider settings.
  * Test new or edited credentials without saving changes.
  * Shows testing, success, error, and unavailable status messages.
  * Hides testing for unsupported providers.
  * Added accessible announcements for connection-test results.

* **Bug Fixes**
  * Prevented stale results after credentials or provider settings change.
  * Improved handling of masked, missing, invalid, and failed credentials.

* **Tests**
  * Expanded coverage for credential validation, provider eligibility, rate limits, and connection-test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
