### PR TITLE
perf(ci): give the last 20 workflows a concurrency group

### DIFF
--- a/.github/workflows/agent-plugin-publish.yml
+++ b/.github/workflows/agent-plugin-publish.yml
@@ -17,6 +17,12 @@ on:
       - "agent-plugin@v*"
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app. Tag pushes are unique, so the
+# collision this actually guards is a re-dispatch of a tag already publishing.
+concurrency:
+  group: agent-plugin-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/coderabbit-config-check.yml
+++ b/.github/workflows/coderabbit-config-check.yml
@@ -17,6 +17,10 @@ on:
       - "dev/lint/**"
       - ".github/workflows/coderabbit-config-check.yml"
 
+concurrency:
+  group: coderabbit-config-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -19,6 +19,13 @@ on:
       - "platform/app/.env.example"
       - "docs/self-hosting/**"
 
+# Triggered on `edited`, and it reads the PR description, so an in-flight run
+# is grading a body the author has already rewritten. 18 of the last 100 runs
+# were superseded that way.
+concurrency:
+  group: deployment-impact-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/langevals-publish-pypi.yml
+++ b/.github/workflows/langevals-publish-pypi.yml
@@ -6,6 +6,13 @@ on:
       - published
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app. PyPI rejects a re-upload of an
+# existing version outright, so the loser of a race fails the release rather
+# than producing a wrong one, but it fails loudly and for no reason.
+concurrency:
+  group: langevals-publish-pypi-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/mcp-javascript-cd.yml
+++ b/.github/workflows/mcp-javascript-cd.yml
@@ -6,6 +6,13 @@ on:
       - published
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app. This one holds id-token:write
+# for npm provenance, and a cancel between `npm publish` and the provenance
+# exchange is not something a later run can repair.
+concurrency:
+  group: mcp-javascript-cd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -38,6 +38,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app. This job uploads monobinaries
+# onto the GitHub release AND publishes to npm, so a cancelled run can leave a
+# release carrying a partial set of assets that nothing reconciles.
+concurrency:
+  group: npx-server-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write # for creating/updating GH release with aigateway monobinaries
   id-token: write # for npm provenance + Trusted Publishers OIDC exchange

--- a/.github/workflows/pr-conventional-commits-title.yml
+++ b/.github/workflows/pr-conventional-commits-title.yml
@@ -4,6 +4,14 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# `edited` is in the trigger list, so every keystroke-save on a PR title starts
+# a run: 18 of the last 100 overlapped a newer one for the same branch. The
+# check reads the title as it is NOW, so an older run can only ever post a
+# verdict about a title that has already been replaced.
+concurrency:
+  group: pr-conventions-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
   statuses: write

--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -10,6 +10,15 @@ on:
         required: false
         default: 'next'
 
+# A publish run drains — the reasoning is spelled out in prerelease-charts-oci.
+# Re-running a release (or dispatching the same tag twice) otherwise has two
+# runs pushing one image tag and signing whichever digest won, and a cancel
+# between `docker push` and `cosign sign` leaves an unsigned image in the
+# registry that reports "cancelled" rather than failed, so nothing retries it.
+concurrency:
+  group: publish-docker-app-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   extract-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docker-clickhouse-serverless.yml
+++ b/.github/workflows/publish-docker-clickhouse-serverless.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: 'next'
 
+# A publish run drains — see publish-docker-app.
+concurrency:
+  group: publish-docker-clickhouse-serverless-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   extract-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-clickhouse-serverless-chart.yml
+++ b/.github/workflows/release-clickhouse-serverless-chart.yml
@@ -7,6 +7,13 @@ permissions:
   contents: write
   pages: write
 
+# Shared with release-langwatch-chart — see the note there. Both push the same
+# gh-pages index.yaml, so they serialize against each other under one group
+# rather than one group each.
+concurrency:
+  group: helm-chart-index
+  cancel-in-progress: false
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-langwatch-chart.yml
+++ b/.github/workflows/release-langwatch-chart.yml
@@ -10,6 +10,21 @@ permissions:
   contents: write
   pages: write
 
+# Shared with release-clickhouse-serverless-chart on purpose. Both run
+# `cr index --push`, and `cr index` rebuilds index.yaml from the repository's
+# release list and force-pushes it to the same gh-pages branch of the same
+# repo. Run the two together and the loser pushes an index it built before the
+# winner's `cr upload` registered, so a chart version that published
+# successfully disappears from the index — the release exists, `helm repo
+# update` just stops seeing it. A per-workflow group would not help: the race
+# is between the two workflows, not between runs of either.
+concurrency:
+  group: helm-chart-index
+  # A publish run drains. Cancelling lands between `cr upload` and `cr index`
+  # often enough to matter, and leaves exactly the same missing-from-index
+  # state with nothing to reconcile it.
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -33,6 +33,14 @@ on:
       - "charts/langwatch/Chart.yaml"
       - "charts/clickhouse-serverless/Chart.yaml"
 
+# A writer, so it queues rather than cancels: the job pushes a Chart.lock
+# commit to the release PR's branch, and two runs doing that at once is a
+# force-push race rather than wasted minutes. Serialized, the second run finds
+# the lock already in sync and does nothing.
+concurrency:
+  group: release-please-chart-lock-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -6,6 +6,18 @@ on:
       - main
   workflow_dispatch:
 
+# This one is not hypothetical: 12 of the last 60 runs were still in flight
+# when the next merge to main started another. release-please reads the commits
+# since the last release and then creates-or-updates a release PR per package,
+# so two overlapping runs compute their plan from the same history and race on
+# the same PRs — the observable results are a duplicate release PR, or one run
+# reverting the other's version bump.
+concurrency:
+  group: release-please-sdks-${{ github.ref }}
+  # Queue, never cancel. A cancelled run can land between "PR created" and
+  # "labels and body written", leaving a release PR that nothing will finish.
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release-scope-guard.yml
+++ b/.github/workflows/release-scope-guard.yml
@@ -11,6 +11,17 @@ on:
       - ".github/release-please-config.json"
   workflow_dispatch:
 
+# The heaviest superseder in the repo: 29 of its last 100 runs were still
+# going when a newer run for the same branch started. `edited`, `labeled` and
+# `unlabeled` are in the trigger list, so re-titling a PR or toggling a label
+# starts a run — and the guard reads the PR's CURRENT title and labels, which
+# means an in-flight run is already answering a question about a state that no
+# longer exists.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Never on main: a commit that lands keeps its own verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/sdk-go-cd.yml
+++ b/.github/workflows/sdk-go-cd.yml
@@ -6,6 +6,13 @@ on:
       - published
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app. This one fans a version out
+# across the sibling module tags, so a cancel partway through leaves the Go
+# module tags disagreeing about which version exists.
+concurrency:
+  group: sdk-go-cd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   # write, because the release fans the version out to the sibling module tags
   # (see "Tag the sibling modules"). Nothing else here needs it.

--- a/.github/workflows/sdk-javascript-cd.yml
+++ b/.github/workflows/sdk-javascript-cd.yml
@@ -6,6 +6,11 @@ on:
       - published
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app.
+concurrency:
+  group: sdk-javascript-cd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/sdk-python-cd.yml
+++ b/.github/workflows/sdk-python-cd.yml
@@ -6,6 +6,11 @@ on:
       - published
   workflow_dispatch:
 
+# A publish run drains — see publish-docker-app.
+concurrency:
+  group: sdk-python-cd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/sign-release-images.yml
+++ b/.github/workflows/sign-release-images.yml
@@ -17,6 +17,17 @@ on:
         type: boolean
         default: true
 
+# Backfilling signatures onto images that are already public, so two runs over
+# the same release would sign and attach SBOMs to the same digests at once, and
+# `gh release upload --clobber` makes the last writer win. Serialize; never
+# cancel, for the same reason publish-docker-app does not.
+concurrency:
+  # Keyed on the version being signed, not the ref: this is dispatch-only, so
+  # every run has the same ref and a ref-keyed group would serialize two
+  # unrelated backfills for no reason.
+  group: sign-release-images-${{ inputs.version }}
+  cancel-in-progress: false
+
 permissions:
   contents: write # attach SBOMs to the GitHub release
   id-token: write # keyless OIDC signing via Sigstore

--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -12,6 +12,12 @@ on:
       - 'skills/version.txt'
   workflow_dispatch:
 
+# Fires on merges to main, so a burst of merges starts overlapping publishes of
+# the same skills. Serialize; the second run republishes from the newer tree.
+concurrency:
+  group: skills-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-security-guard.yml
+++ b/.github/workflows/workflow-security-guard.yml
@@ -17,6 +17,11 @@ on:
       - ".github/scripts/guard-pull-request-target*.ts"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Never on main: a commit that lands keeps its own verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## What

Every workflow in the repo now declares a `concurrency` group except one, and each group either cancels superseded runs or queues them — chosen by what the workflow *does*, not by what it costs.

Before this, 21 of 56 workflows had no group at all. Two of those gaps were live races, not just wasted minutes.

## Why

**Gates cancel.** A gate's verdict describes the PR as it is *now*. `release-scope-guard`, `pr-conventional-commits-title` and `deployment-impact-check` all take `edited` in their trigger list, so re-titling a PR or editing its body starts a run — and all three read the title, body or labels at read time. An older run in flight is already answering a question about a state that no longer exists.

Measured over the last 100 runs of each, counting runs still going when a newer run for the same branch started:

| workflow | superseded | avg run |
|---|---:|---:|
| `release-scope-guard` | 29 / 100 | 107s |
| `pr-conventional-commits-title` | 18 / 100 | 95s |
| `deployment-impact-check` | 18 / 100 | 68s |
| `release-please-chart-lock-sync` | 5 / 100 | 101s |
| `workflow-security-guard` | 3 / 100 | 102s |
| `coderabbit-config-check` | 2 / 100 | 178s |
| `issue-link` | 0 / 100 | 133s |

They cancel on PR refs and never on `main` — `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`, the idiom the other 20 workflows here already use — so a commit that lands on main keeps its own validation.

**Writers queue.** A cancelled publish has no cleanup path: it reports `cancelled` rather than `failed`, so nothing retries it and nothing reconciles it. That reasoning is already written down in `prerelease-charts-oci.yml`; this applies it to the remaining publishers rather than restating it in each.

### The two real races

**`release-please-sdks` — 12 of its last 60 runs overlapped a previous one.** It fires on every merge to `main`, and a burst of merges starts overlapping runs that compute a release plan from the same history and then race on the same release PRs. The observable outcomes are a duplicate release PR, or one run reverting the other's version bump. This is the one that was actually happening.

**`release-langwatch-chart` and `release-clickhouse-serverless-chart` share a `gh-pages` index.** Both run `cr index --push` with the same `--owner`/`--git-repo`, and `cr index` rebuilds `index.yaml` from the repository's release list and force-pushes it. Run together, the loser pushes an index it built before the winner's `cr upload` registered — so a chart version that published successfully disappears from the index. The release still exists; `helm repo update` just stops seeing it.

They share **one** group, `helm-chart-index`. A per-workflow group would not have helped: the race is *between the two workflows*, not between runs of either.

## What is deliberately left alone

**`issue-link.yml`** — triggers on `types: [opened]`, which fires exactly once per PR. It has no second run to collide with, and 0/100 overlapping runs confirms it. A group here would be symmetry for its own sake.

**`langwatch-chart.yml` and `clickhouse-serverless-chart.yml`** — the only other two without a group. They get theirs in #6820, so they are left untouched here to avoid a conflict.

## Testing

- `actionlint` over the whole tree: no syntax or expression errors. The one finding is a pre-existing unknown-runner-label warning on `publish-docker-app` for the self-hosted `arm64-runner-32gb`.
- Coverage re-checked after the change: 48 workflows with a group, 3 without (the two above plus `issue-link`).
- No literal group-name collisions except the intended `helm-chart-index`. The shared `${{ github.workflow }}-…` templates differ per workflow by construction.

## Risk

Low, and mostly one-directional: every change adds a group where there was none, so nothing that ran before stops running. The behaviour changes are that a superseded gate run now ends as `cancelled` instead of finishing, and a second publisher run now waits instead of starting immediately.

The one judgement call worth a second opinion is `release-please-chart-lock-sync`: it pushes a `Chart.lock` commit to the release PR's branch, so I gave it `cancel-in-progress: false` (queue, don't cancel) rather than treating it as a gate. Serialized, the second run finds the lock already in sync and no-ops; cancelling it mid-push would be a force-push race instead.
