### PR TITLE
feat(otlp): serve the paths a misconfigured exporter posts to

### DIFF
--- a/platform/app/src/server/api-router.ts
+++ b/platform/app/src/server/api-router.ts
@@ -199,9 +199,9 @@ export function createApiRouter() {
   api.route("/", authCliApp); // /api/auth/cli/* — RFC 8628 device-flow for CLI
   api.route("/", authApp);
   api.route("/", collectorApp);
-  // ORDERING: last of the ingestion apps. It claims the OTLP paths a
-  // misconfigured exporter produces, which overlap the /api/otel and
-  // /api/collector namespaces, so every real route must get its match first.
+  // ORDERING: must come after otelApp and collectorApp, whose namespaces its
+  // aliases overlap — the real routes get their match first. It declines
+  // anything it does not recognise, so apps mounted after it are unaffected.
   api.route("/", otelPathAliasApp);
   api.route("/", ingestionRoutesApp); // /api/ingest/* — Activity Monitor receivers
   api.route("/", cronApp);

--- a/platform/app/src/server/api-router.ts
+++ b/platform/app/src/server/api-router.ts
@@ -72,6 +72,7 @@ import { app as langyRelayApp } from "./routes/langy-relay";
 import { app as miscApp } from "./routes/misc";
 import { app as opsApp } from "./routes/ops";
 import { app as otelApp } from "./routes/otel";
+import { app as otelPathAliasApp } from "./routes/otel-path-aliases";
 import { app as playgroundApp } from "./routes/playground";
 import { app as rumApp } from "./routes/rum";
 import { app as scenarioGenerateApp } from "./routes/scenario-generate";
@@ -198,6 +199,10 @@ export function createApiRouter() {
   api.route("/", authCliApp); // /api/auth/cli/* — RFC 8628 device-flow for CLI
   api.route("/", authApp);
   api.route("/", collectorApp);
+  // ORDERING: last of the ingestion apps. It claims the OTLP paths a
+  // misconfigured exporter produces, which overlap the /api/otel and
+  // /api/collector namespaces, so every real route must get its match first.
+  api.route("/", otelPathAliasApp);
   api.route("/", ingestionRoutesApp); // /api/ingest/* — Activity Monitor receivers
   api.route("/", cronApp);
   api.route("/", evaluationsLegacyApp);

--- a/platform/app/src/server/otel/otlpPathCanonicalisation.ts
+++ b/platform/app/src/server/otel/otlpPathCanonicalisation.ts
@@ -1,0 +1,93 @@
+/**
+ * Maps the URLs a misconfigured OpenTelemetry exporter produces onto the
+ * canonical OTLP ingestion paths.
+ *
+ * An exporter builds its own URL: given a base endpoint it appends
+ * `/v1/traces`, `/v1/logs` or `/v1/metrics` itself. A customer who puts our
+ * signal-specific URL in the base setting therefore posts to
+ * `/api/otel/v1/traces/v1/logs`, and one who puts the collector URL there posts
+ * to `/api/collector/api/otel/v1/traces`. Both are seen in production, and the
+ * customer sees nothing at all — an exporter surfaces a 404 nowhere a human
+ * looks, so the telemetry just never arrives.
+ *
+ * The suffix decides the signal, never the base: the suffix is the part the
+ * exporter appended, so it is the part that describes the payload.
+ *
+ * See specs/otlp/endpoint-path-canonicalisation.feature.
+ */
+
+import { randomUUID } from "node:crypto";
+
+export const CANONICAL_OTLP_BASE_PATH = "/api/otel/v1";
+
+/** The suffix an exporter appends for each signal. */
+const SIGNAL_SUFFIX = /\/v1\/(traces|logs|metrics)$/;
+
+/**
+ * What a known misconfiguration leaves in front of that suffix, and nothing
+ * else. Deliberately an allow-list rather than "any path ending in a signal
+ * name": a permissive rule would quietly claim any future namespace that grows
+ * a `/v1/traces` of its own.
+ *
+ *   (empty)                       base endpoint was the site root
+ *   /api                          base endpoint was the API root
+ *   /api/otel                     the canonical path itself
+ *   /api/otel/v1/<signal>         base endpoint was a signal-specific URL
+ *   /api/collector[...]           base endpoint was the collector URL
+ */
+const RECOGNISED_PREFIX =
+  /^(?:\/api\/collector)?(?:\/api(?:\/otel(?:\/v1\/(?:traces|logs|metrics))?)?)?$/;
+
+/**
+ * The canonical ingestion path this URL is trying to reach, or null when the
+ * path is not an OTLP ingestion path at all.
+ *
+ * Returns the canonical path for an already-canonical input too, so callers
+ * decide what "needs correcting" means by comparing against the path they were
+ * given — `/api/otel/v1/traces/` differs from the canonical route while
+ * normalising to it.
+ */
+export function canonicalOtlpPath(pathname: string): string | null {
+  const normalised = pathname.replace(/\/{2,}/g, "/").replace(/(.)\/+$/, "$1");
+
+  const suffix = SIGNAL_SUFFIX.exec(normalised);
+  if (!suffix) return null;
+
+  const prefix = normalised.slice(0, normalised.length - suffix[0].length);
+  if (!RECOGNISED_PREFIX.test(prefix)) return null;
+
+  return `${CANONICAL_OTLP_BASE_PATH}/${suffix[1]}`;
+}
+
+export const OTLP_CORRECTED_PATH_HEADER = "x-langwatch-otlp-corrected-path";
+
+/**
+ * A corrected request is replayed through the canonical route as a new HTTP
+ * request, so the original path can only travel with it as a header — and a
+ * header is something the customer can send too. The value is prefixed with a
+ * per-process secret so the receiver can tell its own replay from a caller
+ * claiming one, and never reports a correction that did not happen.
+ */
+const CORRECTION_SECRET = randomUUID();
+
+export function stampCorrectedPath({
+  headers,
+  originalPath,
+}: {
+  headers: Headers;
+  originalPath: string;
+}): void {
+  headers.set(
+    OTLP_CORRECTED_PATH_HEADER,
+    `${CORRECTION_SECRET} ${originalPath}`,
+  );
+}
+
+/** The path the exporter actually used, or null if this was not our replay. */
+export function readCorrectedPath(value: string | undefined): string | null {
+  if (!value) return null;
+  const separator = value.indexOf(" ");
+  if (separator === -1) return null;
+  if (value.slice(0, separator) !== CORRECTION_SECRET) return null;
+  return value.slice(separator + 1) || null;
+}

--- a/platform/app/src/server/otel/otlpPathCanonicalisation.unit.test.ts
+++ b/platform/app/src/server/otel/otlpPathCanonicalisation.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * specs/otlp/endpoint-path-canonicalisation.feature — the path mapping itself.
+ * The routing that uses it is covered in
+ * routes/__tests__/otel.path-aliases.unit.test.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  canonicalOtlpPath,
+  readCorrectedPath,
+  stampCorrectedPath,
+} from "./otlpPathCanonicalisation";
+
+describe("canonicalOtlpPath", () => {
+  describe("given a base endpoint that already named a signal", () => {
+    /** @scenario An endpoint that already named a signal */
+    it("maps the appended signal onto its canonical path", () => {
+      expect(canonicalOtlpPath("/api/otel/v1/traces/v1/logs")).toBe(
+        "/api/otel/v1/logs",
+      );
+    });
+
+    /** @scenario A metrics suffix under a traces base is metric ingestion */
+    it("takes the signal from the suffix, not the base", () => {
+      expect(canonicalOtlpPath("/api/otel/v1/traces/v1/metrics")).toBe(
+        "/api/otel/v1/metrics",
+      );
+      expect(canonicalOtlpPath("/api/otel/v1/logs/v1/traces")).toBe(
+        "/api/otel/v1/traces",
+      );
+    });
+  });
+
+  describe("given a base endpoint that named the collector", () => {
+    /** @scenario An endpoint that named the collector */
+    it("maps the collector-prefixed path onto its canonical path", () => {
+      expect(canonicalOtlpPath("/api/collector/api/otel/v1/traces")).toBe(
+        "/api/otel/v1/traces",
+      );
+      expect(canonicalOtlpPath("/api/collector/v1/traces")).toBe(
+        "/api/otel/v1/traces",
+      );
+    });
+  });
+
+  describe("given a base endpoint that named a root", () => {
+    /** @scenario An endpoint that named the site root */
+    it("maps a root-level signal path onto its canonical path", () => {
+      expect(canonicalOtlpPath("/v1/traces")).toBe("/api/otel/v1/traces");
+      expect(canonicalOtlpPath("/api/v1/traces")).toBe("/api/otel/v1/traces");
+    });
+  });
+
+  describe("given a path that is already canonical", () => {
+    it("reports the canonical path it is on", () => {
+      expect(canonicalOtlpPath("/api/otel/v1/traces")).toBe(
+        "/api/otel/v1/traces",
+      );
+    });
+
+    /** @scenario An endpoint with a stray trailing slash */
+    it("normalises stray slashes to it", () => {
+      expect(canonicalOtlpPath("/api/otel/v1/traces/")).toBe(
+        "/api/otel/v1/traces",
+      );
+      expect(canonicalOtlpPath("/api/otel/v1//traces")).toBe(
+        "/api/otel/v1/traces",
+      );
+    });
+  });
+
+  describe("given a path no misconfiguration produces", () => {
+    /** @scenario An unrelated path that happens to end in a signal name */
+    it("claims nothing outside the recognised prefixes", () => {
+      expect(canonicalOtlpPath("/api/gateway/v1/traces")).toBeNull();
+      expect(canonicalOtlpPath("/api/rum/v1/traces")).toBeNull();
+      expect(
+        canonicalOtlpPath("/api/ingest/otel/src_123/v1/traces"),
+      ).toBeNull();
+    });
+
+    /** @scenario A path naming something other than a signal */
+    it("claims nothing whose suffix is not a signal", () => {
+      expect(canonicalOtlpPath("/api/otel/v1/traces/v1/profiles")).toBeNull();
+      expect(canonicalOtlpPath("/api/otel/v1/traces/v2/traces")).toBeNull();
+      expect(canonicalOtlpPath("/api/collector")).toBeNull();
+      expect(canonicalOtlpPath("/")).toBeNull();
+    });
+  });
+});
+
+describe("the corrected-path marker", () => {
+  /** @scenario The correction names the path the exporter used */
+  it("carries the path the exporter used back to the receiver", () => {
+    const headers = new Headers();
+    stampCorrectedPath({
+      headers,
+      originalPath: "/api/otel/v1/traces/v1/logs",
+    });
+
+    expect(
+      readCorrectedPath(
+        headers.get("x-langwatch-otlp-corrected-path") ?? void 0,
+      ),
+    ).toBe("/api/otel/v1/traces/v1/logs");
+  });
+
+  describe("when the caller supplies the header itself", () => {
+    /** @scenario A caller cannot claim its path was corrected */
+    it("discards a marker this process did not write", () => {
+      expect(readCorrectedPath("/api/otel/v1/traces/v1/logs")).toBeNull();
+      expect(
+        readCorrectedPath(
+          "00000000-0000-0000-0000-000000000000 /api/otel/v1/traces/v1/logs",
+        ),
+      ).toBeNull();
+      expect(readCorrectedPath(void 0)).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
@@ -231,17 +231,65 @@ describe("OTLP endpoint path canonicalisation", () => {
       });
     });
 
+    // Each reporting test uses a path of its own: the report is throttled per
+    // (project, path) pair for ten minutes, and that state outlives a single
+    // test the way it outlives a single request.
     /** @scenario The correction names the path the exporter used */
     it("records the path the exporter used and the one it was served from", async () => {
-      await post("/api/otel/v1/traces/v1/logs", logPayload);
+      await post("/api/collector/v1/logs", logPayload);
 
       expect(mockWarn).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId: "project-123",
-          originalPath: "/api/otel/v1/traces/v1/logs",
+          originalPath: "/api/collector/v1/logs",
           canonicalPath: "/api/otel/v1/logs",
         }),
         expect.stringContaining("non-canonical path"),
+      );
+    });
+
+    /** @scenario A repeated misconfiguration is reported once a window */
+    it("reports a repeated misconfiguration once, not once per batch", async () => {
+      await post("/api/otel/v1/metrics/v1/logs", logPayload);
+      await post("/api/otel/v1/metrics/v1/logs", logPayload);
+      await post("/api/otel/v1/metrics/v1/logs", logPayload);
+
+      expect(mockHandleLogs).toHaveBeenCalledTimes(3);
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+    });
+
+    // The correction rebuilds the request around a new path, and an exporter
+    // streams rather than buffers. A body dropped there would be answered with
+    // a cheerful 200 - the exact failure this feature exists to remove.
+    /** @scenario A streamed payload survives the correction */
+    it("carries a streamed payload through to ingestion", async () => {
+      const streamed: RequestInit & { duplex: "half" } = {
+        method: "POST",
+        headers: {
+          "X-Auth-Token": "test-token",
+          "Content-Type": "application/json",
+        },
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(JSON.stringify(tracePayload)),
+            );
+            controller.close();
+          },
+        }),
+        duplex: "half",
+      };
+
+      const response = await testApp.request(
+        new Request("http://localhost/api/v1/traces", streamed),
+      );
+
+      expect(response.status).toBe(200);
+      // An empty body short-circuits before the handler with "No traces to
+      // process", so reaching it at all proves the bytes survived the replay.
+      expect(mockHandleTraces).toHaveBeenCalledTimes(1);
+      expect(mockHandleTraces.mock.calls[0]?.[1]).toEqual(
+        expect.objectContaining({ resourceSpans: tracePayload.resourceSpans }),
       );
     });
   });

--- a/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
@@ -106,11 +106,15 @@ const metricPayload = {
   ],
 };
 
-function post(
-  path: string,
-  payload: unknown,
-  headers: Record<string, string> = {},
-) {
+function post({
+  path,
+  payload,
+  headers = {},
+}: {
+  path: string;
+  payload: unknown;
+  headers?: Record<string, string>;
+}) {
   return testApp.request(`http://localhost${path}`, {
     method: "POST",
     headers: {
@@ -148,7 +152,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("given an exporter configured with a signal URL as its base", () => {
     /** @scenario An endpoint that already named a signal */
     it("serves the doubled path as the signal the exporter appended", async () => {
-      const response = await post("/api/otel/v1/traces/v1/logs", logPayload);
+      const response = await post({
+        path: "/api/otel/v1/traces/v1/logs",
+        payload: logPayload,
+      });
 
       expect(response.status).toBe(200);
       expect(mockHandleLogs).toHaveBeenCalledTimes(1);
@@ -156,10 +163,10 @@ describe("OTLP endpoint path canonicalisation", () => {
 
     /** @scenario A metrics suffix under a traces base is metric ingestion */
     it("does not serve a metrics suffix as trace ingestion", async () => {
-      const response = await post(
-        "/api/otel/v1/traces/v1/metrics",
-        metricPayload,
-      );
+      const response = await post({
+        path: "/api/otel/v1/traces/v1/metrics",
+        payload: metricPayload,
+      });
 
       expect(response.status).toBe(200);
       expect(mockHandleMetrics).toHaveBeenCalledTimes(1);
@@ -170,10 +177,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("given an exporter configured with the collector URL as its base", () => {
     /** @scenario An endpoint that named the collector */
     it("serves the collector-prefixed path as trace ingestion", async () => {
-      const response = await post(
-        "/api/collector/api/otel/v1/traces",
-        tracePayload,
-      );
+      const response = await post({
+        path: "/api/collector/api/otel/v1/traces",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(200);
       expect(mockHandleTraces).toHaveBeenCalledTimes(1);
@@ -183,7 +190,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("given an exporter configured with the site root as its base", () => {
     /** @scenario An endpoint that named the site root */
     it("serves the root-level path as trace ingestion", async () => {
-      const response = await post("/v1/traces", tracePayload);
+      const response = await post({
+        path: "/v1/traces",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain(
@@ -196,7 +206,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("given a stray trailing slash on the canonical path", () => {
     /** @scenario An endpoint with a stray trailing slash */
     it("serves it as trace ingestion", async () => {
-      const response = await post("/api/otel/v1/traces/", tracePayload);
+      const response = await post({
+        path: "/api/otel/v1/traces/",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(200);
       expect(mockHandleTraces).toHaveBeenCalledTimes(1);
@@ -208,7 +221,10 @@ describe("OTLP endpoint path canonicalisation", () => {
     it("refuses it exactly as the canonical path would", async () => {
       mockExtractCredentials.mockReturnValue(void 0);
 
-      const response = await post("/api/otel/v1/traces/v1/logs", logPayload);
+      const response = await post({
+        path: "/api/otel/v1/traces/v1/logs",
+        payload: logPayload,
+      });
 
       expect(response.status).toBe(401);
       expect(mockHandleLogs).not.toHaveBeenCalled();
@@ -218,10 +234,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("when the corrected request is accepted", () => {
     /** @scenario A corrected path answers like the canonical one */
     it("answers with the ordinary ingestion response, not a redirect", async () => {
-      const response = await post(
-        "/api/otel/v1/traces/v1/traces",
-        tracePayload,
-      );
+      const response = await post({
+        path: "/api/otel/v1/traces/v1/traces",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(200);
       expect(response.headers.get("location")).toBeNull();
@@ -236,7 +252,7 @@ describe("OTLP endpoint path canonicalisation", () => {
     // test the way it outlives a single request.
     /** @scenario The correction names the path the exporter used */
     it("records the path the exporter used and the one it was served from", async () => {
-      await post("/api/collector/v1/logs", logPayload);
+      await post({ path: "/api/collector/v1/logs", payload: logPayload });
 
       expect(mockWarn).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -250,9 +266,9 @@ describe("OTLP endpoint path canonicalisation", () => {
 
     /** @scenario A repeated misconfiguration is reported once a window */
     it("reports a repeated misconfiguration once, not once per batch", async () => {
-      await post("/api/otel/v1/metrics/v1/logs", logPayload);
-      await post("/api/otel/v1/metrics/v1/logs", logPayload);
-      await post("/api/otel/v1/metrics/v1/logs", logPayload);
+      await post({ path: "/api/otel/v1/metrics/v1/logs", payload: logPayload });
+      await post({ path: "/api/otel/v1/metrics/v1/logs", payload: logPayload });
+      await post({ path: "/api/otel/v1/metrics/v1/logs", payload: logPayload });
 
       expect(mockHandleLogs).toHaveBeenCalledTimes(3);
       expect(mockWarn).toHaveBeenCalledTimes(1);
@@ -297,8 +313,12 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("when a caller claims its own path was corrected", () => {
     /** @scenario A caller cannot claim its path was corrected */
     it("discards the claim", async () => {
-      await post("/api/otel/v1/logs", logPayload, {
-        "x-langwatch-otlp-corrected-path": "/api/otel/v1/traces/v1/logs",
+      await post({
+        path: "/api/otel/v1/logs",
+        payload: logPayload,
+        headers: {
+          "x-langwatch-otlp-corrected-path": "/api/otel/v1/traces/v1/logs",
+        },
       });
 
       expect(mockHandleLogs).toHaveBeenCalledTimes(1);
@@ -309,9 +329,13 @@ describe("OTLP endpoint path canonicalisation", () => {
       const headers = new Headers();
       stampCorrectedPath({ headers, originalPath: "/v1/logs" });
 
-      await post("/api/otel/v1/logs", logPayload, {
-        "x-langwatch-otlp-corrected-path":
-          headers.get("x-langwatch-otlp-corrected-path") ?? "",
+      await post({
+        path: "/api/otel/v1/logs",
+        payload: logPayload,
+        headers: {
+          "x-langwatch-otlp-corrected-path":
+            headers.get("x-langwatch-otlp-corrected-path") ?? "",
+        },
       });
 
       expect(mockWarn).toHaveBeenCalledWith(
@@ -324,7 +348,10 @@ describe("OTLP endpoint path canonicalisation", () => {
   describe("given a path no misconfiguration produces", () => {
     /** @scenario An unrelated path that happens to end in a signal name */
     it("leaves an unrelated namespace alone", async () => {
-      const response = await post("/api/rum/v1/traces", tracePayload);
+      const response = await post({
+        path: "/api/rum/v1/traces",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(404);
       expect(mockHandleTraces).not.toHaveBeenCalled();
@@ -332,10 +359,10 @@ describe("OTLP endpoint path canonicalisation", () => {
 
     /** @scenario A path naming something other than a signal */
     it("leaves an unknown suffix alone", async () => {
-      const response = await post(
-        "/api/otel/v1/traces/v1/profiles",
-        tracePayload,
-      );
+      const response = await post({
+        path: "/api/otel/v1/traces/v1/profiles",
+        payload: tracePayload,
+      });
 
       expect(response.status).toBe(404);
       expect(mockHandleTraces).not.toHaveBeenCalled();

--- a/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
@@ -1,0 +1,296 @@
+/**
+ * specs/otlp/endpoint-path-canonicalisation.feature — the routing.
+ * The path mapping itself is covered in
+ * src/server/otel/otlpPathCanonicalisation.unit.test.ts.
+ */
+
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCheckLimit = vi.fn();
+const mockHandleTraces = vi.fn();
+const mockHandleLogs = vi.fn();
+const mockHandleMetrics = vi.fn();
+const mockResolve = vi.fn();
+const mockMarkUsed = vi.fn();
+const mockExtractCredentials = vi.fn();
+const mockWarn = vi.fn();
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    usage: { checkLimit: mockCheckLimit },
+    planProvider: {
+      getActivePlan: vi.fn().mockResolvedValue({ name: "free" }),
+    },
+    usageLimits: { notifyPlanLimitReached: vi.fn() },
+    traces: {
+      collection: { handleOtlpTraceRequest: mockHandleTraces },
+      logCollection: { handleOtlpLogRequest: mockHandleLogs },
+      metricCollection: { handleOtlpMetricRequest: mockHandleMetrics },
+    },
+  })),
+}));
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({ resolve: mockResolve, markUsed: mockMarkUsed })),
+  },
+}));
+
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: mockExtractCredentials,
+    enforceApiKeyCeiling: vi.fn().mockResolvedValue(void 0),
+  };
+});
+
+vi.mock("@langwatch/observability", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langwatch/observability")>();
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      warn: mockWarn,
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+vi.mock("~/utils/posthogErrorCapture", () => ({ captureException: vi.fn() }));
+
+const { app: otelApp } = await import("../otel");
+const { app: otelPathAliasApp } = await import("../otel-path-aliases");
+const { stampCorrectedPath } = await import(
+  "~/server/otel/otlpPathCanonicalisation"
+);
+
+// Mount order mirrors api-router.ts: the canonical routes get first refusal.
+const testApp = new Hono();
+testApp.route("/", otelApp);
+testApp.route("/", otelPathAliasApp);
+
+const fakeProject = {
+  id: "project-123",
+  teamId: "team-1",
+  team: { id: "team-1", organizationId: "org-1" },
+};
+
+const tracePayload = {
+  resourceSpans: [
+    {
+      resource: { attributes: [] },
+      scopeSpans: [{ scope: { name: "test" }, spans: [] }],
+    },
+  ],
+};
+const logPayload = {
+  resourceLogs: [
+    {
+      resource: { attributes: [] },
+      scopeLogs: [{ scope: { name: "test" }, logRecords: [] }],
+    },
+  ],
+};
+const metricPayload = {
+  resourceMetrics: [
+    {
+      resource: { attributes: [] },
+      scopeMetrics: [{ scope: { name: "test" }, metrics: [] }],
+    },
+  ],
+};
+
+function post(
+  path: string,
+  payload: unknown,
+  headers: Record<string, string> = {},
+) {
+  return testApp.request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      "X-Auth-Token": "test-token",
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+describe("OTLP endpoint path canonicalisation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractCredentials.mockReturnValue({
+      token: "test-token",
+      projectId: "project-123",
+    });
+    mockResolve.mockResolvedValue({
+      type: "legacyProjectKey",
+      project: fakeProject,
+    });
+    mockCheckLimit.mockResolvedValue({ exceeded: false });
+    mockHandleTraces.mockResolvedValue({ rejectedSpans: 0, errorMessage: "" });
+    mockHandleLogs.mockResolvedValue({
+      outcome: "collected",
+      rejectedLogRecords: 0,
+    });
+    mockHandleMetrics.mockResolvedValue({
+      outcome: "collected",
+      rejectedDataPoints: 0,
+    });
+  });
+
+  describe("given an exporter configured with a signal URL as its base", () => {
+    /** @scenario An endpoint that already named a signal */
+    it("serves the doubled path as the signal the exporter appended", async () => {
+      const response = await post("/api/otel/v1/traces/v1/logs", logPayload);
+
+      expect(response.status).toBe(200);
+      expect(mockHandleLogs).toHaveBeenCalledTimes(1);
+    });
+
+    /** @scenario A metrics suffix under a traces base is metric ingestion */
+    it("does not serve a metrics suffix as trace ingestion", async () => {
+      const response = await post(
+        "/api/otel/v1/traces/v1/metrics",
+        metricPayload,
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockHandleMetrics).toHaveBeenCalledTimes(1);
+      expect(mockHandleTraces).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given an exporter configured with the collector URL as its base", () => {
+    /** @scenario An endpoint that named the collector */
+    it("serves the collector-prefixed path as trace ingestion", async () => {
+      const response = await post(
+        "/api/collector/api/otel/v1/traces",
+        tracePayload,
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockHandleTraces).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given an exporter configured with the site root as its base", () => {
+    /** @scenario An endpoint that named the site root */
+    it("serves the root-level path as trace ingestion", async () => {
+      const response = await post("/v1/traces", tracePayload);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+      expect(mockHandleTraces).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a stray trailing slash on the canonical path", () => {
+    /** @scenario An endpoint with a stray trailing slash */
+    it("serves it as trace ingestion", async () => {
+      const response = await post("/api/otel/v1/traces/", tracePayload);
+
+      expect(response.status).toBe(200);
+      expect(mockHandleTraces).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the corrected request carries no credentials", () => {
+    /** @scenario A corrected path still needs a valid key */
+    it("refuses it exactly as the canonical path would", async () => {
+      mockExtractCredentials.mockReturnValue(void 0);
+
+      const response = await post("/api/otel/v1/traces/v1/logs", logPayload);
+
+      expect(response.status).toBe(401);
+      expect(mockHandleLogs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the corrected request is accepted", () => {
+    /** @scenario A corrected path answers like the canonical one */
+    it("answers with the ordinary ingestion response, not a redirect", async () => {
+      const response = await post(
+        "/api/otel/v1/traces/v1/traces",
+        tracePayload,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+      expect(await response.json()).toEqual({
+        message: "Trace received successfully.",
+        partialSuccess: { rejectedSpans: 0, errorMessage: "" },
+      });
+    });
+
+    /** @scenario The correction names the path the exporter used */
+    it("records the path the exporter used and the one it was served from", async () => {
+      await post("/api/otel/v1/traces/v1/logs", logPayload);
+
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-123",
+          originalPath: "/api/otel/v1/traces/v1/logs",
+          canonicalPath: "/api/otel/v1/logs",
+        }),
+        expect.stringContaining("non-canonical path"),
+      );
+    });
+  });
+
+  describe("when a caller claims its own path was corrected", () => {
+    /** @scenario A caller cannot claim its path was corrected */
+    it("discards the claim", async () => {
+      await post("/api/otel/v1/logs", logPayload, {
+        "x-langwatch-otlp-corrected-path": "/api/otel/v1/traces/v1/logs",
+      });
+
+      expect(mockHandleLogs).toHaveBeenCalledTimes(1);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it("still reports a correction this process did make", async () => {
+      const headers = new Headers();
+      stampCorrectedPath({ headers, originalPath: "/v1/logs" });
+
+      await post("/api/otel/v1/logs", logPayload, {
+        "x-langwatch-otlp-corrected-path":
+          headers.get("x-langwatch-otlp-corrected-path") ?? "",
+      });
+
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ originalPath: "/v1/logs" }),
+        expect.stringContaining("non-canonical path"),
+      );
+    });
+  });
+
+  describe("given a path no misconfiguration produces", () => {
+    /** @scenario An unrelated path that happens to end in a signal name */
+    it("leaves an unrelated namespace alone", async () => {
+      const response = await post("/api/rum/v1/traces", tracePayload);
+
+      expect(response.status).toBe(404);
+      expect(mockHandleTraces).not.toHaveBeenCalled();
+    });
+
+    /** @scenario A path naming something other than a signal */
+    it("leaves an unknown suffix alone", async () => {
+      const response = await post(
+        "/api/otel/v1/traces/v1/profiles",
+        tracePayload,
+      );
+
+      expect(response.status).toBe(404);
+      expect(mockHandleTraces).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/server/routes/otel-path-aliases.ts
+++ b/platform/app/src/server/routes/otel-path-aliases.ts
@@ -1,0 +1,67 @@
+/**
+ * Serves the OTLP paths a misconfigured exporter produces from the canonical
+ * handlers in `./otel`.
+ *
+ * Not a redirect. An OTLP exporter is not a browser and the two largest client
+ * stacks will not follow one: OkHttp, under the Java exporter, refuses to
+ * replay a POST across 307/308, and the Node exporter issues its request
+ * through `http.request` with no redirect handling at all. A redirect would
+ * repair part of the fleet and go on silently dropping the rest, so the request
+ * is replayed internally instead — the same shape as the experiments-v3 legacy
+ * alias.
+ *
+ * MOUNT ORDER: this app must be registered after `otelApp` and `collectorApp`
+ * so the canonical routes and the collector's own POST match first. The
+ * wildcards below are broad on purpose — the decision lives in
+ * `canonicalOtlpPath`, which is an allow-list — and anything they catch that is
+ * not a known misconfiguration is passed straight on, so a namespace mounted
+ * after this one keeps its own routing and its own 404.
+ *
+ * Raw Hono rather than a SecuredApp on purpose: this app declares no access
+ * policy because it terminates nothing. It rewrites the path and hands the
+ * request to the canonical route, which authenticates it exactly as it would
+ * any other — a corrected path is refused for want of credentials the same way
+ * the canonical one is, and the spec pins that.
+ *
+ * See specs/otlp/endpoint-path-canonicalisation.feature.
+ */
+
+import { Hono } from "hono";
+import {
+  canonicalOtlpPath,
+  stampCorrectedPath,
+} from "~/server/otel/otlpPathCanonicalisation";
+import { app as otelApp } from "./otel";
+
+export const app = new Hono();
+
+/**
+ * Every namespace a recognised misconfiguration can land in. `/v1/*` is only
+ * reachable because start.ts routes root-level OTLP paths into the API — left
+ * to the SPA fallback it answered with the HTML shell and a 200, which an
+ * exporter reads as success before dropping the batch.
+ */
+const CANDIDATE_PATTERNS = [
+  "/api/otel/*",
+  "/api/collector/*",
+  "/api/v1/*",
+  "/v1/*",
+];
+
+for (const pattern of CANDIDATE_PATTERNS) {
+  app.all(pattern, async (c, next) => {
+    const url = new URL(c.req.url);
+    const originalPath = url.pathname;
+
+    const canonical = canonicalOtlpPath(originalPath);
+    // `canonical === originalPath` means the canonical route already had its
+    // chance and declined (wrong method, say). Replaying it would loop.
+    if (!canonical || canonical === originalPath) return next();
+
+    url.pathname = canonical;
+    const forwarded = new Request(url.toString(), c.req.raw);
+    stampCorrectedPath({ headers: forwarded.headers, originalPath });
+
+    return otelApp.fetch(forwarded);
+  });
+}

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -201,7 +201,13 @@ const CORRECTED_PATH_LOG_WINDOW_MS = 10 * 60 * 1000;
 const CORRECTED_PATH_LOG_MAX_PAIRS = 1000;
 const correctedPathLastLoggedAt = new Map<string, number>();
 
-function correctedPathIsDueToLog(pair: string, now: number): boolean {
+function correctedPathIsDueToLog({
+  pair,
+  now,
+}: {
+  pair: string;
+  now: number;
+}): boolean {
   const last = correctedPathLastLoggedAt.get(pair);
   if (last !== void 0 && now - last < CORRECTED_PATH_LOG_WINDOW_MS)
     return false;
@@ -232,8 +238,10 @@ function logCorrectedPath({
     c.req.header(OTLP_CORRECTED_PATH_HEADER),
   );
   if (!originalPath) return;
-  if (!correctedPathIsDueToLog(`${projectId}\u0000${originalPath}`, Date.now()))
-    return;
+  // NUL joins the pair because it cannot appear in a URL pathname, so no
+  // project and path can collide with a different pair.
+  const pair = `${projectId}\u0000${originalPath}`;
+  if (!correctedPathIsDueToLog({ pair, now: Date.now() })) return;
 
   logger.warn(
     { projectId, originalPath, canonicalPath: c.req.path },

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -36,6 +36,10 @@ import type { UsageLimitResult } from "~/server/app-layer/usage/usage.service";
 import { prisma } from "~/server/db";
 import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
+  OTLP_CORRECTED_PATH_HEADER,
+  readCorrectedPath,
+} from "~/server/otel/otlpPathCanonicalisation";
+import {
   OTLP_MAX_BODY_BYTES,
   parseOtlpLogs,
   parseOtlpMetrics,
@@ -179,7 +183,35 @@ async function authenticate(
     };
   }
 
+  logCorrectedPath({ c, projectId: resolved.project.id, logger });
+
   return { project: resolved.project, resolved };
+}
+
+/**
+ * Records that this request reached us on a path a misconfigured exporter
+ * produced (see otel-path-aliases). Logged here rather than at the alias
+ * because the project is what makes it actionable: it is the difference
+ * between "somebody's exporter is misconfigured" and knowing whose.
+ */
+function logCorrectedPath({
+  c,
+  projectId,
+  logger,
+}: {
+  c: RouteContext;
+  projectId: string;
+  logger: ReturnType<typeof createLogger>;
+}): void {
+  const originalPath = readCorrectedPath(
+    c.req.header(OTLP_CORRECTED_PATH_HEADER),
+  );
+  if (!originalPath) return;
+
+  logger.warn(
+    { projectId, originalPath, canonicalPath: c.req.path },
+    "OTLP exporter posted to a non-canonical path; served from the canonical route",
+  );
 }
 
 /**

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -232,7 +232,7 @@ function logCorrectedPath({
     c.req.header(OTLP_CORRECTED_PATH_HEADER),
   );
   if (!originalPath) return;
-  if (!correctedPathIsDueToLog(`${projectId} ${originalPath}`, Date.now()))
+  if (!correctedPathIsDueToLog(`${projectId}\u0000${originalPath}`, Date.now()))
     return;
 
   logger.warn(

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -189,6 +189,31 @@ async function authenticate(
 }
 
 /**
+ * A misconfigured exporter fleet posts continuously and the signal — which
+ * project, which path — is identical on every batch, so a pair is reported at
+ * most once a window. Repetition costs money on an ingestion hot path and
+ * carries no information the first line did not.
+ *
+ * The map is bounded rather than grown: past the cap it is cleared wholesale,
+ * which costs one extra line per live pair afterwards and cannot leak.
+ */
+const CORRECTED_PATH_LOG_WINDOW_MS = 10 * 60 * 1000;
+const CORRECTED_PATH_LOG_MAX_PAIRS = 1000;
+const correctedPathLastLoggedAt = new Map<string, number>();
+
+function correctedPathIsDueToLog(pair: string, now: number): boolean {
+  const last = correctedPathLastLoggedAt.get(pair);
+  if (last !== void 0 && now - last < CORRECTED_PATH_LOG_WINDOW_MS)
+    return false;
+
+  if (correctedPathLastLoggedAt.size >= CORRECTED_PATH_LOG_MAX_PAIRS) {
+    correctedPathLastLoggedAt.clear();
+  }
+  correctedPathLastLoggedAt.set(pair, now);
+  return true;
+}
+
+/**
  * Records that this request reached us on a path a misconfigured exporter
  * produced (see otel-path-aliases). Logged here rather than at the alias
  * because the project is what makes it actionable: it is the difference
@@ -207,6 +232,8 @@ function logCorrectedPath({
     c.req.header(OTLP_CORRECTED_PATH_HEADER),
   );
   if (!originalPath) return;
+  if (!correctedPathIsDueToLog(`${projectId} ${originalPath}`, Date.now()))
+    return;
 
   logger.warn(
     { projectId, originalPath, canonicalPath: c.req.path },

--- a/platform/app/src/start.ts
+++ b/platform/app/src/start.ts
@@ -107,11 +107,15 @@ export const metricsMiddleware = promBundle({
   customLabels: { project_name: "langwatch" },
   bypass: {
     onRequest: (req) => {
-      // `v1` covers the root-level OTLP paths a misconfigured exporter posts
-      // to. They are served by the API (see the handler below), so leaving
-      // them out would hide exactly the traffic worth watching. Bounded
-      // cardinality: /v1/traces, /v1/logs, /v1/metrics and nothing else.
-      if (/^\/(api|assets|auth|settings|share|v1|$)/.test(req.url ?? "")) {
+      // The three root-level OTLP paths a misconfigured exporter posts to are
+      // served by the API (see the handler below), so leaving them out would
+      // hide exactly the traffic worth watching. Spelled out rather than a
+      // bare `v1` so the label set stays those three and nothing else.
+      if (
+        /^\/(api|assets|auth|settings|share|v1\/(traces|logs|metrics)|$)/.test(
+          req.url ?? "",
+        )
+      ) {
         return false;
       }
       return true;

--- a/platform/app/src/start.ts
+++ b/platform/app/src/start.ts
@@ -88,6 +88,7 @@ import {
   isMetricsAuthorized,
   normalizeMetricsPath,
 } from "./server/metrics";
+import { canonicalOtlpPath } from "./server/otel/otlpPathCanonicalisation";
 import { shutdownPostHog } from "./server/posthog";
 import { verifyRedisReady } from "./server/redis";
 import { buildSecurityHeaders } from "./server/securityHeaders";
@@ -106,7 +107,11 @@ export const metricsMiddleware = promBundle({
   customLabels: { project_name: "langwatch" },
   bypass: {
     onRequest: (req) => {
-      if (/^\/(api|assets|auth|settings|share|$)/.test(req.url ?? "")) {
+      // `v1` covers the root-level OTLP paths a misconfigured exporter posts
+      // to. They are served by the API (see the handler below), so leaving
+      // them out would hide exactly the traffic worth watching. Bounded
+      // cardinality: /v1/traces, /v1/logs, /v1/metrics and nothing else.
+      if (/^\/(api|assets|auth|settings|share|v1|$)/.test(req.url ?? "")) {
         return false;
       }
       return true;
@@ -277,7 +282,15 @@ export const startApp = async (dir = resolveAppPackageRoot()) => {
       });
 
       // ---- API Routes (all go through Hono) ----
-      if (pathname.startsWith("/api/")) {
+      // An exporter given the site root as its OTLP endpoint posts to
+      // `/v1/traces`, which the SPA fallback below answers with the HTML shell
+      // and a 200 — the exporter reads that as success and drops the batch.
+      // Those paths belong to the API, which canonicalises them
+      // (src/server/routes/otel-path-aliases.ts).
+      if (
+        pathname.startsWith("/api/") ||
+        canonicalOtlpPath(pathname) !== null
+      ) {
         await apiListener(req, res);
         return;
       }

--- a/platform/app/src/start.ts
+++ b/platform/app/src/start.ts
@@ -109,10 +109,12 @@ export const metricsMiddleware = promBundle({
     onRequest: (req) => {
       // The three root-level OTLP paths a misconfigured exporter posts to are
       // served by the API (see the handler below), so leaving them out would
-      // hide exactly the traffic worth watching. Spelled out rather than a
-      // bare `v1` so the label set stays those three and nothing else.
+      // hide exactly the traffic worth watching. The OTLP branch is the only
+      // one anchored at the end: the others are deliberately prefixes, while
+      // this one must not let `/v1/traces-anything` in and turn a claim of
+      // three bounded labels into an open set.
       if (
-        /^\/(api|assets|auth|settings|share|v1\/(traces|logs|metrics)|$)/.test(
+        /^\/(?:api|assets|auth|settings|share|v1\/(?:traces|logs|metrics)\/?(?:\?.*)?$|$)/.test(
           req.url ?? "",
         )
       ) {

--- a/platform/app/vite.config.ts
+++ b/platform/app/vite.config.ts
@@ -323,7 +323,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
       // `/v1/traces`. In production start.ts routes those into the API; in dev
       // the frontend owns the root, so they need an entry of their own or they
       // fall through to the SPA. Exact-match, same reasoning as /mcp below.
-      "^/v1/(?:traces|logs|metrics)(?:\\?.*)?$": {
+      "^/v1/(?:traces|logs|metrics)/?(?:\\?.*)?$": {
         target: API_TARGET,
         changeOrigin: true,
         secure: false,

--- a/platform/app/vite.config.ts
+++ b/platform/app/vite.config.ts
@@ -1,12 +1,12 @@
-import react from "@vitejs/plugin-react";
 import dotenv from "dotenv";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import path from "path";
 import { generate as generateSelfsigned } from "selfsigned";
-import { defineConfig, type Plugin, type UserConfig } from "vite";
 import { shikiManualChunk } from "./src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking";
-import { ASSET_URL_GLOBAL } from "./src/server/asset-base";
 import { havenHmrGate } from "./vite/havenHmrGate";
+import { ASSET_URL_GLOBAL } from "./src/server/asset-base";
 
 // Load `.env` into the Vite config's process environment. Vite normally
 // only exposes `VITE_*` vars to client code — but this config itself
@@ -23,9 +23,7 @@ dotenv.config({
   quiet: true,
 });
 
-const FRONTEND_PORT = parseInt(
-  process.env.LANGWATCH_APP_PORT ?? process.env.PORT ?? "5560",
-);
+const FRONTEND_PORT = parseInt(process.env.LANGWATCH_APP_PORT ?? process.env.PORT ?? "5560");
 const API_PORT = FRONTEND_PORT + 1000;
 
 // When `LANGWATCH_DEV_HTTP2=1` is set, Vite serves the SPA over
@@ -43,8 +41,7 @@ const API_PROTOCOL = USE_HTTP2 ? "https" : "http";
 const API_TARGET =
   process.env.LANGWATCH_PORTLESS === "1"
     ? `http://127.0.0.1:${process.env.LANGWATCH_API_PORT ?? API_PORT}`
-    : (process.env.LANGWATCH_API_URL ??
-      `${API_PROTOCOL}://localhost:${API_PORT}`);
+    : (process.env.LANGWATCH_API_URL ?? `${API_PROTOCOL}://localhost:${API_PORT}`);
 
 /**
  * Load (and lazily generate) the dev TLS credentials. Mirrors
@@ -53,10 +50,9 @@ const API_TARGET =
  * the race benign — whichever loses the race overwrites with the same
  * effective contents, and subsequent reads find a valid pair.
  */
-async function loadDevHttpsCredentials(): Promise<{
-  cert: Buffer;
-  key: Buffer;
-} | null> {
+async function loadDevHttpsCredentials(): Promise<
+  { cert: Buffer; key: Buffer } | null
+> {
   if (!USE_HTTP2) return null;
 
   if (process.env.DEV_HTTPS_CERT && process.env.DEV_HTTPS_KEY) {
@@ -67,7 +63,8 @@ async function loadDevHttpsCredentials(): Promise<{
   }
 
   const cacheDir =
-    process.env.LANGWATCH_DEV_CERT_DIR ?? path.join(__dirname, ".dev-certs");
+    process.env.LANGWATCH_DEV_CERT_DIR ??
+    path.join(__dirname, ".dev-certs");
   const certPath = path.join(cacheDir, "dev.pem");
   const keyPath = path.join(cacheDir, "dev-key.pem");
 
@@ -121,11 +118,7 @@ function patchObjectInspectBrowserStub(): Plugin {
     name: "patch-object-inspect-browser-stub",
     enforce: "pre",
     resolveId(id, importer) {
-      if (
-        id === "./util.inspect" &&
-        importer &&
-        importer.includes("/object-inspect/")
-      ) {
+      if (id === "./util.inspect" && importer && importer.includes("/object-inspect/")) {
         return noopPath;
       }
       return undefined;
@@ -152,233 +145,231 @@ export default defineConfig(async (): Promise<UserConfig> => {
   }
 
   return {
-    plugins: [react(), patchObjectInspectBrowserStub(), havenHmrGate()],
-    resolve: {
-      alias: {
-        // Path aliases (matching tsconfig paths)
-        "~": path.resolve(__dirname, "./src"),
-        "@app": path.resolve(__dirname, "./src/server/app-layer"),
-        "@ee": path.resolve(__dirname, "./ee"),
+  plugins: [react(), patchObjectInspectBrowserStub(), havenHmrGate()],
+  resolve: {
+    alias: {
+      // Path aliases (matching tsconfig paths)
+      "~": path.resolve(__dirname, "./src"),
+      "@app": path.resolve(__dirname, "./src/server/app-layer"),
+      "@ee": path.resolve(__dirname, "./ee"),
+    },
+    // ONE zod instance for the app AND linked workspace packages
+    // (@langwatch/langy): zod v3 instanceof-checks its own classes (e.g.
+    // z.record's key/value overload detection), so a second physical copy
+    // resolved from a package's own node_modules silently mis-parses.
+    dedupe: ["zod"],
+  },
+  define: {
+    // Literal replacements for process.env references in browser code.
+    // Vite auto-handles NODE_ENV but not arbitrary env vars.
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "development"),
+    "process.env.PINO_LOG_LEVEL": JSON.stringify("info"),
+    // Catch-all: prevent ReferenceError for any other process.env.* access
+    // that slips into client code (e.g. dead branches behind typeof window checks)
+    "process.env.BASE_HOST": "undefined",
+    "process.env.PORT": "undefined",
+    "process.env.SKIP_ENV_VALIDATION": "undefined",
+    "process.env.BUILD_TIME": "undefined",
+    "process.env.VERCEL": "undefined",
+    "process.env.VERCEL_URL": "undefined",
+  },
+  optimizeDeps: {
+    // DEV-ONLY: optimizeDeps never touches the production build (prod bundles
+    // Shiki via the manualChunks rule below). Pre-bundle the whole Shiki
+    // ecosystem at dev-server start so the server doesn't discover Shiki's
+    // Oniguruma WASM engine + langs/themes lazily on the first /traces
+    // navigation and re-optimize mid-session. That re-optimization invalidates
+    // the in-flight `.vite/deps/wasm-*.js` (onig.wasm, ~620KB) request the span
+    // highlighter awaits, leaving the trace drawer stuck on "loading spans".
+    include: [
+      "shiki",
+      "@shikijs/core",
+      "@shikijs/engine-oniguruma",
+      "@shikijs/langs",
+      "@shikijs/themes",
+    ],
+  },
+  build: {
+    outDir: "dist/client",
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          // Shiki chunk-splitting lives in shikiChunking.ts (dependency-free) so
+          // its guard test can exercise the real logic. It keeps the core + base
+          // grammars/themes eager and splits the other ~340 grammars into lazy
+          // chunks — removing the ~9.5 MB raw / 1.66 MB gzip eager Shiki chunk
+          // that used to load on every page. See that file for the boot-cycle
+          // rationale.
+          return shikiManualChunk(id);
+        },
       },
-      // ONE zod instance for the app AND linked workspace packages
-      // (@langwatch/langy): zod v3 instanceof-checks its own classes (e.g.
-      // z.record's key/value overload detection), so a second physical copy
-      // resolved from a package's own node_modules silently mis-parses.
-      dedupe: ["zod"],
     },
-    define: {
-      // Literal replacements for process.env references in browser code.
-      // Vite auto-handles NODE_ENV but not arbitrary env vars.
-      "process.env.NODE_ENV": JSON.stringify(
-        process.env.NODE_ENV ?? "development",
-      ),
-      "process.env.PINO_LOG_LEVEL": JSON.stringify("info"),
-      // Catch-all: prevent ReferenceError for any other process.env.* access
-      // that slips into client code (e.g. dead branches behind typeof window checks)
-      "process.env.BASE_HOST": "undefined",
-      "process.env.PORT": "undefined",
-      "process.env.SKIP_ENV_VALIDATION": "undefined",
-      "process.env.BUILD_TIME": "undefined",
-      "process.env.VERCEL": "undefined",
-      "process.env.VERCEL_URL": "undefined",
+  },
+  experimental: {
+    // ADR-086: the base for content-hashed assets is chosen at container start,
+    // not build time — one image serves self-host same-origin and SaaS from a
+    // commit-prefixed CDN. Emit every JS-referenced asset URL as a call to the
+    // runtime resolver defined by the served HTML shell (src/server/asset-base.ts);
+    // keep CSS-referenced assets relative to the CSS file (which lives under the
+    // same base, so fonts/images resolve on the CDN); leave HTML entry refs
+    // base-absolute for the server to rewrite; leave public/ assets same-origin.
+    renderBuiltUrl(filename, { type, hostType }) {
+      if (type === "public") return undefined;
+      if (hostType === "js") {
+        // Self-defaulting so the built bundle is usable even when the server
+        // hasn't injected the resolver: `vite preview`, the boot-smoke, and any
+        // raw-`dist/` static server fall back to same-origin ("/"+path). Read
+        // via `globalThis` (defined in the main document AND in Web Worker
+        // scopes, where `window` is undefined) so a worker chunk degrades to
+        // same-origin instead of throwing. The server sets
+        // `globalThis.__lwAssetUrl` to the CDN prefixer when LANGWATCH_ASSET_BASE
+        // is configured.
+        return {
+          runtime: `(globalThis.${ASSET_URL_GLOBAL}||function(p){return "/"+p})(${JSON.stringify(
+            filename,
+          )})`,
+        };
+      }
+      if (hostType === "css") return { relative: true };
+      return undefined;
     },
-    optimizeDeps: {
-      // DEV-ONLY: optimizeDeps never touches the production build (prod bundles
-      // Shiki via the manualChunks rule below). Pre-bundle the whole Shiki
-      // ecosystem at dev-server start so the server doesn't discover Shiki's
-      // Oniguruma WASM engine + langs/themes lazily on the first /traces
-      // navigation and re-optimize mid-session. That re-optimization invalidates
-      // the in-flight `.vite/deps/wasm-*.js` (onig.wasm, ~620KB) request the span
-      // highlighter awaits, leaving the trace drawer stuck on "loading spans".
-      include: [
-        "shiki",
-        "@shikijs/core",
-        "@shikijs/engine-oniguruma",
-        "@shikijs/langs",
-        "@shikijs/themes",
+  },
+  server: {
+    watch: {
+      ignored: [
+        "**/.git/**",
+        "**/node_modules/.pnpm/**",
+        "**/.pnpm-store/**",
+        "**/dist/**",
+        "**/.next/**",
+        "**/coverage/**",
+        // Any dev-server tee target (server.log, server-qa.log, ...): the
+        // server appends on every request, so watching one turns each page
+        // load into a full-reload loop.
+        "**/server*.log",
+        // Working files agents keep under .claude/tmp, per the repo
+        // convention. A dev-server log teed there reloads the page on every
+        // request, same trap as above under a different name. Agent
+        // worktrees also live under .claude/worktrees, and chokidar
+        // matches ignore globs against full paths, so from a worktree
+        // root any pattern containing .claude/worktrees matches every
+        // file in the tree and blinds the watcher entirely. From a
+        // worktree only .claude/tmp is ignored (worktrees do not nest);
+        // from the main root the entire .claude tree, nested worktree
+        // copies included, stays ignored as before.
+        ...(process.cwd().includes("/.claude/")
+          ? ["**/.claude/tmp/**"]
+          : ["**/.claude/**"]),
       ],
+      // Docker-on-macOS bind mounts don't surface inotify events reliably,
+      // so Vite's default fs.watch sits silent on edits made from the host.
+      // Polling at 250ms is the standard workaround and HMR fires
+      // immediately. Native macOS / Linux hosts opt out via
+      // `LANGWATCH_VITE_NO_POLLING=1` to dodge the CPU tax.
+      ...(process.env.LANGWATCH_VITE_NO_POLLING === "1"
+        ? {}
+        : { usePolling: true, interval: 250 }),
     },
-    build: {
-      outDir: "dist/client",
-      sourcemap: true,
-      rollupOptions: {
-        output: {
-          manualChunks(id: string) {
-            // Shiki chunk-splitting lives in shikiChunking.ts (dependency-free) so
-            // its guard test can exercise the real logic. It keeps the core + base
-            // grammars/themes eager and splits the other ~340 grammars into lazy
-            // chunks — removing the ~9.5 MB raw / 1.66 MB gzip eager Shiki chunk
-            // that used to load on every page. See that file for the boot-cycle
-            // rationale.
-            return shikiManualChunk(id);
+    // Frontend port (default 5560, configurable via PORT env var)
+    host: true,
+    allowedHosts: true,
+    port: FRONTEND_PORT,
+    strictPort: true,
+    // HTTPS+HTTP/2 when LANGWATCH_DEV_HTTP2=1. Vite negotiates h2 over
+    // TLS automatically when `https` is set. Both Vite and the API
+    // share the same auto-generated cert so the browser only has to
+    // trust one cert for the whole stack.
+    ...(devHttpsCredentials
+      ? {
+          https: {
+            cert: devHttpsCredentials.cert,
+            key: devHttpsCredentials.key,
           },
-        },
-      },
-    },
-    experimental: {
-      // ADR-086: the base for content-hashed assets is chosen at container start,
-      // not build time — one image serves self-host same-origin and SaaS from a
-      // commit-prefixed CDN. Emit every JS-referenced asset URL as a call to the
-      // runtime resolver defined by the served HTML shell (src/server/asset-base.ts);
-      // keep CSS-referenced assets relative to the CSS file (which lives under the
-      // same base, so fonts/images resolve on the CDN); leave HTML entry refs
-      // base-absolute for the server to rewrite; leave public/ assets same-origin.
-      renderBuiltUrl(filename, { type, hostType }) {
-        if (type === "public") return undefined;
-        if (hostType === "js") {
-          // Self-defaulting so the built bundle is usable even when the server
-          // hasn't injected the resolver: `vite preview`, the boot-smoke, and any
-          // raw-`dist/` static server fall back to same-origin ("/"+path). Read
-          // via `globalThis` (defined in the main document AND in Web Worker
-          // scopes, where `window` is undefined) so a worker chunk degrades to
-          // same-origin instead of throwing. The server sets
-          // `globalThis.__lwAssetUrl` to the CDN prefixer when LANGWATCH_ASSET_BASE
-          // is configured.
-          return {
-            runtime: `(globalThis.${ASSET_URL_GLOBAL}||function(p){return "/"+p})(${JSON.stringify(
-              filename,
-            )})`,
-          };
         }
-        if (hostType === "css") return { relative: true };
-        return undefined;
+      : {}),
+    // Proxy API requests to the Hono backend (PORT + 1000). `ws: true`
+    // forwards WebSocket upgrades for the tRPC WS transport at /api/trpc-ws.
+    //
+    // The MCP routes (/mcp, /sse, /messages, /oauth/*, /.well-known/oauth-*)
+    // are registered directly on the Node HTTP server in start.ts (NOT
+    // mounted under /api), so they need explicit proxy entries here for
+    // external MCP clients (e.g. Claude Code adding the LangWatch MCP
+    // server in dev) to reach them via the canonical FRONTEND_PORT. The
+    // production server (start.ts) listens on a single port so this
+    // splitting is dev-only.
+    proxy: {
+      // The tRPC WS transport enforces a same-origin allowlist (built from
+      // NEXTAUTH_URL) and fail-closes on a missing/mismatched Origin. The
+      // catch-all `/api` proxy below sets `changeOrigin: true`, which rewrites
+      // the WS handshake Origin so the backend sees a null/foreign origin and
+      // rejects every upgrade — silently breaking all WS-backed workbench
+      // state. A dedicated, earlier entry keeps the browser's real Origin.
+      "/api/trpc-ws": {
+        target: API_TARGET,
+        changeOrigin: false,
+        ws: true,
+        secure: false,
+      },
+      "/api": {
+        target: API_TARGET,
+        changeOrigin: true,
+        ws: true,
+        // Self-signed dev cert — don't fail the proxy on cert verification.
+        // No-op when API is on plain HTTP.
+        secure: false,
+      },
+      // An exporter given the site root as its OTLP endpoint posts to
+      // `/v1/traces`. In production start.ts routes those into the API; in dev
+      // the frontend owns the root, so they need an entry of their own or they
+      // fall through to the SPA. Exact-match, same reasoning as /mcp below.
+      "^/v1/(?:traces|logs|metrics)(?:\\?.*)?$": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
+      // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
+      // sending it to the API server, which has no dev-mode page fallback.
+      // server.proxy regexes test against the full req.url (path + query),
+      // so the optional "(?:\?.*)?" is required or a query-bearing request
+      // like "/mcp?sessionId=..." falls through to the frontend instead.
+      "^/mcp(?:\\?.*)?$": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "^/mcp/health(?:\\?.*)?$": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/sse": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/messages": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/oauth": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/.well-known/oauth-protected-resource": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/.well-known/oauth-authorization-server": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
       },
     },
-    server: {
-      watch: {
-        ignored: [
-          "**/.git/**",
-          "**/node_modules/.pnpm/**",
-          "**/.pnpm-store/**",
-          "**/dist/**",
-          "**/.next/**",
-          "**/coverage/**",
-          // Any dev-server tee target (server.log, server-qa.log, ...): the
-          // server appends on every request, so watching one turns each page
-          // load into a full-reload loop.
-          "**/server*.log",
-          // Working files agents keep under .claude/tmp, per the repo
-          // convention. A dev-server log teed there reloads the page on every
-          // request, same trap as above under a different name. Agent
-          // worktrees also live under .claude/worktrees, and chokidar
-          // matches ignore globs against full paths, so from a worktree
-          // root any pattern containing .claude/worktrees matches every
-          // file in the tree and blinds the watcher entirely. From a
-          // worktree only .claude/tmp is ignored (worktrees do not nest);
-          // from the main root the entire .claude tree, nested worktree
-          // copies included, stays ignored as before.
-          ...(process.cwd().includes("/.claude/")
-            ? ["**/.claude/tmp/**"]
-            : ["**/.claude/**"]),
-        ],
-        // Docker-on-macOS bind mounts don't surface inotify events reliably,
-        // so Vite's default fs.watch sits silent on edits made from the host.
-        // Polling at 250ms is the standard workaround and HMR fires
-        // immediately. Native macOS / Linux hosts opt out via
-        // `LANGWATCH_VITE_NO_POLLING=1` to dodge the CPU tax.
-        ...(process.env.LANGWATCH_VITE_NO_POLLING === "1"
-          ? {}
-          : { usePolling: true, interval: 250 }),
-      },
-      // Frontend port (default 5560, configurable via PORT env var)
-      host: true,
-      allowedHosts: true,
-      port: FRONTEND_PORT,
-      strictPort: true,
-      // HTTPS+HTTP/2 when LANGWATCH_DEV_HTTP2=1. Vite negotiates h2 over
-      // TLS automatically when `https` is set. Both Vite and the API
-      // share the same auto-generated cert so the browser only has to
-      // trust one cert for the whole stack.
-      ...(devHttpsCredentials
-        ? {
-            https: {
-              cert: devHttpsCredentials.cert,
-              key: devHttpsCredentials.key,
-            },
-          }
-        : {}),
-      // Proxy API requests to the Hono backend (PORT + 1000). `ws: true`
-      // forwards WebSocket upgrades for the tRPC WS transport at /api/trpc-ws.
-      //
-      // The MCP routes (/mcp, /sse, /messages, /oauth/*, /.well-known/oauth-*)
-      // are registered directly on the Node HTTP server in start.ts (NOT
-      // mounted under /api), so they need explicit proxy entries here for
-      // external MCP clients (e.g. Claude Code adding the LangWatch MCP
-      // server in dev) to reach them via the canonical FRONTEND_PORT. The
-      // production server (start.ts) listens on a single port so this
-      // splitting is dev-only.
-      proxy: {
-        // The tRPC WS transport enforces a same-origin allowlist (built from
-        // NEXTAUTH_URL) and fail-closes on a missing/mismatched Origin. The
-        // catch-all `/api` proxy below sets `changeOrigin: true`, which rewrites
-        // the WS handshake Origin so the backend sees a null/foreign origin and
-        // rejects every upgrade — silently breaking all WS-backed workbench
-        // state. A dedicated, earlier entry keeps the browser's real Origin.
-        "/api/trpc-ws": {
-          target: API_TARGET,
-          changeOrigin: false,
-          ws: true,
-          secure: false,
-        },
-        "/api": {
-          target: API_TARGET,
-          changeOrigin: true,
-          ws: true,
-          // Self-signed dev cert — don't fail the proxy on cert verification.
-          // No-op when API is on plain HTTP.
-          secure: false,
-        },
-        // An exporter given the site root as its OTLP endpoint posts to
-        // `/v1/traces`. In production start.ts routes those into the API; in dev
-        // the frontend owns the root, so they need an entry of their own or they
-        // fall through to the SPA. Exact-match, same reasoning as /mcp below.
-        "^/v1/(?:traces|logs|metrics)(?:\\?.*)?$": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
-        // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
-        // sending it to the API server, which has no dev-mode page fallback.
-        // server.proxy regexes test against the full req.url (path + query),
-        // so the optional "(?:\?.*)?" is required or a query-bearing request
-        // like "/mcp?sessionId=..." falls through to the frontend instead.
-        "^/mcp(?:\\?.*)?$": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "^/mcp/health(?:\\?.*)?$": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "/sse": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "/messages": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "/oauth": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "/.well-known/oauth-protected-resource": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-        "/.well-known/oauth-authorization-server": {
-          target: API_TARGET,
-          changeOrigin: true,
-          secure: false,
-        },
-      },
-    },
+  },
   };
 });

--- a/platform/app/vite.config.ts
+++ b/platform/app/vite.config.ts
@@ -1,12 +1,12 @@
+import react from "@vitejs/plugin-react";
 import dotenv from "dotenv";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { defineConfig, type Plugin, type UserConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import path from "path";
 import { generate as generateSelfsigned } from "selfsigned";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
 import { shikiManualChunk } from "./src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking";
-import { havenHmrGate } from "./vite/havenHmrGate";
 import { ASSET_URL_GLOBAL } from "./src/server/asset-base";
+import { havenHmrGate } from "./vite/havenHmrGate";
 
 // Load `.env` into the Vite config's process environment. Vite normally
 // only exposes `VITE_*` vars to client code — but this config itself
@@ -23,7 +23,9 @@ dotenv.config({
   quiet: true,
 });
 
-const FRONTEND_PORT = parseInt(process.env.LANGWATCH_APP_PORT ?? process.env.PORT ?? "5560");
+const FRONTEND_PORT = parseInt(
+  process.env.LANGWATCH_APP_PORT ?? process.env.PORT ?? "5560",
+);
 const API_PORT = FRONTEND_PORT + 1000;
 
 // When `LANGWATCH_DEV_HTTP2=1` is set, Vite serves the SPA over
@@ -41,7 +43,8 @@ const API_PROTOCOL = USE_HTTP2 ? "https" : "http";
 const API_TARGET =
   process.env.LANGWATCH_PORTLESS === "1"
     ? `http://127.0.0.1:${process.env.LANGWATCH_API_PORT ?? API_PORT}`
-    : (process.env.LANGWATCH_API_URL ?? `${API_PROTOCOL}://localhost:${API_PORT}`);
+    : (process.env.LANGWATCH_API_URL ??
+      `${API_PROTOCOL}://localhost:${API_PORT}`);
 
 /**
  * Load (and lazily generate) the dev TLS credentials. Mirrors
@@ -50,9 +53,10 @@ const API_TARGET =
  * the race benign — whichever loses the race overwrites with the same
  * effective contents, and subsequent reads find a valid pair.
  */
-async function loadDevHttpsCredentials(): Promise<
-  { cert: Buffer; key: Buffer } | null
-> {
+async function loadDevHttpsCredentials(): Promise<{
+  cert: Buffer;
+  key: Buffer;
+} | null> {
   if (!USE_HTTP2) return null;
 
   if (process.env.DEV_HTTPS_CERT && process.env.DEV_HTTPS_KEY) {
@@ -63,8 +67,7 @@ async function loadDevHttpsCredentials(): Promise<
   }
 
   const cacheDir =
-    process.env.LANGWATCH_DEV_CERT_DIR ??
-    path.join(__dirname, ".dev-certs");
+    process.env.LANGWATCH_DEV_CERT_DIR ?? path.join(__dirname, ".dev-certs");
   const certPath = path.join(cacheDir, "dev.pem");
   const keyPath = path.join(cacheDir, "dev-key.pem");
 
@@ -118,7 +121,11 @@ function patchObjectInspectBrowserStub(): Plugin {
     name: "patch-object-inspect-browser-stub",
     enforce: "pre",
     resolveId(id, importer) {
-      if (id === "./util.inspect" && importer && importer.includes("/object-inspect/")) {
+      if (
+        id === "./util.inspect" &&
+        importer &&
+        importer.includes("/object-inspect/")
+      ) {
         return noopPath;
       }
       return undefined;
@@ -145,222 +152,233 @@ export default defineConfig(async (): Promise<UserConfig> => {
   }
 
   return {
-  plugins: [react(), patchObjectInspectBrowserStub(), havenHmrGate()],
-  resolve: {
-    alias: {
-      // Path aliases (matching tsconfig paths)
-      "~": path.resolve(__dirname, "./src"),
-      "@app": path.resolve(__dirname, "./src/server/app-layer"),
-      "@ee": path.resolve(__dirname, "./ee"),
+    plugins: [react(), patchObjectInspectBrowserStub(), havenHmrGate()],
+    resolve: {
+      alias: {
+        // Path aliases (matching tsconfig paths)
+        "~": path.resolve(__dirname, "./src"),
+        "@app": path.resolve(__dirname, "./src/server/app-layer"),
+        "@ee": path.resolve(__dirname, "./ee"),
+      },
+      // ONE zod instance for the app AND linked workspace packages
+      // (@langwatch/langy): zod v3 instanceof-checks its own classes (e.g.
+      // z.record's key/value overload detection), so a second physical copy
+      // resolved from a package's own node_modules silently mis-parses.
+      dedupe: ["zod"],
     },
-    // ONE zod instance for the app AND linked workspace packages
-    // (@langwatch/langy): zod v3 instanceof-checks its own classes (e.g.
-    // z.record's key/value overload detection), so a second physical copy
-    // resolved from a package's own node_modules silently mis-parses.
-    dedupe: ["zod"],
-  },
-  define: {
-    // Literal replacements for process.env references in browser code.
-    // Vite auto-handles NODE_ENV but not arbitrary env vars.
-    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "development"),
-    "process.env.PINO_LOG_LEVEL": JSON.stringify("info"),
-    // Catch-all: prevent ReferenceError for any other process.env.* access
-    // that slips into client code (e.g. dead branches behind typeof window checks)
-    "process.env.BASE_HOST": "undefined",
-    "process.env.PORT": "undefined",
-    "process.env.SKIP_ENV_VALIDATION": "undefined",
-    "process.env.BUILD_TIME": "undefined",
-    "process.env.VERCEL": "undefined",
-    "process.env.VERCEL_URL": "undefined",
-  },
-  optimizeDeps: {
-    // DEV-ONLY: optimizeDeps never touches the production build (prod bundles
-    // Shiki via the manualChunks rule below). Pre-bundle the whole Shiki
-    // ecosystem at dev-server start so the server doesn't discover Shiki's
-    // Oniguruma WASM engine + langs/themes lazily on the first /traces
-    // navigation and re-optimize mid-session. That re-optimization invalidates
-    // the in-flight `.vite/deps/wasm-*.js` (onig.wasm, ~620KB) request the span
-    // highlighter awaits, leaving the trace drawer stuck on "loading spans".
-    include: [
-      "shiki",
-      "@shikijs/core",
-      "@shikijs/engine-oniguruma",
-      "@shikijs/langs",
-      "@shikijs/themes",
-    ],
-  },
-  build: {
-    outDir: "dist/client",
-    sourcemap: true,
-    rollupOptions: {
-      output: {
-        manualChunks(id: string) {
-          // Shiki chunk-splitting lives in shikiChunking.ts (dependency-free) so
-          // its guard test can exercise the real logic. It keeps the core + base
-          // grammars/themes eager and splits the other ~340 grammars into lazy
-          // chunks — removing the ~9.5 MB raw / 1.66 MB gzip eager Shiki chunk
-          // that used to load on every page. See that file for the boot-cycle
-          // rationale.
-          return shikiManualChunk(id);
+    define: {
+      // Literal replacements for process.env references in browser code.
+      // Vite auto-handles NODE_ENV but not arbitrary env vars.
+      "process.env.NODE_ENV": JSON.stringify(
+        process.env.NODE_ENV ?? "development",
+      ),
+      "process.env.PINO_LOG_LEVEL": JSON.stringify("info"),
+      // Catch-all: prevent ReferenceError for any other process.env.* access
+      // that slips into client code (e.g. dead branches behind typeof window checks)
+      "process.env.BASE_HOST": "undefined",
+      "process.env.PORT": "undefined",
+      "process.env.SKIP_ENV_VALIDATION": "undefined",
+      "process.env.BUILD_TIME": "undefined",
+      "process.env.VERCEL": "undefined",
+      "process.env.VERCEL_URL": "undefined",
+    },
+    optimizeDeps: {
+      // DEV-ONLY: optimizeDeps never touches the production build (prod bundles
+      // Shiki via the manualChunks rule below). Pre-bundle the whole Shiki
+      // ecosystem at dev-server start so the server doesn't discover Shiki's
+      // Oniguruma WASM engine + langs/themes lazily on the first /traces
+      // navigation and re-optimize mid-session. That re-optimization invalidates
+      // the in-flight `.vite/deps/wasm-*.js` (onig.wasm, ~620KB) request the span
+      // highlighter awaits, leaving the trace drawer stuck on "loading spans".
+      include: [
+        "shiki",
+        "@shikijs/core",
+        "@shikijs/engine-oniguruma",
+        "@shikijs/langs",
+        "@shikijs/themes",
+      ],
+    },
+    build: {
+      outDir: "dist/client",
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks(id: string) {
+            // Shiki chunk-splitting lives in shikiChunking.ts (dependency-free) so
+            // its guard test can exercise the real logic. It keeps the core + base
+            // grammars/themes eager and splits the other ~340 grammars into lazy
+            // chunks — removing the ~9.5 MB raw / 1.66 MB gzip eager Shiki chunk
+            // that used to load on every page. See that file for the boot-cycle
+            // rationale.
+            return shikiManualChunk(id);
+          },
         },
       },
     },
-  },
-  experimental: {
-    // ADR-086: the base for content-hashed assets is chosen at container start,
-    // not build time — one image serves self-host same-origin and SaaS from a
-    // commit-prefixed CDN. Emit every JS-referenced asset URL as a call to the
-    // runtime resolver defined by the served HTML shell (src/server/asset-base.ts);
-    // keep CSS-referenced assets relative to the CSS file (which lives under the
-    // same base, so fonts/images resolve on the CDN); leave HTML entry refs
-    // base-absolute for the server to rewrite; leave public/ assets same-origin.
-    renderBuiltUrl(filename, { type, hostType }) {
-      if (type === "public") return undefined;
-      if (hostType === "js") {
-        // Self-defaulting so the built bundle is usable even when the server
-        // hasn't injected the resolver: `vite preview`, the boot-smoke, and any
-        // raw-`dist/` static server fall back to same-origin ("/"+path). Read
-        // via `globalThis` (defined in the main document AND in Web Worker
-        // scopes, where `window` is undefined) so a worker chunk degrades to
-        // same-origin instead of throwing. The server sets
-        // `globalThis.__lwAssetUrl` to the CDN prefixer when LANGWATCH_ASSET_BASE
-        // is configured.
-        return {
-          runtime: `(globalThis.${ASSET_URL_GLOBAL}||function(p){return "/"+p})(${JSON.stringify(
-            filename,
-          )})`,
-        };
-      }
-      if (hostType === "css") return { relative: true };
-      return undefined;
-    },
-  },
-  server: {
-    watch: {
-      ignored: [
-        "**/.git/**",
-        "**/node_modules/.pnpm/**",
-        "**/.pnpm-store/**",
-        "**/dist/**",
-        "**/.next/**",
-        "**/coverage/**",
-        // Any dev-server tee target (server.log, server-qa.log, ...): the
-        // server appends on every request, so watching one turns each page
-        // load into a full-reload loop.
-        "**/server*.log",
-        // Working files agents keep under .claude/tmp, per the repo
-        // convention. A dev-server log teed there reloads the page on every
-        // request, same trap as above under a different name. Agent
-        // worktrees also live under .claude/worktrees, and chokidar
-        // matches ignore globs against full paths, so from a worktree
-        // root any pattern containing .claude/worktrees matches every
-        // file in the tree and blinds the watcher entirely. From a
-        // worktree only .claude/tmp is ignored (worktrees do not nest);
-        // from the main root the entire .claude tree, nested worktree
-        // copies included, stays ignored as before.
-        ...(process.cwd().includes("/.claude/")
-          ? ["**/.claude/tmp/**"]
-          : ["**/.claude/**"]),
-      ],
-      // Docker-on-macOS bind mounts don't surface inotify events reliably,
-      // so Vite's default fs.watch sits silent on edits made from the host.
-      // Polling at 250ms is the standard workaround and HMR fires
-      // immediately. Native macOS / Linux hosts opt out via
-      // `LANGWATCH_VITE_NO_POLLING=1` to dodge the CPU tax.
-      ...(process.env.LANGWATCH_VITE_NO_POLLING === "1"
-        ? {}
-        : { usePolling: true, interval: 250 }),
-    },
-    // Frontend port (default 5560, configurable via PORT env var)
-    host: true,
-    allowedHosts: true,
-    port: FRONTEND_PORT,
-    strictPort: true,
-    // HTTPS+HTTP/2 when LANGWATCH_DEV_HTTP2=1. Vite negotiates h2 over
-    // TLS automatically when `https` is set. Both Vite and the API
-    // share the same auto-generated cert so the browser only has to
-    // trust one cert for the whole stack.
-    ...(devHttpsCredentials
-      ? {
-          https: {
-            cert: devHttpsCredentials.cert,
-            key: devHttpsCredentials.key,
-          },
+    experimental: {
+      // ADR-086: the base for content-hashed assets is chosen at container start,
+      // not build time — one image serves self-host same-origin and SaaS from a
+      // commit-prefixed CDN. Emit every JS-referenced asset URL as a call to the
+      // runtime resolver defined by the served HTML shell (src/server/asset-base.ts);
+      // keep CSS-referenced assets relative to the CSS file (which lives under the
+      // same base, so fonts/images resolve on the CDN); leave HTML entry refs
+      // base-absolute for the server to rewrite; leave public/ assets same-origin.
+      renderBuiltUrl(filename, { type, hostType }) {
+        if (type === "public") return undefined;
+        if (hostType === "js") {
+          // Self-defaulting so the built bundle is usable even when the server
+          // hasn't injected the resolver: `vite preview`, the boot-smoke, and any
+          // raw-`dist/` static server fall back to same-origin ("/"+path). Read
+          // via `globalThis` (defined in the main document AND in Web Worker
+          // scopes, where `window` is undefined) so a worker chunk degrades to
+          // same-origin instead of throwing. The server sets
+          // `globalThis.__lwAssetUrl` to the CDN prefixer when LANGWATCH_ASSET_BASE
+          // is configured.
+          return {
+            runtime: `(globalThis.${ASSET_URL_GLOBAL}||function(p){return "/"+p})(${JSON.stringify(
+              filename,
+            )})`,
+          };
         }
-      : {}),
-    // Proxy API requests to the Hono backend (PORT + 1000). `ws: true`
-    // forwards WebSocket upgrades for the tRPC WS transport at /api/trpc-ws.
-    //
-    // The MCP routes (/mcp, /sse, /messages, /oauth/*, /.well-known/oauth-*)
-    // are registered directly on the Node HTTP server in start.ts (NOT
-    // mounted under /api), so they need explicit proxy entries here for
-    // external MCP clients (e.g. Claude Code adding the LangWatch MCP
-    // server in dev) to reach them via the canonical FRONTEND_PORT. The
-    // production server (start.ts) listens on a single port so this
-    // splitting is dev-only.
-    proxy: {
-      // The tRPC WS transport enforces a same-origin allowlist (built from
-      // NEXTAUTH_URL) and fail-closes on a missing/mismatched Origin. The
-      // catch-all `/api` proxy below sets `changeOrigin: true`, which rewrites
-      // the WS handshake Origin so the backend sees a null/foreign origin and
-      // rejects every upgrade — silently breaking all WS-backed workbench
-      // state. A dedicated, earlier entry keeps the browser's real Origin.
-      "/api/trpc-ws": {
-        target: API_TARGET,
-        changeOrigin: false,
-        ws: true,
-        secure: false,
-      },
-      "/api": {
-        target: API_TARGET,
-        changeOrigin: true,
-        ws: true,
-        // Self-signed dev cert — don't fail the proxy on cert verification.
-        // No-op when API is on plain HTTP.
-        secure: false,
-      },
-      // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
-      // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
-      // sending it to the API server, which has no dev-mode page fallback.
-      // server.proxy regexes test against the full req.url (path + query),
-      // so the optional "(?:\?.*)?" is required or a query-bearing request
-      // like "/mcp?sessionId=..." falls through to the frontend instead.
-      "^/mcp(?:\\?.*)?$": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "^/mcp/health(?:\\?.*)?$": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/sse": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/messages": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/oauth": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/.well-known/oauth-protected-resource": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/.well-known/oauth-authorization-server": {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
+        if (hostType === "css") return { relative: true };
+        return undefined;
       },
     },
-  },
+    server: {
+      watch: {
+        ignored: [
+          "**/.git/**",
+          "**/node_modules/.pnpm/**",
+          "**/.pnpm-store/**",
+          "**/dist/**",
+          "**/.next/**",
+          "**/coverage/**",
+          // Any dev-server tee target (server.log, server-qa.log, ...): the
+          // server appends on every request, so watching one turns each page
+          // load into a full-reload loop.
+          "**/server*.log",
+          // Working files agents keep under .claude/tmp, per the repo
+          // convention. A dev-server log teed there reloads the page on every
+          // request, same trap as above under a different name. Agent
+          // worktrees also live under .claude/worktrees, and chokidar
+          // matches ignore globs against full paths, so from a worktree
+          // root any pattern containing .claude/worktrees matches every
+          // file in the tree and blinds the watcher entirely. From a
+          // worktree only .claude/tmp is ignored (worktrees do not nest);
+          // from the main root the entire .claude tree, nested worktree
+          // copies included, stays ignored as before.
+          ...(process.cwd().includes("/.claude/")
+            ? ["**/.claude/tmp/**"]
+            : ["**/.claude/**"]),
+        ],
+        // Docker-on-macOS bind mounts don't surface inotify events reliably,
+        // so Vite's default fs.watch sits silent on edits made from the host.
+        // Polling at 250ms is the standard workaround and HMR fires
+        // immediately. Native macOS / Linux hosts opt out via
+        // `LANGWATCH_VITE_NO_POLLING=1` to dodge the CPU tax.
+        ...(process.env.LANGWATCH_VITE_NO_POLLING === "1"
+          ? {}
+          : { usePolling: true, interval: 250 }),
+      },
+      // Frontend port (default 5560, configurable via PORT env var)
+      host: true,
+      allowedHosts: true,
+      port: FRONTEND_PORT,
+      strictPort: true,
+      // HTTPS+HTTP/2 when LANGWATCH_DEV_HTTP2=1. Vite negotiates h2 over
+      // TLS automatically when `https` is set. Both Vite and the API
+      // share the same auto-generated cert so the browser only has to
+      // trust one cert for the whole stack.
+      ...(devHttpsCredentials
+        ? {
+            https: {
+              cert: devHttpsCredentials.cert,
+              key: devHttpsCredentials.key,
+            },
+          }
+        : {}),
+      // Proxy API requests to the Hono backend (PORT + 1000). `ws: true`
+      // forwards WebSocket upgrades for the tRPC WS transport at /api/trpc-ws.
+      //
+      // The MCP routes (/mcp, /sse, /messages, /oauth/*, /.well-known/oauth-*)
+      // are registered directly on the Node HTTP server in start.ts (NOT
+      // mounted under /api), so they need explicit proxy entries here for
+      // external MCP clients (e.g. Claude Code adding the LangWatch MCP
+      // server in dev) to reach them via the canonical FRONTEND_PORT. The
+      // production server (start.ts) listens on a single port so this
+      // splitting is dev-only.
+      proxy: {
+        // The tRPC WS transport enforces a same-origin allowlist (built from
+        // NEXTAUTH_URL) and fail-closes on a missing/mismatched Origin. The
+        // catch-all `/api` proxy below sets `changeOrigin: true`, which rewrites
+        // the WS handshake Origin so the backend sees a null/foreign origin and
+        // rejects every upgrade — silently breaking all WS-backed workbench
+        // state. A dedicated, earlier entry keeps the browser's real Origin.
+        "/api/trpc-ws": {
+          target: API_TARGET,
+          changeOrigin: false,
+          ws: true,
+          secure: false,
+        },
+        "/api": {
+          target: API_TARGET,
+          changeOrigin: true,
+          ws: true,
+          // Self-signed dev cert — don't fail the proxy on cert verification.
+          // No-op when API is on plain HTTP.
+          secure: false,
+        },
+        // An exporter given the site root as its OTLP endpoint posts to
+        // `/v1/traces`. In production start.ts routes those into the API; in dev
+        // the frontend owns the root, so they need an entry of their own or they
+        // fall through to the SPA. Exact-match, same reasoning as /mcp below.
+        "^/v1/(?:traces|logs|metrics)(?:\\?.*)?$": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
+        // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
+        // sending it to the API server, which has no dev-mode page fallback.
+        // server.proxy regexes test against the full req.url (path + query),
+        // so the optional "(?:\?.*)?" is required or a query-bearing request
+        // like "/mcp?sessionId=..." falls through to the frontend instead.
+        "^/mcp(?:\\?.*)?$": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "^/mcp/health(?:\\?.*)?$": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/sse": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/messages": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/oauth": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/.well-known/oauth-protected-resource": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+        "/.well-known/oauth-authorization-server": {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
   };
 });

--- a/specs/otlp/endpoint-path-canonicalisation.feature
+++ b/specs/otlp/endpoint-path-canonicalisation.feature
@@ -76,6 +76,15 @@ Feature: OTLP endpoint path canonicalisation
       Then the response is the ordinary ingestion response
       And the response does not ask the client to send the batch elsewhere
 
+    # An exporter streams its payload rather than buffering it, and the
+    # correction rebuilds the request around a new path. A body dropped there
+    # would be answered with a cheerful 200, which is the failure this whole
+    # feature exists to remove.
+    @unit @regression
+    Scenario: A streamed payload survives the correction
+      When an exporter streams spans to a misconfigured path
+      Then the whole payload reaches ingestion
+
   Rule: Only known misconfigurations are accepted
 
     @unit
@@ -95,6 +104,14 @@ Feature: OTLP endpoint path canonicalisation
       When an exporter posts spans to a misconfigured path
       Then the platform records the path the exporter used
       And it records the canonical path the request was served from
+
+    # A misconfigured fleet posts continuously and every batch carries the same
+    # project and the same path, so reporting each one costs money on an
+    # ingestion hot path and says nothing the first line did not.
+    @unit
+    Scenario: A repeated misconfiguration is reported once a window
+      When an exporter posts repeatedly to the same misconfigured path
+      Then the platform reports it once rather than once per batch
 
     @unit
     Scenario: A caller cannot claim its path was corrected

--- a/specs/otlp/endpoint-path-canonicalisation.feature
+++ b/specs/otlp/endpoint-path-canonicalisation.feature
@@ -1,0 +1,102 @@
+Feature: OTLP endpoint path canonicalisation
+
+  An OpenTelemetry exporter builds its own URL. Given a base endpoint it appends
+  `/v1/traces`, `/v1/logs` or `/v1/metrics` itself, so a customer who pastes our
+  signal-specific URL into the base setting ends up posting to
+  `/api/otel/v1/traces/v1/logs`. A customer who pastes the collector URL ends up
+  posting to `/api/collector/api/otel/v1/traces`. Both are seen in production.
+
+  The customer cannot see any of this. Exporters do not surface a 404 anywhere a
+  human looks, so the telemetry simply never arrives and the account looks idle.
+  Worse, a base endpoint of the site root posts to `/v1/traces`, which the web
+  server answered with the application's HTML shell and a 200 - the exporter
+  reads that as success and discards the batch.
+
+  So the receiver accepts these paths and serves them from the canonical
+  handler. It does not redirect: an OTLP exporter is not a browser, and the two
+  largest client stacks will not follow one. The Java exporter's HTTP client
+  refuses to replay a POST across 307 and 308, and the Node exporter issues its
+  request without any redirect handling at all, so a redirect would repair some
+  of the fleet and go on silently dropping the rest.
+
+  The signal is taken from the suffix the exporter appended, never from the base
+  it was given, because the suffix is the part that describes the payload.
+
+  Only paths that a known misconfiguration produces are accepted. Everything
+  else keeps answering exactly as it does today.
+
+  Background:
+    Given a project with a valid ingestion key
+
+  Rule: A misconfigured exporter path still delivers its telemetry
+
+    @unit
+    Scenario: An endpoint that already named a signal
+      Given an exporter configured with our traces URL as its base endpoint
+      When it posts log records to the path that base produces
+      Then the request is served as log ingestion
+
+    @unit
+    Scenario: An endpoint that named the collector
+      Given an exporter configured with our collector URL as its base endpoint
+      When it posts spans to the path that base produces
+      Then the request is served as trace ingestion
+
+    @unit
+    Scenario: An endpoint that named the site root
+      Given an exporter configured with our site root as its base endpoint
+      When it posts spans to the path that base produces
+      Then the request is served as trace ingestion
+      And the response is never the application's web page
+
+    @unit
+    Scenario: An endpoint with a stray trailing slash
+      When an exporter posts spans to the canonical path with a trailing slash
+      Then the request is served as trace ingestion
+
+  Rule: The appended suffix decides the signal, not the base endpoint
+
+    @unit
+    Scenario: A metrics suffix under a traces base is metric ingestion
+      When an exporter posts metrics to a traces base with a metrics suffix
+      Then the request is served as metric ingestion
+      And it is not served as trace ingestion
+
+  Rule: Correcting the path changes nothing else about the request
+
+    @unit
+    Scenario: A corrected path still needs a valid key
+      Given an exporter with no ingestion key
+      When it posts to a misconfigured path
+      Then the response refuses the request for want of credentials
+
+    @unit
+    Scenario: A corrected path answers like the canonical one
+      When an exporter posts spans to a misconfigured path
+      Then the response is the ordinary ingestion response
+      And the response does not ask the client to send the batch elsewhere
+
+  Rule: Only known misconfigurations are accepted
+
+    @unit
+    Scenario: An unrelated path that happens to end in a signal name
+      When a request arrives on an unrelated path ending in a signal name
+      Then the path is not treated as ingestion
+
+    @unit
+    Scenario: A path naming something other than a signal
+      When a request arrives on a misconfigured base with an unknown suffix
+      Then the path is not treated as ingestion
+
+  Rule: A corrected path is recorded so the customer can be told
+
+    @unit
+    Scenario: The correction names the path the exporter used
+      When an exporter posts spans to a misconfigured path
+      Then the platform records the path the exporter used
+      And it records the canonical path the request was served from
+
+    @unit
+    Scenario: A caller cannot claim its path was corrected
+      When a request arrives on the canonical path claiming a corrected origin
+      Then the claim is discarded


### PR DESCRIPTION
## Why

An OpenTelemetry exporter builds its own URL. Given a base endpoint it appends `/v1/traces`, `/v1/logs` or `/v1/metrics` itself, so a customer who pastes our signal-specific URL into the base setting posts to `/api/otel/v1/traces/v1/logs`, and one who pastes the collector URL posts to `/api/collector/api/otel/v1/traces`. Both are live in production right now.

The customer cannot see any of this. An exporter surfaces a 404 nowhere a human looks, so the telemetry never arrives and the account looks idle.

One variant was worse than a 404. A base endpoint of the site root makes the exporter post to `/v1/traces`, which never matched `/api/` and fell through to the SPA fallback — answered with the HTML shell and a **200**. An exporter reads 200 as success and drops the batch. That is silent data loss, and it has presumably been there as long as the SPA fallback has.

## What changed

These paths are now served from the canonical OTLP handlers, and root-level OTLP paths are routed into the API instead of the SPA.

Not by redirect. OkHttp, under the Java exporter, refuses to replay a POST across 307 or 308, and the Node exporter issues its request through `http.request` with no redirect handling at all. A redirect would repair Go and Python and go on silently dropping Java and Node, so the request is replayed internally instead — the same shape as the existing experiments-v3 legacy alias and the legacy OAuth callback rewrite in `api-router.ts`.

The signal comes from the suffix the exporter appended, never from the base it was given, because the suffix is the part that describes the payload.

## How it works

`canonicalOtlpPath` maps a request path onto one of the three canonical paths, or returns null. It is an allow-list of the prefixes a known misconfiguration leaves behind — the site root, `/api`, `/api/otel`, a signal-specific URL, and the collector URL. A permissive "anything ending in `/v1/traces`" rule would quietly claim any future namespace that grows one of its own.

`otel-path-aliases.ts` sits last in the ingestion mounts, rewrites the path, and hands the request to the OTLP app. Anything it catches that is not a recognised misconfiguration is passed straight on, so a namespace mounted after it keeps its own routing and its own 404.

Nothing else about the request changes. The replay enters the canonical route, so auth, the body limit and the plan check all apply exactly as on the canonical path. The original path travels to the receiver behind a per-process secret, so a caller cannot forge a correction that did not happen, and it is logged with the project id — which is what makes it actionable. That report is throttled to once per (project, path) per ten minutes, because a misconfigured fleet posts continuously and every batch carries the same pair.

Root OTLP paths were also excluded from the HTTP metrics by the `bypass` rule in `start.ts`, which would have hidden exactly the traffic worth watching. They are included now; cardinality is bounded at three paths.

## Test plan

- [ ] `pnpm test:unit run src/server/otel/ src/server/routes/__tests__/otel.path-aliases.unit.test.ts` — 24 tests over the mapping and the routing
- [ ] Each production shape is served as the right signal: `/api/otel/v1/traces/v1/logs` as logs, `/api/collector/api/otel/v1/traces` as traces, `/v1/traces` as traces with a JSON response rather than the web page
- [ ] A metrics suffix under a traces base is metric ingestion, and is not served as trace ingestion
- [ ] A corrected path with no credentials is still refused 401, and an accepted one answers with the ordinary ingestion body and no `Location` header
- [ ] An unrelated path ending in a signal name (`/api/rum/v1/traces`) and an unknown suffix (`.../v1/profiles`) are both left alone
- [ ] A caller sending the corrected-path header itself is not believed
- [ ] A streamed payload survives the replay — the correction rebuilds the request around a new path, and a dropped body would be answered with a 200
- [ ] The same misconfiguration is reported once per window, not once per batch
- [ ] `specs/otlp/endpoint-path-canonicalisation.feature` reports 13/13 scenarios bound

Existing OTLP route tests still pass (97 across the traces, logs, metrics and parser suites), as does `src/server/__tests__` including the frontend-boundary guard.

## Anything surprising?

**One thing to check on the infra side.** `/api/collector/api/otel/v1/traces` now reaches ingestion where it previously 404'd. If there is a path-scoped edge rule keyed on `/api/otel/v1/*` — WAF, rate limit, body-size cap — these alias paths route around it. I cannot see the saas infra from this repo, so that wants a second pair of eyes.

**The alias is raw Hono, not a SecuredApp.** Deliberate: it declares no access policy because it terminates nothing. The endpoint-authorization guard excludes `ALL`-plus-wildcard routes from both sides of its cross-check, so this does not punch a hole in that guarantee, and the spec pins that a corrected path is refused for want of credentials.

**The two SDK claims are from knowledge of those clients, not measured here.** OkHttp's refusal to replay a POST across 307/308, and the Node exporter's lack of redirect handling, are the reason this is a replay rather than a redirect. Worth a sanity check by anyone who knows those exporters better than I do.

**Not included:** we now log the misconfiguration with the project id, but nothing tells the customer. The natural follow-up is a project banner or a setup-page nudge off that signal, deliberately left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for common OTLP endpoint path variations, including root-level and collector-prefixed paths.
  * Requests are normalized internally without redirects while preserving authentication, payloads, and ingestion behavior.
  * Added support for trailing slashes and trace, log, and metric signal routing.
  * Added visibility into corrected paths through rate-limited warning logs.

* **Bug Fixes**
  * Prevented valid OTLP requests from falling through to the application interface.

* **Tests**
  * Added comprehensive coverage for supported aliases, invalid paths, authentication, logging, streamed payloads, and correction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
