### PR TITLE
fix: ship the ADR-069 R2 producer flip and bound the graph-trigger query that was killing workers

### DIFF
--- a/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
@@ -2,12 +2,13 @@
  * Unit tests for the app-layer AnalyticsService (ADR-034 Phase 3 rewrite).
  *
  * Drives the service with stub repositories + a stub legacy backend so the
- * test exercises ONLY the orchestration logic — flag check, routing, dispatch
- * — without touching ClickHouse, Prisma, or the feature flag service.
+ * test exercises ONLY the orchestration logic — routing and dispatch —
+ * without touching ClickHouse, Prisma, or the feature flag service.
  *
- * The default mock sets the feature flag to OFF, so getTimeseries goes
- * through the legacy shim. Routed paths get separate coverage via the
- * route-table unit + integration tests.
+ * `release_event_sourced_analytics_read` is gone: it is permanently on, so the
+ * service no longer asks. Which table answers a query is purely a function of
+ * the query's SHAPE, and the legacy shim still serves the shapes the slim and
+ * rollup builders cannot express. The only flag left here is the tripwire.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,16 +25,14 @@ vi.mock("~/server/featureFlag", () => ({
 const isEnabled = vi.mocked(featureFlagService.isEnabled);
 
 /**
- * Turn the read flag on (and, optionally, the tripwire flag). The service
- * resolves them by name, so key off the flag string rather than call order.
+ * Turn the tripwire flag on. The service resolves flags by name, so key off
+ * the flag string rather than call order.
  */
-function enableReadFlag({ tripwire = false }: { tripwire?: boolean } = {}) {
-  isEnabled.mockImplementation(async (flag: string) => {
-    if (flag === "release_event_sourced_analytics_read") return true;
-    if (flag === "release_event_sourced_analytics_read_tripwire")
-      return tripwire;
-    return false;
-  });
+function enableTripwire() {
+  isEnabled.mockImplementation(
+    async (flag: string) =>
+      flag === "release_event_sourced_analytics_read_tripwire",
+  );
 }
 
 function fakeResult(value: number): TimeseriesResult {
@@ -114,19 +113,19 @@ describe("AnalyticsService", () => {
       timeZone: "UTC",
     };
 
-    it("falls back to the legacy trace_summaries shim when the flag is OFF", async () => {
-      const { deps, spies } = makeDeps();
-      const service = new AnalyticsService(deps);
+    // Routing must not consult the feature-flag service at all any more: a
+    // flag read per query bought nothing once the flag was permanently on,
+    // and leaving the call in invites the OFF branch growing back.
+    it("routes without asking whether the event-sourced read flag is on", async () => {
+      const { deps } = makeDeps();
 
-      const result = await service.getTimeseries(input);
+      await new AnalyticsService(deps).getTimeseries(input);
 
-      expect(result.currentPeriod).toHaveLength(1);
-      expect(spies.runLegacy).toHaveBeenCalledTimes(1);
-      expect(spies.runRollupTimeseries).not.toHaveBeenCalled();
-      expect(spies.runSlimTimeseries).not.toHaveBeenCalled();
+      const flagsAsked = isEnabled.mock.calls.map(([flag]) => flag);
+      expect(flagsAsked).not.toContain("release_event_sourced_analytics_read");
     });
 
-    describe("when release_event_sourced_analytics_read is ON", () => {
+    describe("when the query shape decides the table", () => {
       const sumCost = {
         ...input,
         series: [
@@ -136,8 +135,6 @@ describe("AnalyticsService", () => {
           },
         ],
       };
-
-      beforeEach(() => enableReadFlag());
 
       it("dispatches an ungrouped additive sum to the rollup repository", async () => {
         const { deps, spies } = makeDeps();
@@ -195,7 +192,7 @@ describe("AnalyticsService", () => {
     });
 
     describe("when the tripwire flag is ON", () => {
-      beforeEach(() => enableReadFlag({ tripwire: true }));
+      beforeEach(() => enableTripwire());
 
       it("runs BOTH the routed query and the legacy query, returning the routed one", async () => {
         const { deps, spies } = makeDeps();

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -149,7 +149,11 @@ export class AnalyticsService {
         // `trace_summaries`.
         const [routedResult, legacyResult] = await Promise.all([
           this.runRouted(table, input, options),
-          legacyForTripwire(input),
+          // The comparison read carries the caller's ceiling too. Without it a
+          // tripwire-enabled project would still materialise the unbounded
+          // legacy result alongside the bounded routed one — the bound would
+          // hold everywhere except the projects we turned extra reads on for.
+          legacyForTripwire(input, options),
         ]);
         compareForTripwire({
           projectId: input.projectId,
@@ -215,11 +219,6 @@ export class AnalyticsService {
     );
   }
 
-  /**
-   * Resolve which analytics table should serve this `getTimeseries` call.
-   * Flag OFF → always `"trace_summaries"` (legacy code path, unchanged).
-   * Flag ON  → delegate to `pickAnalyticsTable(...)` per query shape.
-   */
   /**
    * Which table answers this query — a pure function of the query's SHAPE.
    *

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -3,11 +3,15 @@
  *
  * Public entrypoint for the analytics read API. Owns NO SQL. Orchestrates:
  *
- *   1. Feature-flag check (`release_event_sourced_analytics_read`)
- *   2. Route-table lookup (`pickAnalyticsTable`)
- *   3. Dispatch to the right repository (rollup / slim / legacy shim)
- *   4. Optional tripwire (`release_event_sourced_analytics_read_tripwire`)
- *   5. Return the routed result
+ *   1. Route-table lookup (`pickAnalyticsTable`) — by query SHAPE
+ *   2. Dispatch to the right repository (rollup / slim / legacy shim)
+ *   3. Optional tripwire (`release_event_sourced_analytics_read_tripwire`)
+ *   4. Return the routed result
+ *
+ * `release_event_sourced_analytics_read` no longer appears here. It is
+ * permanently on, so gating on it spent a feature-flag round trip per query to
+ * be told "yes". Routing to the legacy tables survives it — that is a property
+ * of the query's shape, not of any flag (see `resolveAnalyticsTable`).
  *
  * Routes call this service; this service calls repositories. The legacy
  * `~/server/analytics/analytics.service.ts` has been deleted as part of
@@ -46,6 +50,7 @@ import {
 } from "./repositories/legacy.shim";
 import { type AnalyticsTable, pickAnalyticsTable } from "./routing/route-table";
 import { compareForTripwire } from "./tripwire/divergence-compare";
+import type { TimeseriesReadOptions } from "./types";
 
 const TIMESERIES_CACHE_TTL_MS = 30_000 as const;
 
@@ -87,32 +92,41 @@ export class AnalyticsService {
   /**
    * Get timeseries analytics data (with 30s TTL cache).
    *
-   * Phase 3 routing: when `release_event_sourced_analytics_read` is ON for the
-   * project, `pickAnalyticsTable` picks one of trace_analytics_rollup /
-   * trace_analytics / trace_summaries per query shape. When OFF (default)
-   * every call hits trace_summaries — behaviour unchanged. Tripwire
+   * `pickAnalyticsTable` picks one of trace_analytics_rollup / trace_analytics
+   * / trace_summaries / evaluation_runs per query shape. Tripwire
    * (`release_event_sourced_analytics_read_tripwire`) runs the legacy query
    * alongside the routed query and logs divergence.
+   *
+   * `options` is the CALLER's safety envelope — currently a hard row ceiling
+   * for background readers that collapse a timeseries to a scalar. It is not
+   * part of the wire input, so an API client cannot raise its own limit.
    */
-  async getTimeseries(input: TimeseriesInputType): Promise<TimeseriesResult> {
+  async getTimeseries(
+    input: TimeseriesInputType,
+    options?: TimeseriesReadOptions,
+  ): Promise<TimeseriesResult> {
     return this.tracer.withActiveSpan(
       "AnalyticsService.getTimeseries",
       { attributes: { "tenant.id": input.projectId } },
       async () => {
         const hash = createHash("sha256")
-          .update(JSON.stringify(input))
+          // `options` is part of the cache identity, not a side channel: a
+          // bounded read and an unbounded one are different questions, and a
+          // shared key would let an unbounded UI result satisfy a bounded
+          // background read (or the reverse) purely by arrival order.
+          .update(JSON.stringify({ input, options: options ?? null }))
           .digest("hex");
         const cacheKey = `${input.projectId}:${hash}`;
         const cached = await this.timeseriesCache.get(cacheKey);
         if (cached) return cached;
 
-        const table = await this.resolveAnalyticsTable(input);
+        const table = this.resolveAnalyticsTable(input);
 
-        // OFF (legacy) or routed → a legacy table: single call, no overhead.
-        // Both `trace_summaries` and `evaluation_runs` dispatch through the
-        // same legacy shim — `buildTimeseriesQuery` handles both registries.
+        // Routed → a legacy table: single call, no overhead. Both
+        // `trace_summaries` and `evaluation_runs` dispatch through the same
+        // legacy shim — `buildTimeseriesQuery` handles both registries.
         if (table === "trace_summaries" || table === "evaluation_runs") {
-          const result = await this.deps.legacyShim.run(input);
+          const result = await this.deps.legacyShim.run(input, options);
           await this.timeseriesCache.set(cacheKey, result);
           return result;
         }
@@ -123,7 +137,7 @@ export class AnalyticsService {
         );
 
         if (!tripwireEnabled) {
-          const result = await this.runRouted(table, input);
+          const result = await this.runRouted(table, input, options);
           await this.timeseriesCache.set(cacheKey, result);
           return result;
         }
@@ -134,7 +148,7 @@ export class AnalyticsService {
         // eval-routed query is compared against `evaluation_runs`, not
         // `trace_summaries`.
         const [routedResult, legacyResult] = await Promise.all([
-          this.runRouted(table, input),
+          this.runRouted(table, input, options),
           legacyForTripwire(input),
         ]);
         compareForTripwire({
@@ -206,14 +220,20 @@ export class AnalyticsService {
    * Flag OFF → always `"trace_summaries"` (legacy code path, unchanged).
    * Flag ON  → delegate to `pickAnalyticsTable(...)` per query shape.
    */
-  private async resolveAnalyticsTable(
-    input: TimeseriesInputType,
-  ): Promise<AnalyticsTable> {
-    const enabled = await featureFlagService.isEnabled(
-      "release_event_sourced_analytics_read",
-      { distinctId: input.projectId, projectId: input.projectId },
-    );
-    if (!enabled) return "trace_summaries";
+  /**
+   * Which table answers this query — a pure function of the query's SHAPE.
+   *
+   * `release_event_sourced_analytics_read` used to gate this: off meant every
+   * call fell back to `trace_summaries`. The flag is permanently on, so the
+   * gate only cost a feature-flag round trip per query to answer "yes".
+   *
+   * The legacy tables are NOT dead with the gate gone: `pickAnalyticsTable`
+   * still routes to `trace_summaries` / `evaluation_runs` for the shapes the
+   * slim and rollup builders cannot express (mixed sources, keyed series,
+   * `metadata.model` group-bys, trace-id filters). That routing is by shape,
+   * never by flag, which is why the shim stays.
+   */
+  private resolveAnalyticsTable(input: TimeseriesInputType): AnalyticsTable {
     return pickAnalyticsTable({
       series: input.series,
       filters: input.filters,
@@ -232,6 +252,7 @@ export class AnalyticsService {
   private async runRouted(
     table: Exclude<AnalyticsTable, "trace_summaries" | "evaluation_runs">,
     input: TimeseriesInputType,
+    options?: TimeseriesReadOptions,
   ): Promise<TimeseriesResult> {
     const { previousPeriodStartDate, startDate, endDate } =
       currentVsPreviousDates(
@@ -265,6 +286,7 @@ export class AnalyticsService {
         series: input.series,
         groupBy: input.groupBy,
         originalTimeScale: input.timeScale,
+        maxResultRows: options?.maxResultRows,
       });
     }
     if (table === "trace_analytics") {
@@ -274,6 +296,7 @@ export class AnalyticsService {
         series: input.series,
         groupBy: input.groupBy,
         originalTimeScale: input.timeScale,
+        maxResultRows: options?.maxResultRows,
       });
     }
     if (table === "evaluation_analytics_rollup") {
@@ -283,6 +306,7 @@ export class AnalyticsService {
         series: input.series,
         groupBy: input.groupBy,
         originalTimeScale: input.timeScale,
+        maxResultRows: options?.maxResultRows,
       });
     }
     if (table === "evaluation_analytics") {
@@ -292,6 +316,7 @@ export class AnalyticsService {
         series: input.series,
         groupBy: input.groupBy,
         originalTimeScale: input.timeScale,
+        maxResultRows: options?.maxResultRows,
       });
     }
     // Exhaustiveness check — if AnalyticsTable ever gains a new variant,

--- a/platform/app/src/server/app-layer/analytics/repositories/analyticsTimeseriesRead.repository.ts
+++ b/platform/app/src/server/app-layer/analytics/repositories/analyticsTimeseriesRead.repository.ts
@@ -42,6 +42,39 @@ export interface RunTimeseriesParams {
   readonly series: readonly SeriesInputType[];
   readonly groupBy?: string;
   readonly originalTimeScale?: number | "full";
+  /**
+   * Hard ceiling on rows this query may return, enforced by ClickHouse itself
+   * ({@link maxResultRowsSettings}). Omitted for interactive reads, which a
+   * human is waiting on and whose shape the UI already bounds.
+   */
+  readonly maxResultRows?: number;
+}
+
+/**
+ * ClickHouse settings that make an oversized result a fast query ERROR rather
+ * than a client-side memory event.
+ *
+ * The time axis of a timeseries is already capped (`adjustTimeScaleForBucketCap`
+ * — 1,000 buckets). The GROUP BY axis is not: its cardinality comes from the
+ * data, so `buckets x distinct values` is unbounded, and every row is
+ * materialised into JS objects by `result.json()` before any caller can measure
+ * it. A post-hoc row count cannot help — the memory is already spent by the
+ * time it could run. Only the server can refuse cheaply, so the ceiling belongs
+ * here.
+ *
+ * `result_overflow_mode: "throw"` is the load-bearing half. ClickHouse's
+ * DEFAULT is `break`, which silently returns a TRUNCATED result — for the
+ * graph-alert evaluator that would mean thresholds quietly computed on partial
+ * data, which is worse than a failed evaluation because nothing reports it.
+ */
+export function maxResultRowsSettings(
+  maxResultRows: number | undefined,
+): Record<string, number | string> {
+  if (maxResultRows === undefined) return {};
+  return {
+    max_result_rows: maxResultRows,
+    result_overflow_mode: "throw",
+  };
 }
 
 type TimeseriesBuilder = (input: AnalyticsTimeseriesBuilderInput) => {
@@ -85,7 +118,14 @@ class AnalyticsTimeseriesClickHouseReadRepository
         query: sql,
         query_params: queryParams,
         format: "JSONEachRow",
-        clickhouse_settings: ANALYTICS_CLICKHOUSE_SETTINGS,
+        clickhouse_settings: {
+          ...ANALYTICS_CLICKHOUSE_SETTINGS,
+          // Attributes this read in `clickhouse_result_rows` AND in
+          // `system.query_log`. `targetLabel` is one of four compile-time
+          // constants, so the label set stays closed.
+          log_comment: `analytics:timeseries:${this.targetLabel}`,
+          ...maxResultRowsSettings(params.maxResultRows),
+        },
       });
       const rows = (await result.json()) as AnalyticsTimeseriesRow[];
       return parseTimeseriesRows({

--- a/platform/app/src/server/app-layer/analytics/repositories/legacy.shim.ts
+++ b/platform/app/src/server/app-layer/analytics/repositories/legacy.shim.ts
@@ -33,20 +33,28 @@ import { currentVsPreviousDates } from "~/server/api/routers/analytics/common";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { AnalyticsClientUnavailableError } from "../errors";
 import { adjustTimeScaleForBucketCap } from "../query-builders/_shared";
+import type { TimeseriesReadOptions } from "../types";
 import { parseTimeseriesRows } from "./_timeseries-row-parser";
+import { maxResultRowsSettings } from "./analyticsTimeseriesRead.repository";
 
 const logger = createLogger(
   "langwatch:app-layer:analytics:legacy-analytics-shim",
 );
 
 export interface LegacyAnalyticsShim {
-  run(input: TimeseriesInputType): Promise<TimeseriesResult>;
+  run(
+    input: TimeseriesInputType,
+    options?: TimeseriesReadOptions,
+  ): Promise<TimeseriesResult>;
 }
 
 export class ClickHouseLegacyAnalyticsShim implements LegacyAnalyticsShim {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
-  async run(input: TimeseriesInputType): Promise<TimeseriesResult> {
+  async run(
+    input: TimeseriesInputType,
+    options?: TimeseriesReadOptions,
+  ): Promise<TimeseriesResult> {
     if (!input.projectId) {
       throw new Error(
         "ClickHouseLegacyAnalyticsShim.run: projectId is required",
@@ -88,7 +96,11 @@ export class ClickHouseLegacyAnalyticsShim implements LegacyAnalyticsShim {
         query: sql,
         query_params: params,
         format: "JSONEachRow",
-        clickhouse_settings: ANALYTICS_CLICKHOUSE_SETTINGS,
+        clickhouse_settings: {
+          ...ANALYTICS_CLICKHOUSE_SETTINGS,
+          log_comment: "analytics:timeseries:legacy-shim",
+          ...maxResultRowsSettings(options?.maxResultRows),
+        },
       });
       const rows = (await result.json()) as Array<Record<string, unknown>>;
       return parseTimeseriesRows({

--- a/platform/app/src/server/app-layer/analytics/types.ts
+++ b/platform/app/src/server/app-layer/analytics/types.ts
@@ -45,3 +45,21 @@ export interface AnalyticsTimeseriesBuilderInput {
   timeScale?: number | "full";
   timeZone?: string;
 }
+
+/**
+ * Per-call read options for `AnalyticsService.getTimeseries`.
+ *
+ * Deliberately NOT part of `timeseriesInput` (the tRPC/zod schema): these are
+ * the caller's own safety envelope, not something an API client gets to choose.
+ * A client that could raise its own ceiling would defeat the point.
+ */
+export interface TimeseriesReadOptions {
+  /**
+   * Hard ceiling on rows ClickHouse may return before it fails the query.
+   *
+   * Set by background callers that reduce a timeseries to a scalar and would
+   * otherwise materialise an unbounded `buckets x groupBy-cardinality` result
+   * in the worker process. Omit for interactive reads.
+   */
+  readonly maxResultRows?: number;
+}

--- a/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
@@ -6,6 +6,7 @@ import type { GraphAlertDispatchResult } from "~/server/app-layer/automations/di
 import { DispatchError } from "~/server/event-sourcing/queues/dispatchError";
 import {
   evaluateGraphTrigger,
+  GRAPH_TRIGGER_MAX_RESULT_ROWS,
   type GraphTriggerEvaluationDeps,
 } from "../graph-trigger-evaluation.service";
 import {
@@ -249,6 +250,98 @@ describe("evaluateGraphTrigger", () => {
 
   beforeEach(() => {
     harness = makeHarness({ series: timeseries(15) });
+  });
+
+  describe("given the timeseries read the evaluation issues", () => {
+    it("asks for the result under a row ceiling", async () => {
+      await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(harness.getTimeseries).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
+        }),
+      );
+    });
+  });
+
+  describe("given a graph whose grouped result exceeds the row ceiling", () => {
+    // The failure this replaces was not an error at all: the result was
+    // materialised until the process died, so the job neither completed nor
+    // failed. Three of those in a row poison-parked the tenant's whole
+    // graph-trigger lane and silently stopped every alert in the project.
+    function tooLarge() {
+      const error = new Error(
+        "Limit for result exceeded: TOO_MANY_ROWS_OR_BYTES",
+      );
+      (error as Error & { code?: string }).code = "396";
+      return error;
+    }
+
+    it("skips that trigger instead of failing the evaluation", async () => {
+      harness.getTimeseries.mockRejectedValue(tooLarge());
+
+      const result = await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(result.status).toBe("skipped");
+    });
+
+    // A retry re-asks the identical question, so an oversized trigger that
+    // threw would re-fail on every redelivery until it quarantined the lane —
+    // taking every OTHER trigger in the project down with it.
+    it("does not throw, so one bad graph cannot quarantine the tenant's lane", async () => {
+      harness.getTimeseries.mockRejectedValue(tooLarge());
+
+      await expect(
+        evaluateGraphTrigger({
+          deps: harness.deps,
+          triggerId: TRIGGER_ID,
+          projectId: PROJECT_ID,
+          reason: "real-time",
+        }),
+      ).resolves.toMatchObject({ status: "skipped" });
+    });
+
+    it("never fires an alert on a result it could not read", async () => {
+      harness.getTimeseries.mockRejectedValue(tooLarge());
+
+      await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(harness.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the timeseries read fails for any other reason", () => {
+    // Only the row ceiling is a configuration fault. A real outage must still
+    // reach the queue's retry, or a transient ClickHouse blip would silently
+    // skip evaluations and miss genuine breaches.
+    it("propagates the error rather than skipping", async () => {
+      harness.getTimeseries.mockRejectedValue(new Error("connection refused"));
+
+      await expect(
+        evaluateGraphTrigger({
+          deps: harness.deps,
+          triggerId: TRIGGER_ID,
+          projectId: PROJECT_ID,
+          reason: "real-time",
+        }),
+      ).rejects.toThrow("connection refused");
+    });
   });
 
   describe("given a keyed series whose stored identifier differs from the result bucket key", () => {

--- a/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
+++ b/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
@@ -41,6 +41,7 @@ import {
   aggregateSeriesValues,
   extractSeriesPoints,
 } from "~/server/app-layer/analytics/series-points";
+import type { TimeseriesReadOptions } from "~/server/app-layer/analytics/types";
 import {
   type GraphAlertDispatchInput,
   type GraphAlertDispatchResult,
@@ -71,6 +72,47 @@ export type GraphTriggerEvaluationReason =
   | "real-time"
   | "heartbeat-absence"
   | "heartbeat-resolve";
+
+/**
+ * Row ceiling for a graph-trigger timeseries read.
+ *
+ * A threshold evaluation collapses the whole result to ONE number
+ * (`aggregateSeriesValues`), and the alert template's sparkline needs only the
+ * time axis. But the query it issues carries the graph's `groupBy`, so
+ * ClickHouse returns `buckets x distinct group values` and
+ * `extractSeriesPoints` sums the group axis away in the worker — after every
+ * row has been materialised as a JS object.
+ *
+ * The time axis is already capped at 1,000 buckets
+ * (`adjustTimeScaleForBucketCap`). Cardinality is not capped and cannot be:
+ * it comes from the data, so a `groupBy` on something like a user id makes the
+ * result grow without limit while the answer stays one scalar. That is what
+ * killed the worker outright — the process dies mid-read, so the job never
+ * completes and never fails; three of those in a row and the poison guard
+ * parks the tenant's whole graph-trigger lane, which is how one project's
+ * misconfigured graph silently stopped ALL of its alerts for 19 hours on
+ * 2026-08-09.
+ *
+ * 10,000 rows is 10x the bucket cap, so any single-group-per-bucket read
+ * passes with room to spare, while a genuinely unbounded cardinality fails
+ * fast and cheap — server-side, before anything is materialised here.
+ */
+export const GRAPH_TRIGGER_MAX_RESULT_ROWS = 10_000;
+
+/**
+ * Did ClickHouse refuse this query for exceeding {@link
+ * GRAPH_TRIGGER_MAX_RESULT_ROWS}?
+ *
+ * `TOO_MANY_ROWS_OR_BYTES` (396) is what `result_overflow_mode: "throw"`
+ * raises. Matched on the code rather than the message, which is server copy
+ * and varies by ClickHouse version.
+ */
+function isResultTooLarge(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  if (code === 396 || code === "396") return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("TOO_MANY_ROWS_OR_BYTES");
+}
 
 export type GraphTriggerEvaluationStatus =
   | "fired"
@@ -127,7 +169,10 @@ export interface GraphTriggerEvaluationDeps {
     projectId: string;
   }): Promise<CustomGraph | null>;
   loadProject(projectId: string): Promise<Project | null>;
-  getTimeseries(input: TimeseriesInputType): Promise<TimeseriesResult>;
+  getTimeseries(
+    input: TimeseriesInputType,
+    options?: TimeseriesReadOptions,
+  ): Promise<TimeseriesResult>;
   triggerSent: GraphTriggerSentRepository;
   updateLastRunAt(params: {
     triggerId: string;
@@ -272,7 +317,38 @@ export async function evaluateGraphTrigger({
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   };
 
-  const timeseriesResult = await deps.getTimeseries(timeseriesInput);
+  let timeseriesResult: TimeseriesResult;
+  try {
+    timeseriesResult = await deps.getTimeseries(timeseriesInput, {
+      maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
+    });
+  } catch (error) {
+    if (!isResultTooLarge(error)) throw error;
+    // A configuration fault, not an outage: this graph's `groupBy` has more
+    // distinct values than a threshold read can carry. Retrying re-asks the
+    // identical question, so this must NOT reach the caller's failure count —
+    // an evaluation that throws is redelivered, and a permanently oversized
+    // trigger would then re-fail on every delivery until it quarantined its
+    // tenant's whole lane, taking every OTHER trigger in that project down
+    // with it. Skipping isolates the damage to the one misconfigured trigger.
+    logger.error(
+      {
+        projectId,
+        triggerId,
+        reason,
+        groupBy: graphData.groupBy,
+        timePeriodMinutes: timePeriod,
+        maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
+      },
+      "graph trigger evaluation skipped: timeseries result exceeds the row ceiling",
+    );
+    return skipped({
+      triggerId,
+      projectId,
+      reason,
+      detail: "timeseries result exceeds the row ceiling",
+    });
+  }
   // The stored `seriesName` identifies WHICH series the trigger watches
   // (`{index}/{key|metric}/{aggregation}` — parsed above via
   // `parseSeriesIndex`). Result buckets use a DIFFERENT encoding —

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1046,7 +1046,8 @@ export function initializeDefaultApp(options?: {
                       where: { dashboardId, projectId },
                       orderBy: [{ gridRow: "asc" }, { gridColumn: "asc" }],
                     }),
-                  getTimeseries: (input) => analyticsService.getTimeseries(input),
+                  getTimeseries: (input) =>
+                    analyticsService.getTimeseries(input),
                 },
                 source,
                 projectId,

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1046,8 +1046,7 @@ export function initializeDefaultApp(options?: {
                       where: { dashboardId, projectId },
                       orderBy: [{ gridRow: "asc" }, { gridColumn: "asc" }],
                     }),
-                  getTimeseries: (input, options) =>
-                    analyticsService.getTimeseries(input, options),
+                  getTimeseries: (input) => analyticsService.getTimeseries(input),
                 },
                 source,
                 projectId,

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1046,8 +1046,8 @@ export function initializeDefaultApp(options?: {
                       where: { dashboardId, projectId },
                       orderBy: [{ gridRow: "asc" }, { gridColumn: "asc" }],
                     }),
-                  getTimeseries: (input) =>
-                    analyticsService.getTimeseries(input),
+                  getTimeseries: (input, options) =>
+                    analyticsService.getTimeseries(input, options),
                 },
                 source,
                 projectId,

--- a/platform/app/src/server/event-sourcing/pipelines/automations/automationDispatch.wiring.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/automationDispatch.wiring.ts
@@ -152,8 +152,8 @@ export function buildAutomationDispatchPorts({
     loadCustomGraph: async ({ customGraphId, projectId }) =>
       customGraphs.getById({ customGraphId, projectId }),
     loadProject: async (projectId) => projects.getById(projectId),
-    getTimeseries: async (input) =>
-      getApp().analytics.service.getTimeseries(input),
+    getTimeseries: async (input, options) =>
+      getApp().analytics.service.getTimeseries(input, options),
     triggerSent: graphTriggerSentRepo,
     updateLastRunAt: async ({ triggerId, projectId }) =>
       triggers.updateLastRunAt(triggerId, projectId),

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -447,7 +447,7 @@ describe("codingAgentSpanFactsDispatch", () => {
           spanId: "tool-dedup",
           attributes: { tool_name: "Bash" },
         });
-        const makeId = subscriber.options?.enqueue?.deduplication?.makeId;
+        const makeId = subscriber.options?.deduplication?.makeId;
 
         const liftedId = makeId?.(
           staged(subscriber.options?.enqueue?.stage?.(event)),

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -255,6 +255,24 @@ function makeSubscriber(
 
 const context = { tenantId: "tenant-1", aggregateId: TRACE_ID };
 
+/**
+ * A coding-agent span whose body passes the raw name gate but that the
+ * normalizer cannot read, so the seam cannot lift it.
+ */
+function unliftableSpanEvent(): SpanReceivedEvent {
+  const event = rawSpanEvent({
+    name: "claude_code.tool",
+    spanId: "tool-broken",
+  }) as SpanReceivedEvent;
+  (event.data as { span: unknown }).span = {
+    name: "claude_code.tool",
+    spanId: "tool-broken",
+    startTimeUnixNano: {},
+    endTimeUnixNano: {},
+  };
+  return event;
+}
+
 describe("codingAgentSpanFactsDispatch", () => {
   describe("when a coding-agent span carries the session key", () => {
     /** @scenario a session assembles from spans, logs and metrics */
@@ -448,15 +466,19 @@ describe("codingAgentSpanFactsDispatch", () => {
           attributes: { tool_name: "Bash" },
         });
         const makeId = subscriber.options?.deduplication?.makeId;
+        // Without this the assertion below compares undefined to undefined and
+        // passes even if the subscriber stopped declaring a dedup strategy.
+        expect(makeId).toBeDefined();
 
-        const liftedId = makeId?.(
+        const liftedId = makeId!(
           staged(subscriber.options?.enqueue?.stage?.(event)),
         );
-        const referencedId = makeId?.(
+        const referencedId = makeId!(
           staged(makeSpanReferencedPayload(event as SpanReceivedEvent)),
         );
 
         expect(liftedId).toBe(referencedId);
+        expect(liftedId).toContain("tool-dedup");
       });
     });
 
@@ -467,17 +489,7 @@ describe("codingAgentSpanFactsDispatch", () => {
       /** @scenario an event whose payload cannot be pointed at is still processed */
       it("stages the whole event rather than throwing on the routing path", () => {
         const { subscriber } = makeSubscriber();
-        const event = rawSpanEvent({
-          name: "claude_code.tool",
-          spanId: "tool-broken",
-        }) as SpanReceivedEvent;
-        // A span body the normalizer cannot read at all.
-        (event.data as { span: unknown }).span = {
-          name: "claude_code.tool",
-          spanId: "tool-broken",
-          startTimeUnixNano: {},
-          endTimeUnixNano: {},
-        };
+        const event = unliftableSpanEvent();
 
         const payload = subscriber.options?.enqueue?.stage?.(event);
 
@@ -485,6 +497,28 @@ describe("codingAgentSpanFactsDispatch", () => {
         expect((payload as { type?: string }).type).toBe(
           SPAN_RECEIVED_EVENT_TYPE,
         );
+      });
+
+      // The staged fallback is only safe if the handler can actually finish it.
+      // Normalization is a pure function of the span's bytes, so the full-event
+      // path re-derives the SAME failure: throwing there would spend all 25
+      // attempts and then park the trace's group, losing every other span's
+      // facts in that group — the exact class this change exists to remove.
+      // Driving `handle` is the point; asserting on the staged shape alone
+      // cannot observe it.
+      /** @scenario an event the subscriber declines is still completed quietly */
+      it("completes the staged fallback instead of retrying it into a blocked group", async () => {
+        const { subscriber, dispatched, reads } = makeSubscriber();
+        const payload = subscriber.options?.enqueue?.stage?.(
+          unliftableSpanEvent(),
+        );
+
+        await expect(
+          subscriber.handle(staged(payload), context),
+        ).resolves.toBeUndefined();
+
+        expect(dispatched).toHaveLength(0);
+        expect(reads).toHaveLength(0);
       });
     });
   });

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -373,6 +373,122 @@ describe("codingAgentSpanFactsDispatch", () => {
     });
   });
 
+  describe("given the enqueue-time stage hook (ADR-069 R2)", () => {
+    describe("when a matched coding-agent span is staged", () => {
+      /** @scenario work whose result is a bounded derivation carries it instead of a pointer */
+      it("stages the lifted facts, not a pointer to the span", () => {
+        const { subscriber } = makeSubscriber();
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-lift",
+          attributes: { tool_name: "Bash", "session.id": "sess-1" },
+        });
+
+        const payload = subscriber.options?.enqueue?.stage?.(event);
+
+        const lifted = parseSpanFactsLiftedPayload(payload);
+        expect(lifted).not.toBeNull();
+        expect(lifted!.type).toBe(SPAN_FACTS_LIFTED_PAYLOAD_TYPE);
+        expect(lifted!.version).toBe(SPAN_FACTS_LIFTED_PAYLOAD_VERSION_LATEST);
+        expect(lifted!.data.facts.tool_name).toBe("Bash");
+        expect(lifted!.data.sessionId).toBe("sess-1");
+      });
+
+      // The point of the shape: a job that carries its result cannot race the
+      // sibling spanStorage write, because it never reads it.
+      /** @scenario work carrying its finished result completes without reading anything back */
+      it("resolves through the handler with no span-store read at all", async () => {
+        const { subscriber, dispatched, reads } = makeSubscriber(async () => {
+          throw new Error("the span store must not be read");
+        });
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-noread",
+          attributes: { tool_name: "Edit", "session.id": "sess-2" },
+        });
+
+        const payload = subscriber.options?.enqueue?.stage?.(event);
+        await subscriber.handle(staged(payload), context);
+
+        expect(reads).toHaveLength(0);
+        expect(dispatched).toHaveLength(1);
+        expect(dispatched[0]!.facts.tool_name).toBe("Edit");
+      });
+
+      // The staged payload must not grow with the span it came from: the
+      // vocabulary is closed, so large content stays in the canonical store.
+      /** @scenario a carried derivation never carries content */
+      it("carries the small facts and none of the span's content", () => {
+        const { subscriber } = makeSubscriber();
+        const bulk = "x".repeat(50_000);
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-fat",
+          attributes: { tool_name: "Bash", "gen_ai.prompt": bulk },
+        });
+
+        const payload = subscriber.options?.enqueue?.stage?.(event);
+
+        const lifted = parseSpanFactsLiftedPayload(
+          payload,
+        ) as SpanFactsLiftedPayload | null;
+        expect(lifted).not.toBeNull();
+        expect(JSON.stringify(lifted)).not.toContain(bulk);
+        expect(lifted!.data.facts["gen_ai.prompt"]).toBeUndefined();
+      });
+
+      // The dedup identity has to survive the shape change, or a redelivery
+      // staged by an older build stops collapsing onto the new one.
+      /** @scenario a redelivered event resolves to the unit of work already queued */
+      it("keys identically whether staged as a lift or as a claim-check", () => {
+        const { subscriber } = makeSubscriber();
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-dedup",
+          attributes: { tool_name: "Bash" },
+        });
+        const makeId = subscriber.options?.enqueue?.deduplication?.makeId;
+
+        const liftedId = makeId?.(
+          staged(subscriber.options?.enqueue?.stage?.(event)),
+        );
+        const referencedId = makeId?.(
+          staged(makeSpanReferencedPayload(event as SpanReceivedEvent)),
+        );
+
+        expect(liftedId).toBe(referencedId);
+      });
+    });
+
+    describe("when the span cannot be lifted at the seam", () => {
+      // The seam has no retry, so an unliftable span must degrade to the
+      // full-event path — never to a throw, and never to a claim-check, which
+      // is the racing shape this flip exists to stop producing.
+      /** @scenario an event whose payload cannot be pointed at is still processed */
+      it("stages the whole event rather than throwing on the routing path", () => {
+        const { subscriber } = makeSubscriber();
+        const event = rawSpanEvent({
+          name: "claude_code.tool",
+          spanId: "tool-broken",
+        }) as SpanReceivedEvent;
+        // A span body the normalizer cannot read at all.
+        (event.data as { span: unknown }).span = {
+          name: "claude_code.tool",
+          spanId: "tool-broken",
+          startTimeUnixNano: {},
+          endTimeUnixNano: {},
+        };
+
+        const payload = subscriber.options?.enqueue?.stage?.(event);
+
+        expect(parseSpanFactsLiftedPayload(payload)).toBeNull();
+        expect((payload as { type?: string }).type).toBe(
+          SPAN_RECEIVED_EVENT_TYPE,
+        );
+      });
+    });
+  });
+
   describe("given the dedup key", () => {
     describe("when keying a span job", () => {
       /** @scenario a redelivered event resolves to the unit of work already queued */

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -465,15 +465,19 @@ describe("codingAgentSpanFactsDispatch", () => {
           spanId: "tool-dedup",
           attributes: { tool_name: "Bash" },
         });
-        const makeId = subscriber.options?.deduplication?.makeId;
-        // Without this the assertion below compares undefined to undefined and
-        // passes even if the subscriber stopped declaring a dedup strategy.
-        expect(makeId).toBeDefined();
+        // `deduplication` is the `"aggregate" | DeduplicationConfig` union;
+        // this subscriber uses the custom-key form. Narrowing here also stops
+        // the comparison below degrading into undefined === undefined, which
+        // would pass even if the subscriber stopped declaring a strategy.
+        const dedup = subscriber.options?.deduplication;
+        if (dedup === undefined || dedup === "aggregate") {
+          throw new Error("expected a custom deduplication config");
+        }
 
-        const liftedId = makeId!(
+        const liftedId = dedup.makeId(
           staged(subscriber.options?.enqueue?.stage?.(event)),
         );
-        const referencedId = makeId!(
+        const referencedId = dedup.makeId(
           staged(makeSpanReferencedPayload(event as SpanReceivedEvent)),
         );
 

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -162,77 +162,13 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
         return;
       }
 
-      // Neither staged shape. Before treating this as a full event, establish
-      // that it IS one: a payload of some other type is a shape this build
-      // cannot read — almost certainly staged by a newer worker mid-rollout —
-      // and returning here would COMPLETE the job with no throw, no retry and
-      // no counter, silently dropping that span's facts. Refusing it is the
-      // whole reason the deploy-order rule is enforceable (ADR-069).
-      if (!isSpanReceivedEvent(event)) {
-        throw new Error(
-          `codingAgentSpanFactsDispatch cannot read staged payload of type "${String((event as { type?: unknown }).type)}"; refusing it into the queue's retry rather than completing it. A newer build likely staged it — drain with a build that knows the shape.`,
-        );
-      }
-
-      // The type says `span_received`, so read the body before the name gate
-      // answers for it. The gate's `false` means "an event I decline", and a
-      // body with no span object would reach that answer for the wrong reason
-      // — unreadable, not declined — and complete silently. This cannot fire
-      // for a job this seam minted: `enqueue.filter` already found a listed
-      // span name on `data.span`, so an absent span means the payload came
-      // from somewhere this build does not know.
-      if (!hasReadableSpanBody(event)) {
-        throw new Error(
-          `codingAgentSpanFactsDispatch cannot read the staged "span_received" body (trace ${String(event.aggregateId)}): no span object on it. Refusing it into the queue's retry rather than completing it.`,
-        );
-      }
-
-      // Full-event job: a pre-reference release staged it, or the seam could
-      // not reference the span. Gate, normalize and lift inline — identical to
-      // the pre-reference handler. A span_received carrying a readable span
-      // this subscriber declines is a legitimate quiet completion, not an
-      // unreadable shape — a build that poisons the queue with every ordinary
-      // span is worse than the loss this refusal prevents.
-      if (!isCodingAgentSpan(event)) return;
-
-      // Normalization is a pure function of the span's own bytes, so a body it
-      // cannot read will fail identically on every redelivery. Throwing would
-      // spend all 25 attempts re-deriving the same failure and then park the
-      // TRACE's group — losing every other span's facts in that group to save
-      // one span that was never recoverable. That is the blocked-group class
-      // this whole change removes, so an unreadable body completes quietly and
-      // loudly instead: logged for an operator, not retried.
-      //
-      // This is the only path a span reaches after the seam already failed to
-      // lift it (`makeSpanFactsLiftedPayload` stages the full event on a
-      // normalizer throw), which is exactly why it must not throw here too.
-      let span: NormalizedSpan;
-      try {
-        span = normalization.normalizeSpanReceived(
-          event.tenantId,
-          event.data.span,
-          event.data.resource,
-          event.data.instrumentationScope,
-        );
-      } catch (error) {
-        logger.error(
-          {
-            tenantId: String(event.tenantId),
-            traceId: String(event.aggregateId),
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "codingAgentSpanFactsDispatch: span body failed normalization; completing without contributing rather than blocking the trace's group",
-        );
-        return;
-      }
-
-      await deps.contributeSpanFacts(
-        liftContribution({
-          span,
-          tenantId: event.tenantId,
-          occurredAt: event.occurredAt,
-        }),
-      );
+      // Neither staged shape — the remaining one is a whole event.
+      await handleFullEvent({
+        event,
+        normalization,
+        isCodingAgentSpan,
+        contributeSpanFacts: deps.contributeSpanFacts,
+      });
     },
   };
 }
@@ -253,6 +189,112 @@ function hasReadableSpanBody(event: SpanReceivedEvent): boolean {
   // `typeof [] === "object"`, and an array has no `name`, so an array body
   // would reach the gate and be declined as an ordinary span.
   return typeof span === "object" && span !== null && !Array.isArray(span);
+}
+
+/**
+ * The full-event path: a job carrying the whole `span_received`, staged by a
+ * pre-derivation release or by a seam that could not lift the span.
+ *
+ * Split out of `handle` so that function stays what it reads as — a dispatcher
+ * over the three staged shapes — rather than a dispatcher with one shape's
+ * implementation inlined into it.
+ */
+async function handleFullEvent({
+  event,
+  normalization,
+  isCodingAgentSpan,
+  contributeSpanFacts,
+}: {
+  event: TraceProcessingEvent;
+  normalization: SpanNormalizationPipelineService;
+  isCodingAgentSpan: (
+    event: TraceProcessingEvent,
+  ) => event is SpanReceivedEvent;
+  contributeSpanFacts: (data: ContributeSpanFactsCommandData) => Promise<void>;
+}): Promise<void> {
+  // Before treating this as a full event, establish that it IS one: a payload
+  // of some other type is a shape this build cannot read — almost certainly
+  // staged by a newer worker mid-rollout — and returning here would COMPLETE
+  // the job with no throw, no retry and no counter, silently dropping that
+  // span's facts. Refusing it is the whole reason the deploy-order rule is
+  // enforceable (ADR-069).
+  if (!isSpanReceivedEvent(event)) {
+    throw new Error(
+      `codingAgentSpanFactsDispatch cannot read staged payload of type "${String((event as { type?: unknown }).type)}"; refusing it into the queue's retry rather than completing it. A newer build likely staged it — drain with a build that knows the shape.`,
+    );
+  }
+
+  // The type says `span_received`, so read the body before the name gate
+  // answers for it. The gate's `false` means "an event I decline", and a body
+  // with no span object would reach that answer for the wrong reason —
+  // unreadable, not declined — and complete silently. This cannot fire for a
+  // job this seam minted: `enqueue.filter` already found a listed span name on
+  // `data.span`, so an absent span means the payload came from somewhere this
+  // build does not know.
+  if (!hasReadableSpanBody(event)) {
+    throw new Error(
+      `codingAgentSpanFactsDispatch cannot read the staged "span_received" body (trace ${String(event.aggregateId)}): no span object on it. Refusing it into the queue's retry rather than completing it.`,
+    );
+  }
+
+  // A span_received carrying a readable span this subscriber declines is a
+  // legitimate quiet completion, not an unreadable shape — a build that
+  // poisons the queue with every ordinary span is worse than the loss this
+  // refusal prevents.
+  if (!isCodingAgentSpan(event)) return;
+
+  const span = normalizeOrReport({ event, normalization });
+  if (span === null) return;
+
+  await contributeSpanFacts(
+    liftContribution({
+      span,
+      tenantId: event.tenantId,
+      occurredAt: event.occurredAt,
+    }),
+  );
+}
+
+/**
+ * Normalizes a full event's span, or reports the failure and yields `null`.
+ *
+ * Normalization is a pure function of the span's own bytes, so a body it cannot
+ * read fails identically on every redelivery. Throwing would spend all 25
+ * attempts re-deriving the same failure and then park the TRACE's group —
+ * losing every other span's facts in that group to save one span that was never
+ * recoverable. That is the blocked-group class this whole change removes, so an
+ * unreadable body completes quietly and loudly instead: logged for an operator,
+ * not retried.
+ *
+ * This is the only path such a span can reach, because the seam already failed
+ * to lift it (`makeSpanFactsLiftedPayload` stages the full event on a
+ * normalizer throw) — which is exactly why it must not throw here too.
+ */
+function normalizeOrReport({
+  event,
+  normalization,
+}: {
+  event: SpanReceivedEvent;
+  normalization: SpanNormalizationPipelineService;
+}): NormalizedSpan | null {
+  try {
+    return normalization.normalizeSpanReceived(
+      event.tenantId,
+      event.data.span,
+      event.data.resource,
+      event.data.instrumentationScope,
+    );
+  } catch (error) {
+    logger.error(
+      {
+        tenantId: String(event.tenantId),
+        traceId: String(event.aggregateId),
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "codingAgentSpanFactsDispatch: span body failed normalization; completing without contributing rather than blocking the trace's group",
+    );
+    return null;
+  }
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -4,7 +4,6 @@ import type { EventSubscriberDefinition } from "../../../subscribers/eventSubscr
 import { SPAN_RECEIVED_EVENT_TYPE } from "../../trace-processing/schemas/constants";
 import {
   isSpanReceivedEvent,
-  makeSpanReferencedPayload,
   parseSpanReferencedPayload,
   type SpanReceivedEvent,
   type SpanReferencedPayload,
@@ -12,7 +11,15 @@ import {
 } from "../../trace-processing/schemas/events";
 import type { NormalizedSpan } from "../../trace-processing/schemas/spans";
 import type { ContributeSpanFactsCommandData } from "../schemas/commands";
-import { parseSpanFactsLiftedPayload } from "../schemas/events";
+import {
+  SPAN_FACTS_LIFTED_PAYLOAD_TYPE,
+  SPAN_FACTS_LIFTED_PAYLOAD_VERSION_LATEST,
+} from "../schemas/constants";
+import {
+  parseSpanFactsLiftedPayload,
+  type SpanFactsLiftedPayload,
+  spanFactsLiftedPayloadSchema,
+} from "../schemas/events";
 import {
   CODING_AGENT_CONTRIBUTION_KEYS,
   detectCodingAgent,
@@ -34,26 +41,37 @@ import { CODING_AGENT_SPAN_NAMES } from "../services/coding-agent-session.deriva
  *     (ADR-056 §3).
  *   - A `span_facts_lifted` job carries a bounded derivation: the facts, already
  *     lifted, on the job itself. The handler contributes them directly. Nothing
- *     is read back, so nothing races. This is the shape the seam will stage once
- *     R2 flips the producer (see the handler contract below).
+ *     is read back, so nothing races. **This is the shape this build STAGES**
+ *     (R2 — see the deploy-order note below).
  *   - A `span_referenced` claim-check carries the span's identity, not its
  *     payload, and the handler reads the canonical span back from the span
  *     store. That read races the sibling spanStorage write, which is the
  *     failure the derivation shape exists to remove: on 2026-08-05 it parked 22
- *     per-trace groups in `:blocked`. This build still STAGES it — the producer
- *     flip is R2 — and the handler keeps resolving it after that flip, so
- *     references already in Redis drain.
+ *     per-trace groups in `:blocked`, and on 2026-08-10 the same class blocked
+ *     88 groups while the error rate rose ~10x. This build no longer stages it;
+ *     the handler keeps resolving it so references already in Redis drain.
  *   - A full `span_received` job still processes exactly as before references
  *     existed: jobs staged by a previous release, and matched events the seam
- *     could not reference, carry the whole event, and the handler normalizes
+ *     could not lift, carry the whole event, and the handler normalizes
  *     inline in its own lane.
  *
- * **Deploy order (ADR-069).** This build is the CONSUMER half: it reads
- * `span_facts_lifted` but does not stage it. The producer flip ships a release
- * later, because a worker that predates the type would otherwise complete such
- * a job silently. Anything this build cannot read at all now throws instead of
- * returning, so the next crossing of this boundary fails as a retry rather than
- * as a silent loss.
+ * **Deploy order (ADR-069).** The CONSUMER half shipped in #6621 and has been
+ * live for a full release, so this build is the PRODUCER flip: it stages
+ * `span_facts_lifted`, which every worker already knows how to read. Anything a
+ * build cannot read at all throws instead of returning, so the next crossing of
+ * this boundary fails as a retry rather than as a silent loss.
+ *
+ * **Why the flip is the fix, not a tuning knob.** The claim-check's retry budget
+ * is finite (25 attempts, ~2h27m). The spanStorage map projection it reads from
+ * is sharded into 128 lanes per tenant and coalesces 256 spans per dispatch
+ * (`spanStorageGroupKey.ts`), while this subscriber keys one group PER TRACE.
+ * A tenant with heavy coding-agent traffic therefore mints thousands of
+ * per-trace groups that contend with those 128 lanes for the same per-tenant
+ * in-flight soft cap — so the harder the tenant pushes, the later its spans
+ * land, and the more claim-checks burn attempts against a store that has not
+ * caught up. Every failed attempt re-queues, which adds contention, which
+ * delays the write further. Removing the read-back breaks that loop at its
+ * source; no cap or backoff tuning does.
  */
 export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
   contributeSpanFacts: (data: ContributeSpanFactsCommandData) => Promise<void>;
@@ -84,16 +102,18 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
     options: {
       enqueue: {
         filter: isCodingAgentSpan,
-        // `filter` has already established a coding-agent span_received
-        // event; the stage hook is a total field-pick that swaps the staged
-        // payload for its claim-check (or returns the event unchanged when
-        // the span has no id to reference).
-        stage: (event) => makeSpanReferencedPayload(event as SpanReceivedEvent),
+        // `filter` has already established a coding-agent span_received event.
+        // The stage hook lifts that span's facts HERE, so the job carries its
+        // own finished result and the handler reads nothing back.
+        stage: (event) =>
+          makeSpanFactsLiftedPayload(event as SpanReceivedEvent, normalization),
       },
-      // Debounce past the spanStorage sibling write: the reference resolves
-      // against the span store, and both jobs are staged by the same fan-out.
-      // Two seconds puts the first attempt after that write in the common
-      // case; the queue's backoff covers the tail.
+      // The lifted derivation resolves without touching the span store, so
+      // there is no sibling write left to debounce past. The delay stays only
+      // for the residual full-event fallback, which normalizes in its own lane
+      // and is cheap to defer — and dropping it outright would dispatch a
+      // burst of coding-agent spans at ingest rate rather than spreading them
+      // across the dedup window below.
       delay: 2_000,
       deduplication: {
         makeId: (event) => {
@@ -202,9 +222,70 @@ function hasReadableSpanBody(event: SpanReceivedEvent): boolean {
 }
 
 /**
+ * Lifts a matched span's facts at the routing seam so the staged job carries
+ * its own finished result (ADR-069's bounded derivation).
+ *
+ * Total at runtime, exactly like `makeSpanReferencedPayload` and for the same
+ * reason: this runs as an `enqueue` hook on the shared routing seam, which has
+ * no retry, so a throw here would permanently lose the job. Normalization runs
+ * on untrusted wire data, so it is wrapped rather than trusted.
+ *
+ * The result is validated against the very schema the consumer parses with,
+ * and a payload that does not validate is DISCARDED in favour of staging the
+ * whole event. That is what makes the staged shape provably readable: the
+ * consumer's `parseSpanFactsLiftedPayload` throws on a shape it cannot read
+ * (correctly — it must never half-process), so staging an unvalidated
+ * derivation would convert a malformed span into a job that fails all 25
+ * attempts and then blocks its group, which is the exact failure class this
+ * change removes.
+ *
+ * The fallback is the FULL EVENT, never the claim-check: the full-event path
+ * resolves with no store read at all, so the rare malformed span costs
+ * scheduling-plane bytes instead of re-introducing the race. Only spans this
+ * seam cannot lift take it, and `filter` has already established that the span
+ * carries a listed coding-agent name.
+ */
+function makeSpanFactsLiftedPayload(
+  event: SpanReceivedEvent,
+  normalization: SpanNormalizationPipelineService,
+): SpanFactsLiftedPayload | SpanReceivedEvent {
+  let data: ContributeSpanFactsCommandData;
+  try {
+    const span = normalization.normalizeSpanReceived(
+      event.tenantId,
+      event.data.span,
+      event.data.resource,
+      event.data.instrumentationScope,
+    );
+    data = liftContribution({
+      span,
+      tenantId: event.tenantId,
+      occurredAt: event.occurredAt,
+    });
+  } catch {
+    return event;
+  }
+
+  const candidate = {
+    id: event.id,
+    aggregateId: event.aggregateId,
+    aggregateType: event.aggregateType,
+    tenantId: event.tenantId,
+    createdAt: event.createdAt,
+    occurredAt: event.occurredAt,
+    type: SPAN_FACTS_LIFTED_PAYLOAD_TYPE,
+    version: SPAN_FACTS_LIFTED_PAYLOAD_VERSION_LATEST,
+    data,
+    metadata: event.metadata,
+  };
+  const parsed = spanFactsLiftedPayloadSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : event;
+}
+
+/**
  * Resolves a `span_referenced` claim-check through the span store and lifts its
- * facts. R2 stops producing references; the path stays after it so the ones
- * already staged in Redis drain.
+ * facts. R2 stopped producing references; the path stays so the ones already
+ * staged in Redis drain.
  */
 async function resolveClaimCheck(
   ref: SpanReferencedPayload,

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -1,3 +1,4 @@
+import { createLogger } from "@langwatch/observability";
 import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
 import { SpanNormalizationPipelineService } from "~/server/app-layer/traces/span-normalization.service";
 import type { EventSubscriberDefinition } from "../../../subscribers/eventSubscriber.types";
@@ -26,6 +27,10 @@ import {
   resolveConversationKey,
 } from "../services/coding-agent-normalization";
 import { CODING_AGENT_SPAN_NAMES } from "../services/coding-agent-session.derivation";
+
+const logger = createLogger(
+  "langwatch:coding-agent-processing:span-facts-dispatch",
+);
 
 /**
  * The span→session dispatcher (ADR-056 §2): a subscriber on trace-processing's
@@ -106,7 +111,10 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
         // The stage hook lifts that span's facts HERE, so the job carries its
         // own finished result and the handler reads nothing back.
         stage: (event) =>
-          makeSpanFactsLiftedPayload(event as SpanReceivedEvent, normalization),
+          makeSpanFactsLiftedPayload({
+            event: event as SpanReceivedEvent,
+            normalization,
+          }),
       },
       // The lifted derivation resolves without touching the span store, so
       // there is no sibling write left to debounce past. The delay stays only
@@ -186,12 +194,38 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
       // unreadable shape — a build that poisons the queue with every ordinary
       // span is worse than the loss this refusal prevents.
       if (!isCodingAgentSpan(event)) return;
-      const span = normalization.normalizeSpanReceived(
-        event.tenantId,
-        event.data.span,
-        event.data.resource,
-        event.data.instrumentationScope,
-      );
+
+      // Normalization is a pure function of the span's own bytes, so a body it
+      // cannot read will fail identically on every redelivery. Throwing would
+      // spend all 25 attempts re-deriving the same failure and then park the
+      // TRACE's group — losing every other span's facts in that group to save
+      // one span that was never recoverable. That is the blocked-group class
+      // this whole change removes, so an unreadable body completes quietly and
+      // loudly instead: logged for an operator, not retried.
+      //
+      // This is the only path a span reaches after the seam already failed to
+      // lift it (`makeSpanFactsLiftedPayload` stages the full event on a
+      // normalizer throw), which is exactly why it must not throw here too.
+      let span: NormalizedSpan;
+      try {
+        span = normalization.normalizeSpanReceived(
+          event.tenantId,
+          event.data.span,
+          event.data.resource,
+          event.data.instrumentationScope,
+        );
+      } catch (error) {
+        logger.error(
+          {
+            tenantId: String(event.tenantId),
+            traceId: String(event.aggregateId),
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "codingAgentSpanFactsDispatch: span body failed normalization; completing without contributing rather than blocking the trace's group",
+        );
+        return;
+      }
+
       await deps.contributeSpanFacts(
         liftContribution({
           span,
@@ -245,10 +279,13 @@ function hasReadableSpanBody(event: SpanReceivedEvent): boolean {
  * seam cannot lift take it, and `filter` has already established that the span
  * carries a listed coding-agent name.
  */
-function makeSpanFactsLiftedPayload(
-  event: SpanReceivedEvent,
-  normalization: SpanNormalizationPipelineService,
-): SpanFactsLiftedPayload | SpanReceivedEvent {
+function makeSpanFactsLiftedPayload({
+  event,
+  normalization,
+}: {
+  event: SpanReceivedEvent;
+  normalization: SpanNormalizationPipelineService;
+}): SpanFactsLiftedPayload | SpanReceivedEvent {
   let data: ContributeSpanFactsCommandData;
   try {
     const span = normalization.normalizeSpanReceived(

--- a/specs/event-sourcing/payload-cost.feature
+++ b/specs/event-sourcing/payload-cost.feature
@@ -172,11 +172,11 @@ Feature: Payload cost governs the scheduling plane
   # derivation can carry the derivation instead — cheap for the same reason a
   # pointer is cheap, and with nothing left to race.
   #
-  # This is the PRODUCER half, and it is deliberately not live yet: the
-  # deploy-order rule two scenarios up means the consumer half below must be on
-  # every worker for a full release before anything stages this shape. Flip to
-  # @unit when the producer ships (R2).
-  @unimplemented
+  # This is the PRODUCER half. It is live: the deploy-order rule two scenarios
+  # up required the consumer half to be on every worker for a full release
+  # first, which it has been since #6621, so the seam now stages this shape
+  # instead of the pointer.
+  @unit
   Scenario: work whose result is a bounded derivation carries it instead of a pointer
     Given a relevant event whose payload is large
     And the subscriber's whole result is a derivation drawn from a fixed, closed vocabulary


### PR DESCRIPTION
Two production issues from the 2026-08-10 queue dashboard: 88 blocked groups on "span not readable in the span store" (error rate up ~10x on its 24h baseline), and a graph-trigger sweep that had been killing workers outright since 2026-08-09.

## 1. "Span not there" — the R2 producer flip that was never shipped

`#6621` was supposed to have fixed this. It did not; it *mitigated* it. It re-centred the claim-check's read window on the span's own start time, but left the read-back — and therefore the race with the sibling `spanStorage` write — fully in place. `span_facts_lifted` had a schema, a parser and a consumer, and **nothing in the codebase ever staged it**: the producer flip was deliberately held one release behind by ADR-069's deploy-order rule.

That rule is now satisfied — the consumer half has been live since #6621 (prod is emitting its error text) — so this flips the producer. The enqueue seam lifts the span's facts and stages them on the job; the handler contributes them with no store read at all.

**Why this is the fix and not a tuning knob.** The claim-check has a finite retry budget (25 attempts, ~2h27m). `spanStorage` is sharded into 128 lanes per tenant and coalesces 256 spans per dispatch; this subscriber keys one group **per trace**. A tenant pushing coding-agent traffic therefore mints thousands of per-trace groups that contend with those 128 lanes for the same per-tenant in-flight cap. The harder the tenant pushes, the later its spans land, the more claim-checks burn attempts against a store that has not caught up — and every failure re-queues, adding contention. It is a positive feedback loop, and no cap or backoff setting breaks it. Removing the read-back does.

The stage hook is total (the routing seam has no retry): normalization is wrapped, and the payload is validated against the very schema the consumer parses with. Anything that does not validate stages the **whole event** — never a claim-check, so a malformed span costs scheduling-plane bytes instead of re-introducing the race.

The spec's producer scenario was `@unimplemented`, which enforces nothing; it is now `@unit` and bound.

## 2. The automations job blowing up the worker

A graph-trigger evaluation collapses its entire timeseries to **one number**, but the query carries the graph's `groupBy`, so ClickHouse returns `buckets x distinct group values` and the group axis is summed away in Node — after every row has been materialised as a JS object. The time axis is already capped at 1,000 buckets. Cardinality is not, and cannot be: it comes from the data.

The failure was not an error. The process died mid-read, so the job neither completed nor failed. Three of those in a row trips the poison guard, which parks the tenant's whole graph-trigger lane — which is how one project's misconfigured graph silently stopped **all** of its alerts for 19 hours with 4,184 jobs stranded behind it.

This bounds the read at the ClickHouse boundary for this caller only. `result_overflow_mode: "throw"` is the load-bearing half — ClickHouse defaults to `break`, which silently returns a **truncated** result, and a threshold quietly computed on partial data is worse than a failed evaluation because nothing reports it.

An oversized result is a configuration fault, so it skips that one trigger rather than throwing. Throwing would be redelivered and re-fail forever until it quarantined the lane, taking every other trigger in the project with it. Any other read failure still propagates, so a transient ClickHouse blip cannot silently skip evaluations.

## 3. Result sizes per call site — using what already exists

The original plan here was a new `clickhouse_result_rows` histogram recorded in the `safeClickhouseClient` proxy. That was a third mechanism next to two that already exist, so it is **not** in this PR.

`@langwatch/clickhouse-client` already records row counts on the span (`db.response.returned_rows`) and already exposes `onComplete({ rowCount, durationMs })`, documented as the hook "for counters". Nothing needs adding to the package either.

What this PR does instead is set `log_comment` on the analytics timeseries reads. Result-size distribution per call site is then a query against ClickHouse's own `system.query_log`:

```sql
SELECT log_comment, quantiles(0.5, 0.99, 0.999)(result_rows), max(result_rows), count()
FROM system.query_log
WHERE type = 'QueryFinish' AND log_comment != '' AND event_time > now() - INTERVAL 7 DAY
GROUP BY log_comment ORDER BY max(result_rows) DESC
```

No new code, no new metric, and it works today — which the middleware route would not have, because the app never calls the package's `compose()` and so nothing flows through its pipeline. **Nothing is added under `src/server/clickhouse`.**

Worth noting separately: `src/server/clickhouse/safeClickhouseClient.ts` is a raw `Proxy` over the driver that force-merges default settings into every `.query()` — a second, older mechanism parallel to the package's middleware model. Migrating the app's query path onto `compose()` and deleting that proxy is a follow-up, not part of this incident fix.

## Testing

- `codingAgentSpanFactsDispatch` 37 pass (5 new: lift staged, no store read, no content carried, dedup identity stable across shapes, unliftable span falls back to full event)
- `graph-trigger-evaluation` 30 pass (4 new: ceiling requested, oversized skips, does not throw, other errors still propagate)
- Affected suites: 801 pass. The 6 `emailSuppression` failures are a missing local `NEXTAUTH_SECRET` and fail identically on `main`.
- `check-feature-parity`: `payload-cost.feature` 23/23 bound.
- Biome clean on changed files (no new warnings).

## Not included — needs an operator

The two poison-parked groups are still parked and will not drain on their own:

- `project_smvHkUTq99pgnLr4GIKR1/subscriber/graphTriggerActivity/...` — 4,184 jobs
- `project_Of-AcajfhuzZ9FjDmXlN8/job/deferredComputeRunMetrics` — 2,813 jobs

**Unblock the graph-trigger group only after this ships**, or it will re-kill workers on the same query. `deferredComputeRunMetrics` is a separate poison-parked group this PR does not address.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safer analytics timeseries queries with optional result-row limits.
  - Graph-trigger evaluations now enforce a 10,000-row limit and skip oversized results without failing or dispatching actions.
  - Analytics routing now consistently selects the appropriate read path based on query requirements.
  - Coding-agent span processing now stages validated facts directly, reducing unnecessary data lookups.

- **Bug Fixes**
  - Improved handling of oversized analytics results while preserving normal error reporting.
  - Added graceful fallback for malformed coding-agent span data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->