### PR TITLE
fix(python-sdk): a refused call keeps the platform's own explanation

### DIFF
--- a/sdks/python/src/langwatch/utils/exceptions.py
+++ b/sdks/python/src/langwatch/utils/exceptions.py
@@ -41,10 +41,25 @@ def extract_api_error_detail(body: Any) -> str:
     Reads the discriminant as ``code`` -> ``type`` -> ``kind``; the platform
     sets all three to the same value (``type`` is the OpenAI-compatible name
     Go emits), so the order only decides which answers first.
+
+    Two envelope spellings carry the same failure: the gateway families put
+    ``code`` and ``message`` at the top level, while some routes nest that
+    whole object under ``error``. The nested one is read when the top level
+    describes nothing, so the platform's own sentence reaches the caller either
+    way rather than being reduced to a bare status.
     """
     if not isinstance(body, Mapping):
         return ""
 
+    detail = _detail_from_envelope(body)
+    if detail:
+        return detail
+
+    nested = body.get("error")
+    return _detail_from_envelope(nested) if isinstance(nested, Mapping) else ""
+
+
+def _detail_from_envelope(body: Mapping) -> str:
     code = _first_string(body.get("code"), body.get("type"), body.get("kind"))
 
     meta = body.get("meta")

--- a/sdks/python/src/langwatch/utils/gateway_http.py
+++ b/sdks/python/src/langwatch/utils/gateway_http.py
@@ -52,11 +52,14 @@ def raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
         body = response.text or ""
         detail = body
     label = f"{operation}: " if operation else ""
+    # A 403 is not an authentication failure: the credential was read and
+    # accepted, and the answer is that this call is not allowed with it. The
+    # 401 wording would send the reader to rotate a key that is fine.
     summary = {
         400: "bad request",
         422: "bad request",
         401: "authentication failed",
-        403: "authentication failed",
+        403: "not permitted",
         402: "plan does not include this surface",
         404: "not found",
         409: "conflicts with existing state",

--- a/sdks/python/tests/utils/test_gateway_http_errors.py
+++ b/sdks/python/tests/utils/test_gateway_http_errors.py
@@ -72,7 +72,7 @@ class TestGivenThePlatformRefusesTheCallAndWritesWhy:
             assert isinstance(error, LangWatchApiAuthenticationError)
 
     class TestWhenTheEnvelopeIsNestedUnderError:
-        # @scenario "The platform's sentence is read from either envelope spelling"
+        # @scenario "A refusal keeps its explanation however the platform shapes the answer"
         def test_carries_the_same_platform_sentence(self) -> None:
             error = _raised(403, {"error": FORBIDDEN_BODY})
 

--- a/sdks/python/tests/utils/test_gateway_http_errors.py
+++ b/sdks/python/tests/utils/test_gateway_http_errors.py
@@ -1,0 +1,100 @@
+"""Unit coverage for what a refused gateway call tells the caller.
+
+A refusal the platform wrote prose for has to reach the caller as that prose,
+the way the TypeScript SDK surfaces it, and a 403 has to read as what it is:
+the credential was accepted and this call is not allowed with it.
+
+Spec: specs/errors/handled-error-surfaces.feature
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from langwatch.api_errors import (
+    LangWatchApiAuthenticationError,
+    LangWatchApiError,
+)
+from langwatch.utils.exceptions import extract_api_error_detail
+from langwatch.utils.gateway_http import raise_for_status
+
+pytestmark = pytest.mark.unit
+
+PLAN_SENTENCE = (
+    "The billing events API is an enterprise feature; this organization's "
+    "plan does not include it."
+)
+
+FORBIDDEN_BODY = {
+    "type": "permission_denied",
+    "code": "forbidden",
+    "message": PLAN_SENTENCE,
+    "trace_id": "trace_01HZ",
+}
+
+
+def _refusal(status: int, body: object) -> httpx.Response:
+    return httpx.Response(
+        status,
+        json=body,
+        request=httpx.Request(
+            "GET", "https://app.langwatch.ai/api/gateway/v1/spend-summaries"
+        ),
+    )
+
+
+def _raised(status: int, body: object) -> LangWatchApiError:
+    with pytest.raises(LangWatchApiError) as caught:
+        raise_for_status(_refusal(status, body), operation="read spend summaries")
+    return caught.value
+
+
+class TestGivenThePlatformRefusesTheCallAndWritesWhy:
+    class TestWhenTheEnvelopeIsTopLevel:
+        # @scenario "A refusal the platform explained keeps its explanation in the SDK"
+        def test_carries_the_platform_sentence(self) -> None:
+            error = _raised(403, FORBIDDEN_BODY)
+
+            assert PLAN_SENTENCE in str(error)
+
+        def test_names_the_refusal_without_blaming_the_credential(self) -> None:
+            error = _raised(403, FORBIDDEN_BODY)
+
+            assert "authentication failed" not in str(error)
+            assert "not permitted" in str(error)
+
+        def test_keeps_the_platform_code_and_the_status_class(self) -> None:
+            error = _raised(403, FORBIDDEN_BODY)
+
+            assert error.code == "forbidden"
+            assert error.status == 403
+            assert isinstance(error, LangWatchApiAuthenticationError)
+
+    class TestWhenTheEnvelopeIsNestedUnderError:
+        # @scenario "The platform's sentence is read from either envelope spelling"
+        def test_carries_the_same_platform_sentence(self) -> None:
+            error = _raised(403, {"error": FORBIDDEN_BODY})
+
+            assert PLAN_SENTENCE in str(error)
+            assert "authentication failed" not in str(error)
+
+        def test_reads_the_sentence_out_of_the_body_on_its_own(self) -> None:
+            assert extract_api_error_detail({"error": FORBIDDEN_BODY}) == PLAN_SENTENCE
+
+
+class TestGivenThePlatformRejectsTheCredentialItself:
+    # @scenario "A refused credential still reads as an authentication failure"
+    def test_keeps_the_authentication_failed_summary(self) -> None:
+        error = _raised(401, {"error": "Unauthorized", "message": "Invalid API key"})
+
+        assert "authentication failed" in str(error)
+        assert "Invalid API key" in str(error)
+        assert isinstance(error, LangWatchApiAuthenticationError)
+
+
+class TestGivenAnEnvelopeThatDescribesNothing:
+    def test_falls_back_to_the_status_summary_alone(self) -> None:
+        error = _raised(403, {})
+
+        assert str(error) == "read spend summaries: not permitted"

--- a/specs/errors/handled-error-surfaces.feature
+++ b/specs/errors/handled-error-surfaces.feature
@@ -266,11 +266,10 @@ Feature: Knowable failures reach the customer as themselves
   # The SDK error mappers
   #
   # A refusal the platform wrote prose for reaches the caller as that prose, in
-  # every SDK. The Python mapper read the top-level envelope only and rendered
-  # a word derived from the status, so a plan gate served as a 403 arrived as
-  # "authentication failed" and nothing else: the operator was sent to rotate
-  # credentials that were never the problem, while the sentence explaining the
-  # plan sat unread in the body.
+  # every SDK. Python used to answer with a word derived from the status alone,
+  # so a plan gate served as a 403 arrived as "authentication failed" and
+  # nothing else: the operator was sent to rotate credentials that were never
+  # the problem, while the sentence explaining the plan went unread.
   # ---------------------------------------------------------------------------
 
   @unit
@@ -281,8 +280,8 @@ Feature: Knowable failures reach the customer as themselves
     And it does not report the credential as the problem
 
   @unit
-  Scenario: The platform's sentence is read from either envelope spelling
-    Given the same refusal nested under an error field
+  Scenario: A refusal keeps its explanation however the platform shapes the answer
+    Given the platform refuses the same read and shapes the answer another way
     When the SDK raises for that response
     Then the raised error carries the same sentence
 

--- a/specs/errors/handled-error-surfaces.feature
+++ b/specs/errors/handled-error-surfaces.feature
@@ -261,3 +261,33 @@ Feature: Knowable failures reach the customer as themselves
     Given the member and team governance refusals
     When each is presented
     Then none of them falls through to the generic validation copy
+
+  # ---------------------------------------------------------------------------
+  # The SDK error mappers
+  #
+  # A refusal the platform wrote prose for reaches the caller as that prose, in
+  # every SDK. The Python mapper read the top-level envelope only and rendered
+  # a word derived from the status, so a plan gate served as a 403 arrived as
+  # "authentication failed" and nothing else: the operator was sent to rotate
+  # credentials that were never the problem, while the sentence explaining the
+  # plan sat unread in the body.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A refusal the platform explained keeps its explanation in the SDK
+    Given the platform refuses a gateway read and writes why
+    When the SDK raises for that response
+    Then the raised error carries the platform's sentence
+    And it does not report the credential as the problem
+
+  @unit
+  Scenario: The platform's sentence is read from either envelope spelling
+    Given the same refusal nested under an error field
+    When the SDK raises for that response
+    Then the raised error carries the same sentence
+
+  @unit
+  Scenario: A refused credential still reads as an authentication failure
+    Given the platform rejects the credential itself
+    When the SDK raises for that response
+    Then the raised error says authentication failed


### PR DESCRIPTION
Follow-up to #6807, which merged before this landed, so it comes as its own PR off latest main.

## Why

A production dogfood hit a 403 on the billing events API. The platform named the failure and wrote prose for it:

```json
{"type":"permission_denied","code":"forbidden","message":"The billing events API is an enterprise feature; this organization's plan does not include it.","trace_id":"..."}
```

The TypeScript SDK surfaces that sentence. Python raised `LangWatchApiAuthenticationError` with the message `read spend summaries: authentication failed` and nothing more, so an operator was sent to rotate a credential that was never the problem, while the sentence naming the gated feature sat unread in the body. The `code` attribute was correct throughout, which is why the two SDKs disagreed only in what a human reads.

## What changed

Two defects, both in the shared mapper the gateway, webhook, spend and management facades run through.

1. **A 403 shared the 401 summary.** The credential was read and accepted; only the call was refused. It now reads "not permitted", so the message no longer points at authentication. Error classes and the `code` attribute are unchanged: a 403 stays a `LangWatchApiAuthenticationError` carrying the platform's code, matching the TypeScript SDK, which has no distinct class for it either.

2. **The detail extractor read the top-level envelope only.** These routes nest `code` and `message` under `error`, which is the spelling `extract_api_error_code` already unwrapped, so the code resolved while the sentence did not. It now falls back to the nested envelope when the top level describes nothing, covering both spellings the way TypeScript's formatter does.

The result for the body above, in either spelling:

```
read spend summaries: not permitted: The billing events API is an enterprise feature; this organization's plan does not include it.
```

## Spec

Three `@unit` scenarios in `specs/errors/handled-error-surfaces.feature`, bound to the new tests: the refusal keeping its explanation, the sentence being read from either envelope spelling, and a rejected credential still reading as an authentication failure. `pnpm check:feature-parity` reports that file 28/28 bound.

## How verified

- New unit coverage in `sdks/python/tests/utils/test_gateway_http_errors.py` drives the exact production body through `raise_for_status` in both envelope spellings and asserts the sentence is carried, that the message does not say "authentication failed", and that the code, status and class are unchanged. A 401 case pins the existing wording so the two statuses cannot collapse back together.
- 109 tests green across `tests/utils/`, the gateway, webhook and spend facades, the idempotency suite and the teams/projects facades; 373 green across the wider unit selection (the one failure there is `to_pandas` in an environment without pandas, which is an optional dependency and unrelated).
- `black --check` clean on every file this touches. `walk_numbered_pages` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gateway error responses across supported formats.
  * Preserved platform-provided error messages and codes for access-denied responses.
  * Clarified the distinction between authentication failures and permission-related errors.
  * Retained detailed authentication guidance for invalid credentials.
* **Tests**
  * Added coverage for nested and top-level error responses, missing details, and status-based fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->