### PR TITLE
fix(scenarios): never show a runner crash dump as the run's verdict

### DIFF
--- a/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
@@ -21,8 +21,8 @@ import {
 } from "../scenario-infra-error";
 
 /** The internals a user must never read, each with the name it fails under. */
-const INTERNAL_MARKERS: { label: string; pattern: RegExp }[] = [
-  { label: "stack frame", pattern: /\bat\s+\S+\s+\(/ },
+const INTERNAL_MARKERS = [
+  { label: "stack frame", pattern: /\bat\s+(?:async\s+)?\S+\s*\(/ },
   { label: "interpreter source location", pattern: /node:internal/ },
   {
     label: "container path",
@@ -30,7 +30,11 @@ const INTERNAL_MARKERS: { label: string; pattern: RegExp }[] = [
   },
   { label: "child-process wrapper", pattern: /Child process exited/ },
   { label: "bundle filename", pattern: /\.cjs\b|\.js:/ },
-];
+  {
+    label: "build tree",
+    pattern: /(?:^|[\s'"(/\\])(?:dist|node_modules)[/\\]/,
+  },
+] as const;
 
 /**
  * Nothing a user reads may carry a stack frame, an interpreter source
@@ -326,6 +330,25 @@ describe("classifyScenarioInfraError", () => {
         "TypeError: x is not a function (scenario-child-process.cjs:80978:27)",
       ],
     ])("suppresses %s, which carries no leading slash", (_label, raw) => {
+      expectNoInternals(classifyScenarioInfraError(raw).message);
+    });
+
+    it.each([
+      [
+        "backslash-separated",
+        "Error thrown in C:\\app\\dist\\server\\scenario-child-process.cjs:80978",
+      ],
+      [
+        "a UNC share",
+        "Error thrown in \\\\build\\share\\dist\\server\\workers.cjs:12",
+      ],
+    ])("suppresses our bundle path when %s", (_label, raw) => {
+      // The guard keys on our artefacts (dist, node_modules, .cjs, the runner
+      // bundle's name) with either separator, rather than on path shape — so
+      // the drive letter and the UNC prefix are beside the point. A bare
+      // `C:\app\runner.js` is deliberately NOT suppressed: it names nothing of
+      // ours, and blanket path suppression is what cost the customer their own
+      // diagnostics in the case above.
       expectNoInternals(classifyScenarioInfraError(raw).message);
     });
 

--- a/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
@@ -205,35 +205,82 @@ describe("classifyScenarioInfraError", () => {
       // buildFailureResults() puts this string in the run's `reasoning`, which
       // is what the customer report showed the loader dump in. Pinned exactly,
       // because the whole point of the fix is the words the customer reads.
-      const { message } = classifyScenarioInfraError(moduleNotFoundDump);
-      expect(message).toBe(
+      expect(classifyScenarioInfraError(moduleNotFoundDump).message).toBe(
         "The simulation runner couldn't start, so the scenario never ran.",
       );
-      expect(message).not.toContain("pino");
-      expect(message).not.toContain("MODULE_NOT_FOUND");
     });
 
+    // Every case carries the child-exit wrapper, because that is what marks
+    // the dead process as ours.
     it.each([
-      "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'\n    at Module._load (node:internal/modules/cjs/loader:1294:5)",
-      "Error: Cannot find module '../dist/index.js'\nRequire stack:\n- /app/dist/server/workers.cjs",
-      "Error [ERR_REQUIRE_ESM]: require() of ES Module not supported\n    at Module._compile (node:internal/modules/cjs/loader:1871:14)",
-      "Error: ERR_DLOPEN_FAILED: invalid ELF header\n    at Module._extensions..node (node:internal/modules/cjs/loader:1928:18)",
-    ])("classifies a %s crash as runner-unavailable", (raw) => {
+      [
+        "a missing ESM package",
+        "Child process exited with code 1: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'\n    at Module._load (node:internal/modules/cjs/loader:1294:5)",
+      ],
+      [
+        "a missing relative module",
+        "Child process exited with code 1: Error: Cannot find module '../dist/index.js'\nRequire stack:\n- /app/dist/server/workers.cjs",
+      ],
+      [
+        "an ESM/CJS mismatch",
+        "Child process exited with code 1: Error [ERR_REQUIRE_ESM]: require() of ES Module not supported\n    at Module._compile (node:internal/modules/cjs/loader:1871:14)",
+      ],
+      [
+        "a native addon that won't load",
+        "Child process exited with code 1: Error: ERR_DLOPEN_FAILED: invalid ELF header\n    at Module._extensions..node (node:internal/modules/cjs/loader:1928:18)",
+      ],
+    ])("classifies %s as runner-unavailable", (_label, raw) => {
       expect(classifyScenarioInfraError(raw).code).toBe(
         ScenarioInfraErrorCode.RunnerUnavailable,
       );
     });
+  });
 
+  describe("when the crash text came from the customer's own agent", () => {
     /** @scenario "A customer's own module error is not blamed on our runner" */
-    it("does not claim our runner failed when the words came from the agent", () => {
-      // A customer's Node agent can fail this way and have the text surface
-      // through the adapter. Blaming our deployment would send them looking in
-      // the wrong place, so without a Node crash dump around it this stays in
-      // the generic bucket with their own wording intact.
+    it("does not blame our runner for the agent's missing dependency", () => {
+      // The real shape, not a toy: http-agent.adapter.ts embeds the customer's
+      // HTTP response body verbatim, so their agent's own boot crash arrives
+      // here looking exactly like ours — frames, Require stack and all. What
+      // separates them is the child-exit wrapper, which only our dead child
+      // gets. Telling them the fault is on our side would send them looking in
+      // the wrong place for their own missing `stripe`.
+      const agentBodyThroughAdapter = [
+        "HTTP 500: Internal Server Error from https://acme.example.com/agent (request-id: abc-123): Error: Cannot find module 'stripe'",
+        "Require stack:",
+        "- /srv/customer-agent/handlers/pay.js",
+        "    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)",
+      ].join("\n");
+
+      const result = classifyScenarioInfraError(agentBodyThroughAdapter);
+
+      expect(result.code).not.toBe(ScenarioInfraErrorCode.RunnerUnavailable);
+      expect(result.hint ?? "").not.toMatch(/fault on our side/i);
+    });
+
+    it("does not blame our runner for a bare module sentence either", () => {
       const agentReply = "Cannot find module 'my-tools/pricing'";
       const result = classifyScenarioInfraError(agentReply);
       expect(result.code).toBe(ScenarioInfraErrorCode.Infra);
       expect(result.message).toBe(agentReply);
+    });
+  });
+
+  describe("when the agent's own failure text contains a path", () => {
+    /** @scenario "The agent's own failure text survives the internals guard" */
+    it.each([
+      [
+        "the adapter's HTTP envelope",
+        "HTTP 502: Bad Gateway from https://acme.example.com/agent (request-id: none): upstream /srv/agent/app.py raised ValueError",
+      ],
+      ["an unknown route", "unknown route /v2/chat"],
+      ["a provider endpoint", "POST /v1/chat/completions returned 400"],
+      ["a rate limit", "Rate limited on /v1/messages, retry after 30s"],
+      ["a require-stack lookalike bullet", "- /webhooks/agent is unreachable"],
+    ])("passes %s through untouched", (_label, raw) => {
+      // A path is only an internal when it is OURS. These are all the
+      // customer's own data and the most diagnostic thing they get.
+      expect(classifyScenarioInfraError(raw).message).toBe(raw);
     });
   });
 
@@ -258,7 +305,41 @@ describe("classifyScenarioInfraError", () => {
       const result = classifyScenarioInfraError(framesOnly);
       expect(result.code).toBe(ScenarioInfraErrorCode.Infra);
       expectNoInternals(result.message);
-      expect(result.message).toBe("The simulation failed before it could run.");
+      // NOT "failed before it could run" — that asserts the run never started,
+      // which is false for anything suppressed mid-run.
+      expect(result.message).toBe(
+        "The simulation failed, but it didn't report a reason we can show.",
+      );
+    });
+
+    it.each([
+      [
+        "a bundle-relative frame",
+        "Error thrown in dist/server/workers.cjs:80978",
+      ],
+      [
+        "an async stack frame",
+        "Caused by: at async Foo.bar (dist/server/x.js:1:1)",
+      ],
+      [
+        "our runner bundle by name",
+        "TypeError: x is not a function (scenario-child-process.cjs:80978:27)",
+      ],
+    ])("suppresses %s, which carries no leading slash", (_label, raw) => {
+      expectNoInternals(classifyScenarioInfraError(raw).message);
+    });
+
+    it("does not let an unbalanced bracket swallow the real sentence", () => {
+      // The HTTP adapter truncates response bodies mid-string, so unbalanced
+      // JSON reaches this classifier as a matter of course. A block may only
+      // open on a line that STARTS with `{`; a stray bracket must not.
+      const truncated = [
+        'Child process exited with code 1: {"partial": [',
+        "The judge could not parse the agent's reply.",
+      ].join("\n");
+      expect(classifyScenarioInfraError(truncated).message).toBe(
+        "The judge could not parse the agent's reply.",
+      );
     });
 
     it("still keeps a real sentence buried in a crash dump", () => {

--- a/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario-infra-error.unit.test.ts
@@ -20,6 +20,32 @@ import {
   scenarioErrorTitle,
 } from "../scenario-infra-error";
 
+/** The internals a user must never read, each with the name it fails under. */
+const INTERNAL_MARKERS: { label: string; pattern: RegExp }[] = [
+  { label: "stack frame", pattern: /\bat\s+\S+\s+\(/ },
+  { label: "interpreter source location", pattern: /node:internal/ },
+  {
+    label: "container path",
+    pattern: /(?:^|[\s'"])\/(?:app|usr|home|Users)\//,
+  },
+  { label: "child-process wrapper", pattern: /Child process exited/ },
+  { label: "bundle filename", pattern: /\.cjs\b|\.js:/ },
+];
+
+/**
+ * Nothing a user reads may carry a stack frame, an interpreter source
+ * location, or a path from inside our container. Asserted on the message
+ * rather than the input, so it holds whichever classification rule matched,
+ * and reported by label so a failure names what leaked.
+ */
+function expectNoInternals(message: string): void {
+  const leaked = INTERNAL_MARKERS.filter(({ pattern }) =>
+    pattern.test(message),
+  ).map(({ label }) => label);
+  // biome-ignore lint/suspicious/noMisplacedAssertion: one shared guard for every "no internals" case; the assertion belongs with the marker list it checks
+  expect(leaked).toEqual([]);
+}
+
 describe("classifyScenarioInfraError", () => {
   describe("when the raw error is a self-signed certificate failure", () => {
     /** @scenario "A self-signed certificate failure becomes an untrusted-certificate error" */
@@ -140,6 +166,113 @@ describe("classifyScenarioInfraError", () => {
       const result = classifyScenarioInfraError(undefined);
       expect(result.code).toBe(ScenarioInfraErrorCode.Infra);
       expect(result.message.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("when the runner process failed to boot", () => {
+    // Verbatim from a customer report: the production bundle was built
+    // without pino declared, so the child died in Node's CJS loader and the
+    // whole dump — interpreter paths, stack frames, the bundle's absolute
+    // path inside the container — was stored as the run's verdict reasoning.
+    const moduleNotFoundDump = [
+      "Child process exited with code 1: node:internal/modules/cjs/loader:1520",
+      "  throw err;",
+      "  ^",
+      "",
+      "Error: Cannot find module 'pino'",
+      "Require stack:",
+      "- /app/langwatch/langwatch/dist/scenario-child-process.js",
+      "    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)",
+      "    at Module._load (node:internal/modules/cjs/loader:1294:5)",
+      "{",
+      "  code: 'MODULE_NOT_FOUND',",
+      "  requireStack: [ '/app/langwatch/langwatch/dist/scenario-child-process.js' ]",
+      "}",
+      "",
+      "Node.js v24.18.0",
+      "",
+    ].join("\n");
+
+    /** @scenario "A runner that fails to boot becomes a named runner-unavailable error" */
+    it("classifies the loader crash as runner-unavailable without leaking internals", () => {
+      const result = classifyScenarioInfraError(moduleNotFoundDump);
+      expect(result.code).toBe(ScenarioInfraErrorCode.RunnerUnavailable);
+      expectNoInternals(result.message);
+      expect(result.hint).toMatch(/fault on our side/i);
+    });
+
+    it("keeps the internals out of the reasoning the run stores", () => {
+      // buildFailureResults() puts this string in the run's `reasoning`, which
+      // is what the customer report showed the loader dump in. Pinned exactly,
+      // because the whole point of the fix is the words the customer reads.
+      const { message } = classifyScenarioInfraError(moduleNotFoundDump);
+      expect(message).toBe(
+        "The simulation runner couldn't start, so the scenario never ran.",
+      );
+      expect(message).not.toContain("pino");
+      expect(message).not.toContain("MODULE_NOT_FOUND");
+    });
+
+    it.each([
+      "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'\n    at Module._load (node:internal/modules/cjs/loader:1294:5)",
+      "Error: Cannot find module '../dist/index.js'\nRequire stack:\n- /app/dist/server/workers.cjs",
+      "Error [ERR_REQUIRE_ESM]: require() of ES Module not supported\n    at Module._compile (node:internal/modules/cjs/loader:1871:14)",
+      "Error: ERR_DLOPEN_FAILED: invalid ELF header\n    at Module._extensions..node (node:internal/modules/cjs/loader:1928:18)",
+    ])("classifies a %s crash as runner-unavailable", (raw) => {
+      expect(classifyScenarioInfraError(raw).code).toBe(
+        ScenarioInfraErrorCode.RunnerUnavailable,
+      );
+    });
+
+    /** @scenario "A customer's own module error is not blamed on our runner" */
+    it("does not claim our runner failed when the words came from the agent", () => {
+      // A customer's Node agent can fail this way and have the text surface
+      // through the adapter. Blaming our deployment would send them looking in
+      // the wrong place, so without a Node crash dump around it this stays in
+      // the generic bucket with their own wording intact.
+      const agentReply = "Cannot find module 'my-tools/pricing'";
+      const result = classifyScenarioInfraError(agentReply);
+      expect(result.code).toBe(ScenarioInfraErrorCode.Infra);
+      expect(result.message).toBe(agentReply);
+    });
+  });
+
+  describe("when the raw error is nothing but runtime noise", () => {
+    /** @scenario "An unclassified crash dump degrades to a plain sentence" */
+    it("degrades to a plain sentence rather than a stack frame", () => {
+      // No loader needles here, so this lands in the generic bucket — the
+      // path the old summarize() walked straight into, returning the
+      // interpreter's own source location as the user-facing message.
+      const framesOnly = [
+        "Child process exited with code 1: node:internal/process/task_queues:105",
+        "  throw err;",
+        "  ^",
+        "    at processTicksAndRejections (node:internal/process/task_queues:105:5)",
+        "    at async /app/langwatch/dist/server/scenario-child-process.cjs:80978:27",
+        "{",
+        "  code: 'SOME_CODE'",
+        "}",
+        "",
+        "Node.js v24.18.0",
+      ].join("\n");
+      const result = classifyScenarioInfraError(framesOnly);
+      expect(result.code).toBe(ScenarioInfraErrorCode.Infra);
+      expectNoInternals(result.message);
+      expect(result.message).toBe("The simulation failed before it could run.");
+    });
+
+    it("still keeps a real sentence buried in a crash dump", () => {
+      // The noise filter skips lines, it does not skip the whole blob: a
+      // genuine explanation between the frames still reaches the user.
+      const withRealLine = [
+        "node:internal/process/task_queues:105",
+        "  throw err;",
+        "The judge could not parse the agent's reply.",
+        "    at processTicksAndRejections (node:internal/process/task_queues:105:5)",
+      ].join("\n");
+      expect(classifyScenarioInfraError(withRealLine).message).toBe(
+        "The judge could not parse the agent's reply.",
+      );
     });
   });
 

--- a/platform/app/src/server/scenarios/scenario-infra-error.ts
+++ b/platform/app/src/server/scenarios/scenario-infra-error.ts
@@ -105,7 +105,7 @@ function extractProviderMessage(raw: string): string | undefined {
  * path like `node:internal/modules/cjs/loader:1520` — which is what the
  * fallback used to show for a runner that failed to boot.
  */
-const NOISE_LINE_PATTERNS: RegExp[] = [
+const NOISE_LINE_PATTERNS = [
   /^at\s/,
   /^node:/,
   /^\^+$/,
@@ -116,7 +116,7 @@ const NOISE_LINE_PATTERNS: RegExp[] = [
   /^-\s*[/\\]\S*$/,
   /^[/\\][^\s]*$/,
   /^Node\.js\s+v?\d/i,
-];
+] as const;
 
 /** True when a line is pure runtime noise rather than a human explanation. */
 function isNoiseLine(line: string): boolean {
@@ -141,7 +141,7 @@ function isNoiseLine(line: string): boolean {
  * status, the URL, the request id and their own error body to hide nothing.
  * A path is only an internal when it is ours.
  */
-const INTERNALS_PATTERNS: RegExp[] = [
+const INTERNALS_PATTERNS = [
   /\bnode:[a-z_]+/,
   // `at Foo (…)` and `at async Foo.bar (…)` — the async form has an extra
   // token, which a fixed `\S+\s+\(` shape missed.
@@ -150,7 +150,7 @@ const INTERNALS_PATTERNS: RegExp[] = [
   /(?:^|[\s'"(/\\])(?:dist|node_modules)[/\\]/,
   /\bscenario-child-process\b/,
   /\.cjs\b/,
-];
+] as const;
 
 /** True when a candidate message would expose our internals to the user. */
 function exposesInternals(message: string): boolean {
@@ -244,7 +244,7 @@ const NODE_CRASH_MARKERS = [
   "node:internal/modules",
   "Require stack:",
   "at Module._",
-];
+] as const;
 
 /**
  * The wrapper `scenario.processor.ts` puts on a child that exited non-zero
@@ -413,8 +413,10 @@ export function classifyScenarioInfraError(
   }
 
   for (const rule of CLASSIFICATION_RULES) {
-    const hit = rule.needles.some((needle) => contains(text, needle));
-    if (hit && (rule.alsoRequires?.(text) ?? true)) {
+    const hasMatchingNeedle = rule.needles.some((needle) =>
+      contains(text, needle),
+    );
+    if (hasMatchingNeedle && (rule.alsoRequires?.(text) ?? true)) {
       return rule.build(text);
     }
   }

--- a/platform/app/src/server/scenarios/scenario-infra-error.ts
+++ b/platform/app/src/server/scenarios/scenario-infra-error.ts
@@ -57,8 +57,18 @@ export interface ScenarioErrorEnvelope {
 /** Longest message we keep for the generic fallback; raw dumps get trimmed. */
 const MAX_GENERIC_MESSAGE_LENGTH = 300;
 
-/** Shown when the raw error is empty, or is nothing but runtime noise. */
+/** Shown when there is no raw error at all — nothing ever reported a reason. */
 const GENERIC_FAILURE_MESSAGE = "The simulation failed before it could run.";
+
+/**
+ * Shown when there IS a raw error but none of it can be shown safely.
+ *
+ * Deliberately not GENERIC_FAILURE_MESSAGE: that one asserts the run never
+ * started, which is false for a failure suppressed mid-run and lands in the
+ * verdict a customer reads. A vaguer true sentence beats a precise false one.
+ */
+const UNREADABLE_FAILURE_MESSAGE =
+  "The simulation failed, but it didn't report a reason we can show.";
 
 /** Case-insensitive substring test that tolerates undefined. */
 function contains(haystack: string, needle: string): boolean {
@@ -101,7 +111,9 @@ const NOISE_LINE_PATTERNS: RegExp[] = [
   /^\^+$/,
   /^throw\s/,
   /^Require stack:/i,
-  /^-\s*[/\\]/,
+  // A `Require stack:` entry is a bare path and nothing else. Without the
+  // end anchor this also ate prose bullets like "- /webhooks/agent is down".
+  /^-\s*[/\\]\S*$/,
   /^[/\\][^\s]*$/,
   /^Node\.js\s+v?\d/i,
 ];
@@ -112,19 +124,32 @@ function isNoiseLine(line: string): boolean {
 }
 
 /**
- * Anything that betrays where our code lives or how it is built: an
- * interpreter source location, a stack frame, or an absolute filesystem path.
+ * Anything that betrays where OUR code lives or how it is built: an
+ * interpreter source location, a stack frame, our container root, or our build
+ * tree and bundle filenames.
  *
  * This is the final guard on the generic bucket — the line filter above works
  * by enumeration, and enumeration always lags the next crash shape, so a
- * candidate that still matches here is dropped for the generic sentence rather
- * than shown. The path pattern needs the slash to start the line or follow
- * whitespace/a quote, which is why a URL's `https://host/v1/x` never trips it.
+ * candidate that still matches here is dropped for a generic sentence rather
+ * than shown.
+ *
+ * These name our own artefacts deliberately. An earlier cut matched ANY
+ * two-segment slash path, which also swallowed the single most diagnostic
+ * string the runner produces — the HTTP adapter's
+ * `HTTP 502: … from <url> (request-id: …): <body>` (http-agent.adapter.ts).
+ * That line is all the customer's own data, so suppressing it cost them the
+ * status, the URL, the request id and their own error body to hide nothing.
+ * A path is only an internal when it is ours.
  */
 const INTERNALS_PATTERNS: RegExp[] = [
-  /node:internal/,
-  /\bat\s+\S+\s+\(/,
-  /(?:^|[\s'"(])[/\\][\w.-]+[/\\][\w.-]+/,
+  /\bnode:[a-z_]+/,
+  // `at Foo (…)` and `at async Foo.bar (…)` — the async form has an extra
+  // token, which a fixed `\S+\s+\(` shape missed.
+  /\bat\s+(?:async\s+)?\S+\s*\(/,
+  /(?:^|[\s'"(])\/app\//,
+  /(?:^|[\s'"(/\\])(?:dist|node_modules)[/\\]/,
+  /\bscenario-child-process\b/,
+  /\.cjs\b/,
 ];
 
 /** True when a candidate message would expose our internals to the user. */
@@ -132,29 +157,55 @@ function exposesInternals(message: string): boolean {
   return INTERNALS_PATTERNS.some((pattern) => pattern.test(message));
 }
 
+/** Net bracket depth a line opens (negative when it closes more than it opens). */
+function bracketDelta(line: string): number {
+  return (
+    (line.match(/[{[]/g)?.length ?? 0) - (line.match(/[}\]]/g)?.length ?? 0)
+  );
+}
+
 /**
  * The first line of a crash dump that reads as a human explanation.
  *
  * Node prints the error's own properties as a brace block under the stack
  * (`{ code: 'MODULE_NOT_FOUND', requireStack: [ '/app/…' ] }`). Skipping only
- * the opening brace would leave its inner lines as candidates, so depth is
- * tracked and the block skipped whole.
+ * the opening brace would leave its inner lines as candidates, so the block is
+ * skipped whole by depth.
+ *
+ * A block opens ONLY on a line that starts with `{`, which is how Node prints
+ * it. Counting brackets on every line instead let a stray `[` in prose — or
+ * the truncated JSON the HTTP adapter's body preview can emit — open a block
+ * that never closed, swallowing the real sentence underneath it.
  */
 function findMeaningfulLine(text: string): string | undefined {
+  const lines = text.split("\n").map((line) => line.trim());
+
   let depth = 0;
-  for (const rawLine of text.split("\n")) {
-    const line = rawLine.trim();
-    const insideBlock = depth > 0;
-    depth = Math.max(
-      0,
-      depth +
-        (line.match(/[{[]/g)?.length ?? 0) -
-        (line.match(/[}\]]/g)?.length ?? 0),
-    );
-    if (insideBlock || line.startsWith("{") || line.length === 0) continue;
-    if (!isNoiseLine(line)) return line;
+  let endedInsideBlock = false;
+  for (const line of lines) {
+    if (depth > 0) {
+      depth = Math.max(0, depth + bracketDelta(line));
+      endedInsideBlock = depth > 0;
+      continue;
+    }
+    if (line.startsWith("{")) {
+      depth = Math.max(0, bracketDelta(line));
+      endedInsideBlock = depth > 0;
+      continue;
+    }
+    if (line.length === 0 || isNoiseLine(line)) continue;
+    return line;
   }
-  return undefined;
+
+  // A block that never closed ate the rest of the dump. That happens for real:
+  // the HTTP adapter truncates response bodies mid-string, so unbalanced JSON
+  // arrives as a matter of course. Rescan without depth — still skipping lines
+  // that open an object, so a balanced block's innards can't surface — rather
+  // than lose a genuine sentence sitting under the truncation.
+  if (!endedInsideBlock) return undefined;
+  return lines.find(
+    (line) => line.length > 0 && !line.startsWith("{") && !isNoiseLine(line),
+  );
 }
 
 /**
@@ -188,26 +239,39 @@ interface ClassificationRule {
   build: (text: string) => ScenarioErrorEnvelope;
 }
 
-/**
- * Markers that only an uncaught Node crash prints: a loader frame, the
- * `Require stack:` list, or an internal module frame.
- *
- * The module-resolution words on their own don't identify the process that
- * died — a customer's own Node agent can fail with `Cannot find module` and
- * have that text surface through the adapter. Telling them "this is a fault on
- * our side" would then be worse than saying nothing, so the runner rule needs
- * one of these too, and a bare sentence falls through to the generic bucket
- * where the customer's own text is passed on unchanged.
- */
+/** Markers that only an uncaught Node crash prints. */
 const NODE_CRASH_MARKERS = [
   "node:internal/modules",
   "Require stack:",
   "at Module._",
 ];
 
-/** True when the blob is a Node process's own crash dump. */
-function isNodeCrashDump(text: string): boolean {
-  return NODE_CRASH_MARKERS.some((marker) => contains(text, marker));
+/**
+ * The wrapper `scenario.processor.ts` puts on a child that exited non-zero
+ * WITHOUT reporting a structured error — which is exactly the case where our
+ * own runner died before it could say anything. When the runner does report
+ * (an adapter failure, a judge error), its own text is used and this wrapper
+ * never appears.
+ */
+const CHILD_EXIT_WRAPPER = /Child process exited with code \d+/i;
+
+/**
+ * True when OUR runner process died in Node's module loader.
+ *
+ * Both halves are load-bearing. A Node crash dump says a Node process failed
+ * to load something, not WHICH process: `http-agent.adapter.ts` embeds the
+ * customer's HTTP response body verbatim in the error it throws, so a customer
+ * agent that boots with its own `Cannot find module` — stack frames,
+ * `Require stack:` and all — reaches this classifier looking identical.
+ * Claiming "the fault is on our side" for their missing dependency would send
+ * them looking in the wrong place, so the crash must ALSO carry the wrapper
+ * only our own dead child gets.
+ */
+function isOurRunnerCrash(text: string): boolean {
+  return (
+    CHILD_EXIT_WRAPPER.test(text) &&
+    NODE_CRASH_MARKERS.some((marker) => contains(text, marker))
+  );
 }
 
 /**
@@ -296,7 +360,7 @@ const CLASSIFICATION_RULES: ClassificationRule[] = [
       "ERR_REQUIRE_ESM",
       "ERR_DLOPEN_FAILED",
     ],
-    alsoRequires: isNodeCrashDump,
+    alsoRequires: isOurRunnerCrash,
     build: () => ({
       code: ScenarioInfraErrorCode.RunnerUnavailable,
       message:
@@ -357,7 +421,7 @@ export function classifyScenarioInfraError(
 
   return {
     code: ScenarioInfraErrorCode.Infra,
-    message: summarize(text) ?? GENERIC_FAILURE_MESSAGE,
+    message: summarize(text) ?? UNREADABLE_FAILURE_MESSAGE,
   };
 }
 

--- a/platform/app/src/server/scenarios/scenario-infra-error.ts
+++ b/platform/app/src/server/scenarios/scenario-infra-error.ts
@@ -33,6 +33,8 @@ export const ScenarioInfraErrorCode = {
   ModelToolReasoningConflict: "scenario_model_tool_reasoning_conflict",
   /** The run exceeded its time budget. */
   ExecutionTimeout: "scenario_execution_timeout",
+  /** The runner process itself couldn't boot (a broken build or deployment). */
+  RunnerUnavailable: "scenario_runner_unavailable",
   /** Anything else that failed at the infrastructure level. */
   Infra: "scenario_infra_error",
 } as const;
@@ -54,6 +56,9 @@ export interface ScenarioErrorEnvelope {
 
 /** Longest message we keep for the generic fallback; raw dumps get trimmed. */
 const MAX_GENERIC_MESSAGE_LENGTH = 300;
+
+/** Shown when the raw error is empty, or is nothing but runtime noise. */
+const GENERIC_FAILURE_MESSAGE = "The simulation failed before it could run.";
 
 /** Case-insensitive substring test that tolerates undefined. */
 function contains(haystack: string, needle: string): boolean {
@@ -80,21 +85,93 @@ function extractProviderMessage(raw: string): string | undefined {
 }
 
 /**
+ * Lines that carry no meaning for a user and expose our internals: stack
+ * frames, the interpreter's own source locations, the `throw err; ^` preamble
+ * Node prints above an uncaught throw, `Require stack:` path lists, and the
+ * trailing runtime-version footer.
+ *
+ * The generic fallback picks the first line that survives this filter, so an
+ * unclassified crash dump degrades to a plain sentence rather than leaking a
+ * path like `node:internal/modules/cjs/loader:1520` — which is what the
+ * fallback used to show for a runner that failed to boot.
+ */
+const NOISE_LINE_PATTERNS: RegExp[] = [
+  /^at\s/,
+  /^node:/,
+  /^\^+$/,
+  /^throw\s/,
+  /^Require stack:/i,
+  /^-\s*[/\\]/,
+  /^[/\\][^\s]*$/,
+  /^Node\.js\s+v?\d/i,
+];
+
+/** True when a line is pure runtime noise rather than a human explanation. */
+function isNoiseLine(line: string): boolean {
+  return NOISE_LINE_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+/**
+ * Anything that betrays where our code lives or how it is built: an
+ * interpreter source location, a stack frame, or an absolute filesystem path.
+ *
+ * This is the final guard on the generic bucket — the line filter above works
+ * by enumeration, and enumeration always lags the next crash shape, so a
+ * candidate that still matches here is dropped for the generic sentence rather
+ * than shown. The path pattern needs the slash to start the line or follow
+ * whitespace/a quote, which is why a URL's `https://host/v1/x` never trips it.
+ */
+const INTERNALS_PATTERNS: RegExp[] = [
+  /node:internal/,
+  /\bat\s+\S+\s+\(/,
+  /(?:^|[\s'"(])[/\\][\w.-]+[/\\][\w.-]+/,
+];
+
+/** True when a candidate message would expose our internals to the user. */
+function exposesInternals(message: string): boolean {
+  return INTERNALS_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/**
+ * The first line of a crash dump that reads as a human explanation.
+ *
+ * Node prints the error's own properties as a brace block under the stack
+ * (`{ code: 'MODULE_NOT_FOUND', requireStack: [ '/app/…' ] }`). Skipping only
+ * the opening brace would leave its inner lines as candidates, so depth is
+ * tracked and the block skipped whole.
+ */
+function findMeaningfulLine(text: string): string | undefined {
+  let depth = 0;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    const insideBlock = depth > 0;
+    depth = Math.max(
+      0,
+      depth +
+        (line.match(/[{[]/g)?.length ?? 0) -
+        (line.match(/[}\]]/g)?.length ?? 0),
+    );
+    if (insideBlock || line.startsWith("{") || line.length === 0) continue;
+    if (!isNoiseLine(line)) return line;
+  }
+  return undefined;
+}
+
+/**
  * Collapse a raw error blob (often a multi-line child-process dump) into a
  * single concise line: strip the "Child process exited with code N:" wrapper
- * and any JSON-log noise, keep the first meaningful line, and cap the length.
+ * and any runtime noise, keep the first meaningful line, and cap the length.
+ *
+ * Returns undefined when nothing but noise is left, so the caller falls back to
+ * a generic sentence instead of surfacing a stack frame.
  */
-function summarize(raw: string): string {
+function summarize(raw: string): string | undefined {
   const withoutWrapper = raw
     .replace(/^Child process exited with code \d+:\s*/i, "")
     .trim();
-  const firstMeaningfulLine =
-    withoutWrapper
-      .split("\n")
-      .map((line) => line.trim())
-      .find((line) => line.length > 0 && !line.startsWith("{")) ??
-    withoutWrapper;
-  const collapsed = firstMeaningfulLine.replace(/\s+/g, " ").trim();
+  const meaningful = findMeaningfulLine(withoutWrapper);
+  if (!meaningful || exposesInternals(meaningful)) return undefined;
+  const collapsed = meaningful.replace(/\s+/g, " ").trim();
   if (collapsed.length <= MAX_GENERIC_MESSAGE_LENGTH) return collapsed;
   return `${collapsed.slice(0, MAX_GENERIC_MESSAGE_LENGTH - 1).trimEnd()}…`;
 }
@@ -102,8 +179,35 @@ function summarize(raw: string): string {
 interface ClassificationRule {
   /** Any one of these appearing in the raw error selects this rule. */
   needles: string[];
+  /**
+   * Optional second condition — the rule then needs a needle AND this. Used
+   * where the needle words alone don't say whose process actually failed.
+   */
+  alsoRequires?: (text: string) => boolean;
   /** Build the envelope for a matched raw error. */
   build: (text: string) => ScenarioErrorEnvelope;
+}
+
+/**
+ * Markers that only an uncaught Node crash prints: a loader frame, the
+ * `Require stack:` list, or an internal module frame.
+ *
+ * The module-resolution words on their own don't identify the process that
+ * died — a customer's own Node agent can fail with `Cannot find module` and
+ * have that text surface through the adapter. Telling them "this is a fault on
+ * our side" would then be worse than saying nothing, so the runner rule needs
+ * one of these too, and a bare sentence falls through to the generic bucket
+ * where the customer's own text is passed on unchanged.
+ */
+const NODE_CRASH_MARKERS = [
+  "node:internal/modules",
+  "Require stack:",
+  "at Module._",
+];
+
+/** True when the blob is a Node process's own crash dump. */
+function isNodeCrashDump(text: string): boolean {
+  return NODE_CRASH_MARKERS.some((marker) => contains(text, marker));
 }
 
 /**
@@ -177,6 +281,30 @@ const CLASSIFICATION_RULES: ClassificationRule[] = [
     },
   },
   {
+    // The runner process died before it could run anything — a module missing
+    // from the production bundle, a native addon that won't load, an ESM/CJS
+    // mismatch. Always our deployment, never the customer's scenario, so the
+    // copy says so plainly instead of dumping the loader's stack. The build
+    // gate in scripts/build-server.mjs is what stops the common cause (an
+    // external require that isn't declared in dependencies) from shipping;
+    // this rule is the user-facing half for anything that still gets through.
+    needles: [
+      "MODULE_NOT_FOUND",
+      "ERR_MODULE_NOT_FOUND",
+      "Cannot find module",
+      "Cannot find package",
+      "ERR_REQUIRE_ESM",
+      "ERR_DLOPEN_FAILED",
+    ],
+    alsoRequires: isNodeCrashDump,
+    build: () => ({
+      code: ScenarioInfraErrorCode.RunnerUnavailable,
+      message:
+        "The simulation runner couldn't start, so the scenario never ran.",
+      hint: "This is a fault on our side, not a problem with your scenario. Retry the run, and contact support if it keeps happening.",
+    }),
+  },
+  {
     needles: ["timed out", "ETIMEDOUT"],
     build: () => ({
       code: ScenarioInfraErrorCode.ExecutionTimeout,
@@ -216,19 +344,20 @@ export function classifyScenarioInfraError(
   if (text.length === 0) {
     return {
       code: ScenarioInfraErrorCode.Infra,
-      message: "The simulation failed before it could run.",
+      message: GENERIC_FAILURE_MESSAGE,
     };
   }
 
   for (const rule of CLASSIFICATION_RULES) {
-    if (rule.needles.some((needle) => contains(text, needle))) {
+    const hit = rule.needles.some((needle) => contains(text, needle));
+    if (hit && (rule.alsoRequires?.(text) ?? true)) {
       return rule.build(text);
     }
   }
 
   return {
     code: ScenarioInfraErrorCode.Infra,
-    message: summarize(text),
+    message: summarize(text) ?? GENERIC_FAILURE_MESSAGE,
   };
 }
 
@@ -333,6 +462,8 @@ export function scenarioErrorTitle(code: ScenarioInfraErrorCode): string {
       return "Judge model configuration conflict";
     case ScenarioInfraErrorCode.ExecutionTimeout:
       return "Simulation timed out";
+    case ScenarioInfraErrorCode.RunnerUnavailable:
+      return "Simulation runner unavailable";
     case ScenarioInfraErrorCode.Infra:
       return "Simulation failed";
     default: {

--- a/specs/scenarios/scenario-infra-error-surfacing.feature
+++ b/specs/scenarios/scenario-infra-error-surfacing.feature
@@ -56,33 +56,46 @@ Feature: Scenario infrastructure error surfacing and empty-response state
   # A runner that can't boot — a module missing from the production bundle, a
   # native addon that won't load, an ESM/CJS mismatch — used to reach the user
   # as Node's raw loader dump: the interpreter's own source path, the stack
-  # frames, and the absolute path of our bundle inside the container. The cause
-  # is always our deployment, never the customer's scenario, so it gets a named
-  # code that says exactly that.
+  # frames, and the absolute path of our bundle inside the container. When the
+  # process that died is ours, the cause is our deployment rather than the
+  # customer's scenario, so it gets a named code that says exactly that.
   @unit
   Scenario: A runner that fails to boot becomes a named runner-unavailable error
-    Given a scenario run failed with Node's module-loader crash dump
+    Given a scenario run whose own child process died with Node's module-loader crash dump
     When the failure is classified
     Then the handled error code is "scenario_runner_unavailable"
     And the message does not contain a raw stack trace
     And the message does not name an internal file path
     And the hint says the fault is on our side
 
-  # The module-resolution wording alone doesn't say whose process died: a
-  # customer's own Node agent can fail the same way and have the text reach us
-  # through the adapter. Blaming our deployment would send them looking in the
-  # wrong place, so the runner code needs an actual Node crash dump around it.
+  # A Node crash dump says a Node process failed to load something, not WHICH
+  # process. The HTTP adapter embeds the customer's response body verbatim, so
+  # an agent that boots with its own missing dependency arrives looking
+  # identical — frames, require stack and all. Only our own child carries the
+  # runner's exit wrapper, and that is what separates the two. Claiming the
+  # fault is ours would send them looking anywhere but their own code.
   @unit
   Scenario: A customer's own module error is not blamed on our runner
-    Given a scenario run failed with an agent reply mentioning "Cannot find module" and no crash dump
+    Given an agent replied with its own module-loader crash and our runner exited cleanly
     When the failure is classified
-    Then the handled error code is "scenario_infra_error"
-    And the message keeps the agent's own wording
+    Then the handled error code is not "scenario_runner_unavailable"
+    And the hint does not claim the fault is on our side
+
+  # A path is only an internal when it is ours. Suppressing every path also
+  # suppressed the adapter's HTTP envelope — status, URL, request id and the
+  # agent's own error body — which is the most diagnostic thing a customer
+  # gets, and none of it ours to hide.
+  @unit
+  Scenario: The agent's own failure text survives the internals guard
+    Given a scenario run failed with an agent message naming a route or a path of its own
+    When the failure is classified
+    Then the message keeps the agent's own wording
 
   # Defence in depth for the generic bucket: even an unclassified crash must
   # never surface a stack frame, an interpreter source location, or a bundle
-  # path. When nothing but runtime noise is left, the user gets a plain
-  # sentence instead.
+  # path — including the bundle-relative ones that carry no leading slash.
+  # When nothing readable is left, the user gets a plain sentence that does not
+  # claim to know when the run failed.
   @unit
   Scenario: An unclassified crash dump degrades to a plain sentence
     Given a scenario run failed with a raw error containing only stack frames and interpreter paths
@@ -90,6 +103,7 @@ Feature: Scenario infrastructure error surfacing and empty-response state
     Then the handled error code is "scenario_infra_error"
     And the message does not contain a raw stack trace
     And the message does not name an internal file path
+    And the message does not claim the run failed before it started
 
   # A model pinned to the codex provider refused for the requesting feature
   # (issue #6634's coding-assistant-surfaces backstop, see

--- a/specs/scenarios/scenario-infra-error-surfacing.feature
+++ b/specs/scenarios/scenario-infra-error-surfacing.feature
@@ -53,6 +53,44 @@ Feature: Scenario infrastructure error surfacing and empty-response state
     Then the handled error code is "scenario_infra_error"
     And the message is "Something unexpected happened"
 
+  # A runner that can't boot — a module missing from the production bundle, a
+  # native addon that won't load, an ESM/CJS mismatch — used to reach the user
+  # as Node's raw loader dump: the interpreter's own source path, the stack
+  # frames, and the absolute path of our bundle inside the container. The cause
+  # is always our deployment, never the customer's scenario, so it gets a named
+  # code that says exactly that.
+  @unit
+  Scenario: A runner that fails to boot becomes a named runner-unavailable error
+    Given a scenario run failed with Node's module-loader crash dump
+    When the failure is classified
+    Then the handled error code is "scenario_runner_unavailable"
+    And the message does not contain a raw stack trace
+    And the message does not name an internal file path
+    And the hint says the fault is on our side
+
+  # The module-resolution wording alone doesn't say whose process died: a
+  # customer's own Node agent can fail the same way and have the text reach us
+  # through the adapter. Blaming our deployment would send them looking in the
+  # wrong place, so the runner code needs an actual Node crash dump around it.
+  @unit
+  Scenario: A customer's own module error is not blamed on our runner
+    Given a scenario run failed with an agent reply mentioning "Cannot find module" and no crash dump
+    When the failure is classified
+    Then the handled error code is "scenario_infra_error"
+    And the message keeps the agent's own wording
+
+  # Defence in depth for the generic bucket: even an unclassified crash must
+  # never surface a stack frame, an interpreter source location, or a bundle
+  # path. When nothing but runtime noise is left, the user gets a plain
+  # sentence instead.
+  @unit
+  Scenario: An unclassified crash dump degrades to a plain sentence
+    Given a scenario run failed with a raw error containing only stack frames and interpreter paths
+    When the failure is classified
+    Then the handled error code is "scenario_infra_error"
+    And the message does not contain a raw stack trace
+    And the message does not name an internal file path
+
   # A model pinned to the codex provider refused for the requesting feature
   # (issue #6634's coding-assistant-surfaces backstop, see
   # specs/model-providers/codex-account-provider.feature — "The server


### PR DESCRIPTION
## What

A customer report showed a simulation whose verdict `reasoning` was Node's raw module-loader dump — the interpreter's own source path, the stack frames, and the absolute path of our bundle inside the container:

```
Child process exited with code 1: node:internal/modules/cjs/loader:1520
  throw err;
Error: Cannot find module 'pino'
Require stack:
- /app/langwatch/langwatch/dist/scenario-child-process.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)
...
```

Two distinct problems: a missing module in the runner bundle, and that dump reaching the customer. This PR fixes the second.

| | before | after |
|---|---|---|
| title | Simulation failed | Simulation runner unavailable |
| reasoning | `node:internal/modules/cjs/loader:1520` | The simulation runner couldn't start, so the scenario never ran. |
| hint | — | This is a fault on our side, not a problem with your scenario. Retry the run, and contact support if it keeps happening. |

## Why the classifier didn't catch it

`classifyScenarioInfraError` already kept most raw dumps out of the drawer, but a runner that fails to boot matched none of its rules. The generic fallback then took the dump's first non-brace line — for a loader crash that is `node:internal/modules/cjs/loader:1520`. Internal, and useless to the reader.

## Changes

**A named `scenario_runner_unavailable` code** for a runner that can't start. The cause is our build or deployment, so the copy says that rather than inventing something for the user to fix.

It fires only when **our** process is the one that died. A Node crash dump says *a* Node process failed to load something, not *which*: `http-agent.adapter.ts:205` embeds the customer's HTTP response body verbatim in the error it throws, so an agent that boots with its own missing dependency arrives looking identical — frames, `Require stack:` and all. The discriminator is the `Child process exited with code N:` wrapper, which `scenario.processor.ts:591` adds only when our own child died without reporting anything. Telling a customer the fault is ours for their missing `stripe` would send them looking anywhere but their own code.

**The generic bucket no longer leaks.** It skips runtime noise (stack frames, interpreter locations, `Require stack:` lists, and the property block Node prints under the trace — tracked by brace depth, since skipping only the opening `{` left `code: 'MODULE_NOT_FOUND'` as a candidate). Anything still carrying an internal is dropped for a plain sentence.

The internals guard names **our artefacts** — `node:` locations, stack frames, `/app/`, `dist/`, `node_modules/`, `scenario-child-process`, `.cjs` — rather than matching path shape. An earlier cut matched any two-segment path and so also swallowed the adapter's `HTTP 502: … from <url> (request-id: …): <body>`: the status, URL, request id and the agent's own error body, all the customer's own data, suppressed to hide nothing. A path is only an internal when it is ours. Keying on artefacts also closes two leaks a shape-based pattern missed, both without a leading slash — bundle-relative frames, and `at async X (`.

**Two smaller correctness fixes:** a block opens only on a line starting with `{`, so a stray bracket in prose can't swallow the dump; and an unclosed block (the adapter truncates bodies mid-string) falls back to a bracket-blind rescan rather than losing a real sentence. The suppression fallback also got its own wording — reusing "failed before it could run" asserts the run never started, which is false for anything suppressed mid-run.

## The missing module itself

Already prevented, and the report predates the fix. Its path is `dist/scenario-child-process.js` — the pre-#6557 layout. Since #6557 the bundle is `dist/server/scenario-child-process.cjs` and `scripts/build-server.mjs` fails the build when any external require isn't declared in `dependencies`; `pino` is declared. A missing external is now a build error naming the package, not an image that dies at spawn.

## Testing

- `pnpm test:unit run src/server/scenarios src/components/simulations` — 47 files, 593 tests pass (1 skipped)
- The customer's blob is a verbatim fixture; the user-facing copy is pinned by assertion
- The misattribution case uses the adapter's real envelope shape, not a toy string
- `check:feature-parity` — 18/18 scenarios bound
- biome clean on both changed files

## Spec

`specs/scenarios/scenario-infra-error-surfacing.feature` gains four `@unit` scenarios: the runner-unavailable classification, the misattribution guard, the agent's-own-text-survives guard, and the generic-bucket degradation.
