### PR TITLE
fix(evaluations): stop display and export surfaces from inventing verdicts (no-verdict family)

### DIFF
--- a/platform/app/src/components/annotations/__tests__/annotationRow.export.unit.test.ts
+++ b/platform/app/src/components/annotations/__tests__/annotationRow.export.unit.test.ts
@@ -1,0 +1,32 @@
+/**
+ * CSV export labels for annotation ratings (#6835 item 3).
+ *
+ * `isThumbsUp` is tri-state: the drawer's comment flow never sends it and the
+ * router stores null, so a comment-only annotation carries no verdict. The
+ * export is used as labelled ground truth — fabricating "Thumbs Down" for a
+ * null poisons every downstream consumer with a negative verdict nobody gave.
+ */
+import { describe, expect, it } from "vitest";
+import { annotationRatingExportLabel } from "../annotationRow";
+
+describe("annotationRatingExportLabel", () => {
+  describe("when the annotation carries an explicit rating", () => {
+    it("labels true as Thumbs Up", () => {
+      expect(annotationRatingExportLabel(true)).toBe("Thumbs Up");
+    });
+
+    it("labels false as Thumbs Down", () => {
+      expect(annotationRatingExportLabel(false)).toBe("Thumbs Down");
+    });
+  });
+
+  describe("when the annotation is comment-only (no rating)", () => {
+    it("exports an empty cell for null, never a fabricated Thumbs Down", () => {
+      expect(annotationRatingExportLabel(null)).toBe("");
+    });
+
+    it("exports an empty cell for undefined", () => {
+      expect(annotationRatingExportLabel(undefined)).toBe("");
+    });
+  });
+});

--- a/platform/app/src/components/annotations/annotationRow.ts
+++ b/platform/app/src/components/annotations/annotationRow.ts
@@ -52,6 +52,21 @@ export function suggestionExportLine({
     : annotation.expectedOutput;
 }
 
+/**
+ * The rating cell as the CSV export writes it. `isThumbsUp` is tri-state:
+ * comment-only annotations never carry a rating (the drawer doesn't send one
+ * and the router stores null), and the export doubles as labelled ground
+ * truth — so no rating exports as an empty cell, never a fabricated
+ * "Thumbs Down" (#6835).
+ */
+export function annotationRatingExportLabel(
+  isThumbsUp: boolean | null | undefined,
+): string {
+  if (isThumbsUp === true) return "Thumbs Up";
+  if (isThumbsUp === false) return "Thumbs Down";
+  return "";
+}
+
 /** One score a reviewer gave, named the way the project names it. */
 export interface AnnotationScoreAnswer {
   /** The score's name, or the id it is stored under when the project dropped it. */

--- a/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
+++ b/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
@@ -42,6 +42,11 @@ describe("summarizeEvaluationsTag", () => {
       expect(summary.verdictTotal).toBe(1);
     });
 
+    it("still reports every run in total and counts the skipped one", () => {
+      expect(summary.total).toBe(2);
+      expect(summary.skipped).toBe(1);
+    });
+
     it("is not reported as all-skipped", () => {
       expect(summary.allSkipped).toBe(false);
     });

--- a/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
+++ b/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
@@ -6,7 +6,11 @@
  */
 import { describe, expect, it } from "vitest";
 import type { ElasticSearchEvaluation } from "~/server/tracer/types";
-import { summarizeEvaluationsTag } from "../evaluationSummaryCounts";
+import {
+  evaluationsTagLabel,
+  guardrailsTagLabel,
+  summarizeEvaluationsTag,
+} from "../evaluationSummaryCounts";
 
 function makeEvaluation(
   overrides: Partial<ElasticSearchEvaluation> = {},
@@ -95,6 +99,109 @@ describe("summarizeEvaluationsTag", () => {
         makeEvaluation({ status: "in_progress", passed: null }),
       ]);
       expect(summary.done).toBe(false);
+    });
+  });
+});
+
+describe("evaluationsTagLabel", () => {
+  describe("when the trace mixes fails, errors, and skips", () => {
+    it("keeps every terminal count visible — no state hides another", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: false }),
+        makeEvaluation({ evaluation_id: "e2", status: "error", passed: null }),
+        makeEvaluation({
+          evaluation_id: "e3",
+          status: "skipped",
+          passed: null,
+        }),
+      ]);
+      expect(evaluationsTagLabel(summary)).toBe(
+        "1 evaluation failed, 1 errored, 1 skipped",
+      );
+    });
+  });
+
+  describe("when errored and skipped runs finish without fails", () => {
+    it("names both", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ status: "error", passed: null }),
+        makeEvaluation({
+          evaluation_id: "e2",
+          status: "skipped",
+          passed: null,
+        }),
+      ]);
+      expect(evaluationsTagLabel(summary)).toBe(
+        "1 evaluation errored, 1 skipped",
+      );
+    });
+  });
+
+  describe("when runs are still in flight", () => {
+    it("counts passes out of every evaluation on the trace", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: true }),
+        makeEvaluation({
+          evaluation_id: "e2",
+          status: "in_progress",
+          passed: null,
+        }),
+        makeEvaluation({
+          evaluation_id: "e3",
+          status: "in_progress",
+          passed: null,
+        }),
+      ]);
+      expect(evaluationsTagLabel(summary)).toBe("1/3 evaluations");
+    });
+  });
+
+  describe("when everything passed with some skipped", () => {
+    it("reconciles with the popover list", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: true }),
+        makeEvaluation({
+          evaluation_id: "e2",
+          status: "skipped",
+          passed: null,
+        }),
+      ]);
+      expect(evaluationsTagLabel(summary)).toBe("1/1 evaluations, 1 skipped");
+    });
+  });
+});
+
+describe("guardrailsTagLabel", () => {
+  describe("when a guardrail blocked while another errored", () => {
+    it("shows the block and the error side by side", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: false }),
+        makeEvaluation({ evaluation_id: "g2", status: "error", passed: null }),
+      ]);
+      expect(guardrailsTagLabel(summary)).toBe("1 guardrail block, 1 errored");
+    });
+  });
+
+  describe("when guardrails are still running", () => {
+    it("does not render a green zero-of-zero", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ status: "in_progress", passed: null }),
+      ]);
+      expect(guardrailsTagLabel(summary)).toBe("0/1 guardrails");
+    });
+  });
+
+  describe("when a skipped guardrail rides beside a pass", () => {
+    it("is not counted as a pass, only named", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: true }),
+        makeEvaluation({
+          evaluation_id: "g2",
+          status: "skipped",
+          passed: null,
+        }),
+      ]);
+      expect(guardrailsTagLabel(summary)).toBe("1/1 guardrails, 1 skipped");
     });
   });
 });

--- a/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
+++ b/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Verdict counting for the legacy messages list tag and trace list pills
+ * (#6835 item 2). A skipped evaluation is not a pass, and a crashed
+ * evaluator is not a fail verdict — the counts must keep the three states
+ * apart instead of coercing them into pass/fail.
+ */
+import { describe, expect, it } from "vitest";
+import type { ElasticSearchEvaluation } from "~/server/tracer/types";
+import { summarizeEvaluationsTag } from "../evaluationSummaryCounts";
+
+function makeEvaluation(
+  overrides: Partial<ElasticSearchEvaluation> = {},
+): ElasticSearchEvaluation {
+  return {
+    evaluation_id: "eval-1",
+    evaluator_id: "evaluator-1",
+    name: "Check",
+    status: "processed",
+    passed: true,
+    score: null,
+    label: null,
+    ...overrides,
+  } as unknown as ElasticSearchEvaluation;
+}
+
+describe("summarizeEvaluationsTag", () => {
+  describe("given a mixed passed + skipped trace", () => {
+    const summary = summarizeEvaluationsTag([
+      makeEvaluation({ passed: true }),
+      makeEvaluation({
+        evaluation_id: "eval-2",
+        status: "skipped",
+        passed: null,
+      }),
+    ]);
+
+    it("does not count the skipped run as a pass", () => {
+      expect(summary.passes).toBe(1);
+    });
+
+    it("keeps the skipped run out of the verdict denominator", () => {
+      expect(summary.verdictTotal).toBe(1);
+    });
+
+    it("is not reported as all-skipped", () => {
+      expect(summary.allSkipped).toBe(false);
+    });
+  });
+
+  describe("given a processed fail verdict", () => {
+    it("counts it as failed", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ passed: false }),
+      ]);
+      expect(summary.failed).toBe(1);
+      expect(summary.passes).toBe(0);
+    });
+  });
+
+  describe("given a crashed evaluator", () => {
+    const summary = summarizeEvaluationsTag([
+      makeEvaluation({ status: "error", passed: null }),
+      makeEvaluation({ evaluation_id: "eval-2", passed: true }),
+    ]);
+
+    it("counts it as errored, never as failed", () => {
+      expect(summary.errored).toBe(1);
+      expect(summary.failed).toBe(0);
+    });
+
+    it("keeps it out of the verdict denominator", () => {
+      expect(summary.verdictTotal).toBe(1);
+      expect(summary.passes).toBe(1);
+    });
+  });
+
+  describe("given only skipped evaluations", () => {
+    it("reports all-skipped", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ status: "skipped", passed: null }),
+      ]);
+      expect(summary.allSkipped).toBe(true);
+      expect(summary.verdictTotal).toBe(0);
+    });
+  });
+
+  describe("given an evaluation still running", () => {
+    it("is not done", () => {
+      const summary = summarizeEvaluationsTag([
+        makeEvaluation({ status: "in_progress", passed: null }),
+      ]);
+      expect(summary.done).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
+++ b/platform/app/src/components/checks/__tests__/evaluationSummaryCounts.unit.test.ts
@@ -24,7 +24,7 @@ function makeEvaluation(
 }
 
 describe("summarizeEvaluationsTag", () => {
-  describe("given a mixed passed + skipped trace", () => {
+  describe("when the trace mixes passed and skipped runs", () => {
     const summary = summarizeEvaluationsTag([
       makeEvaluation({ passed: true }),
       makeEvaluation({
@@ -48,11 +48,11 @@ describe("summarizeEvaluationsTag", () => {
     });
 
     it("is not reported as all-skipped", () => {
-      expect(summary.allSkipped).toBe(false);
+      expect(summary.hasOnlySkippedRuns).toBe(false);
     });
   });
 
-  describe("given a processed fail verdict", () => {
+  describe("when a processed run carries a fail verdict", () => {
     it("counts it as failed", () => {
       const summary = summarizeEvaluationsTag([
         makeEvaluation({ passed: false }),
@@ -62,7 +62,7 @@ describe("summarizeEvaluationsTag", () => {
     });
   });
 
-  describe("given a crashed evaluator", () => {
+  describe("when an evaluator crashed", () => {
     const summary = summarizeEvaluationsTag([
       makeEvaluation({ status: "error", passed: null }),
       makeEvaluation({ evaluation_id: "eval-2", passed: true }),
@@ -79,17 +79,17 @@ describe("summarizeEvaluationsTag", () => {
     });
   });
 
-  describe("given only skipped evaluations", () => {
+  describe("when every evaluation was skipped", () => {
     it("reports all-skipped", () => {
       const summary = summarizeEvaluationsTag([
         makeEvaluation({ status: "skipped", passed: null }),
       ]);
-      expect(summary.allSkipped).toBe(true);
+      expect(summary.hasOnlySkippedRuns).toBe(true);
       expect(summary.verdictTotal).toBe(0);
     });
   });
 
-  describe("given an evaluation still running", () => {
+  describe("when an evaluation is still running", () => {
     it("is not done", () => {
       const summary = summarizeEvaluationsTag([
         makeEvaluation({ status: "in_progress", passed: null }),

--- a/platform/app/src/components/checks/evaluationSummaryCounts.ts
+++ b/platform/app/src/components/checks/evaluationSummaryCounts.ts
@@ -1,0 +1,57 @@
+import type { ElasticSearchEvaluation } from "~/server/tracer/types";
+import { evaluationPassed } from "./EvaluationStatus";
+
+/**
+ * Verdict-aware counts for a trace's evaluations (#6835).
+ *
+ * Three states must stay apart:
+ *   - a verdict (processed pass/fail),
+ *   - "ran and found nothing to judge" (skipped),
+ *   - "the evaluator broke" (error).
+ *
+ * The messages-list tag previously counted skipped runs as passes and
+ * errored runs as fails; both invent a verdict nobody produced.
+ */
+export interface EvaluationsTagSummary {
+  /** Every evaluation reached a terminal status. */
+  done: boolean;
+  /** Every evaluation was skipped — "nothing to evaluate", not a verdict. */
+  allSkipped: boolean;
+  /** Processed runs — the only ones that can carry a verdict. */
+  verdictTotal: number;
+  /** Processed runs that did not fail (includes score-only neutrals). */
+  passes: number;
+  /** Processed runs with an explicit fail verdict. */
+  failed: number;
+  /** Runs whose evaluator crashed — an infrastructure state, not a fail. */
+  errored: number;
+}
+
+export function summarizeEvaluationsTag(
+  evaluations: Pick<ElasticSearchEvaluation, "status" | "passed" | "score">[],
+): EvaluationsTagSummary {
+  const done = evaluations.every(
+    (check) =>
+      check.status === "processed" ||
+      check.status === "skipped" ||
+      check.status === "error",
+  );
+  const allSkipped =
+    evaluations.length > 0 &&
+    evaluations.every((check) => check.status === "skipped");
+  const processed = evaluations.filter(
+    (check) => check.status === "processed",
+  );
+  const failed = processed.filter(
+    (check) => evaluationPassed(check) === false,
+  ).length;
+
+  return {
+    done,
+    allSkipped,
+    verdictTotal: processed.length,
+    passes: processed.length - failed,
+    failed,
+    errored: evaluations.filter((check) => check.status === "error").length,
+  };
+}

--- a/platform/app/src/components/checks/evaluationSummaryCounts.ts
+++ b/platform/app/src/components/checks/evaluationSummaryCounts.ts
@@ -16,7 +16,7 @@ export interface EvaluationsTagSummary {
   /** Every evaluation reached a terminal status. */
   done: boolean;
   /** Every evaluation was skipped — "nothing to evaluate", not a verdict. */
-  allSkipped: boolean;
+  hasOnlySkippedRuns: boolean;
   /** Every evaluation on the trace, whatever its state. */
   total: number;
   /** Processed runs — the only ones that can carry a verdict. */
@@ -40,7 +40,7 @@ export function summarizeEvaluationsTag(
       check.status === "skipped" ||
       check.status === "error",
   );
-  const allSkipped =
+  const hasOnlySkippedRuns =
     evaluations.length > 0 &&
     evaluations.every((check) => check.status === "skipped");
   const processed = evaluations.filter((check) => check.status === "processed");
@@ -50,7 +50,7 @@ export function summarizeEvaluationsTag(
 
   return {
     done,
-    allSkipped,
+    hasOnlySkippedRuns,
     total: evaluations.length,
     verdictTotal: processed.length,
     passes: processed.length - failed,

--- a/platform/app/src/components/checks/evaluationSummaryCounts.ts
+++ b/platform/app/src/components/checks/evaluationSummaryCounts.ts
@@ -59,3 +59,55 @@ export function summarizeEvaluationsTag(
     skipped: evaluations.filter((check) => check.status === "skipped").length,
   };
 }
+
+const skippedSuffix = (summary: EvaluationsTagSummary): string =>
+  summary.skipped > 0 ? `, ${summary.skipped} skipped` : "";
+
+const erroredSuffix = (summary: EvaluationsTagSummary): string =>
+  summary.errored > 0 ? `, ${summary.errored} errored` : "";
+
+/**
+ * The evaluations tag label for a trace row. Every terminal state stays
+ * visible — a failed label never hides errored or skipped runs, so the tag
+ * always reconciles with the popover list it sits above (#6835).
+ */
+export function evaluationsTagLabel(summary: EvaluationsTagSummary): string {
+  if (!summary.done) {
+    // Still running: passes so far out of every evaluation on the trace —
+    // terminal and in-flight alike.
+    return `${summary.passes}/${summary.total} evaluations`;
+  }
+  if (summary.hasOnlySkippedRuns) return "Evaluations skipped";
+  if (summary.failed > 0) {
+    const noun = summary.failed === 1 ? "evaluation" : "evaluations";
+    return `${summary.failed} ${noun} failed${erroredSuffix(summary)}${skippedSuffix(summary)}`;
+  }
+  if (summary.errored > 0) {
+    // A crashed evaluator is not a fail verdict — label it as an error
+    // instead of folding it into "failed".
+    const noun = summary.errored === 1 ? "evaluation" : "evaluations";
+    return `${summary.errored} ${noun} errored${skippedSuffix(summary)}`;
+  }
+  return `${summary.passes}/${summary.verdictTotal} evaluations${skippedSuffix(summary)}`;
+}
+
+/**
+ * The guardrails tag label — same shape as {@link evaluationsTagLabel}: a
+ * skipped or errored guardrail is neither a pass nor a block, and no count
+ * hides another.
+ */
+export function guardrailsTagLabel(summary: EvaluationsTagSummary): string {
+  if (!summary.done) {
+    return `${summary.passes}/${summary.total} guardrails`;
+  }
+  if (summary.hasOnlySkippedRuns) return "Guardrails skipped";
+  if (summary.failed > 0) {
+    const noun = summary.failed === 1 ? "guardrail block" : "guardrail blocks";
+    return `${summary.failed} ${noun}${erroredSuffix(summary)}${skippedSuffix(summary)}`;
+  }
+  if (summary.errored > 0) {
+    const noun = summary.errored === 1 ? "guardrail" : "guardrails";
+    return `${summary.errored} ${noun} errored${skippedSuffix(summary)}`;
+  }
+  return `${summary.passes}/${summary.verdictTotal} guardrails${skippedSuffix(summary)}`;
+}

--- a/platform/app/src/components/checks/evaluationSummaryCounts.ts
+++ b/platform/app/src/components/checks/evaluationSummaryCounts.ts
@@ -39,9 +39,7 @@ export function summarizeEvaluationsTag(
   const allSkipped =
     evaluations.length > 0 &&
     evaluations.every((check) => check.status === "skipped");
-  const processed = evaluations.filter(
-    (check) => check.status === "processed",
-  );
+  const processed = evaluations.filter((check) => check.status === "processed");
   const failed = processed.filter(
     (check) => evaluationPassed(check) === false,
   ).length;

--- a/platform/app/src/components/checks/evaluationSummaryCounts.ts
+++ b/platform/app/src/components/checks/evaluationSummaryCounts.ts
@@ -17,6 +17,8 @@ export interface EvaluationsTagSummary {
   done: boolean;
   /** Every evaluation was skipped — "nothing to evaluate", not a verdict. */
   allSkipped: boolean;
+  /** Every evaluation on the trace, whatever its state. */
+  total: number;
   /** Processed runs — the only ones that can carry a verdict. */
   verdictTotal: number;
   /** Processed runs that did not fail (includes score-only neutrals). */
@@ -25,6 +27,8 @@ export interface EvaluationsTagSummary {
   failed: number;
   /** Runs whose evaluator crashed — an infrastructure state, not a fail. */
   errored: number;
+  /** Runs that were skipped — neither passed nor failed. */
+  skipped: number;
 }
 
 export function summarizeEvaluationsTag(
@@ -47,9 +51,11 @@ export function summarizeEvaluationsTag(
   return {
     done,
     allSkipped,
+    total: evaluations.length,
     verdictTotal: processed.length,
     passes: processed.length - failed,
     failed,
     errored: evaluations.filter((check) => check.status === "error").length,
+    skipped: evaluations.filter((check) => check.status === "skipped").length,
   };
 }

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -35,12 +35,15 @@ import {
   isPythonRepr,
   parsePythonInsideJson,
 } from "../../utils/parsePythonInsideJson";
-import { pluralize } from "../../utils/pluralize";
 import { getColorForString } from "../../utils/rotatingColors";
 import { stringifyIfObject } from "../../utils/stringifyIfObject";
 import { getExtractedInput } from "../../utils/traceExtraction";
 import { CheckPassing } from "../CheckPassing";
-import { summarizeEvaluationsTag } from "../checks/evaluationSummaryCounts";
+import {
+  evaluationsTagLabel,
+  guardrailsTagLabel,
+  summarizeEvaluationsTag,
+} from "../checks/evaluationSummaryCounts";
 import { Markdown } from "../Markdown";
 import { OverflownTextWithTooltip } from "../OverflownText";
 import { Popover } from "../ui/popover";
@@ -395,64 +398,24 @@ export function MessageCard({
               >
                 <Tag.Label>
                   <HStack gap={2}>
-                    {!guardSummary.done ? (
-                      // Still running: passes so far out of every guardrail on
-                      // the trace — without this branch an all-pending trace
-                      // would render a green "0/0 guardrails".
-                      <>
-                        <Box>
-                          <Clock />
-                        </Box>
-                        {guardSummary.passes}/{guardSummary.total} guardrails
-                      </>
-                    ) : guardSummary.hasOnlySkippedRuns ? (
-                      <>
-                        <Box>
-                          <MinusCircle />
-                        </Box>
-                        Guardrails skipped
-                      </>
-                    ) : guardSummary.failed > 0 ? (
-                      <>
-                        <Box>
-                          <Shield />
-                        </Box>
-                        {guardSummary.failed}{" "}
-                        {pluralize(
-                          guardSummary.failed,
-                          "guardrail block",
-                          "guardrail blocks",
-                        )}
-                        {guardSummary.errored > 0
-                          ? `, ${guardSummary.errored} errored`
-                          : ""}
-                      </>
-                    ) : guardSummary.errored > 0 ? (
-                      // A crashed guardrail is neither a pass nor a block —
-                      // name it instead of counting it green (#6835).
-                      <>
-                        <Box>
-                          <XCircle />
-                        </Box>
-                        {guardSummary.errored}{" "}
-                        {pluralize(
-                          guardSummary.errored,
-                          "guardrail errored",
-                          "guardrails errored",
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <Box>
-                          <CheckCircle />
-                        </Box>
-                        {guardSummary.passes}/{guardSummary.verdictTotal}{" "}
-                        guardrails
-                        {guardSummary.skipped > 0
-                          ? `, ${guardSummary.skipped} skipped`
-                          : ""}
-                      </>
-                    )}
+                    <Box>
+                      {!guardSummary.done ? (
+                        // Without a pending branch an all-pending trace would
+                        // render a green "0/0 guardrails".
+                        <Clock />
+                      ) : guardSummary.hasOnlySkippedRuns ? (
+                        <MinusCircle />
+                      ) : guardSummary.failed > 0 ? (
+                        <Shield />
+                      ) : guardSummary.errored > 0 ? (
+                        // A crashed guardrail is neither a pass nor a block —
+                        // name it instead of counting it green (#6835).
+                        <XCircle />
+                      ) : (
+                        <CheckCircle />
+                      )}
+                    </Box>
+                    {guardrailsTagLabel(guardSummary)}
                   </HStack>
                 </Tag.Label>
               </Tag.Root>
@@ -508,39 +471,7 @@ export function MessageCard({
                     ) : (
                       <CheckCircle />
                     )}
-                    {!evalSummary.done
-                      ? // Still running: passes so far out of every evaluation
-                        // on the trace — terminal and in-flight alike.
-                        `${evalSummary.passes}/${evalSummary.total} evaluations`
-                      : evalSummary.hasOnlySkippedRuns
-                        ? "Evaluations skipped"
-                        : evalSummary.failed > 0
-                          ? // Errored runs stay visible next to real fails —
-                            // neither count may hide the other.
-                            `${evalSummary.failed} ${
-                              evalSummary.failed == 1
-                                ? "evaluation failed"
-                                : "evaluations failed"
-                            }${
-                              evalSummary.errored > 0
-                                ? `, ${evalSummary.errored} errored`
-                                : ""
-                            }`
-                          : evalSummary.errored > 0
-                            ? // A crashed evaluator is not a fail verdict — label it
-                              // as an error instead of folding it into "failed".
-                              `${evalSummary.errored} ${
-                                evalSummary.errored == 1
-                                  ? "evaluation errored"
-                                  : "evaluations errored"
-                              }`
-                            : // All good: count verdicts, and name skipped runs
-                              // so the tag reconciles with the popover list.
-                              `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations${
-                                evalSummary.skipped > 0
-                                  ? `, ${evalSummary.skipped} skipped`
-                                  : ""
-                              }`}
+                    {evaluationsTagLabel(evalSummary)}
                   </HStack>
                 </Tag.Label>
               </Tag.Root>

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -480,27 +480,25 @@ export function MessageCard({
                     ) : (
                       <CheckCircle />
                     )}
-                    {!evalSummary.done ? (
-                      `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
-                    ) : evalSummary.allSkipped ? (
-                      "Evaluations skipped"
-                    ) : evalSummary.failed > 0 ? (
-                      `${evalSummary.failed} ${
-                        evalSummary.failed == 1
-                          ? "evaluation failed"
-                          : "evaluations failed"
-                      }`
-                    ) : evalSummary.errored > 0 ? (
-                      // A crashed evaluator is not a fail verdict — label it
-                      // as an error instead of folding it into "failed".
-                      `${evalSummary.errored} ${
-                        evalSummary.errored == 1
-                          ? "evaluation errored"
-                          : "evaluations errored"
-                      }`
-                    ) : (
-                      `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
-                    )}
+                    {!evalSummary.done
+                      ? `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
+                      : evalSummary.allSkipped
+                        ? "Evaluations skipped"
+                        : evalSummary.failed > 0
+                          ? `${evalSummary.failed} ${
+                              evalSummary.failed == 1
+                                ? "evaluation failed"
+                                : "evaluations failed"
+                            }`
+                          : evalSummary.errored > 0
+                            ? // A crashed evaluator is not a fail verdict — label it
+                              // as an error instead of folding it into "failed".
+                              `${evalSummary.errored} ${
+                                evalSummary.errored == 1
+                                  ? "evaluation errored"
+                                  : "evaluations errored"
+                              }`
+                            : `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`}
                   </HStack>
                 </Tag.Label>
               </Tag.Root>

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -423,6 +423,9 @@ export function MessageCard({
                           "guardrail block",
                           "guardrail blocks",
                         )}
+                        {guardSummary.errored > 0
+                          ? `, ${guardSummary.errored} errored`
+                          : ""}
                       </>
                     ) : guardSummary.errored > 0 ? (
                       // A crashed guardrail is neither a pass nor a block —
@@ -512,10 +515,16 @@ export function MessageCard({
                       : evalSummary.hasOnlySkippedRuns
                         ? "Evaluations skipped"
                         : evalSummary.failed > 0
-                          ? `${evalSummary.failed} ${
+                          ? // Errored runs stay visible next to real fails —
+                            // neither count may hide the other.
+                            `${evalSummary.failed} ${
                               evalSummary.failed == 1
                                 ? "evaluation failed"
                                 : "evaluations failed"
+                            }${
+                              evalSummary.errored > 0
+                                ? `, ${evalSummary.errored} errored`
+                                : ""
                             }`
                           : evalSummary.errored > 0
                             ? // A crashed evaluator is not a fail verdict — label it

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -481,7 +481,9 @@ export function MessageCard({
                       <CheckCircle />
                     )}
                     {!evalSummary.done
-                      ? `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
+                      ? // Still running: the denominator is every evaluation
+                        // on the trace, so "0/3" reads as three in flight.
+                        `${evalSummary.passes}/${evalSummary.total} evaluations`
                       : evalSummary.allSkipped
                         ? "Evaluations skipped"
                         : evalSummary.failed > 0
@@ -498,7 +500,13 @@ export function MessageCard({
                                   ? "evaluation errored"
                                   : "evaluations errored"
                               }`
-                            : `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`}
+                            : // All good: count verdicts, and name skipped runs
+                              // so the tag reconciles with the popover list.
+                              `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations${
+                                evalSummary.skipped > 0
+                                  ? `, ${evalSummary.skipped} skipped`
+                                  : ""
+                              }`}
                   </HStack>
                 </Tag.Label>
               </Tag.Root>

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -40,7 +40,7 @@ import { getColorForString } from "../../utils/rotatingColors";
 import { stringifyIfObject } from "../../utils/stringifyIfObject";
 import { getExtractedInput } from "../../utils/traceExtraction";
 import { CheckPassing } from "../CheckPassing";
-import { evaluationPassed } from "../checks/EvaluationStatus";
+import { summarizeEvaluationsTag } from "../checks/evaluationSummaryCounts";
 import { Markdown } from "../Markdown";
 import { OverflownTextWithTooltip } from "../OverflownText";
 import { Popover } from "../ui/popover";
@@ -73,24 +73,14 @@ export function MessageCard({
   const guardrails = checksMap
     ? (checksMap[trace.trace_id]?.filter((x) => x.is_guardrail) ?? [])
     : [];
-  const evaluationsDone = evaluations.every(
-    (check) =>
-      check.status == "processed" ||
-      check.status == "skipped" ||
-      check.status == "error",
-  );
-  const evaluationsPasses = evaluations.filter(
-    (check) =>
-      evaluationPassed(check) !== false &&
-      (check.status === "processed" || check.status === "skipped"),
-  ).length;
+  // Skipped and errored runs never produced a verdict, so they stay out of
+  // both sides of the pass count — a skipped run counted as a pass and an
+  // errored run counted as a fail both invent verdicts (#6835).
+  const evalSummary = summarizeEvaluationsTag(evaluations);
   const guardrailsPasses = guardrails.filter(
     (check) => check.passed !== false,
   ).length;
 
-  const allEvaluationsSkipped = evaluations.every(
-    (check) => check.status === "skipped",
-  );
   const allGuardrailsSkipped = guardrails.every(
     (check) => check.status === "skipped",
   );
@@ -465,11 +455,11 @@ export function MessageCard({
                 borderWidth="1px"
                 borderColor="border"
                 color={
-                  !evaluationsDone || allEvaluationsSkipped
+                  !evalSummary.done || evalSummary.allSkipped
                     ? "yellow.fg"
-                    : evaluationsPasses == totalEvaluations
-                      ? "green.fg"
-                      : "red.fg"
+                    : evalSummary.failed > 0 || evalSummary.errored > 0
+                      ? "red.fg"
+                      : "green.fg"
                 }
                 paddingY={1}
                 paddingX={2}
@@ -481,24 +471,36 @@ export function MessageCard({
               >
                 <Tag.Label>
                   <HStack gap={2}>
-                    {!evaluationsDone ? (
+                    {!evalSummary.done ? (
                       <Clock />
-                    ) : allEvaluationsSkipped ? (
+                    ) : evalSummary.allSkipped ? (
                       <MinusCircle />
-                    ) : evaluationsPasses == totalEvaluations ? (
-                      <CheckCircle />
-                    ) : (
+                    ) : evalSummary.failed > 0 || evalSummary.errored > 0 ? (
                       <XCircle />
+                    ) : (
+                      <CheckCircle />
                     )}
-                    {allEvaluationsSkipped
-                      ? "Evaluations skipped"
-                      : evaluationsDone && evaluationsPasses != totalEvaluations
-                        ? `${totalEvaluations - evaluationsPasses} ${
-                            totalEvaluations - evaluationsPasses == 1
-                              ? "evaluation failed"
-                              : "evaluations failed"
-                          }`
-                        : `${evaluationsPasses}/${totalEvaluations} evaluations`}
+                    {!evalSummary.done ? (
+                      `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
+                    ) : evalSummary.allSkipped ? (
+                      "Evaluations skipped"
+                    ) : evalSummary.failed > 0 ? (
+                      `${evalSummary.failed} ${
+                        evalSummary.failed == 1
+                          ? "evaluation failed"
+                          : "evaluations failed"
+                      }`
+                    ) : evalSummary.errored > 0 ? (
+                      // A crashed evaluator is not a fail verdict — label it
+                      // as an error instead of folding it into "failed".
+                      `${evalSummary.errored} ${
+                        evalSummary.errored == 1
+                          ? "evaluation errored"
+                          : "evaluations errored"
+                      }`
+                    ) : (
+                      `${evalSummary.passes}/${evalSummary.verdictTotal} evaluations`
+                    )}
                   </HStack>
                 </Tag.Label>
               </Tag.Root>

--- a/platform/app/src/components/messages/MessageCard.tsx
+++ b/platform/app/src/components/messages/MessageCard.tsx
@@ -75,15 +75,10 @@ export function MessageCard({
     : [];
   // Skipped and errored runs never produced a verdict, so they stay out of
   // both sides of the pass count — a skipped run counted as a pass and an
-  // errored run counted as a fail both invent verdicts (#6835).
+  // errored run counted as a fail both invent verdicts (#6835). Guardrails
+  // get the same treatment: a skipped or errored guardrail is not a pass.
   const evalSummary = summarizeEvaluationsTag(evaluations);
-  const guardrailsPasses = guardrails.filter(
-    (check) => check.passed !== false,
-  ).length;
-
-  const allGuardrailsSkipped = guardrails.every(
-    (check) => check.status === "skipped",
-  );
+  const guardSummary = summarizeEvaluationsTag(guardrails);
 
   const totalEvaluations = evaluations.length;
   const totalGuardrails = guardrails.length;
@@ -384,11 +379,13 @@ export function MessageCard({
                 borderWidth="1px"
                 borderColor="border"
                 color={
-                  allGuardrailsSkipped
+                  !guardSummary.done || guardSummary.hasOnlySkippedRuns
                     ? "yellow.fg"
-                    : guardrailsPasses == totalGuardrails
-                      ? "green.fg"
-                      : "blue.fg"
+                    : guardSummary.failed > 0
+                      ? "blue.fg"
+                      : guardSummary.errored > 0
+                        ? "red.fg"
+                        : "green.fg"
                 }
                 paddingY={1}
                 paddingX={2}
@@ -398,31 +395,59 @@ export function MessageCard({
               >
                 <Tag.Label>
                   <HStack gap={2}>
-                    {allGuardrailsSkipped ? (
+                    {!guardSummary.done ? (
+                      // Still running: passes so far out of every guardrail on
+                      // the trace — without this branch an all-pending trace
+                      // would render a green "0/0 guardrails".
+                      <>
+                        <Box>
+                          <Clock />
+                        </Box>
+                        {guardSummary.passes}/{guardSummary.total} guardrails
+                      </>
+                    ) : guardSummary.hasOnlySkippedRuns ? (
                       <>
                         <Box>
                           <MinusCircle />
                         </Box>
                         Guardrails skipped
                       </>
-                    ) : guardrailsPasses == totalGuardrails ? (
-                      <>
-                        <Box>
-                          <CheckCircle />
-                        </Box>
-                        {guardrailsPasses}/{totalGuardrails} guardrails
-                      </>
-                    ) : (
+                    ) : guardSummary.failed > 0 ? (
                       <>
                         <Box>
                           <Shield />
                         </Box>
-                        {totalGuardrails - guardrailsPasses}{" "}
+                        {guardSummary.failed}{" "}
                         {pluralize(
-                          totalGuardrails - guardrailsPasses,
+                          guardSummary.failed,
                           "guardrail block",
                           "guardrail blocks",
                         )}
+                      </>
+                    ) : guardSummary.errored > 0 ? (
+                      // A crashed guardrail is neither a pass nor a block —
+                      // name it instead of counting it green (#6835).
+                      <>
+                        <Box>
+                          <XCircle />
+                        </Box>
+                        {guardSummary.errored}{" "}
+                        {pluralize(
+                          guardSummary.errored,
+                          "guardrail errored",
+                          "guardrails errored",
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <Box>
+                          <CheckCircle />
+                        </Box>
+                        {guardSummary.passes}/{guardSummary.verdictTotal}{" "}
+                        guardrails
+                        {guardSummary.skipped > 0
+                          ? `, ${guardSummary.skipped} skipped`
+                          : ""}
                       </>
                     )}
                   </HStack>
@@ -455,7 +480,7 @@ export function MessageCard({
                 borderWidth="1px"
                 borderColor="border"
                 color={
-                  !evalSummary.done || evalSummary.allSkipped
+                  !evalSummary.done || evalSummary.hasOnlySkippedRuns
                     ? "yellow.fg"
                     : evalSummary.failed > 0 || evalSummary.errored > 0
                       ? "red.fg"
@@ -473,7 +498,7 @@ export function MessageCard({
                   <HStack gap={2}>
                     {!evalSummary.done ? (
                       <Clock />
-                    ) : evalSummary.allSkipped ? (
+                    ) : evalSummary.hasOnlySkippedRuns ? (
                       <MinusCircle />
                     ) : evalSummary.failed > 0 || evalSummary.errored > 0 ? (
                       <XCircle />
@@ -481,10 +506,10 @@ export function MessageCard({
                       <CheckCircle />
                     )}
                     {!evalSummary.done
-                      ? // Still running: the denominator is every evaluation
-                        // on the trace, so "0/3" reads as three in flight.
+                      ? // Still running: passes so far out of every evaluation
+                        // on the trace — terminal and in-flight alike.
                         `${evalSummary.passes}/${evalSummary.total} evaluations`
-                      : evalSummary.allSkipped
+                      : evalSummary.hasOnlySkippedRuns
                         ? "Evaluations skipped"
                         : evalSummary.failed > 0
                           ? `${evalSummary.failed} ${

--- a/platform/app/src/components/traces/Evaluations.tsx
+++ b/platform/app/src/components/traces/Evaluations.tsx
@@ -148,27 +148,45 @@ export const EvaluationsCount = (
 
   const groups = groupEvaluationsByEvaluator(evaluations);
 
-  const totalErrors = groups.filter(
-    (group) =>
-      group.latest.status === "error" ||
-      evaluationPassed(group.latest) === false,
+  // A fail is a verdict; a crashed evaluator is not (#6835). Keep the two
+  // apart so an infrastructure error never reads as "the output failed".
+  const totalFailed = groups.filter(
+    (group) => evaluationPassed(group.latest) === false,
+  ).length;
+  const totalErrored = groups.filter(
+    (group) => group.latest.status === "error",
   ).length;
 
-  if (totalErrors > 0) {
+  if (totalFailed > 0 || totalErrored > 0) {
     if (trace.countGuardrails) {
       return null;
     }
 
     return (
-      <Text
-        borderRadius={"md"}
-        paddingX={2}
-        backgroundColor={"red.solid"}
-        color={"white"}
-        fontSize={"sm"}
-      >
-        {totalErrors} failed
-      </Text>
+      <HStack gap={1}>
+        {totalFailed > 0 && (
+          <Text
+            borderRadius={"md"}
+            paddingX={2}
+            backgroundColor={"red.solid"}
+            color={"white"}
+            fontSize={"sm"}
+          >
+            {totalFailed} failed
+          </Text>
+        )}
+        {totalErrored > 0 && (
+          <Text
+            borderRadius={"md"}
+            paddingX={2}
+            backgroundColor={"orange.solid"}
+            color={"white"}
+            fontSize={"sm"}
+          >
+            {totalErrored} errored
+          </Text>
+        )}
+      </HStack>
     );
   }
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -186,7 +186,7 @@ export function EvalCard({
         {eval_.runHistory && eval_.runHistory.length > 1 && (
           <RunHistorySparkline runs={eval_.runHistory} />
         )}
-        {!noVerdict && !categoryOnly && (
+        {!noVerdict && !categoryOnly && scoreLabel !== "" && (
           <HStack gap={0.5} align="baseline" flexShrink={0}>
             <Text
               textStyle="lg"

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -75,7 +75,10 @@ export function EvalCard({
   // for them and fetch on open.
   const canLazyLoadInputs =
     !!eval_.evaluationId &&
-    (status === "pass" || status === "fail" || status === "error");
+    (status === "pass" ||
+      status === "fail" ||
+      status === "processed" ||
+      status === "error");
   const mightHaveInputs = hasListInputs || canLazyLoadInputs;
   const hasRetries = (eval_.retries ?? 0) > 0;
   // The labeled categorical/boolean verdict is sometimes more informative
@@ -203,7 +206,10 @@ export function EvalCard({
       </HStack>
 
       {/* Score bar (numeric, only when the eval actually produced a score) */}
-      {!noVerdict && !categoryOnly && scoreType === "numeric" && (
+      {!noVerdict &&
+        !categoryOnly &&
+        scoreType === "numeric" &&
+        typeof score === "number" && (
         <Box
           height="3px"
           bg="bg.subtle"

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -210,23 +210,23 @@ export function EvalCard({
         !categoryOnly &&
         scoreType === "numeric" &&
         typeof score === "number" && (
-        <Box
-          height="3px"
-          bg="bg.subtle"
-          position="relative"
-          borderBottomWidth={
-            hasReasoning || meta.length > 0 || eval_.spanName ? "1px" : "0"
-          }
-          borderColor="border.muted"
-        >
           <Box
-            height="100%"
-            bg={tone.color}
-            width={`${barFill}%`}
-            transition="width 0.3s ease"
-          />
-        </Box>
-      )}
+            height="3px"
+            bg="bg.subtle"
+            position="relative"
+            borderBottomWidth={
+              hasReasoning || meta.length > 0 || eval_.spanName ? "1px" : "0"
+            }
+            borderColor="border.muted"
+          >
+            <Box
+              height="100%"
+              bg={tone.color}
+              width={`${barFill}%`}
+              transition="width 0.3s ease"
+            />
+          </Box>
+        )}
 
       {/* Reasoning / status message */}
       {(hasReasoning || (noVerdict && primaryStatusText)) && (

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/RunHistorySparkline.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/RunHistorySparkline.tsx
@@ -1,6 +1,19 @@
 import { Circle, HStack, Text } from "@chakra-ui/react";
 import type { EvalRunHistoryEntry } from "./utils";
 
+/** Dot color per run status. `processed` (a verdict-less completed run) is
+ *  neutral blue, matching EVALUATION_STATUS_COLORS.processed — not a warning
+ *  (#6835). Everything unrecognized keeps the legacy warning yellow. */
+const DOT_COLOR_BY_STATUS: Record<string, string> = {
+  pass: "green.solid",
+  fail: "red.solid",
+  processed: "blue.solid",
+};
+
+function dotColorFor(status: string): string {
+  return DOT_COLOR_BY_STATUS[status] ?? "yellow.solid";
+}
+
 export function RunHistorySparkline({ runs }: { runs: EvalRunHistoryEntry[] }) {
   if (runs.length <= 1) return null;
 
@@ -15,21 +28,7 @@ export function RunHistorySparkline({ runs }: { runs: EvalRunHistoryEntry[] }) {
     return (
       <HStack gap={0.5}>
         {runs.slice(-8).map((r, i) => (
-          <Circle
-            key={i}
-            size="4px"
-            bg={
-              r.status === "pass"
-                ? "green.solid"
-                : r.status === "fail"
-                  ? "red.solid"
-                  : r.status === "processed"
-                    ? // Neutral, matching EVALUATION_STATUS_COLORS.processed —
-                      // a verdict-less run is not a warning (#6835).
-                      "blue.solid"
-                    : "yellow.solid"
-            }
-          />
+          <Circle key={i} size="4px" bg={dotColorFor(r.status)} />
         ))}
         <Text textStyle="2xs" color="fg.subtle" marginLeft={0.5}>
           ({runs.length})

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/RunHistorySparkline.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/RunHistorySparkline.tsx
@@ -23,7 +23,11 @@ export function RunHistorySparkline({ runs }: { runs: EvalRunHistoryEntry[] }) {
                 ? "green.solid"
                 : r.status === "fail"
                   ? "red.solid"
-                  : "yellow.solid"
+                  : r.status === "processed"
+                    ? // Neutral, matching EVALUATION_STATUS_COLORS.processed —
+                      // a verdict-less run is not a warning (#6835).
+                      "blue.solid"
+                    : "yellow.solid"
             }
           />
         ))}

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -210,14 +210,12 @@ describe("given a processed evaluation with neither passed nor score", () => {
   };
 
   describe("when the card renders", () => {
-    /** @scenario A verdict-less processed run renders neutral */
     it("shows no PASS badge for a run that produced no verdict", () => {
       renderCard(verdictlessEval);
       expect(screen.queryByText("PASS")).not.toBeInTheDocument();
       expect(screen.getByText("PROCESSED")).toBeInTheDocument();
     });
 
-    /** @scenario A verdict-less processed run renders neutral */
     it("shows no fabricated 0.00 score", () => {
       renderCard(verdictlessEval);
       expect(screen.queryByText("0.00")).not.toBeInTheDocument();
@@ -236,7 +234,6 @@ describe("given a processed score-only evaluation (score, no pass/fail)", () => 
   });
 
   describe("when the card renders", () => {
-    /** @scenario A score-only run shows its score without a verdict badge */
     it("shows the real score with the neutral tag, not a PASS badge", () => {
       renderCard({
         name: "Relevance",

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -191,6 +191,67 @@ describe("given a categorising evaluator that returned only a category", () => {
   });
 });
 
+describe("given a processed evaluation with neither passed nor score", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvaluationInputsUseQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
+
+  // How a verdict-less run arrives: processed status, no verdict, no score.
+  const verdictlessEval: EvalEntry = {
+    name: "Custom check",
+    score: null,
+    scoreType: "numeric",
+    status: "processed",
+    evaluationId: "eval-verdictless",
+  };
+
+  describe("when the card renders", () => {
+    /** @scenario A verdict-less processed run renders neutral */
+    it("shows no PASS badge for a run that produced no verdict", () => {
+      renderCard(verdictlessEval);
+      expect(screen.queryByText("PASS")).not.toBeInTheDocument();
+      expect(screen.getByText("PROCESSED")).toBeInTheDocument();
+    });
+
+    /** @scenario A verdict-less processed run renders neutral */
+    it("shows no fabricated 0.00 score", () => {
+      renderCard(verdictlessEval);
+      expect(screen.queryByText("0.00")).not.toBeInTheDocument();
+      expect(screen.queryByText("/ 1.00")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("given a processed score-only evaluation (score, no pass/fail)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvaluationInputsUseQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
+
+  describe("when the card renders", () => {
+    /** @scenario A score-only run shows its score without a verdict badge */
+    it("shows the real score with the neutral tag, not a PASS badge", () => {
+      renderCard({
+        name: "Relevance",
+        score: 0.85,
+        scoreType: "numeric",
+        status: "processed",
+        evaluationId: "eval-score-only",
+      });
+      expect(screen.queryByText("PASS")).not.toBeInTheDocument();
+      expect(screen.getByText("PROCESSED")).toBeInTheDocument();
+      expect(screen.getByText("0.85")).toBeInTheDocument();
+    });
+  });
+});
+
 describe("given an evaluator that returned a label alongside a real verdict", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
@@ -25,6 +25,10 @@ function buildStatusTone(
 
 export const STATUS = {
   pass: buildStatusTone("passed", "PASS"),
+  // The evaluator ran to completion but produced no pass/fail verdict
+  // (score-only or verdict-less runs). Neutral blue, matching the shared
+  // `processed` tone — a run that judged nothing must not read as a pass.
+  processed: buildStatusTone("processed", "PROCESSED"),
   // "Warning" is a legacy trace-summary status with no v3 equivalent;
   // it reads as a not-quite-pass, so route it through the `failed` tone
   // so the chip still turns red rather than picking up a bespoke yellow.
@@ -75,7 +79,7 @@ export function isCategoryOnly(eval_: EvalEntry): boolean {
 }
 
 export interface EvalRunHistoryEntry {
-  score: number | boolean;
+  score: number | boolean | null;
   timestamp: number;
   status: string;
 }

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceEvaluations.mapping.unit.test.ts
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceEvaluations.mapping.unit.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Mapping rules for the drawer's rich evaluation entries (#6835 item 1).
+ *
+ * A processed evaluation with `passed == null` must map to the neutral
+ * "processed" status — never an invented "pass" — and a missing score must
+ * stay null rather than becoming a fabricated 0 that renders as "0.00".
+ */
+import { describe, expect, it } from "vitest";
+import type { Evaluation } from "~/server/tracer/types";
+import { mapScore, mapStatus } from "../useTraceEvaluations";
+
+function makeEvaluation(overrides: Partial<Evaluation> = {}): Evaluation {
+  return {
+    evaluation_id: "eval-1",
+    evaluator_id: "evaluator-1",
+    name: "Custom check",
+    status: "processed",
+    passed: null,
+    score: null,
+    label: null,
+    timestamps: {},
+    ...overrides,
+  } as Evaluation;
+}
+
+describe("mapStatus", () => {
+  describe("when the evaluation is processed with an explicit verdict", () => {
+    it("maps passed true to pass and passed false to fail", () => {
+      expect(mapStatus(makeEvaluation({ passed: true }))).toBe("pass");
+      expect(mapStatus(makeEvaluation({ passed: false }))).toBe("fail");
+    });
+  });
+
+  describe("when the evaluation is processed without a verdict", () => {
+    it("maps to the neutral processed status, not an invented pass", () => {
+      expect(mapStatus(makeEvaluation({ passed: null }))).toBe("processed");
+    });
+
+    it("stays neutral even when a score is present (score-only evaluator)", () => {
+      expect(mapStatus(makeEvaluation({ passed: null, score: 0.85 }))).toBe(
+        "processed",
+      );
+    });
+  });
+
+  describe("when the evaluation did not run to completion", () => {
+    it("preserves error and skipped", () => {
+      expect(mapStatus(makeEvaluation({ status: "error" }))).toBe("error");
+      expect(mapStatus(makeEvaluation({ status: "skipped" }))).toBe("skipped");
+    });
+  });
+});
+
+describe("mapScore", () => {
+  describe("when the evaluation carries a numeric score", () => {
+    it("returns the score", () => {
+      expect(mapScore(makeEvaluation({ score: 0.42 }))).toBe(0.42);
+    });
+  });
+
+  describe("when the evaluation carries only a verdict", () => {
+    it("returns the boolean verdict", () => {
+      expect(mapScore(makeEvaluation({ passed: true }))).toBe(true);
+    });
+  });
+
+  describe("when the evaluation carries neither score nor verdict", () => {
+    it("returns null instead of a fabricated 0", () => {
+      expect(mapScore(makeEvaluation({ score: null, passed: null }))).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useTraceEvaluations.mapping.unit.test.ts
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useTraceEvaluations.mapping.unit.test.ts
@@ -66,7 +66,9 @@ describe("mapScore", () => {
 
   describe("when the evaluation carries neither score nor verdict", () => {
     it("returns null instead of a fabricated 0", () => {
-      expect(mapScore(makeEvaluation({ score: null, passed: null }))).toBeNull();
+      expect(
+        mapScore(makeEvaluation({ score: null, passed: null })),
+      ).toBeNull();
     });
   });
 });

--- a/platform/app/src/features/traces-v2/hooks/useTraceEvaluations.ts
+++ b/platform/app/src/features/traces-v2/hooks/useTraceEvaluations.ts
@@ -61,7 +61,7 @@ function readEvaluationInputs(
     : undefined;
 }
 
-function mapStatus(ev: Evaluation): EvalSummary["status"] {
+export function mapStatus(ev: Evaluation): EvalSummary["status"] {
   // Preserve the distinction between "evaluator failed to run" and
   // "evaluator ran and the verdict was fail". Earlier this collapsed
   // skipped/error into warning/fail, which produced misleading "WARN
@@ -71,7 +71,10 @@ function mapStatus(ev: Evaluation): EvalSummary["status"] {
   if (ev.status === "processed") {
     if (ev.passed === true) return "pass";
     if (ev.passed === false) return "fail";
-    return "pass";
+    // No verdict is not a pass. "processed" is the shared neutral status
+    // (`utils/evaluationResults.ts` normalizes processed + passed == null the
+    // same way), so score-only and verdict-less runs render neutral.
+    return "processed";
   }
   return "warning";
 }
@@ -83,10 +86,12 @@ function mapScoreType(ev: Evaluation): EvalSummary["scoreType"] {
   return "numeric";
 }
 
-function mapScore(ev: Evaluation): number | boolean {
+export function mapScore(ev: Evaluation): number | boolean | null {
   if (typeof ev.score === "number") return ev.score;
   if (ev.passed != null) return ev.passed;
-  return 0;
+  // Neither score nor verdict: null, never a fabricated 0 — a zero here
+  // renders as a real "0.00 / 1.00" on the card and header chip.
+  return null;
 }
 
 export function useTraceEvaluations(): TraceEvaluationsResult {

--- a/platform/app/src/features/traces-v2/types/trace.ts
+++ b/platform/app/src/features/traces-v2/types/trace.ts
@@ -9,16 +9,20 @@ export type TraceStatus = "ok" | "error" | "warning";
  */
 export interface EvalSummary {
   name: string;
-  score: number | boolean;
+  /** `null` when the evaluator produced neither a score nor a verdict —
+   *  never substitute a fabricated 0, it renders as a real "0.00". */
+  score: number | boolean | null;
   scoreType: "numeric" | "boolean" | "categorical";
   /**
    * - `pass` / `fail` / `warning` — the evaluator ran and produced a verdict.
+   * - `processed` — the evaluator ran to completion but produced no pass/fail
+   *   verdict (score-only or verdict-less runs). Neutral: not a pass.
    * - `skipped` — the evaluator wasn't run (e.g. provider not configured,
    *   preconditions not met). The score is meaningless; don't show it.
    * - `error` — the evaluator crashed / errored out. Distinct from a "fail"
    *   verdict — the evaluator never produced a real score.
    */
-  status: "pass" | "warning" | "fail" | "skipped" | "error";
+  status: "pass" | "warning" | "fail" | "processed" | "skipped" | "error";
 }
 
 /**

--- a/platform/app/src/pages/[project]/annotations/all.tsx
+++ b/platform/app/src/pages/[project]/annotations/all.tsx
@@ -4,8 +4,8 @@ import { useMemo } from "react";
 import AnnotationsLayout from "~/components/AnnotationsLayout";
 import { AnnotationsTable } from "~/components/annotations/AnnotationsTable";
 import {
-  annotationRatingExportLabel,
   type AnnotationWithUser,
+  annotationRatingExportLabel,
   groupedAnnotationsToRows,
   suggestionExportLine,
 } from "~/components/annotations/annotationRow";

--- a/platform/app/src/pages/[project]/annotations/all.tsx
+++ b/platform/app/src/pages/[project]/annotations/all.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import AnnotationsLayout from "~/components/AnnotationsLayout";
 import { AnnotationsTable } from "~/components/annotations/AnnotationsTable";
 import {
+  annotationRatingExportLabel,
   type AnnotationWithUser,
   groupedAnnotationsToRows,
   suggestionExportLine,
@@ -155,7 +156,7 @@ export default function Annotations() {
           suggestionExportLine({ annotation, traceId: annotation.traceId }),
           annotation.comment ?? "",
           annotation.traceId ?? "",
-          annotation.isThumbsUp ? "Thumbs Up" : "Thumbs Down",
+          annotationRatingExportLabel(annotation.isThumbsUp),
           JSON.stringify(annotation.scoreOptions ?? {}),
           annotation.createdAt?.toLocaleString() ?? "",
         ];

--- a/platform/app/src/server/app-layer/traces/facet-registry.ts
+++ b/platform/app/src/server/app-layer/traces/facet-registry.ts
@@ -443,13 +443,15 @@ export const FACET_REGISTRY: readonly FacetDefinition[] = [
     label: "Evaluator verdict",
     group: "evaluation",
     table: "evaluation_runs",
-    // Surface a 4-way label so users can pick pass / fail / error / unknown
-    // without dealing with the 0/1/null underlying UInt8 storage. `error`
-    // takes precedence: an errored run's Passed column is meaningless, and
-    // the sidebar's "Errored" pill counts `Status = 'error'` — mapping those
-    // rows to 'unknown' made the pill filter by the wrong value.
+    // Surface a 5-way label so users can pick pass / fail / error / skipped /
+    // unknown without dealing with the 0/1/null underlying UInt8 storage.
+    // `error` and `skipped` take precedence: a run that crashed or never ran
+    // has a meaningless Passed column, and mapping either to 'unknown' buried
+    // it next to score-only runs where it could not be filtered for (#6835).
+    // The sidebar's "Errored" pill counts `Status = 'error'`, so the error
+    // arm must stay aligned with it.
     expression:
-      "multiIf(Status = 'error', 'error', Passed = 1, 'pass', Passed = 0, 'fail', 'unknown')",
+      "multiIf(Status = 'error', 'error', Status = 'skipped', 'skipped', Passed = 1, 'pass', Passed = 0, 'fail', 'unknown')",
   },
   {
     key: "evaluatorScore",

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/evaluator-verdict-mapping.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/evaluator-verdict-mapping.unit.test.ts
@@ -25,6 +25,20 @@ describe("evaluatorVerdict facet", () => {
       expect(expression).toContain("'error'");
     });
 
+    it("routes Status='skipped' to 'skipped' before consulting Passed (#6835)", () => {
+      // A skipped run is "nothing to evaluate", not an unknown verdict —
+      // burying it in 'unknown' next to score-only runs made it unfilterable.
+      const expression = (def as { expression?: string }).expression ?? "";
+      const skippedIdx = expression.indexOf("Status = 'skipped'");
+      const passedIdx = expression.indexOf("Passed = 1");
+      expect(skippedIdx).toBeGreaterThanOrEqual(0);
+      expect(passedIdx).toBeGreaterThan(skippedIdx);
+    });
+
+    it("offers 'skipped' in the query-language vocabulary", () => {
+      expect(FIELD_VALUES.evaluatorVerdict).toContain("skipped");
+    });
+
     it("keeps FIELD_VALUES in sync with the expression's output set", () => {
       const expression = (def as { expression?: string }).expression ?? "";
       for (const value of FIELD_VALUES.evaluatorVerdict ?? []) {

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/__tests__/evaluate.parity.unit.test.ts
@@ -314,6 +314,24 @@ const cases: Case[] = [
     expected: true,
   },
   {
+    name: "evaluatorVerdict skipped is its own bucket",
+    query: "evaluatorVerdict:skipped",
+    trace: makeTrace(
+      {},
+      { evaluations: [makeEval({ status: "skipped", passed: null })] },
+    ),
+    expected: true,
+  },
+  {
+    name: "evaluatorVerdict:unknown misses a skipped run",
+    query: "evaluatorVerdict:unknown",
+    trace: makeTrace(
+      {},
+      { evaluations: [makeEval({ status: "skipped", passed: null })] },
+    ),
+    expected: false,
+  },
+  {
     name: "evaluatorScore range over the loaded runs",
     query: "evaluatorScore:[0.5 TO 1]",
     trace: makeTrace({}, { evaluations: [makeEval({ score: 0.7 })] }),

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/build-handlers.ts
@@ -111,20 +111,22 @@ function crossRangeFacet(
 const evaluatorStatusRead: CategoricalRead = (t) =>
   t.evaluations == null ? UNSUPPORTED : t.evaluations.map((e) => e.status);
 
-// Re-expresses the `evaluatorVerdict` multiIf in JS — `error` wins, then the
-// 0/1/null `Passed` maps to fail/pass/unknown. Kept in lockstep with the SQL
-// expression on the `evaluatorVerdict` facet.
+// Re-expresses the `evaluatorVerdict` multiIf in JS — `error` and `skipped`
+// win, then the 0/1/null `Passed` maps to fail/pass/unknown. Kept in lockstep
+// with the SQL expression on the `evaluatorVerdict` facet.
 const evaluatorVerdictRead: CategoricalRead = (t) =>
   t.evaluations == null
     ? UNSUPPORTED
     : t.evaluations.map((e) =>
         e.status === "error"
           ? "error"
-          : e.passed === true
-            ? "pass"
-            : e.passed === false
-              ? "fail"
-              : "unknown",
+          : e.status === "skipped"
+            ? "skipped"
+            : e.passed === true
+              ? "pass"
+              : e.passed === false
+                ? "fail"
+                : "unknown",
       );
 
 const evaluatorScoreRead: RangeRead = (t) =>

--- a/platform/app/src/server/app-layer/traces/query-language/metadata.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/metadata.ts
@@ -489,9 +489,10 @@ export const FIELD_VALUES: Record<string, string[]> = {
     "skipped",
     "error",
   ],
-  // `unknown` (Passed null but not errored/skipped) is query-language-only:
-  // the sidebar drilldown surfaces pass/fail/error rows and has no unknown
-  // bucket by design — it's reachable by typing the filter by hand.
+  // `skipped` and `unknown` (Passed null but not errored/skipped) are
+  // query-language-only: the sidebar drilldown surfaces pass/fail/error rows
+  // and has no bucket for either — both are reachable by typing the filter
+  // by hand.
   evaluatorVerdict: ["pass", "fail", "error", "skipped", "unknown"],
   spanStatus: ["ok", "error", "unset"],
 };

--- a/platform/app/src/server/app-layer/traces/query-language/metadata.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/metadata.ts
@@ -489,9 +489,9 @@ export const FIELD_VALUES: Record<string, string[]> = {
     "skipped",
     "error",
   ],
-  // `unknown` (Passed null but not errored) is query-language-only: the
-  // sidebar drilldown surfaces pass/fail/error rows and has no unknown
+  // `unknown` (Passed null but not errored/skipped) is query-language-only:
+  // the sidebar drilldown surfaces pass/fail/error rows and has no unknown
   // bucket by design — it's reachable by typing the filter by hand.
-  evaluatorVerdict: ["pass", "fail", "error", "unknown"],
+  evaluatorVerdict: ["pass", "fail", "error", "skipped", "unknown"],
   spanStatus: ["ok", "error", "unset"],
 };

--- a/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -514,6 +514,14 @@ export class ExecuteEvaluationCommand
       // not configured) are emitted earlier via their own path — or, when the
       // failure is thrown from inside execution, by the customer-fault branch
       // in the catch below — and still surface in the UI.
+      //
+      // DECIDED (#6835): this invisibility is intended. The trade-off is that
+      // a monitor whose traces are all non-evaluatable looks like it never ran
+      // rather than "ran and found nothing to evaluate" — but a per-trace
+      // skipped event would multiply event volume by every monitor × every
+      // non-matching trace, which bulk re-evaluations turn into thousands of
+      // rows that carry no verdict. If skip visibility is ever needed, add an
+      // aggregated counter (per monitor per interval), not per-trace events.
       if (result.status === "skipped") {
         logger.debug(
           {


### PR DESCRIPTION
# Related Issue

- Resolves #6835

## For humans

Several screens and exports were inventing verdicts: an evaluator that produced no pass/fail showed up as a green PASS with a score of 0.00, a skipped evaluation counted as a pass in the messages list, a crashed evaluator was labeled "failed", and a comment-only annotation exported to CSV as "Thumbs Down". Each fix follows the same rule: when there is no verdict, show "no verdict" — never coerce it into a pass, a fail, or a zero.

## Why

Five display/export surfaces coerced a "no verdict" state (skipped, errored, score-only, comment-only) into a fabricated pass, fail, or zero. Individually small; together they mean green/red cannot be trusted anywhere the third state occurs.

Closes #6835

## What changed

One commit per item, independently revertable:

1. **traces-v2 eval card and header chip** — `EvalSummary` gains the shared neutral `processed` status and a nullable score; a processed evaluation with `passed == null` renders a neutral blue tag instead of green PASS with a fabricated "0.00 / 1.00". Score-only evaluators show their score in neutral blue.
2. **Legacy messages list and trace pills** — verdict counting extracted into `summarizeEvaluationsTag`: skipped runs leave both sides of the "N/N evaluations" count, real fails show as "failed", and crashed evaluators get their own "errored" label/pill instead of inflating the red "failed" count.
3. **Annotations CSV** — `isThumbsUp: null` (the default comment-only path) exports as an empty rating cell via `annotationRatingExportLabel`, never "Thumbs Down".
4. **Runtime-skipped monitor runs** — decision recorded in the code: invisibility is intended (a per-trace skipped event would multiply event volume by monitor × non-matching trace); if visibility is ever needed, the path is an aggregated per-monitor counter.
5. **traces-v2 verdict facet** — `evaluatorVerdict` gains a `skipped` arm (SQL `multiIf`, query-language vocabulary, and the in-memory JS mirror updated in lockstep), so skipped runs leave the "unknown" bucket and `evaluatorVerdict:skipped` becomes a selectable filter.

## Test plan

Test-first throughout (each new test failed before its fix):

- New `useTraceEvaluations.mapping.unit.test.ts` for the status/score mapping; new EvalCard integration cases proving a verdict-less run renders neutral without a fabricated 0 (12 pass).
- New `evaluationSummaryCounts.unit.test.ts` covering mixed passed+skipped, fail vs errored separation, all-skipped and pending (8 pass).
- New `annotationRow.export.unit.test.ts` on the CSV rating cell (4 pass).
- Extended lockstep contract tests: `evaluator-verdict-mapping.unit.test.ts` (skipped arm precedence + vocabulary sync) and `evaluate.parity.unit.test.ts` (skipped is its own bucket; unknown no longer matches it). Full traces app-layer suite: 1,702 pass.
- `pnpm typecheck` + `pnpm typecheck:tests` clean; biome clean on touched files.

## Anything surprising?

- Item 1 also changes score-only evaluators (real score, no pass/fail) from green PASS to the neutral blue "processed" rendering — that is the shared `normalizeEvalStatus` semantic the rest of the app already uses, but it is a visible change on that surface.
- The sidebar's evaluator drilldown pills (Passed/Failed/Errored) don't get a "Skipped" pill in this PR — skipped is reachable via the verdict filter and the evaluator-status facet; adding a pill needs a new per-evaluator aggregate column and can follow separately if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation summaries now distinguish passed, failed, skipped, errored, and processed evaluations.
  * Trace evaluation cards support completed evaluations without pass/fail verdicts and avoid displaying fabricated scores.
  * Evaluator verdict filters and autocomplete now include skipped evaluations.
  * Annotation exports consistently label thumbs-up and thumbs-down ratings.

* **Bug Fixes**
  * Numeric scores display only when valid, while missing scores remain blank.
  * Skipped and errored evaluations are no longer incorrectly counted as failures.
  * Evaluation history sparklines now use clear status-based colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-ups (post-review commit)

- Messages tag: pending denominator is every run on the trace ("0/3", not "0/0"); every terminal state stays visible ("1 evaluation failed, 1 errored, 1 skipped") so the tag always reconciles with its popover. Label rules live in `evaluationsTagLabel`/`guardrailsTagLabel`, pinned by unit tests.
- Guardrail tag (reviewer finding): skipped/errored guardrails no longer count as green passes — the tag uses the same status-aware summary, with a pending clock state, shield block counts, and named errored/skipped guardrails.
- Sparkline: a verdict-less processed run draws the neutral blue dot, not the yellow warning one; EvalCard no longer renders an empty score slot.
- **Filter semantic note:** `evaluatorVerdict:unknown` no longer matches skipped runs — a saved filter or trigger written as `unknown` to catch skipped runs should be rewritten as `evaluatorVerdict:skipped` after deploy.

