### PR TITLE
perf(ci): one Go version, and stop two buildx caches evicting each other

### DIFF
--- a/.github/workflows/clickhouse-serverless.yml
+++ b/.github/workflows/clickhouse-serverless.yml
@@ -54,7 +54,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          # Its own module declares the version; "1.26" here silently resolved
+          # to whatever 1.26.x was newest that day.
+          go-version-file: infra/clickhouse-serverless/go.mod
           cache-dependency-path: infra/clickhouse-serverless/go.sum
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
@@ -74,7 +76,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          # Its own module declares the version; "1.26" here silently resolved
+          # to whatever 1.26.x was newest that day.
+          go-version-file: infra/clickhouse-serverless/go.mod
           cache-dependency-path: infra/clickhouse-serverless/go.sum
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - run: make e2e

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -148,8 +148,12 @@ jobs:
           file: infra/docker/Dockerfile.langevals
           push: false
           tags: langwatch/langevals:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped, like every other buildx cache in this repo. Unscoped, this
+          # and langwatch-nlp-ci both wrote to buildkit's default scope and
+          # evicted each other's layers on every run — and with mode=max
+          # against a 10 GB per-repo budget, images this size evict a lot.
+          cache-from: type=gha,scope=langevals
+          cache-to: type=gha,mode=max,scope=langevals
 
   langevals-complete:
     needs: [changes, lint, test, docker-build]

--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -70,8 +70,10 @@ jobs:
           file: infra/docker/Dockerfile.langwatch_nlp
           push: false
           tags: langwatch/langwatch_nlp:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped: see the note in langevals-ci.yml. These two were the only
+          # unscoped buildx caches left, which meant they shared one.
+          cache-from: type=gha,scope=langwatch-nlp
+          cache-to: type=gha,mode=max,scope=langwatch-nlp
 
   langwatch-nlp-complete:
     needs: [changes, docker-build]

--- a/.github/workflows/sdk-go-cd.yml
+++ b/.github/workflows/sdk-go-cd.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25"
+          # The SDK's floor lives in its go.mod; read it rather than restate it.
+          go-version-file: sdks/go/go.mod
           cache-dependency-path: sdks/go/go.sum
 
       - name: Run tests

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -66,8 +66,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
-          cache: true
+          # Read the floor from the module instead of restating it. The SDK
+          # deliberately targets an older Go than the rest of the repo — it
+          # must build standalone at its declared directive, which is why
+          # these jobs run with GOWORK=off — and a literal here is a second
+          # copy of that decision, free to drift from the first. It already
+          # had: go.mod said 1.25.0 while three other workflows said "1.25",
+          # "1.26" and go.mod's 1.26.5.
+          go-version-file: sdks/go/go.mod
+          cache-dependency-path: sdks/go/go.sum
 
       - name: Install dependencies
         working-directory: ./sdks/go
@@ -133,8 +140,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
-          cache: true
+          # Read the floor from the module instead of restating it. The SDK
+          # deliberately targets an older Go than the rest of the repo — it
+          # must build standalone at its declared directive, which is why
+          # these jobs run with GOWORK=off — and a literal here is a second
+          # copy of that decision, free to drift from the first. It already
+          # had: go.mod said 1.25.0 while three other workflows said "1.25",
+          # "1.26" and go.mod's 1.26.5.
+          go-version-file: sdks/go/go.mod
+          cache-dependency-path: sdks/go/go.sum
 
       - name: Install dependencies
         working-directory: ./sdks/go

--- a/cmd/ciguard/main.go
+++ b/cmd/ciguard/main.go
@@ -41,10 +41,11 @@ func main() {
 
 	guards := []guard{
 		{name: "lean-checkout", run: ciguard.LeanCheckout},
+		{name: "go-version", run: ciguard.GoVersion},
 	}
 
 	if failed := runAll(guards, repoRoot); failed {
-		fmt.Fprintln(os.Stderr, "\nSee specs/ci/lean-checkout.feature")
+		fmt.Fprintln(os.Stderr, "\nSee specs/ci/lean-checkout.feature and specs/ci/go-version-consistency.feature")
 		os.Exit(1)
 	}
 }

--- a/infra/clickhouse-serverless/Dockerfile
+++ b/infra/clickhouse-serverless/Dockerfile
@@ -1,7 +1,7 @@
 ARG CLICKHOUSE_VERSION=25.10.2.65
 
 # Stage 1: Build Go config generator
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/infra/clickhouse-serverless/go.mod
+++ b/infra/clickhouse-serverless/go.mod
@@ -1,6 +1,6 @@
 module github.com/langwatch/langwatch/infra/clickhouse-serverless
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/go-playground/validator/v10 v10.30.2

--- a/specs/ci/go-version-consistency.feature
+++ b/specs/ci/go-version-consistency.feature
@@ -1,0 +1,62 @@
+Feature: One Go version, stated once
+  As a developer reading a Go build failure
+  I want every part of CI to compile with the toolchain the module asks for
+  So that a passing job and a shipped image mean the same thing
+
+  # The Go version lived in eight places — go.work, three go.mod files and four
+  # Dockerfile base images — plus three workflows that restated it as a literal
+  # string. They had already drifted:
+  #
+  #   go.work                              1.26.5
+  #   go.mod                               1.26.5
+  #   infra/clickhouse-serverless/go.mod   1.26.1
+  #   infra/clickhouse-serverless/Docker*  golang:1.26-alpine   <- floating
+  #   sdks/go/go.mod                       1.25.0 (deliberate)
+  #   sdk-go-ci.yml, sdk-go-cd.yml         "1.25"
+  #   clickhouse-serverless.yml            "1.26"
+  #
+  # Nothing failed. Different jobs simply compiled the same code with different
+  # toolchains, and the published image was built with a third.
+  #
+  # Workflows are fixed by reading go-version-file rather than a literal, so
+  # there is no second copy left to drift. Dockerfiles cannot read a go.mod,
+  # which is what this guard is for.
+
+  Background:
+    Given the root go.mod declares the repository's Go version
+
+  @unit
+  Scenario: Every Go toolchain reference in the repo agrees
+    Given the guard runs against the repository
+    Then it reports no disagreement
+
+  @unit
+  Scenario: The workspace and the root module must agree
+    Given go.work declares a different version from go.mod
+    Then the guard reports the disagreement
+
+  @unit
+  Scenario: A Dockerfile built with a different Go than the module fails the check
+    Given a Dockerfile whose golang base image is a different patch release
+    Then the guard names the file and both versions
+
+  @unit
+  Scenario: A floating Go base image fails the check
+    Given a Dockerfile whose golang base image omits the patch, like "golang:1.26-alpine"
+    Then the guard rejects it as floating
+    # A floating tag resolves to whatever patch was newest that day, so the
+    # image quietly stops matching the module without any file changing.
+
+  @unit
+  Scenario: A workflow states the version by reading the module
+    Given a workflow step that sets up Go with a version literal
+    Then the guard tells it to use go-version-file instead
+
+  @unit
+  Scenario: The published SDK keeps its own floor
+    Given sdks/go is a published module
+    Then it is exempt from matching the root version
+    And the exemption records why
+    # Its go directive is the floor consumers must meet; raising it drops
+    # support for anyone below. sdk-go-ci and sdk-go-cd build it standalone
+    # with GOWORK=off precisely so that stays true.

--- a/tools/ciguard/goversion.go
+++ b/tools/ciguard/goversion.go
@@ -1,0 +1,204 @@
+package ciguard
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/langwatch/langwatch/pkg/ciscan"
+)
+
+// The Go version used to live in eight places — go.work, three go.mod files
+// and four Dockerfile base images — plus three workflows that restated it as
+// a literal string. They had already drifted: go.work and the root module
+// said 1.26.5, infra/clickhouse-serverless said 1.26.1 while its Dockerfile
+// said a floating golang:1.26-alpine, and two workflows pinned "1.25" and
+// "1.26" by hand. Nothing failed; different jobs simply compiled the same
+// code with different toolchains, and the image was built with a third.
+//
+// Workflows are fixed by reading go-version-file instead of a literal, which
+// leaves no second copy to drift. Dockerfiles cannot read a go.mod, so this
+// guard is what keeps them honest.
+
+// GoDockerfileRoots are the directories walked for Dockerfiles.
+var GoDockerfileRoots = []string{"infra", "services", "platform", "tools"}
+
+// ExemptModules are modules that deliberately do not track the root version,
+// each with the reason. An exemption is a decision, so it carries one.
+var ExemptModules = map[string]string{
+	"sdks/go/go.mod": "published SDK: its go directive is the floor consumers must meet, and raising it drops support for anyone below. sdk-go-ci and sdk-go-cd build it standalone with GOWORK=off precisely so that stays true.",
+}
+
+var (
+	goDirectivePattern = regexp.MustCompile(`(?m)^go\s+(\d+\.\d+(?:\.\d+)?)\s*$`)
+	golangImagePattern = regexp.MustCompile(`(?m)^FROM\s+(?:--platform=\S+\s+)?golang:(\S+)`)
+	fullVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+)
+
+func goDirective(text string) string {
+	if match := goDirectivePattern.FindStringSubmatch(text); match != nil {
+		return match[1]
+	}
+
+	return ""
+}
+
+// GoVersion reports every place that disagrees with the root go.mod.
+func GoVersion(repoRoot string) ([]string, error) {
+	rootModule, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		return nil, fmt.Errorf("read go.mod: %w", err)
+	}
+
+	want := goDirective(string(rootModule))
+	if want == "" {
+		return []string{"go.mod has no parseable `go` directive"}, nil
+	}
+
+	var problems []string
+
+	work, err := os.ReadFile(filepath.Join(repoRoot, "go.work"))
+	if err != nil {
+		return nil, fmt.Errorf("read go.work: %w", err)
+	}
+	if got := goDirective(string(work)); got != want {
+		problems = append(problems, fmt.Sprintf(
+			"go.work says %s, go.mod says %s — the workspace and the root module must agree", got, want))
+	}
+
+	literals, err := goVersionLiterals(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	problems = append(problems, literals...)
+
+	images, err := goDockerfileImages(repoRoot, want)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(problems, images...), nil
+}
+
+// goVersionLiterals finds workflows that restate the version rather than
+// reading it. go-version-file cannot drift; go-version: "1.25" already did.
+func goVersionLiterals(repoRoot string) ([]string, error) {
+	workflows, err := ciscan.LoadAll(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var problems []string
+	for _, workflow := range workflows {
+		problems = append(problems, workflowLiterals(workflow)...)
+	}
+
+	return problems, nil
+}
+
+func workflowLiterals(workflow *ciscan.Workflow) []string {
+	var problems []string
+	for _, job := range workflow.JobNames() {
+		for _, step := range workflow.Jobs[job].Steps {
+			literal, ok := step.StringWith("go-version")
+			if !ok || !strings.HasPrefix(step.Uses, "actions/setup-go@") {
+				continue
+			}
+			problems = append(problems, fmt.Sprintf(
+				"%s job %q pins Go with a literal (%s) — use go-version-file so it follows the module",
+				workflow.Path, job, literal))
+		}
+	}
+
+	return problems
+}
+
+func goDockerfileImages(repoRoot, want string) ([]string, error) {
+	paths, err := dockerfilePaths(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var problems []string
+	// Read after the walk rather than inside its callback: a filesystem
+	// operation in a WalkDir callback races the walk itself against a symlink
+	// swap (gosec G122).
+	for _, path := range paths {
+		contents, err := os.ReadFile(filepath.Join(repoRoot, path))
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range golangImagePattern.FindAllStringSubmatch(string(contents), -1) {
+			problems = append(problems, checkGolangImage(path, match[1], want)...)
+		}
+	}
+
+	return problems, nil
+}
+
+func isSkippedDir(name string) bool {
+	return name == "node_modules" || name == ".git" || name == "dist"
+}
+
+func isDockerfile(name string) bool {
+	return name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.")
+}
+
+// dockerfilePaths collects every Dockerfile under the Go roots, repo-relative
+// and sorted so guard output does not reorder between runs.
+func dockerfilePaths(repoRoot string) ([]string, error) {
+	var paths []string
+
+	collect := func(path string, entry fs.DirEntry, err error) error {
+		switch {
+		case err != nil && os.IsNotExist(err):
+			// A root that does not exist in this tree is not a failure.
+			return fs.SkipDir
+		case err != nil:
+			return err
+		case entry.IsDir() && isSkippedDir(entry.Name()):
+			return fs.SkipDir
+		case entry.IsDir() || !isDockerfile(entry.Name()):
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+
+		return nil
+	}
+
+	for _, root := range GoDockerfileRoots {
+		if err := filepath.WalkDir(filepath.Join(repoRoot, root), collect); err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(paths)
+
+	return paths, nil
+}
+
+func checkGolangImage(path, tag, want string) []string {
+	version, _, _ := strings.Cut(tag, "-")
+
+	if !fullVersionPattern.MatchString(version) {
+		// A floating tag resolves to whatever patch was newest that day, so
+		// the image quietly stops matching the module without any file
+		// changing.
+		return []string{fmt.Sprintf(
+			"%s uses golang:%s, a floating tag — pin the patch so the image is built with the toolchain go.mod asks for", path, tag)}
+	}
+
+	if version != want {
+		return []string{fmt.Sprintf("%s builds with Go %s, go.mod says %s", path, version, want)}
+	}
+
+	return nil
+}

--- a/tools/ciguard/goversion_test.go
+++ b/tools/ciguard/goversion_test.go
@@ -1,0 +1,108 @@
+package ciguard_test
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/ciscan"
+	"github.com/langwatch/langwatch/tools/ciguard"
+)
+
+// agreeingRepo is the smallest tree the go-version guard reads: a root
+// module, a workspace, one Dockerfile and one workflow, all in agreement.
+func agreeingRepo(t *testing.T, overrides map[string]string) string {
+	t.Helper()
+
+	files := map[string]string{
+		"go.mod":                       "module x\n\ngo 1.26.5\n",
+		"go.work":                      "go 1.26.5\n\nuse (\n\t.\n)\n",
+		"infra/docker/Dockerfile.svc":  "FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS build\n",
+		".github/workflows/go-ci.yaml": "jobs:\n  build:\n    steps:\n      - uses: actions/setup-go@v7\n        with:\n          go-version-file: go.mod\n",
+	}
+	maps.Copy(files, overrides)
+
+	root := t.TempDir()
+	for path, body := range files {
+		full := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o600))
+	}
+
+	return root
+}
+
+// @scenario "Every Go toolchain reference in the repo agrees"
+func TestGoVersionAcceptsAnAgreeingRepo(t *testing.T) {
+	problems, err := ciguard.GoVersion(agreeingRepo(t, nil))
+
+	require.NoError(t, err)
+	assert.Empty(t, problems)
+}
+
+// @scenario "The workspace and the root module must agree"
+func TestGoVersionReportsAWorkspaceOnADifferentVersion(t *testing.T) {
+	problems, err := ciguard.GoVersion(agreeingRepo(t, map[string]string{
+		"go.work": "go 1.26.1\n",
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "go.work says 1.26.1")
+}
+
+// @scenario "A Dockerfile built with a different Go than the module fails the check"
+func TestGoVersionReportsADockerfileOnADifferentPatch(t *testing.T) {
+	problems, err := ciguard.GoVersion(agreeingRepo(t, map[string]string{
+		"infra/docker/Dockerfile.svc": "FROM golang:1.26.1-alpine AS build\n",
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "builds with Go 1.26.1, go.mod says 1.26.5")
+}
+
+// @scenario "A floating Go base image fails the check"
+func TestGoVersionRejectsAFloatingBaseImage(t *testing.T) {
+	problems, err := ciguard.GoVersion(agreeingRepo(t, map[string]string{
+		"infra/docker/Dockerfile.svc": "FROM golang:1.26-alpine AS build\n",
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "floating tag")
+}
+
+// @scenario "A workflow states the version by reading the module"
+func TestGoVersionReportsAWorkflowPinningALiteral(t *testing.T) {
+	problems, err := ciguard.GoVersion(agreeingRepo(t, map[string]string{
+		".github/workflows/go-ci.yaml": "jobs:\n  build:\n    steps:\n      - uses: actions/setup-go@v7\n        with:\n          go-version: '1.25'\n",
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "pins Go with a literal")
+}
+
+// @scenario "The published SDK keeps its own floor"
+func TestGoVersionExemptsThePublishedSDKWithAReason(t *testing.T) {
+	reason, ok := ciguard.ExemptModules["sdks/go/go.mod"]
+
+	require.True(t, ok, "the SDK's deliberate floor must be recorded as an exemption")
+	assert.Contains(t, strings.ToLower(reason), "floor")
+}
+
+func TestGoVersionHoldsInTheLiveRepo(t *testing.T) {
+	root, err := ciscan.RepoRoot(".")
+	require.NoError(t, err)
+
+	problems, err := ciguard.GoVersion(root)
+
+	require.NoError(t, err)
+	assert.Empty(t, problems)
+}


### PR DESCRIPTION
Stacked on #6820 — review that first, or read this diff against `worktree-ci-checkout-speed`. It needs #6820's `tools/ciguard` + `pkg/ciscan`.

## One Go version, stated once

It lived in eight places and had already drifted:

```
  go.work                              1.26.5
  go.mod                               1.26.5
  infra/clickhouse-serverless/go.mod   1.26.1
  infra/clickhouse-serverless/Docker*  golang:1.26-alpine   <- floating
  sdks/go/go.mod                       1.25.0 (deliberate)
  sdk-go-ci.yml, sdk-go-cd.yml         "1.25"
  clickhouse-serverless.yml            "1.26"
```

Nothing failed. Different jobs simply compiled the same code with different toolchains, and the clickhouse-serverless image was built with a third — its floating tag resolves to whatever `1.26.x` was newest that day.

**Every workflow now reads `go-version-file`** from the module it builds, so there is no literal left to drift. That is also *more* correct than the hardcodes: `sdk-go` tested at `"1.25"` while its module declared `1.25.0`, and now tests at exactly its declared floor.

**The SDK keeps its floor.** Its `go` directive is what consumers must meet, and raising it drops support for anyone below — which is why `sdk-go-ci` and `-cd` already build it standalone with `GOWORK=off`. Consistency here means "read the version from the module", not "bump everything to 1.26". It is recorded as an exemption that carries its reason rather than left as a silent difference.

**clickhouse-serverless moves to 1.26.5** in both its module and its Dockerfile. It is internal, not published, so its floor is ours to set.

## The guard

Dockerfiles cannot read a `go.mod`, so `ciguard go-version` is what keeps them honest. It rejects a mismatched patch, a floating tag, a `go.work` that disagrees, and any workflow that pins a literal. Fixture-driven — each of those four has a test that fails without the rule — plus one that runs it against this repository.

## Two buildx caches sharing one scope

`langevals-ci` and `langwatch-nlp-ci` were the only unscoped `type=gha` caches left. That is worse than it sounds: unscoped means they both wrote to buildkit's *default* scope, so they were evicting each other's layers on every run, both at `mode=max` against a 10 GB per-repo budget. Now scoped, like every other buildx cache in the repo.

## Retracted

I reported this earlier and it is wrong, so it is not in this PR: *"go-services builds linux/arm64 under QEMU on main pushes while publish-docker-app uses native arm64 runners."*

`Dockerfile.go_service` pins its build stage to `$BUILDPLATFORM` and cross-compiles with `GOARCH=${TARGETARCH}`, and its runtime stage is `distroless/static`. There is nothing to emulate. `setup-qemu-action` registers binfmt handlers the build never uses — a second or two — and converting it to a native matrix would have been a large rewrite of a publishing path for no gain.

## Verification

- `go test ./tools/ciguard/...` — passes.
- `go run ./cmd/ciguard` — both guards clean against this tree.
- `golangci-lint run ./pkg/ciscan/... ./tools/ciguard/... ./cmd/ciguard/...` — 0 issues.
- `GOWORK=off go build ./...` in `infra/clickhouse-serverless` at the bumped version — clean. (A fresh worktree fails there on a missing `go.sum` entry both before and after the bump; that is pre-existing and unrelated.)
- All six scenario titles in the new spec match a `@scenario` annotation exactly.
