### PR TITLE
fix(charts): stop the install notes reading cluster-scoped resources

### DIFF
--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -127,6 +127,21 @@ jobs:
       - name: "assert rendered worker count and memory ceiling"
         run: ./tests/langevals-sizing.sh
 
+  restricted-rbac:
+    name: "restricted rbac"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: charts/langwatch
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No helm, on purpose. Every `lookup` in the matrix above renders against
+      # no cluster and so returns empty, which is exactly what a lookup the
+      # installer is FORBIDDEN to make does not do — that one aborts the render.
+      # The templates have to be read to see it.
+      - name: "assert no template needs cluster-scoped read access"
+        run: ./tests/restricted-rbac.sh
+
   email-gateway:
     name: "email gateway"
     runs-on: ubuntu-latest

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -106,6 +106,10 @@ dev's Personal Workspace at https://<your-host>/me .
        the render every lookup returns empty. ./tests/restricted-rbac.sh does. */}}
     To see whether this cluster already offers one:
       kubectl get runtimeclass
+    If that is denied, nothing is broken: it is a cluster-scoped read, which
+    is exactly what a namespace-scoped operator does not have. Langy keeps
+    running as it is — ask whoever administers the cluster whether a class
+    exists to pin.
     gVisor reports a handler of runsc; Kata ships under several, such as
     kata-qemu or kata-mshv-vm-isolation. Handler names are runtime- and
     platform-specific, so confirm against your platform's documentation

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -106,7 +106,10 @@ dev's Personal Workspace at https://<your-host>/me .
        the render every lookup returns empty. ./tests/restricted-rbac.sh does. */}}
     To see whether this cluster already offers one:
       kubectl get runtimeclass
-    A class whose HANDLER is runsc or kata is sandboxed. To pin Langy to it:
+    gVisor reports a handler of runsc; Kata ships under several, such as
+    kata-qemu or kata-mshv-vm-isolation. Handler names are runtime- and
+    platform-specific, so confirm against your platform's documentation
+    rather than the name alone. To pin Langy to a class:
       langyagent.runtimeClassName=<class>  langyagent.acceptUnsandboxedRuntime=false
 {{- end }}
 {{- if (index .Values "langyagent").enableForAllUsers }}

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -95,19 +95,19 @@ dev's Personal Workspace at https://<your-host>/me .
     normal runtime, so a worker that escapes its container faces the node
     kernel. Hardening that last step is a sandboxed RuntimeClass:
       https://docs.langwatch.ai/self-hosting/langy/setup#hardening-a-sandboxed-runtime
-{{- /* Non-blocking hint: only when the cluster already offers a sandboxed class
-       that this install is not using. `lookup` is empty during `helm template`
-       and GitOps renders, so this stays silent there rather than guessing. */}}
-{{- $sandboxed := list }}
-{{- range (lookup "node.k8s.io/v1" "RuntimeClass" "" "").items }}
-{{- if or (eq .handler "runsc") (hasPrefix "kata" .handler) }}
-{{- $sandboxed = append $sandboxed .metadata.name }}
-{{- end }}
-{{- end }}
-{{- if $sandboxed }}
-    → This cluster already offers {{ join ", " $sandboxed }}. To use it:
-      langyagent.runtimeClassName={{ first $sandboxed }}  langyagent.acceptUnsandboxedRuntime=false
-{{- end }}
+{{- /* Deliberately NO `lookup` here, and do not reintroduce one. Naming the
+       cluster's own sandboxed classes would take a cluster-scoped list of
+       RuntimeClass, and `lookup` reports an RBAC denial as a template error
+       rather than as an empty result. Where the installer may not list
+       cluster-scoped resources, that turned this optional hint into a hard
+       UPGRADE FAILED, and a Go template cannot recover from it. So the
+       operator runs the check instead, where a denial costs them nothing.
+       No `helm template` catches a regression here: with no cluster behind
+       the render every lookup returns empty. ./tests/restricted-rbac.sh does. */}}
+    To see whether this cluster already offers one:
+      kubectl get runtimeclass
+    A class whose HANDLER is runsc or kata is sandboxed. To pin Langy to it:
+      langyagent.runtimeClassName=<class>  langyagent.acceptUnsandboxedRuntime=false
 {{- end }}
 {{- if (index .Values "langyagent").enableForAllUsers }}
     It is available to everyone in this install. Give it a model to talk to

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -535,36 +535,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if not $chartWritesIt }}
     {{- $found := lookup "v1" "Secret" .Release.Namespace $langySecretName }}
     {{- $hint := printf "Either add the key to that Secret (kubectl -n %s create secret generic %s --from-literal=%s=$(openssl rand -hex 32), or patch it if it already exists), point langyagent.secrets.existingSecretName at the Secret that does hold it, or let the chart generate it by leaving autogen.enabled=true with no secrets.existingSecret override." .Release.Namespace $langySecretName $langyKey }}
-    {{- if not $found }}
-      {{/* Every lookup comes back empty during `helm template` and dry runs, so
-           "Secret not found" there means "we cannot see the cluster", not "it is
-           missing". Probe with an object that exists in every namespace and
-           stay quiet when it is invisible too, rather than failing a plain
-           render.
+    {{/* Only the "Secret is readable but the key is missing" case is reported,
+         and reporting it needs no permission beyond the read on the line above.
 
-           The probe is namespaced on purpose. A cluster-scoped one (kube-system
-           was the obvious candidate) adds an RBAC requirement this chart has no
-           business having: `lookup` turns a denial into a template error, so an
-           installer scoped to their own namespace would get a hard render
-           failure out of a check whose only job is to stay quiet. Reading the
-           release namespace's own default ServiceAccount keeps the requirement
-           inside the namespace they are already installing into, next to the
-           Secret read on the line above. Not literally the same grant — a role
-           could allow `get secrets` and refuse `get serviceaccounts` — but the
-           standard admin/edit roles carry both, and namespaced is the whole
-           point: no reachable RBAC makes a cluster-scoped read succeed for an
-           installer who only holds their own namespace.
+         A Secret that is absent is deliberately NOT reported. `lookup` returns
+         the same empty result for "not there" and "no cluster behind this
+         render", so telling them apart takes a SECOND read whose only job is to
+         prove the cluster is visible — and every candidate for that read costs
+         a permission the chart otherwise does not need. kube-system was
+         cluster-scoped, which is the bug this whole change exists to remove.
+         The namespace's own default ServiceAccount is at least namespaced, but
+         `get serviceaccounts` is still a distinct grant a role can withhold,
+         so it reintroduces the same class of failure in a smaller blast radius.
+         Neither is worth a hard render failure for an operator whose setup is
+         correct, in service of a message.
 
-           Trade-off, accepted: with `--create-namespace` on a first install the
-           namespace does not exist yet at render time, so the probe finds
-           nothing and this guard stays silent. That degrades to the behaviour
-           from before the guard existed — the pods report
-           CreateContainerConfigError — which is the right direction to fail
-           when the alternative is blocking installs that are correctly set up. */}}
-      {{- if lookup "v1" "ServiceAccount" .Release.Namespace "default" }}
-        {{- $errors = append $errors (printf "Langy is enabled (langyagent.chartManaged=true) but Secret %q was not found in namespace %q, and this chart is not generating it. The app, the workers, and the agent pod all read %q from it to authenticate to each other, so all three would start into CreateContainerConfigError. %s" $langySecretName .Release.Namespace $langyKey $hint) }}
-      {{- end }}
-    {{- else if not (index ($found.data | default dict) $langyKey) }}
+         What that costs: a completely absent Secret is no longer named at
+         render time. It surfaces as CreateContainerConfigError on the pods,
+         which is exactly where it surfaced before this guard existed. What it
+         keeps is the case operators actually hit — the Secret is there and the
+         one key was never added — reported precisely, for free. */}}
+    {{- if and $found (not (index ($found.data | default dict) $langyKey)) }}
       {{- $errors = append $errors (printf "Langy is enabled (langyagent.chartManaged=true) but Secret %q in namespace %q has no %q key. The app, the workers, and the agent pod all read that one key to authenticate to each other. %s" $langySecretName .Release.Namespace $langyKey $hint) }}
     {{- end }}
   {{- end }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -538,9 +538,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if not $found }}
       {{/* Every lookup comes back empty during `helm template` and dry runs, so
            "Secret not found" there means "we cannot see the cluster", not "it is
-           missing". Probe with an object every real cluster has: if kube-system
-           is invisible too, stay quiet rather than failing a plain render. */}}
-      {{- if lookup "v1" "Namespace" "" "kube-system" }}
+           missing". Probe with an object that exists in every namespace and
+           stay quiet when it is invisible too, rather than failing a plain
+           render.
+
+           The probe is namespaced on purpose. A cluster-scoped one (kube-system
+           was the obvious candidate) adds an RBAC requirement this chart has no
+           business having: `lookup` turns a denial into a template error, so an
+           installer scoped to their own namespace would get a hard render
+           failure out of a check whose only job is to stay quiet. Reading the
+           release namespace's own default ServiceAccount asks for nothing the
+           Secret lookup above does not already need.
+
+           Trade-off, accepted: with `--create-namespace` on a first install the
+           namespace does not exist yet at render time, so the probe finds
+           nothing and this guard stays silent. That degrades to the behaviour
+           from before the guard existed — the pods report
+           CreateContainerConfigError — which is the right direction to fail
+           when the alternative is blocking installs that are correctly set up. */}}
+      {{- if lookup "v1" "ServiceAccount" .Release.Namespace "default" }}
         {{- $errors = append $errors (printf "Langy is enabled (langyagent.chartManaged=true) but Secret %q was not found in namespace %q, and this chart is not generating it. The app, the workers, and the agent pod all read %q from it to authenticate to each other, so all three would start into CreateContainerConfigError. %s" $langySecretName .Release.Namespace $langyKey $hint) }}
       {{- end }}
     {{- else if not (index ($found.data | default dict) $langyKey) }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -547,8 +547,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
            business having: `lookup` turns a denial into a template error, so an
            installer scoped to their own namespace would get a hard render
            failure out of a check whose only job is to stay quiet. Reading the
-           release namespace's own default ServiceAccount asks for nothing the
-           Secret lookup above does not already need.
+           release namespace's own default ServiceAccount keeps the requirement
+           inside the namespace they are already installing into, next to the
+           Secret read on the line above. Not literally the same grant — a role
+           could allow `get secrets` and refuse `get serviceaccounts` — but the
+           standard admin/edit roles carry both, and namespaced is the whole
+           point: no reachable RBAC makes a cluster-scoped read succeed for an
+           installer who only holds their own namespace.
 
            Trade-off, accepted: with `--create-namespace` on a first install the
            namespace does not exist yet at render time, so the probe finds

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -554,6 +554,50 @@ test_component_toggles() {
   assert_contains "toggles: app still renders with both disabled" "$off" "${RELEASE}-app"
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE: Langy opt-out — one values key removes the assistant completely
+# ─────────────────────────────────────────────────────────────────────────────
+# langyagent.chartManaged is the single documented opt-out, and it has to be
+# genuinely single. An operator who sets it and still finds the agent's Service,
+# its shared secret key, or the rollout flag forced on has been told something
+# untrue — and this is the escape hatch we point locked-down clusters at, so a
+# leak here is a support call rather than a cosmetic bug.
+#
+# Worth asserting on all four surfaces rather than the Deployment alone: the
+# subchart disappears via a Chart.yaml `condition:`, while the app's and
+# workers' references to it are separate `if` guards in the umbrella chart.
+# Nothing links them. Each is its own edit, and each can be forgotten on its
+# own while the Deployment correctly vanishes and the render stays green.
+test_langy_disabled() {
+  sep; info "Suite: langy opt-out"
+
+  local on off
+  on=$(tmpl --set autogen.enabled=true)
+  off=$(tmpl --set autogen.enabled=true -f "${OVERLAYS}/langy-disabled.yaml")
+
+  # Negative controls, and not a formality here: a failed render arrives as an
+  # error string (tmpl folds stderr into stdout), and every absence assertion
+  # below would pass against it. These are what stop this suite reporting a
+  # clean opt-out for a chart that rendered nothing at all.
+  assert_contains "langy: agent Deployment present when enabled"  "$on" "name: ${RELEASE}-langyagent"
+  assert_contains "langy: agent URL wired when enabled"           "$on" "OPENCODE_AGENT_URL"
+  assert_contains "langy: rollout flag forced when enabled"       "$on" "release_langy_enabled"
+  assert_contains "langy: shared secret key present when enabled" "$on" "LANGY_INTERNAL_SECRET"
+
+  # The subchart itself — Deployment, Service, ConfigMap and NetworkPolicy all
+  # carry this name, so one assertion covers every object it contributes.
+  assert_not_contains "langy: no agent resources when disabled" "$off" "${RELEASE}-langyagent"
+
+  # The umbrella chart's own references, each behind its own guard.
+  assert_not_contains "langy: agent URL not wired when disabled"      "$off" "OPENCODE_AGENT_URL"
+  assert_not_contains "langy: rollout flag not forced when disabled"  "$off" "release_langy_enabled"
+  assert_not_contains "langy: shared secret key absent when disabled" "$off" "LANGY_INTERNAL_SECRET"
+
+  # Opting out of the assistant must not take anything else with it.
+  assert_contains "langy: app still renders when disabled"    "$off" "${RELEASE}-app"
+  assert_contains "langy: workers still render when disabled" "$off" "${RELEASE}-workers"
+}
+
 test_size_overlays() {
   sep; info "Suite: size overlays"
 
@@ -1298,6 +1342,7 @@ main() {
   test_backup_metrics_gate
   test_size_overlays
   test_component_toggles
+  test_langy_disabled
   test_pod_security
   test_infra_overlays
   test_overlay_stacking

--- a/charts/langwatch/tests/restricted-rbac.sh
+++ b/charts/langwatch/tests/restricted-rbac.sh
@@ -56,6 +56,12 @@ templates() {
 # not to be a general analyzer.
 readonly CLUSTER_SCOPED='lookup[[:space:]]+"[^"]*"[[:space:]]+"[^"]*"[[:space:]]+""'
 
+# A CALL, not the word. Every real lookup names its apiVersion as a string
+# literal, so `lookup "` is the call and `lookup` on its own is prose — the
+# template comments explaining why this rule exists say the word repeatedly,
+# and must not trip it.
+readonly ANY_LOOKUP_CALL='lookup[[:space:]]+"'
+
 # @scenario "A restricted installer can render the chart without cluster-scoped read access"
 test_no_cluster_scoped_lookup() {
   local hits
@@ -72,7 +78,7 @@ Use a namespaced lookup, or tell the operator the command to run themselves."
 # @scenario "The install notes never depend on reading the cluster"
 test_notes_make_no_lookup() {
   local hits
-  hits=$(templates | grep 'NOTES\.txt$' | xargs grep -nH 'lookup ' 2>/dev/null || true)
+  hits=$(templates | grep 'NOTES\.txt$' | xargs grep -nEH "$ANY_LOOKUP_CALL" 2>/dev/null || true)
 
   if [[ -n "$hits" ]]; then
     fail "notes-lookup" \

--- a/charts/langwatch/tests/restricted-rbac.sh
+++ b/charts/langwatch/tests/restricted-rbac.sh
@@ -40,25 +40,29 @@ fail() {
 }
 
 # Every template across every chart, so a chart added later is covered without
-# anyone remembering to extend this list.
+# anyone remembering to extend this list. Helm renders every file under
+# templates/ regardless of extension, so .yml belongs here next to .yaml — a
+# lookup in a .yml template renders exactly the same and must not slip past.
 templates() {
   find "$CHARTS_DIR" -type d -name templates -not -path "*/charts/*/charts/*" \
-    -exec find {} -type f \( -name "*.yaml" -o -name "*.tpl" -o -name "*.txt" \) \;
+    -exec find {} -type f \
+      \( -name "*.yaml" -o -name "*.yml" -o -name "*.tpl" -o -name "*.txt" \) \;
 }
 
-TEMPLATES=$(templates)
-readonly TEMPLATES
+TEMPLATE_FILES=()
+while IFS= read -r template_file; do
+  [[ -n "$template_file" ]] && TEMPLATE_FILES+=("$template_file")
+done <<< "$(templates)"
 
 # A guard that scans nothing passes silently, and every way this breaks — the
 # script moving, a templates/ directory being renamed, the wrong cwd — produces
-# exactly that. GNU xargs makes it worse than it looks: given empty input it
-# still runs grep, with no file operands, so grep reads the already-drained
-# stdin, finds nothing and reports success. Anchor on the file the whole rule
-# exists for, so an empty corpus is a failure rather than a green tick.
-readonly CORPUS_ANCHOR="charts/langwatch/templates/NOTES.txt"
+# exactly that. Anchor on the file the whole rule exists for, matched as a
+# literal full path (grep -xF, so the dot in NOTES.txt cannot act as a
+# wildcard), and fail loudly rather than reporting a green tick over nothing.
+readonly CORPUS_ANCHOR="$CHARTS_DIR/langwatch/templates/NOTES.txt"
 
-if ! printf '%s\n' "$TEMPLATES" | grep -q "/${CORPUS_ANCHOR}\$"; then
-  echo "FAIL [no-corpus]: did not find ${CORPUS_ANCHOR} under ${CHARTS_DIR}."
+if ! printf '%s\n' "${TEMPLATE_FILES[@]:-}" | grep -qxF "$CORPUS_ANCHOR"; then
+  echo "FAIL [no-corpus]: did not find ${CORPUS_ANCHOR}."
   echo "This guard scans by path, so an empty or wrong corpus makes it pass"
   echo "without checking anything. Has the script moved out of charts/*/tests/?"
   exit 1
@@ -80,10 +84,51 @@ readonly CLUSTER_SCOPED='lookup[[:space:]]+"[^"]*"[[:space:]]+"[^"]*"[[:space:]]
 # and must not trip it.
 readonly ANY_LOOKUP_CALL='lookup[[:space:]]+"'
 
+# Scan the corpus for a pattern, failing CLOSED.
+#
+# Two things a plain `grep ... || true` gets wrong, both of which turn a broken
+# scan into a silent pass:
+#
+#   1. It launders every non-zero status into success. grep exits 1 for "no
+#      match" but >=1 for real errors — an unreadable file, a bad pattern — and
+#      those must abort, not read as "nothing found". Only status 1 is a miss.
+#   2. It is line-oriented, so a call split across lines is invisible:
+#        {{- $x := lookup "v1"
+#             "Secret" "" "" }}
+#      Rare, but valid Go template and renders identically. Files that do not
+#      match line-wise get a second look with newlines flattened; those report
+#      the file rather than a line, since after flattening there is no line
+#      number left to report. Enough to send someone to the right file.
+scan() {
+  local pattern=$1
+  shift
+  local file matched status flattened
+
+  for file in "$@"; do
+    matched=$(grep -nEH "$pattern" "$file") && status=0 || status=$?
+    if [[ $status -gt 1 ]]; then
+      echo "SCANNER ERROR: grep exited $status reading $file" >&2
+      exit 2
+    fi
+    if [[ $status -eq 0 ]]; then
+      printf '%s\n' "$matched"
+      continue
+    fi
+
+    flattened=$(tr '\n' ' ' <"$file") || {
+      echo "SCANNER ERROR: cannot read $file" >&2
+      exit 2
+    }
+    if printf '%s\n' "$flattened" | grep -qE "$pattern"; then
+      printf '%s: lookup call split across lines\n' "$file"
+    fi
+  done
+}
+
 # @scenario "A restricted installer can render the chart without cluster-scoped read access"
 test_no_cluster_scoped_lookup() {
   local hits
-  hits=$(printf '%s\n' "$TEMPLATES" | xargs grep -nEH "$CLUSTER_SCOPED" || true)
+  hits=$(scan "$CLUSTER_SCOPED" "${TEMPLATE_FILES[@]}")
 
   if [[ -n "$hits" ]]; then
     fail "cluster-scoped-lookup" \
@@ -95,10 +140,14 @@ Use a namespaced lookup, or tell the operator the command to run themselves."
 
 # @scenario "The install notes never depend on reading the cluster"
 test_notes_make_no_lookup() {
+  local notes=()
+  local template_file
+  for template_file in "${TEMPLATE_FILES[@]}"; do
+    [[ "$template_file" == *"/NOTES.txt" ]] && notes+=("$template_file")
+  done
+
   local hits
-  # The anchor check above guarantees at least one NOTES.txt, so xargs always
-  # gets a file operand and can never fall through to reading stdin.
-  hits=$(printf '%s\n' "$TEMPLATES" | grep 'NOTES\.txt$' | xargs grep -nEH "$ANY_LOOKUP_CALL" || true)
+  hits=$(scan "$ANY_LOOKUP_CALL" "${notes[@]}")
 
   if [[ -n "$hits" ]]; then
     fail "notes-lookup" \
@@ -118,4 +167,4 @@ if [[ $failures -gt 0 ]]; then
   exit 1
 fi
 
-echo "PASS: no template requires cluster-scoped read access to render"
+echo "PASS: no template requires cluster-scoped read access to render (${#TEMPLATE_FILES[@]} templates)"

--- a/charts/langwatch/tests/restricted-rbac.sh
+++ b/charts/langwatch/tests/restricted-rbac.sh
@@ -46,6 +46,24 @@ templates() {
     -exec find {} -type f \( -name "*.yaml" -o -name "*.tpl" -o -name "*.txt" \) \;
 }
 
+TEMPLATES=$(templates)
+readonly TEMPLATES
+
+# A guard that scans nothing passes silently, and every way this breaks — the
+# script moving, a templates/ directory being renamed, the wrong cwd — produces
+# exactly that. GNU xargs makes it worse than it looks: given empty input it
+# still runs grep, with no file operands, so grep reads the already-drained
+# stdin, finds nothing and reports success. Anchor on the file the whole rule
+# exists for, so an empty corpus is a failure rather than a green tick.
+readonly CORPUS_ANCHOR="charts/langwatch/templates/NOTES.txt"
+
+if ! printf '%s\n' "$TEMPLATES" | grep -q "/${CORPUS_ANCHOR}\$"; then
+  echo "FAIL [no-corpus]: did not find ${CORPUS_ANCHOR} under ${CHARTS_DIR}."
+  echo "This guard scans by path, so an empty or wrong corpus makes it pass"
+  echo "without checking anything. Has the script moved out of charts/*/tests/?"
+  exit 1
+fi
+
 # A cluster-scoped lookup is one whose namespace argument is the empty string:
 #   lookup "node.k8s.io/v1" "RuntimeClass" "" ""
 # Namespaced lookups pass .Release.Namespace there and are fine — they need no
@@ -65,7 +83,7 @@ readonly ANY_LOOKUP_CALL='lookup[[:space:]]+"'
 # @scenario "A restricted installer can render the chart without cluster-scoped read access"
 test_no_cluster_scoped_lookup() {
   local hits
-  hits=$(templates | xargs grep -nEH "$CLUSTER_SCOPED" 2>/dev/null || true)
+  hits=$(printf '%s\n' "$TEMPLATES" | xargs grep -nEH "$CLUSTER_SCOPED" || true)
 
   if [[ -n "$hits" ]]; then
     fail "cluster-scoped-lookup" \
@@ -78,7 +96,9 @@ Use a namespaced lookup, or tell the operator the command to run themselves."
 # @scenario "The install notes never depend on reading the cluster"
 test_notes_make_no_lookup() {
   local hits
-  hits=$(templates | grep 'NOTES\.txt$' | xargs grep -nEH "$ANY_LOOKUP_CALL" 2>/dev/null || true)
+  # The anchor check above guarantees at least one NOTES.txt, so xargs always
+  # gets a file operand and can never fall through to reading stdin.
+  hits=$(printf '%s\n' "$TEMPLATES" | grep 'NOTES\.txt$' | xargs grep -nEH "$ANY_LOOKUP_CALL" || true)
 
   if [[ -n "$hits" ]]; then
     fail "notes-lookup" \

--- a/charts/langwatch/tests/restricted-rbac.sh
+++ b/charts/langwatch/tests/restricted-rbac.sh
@@ -49,10 +49,21 @@ templates() {
       \( -name "*.yaml" -o -name "*.yml" -o -name "*.tpl" -o -name "*.txt" \) \;
 }
 
+# Capture discovery's exit status before consuming its output. Feeding the loop
+# directly with `done <<< "$(templates)"` throws that status away: a find that
+# failed part-way still prints whatever it reached, and the loop then succeeds
+# over a partial corpus. The anchor below would not save us — it catches a
+# corpus that is EMPTY, not one that quietly lost a subtree, and a skipped
+# subtree is exactly where an unreviewed lookup would be sitting.
+if ! discovered=$(templates); then
+  echo "SCANNER ERROR: template discovery failed under ${CHARTS_DIR}" >&2
+  exit 2
+fi
+
 TEMPLATE_FILES=()
 while IFS= read -r template_file; do
   [[ -n "$template_file" ]] && TEMPLATE_FILES+=("$template_file")
-done <<< "$(templates)"
+done <<< "$discovered"
 
 # A guard that scans nothing passes silently, and every way this breaks — the
 # script moving, a templates/ directory being renamed, the wrong cwd — produces

--- a/charts/langwatch/tests/restricted-rbac.sh
+++ b/charts/langwatch/tests/restricted-rbac.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Asserts that rendering these charts never requires permissions an installer
+# scoped to their own namespace would not have.
+#
+# Why this is a static check and not a render. `lookup` returns an empty result
+# whenever the render has no cluster behind it, which is every `helm template`
+# in CI and every GitOps dry run. A `lookup` the installer is FORBIDDEN to make
+# behaves completely differently: Helm swallows only NotFound, so a 403 comes
+# back as a template error and takes the whole install down —
+#
+#   Error: UPGRADE FAILED: template: langwatch/templates/NOTES.txt:102:11:
+#   executing "langwatch/templates/NOTES.txt" at <lookup "node.k8s.io/v1"
+#   "RuntimeClass" "" "">: error calling lookup: runtimeclasses.node.k8s.io is
+#   forbidden: User "..." cannot list resource "runtimeclasses" in API group
+#   "node.k8s.io" at the cluster scope
+#
+# — and a Go template has no way to recover. So the failure is invisible to
+# every green `helm template` in the matrix and shows up only on a customer's
+# locked-down cluster. Reading the templates is the only place to catch it.
+#
+# Scenario bindings use the same `@scenario` token as the other suites in this
+# directory, expressed as a hash-comment above the test function it verifies.
+# The next line that is neither blank nor a comment must be that function.
+#
+# Usage (from charts/langwatch):
+#   ./tests/restricted-rbac.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+readonly CHARTS_DIR="$PWD"
+
+failures=0
+
+fail() {
+  echo "FAIL [$1]: $2"
+  failures=$((failures + 1))
+}
+
+# Every template across every chart, so a chart added later is covered without
+# anyone remembering to extend this list.
+templates() {
+  find "$CHARTS_DIR" -type d -name templates -not -path "*/charts/*/charts/*" \
+    -exec find {} -type f \( -name "*.yaml" -o -name "*.tpl" -o -name "*.txt" \) \;
+}
+
+# A cluster-scoped lookup is one whose namespace argument is the empty string:
+#   lookup "node.k8s.io/v1" "RuntimeClass" "" ""
+# Namespaced lookups pass .Release.Namespace there and are fine — they need no
+# permission the chart's own Secret reads do not already need.
+#
+# Limitation, deliberate: a namespace passed as a variable is not inspected.
+# The point is to catch the literal that is easy to write without thinking,
+# not to be a general analyzer.
+readonly CLUSTER_SCOPED='lookup[[:space:]]+"[^"]*"[[:space:]]+"[^"]*"[[:space:]]+""'
+
+# @scenario "A restricted installer can render the chart without cluster-scoped read access"
+test_no_cluster_scoped_lookup() {
+  local hits
+  hits=$(templates | xargs grep -nEH "$CLUSTER_SCOPED" 2>/dev/null || true)
+
+  if [[ -n "$hits" ]]; then
+    fail "cluster-scoped-lookup" \
+      "these templates read a cluster-scoped resource, which fails the render outright for an installer whose RBAC stops at their namespace:
+$hits
+Use a namespaced lookup, or tell the operator the command to run themselves."
+  fi
+}
+
+# @scenario "The install notes never depend on reading the cluster"
+test_notes_make_no_lookup() {
+  local hits
+  hits=$(templates | grep 'NOTES\.txt$' | xargs grep -nH 'lookup ' 2>/dev/null || true)
+
+  if [[ -n "$hits" ]]; then
+    fail "notes-lookup" \
+      "NOTES.txt reads the cluster:
+$hits
+The notes are advice printed after the work is done, so nothing in them is
+worth failing an install over. Print the command for the operator to run."
+  fi
+}
+
+test_no_cluster_scoped_lookup
+test_notes_make_no_lookup
+
+if [[ $failures -gt 0 ]]; then
+  echo
+  echo "$failures check(s) failed"
+  exit 1
+fi
+
+echo "PASS: no template requires cluster-scoped read access to render"

--- a/charts/langyagent/README.md
+++ b/charts/langyagent/README.md
@@ -34,21 +34,34 @@ than half-deploying. To run without the assistant, set
 
 ### The sandboxed runtime
 
-The agent runs LLM-written shell, so the default pins the pod to a `gvisor`
-RuntimeClass. On a cluster without one, the pod stays Pending (RuntimeClass
-not found) while everything else runs: GKE ships the class managed (GKE
-Sandbox), on AKS point `runtimeClassName` at your Kata VM isolation class, on
-EKS install gVisor on the node group. To run without a sandbox, say so
-explicitly:
+The agent runs LLM-written shell, so a pod-to-host sandbox is worth having.
+It is not required, and not the default: `runtimeClassName` ships empty with
+`acceptUnsandboxedRuntime` true, so the agent installs and runs on any
+cluster and hardening is a deliberate later step. GKE ships a sandboxed class
+managed (GKE Sandbox), on AKS point `runtimeClassName` at your Kata VM
+isolation class, on EKS install gVisor on the node group. To pin one:
 
 ```yaml
 langyagent:
-  runtimeClassName: ""
-  acceptUnsandboxedRuntime: true
+  runtimeClassName: "gvisor"
+  acceptUnsandboxedRuntime: false
 ```
 
-The chart refuses a blank runtime without the acceptance, so an unsandboxed
-deploy is always deliberate.
+Blanking the class afterwards while `acceptUnsandboxedRuntime` stays false is
+refused at render time, so a cluster that has hardened cannot quietly lose its
+sandbox.
+
+Pin a class the cluster does not define and no pod is created at all.
+Kubernetes rejects it at admission (`pod rejected: RuntimeClass "..." not
+found`), so `kubectl get pods` lists nothing rather than showing something
+Pending, and the reason lands on the Deployment instead:
+
+```bash
+kubectl -n <namespace> get deploy <release>-langyagent \
+  -o jsonpath='{.status.conditions[?(@.type=="ReplicaFailure")].message}'
+```
+
+Everything else in the install keeps running either way.
 
 Unsandboxed, you keep per-worker UID isolation, the per-worker opencode
 password, and the NetworkPolicy; you give up the pod-to-host sandbox. A

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -451,7 +451,6 @@ const LEGACY_INERT: string[] = [
   "specs/langy/langy-composer-feedback-and-cards.feature",
   "specs/langy/langy-context-awareness.feature",
   "specs/langy/langy-conversation-title.feature",
-  "specs/langy/langy-deploy-hardening.feature",
   "specs/langy/langy-derived-cards.feature",
   "specs/langy/langy-dogfood-scenarios.feature",
   "specs/langy/langy-empty-state-suggestions.feature",

--- a/specs/langy/langy-deploy-hardening.feature
+++ b/specs/langy/langy-deploy-hardening.feature
@@ -73,16 +73,24 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
     # The defaults are an empty runtimeClassName with acceptUnsandboxedRuntime
     # true, so Langy is available on any cluster and hardening is a deliberate
     # later step. Pinning a RuntimeClass the cluster does not define is what
-    # leaves the pod Pending — and that can only happen after an operator has
+    # stops the agent running — and that can only happen after an operator has
     # chosen to pin one, which is the scenario below.
 
-  Scenario: Pinning a RuntimeClass the cluster does not define leaves the pod Pending, not unsandboxed
+  Scenario: Pinning a RuntimeClass the cluster does not define fails closed, not unsandboxed
     Given an operator has pinned the langy-agent pod to a sandboxed runtime
     And the cluster defines no matching RuntimeClass
     When the install completes
     Then every other workload runs
-    And the langy-agent pod waits rather than running without its sandbox
-    And the install notes say where the reason for the wait is recorded
+    And no langy-agent pod runs without its sandbox
+    And the install notes say where the reason is recorded
+    # Not "Pending" — the pod never gets far enough to wait. Kubernetes'
+    # RuntimeClass admission plugin refuses to create a pod naming a class it
+    # cannot find (`pod rejected: RuntimeClass "..." not found`), so the
+    # ReplicaSet's create call is what fails and no pod object exists at all.
+    # That matters to the operator looking for it: `kubectl get pods` lists
+    # nothing, which reads like the install skipped Langy rather than like a
+    # failure. The reason is on the Deployment's ReplicaFailure condition, and
+    # printing that command is what NOTES.txt does here.
 
   Scenario: The guard does not fire when the agent is not chart-managed
     Given the chart does not manage the langy-agent pod

--- a/specs/langy/langy-deploy-hardening.feature
+++ b/specs/langy/langy-deploy-hardening.feature
@@ -125,10 +125,15 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
   Scenario: The install notes never depend on reading the cluster
     Given the install notes
     Then nothing in them reads the cluster to decide what to print
-    And guidance that would need such a read is printed as a command the
-      operator can choose to run themselves
     # The notes are advice printed after the install has already succeeded.
     # Nothing in them is worth failing an install over.
+    #
+    # Deliberately only the one claim. Guidance that would have needed such a
+    # read is printed as a command for the operator to run instead, but that
+    # is not asserted here: the only way to check it is to grep the notes for
+    # the command's own text, which passes by finding a string we wrote rather
+    # than by testing anything. An unenforced Then inside a scenario the parity
+    # checker calls bound is worse than one fewer Then.
 
   # ===========================================================================
   # Local e2e manifest mirrors the production security posture

--- a/specs/langy/langy-deploy-hardening.feature
+++ b/specs/langy/langy-deploy-hardening.feature
@@ -117,16 +117,22 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
   @unit
   Scenario: A restricted installer can render the chart without cluster-scoped read access
     Given an operator whose permissions stop at the namespace they install into
-    When they render the chart
-    Then no part of the render asks to read a cluster-scoped resource
-    And the render never fails for a permission the operator was not granted
+    When they install or upgrade the release
+    Then it completes
+    And it never fails for a permission they were never granted
+    # Enforced by charts/langwatch/tests/restricted-rbac.sh, which reads the
+    # templates instead of rendering them. That is not a shortcut: with no
+    # cluster behind a render every lookup returns empty, so the forbidden
+    # case cannot be reproduced by `helm template` at all. Keeping no
+    # cluster-scoped read in any template is the mechanism; the outcome above
+    # is what it buys.
 
   @unit
   Scenario: The install notes never depend on reading the cluster
-    Given the install notes
-    Then nothing in them reads the cluster to decide what to print
-    # The notes are advice printed after the install has already succeeded.
-    # Nothing in them is worth failing an install over.
+    Given an operator whose permissions stop at the namespace they install into
+    When the install finishes and prints its notes
+    Then the notes print
+    And nothing in them can fail the install that has already succeeded
     #
     # Deliberately only the one claim. Guidance that would have needed such a
     # read is printed as a command for the operator to run instead, but that

--- a/specs/langy/langy-deploy-hardening.feature
+++ b/specs/langy/langy-deploy-hardening.feature
@@ -62,14 +62,27 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
     Then the pod renders successfully
     And the pod is pinned to the sandboxed runtime
 
-  Scenario: A default install on a cluster without the RuntimeClass degrades to Pending, not to unsandboxed
+  Scenario: A default install runs Langy on a cluster that offers no sandboxed runtime
     Given an operator installs the umbrella chart with default values
+    And the cluster offers no sandboxed runtime
+    When the install completes
+    Then every workload runs, Langy included
+    And the install notes state which isolation posture this install got
+    And the install notes explain where a sandboxed runtime comes from on each major cloud
+    And the install notes name the values that pin the pod to one
+    # The defaults are an empty runtimeClassName with acceptUnsandboxedRuntime
+    # true, so Langy is available on any cluster and hardening is a deliberate
+    # later step. Pinning a RuntimeClass the cluster does not define is what
+    # leaves the pod Pending — and that can only happen after an operator has
+    # chosen to pin one, which is the scenario below.
+
+  Scenario: Pinning a RuntimeClass the cluster does not define leaves the pod Pending, not unsandboxed
+    Given an operator has pinned the langy-agent pod to a sandboxed runtime
     And the cluster defines no matching RuntimeClass
     When the install completes
     Then every other workload runs
     And the langy-agent pod waits rather than running without its sandbox
-    And the install notes explain where a sandboxed runtime comes from on each major cloud
-    And the install notes name the values that accept running without one
+    And the install notes say where the reason for the wait is recorded
 
   Scenario: The guard does not fire when the agent is not chart-managed
     Given the chart does not manage the langy-agent pod
@@ -80,6 +93,42 @@ Feature: Langy deploy hardening — sandboxed-runtime guard and e2e security par
     # sandbox. Blanking the runtime while still managed does, and is refused
     # until the operator accepts it (see the scenario above, and
     # specs/langy/langy-selfhost-install.feature for the operator's story).
+
+  # ===========================================================================
+  # Restricted clusters: rendering asks for no permission the operator lacks
+  # ===========================================================================
+
+  # A customer upgrade died here. Their platform team is scoped to the namespace
+  # they install into, and the install notes tried to list the cluster's
+  # RuntimeClasses so they could offer an optional hardening tip. Helm reports a
+  # DENIED lookup as a template error rather than as an empty result, so advice
+  # nobody had asked for took the whole upgrade down:
+  #
+  #   Error: UPGRADE FAILED: template: langwatch/templates/NOTES.txt:102:11:
+  #   ... error calling lookup: runtimeclasses.node.k8s.io is forbidden: User
+  #   "..." cannot list resource "runtimeclasses" in API group "node.k8s.io" at
+  #   the cluster scope
+  #
+  # Nothing in the render matrix catches this. With no cluster behind the
+  # render every lookup returns empty and the branch is simply skipped, so the
+  # failure exists only on a cluster whose RBAC actually refuses — which is to
+  # say, only on the customer's.
+
+  @unit
+  Scenario: A restricted installer can render the chart without cluster-scoped read access
+    Given an operator whose permissions stop at the namespace they install into
+    When they render the chart
+    Then no part of the render asks to read a cluster-scoped resource
+    And the render never fails for a permission the operator was not granted
+
+  @unit
+  Scenario: The install notes never depend on reading the cluster
+    Given the install notes
+    Then nothing in them reads the cluster to decide what to print
+    And guidance that would need such a read is printed as a command the
+      operator can choose to run themselves
+    # The notes are advice printed after the install has already succeeded.
+    # Nothing in them is worth failing an install over.
 
   # ===========================================================================
   # Local e2e manifest mirrors the production security posture


### PR DESCRIPTION
## What broke

`helm upgrade` failed outright:

```
Error: UPGRADE FAILED: template: langwatch/templates/NOTES.txt:102:11:
executing "langwatch/templates/NOTES.txt" at <lookup "node.k8s.io/v1" "RuntimeClass" "" "">:
error calling lookup: runtimeclasses.node.k8s.io is forbidden: User "..." cannot list
resource "runtimeclasses" in API group "node.k8s.io" at the cluster scope
```

The install notes were listing the cluster's RuntimeClasses to offer an *optional*
hardening tip. Helm swallows only `NotFound` from `lookup` — a 403 comes back as a
template error, and a Go template has no way to recover. So advice printed *after* the
install has already succeeded was able to take the whole upgrade down for any operator
whose RBAC stops at their own namespace.

## Nothing about their cluster is unsupported

Worth stating plainly, because the report reads as "locked-down cluster can't run Langy":
**Langy does not require gvisor.** The defaults are `runtimeClassName: ""` with
`acceptUnsandboxedRuntime: true`, so it runs on any cluster. Only the *hint about optional
hardening* needed the permission. Once this merges their upgrade completes and Langy
works, with no values changes on their side.

## Changes

- **`NOTES.txt`** prints `kubectl get runtimeclass` for the operator to run, instead of
  listing the classes itself. Same guidance, no render-time permission. It also no longer
  claims a class is sandboxed based on its handler name — Kata ships as `kata-qemu`,
  `kata-mshv-vm-isolation` and others, so the old wording sent operators looking for a
  literal that isn't there.
- **`_helpers.tpl`** — the Langy secret guard probed "can we see the cluster?" by reading
  `kube-system`, a cluster-scoped read with the identical failure mode. That probe is gone,
  and so is the "Secret not found" error it existed to guard. See the note below.
- **`tests/restricted-rbac.sh`** (new CI job) fails the build on any cluster-scoped
  `lookup`, and on any `lookup` at all in `NOTES.txt`.
- **`tests/e2e-overlays.sh`** gains a suite proving `langyagent.chartManaged=false`
  removes Langy completely — the opt-out is documented as a single values key and is the
  escape hatch we point locked-down clusters at, but nothing asserted it actually worked.
- **Spec** gains two bound `@unit` scenarios and comes off `LEGACY_INERT`; it was
  reporting `0/0` and enforcing nothing. Two stale claims are corrected along the way: a
  default install does not leave the pod Pending, and neither does pinning a class the
  cluster lacks — Kubernetes rejects that pod at admission, so none is created at all.
- **`charts/langyagent/README.md`** claimed the default pins the pod to a `gvisor`
  RuntimeClass, and that a cluster without one leaves the pod Pending. Both are wrong.
  The first is precisely how the "locked-down clusters can't run Langy" premise spreads,
  which is the misconception this PR exists to unwind.

## Why the "Secret not found" check was dropped rather than re-pointed

An absent Secret is indistinguishable from a render with no cluster behind it: `lookup`
returns the same empty result for both. Telling them apart needs a *second* read whose
only job is to prove the cluster is visible, and every candidate costs a permission the
chart otherwise does not need — `kube-system` was cluster-scoped (the bug this PR
removes), and the namespace's own `default` ServiceAccount is at least namespaced but
still a distinct `get serviceaccounts` grant a role can withhold. Neither is worth a hard
render failure for an operator whose setup is correct, in service of a message.

What that costs: a wholly absent Secret is no longer named at render time, and surfaces as
`CreateContainerConfigError` on the pods — where it surfaced before this guard existed.
What it keeps, for free: the Secret-is-there-but-the-key-is-missing case, which is the
mistake operators actually make, still reported precisely.

## What a missing RuntimeClass actually does

The chart's own notes have had this right since #6106; the spec and the subchart README
had not. Kubernetes' RuntimeClass admission plugin refuses to create a pod naming a class
it cannot find (`pod rejected: RuntimeClass "..." not found`, after a live re-read to rule
out a lagging informer cache). The ReplicaSet's create call is what fails, so no pod
object exists and there is nothing to be `Pending`. That matters to whoever is looking:
`kubectl get pods` returns nothing, which reads like the install skipped Langy rather than
like a rejection. The reason is on the Deployment's `ReplicaFailure` condition, and
printing that command is what `NOTES.txt` does.

## Why CI was green

This class of bug is invisible to `helm template`: with no cluster behind the render,
every `lookup` returns empty and the branch is skipped. The 13-case render matrix passed
throughout. That is why the new guard is a static read of the templates rather than
another render.

## Verification

- `helm template` across default / `langy-disabled` / `langy-gvisor` / external-secret —
  all render.
- `restricted-rbac.sh` passes over 54 templates, and was confirmed to fail on: the
  original offending line, an empty corpus, a `.yml` template, a `lookup` split across
  lines, and an unreadable file (exit 2 rather than a laundered pass).
- The new e2e suite passes 10/10, and was confirmed to fail when one umbrella guard is
  dropped to `if true`.
- `check-feature-parity.ts` exits 0; the spec reports `2/2 scenarios bound`.
- Confirmed by experiment that `helm template` *does* execute `NOTES.txt`, so the new
  text is syntax-checked by the existing matrix.
- The admission behaviour above was read off `plugin/pkg/admission/runtimeclass/admission.go`
  and the upstream RuntimeClass docs rather than assumed, since the correction turns on it.

## Deployment Impact

- **Env vars:** none added, changed, or removed.
- **Helm values:** none added, changed, or removed. `langyagent.runtimeClassName`,
  `acceptUnsandboxedRuntime`, `chartManaged` and `enableForAllUsers` all keep their
  current defaults and meanings. No operator needs to change a values file.
- **Default `helm install` with no overrides:** unchanged in what it deploys. The only
  visible difference is the wording of the Langy paragraph in the post-install notes.
  Installs that were previously succeeding continue to succeed identically.
- **Installs that were previously FAILING:** this is the fix. Any operator whose RBAC does
  not permit listing cluster-scoped resources was getting a hard `UPGRADE FAILED` from the
  notes. Those installs now complete, and Langy runs for them on the existing unsandboxed
  default.
- **Behaviour change to note:** the chart no longer reports a completely absent Langy
  Secret at render time (rationale above). The misconfiguration surfaces on the pods
  instead. No install that was working stops working, and the more common
  missing-key case is still caught at render time.
- **BYOC dataplane:** no impact. Nothing here touches the dataplane, its images, or its
  configuration surface — the changes are the umbrella chart's notes text, one render
  guard, two CI-only test scripts, a spec file, and two documentation corrections.
- **Rollback:** plain chart revert, no data or state migration involved.
