### PR TITLE
fix(licensing): the subscription page honors what a held plan actually grants

### DIFF
--- a/platform/app/src/components/subscription/SubscriptionPage.tsx
+++ b/platform/app/src/components/subscription/SubscriptionPage.tsx
@@ -41,10 +41,10 @@ import { api } from "~/utils/api";
 import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 import {
   type BillingInterval,
+  buildEnterprisePlanFeatures,
   buildPlanCapabilities,
   type Currency,
   FREE_PLAN_FEATURES as DEVELOPER_FEATURES,
-  ENTERPRISE_PLAN_FEATURES,
   formatPrice,
   getAnnualDiscountPercent,
   getGrowthFeatures,
@@ -360,11 +360,12 @@ export function SubscriptionPage() {
           seatCount: plan?.maxMembers ?? 1,
           perSeatPrice: monthlyEquivalent,
         };
-  // A plan the customer already holds is described by what it grants. Only a
-  // plan we are selling gets marketing copy, which is why a license-sourced
-  // plan is read from its own numbers rather than handed another tier's list.
+  // A plan the customer already holds is described by what it grants: the
+  // enterprise list minus anything their contract withheld, and every other
+  // held plan read from its own numbers rather than handed another tier's
+  // marketing copy. Only a plan we are selling gets the tier's full pitch.
   const currentPlanFeatures = isEnterprisePlan
-    ? ENTERPRISE_PLAN_FEATURES
+    ? buildEnterprisePlanFeatures(plan)
     : isLicenseOverride || isTieredLegacyPaidPlan
       ? buildPlanCapabilities({
           maxMembers: plan?.maxMembers ?? 0,
@@ -514,7 +515,13 @@ export function SubscriptionPage() {
           }
           isManageLoading={isManageLoading}
           deprecatedNotice={isTieredLegacyPaidPlan}
-          contactSalesUrl={isEnterprisePlan ? CONTACT_SALES_URL : undefined}
+          // Sales has nothing to sell a customer already holding a signed
+          // enterprise contract, so they get no upgrade call to action.
+          contactSalesUrl={
+            isEnterprisePlan && !isLicenseOverride
+              ? CONTACT_SALES_URL
+              : undefined
+          }
         />
 
         {/* Invoices Block - always shown; listInvoices returns [] when no Stripe customer exists */}

--- a/platform/app/src/components/subscription/__tests__/SubscriptionPage.tiered.integration.test.tsx
+++ b/platform/app/src/components/subscription/__tests__/SubscriptionPage.tiered.integration.test.tsx
@@ -14,7 +14,10 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ENTERPRISE_PLAN_FEATURES } from "../billing-plans";
+import {
+  ENTERPRISE_PLAN_FEATURES,
+  WEBHOOK_FEATURE_LABEL,
+} from "../billing-plans";
 import { SubscriptionPage } from "../SubscriptionPage";
 import {
   createMockPlan,
@@ -459,6 +462,57 @@ describe("<SubscriptionPage/>", () => {
       expect(
         within(features).queryByText("200,000 events included"),
       ).not.toBeInTheDocument();
+    });
+
+    /** @scenario A licensed enterprise plan is not asked to contact sales about upgrading */
+    it("offers no way to contact sales about upgrading", async () => {
+      renderSubscriptionPage();
+
+      await screen.findByTestId("current-plan-block");
+
+      expect(
+        screen.queryByTestId("contact-sales-button"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the enterprise license withholds webhook endpoints", () => {
+    beforeEach(() => {
+      setMockOrganization({
+        id: "test-org-id",
+        name: "Test Org",
+        pricingModel: "TIERED",
+      });
+      mockGetActivePlan.mockReturnValue({
+        data: createMockPlan({
+          planSource: "license",
+          type: "ENTERPRISE",
+          name: "Enterprise",
+          free: false,
+          maxMembers: 10000,
+          maxMembersLite: 10000,
+          maxMessagesPerMonth: 10_000_000_000,
+          webhookEndpointsEnabled: false,
+        }),
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+    });
+
+    /** @scenario A capability the contract withholds is not advertised as included */
+    it("leaves the withheld capability off the list and keeps the rest", async () => {
+      renderSubscriptionPage();
+
+      const features = await screen.findByTestId("current-plan-features-grid");
+
+      expect(
+        within(features).queryByText(WEBHOOK_FEATURE_LABEL),
+      ).not.toBeInTheDocument();
+      for (const label of ENTERPRISE_PLAN_FEATURES.filter(
+        (feature) => feature !== WEBHOOK_FEATURE_LABEL,
+      )) {
+        expect(within(features).getByText(label)).toBeInTheDocument();
+      }
     });
   });
 

--- a/platform/app/src/components/subscription/__tests__/billing-plans.unit.test.ts
+++ b/platform/app/src/components/subscription/__tests__/billing-plans.unit.test.ts
@@ -7,7 +7,13 @@
 
 import { Currency } from "@prisma/client";
 import { describe, expect, it } from "vitest";
-import { getGrowthFeatures, getGrowthPlanFeatures } from "../billing-plans";
+import {
+  buildEnterprisePlanFeatures,
+  ENTERPRISE_PLAN_FEATURES,
+  getGrowthFeatures,
+  getGrowthPlanFeatures,
+  WEBHOOK_FEATURE_LABEL,
+} from "../billing-plans";
 
 describe("getGrowthFeatures()", () => {
   describe("when currency is EUR", () => {
@@ -41,6 +47,38 @@ describe("getGrowthPlanFeatures()", () => {
       const features = getGrowthPlanFeatures(Currency.USD);
 
       expect(features).toContain("$6 per additional 100,000 events");
+    });
+  });
+});
+
+describe("buildEnterprisePlanFeatures()", () => {
+  describe("given a contract that withholds webhook endpoints", () => {
+    /** @scenario A capability the contract withholds is not advertised as included */
+    it("drops that bullet and keeps every other one", () => {
+      const features = buildEnterprisePlanFeatures({
+        webhookEndpointsEnabled: false,
+      });
+
+      expect(features).not.toContain(WEBHOOK_FEATURE_LABEL);
+      expect(features).toEqual(
+        ENTERPRISE_PLAN_FEATURES.filter(
+          (feature) => feature !== WEBHOOK_FEATURE_LABEL,
+        ),
+      );
+    });
+  });
+
+  describe("given a contract that grants webhook endpoints", () => {
+    it("lists everything the tier offers", () => {
+      expect(
+        buildEnterprisePlanFeatures({ webhookEndpointsEnabled: true }),
+      ).toEqual(ENTERPRISE_PLAN_FEATURES);
+    });
+  });
+
+  describe("given a plan that says nothing about webhook endpoints", () => {
+    it("lists everything, since silence is answered by the tier and not by us", () => {
+      expect(buildEnterprisePlanFeatures({})).toEqual(ENTERPRISE_PLAN_FEATURES);
     });
   });
 });

--- a/platform/app/src/components/subscription/billing-plans.ts
+++ b/platform/app/src/components/subscription/billing-plans.ts
@@ -8,6 +8,7 @@
 import { Currency } from "@prisma/client";
 import { formatNumber } from "~/utils/formatNumber";
 import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
+import type { PlanInfo } from "../../../ee/licensing/planInfo";
 
 export { isAnnualTieredPlan } from "../../../ee/billing/planTypes";
 export type { Currency } from "../../../ee/billing/pricing";
@@ -74,20 +75,60 @@ export const getGrowthPlanFeatures = (currency: Currency): string[] => [
   "Slack support",
 ];
 
-export const ENTERPRISE_PLAN_FEATURES = [
-  "Alternative hosting options",
-  "Custom data retention",
-  "Custom SSO / RBAC",
-  "Audit logs",
-  "Gateway webhooks for metering and rebilling",
-  "Uptime & Support SLA",
-  "Compliance and legal reviews",
-  "Custom terms and DPA",
-  "Dedicated Solution Engineer",
-  "Slack / Teams support",
-  "AWS/Azure/GCP Marketplace",
-  "ISO27001 / SOC2 reports",
+export const WEBHOOK_FEATURE_LABEL =
+  "Gateway webhooks for metering and rebilling";
+
+/**
+ * What the Enterprise tier offers, with each bullet tied to the entitlement
+ * that decides it where a contract can withhold one.
+ *
+ * The tie is the field name, not the sentence: a bullet whose copy is reworded
+ * keeps describing the same capability, and nothing has to match prose to know
+ * which capability a plan is missing.
+ */
+const ENTERPRISE_PLAN_FEATURE_ENTRIES: ReadonlyArray<{
+  label: string;
+  /** The plan field that decides this bullet, when one does. */
+  entitlement?: keyof Pick<PlanInfo, "webhookEndpointsEnabled">;
+}> = [
+  { label: "Alternative hosting options" },
+  { label: "Custom data retention" },
+  { label: "Custom SSO / RBAC" },
+  { label: "Audit logs" },
+  { label: WEBHOOK_FEATURE_LABEL, entitlement: "webhookEndpointsEnabled" },
+  { label: "Uptime & Support SLA" },
+  { label: "Compliance and legal reviews" },
+  { label: "Custom terms and DPA" },
+  { label: "Dedicated Solution Engineer" },
+  { label: "Slack / Teams support" },
+  { label: "AWS/Azure/GCP Marketplace" },
+  { label: "ISO27001 / SOC2 reports" },
 ];
+
+/**
+ * The Enterprise tier as it is SOLD: everything the tier offers, whatever any
+ * one contract settled on. This is the list for the pages that are selling it.
+ */
+export const ENTERPRISE_PLAN_FEATURES = ENTERPRISE_PLAN_FEATURE_ENTRIES.map(
+  (entry) => entry.label,
+);
+
+/**
+ * The Enterprise tier as one customer HOLDS it: the same list, minus anything
+ * their contract explicitly withheld.
+ *
+ * Only an explicit `false` removes a bullet. An entitlement the plan says
+ * nothing about is answered by the tier at resolution, so silence here means
+ * granted, not withheld, and a plan that never reached the resolver is
+ * described by what the tier sells rather than stripped of it.
+ */
+export function buildEnterprisePlanFeatures(
+  plan: Pick<PlanInfo, "webhookEndpointsEnabled">,
+): string[] {
+  return ENTERPRISE_PLAN_FEATURE_ENTRIES.filter(
+    (entry) => !entry.entitlement || plan[entry.entitlement] !== false,
+  ).map((entry) => entry.label);
+}
 
 export function buildPlanCapabilities({
   maxMembers,

--- a/specs/licensing/subscription-page.feature
+++ b/specs/licensing/subscription-page.feature
@@ -157,3 +157,16 @@ Feature: Subscription Page Plan Management
       Given my organization has a license for a plan below enterprise
       When I view the subscription page
       Then I see the features and limits that apply to my plan
+
+    @integration
+    Scenario: A licensed enterprise plan is not asked to contact sales about upgrading
+      Given my organization has an enterprise license
+      When I view the subscription page
+      Then I am not offered a way to contact sales about upgrading
+
+    @integration
+    Scenario: A capability the contract withholds is not advertised as included
+      Given my organization has an enterprise license that withholds webhook endpoints
+      When I view the subscription page
+      Then webhook endpoints are not listed among the features I have
+      And the rest of the enterprise features are still listed


### PR DESCRIPTION
Follow-up to two P2 review comments left on #6847 after it merged:

- [Licensed Enterprise still renders an upgrade CTA](https://github.com/langwatch/langwatch/pull/6847#discussion_r3758877490)
- [An explicitly withheld webhook entitlement is still advertised as included](https://github.com/langwatch/langwatch/pull/6847#discussion_r3758877501)

Both were correct.

## The upgrade call to action

#6847 made `isEnterprisePlan` true for a license-sourced enterprise plan, which was the point: an enterprise customer is on enterprise whichever leg resolved it. That value also decides whether `CurrentPlanBlock` gets a `contactSalesUrl`, and with one, it renders a button reading "Contact us to Upgrade". So the licensed case lost the upgrade badge and the upsell card and kept a third upgrade prompt nobody was looking at. The rule the spec states is that a licensed enterprise plan is not an upgrade candidate, and a button inviting them to talk to sales about upgrading is exactly that.

The url is now supplied only when the plan is enterprise and did not come from a license. Sales has nothing to sell a customer already holding a signed enterprise contract.

The subscription-sourced enterprise case is untouched and keeps the button. Whether "Contact us to Upgrade" is the right label on a top-tier plan at all is a copy question that predates this work and is not answered here.

## The advertised capability a contract withholds

Entitlement resolution deliberately preserves an explicit `webhookEndpointsEnabled: false`, so a contract can withhold a tier feature. The page did not know that: every enterprise plan took the same static `ENTERPRISE_PLAN_FEATURES`, including the gateway webhooks bullet, so such a customer read that webhooks are included while the gate correctly refused them.

The tier's bullets now carry the entitlement field that decides them, where one does. Two lists come off that:

- `ENTERPRISE_PLAN_FEATURES`, the tier as it is SOLD, unchanged in content and still what the plan comparison and contact-sales surfaces render.
- `buildEnterprisePlanFeatures(plan)`, the tier as one customer HOLDS it, which is what the current-plan block renders.

Only an explicit `false` removes a bullet. An entitlement the plan says nothing about is answered by the tier at resolution, so silence reads as granted and a plan that never reached the resolver is described by what the tier sells rather than stripped of it.

The link is the field name, not the sentence, so a bullet whose copy is reworded keeps describing the same capability and nothing matches prose to decide what a plan is missing.

On the reviewer's remaining 5%, whether the list is generic tier marketing or effective contract capabilities: the page's own comment already said a held plan is described by what it grants, and the customer-visible consequence of getting it wrong is a page that contradicts a 403. So the held list is filtered and the selling list is not, which keeps both readings true where each is rendered.

## Specs

Two `@integration` scenarios under the existing rule "A licensed enterprise plan is the current plan, not an upgrade candidate" in `specs/licensing/subscription-page.feature`: one for not being offered a way to contact sales about upgrading, one for a withheld capability not being advertised as included. Both bound.

## How verified

- `pnpm test:unit run` over `src/components/subscription` and `ee/licensing`: 13 files, 231 tests green.
- `pnpm test:integration run` over `src/components/subscription`: 5 files, 91 green, 5 pre-existing skips.
- `pnpm check:feature-parity`: `subscription-page.feature` 5/5 bound, whole run OK.
- `pnpm typecheck:all` clean.
- Biome's new-violation gate against the merge base: no new violations.
- Both tests were confirmed failing first, against the code as merged: the contact-sales button was present, and the webhook bullet was rendered for a plan that withheld it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enterprise plan features now accurately reflect available capabilities, including webhook support.
  - Licensed enterprise plans no longer display a contact-sales upgrade option.
  - Enterprise feature listings retain available capabilities while omitting contractually unavailable features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->