### PR TITLE
fix(evaluations): a verdict only counts when the evaluation actually ran (passed-without-status family)

### DIFF
--- a/platform/app/src/components/traces/Evaluations.tsx
+++ b/platform/app/src/components/traces/Evaluations.tsx
@@ -214,8 +214,11 @@ export const Blocked = (trace: TraceEval) => {
   const guardrails = trace.evaluations?.filter((x) => x.is_guardrail);
   const groups = groupEvaluationsByEvaluator(guardrails);
 
+  // Status-aware: only a guardrail that ran to completion can have blocked —
+  // an errored guardrail's stray `passed: false` is not a block (#6833).
   const totalBlocked = groups.filter(
-    (group) => group.latest.passed === false,
+    (group) =>
+      group.latest.status === "processed" && group.latest.passed === false,
   ).length;
 
   if (totalBlocked === 0) return null;

--- a/platform/app/src/server/app-layer/analytics/__tests__/eval-builders-status-gate.unit.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/eval-builders-status-gate.unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Verdict metrics must only read verdicts from evaluations that actually ran
+ * to completion (#6833). The legacy per-evaluator path in
+ * `metric-translator.ts` guards score and pass-rate with `Status =
+ * 'processed'`; the rollup and slim builders serve the SAME metrics for
+ * unkeyed series, so without the equivalent predicate the project-wide chart
+ * and the per-evaluator chart disagree on identical data whenever an errored
+ * evaluation carries a stray `passed`/`score`.
+ *
+ * `evaluation_runs` counts deliberately stay unfiltered — an errored
+ * evaluation is still a run, matching the legacy `uniqIf` with no status
+ * condition.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildEvalRollupTimeseriesQuery } from "../query-builders/eval-rollup-timeseries-query";
+import { buildEvalSlimTimeseriesQuery } from "../query-builders/eval-slim-timeseries-query";
+
+const baseDates = {
+  startDate: new Date("2026-08-01T00:00:00.000Z"),
+  endDate: new Date("2026-08-02T00:00:00.000Z"),
+  previousPeriodStartDate: new Date("2026-07-31T00:00:00.000Z"),
+};
+
+describe("buildEvalRollupTimeseriesQuery — status gate on verdict metrics", () => {
+  describe("when serving evaluation_pass_rate", () => {
+    const { sql } = buildEvalRollupTimeseriesQuery({
+      projectId: "tenant-eval-rollup",
+      ...baseDates,
+      series: [
+        { metric: "evaluations.evaluation_pass_rate", aggregation: "avg" },
+      ],
+      timeScale: 60,
+    });
+
+    it("only sums PassCount/FailCount from processed rows", () => {
+      expect(sql).toContain(
+        "sumIf(ra.PassCount, ra.Status = 'processed') / nullIf(sumIf(ra.PassCount, ra.Status = 'processed') + sumIf(ra.FailCount, ra.Status = 'processed'), 0)",
+      );
+    });
+  });
+
+  describe("when serving evaluation_score", () => {
+    const { sql } = buildEvalRollupTimeseriesQuery({
+      projectId: "tenant-eval-rollup",
+      ...baseDates,
+      series: [{ metric: "evaluations.evaluation_score", aggregation: "avg" }],
+      timeScale: 60,
+    });
+
+    it("only sums ScoreSum/ScoreCount from processed rows", () => {
+      expect(sql).toContain(
+        "sumIf(ra.ScoreSum, ra.Status = 'processed') / nullIf(sumIf(ra.ScoreCount, ra.Status = 'processed'), 0)",
+      );
+    });
+  });
+
+  describe("when serving evaluation_runs", () => {
+    const { sql } = buildEvalRollupTimeseriesQuery({
+      projectId: "tenant-eval-rollup",
+      ...baseDates,
+      series: [{ metric: "evaluations.evaluation_runs", aggregation: "sum" }],
+      timeScale: 60,
+    });
+
+    it("counts every run regardless of status (errored runs are still runs)", () => {
+      expect(sql).toContain("sum(ra.EvalCount)");
+      expect(sql).not.toContain("sumIf(ra.EvalCount");
+    });
+  });
+});
+
+describe("buildEvalSlimTimeseriesQuery — status gate on verdict metrics", () => {
+  describe("when serving evaluation_pass_rate", () => {
+    const { sql } = buildEvalSlimTimeseriesQuery({
+      projectId: "tenant-eval-slim",
+      ...baseDates,
+      series: [
+        { metric: "evaluations.evaluation_pass_rate", aggregation: "avg" },
+      ],
+      timeScale: 60,
+    });
+
+    it("nulls Passed on non-processed rows so avg excludes them", () => {
+      expect(sql).toContain(
+        "toUInt8(if(ea.Status = 'processed', ea.Passed, NULL))",
+      );
+    });
+  });
+
+  describe("when serving evaluation_score", () => {
+    const { sql } = buildEvalSlimTimeseriesQuery({
+      projectId: "tenant-eval-slim",
+      ...baseDates,
+      series: [{ metric: "evaluations.evaluation_score", aggregation: "avg" }],
+      timeScale: 60,
+    });
+
+    it("nulls Score on non-processed rows so avg excludes them", () => {
+      expect(sql).toContain("if(ea.Status = 'processed', ea.Score, NULL)");
+    });
+  });
+
+  describe("when serving evaluation_runs", () => {
+    const { sql } = buildEvalSlimTimeseriesQuery({
+      projectId: "tenant-eval-slim",
+      ...baseDates,
+      series: [
+        { metric: "evaluations.evaluation_runs", aggregation: "cardinality" },
+      ],
+      timeScale: 60,
+    });
+
+    it("counts every run regardless of status (errored runs are still runs)", () => {
+      expect(sql).toContain("uniq(ea.EvaluationId)");
+      expect(sql).not.toContain("Status = 'processed'");
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/analytics/__tests__/eval-builders-status-gate.unit.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/eval-builders-status-gate.unit.test.ts
@@ -116,4 +116,40 @@ describe("buildEvalSlimTimeseriesQuery — status gate on verdict metrics", () =
       expect(sql).not.toContain("Status = 'processed'");
     });
   });
+
+  describe("when grouping by evaluation_passed", () => {
+    const { sql } = buildEvalSlimTimeseriesQuery({
+      projectId: "tenant-eval-slim",
+      ...baseDates,
+      series: [
+        { metric: "evaluations.evaluation_runs", aggregation: "cardinality" },
+      ],
+      groupBy: "evaluations.evaluation_passed",
+      timeScale: 60,
+    });
+
+    it("buckets a non-processed row's stray verdict as unknown, not failed", () => {
+      expect(sql).toContain(
+        "if(ea.Status != 'processed' OR ea.Passed IS NULL, 'unknown'",
+      );
+    });
+  });
+
+  describe("when grouping by evaluation_label", () => {
+    const { sql } = buildEvalSlimTimeseriesQuery({
+      projectId: "tenant-eval-slim",
+      ...baseDates,
+      series: [
+        { metric: "evaluations.evaluation_runs", aggregation: "cardinality" },
+      ],
+      groupBy: "evaluations.evaluation_label",
+      timeScale: 60,
+    });
+
+    it("buckets a non-processed row's label as unknown", () => {
+      expect(sql).toContain(
+        "if(ea.Status != 'processed', 'unknown', coalesce(ea.Label, 'unknown'))",
+      );
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
@@ -21,9 +21,12 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { createEvaluationReportedEvent } from "~/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/fixtures/evaluation-events.fixtures";
 import {
   EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST,
+  EvaluationAnalyticsFoldProjection,
   type EvaluationAnalyticsRow,
+  projectEvaluationAnalyticsStateToRow,
 } from "~/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection";
 import type { EvaluationAnalyticsRollupRow } from "~/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalyticsRollup.mapProjection";
 
@@ -244,5 +247,52 @@ describe("evaluation_analytics — write path (ADR-034 Phase 6)", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!.score).toBeCloseTo(0.9, 5);
     expect(rows[0]!.passed).toBe(true);
+  });
+
+  it("folds an errored evaluation carrying a stray verdict into a row with Passed and Score NULL (#6833)", async () => {
+    const evalId = `eval-errored-verdict-${nanoid()}`;
+    const fold = new EvaluationAnalyticsFoldProjection({
+      store: { store: async () => {}, get: async () => null },
+    });
+
+    const state = fold.handleEvaluationReported(
+      createEvaluationReportedEvent({
+        tenantId,
+        evaluationId: evalId,
+        status: "error",
+        passed: false,
+        score: 0.1,
+        occurredAt: bucketMs,
+      }),
+      fold.init(),
+    );
+    const row = projectEvaluationAnalyticsStateToRow({
+      state: { ...state, LastEventOccurredAt: bucketMs },
+      tenantId,
+      version: EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST,
+    });
+
+    await slimRepo.upsert(row);
+    await flushAsyncInserts();
+
+    const result = await ch.query({
+      query: `
+        SELECT Status AS status, Passed AS passed, Score AS score
+        FROM evaluation_analytics
+        WHERE TenantId = {tenantId:String}
+          AND EvaluationId = {evalId:String}
+      `,
+      query_params: { tenantId, evalId },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      status: string;
+      passed: boolean | null;
+      score: number | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("error");
+    expect(rows[0]!.passed).toBeNull();
+    expect(rows[0]!.score).toBeNull();
   });
 });

--- a/platform/app/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
@@ -280,9 +280,16 @@ describe("evaluation_analytics — write path (ADR-034 Phase 6)", () => {
         SELECT Status AS status, Passed AS passed, Score AS score
         FROM evaluation_analytics
         WHERE TenantId = {tenantId:String}
+          AND OccurredAt >= fromUnixTimestamp64Milli({bucketStartMs:Int64})
+          AND OccurredAt < fromUnixTimestamp64Milli({bucketEndMs:Int64})
           AND EvaluationId = {evalId:String}
       `,
-      query_params: { tenantId, evalId },
+      query_params: {
+        tenantId,
+        evalId,
+        bucketStartMs: bucketMs - 60_000,
+        bucketEndMs: bucketMs + 60_000,
+      },
       format: "JSONEachRow",
     });
     const rows = (await result.json()) as Array<{

--- a/platform/app/src/server/app-layer/analytics/query-builders/eval-rollup-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/eval-rollup-timeseries-query.ts
@@ -105,15 +105,21 @@ function evalRollupAggExpression(
   metric: EvalRollupMetricKey,
   agg: EvalRollupAggregation,
 ): string {
+  // Verdict metrics (score, pass-rate) only read rows whose evaluation
+  // actually ran to completion — an errored run's stray verdict must not
+  // shift the chart (#6833). Matches the legacy per-evaluator path's
+  // `Status = 'processed'` condition, and covers rollup rows written before
+  // the projection zeroed Pass/FailCount on non-processed events.
+  const processed = `${ra}.Status = 'processed'`;
   switch (metric) {
     case "evaluations.evaluation_score":
       switch (agg) {
         case "sum":
-          return `sum(${ra}.ScoreSum)`;
+          return `sumIf(${ra}.ScoreSum, ${processed})`;
         case "avg":
-          return `sum(${ra}.ScoreSum) / nullIf(sum(${ra}.ScoreCount), 0)`;
+          return `sumIf(${ra}.ScoreSum, ${processed}) / nullIf(sumIf(${ra}.ScoreCount, ${processed}), 0)`;
         case "cardinality":
-          return `sum(${ra}.ScoreCount)`;
+          return `sumIf(${ra}.ScoreCount, ${processed})`;
         default: {
           const _exhaustive: never = agg;
           throw new Error(
@@ -126,11 +132,11 @@ function evalRollupAggExpression(
       // and `cardinality` fall through to their additive shapes.
       switch (agg) {
         case "sum":
-          return `sum(${ra}.PassCount)`;
+          return `sumIf(${ra}.PassCount, ${processed})`;
         case "avg":
-          return `sum(${ra}.PassCount) / nullIf(sum(${ra}.PassCount) + sum(${ra}.FailCount), 0)`;
+          return `sumIf(${ra}.PassCount, ${processed}) / nullIf(sumIf(${ra}.PassCount, ${processed}) + sumIf(${ra}.FailCount, ${processed}), 0)`;
         case "cardinality":
-          return `sum(${ra}.PassCount) + sum(${ra}.FailCount)`;
+          return `sumIf(${ra}.PassCount, ${processed}) + sumIf(${ra}.FailCount, ${processed})`;
         default: {
           const _exhaustive: never = agg;
           throw new Error(

--- a/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
@@ -68,14 +68,20 @@ function isEvalSlimMetricKey(metric: string): metric is EvalSlimMetricKey {
  * Pass-rate is special: `Passed` is `Nullable(Bool)`, and the registry's
  * `avg` over a boolean treats it as 0/1. We coerce with `toUInt8` so the
  * avg comes out as the pass rate.
+ *
+ * Verdict metrics (score, pass-rate) null themselves out on rows whose
+ * evaluation did not run to completion — an errored run's stray verdict must
+ * not shift the chart (#6833). Matches the legacy per-evaluator path's
+ * `Status = 'processed'` condition, and covers slim rows written before the
+ * fold gated Passed/Score at write time.
  */
 function evalSlimColumnFor(metric: EvalSlimMetricKey): string {
   switch (metric) {
     case "evaluations.evaluation_score":
-      return `${ea}.Score`;
+      return `if(${ea}.Status = 'processed', ${ea}.Score, NULL)`;
     case "evaluations.evaluation_pass_rate":
       // Treat true as 1, false as 0; null stays null (excluded from avg).
-      return `toUInt8(${ea}.Passed)`;
+      return `toUInt8(if(${ea}.Status = 'processed', ${ea}.Passed, NULL))`;
     case "evaluations.evaluation_runs":
       return `${ea}.EvaluationId`;
     default: {

--- a/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/eval-slim-timeseries-query.ts
@@ -114,10 +114,14 @@ function evalSlimGroupByExpression(groupBy?: string): string | null {
     case "evaluations.evaluator_type":
       return `if(${ea}.EvaluatorType = '', 'unknown', ${ea}.EvaluatorType)`;
     case "evaluations.evaluation_passed":
-      // Nullable(Bool) → display string for group_key.
-      return `if(${ea}.Passed IS NULL, 'unknown', if(${ea}.Passed, 'passed', 'failed'))`;
+      // Nullable(Bool) → display string for group_key. Status-gated like the
+      // metric columns: a historical errored row carrying a stray verdict
+      // must bucket as 'unknown', not 'failed' — the legacy per-evaluator
+      // path gates the same way (aggregation-builder.ts, #6833).
+      return `if(${ea}.Status != 'processed' OR ${ea}.Passed IS NULL, 'unknown', if(${ea}.Passed, 'passed', 'failed'))`;
     case "evaluations.evaluation_label":
-      return `coalesce(${ea}.Label, 'unknown')`;
+      // Same status gate — an errored run's label is not a verdict (#6833).
+      return `if(${ea}.Status != 'processed', 'unknown', coalesce(${ea}.Label, 'unknown'))`;
     case "evaluations.evaluation_status":
       return `${ea}.Status`;
     default: {

--- a/platform/app/src/server/app-layer/evaluations/repositories/__tests__/evaluation-analytics.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/repositories/__tests__/evaluation-analytics.clickhouse.repository.unit.test.ts
@@ -30,7 +30,10 @@ import { env as nodeProcessEnv } from "node:process";
 nodeProcessEnv.TZ = "Asia/Kolkata";
 
 import { describe, expect, it } from "vitest";
-import type { EvaluationAnalyticsRow } from "~/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection";
+import {
+  EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST,
+  type EvaluationAnalyticsRow,
+} from "~/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection";
 import {
   capturingInsertClient,
   clientReturning,
@@ -367,7 +370,7 @@ describe("EvaluationAnalyticsClickHouseRepository insert settings", () => {
   const ROW: EvaluationAnalyticsRow = {
     tenantId: TENANT_ID,
     evaluationId: EVALUATION_ID,
-    version: "2026-07-27",
+    version: EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST,
     occurredAtMs: 1_750_000_000_000,
     createdAtMs: 1_750_000_000_000,
     updatedAtMs: 1_750_000_000_000,

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -36,6 +36,7 @@ import type {
   EvaluationProcessingEvent,
   EvaluationReportedEvent,
 } from "../schemas/events";
+import { verdictPassedOf, verdictScoreOf } from "../verdictGate";
 
 const logger = createLogger(
   "langwatch:evaluation-processing:execute-evaluation",
@@ -563,9 +564,15 @@ export class ExecuteEvaluationCommand
         tenantId,
         {
           status: result.status,
-          score: result.score,
-          passed: result.passed,
-          label: result.label,
+          // The service's happy-path mapping gates verdicts, but its error
+          // paths spread the raw evaluator result and override status
+          // (`{ ...result, status: "error" }`), so a stray verdict can reach
+          // this emit. Gate here too — the command boundary is the last
+          // producer-side chance to keep an errored run's verdict out of
+          // evaluation_runs (#6833).
+          score: verdictScoreOf(result) ?? undefined,
+          passed: verdictPassedOf(result) ?? undefined,
+          label: result.status === "processed" ? result.label : undefined,
           details: isError ? undefined : result.details,
           error: errorField,
           errorDetails: result.errorDetails ?? null,

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalytics.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalytics.foldProjection.unit.test.ts
@@ -104,6 +104,74 @@ describe("evaluationAnalytics fold projection — slim row derivation", () => {
     });
   });
 
+  describe("given a completed event with a non-processed status carrying a verdict", () => {
+    it("writes passed and score as null when status is error", () => {
+      const fold = makeFold();
+      let state = fold.init();
+      state = fold.handleEvaluationCompleted(
+        createEvaluationCompletedEvent({
+          status: "error",
+          passed: false,
+          score: 0.1,
+        }),
+        state,
+      );
+
+      const row = projectFromState({
+        ...state,
+        LastEventOccurredAt: 1_002_500,
+      });
+      expect(row.status).toBe("error");
+      expect(row.passed).toBeNull();
+      expect(row.score).toBeNull();
+    });
+
+    it("writes passed and score as null when status is skipped", () => {
+      const fold = makeFold();
+      let state = fold.init();
+      state = fold.handleEvaluationCompleted(
+        createEvaluationCompletedEvent({
+          status: "skipped",
+          passed: true,
+          score: 1,
+        }),
+        state,
+      );
+
+      const row = projectFromState({
+        ...state,
+        LastEventOccurredAt: 1_002_500,
+      });
+      expect(row.status).toBe("skipped");
+      expect(row.passed).toBeNull();
+      expect(row.score).toBeNull();
+    });
+  });
+
+  describe("given an atomic reported event with a non-processed status carrying a verdict", () => {
+    it("writes passed and score as null", () => {
+      const fold = makeFold();
+      let state = fold.init();
+      state = fold.handleEvaluationReported(
+        createEvaluationReportedEvent({
+          evaluationId: "eval-3",
+          status: "error",
+          passed: false,
+          score: 0.2,
+        }),
+        state,
+      );
+
+      const row = projectFromState({
+        ...state,
+        LastEventOccurredAt: 1_100_000,
+      });
+      expect(row.status).toBe("error");
+      expect(row.passed).toBeNull();
+      expect(row.score).toBeNull();
+    });
+  });
+
   describe("given an atomic EvaluationReported event", () => {
     it("stamps identity + result in one shot and sets duration to 0", () => {
       const fold = makeFold();

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalytics.parity-vs-evaluation-run-state.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalytics.parity-vs-evaluation-run-state.unit.test.ts
@@ -136,6 +136,39 @@ describe("evaluationAnalytics fold — parity vs evaluationRun fold", () => {
     });
   });
 
+  describe("given an atomic reported event carrying an errored run's stray verdict", () => {
+    it("both folds agree the verdict is null (#6833 — the gate is shared)", () => {
+      const slim = new EvaluationAnalyticsFoldProjection({
+        store: { store: async () => {}, get: async () => null },
+      });
+      const runFold = new EvaluationRunFoldProjection({
+        store: { store: async () => {}, get: async () => null },
+      });
+
+      const errored = {
+        ...makeReported(),
+        data: {
+          ...makeReported().data,
+          status: "error",
+          passed: false,
+          score: 0.4,
+        },
+      } as unknown as EvaluationReportedEvent;
+
+      const slimState = slim.handleEvaluationReported(errored, slim.init());
+      const runState = runFold.handleEvaluationReported(
+        errored,
+        runFold.init(),
+      );
+
+      expect(slimState.passed).toBeNull();
+      expect(slimState.score).toBeNull();
+      expect(runState.passed).toBeNull();
+      expect(runState.score).toBeNull();
+      expect(slimState.status).toBe(runState.status);
+    });
+  });
+
   describe("given an atomic reported event", () => {
     it("agrees on every shared field", () => {
       const slim = new EvaluationAnalyticsFoldProjection({

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalyticsRollup.mapProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationAnalyticsRollup.mapProjection.unit.test.ts
@@ -110,6 +110,28 @@ describe("evaluationAnalyticsRollup map projection — per-event row", () => {
       ).toBe(0);
     });
 
+    it("never counts the same event into FailCount and ErrorCount (verdict requires processed status)", () => {
+      const row = map.mapEvaluationCompleted(
+        makeCompleted({ status: "error", passed: false, score: 0.1 }),
+      );
+      expect(row.errorCount).toBe(1);
+      expect(row.failCount).toBe(0);
+      expect(row.passCount).toBe(0);
+      expect(row.scoreSum).toBe(0);
+      expect(row.scoreCount).toBe(0);
+    });
+
+    it("ignores a verdict on a skipped event", () => {
+      const row = map.mapEvaluationCompleted(
+        makeCompleted({ status: "skipped", passed: true, score: 1 }),
+      );
+      expect(row.skippedCount).toBe(1);
+      expect(row.passCount).toBe(0);
+      expect(row.failCount).toBe(0);
+      expect(row.scoreSum).toBe(0);
+      expect(row.scoreCount).toBe(0);
+    });
+
     it("decodes ScoreSum/ScoreCount with null-aware divisor", () => {
       const a = map.mapEvaluationCompleted(makeCompleted({ score: 0.85 }));
       expect(a.scoreSum).toBe(0.85);
@@ -125,6 +147,17 @@ describe("evaluationAnalyticsRollup map projection — per-event row", () => {
     it("carries the real evaluatorType (identity is on the event)", () => {
       const row = map.mapEvaluationReported(makeReported());
       expect(row.evaluatorType).toBe("langevals/atomic");
+    });
+
+    it("never counts the same event into FailCount and ErrorCount (verdict requires processed status)", () => {
+      const row = map.mapEvaluationReported(
+        makeReported({ status: "error", passed: false, score: 0.1 }),
+      );
+      expect(row.errorCount).toBe(1);
+      expect(row.failCount).toBe(0);
+      expect(row.passCount).toBe(0);
+      expect(row.scoreSum).toBe(0);
+      expect(row.scoreCount).toBe(0);
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection.ts
@@ -20,6 +20,7 @@ import {
   evaluationScheduledEventSchema,
   evaluationStartedEventSchema,
 } from "../schemas/events";
+import { verdictPassedOf, verdictScoreOf } from "../verdictGate";
 
 /**
  * ADR-034 Phase 6 — slim per-evaluation fold projection.
@@ -92,12 +93,17 @@ const evaluationAnalyticsEvents = [
  *  unstarted evaluation and it is treated as a store miss (see
  *  `EvaluationAnalyticsStore.getWithApplied`).
  *
- *  2026-08-11 — Passed/Score are now gated on `status === "processed"`: a
- *  verdict attached to an errored/skipped run folds to NULL instead of being
- *  persisted as a real pass/fail. A row at the older version may carry an
- *  ungated verdict, so it must not be decoded as current state. */
+ *  NOT bumped for the #6833 verdict gate (Passed/Score null unless
+ *  status === "processed"), deliberately: any event that rewrites the row
+ *  overwrites Passed/Score wholesale from the (now gated) event data, a row
+ *  that receives no further event is never re-projected regardless of the
+ *  stamp, and nothing filters on Version at read time — historical rows are
+ *  covered by the Status predicates in the rollup/slim query builders
+ *  instead. A bump here would only trigger a refold wave and reset the
+ *  refoldOnStoreMiss deletion clock (dev/docs/adr/066, ADR-071) for no
+ *  correctness gain. */
 export const EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST =
-  "2026-08-11" as const;
+  "2026-07-27" as const;
 
 /**
  * How far an evaluation's OccurredAt (the partition column) may sit from the
@@ -381,29 +387,6 @@ export function evaluationAnalyticsStateFromRow(
 /** The valid `status` union values, for the read-back guard. */
 const EVALUATION_STATUS_VALUES: ReadonlySet<EvaluationAnalyticsData["status"]> =
   new Set(["scheduled", "in_progress", "processed", "error", "skipped"]);
-
-/**
- * A verdict (passed/score) is only real when the evaluator actually ran to
- * completion. Producers may attach `passed: false` alongside `status: "error"`
- * (the SDKs expose them as independent params), and an errored run's verdict
- * must not reach analytics as a real fail — it poisons pass-rate charts and
- * fires "evaluation failed" triggers on provider timeouts. Gate once here, at
- * the fold, so every downstream reader of the slim row inherits the guard.
- */
-function verdictPassedOf(data: {
-  status: "processed" | "error" | "skipped";
-  passed?: boolean | null;
-}): boolean | null {
-  return data.status === "processed" ? (data.passed ?? null) : null;
-}
-
-function verdictScoreOf(data: {
-  status: "processed" | "error" | "skipped";
-  score?: number | null;
-}): number | null {
-  if (data.status !== "processed") return null;
-  return typeof data.score === "number" ? data.score : null;
-}
 
 /**
  * Merge a passthrough event metadata bag into the slim attributes map.

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalytics.foldProjection.ts
@@ -90,9 +90,14 @@ const evaluationAnalyticsEvents = [
  *  read-back path uses it as the discriminator: a row carrying an OLDER version
  *  predates those columns, so its nulls cannot be told apart from a genuinely
  *  unstarted evaluation and it is treated as a store miss (see
- *  `EvaluationAnalyticsStore.getWithApplied`). */
+ *  `EvaluationAnalyticsStore.getWithApplied`).
+ *
+ *  2026-08-11 — Passed/Score are now gated on `status === "processed"`: a
+ *  verdict attached to an errored/skipped run folds to NULL instead of being
+ *  persisted as a real pass/fail. A row at the older version may carry an
+ *  ungated verdict, so it must not be decoded as current state. */
 export const EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST =
-  "2026-07-27" as const;
+  "2026-08-11" as const;
 
 /**
  * How far an evaluation's OccurredAt (the partition column) may sit from the
@@ -378,6 +383,29 @@ const EVALUATION_STATUS_VALUES: ReadonlySet<EvaluationAnalyticsData["status"]> =
   new Set(["scheduled", "in_progress", "processed", "error", "skipped"]);
 
 /**
+ * A verdict (passed/score) is only real when the evaluator actually ran to
+ * completion. Producers may attach `passed: false` alongside `status: "error"`
+ * (the SDKs expose them as independent params), and an errored run's verdict
+ * must not reach analytics as a real fail — it poisons pass-rate charts and
+ * fires "evaluation failed" triggers on provider timeouts. Gate once here, at
+ * the fold, so every downstream reader of the slim row inherits the guard.
+ */
+function verdictPassedOf(data: {
+  status: "processed" | "error" | "skipped";
+  passed?: boolean | null;
+}): boolean | null {
+  return data.status === "processed" ? (data.passed ?? null) : null;
+}
+
+function verdictScoreOf(data: {
+  status: "processed" | "error" | "skipped";
+  score?: number | null;
+}): number | null {
+  if (data.status !== "processed") return null;
+  return typeof data.score === "number" ? data.score : null;
+}
+
+/**
  * Merge a passthrough event metadata bag into the slim attributes map.
  * Keys arrive as `Record<string, unknown>` so we coerce to string for the
  * CH `Map(String, String)` shape. Anything non-stringifiable is dropped.
@@ -551,8 +579,8 @@ export class EvaluationAnalyticsFoldProjection
       ...state,
       evaluationId: state.evaluationId || event.data.evaluationId,
       status: event.data.status,
-      score: typeof event.data.score === "number" ? event.data.score : null,
-      passed: event.data.passed ?? null,
+      score: verdictScoreOf(event.data),
+      passed: verdictPassedOf(event.data),
       label: event.data.label ?? null,
       completedAt: event.occurredAt,
       costId: event.data.costId ?? null,
@@ -573,8 +601,8 @@ export class EvaluationAnalyticsFoldProjection
       traceId: event.data.traceId ?? null,
       isGuardrail: event.data.isGuardrail ?? false,
       status: event.data.status,
-      score: typeof event.data.score === "number" ? event.data.score : null,
-      passed: event.data.passed ?? null,
+      score: verdictScoreOf(event.data),
+      passed: verdictPassedOf(event.data),
       label: event.data.label ?? null,
       startedAt: event.occurredAt,
       completedAt: event.occurredAt,

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalyticsRollup.mapProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalyticsRollup.mapProjection.ts
@@ -62,17 +62,17 @@ export interface EvaluationAnalyticsRollupRow {
   status: string;
   /** Always 1 (one row per terminal event). */
   evalCount: number;
-  /** 1 when `passed === true`, 0 otherwise (including null and false). */
+  /** 1 when `status === 'processed'` and `passed === true`, 0 otherwise. */
   passCount: number;
-  /** 1 when `passed === false`, 0 otherwise (including null and true). */
+  /** 1 when `status === 'processed'` and `passed === false`, 0 otherwise. */
   failCount: number;
   /** 1 when `status === 'error'`, 0 otherwise. */
   errorCount: number;
   /** 1 when `status === 'skipped'`, 0 otherwise. */
   skippedCount: number;
-  /** The event's `score` value, 0 when null. Pairs with `scoreCount` for true avg. */
+  /** The event's `score` when `status === 'processed'`, 0 otherwise. Pairs with `scoreCount` for true avg. */
   scoreSum: number;
-  /** 1 when `score` is a finite number, 0 otherwise. Divisor for true avg. */
+  /** 1 when `status === 'processed'` and `score` is a finite number, 0 otherwise. Divisor for true avg. */
   scoreCount: number;
   /**
    * Evaluation wall-clock duration in ms. Always 0 from this projection —
@@ -97,20 +97,38 @@ function toStartOfMinute(unixMs: number): Date {
   return new Date(Math.floor(unixMs / 60_000) * 60_000);
 }
 
-function scoreOf(value: number | null | undefined): {
+/**
+ * A verdict (passed/score) is only real when the evaluation ran to
+ * completion — producers can attach `passed: false` alongside
+ * `status: "error"` (#6833). Without the status guard such an event
+ * increments FailCount AND ErrorCount, so the counters double-count and
+ * pass-rate reads an infrastructure error as a real fail.
+ */
+function scoreOf(
+  status: string,
+  value: number | null | undefined,
+): {
   scoreSum: number;
   scoreCount: number;
 } {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (
+    status !== "processed" ||
+    typeof value !== "number" ||
+    !Number.isFinite(value)
+  ) {
     return { scoreSum: 0, scoreCount: 0 };
   }
   return { scoreSum: value, scoreCount: 1 };
 }
 
-function passFailOf(value: boolean | null | undefined): {
+function passFailOf(
+  status: string,
+  value: boolean | null | undefined,
+): {
   passCount: number;
   failCount: number;
 } {
+  if (status !== "processed") return { passCount: 0, failCount: 0 };
   if (value === true) return { passCount: 1, failCount: 0 };
   if (value === false) return { passCount: 0, failCount: 1 };
   return { passCount: 0, failCount: 0 };
@@ -167,8 +185,8 @@ export class EvaluationAnalyticsRollupMapProjection
     event: EvaluationCompletedEvent,
   ): EvaluationAnalyticsRollupRow {
     const { score, passed, status } = event.data;
-    const { scoreSum, scoreCount } = scoreOf(score);
-    const { passCount, failCount } = passFailOf(passed);
+    const { scoreSum, scoreCount } = scoreOf(status, score);
+    const { passCount, failCount } = passFailOf(status, passed);
     return {
       tenantId: event.tenantId,
       bucketStart: toStartOfMinute(event.occurredAt),
@@ -195,8 +213,8 @@ export class EvaluationAnalyticsRollupMapProjection
     event: EvaluationReportedEvent,
   ): EvaluationAnalyticsRollupRow {
     const { score, passed, status, evaluatorType } = event.data;
-    const { scoreSum, scoreCount } = scoreOf(score);
-    const { passCount, failCount } = passFailOf(passed);
+    const { scoreSum, scoreCount } = scoreOf(status, score);
+    const { passCount, failCount } = passFailOf(status, passed);
     return {
       tenantId: event.tenantId,
       bucketStart: toStartOfMinute(event.occurredAt),

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalyticsRollup.mapProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationAnalyticsRollup.mapProjection.ts
@@ -104,33 +104,39 @@ function toStartOfMinute(unixMs: number): Date {
  * increments FailCount AND ErrorCount, so the counters double-count and
  * pass-rate reads an infrastructure error as a real fail.
  */
-function scoreOf(
-  status: string,
-  value: number | null | undefined,
-): {
+function scoreOf({
+  status,
+  score,
+}: {
+  status: string;
+  score: number | null | undefined;
+}): {
   scoreSum: number;
   scoreCount: number;
 } {
   if (
     status !== "processed" ||
-    typeof value !== "number" ||
-    !Number.isFinite(value)
+    typeof score !== "number" ||
+    !Number.isFinite(score)
   ) {
     return { scoreSum: 0, scoreCount: 0 };
   }
-  return { scoreSum: value, scoreCount: 1 };
+  return { scoreSum: score, scoreCount: 1 };
 }
 
-function passFailOf(
-  status: string,
-  value: boolean | null | undefined,
-): {
+function passFailOf({
+  status,
+  passed,
+}: {
+  status: string;
+  passed: boolean | null | undefined;
+}): {
   passCount: number;
   failCount: number;
 } {
   if (status !== "processed") return { passCount: 0, failCount: 0 };
-  if (value === true) return { passCount: 1, failCount: 0 };
-  if (value === false) return { passCount: 0, failCount: 1 };
+  if (passed === true) return { passCount: 1, failCount: 0 };
+  if (passed === false) return { passCount: 0, failCount: 1 };
   return { passCount: 0, failCount: 0 };
 }
 
@@ -185,8 +191,8 @@ export class EvaluationAnalyticsRollupMapProjection
     event: EvaluationCompletedEvent,
   ): EvaluationAnalyticsRollupRow {
     const { score, passed, status } = event.data;
-    const { scoreSum, scoreCount } = scoreOf(status, score);
-    const { passCount, failCount } = passFailOf(status, passed);
+    const { scoreSum, scoreCount } = scoreOf({ status, score });
+    const { passCount, failCount } = passFailOf({ status, passed });
     return {
       tenantId: event.tenantId,
       bucketStart: toStartOfMinute(event.occurredAt),
@@ -213,8 +219,8 @@ export class EvaluationAnalyticsRollupMapProjection
     event: EvaluationReportedEvent,
   ): EvaluationAnalyticsRollupRow {
     const { score, passed, status, evaluatorType } = event.data;
-    const { scoreSum, scoreCount } = scoreOf(status, score);
-    const { passCount, failCount } = passFailOf(status, passed);
+    const { scoreSum, scoreCount } = scoreOf({ status, score });
+    const { passCount, failCount } = passFailOf({ status, passed });
     return {
       tenantId: event.tenantId,
       bucketStart: toStartOfMinute(event.occurredAt),

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationRun.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationRun.foldProjection.ts
@@ -18,6 +18,7 @@ import {
   evaluationScheduledEventSchema,
   evaluationStartedEventSchema,
 } from "../schemas/events";
+import { verdictPassedOf, verdictScoreOf } from "../verdictGate";
 
 export type { EvaluationRunData };
 
@@ -140,8 +141,10 @@ export class EvaluationRunFoldProjection
       ...state,
       evaluationId: state.evaluationId || event.data.evaluationId,
       status: event.data.status,
-      score: typeof event.data.score === "number" ? event.data.score : null,
-      passed: event.data.passed ?? null,
+      // Verdicts are gated on status === "processed" (#6833) — shared with
+      // the slim fold so the documented slim<->runs parity holds.
+      score: verdictScoreOf(event.data),
+      passed: verdictPassedOf(event.data),
       label: event.data.label ?? null,
       details: event.data.details ?? null,
       inputs: event.data.inputs ?? null,
@@ -165,8 +168,10 @@ export class EvaluationRunFoldProjection
       traceId: event.data.traceId ?? null,
       isGuardrail: event.data.isGuardrail ?? false,
       status: event.data.status,
-      score: typeof event.data.score === "number" ? event.data.score : null,
-      passed: event.data.passed ?? null,
+      // Verdicts are gated on status === "processed" (#6833) — shared with
+      // the slim fold so the documented slim<->runs parity holds.
+      score: verdictScoreOf(event.data),
+      passed: verdictPassedOf(event.data),
       label: event.data.label ?? null,
       details: event.data.details ?? null,
       inputs: event.data.inputs ?? null,

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/verdictGate.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/verdictGate.ts
@@ -1,0 +1,29 @@
+/**
+ * A verdict (passed/score) is only real when the evaluator actually ran to
+ * completion. Producers may attach `passed: false` alongside `status:
+ * "error"` (the SDKs expose them as independent params), and an errored
+ * run's verdict must not reach analytics, triggers, or stored rows as a
+ * real fail (#6833).
+ *
+ * Shared by BOTH evaluation folds (`evaluationRun` and the slim
+ * `evaluationAnalytics`) and the executeEvaluation command's emit path, so
+ * the documented parity invariant — the slim row matches `evaluation_runs`
+ * to the cent for the shared fields — holds by construction.
+ */
+
+export type TerminalEvaluationStatus = "processed" | "error" | "skipped";
+
+export function verdictPassedOf(data: {
+  status: TerminalEvaluationStatus;
+  passed?: boolean | null;
+}): boolean | null {
+  return data.status === "processed" ? (data.passed ?? null) : null;
+}
+
+export function verdictScoreOf(data: {
+  status: TerminalEvaluationStatus;
+  score?: number | null;
+}): number | null {
+  if (data.status !== "processed") return null;
+  return typeof data.score === "number" ? data.score : null;
+}

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
@@ -342,6 +342,31 @@ describe("customEvaluationSync reactor", () => {
       expect(call.status).toBe("processed");
     });
 
+    it("drops the verdict when the evaluation reports an error", async () => {
+      const reactor = createCustomEvaluationSyncReactor(deps);
+      const span = makeOtlpSpan([
+        {
+          name: "toxicity",
+          score: 0.1,
+          passed: false,
+          label: "bad",
+          error: { message: "provider timeout" },
+        },
+      ]);
+
+      await reactor.handle(
+        createSpanReceivedEvent(span),
+        createContext(createFoldState()),
+      );
+
+      const call = vi.mocked(deps.reportEvaluation).mock.calls[0]![0];
+      expect(call.status).toBe("error");
+      expect(call.passed).toBeNull();
+      expect(call.score).toBeNull();
+      expect(call.label).toBeNull();
+      expect(call.error).toBe("provider timeout");
+    });
+
     it("uses provided evaluation_id when present", async () => {
       const reactor = createCustomEvaluationSyncReactor(deps);
       const span = makeOtlpSpan([

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
@@ -180,8 +180,8 @@ export function createCustomEvaluationSyncReactor(
           evaluation.status ?? (evaluation.error ? "error" : "processed");
         // A verdict is only real when the evaluator ran to completion — an
         // errored/skipped run's stray passed/score/label must not reach
-        // analytics or triggers as a real result (#6833). Same guard as the
-        // evaluation-execution service producer.
+        // analytics or triggers as a real result (#6833). Same gate as the shared
+        // verdictGate helpers now applied at the executeEvaluation command boundary.
         const hasVerdict = status === "processed";
         const occurredAt = event.occurredAt;
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
@@ -178,6 +178,11 @@ export function createCustomEvaluationSyncReactor(
           evaluation.evaluator_id ?? evaluationNameAutoslug(evaluation.name);
         const status =
           evaluation.status ?? (evaluation.error ? "error" : "processed");
+        // A verdict is only real when the evaluator ran to completion — an
+        // errored/skipped run's stray passed/score/label must not reach
+        // analytics or triggers as a real result (#6833). Same guard as the
+        // evaluation-execution service producer.
+        const hasVerdict = status === "processed";
         const occurredAt = event.occurredAt;
 
         try {
@@ -190,9 +195,9 @@ export function createCustomEvaluationSyncReactor(
             traceId,
             isGuardrail: evaluation.is_guardrail ?? undefined,
             status,
-            score: evaluation.score ?? null,
-            passed: evaluation.passed ?? null,
-            label: evaluation.label ?? null,
+            score: hasVerdict ? (evaluation.score ?? null) : null,
+            passed: hasVerdict ? (evaluation.passed ?? null) : null,
+            label: hasVerdict ? (evaluation.label ?? null) : null,
             details: evaluation.details ?? null,
             error: evaluation.error?.message ?? null,
             errorDetails: evaluation.error?.stacktrace?.join("\n") ?? null,

--- a/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
@@ -653,6 +653,16 @@ describe("matchesEvaluationFilters", () => {
       };
       expect(matchesEvaluationFilters(evals, filters)).toBe(false);
     });
+
+    it("does not match a label attached to an errored run", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "error", label: "toxic" }),
+      ];
+      const filters: TriggerFilters = {
+        "evaluations.evaluator_id.has_label": ["eval-abc"],
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
   });
 
   describe("when filtering by evaluations.passed (keyed)", () => {
@@ -780,6 +790,20 @@ describe("matchesEvaluationFilters", () => {
         "evaluations.label": { "eval-abc": ["positive", "negative"] },
       };
       expect(matchesEvaluationFilters(evals, filters)).toBe(true);
+    });
+
+    it("does not match a label attached to an errored run", () => {
+      const evals = [
+        makeEval({
+          evaluatorId: "eval-abc",
+          status: "error",
+          label: "positive",
+        }),
+      ];
+      const filters: TriggerFilters = {
+        "evaluations.label": { "eval-abc": ["positive"] },
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
     });
 
     it("does not match when label is not in filter values", () => {

--- a/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
@@ -589,6 +589,16 @@ describe("matchesEvaluationFilters", () => {
       };
       expect(matchesEvaluationFilters(evals, filters)).toBe(false);
     });
+
+    it("does not match a verdict attached to an errored run", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "error", passed: false }),
+      ];
+      const filters: TriggerFilters = {
+        "evaluations.evaluator_id.has_passed": ["eval-abc"],
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
   });
 
   describe("when filtering by evaluations.evaluator_id.has_score", () => {
@@ -602,6 +612,16 @@ describe("matchesEvaluationFilters", () => {
 
     it("does not match when score is null", () => {
       const evals = [makeEval({ evaluatorId: "eval-abc", score: null })];
+      const filters: TriggerFilters = {
+        "evaluations.evaluator_id.has_score": ["eval-abc"],
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
+
+    it("does not match a score attached to an errored run", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "error", score: 0.85 }),
+      ];
       const filters: TriggerFilters = {
         "evaluations.evaluator_id.has_score": ["eval-abc"],
       };
@@ -667,6 +687,26 @@ describe("matchesEvaluationFilters", () => {
       };
       expect(matchesEvaluationFilters(evals, filters)).toBe(false);
     });
+
+    it("does not fire on a false verdict attached to an errored run (provider timeout is not a quality regression)", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "error", passed: false }),
+      ];
+      const filters: TriggerFilters = {
+        "evaluations.passed": { "eval-abc": ["false"] },
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
+
+    it("does not fire on a verdict attached to a skipped run", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "skipped", passed: true }),
+      ];
+      const filters: TriggerFilters = {
+        "evaluations.passed": { "eval-abc": ["true"] },
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
   });
 
   describe("when filtering by evaluations.score (double-keyed)", () => {
@@ -680,6 +720,16 @@ describe("matchesEvaluationFilters", () => {
 
     it("does not match when score differs", () => {
       const evals = [makeEval({ evaluatorId: "eval-abc", score: 0.5 })];
+      const filters: TriggerFilters = {
+        "evaluations.score": { "eval-abc": { score: ["0.85"] } },
+      };
+      expect(matchesEvaluationFilters(evals, filters)).toBe(false);
+    });
+
+    it("does not match a score attached to an errored run", () => {
+      const evals = [
+        makeEval({ evaluatorId: "eval-abc", status: "error", score: 0.85 }),
+      ];
       const filters: TriggerFilters = {
         "evaluations.score": { "eval-abc": { score: ["0.85"] } },
       };

--- a/platform/app/src/server/filters/triggerFilter.matcher.ts
+++ b/platform/app/src/server/filters/triggerFilter.matcher.ts
@@ -522,6 +522,7 @@ function matchEvaluatorIdFilter(
       return evaluations.some(
         (e) =>
           evaluatorIds.includes(e.evaluatorId) &&
+          hasVerdict(e) &&
           e.label !== null &&
           e.label !== "",
       );
@@ -556,7 +557,7 @@ function matchEvaluationValues(
 
     case "evaluations.label":
       return evaluations.some(
-        (e) => e.label !== null && values.includes(e.label),
+        (e) => hasVerdict(e) && e.label !== null && values.includes(e.label),
       );
 
     default:

--- a/platform/app/src/server/filters/triggerFilter.matcher.ts
+++ b/platform/app/src/server/filters/triggerFilter.matcher.ts
@@ -475,6 +475,19 @@ function matchEvaluationField(
   return true;
 }
 
+/**
+ * A verdict (passed/score) is only real when the evaluation ran to
+ * completion. Producers can attach `passed: false` alongside `status:
+ * "error"` (the SDKs expose them as independent params), and the run feed is
+ * unfiltered — without this guard a trigger configured as "evaluations.passed
+ * = false" pages someone for a quality regression that is actually a
+ * provider timeout (#6833). Status-based filters (`evaluations.state`) are
+ * the intended way to alert on errored evaluators.
+ */
+function hasVerdict(e: EvaluationRunData): boolean {
+  return e.status === "processed";
+}
+
 function matchEvaluatorIdFilter(
   evaluations: EvaluationRunData[],
   field: FilterField,
@@ -491,12 +504,14 @@ function matchEvaluatorIdFilter(
 
     case "evaluations.evaluator_id.has_passed":
       return evaluations.some(
-        (e) => evaluatorIds.includes(e.evaluatorId) && e.passed !== null,
+        (e) =>
+          evaluatorIds.includes(e.evaluatorId) && hasVerdict(e) && e.passed !== null,
       );
 
     case "evaluations.evaluator_id.has_score":
       return evaluations.some(
-        (e) => evaluatorIds.includes(e.evaluatorId) && e.score !== null,
+        (e) =>
+          evaluatorIds.includes(e.evaluatorId) && hasVerdict(e) && e.score !== null,
       );
 
     case "evaluations.evaluator_id.has_label":
@@ -520,12 +535,14 @@ function matchEvaluationValues(
   switch (field) {
     case "evaluations.passed":
       return evaluations.some(
-        (e) => e.passed !== null && values.includes(String(e.passed)),
+        (e) =>
+          hasVerdict(e) && e.passed !== null && values.includes(String(e.passed)),
       );
 
     case "evaluations.score":
       return evaluations.some(
-        (e) => e.score !== null && values.includes(String(e.score)),
+        (e) =>
+          hasVerdict(e) && e.score !== null && values.includes(String(e.score)),
       );
 
     case "evaluations.state":

--- a/platform/app/src/server/filters/triggerFilter.matcher.ts
+++ b/platform/app/src/server/filters/triggerFilter.matcher.ts
@@ -505,13 +505,17 @@ function matchEvaluatorIdFilter(
     case "evaluations.evaluator_id.has_passed":
       return evaluations.some(
         (e) =>
-          evaluatorIds.includes(e.evaluatorId) && hasVerdict(e) && e.passed !== null,
+          evaluatorIds.includes(e.evaluatorId) &&
+          hasVerdict(e) &&
+          e.passed !== null,
       );
 
     case "evaluations.evaluator_id.has_score":
       return evaluations.some(
         (e) =>
-          evaluatorIds.includes(e.evaluatorId) && hasVerdict(e) && e.score !== null,
+          evaluatorIds.includes(e.evaluatorId) &&
+          hasVerdict(e) &&
+          e.score !== null,
       );
 
     case "evaluations.evaluator_id.has_label":
@@ -536,7 +540,9 @@ function matchEvaluationValues(
     case "evaluations.passed":
       return evaluations.some(
         (e) =>
-          hasVerdict(e) && e.passed !== null && values.includes(String(e.passed)),
+          hasVerdict(e) &&
+          e.passed !== null &&
+          values.includes(String(e.passed)),
       );
 
     case "evaluations.score":

--- a/platform/app/src/server/routes/__tests__/collector.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector.unit.test.ts
@@ -332,6 +332,32 @@ describe("POST /api/collector", () => {
     });
   });
 
+  describe("given an evaluation reporting an error alongside a verdict", () => {
+    it("dispatches with status error and no verdict (passed/score/label null)", async () => {
+      const res = await postCollector({
+        trace_id: "trace-1",
+        spans: [makeSpan(1)],
+        evaluations: [
+          {
+            name: "eval-a",
+            score: 0.1,
+            passed: false,
+            label: "bad",
+            error: { message: "provider timeout", stacktrace: [] },
+          },
+        ],
+      });
+
+      expect(res.status).toBe(200);
+      const call = mockReportEvaluation.mock.calls[0]![0];
+      expect(call.status).toBe("error");
+      expect(call.passed).toBeNull();
+      expect(call.score).toBeNull();
+      expect(call.label).toBeNull();
+      expect(call.error).toBe("provider timeout");
+    });
+  });
+
   describe("given multiple evaluations where one dispatch fails", () => {
     describe("when the first reportEvaluation throws", () => {
       it("continues dispatching the rest and reports the failure count", async () => {

--- a/platform/app/src/server/routes/__tests__/collector.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/collector.unit.test.ts
@@ -333,28 +333,30 @@ describe("POST /api/collector", () => {
   });
 
   describe("given an evaluation reporting an error alongside a verdict", () => {
-    it("dispatches with status error and no verdict (passed/score/label null)", async () => {
-      const res = await postCollector({
-        trace_id: "trace-1",
-        spans: [makeSpan(1)],
-        evaluations: [
-          {
-            name: "eval-a",
-            score: 0.1,
-            passed: false,
-            label: "bad",
-            error: { message: "provider timeout", stacktrace: [] },
-          },
-        ],
-      });
+    describe("when it is dispatched to the evaluations pipeline", () => {
+      it("dispatches with status error and no verdict (passed/score/label null)", async () => {
+        const res = await postCollector({
+          trace_id: "trace-1",
+          spans: [makeSpan(1)],
+          evaluations: [
+            {
+              name: "eval-a",
+              score: 0.1,
+              passed: false,
+              label: "bad",
+              error: { message: "provider timeout", stacktrace: [] },
+            },
+          ],
+        });
 
-      expect(res.status).toBe(200);
-      const call = mockReportEvaluation.mock.calls[0]![0];
-      expect(call.status).toBe("error");
-      expect(call.passed).toBeNull();
-      expect(call.score).toBeNull();
-      expect(call.label).toBeNull();
-      expect(call.error).toBe("provider timeout");
+        expect(res.status).toBe(200);
+        const call = mockReportEvaluation.mock.calls[0]![0];
+        expect(call.status).toBe("error");
+        expect(call.passed).toBeNull();
+        expect(call.score).toBeNull();
+        expect(call.label).toBeNull();
+        expect(call.error).toBe("provider timeout");
+      });
     });
   });
 

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -710,6 +710,11 @@ secured
               evaluationNameAutoslug(evaluation.name);
             const status =
               evaluation.status ?? (evaluation.error ? "error" : "processed");
+            // A verdict is only real when the evaluator ran to completion —
+            // an errored/skipped run's stray passed/score/label must not
+            // reach analytics or triggers as a real result (#6833). Same
+            // guard as the evaluation-execution service producer.
+            const hasVerdict = status === "processed";
 
             await app.evaluations.reportEvaluation({
               tenantId: project.id,
@@ -720,9 +725,9 @@ secured
               traceId,
               isGuardrail: evaluation.is_guardrail ?? undefined,
               status,
-              score: evaluation.score ?? null,
-              passed: evaluation.passed ?? null,
-              label: evaluation.label ?? null,
+              score: hasVerdict ? (evaluation.score ?? null) : null,
+              passed: hasVerdict ? (evaluation.passed ?? null) : null,
+              label: hasVerdict ? (evaluation.label ?? null) : null,
               details: evaluation.details ?? null,
               error: evaluation.error?.message ?? null,
               occurredAt,

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -713,7 +713,8 @@ secured
             // A verdict is only real when the evaluator ran to completion —
             // an errored/skipped run's stray passed/score/label must not
             // reach analytics or triggers as a real result (#6833). Same
-            // guard as the evaluation-execution service producer.
+            // gate as the shared verdictGate helpers applied at the
+            // executeEvaluation command boundary.
             const hasVerdict = status === "processed";
 
             await app.evaluations.reportEvaluation({

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -1703,6 +1703,11 @@ const dispatchToClickHouse = async (
     const evalPromises = batchEvaluation.evaluations.map((evaluation) => {
       const targetId = evaluation.target_id ?? "";
       const evaluationId = `local_eval_${runId}_${evaluation.evaluator}_${evaluation.index}_${targetId}`;
+      // A verdict is only real when the evaluator ran to completion — an
+      // errored/skipped run's stray passed/score/label must not reach
+      // analytics or triggers as a real result (#6833). Same guard as the
+      // evaluation-execution service producer.
+      const hasVerdict = evaluation.status === "processed";
       return appInstance.evaluations
         .reportEvaluation({
           tenantId: project.id,
@@ -1712,9 +1717,11 @@ const dispatchToClickHouse = async (
           evaluatorName: evaluation.name ?? undefined,
           status: evaluation.status,
           score:
-            typeof evaluation.score === "number" ? evaluation.score : undefined,
-          passed: evaluation.passed ?? undefined,
-          label: evaluation.label ?? undefined,
+            hasVerdict && typeof evaluation.score === "number"
+              ? evaluation.score
+              : undefined,
+          passed: hasVerdict ? (evaluation.passed ?? undefined) : undefined,
+          label: hasVerdict ? (evaluation.label ?? undefined) : undefined,
           details: evaluation.details ?? undefined,
           occurredAt: Date.now(),
         })

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -1062,6 +1062,29 @@ export const resolveEvaluatorSettingsDefaults = async (
 
 // --- Evaluator call handler (used by evaluations + guardrails routes) ---
 
+/**
+ * The verdict fields of a `reportEvaluation` payload, gated on the run
+ * actually completing. A verdict is only real when the evaluator ran to
+ * completion — an errored/skipped run's stray passed/score/label must not
+ * reach analytics or triggers as a real result (#6833). Same gate as the
+ * shared verdictGate helpers applied at the executeEvaluation command
+ * boundary. Property presence is no defense: the custom-evaluator error
+ * path spreads the raw evaluator result, so score/passed survive on it.
+ */
+function gatedVerdictFields(result: {
+  status: string;
+  score?: number | null;
+  passed?: boolean | null;
+  label?: string | null;
+}): { score?: number; passed?: boolean; label?: string } {
+  if (result.status !== "processed") return {};
+  return {
+    score: typeof result.score === "number" ? result.score : undefined,
+    passed: result.passed ?? undefined,
+    label: result.label ?? undefined,
+  };
+}
+
 async function handleEvaluatorCall(
   c: Context,
   evaluatorSlug: string,
@@ -1448,9 +1471,10 @@ async function handleEvaluatorCall(
         traceId: params.trace_id ?? undefined,
         isGuardrail: isGuardrail ?? undefined,
         status: result!.status,
-        score: "score" in result! ? result!.score : undefined,
-        passed: "passed" in result! ? result!.passed : undefined,
-        label: "label" in result! ? result!.label : undefined,
+        // The custom-evaluator error path spreads the raw evaluator result
+        // (`{ ...result, status: "error" }`), so `"score" in result` is NOT
+        // protective here — gate on status instead (#6833).
+        ...gatedVerdictFields(result!),
         details: "details" in result! ? result!.details : undefined,
         costId: costId ?? null,
         occurredAt: Date.now(),
@@ -1703,11 +1727,6 @@ const dispatchToClickHouse = async (
     const evalPromises = batchEvaluation.evaluations.map((evaluation) => {
       const targetId = evaluation.target_id ?? "";
       const evaluationId = `local_eval_${runId}_${evaluation.evaluator}_${evaluation.index}_${targetId}`;
-      // A verdict is only real when the evaluator ran to completion — an
-      // errored/skipped run's stray passed/score/label must not reach
-      // analytics or triggers as a real result (#6833). Same guard as the
-      // evaluation-execution service producer.
-      const hasVerdict = evaluation.status === "processed";
       return appInstance.evaluations
         .reportEvaluation({
           tenantId: project.id,
@@ -1716,12 +1735,7 @@ const dispatchToClickHouse = async (
           evaluatorType: evaluation.evaluator,
           evaluatorName: evaluation.name ?? undefined,
           status: evaluation.status,
-          score:
-            hasVerdict && typeof evaluation.score === "number"
-              ? evaluation.score
-              : undefined,
-          passed: hasVerdict ? (evaluation.passed ?? undefined) : undefined,
-          label: hasVerdict ? (evaluation.label ?? undefined) : undefined,
+          ...gatedVerdictFields(evaluation),
           details: evaluation.details ?? undefined,
           occurredAt: Date.now(),
         })


### PR DESCRIPTION
# Related Issue

- Resolves #6833

## For humans

When an evaluator breaks down mid-run — a provider timeout, a misconfiguration — it sometimes still ships a pass/fail verdict alongside the error. LangWatch was treating that verdict as real: alerting rules paged people about "failed evaluations" that were actually infrastructure hiccups, and project-wide pass-rate charts disagreed with per-evaluator charts on the same data. This PR makes the whole pipeline agree on one rule: a verdict only counts when the evaluation actually ran to completion.

## Why

An evaluation's `passed` boolean was persisted and consumed without regard to its `status`, so evaluator infrastructure errors became real verdicts. They could fire "evaluation failed" triggers on provider timeouts and poison pass-rate analytics, where the rollup/slim paths (project-wide charts) disagreed with the legacy per-evaluator path that already filtered `Status = 'processed'`.

Closes #6833

## What changed

One contract, enforced at every layer that previously missed it: **a verdict (passed/score) is only real when `status === "processed"`.**

- **Fold gate (the load-bearing fix):** `evaluationAnalytics.foldProjection.ts` writes `Passed`/`Score` as NULL for non-processed events, in both the completed and reported handlers.
- **Query builders (covers historical rows):** `eval-rollup-timeseries-query.ts` uses `sumIf(..., Status = 'processed')` for pass-rate and score; `eval-slim-timeseries-query.ts` nulls `Passed`/`Score` on non-processed rows at the column expression, and its `evaluation_passed` / `evaluation_label` group-by buckets a non-processed row as `unknown` rather than `failed`. `evaluation_runs` counts stay unfiltered — an errored run is still a run, matching the legacy `uniqIf`.
- **Trigger matcher:** `evaluations.passed`, `evaluations.score`, `evaluations.label` and their `has_*` variants now require `status === "processed"`, so `{status: "error", passed: false}` no longer fires an `evaluations.passed = false` trigger. `evaluations.state` remains the way to alert on errored evaluators.
- **Producers aligned:** the three unguarded producers (collector route, custom-evaluation sync reactor, legacy SDK batch route) now drop the verdict on non-processed status, matching the three already-guarded producers.
- **Rollup counters:** `passFailOf`/`scoreOf` in `evaluationAnalyticsRollup.mapProjection.ts` are status-aware, so one event can never increment both FailCount and ErrorCount — ErrorCount/SkippedCount become trustworthy before anything reads them.
- **Blocked badge:** the trace-view guardrail badge (`Evaluations.tsx`) counts a block only when the guardrail ran to completion — an errored guardrail's stray `passed: false` is not a block.

### The projection version was deliberately NOT bumped

An earlier revision of this PR bumped `EVALUATION_ANALYTICS_PROJECTION_VERSION_LATEST`; that was reverted, and the constant stays at `2026-07-27` with a comment recording why. Any event that rewrites a row overwrites `Passed`/`Score` wholesale from the (now gated) event data, a row that receives no further event is never re-projected regardless of the stamp, and nothing filters on `Version` at read time. Historical rows are covered by the `Status` predicates in the query builders instead. A bump would only trigger a refold wave and reset the `refoldOnStoreMiss` deletion clock (ADR-066, ADR-071) for no correctness gain.

## Test plan

All test-first (each new test failed before its fix):

- Fold unit tests: errored/skipped completed + reported events project `Passed`/`Score` NULL.
- New `eval-builders-status-gate.unit.test.ts`: both builders' SQL carries the status predicate for verdict metrics and NOT for run counts.
- Trigger matcher unit tests: verdicts on errored/skipped runs don't match `evaluations.passed`, `evaluations.score`, `evaluations.label`, `has_passed`, `has_score`.
- Producer unit tests: collector route + custom-evaluation reactor dispatch `passed/score/label: null` when the payload carries an error.
- Rollup projection unit tests: `{status: error, passed: false}` yields `errorCount: 1, failCount: 0`.
- Integration test through the fold: an errored reported event with a stray verdict lands in ClickHouse with `Passed`/`Score` NULL.
- Post-rebase verification: 8 touched unit suites green (170 tests), `pnpm typecheck` + `pnpm typecheck:tests` clean, Biome new-violations gate reports none.

## Anything surprising?

- **Rebased onto #6839.** The sibling no-verdict-family PR landed first and replaced the messages-list pass/guardrail tallies in `MessageCard.tsx` with a shared `summarizeEvaluationsTag` helper that already filters both sides to `status === "processed"`. That subsumes the equivalent fix this PR carried, so `MessageCard.tsx` dropped out of the diff entirely during the rebase. The trace-view `Blocked` badge was untouched by #6839 and is still fixed here.
- The pre-existing rollup write-path integration test (`inserts per-evaluation rows and SimpleAggregateFunction(sum) collapses cleanly on merge`) fails on my native ClickHouse **with and without** these changes — it drives raw repository inserts this PR doesn't touch. CI runs it against testcontainers.
- The legacy SDK batch route's sibling `experimentRuns.recordEvaluatorResult` dispatch has the same unguarded shape, but that feeds the experiments pipeline, not this family — left untouched deliberately.
- The drawer/trace UI was never affected (`utils/evaluationResults.ts` guards at read time); the damage was confined to analytics and alerting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Evaluation verdicts and scores are now recorded only for successfully processed evaluations.
  - Errored or skipped evaluations no longer contribute pass rates, scores, labels, or filter matches.
  - Analytics correctly separates run counts from verdict-based metrics.
  - Guardrail blocked counts now exclude errored and skipped evaluations.
  - Error details are preserved while invalid verdict fields are cleared.
- **Tests**
  - Added regression coverage for analytics, filtering, reporting, projections, and evaluation synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->