### PR TITLE
fix(licensing): an enterprise plan carries its entitlements however it was resolved

### DIFF
--- a/platform/app/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/planLimits.unit.test.ts
@@ -16,4 +16,26 @@ describe("PLAN_LIMITS", () => {
       expect(PLAN_LIMITS[PlanTypes.FREE].maxMembers).toBe(2);
     });
   });
+
+  describe("when checking the webhook endpoints entitlement", () => {
+    /** @scenario An enterprise subscription with no license is entitled */
+    it("states it on ENTERPRISE rather than leaving it to be inferred", () => {
+      expect(PLAN_LIMITS[PlanTypes.ENTERPRISE].webhookEndpointsEnabled).toBe(
+        true,
+      );
+    });
+
+    /** @scenario A plan below enterprise is not entitled */
+    it("does not grant it to the plans sold below enterprise", () => {
+      expect(
+        PLAN_LIMITS[PlanTypes.GROWTH].webhookEndpointsEnabled,
+      ).toBeUndefined();
+      expect(
+        PLAN_LIMITS[PlanTypes.FREE].webhookEndpointsEnabled,
+      ).toBeUndefined();
+      expect(
+        PLAN_LIMITS[PlanTypes.PRO].webhookEndpointsEnabled,
+      ).toBeUndefined();
+    });
+  });
 });

--- a/platform/app/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/planProvider.unit.test.ts
@@ -520,3 +520,29 @@ describe("createSaaSPlanProvider", () => {
     });
   });
 });
+
+describe("createSaaSPlanProvider subscription selection", () => {
+  beforeEach(() => {
+    mockEnv.IS_SAAS = true;
+    mockEnv.ADMIN_EMAILS = undefined;
+  });
+
+  describe("given an organization holding more than one active subscription", () => {
+    it("reads the newest one rather than whichever the database returns first", async () => {
+      const db = createMockDb({
+        findFirstResult: {
+          organizationId: "org_1",
+          plan: PlanTypes.ENTERPRISE,
+          status: SubscriptionStatus.ACTIVE,
+        },
+      });
+
+      await createSaaSPlanProvider(db).getActivePlan("org_1");
+
+      const query = (
+        db.subscription.findFirst as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls[0]![0] as { orderBy?: unknown };
+      expect(query.orderBy).toEqual([{ createdAt: "desc" }, { id: "desc" }]);
+    });
+  });
+});

--- a/platform/app/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/platform/app/ee/billing/__tests__/planProvider.unit.test.ts
@@ -40,6 +40,61 @@ const createMockDb = ({
   } as unknown as PrismaClient;
 };
 
+/**
+ * A `findFirst` that honors the `orderBy` it is handed, reading the clauses the
+ * way Prisma does: the first decides, later ones break ties.
+ *
+ * A canned single row cannot tell whether the query orders anything, so the
+ * only assertion left would be a copy of the query's own literal, which passes
+ * even if the database ignores it. Sorting here lets the test say which row is
+ * selected.
+ */
+type OrderableRow = { id: string; createdAt: Date };
+type OrderByClause = Record<string, "asc" | "desc">;
+
+const compareByClause = (
+  a: OrderableRow,
+  b: OrderableRow,
+  clause: OrderByClause,
+): number => {
+  const [field, direction] = Object.entries(clause)[0] as [
+    "id" | "createdAt",
+    "asc" | "desc",
+  ];
+  const left = a[field];
+  const right = b[field];
+  const ascending = left < right ? -1 : left > right ? 1 : 0;
+  return direction === "desc" ? -ascending : ascending;
+};
+
+const firstUnder = <T extends OrderableRow>(
+  rows: T[],
+  orderBy: OrderByClause[],
+): T | null => {
+  const ordered = [...rows].sort((a, b) => {
+    for (const clause of orderBy) {
+      const settled = compareByClause(a, b, clause);
+      if (settled !== 0) return settled;
+    }
+    return 0;
+  });
+  return ordered[0] ?? null;
+};
+
+const dbHolding = (
+  rows: Array<OrderableRow & { plan: string; status: string }>,
+): PrismaClient =>
+  ({
+    subscription: {
+      findFirst: vi.fn(async (query?: { orderBy?: OrderByClause[] }) =>
+        firstUnder(rows, query?.orderBy ?? []),
+      ),
+    },
+    organization: {
+      findUnique: vi.fn().mockResolvedValue(undefined),
+    },
+  }) as unknown as PrismaClient;
+
 describe("getFreePlanLimits", () => {
   /** @scenario 'All pricing models get 50,000 events on the free tier' */
   it("returns 50,000 messages per month", () => {
@@ -66,17 +121,20 @@ describe("createSaaSPlanProvider", () => {
   });
 
   describe("when IS_SAAS is false", () => {
-    it("returns ENTERPRISE limits", async () => {
+    // Unreachable through the wiring, since a self-hosted deployment resolves
+    // its plan from the license provider. It answers the free baseline anyway:
+    // a deployment that reached this line by mistake must not be handed the
+    // entitlements the top tier carries.
+    it("returns the free baseline rather than a tier nobody bought", async () => {
       mockEnv.IS_SAAS = false;
 
       const db = createMockDb();
       const provider = createSaaSPlanProvider(db);
       const plan = await provider.getActivePlan("org_1");
 
-      expect(plan.type).toBe(PlanTypes.ENTERPRISE);
-      expect(plan.maxMembers).toBe(
-        PLAN_LIMITS[PlanTypes.ENTERPRISE].maxMembers,
-      );
+      expect(plan.type).toBe(PlanTypes.FREE);
+      expect(plan.maxMembers).toBe(PLAN_LIMITS[PlanTypes.FREE].maxMembers);
+      expect(plan.webhookEndpointsEnabled).not.toBe(true);
     });
   });
 
@@ -528,21 +586,51 @@ describe("createSaaSPlanProvider subscription selection", () => {
   });
 
   describe("given an organization holding more than one active subscription", () => {
-    it("reads the newest one rather than whichever the database returns first", async () => {
-      const db = createMockDb({
-        findFirstResult: {
-          organizationId: "org_1",
-          plan: PlanTypes.ENTERPRISE,
-          status: SubscriptionStatus.ACTIVE,
-        },
-      });
+    type ActiveRow = {
+      id: string;
+      organizationId: string;
+      plan: string;
+      status: string;
+      createdAt: Date;
+    };
 
-      await createSaaSPlanProvider(db).getActivePlan("org_1");
+    const NEWEST: ActiveRow = {
+      id: "sub_a",
+      organizationId: "org_1",
+      plan: PlanTypes.ENTERPRISE,
+      status: SubscriptionStatus.ACTIVE,
+      createdAt: new Date("2026-02-01T00:00:00.000Z"),
+    };
+    const OLDER: ActiveRow = {
+      id: "sub_z",
+      organizationId: "org_1",
+      plan: PlanTypes.PRO,
+      status: SubscriptionStatus.ACTIVE,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    };
 
-      const query = (
-        db.subscription.findFirst as unknown as { mock: { calls: unknown[][] } }
-      ).mock.calls[0]![0] as { orderBy?: unknown };
-      expect(query.orderBy).toEqual([{ createdAt: "desc" }, { id: "desc" }]);
+    const planFrom = async (rows: ActiveRow[]) =>
+      (await createSaaSPlanProvider(dbHolding(rows)).getActivePlan("org_1"))
+        .type;
+
+    it("reads the newest contract, not whichever row the database lists first", async () => {
+      // Handed over oldest-first, which is what a query with no ordering can
+      // hand back, so a dropped `orderBy` resolves PRO and fails here.
+      expect(await planFrom([OLDER, NEWEST])).toBe(PlanTypes.ENTERPRISE);
+    });
+
+    it("reads the same contract whichever order the rows arrive in", async () => {
+      expect(await planFrom([NEWEST, OLDER])).toBe(PlanTypes.ENTERPRISE);
+    });
+
+    it("settles two contracts created in the same instant on the id", async () => {
+      const instant = new Date("2026-02-01T00:00:00.000Z");
+      // Highest id wins, so the ENTERPRISE row does, and it is listed second
+      // to keep arrival order from being what decides.
+      const lower = { ...OLDER, id: "sub_a", createdAt: instant };
+      const higher = { ...NEWEST, id: "sub_z", createdAt: instant };
+
+      expect(await planFrom([lower, higher])).toBe(PlanTypes.ENTERPRISE);
     });
   });
 });

--- a/platform/app/ee/billing/planLimits.ts
+++ b/platform/app/ee/billing/planLimits.ts
@@ -141,6 +141,12 @@ export const PLAN_LIMITS: Record<PlanType, PlanInfo> = {
     name: "Enterprise",
     maxMembers: 1000,
     maxMessagesPerMonth: 1_000_000,
+    // Stated here as well as in the tier map (`ee/licensing/planEntitlements`),
+    // and deliberately not in PAID_FEATURES, which every paid plan shares.
+    // The preset is what this plan sells; the tier map is the net that catches
+    // a contract resolved some other way, such as a license signed before the
+    // feature existed.
+    webhookEndpointsEnabled: true,
     prices: {
       USD: 999,
       EUR: 999,

--- a/platform/app/ee/billing/planProvider.ts
+++ b/platform/app/ee/billing/planProvider.ts
@@ -50,6 +50,11 @@ export const createSaaSPlanProvider = (db: PrismaClient): SaaSPlanProvider => {
       const overrideAddingLimitations =
         !!user?.impersonator && isAdmin(user.impersonator);
 
+      // Unreachable through the wiring: a self-hosted deployment resolves
+      // its plan from the license provider, and this one is only constructed
+      // on the SaaS branch. It answers Enterprise, so a future caller that
+      // constructs this directly off Cloud would self-report Enterprise
+      // without a license.
       if (!env.IS_SAAS) {
         return {
           ...PLAN_LIMITS[PlanTypes.ENTERPRISE],
@@ -57,6 +62,10 @@ export const createSaaSPlanProvider = (db: PrismaClient): SaaSPlanProvider => {
         };
       }
 
+      // An organization is not supposed to hold two active subscriptions, but
+      // it can, and then which one answers decides the plan. Newest contract
+      // wins, with the id as a total order so the same row answers every time
+      // rather than whichever the database happens to hand back first.
       const activeSubscription = await db.subscription.findFirst({
         where: {
           organizationId,
@@ -64,6 +73,7 @@ export const createSaaSPlanProvider = (db: PrismaClient): SaaSPlanProvider => {
             in: [SubscriptionStatus.ACTIVE],
           },
         },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       });
 
       const customLimits: Partial<PlanInfo> = {};

--- a/platform/app/ee/billing/planProvider.ts
+++ b/platform/app/ee/billing/planProvider.ts
@@ -2,7 +2,7 @@ import type { PrismaClient, Subscription } from "@prisma/client";
 import { env } from "../../src/env.mjs";
 import type { PlanInfo } from "../licensing/planInfo";
 import { getFreePlanLimits, PLAN_LIMITS } from "./planLimits";
-import { PlanTypes, SubscriptionStatus } from "./planTypes";
+import { ACTIVE_SUBSCRIPTION_ORDER_BY, SubscriptionStatus } from "./planTypes";
 
 // Fields that exist on both PlanInfo (as number) and Subscription (as Int?)
 type NumericOverrideField = {
@@ -50,22 +50,22 @@ export const createSaaSPlanProvider = (db: PrismaClient): SaaSPlanProvider => {
       const overrideAddingLimitations =
         !!user?.impersonator && isAdmin(user.impersonator);
 
-      // Unreachable through the wiring: a self-hosted deployment resolves
-      // its plan from the license provider, and this one is only constructed
-      // on the SaaS branch. It answers Enterprise, so a future caller that
-      // constructs this directly off Cloud would self-report Enterprise
-      // without a license.
+      // Unreachable through the wiring: a self-hosted deployment resolves its
+      // plan from the license provider, and this one is only constructed on
+      // the SaaS branch. It answers the free baseline rather than a tier,
+      // because a plan resolved without a subscription and without a license
+      // is not a plan anyone bought. Answering Enterprise here would hand a
+      // deployment that reached this line by mistake every entitlement the
+      // top tier carries, signed webhook delivery included.
       if (!env.IS_SAAS) {
         return {
-          ...PLAN_LIMITS[PlanTypes.ENTERPRISE],
+          ...getFreePlanLimits(),
           overrideAddingLimitations,
         };
       }
 
       // An organization is not supposed to hold two active subscriptions, but
-      // it can, and then which one answers decides the plan. Newest contract
-      // wins, with the id as a total order so the same row answers every time
-      // rather than whichever the database happens to hand back first.
+      // it can, and then which one answers decides the plan.
       const activeSubscription = await db.subscription.findFirst({
         where: {
           organizationId,
@@ -73,7 +73,7 @@ export const createSaaSPlanProvider = (db: PrismaClient): SaaSPlanProvider => {
             in: [SubscriptionStatus.ACTIVE],
           },
         },
-        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        orderBy: [...ACTIVE_SUBSCRIPTION_ORDER_BY],
       });
 
       const customLimits: Partial<PlanInfo> = {};

--- a/platform/app/ee/billing/planTypes.ts
+++ b/platform/app/ee/billing/planTypes.ts
@@ -51,3 +51,45 @@ export const SubscriptionStatus = {
 
 export type SubscriptionStatus =
   (typeof SubscriptionStatus)[keyof typeof SubscriptionStatus];
+
+/**
+ * How plan resolution picks among an organization's active subscriptions:
+ * newest contract wins, with the id as a total order so the same row answers
+ * every time rather than whichever the database hands back first.
+ *
+ * Lives here, in a module with no imports of its own, so the query that
+ * applies it and the report that explains it read the same rule instead of
+ * restating it. `compareBySubscriptionOrder` is the in-memory reading of this
+ * same list, for callers holding rows rather than issuing a query.
+ */
+export const ACTIVE_SUBSCRIPTION_ORDER_BY = [
+  { createdAt: "desc" },
+  { id: "desc" },
+] as const;
+
+/**
+ * Orders already-fetched rows the way the database would.
+ *
+ * Relational comparison rather than `localeCompare`: Postgres orders text by
+ * the column's collation, which for these ids is byte order, while ICU
+ * collation can disagree on case and punctuation. The ids are lowercase
+ * alphanumeric today, so the two agree, but that is a property of the current
+ * id format rather than a guarantee.
+ */
+export function compareBySubscriptionOrder(
+  a: { id: string; createdAt: Date },
+  b: { id: string; createdAt: Date },
+): number {
+  for (const clause of ACTIVE_SUBSCRIPTION_ORDER_BY) {
+    const [field, direction] = Object.entries(clause)[0] as [
+      "createdAt" | "id",
+      "desc",
+    ];
+    const left = a[field];
+    const right = b[field];
+    const ascending = left < right ? -1 : left > right ? 1 : 0;
+    const ordered = direction === "desc" ? -ascending : ascending;
+    if (ordered !== 0) return ordered;
+  }
+  return 0;
+}

--- a/platform/app/ee/licensing/__tests__/defaults.unit.test.ts
+++ b/platform/app/ee/licensing/__tests__/defaults.unit.test.ts
@@ -134,7 +134,7 @@ describe("resolvePlanDefaults", () => {
       maxMembersLite: 3,
       maxMessagesPerMonth: 50_000,
       canPublish: false,
-      webhookEndpointsEnabled: false,
+      webhookEndpointsEnabled: undefined,
       usageUnit: "traces",
     });
     expect("maxProjects" in resolved).toBe(false);
@@ -167,7 +167,7 @@ describe("resolvePlanDefaults", () => {
     expect(allFields).toEqual(resolved);
   });
 
-  it("defaults the webhook entitlement to false and honors an explicit true", () => {
+  it("leaves the webhook entitlement unanswered and honors an explicit true", () => {
     const withoutFlag = resolvePlanDefaults({
       type: "TEST",
       name: "Test",
@@ -177,8 +177,9 @@ describe("resolvePlanDefaults", () => {
       maxWorkflows: 10,
       canPublish: false,
     });
-    // A paid feature must never leak by default.
-    expect(withoutFlag.webhookEndpointsEnabled).toBe(false);
+    // A paid feature never leaks by default: an unanswered entitlement is
+    // decided by the plan's tier, and no tier grants it below enterprise.
+    expect(withoutFlag.webhookEndpointsEnabled).toBeUndefined();
 
     const withFlag = resolvePlanDefaults({
       type: "TEST",
@@ -191,5 +192,43 @@ describe("resolvePlanDefaults", () => {
       webhookEndpointsEnabled: true,
     });
     expect(withFlag.webhookEndpointsEnabled).toBe(true);
+  });
+});
+
+describe("resolvePlanDefaults and the webhook endpoints entitlement", () => {
+  const licenseWith = (
+    overrides: Partial<LicensePlanLimits> = {},
+  ): LicensePlanLimits => ({
+    type: "ENTERPRISE",
+    name: "Enterprise",
+    maxMembers: 100,
+    maxMessagesPerMonth: 1_000_000,
+    canPublish: true,
+    ...overrides,
+  });
+
+  describe("given a payload that omits it", () => {
+    /** @scenario A licensed webhook entitlement survives the PlanInfo mapping */
+    it("says nothing rather than no, leaving the tier to decide", () => {
+      expect(
+        resolvePlanDefaults(licenseWith()).webhookEndpointsEnabled,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("given a payload that answers explicitly", () => {
+    it("keeps a stated false", () => {
+      expect(
+        resolvePlanDefaults(licenseWith({ webhookEndpointsEnabled: false }))
+          .webhookEndpointsEnabled,
+      ).toBe(false);
+    });
+
+    it("keeps a stated true", () => {
+      expect(
+        resolvePlanDefaults(licenseWith({ webhookEndpointsEnabled: true }))
+          .webhookEndpointsEnabled,
+      ).toBe(true);
+    });
   });
 });

--- a/platform/app/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
+++ b/platform/app/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_LIMIT } from "../constants";
 import { generateLicenseKey } from "../licenseGenerationService";
-import { GROWTH_TEMPLATE } from "../planTemplates";
+import { ENTERPRISE_TEMPLATE, GROWTH_TEMPLATE } from "../planTemplates";
 import { validateLicense } from "../validation";
 import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from "./fixtures/testKeys";
 
@@ -301,6 +301,70 @@ dQIDAQAB
       });
 
       expect(result.valid).toBe(false);
+    });
+  });
+});
+
+describe("generateLicenseKey overrides", () => {
+  const enterpriseParams = {
+    ...baseParams,
+    planType: "ENTERPRISE",
+    maxMembers: 10_000,
+  };
+
+  describe("given no overrides", () => {
+    it("takes the template's numbers and a one-year expiry", () => {
+      const { licenseData } = generateLicenseKey(enterpriseParams);
+
+      expect(licenseData.plan.maxMembersLite).toBe(
+        ENTERPRISE_TEMPLATE.maxMembersLite,
+      );
+      expect(licenseData.plan.maxMessagesPerMonth).toBe(
+        ENTERPRISE_TEMPLATE.maxMessagesPerMonth,
+      );
+      expect(licenseData.expiresAt).toBe("2026-06-15T12:00:00.000Z");
+    });
+  });
+
+  describe("given the numbers a negotiated contract sets", () => {
+    it("mints those rather than quietly cutting them to the template", () => {
+      const { licenseData } = generateLicenseKey({
+        ...enterpriseParams,
+        maxMembersLite: 10_000,
+        maxMessagesPerMonth: 10_000_000_000,
+        expiresAt: new Date("2030-02-05T00:00:00.000Z"),
+      });
+
+      expect(licenseData.plan.maxMembersLite).toBe(10_000);
+      expect(licenseData.plan.maxMessagesPerMonth).toBe(10_000_000_000);
+      expect(licenseData.expiresAt).toBe("2030-02-05T00:00:00.000Z");
+    });
+
+    it("still round-trips signature validation", () => {
+      const { licenseKey } = generateLicenseKey({
+        ...enterpriseParams,
+        maxMembersLite: 10_000,
+        expiresAt: new Date("2030-02-05T00:00:00.000Z"),
+      });
+
+      expect(
+        validateLicense({
+          licenseKey,
+          publicKey: TEST_PUBLIC_KEY,
+          now: baseParams.now,
+        }).valid,
+      ).toBe(true);
+    });
+  });
+
+  describe("given an expiry that has already passed", () => {
+    it("refuses to mint a license that is dead on arrival", () => {
+      expect(() =>
+        generateLicenseKey({
+          ...enterpriseParams,
+          expiresAt: new Date("2025-06-14T12:00:00Z"),
+        }),
+      ).toThrow(/future/i);
     });
   });
 });

--- a/platform/app/ee/licensing/__tests__/planEntitlements.unit.test.ts
+++ b/platform/app/ee/licensing/__tests__/planEntitlements.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { PlanTypes } from "../../billing/planTypes";
+import { UNLIMITED_PLAN } from "../constants";
+import {
+  applyPlanTypeEntitlements,
+  ENTITLEMENTS_BY_PLAN_TYPE,
+} from "../planEntitlements";
+import type { PlanInfo } from "../planInfo";
+
+/**
+ * Spec: specs/licensing/plan-entitlements.feature
+ *
+ * The identity-preserving return is not a micro-optimization: callers
+ * downstream assert on object identity, so a plan with nothing to fill has to
+ * come back as itself.
+ */
+
+const enterprisePlan = (overrides: Partial<PlanInfo> = {}): PlanInfo => ({
+  planSource: "license",
+  type: PlanTypes.ENTERPRISE,
+  name: "Enterprise",
+  free: false,
+  maxMembers: 100,
+  maxMembersLite: 50,
+  maxMessagesPerMonth: 10_000_000,
+  canPublish: true,
+  prices: { USD: 0, EUR: 0 },
+  ...overrides,
+});
+
+describe("applyPlanTypeEntitlements", () => {
+  describe("given an enterprise plan that says nothing about webhook endpoints", () => {
+    /** @scenario An enterprise license signed before the flag existed is entitled */
+    it("entitles it from its tier", () => {
+      const resolved = applyPlanTypeEntitlements(enterprisePlan());
+
+      expect(resolved.webhookEndpointsEnabled).toBe(true);
+    });
+
+    it("leaves everything else on the plan alone", () => {
+      const plan = enterprisePlan({ maxMembers: 7 });
+
+      const resolved = applyPlanTypeEntitlements(plan);
+
+      expect({ ...resolved, webhookEndpointsEnabled: undefined }).toEqual({
+        ...plan,
+        webhookEndpointsEnabled: undefined,
+      });
+    });
+  });
+
+  describe("given an enterprise plan that switches webhook endpoints off", () => {
+    /** @scenario An entitlement switched off in the payload stays off */
+    it("keeps it off, because an explicit answer is a decision", () => {
+      const resolved = applyPlanTypeEntitlements(
+        enterprisePlan({ webhookEndpointsEnabled: false }),
+      );
+
+      expect(resolved.webhookEndpointsEnabled).toBe(false);
+    });
+  });
+
+  describe("given a plan on a tier the map says nothing about", () => {
+    /** @scenario A plan below enterprise is not entitled */
+    it("adds no entitlement to it", () => {
+      const resolved = applyPlanTypeEntitlements(
+        enterprisePlan({ type: PlanTypes.GROWTH, name: "Growth" }),
+      );
+
+      expect(resolved.webhookEndpointsEnabled).toBeUndefined();
+    });
+
+    /** @scenario The unlicensed open-source baseline gains nothing from the tier map */
+    it("hands back the open-source baseline untouched", () => {
+      const resolved = applyPlanTypeEntitlements(UNLIMITED_PLAN);
+
+      expect(resolved).toBe(UNLIMITED_PLAN);
+    });
+  });
+
+  describe("given a plan with nothing left to fill", () => {
+    /** @scenario A plan that needs nothing filled in is handed back untouched */
+    it("returns the very same object", () => {
+      const plan = enterprisePlan({ webhookEndpointsEnabled: true });
+
+      expect(applyPlanTypeEntitlements(plan)).toBe(plan);
+    });
+  });
+
+  describe("given the tier map itself", () => {
+    /** @scenario Impersonation powers are not an entitlement of the enterprise tier */
+    it("does not carry authorization fields for any tier", () => {
+      for (const entitlements of Object.values(ENTITLEMENTS_BY_PLAN_TYPE)) {
+        expect("overrideAddingLimitations" in (entitlements ?? {})).toBe(false);
+      }
+    });
+
+    it("entitles webhook endpoints on enterprise and on nothing else", () => {
+      expect(Object.keys(ENTITLEMENTS_BY_PLAN_TYPE)).toEqual([
+        PlanTypes.ENTERPRISE,
+      ]);
+      expect(
+        ENTITLEMENTS_BY_PLAN_TYPE[PlanTypes.ENTERPRISE]
+          ?.webhookEndpointsEnabled,
+      ).toBe(true);
+    });
+  });
+});

--- a/platform/app/ee/licensing/__tests__/planMapping.unit.test.ts
+++ b/platform/app/ee/licensing/__tests__/planMapping.unit.test.ts
@@ -176,12 +176,20 @@ describe("mapToPlanInfo", () => {
   });
 
   /** @scenario A licensed webhook entitlement survives the PlanInfo mapping */
-  it("carries webhookEndpointsEnabled into PlanInfo, defaulting false when absent", () => {
+  it("carries webhookEndpointsEnabled into PlanInfo, leaving an omitted one to the tier", () => {
     const withFlag = mapToPlanInfo(
       createLicenseData({ webhookEndpointsEnabled: true }),
     );
     expect(withFlag.webhookEndpointsEnabled).toBe(true);
+
+    const explicitlyOff = mapToPlanInfo(
+      createLicenseData({ webhookEndpointsEnabled: false }),
+    );
+    expect(explicitlyOff.webhookEndpointsEnabled).toBe(false);
+
+    // Omitted stays omitted through the mapping. The plan's tier answers it at
+    // resolution, which is what entitles a license signed before the flag.
     const withoutFlag = mapToPlanInfo(createLicenseData({}));
-    expect(withoutFlag.webhookEndpointsEnabled).toBe(false);
+    expect(withoutFlag.webhookEndpointsEnabled).toBeUndefined();
   });
 });

--- a/platform/app/ee/licensing/defaults.ts
+++ b/platform/app/ee/licensing/defaults.ts
@@ -24,7 +24,7 @@ export type ResolvedPlanLimits = {
   maxMembersLite: number;
   maxMessagesPerMonth: number;
   canPublish: boolean;
-  webhookEndpointsEnabled: boolean;
+  webhookEndpointsEnabled: boolean | undefined;
   usageUnit: string;
 };
 
@@ -32,11 +32,17 @@ export type ResolvedPlanLimits = {
  * Resolves the enforced plan limits from a license payload, applying defaults
  * to optional fields that may be missing in older licenses:
  * - maxMembersLite: DEFAULT_MEMBERS_LITE (1)
- * - webhookEndpointsEnabled: false (licenses signed before the flag existed)
  * - usageUnit: "traces"
  *
+ * `webhookEndpointsEnabled` is deliberately NOT defaulted here. A payload that
+ * omits it has said nothing, and saying nothing has to stay distinguishable
+ * from saying no: the plan's tier decides it later (`planEntitlements.ts`),
+ * which is what entitles a license signed before the flag existed. Turning
+ * absent into false here would be an answer the contract never gave, and the
+ * tier map correctly refuses to overrule an explicit false.
+ *
  * @param plan - License plan limits (the signed payload)
- * @returns The enforced limits with all fields guaranteed to have values
+ * @returns The enforced limits, with the levers the license does set resolved
  */
 export function resolvePlanDefaults(
   plan: LicensePlanLimits,
@@ -48,7 +54,7 @@ export function resolvePlanDefaults(
     maxMessagesPerMonth: plan.maxMessagesPerMonth,
     canPublish: plan.canPublish,
     maxMembersLite: plan.maxMembersLite ?? DEFAULT_MEMBERS_LITE,
-    webhookEndpointsEnabled: plan.webhookEndpointsEnabled ?? false,
+    webhookEndpointsEnabled: plan.webhookEndpointsEnabled,
     usageUnit: KNOWN_USAGE_UNITS.includes(plan.usageUnit as any)
       ? plan.usageUnit!
       : "traces",

--- a/platform/app/ee/licensing/licenseGenerationService.ts
+++ b/platform/app/ee/licensing/licenseGenerationService.ts
@@ -9,6 +9,17 @@ interface GenerateLicenseKeyParams {
   planType: string;
   maxMembers: number;
   privateKey: string;
+  /**
+   * The numbers a negotiated contract sets, where they differ from the plan
+   * template. Left off, the template's value is minted. These exist because
+   * the template is a starting point, not the contract: minting a template
+   * number over an agreed one silently cuts what the customer bought, and a
+   * signed license is the enforcement.
+   */
+  maxMembersLite?: number;
+  maxMessagesPerMonth?: number;
+  /** Defaults to one year from `now`. */
+  expiresAt?: Date;
   /** Override current time for deterministic testing */
   now?: Date;
 }
@@ -29,6 +40,9 @@ export function generateLicenseKey({
   email,
   planType,
   maxMembers,
+  maxMembersLite,
+  maxMessagesPerMonth,
+  expiresAt: requestedExpiresAt,
   privateKey,
   now = new Date(),
 }: GenerateLicenseKeyParams): GenerateLicenseKeyResult {
@@ -39,8 +53,15 @@ export function generateLicenseKey({
 
   const seats = maxMembers > 0 ? maxMembers : 1;
 
-  const expiresAt = new Date(now);
-  expiresAt.setFullYear(expiresAt.getFullYear() + 1);
+  const oneYearOut = new Date(now);
+  oneYearOut.setFullYear(oneYearOut.getFullYear() + 1);
+  const expiresAt = requestedExpiresAt ?? oneYearOut;
+  // Same refusal the license router makes: an already-expired license reads as
+  // no license at all, which on Cloud silently drops the org onto whatever
+  // sits underneath it.
+  if (expiresAt <= now) {
+    throw new Error("Expiration date must be in the future");
+  }
 
   const resolvedOrgName = organizationName.trim() || email;
 
@@ -51,8 +72,8 @@ export function generateLicenseKey({
     type: template.type,
     name: template.name,
     maxMembers: seats,
-    maxMembersLite: template.maxMembersLite,
-    maxMessagesPerMonth: template.maxMessagesPerMonth,
+    maxMembersLite: maxMembersLite ?? template.maxMembersLite,
+    maxMessagesPerMonth: maxMessagesPerMonth ?? template.maxMessagesPerMonth,
     canPublish: template.canPublish,
     webhookEndpointsEnabled: template.webhookEndpointsEnabled,
     usageUnit: template.usageUnit,

--- a/platform/app/ee/licensing/licenseGenerationService.ts
+++ b/platform/app/ee/licensing/licenseGenerationService.ts
@@ -56,6 +56,12 @@ export function generateLicenseKey({
   const oneYearOut = new Date(now);
   oneYearOut.setFullYear(oneYearOut.getFullYear() + 1);
   const expiresAt = requestedExpiresAt ?? oneYearOut;
+  // An unparseable date compares false against everything, so it would slip
+  // past the expiry check below and only fail further down, as a RangeError
+  // out of toISOString that names nothing.
+  if (Number.isNaN(expiresAt.getTime())) {
+    throw new Error("Expiration date is not a date");
+  }
   // Same refusal the license router makes: an already-expired license reads as
   // no license at all, which on Cloud silently drops the org onto whatever
   // sits underneath it.

--- a/platform/app/ee/licensing/planEntitlements.ts
+++ b/platform/app/ee/licensing/planEntitlements.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+import { PlanTypes } from "../billing/planTypes";
+import type { PlanInfo } from "./planInfo";
+
+/**
+ * The entitlements a plan tier carries, applied wherever a plan is resolved.
+ *
+ * An entitlement that belongs to a tier is decided from the tier, not copied
+ * into every contract. A flag written after a contract was signed still
+ * reaches that contract, because nothing about the tier changed when the flag
+ * was written, and neither leg of resolution has to be re-run: a signed
+ * license minted years ago and a subscription row created this morning both
+ * arrive on enterprise and both come out entitled.
+ *
+ * Only fields the plan leaves `undefined` are filled. An explicit value is a
+ * decision and always wins, including an explicit `false`: a contract that
+ * withholds a tier feature has to keep withholding it.
+ *
+ * WHAT BELONGS IN THIS MAP: entitlement, meaning what the plan grants. What
+ * does NOT belong: authorization, meaning what a particular reader may do.
+ * `PlanInfo` carries exactly two optional booleans and they sit on opposite
+ * sides of that line. `webhookEndpointsEnabled` is entitlement and is mapped
+ * here. `overrideAddingLimitations` is authorization: it says the reader is an
+ * admin impersonating somebody, the composite provider recomputes it from the
+ * impersonation context on every call, and the unlicensed baseline sets it
+ * true. Deriving it from a tier would hand every enterprise reader the power
+ * to bypass the limits their own plan sets. A future optional flag picks a
+ * side here before it picks a default anywhere else.
+ *
+ * `floorAtOssBaseline` is a different rule and stays where it is: it is
+ * self-hosted policy about what a license may not withdraw, applied on the
+ * license leg only. This map is about what a tier grants, on every leg.
+ */
+type TierEntitlements = Partial<Pick<PlanInfo, "webhookEndpointsEnabled">>;
+
+export const ENTITLEMENTS_BY_PLAN_TYPE: Partial<
+  Record<string, TierEntitlements>
+> = {
+  [PlanTypes.ENTERPRISE]: { webhookEndpointsEnabled: true },
+};
+
+/**
+ * Fills in the entitlements the plan's tier grants and it has not answered.
+ *
+ * Returns the plan itself when there is nothing to fill, so a resolved plan
+ * keeps its identity through this step.
+ */
+export function applyPlanTypeEntitlements(plan: PlanInfo): PlanInfo {
+  const entitlements = ENTITLEMENTS_BY_PLAN_TYPE[plan.type];
+  if (!entitlements) return plan;
+
+  let filled: PlanInfo | undefined;
+  for (const field of Object.keys(entitlements) as Array<
+    keyof TierEntitlements
+  >) {
+    if (plan[field] !== undefined) continue;
+    filled ??= { ...plan };
+    filled[field] = entitlements[field];
+  }
+
+  return filled ?? plan;
+}

--- a/platform/app/ee/licensing/planInfo.ts
+++ b/platform/app/ee/licensing/planInfo.ts
@@ -24,9 +24,13 @@ export type PlanInfo = {
   maxMessagesPerMonth: number;
   canPublish: boolean;
   /**
-   * Webhook endpoints platform (signed outbound event delivery). Enterprise
-   * feature: absent/false on free, PRO, and GROWTH plans; enterprise
-   * licenses and subscriptions carry true.
+   * Webhook endpoints platform (signed outbound event delivery). An
+   * enterprise feature, and the tier is what decides it: absent means the
+   * plan said nothing and its tier answers at resolution
+   * (`planEntitlements.ts`), which is how a contract signed before this
+   * field existed is still entitled. An explicit `false` is a decision and
+   * survives resolution, so a contract may withhold it. Nothing below
+   * enterprise grants it.
    */
   webhookEndpointsEnabled?: boolean;
   /**

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -479,7 +479,6 @@ const LEGACY_INERT: string[] = [
   "specs/licensing/license-status-ui.feature",
   "specs/licensing/notification-coverage-gaps.feature",
   "specs/licensing/resource-limit-notifications.feature",
-  "specs/licensing/subscription-page.feature",
   "specs/licensing/usage-page-navigation.feature",
   "specs/mcp-server/analytics-tool.feature",
   "specs/mcp-server/api-key-tools.feature",

--- a/platform/app/scripts/generate-license.ts
+++ b/platform/app/scripts/generate-license.ts
@@ -132,6 +132,46 @@ interface CliArgs {
   email?: string;
 }
 
+/**
+ * A quota is a whole number of seats or messages, so anything else is a typo
+ * worth stopping on. `Number.parseInt` would read "50GB" as 50 and "1.9" as 1,
+ * and the operator would sign a license carrying a number they never asked
+ * for.
+ */
+function parseQuota(flag: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    process.stderr.write(
+      `Error: ${flag} must be a whole number, got: ${value}\n\n`,
+    );
+    printUsage();
+    process.exit(2);
+  }
+  return parsed;
+}
+
+/**
+ * `new Date("2025-02-31")` rolls forward to March 3rd rather than refusing, so
+ * a mistyped day silently mints a license expiring on a date nobody chose. The
+ * round trip through the parsed date is what catches it.
+ */
+function parseExpiresAt(value: string): Date {
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T00:00:00.000Z`)
+    : new Date(Number.NaN);
+  if (
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    process.stderr.write(
+      `Error: --expires-at must be a calendar date as YYYY-MM-DD, got: ${value}\n\n`,
+    );
+    printUsage();
+    process.exit(2);
+  }
+  return parsed;
+}
+
 function parseArgs(argv: string[]): CliArgs {
   const args: Partial<CliArgs> = { plan: "ENTERPRISE" };
   for (let i = 0; i < argv.length; i++) {
@@ -144,22 +184,16 @@ function parseArgs(argv: string[]): CliArgs {
       args.plan = value.toUpperCase();
       i++;
     } else if (flag === "--max-members" && value) {
-      args.maxMembers = Number.parseInt(value, 10);
+      args.maxMembers = parseQuota(flag, value);
       i++;
     } else if (flag === "--max-members-lite" && value) {
-      args.maxMembersLite = Number.parseInt(value, 10);
+      args.maxMembersLite = parseQuota(flag, value);
       i++;
     } else if (flag === "--max-messages-per-month" && value) {
-      args.maxMessagesPerMonth = Number.parseInt(value, 10);
+      args.maxMessagesPerMonth = parseQuota(flag, value);
       i++;
     } else if (flag === "--expires-at" && value) {
-      const parsed = new Date(value);
-      if (Number.isNaN(parsed.getTime())) {
-        process.stderr.write(`Error: --expires-at is not a date: ${value}\n\n`);
-        printUsage();
-        process.exit(2);
-      }
-      args.expiresAt = parsed;
+      args.expiresAt = parseExpiresAt(value);
       i++;
     } else if (flag === "--email" && value) {
       args.email = value;

--- a/platform/app/scripts/generate-license.ts
+++ b/platform/app/scripts/generate-license.ts
@@ -16,10 +16,15 @@
  *        --org-id <organizationId> \
  *        --plan ENTERPRISE \
  *        [--max-members 50] \
+ *        [--max-members-lite 10000] \
+ *        [--max-messages-per-month 10000000000] \
+ *        [--expires-at 2030-02-05] \
  *        [--email ops@example.com]
  *
  *      Default plan: ENTERPRISE. Default max-members: 50. Default
- *      email: <orgSlug>@local.test.
+ *      email: <orgSlug>@local.test. Everything else defaults to the
+ *      plan template, so a contract with negotiated numbers has to
+ *      pass them: the template's value is what gets enforced.
  *
  *   2. Programmatic — seed/QA scripts import { applyLicenseToOrg }:
  *
@@ -45,6 +50,12 @@ interface ApplyLicenseInput {
   planType: string;
   /** Defaults to 50 — high enough that no realistic dev/QA org bumps the seat ceiling. */
   maxMembers?: number;
+  /** Defaults to the plan template's value. */
+  maxMembersLite?: number;
+  /** Defaults to the plan template's value. */
+  maxMessagesPerMonth?: number;
+  /** Defaults to one year out. Must be in the future. */
+  expiresAt?: Date;
   /** Defaults to `<orgSlug>@local.test`. */
   email?: string;
   privateKey: string;
@@ -79,6 +90,13 @@ export async function applyLicenseToOrg(
     email,
     planType: input.planType,
     maxMembers,
+    ...(input.maxMembersLite !== undefined
+      ? { maxMembersLite: input.maxMembersLite }
+      : {}),
+    ...(input.maxMessagesPerMonth !== undefined
+      ? { maxMessagesPerMonth: input.maxMessagesPerMonth }
+      : {}),
+    ...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
     privateKey: input.privateKey,
   });
 
@@ -87,9 +105,10 @@ export async function applyLicenseToOrg(
     data: {
       license: licenseKey,
       licenseExpiresAt: new Date(licenseData.expiresAt),
-      // Force the next request through the validation cache so the new
-      // license takes effect immediately instead of waiting for the
-      // licenseLastValidatedAt TTL.
+      // Cleared so the stamp describes this license rather than the one it
+      // replaced. Nothing reads it as a cache or a TTL: the license is read
+      // from this row and verified on every request, so the new one takes
+      // effect on the next call either way.
       licenseLastValidatedAt: null,
     },
   });
@@ -107,6 +126,9 @@ interface CliArgs {
   orgId: string;
   plan: string;
   maxMembers?: number;
+  maxMembersLite?: number;
+  maxMessagesPerMonth?: number;
+  expiresAt?: Date;
   email?: string;
 }
 
@@ -123,6 +145,21 @@ function parseArgs(argv: string[]): CliArgs {
       i++;
     } else if (flag === "--max-members" && value) {
       args.maxMembers = Number.parseInt(value, 10);
+      i++;
+    } else if (flag === "--max-members-lite" && value) {
+      args.maxMembersLite = Number.parseInt(value, 10);
+      i++;
+    } else if (flag === "--max-messages-per-month" && value) {
+      args.maxMessagesPerMonth = Number.parseInt(value, 10);
+      i++;
+    } else if (flag === "--expires-at" && value) {
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        process.stderr.write(`Error: --expires-at is not a date: ${value}\n\n`);
+        printUsage();
+        process.exit(2);
+      }
+      args.expiresAt = parsed;
       i++;
     } else if (flag === "--email" && value) {
       args.email = value;
@@ -151,11 +188,20 @@ function printUsage() {
       "      --org-id <organizationId> \\",
       "      [--plan ENTERPRISE|GROWTH|PRO]   (default: ENTERPRISE)",
       "      [--max-members <N>]              (default: 50)",
+      "      [--max-members-lite <N>]         (default: the plan template)",
+      "      [--max-messages-per-month <N>]   (default: the plan template)",
+      "      [--expires-at <YYYY-MM-DD>]      (default: one year out)",
       "      [--email <addr>]                 (default: <orgSlug>@local.test)",
+      "",
+      "Anything left off is minted from the plan template, so pass the numbers",
+      "a negotiated contract sets or the license will enforce the template's.",
       "",
       "Reads LANGWATCH_LICENSE_PRIVATE_KEY from env. The matching public",
       "key must be set as LANGWATCH_LICENSE_PUBLIC_KEY for the runtime",
       "license-enforcement layer to verify it.",
+      "",
+      "Writes Organization.license directly. It does not go through",
+      "validateAndStoreLicense, so it provisions no retention rules.",
       "",
     ].join("\n"),
   );
@@ -178,6 +224,9 @@ async function main() {
     organizationId: args.orgId,
     planType: args.plan,
     maxMembers: args.maxMembers,
+    maxMembersLite: args.maxMembersLite,
+    maxMessagesPerMonth: args.maxMessagesPerMonth,
+    expiresAt: args.expiresAt,
     email: args.email,
     privateKey,
   });

--- a/platform/app/scripts/report-duplicate-subscriptions.ts
+++ b/platform/app/scripts/report-duplicate-subscriptions.ts
@@ -1,0 +1,156 @@
+/**
+ * READ-ONLY. Reports organizations holding more than one active subscription,
+ * and which row plan resolution now picks for them.
+ *
+ * This script issues SELECT queries only. It performs no INSERT, UPDATE or
+ * DELETE and opens no transaction, so it is safe to point at production. It
+ * proposes nothing and deletes nothing: which of a customer's duplicate rows
+ * is the real contract is a billing decision, not a query result.
+ *
+ * An organization is not supposed to hold two active subscriptions. When it
+ * does, the plan comes from whichever row answers first, so the report shows
+ * the winner under the ordering plan resolution applies (newest created, id as
+ * the tiebreak). A duplicate is only invisible while the two rows agree; the
+ * moment they disagree on plan or on a seat override, the organization's plan
+ * depends on row order.
+ *
+ * The pending census is the other half of the picture. Abandoned checkouts
+ * accumulate as PENDING rows forever, and a large count is the signal that
+ * nothing expires them rather than that customers are mid-purchase.
+ *
+ * The counts are a shape, not a ledger. There is no snapshot around the reads,
+ * so a row written while it runs may or may not be seen.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... pnpm tsx scripts/report-duplicate-subscriptions.ts
+ */
+import { PrismaClient } from "@prisma/client";
+
+const ACTIVE = "ACTIVE";
+const PENDING = "PENDING";
+
+type SubscriptionRow = {
+  id: string;
+  organizationId: string;
+  plan: string | null;
+  status: string;
+  createdAt: Date;
+  stripeSubscriptionId: string | null;
+};
+
+/**
+ * The row plan resolution reads: newest created wins, with the id as a total
+ * order so the same row answers every time. Mirrors the `orderBy` on
+ * `createSaaSPlanProvider`; if that ordering changes, this changes with it or
+ * the report stops describing what the product does.
+ */
+function resolutionWinner(rows: SubscriptionRow[]): SubscriptionRow {
+  return [...rows].sort((a, b) => {
+    const byCreatedAt = b.createdAt.getTime() - a.createdAt.getTime();
+    if (byCreatedAt !== 0) return byCreatedAt;
+    return b.id.localeCompare(a.id);
+  })[0]!;
+}
+
+function groupByOrganization(
+  rows: SubscriptionRow[],
+): Map<string, SubscriptionRow[]> {
+  const byOrganization = new Map<string, SubscriptionRow[]>();
+  for (const row of rows) {
+    const existing = byOrganization.get(row.organizationId);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    byOrganization.set(row.organizationId, [row]);
+  }
+  return byOrganization;
+}
+
+function countBy<T>(rows: T[], key: (row: T) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const bucket = key(row);
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  return counts;
+}
+
+async function main(): Promise<void> {
+  // A client of its own rather than the app's singleton: this runs against a
+  // DATABASE_URL the operator points at, and must not pick up whatever the
+  // surrounding environment had configured.
+  const prisma = new PrismaClient();
+  try {
+    const select = {
+      id: true,
+      organizationId: true,
+      plan: true,
+      status: true,
+      createdAt: true,
+      stripeSubscriptionId: true,
+    } as const;
+
+    const active = (await prisma.subscription.findMany({
+      where: { status: ACTIVE },
+      select,
+    })) as SubscriptionRow[];
+
+    const byOrganization = groupByOrganization(active);
+    const duplicated = [...byOrganization.entries()].filter(
+      ([, rows]) => rows.length > 1,
+    );
+
+    console.log(`active subscriptions: ${active.length}`);
+    console.log(`organizations holding one: ${byOrganization.size}`);
+    console.log(`organizations holding more than one: ${duplicated.length}`);
+
+    for (const [organizationId, rows] of duplicated) {
+      const winner = resolutionWinner(rows);
+      const plans = new Set(rows.map((row) => row.plan ?? "unknown"));
+      console.log("");
+      console.log(`organization ${organizationId}`);
+      console.log(
+        `  rows: ${rows.length}, distinct plans: ${[...plans].join(", ")}`,
+      );
+      for (const row of rows) {
+        const marker = row.id === winner.id ? "picked " : "       ";
+        console.log(
+          `  ${marker}${row.id}  ${row.plan ?? "unknown"}  created ${row.createdAt.toISOString()}  stripe ${
+            row.stripeSubscriptionId ?? "none"
+          }`,
+        );
+      }
+    }
+
+    const pending = (await prisma.subscription.findMany({
+      where: { status: PENDING },
+      select,
+    })) as SubscriptionRow[];
+
+    console.log("");
+    console.log(`pending subscriptions: ${pending.length}`);
+    console.log(
+      `organizations with a pending subscription: ${groupByOrganization(pending).size}`,
+    );
+    const pendingByPlan = countBy(pending, (row) => row.plan ?? "unknown");
+    for (const [plan, count] of [...pendingByPlan.entries()].sort(
+      (a, b) => b[1] - a[1],
+    )) {
+      console.log(`  ${plan.padEnd(28)} ${count}`);
+    }
+    const oldestPending = pending
+      .map((row) => row.createdAt)
+      .sort((a, b) => a.getTime() - b.getTime())[0];
+    if (oldestPending) {
+      console.log(`  oldest pending: ${oldestPending.toISOString()}`);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/platform/app/scripts/report-duplicate-subscriptions.ts
+++ b/platform/app/scripts/report-duplicate-subscriptions.ts
@@ -9,8 +9,9 @@
  *
  * An organization is not supposed to hold two active subscriptions. When it
  * does, the plan comes from whichever row answers first, so the report shows
- * the winner under the ordering plan resolution applies (newest created, id as
- * the tiebreak). A duplicate is only invisible while the two rows agree; the
+ * the winner under the ordering plan resolution applies, read from the same
+ * exported rule the query uses. A duplicate is only invisible while the two
+ * rows agree; the
  * moment they disagree on plan or on a seat override, the organization's plan
  * depends on row order.
  *
@@ -24,32 +25,37 @@
  * Usage:
  *   DATABASE_URL=postgres://... pnpm tsx scripts/report-duplicate-subscriptions.ts
  */
-import { PrismaClient } from "@prisma/client";
+import { type Prisma, PrismaClient } from "@prisma/client";
+import {
+  compareBySubscriptionOrder,
+  SubscriptionStatus,
+} from "../ee/billing/planTypes";
 
-const ACTIVE = "ACTIVE";
-const PENDING = "PENDING";
-
-type SubscriptionRow = {
-  id: string;
-  organizationId: string;
-  plan: string | null;
-  status: string;
-  createdAt: Date;
-  stripeSubscriptionId: string | null;
-};
+const SUBSCRIPTION_SELECT = {
+  id: true,
+  organizationId: true,
+  plan: true,
+  status: true,
+  createdAt: true,
+  stripeSubscriptionId: true,
+} as const;
 
 /**
- * The row plan resolution reads: newest created wins, with the id as a total
- * order so the same row answers every time. Mirrors the `orderBy` on
- * `createSaaSPlanProvider`; if that ordering changes, this changes with it or
- * the report stops describing what the product does.
+ * Derived from the selection rather than written out, so dropping a field from
+ * `SUBSCRIPTION_SELECT` is a compile error here instead of an `undefined` the
+ * report reads at runtime.
+ */
+type SubscriptionRow = Prisma.SubscriptionGetPayload<{
+  select: typeof SUBSCRIPTION_SELECT;
+}>;
+
+/**
+ * The row plan resolution reads. Both the query and this report order by the
+ * one rule exported from `planTypes`, so the report cannot describe a winner
+ * the product would not pick.
  */
 function resolutionWinner(rows: SubscriptionRow[]): SubscriptionRow {
-  return [...rows].sort((a, b) => {
-    const byCreatedAt = b.createdAt.getTime() - a.createdAt.getTime();
-    if (byCreatedAt !== 0) return byCreatedAt;
-    return b.id.localeCompare(a.id);
-  })[0]!;
+  return [...rows].sort(compareBySubscriptionOrder)[0]!;
 }
 
 function groupByOrganization(
@@ -76,75 +82,80 @@ function countBy<T>(rows: T[], key: (row: T) => string): Map<string, number> {
   return counts;
 }
 
+function reportDuplicateOrganization(
+  organizationId: string,
+  rows: SubscriptionRow[],
+): void {
+  const winner = resolutionWinner(rows);
+  const plans = new Set(rows.map((row) => row.plan ?? "unknown"));
+  console.log("");
+  console.log(`organization ${organizationId}`);
+  console.log(
+    `  rows: ${rows.length}, distinct plans: ${[...plans].join(", ")}`,
+  );
+  for (const row of rows) {
+    const marker = row.id === winner.id ? "picked " : "       ";
+    console.log(
+      `  ${marker}${row.id}  ${row.plan ?? "unknown"}  created ${row.createdAt.toISOString()}  stripe ${
+        row.stripeSubscriptionId ?? "none"
+      }`,
+    );
+  }
+}
+
+function reportActive(active: SubscriptionRow[]): void {
+  const byOrganization = groupByOrganization(active);
+  const duplicated = [...byOrganization.entries()].filter(
+    ([, rows]) => rows.length > 1,
+  );
+
+  console.log(`active subscriptions: ${active.length}`);
+  console.log(`organizations holding one: ${byOrganization.size}`);
+  console.log(`organizations holding more than one: ${duplicated.length}`);
+
+  for (const [organizationId, rows] of duplicated) {
+    reportDuplicateOrganization(organizationId, rows);
+  }
+}
+
+function reportPending(pending: SubscriptionRow[]): void {
+  console.log("");
+  console.log(`pending subscriptions: ${pending.length}`);
+  console.log(
+    `organizations with a pending subscription: ${groupByOrganization(pending).size}`,
+  );
+  const pendingByPlan = countBy(pending, (row) => row.plan ?? "unknown");
+  for (const [plan, count] of [...pendingByPlan.entries()].sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    console.log(`  ${plan.padEnd(28)} ${count}`);
+  }
+  const oldestPending = pending
+    .map((row) => row.createdAt)
+    .sort((a, b) => a.getTime() - b.getTime())[0];
+  if (oldestPending) {
+    console.log(`  oldest pending: ${oldestPending.toISOString()}`);
+  }
+}
+
 async function main(): Promise<void> {
   // A client of its own rather than the app's singleton: this runs against a
   // DATABASE_URL the operator points at, and must not pick up whatever the
   // surrounding environment had configured.
   const prisma = new PrismaClient();
   try {
-    const select = {
-      id: true,
-      organizationId: true,
-      plan: true,
-      status: true,
-      createdAt: true,
-      stripeSubscriptionId: true,
-    } as const;
-
-    const active = (await prisma.subscription.findMany({
-      where: { status: ACTIVE },
-      select,
-    })) as SubscriptionRow[];
-
-    const byOrganization = groupByOrganization(active);
-    const duplicated = [...byOrganization.entries()].filter(
-      ([, rows]) => rows.length > 1,
+    reportActive(
+      await prisma.subscription.findMany({
+        where: { status: SubscriptionStatus.ACTIVE },
+        select: SUBSCRIPTION_SELECT,
+      }),
     );
-
-    console.log(`active subscriptions: ${active.length}`);
-    console.log(`organizations holding one: ${byOrganization.size}`);
-    console.log(`organizations holding more than one: ${duplicated.length}`);
-
-    for (const [organizationId, rows] of duplicated) {
-      const winner = resolutionWinner(rows);
-      const plans = new Set(rows.map((row) => row.plan ?? "unknown"));
-      console.log("");
-      console.log(`organization ${organizationId}`);
-      console.log(
-        `  rows: ${rows.length}, distinct plans: ${[...plans].join(", ")}`,
-      );
-      for (const row of rows) {
-        const marker = row.id === winner.id ? "picked " : "       ";
-        console.log(
-          `  ${marker}${row.id}  ${row.plan ?? "unknown"}  created ${row.createdAt.toISOString()}  stripe ${
-            row.stripeSubscriptionId ?? "none"
-          }`,
-        );
-      }
-    }
-
-    const pending = (await prisma.subscription.findMany({
-      where: { status: PENDING },
-      select,
-    })) as SubscriptionRow[];
-
-    console.log("");
-    console.log(`pending subscriptions: ${pending.length}`);
-    console.log(
-      `organizations with a pending subscription: ${groupByOrganization(pending).size}`,
+    reportPending(
+      await prisma.subscription.findMany({
+        where: { status: SubscriptionStatus.PENDING },
+        select: SUBSCRIPTION_SELECT,
+      }),
     );
-    const pendingByPlan = countBy(pending, (row) => row.plan ?? "unknown");
-    for (const [plan, count] of [...pendingByPlan.entries()].sort(
-      (a, b) => b[1] - a[1],
-    )) {
-      console.log(`  ${plan.padEnd(28)} ${count}`);
-    }
-    const oldestPending = pending
-      .map((row) => row.createdAt)
-      .sort((a, b) => a.getTime() - b.getTime())[0];
-    if (oldestPending) {
-      console.log(`  oldest pending: ${oldestPending.toISOString()}`);
-    }
   } finally {
     await prisma.$disconnect();
   }

--- a/platform/app/src/components/license/LicenseGeneratorForm.tsx
+++ b/platform/app/src/components/license/LicenseGeneratorForm.tsx
@@ -71,6 +71,9 @@ interface FormData {
   maxMembersLite: number;
   maxMessagesPerMonth: number;
   canPublish: boolean;
+  /** Undefined while a plan template says nothing about it; sent as a definite
+   * answer, so what the operator sees ticked is what the license carries. */
+  webhookEndpointsEnabled?: boolean;
   usageUnit: "traces" | "events";
 }
 
@@ -92,6 +95,7 @@ const defaultFormData: FormData = {
   maxMembersLite: ENTERPRISE_TEMPLATE.maxMembersLite ?? 50,
   maxMessagesPerMonth: ENTERPRISE_TEMPLATE.maxMessagesPerMonth,
   canPublish: ENTERPRISE_TEMPLATE.canPublish,
+  webhookEndpointsEnabled: ENTERPRISE_TEMPLATE.webhookEndpointsEnabled,
   usageUnit: (ENTERPRISE_TEMPLATE.usageUnit as "traces" | "events") ?? "events",
 };
 
@@ -250,6 +254,7 @@ export const LicenseGeneratorForm = forwardRef<
         maxMembersLite: formData.maxMembersLite,
         maxMessagesPerMonth: formData.maxMessagesPerMonth,
         canPublish: formData.canPublish,
+        webhookEndpointsEnabled: !!formData.webhookEndpointsEnabled,
         usageUnit: formData.usageUnit,
       },
     });
@@ -567,6 +572,19 @@ export const LicenseGeneratorForm = forwardRef<
             <Checkbox.Control />
             <Checkbox.Label fontSize="xs" color="fg.muted">
               Enabled to publish Workflows publicly
+            </Checkbox.Label>
+          </Checkbox.Root>
+
+          <Checkbox.Root
+            checked={!!formData.webhookEndpointsEnabled}
+            onCheckedChange={(e) =>
+              handleInputChange("webhookEndpointsEnabled", !!e.checked)
+            }
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label fontSize="xs" color="fg.muted">
+              Enable webhook endpoints and gateway spend APIs
             </Checkbox.Label>
           </Checkbox.Root>
         </VStack>

--- a/platform/app/src/components/license/__tests__/planFormDefaults.unit.test.ts
+++ b/platform/app/src/components/license/__tests__/planFormDefaults.unit.test.ts
@@ -9,6 +9,14 @@ import {
   type PlanType,
 } from "../planFormDefaults";
 
+/**
+ * Spec: specs/licensing/license-generation.feature
+ *
+ * These defaults are both what the generator form shows and what it sends, so
+ * a field missing here is a field silently missing from every license minted
+ * through the product.
+ */
+
 describe("planFormDefaults", () => {
   describe("getPlanDefaults", () => {
     it("returns PRO template defaults for PRO plan", () => {
@@ -17,14 +25,9 @@ describe("planFormDefaults", () => {
       expect(defaults).toEqual({
         maxMembers: PRO_TEMPLATE.maxMembers,
         maxMembersLite: PRO_TEMPLATE.maxMembersLite,
-        maxProjects: PRO_TEMPLATE.maxProjects,
         maxMessagesPerMonth: PRO_TEMPLATE.maxMessagesPerMonth,
-        maxWorkflows: PRO_TEMPLATE.maxWorkflows,
-        maxPrompts: PRO_TEMPLATE.maxPrompts,
-        maxEvaluators: PRO_TEMPLATE.maxEvaluators,
-        maxScenarios: PRO_TEMPLATE.maxScenarios,
-        maxAgents: PRO_TEMPLATE.maxAgents,
         canPublish: PRO_TEMPLATE.canPublish,
+        webhookEndpointsEnabled: PRO_TEMPLATE.webhookEndpointsEnabled,
         usageUnit: PRO_TEMPLATE.usageUnit,
       });
     });
@@ -35,18 +38,14 @@ describe("planFormDefaults", () => {
       expect(defaults).toEqual({
         maxMembers: ENTERPRISE_TEMPLATE.maxMembers,
         maxMembersLite: ENTERPRISE_TEMPLATE.maxMembersLite,
-        maxProjects: ENTERPRISE_TEMPLATE.maxProjects,
         maxMessagesPerMonth: ENTERPRISE_TEMPLATE.maxMessagesPerMonth,
-        maxWorkflows: ENTERPRISE_TEMPLATE.maxWorkflows,
-        maxPrompts: ENTERPRISE_TEMPLATE.maxPrompts,
-        maxEvaluators: ENTERPRISE_TEMPLATE.maxEvaluators,
-        maxScenarios: ENTERPRISE_TEMPLATE.maxScenarios,
-        maxAgents: ENTERPRISE_TEMPLATE.maxAgents,
         canPublish: ENTERPRISE_TEMPLATE.canPublish,
+        webhookEndpointsEnabled: ENTERPRISE_TEMPLATE.webhookEndpointsEnabled,
         usageUnit: ENTERPRISE_TEMPLATE.usageUnit,
       });
     });
 
+    /** @scenario A custom contract carries only what it was given */
     it("returns empty object for CUSTOM plan", () => {
       const defaults = getPlanDefaults("CUSTOM");
 
@@ -90,6 +89,19 @@ describe("planFormDefaults", () => {
       expect(enterpriseDefaults.maxMessagesPerMonth).toBe(
         ENTERPRISE_TEMPLATE.maxMessagesPerMonth,
       );
+    });
+
+    describe("when the operator picks a plan for the webhook entitlement", () => {
+      /** @scenario The generator form mints what it shows */
+      it("ticks it for ENTERPRISE and clears it on a lesser plan", () => {
+        expect(PLAN_DEFAULTS.ENTERPRISE.webhookEndpointsEnabled).toBe(true);
+
+        // Present and undefined, not absent: the form spreads these over the
+        // current values, so an absent key would leave the box ticked after
+        // switching down from ENTERPRISE.
+        expect("webhookEndpointsEnabled" in PLAN_DEFAULTS.PRO).toBe(true);
+        expect(PLAN_DEFAULTS.PRO.webhookEndpointsEnabled).toBeUndefined();
+      });
     });
   });
 });

--- a/platform/app/src/components/license/planFormDefaults.ts
+++ b/platform/app/src/components/license/planFormDefaults.ts
@@ -10,6 +10,7 @@ export interface PlanFormDefaults {
   maxMembersLite?: number;
   maxMessagesPerMonth?: number;
   canPublish?: boolean;
+  webhookEndpointsEnabled?: boolean;
   usageUnit?: "traces" | "events";
 }
 
@@ -17,8 +18,16 @@ export interface PlanFormDefaults {
  * Record map of plan defaults following OCP - add new plans without modifying existing code.
  * Templates already define all values, no fallbacks needed.
  *
- * Only the enforced levers (seats, messages) + identity are templated — projects,
- * teams, and experimentation resources are OSS/uncapped and not part of licenses.
+ * Only the enforced levers (seats, messages, entitlements) + identity are
+ * templated — projects, teams, and experimentation resources are OSS/uncapped
+ * and not part of licenses.
+ *
+ * Every key a template answers is present here even when its value is
+ * undefined: the form spreads these over what is already typed in, so a key
+ * left out would keep the previous plan's value after switching plans.
+ * CUSTOM answers nothing on purpose. It has no tier to inherit from and no
+ * tier decides its entitlements later, so what the operator ticks is the only
+ * thing a custom contract carries.
  */
 export const PLAN_DEFAULTS: Record<PlanType, PlanFormDefaults> = {
   PRO: {
@@ -26,6 +35,7 @@ export const PLAN_DEFAULTS: Record<PlanType, PlanFormDefaults> = {
     maxMembersLite: PRO_TEMPLATE.maxMembersLite,
     maxMessagesPerMonth: PRO_TEMPLATE.maxMessagesPerMonth,
     canPublish: PRO_TEMPLATE.canPublish,
+    webhookEndpointsEnabled: PRO_TEMPLATE.webhookEndpointsEnabled,
     usageUnit: PRO_TEMPLATE.usageUnit as "traces" | "events",
   },
   ENTERPRISE: {
@@ -33,6 +43,7 @@ export const PLAN_DEFAULTS: Record<PlanType, PlanFormDefaults> = {
     maxMembersLite: ENTERPRISE_TEMPLATE.maxMembersLite,
     maxMessagesPerMonth: ENTERPRISE_TEMPLATE.maxMessagesPerMonth,
     canPublish: ENTERPRISE_TEMPLATE.canPublish,
+    webhookEndpointsEnabled: ENTERPRISE_TEMPLATE.webhookEndpointsEnabled,
     usageUnit: ENTERPRISE_TEMPLATE.usageUnit as "traces" | "events",
   },
   CUSTOM: {},

--- a/platform/app/src/components/license/planFormDefaults.ts
+++ b/platform/app/src/components/license/planFormDefaults.ts
@@ -15,8 +15,8 @@ export interface PlanFormDefaults {
 }
 
 /**
- * Record map of plan defaults following OCP - add new plans without modifying existing code.
- * Templates already define all values, no fallbacks needed.
+ * What the mint form fills in for each plan the operator can pick. Templates
+ * already define all values, no fallbacks needed.
  *
  * Only the enforced levers (seats, messages, entitlements) + identity are
  * templated — projects, teams, and experimentation resources are OSS/uncapped

--- a/platform/app/src/components/subscription/SubscriptionPage.tsx
+++ b/platform/app/src/components/subscription/SubscriptionPage.tsx
@@ -41,7 +41,7 @@ import { api } from "~/utils/api";
 import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 import {
   type BillingInterval,
-  buildTieredCapabilities,
+  buildPlanCapabilities,
   type Currency,
   FREE_PLAN_FEATURES as DEVELOPER_FEATURES,
   ENTERPRISE_PLAN_FEATURES,
@@ -154,7 +154,10 @@ export function SubscriptionPage() {
   const isLicenseOverride = plan?.planSource === "license";
   const isTieredPricingModel =
     organization?.pricingModel === PricingModel.TIERED;
-  const isEnterprisePlan = plan?.type === "ENTERPRISE" && !isLicenseOverride;
+  // An enterprise plan is an enterprise plan whichever leg resolved it. Tying
+  // this to the subscription leg made every licensed enterprise customer an
+  // upgrade candidate for a smaller plan they already exceed.
+  const isEnterprisePlan = plan?.type === "ENTERPRISE";
   const isTieredLegacyPaidPlan =
     isTieredPricingModel &&
     !isDeveloperPlan &&
@@ -343,7 +346,7 @@ export function SubscriptionPage() {
   }
 
   const currentPlanName = isLicenseOverride
-    ? `License: ${plan.name ?? "Growth"}`
+    ? `License: ${plan.name ?? formatPlanTypeLabel(plan.type)}`
     : isTieredPricingModel
       ? (plan.name ?? formatPlanTypeLabel(plan.type))
       : isDeveloperPlan
@@ -357,19 +360,20 @@ export function SubscriptionPage() {
           seatCount: plan?.maxMembers ?? 1,
           perSeatPrice: monthlyEquivalent,
         };
-  const currentPlanFeatures = isLicenseOverride
-    ? getGrowthFeatures(effectiveCurrency)
-    : isTieredLegacyPaidPlan
-      ? buildTieredCapabilities({
+  // A plan the customer already holds is described by what it grants. Only a
+  // plan we are selling gets marketing copy, which is why a license-sourced
+  // plan is read from its own numbers rather than handed another tier's list.
+  const currentPlanFeatures = isEnterprisePlan
+    ? ENTERPRISE_PLAN_FEATURES
+    : isLicenseOverride || isTieredLegacyPaidPlan
+      ? buildPlanCapabilities({
           maxMembers: plan?.maxMembers ?? 0,
           maxMessagesPerMonth: plan?.maxMessagesPerMonth ?? 0,
           maxMembersLite: plan?.maxMembersLite ?? 0,
         })
-      : isEnterprisePlan
-        ? ENTERPRISE_PLAN_FEATURES
-        : isDeveloperPlan
-          ? DEVELOPER_FEATURES
-          : getGrowthFeatures(effectiveCurrency);
+      : isDeveloperPlan
+        ? DEVELOPER_FEATURES
+        : getGrowthFeatures(effectiveCurrency);
 
   const isUpgradeSeatsRequired =
     !isDeveloperPlan &&

--- a/platform/app/src/components/subscription/__tests__/SubscriptionPage.tiered.integration.test.tsx
+++ b/platform/app/src/components/subscription/__tests__/SubscriptionPage.tiered.integration.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENTERPRISE_PLAN_FEATURES } from "../billing-plans";
 import { SubscriptionPage } from "../SubscriptionPage";
 import {
   createMockPlan,
@@ -398,6 +399,105 @@ describe("<SubscriptionPage/>", () => {
 
       expect(
         screen.queryByTestId("upgrade-plan-block"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ============================================================================
+  // A plan resolved from a license is still the plan the customer is on
+  // ============================================================================
+
+  describe("when an org on an enterprise license views subscription page", () => {
+    beforeEach(() => {
+      setMockOrganization({
+        id: "test-org-id",
+        name: "Test Org",
+        pricingModel: "TIERED",
+      });
+      mockGetActivePlan.mockReturnValue({
+        data: createMockPlan({
+          planSource: "license",
+          type: "ENTERPRISE",
+          name: "Enterprise",
+          free: false,
+          maxMembers: 10000,
+          maxMembersLite: 10000,
+          maxMessagesPerMonth: 10_000_000_000,
+        }),
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+    });
+
+    /** @scenario A licensed enterprise plan is not offered an upgrade */
+    it("names the plan without asking the customer to upgrade to it", async () => {
+      renderSubscriptionPage();
+
+      const block = await screen.findByTestId("current-plan-block");
+
+      expect(
+        within(block).getByText("License: Enterprise"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Upgrade required")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("upgrade-plan-block"),
+      ).not.toBeInTheDocument();
+    });
+
+    /** @scenario A licensed enterprise plan lists enterprise features */
+    it("lists the enterprise features, not a smaller plan's allowances", async () => {
+      renderSubscriptionPage();
+
+      const features = await screen.findByTestId("current-plan-features-grid");
+
+      expect(
+        within(features).getByText(ENTERPRISE_PLAN_FEATURES[0]!),
+      ).toBeInTheDocument();
+      expect(
+        within(features).queryByText("Up to 20 core users"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(features).queryByText("200,000 events included"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an org on a license below enterprise views subscription page", () => {
+    beforeEach(() => {
+      setMockOrganization({
+        id: "test-org-id",
+        name: "Test Org",
+        pricingModel: "TIERED",
+      });
+      mockGetActivePlan.mockReturnValue({
+        data: createMockPlan({
+          planSource: "license",
+          type: "PRO",
+          name: "Pro",
+          free: false,
+          maxMembers: 10,
+          maxMembersLite: 5,
+          maxMessagesPerMonth: 100_000,
+        }),
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+    });
+
+    /** @scenario A licensed plan below enterprise lists what it actually grants */
+    it("lists what the license itself grants", async () => {
+      renderSubscriptionPage();
+
+      const features = await screen.findByTestId("current-plan-features-grid");
+
+      expect(
+        within(features).getByText("Up to 10 core users"),
+      ).toBeInTheDocument();
+      expect(
+        within(features).getByText("100,000 events included"),
+      ).toBeInTheDocument();
+      expect(
+        within(features).queryByText("Up to 20 core users"),
       ).not.toBeInTheDocument();
     });
   });

--- a/platform/app/src/components/subscription/billing-plans.ts
+++ b/platform/app/src/components/subscription/billing-plans.ts
@@ -89,7 +89,7 @@ export const ENTERPRISE_PLAN_FEATURES = [
   "ISO27001 / SOC2 reports",
 ];
 
-export function buildTieredCapabilities({
+export function buildPlanCapabilities({
   maxMembers,
   maxMessagesPerMonth,
   maxMembersLite,

--- a/platform/app/src/server/app-layer/subscription/__tests__/plan-provider.unit.test.ts
+++ b/platform/app/src/server/app-layer/subscription/__tests__/plan-provider.unit.test.ts
@@ -15,7 +15,81 @@ const STUB_PLAN: PlanInfo = {
   maxMessagesPerMonth: 100_000,
 };
 
+const ENTERPRISE_PLAN: PlanInfo = {
+  ...STUB_PLAN,
+  type: "ENTERPRISE",
+  name: "Enterprise",
+};
+
 describe("PlanProviderService", () => {
+  describe("when the source answers an enterprise plan", () => {
+    /** @scenario An enterprise license signed before the flag existed is entitled */
+    it("entitles a plan whose payload never mentioned webhook endpoints", async () => {
+      const service = PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue(ENTERPRISE_PLAN),
+      });
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.webhookEndpointsEnabled).toBe(true);
+    });
+
+    /** @scenario An enterprise subscription with no license is entitled */
+    it("entitles it the same way whichever leg resolved it", async () => {
+      const service = PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue({
+          ...ENTERPRISE_PLAN,
+          planSource: "subscription",
+        }),
+      });
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.webhookEndpointsEnabled).toBe(true);
+      expect(plan.planSource).toBe("subscription");
+    });
+
+    /** @scenario An entitlement switched off in the payload stays off */
+    it("leaves an entitlement the plan switched off switched off", async () => {
+      const service = PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue({
+          ...ENTERPRISE_PLAN,
+          webhookEndpointsEnabled: false,
+        }),
+      });
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.webhookEndpointsEnabled).toBe(false);
+    });
+
+    /** @scenario Impersonation powers are not an entitlement of the enterprise tier */
+    it("does not hand it the power to add limitations", async () => {
+      const service = PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue(ENTERPRISE_PLAN),
+      });
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      // The source said false. Authorization is not a tier entitlement, so
+      // resolving an enterprise plan must not turn it on.
+      expect(plan.overrideAddingLimitations).toBe(false);
+    });
+  });
+
+  describe("when the source answers a plan below enterprise", () => {
+    /** @scenario A plan below enterprise is not entitled */
+    it("adds no entitlement to it", async () => {
+      const service = PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue(STUB_PLAN),
+      });
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.webhookEndpointsEnabled).toBeUndefined();
+    });
+  });
+
   describe("when created with a SaaS-style source", () => {
     it("delegates getActivePlan with organizationId and user", async () => {
       const source: PlanProvider = {

--- a/platform/app/src/server/app-layer/subscription/plan-provider.ts
+++ b/platform/app/src/server/app-layer/subscription/plan-provider.ts
@@ -1,3 +1,4 @@
+import { applyPlanTypeEntitlements } from "../../../../ee/licensing/planEntitlements";
 import type { PlanInfo } from "../../../../ee/licensing/planInfo";
 
 export type PlanResolver = (organizationId: string) => Promise<PlanInfo>;
@@ -16,6 +17,16 @@ export interface PlanProvider {
   }): Promise<PlanInfo>;
 }
 
+/**
+ * The single point every resolved plan passes through, whichever leg produced
+ * it (a signed license, a subscription row, or the unlicensed baseline) and
+ * whichever deployment mode is wired underneath (the SaaS composite provider
+ * or the self-hosted one).
+ *
+ * That makes it the one place where a tier's entitlements can be applied once
+ * and hold everywhere, so a feature sold with a tier does not have to be
+ * written into every contract that predates it.
+ */
 export class PlanProviderService implements PlanProvider {
   private constructor(private readonly provider: PlanProvider) {}
 
@@ -27,6 +38,6 @@ export class PlanProviderService implements PlanProvider {
     organizationId: string;
     user?: PlanProviderUser;
   }): Promise<PlanInfo> {
-    return this.provider.getActivePlan(params);
+    return applyPlanTypeEntitlements(await this.provider.getActivePlan(params));
   }
 }

--- a/specs/licensing/license-generation.feature
+++ b/specs/licensing/license-generation.feature
@@ -109,7 +109,8 @@ Feature: License Generation
     Scenario: A licensed webhook entitlement survives the PlanInfo mapping
       Given a validated license whose plan enables webhook endpoints
       When the license is mapped to the active PlanInfo
-      Then the entitlement is present, and a payload that omits it leaves the tier to decide
+      Then webhook endpoints stay available
+      And they are available too on an enterprise license that never mentioned them
 
     @unit
     Scenario: The generator form mints what it shows

--- a/specs/licensing/license-generation.feature
+++ b/specs/licensing/license-generation.feature
@@ -109,4 +109,16 @@ Feature: License Generation
     Scenario: A licensed webhook entitlement survives the PlanInfo mapping
       Given a validated license whose plan enables webhook endpoints
       When the license is mapped to the active PlanInfo
-      Then the entitlement is present, and absent means false
+      Then the entitlement is present, and a payload that omits it leaves the tier to decide
+
+    @unit
+    Scenario: The generator form mints what it shows
+      Given the license generator form on the enterprise plan
+      When its defaults are read
+      Then webhook endpoints are ticked, and switching to a lesser plan clears them
+
+    @unit
+    Scenario: A custom contract carries only what it was given
+      Given the custom plan, which has no template to inherit from
+      When its form defaults are read
+      Then nothing is filled in on its behalf

--- a/specs/licensing/plan-entitlements.feature
+++ b/specs/licensing/plan-entitlements.feature
@@ -1,0 +1,62 @@
+Feature: A plan carries its entitlements however it was resolved
+
+  As a customer on an enterprise plan
+  I want the features my plan includes to work
+  So that how my plan happens to be resolved is not my problem
+
+  A plan reaches the product down one of two legs: a signed license, or a
+  subscription row. Both legs answer through one resolution point, and an
+  entitlement that belongs to a tier is decided there, from the tier. A flag
+  added after a contract was signed therefore reaches that contract, because
+  nothing about the tier changed when the flag was written.
+
+  An entitlement the payload states explicitly is never overruled. Stating
+  false is a decision, and a plan that says false keeps saying false.
+
+  Rule: An enterprise plan is entitled on both legs
+
+    @unit
+    Scenario: An enterprise license signed before the flag existed is entitled
+      Given an enterprise license whose payload never mentions webhook endpoints
+      When the active plan is resolved
+      Then the plan carries the webhook endpoints entitlement
+
+    @unit
+    Scenario: An enterprise subscription with no license is entitled
+      Given an enterprise plan resolved from a subscription
+      When the active plan is resolved
+      Then the plan carries the webhook endpoints entitlement
+
+    @unit
+    Scenario: A plan below enterprise is not entitled
+      Given a plan resolved on a tier that does not include webhook endpoints
+      When the active plan is resolved
+      Then the plan does not carry the webhook endpoints entitlement
+
+  Rule: What a plan states explicitly wins
+
+    @unit
+    Scenario: An entitlement switched off in the payload stays off
+      Given an enterprise plan whose payload switches webhook endpoints off
+      When the active plan is resolved
+      Then the plan does not carry the webhook endpoints entitlement
+
+    @unit
+    Scenario: A plan that needs nothing filled in is handed back untouched
+      Given a plan that already answers every entitlement its tier decides
+      When the active plan is resolved
+      Then the plan is the same object it was, with nothing rewritten
+
+  Rule: Authorization is never derived from a tier
+
+    @unit
+    Scenario: Impersonation powers are not an entitlement of the enterprise tier
+      Given an enterprise plan resolved for a reader who is not impersonating
+      When the active plan is resolved
+      Then the plan does not gain the power to add limitations
+
+    @unit
+    Scenario: The unlicensed open-source baseline gains nothing from the tier map
+      Given a deployment running with no license at all
+      When the active plan is resolved
+      Then the plan is unchanged by the tier map

--- a/specs/licensing/subscription-page.feature
+++ b/specs/licensing/subscription-page.feature
@@ -156,4 +156,4 @@ Feature: Subscription Page Plan Management
     Scenario: A licensed plan below enterprise lists what it actually grants
       Given my organization's plan resolves from a license below enterprise
       When I view the subscription page
-      Then the features listed are read from that plan's own numbers
+      Then I see the features and limits that apply to my plan

--- a/specs/licensing/subscription-page.feature
+++ b/specs/licensing/subscription-page.feature
@@ -127,3 +127,33 @@ Feature: Subscription Page Plan Management
     When I view the subscription page
     Then the current plan block is still visible
 
+  # ============================================================================
+  # A plan that came from a license is still the plan the customer is on
+  # ============================================================================
+
+  Rule: A licensed enterprise plan is the current plan, not an upgrade candidate
+
+    An enterprise customer whose plan resolves from a signed license is on
+    enterprise. The page has to say so: no upgrade prompt, no smaller plan's
+    feature list, and no invitation to buy what they already have.
+
+    @integration
+    Scenario: A licensed enterprise plan is not offered an upgrade
+      Given my organization's plan resolves from an enterprise license
+      When I view the subscription page
+      Then the plan is shown as current
+      And I am not told an upgrade is required
+      And I am not offered a smaller plan to buy
+
+    @integration
+    Scenario: A licensed enterprise plan lists enterprise features
+      Given my organization's plan resolves from an enterprise license
+      When I view the subscription page
+      Then the features listed are the enterprise ones
+      And none of them describe a smaller plan's seat or event allowance
+
+    @integration
+    Scenario: A licensed plan below enterprise lists what it actually grants
+      Given my organization's plan resolves from a license below enterprise
+      When I view the subscription page
+      Then the features listed are read from that plan's own numbers

--- a/specs/licensing/subscription-page.feature
+++ b/specs/licensing/subscription-page.feature
@@ -133,13 +133,13 @@ Feature: Subscription Page Plan Management
 
   Rule: A licensed enterprise plan is the current plan, not an upgrade candidate
 
-    An enterprise customer whose plan resolves from a signed license is on
-    enterprise. The page has to say so: no upgrade prompt, no smaller plan's
-    feature list, and no invitation to buy what they already have.
+    An enterprise customer holding a signed license is on enterprise. The page
+    has to say so: no upgrade prompt, no smaller plan's feature list, and no
+    invitation to buy what they already have.
 
     @integration
     Scenario: A licensed enterprise plan is not offered an upgrade
-      Given my organization's plan resolves from an enterprise license
+      Given my organization has an enterprise license
       When I view the subscription page
       Then the plan is shown as current
       And I am not told an upgrade is required
@@ -147,13 +147,13 @@ Feature: Subscription Page Plan Management
 
     @integration
     Scenario: A licensed enterprise plan lists enterprise features
-      Given my organization's plan resolves from an enterprise license
+      Given my organization has an enterprise license
       When I view the subscription page
       Then the features listed are the enterprise ones
       And none of them describe a smaller plan's seat or event allowance
 
     @integration
     Scenario: A licensed plan below enterprise lists what it actually grants
-      Given my organization's plan resolves from a license below enterprise
+      Given my organization has a license for a plan below enterprise
       When I view the subscription page
       Then I see the features and limits that apply to my plan


### PR DESCRIPTION
## What was broken

An entitlement sold with a plan tier was written into each contract when the contract was minted. That works for contracts minted after the flag exists, and for nothing else.

- **Every licensed enterprise organization was refused.** The signed licenses predate `webhookEndpointsEnabled`, and `resolvePlanDefaults` read absent as false. One gate covers both the webhook endpoints API and the billing events API, so those customers got a 403 telling them their plan does not include a feature their plan does include.
- **Every enterprise organization on a subscription was refused too.** The enterprise preset in `PLAN_LIMITS` omitted the flag, so the leg with no license failed the same gate for a different reason.
- **Both mint paths reproduced it.** The generator form had no field for the entitlement at all, so re-issuing a license through the product produced another license without it. The CLI script took seats from its flags and everything else from the plan template, so a contract with negotiated lite seats, message volume or expiry was minted with the template's numbers instead.
- **The subscription page told licensed customers to upgrade.** `isEnterprisePlan` excluded license-sourced plans by construction, so a licensed enterprise customer saw an "Upgrade required" badge, a smaller plan's feature list under an Enterprise heading, and a card offering to sell them a plan they already exceed.
- **Which subscription answered was arbitrary.** The active-subscription lookup had no ordering, so an organization holding more than one active row could resolve a different plan between calls.

## The fix

Entitlements that belong to a tier are decided from the tier, at the one point every resolved plan passes through, `PlanProviderService.getActivePlan`. Both legs (license and subscription) and both deployment modes (SaaS composite, self-hosted) go through it, so one rule covers all of them.

- New `ee/licensing/planEntitlements.ts`: a tier map plus `applyPlanTypeEntitlements`, which fills only what the plan left unanswered. An explicit value always wins, including an explicit `false`, so a contract that withholds a tier feature keeps withholding it. A plan with nothing to fill is returned as the same object, which downstream callers depend on.
- For that to work the license leg had to stop turning absent into false while resolving defaults. Saying nothing and saying no are different answers and only one of them is a decision the customer made.
- `overrideAddingLimitations` stays out of the map. It is authorization rather than entitlement, it is recomputed from the impersonation context on every call, and deriving it from a tier would hand every enterprise reader the power to bypass their own plan's limits. `PlanInfo` carries exactly two optional booleans and the module docstring records which side each sits on, so the next optional flag's author picks one.
- The enterprise preset states the entitlement as well, and deliberately not in the shared paid-plan features. The preset is what the plan sells; the tier map is the net under a contract resolved some other way.
- The page treats enterprise as enterprise on either leg, and a licensed plan below enterprise now describes itself from its own numbers rather than borrowing another tier's marketing copy.
- The generator form gained the checkbox, defaulted from the plan template and cleared when switching to a plan that does not include it, and sends what it shows. The CLI script gained `--max-members-lite`, `--max-messages-per-month` and `--expires-at`, and an expiry in the past is refused where the license is built, matching the guard the license router already had.
- The active-subscription lookup orders by newest created with the id as a total order. A read-only report script lists organizations holding more than one active subscription, which row the ordering picks, and a census of the pending rows abandoned checkouts leave behind. It proposes nothing: deciding which duplicate is the real contract is a billing question.

**Zero licenses are re-minted and no rows change.** This is a resolution fix, not a data fix. The stored payloads still do not carry the flag; the tier answers it on the next request.

## Out of scope

`effectiveMaxSeats` and the billing-seat arithmetic for a licensed plan on a SEAT_EVENT organization are untouched. The seat drawer treats a license-sourced plan as a one-seat baseline, which is a separate question from what the plan grants and wants its own spec.

## How verified

- `pnpm test:unit run` over `ee/licensing`, `ee/billing`, `src/server/app-layer/subscription`, `src/components/license`, `src/components/subscription`: 48 files, 715 tests green.
- `pnpm test:integration run` over `src/components/subscription` and `src/components/license`: 8 files, 101 green, 5 pre-existing skips.
- `pnpm typecheck:all` clean, both the source and the test projects.
- `pnpm check:feature-parity` clean: `plan-entitlements.feature` 7/7 bound, `license-generation.feature` 4/4, `subscription-page.feature` 3/3. That last file came off the parity ratchet's inert list in the same commit that gave it enforced scenarios.
- Written outside-in: each spec first, then a test confirmed failing for the reason it names, then the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enterprise plans now include webhook endpoint access by default, with explicit opt-out support.
  - License generation supports custom member and message limits, expiration dates, and webhook settings.
  - License forms include options for webhook endpoints and gateway spend APIs.
  - Subscription pages accurately display licensed plan names, features, and usage limits.
  - Added a read-only tool to identify duplicate subscriptions and show resolution details.

- **Bug Fixes**
  - Plan switching correctly clears webhook entitlements when unavailable.
  - Active subscription selection consistently uses the newest subscription.
  - Self-hosted installations now receive free-plan limits by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->