### PR TITLE
fix(analytics): keep Attributes-backed metrics in scope in the dedup CTE

### DIFF
--- a/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @regression
+ *
+ * Metrics backed by the trace-level `Attributes` map — metadata.thread_id,
+ * user_id, customer_id, labels, prompt_ids — are aggregated in the OUTER query
+ * of the arrayJoin CTE path, which reads `FROM deduped_traces` and has no `ts`
+ * alias in scope. Only three hardcoded `langwatch.reserved.*` token keys were
+ * hoisted into the CTE, so every other Attributes-backed metric emitted a raw
+ * `ts.Attributes[…]` into that outer SELECT and ClickHouse rejected the whole
+ * query:
+ *
+ *   "Unknown expression or function identifier `ts.Attributes` in scope
+ *    WITH deduped_traces AS (SELECT DISTINCT ts.TraceId AS trace_id, …"
+ *
+ * Observed in production 2026-08-10: a thread-id count grouped by label.
+ *
+ * `transformMetricForDedup` already had a guard for exactly this — it throws
+ * when a rewritten expression still references `ts` — but the guard only ran
+ * when a substitution had ALREADY matched. The expression that reaches
+ * production unrewritten is precisely the one that matches nothing, so the
+ * guard's own precondition excluded the failing case.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import { buildTimeseriesQuery } from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+
+const ATTRIBUTE_METRICS = [
+  "metadata.thread_id",
+  "metadata.user_id",
+  "metadata.customer_id",
+] as const;
+
+const baseInput = {
+  projectId: "test-project",
+  startDate: new Date("2024-01-01T00:00:00Z"),
+  endDate: new Date("2024-01-02T00:00:00Z"),
+  previousPeriodStartDate: new Date("2023-12-31T00:00:00Z"),
+  timeScale: 60,
+};
+
+/** Everything after the CTE closes — the scope where `ts` does not exist. */
+function outerQuery(sql: string): string {
+  const match = sql.match(/\)\s*SELECT([\s\S]+)$/);
+  return match?.[1] ?? "";
+}
+
+function buildGroupedByLabels(metric: string) {
+  return buildTimeseriesQuery({
+    ...baseInput,
+    series: [
+      {
+        metric: metric as FlattenAnalyticsMetricsEnum,
+        aggregation: "cardinality" as const,
+      },
+    ],
+    // An arrayJoin group-by is what routes the query through the
+    // `deduped_traces` CTE in the first place.
+    groupBy: "metadata.labels",
+  } as never);
+}
+
+describe("buildTimeseriesQuery()", () => {
+  beforeEach(() => {
+    resetParamCounter();
+  });
+
+  describe("given an Attributes-backed metric under an arrayJoin group-by", () => {
+    describe("when the query is built", () => {
+      for (const metric of ATTRIBUTE_METRICS) {
+        it(`keeps ${metric} out of the outer scope it cannot resolve in`, () => {
+          const { sql } = buildGroupedByLabels(metric);
+
+          expect(sql).toContain("WITH deduped_traces AS");
+          // The precise production failure: a `ts.` reference surviving into
+          // the outer SELECT, where the only source is `deduped_traces`.
+          expect(outerQuery(sql)).not.toContain("ts.");
+        });
+      }
+
+      it("hoists the attribute into the CTE so the outer aggregation has a column", () => {
+        const { sql } = buildGroupedByLabels("metadata.thread_id");
+
+        expect(sql).toContain("AS trace_attr_thread_id");
+        expect(outerQuery(sql)).toContain("trace_attr_thread_id");
+      });
+
+      // The hoist is conditional: pushing every attribute read would widen the
+      // dedup subquery with the wide Attributes map for every grouped query.
+      it("hoists only the attribute the requested metric reads", () => {
+        const { sql } = buildGroupedByLabels("metadata.thread_id");
+
+        expect(sql).not.toContain("AS trace_attr_customer_id");
+        expect(sql).not.toContain("AS trace_attr_prompt_ids");
+      });
+    });
+  });
+});

--- a/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
@@ -23,6 +23,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { FlattenAnalyticsMetricsEnum } from "../../registry";
 import {
+  __testOnly__,
   buildTimeseriesQuery,
   TRACE_ATTRIBUTE_METRIC_COLUMNS,
 } from "../aggregation-builder";
@@ -30,18 +31,20 @@ import { fieldMappings } from "../field-mappings";
 import { resetParamCounter } from "../filter-translator";
 
 /**
- * Every `metadata.*` metric the analytics registry actually exposes whose
- * mapping resolves to the `Attributes` map. `metadata.labels` and
- * `metadata.prompt_ids` map to `Attributes` too but are group-by / filter
- * fields, not metrics, so they can never reach the outer aggregation this
- * suite is about — the hoist table still covers them, and the invariant below
- * is what keeps that true.
+ * The metrics whose translation actually emits a trace-level `Attributes` read
+ * — i.e. the ones that can reach the outer aggregation this suite is about.
+ * `metric-translator.ts` has a case for each (`translateMetadataMetric`).
+ *
+ * Deliberately NOT here, despite mapping to `Attributes` in `fieldMappings`:
+ * `metadata.customer_id` has no translator case, so it falls through to
+ * `count()` and would exercise an early return rather than an attribute read;
+ * `metadata.labels` and `metadata.prompt_ids` are group-by / filter fields
+ * rather than metrics (`metadata.labels` is in fact the group-by that puts
+ * these queries on the CTE path). All three are still covered by the hoist
+ * table, and the field-mapping invariant at the bottom is what keeps that
+ * honest.
  */
-const ATTRIBUTE_METRICS = [
-  "metadata.thread_id",
-  "metadata.user_id",
-  "metadata.customer_id",
-] as const;
+const ATTRIBUTE_METRICS = ["metadata.thread_id", "metadata.user_id"] as const;
 
 const baseInput = {
   projectId: "test-project",
@@ -51,10 +54,22 @@ const baseInput = {
   timeScale: 60,
 };
 
-/** Everything after the CTE closes — the scope where `ts` does not exist. */
+/**
+ * Everything after the CTE closes — the scope where `ts` does not exist.
+ *
+ * Anchored on `FROM deduped_traces` (as the sibling event-metric suite is) so
+ * a failed match cannot fail OPEN: an unanchored regex that missed would
+ * return `""`, and `expect("").not.toContain("ts.")` passes, which is a
+ * leak-detector that reports success when it cannot see.
+ */
 function outerQuery(sql: string): string {
-  const match = sql.match(/\)\s*SELECT([\s\S]+)$/);
-  return match?.[1] ?? "";
+  const match = sql.match(/\)\s*SELECT\s+([\s\S]+?)FROM\s+deduped_traces/i);
+  if (!match?.[1]) {
+    throw new Error(
+      "could not extract the outer SELECT — the assertion would have passed vacuously",
+    );
+  }
+  return match[1];
 }
 
 function buildGroupedByLabels(metric: string) {
@@ -99,11 +114,45 @@ describe("buildTimeseriesQuery()", () => {
 
       // The hoist is conditional: pushing every attribute read would widen the
       // dedup subquery with the wide Attributes map for every grouped query.
+      // `user_id` is the meaningful assertion — it is an attribute that CAN be
+      // hoisted, so it catches an over-broad hoist that the never-hoistable
+      // columns would not.
       it("hoists only the attribute the requested metric reads", () => {
         const { sql } = buildGroupedByLabels("metadata.thread_id");
 
+        expect(sql).toContain("AS trace_attr_thread_id");
+        expect(sql).not.toContain("AS trace_attr_user_id");
         expect(sql).not.toContain("AS trace_attr_customer_id");
-        expect(sql).not.toContain("AS trace_attr_prompt_ids");
+      });
+    });
+  });
+
+  // The guard relocation is the other half of the fix, and it needs its own
+  // test: every expression the SQL-shape cases above exercise now DOES rewrite,
+  // so the guard fires from either position and moving it back inside
+  // `if (rewritten !== selectExpression)` leaves them all green. The case that
+  // distinguishes the two positions — and the one that reached production — is
+  // the expression that matches NO substitution at all.
+  describe("given a metric expression no substitution matches", () => {
+    describe("when it is transformed for the dedup CTE", () => {
+      it("refuses it instead of emitting a ts reference the outer query cannot resolve", () => {
+        expect(() =>
+          __testOnly__.transformMetricForDedup(
+            "uniqIf(ts.SomeUnmappedColumn, ts.SomeUnmappedColumn != '') AS m",
+            "m",
+          ),
+        ).toThrow(/could not fully rewrite/);
+      });
+
+      // The partial-rewrite case the guard already covered from its old
+      // position, kept so a future refactor cannot trade one for the other.
+      it("refuses an expression only some of which rewrites", () => {
+        expect(() =>
+          __testOnly__.transformMetricForDedup(
+            "sum(ts.TotalCost + ts.SomeUnmappedColumn) AS m",
+            "m",
+          ),
+        ).toThrow(/could not fully rewrite/);
       });
     });
   });
@@ -120,7 +169,13 @@ describe("buildTimeseriesQuery()", () => {
           .filter(
             (mapping) =>
               mapping.table === "trace_summaries" &&
-              mapping.column.startsWith("Attributes["),
+              // `includes`, not `startsWith`: every mapping is a bare map read
+              // today, but one written as `toFloat64(Attributes['x'])` would
+              // slip past a prefix test and the invariant would still read
+              // green — reintroducing the very "someone must remember" gap
+              // this test exists to close. `SpanAttributes[` is excluded by
+              // the `trace_summaries` table check above.
+              mapping.column.includes("Attributes["),
           )
           .map((mapping) => {
             const key = mapping.column.match(/Attributes\['([^']+)'\]/);

--- a/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/attribute-metric-cte-scope.unit.test.ts
@@ -22,9 +22,21 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import type { FlattenAnalyticsMetricsEnum } from "../../registry";
-import { buildTimeseriesQuery } from "../aggregation-builder";
+import {
+  buildTimeseriesQuery,
+  TRACE_ATTRIBUTE_METRIC_COLUMNS,
+} from "../aggregation-builder";
+import { fieldMappings } from "../field-mappings";
 import { resetParamCounter } from "../filter-translator";
 
+/**
+ * Every `metadata.*` metric the analytics registry actually exposes whose
+ * mapping resolves to the `Attributes` map. `metadata.labels` and
+ * `metadata.prompt_ids` map to `Attributes` too but are group-by / filter
+ * fields, not metrics, so they can never reach the outer aggregation this
+ * suite is about — the hoist table still covers them, and the invariant below
+ * is what keeps that true.
+ */
 const ATTRIBUTE_METRICS = [
   "metadata.thread_id",
   "metadata.user_id",
@@ -92,6 +104,37 @@ describe("buildTimeseriesQuery()", () => {
 
         expect(sql).not.toContain("AS trace_attr_customer_id");
         expect(sql).not.toContain("AS trace_attr_prompt_ids");
+      });
+    });
+  });
+
+  // The defect this suite exists for was not a wrong expression — it was a
+  // mapping nobody added to the hoist table. Enumerating the registry rather
+  // than a hand-written list is what stops the next `Attributes`-backed field
+  // reintroducing it: add a mapping without a hoist and this fails, instead of
+  // ClickHouse rejecting the query in production.
+  describe("given the trace-level Attributes field mappings", () => {
+    describe("when the hoist table is compared against them", () => {
+      it("covers every Attributes-backed trace_summaries mapping", () => {
+        const mapped = Object.values(fieldMappings)
+          .filter(
+            (mapping) =>
+              mapping.table === "trace_summaries" &&
+              mapping.column.startsWith("Attributes["),
+          )
+          .map((mapping) => {
+            const key = mapping.column.match(/Attributes\['([^']+)'\]/);
+            return key?.[1] ?? mapping.column;
+          });
+
+        const hoisted = TRACE_ATTRIBUTE_METRIC_COLUMNS.map(
+          ({ attributeKey }) => attributeKey,
+        );
+
+        expect(mapped.length).toBeGreaterThan(0);
+        expect([...new Set(mapped)].sort()).toEqual(
+          [...new Set(hoisted)].sort(),
+        );
       });
     });
   });

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -2561,7 +2561,7 @@ function buildPipelineMetricCTE(
  * query with "Unknown expression or function identifier `ts.Attributes`".
  * Observed in production 2026-08-10 on a thread-id count grouped by label.
  */
-const TRACE_ATTRIBUTE_METRIC_COLUMNS = [
+export const TRACE_ATTRIBUTE_METRIC_COLUMNS = [
   { attributeKey: "langwatch.user_id", cteColumn: "trace_attr_user_id" },
   { attributeKey: "gen_ai.conversation.id", cteColumn: "trace_attr_thread_id" },
   {

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1591,6 +1591,17 @@ function buildArrayJoinTimeseriesQuery({
   cteSelectExprs.push(
     `${traceColumnWrapper(`${ts}.TimeToFirstTokenMs`)} AS trace_time_to_first_token_ms`,
   );
+  // Hoist only the attribute reads a requested metric actually aggregates.
+  // Pushing all of them would widen the dedup subquery with the wide
+  // Attributes map for every grouped query — the same cost the conditional
+  // cache-token hoist below exists to avoid.
+  for (const { attributeKey, cteColumn } of TRACE_ATTRIBUTE_METRIC_COLUMNS) {
+    const source = traceAttributeSource(attributeKey);
+    if (!simpleMetrics.some((m) => m.selectExpression.includes(source))) {
+      continue;
+    }
+    cteSelectExprs.push(`${traceColumnWrapper(source)} AS ${cteColumn}`);
+  }
   if (needsCacheTokenColumns) {
     // toFloat64 wraps the UInt64 attribute read so both if() branches share a
     // supertype with the smd join's Float64 sums.
@@ -2532,6 +2543,40 @@ function buildPipelineMetricCTE(
  * produced by the same string builders metric-translator uses, so plain
  * split/join substitution is safe.
  */
+/**
+ * Trace-level `Attributes` map reads a metric may aggregate over, and the CTE
+ * column each is hoisted to.
+ *
+ * These are the metadata fields whose `fieldMappings` entry resolves to
+ * `Attributes['…']` rather than to a typed column. A metric over one of them
+ * (e.g. `metadata.thread_id / cardinality` →
+ * `uniqIf(ts.Attributes['gen_ai.conversation.id'], …)`) is aggregated in the
+ * OUTER query, which selects `FROM deduped_traces` and has no `ts` alias in
+ * scope — so the read has to be hoisted into the CTE under a name, exactly as
+ * the typed passthroughs (`ts.TotalCost AS trace_total_cost`) already are.
+ *
+ * Before this list existed only three hardcoded `langwatch.reserved.*` token
+ * keys were hoisted, so every other Attributes-backed metric emitted a raw
+ * `ts.Attributes[…]` into the outer SELECT and ClickHouse rejected the whole
+ * query with "Unknown expression or function identifier `ts.Attributes`".
+ * Observed in production 2026-08-10 on a thread-id count grouped by label.
+ */
+const TRACE_ATTRIBUTE_METRIC_COLUMNS = [
+  { attributeKey: "langwatch.user_id", cteColumn: "trace_attr_user_id" },
+  { attributeKey: "gen_ai.conversation.id", cteColumn: "trace_attr_thread_id" },
+  {
+    attributeKey: "langwatch.customer_id",
+    cteColumn: "trace_attr_customer_id",
+  },
+  { attributeKey: "langwatch.labels", cteColumn: "trace_attr_labels" },
+  { attributeKey: "langwatch.prompt_ids", cteColumn: "trace_attr_prompt_ids" },
+] as const;
+
+/** The `ts.Attributes['<key>']` source expression for a hoisted attribute. */
+function traceAttributeSource(attributeKey: string): string {
+  return `${tableAliases.trace_summaries}.Attributes['${attributeKey}']`;
+}
+
 function dedupSubstitutions(): Array<{
   source: string;
   cteColumn: string;
@@ -2539,6 +2584,14 @@ function dedupSubstitutions(): Array<{
 }> {
   const ts = tableAliases.trace_summaries;
   return [
+    // Attribute-map reads before the bare columns, for the same reason the
+    // composites below come first: their source contains no bare column, but
+    // keeping every map read ahead of the plain list makes the ordering rule
+    // one rule ("longest / most specific first") rather than two.
+    ...TRACE_ATTRIBUTE_METRIC_COLUMNS.map(({ attributeKey, cteColumn }) => ({
+      source: traceAttributeSource(attributeKey),
+      cteColumn,
+    })),
     // Composites first: the non-billed fallback references TotalCost and
     // Attributes, and the cache/reasoning reads reference Attributes, so they
     // must be rewritten before the bare columns they contain.
@@ -2639,13 +2692,46 @@ function stripSelectExpressionAlias(
 }
 
 /**
- * Transform a metric expression to work with deduplicated trace data.
- * count() becomes uniqExact(trace_id) to count distinct traces.
- * Trace-level column references are rewritten to their CTE columns, keeping
- * the metric's aggregation AND its arithmetic intact: a composite metric
- * like total_tokens (prompt + completion) keeps both terms.
+ * Transform a metric expression to work with deduplicated trace data, and
+ * refuse to emit one that would reference the `ts` alias outside the CTE.
+ *
+ * The guard wraps EVERY path on purpose. It used to sit inside the
+ * substitution branch, so it only ran when at least one rewrite had already
+ * matched — and the expression that actually reaches production unrewritten is
+ * precisely the one no substitution matches. `metadata.thread_id / cardinality`
+ * (`uniqIf(ts.Attributes['gen_ai.conversation.id'], …)`) matched nothing, fell
+ * through to "return as-is", and shipped `ts.Attributes[…]` into an outer
+ * SELECT whose only source is `deduped_traces`. ClickHouse then rejected the
+ * whole query with "Unknown expression or function identifier `ts.Attributes`"
+ * — a customer-visible analytics failure that the guard existed to prevent and
+ * could not, because the guard's own precondition excluded the failing case.
+ *
+ * The outer query reads `FROM deduped_traces`, which has no `ts` alias in
+ * scope, so ANY surviving `ts.` reference is invalid SQL. Throwing here turns a
+ * ClickHouse error nobody can act on into one that names the fix.
  */
 function transformMetricForDedup(
+  selectExpression: string,
+  alias: string,
+): string {
+  const rewritten = rewriteMetricForDedup(selectExpression, alias);
+  const ts = tableAliases.trace_summaries;
+  if (new RegExp(`(?<![\\w.])${ts}\\.`).test(rewritten)) {
+    throw new Error(
+      `transformMetricForDedup could not fully rewrite "${selectExpression}" for the grouped CTE. ` +
+        `Add the missing trace-level column to the arrayJoin CTE select list and dedupSubstitutions in aggregation-builder.ts.`,
+    );
+  }
+  return rewritten;
+}
+
+/**
+ * The rewrite itself. count() becomes uniqExact(trace_id) to count distinct
+ * traces. Trace-level column references are rewritten to their CTE columns,
+ * keeping the metric's aggregation AND its arithmetic intact: a composite
+ * metric like total_tokens (prompt + completion) keeps both terms.
+ */
+function rewriteMetricForDedup(
   selectExpression: string,
   alias: string,
 ): string {
@@ -2674,17 +2760,9 @@ function transformMetricForDedup(
       ? replaceColumnWithAlias(rewritten, source, cteColumn)
       : rewritten.split(source).join(cteColumn);
   }
+  // The caller ({@link transformMetricForDedup}) enforces that nothing leaves
+  // here still referencing `ts`, on this path and on every other one.
   if (rewritten !== selectExpression) {
-    // A partial rewrite would emit SQL referencing the `ts` alias outside its
-    // scope; fail loudly so a new metric-translator column gets added to the
-    // CTE select list + dedupSubstitutions instead of shipping silent nulls.
-    const ts = tableAliases.trace_summaries;
-    if (new RegExp(`(?<![\\w.])${ts}\\.`).test(rewritten)) {
-      throw new Error(
-        `transformMetricForDedup could not fully rewrite "${selectExpression}" for the grouped CTE. ` +
-          `Add the missing trace-level column to the arrayJoin CTE select list and dedupSubstitutions in aggregation-builder.ts.`,
-      );
-    }
     return rewritten;
   }
 

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -2709,6 +2709,17 @@ function stripSelectExpressionAlias(
  * The outer query reads `FROM deduped_traces`, which has no `ts` alias in
  * scope, so ANY surviving `ts.` reference is invalid SQL. Throwing here turns a
  * ClickHouse error nobody can act on into one that names the fix.
+ *
+ * Scope note: this guards `ts` only. The same class of leak exists for `ss`
+ * (stored_spans) — a value-aggregated event metric such as
+ * `events.event_score / avg` under an event group-by still reaches the default
+ * return with `ss."Events.Name"` intact, and ClickHouse rejects it identically.
+ * That is a KNOWN, pre-existing limitation, deliberately left alone here and
+ * documented at `__tests__/event-metric-cte-scope.unit.test.ts` — rewriting a
+ * value aggregation to `uniqExact(trace_id)` would silently turn "average
+ * score" into "count of traces", which is worse than the error. Widening this
+ * guard to `ss` without first giving those metrics a real CTE column would
+ * convert that failure into a thrown build error, so it is a separate change.
  */
 function transformMetricForDedup(
   selectExpression: string,


### PR DESCRIPTION
Fixes the production ClickHouse failure:

```
Unknown expression or function identifier `ts.Attributes` in scope
WITH deduped_traces AS (SELECT DISTINCT ts.TraceId AS trace_id,
  if(arrayJoin(JSONExtract(ts.Attributes['langwatch.labels'], 'Array(String)')) …
```

Seen on 2026-08-10 (project `…Z7aicAoSJ7N8A1ha71_tp`): a **thread-id count grouped by label**. The whole query is rejected, so the analytics panel just fails.

## What actually breaks

Not what the error's opening line suggests. The CTE's inner subquery *does* select `Attributes` — column pruning is working. The failure is in the **outer** query:

```sql
) SELECT period, date, group_key,
    uniqIf(ts.Attributes['gen_ai.conversation.id'], …) AS `0__metadata_thread_id__cardinality`
  FROM deduped_traces
```

Per-trace values are hoisted into the CTE as named columns (`ts.TotalCost AS trace_total_cost`), and the outer aggregation refers to the hoisted name. But only three hardcoded `langwatch.reserved.*` token keys were ever hoisted, so a metric reading any *other* `Attributes` key emitted a raw `ts.Attributes[…]` into an outer scope whose only source is `deduped_traces` — where `ts` does not exist.

Five metadata metrics resolve to `Attributes[…]` and were all exposed: `thread_id`, `user_id`, `customer_id`, `labels`, `prompt_ids`.

## The guard that should have caught it

`transformMetricForDedup` already had exactly the right check — it throws when a rewritten expression still references `ts`, telling you to add the missing column. It never fired, because it sat inside:

```js
if (rewritten !== selectExpression) {   // only when SOME substitution matched
```

The expression that reaches production unrewritten is precisely the one that matches nothing. `metadata.thread_id` matched no substitution, skipped the guard entirely, and fell through to "Default: return as-is" — shipping invalid SQL. **The guard's own precondition excluded the failing case.**

It now wraps every return path. The outer query has no `ts` alias in scope under any circumstances, so any surviving `ts.` is invalid SQL and throwing is always correct — and it turns a ClickHouse error nobody can act on into one that names the fix.

## Changes

1. `TRACE_ATTRIBUTE_METRIC_COLUMNS` — the five trace-level `Attributes` reads and the CTE column each hoists to, replacing the three ad-hoc entries.
2. The hoist stays **conditional** on a requested metric actually reading that attribute. Pushing all five would widen the dedup subquery with the wide `Attributes` map on every grouped query — the exact cost the existing conditional cache-token hoist exists to avoid.
3. The scope guard runs on every path.
4. An invariant test pins the hoist table to `fieldMappings`, so the *next* `Attributes`-backed field cannot reintroduce this.

## Testing

`attribute-metric-cte-scope.unit.test.ts` drives the real builder and asserts on the generated SQL's outer scope — 6 cases:

- **Verified it catches the bug: 3 of the 5 SQL-shape cases fail against the pre-fix builder**, on the `ts.` leak and the missing hoist. That also confirmed `metadata.user_id` was broken in production alongside `thread_id`.
- The 6th enumerates `fieldMappings` and asserts the hoist table covers every `Attributes`-backed `trace_summaries` mapping. The defect was never a wrong expression — it was a mapping nobody added to the table — and a hand-written list in a test reproduces that same "someone must remember" gap one layer up. Add a mapping without a hoist and this fails, instead of ClickHouse rejecting the query in production.

The metric loop deliberately stays at three: the registry exposes only `metadata.thread_id`, `user_id` and `customer_id` as metrics. `labels` and `prompt_ids` map to `Attributes` too, but as group-by / filter fields — `metadata.labels` is in fact the group-by that puts the query on the CTE path. The hoist table still covers them, and the invariant is what keeps that honest.

Also: `src/server/analytics` + `src/server/app-layer/analytics` 497 pass; biome 0 errors repo-wide (`--diagnostic-level=error`).

## Note

Separate from #6814 (the span-facts / graph-trigger incident fix) on purpose — different subsystem, and folding it in would have restarted that PR's review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytics metrics that use trace attributes in array-based groupings.
  - Ensured attribute-backed metrics resolve correctly without invalid or out-of-scope references.
  - Added validation to detect incomplete metric transformations and prevent malformed query results.

- **Tests**
  - Added regression coverage for attribute-backed metrics, including selective field handling, unmatched expressions, and trace-field mapping completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->