### PR TITLE
fix: preserve no-verdict states in eval display, export and filters

### DIFF
--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -80,10 +80,11 @@ export function MessageCard({
       check.status == "error",
   );
   const evaluationsPasses = evaluations.filter(
-    (check) =>
-      evaluationPassed(check) !== false &&
-      (check.status === "processed" || check.status === "skipped"),
+    (check) => check.status === "processed" && evaluationPassed(check) === true,
   ).length;
+  const someEvaluationsSkipped = evaluations.some(
+    (check) => check.status === "skipped",
+  );
   const guardrailsPasses = guardrails.filter(
     (check) => check.passed !== false,
   ).length;
@@ -467,9 +468,11 @@ export function MessageCard({
                 color={
                   !evaluationsDone || allEvaluationsSkipped
                     ? "yellow.fg"
-                    : evaluationsPasses == totalEvaluations
-                      ? "green.fg"
-                      : "red.fg"
+                    : someEvaluationsSkipped
+                      ? "yellow.fg"
+                      : evaluationsPasses == totalEvaluations
+                        ? "green.fg"
+                        : "red.fg"
                 }
                 paddingY={1}
                 paddingX={2}
@@ -483,7 +486,7 @@ export function MessageCard({
                   <HStack gap={2}>
                     {!evaluationsDone ? (
                       <Clock />
-                    ) : allEvaluationsSkipped ? (
+                    ) : allEvaluationsSkipped || someEvaluationsSkipped ? (
                       <MinusCircle />
                     ) : evaluationsPasses == totalEvaluations ? (
                       <CheckCircle />
@@ -492,12 +495,14 @@ export function MessageCard({
                     )}
                     {allEvaluationsSkipped
                       ? "Evaluations skipped"
-                      : evaluationsDone && evaluationsPasses != totalEvaluations
-                        ? `${totalEvaluations - evaluationsPasses} ${
-                            totalEvaluations - evaluationsPasses == 1
-                              ? "evaluation failed"
-                              : "evaluations failed"
-                          }`
+                      : someEvaluationsSkipped
+                        ? `${evaluationsPasses}/${totalEvaluations} evaluations`
+                        : evaluationsDone && evaluationsPasses != totalEvaluations
+                          ? `${totalEvaluations - evaluationsPasses} ${
+                              totalEvaluations - evaluationsPasses == 1
+                                ? "evaluation failed"
+                                : "evaluations failed"
+                            }`
                         : `${evaluationsPasses}/${totalEvaluations} evaluations`}
                   </HStack>
                 </Tag.Label>

--- a/platform/app/src/components/traces/Evaluations.tsx
+++ b/platform/app/src/components/traces/Evaluations.tsx
@@ -148,13 +148,14 @@ export const EvaluationsCount = (
 
   const groups = groupEvaluationsByEvaluator(evaluations);
 
-  const totalErrors = groups.filter(
-    (group) =>
-      group.latest.status === "error" ||
-      evaluationPassed(group.latest) === false,
+  const totalFailed = groups.filter(
+    (group) => evaluationPassed(group.latest) === false,
+  ).length;
+  const totalErrored = groups.filter(
+    (group) => group.latest.status === "error",
   ).length;
 
-  if (totalErrors > 0) {
+  if (totalFailed > 0) {
     if (trace.countGuardrails) {
       return null;
     }
@@ -167,7 +168,21 @@ export const EvaluationsCount = (
         color={"white"}
         fontSize={"sm"}
       >
-        {totalErrors} failed
+        {totalFailed} failed
+      </Text>
+    );
+  }
+
+  if (totalErrored > 0) {
+    return (
+      <Text
+        borderRadius={"md"}
+        paddingX={2}
+        backgroundColor={"yellow.solid"}
+        color={"white"}
+        fontSize={"sm"}
+      >
+        {totalErrored} errored
       </Text>
     );
   }

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
@@ -38,6 +38,10 @@ export const STATUS = {
   // red.700 from the shared map so "the evaluator broke" reads as a
   // separate failure mode from "the evaluator ran and said no".
   error: buildStatusTone("error", "ERROR"),
+  // Evaluator completed but produced no verdict — no score was assigned,
+  // no pass/fail was decided. Neutral blue keeps it from competing with
+  // real pass/fail rows while still showing that the evaluator ran.
+  processed: buildStatusTone("processed", "PROCESSED"),
 } as const;
 
 /**
@@ -46,7 +50,7 @@ export const STATUS = {
  * meaningless and should be suppressed.
  */
 export function isNoVerdict(status: EvalSummary["status"]): boolean {
-  return status === "skipped" || status === "error";
+  return status === "skipped" || status === "error" || status === "processed";
 }
 
 /**

--- a/platform/app/src/features/traces-v2/hooks/useTraceEvaluations.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceEvaluations.ts
@@ -71,7 +71,7 @@ function mapStatus(ev: Evaluation): EvalSummary["status"] {
   if (ev.status === "processed") {
     if (ev.passed === true) return "pass";
     if (ev.passed === false) return "fail";
-    return "pass";
+    return "processed";
   }
   return "warning";
 }
@@ -83,10 +83,10 @@ function mapScoreType(ev: Evaluation): EvalSummary["scoreType"] {
   return "numeric";
 }
 
-function mapScore(ev: Evaluation): number | boolean {
+function mapScore(ev: Evaluation): number | boolean | null {
   if (typeof ev.score === "number") return ev.score;
   if (ev.passed != null) return ev.passed;
-  return 0;
+  return null;
 }
 
 export function useTraceEvaluations(): TraceEvaluationsResult {

--- a/platform/app/src/features/traces-v2/types/trace.ts
+++ b/platform/app/src/features/traces-v2/types/trace.ts
@@ -9,7 +9,7 @@ export type TraceStatus = "ok" | "error" | "warning";
  */
 export interface EvalSummary {
   name: string;
-  score: number | boolean;
+  score: number | boolean | null;
   scoreType: "numeric" | "boolean" | "categorical";
   /**
    * - `pass` / `fail` / `warning` — the evaluator ran and produced a verdict.
@@ -18,7 +18,7 @@ export interface EvalSummary {
    * - `error` — the evaluator crashed / errored out. Distinct from a "fail"
    *   verdict — the evaluator never produced a real score.
    */
-  status: "pass" | "warning" | "fail" | "skipped" | "error";
+  status: "pass" | "warning" | "fail" | "skipped" | "error" | "processed";
 }
 
 /**

--- a/platform/app/src/pages/[project]/annotations/all.tsx
+++ b/platform/app/src/pages/[project]/annotations/all.tsx
@@ -155,7 +155,11 @@ export default function Annotations() {
           suggestionExportLine({ annotation, traceId: annotation.traceId }),
           annotation.comment ?? "",
           annotation.traceId ?? "",
-          annotation.isThumbsUp ? "Thumbs Up" : "Thumbs Down",
+          annotation.isThumbsUp == null
+            ? "—"
+            : annotation.isThumbsUp
+              ? "Thumbs Up"
+              : "Thumbs Down",
           JSON.stringify(annotation.scoreOptions ?? {}),
           annotation.createdAt?.toLocaleString() ?? "",
         ];

--- a/platform/app/src/server/app-layer/traces/facet-registry.ts
+++ b/platform/app/src/server/app-layer/traces/facet-registry.ts
@@ -449,7 +449,7 @@ export const FACET_REGISTRY: readonly FacetDefinition[] = [
     // the sidebar's "Errored" pill counts `Status = 'error'` — mapping those
     // rows to 'unknown' made the pill filter by the wrong value.
     expression:
-      "multiIf(Status = 'error', 'error', Passed = 1, 'pass', Passed = 0, 'fail', 'unknown')",
+      "multiIf(Status = 'error', 'error', Status = 'skipped', 'skipped', Passed = 1, 'pass', Passed = 0, 'fail', 'unknown')",
   },
   {
     key: "evaluatorScore",

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
@@ -120,11 +120,13 @@ const evaluatorVerdictRead: CategoricalRead = (t) =>
     : t.evaluations.map((e) =>
         e.status === "error"
           ? "error"
-          : e.passed === true
-            ? "pass"
-            : e.passed === false
-              ? "fail"
-              : "unknown",
+          : e.status === "skipped"
+            ? "skipped"
+            : e.passed === true
+              ? "pass"
+              : e.passed === false
+                ? "fail"
+                : "unknown",
       );
 
 const evaluatorScoreRead: RangeRead = (t) =>

--- a/platform/app/src/server/app-layer/traces/query-language/metadata.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/metadata.ts
@@ -492,6 +492,6 @@ export const FIELD_VALUES: Record<string, string[]> = {
   // `unknown` (Passed null but not errored) is query-language-only: the
   // sidebar drilldown surfaces pass/fail/error rows and has no unknown
   // bucket by design — it's reachable by typing the filter by hand.
-  evaluatorVerdict: ["pass", "fail", "error", "unknown"],
+  evaluatorVerdict: ["pass", "fail", "error", "skipped", "unknown"],
   spanStatus: ["ok", "error", "unset"],
 };


### PR DESCRIPTION
Fixes the "invent a verdict" family from #6835 — no-verdict states (skipped, errored, score-only, comment-only) must never be coerced into a pass/fail or a zero.

**Item 1 — traces-v2 verdict-less evals render neutral.** `mapStatus`/`mapScore` in `useTraceEvaluations` rewrote a processed evaluation with neither `passed` nor `score` into `pass` + `0`, before the shared neutral arm in `evaluationResults` could apply. Preserve `processed` + `null` so the eval card, history stack and header chip show the evaluator ran without a verdict instead of inventing a green PASS at 0.00.

**Item 2 — skipped evaluations are not passes.** `MessageCard` counted skipped as passed (`evaluationPassed !== false`), so a mixed passed+skipped trace rendered a green "2/2 evaluations". Only processed+passed counts now; mixed shows neutral. `EvaluationsCount` collapsed errored evaluators into "failed" — separated so crashed evaluators read as "errored", not a fail verdict.

**Item 3 — comment-only annotations export neutrally.** `isThumbsUp` is null for comment-only annotations; the ternary fabricated "Thumbs Down" in the CSV export. Now exports "—".

**Item 5 — skipped evaluator verdict is filterable.** The `evaluatorVerdict` facet spilled skipped into "unknown"; added a `skipped` arm to the SQL `multiIf`, the JS mirror, and the autocomplete vocabulary together.

Item 4 (runtime-skipped monitor runs visibility) is a product decision and intentionally left out.

Each item is a separate commit. No wallet/bounty — pure contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation results now distinguish passed, failed, skipped, processed, and errored states.
  * Skipped and processed evaluations are no longer incorrectly counted as passed or failed.
  * Evaluation badges and counts now use clearer status labels and visual indicators.
  * Trace filters and search suggestions now support skipped evaluations.
  * Evaluations without scores remain unrated instead of displaying a zero score.
  * Annotation CSV exports now distinguish unrated entries from explicit positive and negative ratings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->